### PR TITLE
feat(forge): add GitLab support alongside GitHub

### DIFF
--- a/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
@@ -93,6 +93,7 @@ vi.mock("../../../utils/openExternal.js", () => ({
 vi.mock("../forgeResolution.js", () => ({
   resolveForCwd: resolveForCwdMock,
   getImplForNamespace: () => fakeImpl,
+  getImplForNamespaceActivating: () => Promise.resolve(fakeImpl),
 }));
 
 vi.mock("../../../store.js", () => ({

--- a/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
@@ -96,6 +96,7 @@ vi.mock("../../../utils/openExternal.js", () => ({
 vi.mock("../forgeResolution.js", () => ({
   resolveForCwd: resolveForCwdMock,
   getImplForNamespace: () => fakeImpl,
+  getImplForNamespaceActivating: () => Promise.resolve(fakeImpl),
 }));
 
 vi.mock("../../../store.js", () => ({

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -63,10 +63,12 @@ vi.mock("../../../services/GitServiceCache.js", () => ({
 }));
 
 // The handlers lazy-import PluginService to gate registry reads behind
-// startup load + activation (the #9285 init-race guard); stub the singleton
-// so tests never construct the real service.
+// startup load + activation (the #9285 init-race guard) and to implicitly
+// activate a lazy provider before the credential impl lookup; stub the
+// singleton so tests never construct the real service.
 const pluginServiceMock = vi.hoisted(() => ({
   waitForInit: vi.fn(() => Promise.resolve()),
+  activatePluginForForgeProvider: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../../services/PluginService.js", () => ({
@@ -541,7 +543,32 @@ describe("registerForgeSettingsHandlers", () => {
     expect(workspaceClientMock.updateForgeCredentials).not.toHaveBeenCalled();
   });
 
-  it("setCredential returns a not-activated error when no impl is registered", async () => {
+  it("setCredential activates a lazy provider before the impl lookup", async () => {
+    registerGiteaProvider();
+    const validateToken = vi.fn().mockResolvedValue({ valid: true });
+    // Impl absent on first lookup; activation binds it for the re-read —
+    // modeling a fresh session where Settings is the provider's first touch.
+    registryMock.getForgeProviderImpl.mockReturnValueOnce(undefined);
+    // `mockImplementationOnce`: `clearAllMocks` in beforeEach does not reset
+    // implementations, so a persistent one would leak the re-bound impl into
+    // later tests.
+    pluginServiceMock.activatePluginForForgeProvider.mockImplementationOnce(() => {
+      registryMock.getForgeProviderImpl.mockReturnValue({ validateToken });
+      return Promise.resolve();
+    });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    const result = (await setCredential(null, "acme.gitea", { token: "x" })) as {
+      valid: boolean;
+    };
+
+    expect(pluginServiceMock.activatePluginForForgeProvider).toHaveBeenCalledWith("acme.gitea");
+    expect(result.valid).toBe(true);
+    expect(validateToken).toHaveBeenCalledWith("x");
+  });
+
+  it("setCredential returns an unavailable error when activation binds no impl", async () => {
     registerGiteaProvider();
     registryMock.getForgeProviderImpl.mockReturnValue(undefined);
     registerForgeSettingsHandlers();
@@ -552,8 +579,9 @@ describe("registerForgeSettingsHandlers", () => {
       error?: string;
     };
 
+    expect(pluginServiceMock.activatePluginForForgeProvider).toHaveBeenCalledWith("acme.gitea");
     expect(result.valid).toBe(false);
-    expect(result.error).toMatch(/not activated/i);
+    expect(result.error).toMatch(/isn't available/i);
     expect(storeMock.set).not.toHaveBeenCalledWith("forgeCredentials", expect.anything());
   });
 

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -74,10 +74,12 @@ vi.mock("../../../services/GitServiceCache.js", () => ({
 }));
 
 // The handlers lazy-import PluginService to gate registry reads behind
-// startup load + activation (the #9285 init-race guard); stub the singleton
-// so tests never construct the real service.
+// startup load + activation (the #9285 init-race guard) and to implicitly
+// activate a lazy provider before the credential impl lookup; stub the
+// singleton so tests never construct the real service.
 const pluginServiceMock = vi.hoisted(() => ({
   waitForInit: vi.fn(() => Promise.resolve()),
+  activatePluginForForgeProvider: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../../services/PluginService.js", () => ({
@@ -598,7 +600,32 @@ describe("registerForgeSettingsHandlers", () => {
     expect(workspaceClientMock.updateForgeCredentials).not.toHaveBeenCalled();
   });
 
-  it("setCredential returns a not-activated error when no impl is registered", async () => {
+  it("setCredential activates a lazy provider before the impl lookup", async () => {
+    registerGiteaProvider();
+    const validateToken = vi.fn().mockResolvedValue({ valid: true });
+    // Impl absent on first lookup; activation binds it for the re-read —
+    // modeling a fresh session where Settings is the provider's first touch.
+    registryMock.getForgeProviderImpl.mockReturnValueOnce(undefined);
+    // `mockImplementationOnce`: `clearAllMocks` in beforeEach does not reset
+    // implementations, so a persistent one would leak the re-bound impl into
+    // later tests.
+    pluginServiceMock.activatePluginForForgeProvider.mockImplementationOnce(() => {
+      registryMock.getForgeProviderImpl.mockReturnValue({ validateToken });
+      return Promise.resolve();
+    });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    const result = (await setCredential(null, "acme.gitea", { token: "x" })) as {
+      valid: boolean;
+    };
+
+    expect(pluginServiceMock.activatePluginForForgeProvider).toHaveBeenCalledWith("acme.gitea");
+    expect(result.valid).toBe(true);
+    expect(validateToken).toHaveBeenCalledWith("x");
+  });
+
+  it("setCredential returns an unavailable error when activation binds no impl", async () => {
     registerGiteaProvider();
     registryMock.getForgeProviderImpl.mockReturnValue(undefined);
     registerForgeSettingsHandlers();
@@ -609,8 +636,9 @@ describe("registerForgeSettingsHandlers", () => {
       error?: string;
     };
 
+    expect(pluginServiceMock.activatePluginForForgeProvider).toHaveBeenCalledWith("acme.gitea");
     expect(result.valid).toBe(false);
-    expect(result.error).toMatch(/not activated/i);
+    expect(result.error).toMatch(/isn't available/i);
     expect(storeMock.set).not.toHaveBeenCalledWith("forgeCredentials", expect.anything());
   });
 

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -3,11 +3,12 @@ import { CHANNELS } from "../channels.js";
 import { openExternalUrl } from "../../utils/openExternal.js";
 import { checkRateLimit, typedHandle } from "../utils.js";
 import { defineIpcNamespace, op } from "../define.js";
+import { getRegisteredForgeProviders } from "../../services/forgeProviderRegistry.js";
 import {
-  getForgeProviderImpl,
-  getRegisteredForgeProviders,
-} from "../../services/forgeProviderRegistry.js";
-import { resolveForCwd, getImplForNamespace } from "./forgeResolution.js";
+  resolveForCwd,
+  getImplForNamespace,
+  getImplForNamespaceActivating,
+} from "./forgeResolution.js";
 import { auditForgeCall, summarizeForgeArgs } from "../../services/forge/forgeAuditService.js";
 import type {
   CreateIssueInput,
@@ -945,11 +946,14 @@ export function registerForgeHandlers(): () => void {
         }
 
         const namespaceId = makeForgeProviderId(entry.pluginId, entry.contribution.id);
-        const impl = getForgeProviderImpl(namespaceId);
+        // Testing a token is often the FIRST interaction with a lazy provider,
+        // so activate implicitly before the impl lookup — mirroring
+        // resolveForCwd (#10523 / d434e770c precedent).
+        const impl = await getImplForNamespaceActivating(namespaceId);
         if (!impl) {
           return {
             valid: false as const,
-            error: `Forge provider "${entry.contribution.id}" not activated`,
+            error: `Forge provider "${entry.contribution.id}" isn't available`,
           };
         }
         return auditForgeCall(

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -3,11 +3,12 @@ import { CHANNELS } from "../channels.js";
 import { openExternalUrl } from "../../utils/openExternal.js";
 import { checkRateLimit, typedHandle } from "../utils.js";
 import { defineIpcNamespace, op } from "../define.js";
+import { getRegisteredForgeProviders } from "../../services/forgeProviderRegistry.js";
 import {
-  getForgeProviderImpl,
-  getRegisteredForgeProviders,
-} from "../../services/forgeProviderRegistry.js";
-import { resolveForCwd, getImplForNamespace } from "./forgeResolution.js";
+  resolveForCwd,
+  getImplForNamespace,
+  getImplForNamespaceActivating,
+} from "./forgeResolution.js";
 import { auditForgeCall, summarizeForgeArgs } from "../../services/forge/forgeAuditService.js";
 import type {
   CreateIssueInput,
@@ -950,11 +951,14 @@ export function registerForgeHandlers(): () => void {
         }
 
         const namespaceId = makeForgeProviderId(entry.pluginId, entry.contribution.id);
-        const impl = getForgeProviderImpl(namespaceId);
+        // Testing a token is often the FIRST interaction with a lazy provider,
+        // so activate implicitly before the impl lookup — mirroring
+        // resolveForCwd (#10523 / d434e770c precedent).
+        const impl = await getImplForNamespaceActivating(namespaceId);
         if (!impl) {
           return {
             valid: false as const,
-            error: `Forge provider "${entry.contribution.id}" not activated`,
+            error: `Forge provider "${entry.contribution.id}" isn't available`,
           };
         }
         return auditForgeCall(

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -427,7 +427,13 @@ async function handleForgeGetProjectHealth(payload: {
 
     const { impl, repoRef } = await resolveForCwd(cwd);
     if (!impl.projectHealth) {
-      throw new Error("Provider does not support project health");
+      // Capability absent is not an error and not a missing remote — mark it
+      // so the pulse card hides the health section rather than telling the
+      // user to "connect a git remote" they already have.
+      return {
+        ...buildEmptyForgeProjectHealth({ hasRemote: true }),
+        unsupported: true,
+      };
     }
     const result = await impl.projectHealth.getProjectHealth(repoRef, {
       bypassCache: payload.bypassCache === true,

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -547,7 +547,13 @@ async function handleForgeGetProjectHealth(payload: {
 
     const { impl, repoRef } = await resolveForCwd(cwd);
     if (!impl.projectHealth) {
-      throw new Error("Provider does not support project health");
+      // Capability absent is not an error and not a missing remote — mark it
+      // so the pulse card hides the health section rather than telling the
+      // user to "connect a git remote" they already have.
+      return {
+        ...buildEmptyForgeProjectHealth({ hasRemote: true }),
+        unsupported: true,
+      };
     }
     const result = await impl.projectHealth.getProjectHealth(repoRef, {
       bypassCache: payload.bypassCache === true,

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -125,3 +125,22 @@ export function getImplForNamespace(namespaceId: string): ForgeProviderImpl {
   }
   return impl;
 }
+
+/**
+ * Impl lookup with the same implicit activation as {@link resolveForCwd}, for
+ * provider-scoped surfaces that address a provider by id instead of a cwd
+ * (credential save, token test). Lazy plugins only bind their impl during
+ * activate(), and connecting a provider for the first time is exactly the
+ * moment nothing else has activated it yet — without this, Save/Test on a
+ * fresh session fails with "not activated" while the user is standing in the
+ * Settings screen that's supposed to activate it.
+ */
+export async function getImplForNamespaceActivating(
+  namespaceId: string
+): Promise<ForgeProviderImpl | undefined> {
+  const existing = getForgeProviderImpl(namespaceId);
+  if (existing) return existing;
+  const pluginService = await getPluginService();
+  await pluginService.activatePluginForForgeProvider(namespaceId);
+  return getForgeProviderImpl(namespaceId);
+}

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -401,3 +401,22 @@ export function getImplForNamespace(namespaceId: string): ForgeProviderImpl {
   }
   return impl;
 }
+
+/**
+ * Impl lookup with the same implicit activation as {@link resolveForCwd}, for
+ * provider-scoped surfaces that address a provider by id instead of a cwd
+ * (credential save, token test). Lazy plugins only bind their impl during
+ * activate(), and connecting a provider for the first time is exactly the
+ * moment nothing else has activated it yet — without this, Save/Test on a
+ * fresh session fails with "not activated" while the user is standing in the
+ * Settings screen that's supposed to activate it.
+ */
+export async function getImplForNamespaceActivating(
+  namespaceId: string
+): Promise<ForgeProviderImpl | undefined> {
+  const existing = getForgeProviderImpl(namespaceId);
+  if (existing) return existing;
+  const pluginService = await getPluginService();
+  await pluginService.activatePluginForForgeProvider(namespaceId);
+  return getForgeProviderImpl(namespaceId);
+}

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -15,6 +15,7 @@ import {
   credentialFieldsFor,
   pickPrimaryValue,
 } from "../../services/forge/forgeCredentialUtils.js";
+import { getImplForNamespaceActivating } from "./forgeResolution.js";
 import type { AuthValidation } from "../../../shared/types/forge.js";
 
 /**
@@ -177,9 +178,17 @@ export function registerForgeSettingsHandlers(): () => void {
           return { valid: false, error: "Credential is required" };
         }
 
-        const impl = getForgeProviderImpl(providerId);
+        // Saving a credential is often the FIRST interaction with a lazy
+        // provider (fresh session, no matching project open yet), so the impl
+        // may not be bound — activate implicitly like every other forge IPC
+        // surface (#10523 / d434e770c precedent).
+        await awaitPluginInit();
+        const impl = await getImplForNamespaceActivating(providerId);
         if (!impl) {
-          return { valid: false, error: "Provider not activated. Open it in Settings first." };
+          return {
+            valid: false,
+            error: "Provider isn't available — check it's enabled in Plugins",
+          };
         }
 
         const validation = await auditForgeCall(

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -16,6 +16,7 @@ import {
   credentialFieldsFor,
   pickPrimaryValue,
 } from "../../services/forge/forgeCredentialUtils.js";
+import { getImplForNamespaceActivating } from "./forgeResolution.js";
 import type { AuthValidation, ForgeProviderImpl } from "../../../shared/types/forge.js";
 import { logWarn } from "../../utils/logger.js";
 
@@ -245,9 +246,17 @@ export function registerForgeSettingsHandlers(): () => void {
           return { valid: false, error: "Credential is required" };
         }
 
-        const impl = getForgeProviderImpl(providerId);
+        // Saving a credential is often the FIRST interaction with a lazy
+        // provider (fresh session, no matching project open yet), so the impl
+        // may not be bound — activate implicitly like every other forge IPC
+        // surface (#10523 / d434e770c precedent).
+        await awaitPluginInit();
+        const impl = await getImplForNamespaceActivating(providerId);
         if (!impl) {
-          return { valid: false, error: "Provider not activated. Open it in Settings first." };
+          return {
+            valid: false,
+            error: "Provider isn't available — check it's enabled in Plugins",
+          };
         }
 
         const validation = await auditForgeCall(

--- a/plugins/builtin/gitlab/main/GitLabAuth.ts
+++ b/plugins/builtin/gitlab/main/GitLabAuth.ts
@@ -1,0 +1,363 @@
+import type {
+  ForgeTokenHealthState,
+  ForgeTokenHealthStatus,
+} from "../../../../shared/types/forge.js";
+
+/** Timeout for auth-path requests (`/user`, token introspection). */
+export const GITLAB_AUTH_TIMEOUT_MS = 10_000;
+
+/** Timeout for regular API requests. */
+export const GITLAB_API_TIMEOUT_MS = 15_000;
+
+const DEFAULT_INSTANCE_URL = "https://gitlab.com";
+
+/** Minimum spacing between unforced token-health probes. */
+const HEALTH_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
+
+type InstanceUrlReader = () => Promise<string | undefined>;
+
+interface ValidatedUserInfo {
+  username: string;
+  avatarUrl?: string;
+  scopes?: string[];
+}
+
+/**
+ * In-memory auth state for the GitLab provider. The durable credential lives
+ * in the host's `forgeCredentials` store — the host replays it into
+ * `setCredentials` when the impl binds and on every save — so this module
+ * never persists the token itself. The instance URL is a plugin setting
+ * (`instanceUrl`), read through an accessor injected at `activate()` so this
+ * module stays import-safe in tests.
+ */
+let memoryToken: string | null = null;
+let tokenVersion = 0;
+let validatedUser: ValidatedUserInfo | null = null;
+let validatedUserVersion = -1;
+let instanceUrlReader: InstanceUrlReader | null = null;
+
+let healthState: ForgeTokenHealthState = { status: "unknown", tokenVersion: 0, checkedAt: 0 };
+const healthListeners = new Set<(state: ForgeTokenHealthState) => void>();
+let lastHealthProbeAt = 0;
+
+export function setInstanceUrlReader(reader: InstanceUrlReader | null): void {
+  instanceUrlReader = reader;
+}
+
+function normalizeInstanceUrl(raw: string): string {
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+/**
+ * Read the configured instance base URL. Returns `undefined` when the setting
+ * is unset or blank (a fresh install — the gitlab.com default applies) and
+ * THROWS when the settings read itself failed, so security-sensitive callers
+ * ({@link getInstanceHostStrict}) can fail closed instead of silently
+ * treating a broken read as "gitlab.com".
+ */
+async function readConfiguredInstanceUrl(): Promise<string | undefined> {
+  const raw = await instanceUrlReader?.();
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    return normalizeInstanceUrl(raw);
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the configured instance base URL for display and URL building.
+ * Falls back to gitlab.com when the setting is unset or unreadable — callers
+ * that gate credential attachment must use {@link getInstanceHostStrict}
+ * instead, which does not substitute a different origin on failure.
+ */
+export async function getInstanceUrl(): Promise<string> {
+  try {
+    return (await readConfiguredInstanceUrl()) ?? DEFAULT_INSTANCE_URL;
+  } catch {
+    return DEFAULT_INSTANCE_URL;
+  }
+}
+
+/** Hostname of the configured instance, lowercased. Never throws. */
+export async function getInstanceHost(): Promise<string> {
+  const url = await getInstanceUrl();
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return "gitlab.com";
+  }
+}
+
+/**
+ * Hostname of the configured instance for credential-attachment decisions.
+ * Unlike {@link getInstanceHost} this THROWS when the settings read failed or
+ * the stored value is unparsable — the caller must then withhold the token
+ * rather than fall back to a default origin the token was never scoped to.
+ */
+export async function getInstanceHostStrict(): Promise<string> {
+  const configured = await readConfiguredInstanceUrl();
+  if (configured === undefined) {
+    return "gitlab.com";
+  }
+  return new URL(configured).hostname.toLowerCase();
+}
+
+export function getToken(): string | null {
+  return memoryToken;
+}
+
+export function getTokenVersion(): number {
+  return tokenVersion;
+}
+
+/**
+ * Replace the in-memory token. Bumps the version so late-resolving
+ * validations against the old token can't stamp user info onto the new one,
+ * resets health to `unknown` (the new token has no probe history), and drops
+ * the probe cooldown so the next health refresh isn't blocked by the previous
+ * token's schedule.
+ */
+export function setMemoryToken(token: string | null): void {
+  const next = token && token.trim().length > 0 ? token.trim() : null;
+  if (next === memoryToken) return;
+  memoryToken = next;
+  tokenVersion += 1;
+  validatedUser = null;
+  validatedUserVersion = -1;
+  lastHealthProbeAt = 0;
+  setHealth("unknown");
+}
+
+export function setValidatedUserInfo(info: ValidatedUserInfo, versionAtStart: number): void {
+  if (versionAtStart !== tokenVersion) return;
+  validatedUser = info;
+  validatedUserVersion = versionAtStart;
+}
+
+export function getValidatedUserInfo(): ValidatedUserInfo | null {
+  return validatedUserVersion === tokenVersion ? validatedUser : null;
+}
+
+/** Always re-stamps `checkedAt`; listeners fire only on a status/version change. */
+function setHealth(status: ForgeTokenHealthStatus): void {
+  const changed = healthState.status !== status || healthState.tokenVersion !== tokenVersion;
+  healthState = { status, tokenVersion, checkedAt: Date.now() };
+  if (!changed) return;
+  for (const listener of [...healthListeners]) {
+    try {
+      listener(healthState);
+    } catch {
+      // A throwing listener must not break the others.
+    }
+  }
+}
+
+export function getTokenHealth(): ForgeTokenHealthState {
+  return healthState;
+}
+
+export function onTokenHealthChanged(listener: (state: ForgeTokenHealthState) => void): () => void {
+  healthListeners.add(listener);
+  return () => {
+    healthListeners.delete(listener);
+  };
+}
+
+/**
+ * Record an authoritative auth success against the current token. Pass the
+ * token version captured when the request was SENT so a late response for a
+ * rotated-away token can't stamp the new one.
+ */
+export function markTokenHealthy(versionAtRequest?: number): void {
+  if (!memoryToken) return;
+  if (versionAtRequest !== undefined && versionAtRequest !== tokenVersion) return;
+  setHealth("healthy");
+}
+
+/**
+ * Record an authoritative credential rejection (401 on an authenticated
+ * request). Transient network failures must never call this. Same version
+ * guard as {@link markTokenHealthy}.
+ */
+export function markTokenUnhealthy(versionAtRequest?: number): void {
+  if (!memoryToken) return;
+  if (versionAtRequest !== undefined && versionAtRequest !== tokenVersion) return;
+  setHealth("unhealthy");
+}
+
+/**
+ * Re-probe credential health via `/user`. Applies a cooldown unless forced so
+ * focus-regain bursts can't hammer the API. No-op without a token. Only a
+ * definitive 401 flips to `unhealthy` — a 403 (scope/policy) or network
+ * failure keeps the previous state.
+ */
+export async function refreshTokenHealth(options?: { force?: boolean }): Promise<void> {
+  const token = memoryToken;
+  if (!token) return;
+  const now = Date.now();
+  if (!options?.force && now - lastHealthProbeAt < HEALTH_REFRESH_COOLDOWN_MS) return;
+  lastHealthProbeAt = now;
+  const versionAtStart = tokenVersion;
+  try {
+    const result = await validateGitLabToken(token);
+    if (versionAtStart !== tokenVersion) return;
+    if (result.valid) {
+      markTokenHealthy(versionAtStart);
+    } else if (result.credentialRejected) {
+      markTokenUnhealthy(versionAtStart);
+    }
+  } catch {
+    // Network failure — keep the previous state.
+  }
+}
+
+/** Test-isolation helper: reset every module-level auth state. */
+export function resetAuthStateForTests(): void {
+  memoryToken = null;
+  tokenVersion += 1;
+  validatedUser = null;
+  validatedUserVersion = -1;
+  lastHealthProbeAt = 0;
+  healthListeners.clear();
+  healthState = { status: "unknown", tokenVersion, checkedAt: 0 };
+}
+
+export interface GitLabTokenValidationResult {
+  valid: boolean;
+  /** `true` when GitLab itself answered (2xx or 401/403), not the network. */
+  authoritative: boolean;
+  /** `true` only for a definitive 401 — the signal that flips token health. */
+  credentialRejected: boolean;
+  username?: string;
+  avatarUrl?: string;
+  scopes?: string[];
+  /** Epoch ms; `null` = confirmed non-expiring; absent = expiry unknown. */
+  expiresAt?: number | null;
+  error?: string;
+}
+
+/**
+ * Validate a token against the configured instance's `/user` endpoint, then
+ * best-effort enrich with scopes/expiry from `/personal_access_tokens/self`
+ * (PAT-only introspection — OAuth tokens 404 there, which is fine; expiry
+ * stays unknown rather than "never expires" when introspection is
+ * unavailable).
+ */
+export async function validateGitLabToken(token: string): Promise<GitLabTokenValidationResult> {
+  const instanceUrl = await getInstanceUrl();
+  const instanceHost = (() => {
+    try {
+      return new URL(instanceUrl).hostname;
+    } catch {
+      return instanceUrl;
+    }
+  })();
+
+  let response: Response;
+  try {
+    response = await fetch(`${instanceUrl}/api/v4/user`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      signal: AbortSignal.timeout(GITLAB_AUTH_TIMEOUT_MS),
+    });
+  } catch {
+    return {
+      valid: false,
+      authoritative: false,
+      credentialRejected: false,
+      error: `Couldn't reach ${instanceHost} — check the instance URL and your network`,
+    };
+  }
+
+  if (response.status === 401) {
+    return {
+      valid: false,
+      authoritative: true,
+      credentialRejected: true,
+      error: "GitLab rejected the token (401)",
+    };
+  }
+  if (response.status === 403) {
+    return {
+      valid: false,
+      authoritative: true,
+      credentialRejected: false,
+      error: "Token lacks API access (403) — it needs the api or read_api scope",
+    };
+  }
+  if (!response.ok) {
+    return {
+      valid: false,
+      authoritative: false,
+      credentialRejected: false,
+      error: `${instanceHost} answered ${response.status} — is this a GitLab instance?`,
+    };
+  }
+
+  // An SSO gateway or captive portal can 200 with an HTML page; require JSON
+  // before trusting the payload.
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return {
+      valid: false,
+      authoritative: false,
+      credentialRejected: false,
+      error: `${instanceHost} didn't answer with JSON — is this a GitLab instance?`,
+    };
+  }
+
+  let user: { username?: unknown; avatar_url?: unknown };
+  try {
+    user = (await response.json()) as { username?: unknown; avatar_url?: unknown };
+  } catch {
+    return {
+      valid: false,
+      authoritative: false,
+      credentialRejected: false,
+      error: "GitLab returned an unreadable response",
+    };
+  }
+  if (typeof user.username !== "string" || user.username.length === 0) {
+    return {
+      valid: false,
+      authoritative: false,
+      credentialRejected: false,
+      error: "GitLab returned no user for the token",
+    };
+  }
+
+  const result: GitLabTokenValidationResult = {
+    valid: true,
+    authoritative: true,
+    credentialRejected: false,
+    username: user.username,
+    ...(typeof user.avatar_url === "string" && user.avatar_url.length > 0
+      ? { avatarUrl: user.avatar_url }
+      : {}),
+  };
+
+  try {
+    const introspection = await fetch(`${instanceUrl}/api/v4/personal_access_tokens/self`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      signal: AbortSignal.timeout(GITLAB_AUTH_TIMEOUT_MS),
+    });
+    if (introspection.ok) {
+      const data = (await introspection.json()) as {
+        scopes?: unknown;
+        expires_at?: unknown;
+      };
+      if (Array.isArray(data.scopes)) {
+        result.scopes = data.scopes.filter((s): s is string => typeof s === "string");
+      }
+      if (typeof data.expires_at === "string") {
+        const t = Date.parse(data.expires_at);
+        if (Number.isFinite(t)) result.expiresAt = t;
+      } else if (data.expires_at === null) {
+        result.expiresAt = null;
+      }
+    }
+  } catch {
+    // Introspection is best-effort — OAuth tokens and older instances 404 here.
+  }
+
+  return result;
+}

--- a/plugins/builtin/gitlab/main/GitLabAuth.ts
+++ b/plugins/builtin/gitlab/main/GitLabAuth.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   ForgeTokenHealthState,
   ForgeTokenHealthStatus,
@@ -35,6 +36,16 @@ let tokenVersion = 0;
 let validatedUser: ValidatedUserInfo | null = null;
 let validatedUserVersion = -1;
 let instanceUrlReader: InstanceUrlReader | null = null;
+let cachedInstanceUrl: string | null = null;
+/**
+ * Normalized base URL the in-memory token is bound to — the configured
+ * instance at the moment the host handed the credential over. A token issued
+ * by instance A is never a valid credential for instance B, so changing
+ * `instanceUrl` without re-saving must withhold it rather than replay it at
+ * the new origin. The whole base, not just the hostname: the same host on a
+ * different port or deployment path is a different installation.
+ */
+let tokenInstanceUrl: string | null = null;
 
 let healthState: ForgeTokenHealthState = { status: "unknown", tokenVersion: 0, checkedAt: 0 };
 const healthListeners = new Set<(state: ForgeTokenHealthState) => void>();
@@ -42,6 +53,88 @@ let lastHealthProbeAt = 0;
 
 export function setInstanceUrlReader(reader: InstanceUrlReader | null): void {
   instanceUrlReader = reader;
+}
+
+/**
+ * Durable record of which instance the stored credential was saved for.
+ *
+ * The host's credential store holds a bare token with no instance, so on a
+ * replay (every activation, and every plugin re-enable) the provider has no
+ * way to tell "the token the user saved for this instance" from "a token they
+ * saved for a different one before repointing `instanceUrl`". Deriving
+ * provenance from the current setting is exactly how instance A's token ends
+ * up at instance B.
+ *
+ * The token itself is NEVER written here — plugin storage is plaintext JSON.
+ * Only a digest, which is enough to tell a replay of the same credential from
+ * a genuinely new one.
+ */
+export interface CredentialProvenance {
+  instanceUrl: string;
+  tokenDigest: string;
+}
+
+type ProvenanceReader = () => CredentialProvenance | null;
+type ProvenanceWriter = (record: CredentialProvenance | null) => void;
+
+let provenanceReader: ProvenanceReader | null = null;
+let provenanceWriter: ProvenanceWriter | null = null;
+
+/**
+ * Instances that candidate tokens were proven against, keyed by token digest.
+ * The host's save path is `validateToken(token)` then `setCredentials(token)`,
+ * so this carries the validation's own resolved destination across to the save
+ * instead of letting it re-derive one from settings that may have changed in
+ * between.
+ *
+ * A map rather than one slot: a background probe of the OLD token, or a second
+ * candidate validation, would otherwise evict the record for the token being
+ * saved — and the save would then find no provenance and bind to null, leaving
+ * the user with a credential the UI calls saved and every request omits.
+ *
+ * Entries expire by AGE, never by count. A capacity limit has the same defect
+ * as the single slot it replaced, just further away: enough other validations
+ * while one is still in introspection and the live entry is the one dropped.
+ * A save follows its validation within milliseconds, so the window only has to
+ * outlive that; the host rate-limits the write path, which bounds the map.
+ */
+const provenValidations = new Map<string, { instanceUrl: string; at: number }>();
+const PROVEN_VALIDATION_TTL_MS = 5 * 60 * 1000;
+
+function recordProvenValidation(tokenDigest: string, instanceUrl: string): void {
+  const now = Date.now();
+  for (const [digest, entry] of provenValidations) {
+    if (now - entry.at > PROVEN_VALIDATION_TTL_MS) provenValidations.delete(digest);
+  }
+  provenValidations.set(tokenDigest, { instanceUrl, at: now });
+}
+
+function provenInstanceFor(tokenDigest: string): string | undefined {
+  const entry = provenValidations.get(tokenDigest);
+  if (!entry) return undefined;
+  if (Date.now() - entry.at > PROVEN_VALIDATION_TTL_MS) {
+    provenValidations.delete(tokenDigest);
+    return undefined;
+  }
+  return entry.instanceUrl;
+}
+
+/**
+ * Wire the durable provenance accessors. `activate()` loads the record before
+ * the provider is registered, so the synchronous reader is populated by the
+ * time the host replays the credential into `setCredentials`.
+ */
+export function setProvenanceAccessors(
+  reader: ProvenanceReader | null,
+  writer: ProvenanceWriter | null
+): void {
+  provenanceReader = reader;
+  provenanceWriter = writer;
+}
+
+/** Non-reversible digest of a token — never the token itself. */
+export function digestToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
 }
 
 function normalizeInstanceUrl(raw: string): string {
@@ -59,9 +152,23 @@ function normalizeInstanceUrl(raw: string): string {
 async function readConfiguredInstanceUrl(): Promise<string | undefined> {
   const raw = await instanceUrlReader?.();
   if (typeof raw === "string" && raw.trim().length > 0) {
-    return normalizeInstanceUrl(raw);
+    const normalized = normalizeInstanceUrl(raw);
+    cachedInstanceUrl = normalized;
+    return normalized;
   }
+  cachedInstanceUrl = DEFAULT_INSTANCE_URL;
   return undefined;
+}
+
+/**
+ * Last successfully-read instance base URL, for the synchronous URL builders
+ * (`buildIssueUrl` and friends are sync in the contract, so they cannot await
+ * the setting). Null until the first successful read — callers fall back to
+ * plain `https://<host>`, which is correct for gitlab.com and for any
+ * hostname-matched public instance.
+ */
+export function getCachedInstanceUrl(): string | null {
+  return cachedInstanceUrl;
 }
 
 /**
@@ -95,15 +202,76 @@ export async function getInstanceHost(): Promise<string> {
  * rather than fall back to a default origin the token was never scoped to.
  */
 export async function getInstanceHostStrict(): Promise<string> {
+  return new URL(await getInstanceUrlStrict()).hostname.toLowerCase();
+}
+
+/**
+ * Configured instance base URL for credential-bearing requests. Unlike
+ * {@link getInstanceUrl} this THROWS when the settings read failed, so a
+ * broken read can never redirect a self-hosted token to gitlab.com.
+ */
+export async function getInstanceUrlStrict(): Promise<string> {
   const configured = await readConfiguredInstanceUrl();
-  if (configured === undefined) {
-    return "gitlab.com";
+  return configured ?? DEFAULT_INSTANCE_URL;
+}
+
+/**
+ * Where a token belongs — the instance it was PROVEN against, never the one
+ * that happens to be configured when it arrives.
+ *
+ * Two sources, in order:
+ *
+ * 1. A just-completed validation of this exact token. The host validates
+ *    through this provider immediately before persisting (`validateToken` then
+ *    `setCredentials`), so a matching record is proof the user explicitly
+ *    supplied this token for that instance — including a deliberate re-save of
+ *    the same token against a new one. It resolved the instance itself, so a
+ *    settings change racing the validation can't retarget it.
+ * 2. The durable record from a previous save, which is what a replay is.
+ *
+ * Neither means the provenance is unknown, and the binding is null. That is
+ * deliberately fail-closed: an absent record is NOT evidence of a new save —
+ * it is equally a replay whose record was lost — and adopting the current
+ * setting there is exactly how a repointed instance claims a token it was
+ * never issued.
+ */
+function resolveBinding(token: string): string | null {
+  const digest = digestToken(token);
+  const proven = provenInstanceFor(digest);
+  if (proven !== undefined) {
+    provenanceWriter?.({ instanceUrl: proven, tokenDigest: digest });
+    return proven;
   }
-  return new URL(configured).hostname.toLowerCase();
+  const recorded = provenanceReader?.() ?? null;
+  if (recorded && recorded.tokenDigest === digest) return recorded.instanceUrl;
+  return null;
 }
 
 export function getToken(): string | null {
   return memoryToken;
+}
+
+/**
+ * Normalized base URL the in-memory token was bound to, or null when the
+ * binding could not be established (the settings read failed, in which case
+ * every credential-attachment path already fails closed).
+ */
+export function getTokenInstanceUrl(): string | null {
+  return tokenInstanceUrl;
+}
+
+/**
+ * Whether the in-memory token may be used against `instanceUrl` — the base the
+ * caller resolved and is about to send to, not a second read of the setting.
+ *
+ * Fails closed on an unknown binding. That only happens when the settings read
+ * failed outright, and in that state every attachment path already withholds
+ * the token; adopting "whatever is configured now" would let a repointed
+ * setting silently claim a credential it was never issued.
+ */
+export function tokenMatchesInstance(instanceUrl: string): boolean {
+  if (tokenInstanceUrl === null) return false;
+  return tokenInstanceUrl === instanceUrl;
 }
 
 export function getTokenVersion(): number {
@@ -117,10 +285,19 @@ export function getTokenVersion(): number {
  * the probe cooldown so the next health refresh isn't blocked by the previous
  * token's schedule.
  */
-export function setMemoryToken(token: string | null): void {
+export function setMemoryToken(token: string | null, instanceUrl?: string | null): void {
   const next = token && token.trim().length > 0 ? token.trim() : null;
-  if (next === memoryToken) return;
+  // Unconditional: a clear that arrives while the in-memory token is already
+  // null (the plugin was disabled when the user cleared it) must still drop
+  // the durable record, or a later replay would resurrect its provenance.
+  if (next === null) {
+    provenanceWriter?.(null);
+    provenValidations.clear();
+  }
+  const nextUrl = next === null ? null : (instanceUrl ?? resolveBinding(next));
+  if (next === memoryToken && nextUrl === tokenInstanceUrl) return;
   memoryToken = next;
+  tokenInstanceUrl = nextUrl;
   tokenVersion += 1;
   validatedUser = null;
   validatedUserVersion = -1;
@@ -128,10 +305,37 @@ export function setMemoryToken(token: string | null): void {
   setHealth("unknown");
 }
 
-export function setValidatedUserInfo(info: ValidatedUserInfo, versionAtStart: number): void {
+export function setValidatedUserInfo(
+  info: ValidatedUserInfo,
+  versionAtStart: number,
+  identityGenerationAtStart?: number
+): void {
   if (versionAtStart !== tokenVersion) return;
+  if (identityGenerationAtStart !== undefined && identityGenerationAtStart !== identityGeneration) {
+    return;
+  }
   validatedUser = info;
   validatedUserVersion = versionAtStart;
+}
+
+/** Drop the cached identity — it describes an account on a different instance. */
+export function clearValidatedUserInfo(): void {
+  identityGeneration += 1;
+  validatedUser = null;
+  validatedUserVersion = -1;
+}
+
+/**
+ * Bumped whenever the cached identity is dropped. `tokenVersion` doesn't move
+ * when only the INSTANCE changed, so without this a `/user` lookup already in
+ * flight against the old instance would resolve afterwards and repopulate the
+ * identity of an account on a server we're no longer talking to.
+ */
+let identityGeneration = 0;
+
+/** Snapshot before an identity lookup; hand back to {@link setValidatedUserInfo}. */
+export function currentIdentityGeneration(): number {
+  return identityGeneration;
 }
 
 export function getValidatedUserInfo(): ValidatedUserInfo | null {
@@ -199,7 +403,7 @@ export async function refreshTokenHealth(options?: { force?: boolean }): Promise
   lastHealthProbeAt = now;
   const versionAtStart = tokenVersion;
   try {
-    const result = await validateGitLabToken(token);
+    const result = await validateStoredGitLabToken(token);
     if (versionAtStart !== tokenVersion) return;
     if (result.valid) {
       markTokenHealthy(versionAtStart);
@@ -213,7 +417,11 @@ export async function refreshTokenHealth(options?: { force?: boolean }): Promise
 
 /** Test-isolation helper: reset every module-level auth state. */
 export function resetAuthStateForTests(): void {
+  identityGeneration += 1;
   memoryToken = null;
+  tokenInstanceUrl = null;
+  cachedInstanceUrl = null;
+  provenValidations.clear();
   tokenVersion += 1;
   validatedUser = null;
   validatedUserVersion = -1;
@@ -243,8 +451,64 @@ export interface GitLabTokenValidationResult {
  * stays unknown rather than "never expires" when introspection is
  * unavailable).
  */
-export async function validateGitLabToken(token: string): Promise<GitLabTokenValidationResult> {
-  const instanceUrl = await getInstanceUrl();
+/**
+ * Validate the STORED token — the health probe, `validateCredentials`, and the
+ * cached-identity refresh. Unlike {@link validateGitLabToken}, which validates
+ * a token the user just typed for the instance on screen, this must not send a
+ * credential to an instance it wasn't issued for: after an `instanceUrl`
+ * change the stored token still belongs to the old one.
+ */
+export async function validateStoredGitLabToken(
+  token: string
+): Promise<GitLabTokenValidationResult> {
+  const unavailable = (error: string): GitLabTokenValidationResult => ({
+    valid: false,
+    authoritative: false,
+    credentialRejected: false,
+    error,
+  });
+  let instanceUrl: string;
+  try {
+    instanceUrl = await getInstanceUrlStrict();
+  } catch {
+    return unavailable("Couldn't read the GitLab instance setting — reopen this tab and try again");
+  }
+  // The binding describes the CURRENT stored token, so a caller holding one
+  // captured before a rotation must not borrow its verdict.
+  if (token !== memoryToken || !tokenMatchesInstance(instanceUrl)) {
+    return unavailable(
+      "The stored token belongs to a different GitLab instance — enter one for this instance"
+    );
+  }
+  // Hand the resolved destination through, so the check above and the request
+  // below cannot disagree about where the token is going.
+  return validateGitLabToken(token, instanceUrl, false);
+}
+
+export async function validateGitLabToken(
+  token: string,
+  resolvedInstanceUrl?: string,
+  // Stored-token probes pass false: they re-check a credential whose
+  // provenance is already established.
+  recordProvenance = true
+): Promise<GitLabTokenValidationResult> {
+  let instanceUrl: string;
+  if (resolvedInstanceUrl !== undefined) {
+    instanceUrl = resolvedInstanceUrl;
+  } else {
+    try {
+      // Strict: a failed settings read must not send a self-hosted token to
+      // gitlab.com just because that is the display-time default.
+      instanceUrl = await getInstanceUrlStrict();
+    } catch {
+      return {
+        valid: false,
+        authoritative: false,
+        credentialRejected: false,
+        error: "Couldn't read the GitLab instance setting — reopen this tab and try again",
+      };
+    }
+  }
   const instanceHost = (() => {
     try {
       return new URL(instanceUrl).hostname;
@@ -325,6 +589,15 @@ export async function validateGitLabToken(token: string): Promise<GitLabTokenVal
     };
   }
 
+  // Only when the caller is validating a CANDIDATE token: that is the save
+  // path, and the destination it reached is what the save must bind to. A
+  // stored-token probe is re-checking an already-bound credential and proves
+  // nothing new — letting it write here would let a slow probe of the OLD
+  // token stand in for the new one's provenance.
+  if (recordProvenance) {
+    recordProvenValidation(digestToken(token), instanceUrl);
+  }
+
   const result: GitLabTokenValidationResult = {
     valid: true,
     authoritative: true,
@@ -346,7 +619,20 @@ export async function validateGitLabToken(token: string): Promise<GitLabTokenVal
         expires_at?: unknown;
       };
       if (Array.isArray(data.scopes)) {
-        result.scopes = data.scopes.filter((s): s is string => typeof s === "string");
+        const scopes = data.scopes.filter((s): s is string => typeof s === "string");
+        result.scopes = scopes;
+        // Introspection is the only place scopes are knowable, so it is also
+        // the only place an under-scoped token can be caught. `/user` answers
+        // for a bare `read_user` token, which cannot read a single project —
+        // accepting it would connect the provider and then 403 on every read.
+        if (!scopes.includes("api") && !scopes.includes("read_api")) {
+          return {
+            valid: false,
+            authoritative: true,
+            credentialRejected: false,
+            error: `Token lacks API access — it has ${scopes.join(", ") || "no scopes"}, and needs api or read_api`,
+          };
+        }
       }
       if (typeof data.expires_at === "string") {
         const t = Date.parse(data.expires_at);

--- a/plugins/builtin/gitlab/main/GitLabClient.ts
+++ b/plugins/builtin/gitlab/main/GitLabClient.ts
@@ -1,0 +1,266 @@
+import type { RateLimitInfo } from "../../../../shared/types/forge.js";
+import {
+  GITLAB_API_TIMEOUT_MS,
+  getInstanceHostStrict,
+  getInstanceUrl,
+  getToken,
+  getTokenVersion,
+  markTokenHealthy,
+  markTokenUnhealthy,
+} from "./GitLabAuth.js";
+
+/** GitLab REST/GraphQL error with the HTTP status preserved for callers. */
+export class GitLabApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "GitLabApiError";
+    this.status = status;
+  }
+}
+
+export type QueryValue = string | number | boolean | Array<string | number> | undefined;
+
+export interface GitLabRestOptions {
+  /** Hostname the repo lives on — resolved to a base URL via {@link apiBaseForHost}. */
+  host: string;
+  /** Path under `/api/v4`, with a leading slash. */
+  path: string;
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  query?: Record<string, QueryValue>;
+  body?: unknown;
+  timeoutMs?: number;
+}
+
+export interface GitLabRestResult<T> {
+  data: T;
+  headers: Headers;
+}
+
+/** One page of a REST list plus GitLab's offset-pagination headers. */
+export interface GitLabRestPage<T> {
+  items: T[];
+  /** Next page number as an opaque cursor, `null` on the last page. */
+  nextCursor: string | null;
+  hasMore: boolean;
+  totalCount?: number;
+}
+
+export interface RateLimitSnapshot {
+  info: RateLimitInfo;
+  /** Epoch ms the headers were actually observed. */
+  fetchedAt: number;
+}
+
+/**
+ * Last rate-limit snapshot per hostname. Self-managed instances configure
+ * their own quotas, so one host's headers must never masquerade as
+ * another's.
+ */
+const rateLimitByHost = new Map<string, RateLimitSnapshot>();
+
+export function getRateLimitSnapshot(host: string): RateLimitSnapshot | null {
+  return rateLimitByHost.get(host.toLowerCase()) ?? null;
+}
+
+/** Test-isolation helper. */
+export function resetLastRateLimitInfo(): void {
+  rateLimitByHost.clear();
+}
+
+function captureRateLimit(host: string, headers: Headers): void {
+  const limit = Number.parseInt(headers.get("ratelimit-limit") ?? "", 10);
+  const remaining = Number.parseInt(headers.get("ratelimit-remaining") ?? "", 10);
+  const reset = Number.parseInt(headers.get("ratelimit-reset") ?? "", 10);
+  if (!Number.isFinite(limit) && !Number.isFinite(remaining)) return;
+  rateLimitByHost.set(host.toLowerCase(), {
+    info: {
+      limit: Number.isFinite(limit) ? limit : null,
+      remaining: Number.isFinite(remaining) ? remaining : null,
+      resetAt: Number.isFinite(reset) ? reset * 1000 : null,
+    },
+    fetchedAt: Date.now(),
+  });
+}
+
+/**
+ * Whether the current token may be attached to requests against `host`.
+ * The token is scoped to the configured instance (`instanceUrl` setting) —
+ * never send it to any other host, even one the user routed to this provider
+ * via the per-project override. Fails closed: a broken settings read means
+ * no token, not "assume gitlab.com". The token is read AFTER the async
+ * settings read so a credential cleared or rotated mid-await is honored.
+ */
+export async function tokenAllowedForHost(host: string): Promise<string | null> {
+  let instanceHost: string;
+  try {
+    instanceHost = await getInstanceHostStrict();
+  } catch {
+    return null;
+  }
+  if (host.toLowerCase() !== instanceHost) return null;
+  return getToken();
+}
+
+/**
+ * Base URL for API calls against `host`. When `host` is the configured
+ * instance, the full configured base URL is used so self-hosted installs on
+ * a custom scheme, port, or path prefix (`https://code.example:8443/gitlab`)
+ * reach the right endpoint. Any other GitLab host (public instances matched
+ * by hostname) gets plain `https://` on the default port.
+ */
+async function apiBaseForHost(host: string): Promise<string> {
+  const instanceUrl = await getInstanceUrl();
+  try {
+    if (new URL(instanceUrl).hostname.toLowerCase() === host.toLowerCase()) {
+      return instanceUrl;
+    }
+  } catch {
+    // Unparsable configured URL — fall through to the plain-https default.
+  }
+  return `https://${host}`;
+}
+
+function buildQueryString(query: Record<string, QueryValue> | undefined): string {
+  if (!query) return "";
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) params.append(`${key}[]`, String(entry));
+    } else {
+      params.set(key, String(value));
+    }
+  }
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : "";
+}
+
+async function parseErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { message?: unknown; error?: unknown };
+    const message = body.message ?? body.error;
+    if (typeof message === "string") return message;
+    if (message && typeof message === "object") return JSON.stringify(message);
+  } catch {
+    // Non-JSON error body — fall through to the status line.
+  }
+  return `GitLab request failed (${response.status})`;
+}
+
+/**
+ * Perform a GitLab REST v4 request. Attaches the stored token only when the
+ * target host matches the configured instance (see {@link tokenAllowedForHost});
+ * public projects on other GitLab hosts still work unauthenticated. Captures
+ * rate-limit headers per host and folds authoritative 401s into token health
+ * (guarded by the token version captured at send time).
+ */
+export async function gitlabRest<T>(options: GitLabRestOptions): Promise<GitLabRestResult<T>> {
+  const token = await tokenAllowedForHost(options.host);
+  const base = await apiBaseForHost(options.host);
+  const versionAtRequest = getTokenVersion();
+  const url = `${base}/api/v4${options.path}${buildQueryString(options.query)}`;
+
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (options.body !== undefined) headers["Content-Type"] = "application/json";
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: options.method ?? "GET",
+      headers,
+      ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+      signal: AbortSignal.timeout(options.timeoutMs ?? GITLAB_API_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new GitLabApiError(0, `Couldn't reach ${options.host}: ${(err as Error).message}`);
+  }
+
+  captureRateLimit(options.host, response.headers);
+
+  if (response.status === 401 && token) markTokenUnhealthy(versionAtRequest);
+
+  if (!response.ok) {
+    throw new GitLabApiError(response.status, await parseErrorMessage(response));
+  }
+
+  if (token) markTokenHealthy(versionAtRequest);
+
+  if (response.status === 204) {
+    return { data: undefined as T, headers: response.headers };
+  }
+  const data = (await response.json()) as T;
+  return { data, headers: response.headers };
+}
+
+/**
+ * Fetch one page of a REST list endpoint, translating GitLab's offset
+ * pagination headers (`x-next-page`, `x-total`) into the contract's opaque
+ * cursor shape. `x-total` is absent above 10k rows on gitlab.com — the page
+ * simply carries no `totalCount` then.
+ */
+export async function gitlabRestPage<T>(options: GitLabRestOptions): Promise<GitLabRestPage<T>> {
+  const { data, headers } = await gitlabRest<T[]>(options);
+  const nextPage = headers.get("x-next-page") ?? "";
+  const total = Number.parseInt(headers.get("x-total") ?? "", 10);
+  return {
+    items: Array.isArray(data) ? data : [],
+    nextCursor: nextPage.length > 0 ? nextPage : null,
+    hasMore: nextPage.length > 0,
+    ...(Number.isFinite(total) ? { totalCount: total } : {}),
+  };
+}
+
+/**
+ * Perform a GitLab GraphQL request against `{base}/api/graphql`. Same
+ * token-attachment rule and health accounting as REST. Returns the `data`
+ * payload; GraphQL transport errors and top-level `errors` both throw.
+ */
+export async function gitlabGraphQL<T>(
+  host: string,
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const token = await tokenAllowedForHost(host);
+  const base = await apiBaseForHost(host);
+  const versionAtRequest = getTokenVersion();
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  let response: Response;
+  try {
+    response = await fetch(`${base}/api/graphql`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(GITLAB_API_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new GitLabApiError(0, `Couldn't reach ${host}: ${(err as Error).message}`);
+  }
+
+  captureRateLimit(host, response.headers);
+
+  if (response.status === 401 && token) markTokenUnhealthy(versionAtRequest);
+  if (!response.ok) {
+    throw new GitLabApiError(response.status, await parseErrorMessage(response));
+  }
+
+  const payload = (await response.json()) as {
+    data?: T;
+    errors?: Array<{ message?: string }>;
+  };
+  if (payload.errors && payload.errors.length > 0) {
+    throw new GitLabApiError(200, payload.errors[0]?.message ?? "GitLab GraphQL error");
+  }
+  if (payload.data === undefined || payload.data === null) {
+    throw new GitLabApiError(200, "GitLab GraphQL returned no data");
+  }
+  if (token) markTokenHealthy(versionAtRequest);
+  return payload.data;
+}

--- a/plugins/builtin/gitlab/main/GitLabClient.ts
+++ b/plugins/builtin/gitlab/main/GitLabClient.ts
@@ -12,11 +12,18 @@ import {
 /** GitLab REST/GraphQL error with the HTTP status preserved for callers. */
 export class GitLabApiError extends Error {
   readonly status: number;
+  /**
+   * Epoch ms an active rate-limit block lifts, when a 429 said so. Callers
+   * that render a "back at" banner read this rather than re-deriving it from
+   * the message.
+   */
+  readonly rateLimitResetAt: number | undefined;
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, rateLimitResetAt?: number) {
     super(message);
     this.name = "GitLabApiError";
     this.status = status;
+    this.rateLimitResetAt = rateLimitResetAt;
   }
 }
 
@@ -169,6 +176,21 @@ function buildQueryString(query: Record<string, QueryValue> | undefined): string
   return qs.length > 0 ? `?${qs}` : "";
 }
 
+/**
+ * When a throttle lifts, in epoch ms, from a 429's own headers. GitLab's two
+ * limiters answer differently: the Rack::Attack throttles send `Retry-After`
+ * (seconds) alongside `RateLimit-Reset` (epoch seconds), while the
+ * application rate limiter sends `Retry-After` only. Read both so either one
+ * yields a real resume time; `undefined` when neither header is usable.
+ */
+function rateLimitResetAtFrom(headers: Headers): number | undefined {
+  const retryAfter = Number.parseInt(headers.get("retry-after") ?? "", 10);
+  if (Number.isFinite(retryAfter) && retryAfter >= 0) return Date.now() + retryAfter * 1000;
+  const reset = Number.parseInt(headers.get("ratelimit-reset") ?? "", 10);
+  if (Number.isFinite(reset) && reset > 0) return reset * 1000;
+  return undefined;
+}
+
 async function parseErrorMessage(response: Response): Promise<string> {
   try {
     const body = (await response.json()) as { message?: unknown; error?: unknown };
@@ -214,7 +236,11 @@ export async function gitlabRest<T>(options: GitLabRestOptions): Promise<GitLabR
   if (response.status === 401 && token) markTokenUnhealthy(versionAtRequest);
 
   if (!response.ok) {
-    throw new GitLabApiError(response.status, await parseErrorMessage(response));
+    throw new GitLabApiError(
+      response.status,
+      await parseErrorMessage(response),
+      response.status === 429 ? rateLimitResetAtFrom(response.headers) : undefined
+    );
   }
 
   if (response.status === 204) {
@@ -301,13 +327,32 @@ export async function gitlabGraphQL<T>(
 
   if (response.status === 401 && token) markTokenUnhealthy(versionAtRequest);
   if (!response.ok) {
-    throw new GitLabApiError(response.status, await parseErrorMessage(response));
+    throw new GitLabApiError(
+      response.status,
+      await parseErrorMessage(response),
+      response.status === 429 ? rateLimitResetAtFrom(response.headers) : undefined
+    );
   }
 
-  const payload = (await response.json()) as {
-    data?: T;
-    errors?: Array<{ message?: string }>;
-  };
+  // Same case the REST transport guards: an SSO gateway or captive portal
+  // answers 200 with an HTML sign-in page, which must surface as a
+  // GitLabApiError rather than a bare SyntaxError out of the JSON parse.
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("json")) {
+    throw new GitLabApiError(
+      response.status,
+      `${host} didn't answer with JSON — a sign-in gateway may be intercepting the API`
+    );
+  }
+  let payload: { data?: T; errors?: Array<{ message?: string }> };
+  try {
+    payload = (await response.json()) as {
+      data?: T;
+      errors?: Array<{ message?: string }>;
+    };
+  } catch {
+    throw new GitLabApiError(response.status, `${host} returned an unreadable response`);
+  }
   if (payload.errors && payload.errors.length > 0) {
     throw new GitLabApiError(200, payload.errors[0]?.message ?? "GitLab GraphQL error");
   }

--- a/plugins/builtin/gitlab/main/GitLabClient.ts
+++ b/plugins/builtin/gitlab/main/GitLabClient.ts
@@ -1,12 +1,12 @@
 import type { RateLimitInfo } from "../../../../shared/types/forge.js";
 import {
   GITLAB_API_TIMEOUT_MS,
-  getInstanceHostStrict,
-  getInstanceUrl,
+  getInstanceUrlStrict,
   getToken,
   getTokenVersion,
   markTokenHealthy,
   markTokenUnhealthy,
+  tokenMatchesInstance,
 } from "./GitLabAuth.js";
 
 /** GitLab REST/GraphQL error with the HTTP status preserved for callers. */
@@ -60,6 +60,18 @@ export interface RateLimitSnapshot {
  */
 const rateLimitByHost = new Map<string, RateLimitSnapshot>();
 
+/**
+ * One coherent decision about a request: where it goes, what credential it
+ * carries, and the token version that credential was read at. All three come
+ * from a single settings read so they cannot disagree with each other.
+ */
+export interface RequestAuth {
+  /** API base, including the configured scheme, port, and deployment path. */
+  base: string;
+  token: string | null;
+  version: number;
+}
+
 export function getRateLimitSnapshot(host: string): RateLimitSnapshot | null {
   return rateLimitByHost.get(host.toLowerCase()) ?? null;
 }
@@ -69,7 +81,26 @@ export function resetLastRateLimitInfo(): void {
   rateLimitByHost.clear();
 }
 
-function captureRateLimit(host: string, headers: Headers): void {
+/**
+ * Drop observed quotas. Called on invalidation because a quota belongs to an
+ * account on an instance: after a credential or instance change, the previous
+ * account's exhausted quota would keep the host's polling gate shut.
+ */
+export function resetRateLimitSnapshots(): void {
+  rateLimitGeneration += 1;
+  rateLimitByHost.clear();
+}
+
+/**
+ * Bumped by {@link resetRateLimitSnapshots}. A request in flight when the
+ * credential or instance changed carries the PREVIOUS account's quota
+ * headers; recording them would leave the host's polling gate shut on a quota
+ * the new account never spent.
+ */
+let rateLimitGeneration = 0;
+
+function captureRateLimit(host: string, headers: Headers, epoch: number): void {
+  if (epoch !== rateLimitGeneration) return;
   const limit = Number.parseInt(headers.get("ratelimit-limit") ?? "", 10);
   const remaining = Number.parseInt(headers.get("ratelimit-remaining") ?? "", 10);
   const reset = Number.parseInt(headers.get("ratelimit-reset") ?? "", 10);
@@ -92,34 +123,35 @@ function captureRateLimit(host: string, headers: Headers): void {
  * no token, not "assume gitlab.com". The token is read AFTER the async
  * settings read so a credential cleared or rotated mid-await is honored.
  */
-export async function tokenAllowedForHost(host: string): Promise<string | null> {
+export async function resolveRequestAuth(host: string): Promise<RequestAuth> {
+  const version = getTokenVersion();
+  let instanceUrl: string | null;
+  try {
+    instanceUrl = await getInstanceUrlStrict();
+  } catch {
+    // The configured instance is unknowable, so neither the destination nor
+    // the authorization decision can be made. Public hosts still work.
+    return { base: `https://${host}`, token: null, version };
+  }
   let instanceHost: string;
   try {
-    instanceHost = await getInstanceHostStrict();
+    instanceHost = new URL(instanceUrl).hostname.toLowerCase();
   } catch {
-    return null;
+    return { base: `https://${host}`, token: null, version };
   }
-  if (host.toLowerCase() !== instanceHost) return null;
-  return getToken();
-}
-
-/**
- * Base URL for API calls against `host`. When `host` is the configured
- * instance, the full configured base URL is used so self-hosted installs on
- * a custom scheme, port, or path prefix (`https://code.example:8443/gitlab`)
- * reach the right endpoint. Any other GitLab host (public instances matched
- * by hostname) gets plain `https://` on the default port.
- */
-async function apiBaseForHost(host: string): Promise<string> {
-  const instanceUrl = await getInstanceUrl();
-  try {
-    if (new URL(instanceUrl).hostname.toLowerCase() === host.toLowerCase()) {
-      return instanceUrl;
-    }
-  } catch {
-    // Unparsable configured URL — fall through to the plain-https default.
+  // Not the configured instance: a public GitLab host reached over plain
+  // https, unauthenticated.
+  if (host.toLowerCase() !== instanceHost) {
+    return { base: `https://${host}`, token: null, version };
   }
-  return `https://${host}`;
+  // Destination and authorization come from THE SAME read. Resolving them
+  // separately lets the second read fail and send the token to a fallback
+  // origin — dropping the configured port and deployment path — after the
+  // first read already approved it for the real one.
+  const token = tokenMatchesInstance(instanceUrl) ? getToken() : null;
+  // Token and version are read with no await between them, so a rotation
+  // can't stamp the new version onto the old token's outcome.
+  return { base: instanceUrl, token, version: getTokenVersion() };
 }
 
 function buildQueryString(query: Record<string, QueryValue> | undefined): string {
@@ -157,9 +189,8 @@ async function parseErrorMessage(response: Response): Promise<string> {
  * (guarded by the token version captured at send time).
  */
 export async function gitlabRest<T>(options: GitLabRestOptions): Promise<GitLabRestResult<T>> {
-  const token = await tokenAllowedForHost(options.host);
-  const base = await apiBaseForHost(options.host);
-  const versionAtRequest = getTokenVersion();
+  const rateLimitEpoch = rateLimitGeneration;
+  const { base, token, version: versionAtRequest } = await resolveRequestAuth(options.host);
   const url = `${base}/api/v4${options.path}${buildQueryString(options.query)}`;
 
   const headers: Record<string, string> = { Accept: "application/json" };
@@ -178,7 +209,7 @@ export async function gitlabRest<T>(options: GitLabRestOptions): Promise<GitLabR
     throw new GitLabApiError(0, `Couldn't reach ${options.host}: ${(err as Error).message}`);
   }
 
-  captureRateLimit(options.host, response.headers);
+  captureRateLimit(options.host, response.headers, rateLimitEpoch);
 
   if (response.status === 401 && token) markTokenUnhealthy(versionAtRequest);
 
@@ -186,12 +217,29 @@ export async function gitlabRest<T>(options: GitLabRestOptions): Promise<GitLabR
     throw new GitLabApiError(response.status, await parseErrorMessage(response));
   }
 
-  if (token) markTokenHealthy(versionAtRequest);
-
   if (response.status === 204) {
+    if (token) markTokenHealthy(versionAtRequest);
     return { data: undefined as T, headers: response.headers };
   }
-  const data = (await response.json()) as T;
+
+  // An SSO gateway or captive portal answers 200 with an HTML login page. That
+  // is not a GitLab response, so it must neither certify the token as healthy
+  // nor surface as a bare SyntaxError from the JSON parse.
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("json")) {
+    throw new GitLabApiError(
+      response.status,
+      `${options.host} didn't answer with JSON — a sign-in gateway may be intercepting the API`
+    );
+  }
+  let data: T;
+  try {
+    data = (await response.json()) as T;
+  } catch {
+    throw new GitLabApiError(response.status, `${options.host} returned an unreadable response`);
+  }
+
+  if (token) markTokenHealthy(versionAtRequest);
   return { data, headers: response.headers };
 }
 
@@ -205,8 +253,14 @@ export async function gitlabRestPage<T>(options: GitLabRestOptions): Promise<Git
   const { data, headers } = await gitlabRest<T[]>(options);
   const nextPage = headers.get("x-next-page") ?? "";
   const total = Number.parseInt(headers.get("x-total") ?? "", 10);
+  // A 200 carrying an object (an error envelope, a gateway page that happened
+  // to be JSON) is not an empty page. Reporting it as one tells the user the
+  // project has no issues.
+  if (!Array.isArray(data)) {
+    throw new GitLabApiError(200, `${options.host} returned an unexpected list payload`);
+  }
   return {
-    items: Array.isArray(data) ? data : [],
+    items: data,
     nextCursor: nextPage.length > 0 ? nextPage : null,
     hasMore: nextPage.length > 0,
     ...(Number.isFinite(total) ? { totalCount: total } : {}),
@@ -223,9 +277,8 @@ export async function gitlabGraphQL<T>(
   query: string,
   variables: Record<string, unknown>
 ): Promise<T> {
-  const token = await tokenAllowedForHost(host);
-  const base = await apiBaseForHost(host);
-  const versionAtRequest = getTokenVersion();
+  const rateLimitEpoch = rateLimitGeneration;
+  const { base, token, version: versionAtRequest } = await resolveRequestAuth(host);
   const headers: Record<string, string> = {
     Accept: "application/json",
     "Content-Type": "application/json",
@@ -244,7 +297,7 @@ export async function gitlabGraphQL<T>(
     throw new GitLabApiError(0, `Couldn't reach ${host}: ${(err as Error).message}`);
   }
 
-  captureRateLimit(host, response.headers);
+  captureRateLimit(host, response.headers, rateLimitEpoch);
 
   if (response.status === 401 && token) markTokenUnhealthy(versionAtRequest);
   if (!response.ok) {

--- a/plugins/builtin/gitlab/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/forgeProvider.test.ts
@@ -1,0 +1,532 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import type { RepoRef } from "../../../../../shared/types/forge.js";
+import { gitlabForgeProvider } from "../forgeProvider.js";
+import { resetAuthStateForTests, setInstanceUrlReader } from "../GitLabAuth.js";
+import { resetLastRateLimitInfo } from "../GitLabClient.js";
+import { clearGitLabCaches } from "../readOps.js";
+
+const REPO: RepoRef = { host: "gitlab.com", owner: "group", repo: "project", rawData: null };
+const SELF_HOSTED_REPO: RepoRef = {
+  host: "gitlab.internal.example",
+  owner: "team",
+  repo: "app",
+  rawData: null,
+};
+
+function jsonResponse(data: unknown, init?: { status?: number; headers?: Record<string, string> }) {
+  return new Response(JSON.stringify(data), {
+    status: init?.status ?? 200,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  });
+}
+
+function fetchMock(): Mock {
+  return globalThis.fetch as unknown as Mock;
+}
+
+function requestUrl(call: unknown[]): string {
+  return String(call[0]);
+}
+
+function requestHeaders(call: unknown[]): Record<string, string> {
+  return ((call[1] as RequestInit | undefined)?.headers ?? {}) as Record<string, string>;
+}
+
+function requestBody(call: unknown[]): Record<string, unknown> {
+  return JSON.parse(String((call[1] as RequestInit | undefined)?.body ?? "{}")) as Record<
+    string,
+    unknown
+  >;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+  resetAuthStateForTests();
+  clearGitLabCaches();
+  resetLastRateLimitInfo();
+});
+
+afterEach(() => {
+  setInstanceUrlReader(null);
+  vi.unstubAllGlobals();
+});
+
+describe("token attachment", () => {
+  it("attaches the token to the configured instance host only", async () => {
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-secret" });
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(REPO, {});
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBe("Bearer glpat-secret");
+
+    await gitlabForgeProvider.listIssues(SELF_HOSTED_REPO, {});
+    expect(requestHeaders(fetchMock().mock.calls[1]).Authorization).toBeUndefined();
+  });
+
+  it("follows the instanceUrl setting for self-hosted tokens", async () => {
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.internal.example"));
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-internal" });
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(SELF_HOSTED_REPO, {});
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBe("Bearer glpat-internal");
+
+    await gitlabForgeProvider.listIssues(REPO, {});
+    expect(requestHeaders(fetchMock().mock.calls[1]).Authorization).toBeUndefined();
+  });
+});
+
+describe("parseRemote", () => {
+  it("parses any GitLab-shaped host, deriving identity from the URL", () => {
+    const ref = gitlabForgeProvider.parseRemote("git@gitlab.internal.example:team/sub/app.git");
+    expect(ref).toMatchObject({ host: "gitlab.internal.example", owner: "team/sub", repo: "app" });
+  });
+
+  it("returns null for unparsable remotes", () => {
+    expect(gitlabForgeProvider.parseRemote("not-a-remote")).toBeNull();
+  });
+});
+
+describe("listPRs", () => {
+  it("maps GitLab offset pagination onto the cursor contract", async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse([{ iid: 1, title: "One", state: "opened" }], {
+        headers: { "x-next-page": "2", "x-total": "55" },
+      })
+    );
+
+    const page = await gitlabForgeProvider.listPRs(REPO, { state: "open", perPage: 20 });
+
+    const url = requestUrl(fetchMock().mock.calls[0]);
+    expect(url).toContain("/api/v4/projects/group%2Fproject/merge_requests");
+    expect(url).toContain("state=opened");
+    expect(url).toContain("per_page=20");
+    expect(page.items[0].number).toBe(1);
+    expect(page.nextCursor).toBe("2");
+    expect(page.hasMore).toBe(true);
+    expect(page.totalCount).toBe(55);
+  });
+
+  it("requests the cursor's page number", async () => {
+    fetchMock().mockResolvedValue(jsonResponse([]));
+    await gitlabForgeProvider.listPRs(REPO, { cursor: "3" });
+    expect(requestUrl(fetchMock().mock.calls[0])).toContain("page=3");
+  });
+});
+
+describe("getIssue", () => {
+  it("returns null on 404", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ message: "404 Not Found" }, { status: 404 }));
+    await expect(gitlabForgeProvider.getIssue(REPO, 999)).resolves.toBeNull();
+  });
+
+  it("propagates non-404 failures", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ message: "boom" }, { status: 500 }));
+    await expect(gitlabForgeProvider.getIssue(REPO, 1)).rejects.toThrow("boom");
+  });
+});
+
+describe("findPRByBranch", () => {
+  it("queries by source branch, newest first, any state", async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse([{ iid: 8, title: "MR", state: "merged", source_branch: "feature/x" }])
+    );
+
+    const pr = await gitlabForgeProvider.findPRByBranch(REPO, "feature/x");
+
+    const url = requestUrl(fetchMock().mock.calls[0]);
+    expect(url).toContain("source_branch=feature%2Fx");
+    expect(url).toContain("order_by=created_at");
+    expect(url).not.toContain("state=");
+    expect(pr?.number).toBe(8);
+    expect(pr?.state).toBe("merged");
+  });
+
+  it("returns null when no MR matches", async () => {
+    fetchMock().mockResolvedValue(jsonResponse([]));
+    await expect(gitlabForgeProvider.findPRByBranch(REPO, "feature/none")).resolves.toBeNull();
+  });
+});
+
+describe("findPRsByBranches", () => {
+  it("confirms absent branches as null and picks the newest MR per branch", async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse({
+        data: {
+          project: {
+            mergeRequests: {
+              nodes: [
+                {
+                  iid: "12",
+                  title: "Newest",
+                  state: "opened",
+                  sourceBranch: "feature/a",
+                  targetBranch: "main",
+                  webUrl: "https://gitlab.com/group/project/-/merge_requests/12",
+                  createdAt: "2026-07-02T00:00:00Z",
+                  updatedAt: "2026-07-02T00:00:00Z",
+                },
+                {
+                  iid: "5",
+                  title: "Older",
+                  state: "closed",
+                  sourceBranch: "feature/a",
+                  targetBranch: "main",
+                  webUrl: "https://gitlab.com/group/project/-/merge_requests/5",
+                  createdAt: "2026-06-01T00:00:00Z",
+                  updatedAt: "2026-06-01T00:00:00Z",
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    const result = await gitlabForgeProvider.findPRsByBranches?.(REPO, ["feature/a", "feature/b"]);
+
+    const url = requestUrl(fetchMock().mock.calls[0]);
+    expect(url).toBe("https://gitlab.com/api/graphql");
+    expect(result?.get("feature/a")?.number).toBe(12);
+    expect(result?.has("feature/b")).toBe(true);
+    expect(result?.get("feature/b")).toBeNull();
+  });
+
+  it("omits branches when the query fails so the host falls back", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ message: "unauthorized" }, { status: 401 }));
+    const result = await gitlabForgeProvider.findPRsByBranches?.(REPO, ["feature/a"]);
+    expect(result?.size).toBe(0);
+  });
+
+  it("omits branches when the project is inaccessible (null project)", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ data: { project: null } }));
+    const result = await gitlabForgeProvider.findPRsByBranches?.(REPO, ["feature/a"]);
+    expect(result?.size).toBe(0);
+  });
+
+  it("omits unmatched branches when the result window truncated", async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse({
+        data: {
+          project: {
+            mergeRequests: {
+              pageInfo: { hasNextPage: true },
+              nodes: [
+                {
+                  iid: "12",
+                  title: "Found",
+                  state: "opened",
+                  sourceBranch: "feature/a",
+                  targetBranch: "main",
+                  webUrl: "https://gitlab.com/group/project/-/merge_requests/12",
+                  createdAt: "2026-07-02T00:00:00Z",
+                  updatedAt: "2026-07-02T00:00:00Z",
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    const result = await gitlabForgeProvider.findPRsByBranches?.(REPO, ["feature/a", "feature/b"]);
+
+    // feature/a resolved inside the window; feature/b's newest MR may lie
+    // beyond it, so it must be OMITTED (fallback), not confirmed absent.
+    expect(result?.get("feature/a")?.number).toBe(12);
+    expect(result?.has("feature/b")).toBe(false);
+  });
+});
+
+describe("getCIStatus", () => {
+  it("projects the head pipeline status", async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse({ iid: 3, state: "opened", head_pipeline: { status: "running" } })
+    );
+    const status = await gitlabForgeProvider.getCIStatus(REPO, 3);
+    expect(status?.state).toBe("pending");
+    expect(status?.pending).toBe(1);
+  });
+
+  it("returns null when the MR has no pipeline", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ iid: 3, state: "opened", head_pipeline: null }));
+    await expect(gitlabForgeProvider.getCIStatus(REPO, 3)).resolves.toBeNull();
+  });
+});
+
+describe("mutations", () => {
+  it("creates an MR with a Draft: prefix for draft input", async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse({ iid: 20, title: "Draft: New", state: "opened", draft: true })
+    );
+    const pr = await gitlabForgeProvider.createPR(REPO, {
+      head: "feature/x",
+      base: "main",
+      title: "New",
+      draft: true,
+    });
+    const body = requestBody(fetchMock().mock.calls[0]);
+    expect(body.title).toBe("Draft: New");
+    expect(body.source_branch).toBe("feature/x");
+    expect(pr.isDraft).toBe(true);
+  });
+
+  it("rejects rebase merges as unsupported", async () => {
+    await expect(gitlabForgeProvider.mergePR(REPO, 5, { mergeMethod: "rebase" })).rejects.toThrow(
+      "Not supported"
+    );
+    expect(fetchMock()).not.toHaveBeenCalled();
+  });
+
+  it("passes squash and the squash commit message on squash merges", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ iid: 5, state: "merged" }));
+    await gitlabForgeProvider.mergePR(REPO, 5, {
+      mergeMethod: "squash",
+      commitTitle: "feat: squashed",
+    });
+    const body = requestBody(fetchMock().mock.calls[0]);
+    expect(body.squash).toBe(true);
+    expect(body.squash_commit_message).toBe("feat: squashed");
+  });
+
+  it("translates unmergeable 405s into an actionable error", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ message: "Method Not Allowed" }, { status: 405 }));
+    await expect(gitlabForgeProvider.mergePR(REPO, 5)).rejects.toThrow(
+      /draft, have conflicts, or failing pipelines/
+    );
+  });
+
+  it("converts to draft by prefixing the title", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(jsonResponse({ iid: 6, title: "Feature", state: "opened" }))
+      .mockResolvedValueOnce(jsonResponse({ iid: 6, title: "Draft: Feature", state: "opened" }));
+    await gitlabForgeProvider.convertPRToDraft(REPO, 6);
+    const body = requestBody(fetchMock().mock.calls[1]);
+    expect(body.title).toBe("Draft: Feature");
+  });
+
+  it("skips the write when the MR is already a draft", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ iid: 6, title: "Draft: Feature", state: "opened", draft: true })
+    );
+    await gitlabForgeProvider.convertPRToDraft(REPO, 6);
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks ready for review by stripping draft prefixes", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(
+        jsonResponse({ iid: 6, title: "Draft: WIP: Feature", state: "opened", draft: true })
+      )
+      .mockResolvedValueOnce(jsonResponse({ iid: 6, title: "Feature", state: "opened" }));
+    await gitlabForgeProvider.markPRReadyForReview(REPO, 6);
+    const body = requestBody(fetchMock().mock.calls[1]);
+    expect(body.title).toBe("Feature");
+  });
+
+  it("closes issues via state_event", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ iid: 9, state: "closed" }));
+    const issue = await gitlabForgeProvider.closeIssue(REPO, 9, "completed");
+    expect(requestBody(fetchMock().mock.calls[0]).state_event).toBe("close");
+    expect(issue.state).toBe("closed");
+  });
+
+  it("refuses to remove a label that is not on the issue", async () => {
+    fetchMock().mockResolvedValueOnce(jsonResponse({ iid: 9, state: "opened", labels: ["bug"] }));
+    await expect(gitlabForgeProvider.removeIssueLabel(REPO, 9, "ux")).rejects.toThrow(
+      'Label "ux" is not on issue #9'
+    );
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it("assigns additively via resolved user ids", async () => {
+    fetchMock().mockImplementation(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/users?")) {
+        return jsonResponse([{ id: 77, username: "fixer" }]);
+      }
+      if (url.endsWith("/issues/9") && !url.includes("?")) {
+        return jsonResponse({
+          iid: 9,
+          state: "opened",
+          assignees: [{ id: 3, username: "existing" }],
+        });
+      }
+      return jsonResponse({ iid: 9, state: "opened" });
+    });
+
+    await gitlabForgeProvider.assignIssue(REPO, 9, "fixer");
+
+    const putCall = fetchMock().mock.calls.find(
+      (call) => (call[1] as RequestInit | undefined)?.method === "PUT"
+    );
+    expect(putCall).toBeDefined();
+    // New user first: GitLab Free applies only the first id, so leading with
+    // the requested user replaces instead of silently no-oping.
+    expect(requestBody(putCall as unknown[]).assignee_ids).toEqual([77, 3]);
+  });
+
+  it("pins squash false on an explicit merge method", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ iid: 5, state: "merged" }));
+    await gitlabForgeProvider.mergePR(REPO, 5, { mergeMethod: "merge" });
+    expect(requestBody(fetchMock().mock.calls[0]).squash).toBe(false);
+  });
+
+  it("preserves the draft prefix when editing a draft MR's title", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(
+        jsonResponse({ iid: 6, title: "Draft: Old", state: "opened", draft: true })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ iid: 6, title: "Draft: New title", state: "opened", draft: true })
+      );
+    const pr = await gitlabForgeProvider.editPR(REPO, 6, { title: "New title" });
+    const body = requestBody(fetchMock().mock.calls[1]);
+    expect(body.title).toBe("Draft: New title");
+    expect(pr.isDraft).toBe(true);
+  });
+
+  it("builds the issue-comment URL without a second issue fetch", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ id: 501, body: "Hello", created_at: "2026-07-01T00:00:00Z" })
+    );
+    const comment = await gitlabForgeProvider.addIssueComment(REPO, 9, "Hello");
+    expect(comment.url).toBe("https://gitlab.com/group/project/-/issues/9#note_501");
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("validateToken", () => {
+  it("rejects empty tokens without a request", async () => {
+    const result = await gitlabForgeProvider.validateToken("   ");
+    expect(result.valid).toBe(false);
+    expect(fetchMock()).not.toHaveBeenCalled();
+  });
+
+  it("returns user identity and PAT scopes on success", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(
+        jsonResponse({ username: "dev", avatar_url: "https://gitlab.com/a.png" })
+      )
+      .mockResolvedValueOnce(jsonResponse({ scopes: ["api"], expires_at: "2027-01-01" }));
+
+    const result = await gitlabForgeProvider.validateToken("glpat-good");
+
+    expect(requestUrl(fetchMock().mock.calls[0])).toBe("https://gitlab.com/api/v4/user");
+    expect(result.valid).toBe(true);
+    expect(result.scopes).toEqual(["api"]);
+    expect(result.expiresAt).toBe(Date.parse("2027-01-01"));
+  });
+
+  it("maps 401 to a rejected-token error", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ message: "401 Unauthorized" }, { status: 401 }));
+    const result = await gitlabForgeProvider.validateToken("glpat-bad");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("401");
+  });
+
+  it("rejects non-JSON answers (SSO gateways, wrong URLs)", async () => {
+    fetchMock().mockResolvedValue(
+      new Response("<html>login</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      })
+    );
+    const result = await gitlabForgeProvider.validateToken("glpat-good");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("JSON");
+  });
+
+  it("validates against the configured self-hosted instance", async () => {
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.internal.example"));
+    fetchMock()
+      .mockResolvedValueOnce(jsonResponse({ username: "dev" }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 404 }));
+
+    const result = await gitlabForgeProvider.validateToken("glpat-internal");
+
+    expect(requestUrl(fetchMock().mock.calls[0])).toBe(
+      "https://gitlab.internal.example/api/v4/user"
+    );
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("URL builders", () => {
+  const repo: RepoRef = { host: "gitlab.com", owner: "group/sub", repo: "project", rawData: null };
+
+  it("builds issue, MR, and commit URLs with the /-/ route prefix", () => {
+    expect(gitlabForgeProvider.buildIssueUrl(repo, 7)).toBe(
+      "https://gitlab.com/group/sub/project/-/issues/7"
+    );
+    expect(gitlabForgeProvider.buildPRUrl(repo, 7)).toBe(
+      "https://gitlab.com/group/sub/project/-/merge_requests/7"
+    );
+    expect(gitlabForgeProvider.buildCommitsUrl(repo, "feature/x")).toBe(
+      "https://gitlab.com/group/sub/project/-/commits/feature%2Fx"
+    );
+  });
+
+  it("maps the open state to GitLab's 'opened' in list URLs", () => {
+    expect(gitlabForgeProvider.buildIssuesUrl(repo, { state: "open" })).toContain("state=opened");
+    expect(gitlabForgeProvider.buildPRsUrl(repo, { query: "search term" })).toContain(
+      "search=search+term"
+    );
+    expect(gitlabForgeProvider.buildIssuesUrl(repo, { state: "all" })).not.toContain("state=");
+  });
+});
+
+describe("self-hosted base URL", () => {
+  it("preserves the configured scheme, port, and path prefix for API calls", async () => {
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.internal.example:8443/gitlab"));
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-internal" });
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(SELF_HOSTED_REPO, {});
+
+    const url = requestUrl(fetchMock().mock.calls[0]);
+    expect(url).toContain("https://gitlab.internal.example:8443/gitlab/api/v4/projects/");
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBe("Bearer glpat-internal");
+  });
+
+  it("withholds the token when the settings read fails (fail closed)", async () => {
+    setInstanceUrlReader(() => Promise.reject(new Error("settings store unavailable")));
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-secret" });
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(REPO, {});
+
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBeUndefined();
+  });
+});
+
+describe("repoStats", () => {
+  it("derives counts from x-total headers alongside first pages", async () => {
+    fetchMock().mockImplementation(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/issues")) {
+        return jsonResponse([{ iid: 1, title: "I", state: "opened" }], {
+          headers: { "x-total": "12" },
+        });
+      }
+      return jsonResponse([{ iid: 2, title: "M", state: "opened" }], {
+        headers: { "x-total": "4" },
+      });
+    });
+
+    const stats = await gitlabForgeProvider.repoStats?.getRepoStats(REPO, { bypassCache: true });
+
+    expect(stats?.counts.issueCount).toBe(12);
+    expect(stats?.counts.prCount).toBe(4);
+    expect(stats?.issues?.items[0].number).toBe(1);
+    expect(stats?.prs?.items[0].number).toBe(2);
+    expect(stats?.source).toBe("network");
+  });
+
+  it("reports the error without counts when the fetch fails cold", async () => {
+    fetchMock().mockImplementation(async () => jsonResponse({ message: "boom" }, { status: 500 }));
+    const stats = await gitlabForgeProvider.repoStats?.getRepoStats(REPO, { bypassCache: true });
+    expect(stats?.counts.issueCount).toBeNull();
+    expect(stats?.counts.error).toContain("boom");
+  });
+});

--- a/plugins/builtin/gitlab/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/forgeProvider.test.ts
@@ -696,6 +696,31 @@ describe("listPRs", () => {
     await gitlabForgeProvider.listPRs(REPO, { cursor: "3" });
     expect(requestUrl(fetchMock().mock.calls[0])).toContain("page=3");
   });
+
+  it("ends pagination when GitLab omits x-next-page", async () => {
+    // The last page carries no next-page header at all. Reporting a cursor
+    // there would leave the host offering a load-more that fetches nothing.
+    fetchMock().mockResolvedValue(
+      jsonResponse([{ iid: 1, title: "One", state: "opened" }], { headers: { "x-total": "1" } })
+    );
+
+    const page = await gitlabForgeProvider.listPRs(REPO, { state: "open" });
+
+    expect(page.nextCursor).toBeNull();
+    expect(page.hasMore).toBe(false);
+    expect(page.totalCount).toBe(1);
+  });
+
+  it("maps the sort onto GitLab's order_by parameter", async () => {
+    // A fresh Response per call: a body is readable exactly once.
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+    await gitlabForgeProvider.listPRs(REPO, { sort: "updated" });
+    expect(requestUrl(fetchMock().mock.calls[0])).toContain("order_by=updated_at");
+
+    fetchMock().mockClear();
+    await gitlabForgeProvider.listPRs(REPO, {});
+    expect(requestUrl(fetchMock().mock.calls[0])).toContain("order_by=created_at");
+  });
 });
 
 describe("getIssue", () => {
@@ -1088,6 +1113,23 @@ describe("mutations", () => {
     expect(assignees.map((u) => u.login)).toEqual(["someone"]);
   });
 
+  it("does not unassign a bystander whose row carries no numeric id", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({
+        iid: 9,
+        state: "opened",
+        // `id` is optional on GitLab's user shape. An assignee that arrives
+        // without one drops out of the id list the write would send — so the
+        // "nothing to remove" guard has to be measured on usernames, or this
+        // writes an assignee_ids that quietly unassigns them.
+        assignees: [{ username: "no-id" }, { id: 3, username: "someone" }],
+      })
+    );
+    const assignees = await gitlabForgeProvider.unassignIssue(REPO, 9, "fixer");
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+    expect(assignees.map((u) => u.login)).toEqual(["no-id", "someone"]);
+  });
+
   it("pins squash false on an explicit merge method", async () => {
     fetchMock().mockResolvedValue(jsonResponse({ iid: 5, state: "merged" }));
     await gitlabForgeProvider.mergePR(REPO, 5, { mergeMethod: "merge" });
@@ -1350,5 +1392,40 @@ describe("repoStats", () => {
     const stats = await gitlabForgeProvider.repoStats?.getRepoStats(REPO, { bypassCache: true });
     expect(stats?.counts.issueCount).toBeNull();
     expect(stats?.counts.error).toContain("boom");
+  });
+
+  it("surfaces a 429 as a rate-limit block with the time it lifts", async () => {
+    // The host's rate-limit banner and poll pacing read these fields; an
+    // error string alone leaves both blind to a block that has a known end.
+    fetchMock().mockImplementation(async () =>
+      jsonResponse(
+        { message: "Too many requests" },
+        { status: 429, headers: { "ratelimit-reset": "1800000000" } }
+      )
+    );
+
+    const stats = await gitlabForgeProvider.repoStats?.getRepoStats(REPO, { bypassCache: true });
+
+    expect(stats?.counts.rateLimitKind).toBe("primary");
+    expect(stats?.counts.rateLimitResetAt).toBe(1_800_000_000_000);
+  });
+
+  it("prefers Retry-After over the reset header when both are sent", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T00:00:00Z"));
+    try {
+      fetchMock().mockImplementation(async () =>
+        jsonResponse(
+          { message: "Too many requests" },
+          { status: 429, headers: { "retry-after": "60", "ratelimit-reset": "1800000000" } }
+        )
+      );
+
+      const stats = await gitlabForgeProvider.repoStats?.getRepoStats(REPO, { bypassCache: true });
+
+      expect(stats?.counts.rateLimitResetAt).toBe(Date.parse("2026-07-01T00:01:00Z"));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/plugins/builtin/gitlab/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/forgeProvider.test.ts
@@ -1140,6 +1140,33 @@ async function primeInstanceCache(): Promise<void> {
   fetchMock().mockClear();
 }
 
+describe("PR-head refspec", () => {
+  // The host's default is GitHub-shaped (`pull/<n>/head`), which GitLab does
+  // not serve. Without this, checking out an MR whose source branch isn't
+  // already local fails with "couldn't find remote ref".
+  it("fetches from GitLab's merge-requests namespace", () => {
+    expect(gitlabForgeProvider.buildPRHeadRefspec?.(42, "feature-x")).toBe(
+      "refs/merge-requests/42/head:feature-x"
+    );
+  });
+
+  // `merge-requests/` is not a hierarchy git expands on its own, so a bare
+  // source ref would not resolve.
+  it("fully qualifies the source ref", () => {
+    expect(gitlabForgeProvider.buildPRHeadRefspec?.(1, "b")?.startsWith("refs/")).toBe(true);
+  });
+
+  // The host rejects a refspec whose destination isn't the requested branch
+  // and silently falls back to its default, so this has to land exactly there.
+  it("writes only to the branch the host asked for", () => {
+    const spec = gitlabForgeProvider.buildPRHeadRefspec?.(7, "topic") ?? "";
+    const [source, destination, ...rest] = spec.split(":");
+    expect(rest).toEqual([]);
+    expect(destination).toBe("topic");
+    expect(source).not.toMatch(/^[+\-^]|\*|\s/);
+  });
+});
+
 describe("self-hosted deployment path", () => {
   // A relative install serves clone URLs under its deployment path, but the
   // path is part of the instance base — not of the project namespace.

--- a/plugins/builtin/gitlab/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/forgeProvider.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import type { RepoRef } from "../../../../../shared/types/forge.js";
 import { gitlabForgeProvider } from "../forgeProvider.js";
-import { resetAuthStateForTests, setInstanceUrlReader } from "../GitLabAuth.js";
+import {
+  digestToken,
+  getInstanceUrl,
+  resetAuthStateForTests,
+  setInstanceUrlReader,
+  setProvenanceAccessors,
+} from "../GitLabAuth.js";
 import { resetLastRateLimitInfo } from "../GitLabClient.js";
 import { clearGitLabCaches } from "../readOps.js";
+import { clearValidatedUserInfo } from "../GitLabAuth.js";
 
 const REPO: RepoRef = { host: "gitlab.com", owner: "group", repo: "project", rawData: null };
 const SELF_HOSTED_REPO: RepoRef = {
@@ -39,11 +46,38 @@ function requestBody(call: unknown[]): Record<string, unknown> {
   >;
 }
 
+/**
+ * Mirror the host's real save path: point the settings reader at the instance,
+ * validate the token through the provider (which is what proves where it
+ * belongs), then hand it over — exactly the `validateToken` → persist →
+ * `setCredentials` sequence in `electron/ipc/handlers/forgeSettings.ts`.
+ * Setting credentials WITHOUT a preceding validation is a replay, not a save,
+ * so a test that skips it is not exercising the path it thinks it is.
+ */
+async function connectAs(instanceUrl: string, token: string): Promise<void> {
+  setInstanceUrlReader(() => Promise.resolve(instanceUrl));
+  await getInstanceUrl();
+  const previous = globalThis.fetch;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => jsonResponse({ username: "tester" }))
+  );
+  await gitlabForgeProvider.validateToken(token);
+  vi.stubGlobal("fetch", previous);
+  gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: token });
+}
+
 beforeEach(() => {
   vi.stubGlobal("fetch", vi.fn());
   resetAuthStateForTests();
   clearGitLabCaches();
   resetLastRateLimitInfo();
+  // No durable provenance record: a fresh install, where the first token
+  // adopts the configured instance and that becomes its provenance.
+  setProvenanceAccessors(
+    () => null,
+    () => undefined
+  );
 });
 
 afterEach(() => {
@@ -53,7 +87,7 @@ afterEach(() => {
 
 describe("token attachment", () => {
   it("attaches the token to the configured instance host only", async () => {
-    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-secret" });
+    await connectAs("https://gitlab.com", "glpat-secret");
     fetchMock().mockImplementation(async () => jsonResponse([]));
 
     await gitlabForgeProvider.listIssues(REPO, {});
@@ -64,8 +98,7 @@ describe("token attachment", () => {
   });
 
   it("follows the instanceUrl setting for self-hosted tokens", async () => {
-    setInstanceUrlReader(() => Promise.resolve("https://gitlab.internal.example"));
-    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-internal" });
+    await connectAs("https://gitlab.internal.example", "glpat-internal");
     fetchMock().mockImplementation(async () => jsonResponse([]));
 
     await gitlabForgeProvider.listIssues(SELF_HOSTED_REPO, {});
@@ -73,6 +106,557 @@ describe("token attachment", () => {
 
     await gitlabForgeProvider.listIssues(REPO, {});
     expect(requestHeaders(fetchMock().mock.calls[1]).Authorization).toBeUndefined();
+  });
+
+  it("withholds the token once the instance setting moves off the bound host", async () => {
+    await connectAs("https://gitlab.internal.example", "glpat-internal");
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(SELF_HOSTED_REPO, {});
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBe("Bearer glpat-internal");
+
+    // The generic plugin settings form can repoint instanceUrl without
+    // clearing the credential. The token belongs to the old instance, so it
+    // must not be replayed at the new one.
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.other.example"));
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.other.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(requestHeaders(fetchMock().mock.calls[1]).Authorization).toBeUndefined();
+  });
+
+  it("withholds the token when the instance setting can't be read", async () => {
+    await connectAs("https://gitlab.com", "glpat-secret");
+    setInstanceUrlReader(() => Promise.reject(new Error("store unavailable")));
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(REPO, {});
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBeUndefined();
+  });
+});
+
+describe("identity isolation", () => {
+  // An instance change doesn't move tokenVersion, so without its own guard a
+  // `/user` lookup already in flight against the OLD instance resolves after
+  // the change and repopulates the identity of an account on a server we are
+  // no longer talking to.
+  it("drops an identity write from a lookup that predates an instance change", async () => {
+    await connectAs("https://gitlab.a.example", "glpat-a");
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    fetchMock().mockImplementation(async () => {
+      await gate;
+      return jsonResponse({ username: "user-on-a" });
+    });
+
+    const inFlight = gitlabForgeProvider.identity?.getCurrentUser();
+    clearValidatedUserInfo();
+    release();
+    await inFlight;
+
+    // With the identity dropped, a later read must go back to the network
+    // rather than serve the account from the previous instance.
+    fetchMock().mockImplementation(async () => jsonResponse({ username: "user-on-b" }));
+    const before = fetchMock().mock.calls.length;
+    await gitlabForgeProvider.identity?.getCurrentUser();
+    expect(fetchMock().mock.calls.length).toBeGreaterThan(before);
+  });
+});
+
+describe("cache invalidation", () => {
+  // Invalidation is provider-owned since the host stopped clearing caches
+  // after mutations: a write that skips it serves the pre-write snapshot for
+  // the cache's whole TTL.
+  it("drops the cached tooltip a write just invalidated", async () => {
+    // A fresh Response per call: a body can only be read once.
+    fetchMock().mockImplementation(async () =>
+      jsonResponse({ iid: 9, title: "Before", state: "opened", labels: [] })
+    );
+    await gitlabForgeProvider.tooltips?.getIssueTooltip(REPO, 9);
+    const afterFirstRead = fetchMock().mock.calls.length;
+    // A second read inside the TTL is served from cache.
+    await gitlabForgeProvider.tooltips?.getIssueTooltip(REPO, 9);
+    expect(fetchMock().mock.calls.length).toBe(afterFirstRead);
+
+    await gitlabForgeProvider.closeIssue(REPO, 9);
+    await gitlabForgeProvider.tooltips?.getIssueTooltip(REPO, 9);
+    expect(fetchMock().mock.calls.length).toBeGreaterThan(afterFirstRead + 1);
+  });
+});
+
+describe("stale-write protection", () => {
+  // Clearing the maps is not enough: a read that started before the clear
+  // resolves after it and repopulates the cache with data fetched under the
+  // previous credential or instance.
+  it("drops a cache write from a read that started before an invalidation", async () => {
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    fetchMock().mockImplementation(async () => {
+      await gate;
+      return jsonResponse({ iid: 9, title: "From the old instance", state: "opened", labels: [] });
+    });
+
+    const inFlight = gitlabForgeProvider.tooltips?.getIssueTooltip(REPO, 9);
+    clearGitLabCaches();
+    release();
+    await inFlight;
+
+    // The cache must be empty, so the next read goes back to the network
+    // rather than serving what the pre-invalidation request brought back.
+    const before = fetchMock().mock.calls.length;
+    fetchMock().mockImplementation(async () =>
+      jsonResponse({ iid: 9, title: "Fresh", state: "opened", labels: [] })
+    );
+    await gitlabForgeProvider.tooltips?.getIssueTooltip(REPO, 9);
+    expect(fetchMock().mock.calls.length).toBeGreaterThan(before);
+  });
+});
+
+describe("stale quota protection", () => {
+  // A quota belongs to an account on an instance. A request that was already
+  // in flight when the credential changed carries the PREVIOUS account's
+  // headers; recording them leaves the host's polling gate shut on a quota the
+  // new account never spent.
+  it("ignores rate-limit headers from a request that predates an invalidation", async () => {
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    fetchMock().mockImplementation(async () => {
+      await gate;
+      return jsonResponse([], {
+        headers: { "ratelimit-limit": "100", "ratelimit-remaining": "0" },
+      });
+    });
+
+    const inFlight = gitlabForgeProvider.listIssues(REPO, {});
+    // The credential changed, which is what invalidates the observed quota.
+    clearGitLabCaches();
+    release();
+    await inFlight;
+
+    // The exhausted quota belonged to the previous account, so nothing should
+    // have been recorded for the new one.
+    expect(await gitlabForgeProvider.getRateLimit?.()).toMatchObject({ remaining: null });
+  });
+});
+
+describe("malformed list entries", () => {
+  // The list endpoints filter these, but repo stats and branch lookup map the
+  // same payloads through their own paths.
+  it("keeps unusable rows out of repo stats and branch lookup too", async () => {
+    fetchMock().mockImplementation(async () => jsonResponse([{}], { headers: { "x-total": "1" } }));
+    const stats = await gitlabForgeProvider.repoStats!.getRepoStats(REPO, { bypassCache: true });
+    expect(stats.issues?.items ?? []).toEqual([]);
+    expect(stats.prs?.items ?? []).toEqual([]);
+
+    expect(await gitlabForgeProvider.findPRByBranch(REPO, "feature")).toBeNull();
+  });
+
+  // An entry with no iid maps to "#0" with an empty URL — a row that opens
+  // nothing and acts on nothing.
+  it("drops entries with no usable number instead of rendering issue #0", async () => {
+    fetchMock().mockImplementation(async () =>
+      jsonResponse([{}, { iid: 4, title: "Real", state: "opened" }])
+    );
+    const page = await gitlabForgeProvider.listIssues(REPO, {});
+    expect(page.items.map((i) => i.number)).toEqual([4]);
+
+    const prs = await gitlabForgeProvider.listPRs(REPO, {});
+    expect(prs.items.map((p) => p.number)).toEqual([4]);
+  });
+});
+
+describe("list filters", () => {
+  // Grape silently drops an undeclared parameter, so the wrong shape returns
+  // an UNFILTERED list rather than an error. Both endpoints declare the array.
+  it("sends the assignee filter in the documented array form", async () => {
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+    await gitlabForgeProvider.listIssues(REPO, { assignee: "fixer" });
+    expect(requestUrl(fetchMock().mock.calls[0])).toContain("assignee_username%5B%5D=fixer");
+
+    await gitlabForgeProvider.listPRs(REPO, { assignee: "fixer" });
+    expect(requestUrl(fetchMock().mock.calls[1])).toContain("assignee_username%5B%5D=fixer");
+  });
+});
+
+describe("credential provenance", () => {
+  // The host's credential store holds a bare token. On every activation it is
+  // replayed into setCredentials, so without a durable record of the instance
+  // it was saved for, a repointed `instanceUrl` silently claims it.
+  it("replays a stored token against the instance it was saved for, not the current one", async () => {
+    const saved = { instanceUrl: "https://gitlab.a.example", tokenDigest: digestToken("glpat-a") };
+    setProvenanceAccessors(
+      () => saved,
+      () => undefined
+    );
+    // The user repointed the setting to B without clearing the credential,
+    // then the plugin re-activated and the host replayed token A.
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.b.example"));
+    await getInstanceUrl();
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-a" });
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.b.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBeUndefined();
+  });
+
+  it("records the instance a newly supplied token was validated against", async () => {
+    const writes: unknown[] = [];
+    setProvenanceAccessors(
+      () => null,
+      (record) => writes.push(record)
+    );
+    await connectAs("https://gitlab.b.example", "glpat-new");
+
+    expect(writes).toEqual([
+      { instanceUrl: "https://gitlab.b.example", tokenDigest: digestToken("glpat-new") },
+    ]);
+  });
+
+  // The validation resolved its own destination; the save must use THAT, not
+  // re-derive one from a setting that changed while validation was in flight.
+  it("binds to the instance validation reached, not the one configured on save", async () => {
+    setProvenanceAccessors(
+      () => null,
+      () => undefined
+    );
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.a.example"));
+    await getInstanceUrl();
+    fetchMock().mockImplementation(async () => jsonResponse({ username: "tester" }));
+    await gitlabForgeProvider.validateToken("glpat-a");
+
+    // Another settings surface repoints the instance before the save lands.
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.b.example"));
+    await getInstanceUrl();
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-a" });
+
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.b.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(
+      requestHeaders(fetchMock().mock.calls.at(-1) as unknown[]).Authorization
+    ).toBeUndefined();
+
+    // ...and it is still usable at A, the instance it was actually proven
+    // against. Withholding it everywhere would be safe but useless.
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.a.example"));
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.a.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(requestHeaders(fetchMock().mock.calls.at(-1) as unknown[]).Authorization).toBe(
+      "Bearer glpat-a"
+    );
+  });
+
+  // Token rotation: a slow background probe of the OLD token must not stand in
+  // for the NEW token's provenance, or the save reports success and every
+  // request afterwards goes out unauthenticated.
+  it("keeps a background probe of the old token from clobbering a save in flight", async () => {
+    await connectAs("https://gitlab.a.example", "glpat-old");
+
+    let releaseOld = (): void => undefined;
+    const oldProbe = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    // One implementation for the whole test, keyed on which token the request
+    // carries, so swapping mocks can't accidentally serialize the two.
+    fetchMock().mockImplementation(async (_input: unknown, init?: RequestInit) => {
+      const auth = String((init?.headers as Record<string, string> | undefined)?.Authorization);
+      if (auth.includes("glpat-old")) {
+        // The old token's probe resolves LATE — after the new token's
+        // validation has already recorded where it belongs.
+        await oldProbe;
+      }
+      return jsonResponse({ username: "tester" });
+    });
+
+    const staleProbe = gitlabForgeProvider.validateCredentials?.();
+    // Let the probe actually reach its fetch before the save starts.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The user saves a replacement token: validate, then setCredentials.
+    await gitlabForgeProvider.validateToken("glpat-new");
+    releaseOld();
+    await staleProbe;
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-new" });
+
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.a.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(requestHeaders(fetchMock().mock.calls.at(-1) as unknown[]).Authorization).toBe(
+      "Bearer glpat-new"
+    );
+  });
+
+  // A capacity limit has the same defect as the single slot it replaced, just
+  // further away: enough other validations while one is still in introspection
+  // and the live entry is the one dropped.
+  it("keeps a pending save's provenance through a burst of other validations", async () => {
+    setProvenanceAccessors(
+      () => null,
+      () => undefined
+    );
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.a.example"));
+    await getInstanceUrl();
+
+    let releaseIntrospection = (): void => undefined;
+    const introspection = new Promise<void>((resolve) => {
+      releaseIntrospection = resolve;
+    });
+    fetchMock().mockImplementation(async (input: unknown, init?: RequestInit) => {
+      const auth = String((init?.headers as Record<string, string> | undefined)?.Authorization);
+      if (String(input).endsWith("/personal_access_tokens/self") && auth.includes("glpat-saving")) {
+        await introspection;
+        return jsonResponse({ scopes: ["api"], expires_at: null });
+      }
+      return jsonResponse({ username: "tester" });
+    });
+
+    const saving = gitlabForgeProvider.validateToken("glpat-saving");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Plenty of other candidate validations while that one is still in flight.
+    for (let i = 0; i < 12; i += 1) {
+      await gitlabForgeProvider.validateToken(`glpat-other-${i}`);
+    }
+    releaseIntrospection();
+    await saving;
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-saving" });
+
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.a.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(requestHeaders(fetchMock().mock.calls.at(-1) as unknown[]).Authorization).toBe(
+      "Bearer glpat-saving"
+    );
+  });
+
+  // An absent record is not proof of a new save — it is equally a replay whose
+  // record was lost, so adopting the current instance would be fail-open.
+  it("withholds a replayed token whose provenance record is unreadable", async () => {
+    setProvenanceAccessors(
+      () => null,
+      () => undefined
+    );
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.b.example"));
+    await getInstanceUrl();
+    // Replay: setCredentials with no preceding validation.
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-a" });
+
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.b.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBeUndefined();
+  });
+
+  // A deliberate re-save of the SAME token for a new instance must rebind it;
+  // the stale record must not pin it to the old one forever.
+  it("rebinds the same token when it is explicitly validated for another instance", async () => {
+    const stale = { instanceUrl: "https://gitlab.a.example", tokenDigest: digestToken("glpat-t") };
+    setProvenanceAccessors(
+      () => stale,
+      () => undefined
+    );
+    await connectAs("https://gitlab.b.example", "glpat-t");
+
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.b.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(requestHeaders(fetchMock().mock.calls.at(-1) as unknown[]).Authorization).toBe(
+      "Bearer glpat-t"
+    );
+  });
+
+  // A different token must not inherit an existing record's instance.
+  it("does not let a different token inherit a stored record's instance", async () => {
+    const recorded = {
+      instanceUrl: "https://gitlab.a.example",
+      tokenDigest: digestToken("glpat-a"),
+    };
+    setProvenanceAccessors(
+      () => recorded,
+      () => undefined
+    );
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.a.example"));
+    await getInstanceUrl();
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-different" });
+
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+    await gitlabForgeProvider.listIssues(
+      { host: "gitlab.a.example", owner: "team", repo: "app", rawData: null },
+      {}
+    );
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBeUndefined();
+  });
+
+  it("stores a one-way digest, not the token or a reversible encoding", async () => {
+    const digest = digestToken("glpat-secret");
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+    expect(digest).not.toContain("glpat");
+    expect(Buffer.from(digest, "hex").toString("utf8")).not.toContain("glpat");
+    expect(digestToken("glpat-secret2")).not.toBe(digest);
+  });
+
+  it("never writes the token itself to durable storage", async () => {
+    const writes: { tokenDigest: string }[] = [];
+    setProvenanceAccessors(
+      () => null,
+      (record) => {
+        if (record) writes.push(record);
+      }
+    );
+    setInstanceUrlReader(() => Promise.resolve("https://gitlab.com"));
+    await getInstanceUrl();
+    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-secret" });
+
+    expect(JSON.stringify(writes)).not.toContain("glpat-secret");
+  });
+
+  it("clears the record when the credential is cleared", async () => {
+    const writes: unknown[] = [];
+    setProvenanceAccessors(
+      () => null,
+      (record) => writes.push(record)
+    );
+    await connectAs("https://gitlab.com", "glpat-secret");
+    gitlabForgeProvider.setCredentials?.(null);
+    expect(writes.at(-1)).toBeNull();
+  });
+});
+
+describe("request destination", () => {
+  const SELF_HOSTED = "https://code.example:8443/gitlab";
+  const PREFIXED_REPO = { host: "code.example", owner: "team", repo: "app", rawData: null };
+
+  // Destination and authorization must come from ONE settings read. Two reads
+  // let the second fail and fall back to plain https — dropping the configured
+  // port and deployment path — after the first already approved the token.
+  it("resolves the destination and the credential from a single settings read", async () => {
+    await connectAs(SELF_HOSTED, "glpat-internal");
+    let reads = 0;
+    setInstanceUrlReader(() => {
+      reads += 1;
+      return Promise.resolve(SELF_HOSTED);
+    });
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(PREFIXED_REPO, {});
+
+    expect(reads).toBe(1);
+    const call = fetchMock().mock.calls[0];
+    expect(requestUrl(call)).toContain(`${SELF_HOSTED}/api/v4/projects/`);
+    expect(requestHeaders(call).Authorization).toBe("Bearer glpat-internal");
+  });
+
+  // The same read that authorizes names the destination, so a read that fails
+  // yields no credential AND no confident base — never a token at a fallback.
+  it("sends no credential when that read fails", async () => {
+    await connectAs(SELF_HOSTED, "glpat-internal");
+    setInstanceUrlReader(() => Promise.reject(new Error("settings store unavailable")));
+    fetchMock().mockImplementation(async () => jsonResponse([]));
+
+    await gitlabForgeProvider.listIssues(PREFIXED_REPO, {});
+    expect(requestHeaders(fetchMock().mock.calls[0]).Authorization).toBeUndefined();
+  });
+});
+
+describe("malformed list payloads", () => {
+  // A 200 carrying an object rather than a list used to become an empty page,
+  // so an error envelope read as "this project has no issues".
+  it("rejects a non-list body instead of reporting an empty page", async () => {
+    fetchMock().mockImplementation(async () => jsonResponse({ message: "upstream unavailable" }));
+    await expect(gitlabForgeProvider.listIssues(REPO, {})).rejects.toThrow(
+      /unexpected list payload/
+    );
+    await expect(gitlabForgeProvider.listPRs(REPO, {})).rejects.toThrow(/unexpected list payload/);
+  });
+});
+
+describe("validateToken destination", () => {
+  it("never sends a self-hosted token to gitlab.com when the setting can't be read", async () => {
+    setInstanceUrlReader(() => Promise.reject(new Error("store unavailable")));
+    fetchMock().mockImplementation(async () => jsonResponse({ username: "someone" }));
+
+    const result = await gitlabForgeProvider.validateToken("glpat-internal");
+
+    expect(result.valid).toBe(false);
+    // The point of the fix: no request at all, rather than one to the default
+    // instance carrying a credential issued by a private one.
+    expect(fetchMock()).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token whose introspected scopes can't read the API", async () => {
+    fetchMock().mockImplementation(async (input: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/personal_access_tokens/self")) {
+        return jsonResponse({ scopes: ["read_user"], expires_at: null });
+      }
+      return jsonResponse({ username: "someone" });
+    });
+
+    // `/user` answers for a read_user token, so identity alone is not proof
+    // the provider can read a single project.
+    const result = await gitlabForgeProvider.validateToken("glpat-readuser");
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/api or read_api/);
+  });
+
+  it("accepts read_api for read-only use", async () => {
+    fetchMock().mockImplementation(async (input: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/personal_access_tokens/self")) {
+        return jsonResponse({ scopes: ["read_api"], expires_at: null });
+      }
+      return jsonResponse({ username: "someone" });
+    });
+    const result = await gitlabForgeProvider.validateToken("glpat-readapi");
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("gateway responses", () => {
+  it("rejects a 200 HTML sign-in page instead of parsing it as GitLab data", async () => {
+    await connectAs("https://gitlab.com", "glpat-secret");
+    fetchMock().mockResolvedValue(
+      new Response("<html>sign in</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      })
+    );
+
+    await expect(gitlabForgeProvider.listIssues(REPO, {})).rejects.toThrow(
+      /didn't answer with JSON/
+    );
+    // An SSO gateway's 200 is not evidence the token works.
+    expect(gitlabForgeProvider.healthEvents?.getTokenHealth?.().status).not.toBe("healthy");
+  });
+});
+
+describe("malformed responses", () => {
+  it("wraps an unparsable JSON body instead of leaking a SyntaxError", async () => {
+    fetchMock().mockResolvedValue(
+      new Response("{not json", { status: 200, headers: { "content-type": "application/json" } })
+    );
+    await expect(gitlabForgeProvider.listIssues(REPO, {})).rejects.toThrow(/unreadable response/);
   });
 });
 
@@ -289,6 +873,69 @@ describe("mutations", () => {
     expect(body.squash_commit_message).toBe("feat: squashed");
   });
 
+  // Squashing into a project that uses merge commits populates BOTH fields
+  // with different commits. `MergePRResult.sha` names the commit the change
+  // landed as on the target branch, so the merge commit is the answer.
+  it("prefers the merge commit when a squash merge produces both shas", async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse({ iid: 5, state: "merged", squash_commit_sha: "sq1", merge_commit_sha: "mc1" })
+    );
+    const result = await gitlabForgeProvider.mergePR(REPO, 5, { mergeMethod: "squash" });
+    expect(result).toMatchObject({ prNumber: 5, sha: "mc1", merged: true });
+  });
+
+  // Fast-forward and semi-linear projects create no merge commit, so the
+  // squashed commit IS the commit on the target branch.
+  it("falls back to the squash commit when there is no merge commit", async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse({ iid: 5, state: "merged", squash_commit_sha: "sq1", merge_commit_sha: null })
+    );
+    const result = await gitlabForgeProvider.mergePR(REPO, 5, { mergeMethod: "squash" });
+    expect(result.sha).toBe("sq1");
+  });
+
+  it("reports no sha rather than inventing one when the ack carries neither", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ iid: 5, state: "merged" }));
+    const result = await gitlabForgeProvider.mergePR(REPO, 5);
+    expect(result).toMatchObject({ sha: null, merged: true });
+  });
+
+  // A merge queued behind a pipeline acks 2xx with the MR still `opened`.
+  // Reporting that as merged would tell the user the change landed.
+  it("does not claim merged when the ack says the MR is still open", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ iid: 5, state: "opened" }));
+    const result = await gitlabForgeProvider.mergePR(REPO, 5);
+    expect(result.merged).toBe(false);
+    // The message sits next to the flag, so it must not contradict it.
+    expect(result.message).not.toMatch(/\bmerged\b/);
+    expect(result.message).toMatch(/queued/);
+  });
+
+  // A 200 that isn't a merge request at all (an error envelope, a gateway
+  // page) says nothing about the merge, so neither outcome can be claimed —
+  // reporting it as "queued to merge" would be a fabricated success.
+  it("errors on an unrecognizable merge ack rather than reporting an outcome", async () => {
+    fetchMock().mockResolvedValue(jsonResponse({ message: "upstream unavailable" }));
+    await expect(gitlabForgeProvider.mergePR(REPO, 5)).rejects.toThrow(/unrecognizable response/);
+  });
+
+  // The result is mapped from the server's answer, not synthesized from the
+  // request: the response below reports a state the caller did not ask for,
+  // and that is what must come back.
+  it("returns the MR the server answered with, not the requested state", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ iid: 7, title: "Renamed by a hook", state: "merged" })
+    );
+    const closed = await gitlabForgeProvider.closePR(REPO, 7);
+    expect(requestBody(fetchMock().mock.calls[0]).state_event).toBe("close");
+    expect(closed).toMatchObject({ number: 7, title: "Renamed by a hook", state: "merged" });
+
+    fetchMock().mockResolvedValueOnce(jsonResponse({ iid: 7, title: "Feature", state: "opened" }));
+    const reopened = await gitlabForgeProvider.reopenPR(REPO, 7);
+    expect(requestBody(fetchMock().mock.calls[1]).state_event).toBe("reopen");
+    expect(reopened.state).toBe("open");
+  });
+
   it("translates unmergeable 405s into an actionable error", async () => {
     fetchMock().mockResolvedValue(jsonResponse({ message: "Method Not Allowed" }, { status: 405 }));
     await expect(gitlabForgeProvider.mergePR(REPO, 5)).rejects.toThrow(
@@ -300,28 +947,42 @@ describe("mutations", () => {
     fetchMock()
       .mockResolvedValueOnce(jsonResponse({ iid: 6, title: "Feature", state: "opened" }))
       .mockResolvedValueOnce(jsonResponse({ iid: 6, title: "Draft: Feature", state: "opened" }));
-    await gitlabForgeProvider.convertPRToDraft(REPO, 6);
+    const result = await gitlabForgeProvider.convertPRToDraft(REPO, 6);
     const body = requestBody(fetchMock().mock.calls[1]);
     expect(body.title).toBe("Draft: Feature");
+    expect(result).toEqual({ prNumber: 6, isDraft: true });
+  });
+
+  // The resulting state is read back off the updated MR, not assumed from the
+  // request: a server-side title rewrite must not leave the UI claiming a
+  // draft state the MR never reached.
+  it("reports the state the server ended in, not the one requested", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(jsonResponse({ iid: 6, title: "Feature", state: "opened" }))
+      .mockResolvedValueOnce(jsonResponse({ iid: 6, title: "Feature", state: "opened" }));
+    const result = await gitlabForgeProvider.convertPRToDraft(REPO, 6);
+    expect(result.isDraft).toBe(false);
   });
 
   it("skips the write when the MR is already a draft", async () => {
     fetchMock().mockResolvedValueOnce(
       jsonResponse({ iid: 6, title: "Draft: Feature", state: "opened", draft: true })
     );
-    await gitlabForgeProvider.convertPRToDraft(REPO, 6);
+    const result = await gitlabForgeProvider.convertPRToDraft(REPO, 6);
     expect(fetchMock()).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ prNumber: 6, isDraft: true });
   });
 
   it("marks ready for review by stripping draft prefixes", async () => {
     fetchMock()
       .mockResolvedValueOnce(
-        jsonResponse({ iid: 6, title: "Draft: WIP: Feature", state: "opened", draft: true })
+        jsonResponse({ iid: 6, title: "Draft: [Draft] Feature", state: "opened", draft: true })
       )
       .mockResolvedValueOnce(jsonResponse({ iid: 6, title: "Feature", state: "opened" }));
-    await gitlabForgeProvider.markPRReadyForReview(REPO, 6);
+    const result = await gitlabForgeProvider.markPRReadyForReview(REPO, 6);
     const body = requestBody(fetchMock().mock.calls[1]);
     expect(body.title).toBe("Feature");
+    expect(result).toEqual({ prNumber: 6, isDraft: false });
   });
 
   it("closes issues via state_event", async () => {
@@ -366,6 +1027,67 @@ describe("mutations", () => {
     expect(requestBody(putCall as unknown[]).assignee_ids).toEqual([77, 3]);
   });
 
+  // GitLab Free keeps only the first id, so the requested user is not proof of
+  // what landed — only the updated issue's own list is. The PUT answers with a
+  // third login so returning the pre-write list OR the requested user fails.
+  it("returns the assignees the server kept, not the one requested", async () => {
+    fetchMock().mockImplementation(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/users?")) return jsonResponse([{ id: 77, username: "fixer" }]);
+      if (init?.method === "PUT") {
+        return jsonResponse({
+          iid: 9,
+          state: "opened",
+          assignees: [{ id: 5, username: "whoever-the-server-picked" }],
+        });
+      }
+      return jsonResponse({
+        iid: 9,
+        state: "opened",
+        assignees: [{ id: 3, username: "existing" }],
+      });
+    });
+    const assignees = await gitlabForgeProvider.assignIssue(REPO, 9, "fixer");
+    expect(assignees.map((u) => u.login)).toEqual(["whoever-the-server-picked"]);
+  });
+
+  it("reports the current assignees without writing when already assigned", async () => {
+    fetchMock().mockImplementation(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/users?")) return jsonResponse([{ id: 77, username: "fixer" }]);
+      return jsonResponse({ iid: 9, state: "opened", assignees: [{ id: 77, username: "fixer" }] });
+    });
+    const assignees = await gitlabForgeProvider.assignIssue(REPO, 9, "fixer");
+    expect(assignees.map((u) => u.login)).toEqual(["fixer"]);
+    expect(
+      fetchMock().mock.calls.some((call) => (call[1] as RequestInit | undefined)?.method === "PUT")
+    ).toBe(false);
+  });
+
+  it("clears the last assignee with the [0] sentinel", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(
+        jsonResponse({ iid: 9, state: "opened", assignees: [{ id: 77, username: "fixer" }] })
+      )
+      // The answer disagrees with the locally computed empty list, so
+      // returning that instead of reading the response would fail here.
+      .mockResolvedValueOnce(
+        jsonResponse({ iid: 9, state: "opened", assignees: [{ id: 8, username: "still-here" }] })
+      );
+    const assignees = await gitlabForgeProvider.unassignIssue(REPO, 9, "fixer");
+    expect(requestBody(fetchMock().mock.calls[1]).assignee_ids).toEqual([0]);
+    expect(assignees.map((u) => u.login)).toEqual(["still-here"]);
+  });
+
+  it("reports the current assignees without writing when not assigned", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ iid: 9, state: "opened", assignees: [{ id: 3, username: "someone" }] })
+    );
+    const assignees = await gitlabForgeProvider.unassignIssue(REPO, 9, "fixer");
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+    expect(assignees.map((u) => u.login)).toEqual(["someone"]);
+  });
+
   it("pins squash false on an explicit merge method", async () => {
     fetchMock().mockResolvedValue(jsonResponse({ iid: 5, state: "merged" }));
     await gitlabForgeProvider.mergePR(REPO, 5, { mergeMethod: "merge" });
@@ -393,6 +1115,80 @@ describe("mutations", () => {
     const comment = await gitlabForgeProvider.addIssueComment(REPO, 9, "Hello");
     expect(comment.url).toBe("https://gitlab.com/group/project/-/issues/9#note_501");
     expect(fetchMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it("anchors an MR comment on the merge-request route, not the issue route", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ id: 502, body: "LGTM", created_at: "2026-07-01T00:00:00Z" })
+    );
+    const comment = await gitlabForgeProvider.commentOnPR(REPO, 6, "LGTM");
+    expect(requestUrl(fetchMock().mock.calls[0])).toContain("/merge_requests/6/notes");
+    expect(comment.url).toBe("https://gitlab.com/group/project/-/merge_requests/6#note_502");
+    expect(comment.body).toBe("LGTM");
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * `parseRemote` and the URL builders are synchronous in the contract, so they
+ * read a cache the async settings read fills. `activate()` primes it; here any
+ * call that reads the setting does.
+ */
+async function primeInstanceCache(): Promise<void> {
+  fetchMock().mockResolvedValue(jsonResponse([]));
+  await gitlabForgeProvider.listIssues(REPO, {});
+  fetchMock().mockClear();
+}
+
+describe("self-hosted deployment path", () => {
+  // A relative install serves clone URLs under its deployment path, but the
+  // path is part of the instance base — not of the project namespace.
+  const PREFIXED = "https://code.example:8443/gitlab";
+
+  it("keeps the deployment prefix out of the project namespace", async () => {
+    setInstanceUrlReader(() => Promise.resolve(PREFIXED));
+    await primeInstanceCache();
+
+    const ref = gitlabForgeProvider.parseRemote("https://code.example:8443/gitlab/team/app.git");
+    expect(ref).toMatchObject({ host: "code.example", owner: "team", repo: "app" });
+  });
+
+  it("keeps the port and deployment prefix in browser URLs", async () => {
+    setInstanceUrlReader(() => Promise.resolve(PREFIXED));
+    await primeInstanceCache();
+
+    const ref = { host: "code.example", owner: "team", repo: "app", rawData: null };
+    // Plain `https://<host>/…` would drop both and hand the user a dead link.
+    expect(gitlabForgeProvider.buildIssueUrl(ref, 4)).toBe(
+      "https://code.example:8443/gitlab/team/app/-/issues/4"
+    );
+  });
+
+  // SSH remotes address the git service directly and never carry the web
+  // server's mount point, so their path IS the namespace.
+  it("does not strip the prefix from an ssh remote", async () => {
+    setInstanceUrlReader(() => Promise.resolve(PREFIXED));
+    await primeInstanceCache();
+
+    expect(
+      gitlabForgeProvider.parseRemote("ssh://git@code.example/gitlab/team/app.git")
+    ).toMatchObject({ owner: "gitlab/team", repo: "app" });
+    expect(gitlabForgeProvider.parseRemote("git@code.example:gitlab/team/app.git")).toMatchObject({
+      owner: "gitlab/team",
+      repo: "app",
+    });
+  });
+
+  it("leaves other GitLab hosts on plain https", async () => {
+    setInstanceUrlReader(() => Promise.resolve(PREFIXED));
+    await primeInstanceCache();
+
+    expect(gitlabForgeProvider.buildIssueUrl(REPO, 4)).toBe(
+      "https://gitlab.com/group/project/-/issues/4"
+    );
+    expect(gitlabForgeProvider.parseRemote("https://gitlab.com/gitlab/team/app.git")).toMatchObject(
+      { owner: "gitlab/team", repo: "app" }
+    );
   });
 });
 
@@ -478,8 +1274,7 @@ describe("URL builders", () => {
 
 describe("self-hosted base URL", () => {
   it("preserves the configured scheme, port, and path prefix for API calls", async () => {
-    setInstanceUrlReader(() => Promise.resolve("https://gitlab.internal.example:8443/gitlab"));
-    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-internal" });
+    await connectAs("https://gitlab.internal.example:8443/gitlab", "glpat-internal");
     fetchMock().mockImplementation(async () => jsonResponse([]));
 
     await gitlabForgeProvider.listIssues(SELF_HOSTED_REPO, {});
@@ -490,8 +1285,8 @@ describe("self-hosted base URL", () => {
   });
 
   it("withholds the token when the settings read fails (fail closed)", async () => {
+    await connectAs("https://gitlab.com", "glpat-secret");
     setInstanceUrlReader(() => Promise.reject(new Error("settings store unavailable")));
-    gitlabForgeProvider.setCredentials?.({ kind: "bearer", value: "glpat-secret" });
     fetchMock().mockImplementation(async () => jsonResponse([]));
 
     await gitlabForgeProvider.listIssues(REPO, {});

--- a/plugins/builtin/gitlab/main/__tests__/gitlabRemote.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/gitlabRemote.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeProjectId,
+  parseGitLabRemoteUrl,
+  repoFullPath,
+  repoWebUrl,
+} from "../gitlabRemote.js";
+
+describe("parseGitLabRemoteUrl", () => {
+  it("parses HTTPS clone URLs", () => {
+    expect(parseGitLabRemoteUrl("https://gitlab.com/group/project.git")).toEqual({
+      host: "gitlab.com",
+      owner: "group",
+      repo: "project",
+    });
+  });
+
+  it("parses HTTPS URLs without .git", () => {
+    expect(parseGitLabRemoteUrl("https://gitlab.com/group/project")).toEqual({
+      host: "gitlab.com",
+      owner: "group",
+      repo: "project",
+    });
+  });
+
+  it("parses SCP-style SSH remotes", () => {
+    expect(parseGitLabRemoteUrl("git@gitlab.com:group/project.git")).toEqual({
+      host: "gitlab.com",
+      owner: "group",
+      repo: "project",
+    });
+  });
+
+  it("parses ssh:// remotes with ports", () => {
+    expect(parseGitLabRemoteUrl("ssh://git@gitlab.example.com:2222/group/project.git")).toEqual({
+      host: "gitlab.example.com",
+      owner: "group",
+      repo: "project",
+    });
+  });
+
+  it("preserves nested subgroups in owner", () => {
+    expect(parseGitLabRemoteUrl("git@gitlab.com:group/subgroup/deeper/project.git")).toEqual({
+      host: "gitlab.com",
+      owner: "group/subgroup/deeper",
+      repo: "project",
+    });
+  });
+
+  it("parses self-hosted HTTPS remotes", () => {
+    expect(parseGitLabRemoteUrl("https://code.internal.example/team/app.git")).toEqual({
+      host: "code.internal.example",
+      owner: "team",
+      repo: "app",
+    });
+  });
+
+  it("cuts pasted web URLs at the /-/ route separator", () => {
+    expect(parseGitLabRemoteUrl("https://gitlab.com/group/project/-/merge_requests/42")).toEqual({
+      host: "gitlab.com",
+      owner: "group",
+      repo: "project",
+    });
+  });
+
+  it("lowercases the host but preserves path case", () => {
+    expect(parseGitLabRemoteUrl("https://GitLab.Com/Group/Project.git")).toEqual({
+      host: "gitlab.com",
+      owner: "Group",
+      repo: "Project",
+    });
+  });
+
+  it("rejects single-segment paths", () => {
+    expect(parseGitLabRemoteUrl("https://gitlab.com/group")).toBeNull();
+  });
+
+  it("rejects reserved leading segments", () => {
+    expect(parseGitLabRemoteUrl("https://gitlab.com/api/v4/projects")).toBeNull();
+    expect(parseGitLabRemoteUrl("https://gitlab.com/uploads/foo/bar")).toBeNull();
+  });
+
+  it("rejects empty and garbage input", () => {
+    expect(parseGitLabRemoteUrl("")).toBeNull();
+    expect(parseGitLabRemoteUrl("   ")).toBeNull();
+    expect(parseGitLabRemoteUrl("not a url at all")).toBeNull();
+  });
+});
+
+describe("project id helpers", () => {
+  const repo = { host: "gitlab.com", owner: "group/subgroup", repo: "project" };
+
+  it("builds the full namespace path", () => {
+    expect(repoFullPath(repo)).toBe("group/subgroup/project");
+  });
+
+  it("URL-encodes every slash for REST :id routes", () => {
+    expect(encodeProjectId(repo)).toBe("group%2Fsubgroup%2Fproject");
+  });
+
+  it("builds the web URL with slashes intact", () => {
+    expect(repoWebUrl(repo)).toBe("https://gitlab.com/group/subgroup/project");
+  });
+});

--- a/plugins/builtin/gitlab/main/__tests__/index.activate.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/index.activate.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginHostApi } from "../../../../../shared/types/plugin.js";
+
+const { authMock, readOpsMock, updateForgeCredentialsMock } = vi.hoisted(() => ({
+  authMock: {
+    getToken: vi.fn<() => string | null>(),
+    getTokenVersion: vi.fn(() => 0),
+    validateGitLabToken: vi.fn(),
+    setValidatedUserInfo: vi.fn(),
+    setInstanceUrlReader: vi.fn(),
+    setMemoryToken: vi.fn(),
+    markTokenHealthy: vi.fn(),
+    markTokenUnhealthy: vi.fn(),
+    // Present only because index.ts re-exports them from GitLabAuth.js — a
+    // mocked module must still provide every re-exported binding.
+    getInstanceUrl: vi.fn(),
+    getInstanceHost: vi.fn(),
+    GITLAB_API_TIMEOUT_MS: 15_000,
+    GITLAB_AUTH_TIMEOUT_MS: 10_000,
+  },
+  readOpsMock: { clearGitLabCaches: vi.fn() },
+  updateForgeCredentialsMock: vi.fn(),
+}));
+
+vi.mock("../GitLabAuth.js", () => authMock);
+vi.mock("../forgeProvider.js", () => ({ gitlabForgeProvider: {} }));
+vi.mock("../readOps.js", () => readOpsMock);
+vi.mock("../gitlabRemote.js", () => ({
+  parseGitLabRemoteUrl: vi.fn(),
+  repoFullPath: vi.fn(),
+  encodeProjectId: vi.fn(),
+}));
+vi.mock("../../../../../electron/services/WorkspaceClient.js", () => ({
+  getWorkspaceClient: () => ({ updateForgeCredentials: updateForgeCredentialsMock }),
+}));
+
+import { activate } from "../index.js";
+
+function makeHost(): PluginHostApi {
+  return {
+    registerForgeProvider: vi.fn(() => Promise.resolve(vi.fn())),
+    settings: { get: vi.fn(() => Promise.resolve(undefined)) },
+  } as unknown as PluginHostApi;
+}
+
+describe("gitlab plugin activate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.getToken.mockReturnValue(null);
+    authMock.getTokenVersion.mockReturnValue(0);
+  });
+
+  it("wires the instance-URL reader before registering the forge provider", async () => {
+    const host = makeHost();
+    const order: string[] = [];
+    authMock.setInstanceUrlReader.mockImplementation(() => order.push("reader"));
+    vi.mocked(host.registerForgeProvider).mockImplementation(() => {
+      order.push("provider");
+      return Promise.resolve(vi.fn());
+    });
+
+    await activate(host);
+
+    expect(order).toEqual(["reader", "provider"]);
+    expect(host.registerForgeProvider).toHaveBeenCalledWith({ id: "gitlab" }, expect.any(Object));
+  });
+
+  it("returns synchronously even while a stored-token validate hangs", async () => {
+    authMock.getToken.mockReturnValue("glpat-123");
+    authMock.validateGitLabToken.mockReturnValue(new Promise<never>(() => {}));
+
+    const dispose = await activate(makeHost());
+
+    expect(typeof dispose).toBe("function");
+    expect(authMock.validateGitLabToken).toHaveBeenCalledWith("glpat-123");
+  });
+
+  it("contains a rejected validate so it can't surface as an unhandled rejection", async () => {
+    authMock.getToken.mockReturnValue("glpat-123");
+    authMock.validateGitLabToken.mockRejectedValue(new Error("network down"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      await activate(makeHost());
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(unhandled).toHaveLength(0);
+      expect(authMock.setValidatedUserInfo).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("caches user info under the token version captured before validation", async () => {
+    authMock.getToken.mockReturnValue("glpat-123");
+    authMock.getTokenVersion.mockReturnValue(7);
+    authMock.validateGitLabToken.mockResolvedValue({
+      valid: true,
+      authoritative: true,
+      username: "dev",
+      scopes: ["api"],
+    });
+
+    await activate(makeHost());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(authMock.setValidatedUserInfo).toHaveBeenCalledWith(
+      { username: "dev", scopes: ["api"] },
+      7
+    );
+  });
+
+  it("pushes stored credentials to workspace hosts on activation", async () => {
+    authMock.getToken.mockReturnValue("glpat-123");
+    authMock.validateGitLabToken.mockResolvedValue({ valid: false, authoritative: false });
+
+    await activate(makeHost());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(updateForgeCredentialsMock).toHaveBeenCalledWith("daintree.gitlab.gitlab", {
+      kind: "bearer",
+      value: "glpat-123",
+    });
+  });
+
+  it("skips the credential push and validation when no token is stored", async () => {
+    await activate(makeHost());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(authMock.validateGitLabToken).not.toHaveBeenCalled();
+    expect(updateForgeCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  it("disposes the registration and clears caches on deactivate", async () => {
+    const disposeForge = vi.fn();
+    const host = makeHost();
+    vi.mocked(host.registerForgeProvider).mockResolvedValue(disposeForge);
+    const order: string[] = [];
+    authMock.setMemoryToken.mockImplementation(() => order.push("token"));
+    authMock.setInstanceUrlReader.mockImplementation((reader: unknown) => {
+      if (reader === null) order.push("reader");
+    });
+
+    const dispose = await activate(host);
+    dispose();
+
+    expect(disposeForge).toHaveBeenCalled();
+    expect(readOpsMock.clearGitLabCaches).toHaveBeenCalled();
+    // The token must be cleared BEFORE the settings reader goes away so a
+    // late request can't pair the token with the default-instance fallback.
+    expect(authMock.setMemoryToken).toHaveBeenCalledWith(null);
+    expect(order).toEqual(["token", "reader"]);
+  });
+});

--- a/plugins/builtin/gitlab/main/__tests__/index.activate.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/index.activate.test.ts
@@ -5,15 +5,19 @@ const { authMock, readOpsMock, updateForgeCredentialsMock } = vi.hoisted(() => (
   authMock: {
     getToken: vi.fn<() => string | null>(),
     getTokenVersion: vi.fn(() => 0),
-    validateGitLabToken: vi.fn(),
+    validateStoredGitLabToken: vi.fn(),
     setValidatedUserInfo: vi.fn(),
+    clearValidatedUserInfo: vi.fn(),
+    currentIdentityGeneration: vi.fn(() => 0),
+    setProvenanceAccessors: vi.fn(),
     setInstanceUrlReader: vi.fn(),
     setMemoryToken: vi.fn(),
     markTokenHealthy: vi.fn(),
     markTokenUnhealthy: vi.fn(),
-    // Present only because index.ts re-exports them from GitLabAuth.js — a
-    // mocked module must still provide every re-exported binding.
-    getInstanceUrl: vi.fn(),
+    // activate() awaits this to prime the synchronous instance cache the URL
+    // builders read; getInstanceHost is here only because index.ts re-exports
+    // it, and a mocked module must still provide every re-exported binding.
+    getInstanceUrl: vi.fn(() => Promise.resolve("https://gitlab.com")),
     getInstanceHost: vi.fn(),
     GITLAB_API_TIMEOUT_MS: 15_000,
     GITLAB_AUTH_TIMEOUT_MS: 10_000,
@@ -39,7 +43,15 @@ import { activate } from "../index.js";
 function makeHost(): PluginHostApi {
   return {
     registerForgeProvider: vi.fn(() => Promise.resolve(vi.fn())),
-    settings: { get: vi.fn(() => Promise.resolve(undefined)) },
+    settings: {
+      get: vi.fn(() => Promise.resolve(undefined)),
+      onDidChange: vi.fn(() => Promise.resolve(vi.fn())),
+    },
+    storage: {
+      get: vi.fn(() => Promise.resolve(undefined)),
+      set: vi.fn(() => Promise.resolve()),
+      delete: vi.fn(() => Promise.resolve()),
+    },
   } as unknown as PluginHostApi;
 }
 
@@ -67,17 +79,17 @@ describe("gitlab plugin activate", () => {
 
   it("returns synchronously even while a stored-token validate hangs", async () => {
     authMock.getToken.mockReturnValue("glpat-123");
-    authMock.validateGitLabToken.mockReturnValue(new Promise<never>(() => {}));
+    authMock.validateStoredGitLabToken.mockReturnValue(new Promise<never>(() => {}));
 
     const dispose = await activate(makeHost());
 
     expect(typeof dispose).toBe("function");
-    expect(authMock.validateGitLabToken).toHaveBeenCalledWith("glpat-123");
+    expect(authMock.validateStoredGitLabToken).toHaveBeenCalledWith("glpat-123");
   });
 
   it("contains a rejected validate so it can't surface as an unhandled rejection", async () => {
     authMock.getToken.mockReturnValue("glpat-123");
-    authMock.validateGitLabToken.mockRejectedValue(new Error("network down"));
+    authMock.validateStoredGitLabToken.mockRejectedValue(new Error("network down"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const unhandled: unknown[] = [];
     const onUnhandled = (reason: unknown): void => {
@@ -98,10 +110,13 @@ describe("gitlab plugin activate", () => {
     }
   });
 
-  it("caches user info under the token version captured before validation", async () => {
+  it("caches user info under the token version and identity generation captured before validation", async () => {
     authMock.getToken.mockReturnValue("glpat-123");
     authMock.getTokenVersion.mockReturnValue(7);
-    authMock.validateGitLabToken.mockResolvedValue({
+    // An instance change bumps this, so a validation that started before it
+    // can't repopulate the identity of an account on the previous server.
+    authMock.currentIdentityGeneration.mockReturnValue(3);
+    authMock.validateStoredGitLabToken.mockResolvedValue({
       valid: true,
       authoritative: true,
       username: "dev",
@@ -113,13 +128,14 @@ describe("gitlab plugin activate", () => {
 
     expect(authMock.setValidatedUserInfo).toHaveBeenCalledWith(
       { username: "dev", scopes: ["api"] },
-      7
+      7,
+      3
     );
   });
 
   it("pushes stored credentials to workspace hosts on activation", async () => {
     authMock.getToken.mockReturnValue("glpat-123");
-    authMock.validateGitLabToken.mockResolvedValue({ valid: false, authoritative: false });
+    authMock.validateStoredGitLabToken.mockResolvedValue({ valid: false, authoritative: false });
 
     await activate(makeHost());
     await new Promise((resolve) => setImmediate(resolve));
@@ -134,7 +150,7 @@ describe("gitlab plugin activate", () => {
     await activate(makeHost());
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(authMock.validateGitLabToken).not.toHaveBeenCalled();
+    expect(authMock.validateStoredGitLabToken).not.toHaveBeenCalled();
     expect(updateForgeCredentialsMock).not.toHaveBeenCalled();
   });
 

--- a/plugins/builtin/gitlab/main/__tests__/mappers.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/mappers.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import {
+  absolutizeAvatarUrl,
+  gitlabIssueToForgeIssue,
+  gitlabLabelsToForgeLabels,
+  gitlabReleaseToForgeRelease,
+  graphqlMergeRequestToForgePR,
+  isDraftMergeRequest,
+  mergeRequestToForgePR,
+  normalizeGitLabMRState,
+  pipelineStatusToCIState,
+  stripDraftPrefix,
+} from "../mappers.js";
+import type { GitLabMergeRequest } from "../../shared/types.js";
+
+const HOST = "gitlab.com";
+
+function baseMR(overrides: Partial<GitLabMergeRequest> = {}): GitLabMergeRequest {
+  return {
+    id: 1000,
+    iid: 42,
+    title: "Add feature",
+    description: "Body text",
+    state: "opened",
+    draft: false,
+    web_url: "https://gitlab.com/group/project/-/merge_requests/42",
+    author: { id: 7, username: "dev", avatar_url: "https://gitlab.com/avatar.png" },
+    source_branch: "feature/thing",
+    target_branch: "main",
+    user_notes_count: 3,
+    created_at: "2026-07-01T10:00:00Z",
+    updated_at: "2026-07-02T10:00:00Z",
+    closed_at: null,
+    merged_at: null,
+    ...overrides,
+  };
+}
+
+describe("MR state normalization", () => {
+  it("maps the four GitLab states", () => {
+    expect(normalizeGitLabMRState("opened")).toBe("open");
+    expect(normalizeGitLabMRState("merged")).toBe("merged");
+    expect(normalizeGitLabMRState("closed")).toBe("closed");
+    expect(normalizeGitLabMRState("locked")).toBe("open");
+  });
+});
+
+describe("draft detection", () => {
+  it("honors the boolean draft field", () => {
+    expect(isDraftMergeRequest({ draft: true, title: "Anything" })).toBe(true);
+  });
+
+  it("honors the legacy work_in_progress field", () => {
+    expect(isDraftMergeRequest({ work_in_progress: true, title: "Anything" })).toBe(true);
+  });
+
+  it("falls back to title conventions on old instances", () => {
+    expect(isDraftMergeRequest({ title: "Draft: thing" })).toBe(true);
+    expect(isDraftMergeRequest({ title: "[Draft] thing" })).toBe(true);
+    expect(isDraftMergeRequest({ title: "WIP: thing" })).toBe(true);
+    expect(isDraftMergeRequest({ title: "[WIP] thing" })).toBe(true);
+    expect(isDraftMergeRequest({ title: "(WIP) thing" })).toBe(true);
+    expect(isDraftMergeRequest({ title: "Drafting a doc" })).toBe(false);
+  });
+
+  it("strips stacked draft prefixes", () => {
+    expect(stripDraftPrefix("Draft: WIP: thing")).toBe("thing");
+    expect(stripDraftPrefix("[Draft] thing")).toBe("thing");
+    expect(stripDraftPrefix("[WIP] thing")).toBe("thing");
+    expect(stripDraftPrefix("(WIP) thing")).toBe("thing");
+    expect(stripDraftPrefix("thing")).toBe("thing");
+  });
+});
+
+describe("pipelineStatusToCIState", () => {
+  it("maps terminal and in-flight statuses", () => {
+    expect(pipelineStatusToCIState("success")).toBe("success");
+    expect(pipelineStatusToCIState("failed")).toBe("failure");
+    expect(pipelineStatusToCIState("running")).toBe("pending");
+    expect(pipelineStatusToCIState("created")).toBe("pending");
+    expect(pipelineStatusToCIState("canceled")).toBe("neutral");
+    expect(pipelineStatusToCIState("skipped")).toBe("neutral");
+    expect(pipelineStatusToCIState("manual")).toBe("neutral");
+    expect(pipelineStatusToCIState("something-new")).toBe("unknown");
+    expect(pipelineStatusToCIState(undefined)).toBeUndefined();
+  });
+});
+
+describe("mergeRequestToForgePR", () => {
+  it("numbers by iid, not the global id", () => {
+    const pr = mergeRequestToForgePR(baseMR(), HOST);
+    expect(pr.number).toBe(42);
+  });
+
+  it("maps branches, comment count, and timestamps", () => {
+    const pr = mergeRequestToForgePR(baseMR(), HOST);
+    expect(pr.headRef).toBe("feature/thing");
+    expect(pr.baseRef).toBe("main");
+    expect(pr.commentCount).toBe(3);
+    expect(pr.createdAt).toBe(Date.parse("2026-07-01T10:00:00Z"));
+    expect(pr.state).toBe("open");
+    expect(pr.merged).toBe(false);
+  });
+
+  it("treats merged_at as authoritative for merged state", () => {
+    const pr = mergeRequestToForgePR(
+      baseMR({ state: "merged", merged_at: "2026-07-03T10:00:00Z" }),
+      HOST
+    );
+    expect(pr.state).toBe("merged");
+    expect(pr.merged).toBe(true);
+    expect(pr.mergedAt).toBe(Date.parse("2026-07-03T10:00:00Z"));
+  });
+
+  it("derives mergeable from detailed_merge_status", () => {
+    expect(
+      mergeRequestToForgePR(baseMR({ detailed_merge_status: "mergeable" }), HOST).mergeable
+    ).toBe(true);
+    expect(
+      mergeRequestToForgePR(baseMR({ detailed_merge_status: "conflicts" }), HOST).mergeable
+    ).toBe(false);
+    expect(
+      mergeRequestToForgePR(baseMR({ detailed_merge_status: "checking" }), HOST).mergeable
+    ).toBeNull();
+    expect(
+      mergeRequestToForgePR(baseMR({ detailed_merge_status: "preparing" }), HOST).mergeable
+    ).toBeNull();
+    expect(mergeRequestToForgePR(baseMR(), HOST).mergeable).toBeNull();
+  });
+
+  it("maps the head pipeline into ciStatus", () => {
+    const pr = mergeRequestToForgePR(baseMR({ head_pipeline: { status: "failed" } }), HOST);
+    expect(pr.ciStatus).toBe("failure");
+  });
+
+  it("preserves the verbatim state as rawState", () => {
+    const pr = mergeRequestToForgePR(baseMR({ state: "locked" }), HOST);
+    expect(pr.rawState).toBe("locked");
+    expect(pr.state).toBe("open");
+  });
+});
+
+describe("gitlabIssueToForgeIssue", () => {
+  it("maps iid, labels, assignees, and state", () => {
+    const issue = gitlabIssueToForgeIssue(
+      {
+        id: 900,
+        iid: 7,
+        title: "Bug",
+        description: "It breaks",
+        state: "opened",
+        web_url: "https://gitlab.com/group/project/-/issues/7",
+        author: { id: 1, username: "reporter" },
+        assignees: [{ id: 2, username: "fixer", avatar_url: "/uploads/a.png" }],
+        labels: ["bug", "p1"],
+        user_notes_count: 5,
+        created_at: "2026-07-01T00:00:00Z",
+        updated_at: "2026-07-02T00:00:00Z",
+        closed_at: null,
+      },
+      "gitlab.example.com"
+    );
+    expect(issue.number).toBe(7);
+    expect(issue.state).toBe("open");
+    expect(issue.labels).toEqual([{ name: "bug" }, { name: "p1" }]);
+    expect(issue.assignees[0].login).toBe("fixer");
+    expect(issue.assignees[0].avatarUrl).toBe("https://gitlab.example.com/uploads/a.png");
+    expect(issue.commentCount).toBe(5);
+  });
+});
+
+describe("absolutizeAvatarUrl", () => {
+  it("passes absolute URLs through and prefixes host-relative ones", () => {
+    expect(absolutizeAvatarUrl("https://cdn.example/a.png", HOST)).toBe(
+      "https://cdn.example/a.png"
+    );
+    expect(absolutizeAvatarUrl("/uploads/a.png", "gitlab.example.com")).toBe(
+      "https://gitlab.example.com/uploads/a.png"
+    );
+    expect(absolutizeAvatarUrl(undefined, HOST)).toBeUndefined();
+    expect(absolutizeAvatarUrl("", HOST)).toBeUndefined();
+  });
+});
+
+describe("gitlabLabelsToForgeLabels", () => {
+  it("keeps only string names", () => {
+    expect(gitlabLabelsToForgeLabels(["bug", 3, null, "ux"])).toEqual([
+      { name: "bug" },
+      { name: "ux" },
+    ]);
+    expect(gitlabLabelsToForgeLabels(undefined)).toEqual([]);
+  });
+});
+
+describe("gitlabReleaseToForgeRelease", () => {
+  const repo = { host: "gitlab.com", owner: "group", repo: "project" };
+
+  it("maps tag, body, and published date", () => {
+    const release = gitlabReleaseToForgeRelease(
+      {
+        tag_name: "v1.2.0",
+        name: "v1.2.0",
+        description: "Notes",
+        released_at: "2026-06-01T00:00:00Z",
+        created_at: "2026-05-31T00:00:00Z",
+        _links: { self: "https://gitlab.com/group/project/-/releases/v1.2.0" },
+      },
+      repo
+    );
+    expect(release.tagName).toBe("v1.2.0");
+    expect(release.publishedAt).toBe(Date.parse("2026-06-01T00:00:00Z"));
+    expect(release.isDraft).toBe(false);
+    expect(release.url).toBe("https://gitlab.com/group/project/-/releases/v1.2.0");
+  });
+
+  it("builds the release URL when _links is missing", () => {
+    const release = gitlabReleaseToForgeRelease({ tag_name: "v1.0.0" }, repo);
+    expect(release.url).toBe("https://gitlab.com/group/project/-/releases/v1.0.0");
+  });
+});
+
+describe("graphqlMergeRequestToForgePR", () => {
+  it("parses the string iid and camelCase fields", () => {
+    const pr = graphqlMergeRequestToForgePR(
+      {
+        iid: "42",
+        title: "Draft: thing",
+        description: "Body",
+        state: "opened",
+        draft: true,
+        sourceBranch: "feature/x",
+        targetBranch: "main",
+        webUrl: "https://gitlab.com/g/p/-/merge_requests/42",
+        createdAt: "2026-07-01T00:00:00Z",
+        updatedAt: "2026-07-02T00:00:00Z",
+        author: { username: "dev", avatarUrl: "/uploads/a.png" },
+        headPipeline: { status: "SUCCESS" },
+      },
+      "gitlab.com"
+    );
+    expect(pr).not.toBeNull();
+    expect(pr?.number).toBe(42);
+    expect(pr?.isDraft).toBe(true);
+    expect(pr?.headRef).toBe("feature/x");
+    expect(pr?.ciStatus).toBe("success");
+    expect(pr?.author?.avatarUrl).toBe("https://gitlab.com/uploads/a.png");
+  });
+
+  it("returns null for nodes without a usable iid", () => {
+    expect(graphqlMergeRequestToForgePR({ iid: "not-a-number" }, HOST)).toBeNull();
+    expect(graphqlMergeRequestToForgePR({}, HOST)).toBeNull();
+  });
+});

--- a/plugins/builtin/gitlab/main/__tests__/mappers.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/mappers.test.ts
@@ -11,6 +11,7 @@ import {
   pipelineStatusToCIState,
   stripDraftPrefix,
 } from "../mappers.js";
+import { getInstanceUrl, resetAuthStateForTests, setInstanceUrlReader } from "../GitLabAuth.js";
 import type { GitLabMergeRequest } from "../../shared/types.js";
 
 const HOST = "gitlab.com";
@@ -54,21 +55,59 @@ describe("draft detection", () => {
     expect(isDraftMergeRequest({ work_in_progress: true, title: "Anything" })).toBe(true);
   });
 
-  it("falls back to title conventions on old instances", () => {
+  // The booleans are derived server-side from the title, so a present `false`
+  // is the server disagreeing with what the title looks like — and it wins.
+  it("lets an explicit false override a draft-looking title", () => {
+    expect(isDraftMergeRequest({ draft: false, title: "Draft: thing" })).toBe(false);
+    expect(isDraftMergeRequest({ work_in_progress: false, title: "[Draft] thing" })).toBe(false);
+  });
+
+  it("falls back to title conventions only when neither boolean is present", () => {
     expect(isDraftMergeRequest({ title: "Draft: thing" })).toBe(true);
     expect(isDraftMergeRequest({ title: "[Draft] thing" })).toBe(true);
-    expect(isDraftMergeRequest({ title: "WIP: thing" })).toBe(true);
-    expect(isDraftMergeRequest({ title: "[WIP] thing" })).toBe(true);
-    expect(isDraftMergeRequest({ title: "(WIP) thing" })).toBe(true);
+    expect(isDraftMergeRequest({ title: "(Draft) thing" })).toBe(true);
+    expect(isDraftMergeRequest({ title: "Draft - thing" })).toBe(true);
+    expect(isDraftMergeRequest({ title: "draft: lowercase" })).toBe(true);
     expect(isDraftMergeRequest({ title: "Drafting a doc" })).toBe(false);
   });
 
+  // GitLab removed WIP: in 14.8, so a WIP-titled MR is an ordinary open one.
+  // Calling it a draft would make "convert to draft" a silent no-op.
+  it("does not treat the removed WIP prefix as a draft", () => {
+    expect(isDraftMergeRequest({ title: "WIP: thing" })).toBe(false);
+    expect(isDraftMergeRequest({ title: "[WIP] thing" })).toBe(false);
+    expect(stripDraftPrefix("WIP: thing")).toBe("WIP: thing");
+  });
+
   it("strips stacked draft prefixes", () => {
-    expect(stripDraftPrefix("Draft: WIP: thing")).toBe("thing");
+    expect(stripDraftPrefix("Draft: [Draft] thing")).toBe("thing");
     expect(stripDraftPrefix("[Draft] thing")).toBe("thing");
-    expect(stripDraftPrefix("[WIP] thing")).toBe("thing");
-    expect(stripDraftPrefix("(WIP) thing")).toBe("thing");
+    expect(stripDraftPrefix("(Draft) thing")).toBe("thing");
+    expect(stripDraftPrefix("Draft - thing")).toBe("thing");
     expect(stripDraftPrefix("thing")).toBe("thing");
+  });
+});
+
+describe("mergeableFromMR via mergeRequestToForgePR", () => {
+  const mr = (detailed_merge_status: string): GitLabMergeRequest => ({
+    iid: 1,
+    state: "opened",
+    detailed_merge_status,
+  });
+
+  it("reports the computing states as not-yet-known, not as blocked", () => {
+    // A merge button disabled for a reason GitLab hasn't established yet is
+    // worse than one that says "checking".
+    for (const status of ["checking", "unchecked", "preparing", "approvals_syncing"]) {
+      expect(mergeRequestToForgePR(mr(status), HOST).mergeable).toBeNull();
+    }
+  });
+
+  it("separates mergeable from the blocked states", () => {
+    expect(mergeRequestToForgePR(mr("mergeable"), HOST).mergeable).toBe(true);
+    for (const status of ["conflict", "ci_must_pass", "draft_status", "not_approved"]) {
+      expect(mergeRequestToForgePR(mr(status), HOST).mergeable).toBe(false);
+    }
   });
 });
 
@@ -174,11 +213,26 @@ describe("absolutizeAvatarUrl", () => {
     expect(absolutizeAvatarUrl("https://cdn.example/a.png", HOST)).toBe(
       "https://cdn.example/a.png"
     );
+    // Not the configured instance, so plain https on the default port.
     expect(absolutizeAvatarUrl("/uploads/a.png", "gitlab.example.com")).toBe(
       "https://gitlab.example.com/uploads/a.png"
     );
     expect(absolutizeAvatarUrl(undefined, HOST)).toBeUndefined();
     expect(absolutizeAvatarUrl("", HOST)).toBeUndefined();
+  });
+
+  it("resolves against the configured origin for a self-hosted instance", async () => {
+    setInstanceUrlReader(() => Promise.resolve("http://code.example:8443/gitlab"));
+    await getInstanceUrl();
+    try {
+      // The scheme and port come from the instance, not a hardcoded https.
+      expect(absolutizeAvatarUrl("/uploads/a.png", "code.example")).toBe(
+        "http://code.example:8443/uploads/a.png"
+      );
+    } finally {
+      setInstanceUrlReader(null);
+      resetAuthStateForTests();
+    }
   });
 });
 
@@ -249,5 +303,21 @@ describe("graphqlMergeRequestToForgePR", () => {
   it("returns null for nodes without a usable iid", () => {
     expect(graphqlMergeRequestToForgePR({ iid: "not-a-number" }, HOST)).toBeNull();
     expect(graphqlMergeRequestToForgePR({}, HOST)).toBeNull();
+  });
+
+  // Same precedence as the REST mapper: the server's boolean is derived from
+  // the title, so a present `false` is authoritative and the title loses.
+  it("lets an explicit draft:false override a draft-looking title", () => {
+    const node = { iid: "3", title: "Draft: thing", draft: false };
+    expect(graphqlMergeRequestToForgePR(node, HOST)?.isDraft).toBe(false);
+  });
+
+  it("falls back to the title when the node carries no draft field", () => {
+    expect(graphqlMergeRequestToForgePR({ iid: "3", title: "Draft: thing" }, HOST)?.isDraft).toBe(
+      true
+    );
+    expect(graphqlMergeRequestToForgePR({ iid: "3", title: "WIP: thing" }, HOST)?.isDraft).toBe(
+      false
+    );
   });
 });

--- a/plugins/builtin/gitlab/main/__tests__/mappers.test.ts
+++ b/plugins/builtin/gitlab/main/__tests__/mappers.test.ts
@@ -156,7 +156,7 @@ describe("mergeRequestToForgePR", () => {
       mergeRequestToForgePR(baseMR({ detailed_merge_status: "mergeable" }), HOST).mergeable
     ).toBe(true);
     expect(
-      mergeRequestToForgePR(baseMR({ detailed_merge_status: "conflicts" }), HOST).mergeable
+      mergeRequestToForgePR(baseMR({ detailed_merge_status: "conflict" }), HOST).mergeable
     ).toBe(false);
     expect(
       mergeRequestToForgePR(baseMR({ detailed_merge_status: "checking" }), HOST).mergeable

--- a/plugins/builtin/gitlab/main/forgeProvider.ts
+++ b/plugins/builtin/gitlab/main/forgeProvider.ts
@@ -1,0 +1,310 @@
+import type {
+  AuthValidation,
+  Credentials,
+  ForgeProviderImpl,
+  ForgeUser,
+  HealthEventsCapability,
+  IdentityCapability,
+  RateLimitDetails,
+  ReleaseCapability,
+  RepoRef,
+  RepoStatsCapability,
+  TooltipCapability,
+} from "../../../../shared/types/forge.js";
+import {
+  getInstanceHost,
+  getToken,
+  getTokenHealth,
+  getTokenVersion,
+  getValidatedUserInfo,
+  onTokenHealthChanged,
+  refreshTokenHealth,
+  setMemoryToken,
+  setValidatedUserInfo,
+  validateGitLabToken,
+} from "./GitLabAuth.js";
+import { getRateLimitSnapshot } from "./GitLabClient.js";
+import { parseGitLabRemoteUrl, repoWebUrl } from "./gitlabRemote.js";
+import {
+  clearGitLabCaches,
+  findPRByBranchImpl,
+  findPRsByBranchesImpl,
+  getCIStatusImpl,
+  getIssueImpl,
+  getIssueTooltipImpl,
+  getLatestReleaseImpl,
+  getPRImpl,
+  getPRTooltipImpl,
+  getRateLimitImpl,
+  getRepoMetadataImpl,
+  getRepoStatsImpl,
+  listIssuesImpl,
+  listPRsImpl,
+  listReleasesImpl,
+  resolveAuthorAvatarImpl,
+} from "./readOps.js";
+import {
+  addIssueCommentImpl,
+  addIssueLabelImpl,
+  assignIssueImpl,
+  closeIssueImpl,
+  closePRImpl,
+  commentOnPRImpl,
+  convertPRToDraftImpl,
+  createIssueImpl,
+  createPRImpl,
+  editIssueImpl,
+  editPRImpl,
+  markPRReadyForReviewImpl,
+  mergePRImpl,
+  removeIssueLabelImpl,
+  reopenIssueImpl,
+  reopenPRImpl,
+  unassignIssueImpl,
+} from "./mutations.js";
+
+function toAuthValidation(result: Awaited<ReturnType<typeof validateGitLabToken>>): AuthValidation {
+  return {
+    valid: result.valid,
+    ...(result.scopes ? { scopes: result.scopes } : {}),
+    // Absent = expiry unknown (introspection unavailable); explicit null =
+    // confirmed non-expiring. Don't collapse unknown into "never expires".
+    ...(result.expiresAt !== undefined ? { expiresAt: result.expiresAt } : {}),
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+const identityCapability: IdentityCapability = {
+  /**
+   * Cached "who am I" against the configured instance. Validates lazily on
+   * the first call after a token change and caches the result under the
+   * token version, so repeated calls don't re-hit `/user`.
+   */
+  async getCurrentUser(): Promise<ForgeUser | null> {
+    const token = getToken();
+    if (!token) return null;
+    const cached = getValidatedUserInfo();
+    if (cached) {
+      return {
+        login: cached.username,
+        ...(cached.avatarUrl ? { avatarUrl: cached.avatarUrl } : {}),
+        rawData: { source: "GitLabAuth.cached" },
+      };
+    }
+    const versionAtStart = getTokenVersion();
+    const result = await validateGitLabToken(token);
+    if (!result.valid || !result.username) return null;
+    setValidatedUserInfo(
+      {
+        username: result.username,
+        ...(result.avatarUrl ? { avatarUrl: result.avatarUrl } : {}),
+        ...(result.scopes ? { scopes: result.scopes } : {}),
+      },
+      versionAtStart
+    );
+    return {
+      login: result.username,
+      ...(result.avatarUrl ? { avatarUrl: result.avatarUrl } : {}),
+      rawData: { source: "GitLabAuth.validated" },
+    };
+  },
+};
+
+const tooltipCapability: TooltipCapability = {
+  getIssueTooltip: getIssueTooltipImpl,
+  getPRTooltip: getPRTooltipImpl,
+};
+
+const releaseCapability: ReleaseCapability = {
+  listReleases: listReleasesImpl,
+  getLatestRelease: getLatestReleaseImpl,
+};
+
+const repoStatsCapability: RepoStatsCapability = {
+  getRepoStats: getRepoStatsImpl,
+};
+
+const healthEventsCapability: HealthEventsCapability = {
+  getTokenHealth,
+  onTokenHealthChanged,
+  refreshTokenHealth,
+
+  /**
+   * GitLab reports one per-user REST quota via `RateLimit-*` headers rather
+   * than named buckets; project the configured instance's last-seen snapshot
+   * as a single bucket, or `null` before any request has observed the
+   * headers. `fetchedAt` is the real capture time, not the call time.
+   */
+  async getRateLimitDetails(): Promise<RateLimitDetails | null> {
+    const snapshot = getRateLimitSnapshot(await getInstanceHost());
+    if (!snapshot) return null;
+    const { info, fetchedAt } = snapshot;
+    if (info.limit === null || info.remaining === null || info.resetAt === null) {
+      return null;
+    }
+    return {
+      buckets: [
+        {
+          name: "rest",
+          limit: info.limit,
+          used: info.limit - info.remaining,
+          remaining: info.remaining,
+          resetAt: info.resetAt,
+        },
+      ],
+      fetchedAt,
+    };
+  },
+};
+
+// No clone capability in v1: the host's fallback is a plain anonymous
+// `git clone`, which is the safe default. A token-embedded clone URL would
+// persist the PAT into `.git/config` via `remote.origin.url` — authenticated
+// clone needs an askpass-style flow (see the GitHub plugin's `gh repo clone`
+// path) and is deliberately deferred.
+
+function listUrl(
+  repo: RepoRef,
+  kind: "issues" | "merge_requests",
+  options?: { query?: string; state?: string }
+): string {
+  const base = `${repoWebUrl(repo)}/-/${kind}`;
+  const params = new URLSearchParams();
+  if (options?.query) params.set("search", options.query);
+  if (options?.state && options.state !== "all") {
+    params.set("state", options.state === "open" ? "opened" : options.state);
+  }
+  const qs = params.toString();
+  return qs.length > 0 ? `${base}/?${qs}` : base;
+}
+
+export const gitlabForgeProvider: ForgeProviderImpl = {
+  async getCredentials(): Promise<Credentials | null> {
+    const token = getToken();
+    if (!token) return null;
+    return { kind: "bearer", value: token };
+  },
+
+  setCredentials(credentials: Credentials | null): void {
+    const before = getTokenVersion();
+    if (credentials === null) {
+      setMemoryToken(null);
+    } else if (credentials.kind === "bearer") {
+      setMemoryToken(credentials.value);
+    }
+    // Non-bearer credentials are silently ignored — GitLab tokens are bearer.
+    // A credential change invalidates everything fetched under the old one
+    // (private tooltips, stats, instance-scoped avatars).
+    if (getTokenVersion() !== before) {
+      clearGitLabCaches();
+    }
+  },
+
+  async validateCredentials(): Promise<AuthValidation> {
+    const token = getToken();
+    if (!token) {
+      return { valid: false, error: "No GitLab token configured" };
+    }
+    const versionAtStart = getTokenVersion();
+    const result = await validateGitLabToken(token);
+    if (result.valid && result.username) {
+      setValidatedUserInfo(
+        {
+          username: result.username,
+          ...(result.avatarUrl ? { avatarUrl: result.avatarUrl } : {}),
+          ...(result.scopes ? { scopes: result.scopes } : {}),
+        },
+        versionAtStart
+      );
+    }
+    return toAuthValidation(result);
+  },
+
+  parseRemote(url: string): RepoRef | null {
+    // Host-agnostic on purpose: routing (manifest hostnames, per-project
+    // override, global default) happens before parseRemote, so a self-hosted
+    // GitLab remote parses here and the REST base derives from its host.
+    const parsed = parseGitLabRemoteUrl(url);
+    if (!parsed) return null;
+    return {
+      host: parsed.host,
+      owner: parsed.owner,
+      repo: parsed.repo,
+      rawData: { url },
+    };
+  },
+
+  listIssues: listIssuesImpl,
+  listPRs: listPRsImpl,
+  getIssue: getIssueImpl,
+  getPR: getPRImpl,
+  findPRByBranch: findPRByBranchImpl,
+  findPRsByBranches: findPRsByBranchesImpl,
+  getCIStatus: getCIStatusImpl,
+  getRepoMetadata: getRepoMetadataImpl,
+
+  buildIssueUrl(repo: RepoRef, number: number): string {
+    return `${repoWebUrl(repo)}/-/issues/${number}`;
+  },
+
+  buildPRUrl(repo: RepoRef, number: number): string {
+    return `${repoWebUrl(repo)}/-/merge_requests/${number}`;
+  },
+
+  buildIssuesUrl(repo: RepoRef, options?: { query?: string; state?: string }): string {
+    return listUrl(repo, "issues", options);
+  },
+
+  buildPRsUrl(repo: RepoRef, options?: { query?: string; state?: string }): string {
+    return listUrl(repo, "merge_requests", options);
+  },
+
+  buildCommitsUrl(repo: RepoRef, branch?: string): string {
+    const base = `${repoWebUrl(repo)}/-/commits`;
+    return branch ? `${base}/${encodeURIComponent(branch)}` : base;
+  },
+
+  createIssue: createIssueImpl,
+  assignIssue: assignIssueImpl,
+  unassignIssue: unassignIssueImpl,
+  createPR: createPRImpl,
+  closePR: closePRImpl,
+  reopenPR: reopenPRImpl,
+  mergePR: mergePRImpl,
+  convertPRToDraft: convertPRToDraftImpl,
+  markPRReadyForReview: markPRReadyForReviewImpl,
+  commentOnPR: commentOnPRImpl,
+  editPR: editPRImpl,
+  closeIssue: closeIssueImpl,
+  reopenIssue: reopenIssueImpl,
+  editIssue: editIssueImpl,
+  addIssueComment: addIssueCommentImpl,
+  addIssueLabel: addIssueLabelImpl,
+  removeIssueLabel: removeIssueLabelImpl,
+
+  async validateToken(token: string): Promise<AuthValidation> {
+    if (!token || !token.trim()) {
+      return { valid: false, error: "Token is required" };
+    }
+    const result = await validateGitLabToken(token.trim());
+    return toAuthValidation(result);
+  },
+
+  getRateLimit: getRateLimitImpl,
+
+  clearPullRequestCaches(): void {
+    clearGitLabCaches();
+  },
+
+  identity: identityCapability,
+  tooltips: tooltipCapability,
+  releases: releaseCapability,
+  repoStats: repoStatsCapability,
+  healthEvents: healthEventsCapability,
+
+  avatars: {
+    async resolveAuthorAvatar(email: string): Promise<string | null> {
+      return resolveAuthorAvatarImpl(await getInstanceHost(), email);
+    },
+  },
+};

--- a/plugins/builtin/gitlab/main/forgeProvider.ts
+++ b/plugins/builtin/gitlab/main/forgeProvider.ts
@@ -274,6 +274,21 @@ export const gitlabForgeProvider: ForgeProviderImpl = {
     return branch ? `${base}/${encodeURIComponent(branch)}` : base;
   },
 
+  /**
+   * GitLab publishes merge-request heads under `refs/merge-requests/<iid>/head`,
+   * not GitHub's `pull/<n>/head`, so without this the host's default refspec
+   * fails with "couldn't find remote ref" on any MR whose source branch isn't
+   * already local (a fork MR, or one never fetched).
+   *
+   * Fully qualified on purpose: `merge-requests/` is not one of the hierarchies
+   * git expands on its own, so the bare form would not resolve. `prNumber` is
+   * the project-scoped `iid` the MR's URL shows, which is what this provider
+   * numbers merge requests by throughout.
+   */
+  buildPRHeadRefspec(prNumber: number, headRefName: string): string {
+    return `refs/merge-requests/${prNumber}/head:${headRefName}`;
+  },
+
   createIssue: createIssueImpl,
   assignIssue: assignIssueImpl,
   unassignIssue: unassignIssueImpl,

--- a/plugins/builtin/gitlab/main/forgeProvider.ts
+++ b/plugins/builtin/gitlab/main/forgeProvider.ts
@@ -15,6 +15,7 @@ import {
   getInstanceHost,
   getToken,
   getTokenHealth,
+  currentIdentityGeneration,
   getTokenVersion,
   getValidatedUserInfo,
   onTokenHealthChanged,
@@ -22,6 +23,7 @@ import {
   setMemoryToken,
   setValidatedUserInfo,
   validateGitLabToken,
+  validateStoredGitLabToken,
 } from "./GitLabAuth.js";
 import { getRateLimitSnapshot } from "./GitLabClient.js";
 import { parseGitLabRemoteUrl, repoWebUrl } from "./gitlabRemote.js";
@@ -91,8 +93,10 @@ const identityCapability: IdentityCapability = {
         rawData: { source: "GitLabAuth.cached" },
       };
     }
+
     const versionAtStart = getTokenVersion();
-    const result = await validateGitLabToken(token);
+    const identityAtStart = currentIdentityGeneration();
+    const result = await validateStoredGitLabToken(token);
     if (!result.valid || !result.username) return null;
     setValidatedUserInfo(
       {
@@ -100,7 +104,8 @@ const identityCapability: IdentityCapability = {
         ...(result.avatarUrl ? { avatarUrl: result.avatarUrl } : {}),
         ...(result.scopes ? { scopes: result.scopes } : {}),
       },
-      versionAtStart
+      versionAtStart,
+      identityAtStart
     );
     return {
       login: result.username,
@@ -195,6 +200,9 @@ export const gitlabForgeProvider: ForgeProviderImpl = {
     // Non-bearer credentials are silently ignored — GitLab tokens are bearer.
     // A credential change invalidates everything fetched under the old one
     // (private tooltips, stats, instance-scoped avatars).
+    // `setMemoryToken` binds the credential to the instance configured right
+    // now, so a later `instanceUrl` change withholds it instead of replaying
+    // it at the new origin.
     if (getTokenVersion() !== before) {
       clearGitLabCaches();
     }
@@ -206,7 +214,8 @@ export const gitlabForgeProvider: ForgeProviderImpl = {
       return { valid: false, error: "No GitLab token configured" };
     }
     const versionAtStart = getTokenVersion();
-    const result = await validateGitLabToken(token);
+    const identityAtStart = currentIdentityGeneration();
+    const result = await validateStoredGitLabToken(token);
     if (result.valid && result.username) {
       setValidatedUserInfo(
         {
@@ -214,7 +223,8 @@ export const gitlabForgeProvider: ForgeProviderImpl = {
           ...(result.avatarUrl ? { avatarUrl: result.avatarUrl } : {}),
           ...(result.scopes ? { scopes: result.scopes } : {}),
         },
-        versionAtStart
+        versionAtStart,
+        identityAtStart
       );
     }
     return toAuthValidation(result);

--- a/plugins/builtin/gitlab/main/gitlabRemote.ts
+++ b/plugins/builtin/gitlab/main/gitlabRemote.ts
@@ -1,0 +1,101 @@
+import type { RepoRef } from "../../../../shared/types/forge.js";
+
+/**
+ * Parsed identity of a GitLab repository. GitLab nests projects in subgroups
+ * up to 20 levels deep, so `owner` is the full namespace path
+ * (`group/subgroup/…`) and `repo` the final project segment. The REST `:id`
+ * and GraphQL `fullPath` forms both derive from `${owner}/${repo}`.
+ */
+export interface ParsedGitLabRemote {
+  host: string;
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Path segments that can never start a project namespace on a GitLab web
+ * host. A remote URL is the only input here so the list stays minimal —
+ * these appear when a user pastes a non-repo GitLab URL (an MR page, an API
+ * URL) instead of a clone URL.
+ */
+const RESERVED_LEADING_SEGMENTS = new Set(["api", "-", "uploads", "help"]);
+
+function cleanPath(rawPath: string): string[] | null {
+  let path = rawPath.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (path.endsWith(".git")) path = path.slice(0, -4);
+  if (path.length === 0) return null;
+  const segments = path.split("/").filter((s) => s.length > 0);
+  // A GitLab project path is at least `namespace/project`.
+  if (segments.length < 2) return null;
+  if (RESERVED_LEADING_SEGMENTS.has(segments[0].toLowerCase())) return null;
+  // Web URLs (not clone URLs) carry `/-/` route separators — cut there so a
+  // pasted MR/issue URL still resolves to its project.
+  const dashIndex = segments.indexOf("-");
+  const projectSegments = dashIndex > 1 ? segments.slice(0, dashIndex) : segments;
+  if (projectSegments.length < 2) return null;
+  return projectSegments;
+}
+
+function fromSegments(host: string, segments: string[]): ParsedGitLabRemote {
+  return {
+    host: host.toLowerCase(),
+    owner: segments.slice(0, -1).join("/"),
+    repo: segments[segments.length - 1],
+  };
+}
+
+/**
+ * Parse a git remote URL into a GitLab repo identity. Deliberately
+ * host-agnostic: hostname routing already happened (manifest `matches`, the
+ * per-project provider override, or the global default) before the host calls
+ * `parseRemote`, so any self-hosted GitLab domain parses here and the REST
+ * base URL derives from the returned `host`.
+ *
+ * Handles the clone-URL forms git produces: SCP-ish `git@host:group/repo.git`,
+ * `ssh://git@host[:port]/group/repo.git`, `http(s)://host/group/repo(.git)`,
+ * and bare `host/group/repo` pastes. Nested subgroups are preserved in
+ * `owner`.
+ */
+export function parseGitLabRemoteUrl(url: string): ParsedGitLabRemote | null {
+  if (typeof url !== "string") return null;
+  const trimmed = url.trim();
+  if (trimmed.length === 0) return null;
+
+  // SCP-like syntax: [user@]host:path (no scheme, single colon, no leading //).
+  const scpMatch = /^(?:[\w.-]+@)?([\w.-]+):(?!\/\/)(.+)$/.exec(trimmed);
+  if (scpMatch && !trimmed.includes("://")) {
+    const segments = cleanPath(scpMatch[2]);
+    if (!segments) return null;
+    return fromSegments(scpMatch[1], segments);
+  }
+
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    return null;
+  }
+  if (!parsed.hostname) return null;
+  const segments = cleanPath(parsed.pathname);
+  if (!segments) return null;
+  return fromSegments(parsed.hostname, segments);
+}
+
+/** Full namespace path (`group/subgroup/project`) for a parsed repo. */
+export function repoFullPath(repo: Pick<RepoRef, "owner" | "repo">): string {
+  return `${repo.owner}/${repo.repo}`;
+}
+
+/**
+ * URL-encoded project id for REST `/projects/:id` routes. The whole path is
+ * a single path segment, so every `/` must encode as `%2F`.
+ */
+export function encodeProjectId(repo: Pick<RepoRef, "owner" | "repo">): string {
+  return encodeURIComponent(repoFullPath(repo));
+}
+
+/** Web URL of the project's home page. */
+export function repoWebUrl(repo: Pick<RepoRef, "host" | "owner" | "repo">): string {
+  return `https://${repo.host}/${repo.owner}/${repo.repo}`;
+}

--- a/plugins/builtin/gitlab/main/gitlabRemote.ts
+++ b/plugins/builtin/gitlab/main/gitlabRemote.ts
@@ -1,4 +1,27 @@
 import type { RepoRef } from "../../../../shared/types/forge.js";
+import { getCachedInstanceUrl } from "./GitLabAuth.js";
+
+/**
+ * The configured instance base as `{ host, prefix }`, or null when no setting
+ * has been read yet. `prefix` is the deployment path a relative install sits
+ * under (`https://code.example:8443/gitlab` → `/gitlab`), normalized without a
+ * trailing slash. Read from the synchronous cache because the contract's
+ * `parseRemote` and URL builders can't await the setting.
+ */
+function configuredInstance(): { origin: string; host: string; prefix: string } | null {
+  const configured = getCachedInstanceUrl();
+  if (configured === null) return null;
+  try {
+    const url = new URL(configured);
+    return {
+      origin: url.origin,
+      host: url.hostname.toLowerCase(),
+      prefix: url.pathname.replace(/\/+$/, ""),
+    };
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Parsed identity of a GitLab repository. GitLab nests projects in subgroups
@@ -77,9 +100,42 @@ export function parseGitLabRemoteUrl(url: string): ParsedGitLabRemote | null {
     return null;
   }
   if (!parsed.hostname) return null;
-  const segments = cleanPath(parsed.pathname);
+  // A relative install serves clone URLs under its deployment path
+  // (`https://code.example:8443/gitlab/team/app.git`). That prefix is part of
+  // the URL, not of the project namespace — leaving it in would ask the API
+  // for project `gitlab/team/app` under a base that already includes
+  // `/gitlab`, and 404 on a project that exists.
+  const segments = cleanPath(
+    stripInstancePrefix(parsed.protocol, parsed.hostname, parsed.pathname)
+  );
   if (!segments) return null;
   return fromSegments(parsed.hostname, segments);
+}
+
+/**
+ * Only HTTP(S) clone URLs carry the deployment prefix — it is a web-server
+ * mount point. SSH remotes address the git service directly, so their path IS
+ * the namespace: stripping there would turn a genuine `gitlab/team/app`
+ * project into `team/app`.
+ */
+function stripInstancePrefix(protocol: string, host: string, pathname: string): string {
+  if (protocol !== "http:" && protocol !== "https:") return pathname;
+  const instance = configuredInstance();
+  if (!instance || instance.prefix.length === 0) return pathname;
+  if (host.toLowerCase() !== instance.host) return pathname;
+  const prefix = instance.prefix;
+  if (pathname === prefix) return "";
+  return pathname.startsWith(`${prefix}/`) ? pathname.slice(prefix.length) : pathname;
+}
+
+/**
+ * Origin (scheme, host, port) the instance is served on, for absolutizing the
+ * relative paths GitLab returns. Falls back to plain https for any host that
+ * isn't the configured instance.
+ */
+export function instanceOriginFor(host: string): string {
+  const instance = configuredInstance();
+  return instance && instance.host === host.toLowerCase() ? instance.origin : `https://${host}`;
 }
 
 /** Full namespace path (`group/subgroup/project`) for a parsed repo. */
@@ -95,7 +151,18 @@ export function encodeProjectId(repo: Pick<RepoRef, "owner" | "repo">): string {
   return encodeURIComponent(repoFullPath(repo));
 }
 
-/** Web URL of the project's home page. */
+/**
+ * Web URL of the project's home page. Built from the configured instance base
+ * when the repo lives on it, so a self-hosted install on a custom port or
+ * under a deployment path keeps both — `https://<host>/…` would drop them and
+ * hand the user a dead link. Any other GitLab host (hostname-matched public
+ * instances) gets plain https, which is what those serve.
+ */
 export function repoWebUrl(repo: Pick<RepoRef, "host" | "owner" | "repo">): string {
-  return `https://${repo.host}/${repo.owner}/${repo.repo}`;
+  const instance = configuredInstance();
+  const base =
+    instance && instance.host === repo.host.toLowerCase()
+      ? `${instance.origin}${instance.prefix}`
+      : `https://${repo.host}`;
+  return `${base}/${repo.owner}/${repo.repo}`;
 }

--- a/plugins/builtin/gitlab/main/index.ts
+++ b/plugins/builtin/gitlab/main/index.ts
@@ -1,0 +1,113 @@
+import type { PluginHostApi } from "../../../../shared/types/plugin.js";
+import { BUILTIN_GITLAB_PROVIDER_ID } from "../../../../shared/utils/forgeProviderIds.js";
+import {
+  getToken,
+  getTokenVersion,
+  markTokenHealthy,
+  markTokenUnhealthy,
+  setInstanceUrlReader,
+  setMemoryToken,
+  setValidatedUserInfo,
+  validateGitLabToken,
+} from "./GitLabAuth.js";
+import { gitlabForgeProvider } from "./forgeProvider.js";
+import { clearGitLabCaches } from "./readOps.js";
+
+/**
+ * Float a one-shot validation of the stored token so user info (username,
+ * avatar, scopes) is cached for the session and token health reflects
+ * reality. Never awaited — validation has an internal timeout and the
+ * tokenVersion guard makes both the cache write and the health stamp no-ops
+ * if the token rotates (or the plugin deactivates and clears it) mid-flight.
+ */
+function validateStoredTokenInBackground(): void {
+  const token = getToken();
+  if (!token) return;
+  const versionAtStart = getTokenVersion();
+  void (async () => {
+    try {
+      const validation = await validateGitLabToken(token);
+      if (validation.valid && validation.username) {
+        setValidatedUserInfo(
+          {
+            username: validation.username,
+            ...(validation.avatarUrl ? { avatarUrl: validation.avatarUrl } : {}),
+            ...(validation.scopes ? { scopes: validation.scopes } : {}),
+          },
+          versionAtStart
+        );
+        console.log("[gitlab-plugin] user info cached for:", validation.username);
+      }
+      // Health flows straight from this validation — a second probe via
+      // refreshTokenHealth would double-hit /user and, worse, could run
+      // after deactivation against the fallback instance URL.
+      if (validation.valid) {
+        markTokenHealthy(versionAtStart);
+      } else if (validation.credentialRejected) {
+        markTokenUnhealthy(versionAtStart);
+      }
+    } catch (err) {
+      console.warn("[gitlab-plugin] Failed to validate stored GitLab token:", err);
+    }
+  })();
+}
+
+/**
+ * Push the current credentials to every running workspace host. Covers hosts
+ * that became ready before this plugin activated — the host-side ready replay
+ * pulls from the forge registry, which only knows this provider after
+ * activate() binds it.
+ */
+async function syncCredentialsToWorkspaceHosts(): Promise<void> {
+  const token = getToken();
+  if (!token) return;
+  try {
+    const { getWorkspaceClient } = await import("../../../../electron/services/WorkspaceClient.js");
+    getWorkspaceClient().updateForgeCredentials(BUILTIN_GITLAB_PROVIDER_ID, {
+      kind: "bearer",
+      value: token,
+    });
+  } catch {
+    // WorkspaceClient may not be initialized yet — hosts created later are
+    // seeded from the registry-backed ready replay.
+  }
+}
+
+/**
+ * Plugin activation entry point — called by `PluginService` after manifest
+ * validation. Registers the `gitlab` forge provider declared in
+ * `plugin.json`. The durable token lives in the host's `forgeCredentials`
+ * store and is replayed into `setCredentials` during registration; the
+ * instance URL is the plugin's `instanceUrl` setting, read through the
+ * accessor wired here so auth-path requests always see the current value.
+ */
+export async function activate(host: PluginHostApi): Promise<() => void> {
+  setInstanceUrlReader(() => host.settings.get<string>("instanceUrl"));
+  const disposeForge = await host.registerForgeProvider({ id: "gitlab" }, gitlabForgeProvider);
+  validateStoredTokenInBackground();
+  void syncCredentialsToWorkspaceHosts();
+  return () => {
+    disposeForge();
+    // Clear the in-memory token BEFORE removing the settings reader: any
+    // still-floating request that resolves after this point must find no
+    // credential rather than a token paired with the default-instance
+    // fallback. Re-enable replays the durable credential via setCredentials.
+    setMemoryToken(null);
+    setInstanceUrlReader(null);
+    // Drop cached tooltip/stats/avatar pages so a later re-enable (possibly
+    // under a different token or instance) starts from the network.
+    clearGitLabCaches();
+  };
+}
+
+export { gitlabForgeProvider } from "./forgeProvider.js";
+export {
+  getInstanceUrl,
+  getInstanceHost,
+  setInstanceUrlReader,
+  validateGitLabToken,
+  GITLAB_API_TIMEOUT_MS,
+  GITLAB_AUTH_TIMEOUT_MS,
+} from "./GitLabAuth.js";
+export { parseGitLabRemoteUrl, repoFullPath, encodeProjectId } from "./gitlabRemote.js";
+export { clearGitLabCaches } from "./readOps.js";

--- a/plugins/builtin/gitlab/main/index.ts
+++ b/plugins/builtin/gitlab/main/index.ts
@@ -1,16 +1,28 @@
 import type { PluginHostApi } from "../../../../shared/types/plugin.js";
 import { BUILTIN_GITLAB_PROVIDER_ID } from "../../../../shared/utils/forgeProviderIds.js";
 import {
+  getInstanceUrl,
   getToken,
+  currentIdentityGeneration,
   getTokenVersion,
   markTokenHealthy,
   markTokenUnhealthy,
   setInstanceUrlReader,
   setMemoryToken,
+  setProvenanceAccessors,
   setValidatedUserInfo,
-  validateGitLabToken,
+  clearValidatedUserInfo,
+  validateStoredGitLabToken,
+  type CredentialProvenance,
 } from "./GitLabAuth.js";
 import { gitlabForgeProvider } from "./forgeProvider.js";
+
+/**
+ * Plugin-storage key holding {@link CredentialProvenance}. Storage is
+ * plaintext JSON, so this records only the instance and a token DIGEST —
+ * never the credential.
+ */
+const CREDENTIAL_PROVENANCE_KEY = "credentialProvenance";
 import { clearGitLabCaches } from "./readOps.js";
 
 /**
@@ -24,9 +36,10 @@ function validateStoredTokenInBackground(): void {
   const token = getToken();
   if (!token) return;
   const versionAtStart = getTokenVersion();
+  const identityAtStart = currentIdentityGeneration();
   void (async () => {
     try {
-      const validation = await validateGitLabToken(token);
+      const validation = await validateStoredGitLabToken(token);
       if (validation.valid && validation.username) {
         setValidatedUserInfo(
           {
@@ -34,7 +47,8 @@ function validateStoredTokenInBackground(): void {
             ...(validation.avatarUrl ? { avatarUrl: validation.avatarUrl } : {}),
             ...(validation.scopes ? { scopes: validation.scopes } : {}),
           },
-          versionAtStart
+          versionAtStart,
+          identityAtStart
         );
         console.log("[gitlab-plugin] user info cached for:", validation.username);
       }
@@ -83,10 +97,60 @@ async function syncCredentialsToWorkspaceHosts(): Promise<void> {
  */
 export async function activate(host: PluginHostApi): Promise<() => void> {
   setInstanceUrlReader(() => host.settings.get<string>("instanceUrl"));
+  // Prime the synchronous instance cache before the provider is reachable.
+  // The contract's URL builders and `parseRemote` are synchronous, so on a
+  // self-hosted install they'd otherwise emit `https://<host>/…` — dropping a
+  // custom port and deployment path — until some other call happened to read
+  // the setting first.
+  await getInstanceUrl().catch(() => undefined);
+
+  // Load the credential's durable provenance BEFORE registration, because the
+  // host replays the stored credential into `setCredentials` as part of it.
+  // Without the record loaded, the replayed token would take its instance from
+  // whatever `instanceUrl` currently says — which is how a token saved for one
+  // instance ends up authenticating against another.
+  let provenance: CredentialProvenance | null = null;
+  try {
+    provenance = (await host.storage.get<CredentialProvenance>(CREDENTIAL_PROVENANCE_KEY)) ?? null;
+  } catch {
+    // Unreadable storage leaves the provenance unknown, which withholds the
+    // token rather than guessing where it belongs.
+  }
+  setProvenanceAccessors(
+    () => provenance,
+    (record) => {
+      provenance = record;
+      void (
+        record === null
+          ? host.storage.delete(CREDENTIAL_PROVENANCE_KEY)
+          : host.storage.set(CREDENTIAL_PROVENANCE_KEY, record)
+      ).catch(() => undefined);
+    }
+  );
+
+  // Keep the instance cache honest. It backs the synchronous URL builders and
+  // the remote parser, so a stale base after an instance change would strip a
+  // namespace segment that is no longer a deployment prefix, or build links
+  // against the old origin. Subscribing must happen during activate().
+  const disposeSettings = await host.settings
+    .onDidChange<string>("instanceUrl", () => {
+      void getInstanceUrl()
+        .catch(() => undefined)
+        // Everything cached — tooltips, stats, avatars, the validated identity
+        // — was fetched from the previous instance and describes projects that
+        // may not even exist on the new one.
+        .finally(() => {
+          clearGitLabCaches();
+          clearValidatedUserInfo();
+        });
+    })
+    .catch(() => () => undefined);
   const disposeForge = await host.registerForgeProvider({ id: "gitlab" }, gitlabForgeProvider);
   validateStoredTokenInBackground();
   void syncCredentialsToWorkspaceHosts();
   return () => {
+    disposeSettings();
+    setProvenanceAccessors(null, null);
     disposeForge();
     // Clear the in-memory token BEFORE removing the settings reader: any
     // still-floating request that resolves after this point must find no
@@ -101,8 +165,8 @@ export async function activate(host: PluginHostApi): Promise<() => void> {
 }
 
 export { gitlabForgeProvider } from "./forgeProvider.js";
+export { getInstanceUrl };
 export {
-  getInstanceUrl,
   getInstanceHost,
   setInstanceUrlReader,
   validateGitLabToken,

--- a/plugins/builtin/gitlab/main/mappers.ts
+++ b/plugins/builtin/gitlab/main/mappers.ts
@@ -1,0 +1,381 @@
+import type {
+  CIStatusState,
+  ForgeLabel,
+  ForgeUser,
+  Issue,
+  IssueComment,
+  IssueTooltipData,
+  ListOptions,
+  NormalizedIssueState,
+  NormalizedPRState,
+  PR,
+  PRTooltipData,
+  Release,
+} from "../../../../shared/types/forge.js";
+import type {
+  GitLabIssue,
+  GitLabMergeRequest,
+  GitLabNote,
+  GitLabRelease,
+  GitLabUser,
+} from "../shared/types.js";
+import { repoWebUrl } from "./gitlabRemote.js";
+
+const TOOLTIP_EXCERPT_MAX = 280;
+
+export function isoToMs(value: unknown): number {
+  if (typeof value !== "string") return 0;
+  const t = Date.parse(value);
+  return Number.isFinite(t) ? t : 0;
+}
+
+export function isoToMsOrNull(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const t = Date.parse(value);
+  return Number.isFinite(t) ? t : null;
+}
+
+/**
+ * Self-hosted GitLab returns upload-backed avatars as host-relative paths
+ * (`/uploads/-/system/...`); prefix the instance so the renderer can load them.
+ */
+export function absolutizeAvatarUrl(avatarUrl: unknown, host: string): string | undefined {
+  if (typeof avatarUrl !== "string" || avatarUrl.length === 0) return undefined;
+  if (/^https?:\/\//i.test(avatarUrl)) return avatarUrl;
+  return avatarUrl.startsWith("/") ? `https://${host}${avatarUrl}` : undefined;
+}
+
+export function gitlabUserToForgeUser(
+  user: GitLabUser | null | undefined,
+  host: string
+): ForgeUser | undefined {
+  if (!user || typeof user.username !== "string" || user.username.length === 0) return undefined;
+  const avatarUrl = absolutizeAvatarUrl(user.avatar_url, host);
+  return {
+    login: user.username,
+    ...(avatarUrl ? { avatarUrl } : {}),
+    rawData: user,
+  };
+}
+
+function gitlabUsersToForgeUsers(
+  users: GitLabUser[] | null | undefined,
+  host: string
+): ForgeUser[] {
+  if (!Array.isArray(users)) return [];
+  return users
+    .map((u) => gitlabUserToForgeUser(u, host))
+    .filter((u): u is ForgeUser => u !== undefined);
+}
+
+/** Issue/MR payloads carry labels as plain name strings — no colors. */
+export function gitlabLabelsToForgeLabels(labels: unknown): ForgeLabel[] {
+  if (!Array.isArray(labels)) return [];
+  return labels.filter((l): l is string => typeof l === "string").map((name) => ({ name }));
+}
+
+export function normalizeGitLabIssueState(rawState: string): NormalizedIssueState {
+  return rawState.toLowerCase() === "closed" ? "closed" : "open";
+}
+
+/**
+ * GitLab MR states: `opened | closed | locked | merged`. `locked` is the
+ * transient mid-merge state, so it normalizes to `open`; `rawState` preserves
+ * the verbatim value for anything that needs the distinction.
+ */
+export function normalizeGitLabMRState(rawState: string): NormalizedPRState {
+  const lower = rawState.toLowerCase();
+  if (lower === "merged") return "merged";
+  if (lower === "closed") return "closed";
+  return "open";
+}
+
+/**
+ * Draft detection across GitLab versions: the boolean `draft` field is
+ * current, `work_in_progress` predates it, and very old self-managed
+ * instances only carry the title convention (`Draft:`/`[Draft]`/`WIP:`).
+ */
+export function isDraftMergeRequest(
+  mr: Pick<GitLabMergeRequest, "draft" | "work_in_progress" | "title">
+): boolean {
+  if (mr.draft === true || mr.work_in_progress === true) return true;
+  return isDraftTitle(mr.title ?? "");
+}
+
+export function isDraftTitle(title: string): boolean {
+  return /^\s*(?:\[draft\]|\(draft\)|draft:|\[wip\]|\(wip\)|wip:)/i.test(title);
+}
+
+/** Strip every GitLab-recognized draft/WIP prefix from an MR title. */
+export function stripDraftPrefix(title: string): string {
+  let result = title;
+  const prefix = /^\s*(?:\[draft\]|\(draft\)|draft:|\[wip\]|\(wip\)|wip:)\s*/i;
+  while (prefix.test(result)) {
+    result = result.replace(prefix, "");
+  }
+  return result.trim();
+}
+
+/**
+ * Pipeline status → forge CI roll-up. GitLab reports a single head-pipeline
+ * status rather than per-check counts, so the roll-up is that status folded
+ * into the shared vocabulary: user-interrupted and blocked states are
+ * `neutral` (not failures), everything in flight is `pending`.
+ */
+export function pipelineStatusToCIState(status: unknown): CIStatusState | undefined {
+  if (typeof status !== "string") return undefined;
+  switch (status.toLowerCase()) {
+    case "success":
+      return "success";
+    case "failed":
+      return "failure";
+    case "canceled":
+    case "canceling":
+    case "skipped":
+    case "manual":
+      return "neutral";
+    case "created":
+    case "waiting_for_resource":
+    case "waiting_for_callback":
+    case "preparing":
+    case "pending":
+    case "running":
+    case "scheduled":
+      return "pending";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Mergeability from the modern `detailed_merge_status` when present, falling
+ * back to `has_conflicts`. `null` when GitLab hasn't computed it (matching
+ * the contract's "not computed yet" meaning).
+ */
+function mergeableFromMR(mr: GitLabMergeRequest): boolean | null {
+  if (typeof mr.detailed_merge_status === "string") {
+    if (mr.detailed_merge_status === "mergeable") return true;
+    if (
+      mr.detailed_merge_status === "checking" ||
+      mr.detailed_merge_status === "unchecked" ||
+      mr.detailed_merge_status === "preparing"
+    ) {
+      return null;
+    }
+    return false;
+  }
+  if (mr.has_conflicts === true) return false;
+  return null;
+}
+
+/** Map a REST merge-request payload onto the contract PR (numbering by `iid`). */
+export function mergeRequestToForgePR(mr: GitLabMergeRequest, host: string): PR {
+  const rawState = typeof mr.state === "string" ? mr.state : "opened";
+  const merged = rawState.toLowerCase() === "merged" || typeof mr.merged_at === "string";
+  const ciStatus = pipelineStatusToCIState(mr.head_pipeline?.status);
+  const author = gitlabUserToForgeUser(mr.author, host);
+  return {
+    number: mr.iid ?? 0,
+    title: mr.title ?? "",
+    body: mr.description ?? "",
+    state: merged ? "merged" : normalizeGitLabMRState(rawState),
+    rawState,
+    isDraft: isDraftMergeRequest(mr),
+    merged,
+    url: mr.web_url ?? "",
+    ...(author ? { author } : {}),
+    baseRef: mr.target_branch ?? "",
+    headRef: mr.source_branch ?? "",
+    mergeable: mergeableFromMR(mr),
+    ...(typeof mr.user_notes_count === "number" ? { commentCount: mr.user_notes_count } : {}),
+    ...(ciStatus && ciStatus !== "unknown" ? { ciStatus } : {}),
+    createdAt: isoToMs(mr.created_at ?? mr.updated_at),
+    updatedAt: isoToMs(mr.updated_at),
+    closedAt: isoToMsOrNull(mr.closed_at),
+    mergedAt: isoToMsOrNull(mr.merged_at),
+    rawData: mr,
+  };
+}
+
+/** Map a REST issue payload onto the contract Issue (numbering by `iid`). */
+export function gitlabIssueToForgeIssue(issue: GitLabIssue, host: string): Issue {
+  const rawState = typeof issue.state === "string" ? issue.state : "opened";
+  const author = gitlabUserToForgeUser(issue.author, host);
+  return {
+    number: issue.iid ?? 0,
+    title: issue.title ?? "",
+    body: issue.description ?? "",
+    state: normalizeGitLabIssueState(rawState),
+    rawState,
+    url: issue.web_url ?? "",
+    ...(author ? { author } : {}),
+    assignees: gitlabUsersToForgeUsers(issue.assignees, host),
+    labels: gitlabLabelsToForgeLabels(issue.labels),
+    ...(typeof issue.user_notes_count === "number" ? { commentCount: issue.user_notes_count } : {}),
+    createdAt: isoToMs(issue.created_at ?? issue.updated_at),
+    updatedAt: isoToMs(issue.updated_at),
+    closedAt: isoToMsOrNull(issue.closed_at),
+    rawData: issue,
+  };
+}
+
+function truncateExcerpt(body: string): string {
+  const trimmed = body.trim();
+  if (trimmed.length <= TOOLTIP_EXCERPT_MAX) return trimmed;
+  return `${trimmed.slice(0, TOOLTIP_EXCERPT_MAX)}…`;
+}
+
+export function issueToTooltipData(issue: Issue): IssueTooltipData {
+  return {
+    number: issue.number,
+    title: issue.title,
+    bodyExcerpt: truncateExcerpt(issue.body),
+    state: issue.state,
+    rawState: issue.rawState,
+    createdAt: issue.createdAt,
+    ...(issue.author ? { author: issue.author } : {}),
+    assignees: issue.assignees,
+    labels: issue.labels,
+  };
+}
+
+export function prToTooltipData(pr: PR, host: string): PRTooltipData {
+  // Tooltips are built from the REST single-MR fetch, whose payload rides on
+  // `rawData` and carries assignees/labels the PR contract itself doesn't
+  // model. Read them defensively so a non-REST rawData shape degrades to
+  // empty arrays instead of throwing.
+  const raw = (pr.rawData ?? null) as GitLabMergeRequest | null;
+  const assignees = Array.isArray(raw?.assignees)
+    ? raw.assignees
+        .map((a) => gitlabUserToForgeUser(a, host))
+        .filter((u): u is NonNullable<typeof u> => u !== undefined)
+    : [];
+  return {
+    number: pr.number,
+    title: pr.title,
+    bodyExcerpt: truncateExcerpt(pr.body),
+    state: pr.state,
+    rawState: pr.rawState,
+    isDraft: pr.isDraft,
+    createdAt: pr.createdAt,
+    ...(pr.author ? { author: pr.author } : {}),
+    assignees,
+    labels: gitlabLabelsToForgeLabels(raw?.labels),
+  };
+}
+
+/**
+ * Map a REST release payload. GitLab has no draft releases; `upcoming_release`
+ * marks a future-dated release, the closest analogue to a prerelease flag.
+ */
+export function gitlabReleaseToForgeRelease(
+  release: GitLabRelease,
+  repo: { host: string; owner: string; repo: string }
+): Release {
+  const tagName = release.tag_name ?? "";
+  const publishedAt = isoToMsOrNull(release.released_at);
+  return {
+    id: tagName,
+    tagName,
+    name: release.name ?? tagName,
+    body: release.description ?? "",
+    isDraft: false,
+    isPrerelease: release.upcoming_release === true,
+    url:
+      typeof release._links?.self === "string" && release._links.self.length > 0
+        ? release._links.self
+        : `${repoWebUrl(repo)}/-/releases/${encodeURIComponent(tagName)}`,
+    publishedAt,
+    createdAt: isoToMs(release.created_at ?? release.released_at),
+    rawData: release,
+  };
+}
+
+/** Map a REST note (comment) created on an issue. Notes carry no web URL, so build the anchor. */
+export function gitlabNoteToIssueComment(
+  note: GitLabNote,
+  issueUrl: string,
+  host: string
+): IssueComment {
+  const author = gitlabUserToForgeUser(note.author, host);
+  return {
+    id: String(note.id ?? ""),
+    body: note.body ?? "",
+    url: note.id != null ? `${issueUrl}#note_${note.id}` : issueUrl,
+    ...(author ? { author } : {}),
+    createdAt: isoToMs(note.created_at),
+    rawData: note,
+  };
+}
+
+/** Contract list state → GitLab REST `state` filter for issues. */
+export function mapIssueListState(state: ListOptions["state"]): string | undefined {
+  if (state === "closed") return "closed";
+  if (state === "all") return undefined;
+  // "merged" is PR-only; issues treat it as the default open set.
+  return "opened";
+}
+
+/** Contract list state → GitLab REST `state` filter for merge requests. */
+export function mapMRListState(state: ListOptions["state"]): string | undefined {
+  if (state === "closed") return "closed";
+  if (state === "merged") return "merged";
+  if (state === "all") return undefined;
+  return "opened";
+}
+
+/** Contract sort key → GitLab `order_by`. Unknown keys fall back to created. */
+export function mapListOrderBy(sort: string | undefined): string {
+  if (sort === "updated" || sort === "updated_at") return "updated_at";
+  return "created_at";
+}
+
+/**
+ * GraphQL merge-request node (camelCase, string `iid`) → contract PR. Used by
+ * the batched branch→MR lookup; the REST mapper handles everything else.
+ */
+export function graphqlMergeRequestToForgePR(
+  node: Record<string, unknown>,
+  host: string
+): PR | null {
+  const iid = Number.parseInt(String(node.iid ?? ""), 10);
+  if (!Number.isFinite(iid) || iid <= 0) return null;
+  const rawState = typeof node.state === "string" ? node.state : "opened";
+  const merged = rawState.toLowerCase() === "merged" || typeof node.mergedAt === "string";
+  const author = node.author as { username?: unknown; avatarUrl?: unknown } | null | undefined;
+  const authorUser: ForgeUser | undefined =
+    author && typeof author.username === "string" && author.username.length > 0
+      ? {
+          login: author.username,
+          ...(absolutizeAvatarUrl(author.avatarUrl, host)
+            ? { avatarUrl: absolutizeAvatarUrl(author.avatarUrl, host) }
+            : {}),
+          rawData: author,
+        }
+      : undefined;
+  const headPipeline = node.headPipeline as { status?: unknown } | null | undefined;
+  const ciStatus = pipelineStatusToCIState(
+    typeof headPipeline?.status === "string" ? headPipeline.status.toLowerCase() : undefined
+  );
+  const title = typeof node.title === "string" ? node.title : "";
+  return {
+    number: iid,
+    title,
+    body: typeof node.description === "string" ? node.description : "",
+    state: merged ? "merged" : normalizeGitLabMRState(rawState),
+    rawState,
+    isDraft: node.draft === true || isDraftTitle(title),
+    merged,
+    url: typeof node.webUrl === "string" ? node.webUrl : "",
+    ...(authorUser ? { author: authorUser } : {}),
+    baseRef: typeof node.targetBranch === "string" ? node.targetBranch : "",
+    headRef: typeof node.sourceBranch === "string" ? node.sourceBranch : "",
+    mergeable: null,
+    ...(ciStatus && ciStatus !== "unknown" ? { ciStatus } : {}),
+    createdAt: isoToMs(node.createdAt ?? node.updatedAt),
+    updatedAt: isoToMs(node.updatedAt),
+    closedAt: isoToMsOrNull(node.closedAt),
+    mergedAt: isoToMsOrNull(node.mergedAt),
+    rawData: node,
+  };
+}

--- a/plugins/builtin/gitlab/main/mappers.ts
+++ b/plugins/builtin/gitlab/main/mappers.ts
@@ -19,7 +19,7 @@ import type {
   GitLabRelease,
   GitLabUser,
 } from "../shared/types.js";
-import { repoWebUrl } from "./gitlabRemote.js";
+import { instanceOriginFor, repoWebUrl } from "./gitlabRemote.js";
 
 const TOOLTIP_EXCERPT_MAX = 280;
 
@@ -42,7 +42,10 @@ export function isoToMsOrNull(value: unknown): number | null {
 export function absolutizeAvatarUrl(avatarUrl: unknown, host: string): string | undefined {
   if (typeof avatarUrl !== "string" || avatarUrl.length === 0) return undefined;
   if (/^https?:\/\//i.test(avatarUrl)) return avatarUrl;
-  return avatarUrl.startsWith("/") ? `https://${host}${avatarUrl}` : undefined;
+  // GitLab serves relative avatar paths from the instance root, so a
+  // self-hosted install on a custom scheme or port needs its own origin —
+  // plain `https://<host>` would 404 or hit the wrong service.
+  return avatarUrl.startsWith("/") ? `${instanceOriginFor(host)}${avatarUrl}` : undefined;
 }
 
 export function gitlabUserToForgeUser(
@@ -92,26 +95,38 @@ export function normalizeGitLabMRState(rawState: string): NormalizedPRState {
 
 /**
  * Draft detection across GitLab versions: the boolean `draft` field is
- * current, `work_in_progress` predates it, and very old self-managed
- * instances only carry the title convention (`Draft:`/`[Draft]`/`WIP:`).
+ * current and `work_in_progress` predates it. Both are derived server-side
+ * from the title, so a present boolean — including an explicit `false` — is
+ * authoritative and the title is only consulted when neither is present.
  */
 export function isDraftMergeRequest(
   mr: Pick<GitLabMergeRequest, "draft" | "work_in_progress" | "title">
 ): boolean {
-  if (mr.draft === true || mr.work_in_progress === true) return true;
+  // An explicit `false` must win over the title. GitLab dropped `WIP:` in
+  // 14.8, so an MR titled "WIP: …" is an ordinary open MR — reading the title
+  // first would call it a draft and make "convert to draft" a silent no-op.
+  if (typeof mr.draft === "boolean") return mr.draft;
+  if (typeof mr.work_in_progress === "boolean") return mr.work_in_progress;
   return isDraftTitle(mr.title ?? "");
 }
 
+/**
+ * The prefixes GitLab itself recognizes, from `Gitlab::Regex.merge_request_draft`:
+ * `Draft:`, `[Draft]`, `(Draft)` and `Draft -`, case-insensitive. `WIP:` was
+ * removed in GitLab 14.8 and is deliberately absent — treating it as a draft
+ * would disagree with the server about every MR that still uses it.
+ */
+const DRAFT_TITLE_PREFIX = /^\s*(?:\[draft\]|\(draft\)|draft\s*[:-])\s*/i;
+
 export function isDraftTitle(title: string): boolean {
-  return /^\s*(?:\[draft\]|\(draft\)|draft:|\[wip\]|\(wip\)|wip:)/i.test(title);
+  return DRAFT_TITLE_PREFIX.test(title);
 }
 
-/** Strip every GitLab-recognized draft/WIP prefix from an MR title. */
+/** Strip every GitLab-recognized draft prefix from an MR title. */
 export function stripDraftPrefix(title: string): string {
   let result = title;
-  const prefix = /^\s*(?:\[draft\]|\(draft\)|draft:|\[wip\]|\(wip\)|wip:)\s*/i;
-  while (prefix.test(result)) {
-    result = result.replace(prefix, "");
+  while (DRAFT_TITLE_PREFIX.test(result)) {
+    result = result.replace(DRAFT_TITLE_PREFIX, "");
   }
   return result.trim();
 }
@@ -155,10 +170,14 @@ export function pipelineStatusToCIState(status: unknown): CIStatusState | undefi
 function mergeableFromMR(mr: GitLabMergeRequest): boolean | null {
   if (typeof mr.detailed_merge_status === "string") {
     if (mr.detailed_merge_status === "mergeable") return true;
+    // The four states GitLab documents as "still being computed". Reporting
+    // any of them as not-mergeable would show a merge button disabled for a
+    // reason that hasn't been established yet.
     if (
       mr.detailed_merge_status === "checking" ||
       mr.detailed_merge_status === "unchecked" ||
-      mr.detailed_merge_status === "preparing"
+      mr.detailed_merge_status === "preparing" ||
+      mr.detailed_merge_status === "approvals_syncing"
     ) {
       return null;
     }
@@ -364,7 +383,7 @@ export function graphqlMergeRequestToForgePR(
     body: typeof node.description === "string" ? node.description : "",
     state: merged ? "merged" : normalizeGitLabMRState(rawState),
     rawState,
-    isDraft: node.draft === true || isDraftTitle(title),
+    isDraft: typeof node.draft === "boolean" ? node.draft : isDraftTitle(title),
     merged,
     url: typeof node.webUrl === "string" ? node.webUrl : "",
     ...(authorUser ? { author: authorUser } : {}),

--- a/plugins/builtin/gitlab/main/mutations.ts
+++ b/plugins/builtin/gitlab/main/mutations.ts
@@ -1,0 +1,361 @@
+import type {
+  CreateIssueInput,
+  CreatePRInput,
+  EditIssueInput,
+  EditPRInput,
+  ForgeLabel,
+  Issue,
+  IssueCloseReason,
+  IssueComment,
+  MergePRInput,
+  PR,
+  RepoRef,
+} from "../../../../shared/types/forge.js";
+import type { GitLabIssue, GitLabMergeRequest, GitLabNote, GitLabUser } from "../shared/types.js";
+import { GitLabApiError, gitlabRest } from "./GitLabClient.js";
+import { encodeProjectId, repoWebUrl } from "./gitlabRemote.js";
+import {
+  gitlabIssueToForgeIssue,
+  gitlabLabelsToForgeLabels,
+  gitlabNoteToIssueComment,
+  isDraftMergeRequest,
+  isDraftTitle,
+  mergeRequestToForgePR,
+  stripDraftPrefix,
+} from "./mappers.js";
+
+function projectPath(repo: RepoRef): string {
+  return `/projects/${encodeProjectId(repo)}`;
+}
+
+async function fetchIssueRaw(repo: RepoRef, issueNumber: number): Promise<GitLabIssue> {
+  const { data } = await gitlabRest<GitLabIssue>({
+    host: repo.host,
+    path: `${projectPath(repo)}/issues/${issueNumber}`,
+  });
+  return data;
+}
+
+async function fetchMRRaw(repo: RepoRef, prNumber: number): Promise<GitLabMergeRequest> {
+  const { data } = await gitlabRest<GitLabMergeRequest>({
+    host: repo.host,
+    path: `${projectPath(repo)}/merge_requests/${prNumber}`,
+  });
+  return data;
+}
+
+/** Resolve a username to its numeric user id via exact-match user search. */
+async function resolveUserId(repo: RepoRef, username: string): Promise<number> {
+  const { data } = await gitlabRest<GitLabUser[]>({
+    host: repo.host,
+    path: "/users",
+    query: { username },
+  });
+  const match = Array.isArray(data)
+    ? data.find(
+        (u) => typeof u.username === "string" && u.username.toLowerCase() === username.toLowerCase()
+      )
+    : undefined;
+  if (!match || typeof match.id !== "number") {
+    throw new Error(`GitLab user "${username}" not found`);
+  }
+  return match.id;
+}
+
+function currentAssigneeIds(issue: GitLabIssue): number[] {
+  if (!Array.isArray(issue.assignees)) return [];
+  return issue.assignees.map((a) => a.id).filter((id): id is number => typeof id === "number");
+}
+
+export async function createIssueImpl(repo: RepoRef, input: CreateIssueInput): Promise<Issue> {
+  const { data } = await gitlabRest<GitLabIssue>({
+    host: repo.host,
+    method: "POST",
+    path: `${projectPath(repo)}/issues`,
+    body: {
+      title: input.title,
+      ...(input.body !== undefined ? { description: input.body } : {}),
+      ...(input.labels && input.labels.length > 0 ? { labels: input.labels.join(",") } : {}),
+    },
+  });
+  return gitlabIssueToForgeIssue(data, repo.host);
+}
+
+export async function assignIssueImpl(
+  repo: RepoRef,
+  issueNumber: number,
+  username: string
+): Promise<void> {
+  const [userId, issue] = await Promise.all([
+    resolveUserId(repo, username),
+    fetchIssueRaw(repo, issueNumber),
+  ]);
+  const ids = currentAssigneeIds(issue);
+  if (ids.includes(userId)) return;
+  await gitlabRest({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/issues/${issueNumber}`,
+    // The new user goes FIRST: GitLab Free applies only the first id
+    // (multi-assignee is Premium/Ultimate), so leading with the requested
+    // user makes Free replace the assignee instead of silently ignoring the
+    // request. On multi-assignee tiers the order is irrelevant and the
+    // semantics stay additive.
+    body: { assignee_ids: [userId, ...ids] },
+  });
+}
+
+export async function unassignIssueImpl(
+  repo: RepoRef,
+  issueNumber: number,
+  username: string
+): Promise<void> {
+  const issue = await fetchIssueRaw(repo, issueNumber);
+  const assignees = Array.isArray(issue.assignees) ? issue.assignees : [];
+  const remaining = assignees
+    .filter((a) => (a.username ?? "").toLowerCase() !== username.toLowerCase())
+    .map((a) => a.id)
+    .filter((id): id is number => typeof id === "number");
+  if (remaining.length === assignees.length) return;
+  await gitlabRest({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/issues/${issueNumber}`,
+    // `[0]` is GitLab's documented "unassign everyone" sentinel.
+    body: { assignee_ids: remaining.length > 0 ? remaining : [0] },
+  });
+}
+
+export async function createPRImpl(repo: RepoRef, input: CreatePRInput): Promise<PR> {
+  const title =
+    input.draft === true && !/^\s*draft:/i.test(input.title)
+      ? `Draft: ${input.title}`
+      : input.title;
+  const { data } = await gitlabRest<GitLabMergeRequest>({
+    host: repo.host,
+    method: "POST",
+    path: `${projectPath(repo)}/merge_requests`,
+    body: {
+      source_branch: input.head,
+      target_branch: input.base,
+      title,
+      ...(input.body !== undefined ? { description: input.body } : {}),
+    },
+  });
+  return mergeRequestToForgePR(data, repo.host);
+}
+
+async function setMRStateEvent(
+  repo: RepoRef,
+  prNumber: number,
+  stateEvent: "close" | "reopen"
+): Promise<void> {
+  await gitlabRest({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/merge_requests/${prNumber}`,
+    body: { state_event: stateEvent },
+  });
+}
+
+export async function closePRImpl(repo: RepoRef, prNumber: number): Promise<void> {
+  await setMRStateEvent(repo, prNumber, "close");
+}
+
+export async function reopenPRImpl(repo: RepoRef, prNumber: number): Promise<void> {
+  await setMRStateEvent(repo, prNumber, "reopen");
+}
+
+export async function mergePRImpl(
+  repo: RepoRef,
+  prNumber: number,
+  input?: MergePRInput
+): Promise<void> {
+  if (input?.mergeMethod === "rebase") {
+    // GitLab's merge method is project-level configuration, not a per-merge
+    // parameter; only squash can be chosen per merge.
+    throw new Error("Not supported: GitLab configures the merge method per project");
+  }
+  const squash = input?.mergeMethod === "squash";
+  const commitMessage =
+    input?.commitTitle || input?.commitMessage
+      ? [input.commitTitle, input.commitMessage].filter(Boolean).join("\n\n")
+      : undefined;
+  try {
+    await gitlabRest({
+      host: repo.host,
+      method: "PUT",
+      path: `${projectPath(repo)}/merge_requests/${prNumber}/merge`,
+      body: {
+        // An explicit method pins `squash` both ways so the project's
+        // squash-by-default option can't silently override the caller;
+        // omitting the method leaves the project default in charge.
+        ...(input?.mergeMethod !== undefined ? { squash } : {}),
+        ...(commitMessage !== undefined
+          ? squash
+            ? { squash_commit_message: commitMessage }
+            : { merge_commit_message: commitMessage }
+          : {}),
+      },
+    });
+  } catch (err) {
+    // GitLab answers 405/406 for unmergeable states with a terse body;
+    // translate them so the confirm-dialog error is actionable.
+    if (err instanceof GitLabApiError && (err.status === 405 || err.status === 406)) {
+      throw new Error(
+        "GitLab refused the merge — the merge request may be a draft, have conflicts, or failing pipelines",
+        { cause: err }
+      );
+    }
+    throw err;
+  }
+}
+
+export async function convertPRToDraftImpl(repo: RepoRef, prNumber: number): Promise<void> {
+  const mr = await fetchMRRaw(repo, prNumber);
+  if (isDraftMergeRequest(mr)) return;
+  await gitlabRest({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/merge_requests/${prNumber}`,
+    // Draft state IS the title prefix in GitLab — there's no writable flag.
+    body: { title: `Draft: ${mr.title ?? ""}` },
+  });
+}
+
+export async function markPRReadyForReviewImpl(repo: RepoRef, prNumber: number): Promise<void> {
+  const mr = await fetchMRRaw(repo, prNumber);
+  if (!isDraftMergeRequest(mr)) return;
+  await gitlabRest({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/merge_requests/${prNumber}`,
+    body: { title: stripDraftPrefix(mr.title ?? "") },
+  });
+}
+
+export async function commentOnPRImpl(
+  repo: RepoRef,
+  prNumber: number,
+  body: string
+): Promise<void> {
+  await gitlabRest({
+    host: repo.host,
+    method: "POST",
+    path: `${projectPath(repo)}/merge_requests/${prNumber}/notes`,
+    body: { body },
+  });
+}
+
+export async function editPRImpl(repo: RepoRef, prNumber: number, input: EditPRInput): Promise<PR> {
+  let title = input.title;
+  if (title !== undefined && !isDraftTitle(title)) {
+    // Draft state IS the title prefix in GitLab, so a plain title edit on a
+    // draft MR would silently mark it ready. Preserve the current draft state;
+    // draft transitions go through the dedicated convert/mark-ready ops.
+    const current = await fetchMRRaw(repo, prNumber);
+    if (isDraftMergeRequest(current)) {
+      title = `Draft: ${title}`;
+    }
+  }
+  const { data } = await gitlabRest<GitLabMergeRequest>({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/merge_requests/${prNumber}`,
+    body: {
+      ...(title !== undefined ? { title } : {}),
+      ...(input.body !== undefined ? { description: input.body } : {}),
+    },
+  });
+  return mergeRequestToForgePR(data, repo.host);
+}
+
+export async function closeIssueImpl(
+  repo: RepoRef,
+  issueNumber: number,
+  _stateReason?: IssueCloseReason
+): Promise<Issue> {
+  // GitLab has no close-reason concept; the reason is accepted and dropped.
+  const { data } = await gitlabRest<GitLabIssue>({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/issues/${issueNumber}`,
+    body: { state_event: "close" },
+  });
+  return gitlabIssueToForgeIssue(data, repo.host);
+}
+
+export async function reopenIssueImpl(repo: RepoRef, issueNumber: number): Promise<Issue> {
+  const { data } = await gitlabRest<GitLabIssue>({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/issues/${issueNumber}`,
+    body: { state_event: "reopen" },
+  });
+  return gitlabIssueToForgeIssue(data, repo.host);
+}
+
+export async function editIssueImpl(
+  repo: RepoRef,
+  issueNumber: number,
+  input: EditIssueInput
+): Promise<Issue> {
+  const { data } = await gitlabRest<GitLabIssue>({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/issues/${issueNumber}`,
+    body: {
+      ...(input.title !== undefined ? { title: input.title } : {}),
+      ...(input.body !== undefined ? { description: input.body } : {}),
+    },
+  });
+  return gitlabIssueToForgeIssue(data, repo.host);
+}
+
+export async function addIssueCommentImpl(
+  repo: RepoRef,
+  issueNumber: number,
+  body: string
+): Promise<IssueComment> {
+  const { data } = await gitlabRest<GitLabNote>({
+    host: repo.host,
+    method: "POST",
+    path: `${projectPath(repo)}/issues/${issueNumber}/notes`,
+    body: { body },
+  });
+  const issueUrl = `${repoWebUrl(repo)}/-/issues/${issueNumber}`;
+  return gitlabNoteToIssueComment(data, issueUrl, repo.host);
+}
+
+export async function addIssueLabelImpl(
+  repo: RepoRef,
+  issueNumber: number,
+  label: string
+): Promise<ForgeLabel[]> {
+  const { data } = await gitlabRest<GitLabIssue>({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/issues/${issueNumber}`,
+    body: { add_labels: label },
+  });
+  return gitlabLabelsToForgeLabels(data.labels);
+}
+
+export async function removeIssueLabelImpl(
+  repo: RepoRef,
+  issueNumber: number,
+  label: string
+): Promise<ForgeLabel[]> {
+  const issue = await fetchIssueRaw(repo, issueNumber);
+  const present = Array.isArray(issue.labels) && issue.labels.some((l) => l === label);
+  if (!present) {
+    throw new Error(`Label "${label}" is not on issue #${issueNumber}`);
+  }
+  const { data } = await gitlabRest<GitLabIssue>({
+    host: repo.host,
+    method: "PUT",
+    path: `${projectPath(repo)}/issues/${issueNumber}`,
+    body: { remove_labels: label },
+  });
+  return gitlabLabelsToForgeLabels(data.labels);
+}

--- a/plugins/builtin/gitlab/main/mutations.ts
+++ b/plugins/builtin/gitlab/main/mutations.ts
@@ -187,9 +187,11 @@ export async function mergePRImpl(
       method: "PUT",
       path: `${projectPath(repo)}/merge_requests/${prNumber}/merge`,
       body: {
-        // An explicit method pins `squash` both ways so the project's
-        // squash-by-default option can't silently override the caller;
-        // omitting the method leaves the project default in charge.
+        // An explicit method sends `squash` both ways so the project's
+        // squash-by-default option doesn't silently flip the caller's choice.
+        // The project's `squash_option` stays authoritative at the extremes
+        // (`always`/`never` ignore the per-request flag); omitting the method
+        // leaves the project default in charge.
         ...(input?.mergeMethod !== undefined ? { squash } : {}),
         ...(commitMessage !== undefined
           ? squash

--- a/plugins/builtin/gitlab/main/mutations.ts
+++ b/plugins/builtin/gitlab/main/mutations.ts
@@ -4,11 +4,14 @@ import type {
   EditIssueInput,
   EditPRInput,
   ForgeLabel,
+  ForgeUser,
   Issue,
   IssueCloseReason,
   IssueComment,
   MergePRInput,
+  MergePRResult,
   PR,
+  PRDraftStateResult,
   RepoRef,
 } from "../../../../shared/types/forge.js";
 import type { GitLabIssue, GitLabMergeRequest, GitLabNote, GitLabUser } from "../shared/types.js";
@@ -18,11 +21,13 @@ import {
   gitlabIssueToForgeIssue,
   gitlabLabelsToForgeLabels,
   gitlabNoteToIssueComment,
+  gitlabUserToForgeUser,
   isDraftMergeRequest,
   isDraftTitle,
   mergeRequestToForgePR,
   stripDraftPrefix,
 } from "./mappers.js";
+import { clearGitLabCaches } from "./readOps.js";
 
 function projectPath(repo: RepoRef): string {
   return `/projects/${encodeProjectId(repo)}`;
@@ -62,6 +67,14 @@ async function resolveUserId(repo: RepoRef, username: string): Promise<number> {
   return match.id;
 }
 
+/** The issue's resulting assignee list — what actually landed, not what was asked for. */
+function gitlabAssigneesToForgeUsers(issue: GitLabIssue, host: string): ForgeUser[] {
+  if (!Array.isArray(issue.assignees)) return [];
+  return issue.assignees
+    .map((u) => gitlabUserToForgeUser(u, host))
+    .filter((u): u is ForgeUser => u !== undefined);
+}
+
 function currentAssigneeIds(issue: GitLabIssue): number[] {
   if (!Array.isArray(issue.assignees)) return [];
   return issue.assignees.map((a) => a.id).filter((id): id is number => typeof id === "number");
@@ -78,6 +91,7 @@ export async function createIssueImpl(repo: RepoRef, input: CreateIssueInput): P
       ...(input.labels && input.labels.length > 0 ? { labels: input.labels.join(",") } : {}),
     },
   });
+  clearGitLabCaches();
   return gitlabIssueToForgeIssue(data, repo.host);
 }
 
@@ -85,14 +99,16 @@ export async function assignIssueImpl(
   repo: RepoRef,
   issueNumber: number,
   username: string
-): Promise<void> {
+): Promise<ForgeUser[]> {
   const [userId, issue] = await Promise.all([
     resolveUserId(repo, username),
     fetchIssueRaw(repo, issueNumber),
   ]);
   const ids = currentAssigneeIds(issue);
-  if (ids.includes(userId)) return;
-  await gitlabRest({
+  // Already assigned — the state the caller asked for is the state on the
+  // server, so report the current list rather than writing it back.
+  if (ids.includes(userId)) return gitlabAssigneesToForgeUsers(issue, repo.host);
+  const { data } = await gitlabRest<GitLabIssue>({
     host: repo.host,
     method: "PUT",
     path: `${projectPath(repo)}/issues/${issueNumber}`,
@@ -103,27 +119,35 @@ export async function assignIssueImpl(
     // semantics stay additive.
     body: { assignee_ids: [userId, ...ids] },
   });
+  clearGitLabCaches();
+  // The updated issue's own list, not the requested id: on GitLab Free the
+  // extra ids are dropped, so only the response says what actually landed.
+  return gitlabAssigneesToForgeUsers(data, repo.host);
 }
 
 export async function unassignIssueImpl(
   repo: RepoRef,
   issueNumber: number,
   username: string
-): Promise<void> {
+): Promise<ForgeUser[]> {
   const issue = await fetchIssueRaw(repo, issueNumber);
   const assignees = Array.isArray(issue.assignees) ? issue.assignees : [];
   const remaining = assignees
     .filter((a) => (a.username ?? "").toLowerCase() !== username.toLowerCase())
     .map((a) => a.id)
     .filter((id): id is number => typeof id === "number");
-  if (remaining.length === assignees.length) return;
-  await gitlabRest({
+  // Not assigned in the first place — nothing to write, and the current list
+  // is already the resulting list.
+  if (remaining.length === assignees.length) return gitlabAssigneesToForgeUsers(issue, repo.host);
+  const { data } = await gitlabRest<GitLabIssue>({
     host: repo.host,
     method: "PUT",
     path: `${projectPath(repo)}/issues/${issueNumber}`,
     // `[0]` is GitLab's documented "unassign everyone" sentinel.
     body: { assignee_ids: remaining.length > 0 ? remaining : [0] },
   });
+  clearGitLabCaches();
+  return gitlabAssigneesToForgeUsers(data, repo.host);
 }
 
 export async function createPRImpl(repo: RepoRef, input: CreatePRInput): Promise<PR> {
@@ -142,6 +166,7 @@ export async function createPRImpl(repo: RepoRef, input: CreatePRInput): Promise
       ...(input.body !== undefined ? { description: input.body } : {}),
     },
   });
+  clearGitLabCaches();
   return mergeRequestToForgePR(data, repo.host);
 }
 
@@ -149,28 +174,30 @@ async function setMRStateEvent(
   repo: RepoRef,
   prNumber: number,
   stateEvent: "close" | "reopen"
-): Promise<void> {
-  await gitlabRest({
+): Promise<PR> {
+  const { data } = await gitlabRest<GitLabMergeRequest>({
     host: repo.host,
     method: "PUT",
     path: `${projectPath(repo)}/merge_requests/${prNumber}`,
     body: { state_event: stateEvent },
   });
+  clearGitLabCaches();
+  return mergeRequestToForgePR(data, repo.host);
 }
 
-export async function closePRImpl(repo: RepoRef, prNumber: number): Promise<void> {
-  await setMRStateEvent(repo, prNumber, "close");
+export async function closePRImpl(repo: RepoRef, prNumber: number): Promise<PR> {
+  return setMRStateEvent(repo, prNumber, "close");
 }
 
-export async function reopenPRImpl(repo: RepoRef, prNumber: number): Promise<void> {
-  await setMRStateEvent(repo, prNumber, "reopen");
+export async function reopenPRImpl(repo: RepoRef, prNumber: number): Promise<PR> {
+  return setMRStateEvent(repo, prNumber, "reopen");
 }
 
 export async function mergePRImpl(
   repo: RepoRef,
   prNumber: number,
   input?: MergePRInput
-): Promise<void> {
+): Promise<MergePRResult> {
   if (input?.mergeMethod === "rebase") {
     // GitLab's merge method is project-level configuration, not a per-merge
     // parameter; only squash can be chosen per merge.
@@ -182,7 +209,7 @@ export async function mergePRImpl(
       ? [input.commitTitle, input.commitMessage].filter(Boolean).join("\n\n")
       : undefined;
   try {
-    await gitlabRest({
+    const { data } = await gitlabRest<GitLabMergeRequest>({
       host: repo.host,
       method: "PUT",
       path: `${projectPath(repo)}/merge_requests/${prNumber}/merge`,
@@ -200,6 +227,38 @@ export async function mergePRImpl(
           : {}),
       },
     });
+    clearGitLabCaches();
+    // GitLab answers the merge endpoint with the updated merge request, not a
+    // dedicated ack. Squash and merge-commit land in different fields, so both
+    // are read; a 2xx means the merge happened, which is why `state` only gets
+    // to deny it when it explicitly says otherwise.
+    // Merge commit first: GitLab can squash the source commits AND still
+    // create a merge commit, returning both. `MergePRResult.sha` names the
+    // commit the change landed as on the target branch, so the squash sha is
+    // only right when there is no merge commit (fast-forward/semi-linear).
+    const sha =
+      (typeof data.merge_commit_sha === "string" && data.merge_commit_sha) ||
+      (typeof data.squash_commit_sha === "string" && data.squash_commit_sha) ||
+      null;
+    // A 200 whose body isn't a merge request at all (an error envelope, a
+    // gateway page) says nothing about the merge. Claiming either outcome
+    // from it would be a guess, so it's an error.
+    if (typeof data.state !== "string") {
+      throw new Error("GitLab returned an unrecognizable response to the merge");
+    }
+    // Only an explicit "merged" counts: a queued merge acks with the MR still
+    // open, and reporting a merge that didn't happen is the worse mistake.
+    const merged = data.state === "merged";
+    return {
+      prNumber,
+      sha,
+      merged,
+      // A queued merge (merge-when-pipeline-succeeds) acks 2xx with the MR
+      // still open. Saying "merged" there would contradict the flag beside it.
+      message: merged
+        ? `Merge request !${prNumber} merged`
+        : `Merge request !${prNumber} is queued to merge`,
+    };
   } catch (err) {
     // GitLab answers 405/406 for unmergeable states with a terse body;
     // translate them so the confirm-dialog error is actionable.
@@ -213,40 +272,60 @@ export async function mergePRImpl(
   }
 }
 
-export async function convertPRToDraftImpl(repo: RepoRef, prNumber: number): Promise<void> {
+/**
+ * Draft state IS the title prefix in GitLab — there is no writable flag — so a
+ * toggle is a title rewrite. The resulting state is read back off the updated
+ * merge request rather than assumed from the request, so a project rule that
+ * rewrites the title can't leave the UI claiming a state the server rejected.
+ */
+async function setMRDraftState(
+  repo: RepoRef,
+  prNumber: number,
+  draft: boolean
+): Promise<PRDraftStateResult> {
   const mr = await fetchMRRaw(repo, prNumber);
-  if (isDraftMergeRequest(mr)) return;
-  await gitlabRest({
+  if (isDraftMergeRequest(mr) === draft) return { prNumber, isDraft: draft };
+  const title = draft ? `Draft: ${mr.title ?? ""}` : stripDraftPrefix(mr.title ?? "");
+  const { data } = await gitlabRest<GitLabMergeRequest>({
     host: repo.host,
     method: "PUT",
     path: `${projectPath(repo)}/merge_requests/${prNumber}`,
-    // Draft state IS the title prefix in GitLab — there's no writable flag.
-    body: { title: `Draft: ${mr.title ?? ""}` },
+    body: { title },
   });
+  clearGitLabCaches();
+  return { prNumber, isDraft: isDraftMergeRequest(data) };
 }
 
-export async function markPRReadyForReviewImpl(repo: RepoRef, prNumber: number): Promise<void> {
-  const mr = await fetchMRRaw(repo, prNumber);
-  if (!isDraftMergeRequest(mr)) return;
-  await gitlabRest({
-    host: repo.host,
-    method: "PUT",
-    path: `${projectPath(repo)}/merge_requests/${prNumber}`,
-    body: { title: stripDraftPrefix(mr.title ?? "") },
-  });
+export async function convertPRToDraftImpl(
+  repo: RepoRef,
+  prNumber: number
+): Promise<PRDraftStateResult> {
+  return setMRDraftState(repo, prNumber, true);
+}
+
+export async function markPRReadyForReviewImpl(
+  repo: RepoRef,
+  prNumber: number
+): Promise<PRDraftStateResult> {
+  return setMRDraftState(repo, prNumber, false);
 }
 
 export async function commentOnPRImpl(
   repo: RepoRef,
   prNumber: number,
   body: string
-): Promise<void> {
-  await gitlabRest({
+): Promise<IssueComment> {
+  const { data } = await gitlabRest<GitLabNote>({
     host: repo.host,
     method: "POST",
     path: `${projectPath(repo)}/merge_requests/${prNumber}/notes`,
     body: { body },
   });
+  // A note changes the MR's comment count and timeline, so the cached
+  // tooltips that carry it are stale.
+  clearGitLabCaches();
+  const prUrl = `${repoWebUrl(repo)}/-/merge_requests/${prNumber}`;
+  return gitlabNoteToIssueComment(data, prUrl, repo.host);
 }
 
 export async function editPRImpl(repo: RepoRef, prNumber: number, input: EditPRInput): Promise<PR> {
@@ -269,6 +348,7 @@ export async function editPRImpl(repo: RepoRef, prNumber: number, input: EditPRI
       ...(input.body !== undefined ? { description: input.body } : {}),
     },
   });
+  clearGitLabCaches();
   return mergeRequestToForgePR(data, repo.host);
 }
 
@@ -284,6 +364,7 @@ export async function closeIssueImpl(
     path: `${projectPath(repo)}/issues/${issueNumber}`,
     body: { state_event: "close" },
   });
+  clearGitLabCaches();
   return gitlabIssueToForgeIssue(data, repo.host);
 }
 
@@ -294,6 +375,7 @@ export async function reopenIssueImpl(repo: RepoRef, issueNumber: number): Promi
     path: `${projectPath(repo)}/issues/${issueNumber}`,
     body: { state_event: "reopen" },
   });
+  clearGitLabCaches();
   return gitlabIssueToForgeIssue(data, repo.host);
 }
 
@@ -311,6 +393,7 @@ export async function editIssueImpl(
       ...(input.body !== undefined ? { description: input.body } : {}),
     },
   });
+  clearGitLabCaches();
   return gitlabIssueToForgeIssue(data, repo.host);
 }
 
@@ -325,6 +408,7 @@ export async function addIssueCommentImpl(
     path: `${projectPath(repo)}/issues/${issueNumber}/notes`,
     body: { body },
   });
+  clearGitLabCaches();
   const issueUrl = `${repoWebUrl(repo)}/-/issues/${issueNumber}`;
   return gitlabNoteToIssueComment(data, issueUrl, repo.host);
 }
@@ -340,6 +424,7 @@ export async function addIssueLabelImpl(
     path: `${projectPath(repo)}/issues/${issueNumber}`,
     body: { add_labels: label },
   });
+  clearGitLabCaches();
   return gitlabLabelsToForgeLabels(data.labels);
 }
 
@@ -359,5 +444,6 @@ export async function removeIssueLabelImpl(
     path: `${projectPath(repo)}/issues/${issueNumber}`,
     body: { remove_labels: label },
   });
+  clearGitLabCaches();
   return gitlabLabelsToForgeLabels(data.labels);
 }

--- a/plugins/builtin/gitlab/main/mutations.ts
+++ b/plugins/builtin/gitlab/main/mutations.ts
@@ -132,13 +132,14 @@ export async function unassignIssueImpl(
 ): Promise<ForgeUser[]> {
   const issue = await fetchIssueRaw(repo, issueNumber);
   const assignees = Array.isArray(issue.assignees) ? issue.assignees : [];
-  const remaining = assignees
-    .filter((a) => (a.username ?? "").toLowerCase() !== username.toLowerCase())
-    .map((a) => a.id)
-    .filter((id): id is number => typeof id === "number");
+  const kept = assignees.filter((a) => (a.username ?? "").toLowerCase() !== username.toLowerCase());
   // Not assigned in the first place — nothing to write, and the current list
-  // is already the resulting list.
-  if (remaining.length === assignees.length) return gitlabAssigneesToForgeUsers(issue, repo.host);
+  // is already the resulting list. Measured on the username filter ALONE: an
+  // assignee GitLab returned without a numeric id drops out of the id list
+  // below, and comparing that against the full list would read as a removal
+  // and write back an `assignee_ids` that silently unassigns them.
+  if (kept.length === assignees.length) return gitlabAssigneesToForgeUsers(issue, repo.host);
+  const remaining = kept.map((a) => a.id).filter((id): id is number => typeof id === "number");
   const { data } = await gitlabRest<GitLabIssue>({
     host: repo.host,
     method: "PUT",
@@ -151,10 +152,11 @@ export async function unassignIssueImpl(
 }
 
 export async function createPRImpl(repo: RepoRef, input: CreatePRInput): Promise<PR> {
+  // `isDraftTitle` knows every prefix GitLab itself recognizes — `[Draft]`,
+  // `(Draft)` and `Draft -` as well as `Draft:` — so a title that already
+  // reads as a draft isn't prefixed a second time.
   const title =
-    input.draft === true && !/^\s*draft:/i.test(input.title)
-      ? `Draft: ${input.title}`
-      : input.title;
+    input.draft === true && !isDraftTitle(input.title) ? `Draft: ${input.title}` : input.title;
   const { data } = await gitlabRest<GitLabMergeRequest>({
     host: repo.host,
     method: "POST",
@@ -285,7 +287,11 @@ async function setMRDraftState(
 ): Promise<PRDraftStateResult> {
   const mr = await fetchMRRaw(repo, prNumber);
   if (isDraftMergeRequest(mr) === draft) return { prNumber, isDraft: draft };
-  const title = draft ? `Draft: ${mr.title ?? ""}` : stripDraftPrefix(mr.title ?? "");
+  // Strip first either way: `isDraftMergeRequest` trusts the explicit `draft`
+  // flag over the title, so an MR the server calls ready can still carry a
+  // `[Draft]` prefix — prefixing that unstripped yields "Draft: [Draft] Foo".
+  const base = stripDraftPrefix(mr.title ?? "");
+  const title = draft ? `Draft: ${base}` : base;
   const { data } = await gitlabRest<GitLabMergeRequest>({
     host: repo.host,
     method: "PUT",

--- a/plugins/builtin/gitlab/main/readOps.ts
+++ b/plugins/builtin/gitlab/main/readOps.ts
@@ -1,0 +1,519 @@
+import type {
+  CIStatus,
+  Issue,
+  IssueTooltipData,
+  ListOptions,
+  Page,
+  PR,
+  PRTooltipData,
+  RateLimitInfo,
+  RepoMetadata,
+  RepoRef,
+  RepoStatsSnapshot,
+  StatsPage,
+} from "../../../../shared/types/forge.js";
+import type {
+  GitLabIssue,
+  GitLabMergeRequest,
+  GitLabProject,
+  GitLabRelease,
+} from "../shared/types.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import {
+  GitLabApiError,
+  gitlabGraphQL,
+  gitlabRest,
+  gitlabRestPage,
+  getRateLimitSnapshot,
+} from "./GitLabClient.js";
+import { getInstanceHost } from "./GitLabAuth.js";
+import { encodeProjectId, repoFullPath } from "./gitlabRemote.js";
+import {
+  gitlabIssueToForgeIssue,
+  gitlabReleaseToForgeRelease,
+  graphqlMergeRequestToForgePR,
+  issueToTooltipData,
+  mapIssueListState,
+  mapListOrderBy,
+  mapMRListState,
+  mergeRequestToForgePR,
+  pipelineStatusToCIState,
+  prToTooltipData,
+} from "./mappers.js";
+
+const TOOLTIP_CACHE_TTL_MS = 30_000;
+const AVATAR_CACHE_TTL_MS = 60 * 60 * 1000;
+const REPO_STATS_CACHE_TTL_MS = 30_000;
+const STATS_FIRST_PAGE_SIZE = 20;
+
+/** Branches per batched GraphQL branch→MR query. */
+export const GRAPHQL_BRANCH_CHUNK_SIZE = 20;
+
+interface CacheEntry<T> {
+  value: T;
+  at: number;
+}
+
+const issueTooltipCache = new Map<string, CacheEntry<IssueTooltipData | null>>();
+const prTooltipCache = new Map<string, CacheEntry<PRTooltipData | null>>();
+const avatarCache = new Map<string, CacheEntry<string | null>>();
+const repoStatsCache = new Map<string, CacheEntry<RepoStatsSnapshot>>();
+
+export function clearGitLabCaches(): void {
+  issueTooltipCache.clear();
+  prTooltipCache.clear();
+  avatarCache.clear();
+  repoStatsCache.clear();
+}
+
+function cacheGet<T>(map: Map<string, CacheEntry<T>>, key: string, ttlMs: number): T | undefined {
+  const entry = map.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.at > ttlMs) {
+    map.delete(key);
+    return undefined;
+  }
+  return entry.value;
+}
+
+function tooltipKey(repo: RepoRef, number: number): string {
+  return `${repo.host}/${repoFullPath(repo)}#${number}`;
+}
+
+function listQuery(opts: ListOptions, state: string | undefined) {
+  return {
+    ...(state !== undefined ? { state } : {}),
+    per_page: opts.perPage ?? 30,
+    page: opts.cursor ?? "1",
+    order_by: mapListOrderBy(opts.sort),
+    sort: opts.direction ?? "desc",
+    ...(opts.search ? { search: opts.search } : {}),
+    ...(opts.labels && opts.labels.length > 0 ? { labels: opts.labels.join(",") } : {}),
+    ...(opts.assignee ? { assignee_username: opts.assignee } : {}),
+  };
+}
+
+export async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Issue>> {
+  const page = await gitlabRestPage<GitLabIssue>({
+    host: repo.host,
+    path: `/projects/${encodeProjectId(repo)}/issues`,
+    query: listQuery(opts, mapIssueListState(opts.state)),
+  });
+  return {
+    items: page.items.map((issue) => gitlabIssueToForgeIssue(issue, repo.host)),
+    nextCursor: page.nextCursor,
+    hasMore: page.hasMore,
+    ...(page.totalCount !== undefined ? { totalCount: page.totalCount } : {}),
+  };
+}
+
+export async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> {
+  const page = await gitlabRestPage<GitLabMergeRequest>({
+    host: repo.host,
+    path: `/projects/${encodeProjectId(repo)}/merge_requests`,
+    query: listQuery(opts, mapMRListState(opts.state)),
+  });
+  return {
+    items: page.items.map((mr) => mergeRequestToForgePR(mr, repo.host)),
+    nextCursor: page.nextCursor,
+    hasMore: page.hasMore,
+    ...(page.totalCount !== undefined ? { totalCount: page.totalCount } : {}),
+  };
+}
+
+/** `null` on 404 per contract; every other failure propagates. */
+function nullOn404<T>(err: unknown): T | null {
+  if (err instanceof GitLabApiError && err.status === 404) return null;
+  throw err;
+}
+
+export async function getIssueImpl(repo: RepoRef, number: number): Promise<Issue | null> {
+  try {
+    const { data } = await gitlabRest<GitLabIssue>({
+      host: repo.host,
+      path: `/projects/${encodeProjectId(repo)}/issues/${number}`,
+    });
+    return gitlabIssueToForgeIssue(data, repo.host);
+  } catch (err) {
+    return nullOn404<Issue>(err);
+  }
+}
+
+export async function getPRImpl(repo: RepoRef, number: number): Promise<PR | null> {
+  try {
+    const { data } = await gitlabRest<GitLabMergeRequest>({
+      host: repo.host,
+      path: `/projects/${encodeProjectId(repo)}/merge_requests/${number}`,
+    });
+    return mergeRequestToForgePR(data, repo.host);
+  } catch (err) {
+    return nullOn404<PR>(err);
+  }
+}
+
+/**
+ * Newest MR (any state) whose source branch matches — mirroring the GitHub
+ * provider's `head:` search semantics so a merged MR still badges its
+ * worktree.
+ */
+export async function findPRByBranchImpl(repo: RepoRef, branchName: string): Promise<PR | null> {
+  const page = await gitlabRestPage<GitLabMergeRequest>({
+    host: repo.host,
+    path: `/projects/${encodeProjectId(repo)}/merge_requests`,
+    query: {
+      source_branch: branchName,
+      order_by: "created_at",
+      sort: "desc",
+      per_page: 1,
+    },
+  });
+  const first = page.items[0];
+  return first ? mergeRequestToForgePR(first, repo.host) : null;
+}
+
+const BRANCH_BATCH_QUERY = `
+query DaintreeMRsForBranches($fullPath: ID!, $branches: [String!]) {
+  project(fullPath: $fullPath) {
+    mergeRequests(sourceBranches: $branches, sort: CREATED_DESC, first: 100) {
+      pageInfo { hasNextPage }
+      nodes {
+        iid
+        title
+        description
+        state
+        draft
+        sourceBranch
+        targetBranch
+        webUrl
+        createdAt
+        updatedAt
+        mergedAt
+        closedAt
+        author { username avatarUrl }
+        headPipeline { status }
+      }
+    }
+  }
+}`;
+
+interface BranchBatchResponse {
+  project: {
+    mergeRequests: {
+      pageInfo?: { hasNextPage?: boolean } | null;
+      nodes: Array<Record<string, unknown>>;
+    } | null;
+  } | null;
+}
+
+/**
+ * Batched branch→MR lookup via GraphQL `mergeRequests(sourceBranches:)` —
+ * one query per {@link GRAPHQL_BRANCH_CHUNK_SIZE} branches instead of one
+ * REST call per branch. Branches in a successful chunk with no returned MR
+ * are confirmed absent (`null`); branches in a failed chunk are omitted so
+ * the host's per-branch fallback re-resolves them. Nodes arrive
+ * created-desc, so the first node per branch is the newest — matching
+ * {@link findPRByBranchImpl}. When the 100-node window truncates
+ * (`pageInfo.hasNextPage`), branches with no returned node are omitted
+ * rather than confirmed absent, since their newest MR may lie beyond the
+ * window.
+ */
+export async function findPRsByBranchesImpl(
+  repo: RepoRef,
+  branches: string[]
+): Promise<Map<string, PR | null>> {
+  const unique = [...new Set(branches.filter((b) => typeof b === "string" && b.length > 0))];
+  const result = new Map<string, PR | null>();
+
+  for (let start = 0; start < unique.length; start += GRAPHQL_BRANCH_CHUNK_SIZE) {
+    const chunk = unique.slice(start, start + GRAPHQL_BRANCH_CHUNK_SIZE);
+    let response: BranchBatchResponse;
+    try {
+      response = await gitlabGraphQL<BranchBatchResponse>(repo.host, BRANCH_BATCH_QUERY, {
+        fullPath: repoFullPath(repo),
+        branches: chunk,
+      });
+    } catch {
+      // Omit the chunk — the host falls back to per-branch resolution.
+      continue;
+    }
+    const connection = response.project?.mergeRequests;
+    const nodes = connection?.nodes;
+    if (!connection || !Array.isArray(nodes)) {
+      // `project: null` means no access / not found — absence is unconfirmed.
+      continue;
+    }
+    const found = new Map<string, PR>();
+    for (const node of nodes) {
+      const pr = graphqlMergeRequestToForgePR(node, repo.host);
+      if (!pr || pr.headRef.length === 0) continue;
+      if (!found.has(pr.headRef)) found.set(pr.headRef, pr);
+    }
+    // A truncated window (100+ MRs across the chunk's branches) means a
+    // branch with no returned node might still have an MR beyond the window —
+    // only a complete window confirms absence. Omitted branches route to the
+    // host's per-branch fallback per the contract.
+    const windowComplete = connection.pageInfo?.hasNextPage !== true;
+    for (const branch of chunk) {
+      const pr = found.get(branch);
+      if (pr) {
+        result.set(branch, pr);
+      } else if (windowComplete) {
+        result.set(branch, null);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * CI roll-up from the MR's head pipeline. GitLab reports one pipeline status
+ * rather than per-check counts, so the roll-up projects that single status.
+ */
+export async function getCIStatusImpl(repo: RepoRef, prNumber: number): Promise<CIStatus | null> {
+  let mr: GitLabMergeRequest;
+  try {
+    const { data } = await gitlabRest<GitLabMergeRequest>({
+      host: repo.host,
+      path: `/projects/${encodeProjectId(repo)}/merge_requests/${prNumber}`,
+    });
+    mr = data;
+  } catch (err) {
+    return nullOn404<CIStatus>(err);
+  }
+  const state = pipelineStatusToCIState(mr.head_pipeline?.status);
+  if (!state || !mr.head_pipeline) return null;
+  return {
+    state,
+    total: 1,
+    passed: state === "success" ? 1 : 0,
+    failed: state === "failure" ? 1 : 0,
+    pending: state === "pending" ? 1 : 0,
+    rawData: mr.head_pipeline,
+  };
+}
+
+export async function getRepoMetadataImpl(repo: RepoRef): Promise<RepoMetadata> {
+  const { data } = await gitlabRest<GitLabProject>({
+    host: repo.host,
+    path: `/projects/${encodeProjectId(repo)}`,
+    query: { license: true },
+  });
+  return {
+    defaultBranch: data.default_branch ?? "main",
+    isPrivate: data.visibility !== "public",
+    isFork: data.forked_from_project != null,
+    isArchived: data.archived === true,
+    description: data.description ?? null,
+    license: data.license?.nickname ?? data.license?.name ?? null,
+    ...(Array.isArray(data.topics) ? { topics: data.topics } : {}),
+    rawData: data,
+  };
+}
+
+export async function listReleasesImpl(repo: RepoRef, opts: ListOptions) {
+  const page = await gitlabRestPage<GitLabRelease>({
+    host: repo.host,
+    path: `/projects/${encodeProjectId(repo)}/releases`,
+    query: {
+      per_page: opts.perPage ?? 30,
+      page: opts.cursor ?? "1",
+    },
+  });
+  return {
+    items: page.items.map((release) =>
+      gitlabReleaseToForgeRelease(release, { host: repo.host, owner: repo.owner, repo: repo.repo })
+    ),
+    nextCursor: page.nextCursor,
+    hasMore: page.hasMore,
+    ...(page.totalCount !== undefined ? { totalCount: page.totalCount } : {}),
+  };
+}
+
+export async function getLatestReleaseImpl(repo: RepoRef) {
+  try {
+    const { data } = await gitlabRest<GitLabRelease>({
+      host: repo.host,
+      path: `/projects/${encodeProjectId(repo)}/releases/permalink/latest`,
+    });
+    return gitlabReleaseToForgeRelease(data, {
+      host: repo.host,
+      owner: repo.owner,
+      repo: repo.repo,
+    });
+  } catch (err) {
+    // Older instances (pre-13.12) lack the permalink route; 404 also means
+    // "no releases yet". Either way fall back to the newest list entry.
+    if (!(err instanceof GitLabApiError && err.status === 404)) throw err;
+  }
+  const page = await listReleasesImpl(repo, { perPage: 1 });
+  return page.items[0] ?? null;
+}
+
+export async function getIssueTooltipImpl(
+  repo: RepoRef,
+  issueNumber: number
+): Promise<IssueTooltipData | null> {
+  const key = tooltipKey(repo, issueNumber);
+  const cached = cacheGet(issueTooltipCache, key, TOOLTIP_CACHE_TTL_MS);
+  if (cached !== undefined) return cached;
+  try {
+    const issue = await getIssueImpl(repo, issueNumber);
+    const tooltip = issue ? issueToTooltipData(issue) : null;
+    issueTooltipCache.set(key, { value: tooltip, at: Date.now() });
+    return tooltip;
+  } catch {
+    return null;
+  }
+}
+
+export async function getPRTooltipImpl(
+  repo: RepoRef,
+  prNumber: number
+): Promise<PRTooltipData | null> {
+  const key = tooltipKey(repo, prNumber);
+  const cached = cacheGet(prTooltipCache, key, TOOLTIP_CACHE_TTL_MS);
+  if (cached !== undefined) return cached;
+  try {
+    const pr = await getPRImpl(repo, prNumber);
+    const tooltip = pr ? prToTooltipData(pr, repo.host) : null;
+    prTooltipCache.set(key, { value: tooltip, at: Date.now() });
+    return tooltip;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Commit-author avatar via the public `/avatar?email=` endpoint on the
+ * configured instance. Works unauthenticated (it falls back to Gravatar
+ * server-side), cached per email.
+ */
+export async function resolveAuthorAvatarImpl(
+  instanceHost: string,
+  email: string
+): Promise<string | null> {
+  const key = email.trim().toLowerCase();
+  if (key.length === 0) return null;
+  const cached = cacheGet(avatarCache, key, AVATAR_CACHE_TTL_MS);
+  if (cached !== undefined) return cached;
+  try {
+    const { data } = await gitlabRest<{ avatar_url?: unknown }>({
+      host: instanceHost,
+      path: "/avatar",
+      query: { email: key, size: 64 },
+    });
+    const url =
+      typeof data.avatar_url === "string" && data.avatar_url.length > 0 ? data.avatar_url : null;
+    avatarCache.set(key, { value: url, at: Date.now() });
+    return url;
+  } catch {
+    avatarCache.set(key, { value: null, at: Date.now() });
+    return null;
+  }
+}
+
+function toStatsPage<T>(
+  items: T[],
+  hasMore: boolean,
+  totalCount: number | undefined
+): StatsPage<T> {
+  return {
+    items,
+    endCursor: hasMore ? "2" : null,
+    hasNextPage: hasMore,
+    ...(totalCount !== undefined ? { totalCount } : {}),
+  };
+}
+
+/**
+ * Toolbar counts + first pages in two REST calls: the first page of open
+ * issues and open MRs each carry `x-total`, so no separate count probes are
+ * needed. Cached briefly to absorb mount bursts; `bypassCache` skips the
+ * cache for explicit refreshes.
+ */
+export async function getRepoStatsImpl(
+  repo: RepoRef,
+  opts?: { bypassCache?: boolean }
+): Promise<RepoStatsSnapshot> {
+  const key = `${repo.host}/${repoFullPath(repo)}`;
+  if (!opts?.bypassCache) {
+    const cached = cacheGet(repoStatsCache, key, REPO_STATS_CACHE_TTL_MS);
+    if (cached !== undefined) return { ...cached, source: "memory-cache" };
+  }
+
+  const now = Date.now();
+  try {
+    const [issuesPage, mrsPage] = await Promise.all([
+      gitlabRestPage<GitLabIssue>({
+        host: repo.host,
+        path: `/projects/${encodeProjectId(repo)}/issues`,
+        query: {
+          state: "opened",
+          per_page: STATS_FIRST_PAGE_SIZE,
+          order_by: "created_at",
+          sort: "desc",
+        },
+      }),
+      gitlabRestPage<GitLabMergeRequest>({
+        host: repo.host,
+        path: `/projects/${encodeProjectId(repo)}/merge_requests`,
+        query: {
+          state: "opened",
+          per_page: STATS_FIRST_PAGE_SIZE,
+          order_by: "created_at",
+          sort: "desc",
+        },
+      }),
+    ]);
+
+    const snapshot: RepoStatsSnapshot = {
+      counts: {
+        issueCount: issuesPage.totalCount ?? null,
+        prCount: mrsPage.totalCount ?? null,
+        lastUpdated: now,
+        issueCountRefreshedAt: now,
+        prCountRefreshedAt: now,
+      },
+      issues: toStatsPage(
+        issuesPage.items.map((issue) => gitlabIssueToForgeIssue(issue, repo.host)),
+        issuesPage.hasMore,
+        issuesPage.totalCount
+      ),
+      prs: toStatsPage(
+        mrsPage.items.map((mr) => mergeRequestToForgePR(mr, repo.host)),
+        mrsPage.hasMore,
+        mrsPage.totalCount
+      ),
+      source: "network",
+    };
+    repoStatsCache.set(key, { value: snapshot, at: now });
+    return snapshot;
+  } catch (err) {
+    const stale = repoStatsCache.get(key)?.value;
+    const message = formatErrorMessage(err, "GitLab request failed");
+    if (stale) {
+      return {
+        ...stale,
+        counts: { ...stale.counts, stale: true, error: message },
+        source: "memory-cache",
+      };
+    }
+    return {
+      counts: { issueCount: null, prCount: null, error: message },
+      issues: null,
+      prs: null,
+      source: "network",
+    };
+  }
+}
+
+/**
+ * Rate-limit projection for the CONFIGURED instance — snapshots are kept per
+ * host so an unauthenticated public-instance request can't masquerade as the
+ * credentialed instance's quota.
+ */
+export async function getRateLimitImpl(): Promise<RateLimitInfo> {
+  const snapshot = getRateLimitSnapshot(await getInstanceHost());
+  return snapshot?.info ?? { limit: null, remaining: null, resetAt: null };
+}

--- a/plugins/builtin/gitlab/main/readOps.ts
+++ b/plugins/builtin/gitlab/main/readOps.ts
@@ -342,7 +342,7 @@ export async function getLatestReleaseImpl(repo: RepoRef) {
       repo: repo.repo,
     });
   } catch (err) {
-    // Older instances (pre-13.12) lack the permalink route; 404 also means
+    // Older instances (pre-14.10) lack the permalink route; 404 also means
     // "no releases yet". Either way fall back to the newest list entry.
     if (!(err instanceof GitLabApiError && err.status === 404)) throw err;
   }
@@ -393,15 +393,18 @@ export async function resolveAuthorAvatarImpl(
   instanceHost: string,
   email: string
 ): Promise<string | null> {
-  const key = email.trim().toLowerCase();
-  if (key.length === 0) return null;
+  const normalizedEmail = email.trim().toLowerCase();
+  if (normalizedEmail.length === 0) return null;
+  // Keyed by host + email: an instance-URL change must not serve avatars
+  // resolved against the previous instance.
+  const key = `${instanceHost.toLowerCase()}:${normalizedEmail}`;
   const cached = cacheGet(avatarCache, key, AVATAR_CACHE_TTL_MS);
   if (cached !== undefined) return cached;
   try {
     const { data } = await gitlabRest<{ avatar_url?: unknown }>({
       host: instanceHost,
       path: "/avatar",
-      query: { email: key, size: 64 },
+      query: { email: normalizedEmail, size: 64 },
     });
     const url =
       typeof data.avatar_url === "string" && data.avatar_url.length > 0 ? data.avatar_url : null;

--- a/plugins/builtin/gitlab/main/readOps.ts
+++ b/plugins/builtin/gitlab/main/readOps.ts
@@ -25,10 +25,12 @@ import {
   gitlabRest,
   gitlabRestPage,
   getRateLimitSnapshot,
+  resetRateLimitSnapshots,
 } from "./GitLabClient.js";
 import { getInstanceHost } from "./GitLabAuth.js";
 import { encodeProjectId, repoFullPath } from "./gitlabRemote.js";
 import {
+  absolutizeAvatarUrl,
   gitlabIssueToForgeIssue,
   gitlabReleaseToForgeRelease,
   graphqlMergeRequestToForgePR,
@@ -59,11 +61,31 @@ const prTooltipCache = new Map<string, CacheEntry<PRTooltipData | null>>();
 const avatarCache = new Map<string, CacheEntry<string | null>>();
 const repoStatsCache = new Map<string, CacheEntry<RepoStatsSnapshot>>();
 
+/**
+ * Bumped by every invalidation. A read that started before the bump writes its
+ * result under the old generation and is dropped — clearing the maps alone
+ * would let an in-flight request repopulate them a moment later with data
+ * fetched under the previous credential or instance.
+ */
+let cacheGeneration = 0;
+
 export function clearGitLabCaches(): void {
+  cacheGeneration += 1;
   issueTooltipCache.clear();
   prTooltipCache.clear();
   avatarCache.clear();
   repoStatsCache.clear();
+  resetRateLimitSnapshots();
+}
+
+/** Snapshot the generation before an await; pass it to {@link cacheSet}. */
+function cacheEpoch(): number {
+  return cacheGeneration;
+}
+
+function cacheSet<T>(map: Map<string, CacheEntry<T>>, key: string, value: T, epoch: number): void {
+  if (epoch !== cacheGeneration) return;
+  map.set(key, { value, at: Date.now() });
 }
 
 function cacheGet<T>(map: Map<string, CacheEntry<T>>, key: string, ttlMs: number): T | undefined {
@@ -74,6 +96,15 @@ function cacheGet<T>(map: Map<string, CacheEntry<T>>, key: string, ttlMs: number
     return undefined;
   }
   return entry.value;
+}
+
+/**
+ * Entries GitLab can't identify. Without an `iid` a row maps to "#0" with an
+ * empty URL — it opens nothing and no action can target it — so it is dropped
+ * rather than rendered as if it were real.
+ */
+function withUsableNumber<T extends { iid?: number }>(items: T[]): T[] {
+  return items.filter((item) => typeof item.iid === "number");
 }
 
 function tooltipKey(repo: RepoRef, number: number): string {
@@ -89,7 +120,11 @@ function listQuery(opts: ListOptions, state: string | undefined) {
     sort: opts.direction ?? "desc",
     ...(opts.search ? { search: opts.search } : {}),
     ...(opts.labels && opts.labels.length > 0 ? { labels: opts.labels.join(",") } : {}),
-    ...(opts.assignee ? { assignee_username: opts.assignee } : {}),
+    // `assignee_username[]` is the documented array type on BOTH the issues
+    // and merge_requests endpoints. Grape silently drops an undeclared
+    // parameter, so a wrong shape here would return an UNFILTERED list rather
+    // than an error — send the form the docs declare.
+    ...(opts.assignee ? { assignee_username: [opts.assignee] } : {}),
   };
 }
 
@@ -100,7 +135,9 @@ export async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<
     query: listQuery(opts, mapIssueListState(opts.state)),
   });
   return {
-    items: page.items.map((issue) => gitlabIssueToForgeIssue(issue, repo.host)),
+    // An entry with no `iid` maps to issue #0 with an empty URL — unopenable
+    // and unactionable, so it is dropped rather than rendered as a real row.
+    items: withUsableNumber(page.items).map((issue) => gitlabIssueToForgeIssue(issue, repo.host)),
     nextCursor: page.nextCursor,
     hasMore: page.hasMore,
     ...(page.totalCount !== undefined ? { totalCount: page.totalCount } : {}),
@@ -114,7 +151,7 @@ export async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Pag
     query: listQuery(opts, mapMRListState(opts.state)),
   });
   return {
-    items: page.items.map((mr) => mergeRequestToForgePR(mr, repo.host)),
+    items: withUsableNumber(page.items).map((mr) => mergeRequestToForgePR(mr, repo.host)),
     nextCursor: page.nextCursor,
     hasMore: page.hasMore,
     ...(page.totalCount !== undefined ? { totalCount: page.totalCount } : {}),
@@ -168,7 +205,7 @@ export async function findPRByBranchImpl(repo: RepoRef, branchName: string): Pro
     },
   });
   const first = page.items[0];
-  return first ? mergeRequestToForgePR(first, repo.host) : null;
+  return first && typeof first.iid === "number" ? mergeRequestToForgePR(first, repo.host) : null;
 }
 
 const BRANCH_BATCH_QUERY = `
@@ -357,10 +394,11 @@ export async function getIssueTooltipImpl(
   const key = tooltipKey(repo, issueNumber);
   const cached = cacheGet(issueTooltipCache, key, TOOLTIP_CACHE_TTL_MS);
   if (cached !== undefined) return cached;
+  const epoch = cacheEpoch();
   try {
     const issue = await getIssueImpl(repo, issueNumber);
     const tooltip = issue ? issueToTooltipData(issue) : null;
-    issueTooltipCache.set(key, { value: tooltip, at: Date.now() });
+    cacheSet(issueTooltipCache, key, tooltip, epoch);
     return tooltip;
   } catch {
     return null;
@@ -374,10 +412,11 @@ export async function getPRTooltipImpl(
   const key = tooltipKey(repo, prNumber);
   const cached = cacheGet(prTooltipCache, key, TOOLTIP_CACHE_TTL_MS);
   if (cached !== undefined) return cached;
+  const epoch = cacheEpoch();
   try {
     const pr = await getPRImpl(repo, prNumber);
     const tooltip = pr ? prToTooltipData(pr, repo.host) : null;
-    prTooltipCache.set(key, { value: tooltip, at: Date.now() });
+    cacheSet(prTooltipCache, key, tooltip, epoch);
     return tooltip;
   } catch {
     return null;
@@ -400,18 +439,22 @@ export async function resolveAuthorAvatarImpl(
   const key = `${instanceHost.toLowerCase()}:${normalizedEmail}`;
   const cached = cacheGet(avatarCache, key, AVATAR_CACHE_TTL_MS);
   if (cached !== undefined) return cached;
+  const epoch = cacheEpoch();
   try {
     const { data } = await gitlabRest<{ avatar_url?: unknown }>({
       host: instanceHost,
       path: "/avatar",
       query: { email: normalizedEmail, size: 64 },
     });
-    const url =
-      typeof data.avatar_url === "string" && data.avatar_url.length > 0 ? data.avatar_url : null;
-    avatarCache.set(key, { value: url, at: Date.now() });
+    // GitLab documents this as an absolute URL — the instance's own uploads
+    // path, or an external avatar service for an unknown email — which
+    // absolutizeAvatarUrl passes through untouched. It runs through the same
+    // helper anyway so a relative value can't reach the renderer as one.
+    const url = absolutizeAvatarUrl(data.avatar_url, instanceHost) ?? null;
+    cacheSet(avatarCache, key, url, epoch);
     return url;
   } catch {
-    avatarCache.set(key, { value: null, at: Date.now() });
+    cacheSet(avatarCache, key, null, epoch);
     return null;
   }
 }
@@ -440,6 +483,7 @@ export async function getRepoStatsImpl(
   opts?: { bypassCache?: boolean }
 ): Promise<RepoStatsSnapshot> {
   const key = `${repo.host}/${repoFullPath(repo)}`;
+  const epoch = cacheEpoch();
   if (!opts?.bypassCache) {
     const cached = cacheGet(repoStatsCache, key, REPO_STATS_CACHE_TTL_MS);
     if (cached !== undefined) return { ...cached, source: "memory-cache" };
@@ -479,18 +523,20 @@ export async function getRepoStatsImpl(
         prCountRefreshedAt: now,
       },
       issues: toStatsPage(
-        issuesPage.items.map((issue) => gitlabIssueToForgeIssue(issue, repo.host)),
+        withUsableNumber(issuesPage.items).map((issue) =>
+          gitlabIssueToForgeIssue(issue, repo.host)
+        ),
         issuesPage.hasMore,
         issuesPage.totalCount
       ),
       prs: toStatsPage(
-        mrsPage.items.map((mr) => mergeRequestToForgePR(mr, repo.host)),
+        withUsableNumber(mrsPage.items).map((mr) => mergeRequestToForgePR(mr, repo.host)),
         mrsPage.hasMore,
         mrsPage.totalCount
       ),
       source: "network",
     };
-    repoStatsCache.set(key, { value: snapshot, at: now });
+    cacheSet(repoStatsCache, key, snapshot, epoch);
     return snapshot;
   } catch (err) {
     const stale = repoStatsCache.get(key)?.value;

--- a/plugins/builtin/gitlab/main/readOps.ts
+++ b/plugins/builtin/gitlab/main/readOps.ts
@@ -46,7 +46,15 @@ import {
 const TOOLTIP_CACHE_TTL_MS = 30_000;
 const AVATAR_CACHE_TTL_MS = 60 * 60 * 1000;
 const REPO_STATS_CACHE_TTL_MS = 30_000;
-const STATS_FIRST_PAGE_SIZE = 20;
+/**
+ * One page size for BOTH the list endpoints and the stats first page — they
+ * cannot diverge. GitLab pages by NUMBER, so the `"2"` cursor the stats page
+ * hands back is only meaningful at the page size that produced it, and the
+ * host seeds its list cache with that cursor
+ * (`src/hooks/useRepositoryStats.ts`). A smaller stats page would make the
+ * first load-more skip every row between the two sizes.
+ */
+const DEFAULT_LIST_PAGE_SIZE = 30;
 
 /** Branches per batched GraphQL branch→MR query. */
 export const GRAPHQL_BRANCH_CHUNK_SIZE = 20;
@@ -114,7 +122,7 @@ function tooltipKey(repo: RepoRef, number: number): string {
 function listQuery(opts: ListOptions, state: string | undefined) {
   return {
     ...(state !== undefined ? { state } : {}),
-    per_page: opts.perPage ?? 30,
+    per_page: opts.perPage ?? DEFAULT_LIST_PAGE_SIZE,
     page: opts.cursor ?? "1",
     order_by: mapListOrderBy(opts.sort),
     sort: opts.direction ?? "desc",
@@ -353,7 +361,7 @@ export async function listReleasesImpl(repo: RepoRef, opts: ListOptions) {
     host: repo.host,
     path: `/projects/${encodeProjectId(repo)}/releases`,
     query: {
-      per_page: opts.perPage ?? 30,
+      per_page: opts.perPage ?? DEFAULT_LIST_PAGE_SIZE,
       page: opts.cursor ?? "1",
     },
   });
@@ -424,6 +432,17 @@ export async function getPRTooltipImpl(
 }
 
 /**
+ * A failure that says nothing about the email itself — a timeout, a throttle,
+ * a server error, or anything the transport didn't classify. Caching `null`
+ * for one of these would blank every commit by that author for the whole
+ * hour-long avatar TTL over a momentary blip.
+ */
+function isDefinitiveAvatarMiss(err: unknown): boolean {
+  if (!(err instanceof GitLabApiError)) return false;
+  return err.status !== 0 && err.status !== 429 && err.status < 500;
+}
+
+/**
  * Commit-author avatar via the public `/avatar?email=` endpoint on the
  * configured instance. Works unauthenticated (it falls back to Gravatar
  * server-side), cached per email.
@@ -453,8 +472,10 @@ export async function resolveAuthorAvatarImpl(
     const url = absolutizeAvatarUrl(data.avatar_url, instanceHost) ?? null;
     cacheSet(avatarCache, key, url, epoch);
     return url;
-  } catch {
-    cacheSet(avatarCache, key, null, epoch);
+  } catch (err) {
+    // Only an answer the instance actually gave is worth remembering as "no
+    // avatar"; a transient failure is retried on the next read instead.
+    if (isDefinitiveAvatarMiss(err)) cacheSet(avatarCache, key, null, epoch);
     return null;
   }
 }
@@ -497,7 +518,7 @@ export async function getRepoStatsImpl(
         path: `/projects/${encodeProjectId(repo)}/issues`,
         query: {
           state: "opened",
-          per_page: STATS_FIRST_PAGE_SIZE,
+          per_page: DEFAULT_LIST_PAGE_SIZE,
           order_by: "created_at",
           sort: "desc",
         },
@@ -507,7 +528,7 @@ export async function getRepoStatsImpl(
         path: `/projects/${encodeProjectId(repo)}/merge_requests`,
         query: {
           state: "opened",
-          per_page: STATS_FIRST_PAGE_SIZE,
+          per_page: DEFAULT_LIST_PAGE_SIZE,
           order_by: "created_at",
           sort: "desc",
         },
@@ -541,15 +562,28 @@ export async function getRepoStatsImpl(
   } catch (err) {
     const stale = repoStatsCache.get(key)?.value;
     const message = formatErrorMessage(err, "GitLab request failed");
+    // A 429 is a block with a known end, not a generic failure: the host
+    // renders its rate-limit banner and paces its polling off these fields,
+    // and gets neither from an error string. GitLab has no equivalent of
+    // GitHub's secondary abuse throttle, so the kind is always the quota.
+    const rateLimit =
+      err instanceof GitLabApiError && err.status === 429
+        ? {
+            rateLimitKind: "primary" as const,
+            ...(err.rateLimitResetAt !== undefined
+              ? { rateLimitResetAt: err.rateLimitResetAt }
+              : {}),
+          }
+        : {};
     if (stale) {
       return {
         ...stale,
-        counts: { ...stale.counts, stale: true, error: message },
+        counts: { ...stale.counts, stale: true, error: message, ...rateLimit },
         source: "memory-cache",
       };
     }
     return {
-      counts: { issueCount: null, prCount: null, error: message },
+      counts: { issueCount: null, prCount: null, error: message, ...rateLimit },
       issues: null,
       prs: null,
       source: "network",

--- a/plugins/builtin/gitlab/plugin.json
+++ b/plugins/builtin/gitlab/plugin.json
@@ -1,0 +1,61 @@
+{
+  "name": "daintree.gitlab",
+  "version": "0.1.0",
+  "displayName": "GitLab",
+  "description": "First-party GitLab forge provider — issues, merge requests, CI status, and releases for gitlab.com and self-hosted GitLab instances.",
+  "tagline": "Merge requests, issues, and pipelines for GitLab repositories",
+  "category": "forge",
+  "main": "main/index.js",
+  "engines": {
+    "daintree": ">=0.11.0"
+  },
+  "capabilities": [],
+  "contributes": {
+    "settings": [
+      {
+        "id": "instanceUrl",
+        "type": "string",
+        "label": "GitLab instance URL",
+        "description": "Base URL of the GitLab instance Daintree authenticates against. Change for self-hosted GitLab.",
+        "default": "https://gitlab.com"
+      }
+    ],
+    "forgeProviders": [
+      {
+        "id": "gitlab",
+        "name": "GitLab",
+        "matches": [
+          "gitlab.com",
+          "invent.kde.org",
+          "salsa.debian.org",
+          "gitlab.freedesktop.org",
+          "gitlab.gnome.org",
+          "gitlab.haskell.org"
+        ],
+        "capabilities": [
+          "issues",
+          "pulls",
+          "draft-prs",
+          "assignees",
+          "releases",
+          "batch-branch-prs",
+          "identity"
+        ],
+        "credentialFields": [
+          {
+            "id": "token",
+            "label": "Personal access token",
+            "type": "password",
+            "placeholder": "glpat-…",
+            "helpText": "Create under GitLab → User settings → Access tokens with the api scope (read_api works for read-only use)."
+          }
+        ],
+        "settingsScopeRef": "instanceUrl",
+        "slots": {
+          "settingsTab": "gitlab.forgeSettingsTab",
+          "icon": "gitlab.providerIcon"
+        }
+      }
+    ]
+  }
+}

--- a/plugins/builtin/gitlab/renderer/components/GitLabSettingsTab.tsx
+++ b/plugins/builtin/gitlab/renderer/components/GitLabSettingsTab.tsx
@@ -1,0 +1,367 @@
+import { useEffect, useRef, useState, type ComponentType, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Key, Check, AlertCircle, FlaskConical, ExternalLink, Server } from "lucide-react";
+import { GitLabIcon } from "@/components/icons/brands";
+import { actionService } from "@/services/ActionService";
+import { BUILTIN_GITLAB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
+import type { GitLabTokenValidation } from "../../shared/types.js";
+import { logError } from "@/utils/logger";
+
+const GITLAB_PLUGIN_ID = "daintree.gitlab";
+const INSTANCE_URL_SETTING = "instanceUrl";
+const DEFAULT_INSTANCE_URL = "https://gitlab.com";
+
+interface ForgeSettingBlockProps {
+  id?: string;
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+  children: ReactNode;
+}
+
+function ForgeSettingBlock({
+  id,
+  icon: Icon,
+  title,
+  description,
+  children,
+}: ForgeSettingBlockProps) {
+  return (
+    <div
+      id={id}
+      className="rounded-[var(--radius-lg)] border border-daintree-border bg-daintree-bg/30 p-4 space-y-3 scroll-mt-12"
+    >
+      <div>
+        <h5 className="text-sm font-medium text-daintree-text flex items-center gap-2">
+          <Icon className="w-4 h-4 text-daintree-text/70" aria-hidden="true" />
+          {title}
+        </h5>
+        <p className="text-xs text-daintree-text/50 mt-0.5 select-text">{description}</p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+type ValidationResult = "success" | "error" | "test-success" | "test-error" | null;
+
+function normalizeInstanceUrl(raw: string): string {
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  if (trimmed.length === 0) return DEFAULT_INSTANCE_URL;
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+export function GitLabSettingsTab() {
+  const [instanceUrl, setInstanceUrl] = useState(DEFAULT_INSTANCE_URL);
+  const [savedInstanceUrl, setSavedInstanceUrl] = useState(DEFAULT_INSTANCE_URL);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [token, setToken] = useState("");
+  const [hasToken, setHasToken] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+  const [validationResult, setValidationResult] = useState<ValidationResult>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  // Set the moment the user types in the URL field so a slow settings load
+  // resolving afterwards can't clobber their edit.
+  const instanceUrlDirtyRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electron.plugin
+      .getSettingValues(GITLAB_PLUGIN_ID, "user", null)
+      .then((snapshot) => {
+        if (cancelled) return;
+        const stored = snapshot.values[INSTANCE_URL_SETTING];
+        if (typeof stored === "string" && stored.trim().length > 0) {
+          if (!instanceUrlDirtyRef.current) setInstanceUrl(stored);
+          setSavedInstanceUrl(stored);
+        }
+        setSettingsLoaded(true);
+      })
+      .catch((err) => {
+        logError("Failed to load GitLab instance URL", err);
+        // Leave settingsLoaded false — validating a token against a default
+        // URL when the real one couldn't be read would mislead self-hosted
+        // users. The banner asks them to reopen the tab.
+        if (!cancelled) setErrorMessage("Couldn't load GitLab settings — reopen this tab");
+      });
+    window.electron.forge
+      .getCredentialStatus(BUILTIN_GITLAB_PROVIDER_ID)
+      .then((status) => {
+        if (!cancelled) setHasToken(status.hasCredential);
+      })
+      .catch((err) => logError("Failed to load GitLab credential status", err));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!validationResult) return;
+    const timer = setTimeout(() => {
+      setValidationResult(null);
+      setErrorMessage(null);
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, [validationResult]);
+
+  /**
+   * Persist the instance URL when it changed. Token validation runs in the
+   * main process against the STORED instance URL, so this must land before
+   * `forge.validateToken` / `forge.setCredential` — otherwise a self-hosted
+   * token gets validated against the previous host and rejected.
+   *
+   * An instance SWITCH also clears any stored token: the credential is scoped
+   * to the instance it was validated against, and re-pointing the URL must
+   * not silently re-scope the old token to the new host.
+   */
+  const persistInstanceUrlIfDirty = async (): Promise<void> => {
+    const normalized = normalizeInstanceUrl(instanceUrl);
+    if (normalized === savedInstanceUrl) return;
+    await window.electron.plugin.setSettingValue(
+      GITLAB_PLUGIN_ID,
+      INSTANCE_URL_SETTING,
+      normalized,
+      "user",
+      null
+    );
+    setInstanceUrl(normalized);
+    setSavedInstanceUrl(normalized);
+    instanceUrlDirtyRef.current = false;
+    if (hasToken) {
+      await window.electron.forge.clearCredential(BUILTIN_GITLAB_PROVIDER_ID);
+      setHasToken(false);
+      setNotice("Instance changed — enter a token for the new instance");
+    }
+  };
+
+  const handleSaveToken = async () => {
+    if (!token.trim()) return;
+    setIsValidating(true);
+    setValidationResult(null);
+    setErrorMessage(null);
+    try {
+      await persistInstanceUrlIfDirty();
+      // The host's forge credential surface validates against GitLab before
+      // persisting and delivers the token to the live provider impl.
+      const validation = await window.electron.forge.setCredential(BUILTIN_GITLAB_PROVIDER_ID, {
+        token: token.trim(),
+      });
+      if (validation.valid) {
+        setToken("");
+        setValidationResult("success");
+        setHasToken(true);
+        setNotice(null);
+        void actionService.dispatch("worktree.refresh", undefined, { source: "user" });
+      } else {
+        setValidationResult("error");
+        setErrorMessage(validation.error || "Invalid token");
+      }
+    } catch (error) {
+      logError("Failed to save GitLab token", error);
+      setValidationResult("error");
+      setErrorMessage("Couldn't save token");
+    } finally {
+      setIsValidating(false);
+    }
+  };
+
+  const handleTestToken = async () => {
+    if (!token.trim()) return;
+    setIsTesting(true);
+    setValidationResult(null);
+    setErrorMessage(null);
+    try {
+      await persistInstanceUrlIfDirty();
+      const result = await actionService.dispatch<GitLabTokenValidation>(
+        "forge.validateToken",
+        // The GitLab tab is GitLab-pinned by design, so the test always
+        // validates against this provider regardless of the default forge.
+        { providerId: BUILTIN_GITLAB_PROVIDER_ID, token: token.trim() },
+        { source: "user" }
+      );
+      if (!result.ok) {
+        throw new Error(result.error.message);
+      }
+      const validation = result.result;
+      setValidationResult(validation.valid ? "test-success" : "test-error");
+      if (!validation.valid) {
+        setErrorMessage(validation.error || "Invalid token");
+      }
+    } catch (error) {
+      logError("Failed to test GitLab token", error);
+      setValidationResult("test-error");
+      setErrorMessage("Couldn't validate token");
+    } finally {
+      setIsTesting(false);
+    }
+  };
+
+  const handleClearToken = async () => {
+    try {
+      await window.electron.forge.clearCredential(BUILTIN_GITLAB_PROVIDER_ID);
+      setHasToken(false);
+      setValidationResult(null);
+      setErrorMessage(null);
+    } catch (error) {
+      logError("Failed to clear GitLab token", error);
+      setValidationResult("error");
+      setErrorMessage("Couldn't clear token");
+    }
+  };
+
+  const handleInstanceUrlBlur = () => {
+    void persistInstanceUrlIfDirty().catch((err) => {
+      logError("Failed to save GitLab instance URL", err);
+      setValidationResult("error");
+      setErrorMessage("Couldn't save instance URL");
+    });
+  };
+
+  const openTokenPage = () => {
+    const base = normalizeInstanceUrl(instanceUrl);
+    void actionService.dispatch(
+      "system.openExternal",
+      { url: `${base}/-/user_settings/personal_access_tokens?name=Daintree&scopes=api` },
+      { source: "user" }
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <ForgeSettingBlock
+        id="gitlab-instance"
+        icon={Server}
+        title="GitLab instance"
+        description="The instance your token authenticates against. Keep gitlab.com, or point it at a self-hosted GitLab."
+      >
+        <input
+          type="text"
+          value={instanceUrl}
+          onChange={(e) => {
+            instanceUrlDirtyRef.current = true;
+            setInstanceUrl(e.target.value);
+          }}
+          onBlur={handleInstanceUrlBlur}
+          placeholder={DEFAULT_INSTANCE_URL}
+          aria-label="GitLab instance URL"
+          autoComplete="off"
+          className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent transition-colors"
+          disabled={isValidating || isTesting}
+        />
+        <p className="text-xs text-daintree-text/50 select-text">
+          For self-hosted projects whose remote hostname isn't a known GitLab domain, also set this
+          project's forge provider to GitLab under Code forge → Active project routing.
+        </p>
+      </ForgeSettingBlock>
+
+      <ForgeSettingBlock
+        id="gitlab-token"
+        icon={Key}
+        title="Personal access token"
+        description="Used for repository statistics, issue and merge request detection, and linking worktrees to GitLab."
+      >
+        {hasToken && (
+          <div className="flex items-center gap-1 text-xs text-status-success">
+            <Check className="w-3 h-3" />
+            GitLab connected
+          </div>
+        )}
+        {notice && <p className="text-xs text-daintree-text/70 select-text">{notice}</p>}
+
+        <div className="flex gap-2">
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder={hasToken ? "Enter new token to replace" : "glpat-…"}
+            aria-label="GitLab personal access token"
+            autoComplete="new-password"
+            className="flex-1 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent transition-colors"
+            disabled={isValidating || isTesting}
+          />
+          <Button
+            onClick={handleTestToken}
+            disabled={isValidating || !settingsLoaded || !token.trim()}
+            loading={isTesting}
+            variant="outline"
+            size="sm"
+            aria-label="Test token"
+            className="min-w-[70px] text-daintree-text border-daintree-border hover:bg-daintree-border"
+          >
+            <FlaskConical aria-hidden="true" />
+            Test
+          </Button>
+          <Button
+            onClick={handleSaveToken}
+            disabled={isTesting || !settingsLoaded || !token.trim()}
+            loading={isValidating}
+            size="sm"
+            aria-label="Save token"
+            className="min-w-[70px]"
+          >
+            Save
+          </Button>
+          {hasToken && (
+            <Button
+              onClick={handleClearToken}
+              variant="outline"
+              size="sm"
+              aria-label="Clear token"
+              className="text-status-error border-daintree-border hover:bg-status-error/10 hover:text-status-error/70 hover:border-status-error/20"
+            >
+              Clear token
+            </Button>
+          )}
+        </div>
+
+        {validationResult === "success" && (
+          <p className="text-xs text-status-success flex items-center gap-1">
+            <Check className="w-3 h-3" />
+            Token saved
+          </p>
+        )}
+        {validationResult === "test-success" && (
+          <p className="text-xs text-status-success flex items-center gap-1">
+            <Check className="w-3 h-3" />
+            Token valid — click Save to store it
+          </p>
+        )}
+        {(validationResult === "error" || validationResult === "test-error") && (
+          <p className="text-xs text-status-error flex items-center gap-1">
+            <AlertCircle className="w-3 h-3" />
+            {errorMessage || "Invalid token"}
+          </p>
+        )}
+      </ForgeSettingBlock>
+
+      <ForgeSettingBlock
+        icon={GitLabIcon}
+        title="Create a new token"
+        description="Opens your GitLab instance's access-token page in the browser with the right scope preselected."
+      >
+        <Button
+          onClick={openTokenPage}
+          variant="outline"
+          size="sm"
+          className="text-daintree-text border-daintree-border hover:bg-daintree-border"
+        >
+          <ExternalLink />
+          Create token on GitLab
+        </Button>
+        <div className="space-y-1">
+          <p className="text-xs text-daintree-text/50">Required scope:</p>
+          <ul className="text-xs text-daintree-text/50 list-disc list-inside space-y-0.5">
+            <li>
+              <code className="text-daintree-text/70 bg-daintree-bg px-1 rounded">api</code> — Full
+              API access for issues, merge requests, and repository data (
+              <code className="text-daintree-text/70 bg-daintree-bg px-1 rounded">read_api</code>{" "}
+              works for read-only use)
+            </li>
+          </ul>
+        </div>
+      </ForgeSettingBlock>
+    </div>
+  );
+}

--- a/plugins/builtin/gitlab/renderer/components/GitLabSettingsTab.tsx
+++ b/plugins/builtin/gitlab/renderer/components/GitLabSettingsTab.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Key, Check, AlertCircle, FlaskConical, ExternalLink, Server } from "lucide-react";
 import { GitLabIcon } from "@/components/icons/brands";
 import { actionService } from "@/services/ActionService";
+import { SettingsLoadErrorBanner } from "@/components/Settings/SettingsLoadErrorBanner";
 import { BUILTIN_GITLAB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 import type { GitLabTokenValidation } from "../../shared/types.js";
 import { logError } from "@/utils/logger";
@@ -29,14 +30,14 @@ function ForgeSettingBlock({
   return (
     <div
       id={id}
-      className="rounded-[var(--radius-lg)] border border-daintree-border bg-daintree-bg/30 p-4 space-y-3 scroll-mt-12"
+      className="rounded-[var(--radius-lg)] border border-border-default bg-surface-canvas/30 p-4 space-y-3 scroll-mt-12"
     >
       <div>
-        <h5 className="text-sm font-medium text-daintree-text flex items-center gap-2">
-          <Icon className="w-4 h-4 text-daintree-text/70" aria-hidden="true" />
+        <h5 className="text-sm font-medium text-text-primary flex items-center gap-2">
+          <Icon className="w-4 h-4 text-text-secondary" aria-hidden="true" />
           {title}
         </h5>
-        <p className="text-xs text-daintree-text/50 mt-0.5 select-text">{description}</p>
+        <p className="text-xs text-text-secondary mt-0.5 select-text">{description}</p>
       </div>
       {children}
     </div>
@@ -59,15 +60,34 @@ export function GitLabSettingsTab() {
   const [hasToken, setHasToken] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
+  const [isPersistingUrl, setIsPersistingUrl] = useState(false);
+  /**
+   * Credential writes are serialized. Save validates over the network before
+   * persisting, so a Clear that lands mid-Save is undone when the Save
+   * resolves — and a Save that lands mid-Clear re-stores what was just
+   * removed. Whichever started first wins.
+   */
+  const credentialOpInFlight = () => isValidating || isTesting || isClearing || isPersistingUrl;
   const [validationResult, setValidationResult] = useState<ValidationResult>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   // Set the moment the user types in the URL field so a slow settings load
   // resolving afterwards can't clobber their edit.
   const instanceUrlDirtyRef = useRef(false);
+  // Two independent loads, so two error slots: one clearing the other's
+  // message on success would hide a real failure behind an unrelated result.
+  const [settingsLoadError, setSettingsLoadError] = useState<string | null>(null);
+  const [credentialLoadError, setCredentialLoadError] = useState<string | null>(null);
+  const [loadAttempt, setLoadAttempt] = useState(0);
+  const loadError = settingsLoadError ?? credentialLoadError;
 
   useEffect(() => {
     let cancelled = false;
+    // A retry re-gates the form: if this attempt fails, Save and Test must go
+    // back to disabled rather than stay enabled on the previous attempt's
+    // successfully-read URL.
+    setSettingsLoaded(false);
     window.electron.plugin
       .getSettingValues(GITLAB_PLUGIN_ID, "user", null)
       .then((snapshot) => {
@@ -77,25 +97,34 @@ export function GitLabSettingsTab() {
           if (!instanceUrlDirtyRef.current) setInstanceUrl(stored);
           setSavedInstanceUrl(stored);
         }
+        setSettingsLoadError(null);
         setSettingsLoaded(true);
       })
       .catch((err) => {
         logError("Failed to load GitLab instance URL", err);
-        // Leave settingsLoaded false — validating a token against a default
+        // settingsLoaded stays false — validating a token against a default
         // URL when the real one couldn't be read would mislead self-hosted
-        // users. The banner asks them to reopen the tab.
-        if (!cancelled) setErrorMessage("Couldn't load GitLab settings — reopen this tab");
+        // users. That disables Save and Test, so the banner has to say why:
+        // without it the form sits inert with no explanation and no way back.
+        if (!cancelled) setSettingsLoadError("Couldn't read the GitLab instance setting");
       });
     window.electron.forge
       .getCredentialStatus(BUILTIN_GITLAB_PROVIDER_ID)
       .then((status) => {
-        if (!cancelled) setHasToken(status.hasCredential);
+        if (cancelled) return;
+        setHasToken(status.hasCredential);
+        setCredentialLoadError(null);
       })
-      .catch((err) => logError("Failed to load GitLab credential status", err));
+      .catch((err) => {
+        logError("Failed to load GitLab credential status", err);
+        // `hasToken` stays false, so the tab would silently claim no token is
+        // stored and hide Clear. Say the status is unknown instead.
+        if (!cancelled) setCredentialLoadError("Couldn't read the stored GitLab token's status");
+      });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadAttempt]);
 
   useEffect(() => {
     if (!validationResult) return;
@@ -137,7 +166,7 @@ export function GitLabSettingsTab() {
   };
 
   const handleSaveToken = async () => {
-    if (!token.trim()) return;
+    if (!token.trim() || credentialOpInFlight()) return;
     setIsValidating(true);
     setValidationResult(null);
     setErrorMessage(null);
@@ -168,7 +197,7 @@ export function GitLabSettingsTab() {
   };
 
   const handleTestToken = async () => {
-    if (!token.trim()) return;
+    if (!token.trim() || credentialOpInFlight()) return;
     setIsTesting(true);
     setValidationResult(null);
     setErrorMessage(null);
@@ -199,6 +228,10 @@ export function GitLabSettingsTab() {
   };
 
   const handleClearToken = async () => {
+    // Guarded rather than merely disabled, so a keyboard-queued activation
+    // can't slip past the disabled attribute.
+    if (credentialOpInFlight()) return;
+    setIsClearing(true);
     try {
       await window.electron.forge.clearCredential(BUILTIN_GITLAB_PROVIDER_ID);
       setHasToken(false);
@@ -208,15 +241,21 @@ export function GitLabSettingsTab() {
       logError("Failed to clear GitLab token", error);
       setValidationResult("error");
       setErrorMessage("Couldn't clear token");
+    } finally {
+      setIsClearing(false);
     }
   };
 
   const handleInstanceUrlBlur = () => {
-    void persistInstanceUrlIfDirty().catch((err) => {
-      logError("Failed to save GitLab instance URL", err);
-      setValidationResult("error");
-      setErrorMessage("Couldn't save instance URL");
-    });
+    if (credentialOpInFlight()) return;
+    setIsPersistingUrl(true);
+    void persistInstanceUrlIfDirty()
+      .catch((err) => {
+        logError("Failed to save GitLab instance URL", err);
+        setValidationResult("error");
+        setErrorMessage("Couldn't save instance URL");
+      })
+      .finally(() => setIsPersistingUrl(false));
   };
 
   const openTokenPage = () => {
@@ -230,6 +269,10 @@ export function GitLabSettingsTab() {
 
   return (
     <div className="space-y-4">
+      {loadError && (
+        <SettingsLoadErrorBanner message={loadError} onRetry={() => setLoadAttempt((n) => n + 1)} />
+      )}
+
       <ForgeSettingBlock
         id="gitlab-instance"
         icon={Server}
@@ -244,13 +287,16 @@ export function GitLabSettingsTab() {
             setInstanceUrl(e.target.value);
           }}
           onBlur={handleInstanceUrlBlur}
+          // The blur persists the URL and can clear the credential, so it
+          // takes the same lock every other credential write does.
+          readOnly={credentialOpInFlight()}
           placeholder={DEFAULT_INSTANCE_URL}
           aria-label="GitLab instance URL"
           autoComplete="off"
-          className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent transition-colors"
+          className="w-full bg-surface-canvas border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:outline-hidden focus:border-accent-primary transition-colors"
           disabled={isValidating || isTesting}
         />
-        <p className="text-xs text-daintree-text/50 select-text">
+        <p className="text-xs text-text-secondary select-text">
           For self-hosted projects whose remote hostname isn't a known GitLab domain, also set this
           project's forge provider to GitLab under Code forge → Active project routing.
         </p>
@@ -260,15 +306,15 @@ export function GitLabSettingsTab() {
         id="gitlab-token"
         icon={Key}
         title="Personal access token"
-        description="Used for repository statistics, issue and merge request detection, and linking worktrees to GitLab."
+        description="Used for repository statistics, issue and merge request detection, and linking worktrees to GitLab"
       >
         {hasToken && (
-          <div className="flex items-center gap-1 text-xs text-status-success">
+          <div className="flex items-center gap-1 text-xs text-text-secondary">
             <Check className="w-3 h-3" />
             GitLab connected
           </div>
         )}
-        {notice && <p className="text-xs text-daintree-text/70 select-text">{notice}</p>}
+        {notice && <p className="text-xs text-text-secondary select-text">{notice}</p>}
 
         <div className="flex gap-2">
           <input
@@ -278,24 +324,24 @@ export function GitLabSettingsTab() {
             placeholder={hasToken ? "Enter new token to replace" : "glpat-…"}
             aria-label="GitLab personal access token"
             autoComplete="new-password"
-            className="flex-1 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent transition-colors"
+            className="flex-1 bg-surface-canvas border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-text-primary placeholder:text-text-muted focus:outline-hidden focus:border-accent-primary transition-colors"
             disabled={isValidating || isTesting}
           />
           <Button
             onClick={handleTestToken}
-            disabled={isValidating || !settingsLoaded || !token.trim()}
+            disabled={credentialOpInFlight() || !settingsLoaded || !token.trim()}
             loading={isTesting}
             variant="outline"
             size="sm"
             aria-label="Test token"
-            className="min-w-[70px] text-daintree-text border-daintree-border hover:bg-daintree-border"
+            className="min-w-[70px] text-text-primary border-border-default hover:bg-border-default"
           >
             <FlaskConical aria-hidden="true" />
             Test
           </Button>
           <Button
             onClick={handleSaveToken}
-            disabled={isTesting || !settingsLoaded || !token.trim()}
+            disabled={credentialOpInFlight() || !settingsLoaded || !token.trim()}
             loading={isValidating}
             size="sm"
             aria-label="Save token"
@@ -309,54 +355,68 @@ export function GitLabSettingsTab() {
               variant="outline"
               size="sm"
               aria-label="Clear token"
-              className="text-status-error border-daintree-border hover:bg-status-error/10 hover:text-status-error/70 hover:border-status-error/20"
+              disabled={credentialOpInFlight()}
+              loading={isClearing}
+              className="text-status-error border-border-default hover:bg-status-error/10 hover:border-status-error/20"
             >
               Clear token
             </Button>
           )}
         </div>
 
-        {validationResult === "success" && (
-          <p className="text-xs text-status-success flex items-center gap-1">
-            <Check className="w-3 h-3" />
-            Token saved
-          </p>
-        )}
-        {validationResult === "test-success" && (
-          <p className="text-xs text-status-success flex items-center gap-1">
-            <Check className="w-3 h-3" />
-            Token valid — click Save to store it
-          </p>
-        )}
-        {(validationResult === "error" || validationResult === "test-error") && (
-          <p className="text-xs text-status-error flex items-center gap-1">
-            <AlertCircle className="w-3 h-3" />
-            {errorMessage || "Invalid token"}
-          </p>
+        {/* The result clears itself after 5s, so a screen reader that isn't
+            told about it never learns whether Save worked. Mounted only when
+            it has something to say: an always-present empty div is still a
+            `space-y-3` child and would pad the row above it. */}
+        {validationResult !== null && (
+          <div role="status" aria-live="polite">
+            {validationResult === "success" && (
+              <p className="text-xs text-status-success flex items-center gap-1">
+                <Check className="w-3 h-3" />
+                Token saved
+              </p>
+            )}
+            {validationResult === "test-success" && (
+              <p className="text-xs text-status-success flex items-center gap-1">
+                <Check className="w-3 h-3" />
+                Token valid — click Save to store it
+              </p>
+            )}
+            {(validationResult === "error" || validationResult === "test-error") && (
+              <p className="text-xs text-status-error flex items-center gap-1">
+                <AlertCircle className="w-3 h-3" />
+                {errorMessage || "Invalid token"}
+              </p>
+            )}
+          </div>
         )}
       </ForgeSettingBlock>
 
       <ForgeSettingBlock
         icon={GitLabIcon}
         title="Create a new token"
-        description="Opens your GitLab instance's access-token page in the browser with the right scope preselected."
+        description="Opens your GitLab instance's access-token page in the browser with the right scope preselected"
       >
         <Button
           onClick={openTokenPage}
           variant="outline"
           size="sm"
-          className="text-daintree-text border-daintree-border hover:bg-daintree-border"
+          className="text-text-primary border-border-default hover:bg-border-default"
         >
           <ExternalLink />
           Create token on GitLab
         </Button>
         <div className="space-y-1">
-          <p className="text-xs text-daintree-text/50">Required scope:</p>
-          <ul className="text-xs text-daintree-text/50 list-disc list-inside space-y-0.5">
+          <p className="text-xs text-text-secondary">Required scope:</p>
+          <ul className="text-xs text-text-secondary list-disc list-inside space-y-0.5">
             <li>
-              <code className="text-daintree-text/70 bg-daintree-bg px-1 rounded">api</code> — Full
-              API access for issues, merge requests, and repository data (
-              <code className="text-daintree-text/70 bg-daintree-bg px-1 rounded">read_api</code>{" "}
+              <code className="text-text-secondary bg-surface-canvas px-1 rounded-[var(--radius-sm)]">
+                api
+              </code>{" "}
+              — Full API access for issues, merge requests, and repository data (
+              <code className="text-text-secondary bg-surface-canvas px-1 rounded-[var(--radius-sm)]">
+                read_api
+              </code>{" "}
               works for read-only use)
             </li>
           </ul>

--- a/plugins/builtin/gitlab/renderer/index.tsx
+++ b/plugins/builtin/gitlab/renderer/index.tsx
@@ -1,0 +1,14 @@
+import { lazy } from "react";
+import { registerBuiltinView } from "@/registry/builtinRendererRegistry";
+import { GitLabIcon } from "@/components/icons/brands";
+
+const GitLabSettingsTab = lazy(() =>
+  import("./components/GitLabSettingsTab").then((m) => ({ default: m.GitLabSettingsTab }))
+);
+
+// Registration stays synchronous while the settings view loads only when
+// rendered. The ids must match the manifest's `slots` values exactly.
+registerBuiltinView("gitlab.forgeSettingsTab", GitLabSettingsTab, {
+  pluginId: "daintree.gitlab",
+});
+registerBuiltinView("gitlab.providerIcon", GitLabIcon, { pluginId: "daintree.gitlab" });

--- a/plugins/builtin/gitlab/shared/types.ts
+++ b/plugins/builtin/gitlab/shared/types.ts
@@ -1,0 +1,108 @@
+/**
+ * GitLab REST v4 response shapes — the subset of fields the plugin reads.
+ * Responses are treated defensively (fields may be absent on older
+ * self-managed instances), so every field is optional unless GitLab has
+ * carried it since API v4 was frozen. Full payloads ride through to the
+ * contract shapes as `rawData`.
+ */
+
+export interface GitLabUser {
+  id?: number;
+  username?: string;
+  name?: string;
+  avatar_url?: string | null;
+  web_url?: string;
+}
+
+/** Labels arrive as plain names on issue/MR payloads (`labels: string[]`). */
+export interface GitLabIssue {
+  id?: number;
+  iid?: number;
+  title?: string;
+  description?: string | null;
+  state?: string;
+  web_url?: string;
+  author?: GitLabUser | null;
+  assignees?: GitLabUser[] | null;
+  labels?: string[] | null;
+  user_notes_count?: number;
+  created_at?: string;
+  updated_at?: string;
+  closed_at?: string | null;
+}
+
+export interface GitLabMergeRequest {
+  id?: number;
+  iid?: number;
+  title?: string;
+  description?: string | null;
+  state?: string;
+  draft?: boolean;
+  work_in_progress?: boolean;
+  web_url?: string;
+  author?: GitLabUser | null;
+  assignees?: GitLabUser[] | null;
+  labels?: string[] | null;
+  source_branch?: string;
+  target_branch?: string;
+  user_notes_count?: number;
+  has_conflicts?: boolean;
+  detailed_merge_status?: string;
+  head_pipeline?: GitLabPipeline | null;
+  created_at?: string;
+  updated_at?: string;
+  closed_at?: string | null;
+  merged_at?: string | null;
+}
+
+export interface GitLabPipeline {
+  id?: number;
+  status?: string;
+  web_url?: string;
+}
+
+export interface GitLabProject {
+  id?: number;
+  path_with_namespace?: string;
+  default_branch?: string;
+  visibility?: string;
+  archived?: boolean;
+  description?: string | null;
+  topics?: string[] | null;
+  forked_from_project?: unknown;
+  license?: { name?: string | null; nickname?: string | null } | null;
+  open_issues_count?: number;
+}
+
+export interface GitLabRelease {
+  name?: string;
+  tag_name?: string;
+  description?: string | null;
+  released_at?: string | null;
+  created_at?: string;
+  upcoming_release?: boolean;
+  _links?: { self?: string } | null;
+}
+
+export interface GitLabNote {
+  id?: number;
+  body?: string;
+  author?: GitLabUser | null;
+  created_at?: string;
+}
+
+/** `GET /personal_access_tokens/self` — PAT introspection (404s for OAuth tokens). */
+export interface GitLabTokenIntrospection {
+  scopes?: string[] | null;
+  expires_at?: string | null;
+  active?: boolean;
+}
+
+/** Renderer↔main config projection for the settings tab. */
+export interface GitLabTokenValidation {
+  valid: boolean;
+  username?: string;
+  avatarUrl?: string;
+  scopes?: string[];
+  error?: string;
+}

--- a/plugins/builtin/gitlab/shared/types.ts
+++ b/plugins/builtin/gitlab/shared/types.ts
@@ -53,6 +53,9 @@ export interface GitLabMergeRequest {
   updated_at?: string;
   closed_at?: string | null;
   merged_at?: string | null;
+  /** Present on the merge endpoint's response; which one is set depends on squash. */
+  merge_commit_sha?: string | null;
+  squash_commit_sha?: string | null;
 }
 
 export interface GitLabPipeline {

--- a/shared/types/ipc/forge.ts
+++ b/shared/types/ipc/forge.ts
@@ -187,6 +187,14 @@ export interface ForgeProjectHealthPayload extends ProjectHealthSnapshot {
   hasRemote: boolean;
   loading: boolean;
   error?: string;
+  /**
+   * `true` when the resolved provider implements no `projectHealth`
+   * capability. Distinct from an error or a missing remote: the repository
+   * and provider are fine, this provider just has no health signal, so the
+   * pulse card hides the health section instead of hinting at recovery
+   * steps that wouldn't help.
+   */
+  unsupported?: boolean;
 }
 
 /**

--- a/shared/types/ipc/forge.ts
+++ b/shared/types/ipc/forge.ts
@@ -233,6 +233,14 @@ export interface ForgeProjectHealthPayload extends ProjectHealthSnapshot {
   hasRemote: boolean;
   loading: boolean;
   error?: string;
+  /**
+   * `true` when the resolved provider implements no `projectHealth`
+   * capability. Distinct from an error or a missing remote: the repository
+   * and provider are fine, this provider just has no health signal, so the
+   * pulse card hides the health section instead of hinting at recovery
+   * steps that wouldn't help.
+   */
+  unsupported?: boolean;
 }
 
 /**

--- a/shared/utils/forgeProviderIds.ts
+++ b/shared/utils/forgeProviderIds.ts
@@ -31,7 +31,12 @@ export function makeForgeProviderId<const P extends string, const C extends stri
 /** Canonical id of the built-in GitHub forge provider. */
 export const BUILTIN_GITHUB_PROVIDER_ID = makeForgeProviderId("daintree.github", "github");
 
-export type BuiltInForgeProviderId = typeof BUILTIN_GITHUB_PROVIDER_ID;
+/** Canonical id of the built-in GitLab forge provider. */
+export const BUILTIN_GITLAB_PROVIDER_ID = makeForgeProviderId("daintree.gitlab", "gitlab");
+
+export type BuiltInForgeProviderId =
+  | typeof BUILTIN_GITHUB_PROVIDER_ID
+  | typeof BUILTIN_GITLAB_PROVIDER_ID;
 
 /**
  * Open union — built-in ids autocomplete while still allowing any

--- a/shared/utils/forgeProviderIds.ts
+++ b/shared/utils/forgeProviderIds.ts
@@ -35,8 +35,7 @@ export const BUILTIN_GITHUB_PROVIDER_ID = makeForgeProviderId("daintree.github",
 export const BUILTIN_GITLAB_PROVIDER_ID = makeForgeProviderId("daintree.gitlab", "gitlab");
 
 export type BuiltInForgeProviderId =
-  | typeof BUILTIN_GITHUB_PROVIDER_ID
-  | typeof BUILTIN_GITLAB_PROVIDER_ID;
+  typeof BUILTIN_GITHUB_PROVIDER_ID | typeof BUILTIN_GITLAB_PROVIDER_ID;
 
 /**
  * Open union — built-in ids autocomplete while still allowing any

--- a/src/components/Layout/ForgeStatsToolbarButton.tsx
+++ b/src/components/Layout/ForgeStatsToolbarButton.tsx
@@ -664,6 +664,10 @@ export const ForgeStatsToolbarButton = memo(
     const handlePrefetchPointerEnter = useCallback(
       (type: "issue" | "pr", e: React.PointerEvent) => {
         if (e.pointerType !== "mouse") return;
+        // No dropdown view (provider contributes no statsDropdown slot) means
+        // no consumer for the warmed list — a click opens the forge website
+        // instead, so prefetching would be pure wasted quota.
+        if (!DropdownView) return;
         const isOpen = type === "issue" ? issuesOpen : prsOpen;
         if (isOpen) return;
         // Fire immediately — no debounce. The in-flight + freshness guards in
@@ -672,7 +676,7 @@ export const ForgeStatsToolbarButton = memo(
         // cursor lands buys the maximum head-start before the click.
         prefetchResourceList(type);
       },
-      [issuesOpen, prsOpen, prefetchResourceList]
+      [DropdownView, issuesOpen, prsOpen, prefetchResourceList]
     );
 
     // Delta check for the digit-pulse animation. Wrapped in useEffectEvent so
@@ -812,6 +816,16 @@ export const ForgeStatsToolbarButton = memo(
             openSettingsForToken();
             return;
           }
+          // No dropdown view for this provider — route to the forge website,
+          // mirroring the pill's own click handling.
+          if (!DropdownView) {
+            void actionService.dispatch(
+              "forge.openIssues",
+              { projectPath: currentProject?.path },
+              { source: "user" }
+            );
+            return;
+          }
           // Clear the chip on the open transition only — toggling closed
           // should not dismiss it, and the digit-pulse detector won't fire
           // again until a fresh count increase.
@@ -823,6 +837,14 @@ export const ForgeStatsToolbarButton = memo(
             openSettingsForToken();
             return;
           }
+          if (!DropdownView) {
+            void actionService.dispatch(
+              "forge.openPRs",
+              { projectPath: currentProject?.path },
+              { source: "user" }
+            );
+            return;
+          }
           if (!prsOpenRef.current) setPrsPulseAt(null);
           setPrsOpen((p) => !p);
         },
@@ -831,7 +853,7 @@ export const ForgeStatsToolbarButton = memo(
         },
         stats,
       }),
-      [stats, isTokenError, openSettingsForToken]
+      [stats, isTokenError, openSettingsForToken, DropdownView, currentProject?.path]
     );
 
     // No project: nothing to count. While provider resolution is in flight,
@@ -906,6 +928,18 @@ export const ForgeStatsToolbarButton = memo(
                   if (isTokenError) {
                     setIssuesOpen(false);
                     openSettingsForToken();
+                    return;
+                  }
+                  // Provider contributes no dropdown view — route the click to
+                  // the forge's own issues page instead of toggling an empty
+                  // popover shell.
+                  if (!DropdownView) {
+                    setIssuesOpen(false);
+                    void actionService.dispatch(
+                      "forge.openIssues",
+                      { projectPath: currentProject.path },
+                      { source: "user" }
+                    );
                     return;
                   }
                   const willOpen = !issuesOpen;
@@ -989,6 +1023,16 @@ export const ForgeStatsToolbarButton = memo(
                   if (isTokenError) {
                     setPrsOpen(false);
                     openSettingsForToken();
+                    return;
+                  }
+                  // Same no-dropdown routing as the issues pill.
+                  if (!DropdownView) {
+                    setPrsOpen(false);
+                    void actionService.dispatch(
+                      "forge.openPRs",
+                      { projectPath: currentProject.path },
+                      { source: "user" }
+                    );
                     return;
                   }
                   const willOpen = !prsOpen;

--- a/src/components/Layout/ForgeStatsToolbarButton.tsx
+++ b/src/components/Layout/ForgeStatsToolbarButton.tsx
@@ -678,6 +678,10 @@ export const ForgeStatsToolbarButton = memo(
     const handlePrefetchPointerEnter = useCallback(
       (type: "issue" | "pr", e: React.PointerEvent) => {
         if (e.pointerType !== "mouse") return;
+        // No dropdown view (provider contributes no statsDropdown slot) means
+        // no consumer for the warmed list — a click opens the forge website
+        // instead, so prefetching would be pure wasted quota.
+        if (!DropdownView) return;
         const isOpen = type === "issue" ? issuesOpen : prsOpen;
         if (isOpen) return;
         // Fire immediately — no debounce. The in-flight + freshness guards in
@@ -686,7 +690,7 @@ export const ForgeStatsToolbarButton = memo(
         // cursor lands buys the maximum head-start before the click.
         prefetchResourceList(type);
       },
-      [issuesOpen, prsOpen, prefetchResourceList]
+      [DropdownView, issuesOpen, prsOpen, prefetchResourceList]
     );
 
     // Delta check for the digit-pulse animation. Wrapped in useEffectEvent so
@@ -826,6 +830,16 @@ export const ForgeStatsToolbarButton = memo(
             openSettingsForToken();
             return;
           }
+          // No dropdown view for this provider — route to the forge website,
+          // mirroring the pill's own click handling.
+          if (!DropdownView) {
+            void actionService.dispatch(
+              "forge.openIssues",
+              { projectPath: currentProject?.path },
+              { source: "user" }
+            );
+            return;
+          }
           // Clear the chip on the open transition only — toggling closed
           // should not dismiss it, and the digit-pulse detector won't fire
           // again until a fresh count increase.
@@ -837,6 +851,14 @@ export const ForgeStatsToolbarButton = memo(
             openSettingsForToken();
             return;
           }
+          if (!DropdownView) {
+            void actionService.dispatch(
+              "forge.openPRs",
+              { projectPath: currentProject?.path },
+              { source: "user" }
+            );
+            return;
+          }
           if (!prsOpenRef.current) setPrsPulseAt(null);
           setPrsOpen((p) => !p);
         },
@@ -845,7 +867,7 @@ export const ForgeStatsToolbarButton = memo(
         },
         stats,
       }),
-      [stats, isTokenError, openSettingsForToken]
+      [stats, isTokenError, openSettingsForToken, DropdownView, currentProject?.path]
     );
 
     // No project: nothing to count. While provider resolution is in flight,
@@ -920,6 +942,18 @@ export const ForgeStatsToolbarButton = memo(
                   if (isTokenError) {
                     setIssuesOpen(false);
                     openSettingsForToken();
+                    return;
+                  }
+                  // Provider contributes no dropdown view — route the click to
+                  // the forge's own issues page instead of toggling an empty
+                  // popover shell.
+                  if (!DropdownView) {
+                    setIssuesOpen(false);
+                    void actionService.dispatch(
+                      "forge.openIssues",
+                      { projectPath: currentProject.path },
+                      { source: "user" }
+                    );
                     return;
                   }
                   const willOpen = !issuesOpen;
@@ -1003,6 +1037,16 @@ export const ForgeStatsToolbarButton = memo(
                   if (isTokenError) {
                     setPrsOpen(false);
                     openSettingsForToken();
+                    return;
+                  }
+                  // Same no-dropdown routing as the issues pill.
+                  if (!DropdownView) {
+                    setPrsOpen(false);
+                    void actionService.dispatch(
+                      "forge.openPRs",
+                      { projectPath: currentProject.path },
+                      { source: "user" }
+                    );
                     return;
                   }
                   const willOpen = !prsOpen;

--- a/src/components/Layout/__tests__/ForgeStatsToolbarButton.hoverPrefetch.test.tsx
+++ b/src/components/Layout/__tests__/ForgeStatsToolbarButton.hoverPrefetch.test.tsx
@@ -67,8 +67,11 @@ vi.mock("@/hooks/useResolvedForgeProvider", () => ({
   }),
 }));
 
+// The provider must resolve a dropdown view: hover prefetch is gated on a
+// consumer existing for the warmed list (a slotless provider routes clicks to
+// the forge website instead, so prefetching would waste quota).
 vi.mock("@/registry/builtinRendererRegistry", () => ({
-  useBuiltinView: () => null,
+  useBuiltinView: (slotId: string) => (slotId === "github.statsDropdown" ? () => null : null),
 }));
 
 vi.mock("@/hooks/useGlobalMinuteTicker", () => ({

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -646,9 +646,11 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
             (signals, skeleton, no-remote hint, offline hint) can swap without
             growing or collapsing the card. `min-h-9` matches the chip row
             height (h-5 chip + pt-3 padding) so the loaded HealthSignals row
-            doesn't push siblings down when it resolves after pulse (#7671). */}
+            doesn't push siblings down when it resolves after pulse (#7671).
+            A provider with no projectHealth capability (`unsupported`) stays
+            quiet — hinting at remote/network recovery wouldn't help. */}
         <div className="border-t border-daintree-border pt-3 min-h-9">
-          {health && !health.error && health.repoUrl ? (
+          {health?.unsupported ? null : health && !health.error && health.repoUrl ? (
             <HealthSignals health={health} rangeDays={rangeDays} />
           ) : healthLoading ? (
             <HealthSectionSkeleton />

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -555,8 +555,11 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
   const updatedLabel = formatTimeSince(pulse.generatedAt, Date.now());
 
   // pulse.rangeDays, not the selector's — the chip describes the same snapshot
-  // the coach line above it does.
-  const healthSection = usableHealth ? (
+  // the coach line above it does. A provider with no `projectHealth`
+  // capability (`unsupported`) is neither an error nor a missing remote —
+  // there is no signal to wait for, so the section stays out instead of
+  // hinting at recovery steps that wouldn't help.
+  const healthSection = health?.unsupported ? null : usableHealth ? (
     <HealthSignals health={usableHealth} rangeDays={pulse.rangeDays} />
   ) : healthLoading ? (
     <HealthSectionSkeleton />

--- a/src/components/Worktree/views/IssueSelectorView.tsx
+++ b/src/components/Worktree/views/IssueSelectorView.tsx
@@ -38,6 +38,9 @@ export function IssueLinkerView({
   const IssueSelector = useBuiltinView<ForgeIssueSelectorProps>(
     entry?.contribution.slots?.issueSelector ?? ""
   );
+  // No issue-selector view from the active provider — hide the whole section
+  // rather than rendering an orphaned "Link Issue" label with no control.
+  if (!IssueSelector) return null;
   return (
     <>
       <div className="space-y-2">

--- a/src/components/icons/brands/GitLabIcon.tsx
+++ b/src/components/icons/brands/GitLabIcon.tsx
@@ -1,0 +1,34 @@
+/**
+ * GitLab tanuki mark — simplified single-path outline of the brand logo.
+ * 24x24 viewBox, currentColor-aware to match other brand icons.
+ */
+
+import type { SVGProps } from "react";
+import { cn } from "@/lib/utils";
+
+type GitLabIconProps = SVGProps<SVGSVGElement> & {
+  size?: number;
+  brandColor?: string;
+};
+
+export function GitLabIcon({ className, size = 16, brandColor, ...props }: GitLabIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={brandColor || "currentColor"}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn(className)}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="m22 13.29-3.33-10a.42.42 0 0 0-.14-.18.38.38 0 0 0-.22-.11.39.39 0 0 0-.23.07.42.42 0 0 0-.14.18l-2.26 6.67H8.32L6.1 3.26a.42.42 0 0 0-.1-.18.38.38 0 0 0-.26-.08.39.39 0 0 0-.23.07.42.42 0 0 0-.14.18L2 13.29a.74.74 0 0 0 .27.83L12 21l9.69-6.88a.71.71 0 0 0 .31-.83Z" />
+    </svg>
+  );
+}
+
+export default GitLabIcon;

--- a/src/components/icons/brands/index.ts
+++ b/src/components/icons/brands/index.ts
@@ -1,5 +1,6 @@
 // Forges
 export { GitHubIcon } from "./GitHubIcon";
+export { GitLabIcon } from "./GitLabIcon";
 
 // AI Agent icons
 export { ClaudeIcon } from "./ClaudeIcon";


### PR DESCRIPTION
Resolves #5167

This adds GitLab as a built-in forge provider plugin at `plugins/builtin/gitlab`, sitting alongside the GitHub plugin. It's built on the forge provider abstraction that shipped after this issue was filed, and the abstraction held up well: the host needed zero changes for the provider itself. The registry, IPC surface, credential storage, and the Code Forge preferences UI all picked the new provider up automatically.

## What's implemented

The plugin implements the full `ForgeProviderImpl` contract over the GitLab REST v4 API:

- Issues and merge requests: paginated lists with search/label/assignee filters, single fetches, and the full mutation set (create, close/reopen, edit, comment, labels, assign/unassign, merge, draft toggling).
- Branch to MR detection, so worktree cards get their MR badges. Batched lookups go through GitLab's GraphQL `mergeRequests(sourceBranches:)` in chunks of 20 branches, with the REST `source_branch` filter as the per-branch fallback.
- CI status from the MR's head pipeline, mapped into the normalized vocabulary.
- Repo metadata, releases, hover tooltips, viewer identity, commit-author avatars via `/avatar`, toolbar repo stats (open issue/MR counts from `x-total` headers), token health, and rate limit reporting.

MRs are numbered by `iid` throughout, and nested subgroups are handled (the whole `group/subgroup/project` path URL-encodes as the project id).

## Auth and self-hosted

Auth is a personal access token (`api` scope, or `read_api` for read-only), validated against `/user` with scope and expiry introspection via `/personal_access_tokens/self`. Storage rides the host's existing forge credential store.

Self-hosted support works through an instance URL setting on the plugin's settings tab. Custom schemes, ports, and path prefixes are preserved on API calls, and the token is strictly scoped to the configured instance: it's never attached to a request against any other host, and it fails closed if the settings read breaks. gitlab.com plus a handful of well-known public instances (`invent.kde.org`, `salsa.debian.org`, `gitlab.freedesktop.org`, `gitlab.gnome.org`, `gitlab.haskell.org`) match by hostname; anything else routes via the existing per-project provider override. Switching the instance URL clears the stored token rather than silently re-scoping it.

## Host integration fixes

A second review pass traced the real host call paths end to end (activation, credential replay, the workspace-host RPC bridge, the toolbar, settings IPC) and fixed four seams a second provider exposed:

- Credential save and token test now implicitly activate a lazy provider before the impl lookup. Previously, connecting GitLab on a fresh session failed with "Provider not activated" while you were standing in the Settings screen that was supposed to activate it.
- The toolbar issue/MR pills route clicks to the forge's own web pages when the provider contributes no stats-dropdown view, instead of toggling an empty popover. Hover prefetch is skipped in that case too.
- A provider without the `projectHealth` capability now reports `unsupported`, and the pulse card stays quiet instead of telling you to "Connect a git remote" you already have.
- The New Worktree dialog hides the "Link Issue" section when the provider contributes no issue-selector view, rather than rendering an orphaned label.

## Review

Both Codex review passes are folded in. The first caught a token scoping leak where a deactivation race could send a self-hosted token to the gitlab.com fallback, and a GraphQL truncation bug where branches could be reported as having no MR when the contract requires omitting them so the host falls back per-branch. The second pass audited every request against the real GitLab API (REST params, GraphQL field and enum names, Bearer PAT auth, pagination headers, `%2F` project-id encoding all check out) and produced the host integration fixes above.

## Deliberate follow-ups

- Stats dropdown, bulk create worktrees, and issue selector views. Counts and web click-through work today; the in-app list views are the next chunk of renderer work.
- Merge request terminology in the host UI. "PR" is hardcoded across host-owned components and needs a terminology field on the provider contract.
- Multi-account support (one token per provider today, so gitlab.com plus a self-hosted instance means picking one).
- Authenticated cloning. I dropped this on purpose: embedding the token in the clone URL persists it into `.git/config` via `remote.origin.url`. It needs an askpass-style flow like the GitHub plugin's `gh repo clone` path.
- Two pre-existing host gaps the review surfaced that affect GitHub too: provider resolution reads the `origin` remote only (a configured `forgeRemote` is honored by workspace polling but not by stats/tooltips/actions), and the renderer treats public repos as token-required for tooltips and badge clicks even though unauthenticated reads work.

## Testing

80 plugin unit tests cover remote parsing, mappers, the provider contract, and activation, plus updated host handler and toolbar tests for the integration fixes. `npm run check` is green. This is a draft because it still needs real-API testing against gitlab.com and a self-hosted instance before it's ready to merge.
