### PR TITLE
fix(window): match the Windows caption strip to the global banner

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -26,6 +26,7 @@ const registerMocks = vi.hoisted(() => ({
   registerSlashCommandHandlers: vi.fn(),
   registerSystemShellHandlers: vi.fn(),
   registerEditorConfigHandlers: vi.fn(),
+  registerWindowChromeHandlers: vi.fn(),
   registerPaintFabricSurfaceHandlers: vi.fn(),
   registerAgentCliHandlers: vi.fn(),
   registerProjectCrudHandlers: vi.fn(),
@@ -111,6 +112,9 @@ vi.mock("../handlers/systemShell.js", () => ({
 }));
 vi.mock("../handlers/editorConfig.js", () => ({
   registerEditorConfigHandlers: registerMocks.registerEditorConfigHandlers,
+}));
+vi.mock("../handlers/windowChrome.js", () => ({
+  registerWindowChromeHandlers: registerMocks.registerWindowChromeHandlers,
 }));
 vi.mock("../handlers/paintFabricSurface.js", () => ({
   registerPaintFabricSurfaceHandlers: registerMocks.registerPaintFabricSurfaceHandlers,

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -562,6 +562,8 @@ export const CHANNELS = {
   APP_THEME_SET_ACCENT_COLOR_OVERRIDE: "app-theme:set-accent-color-override",
   APP_THEME_SYSTEM_APPEARANCE_CHANGED: "app-theme:system-appearance-changed",
 
+  WINDOW_CHROME_SET_BANNER_SEVERITY: "window-chrome:set-banner-severity",
+
   TELEMETRY_GET: "telemetry:get",
   TELEMETRY_SET_ENABLED: "telemetry:set-enabled",
   TELEMETRY_MARK_PROMPT_SHOWN: "telemetry:mark-prompt-shown",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -5,6 +5,7 @@ import { registerCopyTreeHandlers } from "./handlers/copyTree.js";
 import { registerAiHandlers } from "./handlers/ai.js";
 import { registerSystemShellHandlers } from "./handlers/systemShell.js";
 import { registerEditorConfigHandlers } from "./handlers/editorConfig.js";
+import { registerWindowChromeHandlers } from "./handlers/windowChrome.js";
 import { registerPaintFabricSurfaceHandlers } from "./handlers/paintFabricSurface.js";
 import { registerAgentCliHandlers } from "./handlers/agentCli.js";
 import { registerProjectCrudHandlers } from "./handlers/projectCrud/index.js";
@@ -137,6 +138,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerSlashCommandHandlers());
     register(() => registerSystemShellHandlers(deps));
     register(() => registerEditorConfigHandlers(deps));
+    register(() => registerWindowChromeHandlers(deps));
     register(() => registerPaintFabricSurfaceHandlers(deps));
     register(() => registerAgentCliHandlers(deps));
     register(() => registerProjectCrudHandlers(deps));

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -141,7 +141,10 @@ import { ipcMain, dialog, BrowserWindow } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerAppThemeHandlers } from "../appTheme.js";
 import { typedSend } from "../../utils.js";
-import { setTitleBarOverlayBannerSeverity } from "../../../window/titleBarOverlay.js";
+import {
+  seedTitleBarOverlay,
+  setTitleBarOverlayBannerSeverity,
+} from "../../../window/titleBarOverlay.js";
 import {
   WINDOWS_CAPTION_SYMBOL_COLOR,
   WINDOWS_TITLEBAR_HEIGHT_PX,
@@ -548,8 +551,15 @@ describe("appTheme handlers", () => {
 
       registerAppThemeHandlers(mockWindow as never);
 
+      // Match production: the window is seeded at creation, so the banner
+      // report below is a real repaint rather than the first paint.
+      seedTitleBarOverlay(mockWindow as never, {
+        "surface-canvas": "#0b0b16",
+        "status-warning": "#f0b429",
+      });
       // A global banner owns the caption band before the theme changes.
       setTitleBarOverlayBannerSeverity(mockWindow as never, "warning");
+      expect(mockWindow.setTitleBarOverlay).toHaveBeenCalled();
       mockWindow.setTitleBarOverlay.mockClear();
 
       getNativeThemeHandler()();

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -76,7 +76,15 @@ vi.mock("../../../utils/appThemeImporter.js", () => ({
 vi.mock("../../../../shared/theme/index.js", () => ({
   resolveAppTheme: vi.fn((id: string) => ({
     id,
-    tokens: { "surface-canvas": "#1a1a2e" },
+    // Status tokens are present so the banner-tint path (#11766) has something
+    // to blend; without them every severity would fall back to the canvas.
+    tokens: {
+      "surface-canvas": "#1a1a2e",
+      "status-warning": "#f0b429",
+      "status-danger": "#e5484d",
+      "status-info": "#0091ff",
+      "status-success": "#30a46c",
+    },
   })),
   normalizeAppColorScheme: vi.fn((s: unknown) => s),
   normalizeAccentHex: vi.fn((value: unknown): string | null => {
@@ -133,6 +141,11 @@ import { ipcMain, dialog, BrowserWindow } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerAppThemeHandlers } from "../appTheme.js";
 import { typedSend } from "../../utils.js";
+import { setTitleBarOverlayBannerSeverity } from "../../../window/titleBarOverlay.js";
+import {
+  WINDOWS_CAPTION_SYMBOL_COLOR,
+  WINDOWS_TITLEBAR_HEIGHT_PX,
+} from "../../../../shared/config/windowChrome.js";
 
 type Handler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
 
@@ -491,7 +504,7 @@ describe("appTheme handlers", () => {
     expect(mockWindow.setBackgroundColor).not.toHaveBeenCalled();
   });
 
-  it("nativeTheme updated re-applies Windows titleBarOverlay at 48px height — issue #7951", () => {
+  it("nativeTheme updated re-applies the Windows titleBarOverlay — issue #7951", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
     try {
@@ -509,11 +522,44 @@ describe("appTheme handlers", () => {
       themeHandler();
       vi.advanceTimersByTime(300);
 
-      expect(mockWindow.setTitleBarOverlay).toHaveBeenCalledWith({
-        color: "#1a1a2e",
-        symbolColor: "#a1a1aa",
-        height: 48,
-      });
+      // The overlay must land on the same colour the window background just
+      // took, at the shared caption height.
+      const [applied] = mockWindow.setTitleBarOverlay.mock.calls.at(-1)!;
+      const [background] = mockWindow.setBackgroundColor.mock.calls.at(-1)!;
+      expect(applied.color).toBe(background);
+      expect(applied.height).toBe(WINDOWS_TITLEBAR_HEIGHT_PX);
+      expect(applied.symbolColor).toBe(WINDOWS_CAPTION_SYMBOL_COLOR);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("nativeTheme updated keeps a live banner's tint instead of reverting to canvas — issue #11766", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      const mockWindow = {
+        isDestroyed: () => false,
+        setBackgroundColor: vi.fn(),
+        setTitleBarOverlay: vi.fn(),
+      };
+      storeState.data.appTheme = { colorSchemeId: "daintree", followSystem: true };
+      nativeThemeMock.shouldUseDarkColors = true;
+
+      registerAppThemeHandlers(mockWindow as never);
+
+      // A global banner owns the caption band before the theme changes.
+      setTitleBarOverlayBannerSeverity(mockWindow as never, "warning");
+      mockWindow.setTitleBarOverlay.mockClear();
+
+      getNativeThemeHandler()();
+      vi.advanceTimersByTime(300);
+
+      const [applied] = mockWindow.setTitleBarOverlay.mock.calls.at(-1)!;
+      const [background] = mockWindow.setBackgroundColor.mock.calls.at(-1)!;
+      // Theme and banner are two writers over one native surface; the theme
+      // handler must re-tint rather than clobber the banner back to canvas.
+      expect(applied.color).not.toBe(background);
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     }

--- a/electron/ipc/handlers/__tests__/windowChrome.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/windowChrome.handlers.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ipcHandlers = vi.hoisted(() => new Map<string, unknown>());
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn((channel: string, fn: unknown) => ipcHandlers.set(channel, fn)),
+  removeHandler: vi.fn((channel: string) => ipcHandlers.delete(channel)),
+}));
+
+const registryMock = vi.hoisted(() => ({
+  getWindowForWebContents: vi.fn(),
+  getProjectForWebContents: vi.fn(() => null),
+  getAppWebContents: vi.fn(),
+  getAllAppWebContents: vi.fn(() => []),
+  getWebContentsForProject: vi.fn(),
+  hasRegisteredProjectViews: vi.fn(() => false),
+  isCachedViewWebContents: vi.fn(() => false),
+}));
+
+const overlayMock = vi.hoisted(() => ({ setTitleBarOverlayBannerSeverity: vi.fn() }));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock, BrowserWindow: class {} }));
+vi.mock("../../../window/webContentsRegistry.js", () => registryMock);
+vi.mock("../../../window/titleBarOverlay.js", () => overlayMock);
+
+import { registerWindowChromeHandlers } from "../windowChrome.js";
+import { WINDOW_CHROME_METHOD_CHANNELS } from "../windowChrome.preload.js";
+import type { HandlerDependencies } from "../../types.js";
+
+type Handler = (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+
+function getHandler(): Handler {
+  const fn = ipcHandlers.get(WINDOW_CHROME_METHOD_CHANNELS.setBannerSeverity);
+  if (!fn) throw new Error("windowChrome.setBannerSeverity handler not registered");
+  return fn as Handler;
+}
+
+function makeWindow(destroyed = false) {
+  return { isDestroyed: () => destroyed };
+}
+
+function eventFrom(id = 1): Electron.IpcMainInvokeEvent {
+  return { sender: { id } as Electron.WebContents } as Electron.IpcMainInvokeEvent;
+}
+
+/**
+ * Issue #11766. A renderer report may only recolour the chrome of the window it
+ * came from, and only for severities the banner scale actually defines.
+ */
+describe("windowChrome IPC", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    vi.clearAllMocks();
+    registryMock.getWindowForWebContents.mockReturnValue(makeWindow());
+    cleanup = registerWindowChromeHandlers({} as HandlerDependencies);
+  });
+
+  afterEach(() => cleanup());
+
+  it("forwards a severity to the sender's own window", async () => {
+    const win = makeWindow();
+    registryMock.getWindowForWebContents.mockReturnValue(win);
+
+    await getHandler()(eventFrom(), { severity: "warning" });
+
+    expect(overlayMock.setTitleBarOverlayBannerSeverity).toHaveBeenCalledWith(win, "warning");
+  });
+
+  it("forwards a null severity when the banner leaves the band", async () => {
+    await getHandler()(eventFrom(), { severity: null });
+
+    expect(overlayMock.setTitleBarOverlayBannerSeverity).toHaveBeenCalledWith(
+      expect.anything(),
+      null
+    );
+  });
+
+  it("routes each sender to its own window, never a sibling's", async () => {
+    const first = makeWindow();
+    const second = makeWindow();
+
+    registryMock.getWindowForWebContents.mockReturnValueOnce(first);
+    await getHandler()(eventFrom(1), { severity: "error" });
+    registryMock.getWindowForWebContents.mockReturnValueOnce(second);
+    await getHandler()(eventFrom(2), { severity: "info" });
+
+    expect(overlayMock.setTitleBarOverlayBannerSeverity).toHaveBeenNthCalledWith(1, first, "error");
+    expect(overlayMock.setTitleBarOverlayBannerSeverity).toHaveBeenNthCalledWith(2, second, "info");
+  });
+
+  it("ignores a report whose sender has no resolvable window", async () => {
+    registryMock.getWindowForWebContents.mockReturnValue(null);
+
+    await getHandler()(eventFrom(), { severity: "warning" });
+
+    expect(overlayMock.setTitleBarOverlayBannerSeverity).not.toHaveBeenCalled();
+  });
+
+  it("ignores a report arriving after its window was destroyed", async () => {
+    registryMock.getWindowForWebContents.mockReturnValue(makeWindow(true));
+
+    await getHandler()(eventFrom(), { severity: "warning" });
+
+    expect(overlayMock.setTitleBarOverlayBannerSeverity).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["an unknown severity", { severity: "catastrophic" }],
+    ["a non-string severity", { severity: 3 }],
+    ["a missing severity key", {}],
+    ["a bare string instead of a payload", "warning"],
+    ["no payload at all", undefined],
+  ])("rejects %s without touching the native overlay", async (_label, payload) => {
+    await expect(getHandler()(eventFrom(), payload)).rejects.toThrow();
+
+    expect(overlayMock.setTitleBarOverlayBannerSeverity).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/__tests__/windowChrome.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/windowChrome.handlers.test.ts
@@ -53,6 +53,7 @@ describe("windowChrome IPC", () => {
     ipcHandlers.clear();
     vi.clearAllMocks();
     registryMock.getWindowForWebContents.mockReturnValue(makeWindow());
+    registryMock.isCachedViewWebContents.mockReturnValue(false);
     cleanup = registerWindowChromeHandlers({} as HandlerDependencies);
   });
 
@@ -87,6 +88,17 @@ describe("windowChrome IPC", () => {
 
     expect(overlayMock.setTitleBarOverlayBannerSeverity).toHaveBeenNthCalledWith(1, first, "error");
     expect(overlayMock.setTitleBarOverlayBannerSeverity).toHaveBeenNthCalledWith(2, second, "info");
+  });
+
+  it("ignores a report from a cached, off-screen project view", async () => {
+    // A window holds several WebContentsViews at once and only one is on
+    // screen. The banner stores are project-scoped, so letting a hidden view
+    // report would recolour the chrome of the project the user is looking at.
+    registryMock.isCachedViewWebContents.mockReturnValue(true);
+
+    await getHandler()(eventFrom(), { severity: "warning" });
+
+    expect(overlayMock.setTitleBarOverlayBannerSeverity).not.toHaveBeenCalled();
   });
 
   it("ignores a report whose sender has no resolvable window", async () => {

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -75,6 +75,21 @@ function getAppThemeConfig(): AppThemeConfig {
 export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void {
   const handlers: Array<() => void> = [];
 
+  /**
+   * Push the freshly-persisted scheme at every window's caption strip.
+   * Picking a theme in settings only writes the store — without this the
+   * native strip keeps the previous theme's colours until an OS appearance
+   * change happens to reapply them (#11766).
+   */
+  const refreshTitleBarOverlayTheme = () => {
+    if (process.platform !== "win32") return;
+    const config = getAppThemeConfig();
+    const scheme = resolveAppTheme(config.colorSchemeId, config.customSchemes ?? []);
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) setTitleBarOverlayTheme(win, scheme.tokens);
+    }
+  };
+
   handlers.push(typedHandle(CHANNELS.APP_THEME_GET, async () => getAppThemeConfig()));
 
   handlers.push(
@@ -84,6 +99,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
         return;
       }
       store.set("appTheme.colorSchemeId", schemeId.trim());
+      refreshTitleBarOverlayTheme();
     })
   );
 
@@ -95,6 +111,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
         return;
       }
       store.set("appTheme.customSchemes", result.data as AppColorScheme[]);
+      refreshTitleBarOverlayTheme();
     })
   );
 

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -6,6 +6,7 @@ import { store } from "../../store.js";
 import { parseAppThemeFile } from "../../utils/appThemeImporter.js";
 import { resolveAppTheme, normalizeAccentHex } from "../../../shared/theme/index.js";
 import { typedHandle, typedHandleWithContext, typedSend } from "../utils.js";
+import { setTitleBarOverlayTheme } from "../../window/titleBarOverlay.js";
 import {
   appCustomSchemesReadSchema,
   appCustomSchemesWriteSchema,
@@ -246,13 +247,10 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
       const scheme = resolveAppTheme(schemeId, customSchemes);
       win.setBackgroundColor(scheme.tokens["surface-canvas"]);
 
-      if (process.platform === "win32") {
-        win.setTitleBarOverlay({
-          color: scheme.tokens["surface-canvas"],
-          symbolColor: "#a1a1aa",
-          height: 48,
-        });
-      }
+      // Hand the new tokens to the overlay owner rather than writing the native
+      // strip here: it re-tints in place when a global banner currently holds
+      // the caption band, instead of reverting it to bare canvas (#11766).
+      setTitleBarOverlayTheme(win, scheme.tokens);
     }, 300);
   };
 

--- a/electron/ipc/handlers/windowChrome.preload.ts
+++ b/electron/ipc/handlers/windowChrome.preload.ts
@@ -1,0 +1,24 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const WINDOW_CHROME_METHOD_CHANNELS = {
+  setBannerSeverity: "window-chrome:set-banner-severity",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof WINDOW_CHROME_METHOD_CHANNELS;
+
+export type WindowChromePreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildWindowChromePreloadBindings(invoke: Invoker): WindowChromePreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(WINDOW_CHROME_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = WINDOW_CHROME_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as WindowChromePreloadBindings;
+}

--- a/electron/ipc/handlers/windowChrome.preload.ts
+++ b/electron/ipc/handlers/windowChrome.preload.ts
@@ -1,5 +1,8 @@
 import type { IpcInvokeMap } from "../../types/index.js";
 
+// Literal channel names, matching every other namespace: the renderer-API
+// generator reads this object from source and cannot resolve an identifier.
+// `channelDrift.test.ts` holds these against the CHANNELS registry.
 export const WINDOW_CHROME_METHOD_CHANNELS = {
   setBannerSeverity: "window-chrome:set-banner-severity",
 } as const satisfies Record<string, keyof IpcInvokeMap>;

--- a/electron/ipc/handlers/windowChrome.ts
+++ b/electron/ipc/handlers/windowChrome.ts
@@ -3,6 +3,7 @@ import type { HandlerDependencies, IpcContext } from "../types.js";
 import { defineIpcNamespace, opValidated } from "../define.js";
 import { WINDOW_CHROME_METHOD_CHANNELS } from "./windowChrome.preload.js";
 import { setTitleBarOverlayBannerSeverity } from "../../window/titleBarOverlay.js";
+import { isCachedViewWebContents } from "../../window/webContentsRegistry.js";
 import { BANNER_SEVERITIES } from "../../../shared/config/windowChrome.js";
 
 /**
@@ -11,6 +12,13 @@ import { BANNER_SEVERITIES } from "../../../shared/config/windowChrome.js";
  *
  * Scoped to the sender's own window: a report can only recolour the chrome of
  * the window it came from, never a sibling's.
+ *
+ * Reports from cached project views are dropped. A window can hold several
+ * WebContentsViews at once and only one is on screen; the others stay mounted
+ * with their own store instances, and the banner states are project-scoped
+ * (`useCloudSyncBannerStore` in particular), so an off-screen view raising or
+ * clearing its own banner would otherwise recolour the chrome of the project
+ * the user is actually looking at.
  */
 const bannerSeveritySchema = z.object({
   severity: z.enum(BANNER_SEVERITIES).nullable(),
@@ -25,6 +33,7 @@ export const windowChromeNamespace = defineIpcNamespace({
       async (ctx: IpcContext, payload: z.infer<typeof bannerSeveritySchema>) => {
         const win = ctx.senderWindow;
         if (!win || win.isDestroyed()) return;
+        if (isCachedViewWebContents(ctx.webContentsId)) return;
         setTitleBarOverlayBannerSeverity(win, payload.severity);
       },
       { withContext: true }

--- a/electron/ipc/handlers/windowChrome.ts
+++ b/electron/ipc/handlers/windowChrome.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import type { HandlerDependencies, IpcContext } from "../types.js";
+import { defineIpcNamespace, opValidated } from "../define.js";
+import { WINDOW_CHROME_METHOD_CHANNELS } from "./windowChrome.preload.js";
+import { setTitleBarOverlayBannerSeverity } from "../../window/titleBarOverlay.js";
+import { BANNER_SEVERITIES } from "../../../shared/config/windowChrome.js";
+
+/**
+ * Renderer → main report of which global banner currently occupies the top
+ * band, so the native Windows caption strip can be tinted to match it (#11766).
+ *
+ * Scoped to the sender's own window: a report can only recolour the chrome of
+ * the window it came from, never a sibling's.
+ */
+const bannerSeveritySchema = z.object({
+  severity: z.enum(BANNER_SEVERITIES).nullable(),
+});
+
+export const windowChromeNamespace = defineIpcNamespace({
+  name: "windowChrome",
+  ops: {
+    setBannerSeverity: opValidated(
+      WINDOW_CHROME_METHOD_CHANNELS.setBannerSeverity,
+      bannerSeveritySchema,
+      async (ctx: IpcContext, payload: z.infer<typeof bannerSeveritySchema>) => {
+        const win = ctx.senderWindow;
+        if (!win || win.isDestroyed()) return;
+        setTitleBarOverlayBannerSeverity(win, payload.severity);
+      },
+      { withContext: true }
+    ),
+  },
+});
+
+export function registerWindowChromeHandlers(_deps: HandlerDependencies): () => void {
+  return windowChromeNamespace.register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -76,6 +76,7 @@ import { buildMenuPreloadBindings } from "./ipc/handlers/menu.preload.js";
 import { buildCliPreloadBindings } from "./ipc/handlers/cli.preload.js";
 import { buildGlobalRecipesPreloadBindings } from "./ipc/handlers/globalRecipes.preload.js";
 import { buildEditorConfigPreloadBindings } from "./ipc/handlers/editorConfig.preload.js";
+import { buildWindowChromePreloadBindings } from "./ipc/handlers/windowChrome.preload.js";
 import { buildFleetPreloadBindings } from "./ipc/handlers/fleet.preload.js";
 import { buildProjectHistoryPreloadBindings } from "./ipc/handlers/projectHistory.preload.js";
 import { buildProjectRelocationPreloadBindings } from "./ipc/handlers/projectRelocation.preload.js";
@@ -1479,6 +1480,10 @@ function buildElectronApi(): ElectronAPI {
 
     // Editor API
     editor: buildEditorConfigPreloadBindings(_unwrappingInvoke),
+
+    // Native window chrome — keeps the Windows caption strip in step with the
+    // global banner occupying the same band (#11766)
+    windowChrome: buildWindowChromePreloadBindings(_unwrappingInvoke),
 
     // Per-window back/forward over visited projects
     projectHistory: buildProjectHistoryPreloadBindings(_unwrappingInvoke),

--- a/electron/window/__tests__/createWindow.platform-options.test.ts
+++ b/electron/window/__tests__/createWindow.platform-options.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { getPlatformWindowOptions } from "../platformWindowOptions.js";
 import {
@@ -67,5 +69,20 @@ describe("platform BrowserWindow options (#7939)", () => {
     expect(opts.titleBarStyle).toBeUndefined();
     expect(opts.titleBarOverlay).toBeUndefined();
     expect(opts.trafficLightPosition).toBeUndefined();
+  });
+});
+
+describe("createWindow wires the overlay owner — issue #11766", () => {
+  it("seeds the resolved scheme so the first banner report has tokens to blend", async () => {
+    // Without the seed, `setTitleBarOverlayBannerSeverity` silently no-ops
+    // until some later theme event happens to supply tokens — a failure mode
+    // no unit test of the overlay module itself can see, because those seed
+    // their own mock windows.
+    const source = await fs.readFile(path.resolve(__dirname, "../createWindow.ts"), "utf-8");
+    expect(source).toContain("seedTitleBarOverlay(win, scheme.tokens)");
+    expect(source).toContain("getPlatformWindowOptions(windowBg)");
+    // The seeded tokens must be the same object the constructor colour came
+    // from, or the recorded "already applied" colour would be a lie.
+    expect(source).toContain('const windowBg = scheme.tokens["surface-canvas"]');
   });
 });

--- a/electron/window/__tests__/createWindow.platform-options.test.ts
+++ b/electron/window/__tests__/createWindow.platform-options.test.ts
@@ -1,77 +1,68 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { getPlatformWindowOptions } from "../platformWindowOptions.js";
+import {
+  WINDOWS_CAPTION_SYMBOL_COLOR,
+  WINDOWS_TITLEBAR_HEIGHT_PX,
+} from "../../../shared/config/windowChrome.js";
 
 /**
- * Tests the platform-specific BrowserWindow constructor options from
- * createWindow.ts (#7939).
+ * Platform-specific BrowserWindow constructor options (#7939).
  *
- * The options object is inlined inside setupBrowserWindow, so we replicate
- * its exact platform branching here to verify that:
- *   - macOS gets titleBarStyle: "hiddenInset" + trafficLightPosition, no autoHideMenuBar
- *   - Windows gets titleBarStyle: "hidden" + titleBarOverlay + autoHideMenuBar
- *   - Linux gets autoHideMenuBar only (no titleBarStyle override)
- *
- * If createWindow.ts changes, update this replica to match.
+ * This exercises the production helper `createWindow.ts` actually calls. It
+ * used to replicate the options object by hand, which silently drifted — the
+ * replica still asserted a 36px overlay long after production moved to 48px
+ * (#11766).
  */
 
-type PlatformOptions = {
-  titleBarStyle?: "hidden" | "hiddenInset";
-  titleBarOverlay?: { color: string; symbolColor: string; height: number };
-  trafficLightPosition?: { x: number; y: number };
-  autoHideMenuBar?: boolean;
-};
+const originalPlatform = process.platform;
 
-function getPlatformBrowserWindowOptions(windowBg: string): PlatformOptions {
-  if (process.platform === "darwin") {
-    return {
-      titleBarStyle: "hiddenInset" as const,
-      trafficLightPosition: { x: 12, y: 18 },
-    };
-  }
-  if (process.platform === "win32") {
-    return {
-      titleBarStyle: "hidden" as const,
-      titleBarOverlay: {
-        color: windowBg,
-        symbolColor: "#a1a1aa",
-        height: 36,
-      },
-      autoHideMenuBar: true,
-    };
-  }
-  return { autoHideMenuBar: true };
+function setPlatform(value: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value, configurable: true });
 }
 
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+});
+
 describe("platform BrowserWindow options (#7939)", () => {
-  const originalPlatform = process.platform;
-
-  afterEach(() => {
-    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
-  });
-
   it("macOS gets hiddenInset titleBarStyle and trafficLightPosition, no autoHideMenuBar", () => {
-    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-    const opts = getPlatformBrowserWindowOptions("#1a1a1a");
+    setPlatform("darwin");
+    const opts = getPlatformWindowOptions("#1a1a1a");
     expect(opts.titleBarStyle).toBe("hiddenInset");
     expect(opts.trafficLightPosition).toEqual({ x: 12, y: 18 });
+    expect(opts.acceptFirstMouse).toBe(true);
     expect(opts.autoHideMenuBar).toBeUndefined();
     expect(opts.titleBarOverlay).toBeUndefined();
   });
 
   it("Windows gets hidden titleBarStyle + titleBarOverlay + autoHideMenuBar: true", () => {
-    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
-    const opts = getPlatformBrowserWindowOptions("#1a1a1a");
+    setPlatform("win32");
+    const opts = getPlatformWindowOptions("#1a1a1a");
     expect(opts.titleBarStyle).toBe("hidden");
-    expect(opts.titleBarOverlay).toEqual({
-      color: "#1a1a1a",
-      symbolColor: "#a1a1aa",
-      height: 36,
-    });
     expect(opts.autoHideMenuBar).toBe(true);
+    expect(opts.trafficLightPosition).toBeUndefined();
+  });
+
+  it("paints the caption strip with the window background it was created for", () => {
+    setPlatform("win32");
+    // The overlay has to start life matching the window it sits on; drift here
+    // is the pale-rectangle bug from #11766 at first paint.
+    expect(getPlatformWindowOptions("#1a1a1a").titleBarOverlay?.color).toBe("#1a1a1a");
+    expect(getPlatformWindowOptions("#fbfbfb").titleBarOverlay?.color).toBe("#fbfbfb");
+  });
+
+  it("sizes and styles the overlay from the shared window-chrome constants", () => {
+    setPlatform("win32");
+    const overlay = getPlatformWindowOptions("#1a1a1a").titleBarOverlay;
+    // Bound to the same source the renderer's inset reads, so the native strip
+    // and the space reserved for it cannot disagree.
+    expect(overlay?.height).toBe(WINDOWS_TITLEBAR_HEIGHT_PX);
+    expect(overlay?.symbolColor).toBe(WINDOWS_CAPTION_SYMBOL_COLOR);
   });
 
   it("Linux gets autoHideMenuBar: true with no titleBarStyle override", () => {
-    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-    const opts = getPlatformBrowserWindowOptions("#1a1a1a");
+    setPlatform("linux");
+    const opts = getPlatformWindowOptions("#1a1a1a");
     expect(opts.autoHideMenuBar).toBe(true);
     expect(opts.titleBarStyle).toBeUndefined();
     expect(opts.titleBarOverlay).toBeUndefined();

--- a/electron/window/__tests__/titleBarOverlay.test.ts
+++ b/electron/window/__tests__/titleBarOverlay.test.ts
@@ -6,6 +6,10 @@ import {
   setTitleBarOverlayBannerSeverity,
   setTitleBarOverlayTheme,
 } from "../titleBarOverlay.js";
+import {
+  WINDOWS_CAPTION_SYMBOL_COLOR,
+  WINDOWS_TITLEBAR_HEIGHT_PX,
+} from "../../../shared/config/windowChrome.js";
 
 /**
  * Issue #11766. The native Windows caption strip paints above every
@@ -85,6 +89,27 @@ describe("resolveOverlayColor", () => {
     expect(resolveOverlayColor(TOKENS, "warning")).not.toBe(resolveOverlayColor(TOKENS, "error"));
   });
 
+  it("maps each severity to its own token, not a neighbour's", () => {
+    // With only one status token present, exactly the severity that maps to it
+    // may tint — a swapped mapping would tint the wrong one.
+    const onlyDanger = { "surface-canvas": CANVAS, "status-danger": DANGER };
+    expect(resolveOverlayColor(onlyDanger, "error")).not.toBe(CANVAS);
+    expect(resolveOverlayColor(onlyDanger, "warning")).toBe(CANVAS);
+
+    const onlyWarning = { "surface-canvas": CANVAS, "status-warning": WARNING };
+    expect(resolveOverlayColor(onlyWarning, "warning")).not.toBe(CANVAS);
+    expect(resolveOverlayColor(onlyWarning, "error")).toBe(CANVAS);
+  });
+
+  it("keeps the strip a subtle wash, much nearer the canvas than the status colour", () => {
+    // The banner paints a light tint over the canvas; a heavy blend (say 50%)
+    // would make the caption strip louder than the banner it is matching.
+    const [tr] = channels(resolveOverlayColor(TOKENS, "warning")!);
+    const [cr] = channels(CANVAS);
+    const [wr] = channels(WARNING);
+    expect(Math.abs(tr - cr)).toBeLessThan(Math.abs(tr - wr) / 2);
+  });
+
   it("tracks the theme: the same severity resolves differently per canvas", () => {
     expect(resolveOverlayColor(TOKENS, "warning")).not.toBe(
       resolveOverlayColor(LIGHT_TOKENS, "warning")
@@ -102,6 +127,37 @@ describe("resolveOverlayColor", () => {
 
   it("resolves to nothing when the theme has no canvas to blend against", () => {
     expect(resolveOverlayColor({}, "warning")).toBeNull();
+  });
+
+  // Custom and imported themes persist tokens as unvalidated strings, so a
+  // non-hex value must not reach Electron as "#NaNNaNNaN".
+  it.each(["oklch(0.7 0.15 80)", "var(--something)", "rgb(1,2,3)", "goldenrod", ""])(
+    "ignores the unparseable status token %j and keeps the canvas",
+    (tint) => {
+      expect(resolveOverlayColor({ ...TOKENS, "status-warning": tint }, "warning")).toBe(CANVAS);
+    }
+  );
+
+  it.each(["oklch(0.2 0 0)", "var(--bg)", "not a colour"])(
+    "declines to touch the strip when the canvas itself is unparseable (%j)",
+    (canvas) => {
+      expect(resolveOverlayColor({ ...TOKENS, "surface-canvas": canvas }, "warning")).toBeNull();
+      expect(resolveOverlayColor({ ...TOKENS, "surface-canvas": canvas }, null)).toBeNull();
+    }
+  );
+
+  it("accepts shorthand hex tokens", () => {
+    const shorthand = resolveOverlayColor(
+      { "surface-canvas": "#111", "status-warning": "#fc0" },
+      "warning"
+    );
+    expect(shorthand).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+
+  it("always yields a colour Electron can parse", () => {
+    for (const severity of [null, "error", "warning", "info", "success", "neutral"] as const) {
+      expect(resolveOverlayColor(TOKENS, severity)).toMatch(/^#[0-9a-f]{6}$/i);
+    }
   });
 });
 
@@ -158,6 +214,23 @@ describe("native overlay writes", () => {
     expect(applied.color).not.toBe(LIGHT_TOKENS["surface-canvas"]);
   });
 
+  it("retries after a rejected native write instead of caching a colour that never landed", () => {
+    const win = makeWindow();
+    seedTitleBarOverlay(win, TOKENS);
+    win.setTitleBarOverlay.mockImplementationOnce(() => {
+      throw new Error("Invalid color");
+    });
+
+    setTitleBarOverlayBannerSeverity(win, "warning");
+    setTitleBarOverlayBannerSeverity(win, null);
+    setTitleBarOverlayBannerSeverity(win, "warning");
+
+    // The failed attempt must not be recorded as applied, or dedup would
+    // swallow the retry and strand the strip on the wrong colour.
+    const colors = win.setTitleBarOverlay.mock.calls.map((c) => (c[0] as { color: string }).color);
+    expect(colors.at(-1)).toBe(resolveOverlayColor(TOKENS, "warning"));
+  });
+
   it("keeps windows independent", () => {
     const a = makeWindow();
     const b = makeWindow();
@@ -195,8 +268,10 @@ describe("native overlay writes", () => {
       height: number;
       symbolColor: string;
     };
-    expect(applied.height).toBeGreaterThan(0);
-    expect(applied.symbolColor).toMatch(/^#[0-9a-f]{6}$/i);
+    // Bound to the same constants the constructor and the renderer's inset use,
+    // so a runtime repaint can't quietly resize or restyle the strip.
+    expect(applied.height).toBe(WINDOWS_TITLEBAR_HEIGHT_PX);
+    expect(applied.symbolColor).toBe(WINDOWS_CAPTION_SYMBOL_COLOR);
   });
 });
 

--- a/electron/window/__tests__/titleBarOverlay.test.ts
+++ b/electron/window/__tests__/titleBarOverlay.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserWindow } from "electron";
+import {
+  resolveOverlayColor,
+  seedTitleBarOverlay,
+  setTitleBarOverlayBannerSeverity,
+  setTitleBarOverlayTheme,
+} from "../titleBarOverlay.js";
+
+/**
+ * Issue #11766. The native Windows caption strip paints above every
+ * WebContentsView, so its colour has to track whatever the renderer puts in
+ * that band. Two independent inputs drive it — theme and active global banner
+ * — and these tests pin the reconciliation between them.
+ */
+
+const CANVAS = "#1a1a1a";
+const WARNING = "#f0b429";
+const DANGER = "#e5484d";
+
+const TOKENS: Record<string, string> = {
+  "surface-canvas": CANVAS,
+  "status-warning": WARNING,
+  "status-danger": DANGER,
+  "status-info": "#0091ff",
+  "status-success": "#30a46c",
+};
+
+const LIGHT_TOKENS: Record<string, string> = { ...TOKENS, "surface-canvas": "#fbfbfb" };
+
+function channels(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ];
+}
+
+function makeWindow() {
+  return {
+    setTitleBarOverlay: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+  } as unknown as BrowserWindow & {
+    setTitleBarOverlay: ReturnType<typeof vi.fn>;
+    isDestroyed: ReturnType<typeof vi.fn>;
+  };
+}
+
+const originalPlatform = process.platform;
+
+function setPlatform(value: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  vi.restoreAllMocks();
+});
+
+describe("resolveOverlayColor", () => {
+  it("leaves the strip at the canvas when no banner holds the band", () => {
+    expect(resolveOverlayColor(TOKENS, null)).toBe(CANVAS);
+  });
+
+  it("pulls the strip toward the severity colour without reaching it", () => {
+    const tinted = resolveOverlayColor(TOKENS, "warning");
+    expect(tinted).not.toBe(CANVAS);
+    expect(tinted).not.toBe(WARNING);
+
+    const [tr, tg, tb] = channels(tinted!);
+    const [cr, cg, cb] = channels(CANVAS);
+    const [wr, wg, wb] = channels(WARNING);
+
+    // The wash is a partial blend, so every channel lands strictly between the
+    // canvas and the status colour it is tinting with.
+    expect(tr).toBeGreaterThan(cr);
+    expect(tr).toBeLessThan(wr);
+    expect(tg).toBeGreaterThan(cg);
+    expect(tg).toBeLessThan(wg);
+    expect(tb).toBeGreaterThan(cb);
+    expect(tb).toBeLessThan(wb);
+  });
+
+  it("distinguishes severities that tint with different tokens", () => {
+    expect(resolveOverlayColor(TOKENS, "warning")).not.toBe(resolveOverlayColor(TOKENS, "error"));
+  });
+
+  it("tracks the theme: the same severity resolves differently per canvas", () => {
+    expect(resolveOverlayColor(TOKENS, "warning")).not.toBe(
+      resolveOverlayColor(LIGHT_TOKENS, "warning")
+    );
+  });
+
+  it("falls back to the canvas for neutral, whose wash is not a status colour", () => {
+    expect(resolveOverlayColor(TOKENS, "neutral")).toBe(CANVAS);
+  });
+
+  it("falls back to the canvas when the severity's token is missing from the theme", () => {
+    const partial = { "surface-canvas": CANVAS };
+    expect(resolveOverlayColor(partial, "warning")).toBe(CANVAS);
+  });
+
+  it("resolves to nothing when the theme has no canvas to blend against", () => {
+    expect(resolveOverlayColor({}, "warning")).toBeNull();
+  });
+});
+
+describe("native overlay writes", () => {
+  beforeEach(() => setPlatform("win32"));
+
+  it("repaints the frame when a banner claims the band, and again when it leaves", () => {
+    const win = makeWindow();
+    seedTitleBarOverlay(win, TOKENS);
+
+    setTitleBarOverlayBannerSeverity(win, "warning");
+    expect(win.setTitleBarOverlay).toHaveBeenCalledTimes(1);
+    const tinted = win.setTitleBarOverlay.mock.calls[0]![0] as { color: string };
+    expect(tinted.color).toBe(resolveOverlayColor(TOKENS, "warning"));
+
+    setTitleBarOverlayBannerSeverity(win, null);
+    expect(win.setTitleBarOverlay).toHaveBeenCalledTimes(2);
+    expect((win.setTitleBarOverlay.mock.calls[1]![0] as { color: string }).color).toBe(CANVAS);
+  });
+
+  it("seeding records the constructor's colour so an unchanged theme repaints nothing", () => {
+    const win = makeWindow();
+    seedTitleBarOverlay(win, TOKENS);
+    expect(win.setTitleBarOverlay).not.toHaveBeenCalled();
+
+    setTitleBarOverlayTheme(win, TOKENS);
+    expect(win.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("collapses repeated reports of the same severity into one repaint", () => {
+    const win = makeWindow();
+    seedTitleBarOverlay(win, TOKENS);
+
+    setTitleBarOverlayBannerSeverity(win, "warning");
+    setTitleBarOverlayBannerSeverity(win, "warning");
+    setTitleBarOverlayBannerSeverity(win, "warning");
+
+    expect(win.setTitleBarOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-tints rather than reverting when the theme changes under a live banner", () => {
+    const win = makeWindow();
+    seedTitleBarOverlay(win, TOKENS);
+    setTitleBarOverlayBannerSeverity(win, "warning");
+    win.setTitleBarOverlay.mockClear();
+
+    setTitleBarOverlayTheme(win, LIGHT_TOKENS);
+
+    expect(win.setTitleBarOverlay).toHaveBeenCalledTimes(1);
+    const applied = win.setTitleBarOverlay.mock.calls[0]![0] as { color: string };
+    // The banner is still up, so the new colour must be the light theme's
+    // *tinted* value — not its bare canvas.
+    expect(applied.color).toBe(resolveOverlayColor(LIGHT_TOKENS, "warning"));
+    expect(applied.color).not.toBe(LIGHT_TOKENS["surface-canvas"]);
+  });
+
+  it("keeps windows independent", () => {
+    const a = makeWindow();
+    const b = makeWindow();
+    seedTitleBarOverlay(a, TOKENS);
+    seedTitleBarOverlay(b, TOKENS);
+
+    setTitleBarOverlayBannerSeverity(a, "error");
+
+    expect(a.setTitleBarOverlay).toHaveBeenCalledTimes(1);
+    expect(b.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("does not write to a destroyed window", () => {
+    const win = makeWindow();
+    seedTitleBarOverlay(win, TOKENS);
+    win.isDestroyed.mockReturnValue(true);
+
+    setTitleBarOverlayBannerSeverity(win, "warning");
+
+    expect(win.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for a window that was never seeded with a theme", () => {
+    const win = makeWindow();
+    setTitleBarOverlayBannerSeverity(win, "warning");
+    expect(win.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("applies the shared caption height and symbol colour", () => {
+    const win = makeWindow();
+    seedTitleBarOverlay(win, TOKENS);
+    setTitleBarOverlayBannerSeverity(win, "warning");
+
+    const applied = win.setTitleBarOverlay.mock.calls[0]![0] as {
+      height: number;
+      symbolColor: string;
+    };
+    expect(applied.height).toBeGreaterThan(0);
+    expect(applied.symbolColor).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});
+
+describe("non-Windows platforms", () => {
+  it.each(["darwin", "linux"] as const)("never touches the native overlay on %s", (platform) => {
+    setPlatform(platform);
+    const win = makeWindow();
+    seedTitleBarOverlay(win, TOKENS);
+
+    setTitleBarOverlayBannerSeverity(win, "warning");
+    setTitleBarOverlayTheme(win, LIGHT_TOKENS);
+
+    expect(win.setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+});

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -41,6 +41,8 @@ import {
   INITIAL_COLOR_SCHEME_ARG,
   INSTANCE_ROLE_ARG,
 } from "./skeletonCss.js";
+import { getPlatformWindowOptions } from "./platformWindowOptions.js";
+import { seedTitleBarOverlay } from "./titleBarOverlay.js";
 import { readLastActiveProjectIdentitySync } from "../services/persistence/readLastProjectId.js";
 import { attachRendererConsoleCapture } from "./rendererConsoleCapture.js";
 import { markPerformance } from "../utils/performance.js";
@@ -218,36 +220,16 @@ export function setupBrowserWindow(
       show: false,
       minWidth: 800,
       minHeight: 600,
-      ...(process.platform === "darwin"
-        ? {
-            titleBarStyle: "hiddenInset" as const,
-            trafficLightPosition: { x: 12, y: 18 },
-            // Deliver the window-activating click to the content instead of
-            // swallowing it (macOS default), so clicking a panel in an
-            // inactive window focuses that panel. Propagates to all child
-            // WebContentsViews. Matches VS Code (clickThroughInactive) and iTerm2.
-            acceptFirstMouse: true,
-          }
-        : process.platform === "win32"
-          ? {
-              titleBarStyle: "hidden" as const,
-              titleBarOverlay: {
-                color: windowBg,
-                symbolColor: "#a1a1aa",
-                height: 48,
-              },
-              // Hide the native menu bar so the custom 48px toolbar is the
-              // only chrome; Alt still reveals the menu. Must be set in the
-              // constructor — calling setAutoHideMenuBar after creation can
-              // cause Window Controls Overlay layout shifts.
-              autoHideMenuBar: true,
-            }
-          : { autoHideMenuBar: true }),
+      ...getPlatformWindowOptions(windowBg),
       backgroundColor: windowBg,
     },
     projectPath ?? undefined
   );
   markPerformance(PERF_MARKS.MAIN_WINDOW_CREATED);
+
+  // Record the overlay colour the constructor just applied natively, so the
+  // first banner or theme change doesn't repaint the frame redundantly.
+  seedTitleBarOverlay(win, scheme.tokens);
 
   // Register the window's own webContents for getWindowForWebContents() fallback
   registerWebContents(win.webContents, win);

--- a/electron/window/platformWindowOptions.ts
+++ b/electron/window/platformWindowOptions.ts
@@ -1,0 +1,52 @@
+import {
+  WINDOWS_CAPTION_SYMBOL_COLOR,
+  WINDOWS_TITLEBAR_HEIGHT_PX,
+} from "../../shared/config/windowChrome.js";
+
+export interface PlatformWindowOptions {
+  titleBarStyle?: "hidden" | "hiddenInset";
+  titleBarOverlay?: { color: string; symbolColor: string; height: number };
+  trafficLightPosition?: { x: number; y: number };
+  acceptFirstMouse?: boolean;
+  autoHideMenuBar?: boolean;
+}
+
+/**
+ * Platform-specific slice of the main BrowserWindow's constructor options.
+ *
+ * Lives in its own module (rather than inline in `createWindow.ts`) so tests
+ * can exercise the real branching without pulling in Electron and the whole
+ * window-creation graph — the previous hand-maintained replica had already
+ * drifted from production (36px vs 48px overlay height).
+ */
+export function getPlatformWindowOptions(windowBg: string): PlatformWindowOptions {
+  if (process.platform === "darwin") {
+    return {
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 12, y: 18 },
+      // Deliver the window-activating click to the content instead of
+      // swallowing it (macOS default), so clicking a panel in an inactive
+      // window focuses that panel. Propagates to all child WebContentsViews.
+      // Matches VS Code (clickThroughInactive) and iTerm2.
+      acceptFirstMouse: true,
+    };
+  }
+
+  if (process.platform === "win32") {
+    return {
+      titleBarStyle: "hidden",
+      titleBarOverlay: {
+        color: windowBg,
+        symbolColor: WINDOWS_CAPTION_SYMBOL_COLOR,
+        height: WINDOWS_TITLEBAR_HEIGHT_PX,
+      },
+      // Hide the native menu bar so the custom toolbar is the only chrome; Alt
+      // still reveals the menu. Must be set in the constructor — calling
+      // setAutoHideMenuBar after creation can cause Window Controls Overlay
+      // layout shifts.
+      autoHideMenuBar: true,
+    };
+  }
+
+  return { autoHideMenuBar: true };
+}

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -16,6 +16,7 @@ import {
 } from "../../shared/theme/index.js";
 import type { AppColorScheme, AppThemeConfig } from "../../shared/theme/index.js";
 import type { Project } from "../../shared/types/project.js";
+import { WINDOWS_CAPTION_WIDTH_PX } from "../../shared/config/windowChrome.js";
 import {
   appCustomSchemesReadSchema,
   appCustomSchemesWriteSchema,
@@ -216,13 +217,13 @@ export function buildSkeletonCss(
   lines.push(`  --skeleton-focus-mode: ${focusMode ? "1" : "0"};`);
 
   // Reserve space for Windows native caption buttons in the pre-React skeleton
-  // (consumed by index.html's .skeleton-toolbar-right). The live Toolbar reads
-  // env(titlebar-area-width) directly via the Window Controls Overlay API, so
-  // this variable only covers the brief skeleton phase before WCO env vars are
-  // wired up in the renderer. 138px ≈ 3 × 46px backplates on Windows 11 @ 96 DPI.
-  // See issues #7951 and #8167.
+  // (consumed by index.html's .skeleton-toolbar-right). The live Toolbar reserves
+  // the same width from the same constant — Window Controls Overlay env vars
+  // never resolve in the child WebContentsView the app renders in, so both the
+  // skeleton and the app rely on this measurement. See shared/config/windowChrome.ts
+  // and issues #7951, #8167, #11766.
   if (process.platform === "win32") {
-    lines.push("  --win-caption-width: 138px;");
+    lines.push(`  --win-caption-width: ${WINDOWS_CAPTION_WIDTH_PX}px;`);
   }
 
   lines.push("}");

--- a/electron/window/titleBarOverlay.ts
+++ b/electron/window/titleBarOverlay.ts
@@ -1,0 +1,106 @@
+import type { BrowserWindow } from "electron";
+import { blendOverBackground } from "../../shared/theme/contrast.js";
+import {
+  BANNER_SEVERITY_TOKEN,
+  BANNER_TINT_ALPHA,
+  WINDOWS_CAPTION_SYMBOL_COLOR,
+  WINDOWS_TITLEBAR_HEIGHT_PX,
+  type BannerSeverity,
+} from "../../shared/config/windowChrome.js";
+
+/**
+ * Sole owner of `setTitleBarOverlay` after window creation (#11766).
+ *
+ * The native caption strip is painted by the OS above every WebContentsView, so
+ * an opaque `surface-canvas` strip reads as a pale rectangle punched into any
+ * tinted global banner sharing that band. Keeping the strip's colour in step
+ * with whatever the renderer actually paints there is the only fix available:
+ * a transparent overlay is not usable on Windows, where alpha < 255 makes the
+ * controls fall back to opaque defaults and breaks hover feedback
+ * (electron/electron#51014, #38431, #48193).
+ *
+ * Two inputs drive that colour — the active theme and the active global banner
+ * — and they arrive from different places at different times. Routing both
+ * through this module keeps them from clobbering each other: a theme change
+ * while a banner is up re-tints rather than reverting to canvas.
+ *
+ * State is keyed by BrowserWindow in WeakMaps, so each window resolves
+ * independently and entries die with the window — no disposal wiring needed.
+ */
+
+type ThemeTokens = Record<string, string>;
+
+const themeTokens = new WeakMap<BrowserWindow, ThemeTokens>();
+const bannerSeverity = new WeakMap<BrowserWindow, BannerSeverity | null>();
+const appliedColor = new WeakMap<BrowserWindow, string>();
+
+/**
+ * Colour the caption strip should take for a given theme + banner pairing.
+ *
+ * Mirrors `InlineStatusBanner`'s `color-mix(... BANNER_TINT_ALPHA, transparent)`
+ * wash over the canvas. Both sides read the alpha from the same constant so the
+ * two surfaces can't drift apart.
+ */
+export function resolveOverlayColor(
+  tokens: ThemeTokens,
+  severity: BannerSeverity | null
+): string | null {
+  const canvas = tokens["surface-canvas"];
+  if (!canvas) return null;
+  if (!severity) return canvas;
+
+  const token = BANNER_SEVERITY_TOKEN[severity];
+  if (!token) return canvas;
+
+  const tint = tokens[token];
+  if (!tint) return canvas;
+
+  return blendOverBackground(tint, canvas, BANNER_TINT_ALPHA);
+}
+
+function apply(win: BrowserWindow): void {
+  if (process.platform !== "win32") return;
+  if (win.isDestroyed()) return;
+
+  const tokens = themeTokens.get(win);
+  if (!tokens) return;
+
+  const color = resolveOverlayColor(tokens, bannerSeverity.get(win) ?? null);
+  if (!color) return;
+
+  // Every accepted call repaints the native non-client frame, so skip no-ops.
+  if (appliedColor.get(win) === color) return;
+  appliedColor.set(win, color);
+
+  win.setTitleBarOverlay({
+    color,
+    symbolColor: WINDOWS_CAPTION_SYMBOL_COLOR,
+    height: WINDOWS_TITLEBAR_HEIGHT_PX,
+  });
+}
+
+/**
+ * Seed the window's theme without repainting. Called right after creation,
+ * where the constructor has already applied `color` natively — recording it as
+ * applied keeps the first real change from firing a redundant repaint.
+ */
+export function seedTitleBarOverlay(win: BrowserWindow, tokens: ThemeTokens): void {
+  themeTokens.set(win, tokens);
+  const color = resolveOverlayColor(tokens, null);
+  if (color) appliedColor.set(win, color);
+}
+
+/** Theme changed. Re-tints in place when a banner is currently up. */
+export function setTitleBarOverlayTheme(win: BrowserWindow, tokens: ThemeTokens): void {
+  themeTokens.set(win, tokens);
+  apply(win);
+}
+
+/** A global banner mounted (`severity`) or unmounted (`null`). */
+export function setTitleBarOverlayBannerSeverity(
+  win: BrowserWindow,
+  severity: BannerSeverity | null
+): void {
+  bannerSeverity.set(win, severity);
+  apply(win);
+}

--- a/electron/window/titleBarOverlay.ts
+++ b/electron/window/titleBarOverlay.ts
@@ -35,6 +35,20 @@ const bannerSeverity = new WeakMap<BrowserWindow, BannerSeverity | null>();
 const appliedColor = new WeakMap<BrowserWindow, string>();
 
 /**
+ * Custom and imported themes are persisted as `Record<string, string>` with no
+ * colour validation, so a token can hold anything — `oklch(…)`, `var(…)`, junk.
+ * `blendOverBackground` parses hex, and would turn those into `#NaNNaNNaN`;
+ * Electron rejects an unparseable colour, which would take out whichever
+ * handler triggered the write. Anything that isn't plain hex is treated as
+ * unusable and falls back rather than reaching the native call.
+ *
+ * Alpha-bearing hex is excluded too: `blendOverBackground` drops the alpha
+ * channel, which would tint the strip more strongly than the wash the renderer
+ * actually composites.
+ */
+const HEX_COLOR = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/**
  * Colour the caption strip should take for a given theme + banner pairing.
  *
  * Mirrors `InlineStatusBanner`'s `color-mix(... BANNER_TINT_ALPHA, transparent)`
@@ -46,16 +60,17 @@ export function resolveOverlayColor(
   severity: BannerSeverity | null
 ): string | null {
   const canvas = tokens["surface-canvas"];
-  if (!canvas) return null;
+  if (!canvas || !HEX_COLOR.test(canvas)) return null;
   if (!severity) return canvas;
 
   const token = BANNER_SEVERITY_TOKEN[severity];
   if (!token) return canvas;
 
   const tint = tokens[token];
-  if (!tint) return canvas;
+  if (!tint || !HEX_COLOR.test(tint)) return canvas;
 
-  return blendOverBackground(tint, canvas, BANNER_TINT_ALPHA);
+  const blended = blendOverBackground(tint, canvas, BANNER_TINT_ALPHA);
+  return HEX_COLOR.test(blended) ? blended : canvas;
 }
 
 function apply(win: BrowserWindow): void {
@@ -70,13 +85,20 @@ function apply(win: BrowserWindow): void {
 
   // Every accepted call repaints the native non-client frame, so skip no-ops.
   if (appliedColor.get(win) === color) return;
-  appliedColor.set(win, color);
 
-  win.setTitleBarOverlay({
-    color,
-    symbolColor: WINDOWS_CAPTION_SYMBOL_COLOR,
-    height: WINDOWS_TITLEBAR_HEIGHT_PX,
-  });
+  try {
+    win.setTitleBarOverlay({
+      color,
+      symbolColor: WINDOWS_CAPTION_SYMBOL_COLOR,
+      height: WINDOWS_TITLEBAR_HEIGHT_PX,
+    });
+  } catch {
+    // Caching a colour the native side rejected would dedup away the retry and
+    // strand the strip. Leave the cache untouched so the next attempt runs.
+    return;
+  }
+
+  appliedColor.set(win, color);
 }
 
 /**

--- a/shared/config/windowChrome.ts
+++ b/shared/config/windowChrome.ts
@@ -1,0 +1,50 @@
+/**
+ * Windows caption-strip geometry, shared by the main process (which configures
+ * the native `titleBarOverlay`) and the renderer (which reserves space for it).
+ *
+ * The renderer cannot measure this strip. `env(titlebar-area-*)` and
+ * `navigator.windowControlsOverlay` are scoped to the BrowserWindow's own
+ * webContents, and Daintree's React app runs in a child WebContentsView — so
+ * those never resolve here and silently fall back (electron/electron#34947,
+ * open through Electron 42; see also #7951). A constant is the honest
+ * representation: the env-var expression that used to live at the call sites
+ * could only ever evaluate to its fallback.
+ *
+ * The width is CSS px (DIPs), which is why one constant holds across 100/125/
+ * 150/175% display scaling and in both maximized and restored states:
+ * 138px ≈ 3 × 46px backplates for the Windows 11 caption cluster.
+ */
+export const WINDOWS_CAPTION_WIDTH_PX = 138;
+
+/** Height of the native caption strip, and of the toolbar it sits over. */
+export const WINDOWS_TITLEBAR_HEIGHT_PX = 48;
+
+/** Glyph colour for the native minimize/maximize/close symbols. */
+export const WINDOWS_CAPTION_SYMBOL_COLOR = "#a1a1aa";
+
+/**
+ * Opacity of a status banner's severity wash over the surface behind it.
+ * `InlineStatusBanner` mixes its background at this alpha, and the main
+ * process blends the same alpha to pick a matching native overlay colour —
+ * keeping both ends of the band one surface. Changing this in one place only
+ * would make the caption strip visibly disagree with the banner.
+ */
+export const BANNER_TINT_ALPHA = 0.1;
+
+/** Severity scale shared by `InlineStatusBanner` and the native overlay tint. */
+export const BANNER_SEVERITIES = ["error", "warning", "info", "success", "neutral"] as const;
+
+export type BannerSeverity = (typeof BANNER_SEVERITIES)[number];
+
+/**
+ * Theme token each severity tints with. `neutral` maps to nothing: its wash is
+ * `overlay-subtle` rather than a status colour, and leaving the caption strip
+ * at the plain canvas is closer than guessing at that overlay.
+ */
+export const BANNER_SEVERITY_TOKEN: Record<BannerSeverity, string | null> = {
+  error: "status-danger",
+  warning: "status-warning",
+  info: "status-info",
+  success: "status-success",
+  neutral: null,
+};

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -729,4 +729,9 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["webview:go-to-history-index"]["args"]
     ): Promise<IpcInvokeMap["webview:go-to-history-index"]["result"]>;
   };
+  windowChrome: {
+    setBannerSeverity(
+      ...args: IpcInvokeMap["window-chrome:set-banner-severity"]["args"]
+    ): Promise<IpcInvokeMap["window-chrome:set-banner-severity"]["result"]>;
+  };
 }

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1709,6 +1709,10 @@ export interface GeneratedIpcInvokeMap {
     args: [webContentsId: number, index: number];
     result: void;
   };
+  "window-chrome:set-banner-severity": {
+    args: [payload: { severity: "success" | "error" | "info" | "warning" | "neutral" | null }];
+    result: void;
+  };
   "worktree-config:dismiss-wsl-banner": {
     args: [payload: { worktreeId: string }];
     result: void;

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -39,6 +39,7 @@ import { getToolbarDividerAfterIds, orderToolbarButtonsByGroup } from "./toolbar
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { cn } from "@/lib/utils";
 import { isMac, isLinux, isWindows } from "@/lib/platform";
+import { WINDOWS_CAPTION_WIDTH_PX } from "@shared/config/windowChrome";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { AgentButton } from "./AgentButton";
 import {
@@ -2211,11 +2212,7 @@ export function Toolbar({
                 "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
                 isFullscreen && "w-0"
               )}
-              style={
-                isFullscreen
-                  ? undefined
-                  : { width: "calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))" }
-              }
+              style={isFullscreen ? undefined : { width: `${WINDOWS_CAPTION_WIDTH_PX}px` }}
             />
           )}
         </div>

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -254,8 +254,16 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(source).toMatch(/isWindows\(\)\s*&&\s*\(/);
     });
 
-    it("derives spacer width from the WCO env(titlebar-area-width) expression", () => {
-      expect(source).toContain("calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))");
+    it("sizes the spacer from the shared caption-width constant", () => {
+      // Issue #11766: the old env(titlebar-area-width, …) expression could only
+      // ever resolve to its fallback — WCO variables are scoped to the
+      // BrowserWindow's own webContents and never reach the child
+      // WebContentsView the app renders in (electron/electron#34947).
+      expect(source).toMatch(
+        /import\s*{[^}]*\bWINDOWS_CAPTION_WIDTH_PX\b[^}]*}\s*from\s*"@shared\/config\/windowChrome"/
+      );
+      expect(source).toContain("width: `${WINDOWS_CAPTION_WIDTH_PX}px`");
+      expect(source).not.toContain("titlebar-area-width");
       expect(source).not.toContain("var(--win-caption-width");
     });
 
@@ -265,7 +273,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
 
     it("places the spacer inside the right toolbar group, after the portal toggle", () => {
       const rightGroupIndex = source.indexOf('aria-label="Tools and settings"');
-      const spacerIndex = source.indexOf("env(titlebar-area-width");
+      const spacerIndex = source.indexOf("width: `${WINDOWS_CAPTION_WIDTH_PX}px`");
       const portalToggleIndex = source.indexOf('buttonRegistry["portal-toggle"]');
       expect(rightGroupIndex).toBeGreaterThan(-1);
       expect(spacerIndex).toBeGreaterThan(-1);
@@ -298,7 +306,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     it("spacer is decorative (aria-hidden) and not focusable as a toolbar item", () => {
       const spacerBlock = source.slice(
         source.indexOf("isWindows() &&"),
-        source.indexOf("env(titlebar-area-width") + 200
+        source.indexOf("width: `${WINDOWS_CAPTION_WIDTH_PX}px`") + 200
       );
       expect(spacerBlock).toContain('aria-hidden="true"');
       expect(spacerBlock).not.toContain("data-toolbar-item");

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -25,6 +25,7 @@ import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { logError } from "@/utils/logger";
 import { cn } from "@/lib/utils";
 import { isMac, isWindows } from "@/lib/platform";
+import { WINDOWS_CAPTION_WIDTH_PX } from "@shared/config/windowChrome";
 import { usePluginManager } from "./usePluginManager";
 import { PluginDetailPane, SOURCE_BADGE_LABELS, pluginLabel } from "./PluginDetailPane";
 import { PluginInstallProgressBanner } from "./PluginInstallProgressBanner";
@@ -496,11 +497,7 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
                 "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
                 isFullscreen && "w-0"
               )}
-              style={
-                isFullscreen
-                  ? undefined
-                  : { width: "calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))" }
-              }
+              style={isFullscreen ? undefined : { width: `${WINDOWS_CAPTION_WIDTH_PX}px` }}
             />
           )}
         </div>

--- a/src/components/Recovery/GlobalBannerCoordinator.tsx
+++ b/src/components/Recovery/GlobalBannerCoordinator.tsx
@@ -5,8 +5,10 @@ import { RestoreConfirmationBanner } from "./RestoreConfirmationBanner";
 import { ForgeTokenBanner } from "./ForgeTokenBanner";
 import { CloudSyncBanner } from "./CloudSyncBanner";
 import { RosettaBanner } from "./RosettaBanner";
+import { useCallback } from "react";
 import { useGlobalBannerPriority } from "./useGlobalBannerPriority";
 import { WindowControlsInsetProvider } from "@/components/ui/WindowControlsInset";
+import type { BannerSeverity } from "@shared/config/windowChrome";
 
 function activeBanner(slot: ReturnType<typeof useGlobalBannerPriority>) {
   switch (slot) {
@@ -42,7 +44,22 @@ function activeBanner(slot: ReturnType<typeof useGlobalBannerPriority>) {
 // them, on every platform.
 export function GlobalBannerCoordinator() {
   const slot = useGlobalBannerPriority();
+
+  // The native Windows caption strip is painted above all web content, so it
+  // has to be told which banner colour it is sitting on. The report comes from
+  // the mounted banner rather than the slot: a slot can be claimed by a banner
+  // that renders nothing (HostCrashBanner during its Doherty gate,
+  // ForgeTokenBanner resolving to null), and tinting for an absent banner would
+  // recreate the mismatch this fixes.
+  const reportSeverity = useCallback((severity: BannerSeverity | null) => {
+    void window.electron?.windowChrome?.setBannerSeverity({ severity });
+  }, []);
+
   const banner = activeBanner(slot);
   if (!banner) return null;
-  return <WindowControlsInsetProvider>{banner}</WindowControlsInsetProvider>;
+  return (
+    <WindowControlsInsetProvider onSeverityChange={reportSeverity}>
+      {banner}
+    </WindowControlsInsetProvider>
+  );
 }

--- a/src/components/Recovery/GlobalBannerCoordinator.tsx
+++ b/src/components/Recovery/GlobalBannerCoordinator.tsx
@@ -5,10 +5,16 @@ import { RestoreConfirmationBanner } from "./RestoreConfirmationBanner";
 import { ForgeTokenBanner } from "./ForgeTokenBanner";
 import { CloudSyncBanner } from "./CloudSyncBanner";
 import { RosettaBanner } from "./RosettaBanner";
-import { useCallback } from "react";
+import { useEffect, useState } from "react";
 import { useGlobalBannerPriority } from "./useGlobalBannerPriority";
 import { WindowControlsInsetProvider } from "@/components/ui/WindowControlsInset";
 import type { BannerSeverity } from "@shared/config/windowChrome";
+
+// Chrome tinting is decoration: a rejected report (host without the bridge, a
+// window torn down mid-flight) must not surface as an unhandled rejection.
+function reportBannerSeverity(severity: BannerSeverity | null): void {
+  window.electron?.windowChrome?.setBannerSeverity({ severity })?.catch(() => {});
+}
 
 function activeBanner(slot: ReturnType<typeof useGlobalBannerPriority>) {
   switch (slot) {
@@ -45,20 +51,45 @@ function activeBanner(slot: ReturnType<typeof useGlobalBannerPriority>) {
 export function GlobalBannerCoordinator() {
   const slot = useGlobalBannerPriority();
 
-  // The native Windows caption strip is painted above all web content, so it
-  // has to be told which banner colour it is sitting on. The report comes from
+  // The native Windows caption strip is painted above all web content, so main
+  // has to be told which banner colour sits under it. The severity comes from
   // the mounted banner rather than the slot: a slot can be claimed by a banner
   // that renders nothing (HostCrashBanner during its Doherty gate,
   // ForgeTokenBanner resolving to null), and tinting for an absent banner would
   // recreate the mismatch this fixes.
-  const reportSeverity = useCallback((severity: BannerSeverity | null) => {
+  //
+  // Holding it in state rather than reporting straight from the banner also
+  // coalesces a swap: React commits the outgoing banner's `null` and the
+  // incoming banner's severity in one pass, so the strip goes warning→error
+  // instead of flashing back through the canvas.
+  const [severity, setSeverity] = useState<BannerSeverity | null>(null);
+
+  useEffect(() => {
+    // Also fires with `null` when no banner is up, which is what clears a tint
+    // left behind by whichever view was presenting before this one.
     void window.electron?.windowChrome?.setBannerSeverity({ severity });
-  }, []);
+  }, [severity]);
+
+  // Tearing this view down leaves main holding its last severity, which would
+  // outlive the banner it described.
+  useEffect(() => () => reportBannerSeverity(null), []);
+
+  useEffect(() => {
+    // A cached project view keeps this component mounted while hidden, so
+    // becoming visible again produces no render and no report of its own —
+    // main would still be showing the previously presenting view's tint.
+    const republish = () => {
+      if (document.visibilityState !== "visible") return;
+      reportBannerSeverity(severity);
+    };
+    document.addEventListener("visibilitychange", republish);
+    return () => document.removeEventListener("visibilitychange", republish);
+  }, [severity]);
 
   const banner = activeBanner(slot);
   if (!banner) return null;
   return (
-    <WindowControlsInsetProvider onSeverityChange={reportSeverity}>
+    <WindowControlsInsetProvider onSeverityChange={setSeverity}>
       {banner}
     </WindowControlsInsetProvider>
   );

--- a/src/components/Recovery/GlobalBannerCoordinator.tsx
+++ b/src/components/Recovery/GlobalBannerCoordinator.tsx
@@ -67,7 +67,7 @@ export function GlobalBannerCoordinator() {
   useEffect(() => {
     // Also fires with `null` when no banner is up, which is what clears a tint
     // left behind by whichever view was presenting before this one.
-    void window.electron?.windowChrome?.setBannerSeverity({ severity });
+    reportBannerSeverity(severity);
   }, [severity]);
 
   // Tearing this view down leaves main holding its last severity, which would
@@ -83,7 +83,18 @@ export function GlobalBannerCoordinator() {
       reportBannerSeverity(severity);
     };
     document.addEventListener("visibilitychange", republish);
-    return () => document.removeEventListener("visibilitychange", republish);
+    // A cached view is parked with `setVisible(false)`, which emits no DOM
+    // lifecycle event at all — `visibilitychange` never fires for the warm
+    // project switch this guards. `app:view-revealed` is main's explicit signal
+    // for that reveal, and it lands after the cached-view drop, so it is the
+    // one that actually re-asserts the tint.
+    const offRevealed = window.electron?.app?.onViewRevealed?.(() => {
+      reportBannerSeverity(severity);
+    });
+    return () => {
+      document.removeEventListener("visibilitychange", republish);
+      offRevealed?.();
+    };
   }, [severity]);
 
   const banner = activeBanner(slot);

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -382,3 +382,66 @@ describe("GlobalBannerCoordinator", () => {
     expect(screen.queryByText("Running under Rosetta")).toBeNull();
   });
 });
+
+/**
+ * Issue #11766. The Windows caption strip is painted by the OS above every
+ * WebContentsView, so main has to be told which banner severity currently sits
+ * under it — otherwise the strip keeps the canvas colour and reads as a pale
+ * rectangle punched into a tinted banner.
+ */
+describe("GlobalBannerCoordinator caption-strip reporting", () => {
+  let setBannerSeverity: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setBannerSeverity = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { electron?: unknown }).electron = {
+      windowChrome: { setBannerSeverity },
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { electron?: unknown }).electron;
+  });
+
+  it("reports the severity of the banner actually on screen", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: "warning" });
+  });
+
+  it("reports the winning banner's severity, not the suppressed one's", () => {
+    // Host crash (error) outranks cloud sync (warning); the strip must follow
+    // whichever banner actually renders.
+    usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: "error" });
+    expect(setBannerSeverity).not.toHaveBeenCalledWith({ severity: "warning" });
+  });
+
+  it("stays silent while no banner occupies the band", () => {
+    render(<GlobalBannerCoordinator />);
+    expect(setBannerSeverity).not.toHaveBeenCalled();
+  });
+
+  it("clears the report when the banner goes away", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    const { unmount } = render(<GlobalBannerCoordinator />);
+    setBannerSeverity.mockClear();
+
+    unmount();
+
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: null });
+  });
+
+  it("survives a host without the windowChrome bridge", () => {
+    delete (window as unknown as { electron?: unknown }).electron;
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+
+    expect(() => render(<GlobalBannerCoordinator />)).not.toThrow();
+  });
+});

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -423,9 +423,74 @@ describe("GlobalBannerCoordinator caption-strip reporting", () => {
     expect(setBannerSeverity).not.toHaveBeenCalledWith({ severity: "warning" });
   });
 
-  it("stays silent while no banner occupies the band", () => {
+  it("asserts an empty band rather than staying silent", () => {
+    // A project view that becomes visible with no banner has to clear whatever
+    // tint the previously presenting view left on the caption strip.
     render(<GlobalBannerCoordinator />);
-    expect(setBannerSeverity).not.toHaveBeenCalled();
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: null });
+  });
+
+  it("goes straight from one severity to the next when banners swap", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    render(<GlobalBannerCoordinator />);
+    setBannerSeverity.mockClear();
+
+    // Host crash outranks cloud sync, so the mounted banner is replaced.
+    act(() => {
+      usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    });
+
+    // Bouncing through null would repaint the native frame back to canvas
+    // mid-swap — a visible flash between two tinted banners.
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: "error" });
+    expect(setBannerSeverity).not.toHaveBeenCalledWith({ severity: null });
+  });
+
+  it("does not tint for a slot whose banner is still gated and renders nothing", () => {
+    // HostCrashBanner claims the slot immediately but renders nothing for the
+    // first 400ms (Doherty gate). Tinting off the slot rather than the mounted
+    // banner would colour the strip for a banner that isn't on screen.
+    vi.useFakeTimers();
+    try {
+      usePanelStore.setState({ backendStatus: "recovering", lastCrashType: null });
+      render(<GlobalBannerCoordinator />);
+
+      expect(screen.queryByText("Terminal service crashed")).toBeNull();
+      expect(setBannerSeverity).not.toHaveBeenCalledWith({ severity: "error" });
+      expect(setBannerSeverity).not.toHaveBeenCalledWith({ severity: "warning" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-asserts its severity when a cached view becomes visible again", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    render(<GlobalBannerCoordinator />);
+    setBannerSeverity.mockClear();
+
+    // Switching back to a cached project view produces no re-render, so
+    // without this the strip would keep the other view's tint.
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: "warning" });
+  });
+
+  it("does not re-assert while hidden", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    render(<GlobalBannerCoordinator />);
+    setBannerSeverity.mockClear();
+
+    const visibility = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    try {
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      expect(setBannerSeverity).not.toHaveBeenCalled();
+    } finally {
+      visibility.mockRestore();
+    }
   });
 
   it("clears the report when the banner goes away", () => {

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -510,3 +510,95 @@ describe("GlobalBannerCoordinator caption-strip reporting", () => {
     expect(() => render(<GlobalBannerCoordinator />)).not.toThrow();
   });
 });
+
+/**
+ * A cached project view is parked with `setVisible(false)`, which emits no DOM
+ * lifecycle event — so DOM `visibilitychange` never fires for a warm project
+ * switch and main's explicit `app:view-revealed` signal is the only thing that
+ * can drive the re-assert.
+ */
+describe("GlobalBannerCoordinator cached-view reveal", () => {
+  let setBannerSeverity: ReturnType<typeof vi.fn>;
+  let revealListeners: Set<() => void>;
+
+  function revealView() {
+    act(() => {
+      for (const listener of [...revealListeners]) listener();
+    });
+  }
+
+  beforeEach(() => {
+    setBannerSeverity = vi.fn().mockResolvedValue(undefined);
+    revealListeners = new Set();
+    (window as unknown as { electron?: unknown }).electron = {
+      windowChrome: { setBannerSeverity },
+      app: {
+        onViewRevealed: (callback: () => void) => {
+          revealListeners.add(callback);
+          return () => revealListeners.delete(callback);
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { electron?: unknown }).electron;
+  });
+
+  it("re-asserts its severity when main reveals the cached view", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    render(<GlobalBannerCoordinator />);
+    setBannerSeverity.mockClear();
+
+    revealView();
+
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: "warning" });
+  });
+
+  it("re-asserts the severity on screen now, not the one captured at subscribe time", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    render(<GlobalBannerCoordinator />);
+
+    act(() => {
+      usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    });
+    setBannerSeverity.mockClear();
+
+    revealView();
+
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: "error" });
+    expect(setBannerSeverity).not.toHaveBeenCalledWith({ severity: "warning" });
+  });
+
+  it("re-asserts an empty band when the revealed view has no banner", () => {
+    render(<GlobalBannerCoordinator />);
+    setBannerSeverity.mockClear();
+
+    revealView();
+
+    expect(setBannerSeverity).toHaveBeenCalledWith({ severity: null });
+  });
+
+  it("keeps a single reveal subscription across banner swaps", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    render(<GlobalBannerCoordinator />);
+
+    act(() => {
+      usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    });
+
+    expect(revealListeners.size).toBe(1);
+  });
+
+  it("stops listening once the view is torn down", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    const { unmount } = render(<GlobalBannerCoordinator />);
+
+    unmount();
+    setBannerSeverity.mockClear();
+    revealView();
+
+    expect(revealListeners.size).toBe(0);
+    expect(setBannerSeverity).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -3,9 +3,13 @@ import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Spinner } from "@/components/ui/Spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useWindowControlsInset } from "@/components/ui/WindowControlsInset";
+import { useWindowControlsInset, useTitleBarSurface } from "@/components/ui/WindowControlsInset";
+import { isLinux } from "@/lib/platform";
+import { BANNER_TINT_ALPHA, type BannerSeverity } from "@shared/config/windowChrome";
 
 type ButtonVariant = "primary" | "accent" | "dismiss" | "danger" | "dangerFilled";
+
+const TINT_PERCENT = `${BANNER_TINT_ALPHA * 100}%`;
 
 export interface BannerAction {
   id: string;
@@ -20,7 +24,11 @@ export interface BannerAction {
   disabled?: boolean;
 }
 
-export type InlineStatusBannerSeverity = "error" | "warning" | "info" | "success" | "neutral";
+/**
+ * Aliased to the shared scale so the main process can map the same severities
+ * onto the native Windows caption strip (#11766).
+ */
+export type InlineStatusBannerSeverity = BannerSeverity;
 
 interface BaseInlineStatusBannerProps {
   icon: React.ComponentType<{ className?: string; style?: CSSProperties }>;
@@ -162,6 +170,21 @@ export function InlineStatusBanner({
   // Empty for the common inline usage — see WindowControlsInset.
   const windowControlsInset = useWindowControlsInset();
 
+  // Non-null only in the global banner host, where this banner owns the
+  // window's title-bar band: it has to supply the drag region and top-edge
+  // resize strip the toolbar normally provides (both get pushed below the
+  // caption buttons while a banner is up), and report its severity so the
+  // native caption strip can be tinted to match. Inline banners get none of
+  // this — a banner inside a terminal must never drag the window.
+  const reportSeverity = useTitleBarSurface();
+  const isTitleBarSurface = reportSeverity !== null;
+
+  useEffect(() => {
+    if (!reportSeverity) return;
+    reportSeverity(severity);
+    return () => reportSeverity(null);
+  }, [reportSeverity, severity]);
+
   const onCloseRef = useRef(onClose);
 
   useEffect(() => {
@@ -202,7 +225,10 @@ export function InlineStatusBanner({
         onClose();
       }}
       aria-label={closeAriaLabel}
-      className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
+      className={cn(
+        "p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0",
+        isTitleBarSurface && "app-no-drag"
+      )}
     >
       <X className="h-3.5 w-3.5" aria-hidden="true" />
     </button>
@@ -219,13 +245,17 @@ export function InlineStatusBanner({
         shouldAnimate && "transition duration-250",
         shouldAnimate && (isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2"),
         isNeutral && "bg-overlay-subtle",
+        // The native caption strip is a fixed 48px tall. A shorter banner would
+        // let the tint applied to that strip bleed over the toolbar beneath it,
+        // so a title-bar banner always fills the band it is colouring.
+        isTitleBarSurface && "relative min-h-12 app-drag-region",
         className
       )}
       style={{
         ...(isNeutral
           ? undefined
           : {
-              backgroundColor: `color-mix(in oklab, var(${colorVar}) 10%, transparent)`,
+              backgroundColor: `color-mix(in oklab, var(${colorVar}) ${TINT_PERCENT}, transparent)`,
               borderBottom: `1px solid color-mix(in oklab, var(${colorVar}) 20%, transparent)`,
             }),
         ...windowControlsInset,
@@ -234,6 +264,7 @@ export function InlineStatusBanner({
       aria-live={ariaLive}
       aria-atomic={ariaLive && ariaLive !== "off" ? "true" : undefined}
     >
+      {isTitleBarSurface && !isLinux() && <div className="window-resize-strip" />}
       <div className={cn("flex", hasDescription ? "items-start" : "items-center", "gap-2 min-w-0")}>
         <IconComponent
           className={cn(
@@ -283,7 +314,11 @@ export function InlineStatusBanner({
                 {contextLine}
               </p>
             )}
-            {descriptionExtras}
+            {isTitleBarSurface && descriptionExtras ? (
+              <div className="app-no-drag">{descriptionExtras}</div>
+            ) : (
+              descriptionExtras
+            )}
           </div>
         ) : (
           <span
@@ -296,7 +331,15 @@ export function InlineStatusBanner({
       </div>
 
       {showControlsRow && (
-        <div className={cn("flex items-center shrink-0", hasDescription ? "gap-2 ml-6" : "gap-1")}>
+        <div
+          className={cn(
+            "flex items-center shrink-0",
+            hasDescription ? "gap-2 ml-6" : "gap-1",
+            // `.app-no-drag *` carries the opt-out down to every control in the
+            // row, including nested popover triggers.
+            isTitleBarSurface && "app-no-drag"
+          )}
+        >
           {trailingSlot}
           {!hasDescription && closeButton}
           {actionList.map((action) => {

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -558,6 +558,25 @@ describe("InlineStatusBanner as the window title-bar surface", () => {
     return screen.getByRole("alert");
   }
 
+  function withNavigator(platform: string, userAgent: string, body: () => void) {
+    const original = {
+      platform: Object.getOwnPropertyDescriptor(window.navigator, "platform"),
+      userAgent: Object.getOwnPropertyDescriptor(window.navigator, "userAgent"),
+    };
+    Object.defineProperty(window.navigator, "platform", { value: platform, configurable: true });
+    Object.defineProperty(window.navigator, "userAgent", { value: userAgent, configurable: true });
+    try {
+      body();
+    } finally {
+      if (original.platform) {
+        Object.defineProperty(window.navigator, "platform", original.platform);
+      }
+      if (original.userAgent) {
+        Object.defineProperty(window.navigator, "userAgent", original.userAgent);
+      }
+    }
+  }
+
   it("becomes draggable and fills the caption band's height", () => {
     renderGlobal();
     // A banner shorter than the 48px native strip would let the tint applied to
@@ -575,9 +594,29 @@ describe("InlineStatusBanner as the window title-bar surface", () => {
     expect(root().querySelector(".window-resize-strip")).toBeNull();
   });
 
-  it("carries the top-edge resize strip the displaced toolbar can no longer provide", () => {
-    renderGlobal();
-    expect(root().querySelector(".window-resize-strip")).not.toBeNull();
+  it.each([
+    ["Win32", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"],
+    ["MacIntel", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"],
+  ])(
+    "carries the top-edge resize strip the displaced toolbar can no longer provide (%s)",
+    (platform, userAgent) => {
+      // isLinux() reads navigator.userAgent, so pin it rather than relying on
+      // whatever jsdom's default happens to be — Ubuntu CI would otherwise
+      // never establish which branch it is exercising.
+      withNavigator(platform, userAgent, () => {
+        renderGlobal();
+        expect(root().querySelector(".window-resize-strip")).not.toBeNull();
+      });
+    }
+  );
+
+  it("omits the resize strip on Linux, whose WM owns the window edges", () => {
+    withNavigator("Linux x86_64", "Mozilla/5.0 (X11; Linux x86_64)", () => {
+      renderGlobal();
+      expect(root().querySelector(".window-resize-strip")).toBeNull();
+      // The drag region is still wanted — only the resize strip is skipped.
+      expect(root().className).toContain("app-drag-region");
+    });
   });
 
   it("keeps every interactive control out of the drag region", () => {
@@ -639,11 +678,21 @@ describe("InlineStatusBanner as the window title-bar surface", () => {
     expect(onSeverityChange).toHaveBeenCalledWith(null);
   });
 
-  it("never reports from an inline banner", () => {
+  it("does not report through a provider that supplies no reporter", () => {
+    // The bare provider is used for its inset alone; only the global banner
+    // host opts a banner into reporting.
     const onSeverityChange = vi.fn();
     render(
-      <InlineStatusBanner icon={AlertTriangle} title="Inline" severity="warning" animated={false} />
+      <WindowControlsInsetProvider>
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="Inset only"
+          severity="warning"
+          animated={false}
+        />
+      </WindowControlsInsetProvider>
     );
     expect(onSeverityChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert").className).not.toContain("app-drag-region");
   });
 });

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { useEffect, useState } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { AlertTriangle, CheckCircle2, FileEdit, Info, XCircle } from "lucide-react";
 import { InlineStatusBanner } from "../InlineStatusBanner";
+import { WindowControlsInsetProvider } from "@/components/ui/WindowControlsInset";
 
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -523,5 +524,126 @@ describe("InlineStatusBanner", () => {
     } finally {
       document.body.removeAttribute("data-performance-mode");
     }
+  });
+});
+
+/**
+ * Issue #11766. In the global banner host this component owns the window's
+ * title-bar band: the toolbar that normally supplies the drag region and
+ * top-edge resize strip has been pushed below the caption buttons, and the
+ * native caption strip needs to know which severity is painted beneath it.
+ * None of that may leak into the far more common inline usage — a banner
+ * inside a terminal must never become a window drag handle.
+ */
+describe("InlineStatusBanner as the window title-bar surface", () => {
+  function renderGlobal(
+    props: Partial<React.ComponentProps<typeof InlineStatusBanner>> = {},
+    onSeverityChange = vi.fn()
+  ) {
+    const result = render(
+      <WindowControlsInsetProvider onSeverityChange={onSeverityChange}>
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="Project in a synced folder"
+          severity="warning"
+          animated={false}
+          {...props}
+        />
+      </WindowControlsInsetProvider>
+    );
+    return { ...result, onSeverityChange };
+  }
+
+  function root(): HTMLElement {
+    return screen.getByRole("alert");
+  }
+
+  it("becomes draggable and fills the caption band's height", () => {
+    renderGlobal();
+    // A banner shorter than the 48px native strip would let the tint applied to
+    // that strip bleed over the toolbar below it.
+    expect(root().className).toContain("app-drag-region");
+    expect(root().className).toContain("min-h-12");
+  });
+
+  it("leaves an inline banner undraggable and unconstrained", () => {
+    render(
+      <InlineStatusBanner icon={AlertTriangle} title="Inline" severity="warning" animated={false} />
+    );
+    expect(root().className).not.toContain("app-drag-region");
+    expect(root().className).not.toContain("min-h-12");
+    expect(root().querySelector(".window-resize-strip")).toBeNull();
+  });
+
+  it("carries the top-edge resize strip the displaced toolbar can no longer provide", () => {
+    renderGlobal();
+    expect(root().querySelector(".window-resize-strip")).not.toBeNull();
+  });
+
+  it("keeps every interactive control out of the drag region", () => {
+    renderGlobal({
+      description: "This project is in a synced folder.",
+      onClose: vi.fn(),
+      actions: [
+        { id: "dismiss", label: "Don't warn for this project", onClick: vi.fn() },
+        { id: "more", label: "Learn more", onClick: vi.fn() },
+      ],
+      descriptionExtras: <a href="#extra">Details</a>,
+    });
+
+    // A control swallowed by the drag region becomes unclickable, which is
+    // exactly what the issue calls out for "Don't warn for this project".
+    for (const name of ["Don't warn for this project", "Learn more", "Dismiss"]) {
+      expect(screen.getByRole("button", { name }).closest(".app-no-drag")).not.toBeNull();
+    }
+    expect(screen.getByRole("link", { name: "Details" }).closest(".app-no-drag")).not.toBeNull();
+  });
+
+  it("still fires the dismiss action while inside the drag region", () => {
+    const onClick = vi.fn();
+    renderGlobal({
+      description: "This project is in a synced folder.",
+      actions: [{ id: "dismiss", label: "Don't warn for this project", onClick }],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Don't warn for this project" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports its severity on mount so the caption strip can match it", () => {
+    const { onSeverityChange } = renderGlobal({ severity: "error" });
+    expect(onSeverityChange).toHaveBeenCalledWith("error");
+  });
+
+  it("re-reports when the severity changes", () => {
+    const onSeverityChange = vi.fn();
+    const { rerender } = renderGlobal({ severity: "warning" }, onSeverityChange);
+    onSeverityChange.mockClear();
+
+    rerender(
+      <WindowControlsInsetProvider onSeverityChange={onSeverityChange}>
+        <InlineStatusBanner icon={AlertTriangle} title="t" severity="info" animated={false} />
+      </WindowControlsInsetProvider>
+    );
+
+    expect(onSeverityChange).toHaveBeenLastCalledWith("info");
+  });
+
+  it("clears the report on unmount so the strip returns to the canvas", () => {
+    const { onSeverityChange, unmount } = renderGlobal();
+    onSeverityChange.mockClear();
+
+    unmount();
+
+    expect(onSeverityChange).toHaveBeenCalledWith(null);
+  });
+
+  it("never reports from an inline banner", () => {
+    const onSeverityChange = vi.fn();
+    render(
+      <InlineStatusBanner icon={AlertTriangle} title="Inline" severity="warning" animated={false} />
+    );
+    expect(onSeverityChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ui/WindowControlsInset.tsx
+++ b/src/components/ui/WindowControlsInset.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { isMac, isWindows } from "@/lib/platform";
+import { WINDOWS_CAPTION_WIDTH_PX, type BannerSeverity } from "@shared/config/windowChrome";
 
 // Padding that pushes a top-of-window surface's content clear of the OS window
 // controls — macOS traffic lights (top-left) and Windows caption buttons
@@ -16,8 +17,29 @@ import { isMac, isWindows } from "@/lib/platform";
 const EMPTY: CSSProperties = Object.freeze({});
 const WindowControlsInsetContext = createContext<CSSProperties>(EMPTY);
 
+/**
+ * Set only by the global banner host. A surface that has this is sharing the
+ * window's title-bar band with the OS caption buttons, which makes it
+ * responsible for the drag region the toolbar normally provides — and lets it
+ * report itself so the native caption strip can be tinted to match.
+ *
+ * `null` for every ordinary in-page usage, which is what keeps banners inside
+ * terminals and dialogs from turning into window drag handles.
+ */
+const TitleBarSurfaceContext = createContext<((severity: BannerSeverity | null) => void) | null>(
+  null
+);
+
 export function useWindowControlsInset(): CSSProperties {
   return useContext(WindowControlsInsetContext);
+}
+
+/**
+ * Reporter for a surface occupying the window's title-bar band, or `null` when
+ * rendered anywhere else. Presence doubles as the "am I the global banner?" flag.
+ */
+export function useTitleBarSurface(): ((severity: BannerSeverity | null) => void) | null {
+  return useContext(TitleBarSurfaceContext);
 }
 
 /**
@@ -25,24 +47,37 @@ export function useWindowControlsInset(): CSSProperties {
  * top of the window (the global banner host). Mirrors the Toolbar /
  * PluginManager spacers: macOS reserves ~80px on the left (matching the
  * toolbar's `px-4` + `w-16` lead-in), Windows reserves the caption-button strip
- * on the right via `titlebar-area-width`, Linux reserves nothing. All collapse
- * in fullscreen, where the OS chrome is gone.
+ * on the right, Linux reserves nothing. All collapse in fullscreen, where the
+ * OS chrome is gone.
+ *
+ * The Windows width is a constant rather than `env(titlebar-area-width)`: those
+ * variables are scoped to the BrowserWindow's own webContents and never resolve
+ * in the child WebContentsView this app renders in — see
+ * `shared/config/windowChrome.ts`.
  */
-export function WindowControlsInsetProvider({ children }: { children: ReactNode }) {
+export function WindowControlsInsetProvider({
+  children,
+  onSeverityChange,
+}: {
+  children: ReactNode;
+  /** Present only for the global banner host — see {@link useTitleBarSurface}. */
+  onSeverityChange?: (severity: BannerSeverity | null) => void;
+}) {
   const [isFullscreen, setIsFullscreen] = useState(false);
   useEffect(() => window.electron?.window?.onFullscreenChange?.(setIsFullscreen), []);
 
   const inset = useMemo<CSSProperties>(() => {
     if (isFullscreen) return EMPTY;
     if (isMac()) return { paddingLeft: "5rem" };
-    if (isWindows())
-      return { paddingRight: "calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))" };
+    if (isWindows()) return { paddingRight: `${WINDOWS_CAPTION_WIDTH_PX}px` };
     return EMPTY;
   }, [isFullscreen]);
 
   return (
     <WindowControlsInsetContext.Provider value={inset}>
-      {children}
+      <TitleBarSurfaceContext.Provider value={onSeverityChange ?? null}>
+        {children}
+      </TitleBarSurfaceContext.Provider>
     </WindowControlsInsetContext.Provider>
   );
 }

--- a/src/components/ui/__tests__/WindowControlsInset.test.tsx
+++ b/src/components/ui/__tests__/WindowControlsInset.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  WindowControlsInsetProvider,
+  useTitleBarSurface,
+  useWindowControlsInset,
+} from "../WindowControlsInset";
+import { WINDOWS_CAPTION_WIDTH_PX } from "@shared/config/windowChrome";
+
+/**
+ * Issue #11766. `isWindows()`/`isMac()` read `navigator.platform`, so these
+ * stub that rather than `process.platform` — the renderer never sees the Node
+ * value, and a `process.platform` guard would make every case below vacuous on
+ * Daintree's Ubuntu-only unit CI.
+ */
+
+const originalPlatform = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+
+function setNavigatorPlatform(value: string) {
+  Object.defineProperty(window.navigator, "platform", { value, configurable: true });
+}
+
+function Probe() {
+  const inset = useWindowControlsInset();
+  const surface = useTitleBarSurface();
+  return (
+    <div data-testid="probe" data-title-bar-surface={surface ? "true" : "false"} style={inset} />
+  );
+}
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(window.navigator, "platform", originalPlatform);
+  } else {
+    delete (window.navigator as unknown as Record<string, unknown>).platform;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("WindowControlsInsetProvider", () => {
+  it("reserves the shared caption width on Windows", () => {
+    setNavigatorPlatform("Win32");
+    render(
+      <WindowControlsInsetProvider>
+        <Probe />
+      </WindowControlsInsetProvider>
+    );
+    // Constant, not env(titlebar-area-width): WCO variables never resolve in
+    // the child WebContentsView the app renders in (electron/electron#34947).
+    expect(screen.getByTestId("probe").style.paddingRight).toBe(`${WINDOWS_CAPTION_WIDTH_PX}px`);
+    expect(screen.getByTestId("probe").style.paddingLeft).toBe("");
+  });
+
+  it("reserves space on the left for the macOS traffic lights instead", () => {
+    setNavigatorPlatform("MacIntel");
+    render(
+      <WindowControlsInsetProvider>
+        <Probe />
+      </WindowControlsInsetProvider>
+    );
+    expect(screen.getByTestId("probe").style.paddingLeft).toBe("5rem");
+    expect(screen.getByTestId("probe").style.paddingRight).toBe("");
+  });
+
+  it("reserves nothing on Linux, which has no overlaid window controls", () => {
+    setNavigatorPlatform("Linux x86_64");
+    render(
+      <WindowControlsInsetProvider>
+        <Probe />
+      </WindowControlsInsetProvider>
+    );
+    const probe = screen.getByTestId("probe");
+    expect(probe.style.paddingRight).toBe("");
+    expect(probe.style.paddingLeft).toBe("");
+  });
+
+  it("reserves nothing outside a provider, where no OS chrome overlaps", () => {
+    setNavigatorPlatform("Win32");
+    render(<Probe />);
+    expect(screen.getByTestId("probe").style.paddingRight).toBe("");
+  });
+
+  it("marks the surface as a title-bar host only when a reporter is supplied", () => {
+    setNavigatorPlatform("Win32");
+    const { rerender } = render(
+      <WindowControlsInsetProvider>
+        <Probe />
+      </WindowControlsInsetProvider>
+    );
+    // A bare provider is still just an inset — the drag region and severity
+    // reporting belong to the global banner host alone.
+    expect(screen.getByTestId("probe").dataset.titleBarSurface).toBe("false");
+
+    rerender(
+      <WindowControlsInsetProvider onSeverityChange={vi.fn()}>
+        <Probe />
+      </WindowControlsInsetProvider>
+    );
+    expect(screen.getByTestId("probe").dataset.titleBarSurface).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary

The padding chain was never actually broken. `env(titlebar-area-width, calc(100vw - 138px))` always resolves to its fallback: Window Controls Overlay env vars are scoped to the `BrowserWindow`'s own webContents and never reach the child `WebContentsView` the React app renders in (electron/electron#34947, still open through Electron 42, and Daintree already hit this once in #7951). So the expression was algebraically a constant 138px, which is the correct width all along. What looks like "caption buttons on top of the banner" is the issue's second bullet: Windows paints an opaque `surface-canvas` rectangle (138x48) above all web content, masking the banner's tint in that corner. The banner's text and buttons were already clear of it.

Resolves #11766

## Changes

- The native `titleBarOverlay` is now tinted to the active global banner's severity, blended from the same alpha the banner's `color-mix` wash uses, so the strip and the banner read as one surface. Transparency isn't an option on Windows: alpha under 255 makes the caption controls fall back to their opaque defaults and breaks hover (electron#51014, #38431, #48193).
- `electron/window/titleBarOverlay.ts` is now the single post-creation writer of `setTitleBarOverlay`. Theme changes and banner changes used to clobber each other; now a theme change under a live banner re-tints instead of reverting to canvas. It also follows the theme picker now, which never updated the strip before, only OS-level appearance changes did.
- The global banner supplies the drag region and top-edge resize strip that the toolbar normally owns, since a visible banner pushes the toolbar below the caption band. Every interactive control sits inside `app-no-drag`, so cloud sync's "Don't warn for this project" button stays clickable. Inline banners (terminals, dialogs, plugin manager) are untouched: this behaviour is opt-in through the global banner host's context.
- Global banners are held to the 48px caption height so their tint can't bleed onto the toolbar underneath.
- The dead `env()` expression is replaced with `WINDOWS_CAPTION_WIDTH_PX` in `shared/config/windowChrome.ts`, shared by the inset, the toolbar spacer, the plugin manager spacer, the window constructor, and the pre-React skeleton. The skeleton comment claiming the live toolbar reads the env var was false, and it's corrected.
- Reports from cached, off-screen project views are dropped, and a view that presents with no banner clears the strip. The banner stores are project-scoped (`useCloudSyncBannerStore` especially) and cached views stay mounted, so a hidden view could otherwise recolour the visible project's chrome.
- Theme tokens that aren't opaque hex fall back to the canvas colour. Custom and imported themes can use `oklch()`, `rgb()`, or `var()`, which the hex blender would previously have turned into `#NaNNaNNaN` and handed straight to Electron.
- `createWindow.platform-options.test.ts` now exercises the real `getPlatformWindowOptions()` helper instead of a hand-maintained replica that had drifted: it was asserting a 36px overlay while production shipped 48px.

## Testing

413 tests across 21 files pass locally: the new overlay, IPC, and inset suites, every banner component, plus the channel-drift and handler-registry guards. Windows branches are covered by mocking `process.platform` in main and `navigator.platform`/`userAgent` in the renderer, so they actually execute on Ubuntu CI instead of passing vacuously.

**Needs manual Windows verification.** The native caption strip is painted outside Chromium's paint tree, so no Playwright screenshot can see its colour. Please check at 100/125/150/175% scaling, maximized and restored, with DevTools closed (drag-region hit-testing is disabled while it's open).

## Known follow-ups (out of scope)

- Page zoom scales the CSS inset but not the native strip, so they drift apart at non-100% zoom. The old `env()` fallback had exactly the same property.
- Colour-vision modes remap status tokens in the renderer only, so the tint is blended from the unmapped token. A much smaller mismatch than the canvas-vs-tint one this fixes, but still a mismatch.
- The plugin manager's full-window overlay can sit above a mounted banner, so the strip keeps the banner tint while the visible surface is canvas. Narrow: needs a banner active and the manager open at the same time.
