### PR TITLE
fix(git): anchor binary-file detection to git's marker line

### DIFF
--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -11,6 +11,7 @@ import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "../../shared/ty
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { validateBranchName } from "../../shared/utils/pathPattern.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { isBinaryDiffOutput } from "../../shared/utils/gitDiffParsing.js";
 import { parseNumstat } from "../utils/git.js";
 import type { DiffStat } from "../utils/git.js";
 import { branchRefName, readBranchCommitterDates } from "../utils/branchCommitterDates.js";
@@ -304,7 +305,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         await this.getGit()
       ).diff(["HEAD", "--no-ext-diff", "--no-textconv", "--no-color", "--", normalizedPath]);
 
-      if (diff.includes("Binary files")) {
+      if (isBinaryDiffOutput(diff)) {
         return "BINARY_FILE";
       }
 
@@ -510,7 +511,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
           return "NO_CHANGES";
         }
 
-        if (diff.includes("Binary files")) {
+        if (isBinaryDiffOutput(diff)) {
           return "BINARY_FILE";
         }
 

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -400,6 +400,36 @@ index 1a2b3c4..5d6e7f8 100644
       expect(result).toBe("BINARY_FILE");
     });
 
+    it("classifies the deleted-file marker form, which names /dev/null second", async () => {
+      gitClientMock.raw.mockResolvedValue(
+        "diff --git a/logo.png b/logo.png\ndeleted file mode 100644\nBinary files a/logo.png and /dev/null differ\n"
+      );
+
+      const service = new GitService(tempDir);
+      const result = await service.compareWorktrees("main", "feature/test", "logo.png");
+
+      expect(result).toBe("BINARY_FILE");
+    });
+
+    it("classifies on content, not on whether --ignore-all-space was requested", async () => {
+      const markerDiff =
+        "diff --git a/logo.png b/logo.png\nindex 1a2b3c4..5d6e7f8 100644\nBinary files a/logo.png and b/logo.png differ\n";
+      gitClientMock.raw.mockResolvedValue(markerDiff);
+
+      const service = new GitService(tempDir);
+      const ignoring = await service.compareWorktrees(
+        "main",
+        "feature/test",
+        "logo.png",
+        false,
+        true
+      );
+      const notIgnoring = await service.compareWorktrees("main", "feature/test", "logo.png");
+
+      expect(ignoring).toBe(notIgnoring);
+      expect(ignoring).toBe("BINARY_FILE");
+    });
+
     it("returns empty file list without calling git when branch1 equals branch2", async () => {
       const service = new GitService(tempDir);
       const result = await service.compareWorktrees("main", "main");

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -127,6 +127,34 @@ describe("GitService", () => {
     expect(diff).toContain("diff --git");
   });
 
+  it("returns the diff for a tracked file whose added lines quote the binary marker", async () => {
+    const trackedDiff = `diff --git a/README.md b/README.md
+index 1a2b3c4..5d6e7f8 100644
+--- a/README.md
++++ b/README.md
+@@ -1,2 +1,3 @@
+ # Notes
++Git prints Binary files a/x and b/x differ when it skips a blob.
+`;
+    gitClientMock.diff.mockResolvedValue(trackedDiff);
+
+    const service = new GitService(tempDir);
+    const diff = await service.getFileDiff("README.md", "modified");
+
+    expect(diff).toBe(trackedDiff);
+  });
+
+  it("returns BINARY_FILE for a tracked file git reports as binary", async () => {
+    gitClientMock.diff.mockResolvedValue(
+      "diff --git a/logo.png b/logo.png\nindex 1a2b3c4..5d6e7f8 100644\nBinary files a/logo.png and b/logo.png differ\n"
+    );
+
+    const service = new GitService(tempDir);
+    const diff = await service.getFileDiff("logo.png", "modified");
+
+    expect(diff).toBe("BINARY_FILE");
+  });
+
   it("finds next local branch suffix while ignoring remote-only conflicts", async () => {
     gitClientMock.branch.mockResolvedValue({
       branches: {
@@ -342,6 +370,34 @@ describe("GitService", () => {
       const result = await service.compareWorktrees("main", "feature/test", "src/app.ts");
 
       expect(result).toBe("NO_CHANGES");
+    });
+
+    it("returns the diff when a compared file's added lines quote the binary marker", async () => {
+      const comparedDiff = `diff --git a/README.md b/README.md
+index 1a2b3c4..5d6e7f8 100644
+--- a/README.md
++++ b/README.md
+@@ -1,2 +1,3 @@
+ # Notes
++Git prints Binary files a/x and b/x differ when it skips a blob.
+`;
+      gitClientMock.raw.mockResolvedValue(comparedDiff);
+
+      const service = new GitService(tempDir);
+      const result = await service.compareWorktrees("main", "feature/test", "README.md");
+
+      expect(result).toBe(comparedDiff);
+    });
+
+    it("returns BINARY_FILE when git reports a compared file as binary", async () => {
+      gitClientMock.raw.mockResolvedValue(
+        "diff --git a/logo.png b/logo.png\nindex 1a2b3c4..5d6e7f8 100644\nBinary files a/logo.png and b/logo.png differ\n"
+      );
+
+      const service = new GitService(tempDir);
+      const result = await service.compareWorktrees("main", "feature/test", "logo.png");
+
+      expect(result).toBe("BINARY_FILE");
     });
 
     it("returns empty file list without calling git when branch1 equals branch2", async () => {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -14,6 +14,7 @@ import { settingsFilePath } from "../services/projectStorePaths.js";
 import { SimpleGit, BranchSummary } from "simple-git";
 import { createHardenedGit, createAuthenticatedGit } from "../utils/hardenedGit.js";
 import { classifyGitError, getGitRecoveryAction } from "../../shared/utils/gitOperationErrors.js";
+import { isBinaryDiffOutput } from "../../shared/utils/gitDiffParsing.js";
 import type { Worktree, WslGitEligibility } from "../../shared/types/worktree.js";
 import type {
   WorkspaceHostEvent,
@@ -3405,7 +3406,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         normalizedPath,
       ]);
 
-      if (diff.includes("Binary files")) {
+      if (isBinaryDiffOutput(diff)) {
         sendSentinel("BINARY_FILE");
         return;
       }

--- a/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
@@ -261,6 +261,24 @@ describe("WorkspaceService.getFileDiff", () => {
     );
   });
 
+  it("windows a text diff whose added lines quote the binary marker", async () => {
+    const textDiff = `diff --git a/README.md b/README.md
+index 1a2b3c4..5d6e7f8 100644
+--- a/README.md
++++ b/README.md
+@@ -1,2 +1,3 @@
+ # Notes
++Git prints Binary files a/x and b/x differ when it skips a blob.
+`;
+    mockSimpleGit.diff.mockResolvedValueOnce(textDiff);
+
+    await service.getFileDiff("req-18", "/test/repo", "README.md", "modified");
+
+    const event = mockSendEvent.mock.calls.at(-1)?.[0];
+    expect(event.diff).toBe(textDiff);
+    expect(event.totalBytes).toBe(Buffer.byteLength(textDiff, "utf8"));
+  });
+
   it("reconstructs a multibyte diff across windows without replacement characters", async () => {
     const full = "diff --git a/f.ts b/f.ts\n" + "+日本語テキスト😀\n".repeat(50);
     mockSimpleGit.diff.mockResolvedValue(full);

--- a/shared/utils/__tests__/gitDiffParsing.test.ts
+++ b/shared/utils/__tests__/gitDiffParsing.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { isBinaryDiffOutput } from "../gitDiffParsing.js";
+
+const header = (path: string) => `diff --git a/${path} b/${path}\nindex 1a2b3c4..5d6e7f8 100644`;
+
+describe("isBinaryDiffOutput", () => {
+  describe("genuine binary markers", () => {
+    it.each([
+      ["modified", "Binary files a/logo.png and b/logo.png differ"],
+      ["added", "Binary files /dev/null and b/logo.png differ"],
+      ["deleted", "Binary files a/logo.png and /dev/null differ"],
+    ])("classifies the %s form", (_form, marker) => {
+      expect(isBinaryDiffOutput(`${header("logo.png")}\n${marker}\n`)).toBe(true);
+    });
+
+    it("classifies a marker that ends the output with no trailing newline", () => {
+      const withNewline = `${header("logo.png")}\nBinary files a/logo.png and b/logo.png differ\n`;
+      const withoutNewline = withNewline.trimEnd();
+
+      expect(isBinaryDiffOutput(withoutNewline)).toBe(isBinaryDiffOutput(withNewline));
+      expect(isBinaryDiffOutput(withoutNewline)).toBe(true);
+    });
+
+    it("is insensitive to CRLF line endings", () => {
+      const lf = `${header("logo.png")}\nBinary files a/logo.png and b/logo.png differ\n`;
+
+      expect(isBinaryDiffOutput(lf.replace(/\n/g, "\r\n"))).toBe(isBinaryDiffOutput(lf));
+    });
+
+    it("does not assume the a/ and b/ path prefixes", () => {
+      // --no-prefix, custom --src-prefix/--dst-prefix, and diff.mnemonicPrefix
+      // all re-render these tokens.
+      const noPrefix = "Binary files logo.png and logo.png differ";
+      const mnemonic = "Binary files i/logo.png and w/logo.png differ";
+
+      expect(isBinaryDiffOutput(noPrefix)).toBe(true);
+      expect(isBinaryDiffOutput(mnemonic)).toBe(true);
+    });
+
+    it("classifies a marker whose own filenames contain the word differ", () => {
+      const path = "docs/how files differ.md";
+
+      expect(isBinaryDiffOutput(`Binary files a/${path} and b/${path} differ`)).toBe(true);
+    });
+
+    it("classifies a quoted path emitted under core.quotePath", () => {
+      expect(isBinaryDiffOutput('Binary files "a/caf\\303\\251.png" and /dev/null differ')).toBe(
+        true
+      );
+    });
+  });
+
+  describe("marker-shaped text content", () => {
+    it("does not classify an added line quoting the marker", () => {
+      const diff = `${header("README.md")}
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,4 @@
+ # Notes
++Git prints Binary files a/x and b/x differ when it skips a blob.
+ Nothing else changed.
+`;
+
+      expect(isBinaryDiffOutput(diff)).toBe(false);
+    });
+
+    it("does not classify the marker regardless of which hunk prefix carries it", () => {
+      const marker = "Binary files a/x and b/x differ";
+
+      for (const prefix of ["+", "-", " ", "\\"]) {
+        expect(isBinaryDiffOutput(`@@ -1 +1 @@\n${prefix}${marker}\n`)).toBe(false);
+      }
+    });
+
+    it("distinguishes a marker-shaped line only by its column-zero position", () => {
+      const marker = "Binary files a/x and b/x differ";
+
+      expect(isBinaryDiffOutput(`@@ -1 +1 @@\n+${marker}`)).toBe(false);
+      expect(isBinaryDiffOutput(`@@ -1 +1 @@\n${marker}`)).toBe(true);
+    });
+
+    it("does not classify a file whose name is itself the marker", () => {
+      const path = "Binary files a/x and b/x differ";
+
+      expect(isBinaryDiffOutput(`${header(path)}\n--- a/${path}\n+++ b/${path}\n`)).toBe(false);
+    });
+  });
+
+  describe("non-markers", () => {
+    it.each([
+      ["empty output", ""],
+      ["whitespace only", "\n\n"],
+      ["the no-newline sentinel", "@@ -1 +1 @@\n-old\n\\ No newline at end of file\n"],
+      ["a plain text diff", `${header("a.ts")}\n@@ -1 +1 @@\n-old\n+new\n`],
+      ["trailing content after differ", "Binary files a/x and b/x differ later"],
+      ["a marker with no paths", "Binary files  differ"],
+      ["a lowercase marker", "binary files a/x and b/x differ"],
+    ])("rejects %s", (_label, input) => {
+      expect(isBinaryDiffOutput(input)).toBe(false);
+    });
+
+    it("leaves --binary payloads to the caller that opts into them", () => {
+      // No call site passes --binary, so this form is deliberately out of scope.
+      // Recognising it is a decision a future --binary caller must make.
+      const literalPatch = "GIT binary patch\nliteral 1234\nzcmZ?wbhEHb\n";
+
+      expect(isBinaryDiffOutput(literalPatch)).toBe(false);
+    });
+  });
+
+  it("holds no match state across repeated calls", () => {
+    const marker = "Binary files a/x and b/x differ";
+
+    const results = [marker, marker, marker].map((d) => isBinaryDiffOutput(d));
+
+    expect(results).toEqual([true, true, true]);
+  });
+});

--- a/shared/utils/__tests__/gitDiffParsing.test.ts
+++ b/shared/utils/__tests__/gitDiffParsing.test.ts
@@ -17,14 +17,26 @@ describe("isBinaryDiffOutput", () => {
       const withNewline = `${header("logo.png")}\nBinary files a/logo.png and b/logo.png differ\n`;
       const withoutNewline = withNewline.trimEnd();
 
-      expect(isBinaryDiffOutput(withoutNewline)).toBe(isBinaryDiffOutput(withNewline));
       expect(isBinaryDiffOutput(withoutNewline)).toBe(true);
+      expect(isBinaryDiffOutput(withoutNewline)).toBe(isBinaryDiffOutput(withNewline));
     });
 
     it("is insensitive to CRLF line endings", () => {
       const lf = `${header("logo.png")}\nBinary files a/logo.png and b/logo.png differ\n`;
 
+      expect(isBinaryDiffOutput(lf.replace(/\n/g, "\r\n"))).toBe(true);
       expect(isBinaryDiffOutput(lf.replace(/\n/g, "\r\n"))).toBe(isBinaryDiffOutput(lf));
+    });
+
+    it.each([
+      ["U+2028 line separator", "\u2028"],
+      ["U+2029 paragraph separator", "\u2029"],
+    ])("classifies a marker whose path contains a %s", (_label, char) => {
+      // Legal in a path, but ECMAScript line terminators: a `.`-based pattern
+      // refuses to match them and would silently miss a real binary file.
+      const path = `assets/ic${char}on.png`;
+
+      expect(isBinaryDiffOutput(`Binary files /dev/null and b/${path} differ`)).toBe(true);
     });
 
     it("does not assume the a/ and b/ path prefixes", () => {
@@ -55,10 +67,9 @@ describe("isBinaryDiffOutput", () => {
       const diff = `${header("README.md")}
 --- a/README.md
 +++ b/README.md
-@@ -1,3 +1,4 @@
+@@ -1,2 +1,3 @@
  # Notes
 +Git prints Binary files a/x and b/x differ when it skips a blob.
- Nothing else changed.
 `;
 
       expect(isBinaryDiffOutput(diff)).toBe(false);
@@ -72,7 +83,20 @@ describe("isBinaryDiffOutput", () => {
       }
     });
 
-    it("distinguishes a marker-shaped line only by its column-zero position", () => {
+    it.each([
+      ["a bare carriage return", "\r"],
+      ["a U+2028 line separator", "\u2028"],
+      ["a U+2029 paragraph separator", "\u2029"],
+    ])("does not treat %s inside a hunk line as a record boundary", (_label, char) => {
+      // Git frames patch records with \n alone. ECMAScript also counts these
+      // three as line terminators, so a multiline-anchored pattern would let
+      // marker-shaped content masquerade as metadata.
+      const diff = `@@ -0,0 +1 @@\n+intro${char}Binary files a/x and b/x differ\n`;
+
+      expect(isBinaryDiffOutput(diff)).toBe(false);
+    });
+
+    it("distinguishes a marker-shaped line only by its position after a newline", () => {
       const marker = "Binary files a/x and b/x differ";
 
       expect(isBinaryDiffOutput(`@@ -1 +1 @@\n+${marker}`)).toBe(false);
@@ -93,7 +117,7 @@ describe("isBinaryDiffOutput", () => {
       ["the no-newline sentinel", "@@ -1 +1 @@\n-old\n\\ No newline at end of file\n"],
       ["a plain text diff", `${header("a.ts")}\n@@ -1 +1 @@\n-old\n+new\n`],
       ["trailing content after differ", "Binary files a/x and b/x differ later"],
-      ["a marker with no paths", "Binary files  differ"],
+      ["a marker with an empty middle", "Binary files  differ"],
       ["a lowercase marker", "binary files a/x and b/x differ"],
     ])("rejects %s", (_label, input) => {
       expect(isBinaryDiffOutput(input)).toBe(false);

--- a/shared/utils/__tests__/gitDiffParsing.test.ts
+++ b/shared/utils/__tests__/gitDiffParsing.test.ts
@@ -39,6 +39,20 @@ describe("isBinaryDiffOutput", () => {
       expect(isBinaryDiffOutput(`Binary files /dev/null and b/${path} differ`)).toBe(true);
     });
 
+    it("classifies a marker followed by a further diff record", () => {
+      // A pathspec can select more than one file, so the marker is not always
+      // the last record in the output.
+      const diff = `${header("logo.png")}
+Binary files a/logo.png and b/logo.png differ
+${header("notes.md")}
+@@ -1 +1 @@
+-old
++new
+`;
+
+      expect(isBinaryDiffOutput(diff)).toBe(true);
+    });
+
     it("does not assume the a/ and b/ path prefixes", () => {
       // --no-prefix, custom --src-prefix/--dst-prefix, and diff.mnemonicPrefix
       // all re-render these tokens.

--- a/shared/utils/gitDiffParsing.ts
+++ b/shared/utils/gitDiffParsing.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure classifier for git's textual binary-file marker.
+ *
+ * Git emits `Binary files <old> and <new> differ` at column 0 as diff metadata.
+ * Every line inside a hunk carries a `+`, `-`, ` `, or `\` prefix, so anchoring
+ * to the line start is what separates the real marker from a text file whose
+ * own content happens to contain the phrase.
+ *
+ * The middle is left unconstrained: `--no-prefix`, custom `--src-prefix`/
+ * `--dst-prefix`, `diff.mnemonicPrefix`, and `core.quotePath` all change how
+ * the paths render. `/dev/null` appears on the added and deleted forms.
+ *
+ * Scope: git's normal diff output. `--binary` produces a `GIT binary patch`
+ * payload instead, which no caller requests and this helper does not classify.
+ *
+ * Renderer-safe: no Node.js built-ins, no Electron deps.
+ */
+const BINARY_FILE_MARKER = /^Binary files .+ differ\r?$/m;
+
+export function isBinaryDiffOutput(diffText: string): boolean {
+  return BINARY_FILE_MARKER.test(diffText);
+}

--- a/shared/utils/gitDiffParsing.ts
+++ b/shared/utils/gitDiffParsing.ts
@@ -13,9 +13,15 @@
  * Scope: git's normal diff output. `--binary` produces a `GIT binary patch`
  * payload instead, which no caller requests and this helper does not classify.
  *
+ * Framing is deliberately `\n`-only rather than the `m` flag: ECMAScript also
+ * treats a bare `\r`, U+2028, and U+2029 as line terminators, so `^` under `m`
+ * would anchor mid-line and re-open this bug for content carrying those bytes.
+ * `[^\n]` over `.` for the same reason — `.` rejects U+2028/U+2029, which are
+ * legal in a path and would hide a genuine marker.
+ *
  * Renderer-safe: no Node.js built-ins, no Electron deps.
  */
-const BINARY_FILE_MARKER = /^Binary files .+ differ\r?$/m;
+const BINARY_FILE_MARKER = /(?:^|\n)Binary files [^\n]+ differ\r?(?:\n|$)/;
 
 export function isBinaryDiffOutput(diffText: string): boolean {
   return BINARY_FILE_MARKER.test(diffText);


### PR DESCRIPTION
## The bug

Binary detection ran `diff.includes("Binary files")` against raw `git diff` output at three call sites. Any text file whose own content contains that phrase — a README documenting binary-file handling, for instance — was classified as binary and its entire diff blanked out.

Git's marker only ever appears at column 0. Every content line inside a hunk carries a `+`, `-`, ` `, or `\` prefix, so anchoring to the record boundary separates real metadata from text that merely quotes it.

## The fix

New `shared/utils/gitDiffParsing.ts` exporting `isBinaryDiffOutput()`, wired into all three sites:

- `electron/services/GitService.ts` — worktree diff vs HEAD, and the branch-comparison path
- `electron/workspace-host/WorkspaceService.ts` — the streaming path that emits the `BINARY_FILE` sentinel

No extra git invocation; it inspects output already in hand. `--no-textconv` and the rest of the argv hardening are untouched, and the `BINARY_FILE` sentinel contract is unchanged, so no renderer code moves.

## Why the pattern looks the way it does

Framing is `\n`-only rather than the `m` flag, and the middle matches `[^\n]` rather than `.`. ECMAScript also treats a bare `\r`, U+2028 and U+2029 as line terminators, so a multiline-anchored pattern would anchor mid-record and keep this very bug alive for content carrying those bytes — and `.` refuses to match U+2028/U+2029, which are legal in a path and would hide a genuine marker. Both directions are covered by tests.

The middle is otherwise left unconstrained: `--no-prefix`, custom `--src-prefix`/`--dst-prefix`, `diff.mnemonicPrefix` and `core.quotePath` all change how the paths render, so hardcoding `a/`/`b/` would be needless fragility.

Rejected the `--numstat` alternative (it reports `-`/`-` for binary): more robust against exotic prefix config, but it doubles git spawns on three hot paths to buy a margin the anchor already covers.

## Tests

112 targeted tests pass. The unit suite pins git's marker grammar — all three forms, CRLF, no-trailing-newline, quoted paths, custom prefixes — plus the false-positive cases that motivated the fix. Both Main call sites and the workspace-host path get regression coverage in each direction.

Worth noting the tracked-file path had no test coverage at all before this: the existing binary tests in `GitService.test.ts` all pass `"untracked"`, which routes through byte-sniffing and never reaches the `git diff` check.

## Out of scope

Three adjacent issues surfaced while reviewing this; none is caused by this change and each deserves its own fix:

- `status === "added"` bypasses git and byte-sniffs the file instead, so it can disagree with git's own verdict for files carrying the `-diff` attribute.
- The three `git diff -- <path>` calls pass paths as pathspecs, not literal paths, so a filename containing `*`, `?` or `[` can select zero or several files. `pages/[...slug].tsx` — already a fixture in this repo — is glob-magic.
- The two `isBinaryBuffer` helpers disagree: `GitService` treats >30% non-ASCII as binary, `WorkspaceService` looks only for NUL.

Resolves #11756