### PR TITLE
fix(ui): stop the cloud sync warning asserting sync from a path match

### DIFF
--- a/src/components/Recovery/CloudSyncBanner.tsx
+++ b/src/components/Recovery/CloudSyncBanner.tsx
@@ -6,6 +6,7 @@ import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
+import { getCloudSyncWarningCopy } from "@/utils/cloudSyncWarningCopy";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export function CloudSyncBanner() {
@@ -14,6 +15,8 @@ export function CloudSyncBanner() {
   const { saveSettings } = useProjectSettings();
 
   if (!service) return null;
+
+  const copy = getCloudSyncWarningCopy(service);
 
   const handleDismiss = async () => {
     // Guard against project switch race: the store carries the projectId the
@@ -50,8 +53,8 @@ export function CloudSyncBanner() {
   return (
     <InlineStatusBanner
       icon={AlertTriangle}
-      title="Project in a synced folder"
-      description={`This project is in a ${service}-synced folder, which can interfere with terminal operations and git. Consider moving it to a local folder.`}
+      title={copy.title}
+      description={copy.description}
       severity="warning"
       role="status"
       actions={[

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -91,7 +91,7 @@ describe("CloudSyncBanner", () => {
     // Detection is a path-prefix match, so it establishes the location but
     // never that sync is running (#11767).
     expect(text).not.toMatch(/-synced folder/i);
-    expect(text).toMatch(/\bmay\b/i);
+    expect(text).toMatch(/\b(?:may|might|could) be syncing\b/i);
   });
 
   it("renders the same title and message the inbox entry receives", () => {
@@ -117,7 +117,7 @@ describe("CloudSyncBanner", () => {
     expect(message).toContain("OneDrive");
     // The inbox surface must hedge too, not just the banner (#11767).
     expect(message).not.toMatch(/-synced folder/i);
-    expect(message).toMatch(/\bmay\b/i);
+    expect(message).toMatch(/\b(?:may|might|could) be syncing\b/i);
 
     render(<CloudSyncBanner />);
     const region = screen.getByRole("status");

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -1,6 +1,20 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import {
+  render,
+  renderHook,
+  screen,
+  within,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
+
+vi.mock("@/lib/platform", () => ({
+  isMac: () => true,
+  isLinux: () => false,
+  isWindows: () => false,
+}));
 
 const saveSettingsMock = vi.fn(() => Promise.resolve());
 vi.mock("@/hooks/useProjectSettings", () => ({
@@ -15,6 +29,7 @@ vi.mock("@/lib/notify", () => ({
 }));
 
 import { CloudSyncBanner } from "../CloudSyncBanner";
+import { useCloudSyncWarning } from "@/hooks/app/useCloudSyncWarning";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectStore } from "@/store/projectStore";
@@ -64,9 +79,47 @@ describe("CloudSyncBanner", () => {
     render(<CloudSyncBanner />);
     const region = screen.getByRole("status");
     expect(region.hasAttribute("aria-live")).toBe(false);
-    expect(screen.getByText("Project in a synced folder")).toBeTruthy();
-    expect(screen.getByText(/Dropbox-synced folder/i)).toBeTruthy();
+    expect(region.textContent).toContain("Dropbox");
     expect(screen.getByRole("button", { name: /Don.*t warn for this project/i })).toBeTruthy();
+  });
+
+  it("hedges the sync claim instead of asserting the folder is syncing", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    render(<CloudSyncBanner />);
+    const text = screen.getByRole("status").textContent ?? "";
+
+    // Detection is a path-prefix match, so it establishes the location but
+    // never that sync is running (#11767).
+    expect(text).not.toMatch(/-synced folder/i);
+    expect(text).toMatch(/\bmay\b/i);
+  });
+
+  it("renders the same title and message the inbox entry receives", () => {
+    // The hook routes the inbox entry, the banner renders the live surface;
+    // #11767 requires the two agree. Drive the real hook, then assert the
+    // banner renders exactly the strings the notification was given — no
+    // literals here, so this survives future rewording but catches drift.
+    useProjectStore.setState({
+      currentProject: {
+        id: "p1",
+        path: "/Users/foo/Library/CloudStorage/OneDrive-Personal/work",
+      } as never,
+    });
+
+    renderHook(() => useCloudSyncWarning("/Users/foo"));
+
+    const payload = notifyMock.mock.calls
+      .map(([p]) => p as { title?: string; message?: string; supersedeKey?: string })
+      .find((p) => p?.supersedeKey === "cloud-sync:p1");
+    const title = payload?.title ?? "";
+    const message = payload?.message ?? "";
+    expect(title).not.toBe("");
+    expect(message).toContain("OneDrive");
+
+    render(<CloudSyncBanner />);
+    const region = screen.getByRole("status");
+    expect(within(region).getByText(title)).toBeTruthy();
+    expect(within(region).getByText(message)).toBeTruthy();
   });
 
   it("persists dismiss preference and clears the banner", async () => {

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -115,11 +115,21 @@ describe("CloudSyncBanner", () => {
     const message = payload?.message ?? "";
     expect(title).not.toBe("");
     expect(message).toContain("OneDrive");
+    // The inbox surface must hedge too, not just the banner (#11767).
+    expect(message).not.toMatch(/-synced folder/i);
+    expect(message).toMatch(/\bmay\b/i);
 
     render(<CloudSyncBanner />);
     const region = screen.getByRole("status");
-    expect(within(region).getByText(title)).toBeTruthy();
-    expect(within(region).getByText(message)).toBeTruthy();
+    const titleEl = within(region).getByText(title);
+    const descEl = within(region).getByText(message);
+
+    // Compare raw textContent in the matching slots: getByText normalises
+    // whitespace and would also pass if the two fields were swapped.
+    expect(titleEl.textContent).toBe(title);
+    expect(descEl.textContent).toBe(message);
+    expect(descEl).toBe(region.querySelector("p"));
+    expect(titleEl).not.toBe(descEl);
   });
 
   it("persists dismiss preference and clears the banner", async () => {

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -23,9 +23,10 @@ vi.mock("@/hooks/useProjectSettings", () => ({
   }),
 }));
 
-const notifyMock = vi.fn();
+type NotifyPayload = { title?: string; message?: string; supersedeKey?: string };
+const notifyMock = vi.fn<(payload: NotifyPayload) => void>();
 vi.mock("@/lib/notify", () => ({
-  notify: (payload: unknown) => notifyMock(payload),
+  notify: (payload: NotifyPayload) => notifyMock(payload),
 }));
 
 import { CloudSyncBanner } from "../CloudSyncBanner";
@@ -34,9 +35,9 @@ import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectStore } from "@/store/projectStore";
 
-function setProject(id: string | null) {
+function setProject(id: string | null, path = "/x") {
   useProjectStore.setState({
-    currentProject: id ? ({ id, path: "/x" } as never) : null,
+    currentProject: id ? ({ id, path } as never) : null,
   });
 }
 
@@ -99,18 +100,11 @@ describe("CloudSyncBanner", () => {
     // #11767 requires the two agree. Drive the real hook, then assert the
     // banner renders exactly the strings the notification was given — no
     // literals here, so this survives future rewording but catches drift.
-    useProjectStore.setState({
-      currentProject: {
-        id: "p1",
-        path: "/Users/foo/Library/CloudStorage/OneDrive-Personal/work",
-      } as never,
-    });
+    setProject("p1", "/Users/foo/Library/CloudStorage/OneDrive-Personal/work");
 
     renderHook(() => useCloudSyncWarning("/Users/foo"));
 
-    const payload = notifyMock.mock.calls
-      .map(([p]) => p as { title?: string; message?: string; supersedeKey?: string })
-      .find((p) => p?.supersedeKey === "cloud-sync:p1");
+    const payload = notifyMock.mock.calls.find(([p]) => p?.supersedeKey === "cloud-sync:p1")?.[0];
     const title = payload?.title ?? "";
     const message = payload?.message ?? "";
     expect(title).not.toBe("");

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -296,7 +296,7 @@ describe("GlobalBannerCoordinator", () => {
 
     expect(screen.getByText("Crash watchdog disabled")).toBeTruthy();
     expect(screen.queryByText("GitHub token expired")).toBeNull();
-    expect(screen.queryByText("Project in a synced folder")).toBeNull();
+    expect(screen.queryByText("Project in a cloud folder")).toBeNull();
   });
 
   it("renders the GitHub token banner when only the token is unhealthy", () => {
@@ -312,7 +312,7 @@ describe("GlobalBannerCoordinator", () => {
 
     render(<GlobalBannerCoordinator />);
 
-    expect(screen.getByText("Project in a synced folder")).toBeTruthy();
+    expect(screen.getByText("Project in a cloud folder")).toBeTruthy();
   });
 
   it("prefers the GitHub token banner over cloud sync when both are active", () => {
@@ -322,7 +322,7 @@ describe("GlobalBannerCoordinator", () => {
     render(<GlobalBannerCoordinator />);
 
     expect(screen.getByText("GitHub token expired")).toBeTruthy();
-    expect(screen.queryByText("Project in a synced folder")).toBeNull();
+    expect(screen.queryByText("Project in a cloud folder")).toBeNull();
   });
 
   it("suppresses forge-token and cloud-sync while restore is active", () => {
@@ -334,7 +334,7 @@ describe("GlobalBannerCoordinator", () => {
 
     expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
     expect(screen.queryByText("GitHub token expired")).toBeNull();
-    expect(screen.queryByText("Project in a synced folder")).toBeNull();
+    expect(screen.queryByText("Project in a cloud folder")).toBeNull();
   });
 
   it("suppresses every lower-priority banner when the host has crashed", () => {
@@ -346,7 +346,7 @@ describe("GlobalBannerCoordinator", () => {
 
     expect(screen.getByText("Terminal service crashed")).toBeTruthy();
     expect(screen.queryByText("GitHub token expired")).toBeNull();
-    expect(screen.queryByText("Project in a synced folder")).toBeNull();
+    expect(screen.queryByText("Project in a cloud folder")).toBeNull();
   });
 
   it("renders the Rosetta banner when only the translation warning is active", () => {
@@ -373,7 +373,7 @@ describe("GlobalBannerCoordinator", () => {
 
     render(<GlobalBannerCoordinator />);
 
-    expect(screen.getByText("Project in a synced folder")).toBeTruthy();
+    expect(screen.getByText("Project in a cloud folder")).toBeTruthy();
     expect(screen.queryByText("Running under Rosetta")).toBeNull();
   });
 });

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -22,8 +22,13 @@ import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
+import { getCloudSyncWarningCopy } from "@/utils/cloudSyncWarningCopy";
 
 const PROVIDER_ID = "daintree.github.github";
+
+// These cases assert which banner wins the slot, not its wording — resolve the
+// title from the copy module so rewording can't churn the routing tests.
+const cloudSyncTitle = getCloudSyncWarningCopy("Dropbox").title;
 
 function setForgeTokenUnhealthy(value: boolean) {
   const store = useForgeProviderHealthStore.getState();
@@ -296,7 +301,7 @@ describe("GlobalBannerCoordinator", () => {
 
     expect(screen.getByText("Crash watchdog disabled")).toBeTruthy();
     expect(screen.queryByText("GitHub token expired")).toBeNull();
-    expect(screen.queryByText("Project in a cloud folder")).toBeNull();
+    expect(screen.queryByText(cloudSyncTitle)).toBeNull();
   });
 
   it("renders the GitHub token banner when only the token is unhealthy", () => {
@@ -312,7 +317,7 @@ describe("GlobalBannerCoordinator", () => {
 
     render(<GlobalBannerCoordinator />);
 
-    expect(screen.getByText("Project in a cloud folder")).toBeTruthy();
+    expect(screen.getByText(cloudSyncTitle)).toBeTruthy();
   });
 
   it("prefers the GitHub token banner over cloud sync when both are active", () => {
@@ -322,7 +327,7 @@ describe("GlobalBannerCoordinator", () => {
     render(<GlobalBannerCoordinator />);
 
     expect(screen.getByText("GitHub token expired")).toBeTruthy();
-    expect(screen.queryByText("Project in a cloud folder")).toBeNull();
+    expect(screen.queryByText(cloudSyncTitle)).toBeNull();
   });
 
   it("suppresses forge-token and cloud-sync while restore is active", () => {
@@ -334,7 +339,7 @@ describe("GlobalBannerCoordinator", () => {
 
     expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
     expect(screen.queryByText("GitHub token expired")).toBeNull();
-    expect(screen.queryByText("Project in a cloud folder")).toBeNull();
+    expect(screen.queryByText(cloudSyncTitle)).toBeNull();
   });
 
   it("suppresses every lower-priority banner when the host has crashed", () => {
@@ -346,7 +351,7 @@ describe("GlobalBannerCoordinator", () => {
 
     expect(screen.getByText("Terminal service crashed")).toBeTruthy();
     expect(screen.queryByText("GitHub token expired")).toBeNull();
-    expect(screen.queryByText("Project in a cloud folder")).toBeNull();
+    expect(screen.queryByText(cloudSyncTitle)).toBeNull();
   });
 
   it("renders the Rosetta banner when only the translation warning is active", () => {
@@ -373,7 +378,7 @@ describe("GlobalBannerCoordinator", () => {
 
     render(<GlobalBannerCoordinator />);
 
-    expect(screen.getByText("Project in a cloud folder")).toBeTruthy();
+    expect(screen.getByText(cloudSyncTitle)).toBeTruthy();
     expect(screen.queryByText("Running under Rosetta")).toBeNull();
   });
 });

--- a/src/hooks/app/__tests__/useCloudSyncWarning.test.tsx
+++ b/src/hooks/app/__tests__/useCloudSyncWarning.test.tsx
@@ -111,7 +111,7 @@ describe("useCloudSyncWarning", () => {
     rerender({ home: "/Users/foo" });
 
     const cloudSyncCalls = notify.mock.calls.filter(
-      ([payload]) => payload?.title === "Cloud sync folder detected"
+      ([payload]) => payload?.supersedeKey === "cloud-sync:p1"
     );
     expect(cloudSyncCalls).toHaveLength(1);
     expect(cloudSyncCalls[0]?.[0]).toMatchObject({

--- a/src/hooks/app/useCloudSyncWarning.tsx
+++ b/src/hooks/app/useCloudSyncWarning.tsx
@@ -4,6 +4,7 @@ import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { notify } from "@/lib/notify";
 import { detectCloudSyncService, type Platform } from "@/utils/cloudSyncDetection";
+import { getCloudSyncWarningCopy } from "@/utils/cloudSyncWarningCopy";
 import { isMac, isLinux } from "@/lib/platform";
 
 function getPlatform(): Platform {
@@ -56,11 +57,12 @@ export function useCloudSyncWarning(homeDir?: string) {
     // the ref guards against re-firing on rerenders.
     if (lastInboxedProjectRef.current !== currentProject.id) {
       lastInboxedProjectRef.current = currentProject.id;
+      const copy = getCloudSyncWarningCopy(service);
       notify({
         type: "warning",
         priority: "low",
-        title: "Cloud sync folder detected",
-        message: `Project is in a ${service}-synced folder which can interfere with terminal operations and git.`,
+        title: copy.title,
+        message: copy.description,
         supersedeKey: `cloud-sync:${currentProject.id}`,
         countable: false,
         context: { eventKind: "host" },

--- a/src/hooks/app/useCloudSyncWarning.tsx
+++ b/src/hooks/app/useCloudSyncWarning.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useProjectStore } from "@/store";
+import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { notify } from "@/lib/notify";

--- a/src/utils/cloudSyncWarningCopy.ts
+++ b/src/utils/cloudSyncWarningCopy.ts
@@ -15,10 +15,13 @@ export interface CloudSyncWarningCopy {
  * sync (which it doesn't): Windows redirects Documents into OneDrive by
  * default, so the match fires whether or not sync is paused, unlinked, or
  * switched off.
+ *
+ * "your ${service} folder" also keeps the sentence article-free — "a iCloud
+ * Drive folder" would be wrong, and the roots are all under the home dir.
  */
 export function getCloudSyncWarningCopy(service: CloudSyncService): CloudSyncWarningCopy {
   return {
     title: "Project in a cloud folder",
-    description: `This project is inside a ${service} folder that may be syncing, which can interfere with terminal operations and git. Consider moving it to a local folder.`,
+    description: `This project is inside your ${service} folder, which may be syncing. That can interfere with terminal operations and git, so consider moving it to a local folder.`,
   };
 }

--- a/src/utils/cloudSyncWarningCopy.ts
+++ b/src/utils/cloudSyncWarningCopy.ts
@@ -1,0 +1,24 @@
+import type { CloudSyncService } from "@/utils/cloudSyncDetection";
+
+export interface CloudSyncWarningCopy {
+  title: string;
+  description: string;
+}
+
+/**
+ * Copy for the cloud-sync warning, shared by the banner and the inbox entry so
+ * the two surfaces can't drift apart.
+ *
+ * `detectCloudSyncService` only matches the project path against known
+ * cloud-folder name prefixes — it never establishes that sync is running. The
+ * wording asserts the location (which the match does establish) and hedges the
+ * sync (which it doesn't): Windows redirects Documents into OneDrive by
+ * default, so the match fires whether or not sync is paused, unlinked, or
+ * switched off.
+ */
+export function getCloudSyncWarningCopy(service: CloudSyncService): CloudSyncWarningCopy {
+  return {
+    title: "Project in a cloud folder",
+    description: `This project is inside a ${service} folder that may be syncing, which can interfere with terminal operations and git. Consider moving it to a local folder.`,
+  };
+}


### PR DESCRIPTION
## Summary
- `detectCloudSyncService` (`src/utils/cloudSyncDetection.ts`) only checks whether a project path sits under a known cloud folder name (e.g. `${home}/OneDrive` on Windows). It never confirms sync is actually running.
- Despite that, both user-facing surfaces stated it as fact: the banner said "This project is in a OneDrive-synced folder, which can interfere with terminal operations and git," and the inbox entry repeated the claim. Windows redirects Documents into OneDrive by default, so this fired whether sync was active, paused, unlinked, or switched off entirely, which is exactly how this was reported.
- Fixed the copy so both surfaces assert only what the check establishes (location) and hedge the sync claim. Detection itself is untouched.

Resolves #11767

## Why not strengthen detection instead
The issue offered this as an alternative, and it was researched and rejected. Node's `fs.Stats` (via libuv) strips every Windows attribute bit, so `FILE_ATTRIBUTE_REPARSE_POINT`, `IO_REPARSE_TAG_CLOUD`, and pinned/unpinned state simply aren't reachable from plain `fs`. `fsutil reparsepoint query` needs admin rights. `attrib` and PowerShell's `Get-Item .Attributes` run unprivileged, but only see placeholder (not-yet-downloaded) files, so a fully downloaded, actively syncing OneDrive folder would read as "not syncing," inverting the bug rather than fixing it. The `SyncRootManager` registry schema is unstable across OneDrive versions, and macOS only offers a partial iCloud-only signal, nothing for Dropbox or Google Drive. So this stays a copy-only fix; `cloudSyncDetection.ts` is deliberately untouched.

## Changes
- New `getCloudSyncWarningCopy(service)` in `src/utils/cloudSyncWarningCopy.ts` returns one `{title, description}` pair that both surfaces now render, so they can't drift apart again (the issue's ask that "both surfaces need to agree").
- New copy asserts the location, which the path match genuinely establishes, and hedges only the sync:
  - Title: `Project in a cloud folder`
  - Body: `This project is inside your ${service} folder, which may be syncing. That can interfere with terminal operations and git, so consider moving it to a local folder.`
- Phrasing it as "your ${service} folder" also avoids "a iCloud Drive folder," which the old template produced.
- `src/components/Recovery/CloudSyncBanner.tsx` and `src/hooks/app/useCloudSyncWarning.tsx` both now render from the shared copy function.

## Testing
- Added a cross-surface test that drives the real hook, captures the notify payload by `supersedeKey`, then renders the banner and asserts the rendered title/description match that payload field for field. It imports neither the copy literals nor the copy module, so it survives rewording but fails on drift. Verified it has teeth by temporarily swapping the banner's `title`/`description` props, confirming it failed, then reverting.
- Added hedge invariant assertions that check for the absence of the old "-synced folder" claim and the presence of a "(may|might|could) be syncing" phrase on both surfaces.
- `GlobalBannerCoordinator`'s routing test cases now resolve the expected title from the copy module rather than hardcoding it six separate times.
- `npx vitest run` over `CloudSyncBanner.test.tsx`, `useCloudSyncWarning.test.tsx`, `GlobalBannerCoordinator.test.tsx`, `cloudSyncDetection.test.ts`, `recoveryCopy.test.ts`, `useShouldSuppressLocalError.test.tsx`: 104 tests pass.
- `npx eslint` on all 6 changed files: 0 errors, no new warnings vs the per-rule ratchet baseline.
- `npx prettier --check` on all 6 changed files: clean.

## Note
This is user-facing copy, so feel free to weigh in on the wording specifically.
