### PR TITLE
fix(agents): route unavailable agent clicks through the soft launch gate

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1094,6 +1094,22 @@ export function HelpPanel({
     controller.runAnyway();
   }, [controller]);
 
+  // Once a re-check confirms the CLI, the launch no longer needs to bypass the
+  // probe — take the ordinary session path so the gate can still catch a state
+  // that changed again underneath us.
+  const handleAvailabilityReady = useCallback(() => {
+    controller.newSession();
+  }, [controller]);
+
+  const handleOpenAgentSettings = useCallback(() => {
+    if (!agentId) return;
+    void actionService.dispatch(
+      "app.settings.openTab",
+      { tab: "agents", subtab: agentId },
+      { source: "user" }
+    );
+  }, [agentId]);
+
   // The agent the idle empty state's "Start assistant" CTA would launch — the
   // user's preference, or the sole installed assistant backend. Mirrors the
   // controller's own auto-launch eligibility so the CTA is shown only when a
@@ -1287,6 +1303,8 @@ export function HelpPanel({
               agentId={agentId}
               detail={cliDetail ?? { state: "missing", resolvedPath: null, via: null }}
               onRunAnyway={handleRunAnyway}
+              onAvailabilityReady={handleAvailabilityReady}
+              onOpenAgentSettings={handleOpenAgentSettings}
             />
           ) : (
             <>

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -302,8 +302,8 @@ export function AgentButton({
   const isLaunchable = isAgentLaunchable(availability);
   // `installed` now only fires for WSL-capped binaries (launch not wired
   // through wsl.exe yet); all other binary-on-PATH agents reach `ready`.
-  // `needsSetup` dims the button and routes clicks to Settings for these
-  // genuinely non-launchable cases.
+  // `needsSetup` dims the button for these genuinely non-launchable cases —
+  // presentation only. Clicking still launches; the gate owns recovery (#11760).
   const needsSetup = isAgentInstalled(availability) && !isLaunchable;
   // Surfaced in the tooltip only — launchable agents whose passive auth
   // probe came back empty get a soft cue rather than a disabled look,
@@ -354,24 +354,23 @@ export function AgentButton({
 
   const handleClick = (e?: ReactMouseEvent<HTMLElement>) => {
     if (isLoading) return;
-    if (isLaunchable) {
-      // Drop focus on launch so Enter at a CLI prompt can't re-fire this button
-      // and spawn a duplicate agent before the input bar claims focus. See #10541.
-      e?.currentTarget?.blur();
-      // Defer all preset resolution to useAgentLauncher. Forwarding the
-      // resolved savedPresetId explicitly would block the launcher's
-      // stale-fallback path: when a worktree-scoped pick references a
-      // deleted preset, an explicit presetId bypasses the agent-level
-      // default and launches preset-free instead. Omitting presetId lets
-      // the launcher run resolveEffectivePresetId + fallback in one place.
-      void actionService.dispatch("agent.launch", { agentId: type }, { source: "user" });
-    } else {
-      void actionService.dispatch(
-        "app.settings.openTab",
-        { tab: "agents", subtab: type },
-        { source: "user" }
-      );
-    }
+    // Drop focus on launch so Enter at a CLI prompt can't re-fire this button
+    // and spawn a duplicate agent before the input bar claims focus. See #10541.
+    // Unconditional: an unavailable agent now opens a recovery panel that can
+    // take Enter just as readily, so the blur can't be scoped to the ready path.
+    e?.currentTarget?.blur();
+    // Every click dispatches the launch, whatever the last probe reported.
+    // `useAgentLauncher` re-probes availability and owns the decision to spawn a
+    // PTY or a missing-CLI recovery panel, so routing to Settings here would
+    // both act on a stale reading and skip the gate entirely (#11760).
+    //
+    // Defer all preset resolution to useAgentLauncher. Forwarding the
+    // resolved savedPresetId explicitly would block the launcher's
+    // stale-fallback path: when a worktree-scoped pick references a
+    // deleted preset, an explicit presetId bypasses the agent-level
+    // default and launches preset-free instead. Omitting presetId lets
+    // the launcher run resolveEffectivePresetId + fallback in one place.
+    void actionService.dispatch("agent.launch", { agentId: type }, { source: "user" });
   };
 
   // Per-agent unpin: agent IDs read pin state from agentSettingsStore

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -54,6 +54,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
+import { unavailableAgentHint } from "@/utils/agentAvailabilityCopy";
 
 import { resolveEffectivePresetId } from "@shared/types";
 import {
@@ -322,24 +323,26 @@ export function AgentButton({
   const showSeam = !isLoading && isLaunchable;
 
   const presetSegment = activePresetName ? ` · ${activePresetName}` : "";
+  // The click still launches when the CLI is unavailable — it lands on the
+  // recovery panel, not Settings — so both surfaces borrow the dock's hint
+  // rather than naming an action this button no longer performs (#11760).
+  const unavailableLabel = unavailableAgentHint(config.name, availability);
   const tooltipLabel = isLoading
     ? `Checking ${config.name} CLI…`
     : isLaunchable
       ? signInUnconfirmed
         ? `Start ${config.name}${presetSegment}${visibleStateSuffix} — sign-in not detected`
         : `Start ${config.name}${presetSegment}${visibleStateSuffix}`
-      : needsSetup
-        ? `Configure ${config.name}`
-        : `Install ${config.name} CLI`;
+      : unavailableLabel;
   const tooltipShortcut = isLaunchable ? displayCombo : undefined;
   const chevronTooltip = isLoading
     ? `Checking ${config.name} CLI availability...`
     : isLaunchable
       ? `Set ${config.name} preset`
       : needsSetup
-        ? // The chevron blocks clicks when not launchable, so its copy
-          // names the precondition instead of promising an action the
-          // primary button owns (mirrors the `ariaLabel` strings below).
+        ? // The chevron blocks clicks when not launchable, so its copy names
+          // the precondition alone — unlike the primary button, it opens
+          // nothing, so it must not offer the recovery route.
           `${config.name} needs setup`
         : `${config.name} CLI not found`;
   const isChevronDisabled = isLoading || !isLaunchable;
@@ -348,9 +351,7 @@ export function AgentButton({
     ? `Checking ${config.name} CLI`
     : isLaunchable
       ? `Start ${config.name}${visibleStateSuffix}`
-      : needsSetup
-        ? `Configure ${config.name}`
-        : `Install ${config.name} CLI`;
+      : unavailableLabel;
 
   const handleClick = (e?: ReactMouseEvent<HTMLElement>) => {
     if (isLoading) return;

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -539,25 +539,15 @@ export function AgentButton({
             }
           }}
         >
-          <ContextMenuActionItem
-            actionId="agent.launch"
-            args={{ agentId: type }}
-            disabled={!isLaunchable}
-          >
+          <ContextMenuActionItem actionId="agent.launch" args={{ agentId: type }}>
             Launch {config.name}
           </ContextMenuActionItem>
-          <ContextMenuActionItem
-            actionId="agent.launch"
-            args={{ agentId: type, location: "dock" }}
-            disabled={!isLaunchable}
-          >
+          <ContextMenuActionItem actionId="agent.launch" args={{ agentId: type, location: "dock" }}>
             Launch {config.name} in Dock
           </ContextMenuActionItem>
           {hasWorktrees && (
             <ContextMenuSub>
-              <ContextMenuSubTrigger disabled={!isLaunchable}>
-                Launch in Worktree
-              </ContextMenuSubTrigger>
+              <ContextMenuSubTrigger>Launch in Worktree</ContextMenuSubTrigger>
               <ContextMenuSubContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
                 <WorktreeMenuItems agentType={type} />
               </ContextMenuSubContent>
@@ -779,18 +769,10 @@ export function AgentButton({
           }
         }}
       >
-        <ContextMenuActionItem
-          actionId="agent.launch"
-          args={{ agentId: type }}
-          disabled={!isLaunchable}
-        >
+        <ContextMenuActionItem actionId="agent.launch" args={{ agentId: type }}>
           Launch {config.name}
         </ContextMenuActionItem>
-        <ContextMenuActionItem
-          actionId="agent.launch"
-          args={{ agentId: type, location: "dock" }}
-          disabled={!isLaunchable}
-        >
+        <ContextMenuActionItem actionId="agent.launch" args={{ agentId: type, location: "dock" }}>
           Launch {config.name} in Dock
         </ContextMenuActionItem>
         {hasPresets && (
@@ -851,9 +833,7 @@ export function AgentButton({
         )}
         {hasWorktrees && (
           <ContextMenuSub>
-            <ContextMenuSubTrigger disabled={!isLaunchable}>
-              Launch in Worktree
-            </ContextMenuSubTrigger>
+            <ContextMenuSubTrigger>Launch in Worktree</ContextMenuSubTrigger>
             <ContextMenuSubContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
               <WorktreeMenuItems agentType={type} />
             </ContextMenuSubContent>

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -53,8 +53,8 @@ import {
   type DockLaunchInventoryState,
   type DockLaunchItem,
   type DockLaunchRow,
-  unavailableAgentHint,
 } from "./dockLaunchItems";
+import { unavailableAgentHint } from "@/utils/agentAvailabilityCopy";
 import type { RecipeContext } from "@/utils/recipeVariables";
 
 // Same weighting as the ⌘⇧P panel palette so a name match outranks an alias or

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -16,7 +16,7 @@ import { agentStateDotColor } from "@/components/Worktree/AgentStatusIndicator";
 import { cn } from "@/lib/utils";
 import { notify } from "@/lib/notify";
 import { deriveAgentDominantStates } from "@/lib/agentDominantStates";
-import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
+import { isAgentLaunchable } from "@shared/utils/agentAvailability";
 import { isAgentButtonOnToolbar } from "@shared/utils/agentPinned";
 import { isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import {
@@ -53,6 +53,7 @@ import {
   type DockLaunchInventoryState,
   type DockLaunchItem,
   type DockLaunchRow,
+  unavailableAgentHint,
 } from "./dockLaunchItems";
 import type { RecipeContext } from "@/utils/recipeVariables";
 
@@ -553,16 +554,15 @@ export function DockLaunchButton({
       // Everything closes through `closeLauncher`, so Radix cannot tell a
       // launch from an Escape and restores focus to the trigger either way —
       // landing a beat after the new panel took it, once the content's exit
-      // animation ends (#11664). Cancel that return, but only for rows that
-      // genuinely launch: the redirect below navigates instead, into settings
-      // that manage their own focus, and its dispatch can fail — the WAI-ARIA
-      // return is what keeps the keyboard somewhere useful if it does.
+      // animation ends (#11664). Every non-disabled item row now launches:
+      // an unavailable agent opens a recovery panel rather than navigating to
+      // settings (#11760), and that panel claims focus exactly like a terminal,
+      // so the return has to be cancelled for it too. Cue rows keep the return —
+      // they navigate into surfaces that manage their own focus.
       //
       // Decided on intent, not outcome: every launch below is fire-and-forget,
       // so whether a panel actually appears is not knowable here.
-      const launches = item.category !== "agent" || isAgentLaunchable(item.agent.availability);
-
-      closeLauncher(launches);
+      closeLauncher(true);
       activateDockLaunchItem(
         item,
         { cwd, activeWorktreeId, recipeContext, onLaunchAgent: launchAgent, source: "menu" },
@@ -1047,9 +1047,10 @@ function DockLaunchOption({
     shortcutAgentId ? `agent.${shortcutAgentId}` : panelActionId
   );
 
-  // A filtered row must carry the same warnings as its unfiltered twin: a
-  // blocked agent that silently opens Settings, or a shadowed recipe that
-  // resolves to a different winner, is worse when the row looks ordinary.
+  // A filtered row must carry the same warnings as its unfiltered twin: an
+  // agent that lands on the recovery panel instead of a session, or a shadowed
+  // recipe that resolves to a different winner, is worse when the row looks
+  // ordinary.
   const unavailableAgent = agent && !isAgentLaunchable(agent.availability) ? agent : null;
   const disabledReason = item?.disabled?.reason;
   const isDimmed =
@@ -1057,9 +1058,7 @@ function DockLaunchOption({
     disabledReason !== undefined ||
     (item?.category === "recipe" && item.isShadowed);
   const title = unavailableAgent
-    ? isAgentBlocked(unavailableAgent.availability)
-      ? `${unavailableAgent.name} is blocked by endpoint security. Click to configure.`
-      : `${unavailableAgent.name} needs setup. Click to configure.`
+    ? unavailableAgentHint(unavailableAgent.name, unavailableAgent.availability)
     : undefined;
 
   const displayName =

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -15,8 +15,8 @@ import {
   type DockLaunchPanelItem,
   type DockLaunchRecipeItem,
   type DockLaunchSurface,
-  unavailableAgentHint,
 } from "./dockLaunchItems";
+import { unavailableAgentHint } from "@/utils/agentAvailabilityCopy";
 
 export type { DockLaunchAgent } from "./dockLaunchItems";
 

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -5,7 +5,7 @@ import { BrandMark, Workflow } from "@/components/icons";
 import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
 import type { RecipeContext } from "@/utils/recipeVariables";
 import type { ActionSource } from "@shared/types";
-import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
+import { isAgentLaunchable } from "@shared/utils/agentAvailability";
 import {
   activateCreateRecipeCue,
   activateDockLaunchItem,
@@ -15,6 +15,7 @@ import {
   type DockLaunchPanelItem,
   type DockLaunchRecipeItem,
   type DockLaunchSurface,
+  unavailableAgentHint,
 } from "./dockLaunchItems";
 
 export type { DockLaunchAgent } from "./dockLaunchItems";
@@ -86,15 +87,11 @@ export function DockLaunchMenuItems({
   const renderAgentItem = (agent: DockLaunchAgent, keyPrefix?: string) => {
     const Icon = agent.icon;
     const isLaunchable = isAgentLaunchable(agent.availability);
-    const blocked = isAgentBlocked(agent.availability);
-    const settingsTooltip = blocked
-      ? `${agent.name} is blocked by endpoint security. Click to configure.`
-      : `${agent.name} needs setup. Click to configure.`;
     return (
       <C.Item
         key={keyPrefix ? `${keyPrefix}-${agent.id}` : agent.id}
         className={!isLaunchable ? "opacity-70" : undefined}
-        title={!isLaunchable ? settingsTooltip : undefined}
+        title={!isLaunchable ? unavailableAgentHint(agent.name, agent.availability) : undefined}
         onSelect={() =>
           activate({
             category: "agent",

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -1766,11 +1766,14 @@ describe("AgentButton preset UX", () => {
       expect(primary!.getAttribute("aria-label")).toBe("Checking Claude CLI");
     });
 
-    it("non-launchable copy is verb-noun with no gesture language", () => {
+    // The click routes to the recovery panel, so the accessible name has to
+    // describe that outcome — and word it the way the dock rows already do,
+    // or the same agent announces two different things in two surfaces.
+    it("non-launchable copy names the recovery panel, matching the dock hint", () => {
       const cases: Array<[string, string]> = [
-        ["missing", "Install Claude CLI"],
-        ["installed", "Configure Claude"],
-        ["blocked", "Configure Claude"],
+        ["missing", "Claude needs setup. Select to see recovery options"],
+        ["installed", "Claude needs setup. Select to see recovery options"],
+        ["blocked", "Claude is blocked by endpoint security. Select to see recovery options"],
       ];
       for (const [state, expected] of cases) {
         mockMergedPresetsFn = () => [];

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -1054,20 +1054,66 @@ describe("AgentButton preset UX", () => {
   });
 
   describe("not-ready state", () => {
-    it("primary click when CLI is not installed opens settings (does not launch)", () => {
+    // Every unlaunchable state now launches: the last probe can be stale, and
+    // `useAgentLauncher` re-probes and owns the choice between a PTY and the
+    // recovery gate. Routing to settings here skipped that gate entirely
+    // (#11760), so the redirect must be gone from all three states.
+    it.each(["missing", "installed", "blocked"])(
+      "primary click dispatches the launch and never the settings redirect when %s",
+      (availability) => {
+        mockSettings = settingsWith({ claude: {} });
+        mockMergedPresetsFn = () => [];
+
+        const { getByRole } = render(
+          <AgentButton
+            type="claude"
+            availability={availability as unknown as CliAvailability[string]}
+          />
+        );
+        fireEvent.click(getByRole("button"));
+
+        expect(dispatchMock).toHaveBeenCalledWith(
+          "agent.launch",
+          { agentId: "claude" },
+          { source: "user" }
+        );
+        expect(dispatchMock).not.toHaveBeenCalledWith(
+          "app.settings.openTab",
+          expect.anything(),
+          expect.anything()
+        );
+      }
+    );
+
+    // The gate panel takes Enter as readily as a terminal does, so the blur
+    // that stops a trust-prompt Enter re-firing the button (#10541) has to
+    // survive on the path that used to skip it.
+    it("drops focus on an unlaunchable launch click", () => {
       mockSettings = settingsWith({ claude: {} });
       mockMergedPresetsFn = () => [];
 
       const { getByRole } = render(
         <AgentButton type="claude" availability={"missing" as unknown as CliAvailability[string]} />
       );
+      const button = getByRole("button");
+      button.focus();
+      expect(document.activeElement).toBe(button);
+
+      fireEvent.click(button);
+
+      expect(document.activeElement).not.toBe(button);
+    });
+
+    it("stays inert while the availability probe is still loading", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [];
+
+      const { getByRole } = render(
+        <AgentButton type="claude" availability={undefined as unknown as CliAvailability[string]} />
+      );
       fireEvent.click(getByRole("button"));
 
-      expect(dispatchMock).toHaveBeenCalledWith(
-        "app.settings.openTab",
-        { tab: "agents", subtab: "claude" },
-        { source: "user" }
-      );
+      expect(dispatchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -715,14 +715,19 @@ describe("DockLaunchButton", () => {
     });
 
     it("explains a blocked agent in the results with its setup tooltip", () => {
-      // A filtered row that looks ordinary but silently opens Settings is worse
-      // than the unfiltered one, which explains itself before you click. The
-      // dimming that accompanies it is styling, so it isn't asserted here.
+      // A filtered row that looks ordinary is worse than the unfiltered one,
+      // which explains before you click that this lands on recovery rather than
+      // a session. Asserted as the invariant "both rows say the same thing" so
+      // it keeps holding when the copy changes. The dimming that accompanies it
+      // is styling, so it isn't asserted here.
       const { container, getByText } = renderButton();
-      fireEvent.change(searchInput(container), { target: { value: "gemini" } });
+      const unfiltered = getByText("Gemini").closest(OPTION)?.getAttribute("title");
 
-      const row = getByText("Gemini").closest(OPTION);
-      expect(row?.getAttribute("title")).toContain("blocked by endpoint security");
+      fireEvent.change(searchInput(container), { target: { value: "gemini" } });
+      const filtered = getByText("Gemini").closest(OPTION)?.getAttribute("title");
+
+      expect(filtered).toBeTruthy();
+      expect(filtered).toBe(unfiltered);
     });
 
     it("keeps the Overridden marker on a shadowed recipe in the results", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -565,19 +565,18 @@ describe("DockLaunchButton", () => {
     expect(recordActionMruMock).toHaveBeenCalledWith("agent.claude");
   });
 
-  it("routes non-launchable agent clicks to the agent settings subtab", () => {
+  it("launches non-launchable agent clicks instead of routing to settings", () => {
     const onLaunchAgent = vi.fn();
     const { getByText } = renderButton({ onLaunchAgent });
 
     fireEvent.click(getByText("Gemini"));
-    expect(onLaunchAgent).not.toHaveBeenCalled();
-    expect(actionDispatchMock).toHaveBeenCalledWith(
-      "app.settings.openTab",
-      { tab: "agents", subtab: "gemini" },
-      { source: "menu" }
-    );
-    // A settings redirect is not a launch — it must not pollute the band.
-    expect(recordActionMruMock).not.toHaveBeenCalled();
+    // The launcher re-probes and answers with a session or the recovery gate;
+    // deciding it here on a stale reading skipped the gate entirely (#11760).
+    // `undefined` is the inherit-the-saved-preset sentinel, same as a
+    // launchable row — an unavailable agent is not a different kind of launch.
+    expect(onLaunchAgent).toHaveBeenCalledWith("gemini", undefined);
+    expect(actionDispatchMock).not.toHaveBeenCalled();
+    expect(recordActionMruMock).toHaveBeenCalledWith("agent.gemini");
   });
 
   it("discriminates tooltip copy between blocked and installed-only agents", () => {
@@ -593,10 +592,10 @@ describe("DockLaunchButton", () => {
     // row itself.
     expect(getByText("Claude").closest(OPTION)?.getAttribute("title")).toBeNull();
     expect(getByText("Gemini").closest(OPTION)?.getAttribute("title")).toBe(
-      "Gemini is blocked by endpoint security. Click to configure."
+      "Gemini is blocked by endpoint security. Select to see recovery options"
     );
     expect(getByText("Codex").closest(OPTION)?.getAttribute("title")).toBe(
-      "Codex needs setup. Click to configure."
+      "Codex needs setup. Select to see recovery options"
     );
   });
 
@@ -1363,14 +1362,17 @@ describe("DockLaunchButton", () => {
       expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
     });
 
-    it("keeps the return when a row routes to settings instead of launching", () => {
+    // An unavailable agent opens the recovery panel, which claims focus exactly
+    // like a terminal — so the trigger must not pull focus back from it either
+    // (#11760). Cue rows keep the return; they navigate rather than launch.
+    it("cancels the return for an unavailable agent row now that it launches", () => {
       const onLaunchAgent = vi.fn();
       const { getByText } = renderButton({ onLaunchAgent });
 
       fireEvent.click(getByText("Gemini"));
 
-      expect(onLaunchAgent).not.toHaveBeenCalled();
-      expect(fireCloseAutoFocus()).not.toHaveBeenCalled();
+      expect(onLaunchAgent).toHaveBeenCalledWith("gemini", undefined);
+      expect(fireCloseAutoFocus()).toHaveBeenCalledTimes(1);
     });
 
     it("keeps the return for the Create a recipe cue", () => {

--- a/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
@@ -180,18 +180,17 @@ describe("DockLaunchMenuItems", () => {
     expect(recordActionMruMock).toHaveBeenCalledWith("agent.claude");
   });
 
-  it("routes a blocked agent to its settings subtab under the caller's source", () => {
+  // Convergence (#11760): the dock and context menus must recover the same way
+  // the toolbar and palette do, so a blocked agent launches into the gate here
+  // too rather than being redirected on a possibly-stale probe.
+  it("launches a blocked agent rather than redirecting it to settings", () => {
     const onLaunchAgent = vi.fn();
     const { getByText } = renderItems({ onLaunchAgent, source: "context-menu" });
 
     fireEvent.click(getByText("Gemini"));
-    expect(onLaunchAgent).not.toHaveBeenCalled();
-    expect(actionDispatchMock).toHaveBeenCalledWith(
-      "app.settings.openTab",
-      { tab: "agents", subtab: "gemini" },
-      { source: "context-menu" }
-    );
-    expect(recordActionMruMock).not.toHaveBeenCalled();
+    expect(onLaunchAgent).toHaveBeenCalledWith("gemini", undefined);
+    expect(recordActionMruMock).toHaveBeenCalledWith("agent.gemini");
+    expect(actionDispatchMock).not.toHaveBeenCalled();
   });
 
   it("routes the create-recipe cue to the manager when no worktree is active", () => {

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -799,7 +799,12 @@ describe("activateDockLaunchItem", () => {
     expect(notifyMock).not.toHaveBeenCalled();
   });
 
-  it("routes a non-launchable agent to settings without recording MRU", () => {
+  // A non-launchable agent is a launch attempt like any other now: the launcher
+  // re-probes and answers with either a session or the recovery gate. Settling
+  // it here on a stale reading skipped that gate (#11760). MRU records the
+  // attempt — the visible recency band filters to the launch band, so an
+  // unavailable agent only surfaces there once it actually resolves.
+  it("launches a non-launchable agent and records MRU instead of redirecting", () => {
     const item: DockLaunchItem = {
       category: "agent",
       key: "agent:gemini",
@@ -808,13 +813,21 @@ describe("activateDockLaunchItem", () => {
       agentBand: "needs-setup",
     };
     activateDockLaunchItem(item, ctx);
-    expect(ctx.onLaunchAgent).not.toHaveBeenCalled();
-    expect(recordActionMruMock).not.toHaveBeenCalled();
-    expect(actionDispatchMock).toHaveBeenCalledWith(
-      "app.settings.openTab",
-      { tab: "agents", subtab: "gemini" },
-      { source: "menu" }
-    );
+    expect(ctx.onLaunchAgent).toHaveBeenCalledWith("gemini", undefined);
+    expect(recordActionMruMock).toHaveBeenCalledWith("agent.gemini");
+    expect(actionDispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards an explicit preset for a non-launchable agent so the gate can carry it", () => {
+    const item: DockLaunchItem = {
+      category: "agent",
+      key: "agent:gemini",
+      name: "Gemini",
+      agent: AGENTS[1]!,
+      agentBand: "needs-setup",
+    };
+    activateDockLaunchItem(item, ctx, "fast");
+    expect(ctx.onLaunchAgent).toHaveBeenCalledWith("gemini", "fast");
   });
 
   it("runs a recipe and surfaces spawn failures", async () => {

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -19,7 +19,7 @@ import { notify } from "@/lib/notify";
 import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
 import { getRecipeScope } from "@/utils/recipeScope";
 import { logError } from "@/utils/logger";
-import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
+import { isAgentLaunchable } from "@shared/utils/agentAvailability";
 import type {
   ActionSource,
   AgentAvailabilityState,
@@ -795,21 +795,6 @@ export interface ActivateDockLaunchItemContext {
   /** Dispatch source for everything this activation dispatches. Must stay a
    * foreground source, or panel actions silently skip their focus handling. */
   source: ActionSource;
-}
-
-/**
- * Hint for an agent row whose last probe came back unlaunchable. Shared by the
- * searchable launcher and the dock/context menus so both name the same outcome:
- * selecting still launches, and the recovery panel — not Settings — is what
- * opens (#11760).
- */
-export function unavailableAgentHint(
-  name: string,
-  availability: AgentAvailabilityState | undefined
-): string {
-  return isAgentBlocked(availability)
-    ? `${name} is blocked by endpoint security. Select to see recovery options`
-    : `${name} needs setup. Select to see recovery options`;
 }
 
 /** Route a cue row — the launcher entries that navigate rather than launch. */

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -19,7 +19,7 @@ import { notify } from "@/lib/notify";
 import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
 import { getRecipeScope } from "@/utils/recipeScope";
 import { logError } from "@/utils/logger";
-import { isAgentLaunchable } from "@shared/utils/agentAvailability";
+import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
 import type {
   ActionSource,
   AgentAvailabilityState,
@@ -797,6 +797,21 @@ export interface ActivateDockLaunchItemContext {
   source: ActionSource;
 }
 
+/**
+ * Hint for an agent row whose last probe came back unlaunchable. Shared by the
+ * searchable launcher and the dock/context menus so both name the same outcome:
+ * selecting still launches, and the recovery panel — not Settings — is what
+ * opens (#11760).
+ */
+export function unavailableAgentHint(
+  name: string,
+  availability: AgentAvailabilityState | undefined
+): string {
+  return isAgentBlocked(availability)
+    ? `${name} is blocked by endpoint security. Select to see recovery options`
+    : `${name} needs setup. Select to see recovery options`;
+}
+
 /** Route a cue row — the launcher entries that navigate rather than launch. */
 export function activateDockLaunchCue(
   cue: DockLaunchCueId,
@@ -826,17 +841,15 @@ export function activateDockLaunchItem(
 ): void {
   if (item.category === "agent") {
     const { agent } = item;
-    if (!isAgentLaunchable(agent.availability)) {
-      // Mirrors AgentButton.tsx: a non-launchable agent routes to its settings
-      // subtab so the user can resolve the precondition instead of bouncing off
-      // a disabled row. Not a launch, so it must not pollute the MRU band.
-      void actionService.dispatch(
-        "app.settings.openTab",
-        { tab: "agents", subtab: agent.id },
-        { source: ctx.source }
-      );
-      return;
-    }
+    // Mirrors AgentButton.tsx: every agent row launches, whatever the last
+    // probe reported. `useAgentLauncher` re-probes and decides between a PTY
+    // and a missing-CLI recovery panel, so redirecting to settings here would
+    // act on a stale reading and skip the gate entirely (#11760).
+    //
+    // Recorded in the MRU because it is a launch attempt like any other. An
+    // unavailable agent still stays out of the visible recency band, which
+    // filters to `agentBand === "launch"` — it becomes eligible only once the
+    // agent actually resolves.
     useActionMruStore.getState().recordActionMru(`${AGENT_MRU_PREFIX}${agent.id}`);
     ctx.onLaunchAgent(agent.id, presetId);
     return;

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -190,8 +190,15 @@ export function MissingCliGate({
     };
   }, []);
 
+  // Held in a ref, not read off `isRefreshing`: that value is captured at
+  // render, so a second press landing before React re-renders would sail past
+  // it. The store singleflights the probe itself, but two handlers resuming
+  // would both reach the continuation below and launch twice.
+  const probeInFlightRef = useRef(false);
+
   const handleRefresh = async () => {
-    if (isRefreshing) return;
+    if (probeInFlightRef.current) return;
+    probeInFlightRef.current = true;
     setRefreshFailed(false);
     try {
       // `force` skips the passive throttle window — this is an explicit gesture,
@@ -200,6 +207,8 @@ export function MissingCliGate({
     } catch {
       if (mountedRef.current) setRefreshFailed(true);
       return;
+    } finally {
+      probeInFlightRef.current = false;
     }
     if (!mountedRef.current) return;
     // Read `availability`, not `details`: the store's fetch deliberately

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -216,7 +216,7 @@ export function MissingCliGate({
     // still resolving, so details can be stale here. Availability is always
     // replaced by a refresh that resolved.
     const availability = useCliAvailabilityStore.getState().availability;
-    if (isAgentLaunchable(availability[agentId as keyof typeof availability])) {
+    if (isAgentLaunchable(availability[agentId])) {
       onAvailabilityReady();
     }
   };

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -1,9 +1,13 @@
-import { AlertTriangle, Terminal, Check, ExternalLink } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { AlertTriangle, Terminal, Check, ExternalLink, KeyRound, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { CopyableCommand } from "@/components/Setup/CopyableCommand";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { getAgentConfig } from "@/config/agents";
 import { isMac, isLinux } from "@/lib/platform";
-import { cn } from "@/lib/utils";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { isAgentLaunchable } from "@shared/utils/agentAvailability";
 import type { AgentCliDetail, AgentAvailabilityState } from "@shared/types/ipc";
 import type { AgentInstallBlock } from "@shared/config/agentRegistry";
 
@@ -27,7 +31,26 @@ function StateBanner({ state, detail }: { state: AgentAvailabilityState; detail:
         <div>
           <p className="text-sm font-medium">CLI is now available</p>
           <p className="text-xs text-daintree-text/60 mt-1">
-            The agent binary was detected. Close this panel and re-launch to start a session.
+            The agent binary was detected. Re-check to continue the launch.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Launchable by design — the CLI prompts for sign-in itself — so this is
+  // reachable only when a re-check lands here mid-flight or a probe reports it
+  // defensively. Without its own branch it fell through to "blocked", which
+  // sends the user hunting through endpoint security for a sign-in prompt.
+  if (state === "unauthenticated") {
+    return (
+      <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-status-success/20 bg-status-success/5">
+        <KeyRound className="w-5 h-5 text-status-success shrink-0 mt-px" />
+        <div>
+          <p className="text-sm font-medium">Sign-in not detected</p>
+          <p className="text-xs text-daintree-text/60 mt-1">
+            The CLI is available but no signed-in session was found. Re-check to continue — the CLI
+            prompts for sign-in on its first run.
           </p>
         </div>
       </div>
@@ -132,12 +155,62 @@ export interface MissingCliGateProps {
   agentId: string;
   detail: AgentCliDetail;
   onRunAnyway: () => void;
+  /**
+   * Continue the launch this gate stood in for. Fired only after a re-check
+   * confirms the CLI became launchable — the gate owns the probe, the caller
+   * owns what relaunching means for its own surface.
+   */
+  onAvailabilityReady: () => void;
+  /** Secondary route to the agent's persistent CLI configuration. */
+  onOpenAgentSettings: () => void;
 }
 
-export function MissingCliGate({ agentId, detail, onRunAnyway }: MissingCliGateProps) {
+export function MissingCliGate({
+  agentId,
+  detail,
+  onRunAnyway,
+  onAvailabilityReady,
+  onOpenAgentSettings,
+}: MissingCliGateProps) {
   const agentConfig = getAgentConfig(agentId);
   const agentName = agentConfig?.name ?? agentId;
   const state = detail.state;
+
+  const refresh = useCliAvailabilityStore((s) => s.refresh);
+  const isRefreshing = useCliAvailabilityStore((s) => s.isRefreshing);
+  const [refreshFailed, setRefreshFailed] = useState(false);
+
+  // The probe outlives the panel: closing the gate mid-re-check must not
+  // relaunch an agent into a pane that no longer exists.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const handleRefresh = async () => {
+    if (isRefreshing) return;
+    setRefreshFailed(false);
+    try {
+      // `force` skips the passive throttle window — this is an explicit gesture,
+      // and a user who just installed the CLI is exactly who the window blocks.
+      await refresh(true);
+    } catch {
+      if (mountedRef.current) setRefreshFailed(true);
+      return;
+    }
+    if (!mountedRef.current) return;
+    // Read `availability`, not `details`: the store's fetch deliberately
+    // swallows a `getDetails` failure and keeps the previous details while
+    // still resolving, so details can be stale here. Availability is always
+    // replaced by a refresh that resolved.
+    const availability = useCliAvailabilityStore.getState().availability;
+    if (isAgentLaunchable(availability[agentId as keyof typeof availability])) {
+      onAvailabilityReady();
+    }
+  };
 
   const osKey = getOsKey();
   const installBlocks = agentConfig?.install?.byOs?.[osKey];
@@ -153,7 +226,11 @@ export function MissingCliGate({ agentId, detail, onRunAnyway }: MissingCliGateP
           </div>
           <div>
             <h2 className="text-sm font-semibold">{agentName}</h2>
-            <p className="text-xs text-daintree-text/40">Setup required before launch</p>
+            <p className="text-xs text-daintree-text/40">
+              {isAgentLaunchable(state)
+                ? "Ready to continue launch"
+                : "Setup required before launch"}
+            </p>
           </div>
         </div>
 
@@ -179,12 +256,16 @@ export function MissingCliGate({ agentId, detail, onRunAnyway }: MissingCliGateP
           </div>
         )}
 
-        <div
-          className={cn(
-            "flex items-center gap-2 pt-1",
-            state === "missing" ? "justify-between" : "justify-end"
-          )}
-        >
+        {refreshFailed && (
+          <InlineStatusBanner
+            severity="error"
+            icon={AlertTriangle}
+            title="Couldn't re-check the CLI"
+            description="The availability probe didn't finish. Try again, or run the agent anyway if you know the binary works."
+          />
+        )}
+
+        <div className="flex flex-wrap items-center gap-2 pt-1">
           {docsUrl && (
             <Button
               size="sm"
@@ -195,9 +276,25 @@ export function MissingCliGate({ agentId, detail, onRunAnyway }: MissingCliGateP
               Docs
             </Button>
           )}
-          <Button size="sm" variant="outline" onClick={onRunAnyway}>
-            Run anyway
-          </Button>
+          {/* `ml-auto` right-aligns the recovery group whether or not Docs
+              renders, so the row needs no state-dependent justification. */}
+          <div className="flex flex-wrap items-center gap-2 ml-auto">
+            <Button size="sm" variant="ghost" onClick={onOpenAgentSettings}>
+              Agent settings
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => void handleRefresh()}
+              disabled={isRefreshing}
+            >
+              <SpinningIcon icon={RefreshCw} active={isRefreshing} size={14} className="mr-1.5" />
+              Re-check
+            </Button>
+            <Button size="sm" variant="outline" onClick={onRunAnyway}>
+              Run anyway
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -66,7 +66,10 @@ import { isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { notifyWorktreeTerminalAttached } from "@/services/terminal/worktreeRevealCoordinator";
 import { actionService } from "@/services/ActionService";
-import { buildMissingCliRelaunchOptions, readPresetEnv } from "@/utils/missingCliGate";
+import {
+  buildMissingCliContinueArgs,
+  buildMissingCliRelaunchOptions,
+} from "@/utils/missingCliGate";
 import { useReviewDialogOpenForWorktree } from "./useReviewDialogOpenForWorktree";
 import { InputTracker } from "@/services/clearCommandDetection";
 import { getAgentConfig, getMergedPresets } from "@/config/agents";
@@ -451,27 +454,12 @@ function TerminalPaneComponent({
    */
   const continueMissingCliLaunch = () => {
     const panel = usePanelStore.getState().panelsById[id];
-    if (!panel || !isPtyPanel(panel) || !panel.launchAgentId) return;
-    const location = panel.location === "dock" ? "dock" : "grid";
+    if (!panel || !isPtyPanel(panel)) return;
+    const args = buildMissingCliContinueArgs(panel);
+    if (!args) return;
 
     removePanel(id);
-    void actionService.dispatch(
-      "agent.launch",
-      {
-        agentId: panel.launchAgentId,
-        location,
-        cwd: panel.cwd,
-        worktreeId: panel.worktreeId,
-        model: panel.agentModelId,
-        // Explicit null preserves a deliberately preset-free launch; forwarding
-        // undefined would let the agent-level default reappear on recovery.
-        presetId: panel.agentPresetId ?? null,
-        ...(location === "dock" ? { activateDockOnCreate: true } : {}),
-        env: readPresetEnv(panel),
-        excludeFromPersistence: panel.excludeFromPersistence,
-      },
-      { source: "user" }
-    );
+    void actionService.dispatch("agent.launch", args, { source: "user" });
   };
 
   // Fleet arming store for multi-select gestures. Selection treatment is

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -66,6 +66,7 @@ import { isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { notifyWorktreeTerminalAttached } from "@/services/terminal/worktreeRevealCoordinator";
 import { actionService } from "@/services/ActionService";
+import { buildMissingCliRelaunchOptions } from "@/utils/missingCliGate";
 import { useReviewDialogOpenForWorktree } from "./useReviewDialogOpenForWorktree";
 import { InputTracker } from "@/services/clearCommandDetection";
 import { getAgentConfig, getMergedPresets } from "@/config/agents";
@@ -424,33 +425,20 @@ function TerminalPaneComponent({
     return cliDetails[agentId];
   };
 
-  const handleRunAnyway = () => {
-    const _panel = usePanelStore.getState().panelsById[id];
-    if (!_panel || !agentId || !isPtyPanel(_panel)) return;
-    const panel = _panel;
-
-    const presetEnv = panel.extensionState?.presetEnv as Record<string, string> | undefined;
+  /**
+   * Replace the gate with the launch it stood in for. Both recovery exits use
+   * it: "Run anyway" (bypassing the probe on the user's word) and the
+   * post-re-check continuation (the probe now agrees). `addPanel` never
+   * re-checks the gate, so one path serves both.
+   */
+  const continueMissingCliLaunch = () => {
+    const panel = usePanelStore.getState().panelsById[id];
+    if (!panel || !isPtyPanel(panel)) return;
+    const options = buildMissingCliRelaunchOptions(panel);
+    if (!options) return;
 
     removePanel(id);
-    void addPanel({
-      kind: "terminal",
-      launchAgentId: agentId,
-      command: panel.command,
-      title: panel.title,
-      cwd: panel.cwd ?? "",
-      worktreeId: panel.worktreeId,
-      location: panel.location as "grid" | "dock" | undefined,
-      agentLaunchFlags: panel.agentLaunchFlags,
-      agentModelId: panel.agentModelId,
-      agentPresetId: panel.agentPresetId,
-      env: presetEnv,
-      // Carry the gate panel's persistence policy through the re-launch. Since
-      // env is now persisted onto the panel (#10922), dropping these would let a
-      // session-scoped secret (e.g. DAINTREE_MCP_TOKEN on a help session, which
-      // launches excluded) leak into the on-disk snapshot on "Run anyway".
-      excludeFromPersistence: panel.excludeFromPersistence,
-      removeOnExit: panel.removeOnExit,
-    });
+    void addPanel(options);
   };
 
   // Fleet arming store for multi-select gestures. Selection treatment is
@@ -1411,7 +1399,15 @@ function TerminalPaneComponent({
           <MissingCliGate
             agentId={agentId}
             detail={getPanelCliDetail() ?? { state: "missing", resolvedPath: null, via: null }}
-            onRunAnyway={handleRunAnyway}
+            onRunAnyway={continueMissingCliLaunch}
+            onAvailabilityReady={continueMissingCliLaunch}
+            onOpenAgentSettings={() =>
+              void actionService.dispatch(
+                "app.settings.openTab",
+                { tab: "agents", subtab: agentId },
+                { source: "user" }
+              )
+            }
           />
         ) : spawnStatus === "spawning" && !eagerAttach ? (
           <TerminalStartupPlaceholder agentId={agentId} onCancel={() => onClose()} />

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -66,7 +66,7 @@ import { isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { notifyWorktreeTerminalAttached } from "@/services/terminal/worktreeRevealCoordinator";
 import { actionService } from "@/services/ActionService";
-import { buildMissingCliRelaunchOptions } from "@/utils/missingCliGate";
+import { buildMissingCliRelaunchOptions, readPresetEnv } from "@/utils/missingCliGate";
 import { useReviewDialogOpenForWorktree } from "./useReviewDialogOpenForWorktree";
 import { InputTracker } from "@/services/clearCommandDetection";
 import { getAgentConfig, getMergedPresets } from "@/config/agents";
@@ -467,7 +467,7 @@ function TerminalPaneComponent({
         // undefined would let the agent-level default reappear on recovery.
         presetId: panel.agentPresetId ?? null,
         ...(location === "dock" ? { activateDockOnCreate: true } : {}),
-        env: panel.extensionState?.presetEnv as Record<string, string> | undefined,
+        env: readPresetEnv(panel),
         excludeFromPersistence: panel.excludeFromPersistence,
       },
       { source: "user" }

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -426,12 +426,12 @@ function TerminalPaneComponent({
   };
 
   /**
-   * Replace the gate with the launch it stood in for. Both recovery exits use
-   * it: "Run anyway" (bypassing the probe on the user's word) and the
-   * post-re-check continuation (the probe now agrees). `addPanel` never
-   * re-checks the gate, so one path serves both.
+   * "Run anyway" — spawn the command the gate captured, on the user's word.
+   * Goes straight to `addPanel` precisely because that skips the probe: the
+   * whole point is overriding a verdict the user believes is wrong (an alias,
+   * a wrapper, a version-manager shim, a false-negative probe).
    */
-  const continueMissingCliLaunch = () => {
+  const runMissingCliAnyway = () => {
     const panel = usePanelStore.getState().panelsById[id];
     if (!panel || !isPtyPanel(panel)) return;
     const options = buildMissingCliRelaunchOptions(panel);
@@ -439,6 +439,39 @@ function TerminalPaneComponent({
 
     removePanel(id);
     void addPanel(options);
+  };
+
+  /**
+   * Re-check found the CLI — continue the original launch through the launcher
+   * rather than replaying the captured command. The gate's command was resolved
+   * while the CLI was unavailable, so it fell back to the bare registry name;
+   * re-dispatching re-resolves it against the freshly probed path, which is the
+   * whole reason the binary is now reachable. It also re-runs the gate check,
+   * so a state that flipped back lands on a gate instead of a failed spawn.
+   */
+  const continueMissingCliLaunch = () => {
+    const panel = usePanelStore.getState().panelsById[id];
+    if (!panel || !isPtyPanel(panel) || !panel.launchAgentId) return;
+    const location = panel.location === "dock" ? "dock" : "grid";
+
+    removePanel(id);
+    void actionService.dispatch(
+      "agent.launch",
+      {
+        agentId: panel.launchAgentId,
+        location,
+        cwd: panel.cwd,
+        worktreeId: panel.worktreeId,
+        model: panel.agentModelId,
+        // Explicit null preserves a deliberately preset-free launch; forwarding
+        // undefined would let the agent-level default reappear on recovery.
+        presetId: panel.agentPresetId ?? null,
+        ...(location === "dock" ? { activateDockOnCreate: true } : {}),
+        env: panel.extensionState?.presetEnv as Record<string, string> | undefined,
+        excludeFromPersistence: panel.excludeFromPersistence,
+      },
+      { source: "user" }
+    );
   };
 
   // Fleet arming store for multi-select gestures. Selection treatment is
@@ -1399,7 +1432,7 @@ function TerminalPaneComponent({
           <MissingCliGate
             agentId={agentId}
             detail={getPanelCliDetail() ?? { state: "missing", resolvedPath: null, via: null }}
-            onRunAnyway={continueMissingCliLaunch}
+            onRunAnyway={runMissingCliAnyway}
             onAvailabilityReady={continueMissingCliLaunch}
             onOpenAgentSettings={() =>
               void actionService.dispatch(

--- a/src/components/Terminal/__tests__/MissingCliGate.test.tsx
+++ b/src/components/Terminal/__tests__/MissingCliGate.test.tsx
@@ -1,8 +1,30 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import { MissingCliGate } from "../MissingCliGate";
 import type { AgentCliDetail } from "@shared/types/ipc";
+
+// A hand-rolled store double rather than the real one: the gate reads it both
+// as a hook (`refresh`, `isRefreshing`) and imperatively (`getState().availability`),
+// and the availability half is what the continuation decision hangs on.
+const cliStore = vi.hoisted(() => {
+  const state = {
+    refresh: vi.fn<(force?: boolean) => Promise<void>>(),
+    isRefreshing: false,
+    availability: {} as Record<string, string>,
+  };
+  const useStore = ((selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state) as unknown as {
+    (selector?: (s: typeof state) => unknown): unknown;
+    getState: () => typeof state;
+  };
+  useStore.getState = () => state;
+  return { state, useStore };
+});
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: cliStore.useStore,
+}));
 
 // Mock platform detection
 const mockPlatform = vi.hoisted(() => ({
@@ -58,66 +80,69 @@ function detail(overrides: Partial<AgentCliDetail> = {}): AgentCliDetail {
   };
 }
 
+function renderGate(
+  props: Partial<React.ComponentProps<typeof MissingCliGate>> & { detail: AgentCliDetail }
+) {
+  const handlers = {
+    onRunAnyway: vi.fn(),
+    onAvailabilityReady: vi.fn(),
+    onOpenAgentSettings: vi.fn(),
+  };
+  const view = render(<MissingCliGate agentId="claude" {...handlers} {...props} />);
+  return { ...view, ...handlers };
+}
+
+// `InlineStatusBanner` reads the reduced-motion preference on render, and jsdom
+// ships no `matchMedia`. Same stub the banner's own suite installs.
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
 describe("MissingCliGate", () => {
   beforeEach(() => {
     mockPlatform.isMac.mockReturnValue(true);
     mockPlatform.isLinux.mockReturnValue(false);
+    cliStore.state.refresh = vi.fn<(force?: boolean) => Promise<void>>().mockResolvedValue();
+    cliStore.state.isRefreshing = false;
+    cliStore.state.availability = {};
   });
 
   it("renders the agent name", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "missing" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "missing" }) });
     expect(screen.getByText("Claude")).toBeTruthy();
   });
 
   it("shows 'CLI binary not found' for missing state", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "missing" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "missing" }) });
     expect(screen.getByText("CLI binary not found")).toBeTruthy();
   });
 
   it("shows install commands for missing state on macOS", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "missing" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "missing" }) });
     expect(screen.getByText("Install on macOS")).toBeTruthy();
     expect(screen.getByText("npm install -g @anthropic-ai/claude-code")).toBeTruthy();
   });
 
   it("shows troubleshooting tips for missing state", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "missing" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "missing" }) });
     expect(screen.getByText("Troubleshooting")).toBeTruthy();
     expect(screen.getByText("Restart Daintree after install")).toBeTruthy();
   });
 
   it("shows WSL message for installed state via wsl", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "installed", via: "wsl", wslDistro: "Ubuntu" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "installed", via: "wsl", wslDistro: "Ubuntu" }) });
     expect(screen.getByText("Detected in WSL")).toBeTruthy();
     expect(
       screen.getByText(/Found in WSL \(Ubuntu\).*only host binaries can be launched directly/)
@@ -125,72 +150,157 @@ describe("MissingCliGate", () => {
   });
 
   it("shows blocked message for blocked state", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "blocked", message: "EACCES: permission denied" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "blocked", message: "EACCES: permission denied" }) });
     expect(screen.getByText("Blocked by security software")).toBeTruthy();
     expect(screen.getByText("EACCES: permission denied")).toBeTruthy();
   });
 
   it("calls onRunAnyway when 'Run anyway' button is clicked", () => {
-    const onRunAnyway = vi.fn();
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "missing" })}
-        onRunAnyway={onRunAnyway}
-      />
-    );
+    const { onRunAnyway } = renderGate({ detail: detail({ state: "missing" }) });
     fireEvent.click(screen.getByText("Run anyway"));
     expect(onRunAnyway).toHaveBeenCalledOnce();
   });
 
   it("shows docs link when docsUrl is present", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "missing" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "missing" }) });
     expect(screen.getByText("Docs")).toBeTruthy();
   });
 
   it("shows resolved path when present in detail", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "missing", resolvedPath: "/usr/local/bin/claude" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "missing", resolvedPath: "/usr/local/bin/claude" }) });
     expect(screen.getByText("Last known path: /usr/local/bin/claude")).toBeTruthy();
   });
 
   it("does not show install commands for installed state", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "installed", via: "npm-global" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "installed", via: "npm-global" }) });
     expect(screen.queryByText("Install on macOS")).toBeNull();
     expect(screen.queryByText("Troubleshooting")).toBeNull();
   });
 
   it("does not show install commands for blocked state", () => {
-    render(
-      <MissingCliGate
-        agentId="claude"
-        detail={detail({ state: "blocked" })}
-        onRunAnyway={() => {}}
-      />
-    );
+    renderGate({ detail: detail({ state: "blocked" }) });
     expect(screen.queryByText("Install on macOS")).toBeNull();
+  });
+
+  // `unauthenticated` used to fall through to the blocked branch, sending a
+  // user who only needs to sign in hunting through endpoint-security settings.
+  it("distinguishes unauthenticated from blocked", () => {
+    renderGate({ detail: detail({ state: "unauthenticated" }) });
+    expect(screen.getByText("Sign-in not detected")).toBeTruthy();
+    expect(screen.queryByText("Blocked by security software")).toBeNull();
+  });
+
+  it("routes to the agent's settings without making it the only way out", () => {
+    const { onOpenAgentSettings } = renderGate({ detail: detail({ state: "missing" }) });
+    fireEvent.click(screen.getByText("Agent settings"));
+    expect(onOpenAgentSettings).toHaveBeenCalledOnce();
+    // Settings is demoted, not promoted: the recovery actions stay on the panel.
+    expect(screen.getByText("Run anyway")).toBeTruthy();
+    expect(screen.getByText("Re-check")).toBeTruthy();
+  });
+
+  describe("re-check", () => {
+    it("forces the probe past the passive throttle window", async () => {
+      renderGate({ detail: detail({ state: "missing" }) });
+      await act(async () => {
+        fireEvent.click(screen.getByText("Re-check"));
+      });
+      // A user who just installed the CLI is exactly who the throttle blocks.
+      expect(cliStore.state.refresh).toHaveBeenCalledWith(true);
+    });
+
+    it.each(["ready", "unauthenticated"])(
+      "continues the original launch when the probe comes back %s",
+      async (state) => {
+        cliStore.state.refresh = vi.fn(async () => {
+          cliStore.state.availability = { claude: state };
+        });
+        const { onAvailabilityReady } = renderGate({ detail: detail({ state: "missing" }) });
+
+        await act(async () => {
+          fireEvent.click(screen.getByText("Re-check"));
+        });
+
+        await waitFor(() => expect(onAvailabilityReady).toHaveBeenCalledOnce());
+      }
+    );
+
+    it("stays on the gate when the probe still reports it unlaunchable", async () => {
+      cliStore.state.refresh = vi.fn(async () => {
+        cliStore.state.availability = { claude: "missing" };
+      });
+      const { onAvailabilityReady, onRunAnyway } = renderGate({
+        detail: detail({ state: "missing" }),
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Re-check"));
+      });
+
+      expect(onAvailabilityReady).not.toHaveBeenCalled();
+      expect(onRunAnyway).not.toHaveBeenCalled();
+      expect(screen.getByText("Re-check")).toBeTruthy();
+    });
+
+    it("reads availability rather than details, which a resolved probe may leave stale", async () => {
+      // The store swallows a `getDetails` failure and keeps the old details
+      // while still resolving, so a details-driven decision would never fire.
+      cliStore.state.refresh = vi.fn(async () => {
+        cliStore.state.availability = { claude: "ready" };
+      });
+      const { onAvailabilityReady } = renderGate({
+        detail: detail({ state: "missing" }),
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Re-check"));
+      });
+
+      await waitFor(() => expect(onAvailabilityReady).toHaveBeenCalledOnce());
+    });
+
+    it("surfaces a failed probe inline and keeps the recovery actions", async () => {
+      cliStore.state.refresh = vi.fn().mockRejectedValue(new Error("IPC down"));
+      const { onAvailabilityReady } = renderGate({ detail: detail({ state: "missing" }) });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Re-check"));
+      });
+
+      await waitFor(() => expect(screen.getByText("Couldn't re-check the CLI")).toBeTruthy());
+      expect(onAvailabilityReady).not.toHaveBeenCalled();
+      expect(screen.getByText("Run anyway")).toBeTruthy();
+    });
+
+    it("blocks a second probe while one is already in flight", () => {
+      cliStore.state.isRefreshing = true;
+      renderGate({ detail: detail({ state: "missing" }) });
+
+      fireEvent.click(screen.getByText("Re-check"));
+
+      expect(cliStore.state.refresh).not.toHaveBeenCalled();
+    });
+
+    it("does not continue a launch into a panel that closed mid-probe", async () => {
+      let settle: (() => void) | undefined;
+      cliStore.state.refresh = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            settle = () => {
+              cliStore.state.availability = { claude: "ready" };
+              resolve();
+            };
+          })
+      );
+      const { onAvailabilityReady, unmount } = renderGate({ detail: detail({ state: "missing" }) });
+
+      fireEvent.click(screen.getByText("Re-check"));
+      unmount();
+      await act(async () => {
+        settle?.();
+      });
+
+      expect(onAvailabilityReady).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Terminal/__tests__/MissingCliGate.test.tsx
+++ b/src/components/Terminal/__tests__/MissingCliGate.test.tsx
@@ -272,13 +272,35 @@ describe("MissingCliGate", () => {
       expect(screen.getByText("Run anyway")).toBeTruthy();
     });
 
-    it("blocks a second probe while one is already in flight", () => {
+    // Two independent stops, asserted separately — a disabled button alone
+    // would hide a missing guard, and the guard alone would let a
+    // programmatic/Enter-during-transition press through.
+    it("disables the control while a probe is in flight", () => {
       cliStore.state.isRefreshing = true;
       renderGate({ detail: detail({ state: "missing" }) });
 
-      fireEvent.click(screen.getByText("Re-check"));
+      expect(screen.getByText("Re-check").closest("button")?.disabled).toBe(true);
+    });
 
-      expect(cliStore.state.refresh).not.toHaveBeenCalled();
+    it("refuses a second probe even when the disabled control is bypassed", async () => {
+      let inFlight = 0;
+      cliStore.state.refresh = vi.fn(() => {
+        inFlight += 1;
+        // Mirror the store flipping its flag for the duration of the probe.
+        cliStore.state.isRefreshing = true;
+        return Promise.resolve();
+      });
+      renderGate({ detail: detail({ state: "missing" }) });
+      const button = screen.getByText("Re-check").closest("button")!;
+
+      await act(async () => {
+        // `click()` bypasses the disabled attribute the way a stale render or a
+        // keyboard press mid-transition can; only the guard stops this one.
+        button.click();
+        button.click();
+      });
+
+      expect(inFlight).toBe(1);
     });
 
     it("does not continue a launch into a panel that closed mid-probe", async () => {

--- a/src/components/Terminal/__tests__/MissingCliGate.test.tsx
+++ b/src/components/Terminal/__tests__/MissingCliGate.test.tsx
@@ -8,17 +8,21 @@ import type { AgentCliDetail } from "@shared/types/ipc";
 // as a hook (`refresh`, `isRefreshing`) and imperatively (`getState().availability`),
 // and the availability half is what the continuation decision hangs on.
 const cliStore = vi.hoisted(() => {
-  const state = {
+  const state: {
+    refresh: (force?: boolean) => Promise<void>;
+    isRefreshing: boolean;
+    availability: Record<string, string>;
+  } = {
     refresh: vi.fn<(force?: boolean) => Promise<void>>(),
     isRefreshing: false,
-    availability: {} as Record<string, string>,
+    availability: {},
   };
-  const useStore = ((selector?: (s: typeof state) => unknown) =>
-    selector ? selector(state) : state) as unknown as {
-    (selector?: (s: typeof state) => unknown): unknown;
-    getState: () => typeof state;
-  };
-  useStore.getState = () => state;
+  // `Object.assign` rather than an assertion — the store is callable with a
+  // selector AND carries `getState`, and the intersection falls out for free.
+  const useStore = Object.assign(
+    (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state),
+    { getState: () => state }
+  );
   return { state, useStore };
 });
 

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -31,6 +31,7 @@ import {
   resolveEffectivePresetId,
 } from "@shared/types";
 import { isAgentLaunchable } from "@shared/utils/agentAvailability";
+import { findEquivalentMissingCliGate } from "@/utils/missingCliGate";
 import { escapeShellArgOptional } from "@shared/utils/shellEscape";
 import {
   getAgentConfig,
@@ -718,39 +719,62 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               spawnedBy,
               focusPolicy,
             };
+            // Resolved inside the updater, read after it: the gate may reuse a
+            // panel that already exists rather than the id minted above.
+            let resolvedGateId = gateId;
             usePanelStore.setState((state) => {
-              const next: Partial<typeof state> = {
-                panelsById: { ...state.panelsById, [gateId]: gatePanel },
-                panelIds: [...state.panelIds, gateId],
-                // The gate panel bypasses `addPanel`, so it must join the
-                // per-worktree index here — sidebar summaries and worktree
-                // cycling derive terminal counts from it.
-                panelIdsByWorktreeId: addToWorktreeIndex(
-                  state.panelIdsByWorktreeId,
-                  gatePanel.worktreeId,
-                  gateId
-                ),
-              };
+              // The in-flight guard above only spans a single call, so repeated
+              // clicks on an unavailable agent would each append another gate.
+              // A launch carrying `requestedId` opts out — that id is an
+              // identity contract with the caller, so it must get its own panel.
+              const existingGateId = launchOptions?.requestedId
+                ? null
+                : findEquivalentMissingCliGate(state.panelsById, state.panelIds, gatePanel);
+              resolvedGateId = existingGateId ?? gateId;
+
+              const next: Partial<typeof state> = existingGateId
+                ? {}
+                : {
+                    panelsById: { ...state.panelsById, [gateId]: gatePanel },
+                    panelIds: [...state.panelIds, gateId],
+                    // The gate panel bypasses `addPanel`, so it must join the
+                    // per-worktree index here — sidebar summaries and worktree
+                    // cycling derive terminal counts from it.
+                    panelIdsByWorktreeId: addToWorktreeIndex(
+                      state.panelIdsByWorktreeId,
+                      gatePanel.worktreeId,
+                      gateId
+                    ),
+                  };
               // Atomic dock activation — same race fix as `addPanel`. The gate
               // panel bypasses `addPanel`, so the activation must be folded
               // into this `set()` directly. See #6590.
               if (launchOptions?.activateDockOnCreate && launchOptions?.location === "dock") {
                 const prevFocusedId = state.focusedId ?? null;
-                const focusActuallyChanged = gateId !== prevFocusedId;
-                next.activeDockTerminalId = gateId;
+                const focusActuallyChanged = resolvedGateId !== prevFocusedId;
+                next.activeDockTerminalId = resolvedGateId;
                 // Focus-preserve launches still expose the gate panel in the
                 // dock but never claim keyboard focus. See #6959.
                 if (focusPolicy !== "preserve") {
-                  next.focusedId = gateId;
+                  next.focusedId = resolvedGateId;
                   if (focusActuallyChanged) {
                     next.previousFocusedId = prevFocusedId;
                   }
+                }
+              } else if (existingGateId && focusPolicy !== "preserve") {
+                // Relaunching onto an existing grid gate changes nothing on
+                // screen, so the re-click would read as a dead button. Reveal
+                // the panel already holding the answer instead.
+                const prevFocusedId = state.focusedId ?? null;
+                if (existingGateId !== prevFocusedId) {
+                  next.focusedId = existingGateId;
+                  next.previousFocusedId = prevFocusedId;
                 }
               }
               return next;
             });
             return {
-              terminalId: gateId,
+              terminalId: resolvedGateId,
               location: gatePanel.location === "dock" ? "dock" : "grid",
               spawnStatus: "missing-cli" as const,
               ...launchIdentity,

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -32,6 +32,7 @@ import {
 } from "@shared/types";
 import { isAgentLaunchable } from "@shared/utils/agentAvailability";
 import { findEquivalentMissingCliGate } from "@/utils/missingCliGate";
+import { isAssistantFocused } from "@/store/macroFocusStore";
 import { escapeShellArgOptional } from "@shared/utils/shellEscape";
 import {
   getAgentConfig,
@@ -725,11 +726,12 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             usePanelStore.setState((state) => {
               // The in-flight guard above only spans a single call, so repeated
               // clicks on an unavailable agent would each append another gate.
-              // A launch carrying `requestedId` opts out — that id is an
-              // identity contract with the caller, so it must get its own panel.
-              const existingGateId = launchOptions?.requestedId
-                ? null
-                : findEquivalentMissingCliGate(state.panelsById, state.panelIds, gatePanel);
+              const existingGateId = findEquivalentMissingCliGate(
+                state.panelsById,
+                state.panelIds,
+                gatePanel,
+                { requestedId: launchOptions?.requestedId }
+              );
               resolvedGateId = existingGateId ?? gateId;
 
               const next: Partial<typeof state> = existingGateId
@@ -761,18 +763,26 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
                     next.previousFocusedId = prevFocusedId;
                   }
                 }
-              } else if (existingGateId && focusPolicy !== "preserve") {
-                // Relaunching onto an existing grid gate changes nothing on
-                // screen, so the re-click would read as a dead button. Reveal
-                // the panel already holding the answer instead.
-                const prevFocusedId = state.focusedId ?? null;
-                if (existingGateId !== prevFocusedId) {
-                  next.focusedId = existingGateId;
-                  next.previousFocusedId = prevFocusedId;
-                }
               }
               return next;
             });
+
+            // Grid gates bypass `addPanel`, so they never inherited its focus
+            // handling. Both halves matter: a gate created behind a maximized
+            // panel renders nowhere (#11060), and without taking focus the
+            // keyboard is stranded — the toolbar button blurs on click and the
+            // launcher suppresses its own focus return because this IS a launch.
+            // Reuse needs it too, or a repeated click reads as a dead button.
+            // `setFocused` rather than a raw write, so the dock/recency
+            // invariants it owns keep holding.
+            const takesFocus =
+              gatePanel.location !== "dock" &&
+              focusPolicy !== "preserve" &&
+              !(focusPolicy === undefined && isAssistantFocused());
+            if (takesFocus) {
+              usePanelStore.getState().exitMaximize();
+              usePanelStore.getState().setFocused(resolvedGateId);
+            }
             return {
               terminalId: resolvedGateId,
               location: gatePanel.location === "dock" ? "dock" : "grid",

--- a/src/utils/__tests__/missingCliGate.test.ts
+++ b/src/utils/__tests__/missingCliGate.test.ts
@@ -56,6 +56,7 @@ describe("buildMissingCliRelaunchOptions", () => {
     expect(options).toMatchObject({
       launchAgentId: "claude",
       command: "claude --resume",
+      title: "Claude",
       titleMode: "custom",
       cwd: "/repo",
       worktreeId: "wt-1",
@@ -116,12 +117,30 @@ describe("findEquivalentMissingCliGate", () => {
     expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBeNull();
   });
 
-  it("does not resurrect a gate the user already dismissed", () => {
-    const trashed = gate({ id: "gate-trashed", location: "trash" });
+  // Reusing a gate the user can't see answers the click by pointing at nothing.
+  it.each([
+    ["dismissed to the trash", "trash"],
+    ["sent to the background", "background"],
+  ])("does not reuse a gate %s", (_label, location) => {
+    const hidden = gate({ id: "gate-hidden", location: location as PtyPanelData["location"] });
     const candidate = gate({ id: "gate-new" });
 
-    const { panelsById, panelIds } = index([trashed]);
+    const { panelsById, panelIds } = index([hidden]);
     expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBeNull();
+  });
+
+  // A caller that reserved an id (the help panel, MCP automation) is promised
+  // that exact panel, so collapsing its launch onto someone else's gate would
+  // hand back an id it never asked for.
+  it("opts a launch with a caller-owned id out of reuse entirely", () => {
+    const existing = gate({ id: "gate-existing" });
+    const candidate = gate({ id: "gate-new" });
+    const { panelsById, panelIds } = index([existing]);
+
+    expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBe("gate-existing");
+    expect(
+      findEquivalentMissingCliGate(panelsById, panelIds, candidate, { requestedId: "terminal-X" })
+    ).toBeNull();
   });
 
   it("never matches the candidate against itself", () => {

--- a/src/utils/__tests__/missingCliGate.test.ts
+++ b/src/utils/__tests__/missingCliGate.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildMissingCliRelaunchOptions,
+  findEquivalentMissingCliGate,
+} from "@/utils/missingCliGate";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
+
+function gate(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
+  return {
+    id: "gate-1",
+    kind: "terminal",
+    launchAgentId: "claude",
+    title: "Claude",
+    cwd: "/repo",
+    worktreeId: "wt-1",
+    cols: 80,
+    rows: 24,
+    location: "grid",
+    spawnStatus: "missing-cli",
+    startedAt: 0,
+    isVisible: true,
+    ...overrides,
+  } as PtyPanelData;
+}
+
+function index(panels: PtyPanelData[]): {
+  panelsById: Record<string, PanelInstance>;
+  panelIds: string[];
+} {
+  const panelsById: Record<string, PanelInstance> = {};
+  for (const panel of panels) panelsById[panel.id] = panel as unknown as PanelInstance;
+  return { panelsById, panelIds: panels.map((p) => p.id) };
+}
+
+describe("buildMissingCliRelaunchOptions", () => {
+  it("carries every launch field the gate captured", () => {
+    const options = buildMissingCliRelaunchOptions(
+      gate({
+        command: "claude --resume",
+        titleMode: "custom",
+        agentLaunchFlags: ["--verbose"],
+        agentModelId: "opus",
+        agentPresetId: "fast",
+        agentPresetColor: "#ff0000",
+        extensionState: { presetEnv: { TOKEN: "secret" } },
+        excludeFromPersistence: true,
+        removeOnExit: true,
+        spawnedBy: "user",
+        focusPolicy: "preserve",
+      })
+    );
+
+    // Asserted as a whole so a field silently dropped from the builder fails
+    // here rather than surviving as an untested omission — the exact way
+    // `agentPresetColor` and `titleMode` were lost before.
+    expect(options).toMatchObject({
+      launchAgentId: "claude",
+      command: "claude --resume",
+      titleMode: "custom",
+      cwd: "/repo",
+      worktreeId: "wt-1",
+      location: "grid",
+      agentLaunchFlags: ["--verbose"],
+      agentModelId: "opus",
+      agentPresetId: "fast",
+      agentPresetColor: "#ff0000",
+      env: { TOKEN: "secret" },
+      excludeFromPersistence: true,
+      removeOnExit: true,
+      spawnedBy: "user",
+      focusPolicy: "preserve",
+    });
+  });
+
+  it("refuses a panel with no agent to relaunch", () => {
+    expect(buildMissingCliRelaunchOptions(gate({ launchAgentId: undefined }))).toBeNull();
+  });
+
+  it("normalises any non-dock location to the grid", () => {
+    expect(buildMissingCliRelaunchOptions(gate({ location: "trash" }))?.location).toBe("grid");
+    expect(buildMissingCliRelaunchOptions(gate({ location: "dock" }))?.location).toBe("dock");
+  });
+});
+
+describe("findEquivalentMissingCliGate", () => {
+  it("collapses repeated clicks onto the gate already standing in for the launch", () => {
+    const existing = gate({ id: "gate-existing" });
+    const candidate = gate({ id: "gate-new" });
+
+    const { panelsById, panelIds } = index([existing]);
+    expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBe("gate-existing");
+  });
+
+  it.each([
+    ["worktree", { worktreeId: "wt-2" }],
+    ["location", { location: "dock" as const }],
+    ["preset", { agentPresetId: "other" }],
+    ["model", { agentModelId: "sonnet" }],
+    ["cwd", { cwd: "/elsewhere" }],
+    ["command", { command: "claude --resume" }],
+    ["launch flags", { agentLaunchFlags: ["--verbose"] }],
+    ["agent", { launchAgentId: "gemini" }],
+  ])("keeps a gate whose %s differs separate", (_label, difference) => {
+    const existing = gate({ id: "gate-existing" });
+    const candidate = gate({ id: "gate-new", ...difference });
+
+    const { panelsById, panelIds } = index([existing]);
+    expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBeNull();
+  });
+
+  it("ignores panels that are not missing-CLI gates", () => {
+    const running = gate({ id: "running", spawnStatus: "ready" });
+    const candidate = gate({ id: "gate-new" });
+
+    const { panelsById, panelIds } = index([running]);
+    expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBeNull();
+  });
+
+  it("does not resurrect a gate the user already dismissed", () => {
+    const trashed = gate({ id: "gate-trashed", location: "trash" });
+    const candidate = gate({ id: "gate-new" });
+
+    const { panelsById, panelIds } = index([trashed]);
+    expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBeNull();
+  });
+
+  it("never matches the candidate against itself", () => {
+    const candidate = gate({ id: "gate-self" });
+    const { panelsById, panelIds } = index([candidate]);
+    expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBeNull();
+  });
+
+  it("matches regardless of the order fields were written onto the panel", () => {
+    const existing = gate({ id: "gate-existing", agentModelId: "opus", agentPresetId: "fast" });
+    const candidate = gate({ id: "gate-new", agentPresetId: "fast", agentModelId: "opus" });
+
+    const { panelsById, panelIds } = index([existing]);
+    expect(findEquivalentMissingCliGate(panelsById, panelIds, candidate)).toBe("gate-existing");
+  });
+});

--- a/src/utils/__tests__/missingCliGate.test.ts
+++ b/src/utils/__tests__/missingCliGate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildMissingCliContinueArgs,
   buildMissingCliRelaunchOptions,
   findEquivalentMissingCliGate,
 } from "@/utils/missingCliGate";
@@ -80,6 +81,70 @@ describe("buildMissingCliRelaunchOptions", () => {
   it("normalises any non-dock location to the grid", () => {
     expect(buildMissingCliRelaunchOptions(gate({ location: "trash" }))?.location).toBe("grid");
     expect(buildMissingCliRelaunchOptions(gate({ location: "dock" }))?.location).toBe("dock");
+  });
+});
+
+describe("buildMissingCliContinueArgs", () => {
+  it("replays every choice the caller made, not just the ones the panel shows", () => {
+    const args = buildMissingCliContinueArgs(
+      gate({
+        agentModelId: "opus",
+        agentPresetId: "fast",
+        extensionState: { presetEnv: { TOKEN: "secret" } },
+        excludeFromPersistence: true,
+        removeOnExit: true,
+        spawnedBy: "mcp",
+        focusPolicy: "preserve",
+      })
+    );
+
+    // Asserted as a whole because a dropped field silently rewrites the launch
+    // on the way through: `removeOnExit` was lost here, so an ephemeral launch
+    // recovered into a permanent panel.
+    expect(args).toMatchObject({
+      agentId: "claude",
+      location: "grid",
+      cwd: "/repo",
+      worktreeId: "wt-1",
+      model: "opus",
+      presetId: "fast",
+      env: { TOKEN: "secret" },
+      excludeFromPersistence: true,
+      removeOnExit: true,
+      spawnedBy: "mcp",
+      focusPolicy: "preserve",
+    });
+  });
+
+  // The whole point of re-dispatching is that the launcher rebuilds these
+  // against the path the probe just found; the captured flags are already a
+  // resolved set, so forwarding them would append them a second time.
+  it("leaves what the launcher rebuilds to the launcher", () => {
+    const args = buildMissingCliContinueArgs(
+      gate({ command: "claude --resume", agentLaunchFlags: ["--verbose"], titleMode: "custom" })
+    );
+
+    expect(args).not.toHaveProperty("agentLaunchFlags");
+    expect(args).not.toHaveProperty("command");
+  });
+
+  it("keeps a deliberately preset-free launch preset-free", () => {
+    // undefined would let the agent-level default reappear on recovery.
+    expect(buildMissingCliContinueArgs(gate({ agentPresetId: undefined }))?.presetId).toBeNull();
+  });
+
+  it("activates the dock only for a gate that lived in it", () => {
+    expect(buildMissingCliContinueArgs(gate({ location: "dock" }))).toMatchObject({
+      location: "dock",
+      activateDockOnCreate: true,
+    });
+    expect(buildMissingCliContinueArgs(gate({ location: "trash" }))?.activateDockOnCreate).toBe(
+      undefined
+    );
+  });
+
+  it("refuses a panel with no agent to relaunch", () => {
+    expect(buildMissingCliContinueArgs(gate({ launchAgentId: undefined }))).toBeNull();
   });
 });
 

--- a/src/utils/__tests__/missingCliGate.test.ts
+++ b/src/utils/__tests__/missingCliGate.test.ts
@@ -28,7 +28,7 @@ function index(panels: PtyPanelData[]): {
   panelIds: string[];
 } {
   const panelsById: Record<string, PanelInstance> = {};
-  for (const panel of panels) panelsById[panel.id] = panel as unknown as PanelInstance;
+  for (const panel of panels) panelsById[panel.id] = panel;
   return { panelsById, panelIds: panels.map((p) => p.id) };
 }
 
@@ -45,7 +45,7 @@ describe("buildMissingCliRelaunchOptions", () => {
         extensionState: { presetEnv: { TOKEN: "secret" } },
         excludeFromPersistence: true,
         removeOnExit: true,
-        spawnedBy: "user",
+        spawnedBy: "palette",
         focusPolicy: "preserve",
       })
     );
@@ -68,7 +68,7 @@ describe("buildMissingCliRelaunchOptions", () => {
       env: { TOKEN: "secret" },
       excludeFromPersistence: true,
       removeOnExit: true,
-      spawnedBy: "user",
+      spawnedBy: "palette",
       focusPolicy: "preserve",
     });
   });
@@ -121,8 +121,8 @@ describe("findEquivalentMissingCliGate", () => {
   it.each([
     ["dismissed to the trash", "trash"],
     ["sent to the background", "background"],
-  ])("does not reuse a gate %s", (_label, location) => {
-    const hidden = gate({ id: "gate-hidden", location: location as PtyPanelData["location"] });
+  ] as const)("does not reuse a gate %s", (_label, location) => {
+    const hidden = gate({ id: "gate-hidden", location });
     const candidate = gate({ id: "gate-new" });
 
     const { panelsById, panelIds } = index([hidden]);

--- a/src/utils/agentAvailabilityCopy.ts
+++ b/src/utils/agentAvailabilityCopy.ts
@@ -1,0 +1,21 @@
+import { isAgentBlocked } from "@shared/utils/agentAvailability";
+import type { AgentAvailabilityState } from "@shared/types";
+
+/**
+ * Hint for an agent surface whose last probe came back unlaunchable. Shared by
+ * the toolbar button, the searchable launcher and the dock/context menus so all
+ * of them name the same outcome: activating still launches, and the recovery
+ * panel — not Settings — is what opens (#11760).
+ *
+ * A leaf module rather than a helper inside `dockLaunchItems`: the toolbar
+ * button would otherwise pull the whole launcher graph (panel registry,
+ * recipes, notify) in behind one string.
+ */
+export function unavailableAgentHint(
+  name: string,
+  availability: AgentAvailabilityState | undefined
+): string {
+  return isAgentBlocked(availability)
+    ? `${name} is blocked by endpoint security. Select to see recovery options`
+    : `${name} needs setup. Select to see recovery options`;
+}

--- a/src/utils/missingCliGate.ts
+++ b/src/utils/missingCliGate.ts
@@ -1,0 +1,92 @@
+import type { AddPanelOptions } from "@shared/types";
+import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+
+/**
+ * Rebuild the launch a missing-CLI gate panel stood in for.
+ *
+ * Single source of truth for which fields survive the hop. Both recovery exits
+ * relaunch through this — "Run anyway" and the post-refresh continuation — and
+ * `missingCliRelaunchKey` derives gate identity from the same output, so a
+ * field added here is automatically carried AND compared instead of drifting
+ * out of one of three hand-maintained lists.
+ *
+ * Returns null when the panel carries no agent, which makes it unrelaunchable.
+ */
+export function buildMissingCliRelaunchOptions(panel: PtyPanelData): AddPanelOptions | null {
+  const agentId = panel.launchAgentId;
+  if (!agentId) return null;
+
+  return {
+    kind: "terminal",
+    launchAgentId: agentId,
+    command: panel.command,
+    title: panel.title,
+    // Without this a custom-titled relaunch reverts to detection-driven
+    // titling, so the name the user chose is silently overwritten.
+    titleMode: panel.titleMode,
+    cwd: panel.cwd ?? "",
+    worktreeId: panel.worktreeId,
+    location: panel.location === "dock" ? "dock" : "grid",
+    agentLaunchFlags: panel.agentLaunchFlags,
+    agentModelId: panel.agentModelId,
+    agentPresetId: panel.agentPresetId,
+    // The fallback tint when the preset is later deleted — dropping it changes
+    // the relaunched pane's chrome, so the continued launch would not be the
+    // launch that was originally asked for.
+    agentPresetColor: panel.agentPresetColor,
+    env: panel.extensionState?.presetEnv as Record<string, string> | undefined,
+    // Since env is persisted onto the panel (#10922), dropping these would let
+    // a session-scoped secret leak into the on-disk snapshot on relaunch.
+    excludeFromPersistence: panel.excludeFromPersistence,
+    removeOnExit: panel.removeOnExit,
+    spawnedBy: panel.spawnedBy,
+    focusPolicy: panel.focusPolicy,
+  };
+}
+
+/** Key-sorted, undefined-pruned serialization so field order never splits two equal launches. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
+}
+
+/**
+ * Identity of the launch a gate stands in for. Two gates are the same gate
+ * exactly when they would relaunch identically — so a different worktree,
+ * location, preset, model, cwd, or flag set stays a separate panel.
+ */
+export function missingCliRelaunchKey(panel: PtyPanelData): string | null {
+  const options = buildMissingCliRelaunchOptions(panel);
+  return options ? stableStringify(options) : null;
+}
+
+/**
+ * Find a live gate already standing in for this launch.
+ *
+ * The gate bypasses `addPanel`, so nothing else caps how many can exist: without
+ * this, clicking an unavailable agent three times would append three identical
+ * diagnostic panels. Trashed panels are excluded — a dismissed gate must not
+ * silently resurrect in place of a fresh one.
+ */
+export function findEquivalentMissingCliGate(
+  panelsById: Record<string, PanelInstance>,
+  panelIds: string[],
+  candidate: PtyPanelData
+): string | null {
+  const key = missingCliRelaunchKey(candidate);
+  if (key === null) return null;
+
+  for (const id of panelIds) {
+    if (id === candidate.id) continue;
+    const panel = panelsById[id];
+    if (!panel || !isPtyPanel(panel)) continue;
+    if (panel.spawnStatus !== "missing-cli") continue;
+    if (panel.location === "trash") continue;
+    if (missingCliRelaunchKey(panel) === key) return id;
+  }
+  return null;
+}

--- a/src/utils/missingCliGate.ts
+++ b/src/utils/missingCliGate.ts
@@ -12,6 +12,22 @@ import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types
  *
  * Returns null when the panel carries no agent, which makes it unrelaunchable.
  */
+/**
+ * Narrow the preset environment out of the panel's untyped extension bag.
+ * Non-string values are dropped rather than trusted: this feeds a real
+ * subprocess environment, where a non-string would stringify into something
+ * nobody wrote.
+ */
+export function readPresetEnv(panel: PtyPanelData): Record<string, string> | undefined {
+  const raw = panel.extensionState?.presetEnv;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return Object.keys(env).length > 0 ? env : undefined;
+}
+
 export function buildMissingCliRelaunchOptions(panel: PtyPanelData): AddPanelOptions | null {
   const agentId = panel.launchAgentId;
   if (!agentId) return null;
@@ -38,7 +54,7 @@ export function buildMissingCliRelaunchOptions(panel: PtyPanelData): AddPanelOpt
     // the relaunched pane's chrome, so the continued launch would not be the
     // launch that was originally asked for.
     agentPresetColor: panel.agentPresetColor,
-    env: panel.extensionState?.presetEnv as Record<string, string> | undefined,
+    env: readPresetEnv(panel),
     // Since env is persisted onto the panel (#10922), dropping these would let
     // a session-scoped secret leak into the on-disk snapshot on relaunch.
     excludeFromPersistence: panel.excludeFromPersistence,
@@ -52,7 +68,7 @@ export function buildMissingCliRelaunchOptions(panel: PtyPanelData): AddPanelOpt
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
-  const entries = Object.entries(value as Record<string, unknown>)
+  const entries = Object.entries(value)
     .filter(([, v]) => v !== undefined)
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
   return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;

--- a/src/utils/missingCliGate.ts
+++ b/src/utils/missingCliGate.ts
@@ -27,6 +27,10 @@ export function buildMissingCliRelaunchOptions(panel: PtyPanelData): AddPanelOpt
     cwd: panel.cwd ?? "",
     worktreeId: panel.worktreeId,
     location: panel.location === "dock" ? "dock" : "grid",
+    // A dock replacement that doesn't activate starts parked and offscreen, so
+    // the recovery the user just asked for would produce nothing visible. The
+    // gate itself is what they were looking at, so the dock is already open.
+    activateDockOnCreate: panel.location === "dock" ? true : undefined,
     agentLaunchFlags: panel.agentLaunchFlags,
     agentModelId: panel.agentModelId,
     agentPresetId: panel.agentPresetId,
@@ -69,14 +73,22 @@ export function missingCliRelaunchKey(panel: PtyPanelData): string | null {
  *
  * The gate bypasses `addPanel`, so nothing else caps how many can exist: without
  * this, clicking an unavailable agent three times would append three identical
- * diagnostic panels. Trashed panels are excluded — a dismissed gate must not
- * silently resurrect in place of a fresh one.
+ * diagnostic panels.
+ *
+ * Only gates the user can actually see are reusable. A trashed or backgrounded
+ * gate still sits in the registry, and matching one would answer the click by
+ * pointing at a panel that renders nowhere — worse than making a second gate.
  */
 export function findEquivalentMissingCliGate(
   panelsById: Record<string, PanelInstance>,
   panelIds: string[],
-  candidate: PtyPanelData
+  candidate: PtyPanelData,
+  options: { requestedId?: string } = {}
 ): string | null {
+  // A caller-owned id is an identity contract — that launch is owed its own
+  // panel, so it must never collapse onto someone else's gate.
+  if (options.requestedId) return null;
+
   const key = missingCliRelaunchKey(candidate);
   if (key === null) return null;
 
@@ -85,7 +97,7 @@ export function findEquivalentMissingCliGate(
     const panel = panelsById[id];
     if (!panel || !isPtyPanel(panel)) continue;
     if (panel.spawnStatus !== "missing-cli") continue;
-    if (panel.location === "trash") continue;
+    if (panel.location !== "grid" && panel.location !== "dock") continue;
     if (missingCliRelaunchKey(panel) === key) return id;
   }
   return null;

--- a/src/utils/missingCliGate.ts
+++ b/src/utils/missingCliGate.ts
@@ -2,17 +2,6 @@ import type { AddPanelOptions } from "@shared/types";
 import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
 
 /**
- * Rebuild the launch a missing-CLI gate panel stood in for.
- *
- * Single source of truth for which fields survive the hop. Both recovery exits
- * relaunch through this — "Run anyway" and the post-refresh continuation — and
- * `missingCliRelaunchKey` derives gate identity from the same output, so a
- * field added here is automatically carried AND compared instead of drifting
- * out of one of three hand-maintained lists.
- *
- * Returns null when the panel carries no agent, which makes it unrelaunchable.
- */
-/**
  * Narrow the preset environment out of the panel's untyped extension bag.
  * Non-string values are dropped rather than trusted: this feeds a real
  * subprocess environment, where a non-string would stringify into something
@@ -28,6 +17,21 @@ export function readPresetEnv(panel: PtyPanelData): Record<string, string> | und
   return Object.keys(env).length > 0 ? env : undefined;
 }
 
+/**
+ * Rebuild the launch a missing-CLI gate panel stood in for.
+ *
+ * Single source of truth for which fields survive the "Run anyway" hop, which
+ * hands them straight to `addPanel`. `missingCliRelaunchKey` derives gate
+ * identity from the same output, so a field added here is automatically carried
+ * AND compared instead of drifting out of two hand-maintained lists.
+ *
+ * The re-check exit does not relaunch through this — it re-dispatches
+ * `agent.launch` so the launcher re-resolves the command against the path the
+ * probe just found, and so replays only the caller's own choices. See
+ * `buildMissingCliContinueArgs`.
+ *
+ * Returns null when the panel carries no agent, which makes it unrelaunchable.
+ */
 export function buildMissingCliRelaunchOptions(panel: PtyPanelData): AddPanelOptions | null {
   const agentId = panel.launchAgentId;
   if (!agentId) return null;
@@ -61,6 +65,64 @@ export function buildMissingCliRelaunchOptions(panel: PtyPanelData): AddPanelOpt
     removeOnExit: panel.removeOnExit,
     spawnedBy: panel.spawnedBy,
     focusPolicy: panel.focusPolicy,
+  };
+}
+
+/** `agent.launch` arguments that continue the launch a gate stood in for. */
+export interface MissingCliContinueArgs {
+  agentId: string;
+  location: "grid" | "dock";
+  cwd?: string;
+  worktreeId?: string;
+  model?: string;
+  presetId: string | null;
+  activateDockOnCreate?: true;
+  env?: Record<string, string>;
+  excludeFromPersistence?: boolean;
+  removeOnExit?: boolean;
+  spawnedBy?: PtyPanelData["spawnedBy"];
+  focusPolicy?: PtyPanelData["focusPolicy"];
+}
+
+/**
+ * Continue a gated launch through the launcher after a re-check found the CLI.
+ *
+ * Deliberately not the relaunch options above: this exit re-dispatches
+ * `agent.launch`, so the launcher rebuilds the command, the flag set and the
+ * title against the freshly resolved path. Only what the original caller chose
+ * is replayed — forwarding the gate's already-resolved `agentLaunchFlags` would
+ * append them a second time on top of the set the launcher rebuilds, and its
+ * title is recomposed from the same agent, preset and model.
+ *
+ * Returns null when the panel carries no agent, which makes it unrelaunchable.
+ */
+export function buildMissingCliContinueArgs(panel: PtyPanelData): MissingCliContinueArgs | null {
+  const agentId = panel.launchAgentId;
+  if (!agentId) return null;
+
+  const location = panel.location === "dock" ? "dock" : "grid";
+  return {
+    agentId,
+    location,
+    cwd: panel.cwd,
+    worktreeId: panel.worktreeId,
+    model: panel.agentModelId,
+    // Explicit null preserves a deliberately preset-free launch; forwarding
+    // undefined would let the agent-level default reappear on recovery.
+    presetId: panel.agentPresetId ?? null,
+    // A dock replacement that doesn't activate starts parked and offscreen, so
+    // the recovery the user just asked for would produce nothing visible.
+    activateDockOnCreate: location === "dock" ? true : undefined,
+    env: readPresetEnv(panel),
+    // Since env is persisted onto the panel (#10922), dropping this would let a
+    // session-scoped secret leak into the on-disk snapshot on relaunch.
+    excludeFromPersistence: panel.excludeFromPersistence,
+    // Dropping these three rewrote the launch on the way through: an ephemeral
+    // pane came back permanent, a background spawn stole focus, and an
+    // automated one came back attributed to the user.
+    removeOnExit: panel.removeOnExit,
+    focusPolicy: panel.focusPolicy,
+    spawnedBy: panel.spawnedBy,
   };
 }
 


### PR DESCRIPTION
## Summary
- Clicking an agent whose CLI was last probed as unavailable dispatched `app.settings.openTab` (a deep link into Preferences) instead of `agent.launch`, so the inline missing-CLI diagnostic panel built for #6048 was unreachable from the toolbar, dock, searchable launcher, and context menus.
- The redirect was duplicated across two near-identical call sites; the per-agent palette actions in `agentActions.ts` already did it correctly.
- This routes every entry point through `agent.launch` and lets `useAgentLauncher` re-probe availability and own the choice between opening a terminal and showing the recovery gate.

Resolves #11760

## Changes
- `AgentButton.handleClick` and `activateDockLaunchItem` now always dispatch `agent.launch`. Also enabled the context menu's Launch, Launch in Dock, and Launch in Worktree entries, which already dispatched `agent.launch` but were disabled.
- Moved the focus blur outside the launchable branch so the gate panel takes Enter the same way a terminal pane does (closes a duplicate-spawn class from #10541).
- MRU now records unavailable agents; the visible recency band already filters to the launch band, so they only surface once they resolve. The launcher's Radix focus return is cancelled for unavailable rows, which now open a panel instead of navigating.
- `MissingCliGate` gained an explicit unauthenticated banner (it previously fell through to "Blocked by security software"), a Re-check action, and a demoted Agent settings route. A successful re-check re-dispatches `agent.launch` instead of replaying the gate's captured command, since that command resolved to the bare registry name while the CLI was unavailable and would ignore the path the probe just found. Run anyway keeps its direct `addPanel` bypass, since overriding the verdict is the point.
- Grid gates get `addPanel`'s focus handling: exit maximize before focusing (#11060, otherwise a gate born behind a maximized panel is invisible) and take focus via `setFocused` so dock and recency invariants hold.
- Equivalent gate panels are deduplicated so repeated clicks stop stacking diagnostic panels. Only gates the user can actually see are reusable; a launch carrying `requestedId` opts out, since that id is an identity contract.
- `agentPresetColor` and `titleMode` now survive the relaunch; both were silently dropped by the old Run anyway reconstruction. Dock recoveries carry `activateDockOnCreate`, which previously produced a parked offscreen pane.

## Testing
- 4799 tests across 278 files pass locally (Layout, Terminal, HelpPanel, hooks, utils).
- Typecheck clean. Lint on touched files: 0 errors, no new warnings (removed six type assertions the new code introduced to keep the ratchet flat).
- Seven stale assertions that encoded the old redirect were inverted across four test files. New coverage added for the gate's re-check lifecycle (force flag, continuation, failure banner, in-flight guard, unmount during probe) and for the relaunch/dedup utility.

## Known limitations
- `requestedId` still isn't honored by the gate itself, it mints its own UUID. Pre-existing, out of scope here.
- No hook-level integration coverage of the dedup path exists; this repo's `useAgentLauncher` suites document the hook as store-coupled and untestable in isolation, so the decision logic was extracted and unit-tested instead.
- "Locate binary" from the issue's prose isn't implemented, no manual-path infrastructure exists anywhere (no file picker tied to agent CLIs, no `manualPath` concept), and it only appears in prose, never as a listed acceptance criterion. The stated AC is fully covered.