### PR TITLE
fix(projectview): spend the cold skeleton paint bound from load settle

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -234,10 +234,12 @@ export class ProjectViewManager {
    * view being detached (or the switch rolling back).
    *
    * `pendingPaintGate` cannot answer "is the outgoing view still on screen?":
-   * the gate resolves on the incoming view's skeleton signal — or its own 4s
-   * hard timeout — and nulls itself, while the outgoing view stays attached
-   * and visible until `loadView` resolves. With the load ceiling raised to
-   * 30s (#11459) that divergence is wide enough to matter, so the two
+   * the gate resolves on the incoming view's skeleton signal — which lands
+   * during the load — and nulls itself, while the outgoing view stays attached
+   * and visible until `loadView` resolves. (A focus-intent `"painted"` gate can
+   * also hard-time-out inside the load window; a skeleton gate no longer can,
+   * since #11765 sizes it past the load's own ceiling.) With the load ceiling
+   * raised to 30s (#11459) that divergence is wide enough to matter, so the two
    * consumers that need the real answer read this instead:
    *   - eviction, so a pressure pass can't destroy the visible outgoing view
    *     and leave a blank window behind (the guard in
@@ -486,6 +488,18 @@ export class ProjectViewManager {
   }
 
   /**
+   * Restart an open skeleton-channel gate's hard timer from now, so the paint
+   * bound is spent on the paint rather than on the load that preceded it
+   * (#11765). See ProjectViewPaintGateController for the full rationale.
+   *
+   * A real instance method for the same reason as `waitForPaint`: suites that
+   * stub that out never open a gate, and this has to stay a safe no-op there.
+   */
+  retimeSkeletonPaintGateHardTimeout(webContentsId: number, hardMs: number): boolean {
+    return PaintGateController.retimeSkeletonPaintGateHardTimeout(this, webContentsId, hardMs);
+  }
+
+  /**
    * Renderer-driven gate release. Called from the `APP_VIEW_PAINTED` IPC
    * handler with the webContentsId of the renderer that just painted.
    */
@@ -533,9 +547,9 @@ export class ProjectViewManager {
    * must skip both (mirrors the LRU guard in `evictStaleViews`).
    *
    * Spans the whole load, not just the paint gate: the gate resolves on the
-   * incoming skeleton signal (or its own hard timeout) and nulls itself, while
-   * the outgoing view stays attached until `loadView` settles — up to the load
-   * ceiling (#11459). Falling back to `pendingColdSwitch` closes that window
+   * incoming skeleton signal — which lands during the load — and nulls itself,
+   * while the outgoing view stays attached until `loadView` settles, up to the
+   * load ceiling (#11459). Falling back to `pendingColdSwitch` closes that window
    * for every consumer (hibernation, idle auto-close, relocation, menu state),
    * any of which would otherwise destroy the visible outgoing view and leave
    * rollback with nothing to restore.

--- a/electron/window/ProjectViewManagerTypes.ts
+++ b/electron/window/ProjectViewManagerTypes.ts
@@ -46,7 +46,9 @@ export interface PaintGate {
   softTimeout: ReturnType<typeof setTimeout>;
   /**
    * Hard timer — resolves the gate as `"hard-timeout"`, signalling the
-   * caller to detach the outgoing view as a last resort.
+   * caller to detach the outgoing view as a last resort. Replaced in place
+   * once when a cold skeleton gate is retimed after its load settles
+   * (#11765); `resolve` always clears whichever handle is current.
    */
   hardTimeout: ReturnType<typeof setTimeout>;
   /**

--- a/electron/window/ProjectViewManagerTypes.ts
+++ b/electron/window/ProjectViewManagerTypes.ts
@@ -45,10 +45,13 @@ export interface PaintGate {
    */
   softTimeout: ReturnType<typeof setTimeout>;
   /**
-   * Hard timer — resolves the gate as `"hard-timeout"`, signalling the
-   * caller to detach the outgoing view as a last resort. Replaced in place
-   * once when a cold skeleton gate is retimed after its load settles
-   * (#11765); `resolve` always clears whichever handle is current.
+   * Hard timer — resolves the gate as `"hard-timeout"`, which hands the
+   * decision back to the caller rather than deciding anything itself. The
+   * policy is per channel: a warm gate falls through and detaches, a cold one
+   * must abandon and roll back BEFORE any detach, or it strands the user on a
+   * view that never rendered (#11635). Replaced in place once when a cold
+   * skeleton gate is retimed after its load settles (#11765); `resolve` always
+   * clears whichever handle is current.
    */
   hardTimeout: ReturnType<typeof setTimeout>;
   /**

--- a/electron/window/ProjectViewPaintGateController.ts
+++ b/electron/window/ProjectViewPaintGateController.ts
@@ -26,7 +26,10 @@ import type { PaintGate, PaintGateOutcome } from "./ProjectViewManagerTypes.js";
  *
  * Both timer values are captured at gate creation. A later
  * `setPaintGateTimeoutMs` / `setPaintGateHardTimeoutMs` call updates the
- * fields but does NOT retime an in-flight gate.
+ * fields but does NOT retime an in-flight gate. The sole exception is
+ * {@link retimeSkeletonPaintGateHardTimeout}, an explicit lifecycle call from
+ * the switch controller that restarts the hard timer on a value captured
+ * before navigation — not a setter-driven retime, so that guarantee holds.
  */
 export function waitForPaint(
   host: ProjectViewManager,
@@ -85,6 +88,45 @@ export function waitForPaint(
     };
     host.pendingPaintGate = gate;
   });
+}
+
+/**
+ * Restart an open cold-start skeleton gate's hard timer from now, for `hardMs`.
+ * Called once by the switch controller when `loadView()` resolves.
+ *
+ * The gate is armed before navigation starts (so a signal landing on the same
+ * tick as `did-finish-load` is captured rather than dropped), which means its
+ * bound would otherwise be spent on renderer spawn, preload eval and the load
+ * itself — and a slow-but-legitimate cold load expired it mid-flight, losing
+ * the switch to a rollback and an error toast (#11765). The switch controller
+ * arms it wide enough to outlast the load's own fatal ceiling and tightens it
+ * back to the paint bound here, so "never painted" is measured from the moment
+ * the document was verified rather than from before it was even requested.
+ *
+ * Returns whether the retime happened. `false` is normal and expected: the
+ * common fast path releases the gate on its signal during the load, a
+ * superseding switch may have cancelled it, and suites that stub `waitForPaint`
+ * out have no gate at all. Guarded on gate identity exactly like
+ * {@link signalSkeletonPainted}, so a late call from a switch that has already
+ * been superseded can never retime the gate that replaced it.
+ */
+export function retimeSkeletonPaintGateHardTimeout(
+  host: ProjectViewManager,
+  webContentsId: number,
+  hardMs: number
+): boolean {
+  const gate = host.pendingPaintGate;
+  if (!gate) return false;
+  if (gate.releaseChannel !== "skeleton-painted") return false;
+  if (gate.webContentsId !== webContentsId) return false;
+  // Cleared before reassigning: overwriting the handle first would drop the
+  // only reference that can cancel the provisional timer, leaving it to fire
+  // later against a gate `resolve` has since settled.
+  clearTimeout(gate.hardTimeout);
+  gate.hardTimeout = setTimeout(() => {
+    gate.resolve("hard-timeout");
+  }, hardMs);
+  return true;
 }
 
 export function clearPaintGate(host: ProjectViewManager): void {

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -312,6 +312,14 @@ export async function performSwitch(
     });
   }
 
+  // Both load bounds are captured once, here: the gate's provisional ceiling is
+  // sized against them and `loadView` below runs on the same numbers, so a
+  // resource-profile push landing between the two reads cannot leave the gate
+  // sized for a load budget the load is no longer using. `loadHardMs` mirrors
+  // loadView's own `max(hard, soft)` clamp so this is the bound it will apply.
+  const loadSoftMs = host.viewLoadTimeoutMs;
+  const loadHardMs = Math.max(host.viewLoadHardTimeoutMs, loadSoftMs);
+
   // The `"painted"` channel holds for the whole React cold boot — ~1.5–4s per
   // the note above, which the paint-gate hard bound (4s balanced) does not
   // bracket, and the bound is spent from before `loadView` so it also pays for
@@ -319,16 +327,28 @@ export async function performSwitch(
   // "slow", not "wrong document", and abandoning would turn a cold
   // focus-next-waiting into an error toast. Stretch it to the view-load soft
   // bound — the same family's profile-scaled "something is genuinely wrong"
-  // threshold. `"skeleton-painted"` keeps the tight bound: its signal is a
-  // parse-time script tag that lands during the load, so a skeleton gate still
-  // open when the load settles really has seen a document that cannot render.
+  // threshold.
   //
-  // Deliberate consequence of pre-arming: on a cold switch this bound, not
-  // `viewLoadHardTimeoutMs`, is the effective ceiling — a load slower than it
-  // expires the gate mid-flight and the switch is abandoned once the load
-  // settles. `viewLoadHardTimeoutMs` still bounds a load that never settles.
+  // `"skeleton-painted"` keeps that same tight bound but spends it from when
+  // the load settles rather than from here: it is armed wide enough to outlast
+  // the load's own fatal ceiling, then retimed back down to `paintHardMs` the
+  // moment `loadView` resolves (#11765). Pre-arming is what makes the one-shot
+  // signal reliable, and it is also what made the bound pay for the load — a
+  // cold load slow enough to blow 4s of it (cold disk cache, no V8 code cache,
+  // a contended main process) is slow, not broken, and abandoning it lost a
+  // switch that was about to succeed. The provisional bound is deliberately
+  // larger than `loadHardMs` rather than equal to it: this timer is armed
+  // before `loadView` arms its own, so equal delays would expire this one first.
+  //
+  // What the gate still catches is unchanged, and is now the whole of its job —
+  // a document that loaded and verified, then produced no readiness frame at
+  // all. The wrong-document case it used to also cover now rejects inside
+  // `loadView`, where `verifyProjectBootstrap` probes for `#root` and the
+  // bootstrap id (#11635), well before this gate is ever awaited. That leaves a
+  // verdict only meaningful once the load has settled — which is exactly when
+  // the tight bound now starts.
   const hardMs =
-    coldReleaseChannel === "painted" ? Math.max(paintHardMs, host.viewLoadTimeoutMs) : paintHardMs;
+    coldReleaseChannel === "painted" ? Math.max(paintHardMs, loadSoftMs) : loadHardMs + paintHardMs;
 
   const paintGatePromise = host.waitForPaint(
     view.webContents.id,
@@ -360,10 +380,19 @@ export async function performSwitch(
     // primitives so a resource-profile transition mid-load can't retime an
     // in-flight load, matching the paint gate's capture-at-creation contract.
     await loadView(view, projectId, {
-      softMs: host.viewLoadTimeoutMs,
-      hardMs: host.viewLoadHardTimeoutMs,
+      softMs: loadSoftMs,
+      hardMs: loadHardMs,
     });
     loadFinishedAt = performance.now();
+
+    // The skeleton gate's tight paint bound starts HERE, not at arm time — see
+    // the sizing note above. `false` on the common fast path, where the
+    // parse-time skeleton signal already released the gate during the load, and
+    // on a switch a later one has superseded. Runs before the unfreeze below so
+    // the window a slow rAF is measured against is already the right one.
+    const paintGateRetimed =
+      coldReleaseChannel === "skeleton-painted" &&
+      host.retimeSkeletonPaintGateHardTimeout(view.webContents.id, paintHardMs);
 
     // The incoming view is stacked behind the still-visible outgoing view,
     // so Chromium's compositor marks it occluded and throttles its
@@ -389,15 +418,26 @@ export async function performSwitch(
     const gateResult = await paintGatePromise;
     visibleAt = performance.now();
     if (gateResult === "hard-timeout") {
+      // The bound that actually expired: once a skeleton gate has been retimed
+      // the provisional `hardMs` is dead, and reporting it would overstate the
+      // wait by the whole load. `hardTimeoutOrigin` says which clock it was
+      // spent from — `waitedMs` alone cannot distinguish a paint that never
+      // came from a budget that also paid for the load.
+      const effectiveHardMs = paintGateRetimed ? paintHardMs : hardMs;
       logWarn("projectview.paintgate.hardtimeout", {
         projectId,
-        waitedMs: hardMs,
+        waitedMs: effectiveHardMs,
+        releaseChannel: coldReleaseChannel,
+        hardTimeoutOrigin: paintGateRetimed ? "load-finished" : "gate-armed",
       });
       // Abandon rather than commit. Both release signals are document-owned
       // (APP_SKELETON_PARSED from a script tag in index.html, APP_VIEW_PAINTED
       // from React), so exhausting the budget without either means this view
-      // gave no evidence it can render — including having committed the wrong
-      // document entirely (#11635). Detaching the outgoing view here strands
+      // gave no evidence it can render. Reaching here now means specifically
+      // that: the load already settled and `verifyProjectBootstrap` already
+      // vouched for the document (#11635), so what timed out is a verified
+      // application document that produced no frame — not a wrong document, and
+      // not merely a slow one (#11765). Detaching the outgoing view here strands
       // the user on that frame with no in-app recovery, while rolling back
       // keeps a known-good view on screen and stays retryable. Thrown BEFORE
       // any detach so the rollback restores an attached view. #11462 still
@@ -417,7 +457,7 @@ export async function performSwitch(
       throw new AppError({
         code: "INTERNAL",
         message: "View never painted: project view abandoned after paint gate hard timeout",
-        context: { phase: "paint", projectId, waitedMs: hardMs },
+        context: { phase: "paint", projectId, waitedMs: effectiveHardMs },
       });
     }
 

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -37,6 +37,13 @@ import type { ProjectViewManager } from "./ProjectViewManager.js";
 import type { ViewEntry } from "./ProjectViewManagerTypes.js";
 import type { ProjectFocusOnActivateIntent } from "../../shared/types/ipc/project.js";
 
+/**
+ * Largest delay `setTimeout` stores as-is (INT32_MAX ms, ~24.9 days). Anything
+ * beyond it wraps to 1ms, turning a deliberately distant deadline into an
+ * immediate one.
+ */
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
 function consumePendingFocusIntent(
   host: ProjectViewManager,
   projectId: string
@@ -347,8 +354,16 @@ export async function performSwitch(
   // bootstrap id (#11635), well before this gate is ever awaited. That leaves a
   // verdict only meaningful once the load has settled — which is exactly when
   // the tight bound now starts.
+  //
+  // Clamped to the largest delay Node can hold: a sum past it wraps to a 1ms
+  // timer, which would fire the provisional gate almost immediately and abandon
+  // every cold switch. The clamp cannot cost anything the load does not already
+  // cost — a `loadHardMs` big enough to reach it overflows loadView's own timer
+  // the same way, and that rejection clears this gate.
   const hardMs =
-    coldReleaseChannel === "painted" ? Math.max(paintHardMs, loadSoftMs) : loadHardMs + paintHardMs;
+    coldReleaseChannel === "painted"
+      ? Math.max(paintHardMs, loadSoftMs)
+      : Math.min(loadHardMs + paintHardMs, MAX_TIMEOUT_MS);
 
   const paintGatePromise = host.waitForPaint(
     view.webContents.id,

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -357,9 +357,11 @@ export async function performSwitch(
   //
   // Clamped to the largest delay Node can hold: a sum past it wraps to a 1ms
   // timer, which would fire the provisional gate almost immediately and abandon
-  // every cold switch. The clamp cannot cost anything the load does not already
-  // cost — a `loadHardMs` big enough to reach it overflows loadView's own timer
-  // the same way, and that rejection clears this gate.
+  // every cold switch. The clamp only bites once `loadHardMs` comes within
+  // `paintHardMs` of that ceiling — a load budget of ~24 days — and there it
+  // narrows the margin over the load rather than keeping it. That is strictly
+  // better than the wrap it replaces, and far outside anything the resource
+  // profiles set.
   const hardMs =
     coldReleaseChannel === "painted"
       ? Math.max(paintHardMs, loadSoftMs)

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -269,6 +269,12 @@ function expectRejection(promise: Promise<unknown>): Promise<Error> {
 }
 
 describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
+  // Small, non-zero bounds so each phase is observable. Named because the
+  // timeout telemetry asserts against them: comparing a reported bound to the
+  // fixture's own input is the only way to catch it reporting the wrong one.
+  const PAINT_SOFT_MS = 50;
+  const PAINT_HARD_MS = 150;
+
   let manager: ProjectViewManager;
   let win: ReturnType<typeof createMockWindow>;
   let initialWc: MockWc;
@@ -288,8 +294,8 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     // Both must be set explicitly because the PVM defaults are 1.5 s / 4 s.
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
-      paintGateTimeoutMs: 50,
-      paintGateHardTimeoutMs: 150,
+      paintGateTimeoutMs: PAINT_SOFT_MS,
+      paintGateHardTimeoutMs: PAINT_HARD_MS,
       // Compressed onto the same scale: the focus-intent (`painted`) channel
       // stretches its hard bound to this value, and the hard-timeout tests
       // below are written against the 150 ms bound.
@@ -455,13 +461,21 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       const slowWc = createMockWebContents({ autoFinishLoad: false });
       wcQueue.push(slowWc);
 
+      // Compress the load ceiling onto the same scale as the paint bounds, so
+      // "the gate outlasts the load" is measured against the load's own budget
+      // rather than against some arbitrary larger number. Without this the
+      // default 30 s ceiling makes any widened bound pass.
+      const loadHardMs = 1_000;
+      manager.setViewLoadHardTimeoutMs(loadHardMs);
+
       const switchPromise = manager.switchTo("proj-b", "/path/b");
       await vi.advanceTimersByTimeAsync(0);
 
-      // Well past the skeleton channel's own hard bound (150 ms), but the load
-      // has not settled — nothing has been learned about this view yet, so the
-      // gate must still be open and the outgoing view still bridging.
-      await vi.advanceTimersByTimeAsync(400);
+      // Right up to the load's own fatal ceiling — the whole window in which a
+      // legitimately slow load can still settle. The gate must survive all of
+      // it: until the load settles nothing has been learned about this view.
+      // (The old bound expired at 150 ms, a fraction of the way in.)
+      await vi.advanceTimersByTimeAsync(loadHardMs - 1);
       expect(manager.pendingPaintGate).not.toBeNull();
       expect(win.contentView.removeChildView).not.toHaveBeenCalled();
 
@@ -518,8 +532,11 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       expect(err.message).toContain("View never painted");
       expect(manager.getActiveProjectId()).toBe("proj-a");
 
-      // The retimed bound is what expired, and the log must say so rather than
-      // reporting the provisional ceiling the gate was armed with.
+      // The retimed bound is what expired, and both the log and the error must
+      // say so rather than reporting the provisional ceiling the gate was armed
+      // with — that one outlasts the load, so it would overstate the wait by
+      // the whole load. PAINT_HARD_MS is this fixture's own input, not a
+      // production literal.
       const hardTimeouts = vi
         .mocked(logWarn)
         .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout");
@@ -528,21 +545,26 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
         projectId: "proj-b",
         releaseChannel: "skeleton-painted",
         hardTimeoutOrigin: "load-finished",
+        waitedMs: PAINT_HARD_MS,
       });
-      // The provisional bound outlasts the load ceiling by design, so a
-      // `waitedMs` still carrying it would be off by the whole load.
-      const waited = (hardTimeouts[0]?.[1] as { waitedMs: number }).waitedMs;
-      expect(waited).toBeLessThan(400);
+      expect((err as { context?: Record<string, unknown> }).context).toMatchObject({
+        phase: "paint",
+        waitedMs: PAINT_HARD_MS,
+      });
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("leaves no provisional timer behind after the gate releases", async () => {
-    // The retime replaces `gate.hardTimeout` in place. Clearing the old handle
-    // is what keeps the provisional timer from firing later against a gate that
-    // has already settled — a leak the `settled` latch would mask but which
-    // would still resolve a superseded gate's promise.
+  it("replaces the provisional hard timer rather than leaving it armed", async () => {
+    // The retime swaps `gate.hardTimeout` in place, so the old handle is the
+    // only reference that can cancel the provisional timer. Dropping it without
+    // clearing is invisible from behaviour alone: the orphan fires ~30 s later,
+    // hits the `settled` latch and changes nothing observable, while its
+    // closure pins the gate and the views it captures for that whole window.
+    // Only a timer inventory catches it — same reason the load-timer test does
+    // this. Counting rather than advancing is also what keeps this honest: an
+    // orphan that never fires still fails here.
     vi.useFakeTimers();
     try {
       const slowWc = createMockWebContents({ autoFinishLoad: false });
@@ -551,13 +573,27 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       const switchPromise = manager.switchTo("proj-b", "/path/b");
       await vi.advanceTimersByTimeAsync(0);
 
+      const gate = manager.pendingPaintGate;
+      expect(gate).not.toBeNull();
+      const provisionalHandle = gate?.hardTimeout;
+
+      // Measured around the retime alone, with the load deliberately still in
+      // flight. Straddling the load settle instead would net this against
+      // loadView's own two timers clearing, and the swap would vanish into
+      // that noise.
+      const armedCount = vi.getTimerCount();
+      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id, PAINT_HARD_MS)).toBe(true);
+
+      // A different handle proves the swap happened; an unchanged total proves
+      // the one it replaced was cancelled rather than orphaned.
+      expect(manager.pendingPaintGate).toBe(gate);
+      expect(gate?.hardTimeout).not.toBe(provisionalHandle);
+      expect(vi.getTimerCount()).toBe(armedCount);
+
       slowWc._fireOnce("did-finish-load");
       await vi.advanceTimersByTimeAsync(0);
       manager.signalSkeletonPainted(slowWc.id);
       await switchPromise;
-
-      // Run past every deadline either timer could have been armed with.
-      await vi.advanceTimersByTimeAsync(60_000);
 
       expect(manager.getActiveProjectId()).toBe("proj-b");
       expect(
@@ -572,8 +608,9 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
 
   it("retime is a no-op for a gate that is missing, superseded or on another channel", async () => {
     // The retime lands after an await, so by the time it runs the gate it was
-    // meant for may be gone. Every mismatch must leave the pending gate alone —
-    // a late call from a superseded switch must never retime its replacement.
+    // meant for may be gone, replaced, or waiting on a different channel. Every
+    // mismatch must leave the pending gate's timer alone — a late call from a
+    // superseded switch must never retime whatever replaced it.
     vi.useFakeTimers();
     try {
       // No gate at all — the shape suites that stub `waitForPaint` produce.
@@ -587,20 +624,93 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       const gate = manager.pendingPaintGate;
       expect(gate?.releaseChannel).toBe("skeleton-painted");
 
+      // A rejected call must leave the timer alone, not just the pointer: the
+      // retime mutates `hardTimeout` in place, so an implementation that
+      // retimed and *then* returned false would keep gate identity and slip
+      // past a pointer-only assertion.
+      const untouched = gate?.hardTimeout;
+
       // Wrong webContents — a stale call from an earlier switch.
-      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id + 1, 150)).toBe(false);
+      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id + 1, PAINT_HARD_MS)).toBe(false);
       expect(manager.pendingPaintGate).toBe(gate);
+      expect(gate?.hardTimeout).toBe(untouched);
 
       // Matching open skeleton gate — the only case that retimes.
-      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id, 150)).toBe(true);
+      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id, PAINT_HARD_MS)).toBe(true);
       expect(manager.pendingPaintGate).toBe(gate);
+      expect(gate?.hardTimeout).not.toBe(untouched);
 
       manager.signalSkeletonPainted(slowWc.id);
       slowWc._fireOnce("did-finish-load");
       await switchPromise;
 
       // Released gate — the common fast path's result.
-      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id, 150)).toBe(false);
+      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id, PAINT_HARD_MS)).toBe(false);
+
+      // Wrong channel: a warm gate on the very same webContents. Only the
+      // skeleton channel is spent from before its load, so retiming any other
+      // would shorten a bound that was never oversized to begin with.
+      const warmGatePromise = manager.waitForPaint(slowWc.id, null, null, undefined, {
+        releaseChannel: "warm-painted",
+      });
+      const warmGate = manager.pendingPaintGate;
+      const warmHandle = warmGate?.hardTimeout;
+      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id, PAINT_HARD_MS)).toBe(false);
+      expect(warmGate?.hardTimeout).toBe(warmHandle);
+      manager.clearPaintGate();
+      await warmGatePromise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("abandons a painted-channel switch whose gate expired while the load ran", async () => {
+    // Only the skeleton channel's bound moved (#11765); the focus-intent
+    // `"painted"` gate is still spent from arm time, so it can still expire
+    // with the load in flight. Nothing acts on that until the load settles —
+    // the gate is awaited after it — and the verdict when it does is abandon
+    // and roll back, never a commit onto a view that never painted (#11635).
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents({ autoFinishLoad: false });
+      wcQueue.push(slowWc);
+
+      manager.setPendingFocusIntent("proj-b", { intent: "focus-next-waiting" });
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      const rejection = expectRejection(switchPromise);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Gate expires mid-load. The outgoing view stays attached and is still
+      // reported as the on-screen bridge across that boundary — from
+      // `pendingColdSwitch` now that the gate has dropped itself.
+      await vi.advanceTimersByTimeAsync(PAINT_HARD_MS + 10);
+      expect(manager.pendingPaintGate).toBeNull();
+      expect(manager.getOutgoingBridgeProjectId()).toBe("proj-a");
+      expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+      // The load settles successfully — and the already-expired gate still
+      // abandons, because a load that finished is not a view that painted.
+      slowWc._fireOnce("did-finish-load");
+      await vi.advanceTimersByTimeAsync(0);
+      const err = await rejection;
+
+      expect(err.message).toContain("View never painted");
+      expect(manager.getActiveProjectId()).toBe("proj-a");
+      expect(manager.getOutgoingBridgeProjectId()).toBeNull();
+
+      // The non-retimed regime: this bound really was spent from the arm, and
+      // the telemetry has to name that clock rather than implying the
+      // post-load window the skeleton channel now gets.
+      const hardTimeouts = vi
+        .mocked(logWarn)
+        .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout");
+      expect(hardTimeouts).toHaveLength(1);
+      expect(hardTimeouts[0]?.[1]).toMatchObject({
+        releaseChannel: "painted",
+        hardTimeoutOrigin: "gate-armed",
+        waitedMs: PAINT_HARD_MS,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -375,9 +375,10 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
 
   it("abandons the switch at hard timeout when the signal never arrives", async () => {
     // Both release signals are document-owned, so exhausting the budget means
-    // the incoming view produced no evidence it can render — including having
-    // committed the wrong document entirely (#11635). Committing here is what
-    // stranded users on a bare "Not Found" frame with no in-app recovery.
+    // the incoming view produced no evidence it can render. Committing anyway
+    // is what stranded users on a frame with no in-app recovery (#11635). This
+    // load settles immediately, so the retimed window (#11765) opens at once
+    // and the bound behaves exactly as it did before it moved.
     vi.useFakeTimers();
     try {
       const slowWc = createMockWebContents();
@@ -438,6 +439,168 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       expect(
         vi.mocked(logInfo).mock.calls.filter(([event]) => event === "projectview.coldstart")
       ).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets a slow cold load outlive the skeleton paint bound", async () => {
+    // #11765: the gate is armed before `loadView` starts, so its bound used to
+    // be spent on renderer spawn, preload eval and the load itself. A cold load
+    // slower than the paint bound but well inside the load budget expired the
+    // gate mid-flight and the switch was abandoned — a rollback and an error
+    // toast for a switch that was about to succeed. Slow is not broken.
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents({ autoFinishLoad: false });
+      wcQueue.push(slowWc);
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Well past the skeleton channel's own hard bound (150 ms), but the load
+      // has not settled — nothing has been learned about this view yet, so the
+      // gate must still be open and the outgoing view still bridging.
+      await vi.advanceTimersByTimeAsync(400);
+      expect(manager.pendingPaintGate).not.toBeNull();
+      expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+      // The real renderer fires the parse-time skeleton signal during the load,
+      // so drive that ordering rather than a post-settle signal.
+      slowWc._emitIpcOnce(CHANNELS.APP_SKELETON_PARSED);
+      slowWc._fireOnce("did-finish-load");
+      await switchPromise;
+
+      expect(manager.getActiveProjectId()).toBe("proj-b");
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout")
+      ).toHaveLength(0);
+      expect(
+        vi
+          .mocked(logInfo)
+          .mock.calls.filter(([event]) => event === "projectview.coldstart.rejected")
+      ).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spends the skeleton paint bound from load settle, not from gate arm", async () => {
+    // The other half of #11765: widening the bound must not also slow the
+    // abandon of a view that genuinely never renders. A load that settles late
+    // and then never signals still gets the same tight paint window it always
+    // had — just measured from the settle rather than from before the load.
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents({ autoFinishLoad: false });
+      wcQueue.push(slowWc);
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      const rejection = expectRejection(switchPromise);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Hold the load past the paint bound with no signal at all, then settle.
+      await vi.advanceTimersByTimeAsync(400);
+      slowWc._fireOnce("did-finish-load");
+      // Flush the bootstrap probe so the retime has actually run.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(manager.pendingPaintGate).not.toBeNull();
+
+      // Just short of the paint bound measured from the settle — still waiting.
+      await vi.advanceTimersByTimeAsync(140);
+      expect(manager.pendingPaintGate).not.toBeNull();
+
+      // Crossing it abandons, exactly as it did before this window moved.
+      await vi.advanceTimersByTimeAsync(20);
+      const err = await rejection;
+      expect(err.message).toContain("View never painted");
+      expect(manager.getActiveProjectId()).toBe("proj-a");
+
+      // The retimed bound is what expired, and the log must say so rather than
+      // reporting the provisional ceiling the gate was armed with.
+      const hardTimeouts = vi
+        .mocked(logWarn)
+        .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout");
+      expect(hardTimeouts).toHaveLength(1);
+      expect(hardTimeouts[0]?.[1]).toMatchObject({
+        projectId: "proj-b",
+        releaseChannel: "skeleton-painted",
+        hardTimeoutOrigin: "load-finished",
+      });
+      // The provisional bound outlasts the load ceiling by design, so a
+      // `waitedMs` still carrying it would be off by the whole load.
+      const waited = (hardTimeouts[0]?.[1] as { waitedMs: number }).waitedMs;
+      expect(waited).toBeLessThan(400);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves no provisional timer behind after the gate releases", async () => {
+    // The retime replaces `gate.hardTimeout` in place. Clearing the old handle
+    // is what keeps the provisional timer from firing later against a gate that
+    // has already settled — a leak the `settled` latch would mask but which
+    // would still resolve a superseded gate's promise.
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents({ autoFinishLoad: false });
+      wcQueue.push(slowWc);
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      await vi.advanceTimersByTimeAsync(0);
+
+      slowWc._fireOnce("did-finish-load");
+      await vi.advanceTimersByTimeAsync(0);
+      manager.signalSkeletonPainted(slowWc.id);
+      await switchPromise;
+
+      // Run past every deadline either timer could have been armed with.
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(manager.getActiveProjectId()).toBe("proj-b");
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout")
+      ).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retime is a no-op for a gate that is missing, superseded or on another channel", async () => {
+    // The retime lands after an await, so by the time it runs the gate it was
+    // meant for may be gone. Every mismatch must leave the pending gate alone —
+    // a late call from a superseded switch must never retime its replacement.
+    vi.useFakeTimers();
+    try {
+      // No gate at all — the shape suites that stub `waitForPaint` produce.
+      expect(manager.retimeSkeletonPaintGateHardTimeout(999, 150)).toBe(false);
+
+      const slowWc = createMockWebContents({ autoFinishLoad: false });
+      wcQueue.push(slowWc);
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      await vi.advanceTimersByTimeAsync(0);
+
+      const gate = manager.pendingPaintGate;
+      expect(gate?.releaseChannel).toBe("skeleton-painted");
+
+      // Wrong webContents — a stale call from an earlier switch.
+      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id + 1, 150)).toBe(false);
+      expect(manager.pendingPaintGate).toBe(gate);
+
+      // Matching open skeleton gate — the only case that retimes.
+      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id, 150)).toBe(true);
+      expect(manager.pendingPaintGate).toBe(gate);
+
+      manager.signalSkeletonPainted(slowWc.id);
+      slowWc._fireOnce("did-finish-load");
+      await switchPromise;
+
+      // Released gate — the common fast path's result.
+      expect(manager.retimeSkeletonPaintGateHardTimeout(slowWc.id, 150)).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -496,8 +496,13 @@ describe("ProjectViewManager — switch failure rollback", () => {
   });
 
   /**
-   * A manager whose paint gate expires strictly inside the load window, so the
+   * A manager whose paint gate clears strictly inside the load window, so the
    * gap between "gate gone" and "load settled" can be observed on both sides.
+   * The gate clears on the incoming skeleton signal, which is how it happens in
+   * production — a parse-time script tag fires while the load is still running.
+   * It can no longer clear by hard timeout there: since #11765 a skeleton gate
+   * is armed past the load's own ceiling and only tightened once the load
+   * settles, so a slow load can't expire it mid-flight.
    */
   const GATE_HARD_MS = 50;
   function startBridgedSwitch() {
@@ -528,12 +533,12 @@ describe("ProjectViewManager — switch failure rollback", () => {
   }
 
   it("keeps reporting the outgoing bridge after the paint gate clears mid-load", async () => {
-    // The gate resolves on the incoming skeleton signal — or its own hard
-    // timeout — and nulls itself, while the outgoing view stays attached and
-    // visible until the load settles. Answering from the gate alone left every
-    // consumer (hibernation, idle auto-close, relocation, menu state) blind for
-    // that whole gap, free to destroy the view rollback needs and strand the
-    // window on a project with no live entry (#11459).
+    // The gate resolves on the incoming skeleton signal and nulls itself, while
+    // the outgoing view stays attached and visible until the load settles.
+    // Answering from the gate alone left every consumer (hibernation, idle
+    // auto-close, relocation, menu state) blind for that whole gap, free to
+    // destroy the view rollback needs and strand the window on a project with
+    // no live entry (#11459).
     const { bridgeManager, slowWc, switchPromise } = startBridgedSwitch();
 
     // Gate still open: this is the case that passed before the fix too.
@@ -542,8 +547,13 @@ describe("ProjectViewManager — switch failure rollback", () => {
     const whileGateOpen = bridgeManager.getOutgoingBridgeProjectId();
     expect(whileGateOpen).toBe("bridge-a");
 
-    // Gate hard-times-out and drops itself; the load is still in flight.
+    // A bound that would once have expired the gate passes without touching it
+    // — the load is still in flight, so nothing has been learned yet (#11765).
     await vi.advanceTimersByTimeAsync(GATE_HARD_MS);
+    expect(bridgeManager.pendingPaintGate).not.toBeNull();
+
+    // The skeleton parses and drops the gate; the load is still in flight.
+    bridgeManager.signalSkeletonPainted(slowWc.id);
     expect(bridgeManager.pendingPaintGate).toBeNull();
     expect(bridgeManager.pendingColdSwitch?.projectId).toBe("bridge-b");
 
@@ -551,16 +561,13 @@ describe("ProjectViewManager — switch failure rollback", () => {
     // still the painted frame.
     expect(bridgeManager.getOutgoingBridgeProjectId()).toBe(whileGateOpen);
 
-    // Only once the load settles is the bridge genuinely gone. The already-
-    // expired gate abandons this switch the moment the load resolves (#11635),
-    // so the bridge clears via the rollback rather than via a commit — either
-    // way no view is left reported as on screen.
-    const rejection = expectRejection(switchPromise);
+    // Only once the load settles is the bridge genuinely gone — here via the
+    // commit, since the gate released on its signal rather than expiring.
     slowWc._fireOnce("did-finish-load");
     await vi.advanceTimersByTimeAsync(1);
-    await rejection;
+    await switchPromise;
     expect(bridgeManager.getOutgoingBridgeProjectId()).toBeNull();
-    expect(bridgeManager.getActiveProjectId()).toBe("bridge-a");
+    expect(bridgeManager.getActiveProjectId()).toBe("bridge-b");
   });
 
   it("stops reporting an outgoing bridge once the manager is disposed", async () => {
@@ -571,8 +578,10 @@ describe("ProjectViewManager — switch failure rollback", () => {
     const { bridgeManager, switchPromise } = startBridgedSwitch();
     const errPromise = expectRejection(switchPromise);
 
+    // The gate is still open here — a skeleton gate outlasts the load window
+    // (#11765) — so the bridge is reported from it rather than from
+    // `pendingColdSwitch`. Either source must answer the same.
     await vi.advanceTimersByTimeAsync(GATE_HARD_MS + 1);
-    expect(bridgeManager.pendingPaintGate).toBeNull();
     expect(bridgeManager.getOutgoingBridgeProjectId()).toBe("bridge-a");
 
     bridgeManager.dispose();


### PR DESCRIPTION
## Summary

- On a cold project-view switch, the skeleton paint gate was armed before `loadView()` even started, so its tight 4s hard bound also had to cover renderer spawn, preload eval, and navigation. A slow but legitimate first run (cold disk cache, no V8 code cache, AV scanning, a contended main process) blew that bound mid-load and got abandoned with a rollback and an error toast, even though nothing was actually broken.
- Fixes it with a two-phase sliding window: arm the gate wide enough to outlast the load's own fatal ceiling, then retime it back down to the normal paint bound the moment `loadView()` resolves.
- Adds test coverage for the slow-load case, the retime's timing and timer-swap behavior, and rewrites two `switchFailure` fixtures that depended on the old (now impossible) failure mode.

Resolves #11765

## The bug

On a cold switch, the paint gate is armed before `loadView()` starts. For the `"skeleton-painted"` channel, its hard bound sits at 4000ms on a balanced profile, and that bound ends up paying for renderer spawn, preload eval, and navigation on top of the paint itself. In the reported case, cold disk cache, no V8 code cache, AV scanning, and a contended main process pushed the load to ~5.5s. The issue's telemetry showed 504ms of event-loop lag and a `PullRequestService initialized` log line landing 4.8s in. That 5.5s is comfortably inside the load's own budget (10s soft, 30s hard), but it ran past the 4s paint bound partway through, so the switch got abandoned and rolled back to the previous view with an error toast.

## Why the old reasoning doesn't hold anymore

The tight bound was justified on the reasoning that a skeleton gate still open when the load settles has seen a document that can't render. That was true when it was written. It stopped being true after `ca1e132ff` (#11635): the wrong-document case is now caught inside `loadView` itself, by `verifyProjectBootstrap`'s bootstrap probe (checking for a `#root` element and a `__DAINTREE_INITIAL_PROJECT__` marker), which rejects before the paint gate is ever awaited. So the gate's actual remaining job is narrower than the old bound assumed: catch a document that loaded and verified fine and then produced no frame at all, a verdict that only means anything once the load has settled.

## The fix

Rather than just raising the ceiling, this arms the skeleton gate wide enough to outlast the load's own fatal ceiling, then retimes it down to the normal paint bound the moment `loadView()` resolves. A 5.5s load now lands. A view that genuinely never paints is still abandoned about 4s after settle, so abandon latency doesn't regress (an unconditional stretch to `viewLoadTimeoutMs` would have taken that from 4s to 10s, which felt like the wrong tradeoff).

The provisional bound while the load is in flight is `loadHardMs + paintHardMs`, summed rather than maxed, because this timer gets armed before `loadView` arms its own: with equal delays, a max would let the gate's timer expire first. That sum is clamped to Node's maximum `setTimeout` delay, since going past it silently wraps to a 1ms timer and would abandon every cold switch.

## What didn't change

The `"painted"` focus-intent channel (#4670) keeps its arm-time budget exactly as it was and is never retimed. Resource-profile setters still don't retime an in-flight gate either, since the retime uses a value captured before navigation started.

## Telemetry

`waitedMs` now reports the bound that actually expired rather than the provisional one, and a new `hardTimeoutOrigin` field (`load-finished` | `gate-armed`) names which clock the wait was measured from.

## Testing

188 tests across 10 `ProjectViewManager` suites pass; eslint and prettier are clean on all changed files. New coverage:

- A slow cold load that outlives the old paint bound now lands.
- The retimed bound starts counting from load settle, guarding against abandon-latency regressions.
- The retime swaps the hard timer rather than leaving the old one running as an orphan, via a timer-inventory assertion (behavior alone can't see the leak, since a settled latch swallows the orphaned timer's effect).
- Guard coverage for a missing, superseded, or wrong-channel gate.
- A `"painted"`-channel fixture covering gate-expired-mid-load followed by abandon-on-settle, which also pins the non-retimed telemetry branch.

Two `switchFailure` fixtures were rewritten: they relied on the skeleton gate hard-timing-out mid-load, which this fix makes impossible, so they now clear the gate via the skeleton signal instead, matching the real production ordering.
