### PR TITLE
fix(git): recognize a missing git binary instead of blaming the folder

### DIFF
--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -33,7 +33,7 @@ const probeGitMarkerMock = vi.hoisted(() =>
 vi.mock("../../../services/projectOpenPreflight.js", () => ({
   probeGitMarker: (root: string) => probeGitMarkerMock(root),
   assertProjectDirectory: vi.fn(),
-  isMissingExecutableError: vi.fn(() => false),
+  isMissingGitExecutableError: vi.fn(() => false),
   PROJECT_DIRECTORY_STAT_TIMEOUT_MS: 5_000,
   GIT_MARKER_STAT_TIMEOUT_MS: 1_000,
 }));

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -11,6 +11,7 @@ import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "../../shared/ty
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { validateBranchName } from "../../shared/utils/pathPattern.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { isMissingGitExecutableError } from "../../shared/utils/gitOperationErrors.js";
 import { isBinaryDiffOutput } from "../../shared/utils/gitDiffParsing.js";
 import { parseNumstat } from "../utils/git.js";
 import type { DiffStat } from "../utils/git.js";
@@ -779,6 +780,18 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       return await operation();
     } catch (error) {
       const errorMessage = formatErrorMessage(error, `Git operation failed: ${context}`);
+
+      // Checked against the raw error, and ahead of the ENOENT branch below:
+      // a missing git binary reaches here as a spawn ENOENT, which that branch
+      // would otherwise read as "this worktree was deleted" and act on by
+      // tearing down a worktree that is perfectly fine (#11764).
+      if (isMissingGitExecutableError(error)) {
+        const gitError = toGitOperationError(error, { cwd: this.rootPath, op: context });
+        logWarn(`Git operation failed: git executable not found (${context})`, {
+          rootPath: this.rootPath,
+        });
+        throw gitError;
+      }
 
       if (
         errorMessage.includes("ENOENT") ||

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -785,7 +785,17 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       // a missing git binary reaches here as a spawn ENOENT, which that branch
       // would otherwise read as "this worktree was deleted" and act on by
       // tearing down a worktree that is perfectly fine (#11764).
-      if (isMissingGitExecutableError(error)) {
+      //
+      // The root path still existing is part of the evidence, not a nicety:
+      // Node raises a byte-identical `spawn git ENOENT` (`code: "ENOENT"`,
+      // `syscall: "spawn git"`) when the spawn's *cwd* is gone. This service
+      // caches its SimpleGit instance for its lifetime and `gitServiceCache`
+      // keeps the service itself alive per path, so simple-git's
+      // construction-time folder check has long since passed by the time a
+      // worktree is deleted externally. Without the guard, a removed worktree
+      // would be reported as "install Git and put it on your PATH" — the same
+      // misdirection this branch exists to prevent, inverted.
+      if (isMissingGitExecutableError(error) && existsSync(this.rootPath)) {
         const gitError = toGitOperationError(error, { cwd: this.rootPath, op: context });
         logWarn(`Git operation failed: git executable not found (${context})`, {
           rootPath: this.rootPath,

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -17,7 +17,7 @@ import { existsSync } from "fs";
 import { app } from "electron";
 import { GitService } from "./GitService.js";
 import { AppError, isDaintreeError } from "../utils/errorTypes.js";
-import { assertProjectDirectory, isMissingExecutableError } from "./projectOpenPreflight.js";
+import { assertProjectDirectory, isMissingGitExecutableError } from "./projectOpenPreflight.js";
 import { logError } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { store } from "../store.js";
@@ -422,7 +422,7 @@ export class ProjectStore {
       // of the machine, not the path: a transient stat failure must not mask
       // "git isn't installed", and a missing binary must not be reported as a
       // problem with the folder.
-      if (isMissingExecutableError(error)) {
+      if (isMissingGitExecutableError(error)) {
         throw new AppError({
           code: "GIT_NOT_INSTALLED",
           message: "Git executable not found",

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -34,6 +34,7 @@ vi.mock("../../utils/logger.js", () => ({
 
 import { GitService } from "../GitService.js";
 import { GitError, GitOperationError, WorktreeRemovedError } from "../../utils/errorTypes.js";
+import { simpleGitMissingBinaryError } from "../../../shared/testing/simpleGitErrorFixtures.js";
 
 describe("GitService", () => {
   let tempDir: string;
@@ -655,6 +656,22 @@ index 1a2b3c4..5d6e7f8 100644
     expect(error).not.toBeInstanceOf(WorktreeRemovedError);
     expect(logWarnMock).toHaveBeenCalled();
     expect(logErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing git binary rather than a removed worktree", async () => {
+    // Every method routes through the same handler, whose ENOENT text match
+    // used to claim the worktree was gone — for a machine that just has no
+    // Git installed, and a worktree that is perfectly fine (#11764).
+    gitClientMock.revparse.mockRejectedValue(simpleGitMissingBinaryError());
+
+    const service = new GitService(tempDir);
+
+    const error = await service.getRepositoryRoot(tempDir).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(GitOperationError);
+    expect(error).not.toBeInstanceOf(WorktreeRemovedError);
+    expect(error).toMatchObject({ reason: "git-not-installed" });
+    // The original stays reachable for diagnostics.
+    expect((error as GitOperationError).cause).toBeInstanceOf(Error);
   });
 });
 

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -675,6 +675,25 @@ index 1a2b3c4..5d6e7f8 100644
     // this same failure after another layer has wrapped it.
     expect((error as GitOperationError).cause).toBe(spawnFailure);
   });
+
+  it("still reports a removed worktree when the spawn ENOENT is the missing cwd", async () => {
+    // Node raises the same `spawn git ENOENT` when the spawn's cwd is gone, and
+    // the cached SimpleGit instance means simple-git's construction-time folder
+    // check ran long before the deletion — so the error alone cannot tell the
+    // two apart. Without the root-path guard this reads as "install Git".
+    const removedPath = path.join(tempDir, "removed-worktree");
+    await fs.mkdir(removedPath);
+    gitClientMock.revparse.mockRejectedValue(simpleGitMissingBinaryError());
+
+    const service = new GitService(removedPath);
+    await fs.rm(removedPath, { recursive: true, force: true });
+
+    const error = await service.getRepositoryRoot(removedPath).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(WorktreeRemovedError);
+    // The missing-binary branch throws a GitOperationError instead, so this
+    // rules out having taken it.
+    expect(error).not.toBeInstanceOf(GitOperationError);
+  });
 });
 
 describe("GitService.readFileAtHead", () => {

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -662,7 +662,8 @@ index 1a2b3c4..5d6e7f8 100644
     // Every method routes through the same handler, whose ENOENT text match
     // used to claim the worktree was gone — for a machine that just has no
     // Git installed, and a worktree that is perfectly fine (#11764).
-    gitClientMock.revparse.mockRejectedValue(simpleGitMissingBinaryError());
+    const spawnFailure = simpleGitMissingBinaryError();
+    gitClientMock.revparse.mockRejectedValue(spawnFailure);
 
     const service = new GitService(tempDir);
 
@@ -670,8 +671,9 @@ index 1a2b3c4..5d6e7f8 100644
     expect(error).toBeInstanceOf(GitOperationError);
     expect(error).not.toBeInstanceOf(WorktreeRemovedError);
     expect(error).toMatchObject({ reason: "git-not-installed" });
-    // The original stays reachable for diagnostics.
-    expect((error as GitOperationError).cause).toBeInstanceOf(Error);
+    // The original stays reachable, which is what lets ProjectStore classify
+    // this same failure after another layer has wrapped it.
+    expect((error as GitOperationError).cause).toBe(spawnFailure);
   });
 });
 

--- a/electron/services/__tests__/ProjectStore.openFailures.test.ts
+++ b/electron/services/__tests__/ProjectStore.openFailures.test.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import * as schema from "../persistence/schema.js";
+import { simpleGitMissingBinaryError } from "../../../shared/testing/simpleGitErrorFixtures.js";
 
 /**
  * Producer-side coverage for #11409: these drive `addProject` against a REAL
@@ -108,17 +109,9 @@ import { ProjectStore } from "../ProjectStore.js";
 const REPORTED_RAW_TEXT =
   "Git operation failed: getRepositoryRoot\nCannot use simple-git on a directory that does not exist";
 
-/**
- * simple-git 3.36.0 stringifies a failed spawn into the message and rethrows a
- * bare error — no `code`, no `syscall`, no `cause`. Reproduced faithfully here
- * because a synthetic errno-bearing cause chain would pass against detection
- * that can never fire in production.
- */
-function simpleGitMissingBinaryError(): Error {
-  const error = new Error("Error: spawn git ENOENT");
-  Object.assign(error, { task: { commands: ["rev-parse", "--show-toplevel"] } });
-  return error;
-}
+// The captured shape lives in shared/testing: the single-line version this
+// file used to build passed against detection that could never fire in
+// production, which is how #11764 shipped green.
 
 async function codeOf(run: () => Promise<unknown>): Promise<string> {
   try {

--- a/electron/services/__tests__/ProjectStore.openFailures.test.ts
+++ b/electron/services/__tests__/ProjectStore.openFailures.test.ts
@@ -6,6 +6,7 @@ import os from "os";
 import path from "path";
 import * as schema from "../persistence/schema.js";
 import { simpleGitMissingBinaryError } from "../../../shared/testing/simpleGitErrorFixtures.js";
+import { GitOperationError } from "../../utils/errorTypes.js";
 
 /**
  * Producer-side coverage for #11409: these drive `addProject` against a REAL
@@ -167,6 +168,22 @@ describe("ProjectStore.addProject open failures", () => {
 
   it("reports a missing git binary from the shape simple-git actually throws", async () => {
     gitBehavior.getRepositoryRoot.mockRejectedValue(simpleGitMissingBinaryError());
+
+    expect(await codeOf(() => store.addProject(tmpRoot))).toBe("GIT_NOT_INSTALLED");
+  });
+
+  it("still reports it once GitService has wrapped the failure", async () => {
+    // GitService no longer rethrows the raw spawn error — it classifies it and
+    // throws a GitOperationError carrying the original as `cause`. Detection
+    // has to survive that hand-off, and this is the seam where #11764's two
+    // independently-green layers hid the break from each other.
+    gitBehavior.getRepositoryRoot.mockRejectedValue(
+      new GitOperationError("git-not-installed", "Git operation failed: getRepositoryRoot", {
+        cwd: tmpRoot,
+        op: "getRepositoryRoot",
+        cause: simpleGitMissingBinaryError(),
+      })
+    );
 
     expect(await codeOf(() => store.addProject(tmpRoot))).toBe("GIT_NOT_INSTALLED");
   });

--- a/electron/services/__tests__/projectOpenPreflight.test.ts
+++ b/electron/services/__tests__/projectOpenPreflight.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { constants as fsConstants, type Stats } from "fs";
 import path from "path";
+import { simpleGitMissingBinaryError } from "../../../shared/testing/simpleGitErrorFixtures.js";
 
 const statMock = vi.hoisted(() => vi.fn<(path: string) => Promise<Stats>>());
 const lstatMock = vi.hoisted(() => vi.fn<(path: string) => Promise<Stats>>());
@@ -15,7 +16,7 @@ vi.mock("fs/promises", () => ({
 
 const {
   assertProjectDirectory,
-  isMissingExecutableError,
+  isMissingGitExecutableError,
   probeGitMarker,
   PROJECT_DIRECTORY_STAT_TIMEOUT_MS,
   GIT_MARKER_STAT_TIMEOUT_MS,
@@ -365,52 +366,32 @@ describe("assertProjectDirectory under a hung filesystem", () => {
   });
 });
 
-describe("isMissingExecutableError", () => {
-  it("recognizes a failed spawn of a missing binary", () => {
-    expect(isMissingExecutableError(errnoError("ENOENT", { syscall: "spawn git" }))).toBe(true);
-  });
-
-  it("finds it through the wrapping GitService applies", () => {
-    // handleGitOperation rewraps a missing-binary spawn as WorktreeRemovedError
-    // (its ENOENT text match can't tell a missing binary from a missing
-    // worktree) but preserves the original as `cause`.
-    const spawnFailure = errnoError("ENOENT", { syscall: "spawn git" });
-    const wrapped = Object.assign(new Error("Worktree directory no longer exists"), {
-      cause: Object.assign(new Error("Git operation failed: getRepositoryRoot"), {
-        cause: spawnFailure,
+/**
+ * The predicate itself lives in `shared/utils/gitOperationErrors.ts` and is
+ * exercised in full there. What matters here is that this module keeps
+ * re-exporting it, since `ProjectStore` and the switch-handler mock both reach
+ * it through this façade.
+ */
+describe("isMissingGitExecutableError (re-exported)", () => {
+  it("recognizes what simple-git actually throws, through GitService's wrapping", () => {
+    // The real message is a whole Node stack trace, not the one-liner this
+    // suite used to assume — the gap that made #11764's detection dead code.
+    const wrapped = new Error("Worktree directory no longer exists", {
+      cause: new Error("Git operation failed: getRepositoryRoot", {
+        cause: simpleGitMissingBinaryError(),
       }),
     });
 
-    expect(isMissingExecutableError(wrapped)).toBe(true);
+    expect(isMissingGitExecutableError(wrapped)).toBe(true);
   });
 
-  it("does not match a git error that merely quotes those words", () => {
-    // An unanchored search would classify a repository living at a path like
-    // this as "git isn't installed", hijacking the real failure.
-    const gitStderr = new Error(
-      "fatal: detected dubious ownership in repository at '/repos/spawn git ENOENT'"
-    );
-
-    expect(isMissingExecutableError(gitStderr)).toBe(false);
+  it("recognizes a raw spawn errno that never went through simple-git", () => {
+    expect(isMissingGitExecutableError(errnoError("ENOENT", { syscall: "spawn git" }))).toBe(true);
   });
 
   it("does not mistake a missing directory for a missing binary", () => {
-    expect(isMissingExecutableError(errnoError("ENOENT", { syscall: "stat" }))).toBe(false);
-    expect(isMissingExecutableError(errnoError("ENOENT"))).toBe(false);
-    expect(isMissingExecutableError(errnoError("EACCES", { syscall: "spawn git" }))).toBe(false);
-  });
-
-  it("survives a cause chain that loops", () => {
-    const a = new Error("a") as Error & { cause?: unknown };
-    const b = new Error("b") as Error & { cause?: unknown };
-    a.cause = b;
-    b.cause = a;
-
-    expect(isMissingExecutableError(a)).toBe(false);
-  });
-
-  it("handles values that are not errors", () => {
-    expect(isMissingExecutableError(undefined)).toBe(false);
-    expect(isMissingExecutableError("ENOENT")).toBe(false);
+    expect(isMissingGitExecutableError(errnoError("ENOENT", { syscall: "stat" }))).toBe(false);
+    expect(isMissingGitExecutableError(errnoError("ENOENT"))).toBe(false);
+    expect(isMissingGitExecutableError(errnoError("EACCES", { syscall: "spawn git" }))).toBe(false);
   });
 });

--- a/electron/services/projectOpenPreflight.ts
+++ b/electron/services/projectOpenPreflight.ts
@@ -240,40 +240,14 @@ function classifyStatFailure(directoryPath: string, error: unknown): AppError {
 }
 
 /**
- * Matches the spawn failure Node reports for a binary that isn't on PATH, as
- * simple-git stringifies it: `Error: spawn git ENOENT`. The binary name isn't
- * pinned (simple-git can be configured with another), but the shape is anchored
- * to the whole message — an unanchored search would also match git's own stderr
- * quoting a repository path that happens to contain those words.
- */
-const SPAWN_ENOENT_PATTERN = /^(?:Error: )?spawn [^\r\n]+ ENOENT$/;
-
-/**
- * True when `error` is a failed *spawn* of a missing executable.
+ * Re-exported so this module stays the single project-open guard surface its
+ * callers and tests import from. The detection itself lives in `shared/` because
+ * `classifyGitError` needs the same predicate and can't import from `electron/`
+ * — a missing Git binary should be recognized once, not guessed at separately
+ * by every site that sees the error (#11764).
  *
- * Callers reach this only after {@link assertProjectDirectory} has confirmed the
+ * Callers reach it only after {@link assertProjectDirectory} has confirmed the
  * directory exists and is enterable, so a spawn ENOENT can no longer mean the
  * working directory — it's the git binary.
- *
- * Both a structured check and a message check are needed. simple-git 3.36.0
- * does not preserve the spawn error: it stringifies it into the message and
- * rethrows a bare `GitError` whose only own property is `task` — no `code`, no
- * `syscall`, no `cause`. So the errno walk alone never fires for the real
- * failure, while the message match alone would miss a raw Node error arriving
- * from anywhere that doesn't launder it. Verified against the installed
- * simple-git; re-check on upgrade.
  */
-export function isMissingExecutableError(error: unknown): boolean {
-  const seen = new Set<unknown>();
-  let current: unknown = error;
-
-  while (current && typeof current === "object" && !seen.has(current)) {
-    seen.add(current);
-    const errno = current as NodeJS.ErrnoException;
-    if (errno.code === "ENOENT" && errno.syscall?.startsWith("spawn")) return true;
-    if (errno instanceof Error && SPAWN_ENOENT_PATTERN.test(errno.message)) return true;
-    current = (current as { cause?: unknown }).cause;
-  }
-
-  return false;
-}
+export { isMissingGitExecutableError } from "../../shared/utils/gitOperationErrors.js";

--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -188,7 +188,13 @@ describe("getRetryability", () => {
   });
 
   it("maps git auth/config reasons to 'user-gated'", () => {
-    for (const reason of ["auth-failed", "config-missing", "dubious-ownership"] as const) {
+    for (const reason of [
+      "auth-failed",
+      "config-missing",
+      "dubious-ownership",
+      // Auto-retrying a machine with no Git installed just spins.
+      "git-not-installed",
+    ] as const) {
       const err = new GitOperationError(reason, "boom");
       expect(getRetryability(err)).toBe("user-gated");
     }

--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GitError, WorktreeRemovedError } from "../errorTypes.js";
+import { simpleGitMissingBinaryError } from "../../../shared/testing/simpleGitErrorFixtures.js";
 
 const mockGit = {
   raw: vi.fn(),
@@ -146,6 +147,19 @@ describe("getWorktreeChangesWithStats", () => {
     await expect(getWorktreeChangesWithStats("/valid/worktree", true)).rejects.not.toThrow(
       WorktreeRemovedError
     );
+  });
+
+  it("reports a missing git binary instead of retiring the worktree", async () => {
+    // The spawn failure lands as an ENOENT too, so polling used to conclude
+    // every worktree on the machine had been deleted (#11764).
+    mockGit.status.mockRejectedValue(simpleGitMissingBinaryError(["status", "--porcelain"]));
+
+    const error = await getWorktreeChangesWithStats("/valid/worktree", true).catch(
+      (e: unknown) => e
+    );
+
+    expect(error).not.toBeInstanceOf(WorktreeRemovedError);
+    expect(error).toMatchObject({ reason: "git-not-installed" });
   });
 });
 

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -177,10 +177,11 @@ export function getRetryability(error: unknown, gitReason?: GitOperationReason):
   const reason = gitReason ?? (error instanceof GitOperationError ? error.reason : undefined);
   if (reason) {
     switch (reason) {
+      // `git-not-installed` sits here because retrying can't help until the
+      // user installs Git.
       case "auth-failed":
       case "config-missing":
       case "dubious-ownership":
-      // Retrying can't help until the user installs Git.
       case "git-not-installed":
         return "user-gated";
       case "network-unavailable":

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -180,6 +180,8 @@ export function getRetryability(error: unknown, gitReason?: GitOperationReason):
       case "auth-failed":
       case "config-missing":
       case "dubious-ownership":
+      // Retrying can't help until the user installs Git.
+      case "git-not-installed":
         return "user-gated";
       case "network-unavailable":
       case "system-io-error":

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -3,6 +3,7 @@ import { promises as fs, type Stats } from "fs";
 import type { SimpleGit, StatusResult } from "simple-git";
 import type { FileChangeDetail, GitStatus, WorktreeChanges } from "../types/index.js";
 import { WorktreeRemovedError, toGitOperationError } from "./errorTypes.js";
+import { isMissingGitExecutableError } from "../../shared/utils/gitOperationErrors.js";
 import { logWarn, logError } from "./logger.js";
 import { Cache } from "./cache.js";
 import { createHardenedGit, createWslHardenedGit } from "./hardenedGit.js";
@@ -984,10 +985,15 @@ export async function getWorktreeChangesWithStats(
 
       const errorMessage = formatErrorMessage(error, "Git worktree changes failed");
       if (
-        errorMessage.includes("ENOENT") ||
-        errorMessage.includes("no such file or directory") ||
-        errorMessage.includes("Unable to read current working directory") ||
-        errorMessage.includes("not a git repository")
+        // A missing git binary also arrives as a spawn ENOENT. Left to the
+        // check below it would retire every polled worktree on a machine that
+        // simply has no Git installed, so it falls through to the classified
+        // `toGitOperationError` path instead (#11764).
+        !isMissingGitExecutableError(error) &&
+        (errorMessage.includes("ENOENT") ||
+          errorMessage.includes("no such file or directory") ||
+          errorMessage.includes("Unable to read current working directory") ||
+          errorMessage.includes("not a git repository"))
       ) {
         throw new WorktreeRemovedError(cwd, error instanceof Error ? error : undefined);
       }

--- a/shared/testing/simpleGitErrorFixtures.ts
+++ b/shared/testing/simpleGitErrorFixtures.ts
@@ -1,0 +1,45 @@
+/**
+ * Error shapes captured from the installed simple-git, for tests that classify
+ * git failures.
+ *
+ * These are reproductions, not approximations. #11764 shipped green twice
+ * because its fixtures were hand-written idealizations — a single-line
+ * `"Error: spawn git ENOENT"` and a synthetic errno-bearing cause chain — that
+ * satisfied detection which could never fire against the real thing. A fixture
+ * that is easier to match than production input tests nothing.
+ */
+
+/**
+ * What simple-git 3.36.0 throws when the `git` binary isn't on PATH.
+ *
+ * Its child-process `error` handler pushes `String(err.stack)` into the stderr
+ * buffer, so Node's `SystemError` is destroyed and the whole stack trace
+ * becomes the message. The rethrown `GitError` carries no `code`, `syscall`,
+ * `errno`, or `cause` — its own properties are only `stack`, `message`, and
+ * `task`.
+ */
+export const SIMPLE_GIT_MISSING_BINARY_MESSAGE =
+  "Error: spawn git ENOENT\n" +
+  "    at ChildProcess._handle.onexit (node:internal/child_process:287:19)\n" +
+  "    at onErrorNT (node:internal/child_process:525:16)\n" +
+  "    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)";
+
+/**
+ * Build the thrown value itself. `task` is the only own property simple-git
+ * adds; `commands` defaults to the call the project-open path makes.
+ */
+export function simpleGitMissingBinaryError(
+  commands: string[] = ["rev-parse", "--show-toplevel"]
+): Error {
+  const error = new Error(SIMPLE_GIT_MISSING_BINARY_MESSAGE);
+  Object.assign(error, { task: { commands } });
+  return error;
+}
+
+/**
+ * What simple-git throws when the working directory is gone *before* it spawns
+ * anything. Distinct from a missing binary on purpose: this one never reaches
+ * spawn, so it must keep classifying as a problem with the folder.
+ */
+export const SIMPLE_GIT_MISSING_CWD_MESSAGE =
+  "Cannot use simple-git on a directory that does not exist";

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -143,6 +143,7 @@ export type GitOperationReason =
   | "lfs-missing"
   | "lfs-quota-exceeded"
   | "hook-rejected"
+  | "git-not-installed"
   | "system-io-error"
   | "unknown";
 

--- a/shared/utils/__tests__/errorMessage.test.ts
+++ b/shared/utils/__tests__/errorMessage.test.ts
@@ -180,6 +180,7 @@ describe("humanizeAppError", () => {
       "lfs-missing",
       "lfs-quota-exceeded",
       "hook-rejected",
+      "git-not-installed",
       "system-io-error",
     ];
 

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -350,6 +350,17 @@ describe("classifyGitError — missing git binary", () => {
     expect(classifyGitError(wrapped)).toBe("auth-failed");
   });
 
+  it("outranks the generic filesystem rule when a wrapper quotes its cause", () => {
+    // Wrappers that interpolate the cause's message carry "ENOENT" in their
+    // own text, which the generic system-io-error rule matches. It must not
+    // win: the actionable answer is "install Git", not "check your disk".
+    const wrapped = new Error(`Git worktree changes failed: ${SIMPLE_GIT_MISSING_BINARY_MESSAGE}`, {
+      cause: simpleGitMissingBinaryError(["status", "--porcelain"]),
+    });
+
+    expect(classifyGitError(wrapped)).toBe("git-not-installed");
+  });
+
   it("recognizes the message however the platform ended its lines", () => {
     // Git for Windows is where this failure was reported, and it is also where
     // CRLF turns up.

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -4,8 +4,14 @@ import {
   extractGitErrorMessage,
   getGitRecoveryAction,
   getGitRecoveryHint,
+  isMissingGitExecutableError,
   normalizeGitErrorMessage,
 } from "../gitOperationErrors.js";
+import {
+  SIMPLE_GIT_MISSING_BINARY_MESSAGE,
+  SIMPLE_GIT_MISSING_CWD_MESSAGE,
+  simpleGitMissingBinaryError,
+} from "../../testing/simpleGitErrorFixtures.js";
 import type { GitOperationReason } from "../../types/ipc/errors.js";
 
 describe("classifyGitError — table-driven", () => {
@@ -289,12 +295,139 @@ describe("getGitRecoveryHint", () => {
       "lfs-missing",
       "lfs-quota-exceeded",
       "hook-rejected",
+      "git-not-installed",
       "system-io-error",
     ];
     for (const reason of reasons) {
       expect(getGitRecoveryHint(reason)).toBeTruthy();
     }
     expect(getGitRecoveryHint("unknown")).toBeUndefined();
+  });
+});
+
+describe("classifyGitError — missing git binary", () => {
+  it("classifies the real simple-git failure as git-not-installed", () => {
+    // Pre-fix this fell through to the generic ENOENT rule and was reported as
+    // a filesystem problem, which sent the user looking at their disk instead
+    // of installing Git (#11764).
+    expect(classifyGitError(simpleGitMissingBinaryError())).toBe("git-not-installed");
+    expect(classifyGitError(SIMPLE_GIT_MISSING_BINARY_MESSAGE)).toBe("git-not-installed");
+  });
+
+  it("classifies it through a wrapped cause chain", () => {
+    // The patterns only ever see the outermost message, which by this point
+    // says nothing about spawning — so the guard has to read the raw value.
+    const wrapped = new Error("Git operation failed: status", {
+      cause: simpleGitMissingBinaryError(["status", "--porcelain"]),
+    });
+
+    expect(classifyGitError(wrapped)).toBe("git-not-installed");
+  });
+
+  it("still classifies an ordinary filesystem ENOENT as system-io-error", () => {
+    // The carve-out must not swallow the generic case it was added in front of.
+    expect(classifyGitError("ENOENT: no such file or directory, open '/path/to/file'")).toBe(
+      "system-io-error"
+    );
+    expect(classifyGitError(SIMPLE_GIT_MISSING_CWD_MESSAGE)).not.toBe("git-not-installed");
+  });
+
+  it("leaves a classifiable git failure alone when the phrase is only quoted", () => {
+    const message = `fatal: detected dubious ownership in repository at '/repos/spawn git ENOENT'`;
+
+    expect(classifyGitError(message)).toBe("dubious-ownership");
+  });
+});
+
+describe("isMissingGitExecutableError", () => {
+  it("recognizes what simple-git actually throws for a missing git binary", () => {
+    expect(isMissingGitExecutableError(simpleGitMissingBinaryError())).toBe(true);
+  });
+
+  it("recognizes a raw Node spawn error, whose message carries no stack", () => {
+    // Nothing laundered it, so both signals are intact and either should do.
+    const raw = Object.assign(new Error("spawn git ENOENT"), {
+      code: "ENOENT",
+      syscall: "spawn git",
+    });
+
+    expect(isMissingGitExecutableError(raw)).toBe(true);
+    expect(isMissingGitExecutableError(new Error("spawn git ENOENT"))).toBe(true);
+    expect(isMissingGitExecutableError(Object.assign(new Error("opaque"), raw))).toBe(true);
+  });
+
+  it("finds it through the wrapping GitService applies", () => {
+    // handleGitOperation rewraps failures and keeps the original as `cause`;
+    // detection has to survive that or the reported bug reappears.
+    const wrapped = new Error("Worktree directory no longer exists", {
+      cause: new Error("Git operation failed: getRepositoryRoot", {
+        cause: simpleGitMissingBinaryError(),
+      }),
+    });
+
+    expect(isMissingGitExecutableError(wrapped)).toBe(true);
+  });
+
+  it("ignores a spawn failure of some other binary", () => {
+    // `createWslHardenedGit` spawns `wsl.exe git` — a missing WSL launcher is
+    // not a missing Git, and telling the user to install Git wouldn't help.
+    for (const binary of ["node", "wsl.exe", "git-lfs"]) {
+      const message = SIMPLE_GIT_MISSING_BINARY_MESSAGE.replace("spawn git", `spawn ${binary}`);
+      expect(isMissingGitExecutableError(new Error(message))).toBe(false);
+      expect(
+        isMissingGitExecutableError(
+          Object.assign(new Error(message), { code: "ENOENT", syscall: `spawn ${binary}` })
+        )
+      ).toBe(false);
+    }
+  });
+
+  it("ignores the phrase when it is quoted inside a larger message", () => {
+    // Anchoring is what separates these from the real thing. A repository path
+    // and a hook's own child-process failure both put the exact spawn line in
+    // git's output without Git itself being missing.
+    const quotedPath = new Error(
+      "fatal: detected dubious ownership in repository at '/repos/spawn git ENOENT'"
+    );
+    const hookOutput = new Error(
+      `hook failed:\n${SIMPLE_GIT_MISSING_BINARY_MESSAGE}\nfatal: the remote end hung up`
+    );
+    const ownLineInStderr = new Error(`remote: spawn git ENOENT\nfatal: push declined`);
+
+    expect(isMissingGitExecutableError(quotedPath)).toBe(false);
+    expect(isMissingGitExecutableError(hookOutput)).toBe(false);
+    expect(isMissingGitExecutableError(ownLineInStderr)).toBe(false);
+  });
+
+  it("does not mistake a missing directory for a missing binary", () => {
+    // simple-git never reaches spawn when the cwd is already gone, so this
+    // stays a problem with the folder.
+    expect(isMissingGitExecutableError(new Error(SIMPLE_GIT_MISSING_CWD_MESSAGE))).toBe(false);
+    expect(
+      isMissingGitExecutableError(
+        Object.assign(new Error("ENOENT: no such file or directory, stat '/gone'"), {
+          code: "ENOENT",
+          syscall: "stat",
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("survives a cause chain that loops", () => {
+    const a = new Error("a") as Error & { cause?: unknown };
+    const b = new Error("b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+
+    expect(isMissingGitExecutableError(a)).toBe(false);
+  });
+
+  it("handles values that are not errors", () => {
+    expect(isMissingGitExecutableError(undefined)).toBe(false);
+    expect(isMissingGitExecutableError(null)).toBe(false);
+    expect(isMissingGitExecutableError("ENOENT")).toBe(false);
+    // classifyGitError accepts bare strings, so the predicate has to too.
+    expect(isMissingGitExecutableError(SIMPLE_GIT_MISSING_BINARY_MESSAGE)).toBe(true);
   });
 });
 

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -337,6 +337,30 @@ describe("classifyGitError — missing git binary", () => {
 
     expect(classifyGitError(message)).toBe("dubious-ownership");
   });
+
+  it("lets a classified top-level failure outrank a missing-git ancestor", () => {
+    // A wrapper that says nothing specific should defer to its cause, but one
+    // that reports a real failure of its own must win — otherwise any error
+    // that happened to be wrapped around a spawn ENOENT would be reported as
+    // "Git isn't installed" and its actual cause never surfaced.
+    const wrapped = new Error("Authentication failed for 'https://github.com/org/repo.git/'", {
+      cause: simpleGitMissingBinaryError(),
+    });
+
+    expect(classifyGitError(wrapped)).toBe("auth-failed");
+  });
+
+  it("recognizes the message however the platform ended its lines", () => {
+    // Git for Windows is where this failure was reported, and it is also where
+    // CRLF turns up.
+    const crlf = SIMPLE_GIT_MISSING_BINARY_MESSAGE.replace(/\n/g, "\r\n");
+
+    expect(classifyGitError(new Error(crlf))).toBe("git-not-installed");
+    expect(classifyGitError(new Error(`${SIMPLE_GIT_MISSING_BINARY_MESSAGE}\n`))).toBe(
+      "git-not-installed"
+    );
+    expect(classifyGitError(new Error(`${crlf}\r\n`))).toBe("git-not-installed");
+  });
 });
 
 describe("isMissingGitExecutableError", () => {
@@ -426,8 +450,14 @@ describe("isMissingGitExecutableError", () => {
     expect(isMissingGitExecutableError(undefined)).toBe(false);
     expect(isMissingGitExecutableError(null)).toBe(false);
     expect(isMissingGitExecutableError("ENOENT")).toBe(false);
-    // classifyGitError accepts bare strings, so the predicate has to too.
+    // classifyGitError accepts bare strings, so the predicate has to too —
+    // including one reached partway down a cause chain.
     expect(isMissingGitExecutableError(SIMPLE_GIT_MISSING_BINARY_MESSAGE)).toBe(true);
+    expect(
+      isMissingGitExecutableError(
+        new Error("wrapped", { cause: SIMPLE_GIT_MISSING_BINARY_MESSAGE })
+      )
+    ).toBe(true);
   });
 });
 

--- a/shared/utils/errorMessage.ts
+++ b/shared/utils/errorMessage.ts
@@ -86,6 +86,7 @@ const GIT_REASON_TITLES = {
   "lfs-missing": "Git LFS object missing",
   "lfs-quota-exceeded": "Git LFS quota exceeded",
   "hook-rejected": "Push rejected by server hook",
+  "git-not-installed": "Couldn't find Git",
   "system-io-error": "Git filesystem error",
   unknown: ERROR_TYPE_FALLBACKS.git.title,
 } as const satisfies Record<GitOperationReason, string>;

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -121,11 +121,17 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
     // upstream to rebase onto (#11746).
     /fatal: unable to read config file|fatal: bad config|fatal: The current branch .* has no upstream branch|fatal: no upstream configured for branch|fatal: no push destination configured for branch|fatal: could not resolve the (?:push destination|upstream) for branch|fatal: the remote configured for branch .* has an unusable name/i,
   ],
-  [
-    "system-io-error",
-    /ENOENT|EACCES|EPERM|EBUSY|Disk full|No space left on device|could not create work tree dir/i,
-  ],
 ];
+
+/**
+ * The generic filesystem/permissions catch-all, deliberately kept OUT of
+ * `PATTERNS`: it has to run after the missing-git cause walk, not with the
+ * specific rules. A spawn ENOENT matches it too, so any wrapper that quotes its
+ * cause's message would be bucketed as a disk problem before the walk ever got
+ * to identify it as a missing binary.
+ */
+const SYSTEM_IO_PATTERN =
+  /ENOENT|EACCES|EPERM|EBUSY|Disk full|No space left on device|could not create work tree dir/i;
 
 /**
  * The spawn failure Node reports when the `git` binary isn't on PATH.
@@ -210,7 +216,13 @@ export function classifyGitError(error: unknown): GitOperationReason {
   // its own message — "Git operation failed: <context>" — matches nothing. But
   // an ancestor must not outrank a top-level failure that did classify:
   // "Authentication failed" wrapping a spawn ENOENT is an auth failure.
+  //
+  // Still ahead of the generic rule below, which a spawn ENOENT also matches:
+  // a wrapper that quotes its cause's message would otherwise be reported as a
+  // disk problem.
   if (isMissingGitExecutableError(error)) return "git-not-installed";
+
+  if (normalized && SYSTEM_IO_PATTERN.test(normalized)) return "system-io-error";
 
   return "unknown";
 }

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -166,19 +166,24 @@ const GIT_SPAWN_ENOENT_PATTERN = /^(?:Error: )?spawn git ENOENT(?:\r?\n[ \t]+at 
  * This is deliberately *not* a general "some executable is missing" predicate:
  * callers act on it by telling the user to install Git.
  */
+/** Missing-git evidence carried by one value, ignoring anything it wraps. */
+function showsMissingGitDirectly(value: unknown): boolean {
+  if (typeof value === "string") return GIT_SPAWN_ENOENT_PATTERN.test(value);
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as { code?: unknown; syscall?: unknown; message?: unknown };
+  if (candidate.code === "ENOENT" && candidate.syscall === "spawn git") return true;
+  return typeof candidate.message === "string" && GIT_SPAWN_ENOENT_PATTERN.test(candidate.message);
+}
+
 export function isMissingGitExecutableError(error: unknown): boolean {
   const seen = new Set<unknown>();
   let current: unknown = error;
 
-  if (typeof current === "string") return GIT_SPAWN_ENOENT_PATTERN.test(current);
-
-  while (current && typeof current === "object" && !seen.has(current)) {
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    if (showsMissingGitDirectly(current)) return true;
+    if (typeof current !== "object") return false;
     seen.add(current);
-    const candidate = current as { code?: unknown; syscall?: unknown; message?: unknown };
-    if (candidate.code === "ENOENT" && candidate.syscall === "spawn git") return true;
-    if (typeof candidate.message === "string" && GIT_SPAWN_ENOENT_PATTERN.test(candidate.message)) {
-      return true;
-    }
     current = (current as { cause?: unknown }).cause;
   }
 
@@ -186,19 +191,27 @@ export function isMissingGitExecutableError(error: unknown): boolean {
 }
 
 export function classifyGitError(error: unknown): GitOperationReason {
-  // Runs ahead of the PATTERNS pipeline, and against the *raw* value rather
-  // than the normalized message: a missing binary can only be recognized from
-  // structured errno fields or a cause chain, neither of which survives into
-  // the string the patterns match. Left to fall through, it would reach the
-  // generic `system-io-error` rule and be reported as a filesystem problem.
-  if (isMissingGitExecutableError(error)) return "git-not-installed";
+  // The error's own evidence outranks everything: structured errno fields and
+  // simple-git's laundered stack trace don't survive into the string PATTERNS
+  // matches, so without this the failure reaches the generic `system-io-error`
+  // rule and is reported as a filesystem problem.
+  if (showsMissingGitDirectly(error)) return "git-not-installed";
 
   const raw = extractGitErrorMessage(error);
-  if (!raw) return "unknown";
-  const normalized = normalizeGitErrorMessage(raw);
-  for (const [reason, pattern] of PATTERNS) {
-    if (pattern.test(normalized)) return reason;
+  const normalized = raw ? normalizeGitErrorMessage(raw) : "";
+  if (normalized) {
+    for (const [reason, pattern] of PATTERNS) {
+      if (pattern.test(normalized)) return reason;
+    }
   }
+
+  // Only once the error's own message has said nothing specific. A wrapper
+  // preserves the original as `cause` (`GitService.handleGitOperation`), and
+  // its own message — "Git operation failed: <context>" — matches nothing. But
+  // an ancestor must not outrank a top-level failure that did classify:
+  // "Authentication failed" wrapping a spawn ENOENT is an auth failure.
+  if (isMissingGitExecutableError(error)) return "git-not-installed";
+
   return "unknown";
 }
 

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -127,7 +127,72 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
   ],
 ];
 
+/**
+ * The spawn failure Node reports when the `git` binary isn't on PATH.
+ *
+ * simple-git 3.36.0 destroys the provenance: its child-process `error` handler
+ * pushes `String(err.stack)` into the stderr buffer and rethrows a bare
+ * `GitError` whose own properties are only `stack`, `message`, and `task` — no
+ * `code`, no `syscall`, no `cause`. So the message arrives as a whole Node
+ * stack trace (`Error: spawn git ENOENT\n    at ChildProcess...`), not the
+ * one-line `spawn git ENOENT` the raw `SystemError` carries.
+ *
+ * Both forms are accepted, and the pattern is anchored to the *entire* message
+ * so that neither can be forged by content quoted inside a larger one. That
+ * matters: git stderr legitimately quotes arbitrary text (a repository path
+ * like `/repos/spawn git ENOENT`), and a hook or filter that shells out can
+ * print its own child's spawn failure. Matching such a line anywhere in the
+ * message — which is all a bare `m` flag would buy — would report "Git isn't
+ * installed" for a repo that merely has an unlucky path.
+ *
+ * The binary is pinned to `git` on purpose. `createWslHardenedGit` spawns
+ * `wsl.exe git`, so a missing WSL launcher must not be reported as a missing
+ * Git. Re-check on simple-git upgrade.
+ */
+const GIT_SPAWN_ENOENT_PATTERN = /^(?:Error: )?spawn git ENOENT(?:\r?\n[ \t]+at [^\r\n]*)*\r?\n?$/;
+
+/**
+ * True when `error` is a failed *spawn* of the `git` binary — i.e. Git isn't
+ * installed, or isn't on PATH.
+ *
+ * Walks `.cause` chains because the error is routinely rewrapped before it
+ * reaches a classifier (`GitService.handleGitOperation` turns it into a
+ * `WorktreeRemovedError` whose `.cause` is the original).
+ *
+ * Both a structured check and a message check are needed. The structured one
+ * never fires for simple-git's laundered error, and the message one would miss
+ * a raw Node error arriving from somewhere that doesn't launder it.
+ *
+ * This is deliberately *not* a general "some executable is missing" predicate:
+ * callers act on it by telling the user to install Git.
+ */
+export function isMissingGitExecutableError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  if (typeof current === "string") return GIT_SPAWN_ENOENT_PATTERN.test(current);
+
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const candidate = current as { code?: unknown; syscall?: unknown; message?: unknown };
+    if (candidate.code === "ENOENT" && candidate.syscall === "spawn git") return true;
+    if (typeof candidate.message === "string" && GIT_SPAWN_ENOENT_PATTERN.test(candidate.message)) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return false;
+}
+
 export function classifyGitError(error: unknown): GitOperationReason {
+  // Runs ahead of the PATTERNS pipeline, and against the *raw* value rather
+  // than the normalized message: a missing binary can only be recognized from
+  // structured errno fields or a cause chain, neither of which survives into
+  // the string the patterns match. Left to fall through, it would reach the
+  // generic `system-io-error` rule and be reported as a filesystem problem.
+  if (isMissingGitExecutableError(error)) return "git-not-installed";
+
   const raw = extractGitErrorMessage(error);
   if (!raw) return "unknown";
   const normalized = normalizeGitErrorMessage(raw);
@@ -161,6 +226,7 @@ const RECOVERY_HINTS: Record<GitOperationReason, string | undefined> = {
   "lfs-quota-exceeded":
     "This repository has exceeded its Git LFS storage or bandwidth quota. Contact the repo owner or upgrade the plan.",
   "hook-rejected": "A server-side hook rejected the push. See the server output for details.",
+  "git-not-installed": "Daintree couldn't run Git. Install Git and make sure it's on your PATH.",
   "system-io-error": "A filesystem or permissions problem prevented the git operation.",
   unknown: undefined,
 };

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -83,6 +83,12 @@ export const PUSH_BANNER_CONFIGS: Record<GitOperationReason, PushBannerConfig> =
     detailPolicy: "hide",
     cta: { kind: "retry", label: "Retry" },
   },
+  "git-not-installed": {
+    message: getGitRecoveryHint("git-not-installed") ?? "Daintree couldn't run Git.",
+    // No retry CTA: the push can't succeed until Git is installed, and the
+    // raw detail is a Node stack trace with nothing for the user in it.
+    detailPolicy: "hide",
+  },
   "push-rejected-outdated": {
     message:
       getGitRecoveryHint("push-rejected-outdated") ??


### PR DESCRIPTION
## Summary
- When Git isn't on PATH, Node throws `spawn git ENOENT`, but simple-git 3.36.0 launders that error: its child-process handler pushes `String(err.stack)` into the stderr buffer and rethrows a bare `GitError` with only `stack`, `message`, and `task` as its own properties. No `code`, no `syscall`, no `cause`. So the error that arrives is a full Node stack trace, not the one-line `spawn git ENOENT` everyone assumed it would be.
- Four independent call sites each misread that, so users saw "Couldn't open folder" and had healthy worktrees retired on machines whose only real problem was that Git wasn't installed. The correct "Couldn't find Git" copy already existed and was already wired up; the classification just never reached it.
- Fixes the classification with one predicate, `isMissingGitExecutableError` in `shared/utils/gitOperationErrors.ts`, consumed by all four sites.

Resolves #11764

## Changes
- `classifyGitError` gets a new `git-not-installed` `GitOperationReason` (previously a spawn ENOENT fell through to the generic `system-io-error` rule and was reported as a filesystem or permissions problem).
- `GitService.handleGitOperation` and `getWorktreeChangesWithStats` check it before their `ENOENT` branches, which used to conclude the worktree had been deleted.
- `projectOpenPreflight`'s own detection was dead code: its regex `/^(?:Error: )?spawn [^\r\n]+ ENOENT$/` had no `m` flag, so `$` anchored to end-of-string and could never match a stack trace. Replaced with a re-export of the shared predicate.
- Classification now runs in explicit tiers: the error's own evidence, then specific patterns, then the missing-git cause walk, then the generic filesystem catch-all. That ordering cuts both ways: an "Authentication failed" error that happens to wrap a spawn ENOENT is still an auth failure, and a wrapper that quotes its cause's message is still a missing Git rather than a disk problem.
- The pattern is anchored to the whole message and the binary is pinned to `git`, so a repo path like `/repos/spawn git ENOENT`, a hook printing its own child's spawn failure, and a missing `wsl.exe` launcher (`createWslHardenedGit` spawns `wsl.exe git`) all correctly do not classify as a missing Git.

## Testing
This bug shipped green twice before, both times because the fixtures were idealized: a single-line `"Error: spawn git ENOENT"` string under a docstring claiming it reproduced simple-git faithfully, and errno-bearing fixtures that only ever exercised a structured code path that can't fire in production. The real captured error now lives in `shared/testing/simpleGitErrorFixtures.ts`, and every regression test is built from it. 408 targeted tests pass, covering CRLF and trailing-newline forms, cause-chain traversal through both wrapper types, and the adversarial negatives above.

Not fixed here, worth a follow-up issue: both catch blocks still derive worktree removal from arbitrary `ENOENT` substrings, so a missing `wsl.exe` or an unlucky repository path can still retire a healthy worktree. This change narrows that blast radius but doesn't close it; closing it properly needs structured filesystem revalidation before declaring a worktree gone, a separate change. Related: #11763 covers the startup prerequisite check and explicitly scoped this classification fix out of itself.
