### PR TITLE
feat(setup): detect missing Git at startup, not at first clone

### DIFF
--- a/electron/ipc/handlers/__tests__/agentCli.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/agentCli.adversarial.test.ts
@@ -17,6 +17,7 @@ const storeMock = vi.hoisted(() => ({
 const runSystemHealthCheckMock = vi.hoisted(() => vi.fn());
 const getHealthCheckSpecsMock = vi.hoisted(() => vi.fn());
 const checkPrerequisiteMock = vi.hoisted(() => vi.fn());
+const isShellInertInvocationMock = vi.hoisted(() => vi.fn());
 
 vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
 
@@ -61,6 +62,7 @@ vi.mock("../../../services/SystemHealthCheck.js", () => ({
   runSystemHealthCheck: runSystemHealthCheckMock,
   getHealthCheckSpecs: getHealthCheckSpecsMock,
   checkPrerequisite: checkPrerequisiteMock,
+  isShellInertInvocation: isShellInertInvocationMock,
 }));
 
 import { registerAgentCliHandlers } from "../agentCli.js";
@@ -101,6 +103,7 @@ describe("agentCli IPC adversarial", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     storeMock.get.mockImplementation((_key, fallback) => fallback);
+    isShellInertInvocationMock.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -317,11 +320,42 @@ describe("agentCli IPC adversarial", () => {
     checkPrerequisiteMock.mockReturnValue({ ok: true });
     register();
 
-    const spec = { id: "node" };
+    const spec = { tool: "node", label: "Node.js", versionArgs: ["--version"], severity: "fatal" };
     const result = await getHandler(CHANNELS.SYSTEM_CHECK_TOOL)(fakeEvent(), spec);
 
     expect(result).toEqual({ ok: true });
     expect(checkPrerequisiteMock).toHaveBeenCalledWith(spec);
+  });
+
+  it("SYSTEM_CHECK_TOOL never probes a spec whose invocation isn't shell-inert", async () => {
+    // The spec names the binary and the flags main executes, and a renderer can
+    // send any spec it likes — so a rejected invocation must not reach the probe.
+    isShellInertInvocationMock.mockReturnValue(false);
+    register();
+
+    await expect(
+      getHandler(CHANNELS.SYSTEM_CHECK_TOOL)(fakeEvent(), {
+        tool: "npm",
+        label: "npm",
+        versionArgs: ["--version", "&&", "calc"],
+        severity: "warn",
+      })
+    ).rejects.toThrow(/Invalid PrerequisiteSpec/);
+    expect(checkPrerequisiteMock).not.toHaveBeenCalled();
+  });
+
+  it("SYSTEM_CHECK_TOOL rejects malformed specs before consulting the invocation check", async () => {
+    register();
+    const handler = getHandler(CHANNELS.SYSTEM_CHECK_TOOL);
+
+    await expect(handler(fakeEvent(), null)).rejects.toThrow(/Invalid PrerequisiteSpec/);
+    await expect(handler(fakeEvent(), { tool: "", versionArgs: [] })).rejects.toThrow(
+      /Invalid PrerequisiteSpec/
+    );
+    await expect(handler(fakeEvent(), { tool: "npm", command: 7 })).rejects.toThrow(
+      /Invalid PrerequisiteSpec/
+    );
+    expect(checkPrerequisiteMock).not.toHaveBeenCalled();
   });
 
   it("cleanup removes all registered handlers", async () => {

--- a/electron/ipc/handlers/agentCli.ts
+++ b/electron/ipc/handlers/agentCli.ts
@@ -180,7 +180,22 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
   const handleSystemCheckTool = async (
     spec: import("../../../shared/types/ipc/system.js").PrerequisiteSpec
   ) => {
-    const { checkPrerequisite } = await import("../../services/SystemHealthCheck.js");
+    const { checkPrerequisite, isShellInertInvocation } =
+      await import("../../services/SystemHealthCheck.js");
+
+    // The spec names a binary and the flags main will execute, so it is checked
+    // here rather than trusted: on Windows a `.cmd` shim has to be spawned
+    // through cmd.exe, which parses whatever it is handed.
+    if (
+      !spec ||
+      typeof spec.tool !== "string" ||
+      !spec.tool ||
+      (spec.command !== undefined && typeof spec.command !== "string") ||
+      !isShellInertInvocation(spec.command ?? spec.tool, spec.versionArgs)
+    ) {
+      throw new Error("Invalid PrerequisiteSpec");
+    }
+
     return await checkPrerequisite(spec);
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_CHECK_TOOL, handleSystemCheckTool));

--- a/electron/ipc/handlers/agentCli.ts
+++ b/electron/ipc/handlers/agentCli.ts
@@ -163,9 +163,11 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_START_AGENT_UPDATE, handleSystemStartAgentUpdate));
 
-  const handleSystemHealthCheck = async (agentIds?: string[]) => {
+  const handleSystemHealthCheck = async (
+    options?: import("../../../shared/types/ipc/system.js").SystemHealthCheckOptions
+  ) => {
     const { runSystemHealthCheck } = await import("../../services/SystemHealthCheck.js");
-    return await runSystemHealthCheck(agentIds);
+    return await runSystemHealthCheck(options);
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_HEALTH_CHECK, handleSystemHealthCheck));
 
@@ -179,11 +181,7 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
     spec: import("../../../shared/types/ipc/system.js").PrerequisiteSpec
   ) => {
     const { checkPrerequisite } = await import("../../services/SystemHealthCheck.js");
-    return new Promise<import("../../../shared/types/ipc/system.js").PrerequisiteCheckResult>(
-      (resolve) => {
-        setImmediate(() => resolve(checkPrerequisite(spec)));
-      }
-    );
+    return await checkPrerequisite(spec);
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_CHECK_TOOL, handleSystemCheckTool));
 
@@ -193,10 +191,15 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
   ) => {
     const senderWindow = ctx.senderWindow;
 
+    const hasAgentId = typeof payload?.agentId === "string" && payload.agentId.length > 0;
+    const hasPrerequisiteTool =
+      typeof payload?.prerequisiteTool === "string" && payload.prerequisiteTool.length > 0;
+
+    // Exactly one target — a payload naming both is ambiguous about which
+    // command list main should resolve, so it's rejected rather than guessed.
     if (
       !payload ||
-      !payload.agentId ||
-      typeof payload.agentId !== "string" ||
+      hasAgentId === hasPrerequisiteTool ||
       !payload.jobId ||
       typeof payload.jobId !== "string"
     ) {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1550,8 +1550,8 @@ function buildElectronApi(): ElectronAPI {
       startAgentUpdate: (payload: { agentId: string; method?: string }) =>
         _unwrappingInvoke(CHANNELS.SYSTEM_START_AGENT_UPDATE, payload),
 
-      healthCheck: (agentIds?: string[]) =>
-        _unwrappingInvoke(CHANNELS.SYSTEM_HEALTH_CHECK, agentIds),
+      healthCheck: (options?: import("../shared/types/ipc/system.js").SystemHealthCheckOptions) =>
+        _unwrappingInvoke(CHANNELS.SYSTEM_HEALTH_CHECK, options),
 
       getHealthCheckSpecs: (agentIds?: string[]) =>
         _unwrappingInvoke(CHANNELS.SYSTEM_HEALTH_CHECK_SPECS, agentIds),
@@ -1596,7 +1596,7 @@ function buildElectronApi(): ElectronAPI {
         return _eventBusOn("system:wake", callback);
       },
 
-      installAgent: (payload: { agentId: string; methodIndex?: number; jobId: string }) =>
+      installAgent: (payload: import("../shared/types/ipc/system.js").AgentInstallPayload) =>
         _unwrappingInvoke(CHANNELS.SETUP_AGENT_INSTALL, payload),
 
       onAgentInstallProgress: (

--- a/electron/services/AgentInstallService.ts
+++ b/electron/services/AgentInstallService.ts
@@ -136,6 +136,17 @@ function resolveInstallBlocks(
   return { blocks };
 }
 
+// Installs in flight, keyed by target. The renderer guards against starting a
+// second install of the same thing, but each project view is its own
+// WebContentsView with its own store, so that guard is blind to the other
+// views. Main is the only place that can see them all.
+const inFlightTargets = new Set<string>();
+
+/** Test seam — clears the in-flight install registry. */
+export function resetInFlightInstalls(): void {
+  inFlightTargets.clear();
+}
+
 export async function runAgentInstall(
   payload: AgentInstallPayload,
   onProgress: (event: AgentInstallProgressEvent) => void
@@ -177,15 +188,28 @@ export async function runAgentInstall(
     return { success: false, exitCode: null, error: "No commands in install block" };
   }
 
-  for (const command of block.commands) {
-    const result = await runSingleCommand(command, payload.jobId, onProgress);
-    if (result.exitCode !== 0) {
-      return {
-        success: false,
-        exitCode: result.exitCode,
-        error: `Command failed with exit code ${result.exitCode}: ${command}`,
-      };
+  const target =
+    payload.prerequisiteTool !== undefined
+      ? `prerequisite:${payload.prerequisiteTool}`
+      : `agent:${payload.agentId}`;
+  if (inFlightTargets.has(target)) {
+    return { success: false, exitCode: null, error: "That install is already running" };
+  }
+  inFlightTargets.add(target);
+
+  try {
+    for (const command of block.commands) {
+      const result = await runSingleCommand(command, payload.jobId, onProgress);
+      if (result.exitCode !== 0) {
+        return {
+          success: false,
+          exitCode: result.exitCode,
+          error: `Command failed with exit code ${result.exitCode}: ${command}`,
+        };
+      }
     }
+  } finally {
+    inFlightTargets.delete(target);
   }
 
   return { success: true, exitCode: 0 };

--- a/electron/services/AgentInstallService.ts
+++ b/electron/services/AgentInstallService.ts
@@ -147,6 +147,19 @@ export async function runAgentInstall(
   const { blocks } = resolved;
 
   const methodIndex = payload.methodIndex ?? 0;
+  // A prerequisite's blocks are not interchangeable — on macOS index 0 is
+  // `brew install git` and index 1 hands off to Apple's installer — so an
+  // out-of-range index must fail rather than silently run a different install.
+  // The agent path keeps its long-standing fall back to index 0.
+  if (payload.prerequisiteTool !== undefined) {
+    if (!Number.isInteger(methodIndex) || methodIndex < 0 || methodIndex >= blocks.length) {
+      return {
+        success: false,
+        exitCode: null,
+        error: `No install method ${methodIndex} for ${payload.prerequisiteTool}`,
+      };
+    }
+  }
   const block = blocks[methodIndex] ?? blocks[0];
 
   // Re-checked here even though the renderer gates the button: renderer gating

--- a/electron/services/AgentInstallService.ts
+++ b/electron/services/AgentInstallService.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import { getAgentConfig, type AgentInstallBlock } from "../../shared/config/agentRegistry.js";
+import { BASELINE_PREREQUISITES } from "./baselinePrerequisites.js";
 import type {
   AgentInstallPayload,
   AgentInstallResult,
@@ -9,7 +10,14 @@ import { buildInstallEnv } from "../utils/spawnEnv.js";
 import { scrubSecrets } from "../../shared/utils/secretScrubber.js";
 
 function isManualOnlyCommand(command: string): boolean {
-  return /\|\s*(sudo\s+)?(bash|sh|zsh|pwsh)\b|\|\s*(iex|Invoke-Expression)\b/i.test(command);
+  if (/\|\s*(sudo\s+)?(bash|sh|zsh|pwsh)\b|\|\s*(iex|Invoke-Expression)\b/i.test(command)) {
+    return true;
+  }
+  // A leading `sudo` has no pipe to catch it, but spawning it with piped stdio
+  // hangs forever on a password prompt the user can never see. The baseline
+  // Linux blocks (`sudo apt-get install git`) are exactly this shape, so they
+  // stay copy-paste only.
+  return /^\s*sudo\b/i.test(command);
 }
 
 export function isBlockExecutable(block: AgentInstallBlock): boolean {
@@ -89,25 +97,60 @@ function runSingleCommand(
   });
 }
 
+function selectOsBlocks(
+  byOs: Partial<Record<"macos" | "windows" | "linux" | "generic", AgentInstallBlock[]>> | undefined
+): AgentInstallBlock[] | undefined {
+  const os = detectOS();
+  const osBlocks = byOs?.[os];
+  return osBlocks && osBlocks.length > 0 ? osBlocks : byOs?.generic;
+}
+
+/**
+ * Resolves the install blocks for a payload. The renderer names a target — an
+ * agent id or a baseline prerequisite tool — and main owns the mapping to
+ * commands; renderer-supplied command strings are never accepted.
+ */
+function resolveInstallBlocks(
+  payload: AgentInstallPayload
+): { blocks: AgentInstallBlock[]; error?: never } | { blocks?: never; error: string } {
+  if (payload.prerequisiteTool !== undefined) {
+    const spec = BASELINE_PREREQUISITES.find((s) => s.tool === payload.prerequisiteTool);
+    if (!spec) {
+      return { error: `Unknown prerequisite: ${payload.prerequisiteTool}` };
+    }
+    const blocks = selectOsBlocks(spec.installBlocks);
+    if (!blocks || blocks.length === 0) {
+      return { error: `No install blocks for ${payload.prerequisiteTool}` };
+    }
+    return { blocks };
+  }
+
+  const config = getAgentConfig(payload.agentId);
+  if (!config) {
+    return { error: `Unknown agent: ${payload.agentId}` };
+  }
+  const blocks = selectOsBlocks(config.install?.byOs);
+  if (!blocks || blocks.length === 0) {
+    return { error: `No install blocks for ${payload.agentId}` };
+  }
+  return { blocks };
+}
+
 export async function runAgentInstall(
   payload: AgentInstallPayload,
   onProgress: (event: AgentInstallProgressEvent) => void
 ): Promise<AgentInstallResult> {
-  const config = getAgentConfig(payload.agentId);
-  if (!config) {
-    return { success: false, exitCode: null, error: `Unknown agent: ${payload.agentId}` };
+  const resolved = resolveInstallBlocks(payload);
+  if (resolved.error !== undefined) {
+    return { success: false, exitCode: null, error: resolved.error };
   }
-
-  const os = detectOS();
-  const osBlocks = config.install?.byOs?.[os];
-  const blocks = osBlocks && osBlocks.length > 0 ? osBlocks : config.install?.byOs?.generic;
-  if (!blocks || blocks.length === 0) {
-    return { success: false, exitCode: null, error: `No install blocks for ${payload.agentId}` };
-  }
+  const { blocks } = resolved;
 
   const methodIndex = payload.methodIndex ?? 0;
   const block = blocks[methodIndex] ?? blocks[0];
 
+  // Re-checked here even though the renderer gates the button: renderer gating
+  // is presentation, main is the security boundary.
   if (!isBlockExecutable(block)) {
     return {
       success: false,

--- a/electron/services/SystemHealthCheck.ts
+++ b/electron/services/SystemHealthCheck.ts
@@ -161,7 +161,7 @@ export async function checkPrerequisite(spec: PrerequisiteSpec): Promise<Prerequ
   const checkCmd = process.platform === "win32" ? "where" : "which";
   const command = spec.command ?? spec.tool;
 
-  let resolvedPath = "";
+  let resolvedPath: string;
   try {
     const { stdout } = await execFileAsync(checkCmd, [command], {
       encoding: "utf8",

--- a/electron/services/SystemHealthCheck.ts
+++ b/electron/services/SystemHealthCheck.ts
@@ -124,31 +124,37 @@ async function hasXcodeCommandLineTools(): Promise<boolean> {
   }
 }
 
+/** Whether the PATH lookup landed on a Windows shell shim. */
+function isWindowsShellShim(resolvedPath: string): boolean {
+  return /\.(cmd|bat)$/i.test(resolvedPath.split("\n")[0]?.trim() ?? "");
+}
+
 /**
  * Runs a tool's version command. On Windows the entry point for a lot of tools
  * is a `.cmd`/`.bat` shim (`npm.cmd`, and anything installed as an npm global
  * bin), which current Node refuses to spawn without a shell — it rejects with
  * EINVAL. That used to be invisible because a failed version command still
  * reported the tool as available; now that a failure means unavailable, the
- * shim has to be retried through a shell or every such tool reads as missing.
+ * shim has to run through a shell or every such tool reads as missing.
+ *
+ * The shell is used only when the resolved path is genuinely a shim — a fact
+ * main established from `where`, not something a caller can assert. A tool that
+ * can be spawned directly is never re-run through a shell just because it
+ * exited nonzero, which would both double-execute it and start interpreting its
+ * arguments as shell syntax.
  */
-async function runVersionCommand(command: string, versionArgs: string[]): Promise<string> {
-  try {
-    const { stdout } = await execFileAsync(command, versionArgs, {
-      encoding: "utf8",
-      timeout: CHECK_TIMEOUT_MS,
-    });
-    return stdout;
-  } catch (err) {
-    if (process.platform !== "win32") throw err;
-    const { stdout } = await execFileAsync(command, versionArgs, {
-      encoding: "utf8",
-      timeout: CHECK_TIMEOUT_MS,
-      shell: true,
-      windowsHide: true,
-    });
-    return stdout;
-  }
+async function runVersionCommand(
+  command: string,
+  versionArgs: string[],
+  resolvedPath: string
+): Promise<string> {
+  const useShell = process.platform === "win32" && isWindowsShellShim(resolvedPath);
+  const { stdout } = await execFileAsync(command, versionArgs, {
+    encoding: "utf8",
+    timeout: CHECK_TIMEOUT_MS,
+    ...(useShell ? { shell: true, windowsHide: true } : {}),
+  });
+  return stdout;
 }
 
 export async function checkPrerequisite(spec: PrerequisiteSpec): Promise<PrerequisiteCheckResult> {
@@ -180,7 +186,7 @@ export async function checkPrerequisite(spec: PrerequisiteSpec): Promise<Prerequ
 
   let stdout: string;
   try {
-    stdout = await runVersionCommand(command, spec.versionArgs);
+    stdout = await runVersionCommand(command, spec.versionArgs, resolvedPath);
   } catch {
     return unavailable(spec, "version-command-failed");
   }
@@ -288,11 +294,18 @@ export async function runSystemHealthCheck(
     // probe behind it. Concurrent forced callers (several views regaining focus
     // together) all join that one queued probe rather than each spawning.
     if (!fatalQueuedRefresh) {
+      const generation = fatalGeneration;
       const queued = fatalInflight
         .catch(() => undefined)
-        .then(() => startFatalProbe())
-        .finally(() => {
+        .then(() => {
+          // Released the moment this probe starts, not when it finishes: from
+          // here on it is "already running", so a force arriving later must
+          // queue its own rather than join one that predates it.
           if (fatalQueuedRefresh === queued) fatalQueuedRefresh = null;
+          // A reset landed while this was waiting — run detached so it can't
+          // publish into the new generation's cache or displace its probe.
+          if (generation !== fatalGeneration) return runHealthCheck(undefined, true);
+          return startFatalProbe();
         });
       fatalQueuedRefresh = queued;
     }

--- a/electron/services/SystemHealthCheck.ts
+++ b/electron/services/SystemHealthCheck.ts
@@ -1,13 +1,20 @@
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import * as path from "path";
 import * as semver from "semver";
 import { getEffectiveAgentConfig } from "../../shared/config/agentRegistry.js";
 import { refreshPath } from "../setup/environment.js";
+import { BASELINE_PREREQUISITES } from "./baselinePrerequisites.js";
 import type {
   PrerequisiteSpec,
   PrerequisiteSeverity,
   PrerequisiteCheckResult,
+  PrerequisiteUnavailableReason,
+  SystemHealthCheckOptions,
   SystemHealthCheckResult,
 } from "../../shared/types/ipc.js";
+
+const execFileAsync = promisify(execFile);
 
 const CHECK_TIMEOUT_MS = 5_000;
 
@@ -17,97 +24,7 @@ const SEVERITY_RANK: Record<PrerequisiteSeverity, number> = {
   silent: 0,
 };
 
-export const BASELINE_PREREQUISITES: PrerequisiteSpec[] = [
-  {
-    tool: "git",
-    label: "Git",
-    versionArgs: ["--version"],
-    severity: "fatal",
-    installUrl: "https://git-scm.com/downloads",
-    installBlocks: {
-      macos: [{ label: "Homebrew", commands: ["brew install git"] }],
-      windows: [{ label: "winget", commands: ["winget install --id Git.Git -e --source winget"] }],
-      linux: [{ label: "apt", commands: ["sudo apt-get install git"] }],
-    },
-  },
-  {
-    tool: "node",
-    label: "Node.js",
-    versionArgs: ["--version"],
-    severity: "fatal",
-    minVersion: "18.0.0",
-    installUrl: "https://nodejs.org",
-    installBlocks: {
-      macos: [
-        {
-          label: "Homebrew",
-          commands: ["brew install node"],
-          notes: ["npm is included with Node.js", "Requires Node.js v18.0.0 or later"],
-        },
-      ],
-      windows: [
-        {
-          label: "winget",
-          commands: ["winget install --id OpenJS.NodeJS.LTS -e --source winget"],
-          notes: ["npm is included with Node.js", "Requires Node.js v18.0.0 or later"],
-        },
-      ],
-      linux: [
-        {
-          label: "NodeSource",
-          commands: [
-            "curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -",
-            "sudo apt-get install -y nodejs",
-          ],
-          notes: [
-            "npm is included with Node.js",
-            "Requires Node.js v18.0.0 or later",
-            "The default Ubuntu nodejs package may be outdated — NodeSource provides current versions",
-          ],
-        },
-      ],
-    },
-  },
-  {
-    tool: "npm",
-    label: "npm",
-    versionArgs: ["--version"],
-    severity: "warn",
-    installUrl: "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm",
-    installBlocks: {
-      generic: [
-        {
-          label: "Included with Node.js",
-          steps: ["npm is automatically installed with Node.js"],
-          notes: ["If npm is missing, reinstall Node.js using the instructions above"],
-        },
-      ],
-    },
-  },
-  {
-    tool: "gh",
-    label: "GitHub CLI",
-    versionArgs: ["--version"],
-    severity: "warn",
-    installUrl: "https://cli.github.com",
-    installBlocks: {
-      macos: [{ label: "Homebrew", commands: ["brew install gh"] }],
-      windows: [{ label: "winget", commands: ["winget install --id GitHub.cli"] }],
-      linux: [
-        {
-          label: "Official APT repository",
-          commands: [
-            "sudo mkdir -p -m 755 /etc/apt/keyrings",
-            "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null",
-            "sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg",
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null',
-            "sudo apt update && sudo apt install gh -y",
-          ],
-        },
-      ],
-    },
-  },
-];
+export { BASELINE_PREREQUISITES };
 
 export function resolvePrerequisites(agentIds?: string[]): PrerequisiteSpec[] {
   const specMap = new Map<string, PrerequisiteSpec>();
@@ -163,36 +80,90 @@ function extractVersion(output: string): string | null {
   return coerced?.version ?? null;
 }
 
-export function checkPrerequisite(spec: PrerequisiteSpec): PrerequisiteCheckResult {
+function unavailable(
+  spec: PrerequisiteSpec,
+  reason: PrerequisiteUnavailableReason
+): PrerequisiteCheckResult {
+  return {
+    tool: spec.tool,
+    label: spec.label,
+    available: false,
+    unavailableReason: reason,
+    version: null,
+    severity: spec.severity,
+    meetsMinVersion: false,
+    minVersion: spec.minVersion,
+    installUrl: spec.installUrl,
+    installBlocks: spec.installBlocks,
+  };
+}
+
+/**
+ * Whether the PATH lookup landed on the macOS Command Line Tools shim rather
+ * than a real install. `/usr/bin/git` ships with the OS and exists even when
+ * the tools are absent; a Homebrew git at `/opt/homebrew/bin/git` is a real
+ * binary that works regardless, so it must not be gated behind the CLT probe.
+ */
+function isMacosCommandLineToolShim(resolvedPath: string, command: string): boolean {
+  const firstMatch = resolvedPath.split("\n")[0]?.trim();
+  if (!firstMatch) return false;
+  return firstMatch === path.join("/usr/bin", command);
+}
+
+async function hasXcodeCommandLineTools(): Promise<boolean> {
+  try {
+    // A real binary, not a shim — it exits nonzero and fast when the tools are
+    // missing, and never opens the installer dialog.
+    await execFileAsync("xcode-select", ["-p"], {
+      encoding: "utf8",
+      timeout: CHECK_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function checkPrerequisite(spec: PrerequisiteSpec): Promise<PrerequisiteCheckResult> {
   const checkCmd = process.platform === "win32" ? "where" : "which";
   const command = spec.command ?? spec.tool;
 
+  let resolvedPath = "";
   try {
-    execFileSync(checkCmd, [command], { stdio: "ignore", timeout: CHECK_TIMEOUT_MS });
+    const { stdout } = await execFileAsync(checkCmd, [command], {
+      encoding: "utf8",
+      timeout: CHECK_TIMEOUT_MS,
+    });
+    resolvedPath = stdout;
   } catch {
-    return {
-      tool: spec.tool,
-      label: spec.label,
-      available: false,
-      version: null,
-      severity: spec.severity,
-      meetsMinVersion: false,
-      minVersion: spec.minVersion,
-      installUrl: spec.installUrl,
-      installBlocks: spec.installBlocks,
-    };
+    return unavailable(spec, "not-found");
+  }
+
+  // Never execute the CLT shim blind: without the tools installed it pops the
+  // system installer dialog and hangs until the timeout kills the child, which
+  // a background startup probe must not do to the user.
+  if (
+    process.platform === "darwin" &&
+    spec.macosCommandLineTool &&
+    isMacosCommandLineToolShim(resolvedPath, command) &&
+    !(await hasXcodeCommandLineTools())
+  ) {
+    return unavailable(spec, "macos-command-line-tools-missing");
   }
 
   let version: string | null = null;
   try {
-    const output = execFileSync(command, spec.versionArgs, {
+    const { stdout } = await execFileAsync(command, spec.versionArgs, {
       encoding: "utf8",
       timeout: CHECK_TIMEOUT_MS,
-      stdio: ["ignore", "pipe", "ignore"],
     });
-    version = extractVersion(output);
+    // Parsing is deliberately outside the try: a tool that ran fine but printed
+    // an unrecognisable version string is still usable, so an unparseable
+    // version leaves `available` true with `version: null`. Only a failure to
+    // *execute* means unavailable.
+    version = extractVersion(stdout);
   } catch {
-    // Tool exists but version extraction failed
+    return unavailable(spec, "version-command-failed");
   }
 
   let meetsMinVersion = true;
@@ -224,22 +195,58 @@ export async function getHealthCheckSpecs(agentIds?: string[]): Promise<Prerequi
   return resolvePrerequisites(agentIds);
 }
 
-export async function runSystemHealthCheck(agentIds?: string[]): Promise<SystemHealthCheckResult> {
+// Cache for the fatal-only baseline check — the startup path. Every project
+// view renders its own AppLayout and asks for this, so without a main-side
+// cache the probe spawns once per open project. Deliberately not persisted:
+// process restart is the invalidation boundary, so a prerequisite the user
+// still hasn't installed comes back on the next launch.
+let fatalResultCache: SystemHealthCheckResult | null = null;
+let fatalInflight: Promise<SystemHealthCheckResult> | null = null;
+
+/** Test seam — drops the cached fatal-only result and any in-flight probe. */
+export function resetSystemHealthCheckCache(): void {
+  fatalResultCache = null;
+  fatalInflight = null;
+}
+
+async function runHealthCheck(agentIds?: string[], fatalOnly?: boolean) {
   await refreshPath();
-  const specs = resolvePrerequisites(agentIds);
+  const resolved = resolvePrerequisites(agentIds);
+  const specs = fatalOnly ? resolved.filter((s) => s.severity === "fatal") : resolved;
 
-  const results = await Promise.all(
-    specs.map(
-      (spec) =>
-        new Promise<PrerequisiteCheckResult>((resolve) => {
-          setImmediate(() => resolve(checkPrerequisite(spec)));
-        })
-    )
-  );
+  const prerequisites = await Promise.all(specs.map((spec) => checkPrerequisite(spec)));
 
-  const allRequired = results
+  const allRequired = prerequisites
     .filter((r) => r.severity === "fatal")
     .every((r) => r.available && r.meetsMinVersion);
 
-  return { prerequisites: results, allRequired };
+  return { prerequisites, allRequired };
+}
+
+export async function runSystemHealthCheck(
+  options?: SystemHealthCheckOptions
+): Promise<SystemHealthCheckResult> {
+  const { agentIds, fatalOnly, force } = options ?? {};
+
+  // Only the agent-less fatal subset is cacheable — it's the one every view
+  // requests. Agent-scoped and full checks (Settings, the Setup wizard) stay
+  // fresh so a manual re-check always re-probes.
+  const cacheable = fatalOnly === true && agentIds === undefined;
+  if (!cacheable) return runHealthCheck(agentIds, fatalOnly);
+
+  if (!force && fatalResultCache) return fatalResultCache;
+  // A forced run bypasses the settled cache but still joins an in-flight probe,
+  // so N views regaining focus together produce one spawn, not N.
+  if (fatalInflight) return fatalInflight;
+
+  const inflight = runHealthCheck(agentIds, fatalOnly)
+    .then((result) => {
+      fatalResultCache = result;
+      return result;
+    })
+    .finally(() => {
+      if (fatalInflight === inflight) fatalInflight = null;
+    });
+  fatalInflight = inflight;
+  return inflight;
 }

--- a/electron/services/SystemHealthCheck.ts
+++ b/electron/services/SystemHealthCheck.ts
@@ -129,6 +129,25 @@ function isWindowsShellShim(resolvedPath: string): boolean {
   return /\.(cmd|bat)$/i.test(resolvedPath.split("\n")[0]?.trim() ?? "");
 }
 
+/** A bare binary name or version flag — nothing cmd.exe treats as syntax. */
+const SHELL_INERT_TOKEN = /^[A-Za-z0-9._\-/=]+$/;
+
+/**
+ * Whether a version invocation can survive being flattened into a shell line.
+ * Node joins command and args with spaces and hands the result to
+ * `cmd.exe /d /s /c` without escaping anything (the reason passing args
+ * alongside `shell` is deprecated as DEP0190), so a `&&` or a quote in an
+ * argument is cmd.exe syntax rather than an argument. `checkPrerequisite` is
+ * reachable from the `system:check-tool` IPC channel with a caller-supplied
+ * spec, so the tokens are treated as untrusted wherever a shell is involved.
+ */
+export function isShellInertInvocation(command: unknown, versionArgs: unknown): boolean {
+  if (typeof command !== "string" || !Array.isArray(versionArgs)) return false;
+  return [command, ...versionArgs].every(
+    (token) => typeof token === "string" && SHELL_INERT_TOKEN.test(token)
+  );
+}
+
 /**
  * Runs a tool's version command. On Windows the entry point for a lot of tools
  * is a `.cmd`/`.bat` shim (`npm.cmd`, and anything installed as an npm global
@@ -141,7 +160,10 @@ function isWindowsShellShim(resolvedPath: string): boolean {
  * main established from `where`, not something a caller can assert. A tool that
  * can be spawned directly is never re-run through a shell just because it
  * exited nonzero, which would both double-execute it and start interpreting its
- * arguments as shell syntax.
+ * arguments as shell syntax. Because a shim leaves no argv-safe way to invoke it
+ * (spawning `cmd.exe` directly still hands cmd the raw line), the tokens are
+ * checked instead: an invocation that isn't inert never reaches the shell, and
+ * the caller sees the same unavailable result as any other failed probe.
  */
 async function runVersionCommand(
   command: string,
@@ -149,6 +171,9 @@ async function runVersionCommand(
   resolvedPath: string
 ): Promise<string> {
   const useShell = process.platform === "win32" && isWindowsShellShim(resolvedPath);
+  if (useShell && !isShellInertInvocation(command, versionArgs)) {
+    throw new Error(`Refusing to run "${command}" through a shell: unsafe version arguments`);
+  }
   const { stdout } = await execFileAsync(command, versionArgs, {
     encoding: "utf8",
     timeout: CHECK_TIMEOUT_MS,

--- a/electron/services/SystemHealthCheck.ts
+++ b/electron/services/SystemHealthCheck.ts
@@ -124,6 +124,33 @@ async function hasXcodeCommandLineTools(): Promise<boolean> {
   }
 }
 
+/**
+ * Runs a tool's version command. On Windows the entry point for a lot of tools
+ * is a `.cmd`/`.bat` shim (`npm.cmd`, and anything installed as an npm global
+ * bin), which current Node refuses to spawn without a shell — it rejects with
+ * EINVAL. That used to be invisible because a failed version command still
+ * reported the tool as available; now that a failure means unavailable, the
+ * shim has to be retried through a shell or every such tool reads as missing.
+ */
+async function runVersionCommand(command: string, versionArgs: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(command, versionArgs, {
+      encoding: "utf8",
+      timeout: CHECK_TIMEOUT_MS,
+    });
+    return stdout;
+  } catch (err) {
+    if (process.platform !== "win32") throw err;
+    const { stdout } = await execFileAsync(command, versionArgs, {
+      encoding: "utf8",
+      timeout: CHECK_TIMEOUT_MS,
+      shell: true,
+      windowsHide: true,
+    });
+    return stdout;
+  }
+}
+
 export async function checkPrerequisite(spec: PrerequisiteSpec): Promise<PrerequisiteCheckResult> {
   const checkCmd = process.platform === "win32" ? "where" : "which";
   const command = spec.command ?? spec.tool;
@@ -151,20 +178,17 @@ export async function checkPrerequisite(spec: PrerequisiteSpec): Promise<Prerequ
     return unavailable(spec, "macos-command-line-tools-missing");
   }
 
-  let version: string | null = null;
+  let stdout: string;
   try {
-    const { stdout } = await execFileAsync(command, spec.versionArgs, {
-      encoding: "utf8",
-      timeout: CHECK_TIMEOUT_MS,
-    });
-    // Parsing is deliberately outside the try: a tool that ran fine but printed
-    // an unrecognisable version string is still usable, so an unparseable
-    // version leaves `available` true with `version: null`. Only a failure to
-    // *execute* means unavailable.
-    version = extractVersion(stdout);
+    stdout = await runVersionCommand(command, spec.versionArgs);
   } catch {
     return unavailable(spec, "version-command-failed");
   }
+  // Parsing is deliberately outside the try: a tool that ran fine but printed
+  // an unrecognisable version string is still usable, so an unparseable version
+  // leaves `available` true with `version: null`. Only a failure to *execute*
+  // means unavailable.
+  const version = extractVersion(stdout);
 
   let meetsMinVersion = true;
   if (spec.minVersion && version) {
@@ -202,11 +226,34 @@ export async function getHealthCheckSpecs(agentIds?: string[]): Promise<Prerequi
 // still hasn't installed comes back on the next launch.
 let fatalResultCache: SystemHealthCheckResult | null = null;
 let fatalInflight: Promise<SystemHealthCheckResult> | null = null;
+// A forced probe that has to start only once the running one finishes. Without
+// this, a re-check fired the instant an install completes could join a probe
+// that began *before* it and conclude the tool is still missing.
+let fatalQueuedRefresh: Promise<SystemHealthCheckResult> | null = null;
+// Bumped on reset so a probe still in flight from a previous test can't land
+// its result in the cache afterwards.
+let fatalGeneration = 0;
 
 /** Test seam — drops the cached fatal-only result and any in-flight probe. */
 export function resetSystemHealthCheckCache(): void {
+  fatalGeneration += 1;
   fatalResultCache = null;
   fatalInflight = null;
+  fatalQueuedRefresh = null;
+}
+
+function startFatalProbe(): Promise<SystemHealthCheckResult> {
+  const generation = fatalGeneration;
+  const probe = runHealthCheck(undefined, true)
+    .then((result) => {
+      if (generation === fatalGeneration) fatalResultCache = result;
+      return result;
+    })
+    .finally(() => {
+      if (fatalInflight === probe) fatalInflight = null;
+    });
+  fatalInflight = probe;
+  return probe;
 }
 
 async function runHealthCheck(agentIds?: string[], fatalOnly?: boolean) {
@@ -234,19 +281,24 @@ export async function runSystemHealthCheck(
   const cacheable = fatalOnly === true && agentIds === undefined;
   if (!cacheable) return runHealthCheck(agentIds, fatalOnly);
 
-  if (!force && fatalResultCache) return fatalResultCache;
-  // A forced run bypasses the settled cache but still joins an in-flight probe,
-  // so N views regaining focus together produce one spawn, not N.
-  if (fatalInflight) return fatalInflight;
+  if (force) {
+    // Nothing running — probe now.
+    if (!fatalInflight) return startFatalProbe();
+    // Something is running that may predate this request, so chain a fresh
+    // probe behind it. Concurrent forced callers (several views regaining focus
+    // together) all join that one queued probe rather than each spawning.
+    if (!fatalQueuedRefresh) {
+      const queued = fatalInflight
+        .catch(() => undefined)
+        .then(() => startFatalProbe())
+        .finally(() => {
+          if (fatalQueuedRefresh === queued) fatalQueuedRefresh = null;
+        });
+      fatalQueuedRefresh = queued;
+    }
+    return fatalQueuedRefresh;
+  }
 
-  const inflight = runHealthCheck(agentIds, fatalOnly)
-    .then((result) => {
-      fatalResultCache = result;
-      return result;
-    })
-    .finally(() => {
-      if (fatalInflight === inflight) fatalInflight = null;
-    });
-  fatalInflight = inflight;
-  return inflight;
+  if (fatalResultCache) return fatalResultCache;
+  return fatalInflight ?? startFatalProbe();
 }

--- a/electron/services/__tests__/AgentInstallService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentInstallService.adversarial.test.ts
@@ -13,7 +13,11 @@ vi.mock("../../../shared/config/agentRegistry.js", async (importOriginal) => {
   };
 });
 
-import { isBlockExecutable, runAgentInstall } from "../AgentInstallService.js";
+import {
+  isBlockExecutable,
+  runAgentInstall,
+  resetInFlightInstalls,
+} from "../AgentInstallService.js";
 
 interface FakeChild extends EventEmitter {
   stdout: EventEmitter;
@@ -544,6 +548,69 @@ describe("AgentInstallService — elevation and prerequisite targets (#11763)", 
         expect(spawnMock).not.toHaveBeenCalled();
       }
     );
+  });
+
+  describe("concurrent installs", () => {
+    beforeEach(() => {
+      resetInFlightInstalls();
+    });
+
+    it("refuses a second install of the same target while one is running", async () => {
+      // Each project view is its own WebContentsView with its own store, so the
+      // renderer-side guard cannot see an install started in another view.
+      setPlatform("darwin");
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const first = runAgentInstall({ prerequisiteTool: "git", jobId: "job-a" }, vi.fn());
+      await Promise.resolve();
+      const second = await runAgentInstall({ prerequisiteTool: "git", jobId: "job-b" }, vi.fn());
+
+      expect(second.success).toBe(false);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      child.emitClose(0);
+      expect((await first).success).toBe(true);
+    });
+
+    it("releases the target once the install settles", async () => {
+      setPlatform("darwin");
+      const first = makeFakeChild();
+      spawnMock.mockReturnValue(first);
+
+      const failed = runAgentInstall({ prerequisiteTool: "git", jobId: "job-a" }, vi.fn());
+      await Promise.resolve();
+      first.emitClose(1);
+      expect((await failed).success).toBe(false);
+
+      const second = makeFakeChild();
+      spawnMock.mockReturnValue(second);
+      const retry = runAgentInstall({ prerequisiteTool: "git", jobId: "job-b" }, vi.fn());
+      await Promise.resolve();
+      second.emitClose(0);
+
+      expect((await retry).success).toBe(true);
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not block a different target", async () => {
+      setPlatform("darwin");
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+      getAgentConfigMock.mockReturnValue({
+        install: { byOs: { macos: [{ commands: ["brew install foo"] }] } },
+      });
+
+      const gitInstall = runAgentInstall({ prerequisiteTool: "git", jobId: "job-a" }, vi.fn());
+      await Promise.resolve();
+      const agentInstall = runAgentInstall({ agentId: "foo", jobId: "job-b" }, vi.fn());
+      await Promise.resolve();
+
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+      child.emitClose(0);
+      await gitInstall;
+      await agentInstall;
+    });
   });
 
   describe("windows git command", () => {

--- a/electron/services/__tests__/AgentInstallService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentInstallService.adversarial.test.ts
@@ -411,3 +411,136 @@ describe("AgentInstallService adversarial", () => {
     });
   });
 });
+
+describe("AgentInstallService — elevation and prerequisite targets (#11763)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPlatform("linux");
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  describe("sudo gate", () => {
+    it("refuses a bare sudo command", () => {
+      // No pipe, so the pipe-to-shell regex never saw it: spawning this with
+      // piped stdio hangs on a password prompt the user cannot see.
+      expect(isBlockExecutable({ commands: ["sudo apt-get install git"] })).toBe(false);
+    });
+
+    it("refuses a block where only a later command needs sudo", () => {
+      expect(isBlockExecutable({ commands: ["mkdir -p /tmp/x", "sudo apt-get install gh"] })).toBe(
+        false
+      );
+    });
+
+    it("refuses sudo regardless of leading whitespace or case", () => {
+      expect(isBlockExecutable({ commands: ["   sudo apt-get install git"] })).toBe(false);
+      expect(isBlockExecutable({ commands: ["SUDO apt-get install git"] })).toBe(false);
+    });
+
+    it("allows a command that merely mentions sudo later in the line", () => {
+      expect(isBlockExecutable({ commands: ["echo run sudo yourself"] })).toBe(true);
+    });
+
+    it("allows sudoedit and other commands with a sudo prefix in the name", () => {
+      expect(isBlockExecutable({ commands: ["sudoku --solve"] })).toBe(true);
+    });
+
+    it("never spawns for a sudo block", async () => {
+      getAgentConfigMock.mockReturnValue({
+        install: { byOs: { linux: [{ commands: ["sudo apt-get install gh"] }] } },
+      });
+
+      const result = await runAgentInstall({ agentId: "gh", jobId: "j-sudo" }, vi.fn());
+
+      expect(result.success).toBe(false);
+      expect(spawnMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("prerequisite install targets", () => {
+    it("rejects an unknown prerequisite without spawning", async () => {
+      const result = await runAgentInstall(
+        { prerequisiteTool: "definitely-not-a-tool", jobId: "j2" },
+        vi.fn()
+      );
+
+      expect(result.success).toBe(false);
+      expect(spawnMock).not.toHaveBeenCalled();
+    });
+
+    it("resolves commands from the baseline spec, not from the caller", async () => {
+      setPlatform("darwin");
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const promise = runAgentInstall({ prerequisiteTool: "git", jobId: "j3" }, vi.fn());
+      await Promise.resolve();
+      child.emitClose(0);
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      // The renderer named a tool; main chose the binary and its arguments.
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      expect(spawnMock.mock.calls[0]?.[0]).toBe("brew");
+    });
+
+    it("refuses the Linux git block because it needs sudo", async () => {
+      setPlatform("linux");
+
+      const result = await runAgentInstall({ prerequisiteTool: "git", jobId: "j4" }, vi.fn());
+
+      expect(result.success).toBe(false);
+      expect(spawnMock).not.toHaveBeenCalled();
+    });
+
+    it("does not consult the agent registry for a prerequisite target", async () => {
+      setPlatform("darwin");
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const promise = runAgentInstall({ prerequisiteTool: "git", jobId: "j5" }, vi.fn());
+      await Promise.resolve();
+      child.emitClose(0);
+      await promise;
+
+      expect(getAgentConfigMock).not.toHaveBeenCalled();
+    });
+
+    it("selects the Command Line Tools block by methodIndex on macOS", async () => {
+      setPlatform("darwin");
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const promise = runAgentInstall(
+        { prerequisiteTool: "git", methodIndex: 1, jobId: "j6" },
+        vi.fn()
+      );
+      await Promise.resolve();
+      child.emitClose(0);
+      await promise;
+
+      expect(spawnMock.mock.calls[0]?.[0]).toBe("xcode-select");
+    });
+  });
+
+  describe("windows git command", () => {
+    it("passes the agreement flags winget needs under piped stdio", async () => {
+      setPlatform("win32");
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const promise = runAgentInstall({ prerequisiteTool: "git", jobId: "j7" }, vi.fn());
+      await Promise.resolve();
+      child.emitClose(0);
+      await promise;
+
+      const args = spawnMock.mock.calls[0]?.[1] as string[];
+      expect(spawnMock.mock.calls[0]?.[0]).toBe("winget");
+      expect(args).toContain("--accept-source-agreements");
+      expect(args).toContain("--accept-package-agreements");
+    });
+  });
+});

--- a/electron/services/__tests__/AgentInstallService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentInstallService.adversarial.test.ts
@@ -526,6 +526,26 @@ describe("AgentInstallService — elevation and prerequisite targets (#11763)", 
     });
   });
 
+  describe("install method validation", () => {
+    it.each([99, -1, 1.5, NaN])(
+      "rejects out-of-range prerequisite method %s without spawning",
+      async (methodIndex) => {
+        setPlatform("darwin");
+
+        const result = await runAgentInstall(
+          { prerequisiteTool: "git", methodIndex, jobId: "j-idx" },
+          vi.fn()
+        );
+
+        // Block 0 is `brew install git` and block 1 hands off to Apple's
+        // installer — silently substituting one for the other would run an
+        // install the caller never asked for.
+        expect(result.success).toBe(false);
+        expect(spawnMock).not.toHaveBeenCalled();
+      }
+    );
+  });
+
   describe("windows git command", () => {
     it("passes the agreement flags winget needs under piped stdio", async () => {
       setPlatform("win32");

--- a/electron/services/__tests__/SystemHealthCheck.test.ts
+++ b/electron/services/__tests__/SystemHealthCheck.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
 import {
   runSystemHealthCheck,
   resolvePrerequisites,
+  resetSystemHealthCheckCache,
   BASELINE_PREREQUISITES,
 } from "../SystemHealthCheck.js";
 import { refreshPath } from "../../setup/environment.js";
 import { setUserRegistry, type AgentConfig } from "../../../shared/config/agentRegistry.js";
 
 vi.mock("child_process", () => ({
+  execFile: vi.fn(),
   execFileSync: vi.fn(),
 }));
 
@@ -16,7 +18,44 @@ vi.mock("../../setup/environment.js", () => ({
   refreshPath: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockedExecFileSync = vi.mocked(execFileSync);
+const mockedExecFile = vi.mocked(execFile);
+
+type ExecCallback = (err: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+/**
+ * Drives the promisified `execFile` from a plain (command, args) -> stdout
+ * function. Throwing from the handler stands in for a nonzero exit, which is
+ * the distinction the availability logic now turns on.
+ */
+function mockExec(handler: (cmd: string, args: string[]) => string) {
+  mockedExecFile.mockImplementation(((
+    cmd: string,
+    args: string[],
+    _options: unknown,
+    callback: ExecCallback
+  ) => {
+    try {
+      callback(null, { stdout: handler(cmd, args ?? []), stderr: "" });
+    } catch (err) {
+      callback(err as Error);
+    }
+    return undefined;
+  }) as never);
+}
+
+/** Commands the tool-presence probe should report as found. */
+function mockLookup(found: string[], versions: Record<string, string>) {
+  mockExec((cmd, args) => {
+    if (cmd === "which" || cmd === "where") {
+      const target = args[0] ?? "";
+      if (!found.includes(target)) throw new Error(`${target} not found`);
+      return `/usr/local/bin/${target}\n`;
+    }
+    const version = versions[cmd];
+    if (version === undefined) throw new Error(`${cmd} failed`);
+    return version;
+  });
+}
 
 describe("resolvePrerequisites", () => {
   it("returns baseline prerequisites when no agentIds provided", () => {
@@ -118,303 +157,184 @@ describe("resolvePrerequisites", () => {
 });
 
 describe("runSystemHealthCheck", () => {
+  const ALL_TOOLS = ["git", "node", "npm", "gh"];
+  const ALL_VERSIONS = {
+    git: "git version 2.43.0\n",
+    node: "v20.11.0\n",
+    npm: "10.2.4\n",
+    gh: "gh version 2.40.0 (2024-01-15)\nhttps://github.com/cli/cli\n",
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSystemHealthCheckCache();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  function mockAllBaselineAvailable() {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (cmd === "git") return "git version 2.43.0\n";
-      if (cmd === "node") return "v20.11.0\n";
-      if (cmd === "npm") return "10.2.4\n";
-      if (cmd === "gh") return "gh version 2.40.0 (2024-01-15)\nhttps://github.com/cli/cli\n";
-      if (arg === "git" || arg === "node" || arg === "npm" || arg === "gh") return "";
-      return "";
-    });
-  }
-
   it("calls refreshPath before checking prerequisites", async () => {
-    mockAllBaselineAvailable();
+    mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
     await runSystemHealthCheck();
 
     expect(refreshPath).toHaveBeenCalled();
   });
 
-  it("returns baseline tools when no agentIds provided", async () => {
-    mockAllBaselineAvailable();
+  it("returns a result for every resolved baseline spec", async () => {
+    mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
     const result = await runSystemHealthCheck();
 
-    expect(result.allRequired).toBe(true);
-    expect(result.prerequisites.length).toBe(BASELINE_PREREQUISITES.length);
-
-    const tools = result.prerequisites.map((p) => p.tool);
-    expect(tools).toContain("git");
-    expect(tools).toContain("node");
-    expect(tools).toContain("npm");
-    expect(tools).toContain("gh");
+    expect(result.prerequisites.map((p) => p.tool).sort()).toEqual(
+      resolvePrerequisites()
+        .map((s) => s.tool)
+        .sort()
+    );
   });
 
   it("extracts versions using semver.coerce", async () => {
-    mockAllBaselineAvailable();
+    mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
     const result = await runSystemHealthCheck();
 
     expect(result.prerequisites.find((p) => p.tool === "git")?.version).toBe("2.43.0");
     expect(result.prerequisites.find((p) => p.tool === "node")?.version).toBe("20.11.0");
-    expect(result.prerequisites.find((p) => p.tool === "npm")?.version).toBe("10.2.4");
-    expect(result.prerequisites.find((p) => p.tool === "gh")?.version).toBe("2.40.0");
   });
 
   it("includes agent prerequisites when agentIds provided", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (cmd === "git") return "git version 2.43.0\n";
-      if (cmd === "node") return "v20.11.0\n";
-      if (cmd === "npm") return "10.2.4\n";
-      if (cmd === "gh") return "gh version 2.40.0 (2024-01-15)\n";
-      if (cmd === "claude") return "1.2.3\n";
-      if (arg === "git" || arg === "node" || arg === "npm" || arg === "gh" || arg === "claude")
-        return "";
-      return "";
-    });
+    mockLookup([...ALL_TOOLS, "claude"], { ...ALL_VERSIONS, claude: "1.0.0\n" });
 
-    const result = await runSystemHealthCheck(["claude"]);
+    const result = await runSystemHealthCheck({ agentIds: ["claude"] });
 
-    const claude = result.prerequisites.find((p) => p.tool === "claude");
-    expect(claude).toBeDefined();
-    expect(claude?.available).toBe(true);
-    expect(claude?.severity).toBe("fatal");
-    expect(claude?.label).toBe("Claude CLI");
+    expect(result.prerequisites.some((p) => p.tool === "claude")).toBe(true);
   });
 
-  it("marks tool as unavailable when which/where fails", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (arg === "git") throw new Error("not found");
-      if (cmd === "node") return "v20.11.0\n";
-      if (cmd === "npm") return "10.2.4\n";
-      if (cmd === "gh") return "gh version 2.40.0\n";
-      return "";
-    });
+  it("marks a tool unavailable when the presence probe fails", async () => {
+    mockLookup(["node", "npm", "gh"], ALL_VERSIONS);
 
     const result = await runSystemHealthCheck();
 
     const git = result.prerequisites.find((p) => p.tool === "git");
     expect(git?.available).toBe(false);
+    expect(git?.unavailableReason).toBe("not-found");
+  });
+
+  it("marks a tool unavailable when the version command exits nonzero", async () => {
+    // The macOS Command Line Tools shim in miniature: the binary resolves, but
+    // running it fails. Before #11763 this reported healthy.
+    mockLookup(ALL_TOOLS, { node: ALL_VERSIONS.node, npm: ALL_VERSIONS.npm, gh: ALL_VERSIONS.gh });
+
+    const result = await runSystemHealthCheck();
+
+    const git = result.prerequisites.find((p) => p.tool === "git");
+    expect(git?.available).toBe(false);
+    expect(git?.unavailableReason).toBe("version-command-failed");
     expect(git?.version).toBeNull();
-    expect(result.allRequired).toBe(false);
   });
 
-  it("allRequired is false when fatal prerequisite is missing", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (arg === "node") throw new Error("not found");
-      if (cmd === "git") return "git version 2.43.0\n";
-      if (cmd === "npm") return "10.2.4\n";
-      if (cmd === "gh") return "gh version 2.40.0\n";
-      return "";
-    });
-
-    const result = await runSystemHealthCheck();
-    expect(result.allRequired).toBe(false);
-  });
-
-  it("allRequired is true when only warn-severity tool is missing", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (cmd === "git") return "git version 2.43.0\n";
-      if (cmd === "node") return "v20.11.0\n";
-      if (arg === "npm") throw new Error("not found");
-      if (arg === "gh") throw new Error("not found");
-      return "";
-    });
-
-    const result = await runSystemHealthCheck();
-    expect(result.allRequired).toBe(true);
-  });
-
-  it("returns available=true with null version if version command fails", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (arg === "git") return "";
-      if (cmd === "git") throw new Error("version check failed");
-      if (cmd === "node") return "v20.11.0\n";
-      if (cmd === "npm") return "10.2.4\n";
-      if (cmd === "gh") return "gh version 2.40.0\n";
-      return "";
-    });
+  it("keeps a tool available when it runs but prints an unparseable version", async () => {
+    mockLookup(ALL_TOOLS, { ...ALL_VERSIONS, git: "some custom build\n" });
 
     const result = await runSystemHealthCheck();
 
     const git = result.prerequisites.find((p) => p.tool === "git");
     expect(git?.available).toBe(true);
     expect(git?.version).toBeNull();
+    expect(git?.unavailableReason).toBeUndefined();
   });
 
-  it("allRequired is false when all tools are missing", async () => {
-    mockedExecFileSync.mockImplementation(() => {
-      throw new Error("not found");
-    });
-
-    const result = await runSystemHealthCheck();
-
-    expect(result.allRequired).toBe(false);
-    expect(result.prerequisites.every((p) => !p.available)).toBe(true);
-    expect(result.prerequisites.every((p) => p.version === null)).toBe(true);
-  });
-
-  it("meetsMinVersion is false when version is below minimum", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (cmd === "git") return "git version 2.43.0\n";
-      if (cmd === "node") return "v16.0.0\n"; // Below minVersion 18.0.0
-      if (cmd === "npm") return "10.2.4\n";
-      if (cmd === "gh") return "gh version 2.40.0\n";
-      if (arg === "git" || arg === "node" || arg === "npm" || arg === "gh") return "";
-      return "";
-    });
+  it("fails the minimum-version check when a versioned tool prints unparseable output", async () => {
+    mockLookup(ALL_TOOLS, { ...ALL_VERSIONS, node: "not-a-version\n" });
 
     const result = await runSystemHealthCheck();
 
     const node = result.prerequisites.find((p) => p.tool === "node");
     expect(node?.available).toBe(true);
-    expect(node?.version).toBe("16.0.0");
     expect(node?.meetsMinVersion).toBe(false);
+  });
+
+  it("meetsMinVersion is false when the version is below the minimum", async () => {
+    mockLookup(ALL_TOOLS, { ...ALL_VERSIONS, node: "v16.20.0\n" });
+
+    const result = await runSystemHealthCheck();
+
+    expect(result.prerequisites.find((p) => p.tool === "node")?.meetsMinVersion).toBe(false);
     expect(result.allRequired).toBe(false);
   });
 
-  it("meetsMinVersion is false when version command fails for a tool with minVersion", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (cmd === "git") return "git version 2.43.0\n";
-      if (arg === "node") return ""; // which succeeds
-      if (cmd === "node") throw new Error("version check failed"); // version extraction fails
-      if (cmd === "npm") return "10.2.4\n";
-      if (cmd === "gh") return "gh version 2.40.0\n";
-      return "";
-    });
+  it("allRequired is true when every fatal tool is healthy", async () => {
+    mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
     const result = await runSystemHealthCheck();
 
-    const node = result.prerequisites.find((p) => p.tool === "node");
-    expect(node?.available).toBe(true);
-    expect(node?.version).toBeNull();
-    expect(node?.meetsMinVersion).toBe(false);
+    expect(result.allRequired).toBe(true);
+  });
+
+  it("allRequired ignores warn-severity tools", async () => {
+    const fatalTools = resolvePrerequisites()
+      .filter((s) => s.severity === "fatal")
+      .map((s) => s.tool);
+    mockLookup(fatalTools, ALL_VERSIONS);
+
+    const result = await runSystemHealthCheck();
+
+    expect(result.prerequisites.some((p) => p.severity === "warn" && !p.available)).toBe(true);
+    expect(result.allRequired).toBe(true);
+  });
+
+  it("allRequired is false when a fatal tool is missing", async () => {
+    mockLookup([], {});
+
+    const result = await runSystemHealthCheck();
+
     expect(result.allRequired).toBe(false);
   });
 
-  it("handles unparsable version output gracefully", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (cmd === "git") return "git version 2.43.0\n";
-      if (cmd === "node") return "not-a-version\n";
-      if (cmd === "npm") return "10.2.4\n";
-      if (cmd === "gh") return "gh version 2.40.0\n";
-      if (arg === "git" || arg === "node" || arg === "npm" || arg === "gh") return "";
-      return "";
-    });
+  it("carries label, severity, installUrl and installBlocks from the spec", async () => {
+    mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
     const result = await runSystemHealthCheck();
 
-    const node = result.prerequisites.find((p) => p.tool === "node");
-    expect(node?.available).toBe(true);
-    expect(node?.version).toBeNull();
-    expect(node?.meetsMinVersion).toBe(false);
-  });
-
-  it("meetsMinVersion is true when version meets minimum", async () => {
-    mockAllBaselineAvailable();
-
-    const result = await runSystemHealthCheck();
-
-    const node = result.prerequisites.find((p) => p.tool === "node");
-    expect(node?.meetsMinVersion).toBe(true);
-  });
-
-  it("each result includes label, severity, and installUrl from spec", async () => {
-    mockAllBaselineAvailable();
-
-    const result = await runSystemHealthCheck();
-
+    const gitSpec = resolvePrerequisites().find((s) => s.tool === "git");
     const git = result.prerequisites.find((p) => p.tool === "git");
-    expect(git?.label).toBe("Git");
-    expect(git?.severity).toBe("fatal");
-    expect(git?.installUrl).toBe("https://git-scm.com/downloads");
-
-    const gh = result.prerequisites.find((p) => p.tool === "gh");
-    expect(gh?.label).toBe("GitHub CLI");
-    expect(gh?.severity).toBe("warn");
+    expect(git?.label).toBe(gitSpec?.label);
+    expect(git?.severity).toBe(gitSpec?.severity);
+    expect(git?.installUrl).toBe(gitSpec?.installUrl);
+    expect(git?.installBlocks).toEqual(gitSpec?.installBlocks);
   });
 
-  it("forwards installBlocks from spec to result for available tools", async () => {
-    mockAllBaselineAvailable();
-
-    const result = await runSystemHealthCheck();
-
-    const git = result.prerequisites.find((p) => p.tool === "git");
-    expect(git?.installBlocks).toBeDefined();
-    expect(git?.installBlocks?.macos).toBeDefined();
-    expect(git?.installBlocks?.macos?.[0]?.commands).toContain("brew install git");
-
-    const node = result.prerequisites.find((p) => p.tool === "node");
-    expect(node?.installBlocks?.linux?.[0]?.label).toBe("NodeSource");
-
-    const npm = result.prerequisites.find((p) => p.tool === "npm");
-    expect(npm?.installBlocks?.generic).toBeDefined();
-
-    const gh = result.prerequisites.find((p) => p.tool === "gh");
-    expect(gh?.installBlocks?.windows?.[0]?.commands).toContain("winget install --id GitHub.cli");
-  });
-
-  it("forwards installBlocks from spec to result for unavailable tools", async () => {
-    mockedExecFileSync.mockImplementation(() => {
-      throw new Error("not found");
-    });
+  it("carries installBlocks through for unavailable tools too", async () => {
+    mockLookup([], {});
 
     const result = await runSystemHealthCheck();
 
     const git = result.prerequisites.find((p) => p.tool === "git");
     expect(git?.available).toBe(false);
-    expect(git?.installBlocks?.macos).toBeDefined();
-    expect(git?.installBlocks?.windows).toBeDefined();
-    expect(git?.installBlocks?.linux).toBeDefined();
+    expect(git?.installBlocks).toEqual(
+      resolvePrerequisites().find((s) => s.tool === "git")?.installBlocks
+    );
   });
 
-  it("handles gh --version multi-line output correctly", async () => {
-    mockedExecFileSync.mockImplementation((cmd, args) => {
-      const arg = Array.isArray(args) ? args[0] : "";
-      if (cmd === "gh")
-        return "gh version 2.40.0 (2024-01-15)\nhttps://github.com/cli/cli/releases/tag/v2.40.0\n";
-      if (cmd === "git") return "git version 2.43.0\n";
-      if (cmd === "node") return "v20.11.0\n";
-      if (cmd === "npm") return "10.2.4\n";
-      if (arg === "git" || arg === "node" || arg === "npm" || arg === "gh") return "";
-      return "";
-    });
+  it("reads only the first line of multi-line version output", async () => {
+    mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
     const result = await runSystemHealthCheck();
-    const gh = result.prerequisites.find((p) => p.tool === "gh");
-    expect(gh?.version).toBe("2.40.0");
+
+    expect(result.prerequisites.find((p) => p.tool === "gh")?.version).toBe("2.40.0");
   });
 
   it("uses 'which' on unix-like systems", async () => {
     const originalPlatform = process.platform;
     try {
-      Object.defineProperty(process, "platform", { value: "darwin", writable: true });
-      mockedExecFileSync.mockReturnValue(Buffer.from(""));
+      Object.defineProperty(process, "platform", { value: "linux", writable: true });
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
       await runSystemHealthCheck();
 
-      const calls = mockedExecFileSync.mock.calls;
-      const whichCalls = calls.filter((c) => c[0] === "which");
-      expect(whichCalls.length).toBeGreaterThan(0);
+      expect(mockedExecFile.mock.calls.some((c) => c[0] === "which")).toBe(true);
+      expect(mockedExecFile.mock.calls.some((c) => c[0] === "where")).toBe(false);
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
     }
@@ -424,15 +344,152 @@ describe("runSystemHealthCheck", () => {
     const originalPlatform = process.platform;
     try {
       Object.defineProperty(process, "platform", { value: "win32", writable: true });
-      mockedExecFileSync.mockReturnValue(Buffer.from(""));
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
       await runSystemHealthCheck();
 
-      const calls = mockedExecFileSync.mock.calls;
-      const whereCalls = calls.filter((c) => c[0] === "where");
-      expect(whereCalls.length).toBeGreaterThan(0);
+      expect(mockedExecFile.mock.calls.some((c) => c[0] === "where")).toBe(true);
+      expect(mockedExecFile.mock.calls.some((c) => c[0] === "which")).toBe(false);
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
     }
+  });
+
+  describe("fatalOnly subset", () => {
+    it("probes only fatal specs", async () => {
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
+
+      const result = await runSystemHealthCheck({ fatalOnly: true });
+
+      expect(result.prerequisites.length).toBeGreaterThan(0);
+      expect(result.prerequisites.every((p) => p.severity === "fatal")).toBe(true);
+      expect(result.prerequisites.some((p) => p.tool === "gh")).toBe(false);
+    });
+  });
+
+  describe("fatal-only caching", () => {
+    it("probes once across repeated calls", async () => {
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
+
+      await runSystemHealthCheck({ fatalOnly: true });
+      const callsAfterFirst = mockedExecFile.mock.calls.length;
+      await runSystemHealthCheck({ fatalOnly: true });
+
+      expect(mockedExecFile.mock.calls.length).toBe(callsAfterFirst);
+    });
+
+    it("collapses concurrent callers into a single probe", async () => {
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
+
+      const [a, b] = await Promise.all([
+        runSystemHealthCheck({ fatalOnly: true }),
+        runSystemHealthCheck({ fatalOnly: true }),
+      ]);
+
+      expect(a).toBe(b);
+      expect(refreshPath).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-probes when forced, and reflects a tool that appeared since", async () => {
+      mockLookup(["node", "npm", "gh"], ALL_VERSIONS);
+      const before = await runSystemHealthCheck({ fatalOnly: true });
+      expect(before.prerequisites.find((p) => p.tool === "git")?.available).toBe(false);
+
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
+      const cached = await runSystemHealthCheck({ fatalOnly: true });
+      expect(cached.prerequisites.find((p) => p.tool === "git")?.available).toBe(false);
+
+      const forced = await runSystemHealthCheck({ fatalOnly: true, force: true });
+      expect(forced.prerequisites.find((p) => p.tool === "git")?.available).toBe(true);
+    });
+
+    it("does not serve the cache to a full check", async () => {
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
+      await runSystemHealthCheck({ fatalOnly: true });
+
+      const full = await runSystemHealthCheck();
+
+      expect(full.prerequisites.some((p) => p.severity === "warn")).toBe(true);
+    });
+
+    it("does not cache agent-scoped checks", async () => {
+      mockLookup([...ALL_TOOLS, "claude"], { ...ALL_VERSIONS, claude: "1.0.0\n" });
+
+      await runSystemHealthCheck({ fatalOnly: true, agentIds: ["claude"] });
+      const callsAfterFirst = mockedExecFile.mock.calls.length;
+      await runSystemHealthCheck({ fatalOnly: true, agentIds: ["claude"] });
+
+      expect(mockedExecFile.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
+  });
+
+  describe("macOS Command Line Tools shim", () => {
+    const originalPlatform = process.platform;
+
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    });
+
+    it("never executes the shim when the tools are absent", async () => {
+      mockExec((cmd, args) => {
+        if (cmd === "which") return `/usr/bin/${args[0]}\n`;
+        if (cmd === "xcode-select") throw new Error("unable to get active developer directory");
+        if (cmd === "git") throw new Error("git should never be executed here");
+        return "1.0.0\n";
+      });
+
+      const result = await runSystemHealthCheck({ fatalOnly: true });
+
+      const git = result.prerequisites.find((p) => p.tool === "git");
+      expect(git?.available).toBe(false);
+      expect(git?.unavailableReason).toBe("macos-command-line-tools-missing");
+      expect(mockedExecFile.mock.calls.some((c) => c[0] === "git")).toBe(false);
+    });
+
+    it("runs the version command when the tools are present", async () => {
+      mockExec((cmd, args) => {
+        if (cmd === "which") return `/usr/bin/${args[0]}\n`;
+        if (cmd === "xcode-select") return "/Library/Developer/CommandLineTools\n";
+        if (cmd === "git") return "git version 2.43.0\n";
+        return "v20.11.0\n";
+      });
+
+      const result = await runSystemHealthCheck({ fatalOnly: true });
+
+      expect(result.prerequisites.find((p) => p.tool === "git")?.available).toBe(true);
+    });
+
+    it("skips the tools probe when git resolves outside /usr/bin", async () => {
+      // A Homebrew git is a real binary and works whether or not the Command
+      // Line Tools are installed, so it must not be gated behind them.
+      mockExec((cmd, args) => {
+        if (cmd === "which") return `/opt/homebrew/bin/${args[0]}\n`;
+        if (cmd === "xcode-select") throw new Error("unable to get active developer directory");
+        if (cmd === "git") return "git version 2.43.0\n";
+        return "v20.11.0\n";
+      });
+
+      const result = await runSystemHealthCheck({ fatalOnly: true });
+
+      expect(result.prerequisites.find((p) => p.tool === "git")?.available).toBe(true);
+      expect(mockedExecFile.mock.calls.some((c) => c[0] === "xcode-select")).toBe(false);
+    });
+
+    it("does not probe the tools for prerequisites that aren't CLT-provided", async () => {
+      mockExec((cmd, args) => {
+        if (cmd === "which") return args[0] === "node" ? "/usr/bin/node\n" : "/opt/bin/git\n";
+        if (cmd === "xcode-select") throw new Error("unable to get active developer directory");
+        if (cmd === "git") return "git version 2.43.0\n";
+        return "v20.11.0\n";
+      });
+
+      const result = await runSystemHealthCheck({ fatalOnly: true });
+
+      expect(result.prerequisites.find((p) => p.tool === "node")?.available).toBe(true);
+    });
   });
 });

--- a/electron/services/__tests__/SystemHealthCheck.test.ts
+++ b/electron/services/__tests__/SystemHealthCheck.test.ts
@@ -174,12 +174,19 @@ describe("runSystemHealthCheck", () => {
     vi.restoreAllMocks();
   });
 
-  it("calls refreshPath before checking prerequisites", async () => {
+  it("refreshes PATH before spawning any probe", async () => {
+    // Ordering matters: a probe that runs first would miss a tool installed
+    // since launch, which is the whole point of the mid-session re-check.
+    let refreshedBeforeFirstProbe: boolean | null = null;
+    vi.mocked(refreshPath).mockImplementation(async () => {
+      refreshedBeforeFirstProbe ??= mockedExecFile.mock.calls.length === 0;
+    });
     mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
     await runSystemHealthCheck();
 
-    expect(refreshPath).toHaveBeenCalled();
+    expect(refreshedBeforeFirstProbe).toBe(true);
+    expect(mockedExecFile.mock.calls.length).toBeGreaterThan(0);
   });
 
   it("returns a result for every resolved baseline spec", async () => {
@@ -326,9 +333,9 @@ describe("runSystemHealthCheck", () => {
   });
 
   it("uses 'which' on unix-like systems", async () => {
-    const originalPlatform = process.platform;
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
     try {
-      Object.defineProperty(process, "platform", { value: "linux", writable: true });
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
       mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
       await runSystemHealthCheck();
@@ -336,14 +343,14 @@ describe("runSystemHealthCheck", () => {
       expect(mockedExecFile.mock.calls.some((c) => c[0] === "which")).toBe(true);
       expect(mockedExecFile.mock.calls.some((c) => c[0] === "where")).toBe(false);
     } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+      Object.defineProperty(process, "platform", originalPlatform);
     }
   });
 
   it("uses 'where' on windows", async () => {
-    const originalPlatform = process.platform;
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
     try {
-      Object.defineProperty(process, "platform", { value: "win32", writable: true });
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       mockLookup(ALL_TOOLS, ALL_VERSIONS);
 
       await runSystemHealthCheck();
@@ -351,7 +358,7 @@ describe("runSystemHealthCheck", () => {
       expect(mockedExecFile.mock.calls.some((c) => c[0] === "where")).toBe(true);
       expect(mockedExecFile.mock.calls.some((c) => c[0] === "which")).toBe(false);
     } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+      Object.defineProperty(process, "platform", originalPlatform);
     }
   });
 
@@ -412,6 +419,42 @@ describe("runSystemHealthCheck", () => {
       expect(full.prerequisites.some((p) => p.severity === "warn")).toBe(true);
     });
 
+    it("a forced check never joins a probe that started before it", async () => {
+      // The post-install re-check: a focus probe is already running with the
+      // tool absent when the install finishes. Joining it would report the tool
+      // still missing.
+      let releaseFirstProbe: () => void = () => {};
+      const firstProbeStarted = new Promise<void>((started) => {
+        mockedExecFile.mockImplementation(((
+          cmd: string,
+          args: string[],
+          _options: unknown,
+          callback: ExecCallback
+        ) => {
+          if (cmd === "which" && args[0] === "git") {
+            started();
+            void new Promise<void>((release) => {
+              releaseFirstProbe = () => release();
+            }).then(() => callback(new Error("git not found")));
+            return undefined;
+          }
+          callback(null, { stdout: "v20.11.0\n", stderr: "" });
+          return undefined;
+        }) as never);
+      });
+
+      const slowProbe = runSystemHealthCheck({ fatalOnly: true });
+      await firstProbeStarted;
+
+      // Git gets installed while that probe is still in flight.
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
+      const forced = runSystemHealthCheck({ fatalOnly: true, force: true });
+      releaseFirstProbe();
+
+      expect((await slowProbe).prerequisites.find((p) => p.tool === "git")?.available).toBe(false);
+      expect((await forced).prerequisites.find((p) => p.tool === "git")?.available).toBe(true);
+    });
+
     it("does not cache agent-scoped checks", async () => {
       mockLookup([...ALL_TOOLS, "claude"], { ...ALL_VERSIONS, claude: "1.0.0\n" });
 
@@ -424,14 +467,17 @@ describe("runSystemHealthCheck", () => {
   });
 
   describe("macOS Command Line Tools shim", () => {
-    const originalPlatform = process.platform;
+    // Preserve the whole descriptor: replacing it with a `writable: true` data
+    // property leaks a mutable `process.platform` into every later test sharing
+    // the worker.
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
 
     beforeEach(() => {
-      Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     });
 
     afterEach(() => {
-      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+      Object.defineProperty(process, "platform", originalPlatform);
     });
 
     it("never executes the shim when the tools are absent", async () => {

--- a/electron/services/__tests__/SystemHealthCheck.test.ts
+++ b/electron/services/__tests__/SystemHealthCheck.test.ts
@@ -4,6 +4,7 @@ import {
   runSystemHealthCheck,
   resolvePrerequisites,
   resetSystemHealthCheckCache,
+  checkPrerequisite,
   BASELINE_PREREQUISITES,
 } from "../SystemHealthCheck.js";
 import { refreshPath } from "../../setup/environment.js";
@@ -539,6 +540,38 @@ describe("runSystemHealthCheck", () => {
 
       expect(result.prerequisites.find((p) => p.tool === "git")?.available).toBe(false);
       expect(mockedExecFile.mock.calls.filter((c) => c[0] === "git")).toHaveLength(1);
+    });
+
+    it("only shells out for a shim when every argument is inert", async () => {
+      // `system:check-tool` hands checkPrerequisite a caller-supplied spec, and
+      // Node flattens command + args into the cmd.exe line without escaping, so
+      // a `&&` argument would run a second command. It has to be rejected before
+      // the spawn, not merely quoted.
+      const invocations: string[][] = [];
+      mockExec((cmd, args) => {
+        if (cmd === "where") return `C:\\Program Files\\nodejs\\${args[0]}.cmd\r\n`;
+        invocations.push([cmd, ...args]);
+        return "10.2.4\n";
+      });
+
+      const injected = await checkPrerequisite({
+        tool: "npm",
+        label: "npm",
+        versionArgs: ["--version", "&&", "calc"],
+        severity: "warn",
+      });
+      const inert = await checkPrerequisite({
+        tool: "npm",
+        label: "npm",
+        versionArgs: ["--version"],
+        severity: "warn",
+      });
+
+      expect(injected.available).toBe(false);
+      expect(injected.unavailableReason).toBe("version-command-failed");
+      expect(inert.available).toBe(true);
+      // Only the inert spec ever reached a spawn.
+      expect(invocations).toEqual([["npm", "--version"]]);
     });
   });
 

--- a/electron/services/__tests__/SystemHealthCheck.test.ts
+++ b/electron/services/__tests__/SystemHealthCheck.test.ts
@@ -455,6 +455,23 @@ describe("runSystemHealthCheck", () => {
       expect((await forced).prerequisites.find((p) => p.tool === "git")?.available).toBe(true);
     });
 
+    it("a forced check arriving after the queued probe started gets its own", async () => {
+      // Two forced checks may only share a probe while it has not started yet.
+      // Once it is running it predates the later caller, so that caller needs a
+      // fresh one — otherwise a re-check right after an install can still read
+      // the pre-install world.
+      mockLookup(ALL_TOOLS, ALL_VERSIONS);
+      const slow = runSystemHealthCheck({ fatalOnly: true });
+      const firstForce = runSystemHealthCheck({ fatalOnly: true, force: true });
+      await slow;
+      await firstForce;
+      const callsAfterQueuedProbe = mockedExecFile.mock.calls.length;
+
+      await runSystemHealthCheck({ fatalOnly: true, force: true });
+
+      expect(mockedExecFile.mock.calls.length).toBeGreaterThan(callsAfterQueuedProbe);
+    });
+
     it("does not cache agent-scoped checks", async () => {
       mockLookup([...ALL_TOOLS, "claude"], { ...ALL_VERSIONS, claude: "1.0.0\n" });
 
@@ -463,6 +480,65 @@ describe("runSystemHealthCheck", () => {
       await runSystemHealthCheck({ fatalOnly: true, agentIds: ["claude"] });
 
       expect(mockedExecFile.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
+  });
+
+  describe("Windows shell shims", () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", originalPlatform);
+    });
+
+    /** Options the version command was invoked with, per binary. */
+    function versionCallOptions(bin: string): Record<string, unknown> | undefined {
+      const call = mockedExecFile.mock.calls.find((c) => c[0] === bin);
+      return call?.[2] as Record<string, unknown> | undefined;
+    }
+
+    it("runs a .cmd shim through a shell so it isn't reported missing", async () => {
+      // Node refuses to spawn .cmd directly; without the shell npm would read
+      // as unavailable now that a failed version command means unavailable.
+      mockExec((cmd, args) => {
+        if (cmd === "where") return `C:\\Program Files\\nodejs\\${args[0]}.cmd\r\n`;
+        if (cmd === "npm") return "10.2.4\n";
+        if (cmd === "node") return "v20.11.0\n";
+        return "1.0.0\n";
+      });
+
+      const result = await runSystemHealthCheck();
+
+      expect(result.prerequisites.find((p) => p.tool === "npm")?.available).toBe(true);
+      expect(versionCallOptions("npm")?.shell).toBe(true);
+    });
+
+    it("does not use a shell for a real executable", async () => {
+      mockExec((cmd, args) => {
+        if (cmd === "where") return `C:\\Program Files\\nodejs\\${args[0]}.exe\r\n`;
+        if (cmd === "node") return "v20.11.0\n";
+        return "1.0.0\n";
+      });
+
+      await runSystemHealthCheck();
+
+      expect(versionCallOptions("node")?.shell).toBeUndefined();
+    });
+
+    it("does not re-run a real executable that exited nonzero", async () => {
+      mockExec((cmd, args) => {
+        if (cmd === "where") return `C:\\bin\\${args[0]}.exe\r\n`;
+        if (cmd === "git") throw new Error("git is broken");
+        return "v20.11.0\n";
+      });
+
+      const result = await runSystemHealthCheck();
+
+      expect(result.prerequisites.find((p) => p.tool === "git")?.available).toBe(false);
+      expect(mockedExecFile.mock.calls.filter((c) => c[0] === "git")).toHaveLength(1);
     });
   });
 

--- a/electron/services/baselinePrerequisites.ts
+++ b/electron/services/baselinePrerequisites.ts
@@ -1,0 +1,120 @@
+import type { PrerequisiteSpec } from "../../shared/types/ipc.js";
+
+/**
+ * Tools Daintree needs regardless of which agents are configured. Kept in its
+ * own module so consumers that only need the declarative data — the install
+ * service resolving a one-click target, for one — don't pull in the health
+ * check's `child_process` and PATH-refresh dependencies, which reach into
+ * Electron's `app` and can't load outside the main process.
+ */
+export const BASELINE_PREREQUISITES: PrerequisiteSpec[] = [
+  {
+    tool: "git",
+    label: "Git",
+    versionArgs: ["--version"],
+    severity: "fatal",
+    installUrl: "https://git-scm.com/downloads",
+    macosCommandLineTool: true,
+    installBlocks: {
+      macos: [
+        { label: "Homebrew", commands: ["brew install git"] },
+        {
+          label: "Xcode Command Line Tools",
+          commands: ["xcode-select --install"],
+          opensExternalInstaller: true,
+          notes: ["Opens the macOS installer — finish it there, then re-check"],
+        },
+      ],
+      windows: [
+        {
+          label: "winget",
+          // The agreement flags are part of the canonical command so the
+          // copy-paste and one-click paths run the same string: without them
+          // winget blocks on the source-agreement prompt on first use, which
+          // is invisible under piped stdio.
+          commands: [
+            "winget install --id Git.Git -e --source winget --accept-source-agreements --accept-package-agreements",
+          ],
+        },
+      ],
+      linux: [{ label: "apt", commands: ["sudo apt-get install git"] }],
+    },
+  },
+  {
+    tool: "node",
+    label: "Node.js",
+    versionArgs: ["--version"],
+    severity: "fatal",
+    minVersion: "18.0.0",
+    installUrl: "https://nodejs.org",
+    installBlocks: {
+      macos: [
+        {
+          label: "Homebrew",
+          commands: ["brew install node"],
+          notes: ["npm is included with Node.js", "Requires Node.js v18.0.0 or later"],
+        },
+      ],
+      windows: [
+        {
+          label: "winget",
+          commands: ["winget install --id OpenJS.NodeJS.LTS -e --source winget"],
+          notes: ["npm is included with Node.js", "Requires Node.js v18.0.0 or later"],
+        },
+      ],
+      linux: [
+        {
+          label: "NodeSource",
+          commands: [
+            "curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -",
+            "sudo apt-get install -y nodejs",
+          ],
+          notes: [
+            "npm is included with Node.js",
+            "Requires Node.js v18.0.0 or later",
+            "The default Ubuntu nodejs package may be outdated — NodeSource provides current versions",
+          ],
+        },
+      ],
+    },
+  },
+  {
+    tool: "npm",
+    label: "npm",
+    versionArgs: ["--version"],
+    severity: "warn",
+    installUrl: "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm",
+    installBlocks: {
+      generic: [
+        {
+          label: "Included with Node.js",
+          steps: ["npm is automatically installed with Node.js"],
+          notes: ["If npm is missing, reinstall Node.js using the instructions above"],
+        },
+      ],
+    },
+  },
+  {
+    tool: "gh",
+    label: "GitHub CLI",
+    versionArgs: ["--version"],
+    severity: "warn",
+    installUrl: "https://cli.github.com",
+    installBlocks: {
+      macos: [{ label: "Homebrew", commands: ["brew install gh"] }],
+      windows: [{ label: "winget", commands: ["winget install --id GitHub.cli"] }],
+      linux: [
+        {
+          label: "Official APT repository",
+          commands: [
+            "sudo mkdir -p -m 755 /etc/apt/keyrings",
+            "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null",
+            "sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg",
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null',
+            "sudo apt update && sudo apt install gh -y",
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/electron/services/baselinePrerequisites.ts
+++ b/electron/services/baselinePrerequisites.ts
@@ -58,7 +58,9 @@ export const BASELINE_PREREQUISITES: PrerequisiteSpec[] = [
       windows: [
         {
           label: "winget",
-          commands: ["winget install --id OpenJS.NodeJS.LTS -e --source winget"],
+          commands: [
+            "winget install --id OpenJS.NodeJS.LTS -e --source winget --accept-source-agreements --accept-package-agreements",
+          ],
           notes: ["npm is included with Node.js", "Requires Node.js v18.0.0 or later"],
         },
       ],
@@ -102,7 +104,14 @@ export const BASELINE_PREREQUISITES: PrerequisiteSpec[] = [
     installUrl: "https://cli.github.com",
     installBlocks: {
       macos: [{ label: "Homebrew", commands: ["brew install gh"] }],
-      windows: [{ label: "winget", commands: ["winget install --id GitHub.cli"] }],
+      windows: [
+        {
+          label: "winget",
+          commands: [
+            "winget install --id GitHub.cli -e --source winget --accept-source-agreements --accept-package-agreements",
+          ],
+        },
+      ],
       linux: [
         {
           label: "Official APT repository",

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -13,6 +13,13 @@ export interface AgentInstallBlock {
   steps?: string[];
   commands?: string[];
   notes?: string[];
+  /**
+   * The command hands off to an external/GUI installer and returns before that
+   * installer finishes, so a zero exit code does NOT mean the tool is
+   * installed. `xcode-select --install` is the canonical case. Callers must
+   * surface a "finish it, then re-check" state rather than reporting success.
+   */
+  opensExternalInstaller?: boolean;
 }
 
 export interface AgentInstallHelp {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -434,7 +434,9 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     getAgentUpdateSettings(): Promise<AgentUpdateSettings>;
     setAgentUpdateSettings(settings: AgentUpdateSettings): Promise<void>;
     startAgentUpdate(payload: StartAgentUpdatePayload): Promise<StartAgentUpdateResult>;
-    healthCheck(agentIds?: string[]): Promise<SystemHealthCheckResult>;
+    healthCheck(
+      options?: import("./system.js").SystemHealthCheckOptions
+    ): Promise<SystemHealthCheckResult>;
     getHealthCheckSpecs(agentIds?: string[]): Promise<PrerequisiteSpec[]>;
     checkTool(spec: PrerequisiteSpec): Promise<PrerequisiteCheckResult>;
     downloadDiagnostics(): Promise<boolean>;
@@ -450,11 +452,9 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     getReportEnrichment(): Promise<import("./system.js").ReportIssueEnrichment>;
     startRendererCpuProfile(): Promise<import("./system.js").RendererCpuProfileStartResult>;
     stopRendererCpuProfile(): Promise<import("./system.js").RendererCpuProfileStopResult>;
-    installAgent(payload: {
-      agentId: string;
-      methodIndex?: number;
-      jobId: string;
-    }): Promise<import("./system.js").AgentInstallResult>;
+    installAgent(
+      payload: import("./system.js").AgentInstallPayload
+    ): Promise<import("./system.js").AgentInstallResult>;
     onAgentInstallProgress(
       callback: (event: import("./system.js").AgentInstallProgressEvent) => void
     ): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -56,6 +56,7 @@ import type {
   AgentUpdateSettings,
   StartAgentUpdatePayload,
   StartAgentUpdateResult,
+  SystemHealthCheckOptions,
   SystemHealthCheckResult,
   AppMetricsSummary,
   HardwareInfo,
@@ -347,7 +348,7 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   };
 
   "system:health-check": {
-    args: [agentIds?: string[]];
+    args: [options?: SystemHealthCheckOptions];
     result: SystemHealthCheckResult;
   };
   "system:download-diagnostics": {

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -167,7 +167,24 @@ export interface PrerequisiteSpec {
   installUrl?: string;
   /** OS-specific install instructions shown inline when the tool is missing */
   installBlocks?: Partial<Record<AgentInstallOS, AgentInstallBlock[]>>;
+  /**
+   * On macOS this tool is supplied by the Xcode Command Line Tools, so
+   * `/usr/bin/<tool>` exists as a shim even when the tools are absent.
+   * Executing that shim pops the system installer dialog, which is not
+   * something a background startup probe may do — the check runs
+   * `xcode-select -p` first and skips the exec when it fails. Only consulted
+   * when the PATH lookup actually resolved to the shim path.
+   */
+  macosCommandLineTool?: boolean;
 }
+
+/**
+ * Why a prerequisite came back unavailable. Lets the UI distinguish "not
+ * installed at all" from "the macOS Command Line Tools shim is present but
+ * non-functional", which need different recovery flows.
+ */
+export type PrerequisiteUnavailableReason =
+  "not-found" | "version-command-failed" | "macos-command-line-tools-missing";
 
 /** Result of checking a single system prerequisite */
 export interface PrerequisiteCheckResult {
@@ -175,8 +192,14 @@ export interface PrerequisiteCheckResult {
   tool: string;
   /** Human-readable display name */
   label: string;
-  /** Whether the tool was found in PATH */
+  /**
+   * Whether the tool was found in PATH *and* its version command exited
+   * successfully. A tool whose binary exists but cannot execute (the macOS
+   * Command Line Tools shim) is NOT available.
+   */
   available: boolean;
+  /** Why the tool is unavailable; undefined when `available` is true */
+  unavailableReason?: PrerequisiteUnavailableReason;
   /** Detected version string (e.g. "2.43.0"), null if not available */
   version: string | null;
   /** Severity level from the spec */
@@ -197,6 +220,24 @@ export interface SystemHealthCheckResult {
   prerequisites: PrerequisiteCheckResult[];
   /** True when all fatal prerequisites are available and meet minimum version */
   allRequired: boolean;
+}
+
+/** Options for a system health check run */
+export interface SystemHealthCheckOptions {
+  /** Include agent-declared prerequisites on top of the baseline set */
+  agentIds?: string[];
+  /**
+   * Check only `fatal` prerequisites. This is the startup path: it is the
+   * only variant that is cached in main, because every project view renders
+   * its own AppLayout and would otherwise spawn the probe once per view.
+   */
+  fatalOnly?: boolean;
+  /**
+   * Re-probe instead of returning the cached fatal-only result. Concurrent
+   * forced runs still share a single probe. Only meaningful with `fatalOnly`;
+   * every other variant is always fresh.
+   */
+  force?: boolean;
 }
 
 /** Hardware information for computing panel limit defaults */
@@ -308,14 +349,25 @@ export type RendererCpuProfileStopResult =
       message?: string;
     };
 
-/** Payload for starting an agent install via setup wizard */
-export interface AgentInstallPayload {
-  agentId: string;
+/**
+ * Payload for starting an install job. Either an agent CLI (resolved through
+ * the agent registry) or a baseline prerequisite (resolved through
+ * `BASELINE_PREREQUISITES`). The renderer names a target; it never supplies
+ * commands — main owns the mapping from name to command in both cases.
+ */
+export type AgentInstallPayload = {
   /** Index of the install method to use (defaults to 0) */
   methodIndex?: number;
   /** Unique job identifier for progress correlation */
   jobId: string;
-}
+} & (
+  | { agentId: string; prerequisiteTool?: never }
+  | {
+      /** Baseline prerequisite tool name, e.g. "git". Main-side allowlisted. */
+      prerequisiteTool: string;
+      agentId?: never;
+    }
+);
 
 /** Result of an agent install job */
 export interface AgentInstallResult {

--- a/src/clients/systemClient.ts
+++ b/src/clients/systemClient.ts
@@ -84,8 +84,10 @@ export const systemClient = {
     return promise;
   },
 
-  healthCheck: (agentIds?: string[]): ReturnType<typeof window.electron.system.healthCheck> => {
-    return window.electron.system.healthCheck(agentIds);
+  healthCheck: (
+    options?: import("@shared/types/ipc/system").SystemHealthCheckOptions
+  ): ReturnType<typeof window.electron.system.healthCheck> => {
+    return window.electron.system.healthCheck(options);
   },
 
   getHealthCheckSpecs: (

--- a/src/components/Recovery/GlobalBannerCoordinator.tsx
+++ b/src/components/Recovery/GlobalBannerCoordinator.tsx
@@ -2,6 +2,7 @@ import { HostCrashBanner } from "./HostCrashBanner";
 import { WatchdogDisabledBanner } from "./WatchdogDisabledBanner";
 import { SafeModeBanner } from "./SafeModeBanner";
 import { RestoreConfirmationBanner } from "./RestoreConfirmationBanner";
+import { MissingPrerequisiteBanner } from "./MissingPrerequisiteBanner";
 import { ForgeTokenBanner } from "./ForgeTokenBanner";
 import { CloudSyncBanner } from "./CloudSyncBanner";
 import { RosettaBanner } from "./RosettaBanner";
@@ -26,6 +27,8 @@ function activeBanner(slot: ReturnType<typeof useGlobalBannerPriority>) {
       return <SafeModeBanner />;
     case "restore-confirmation":
       return <RestoreConfirmationBanner />;
+    case "missing-prerequisite":
+      return <MissingPrerequisiteBanner />;
     case "forge-token":
       return <ForgeTokenBanner />;
     case "cloud-sync":

--- a/src/components/Recovery/MissingPrerequisiteBanner.tsx
+++ b/src/components/Recovery/MissingPrerequisiteBanner.tsx
@@ -211,6 +211,10 @@ export function MissingPrerequisiteBanner() {
           stillMissing.length > 0
             ? `Still missing: ${stillMissing.map((p) => p.label).join(", ")}.`
             : `Daintree found ${result.label} on PATH.`,
+        // One-shot: the banner going away is the durable signal, so this
+        // doesn't earn an inbox row.
+        transient: true,
+        context: { eventKind: "host" },
       });
     } catch (err) {
       logError("Prerequisite install failed", err);

--- a/src/components/Recovery/MissingPrerequisiteBanner.tsx
+++ b/src/components/Recovery/MissingPrerequisiteBanner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 import type { AgentInstallBlock } from "@shared/config/agentRegistry";
 import type { PrerequisiteCheckResult } from "@shared/types";
@@ -6,51 +6,77 @@ import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
 import { detectOS, isBlockExecutable } from "@/lib/agentInstall";
 import { systemClient } from "@/clients";
+import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
-/** Install runs well past the Doherty threshold, so the status line switches to
- *  a reassurance once it has been going this long. */
+/** The install runs well past the Doherty threshold, so the status line swaps
+ *  to a reassurance once it has been going this long. A wait threshold rather
+ *  than a motion duration, so it lives with the component. */
 const STILL_WORKING_MS = 5_000;
 
-interface InstallCandidate {
+/** What to show for the first missing prerequisite we can say something about.
+ *  `block` is the instructions to display; `autoInstall` is the strictly
+ *  narrower question of whether we may run them ourselves. */
+interface Guidance {
   result: PrerequisiteCheckResult;
-  block: AgentInstallBlock;
+  block: AgentInstallBlock | null;
   methodIndex: number;
   /** Binary the command drives (`brew`, `winget`) — probed before offering it. */
-  packageManager: string;
+  packageManager: string | null;
+  autoInstallable: boolean;
 }
 
 /**
- * Picks the block to offer for a missing prerequisite on this OS. macOS gets a
- * second block for the Command Line Tools case, which is a different shape:
+ * Picks the block to show for a missing prerequisite on this OS. macOS carries
+ * a second block for the Command Line Tools case, which is a different shape:
  * `xcode-select --install` hands off to Apple's GUI installer, so it's chosen
  * only when the probe says the tools are what's missing.
  */
-function pickInstallCandidate(result: PrerequisiteCheckResult): InstallCandidate | null {
+function pickGuidance(result: PrerequisiteCheckResult): Guidance | null {
   const blocks = result.installBlocks?.[detectOS()] ?? result.installBlocks?.generic;
-  if (!blocks || blocks.length === 0) return null;
+  if (!blocks || blocks.length === 0) {
+    return { result, block: null, methodIndex: 0, packageManager: null, autoInstallable: false };
+  }
 
   const wantsCommandLineTools = result.unavailableReason === "macos-command-line-tools-missing";
-  const methodIndex = blocks.findIndex((b) =>
+  const preferred = blocks.findIndex((b) =>
     wantsCommandLineTools ? b.opensExternalInstaller === true : b.opensExternalInstaller !== true
   );
-  if (methodIndex === -1) return null;
+  const methodIndex = preferred === -1 ? 0 : preferred;
+  const block = blocks[methodIndex] ?? null;
+  if (!block) {
+    return { result, block: null, methodIndex: 0, packageManager: null, autoInstallable: false };
+  }
 
-  const block = blocks[methodIndex];
-  if (!block || !isBlockExecutable(block)) return null;
-
-  const packageManager = block.commands?.[0]?.trim().split(/\s+/)[0];
-  if (!packageManager) return null;
-
-  return { result, block, methodIndex, packageManager };
+  // A block we can't safely run — a sudo or pipe-to-shell command — is still
+  // worth showing: the user can copy it. It just isn't a one-click candidate.
+  const packageManager = block.commands?.[0]?.trim().split(/\s+/)[0] ?? null;
+  return {
+    result,
+    block,
+    methodIndex,
+    packageManager,
+    autoInstallable: isBlockExecutable(block) && packageManager !== null,
+  };
 }
 
 function describe(missing: PrerequisiteCheckResult[]): string {
   const names = missing.map((m) => m.label).join(", ");
   const isOne = missing.length === 1;
-  return `${names} ${isOne ? "is" : "are"} not installed or not on PATH, so git operations and agent launches will fail until ${isOne ? "it's" : "they're"} available.`;
+  const subject = isOne ? "it's" : "they're";
+  const outdated = missing.every((m) => m.available);
+  const problem = outdated
+    ? `${names} ${isOne ? "is" : "are"} below the version Daintree needs`
+    : `${names} ${isOne ? "is" : "are"} not installed or not on PATH`;
+  return `${problem}, so git operations and agent launches will fail until ${subject} sorted.`;
+}
+
+function title(missing: PrerequisiteCheckResult[]): string {
+  const only = missing.length === 1 ? missing[0] : undefined;
+  if (!only) return "Required tools are missing";
+  return only.available ? `${only.label} is out of date` : `${only.label} is missing`;
 }
 
 export function MissingPrerequisiteBanner() {
@@ -61,18 +87,11 @@ export function MissingPrerequisiteBanner() {
 
   const [packageManagerReady, setPackageManagerReady] = useState(false);
   const [stillWorking, setStillWorking] = useState(false);
-  const mountedRef = useRef(true);
+  const [isRechecking, setIsRechecking] = useState(false);
 
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  const candidate = useMemo(() => {
+  const guidance = useMemo(() => {
     for (const result of missing) {
-      const found = pickInstallCandidate(result);
+      const found = pickGuidance(result);
       if (found) return found;
     }
     return null;
@@ -80,14 +99,13 @@ export function MissingPrerequisiteBanner() {
 
   // Don't offer a button that can only ENOENT — winget is absent on plenty of
   // Windows images and Homebrew is not a given on macOS.
+  const packageManager = guidance?.autoInstallable ? guidance.packageManager : null;
   useEffect(() => {
-    if (!candidate) {
-      setPackageManagerReady(false);
-      return;
-    }
+    setPackageManagerReady(false);
+    if (!packageManager) return;
     let active = true;
     void systemClient
-      .checkCommand(candidate.packageManager)
+      .checkCommand(packageManager)
       .then((present) => {
         if (active) setPackageManagerReady(present);
       })
@@ -97,7 +115,7 @@ export function MissingPrerequisiteBanner() {
     return () => {
       active = false;
     };
-  }, [candidate]);
+  }, [packageManager]);
 
   const isRunning = install?.status === "running";
 
@@ -111,12 +129,17 @@ export function MissingPrerequisiteBanner() {
   }, [isRunning]);
 
   const runInstall = useCallback(async () => {
-    if (!candidate) return;
-    const { result, block, methodIndex } = candidate;
+    if (!guidance?.block || !guidance.autoInstallable) return;
+    // The store is the source of truth for whether a job is live: this
+    // component unmounts whenever a higher-priority global banner takes the
+    // slot, so a remount must not be able to start a second install.
+    if (useMissingPrerequisiteStore.getState().install?.status === "running") return;
+
+    const { result, block, methodIndex } = guidance;
     const jobId = crypto.randomUUID();
     const errorLog: string[] = [];
 
-    setInstall({ tool: result.tool, status: "running", statusLine: "", error: null });
+    setInstall({ jobId, tool: result.tool, status: "running", statusLine: "", error: null });
 
     const cleanup = window.electron.system.onAgentInstallProgress((event) => {
       if (event.jobId !== jobId) return;
@@ -124,9 +147,16 @@ export function MissingPrerequisiteBanner() {
       const line = event.chunk.trim().split("\n").filter(Boolean).pop();
       if (!line) return;
       const current = useMissingPrerequisiteStore.getState().install;
-      if (current?.status !== "running") return;
+      // A superseded job's output must not overwrite the live one's status.
+      if (current?.jobId !== jobId || current.status !== "running") return;
       useMissingPrerequisiteStore.getState().setInstall({ ...current, statusLine: line });
     });
+
+    /** Writes only if this job still owns the slot. */
+    const settle = (job: Parameters<typeof setInstall>[0]) => {
+      if (useMissingPrerequisiteStore.getState().install?.jobId !== jobId) return;
+      setInstall(job);
+    };
 
     try {
       const outcome = await window.electron.system.installAgent({
@@ -136,7 +166,8 @@ export function MissingPrerequisiteBanner() {
       });
 
       if (!outcome.success) {
-        setInstall({
+        settle({
+          jobId,
           tool: result.tool,
           status: "error",
           statusLine: "",
@@ -149,7 +180,7 @@ export function MissingPrerequisiteBanner() {
       // installer has done anything, so a zero exit says nothing about whether
       // the tool is there. Ask the user to finish and re-check instead.
       if (block.opensExternalInstaller) {
-        setInstall({ tool: result.tool, status: "handed-off", statusLine: "", error: null });
+        settle({ jobId, tool: result.tool, status: "handed-off", statusLine: "", error: null });
         return;
       }
 
@@ -159,24 +190,32 @@ export function MissingPrerequisiteBanner() {
       useMissingPrerequisiteStore.getState().setMissing(stillMissing);
 
       if (stillMissing.some((p) => p.tool === result.tool)) {
-        setInstall({
+        settle({
+          jobId,
           tool: result.tool,
           status: "error",
           statusLine: "",
-          error: `${result.label} still isn't on PATH after the install finished`,
+          error: `${result.label} isn't usable yet — the install finished but the check still fails`,
         });
         return;
       }
 
-      setInstall(null);
+      settle(null);
+      // The banner is gone for this tool, so the toast is the only close-loop
+      // signal. It speaks for the tool it installed and nothing more — other
+      // prerequisites may still be outstanding.
       notify({
         type: "success",
         title: `${result.label} installed`,
-        message: `${result.label} is now available. Git operations and agent launches will work.`,
+        message:
+          stillMissing.length > 0
+            ? `Still missing: ${stillMissing.map((p) => p.label).join(", ")}.`
+            : `Daintree found ${result.label} on PATH.`,
       });
     } catch (err) {
       logError("Prerequisite install failed", err);
-      setInstall({
+      settle({
+        jobId,
         tool: result.tool,
         status: "error",
         statusLine: "",
@@ -185,9 +224,12 @@ export function MissingPrerequisiteBanner() {
     } finally {
       cleanup();
     }
-  }, [candidate, setInstall]);
+  }, [guidance, setInstall]);
 
   const recheck = useCallback(async () => {
+    // Never wipe a live job's state from under it.
+    if (useMissingPrerequisiteStore.getState().install?.status === "running") return;
+    setIsRechecking(true);
     try {
       const health = await systemClient.healthCheck({ fatalOnly: true, force: true });
       useMissingPrerequisiteStore
@@ -196,54 +238,101 @@ export function MissingPrerequisiteBanner() {
       setInstall(null);
     } catch (err) {
       logError("Prerequisite re-check failed", err);
+      setInstall({
+        jobId: "recheck",
+        tool: guidance?.result.tool ?? "",
+        status: "error",
+        statusLine: "",
+        error: formatErrorMessage(err, "Couldn't check for the tool"),
+      });
+    } finally {
+      setIsRechecking(false);
     }
-  }, [setInstall]);
+  }, [guidance, setInstall]);
+
+  const openInstallUrl = useCallback(() => {
+    if (!guidance?.result.installUrl) return;
+    void actionService.dispatch(
+      "system.openExternal",
+      { url: guidance.result.installUrl },
+      { source: "user" }
+    );
+  }, [guidance]);
 
   if (missing.length === 0) return null;
 
-  const canInstall = candidate !== null && packageManagerReady;
-  const command = candidate?.block.commands?.join(" && ");
+  const failed = install?.status === "error";
   const handedOff = install?.status === "handed-off";
+  const canInstall = guidance?.autoInstallable === true && packageManagerReady;
+  const command = guidance?.block?.commands?.join(" && ");
 
   const description = handedOff
-    ? "Finish the macOS installer, then re-check."
-    : install?.status === "error"
+    ? "Finish the macOS installer, then re-check"
+    : failed
       ? install.error
       : describe(missing);
 
   const contextLine = isRunning
-    ? stillWorking
-      ? install.statusLine || "Still working…"
-      : install.statusLine || "Installing…"
+    ? install.statusLine || (stillWorking ? "Still working…" : "Installing…")
     : command;
 
+  // `isRunning` is read from the store, not local state, so a remount mid-job
+  // still renders the disabled installing action rather than an enabled one.
   const action =
     canInstall && !handedOff
       ? {
           id: "install",
-          label: candidate.block.opensExternalInstaller
+          label: guidance?.block?.opensExternalInstaller
             ? "Open installer"
-            : `Install ${candidate.result.label}`,
+            : `Install ${guidance?.result.label}`,
           variant: "primary" as const,
           loading: isRunning,
           disabled: isRunning,
           onClick: () => void runInstall(),
         }
-      : {
-          id: "recheck",
-          label: "Re-check",
-          variant: "primary" as const,
-          onClick: () => void recheck(),
-        };
+      : guidance?.block || !guidance?.result.installUrl
+        ? {
+            id: "recheck",
+            label: "Re-check",
+            variant: "primary" as const,
+            loading: isRechecking,
+            disabled: isRunning || isRechecking,
+            onClick: () => void recheck(),
+          }
+        : {
+            id: "install-docs",
+            label: "View install guide",
+            variant: "primary" as const,
+            onClick: openInstallUrl,
+          };
+
+  // A failed install is an error the user has to act on; everything else here
+  // is an advisory about the environment.
+  if (failed) {
+    return (
+      <InlineStatusBanner
+        icon={AlertTriangle}
+        title={`Couldn't install ${install.tool || "the tool"}`}
+        description={description}
+        contextLine={command}
+        severity="error"
+        role="alert"
+        onClose={dismiss}
+        closeAriaLabel="Dismiss missing tool warning"
+        action={{
+          id: "retry",
+          label: "Retry",
+          variant: "primary",
+          onClick: () => void (canInstall ? runInstall() : recheck()),
+        }}
+      />
+    );
+  }
 
   return (
     <InlineStatusBanner
       icon={AlertTriangle}
-      title={
-        missing.length === 1 && missing[0]
-          ? `${missing[0].label} is missing`
-          : "Required tools are missing"
-      }
+      title={title(missing)}
       description={description}
       contextLine={contextLine}
       severity="warning"

--- a/src/components/Recovery/MissingPrerequisiteBanner.tsx
+++ b/src/components/Recovery/MissingPrerequisiteBanner.tsx
@@ -330,10 +330,13 @@ export function MissingPrerequisiteBanner() {
   // A failed install is an error the user has to act on; everything else here
   // is an advisory about the environment.
   if (failed) {
+    // The job carries the tool id; the banner speaks the display name.
+    const failedLabel =
+      missing.find((m) => m.tool === install.tool)?.label ?? guidance?.result.label ?? "the tool";
     return (
       <InlineStatusBanner
         icon={AlertTriangle}
-        title={`Couldn't install ${install.tool || "the tool"}`}
+        title={`Couldn't install ${failedLabel}`}
         description={description}
         contextLine={command}
         severity="error"

--- a/src/components/Recovery/MissingPrerequisiteBanner.tsx
+++ b/src/components/Recovery/MissingPrerequisiteBanner.tsx
@@ -227,7 +227,9 @@ export function MissingPrerequisiteBanner() {
   }, [guidance, setInstall]);
 
   const recheck = useCallback(async () => {
-    // Never wipe a live job's state from under it.
+    // Never wipe a live job's state from under it — checked on the way in and
+    // again on the way out, because an install can start while this is in
+    // flight and its state must survive.
     if (useMissingPrerequisiteStore.getState().install?.status === "running") return;
     setIsRechecking(true);
     try {
@@ -235,9 +237,10 @@ export function MissingPrerequisiteBanner() {
       useMissingPrerequisiteStore
         .getState()
         .setMissing(health.prerequisites.filter((p) => !p.available || !p.meetsMinVersion));
-      setInstall(null);
+      if (useMissingPrerequisiteStore.getState().install?.status !== "running") setInstall(null);
     } catch (err) {
       logError("Prerequisite re-check failed", err);
+      if (useMissingPrerequisiteStore.getState().install?.status === "running") return;
       setInstall({
         jobId: "recheck",
         tool: guidance?.result.tool ?? "",
@@ -276,34 +279,48 @@ export function MissingPrerequisiteBanner() {
     ? install.statusLine || (stillWorking ? "Still working…" : "Installing…")
     : command;
 
-  // `isRunning` is read from the store, not local state, so a remount mid-job
-  // still renders the disabled installing action rather than an enabled one.
-  const action =
-    canInstall && !handedOff
+  const installLabel = guidance?.block?.opensExternalInstaller
+    ? "Open installer"
+    : `Install ${guidance?.result.label}`;
+
+  // A live job always renders as the installing action, whatever the
+  // package-manager probe currently says: this component remounts whenever a
+  // higher-priority banner releases the slot, and that remount restarts the
+  // probe, which would otherwise flash a Re-check button over a running install.
+  const action = isRunning
+    ? {
+        id: "install",
+        label: installLabel,
+        variant: "primary" as const,
+        loading: true,
+        disabled: true,
+        onClick: () => {},
+      }
+    : canInstall && !handedOff
       ? {
           id: "install",
-          label: guidance?.block?.opensExternalInstaller
-            ? "Open installer"
-            : `Install ${guidance?.result.label}`,
+          label: installLabel,
           variant: "primary" as const,
-          loading: isRunning,
-          disabled: isRunning,
+          disabled: isRechecking,
           onClick: () => void runInstall(),
         }
-      : guidance?.block || !guidance?.result.installUrl
+      : // Nothing we can run: send them to the docs when we have them, since
+        // Re-check alone is no help when the command on screen needs a package
+        // manager they don't have.
+        !canInstall && guidance?.result.installUrl && !handedOff
         ? {
-            id: "recheck",
-            label: "Re-check",
-            variant: "primary" as const,
-            loading: isRechecking,
-            disabled: isRunning || isRechecking,
-            onClick: () => void recheck(),
-          }
-        : {
             id: "install-docs",
             label: "View install guide",
             variant: "primary" as const,
             onClick: openInstallUrl,
+          }
+        : {
+            id: "recheck",
+            label: "Re-check",
+            variant: "primary" as const,
+            loading: isRechecking,
+            disabled: isRechecking,
+            onClick: () => void recheck(),
           };
 
   // A failed install is an error the user has to act on; everything else here

--- a/src/components/Recovery/MissingPrerequisiteBanner.tsx
+++ b/src/components/Recovery/MissingPrerequisiteBanner.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import type { AgentInstallBlock } from "@shared/config/agentRegistry";
+import type { PrerequisiteCheckResult } from "@shared/types";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
+import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
+import { detectOS, isBlockExecutable } from "@/lib/agentInstall";
+import { systemClient } from "@/clients";
+import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+/** Install runs well past the Doherty threshold, so the status line switches to
+ *  a reassurance once it has been going this long. */
+const STILL_WORKING_MS = 5_000;
+
+interface InstallCandidate {
+  result: PrerequisiteCheckResult;
+  block: AgentInstallBlock;
+  methodIndex: number;
+  /** Binary the command drives (`brew`, `winget`) — probed before offering it. */
+  packageManager: string;
+}
+
+/**
+ * Picks the block to offer for a missing prerequisite on this OS. macOS gets a
+ * second block for the Command Line Tools case, which is a different shape:
+ * `xcode-select --install` hands off to Apple's GUI installer, so it's chosen
+ * only when the probe says the tools are what's missing.
+ */
+function pickInstallCandidate(result: PrerequisiteCheckResult): InstallCandidate | null {
+  const blocks = result.installBlocks?.[detectOS()] ?? result.installBlocks?.generic;
+  if (!blocks || blocks.length === 0) return null;
+
+  const wantsCommandLineTools = result.unavailableReason === "macos-command-line-tools-missing";
+  const methodIndex = blocks.findIndex((b) =>
+    wantsCommandLineTools ? b.opensExternalInstaller === true : b.opensExternalInstaller !== true
+  );
+  if (methodIndex === -1) return null;
+
+  const block = blocks[methodIndex];
+  if (!block || !isBlockExecutable(block)) return null;
+
+  const packageManager = block.commands?.[0]?.trim().split(/\s+/)[0];
+  if (!packageManager) return null;
+
+  return { result, block, methodIndex, packageManager };
+}
+
+function describe(missing: PrerequisiteCheckResult[]): string {
+  const names = missing.map((m) => m.label).join(", ");
+  const isOne = missing.length === 1;
+  return `${names} ${isOne ? "is" : "are"} not installed or not on PATH, so git operations and agent launches will fail until ${isOne ? "it's" : "they're"} available.`;
+}
+
+export function MissingPrerequisiteBanner() {
+  const missing = useMissingPrerequisiteStore((s) => s.missing);
+  const dismiss = useMissingPrerequisiteStore((s) => s.dismiss);
+  const install = useMissingPrerequisiteStore((s) => s.install);
+  const setInstall = useMissingPrerequisiteStore((s) => s.setInstall);
+
+  const [packageManagerReady, setPackageManagerReady] = useState(false);
+  const [stillWorking, setStillWorking] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const candidate = useMemo(() => {
+    for (const result of missing) {
+      const found = pickInstallCandidate(result);
+      if (found) return found;
+    }
+    return null;
+  }, [missing]);
+
+  // Don't offer a button that can only ENOENT — winget is absent on plenty of
+  // Windows images and Homebrew is not a given on macOS.
+  useEffect(() => {
+    if (!candidate) {
+      setPackageManagerReady(false);
+      return;
+    }
+    let active = true;
+    void systemClient
+      .checkCommand(candidate.packageManager)
+      .then((present) => {
+        if (active) setPackageManagerReady(present);
+      })
+      .catch(() => {
+        if (active) setPackageManagerReady(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [candidate]);
+
+  const isRunning = install?.status === "running";
+
+  useEffect(() => {
+    if (!isRunning) {
+      setStillWorking(false);
+      return;
+    }
+    const timer = setTimeout(() => setStillWorking(true), STILL_WORKING_MS);
+    return () => clearTimeout(timer);
+  }, [isRunning]);
+
+  const runInstall = useCallback(async () => {
+    if (!candidate) return;
+    const { result, block, methodIndex } = candidate;
+    const jobId = crypto.randomUUID();
+    const errorLog: string[] = [];
+
+    setInstall({ tool: result.tool, status: "running", statusLine: "", error: null });
+
+    const cleanup = window.electron.system.onAgentInstallProgress((event) => {
+      if (event.jobId !== jobId) return;
+      if (event.stream === "stderr") errorLog.push(event.chunk);
+      const line = event.chunk.trim().split("\n").filter(Boolean).pop();
+      if (!line) return;
+      const current = useMissingPrerequisiteStore.getState().install;
+      if (current?.status !== "running") return;
+      useMissingPrerequisiteStore.getState().setInstall({ ...current, statusLine: line });
+    });
+
+    try {
+      const outcome = await window.electron.system.installAgent({
+        prerequisiteTool: result.tool,
+        methodIndex,
+        jobId,
+      });
+
+      if (!outcome.success) {
+        setInstall({
+          tool: result.tool,
+          status: "error",
+          statusLine: "",
+          error: errorLog.join("").trim() || outcome.error || "Install failed",
+        });
+        return;
+      }
+
+      // A block that hands off to an external installer returns before that
+      // installer has done anything, so a zero exit says nothing about whether
+      // the tool is there. Ask the user to finish and re-check instead.
+      if (block.opensExternalInstaller) {
+        setInstall({ tool: result.tool, status: "handed-off", statusLine: "", error: null });
+        return;
+      }
+
+      // Success is what a fresh probe says, not what the exit code claims.
+      const health = await systemClient.healthCheck({ fatalOnly: true, force: true });
+      const stillMissing = health.prerequisites.filter((p) => !p.available || !p.meetsMinVersion);
+      useMissingPrerequisiteStore.getState().setMissing(stillMissing);
+
+      if (stillMissing.some((p) => p.tool === result.tool)) {
+        setInstall({
+          tool: result.tool,
+          status: "error",
+          statusLine: "",
+          error: `${result.label} still isn't on PATH after the install finished`,
+        });
+        return;
+      }
+
+      setInstall(null);
+      notify({
+        type: "success",
+        title: `${result.label} installed`,
+        message: `${result.label} is now available. Git operations and agent launches will work.`,
+      });
+    } catch (err) {
+      logError("Prerequisite install failed", err);
+      setInstall({
+        tool: result.tool,
+        status: "error",
+        statusLine: "",
+        error: formatErrorMessage(err, "Install failed"),
+      });
+    } finally {
+      cleanup();
+    }
+  }, [candidate, setInstall]);
+
+  const recheck = useCallback(async () => {
+    try {
+      const health = await systemClient.healthCheck({ fatalOnly: true, force: true });
+      useMissingPrerequisiteStore
+        .getState()
+        .setMissing(health.prerequisites.filter((p) => !p.available || !p.meetsMinVersion));
+      setInstall(null);
+    } catch (err) {
+      logError("Prerequisite re-check failed", err);
+    }
+  }, [setInstall]);
+
+  if (missing.length === 0) return null;
+
+  const canInstall = candidate !== null && packageManagerReady;
+  const command = candidate?.block.commands?.join(" && ");
+  const handedOff = install?.status === "handed-off";
+
+  const description = handedOff
+    ? "Finish the macOS installer, then re-check."
+    : install?.status === "error"
+      ? install.error
+      : describe(missing);
+
+  const contextLine = isRunning
+    ? stillWorking
+      ? install.statusLine || "Still working…"
+      : install.statusLine || "Installing…"
+    : command;
+
+  const action =
+    canInstall && !handedOff
+      ? {
+          id: "install",
+          label: candidate.block.opensExternalInstaller
+            ? "Open installer"
+            : `Install ${candidate.result.label}`,
+          variant: "primary" as const,
+          loading: isRunning,
+          disabled: isRunning,
+          onClick: () => void runInstall(),
+        }
+      : {
+          id: "recheck",
+          label: "Re-check",
+          variant: "primary" as const,
+          onClick: () => void recheck(),
+        };
+
+  return (
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      title={
+        missing.length === 1 && missing[0]
+          ? `${missing[0].label} is missing`
+          : "Required tools are missing"
+      }
+      description={description}
+      contextLine={contextLine}
+      severity="warning"
+      role="status"
+      onClose={dismiss}
+      closeAriaLabel="Dismiss missing tool warning"
+      actions={[action]}
+    />
+  );
+}

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -23,6 +23,21 @@ import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
 import { getCloudSyncWarningCopy } from "@/utils/cloudSyncWarningCopy";
+import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
+import type { PrerequisiteCheckResult } from "@shared/types";
+
+function missingGit(overrides: Partial<PrerequisiteCheckResult> = {}): PrerequisiteCheckResult {
+  return {
+    tool: "git",
+    label: "Git",
+    available: false,
+    unavailableReason: "not-found",
+    version: null,
+    severity: "fatal",
+    meetsMinVersion: false,
+    ...overrides,
+  };
+}
 
 const PROVIDER_ID = "daintree.github.github";
 
@@ -34,6 +49,26 @@ function setForgeTokenUnhealthy(value: boolean) {
   const store = useForgeProviderHealthStore.getState();
   store.setTokenUnhealthy(PROVIDER_ID, value);
   store.setProviderMeta(PROVIDER_ID, { providerName: "GitHub", pluginId: "daintree.github" });
+}
+
+// MissingPrerequisiteBanner probes for a package manager on mount whenever it
+// has an install block to offer. Installed per test rather than once for the
+// file: the caption-strip blocks below swap in their own window.electron and
+// delete it on teardown, which would otherwise strip this stub for every test
+// that runs after them.
+function installBaseElectronStub() {
+  Object.defineProperty(window, "electron", {
+    writable: true,
+    configurable: true,
+    value: {
+      system: {
+        checkCommand: vi.fn().mockResolvedValue(false),
+        onAgentInstallProgress: vi.fn().mockReturnValue(() => {}),
+        installAgent: vi.fn(),
+        healthCheck: vi.fn().mockResolvedValue({ prerequisites: [], allRequired: true }),
+      },
+    },
+  });
 }
 
 beforeAll(() => {
@@ -70,9 +105,16 @@ function resetStores() {
   useForgeProviderHealthStore.setState({ providers: {} });
   useCloudSyncBannerStore.setState({ service: null, projectId: null });
   useRosettaBannerStore.setState({ visible: false });
+  useMissingPrerequisiteStore.setState({
+    missing: [],
+    dismissed: false,
+    inlineSurfaceCount: 0,
+    install: null,
+  });
 }
 
 beforeEach(() => {
+  installBaseElectronStub();
   resetStores();
   cleanup();
 });
@@ -600,5 +642,85 @@ describe("GlobalBannerCoordinator cached-view reveal", () => {
 
     expect(revealListeners.size).toBe(0);
     expect(setBannerSeverity).not.toHaveBeenCalled();
+  });
+});
+
+describe("GlobalBannerCoordinator — missing prerequisite slot (#11763)", () => {
+  it("renders the banner when a fatal prerequisite is missing", () => {
+    useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.getByText("Git is missing")).toBeTruthy();
+  });
+
+  it("loses the slot to restore confirmation", () => {
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+    useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.queryByText("Git is missing")).toBeNull();
+    expect(screen.getByText(/Session recovered after unexpected exit/)).toBeTruthy();
+  });
+
+  it("wins the slot over an expired forge token", () => {
+    // A stale token breaks one panel's data; a missing Git breaks every git
+    // operation in the app.
+    setForgeTokenUnhealthy(true);
+    useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.getByText("Git is missing")).toBeTruthy();
+  });
+
+  it("wins the slot over the Rosetta warning", () => {
+    useRosettaBannerStore.setState({ visible: true });
+    useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.getByText("Git is missing")).toBeTruthy();
+    expect(screen.queryByText("Running under Rosetta")).toBeNull();
+  });
+
+  it("yields the slot back once dismissed for the session", () => {
+    setForgeTokenUnhealthy(true);
+    useMissingPrerequisiteStore.setState({ missing: [missingGit()], dismissed: true });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.queryByText("Git is missing")).toBeNull();
+  });
+
+  it("stands down while a surface already showing prerequisites is mounted", () => {
+    useMissingPrerequisiteStore.setState({ missing: [missingGit()], inlineSurfaceCount: 1 });
+
+    const { container } = render(<GlobalBannerCoordinator />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("clears once a re-check reports the tool healthy", () => {
+    useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+    render(<GlobalBannerCoordinator />);
+    expect(screen.getByText("Git is missing")).toBeTruthy();
+
+    act(() => {
+      useMissingPrerequisiteStore.setState({ missing: [] });
+    });
+
+    expect(screen.queryByText("Git is missing")).toBeNull();
+  });
+
+  it("names the tools collectively when more than one is missing", () => {
+    useMissingPrerequisiteStore.setState({
+      missing: [missingGit(), missingGit({ tool: "node", label: "Node.js" })],
+    });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.getByText("Required tools are missing")).toBeTruthy();
   });
 });

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -685,13 +685,16 @@ describe("GlobalBannerCoordinator — missing prerequisite slot (#11763)", () =>
     expect(screen.queryByText("Running under Rosetta")).toBeNull();
   });
 
-  it("yields the slot back once dismissed for the session", () => {
+  it("yields the slot to the next banner once dismissed for the session", () => {
     setForgeTokenUnhealthy(true);
     useMissingPrerequisiteStore.setState({ missing: [missingGit()], dismissed: true });
 
     render(<GlobalBannerCoordinator />);
 
     expect(screen.queryByText("Git is missing")).toBeNull();
+    // Asserting the promotion, not just the disappearance — the slot must go to
+    // forge-token rather than the coordinator rendering nothing.
+    expect(screen.getByText("GitHub token expired")).toBeTruthy();
   });
 
   it("stands down while a surface already showing prerequisites is mounted", () => {

--- a/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
+++ b/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
@@ -500,7 +500,7 @@ describe("MissingPrerequisiteBanner", () => {
       await waitFor(() => expect(notifyMock).toHaveBeenCalled());
       // It must not claim everything works while Node is still missing, and it
       // must not list the tool it just installed as outstanding.
-      const message = notifyMock.mock.calls[0]?.[0].message as string;
+      const message = String(notifyMock.mock.calls[0]?.[0].message);
       const outstanding = useMissingPrerequisiteStore.getState().missing.map((p) => p.label);
       expect(outstanding).toEqual(["Node.js"]);
       for (const label of outstanding) expect(message).toContain(label);

--- a/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
+++ b/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
@@ -159,23 +159,43 @@ describe("MissingPrerequisiteBanner", () => {
       expect(checkCommandMock).toHaveBeenCalledWith("brew");
     });
 
-    it("falls back to re-check when the package manager is absent", async () => {
+    it("never offers the install when the package manager is absent", async () => {
+      checkCommandMock.mockResolvedValue(false);
+      useMissingPrerequisiteStore.setState({ missing: [missingGit({ installUrl: undefined })] });
+
+      render(<MissingPrerequisiteBanner />);
+
+      // Re-check is also the *initial* render, so settle the probe first —
+      // otherwise this passes before the mocked answer has been seen at all.
+      await waitFor(() => expect(checkCommandMock).toHaveBeenCalledWith("brew"));
+      await act(async () => {});
+
+      expect(screen.getByRole("button", { name: "Re-check" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Install Git" })).toBeNull();
+    });
+
+    it("never offers the install when the package manager probe rejects", async () => {
+      checkCommandMock.mockRejectedValue(new Error("probe failed"));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit({ installUrl: undefined })] });
+
+      render(<MissingPrerequisiteBanner />);
+
+      await waitFor(() => expect(checkCommandMock).toHaveBeenCalledWith("brew"));
+      await act(async () => {});
+
+      expect(screen.getByRole("button", { name: "Re-check" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Install Git" })).toBeNull();
+    });
+
+    it("points at the install guide when the package manager is absent", async () => {
       checkCommandMock.mockResolvedValue(false);
       useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
 
       render(<MissingPrerequisiteBanner />);
 
-      expect(await screen.findByRole("button", { name: "Re-check" })).toBeTruthy();
-      expect(screen.queryByRole("button", { name: "Install Git" })).toBeNull();
-    });
-
-    it("falls back to re-check when the package manager probe rejects", async () => {
-      checkCommandMock.mockRejectedValue(new Error("probe failed"));
-      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
-
-      render(<MissingPrerequisiteBanner />);
-
-      expect(await screen.findByRole("button", { name: "Re-check" })).toBeTruthy();
+      // The command on screen needs a package manager they don't have, so
+      // Re-check on its own would be no help.
+      expect(await screen.findByRole("button", { name: "View install guide" })).toBeTruthy();
     });
 
     it("still shows the command when the block is not safe to run for us", async () => {
@@ -386,7 +406,7 @@ describe("MissingPrerequisiteBanner", () => {
   describe("re-check", () => {
     it("clears the banner when the tool is now present", async () => {
       checkCommandMock.mockResolvedValue(false);
-      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      useMissingPrerequisiteStore.setState({ missing: [missingGit({ installUrl: undefined })] });
       render(<MissingPrerequisiteBanner />);
 
       await click(await screen.findByRole("button", { name: "Re-check" }));
@@ -398,7 +418,7 @@ describe("MissingPrerequisiteBanner", () => {
     it("tells the user when the re-check itself fails", async () => {
       checkCommandMock.mockResolvedValue(false);
       healthCheckMock.mockRejectedValue(new Error("probe exploded"));
-      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      useMissingPrerequisiteStore.setState({ missing: [missingGit({ installUrl: undefined })] });
       render(<MissingPrerequisiteBanner />);
 
       await click(await screen.findByRole("button", { name: "Re-check" }));
@@ -406,17 +426,54 @@ describe("MissingPrerequisiteBanner", () => {
       expect(await screen.findByText(/probe exploded/)).toBeTruthy();
     });
 
-    it("refuses to clear a running install", async () => {
+    it("does not clear an install that started while it was in flight", async () => {
+      // The re-check begins with no job running, so its entry guard passes;
+      // an install starts before the probe resolves. Writing `null` on the way
+      // out would strand that job with no state and no progress.
+      let resolveHealth: (value: SystemHealthCheckResult) => void = () => {};
+      healthCheckMock.mockReturnValue(
+        new Promise<SystemHealthCheckResult>((resolve) => {
+          resolveHealth = resolve;
+        })
+      );
+      checkCommandMock.mockResolvedValue(false);
+      useMissingPrerequisiteStore.setState({ missing: [missingGit({ installUrl: undefined })] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Re-check" }));
+
+      act(() => {
+        useMissingPrerequisiteStore.getState().setInstall({
+          jobId: "live",
+          tool: "git",
+          status: "running",
+          statusLine: "",
+          error: null,
+        });
+      });
+      await act(async () => {
+        resolveHealth(health([HEALTHY_GIT]));
+        await Promise.resolve();
+      });
+
+      expect(useMissingPrerequisiteStore.getState().install?.jobId).toBe("live");
+      expect(useMissingPrerequisiteStore.getState().install?.status).toBe("running");
+    });
+
+    it("renders a live job as installing even straight after a remount", async () => {
+      // The remount restarts the package-manager probe, which must not flash a
+      // Re-check button over a running install.
+      checkCommandMock.mockReturnValue(new Promise(() => {}));
       useMissingPrerequisiteStore.setState({
         missing: [missingGit()],
         install: { jobId: "live", tool: "git", status: "running", statusLine: "", error: null },
       });
-      checkCommandMock.mockResolvedValue(false);
+
       render(<MissingPrerequisiteBanner />);
 
-      const button = await screen.findByRole("button", { name: "Re-check" });
+      const button = screen.getByRole("button", { name: "Install Git" });
       expect(button.hasAttribute("disabled")).toBe(true);
-      expect(useMissingPrerequisiteStore.getState().install?.status).toBe("running");
+      expect(screen.queryByRole("button", { name: "Re-check" })).toBeNull();
     });
   });
 
@@ -441,8 +498,13 @@ describe("MissingPrerequisiteBanner", () => {
       await click(await screen.findByRole("button", { name: "Install Git" }));
 
       await waitFor(() => expect(notifyMock).toHaveBeenCalled());
-      // It must not claim everything works while Node is still missing.
-      expect(notifyMock.mock.calls[0]?.[0].message).toContain("Node.js");
+      // It must not claim everything works while Node is still missing, and it
+      // must not list the tool it just installed as outstanding.
+      const message = notifyMock.mock.calls[0]?.[0].message as string;
+      const outstanding = useMissingPrerequisiteStore.getState().missing.map((p) => p.label);
+      expect(outstanding).toEqual(["Node.js"]);
+      for (const label of outstanding) expect(message).toContain(label);
+      expect(message).not.toContain("Git");
     });
   });
 });

--- a/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
+++ b/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
@@ -325,6 +325,19 @@ describe("MissingPrerequisiteBanner", () => {
       expect(await screen.findByRole("button", { name: "Retry" })).toBeTruthy();
     });
 
+    it("titles a failed install with the display name, not the tool id", async () => {
+      installAgentMock.mockResolvedValue({ success: false, exitCode: 1 });
+      const spec = missingGit({ tool: "some-tool", label: "Some Tool" });
+      useMissingPrerequisiteStore.setState({ missing: [spec] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: `Install ${spec.label}` }));
+
+      expect(await screen.findByText(`Couldn't install ${spec.label}`)).toBeTruthy();
+      expect(useMissingPrerequisiteStore.getState().install?.tool).toBe(spec.tool);
+      expect(screen.queryByText(`Couldn't install ${spec.tool}`)).toBeNull();
+    });
+
     it("removes the progress listener when the job settles", async () => {
       installAgentMock.mockResolvedValue({ success: true, exitCode: 0 });
       useMissingPrerequisiteStore.setState({ missing: [missingGit()] });

--- a/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
+++ b/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
@@ -1,0 +1,448 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, act, waitFor, fireEvent } from "@testing-library/react";
+import type { PrerequisiteCheckResult, SystemHealthCheckResult } from "@shared/types";
+import type { AgentInstallProgressEvent } from "@shared/types/ipc/system";
+
+const checkCommandMock = vi.hoisted(() => vi.fn());
+const healthCheckMock = vi.hoisted(() => vi.fn());
+const notifyMock = vi.hoisted(() => vi.fn());
+const dispatchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients", () => ({
+  systemClient: { checkCommand: checkCommandMock, healthCheck: healthCheckMock },
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock.mockResolvedValue({ ok: true, result: undefined }) },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+// The banner reads the current OS to choose an install block.
+vi.mock("@/lib/platform", () => ({
+  isMac: () => true,
+  isWindows: () => false,
+  isLinux: () => false,
+}));
+
+import { MissingPrerequisiteBanner } from "../MissingPrerequisiteBanner";
+import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
+
+const MACOS_BLOCKS = {
+  macos: [
+    { label: "Homebrew", commands: ["brew install git"] },
+    {
+      label: "Xcode Command Line Tools",
+      commands: ["xcode-select --install"],
+      opensExternalInstaller: true,
+    },
+  ],
+};
+
+function missingGit(overrides: Partial<PrerequisiteCheckResult> = {}): PrerequisiteCheckResult {
+  return {
+    tool: "git",
+    label: "Git",
+    available: false,
+    unavailableReason: "not-found",
+    version: null,
+    severity: "fatal",
+    meetsMinVersion: false,
+    installBlocks: MACOS_BLOCKS,
+    installUrl: "https://git-scm.com/downloads",
+    ...overrides,
+  };
+}
+
+function health(prerequisites: PrerequisiteCheckResult[]): SystemHealthCheckResult {
+  return {
+    prerequisites,
+    allRequired: prerequisites.every((p) => p.available && p.meetsMinVersion),
+  };
+}
+
+const HEALTHY_GIT: PrerequisiteCheckResult = {
+  tool: "git",
+  label: "Git",
+  available: true,
+  version: "2.43.0",
+  severity: "fatal",
+  meetsMinVersion: true,
+};
+
+let progressListeners: ((event: AgentInstallProgressEvent) => void)[] = [];
+let installAgentMock: ReturnType<typeof vi.fn>;
+let removeListener: ReturnType<typeof vi.fn>;
+
+function emitProgress(event: AgentInstallProgressEvent) {
+  act(() => {
+    for (const listener of progressListeners) listener(event);
+  });
+}
+
+/** Clicks and lets the handler's first async hop settle. */
+async function click(element: HTMLElement) {
+  await act(async () => {
+    fireEvent.click(element);
+    await Promise.resolve();
+  });
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  if (!("randomUUID" in crypto)) {
+    Object.defineProperty(crypto, "randomUUID", { value: () => "test-uuid", writable: true });
+  }
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  progressListeners = [];
+  removeListener = vi.fn();
+  installAgentMock = vi.fn();
+  Object.defineProperty(window, "electron", {
+    writable: true,
+    configurable: true,
+    value: {
+      system: {
+        installAgent: installAgentMock,
+        onAgentInstallProgress: (cb: (event: AgentInstallProgressEvent) => void) => {
+          progressListeners.push(cb);
+          return removeListener;
+        },
+      },
+    },
+  });
+  useMissingPrerequisiteStore.setState({
+    missing: [],
+    dismissed: false,
+    inlineSurfaceCount: 0,
+    install: null,
+  });
+  checkCommandMock.mockResolvedValue(true);
+  healthCheckMock.mockResolvedValue(health([HEALTHY_GIT]));
+});
+
+afterEach(() => {
+  cleanup();
+  if (vi.isFakeTimers()) vi.useRealTimers();
+});
+
+describe("MissingPrerequisiteBanner", () => {
+  describe("package manager gating", () => {
+    it("offers the install once the package manager is present", async () => {
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+
+      render(<MissingPrerequisiteBanner />);
+
+      expect(await screen.findByRole("button", { name: "Install Git" })).toBeTruthy();
+      expect(checkCommandMock).toHaveBeenCalledWith("brew");
+    });
+
+    it("falls back to re-check when the package manager is absent", async () => {
+      checkCommandMock.mockResolvedValue(false);
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+
+      render(<MissingPrerequisiteBanner />);
+
+      expect(await screen.findByRole("button", { name: "Re-check" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Install Git" })).toBeNull();
+    });
+
+    it("falls back to re-check when the package manager probe rejects", async () => {
+      checkCommandMock.mockRejectedValue(new Error("probe failed"));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+
+      render(<MissingPrerequisiteBanner />);
+
+      expect(await screen.findByRole("button", { name: "Re-check" })).toBeTruthy();
+    });
+
+    it("still shows the command when the block is not safe to run for us", async () => {
+      useMissingPrerequisiteStore.setState({
+        missing: [
+          missingGit({ installBlocks: { macos: [{ commands: ["sudo apt-get install git"] }] } }),
+        ],
+      });
+
+      render(<MissingPrerequisiteBanner />);
+
+      // Linux-style sudo blocks are copy-paste only, but the user still needs
+      // to see what to paste.
+      expect(await screen.findByText("sudo apt-get install git")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Install Git" })).toBeNull();
+    });
+
+    it("offers the install guide when there is no block at all", async () => {
+      useMissingPrerequisiteStore.setState({
+        missing: [missingGit({ installBlocks: undefined })],
+      });
+
+      render(<MissingPrerequisiteBanner />);
+
+      const button = await screen.findByRole("button", { name: "View install guide" });
+      await click(button);
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "system.openExternal",
+        { url: "https://git-scm.com/downloads" },
+        expect.anything()
+      );
+    });
+  });
+
+  describe("install flow", () => {
+    it("streams the latest output line as the status", async () => {
+      installAgentMock.mockReturnValue(new Promise(() => {}));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Install Git" }));
+
+      const jobId = useMissingPrerequisiteStore.getState().install?.jobId ?? "";
+      emitProgress({ jobId, chunk: "Fetching git\nPouring git\n", stream: "stdout" });
+
+      expect(await screen.findByText("Pouring git")).toBeTruthy();
+    });
+
+    it("ignores progress from a job that is not the live one", async () => {
+      installAgentMock.mockReturnValue(new Promise(() => {}));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Install Git" }));
+      emitProgress({ jobId: "some-other-job", chunk: "stale output", stream: "stdout" });
+
+      expect(screen.queryByText("stale output")).toBeNull();
+    });
+
+    it("swaps to a reassurance once the install outlasts the threshold", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      installAgentMock.mockReturnValue(new Promise(() => {}));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      const button = await screen.findByRole("button", { name: "Install Git" });
+      await click(button);
+      await waitFor(() =>
+        expect(useMissingPrerequisiteStore.getState().install?.status).toBe("running")
+      );
+
+      expect(screen.queryByText("Still working…")).toBeNull();
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+
+      expect(screen.getByText("Still working…")).toBeTruthy();
+    });
+
+    it("confirms success against a fresh probe, not the exit code", async () => {
+      installAgentMock.mockResolvedValue({ success: true, exitCode: 0 });
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Install Git" }));
+
+      await waitFor(() => expect(notifyMock).toHaveBeenCalled());
+      expect(healthCheckMock).toHaveBeenCalledWith({ fatalOnly: true, force: true });
+      expect(notifyMock.mock.calls[0]?.[0].title).toBe("Git installed");
+      expect(useMissingPrerequisiteStore.getState().missing).toEqual([]);
+    });
+
+    it("reports failure when the probe still cannot find the tool", async () => {
+      installAgentMock.mockResolvedValue({ success: true, exitCode: 0 });
+      healthCheckMock.mockResolvedValue(health([missingGit()]));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Install Git" }));
+
+      await waitFor(() =>
+        expect(useMissingPrerequisiteStore.getState().install?.status).toBe("error")
+      );
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a failed install as an error with streamed stderr", async () => {
+      let resolveInstall: (value: { success: boolean; exitCode: number | null }) => void = () => {};
+      installAgentMock.mockReturnValue(
+        new Promise<{ success: boolean; exitCode: number | null }>((resolve) => {
+          resolveInstall = resolve;
+        })
+      );
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Install Git" }));
+      const jobId = useMissingPrerequisiteStore.getState().install?.jobId ?? "";
+      emitProgress({ jobId, chunk: "Error: no such formula", stream: "stderr" });
+      await act(async () => {
+        resolveInstall({ success: false, exitCode: 1 });
+        await Promise.resolve();
+      });
+
+      expect(await screen.findByText("Error: no such formula")).toBeTruthy();
+      expect(await screen.findByRole("button", { name: "Retry" })).toBeTruthy();
+    });
+
+    it("removes the progress listener when the job settles", async () => {
+      installAgentMock.mockResolvedValue({ success: true, exitCode: 0 });
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Install Git" }));
+
+      await waitFor(() => expect(removeListener).toHaveBeenCalled());
+    });
+
+    it("does not start a second install while one is running", async () => {
+      installAgentMock.mockReturnValue(new Promise(() => {}));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      const { unmount } = render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Install Git" }));
+      await waitFor(() =>
+        expect(useMissingPrerequisiteStore.getState().install?.status).toBe("running")
+      );
+
+      // A higher-priority global banner takes the slot, then releases it.
+      unmount();
+      render(<MissingPrerequisiteBanner />);
+
+      const button = await screen.findByRole("button", { name: "Install Git" });
+      await click(button);
+
+      expect(installAgentMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("macOS Command Line Tools", () => {
+    it("offers the installer hand-off rather than an auto-install", async () => {
+      useMissingPrerequisiteStore.setState({
+        missing: [missingGit({ unavailableReason: "macos-command-line-tools-missing" })],
+      });
+
+      render(<MissingPrerequisiteBanner />);
+
+      expect(await screen.findByRole("button", { name: "Open installer" })).toBeTruthy();
+      expect(checkCommandMock).toHaveBeenCalledWith("xcode-select");
+    });
+
+    it("asks the user to finish the installer instead of claiming success", async () => {
+      installAgentMock.mockResolvedValue({ success: true, exitCode: 0 });
+      useMissingPrerequisiteStore.setState({
+        missing: [missingGit({ unavailableReason: "macos-command-line-tools-missing" })],
+      });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Open installer" }));
+
+      // Exit 0 only means the GUI installer opened.
+      await waitFor(() =>
+        expect(useMissingPrerequisiteStore.getState().install?.status).toBe("handed-off")
+      );
+      expect(notifyMock).not.toHaveBeenCalled();
+      expect(healthCheckMock).not.toHaveBeenCalled();
+      expect(screen.getByText("Finish the macOS installer, then re-check")).toBeTruthy();
+    });
+
+    it("selects the Command Line Tools method, not Homebrew", async () => {
+      installAgentMock.mockResolvedValue({ success: true, exitCode: 0 });
+      useMissingPrerequisiteStore.setState({
+        missing: [missingGit({ unavailableReason: "macos-command-line-tools-missing" })],
+      });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Open installer" }));
+
+      await waitFor(() => expect(installAgentMock).toHaveBeenCalled());
+      expect(installAgentMock.mock.calls[0]?.[0]).toMatchObject({
+        prerequisiteTool: "git",
+        methodIndex: 1,
+      });
+    });
+  });
+
+  describe("re-check", () => {
+    it("clears the banner when the tool is now present", async () => {
+      checkCommandMock.mockResolvedValue(false);
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Re-check" }));
+
+      await waitFor(() => expect(useMissingPrerequisiteStore.getState().missing).toEqual([]));
+      expect(healthCheckMock).toHaveBeenCalledWith({ fatalOnly: true, force: true });
+    });
+
+    it("tells the user when the re-check itself fails", async () => {
+      checkCommandMock.mockResolvedValue(false);
+      healthCheckMock.mockRejectedValue(new Error("probe exploded"));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit()] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Re-check" }));
+
+      expect(await screen.findByText(/probe exploded/)).toBeTruthy();
+    });
+
+    it("refuses to clear a running install", async () => {
+      useMissingPrerequisiteStore.setState({
+        missing: [missingGit()],
+        install: { jobId: "live", tool: "git", status: "running", statusLine: "", error: null },
+      });
+      checkCommandMock.mockResolvedValue(false);
+      render(<MissingPrerequisiteBanner />);
+
+      const button = await screen.findByRole("button", { name: "Re-check" });
+      expect(button.hasAttribute("disabled")).toBe(true);
+      expect(useMissingPrerequisiteStore.getState().install?.status).toBe("running");
+    });
+  });
+
+  describe("copy", () => {
+    it("titles an outdated tool as out of date rather than missing", () => {
+      useMissingPrerequisiteStore.setState({
+        missing: [missingGit({ available: true, version: "1.0.0", unavailableReason: undefined })],
+      });
+
+      render(<MissingPrerequisiteBanner />);
+
+      expect(screen.getByText("Git is out of date")).toBeTruthy();
+    });
+
+    it("names the still-outstanding tools after a partial fix", async () => {
+      const node = missingGit({ tool: "node", label: "Node.js", installBlocks: undefined });
+      installAgentMock.mockResolvedValue({ success: true, exitCode: 0 });
+      healthCheckMock.mockResolvedValue(health([HEALTHY_GIT, node]));
+      useMissingPrerequisiteStore.setState({ missing: [missingGit(), node] });
+      render(<MissingPrerequisiteBanner />);
+
+      await click(await screen.findByRole("button", { name: "Install Git" }));
+
+      await waitFor(() => expect(notifyMock).toHaveBeenCalled());
+      // It must not claim everything works while Node is still missing.
+      expect(notifyMock.mock.calls[0]?.[0].message).toContain("Node.js");
+    });
+  });
+});

--- a/src/components/Recovery/useGlobalBannerPriority.ts
+++ b/src/components/Recovery/useGlobalBannerPriority.ts
@@ -4,12 +4,17 @@ import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
+import {
+  useMissingPrerequisiteStore,
+  selectMissingPrerequisiteVisible,
+} from "@/store/missingPrerequisiteStore";
 
 export type GlobalBannerSlot =
   | "host-crash"
   | "watchdog-disabled"
   | "safe-mode"
   | "restore-confirmation"
+  | "missing-prerequisite"
   | "forge-token"
   | "cloud-sync"
   | "rosetta"
@@ -20,6 +25,7 @@ export type GlobalBannerSlot =
 //   watchdog-disabled  — deadlock detector is gone; protection layer down (#8674)
 //   safe-mode          — panels weren't restored after a crash loop
 //   restore-confirmation — informational "session recovered" toast-banner
+//   missing-prerequisite — a fatal tool (Git, Node) isn't installed (#11763)
 //   forge-token        — a forge provider's credentials expired; auth failure, panel data broken
 //   cloud-sync         — project sits in a synced folder; environmental warning
 //   rosetta            — x64 build translated on Apple Silicon; permanent perf warning
@@ -33,10 +39,15 @@ export type GlobalBannerSlot =
 // lower-priority banner back in, matching the Doherty anti-flicker pattern
 // used elsewhere in the app.
 //
-// forge-token and cloud-sync sit below the recovery block. restore-confirmation
-// stays above forge-token because its auto-dismiss timer only runs while the
-// banner is mounted, so it must keep that window when both conditions coexist.
-// forge-token outranks cloud-sync because an expired token is an active
+// missing-prerequisite, forge-token and cloud-sync sit below the recovery
+// block. restore-confirmation stays above them all because its auto-dismiss
+// timer only runs while the banner is mounted, so it must keep that window when
+// the conditions coexist. missing-prerequisite outranks forge-token on blast
+// radius: an expired token breaks one panel's data, whereas a missing Git
+// breaks every git operation in the app. It sits below the recovery block
+// because the backend being down is the more urgent read, and it self-clears —
+// the banner re-checks on window focus, so installing the tool mid-session
+// retires it without a restart. forge-token outranks cloud-sync because an expired token is an active
 // failure (forge data is broken now) whereas cloud-sync is a persistent
 // environmental condition with no acute failure. rosetta sits last: like
 // cloud-sync it's environmental with no acute failure, but it's even more
@@ -53,11 +64,13 @@ export function useGlobalBannerPriority(): GlobalBannerSlot {
   );
   const cloudSyncService = useCloudSyncBannerStore((s) => s.service);
   const rosettaVisible = useRosettaBannerStore((s) => s.visible);
+  const prerequisiteVisible = useMissingPrerequisiteStore(selectMissingPrerequisiteVisible);
 
   if (backendStatus !== "connected") return "host-crash";
   if (watchdogStatus === "disabled") return "watchdog-disabled";
   if (safeMode && !safeModeDismissed) return "safe-mode";
   if (restoreVisible) return "restore-confirmation";
+  if (prerequisiteVisible) return "missing-prerequisite";
   if (tokenUnhealthy) return "forge-token";
   if (cloudSyncService !== null) return "cloud-sync";
   if (rosettaVisible) return "rosetta";

--- a/src/components/Recovery/useShouldSuppressLocalError.ts
+++ b/src/components/Recovery/useShouldSuppressLocalError.ts
@@ -42,6 +42,9 @@ const SLOT_IS_RECOVERY: Record<Exclude<GlobalBannerSlot, null>, boolean> = {
   "watchdog-disabled": true,
   "safe-mode": true,
   "restore-confirmation": true,
+  // Advisory: the backend is connected and a pane's own spawn/reconnect errors
+  // stay actionable — a missing Git doesn't make them un-fixable.
+  "missing-prerequisite": false,
   "forge-token": false,
   "cloud-sync": false,
   rosetta: false,

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -21,6 +21,7 @@ import type { AppState, SystemHealthCheckResult } from "@shared/types";
 import { actionService } from "@/services/ActionService";
 import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
 import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
+import { useSettingsStore } from "@/store/settingsStore";
 import { logError, logWarn } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { SettingsSection } from "./SettingsSection";
@@ -36,8 +37,16 @@ function SystemHealthSection() {
   const [checkError, setCheckError] = useState<string | null>(null);
 
   // While this section is on screen the user is already looking at the health
-  // check, so the global missing-prerequisite banner stands down.
-  useEffect(() => useMissingPrerequisiteStore.getState().claimInlineSurface(), []);
+  // check, so the global missing-prerequisite banner stands down. Gated on the
+  // active tab, not just the mount: SettingsDialog keeps visited tabs mounted
+  // behind `hidden`, so a mount-scoped claim would outlive the tab being
+  // visible. The dialog unmounts its children on close, so being mounted at all
+  // already implies Settings is open.
+  const isVisible = useSettingsStore((s) => s.activeTab === "troubleshooting");
+  useEffect(() => {
+    if (!isVisible) return;
+    return useMissingPrerequisiteStore.getState().claimInlineSurface();
+  }, [isVisible]);
 
   const runCheck = async () => {
     setIsChecking(true);

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -20,6 +20,7 @@ import { appClient, systemClient, logsClient } from "@/clients";
 import type { AppState, SystemHealthCheckResult } from "@shared/types";
 import { actionService } from "@/services/ActionService";
 import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
+import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
 import { logError, logWarn } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { SettingsSection } from "./SettingsSection";
@@ -34,11 +35,17 @@ function SystemHealthSection() {
   const [isChecking, setIsChecking] = useState(false);
   const [checkError, setCheckError] = useState<string | null>(null);
 
+  // While this section is on screen the user is already looking at the health
+  // check, so the global missing-prerequisite banner stands down.
+  useEffect(() => useMissingPrerequisiteStore.getState().claimInlineSurface(), []);
+
   const runCheck = async () => {
     setIsChecking(true);
     setCheckError(null);
     try {
-      const data = await systemClient.healthCheck();
+      // Forced: a manual re-check must re-probe, never replay main's cached
+      // startup result.
+      const data = await systemClient.healthCheck({ force: true });
       setResult(data);
     } catch (err) {
       setCheckError(formatErrorMessage(err, "Health check failed"));

--- a/src/components/Setup/useSystemHealthCheck.ts
+++ b/src/components/Setup/useSystemHealthCheck.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { systemClient } from "@/clients";
 import type { PrerequisiteCheckResult, PrerequisiteSpec } from "@shared/types";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
 
 const POOL_CONCURRENCY = 3;
 
@@ -102,6 +103,12 @@ export function useSystemHealthCheck(): SystemHealthCheckState {
       activeRef.current = false;
     };
   }, [runCheck]);
+
+  // Anything rendering this hook already puts prerequisite state on screen, so
+  // the global missing-prerequisite banner would be repeating itself. The claim
+  // is scoped to the mount rather than plumbed from dialog-open state, which
+  // keeps it true by construction for every consumer.
+  useEffect(() => useMissingPrerequisiteStore.getState().claimInlineSurface(), []);
 
   // Re-check when the user returns to Daintree — tools installed while the
   // wizard was backgrounded should appear without a manual "Re-check" click.

--- a/src/hooks/app/__tests__/useMissingPrerequisiteWarning.test.tsx
+++ b/src/hooks/app/__tests__/useMissingPrerequisiteWarning.test.tsx
@@ -164,12 +164,27 @@ describe("useMissingPrerequisiteWarning", () => {
   });
 
   it("ignores a focus event that arrives while the window is not focused", async () => {
-    healthCheckMock.mockResolvedValue(health([result()]));
+    healthCheckMock.mockResolvedValue(health([MISSING_GIT]));
 
     renderHook(() => useMissingPrerequisiteWarning(true));
     await waitFor(() => expect(healthCheckMock).toHaveBeenCalledTimes(1));
 
     vi.mocked(document.hasFocus).mockReturnValue(false);
+    await focusWindow();
+
+    expect(healthCheckMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not force a re-probe on focus when nothing is missing", async () => {
+    // A project-view switch focuses the incoming view, so document.hasFocus()
+    // is true on every switch. A forced probe skips main's cache for a login
+    // shell plus a spawn per tool, which buys nothing with no banner to clear.
+    healthCheckMock.mockResolvedValue(health([result()]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalledTimes(1));
+
+    await focusWindow();
     await focusWindow();
 
     expect(healthCheckMock).toHaveBeenCalledTimes(1);

--- a/src/hooks/app/__tests__/useMissingPrerequisiteWarning.test.tsx
+++ b/src/hooks/app/__tests__/useMissingPrerequisiteWarning.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, waitFor, act, cleanup } from "@testing-library/react";
+import type { PrerequisiteCheckResult, SystemHealthCheckResult } from "@shared/types";
+
+const healthCheckMock = vi.hoisted(() => vi.fn());
+const notifyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients", () => ({
+  systemClient: { healthCheck: healthCheckMock },
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+import { useMissingPrerequisiteWarning } from "../useMissingPrerequisiteWarning";
+import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
+
+function result(overrides: Partial<PrerequisiteCheckResult> = {}): PrerequisiteCheckResult {
+  return {
+    tool: "git",
+    label: "Git",
+    available: true,
+    version: "2.43.0",
+    severity: "fatal",
+    meetsMinVersion: true,
+    ...overrides,
+  };
+}
+
+function health(prerequisites: PrerequisiteCheckResult[]): SystemHealthCheckResult {
+  return {
+    prerequisites,
+    allRequired: prerequisites.every((p) => p.available && p.meetsMinVersion),
+  };
+}
+
+const MISSING_GIT = result({ available: false, unavailableReason: "not-found", version: null });
+
+/** Fires the window focus event and flushes the hook's deferred frame read. */
+async function focusWindow() {
+  await act(async () => {
+    window.dispatchEvent(new Event("focus"));
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useMissingPrerequisiteStore.setState({
+    missing: [],
+    dismissed: false,
+    inlineSurfaceCount: 0,
+    install: null,
+  });
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useMissingPrerequisiteWarning", () => {
+  it("does not probe until enabled", () => {
+    renderHook(() => useMissingPrerequisiteWarning(false));
+
+    expect(healthCheckMock).not.toHaveBeenCalled();
+  });
+
+  it("asks only for the fatal subset, uncached on first read", async () => {
+    healthCheckMock.mockResolvedValue(health([result()]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalled());
+    expect(healthCheckMock).toHaveBeenCalledWith({ fatalOnly: true, force: false });
+  });
+
+  it("stores prerequisites that are unavailable", async () => {
+    healthCheckMock.mockResolvedValue(health([MISSING_GIT, result({ tool: "node" })]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+
+    await waitFor(() =>
+      expect(useMissingPrerequisiteStore.getState().missing.map((m) => m.tool)).toEqual(["git"])
+    );
+  });
+
+  it("stores a tool that exists but is below its minimum version", async () => {
+    healthCheckMock.mockResolvedValue(
+      health([result({ tool: "node", label: "Node.js", meetsMinVersion: false })])
+    );
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+
+    await waitFor(() =>
+      expect(useMissingPrerequisiteStore.getState().missing.map((m) => m.tool)).toEqual(["node"])
+    );
+  });
+
+  it("stores nothing when everything is healthy", async () => {
+    healthCheckMock.mockResolvedValue(health([result()]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalled());
+    expect(useMissingPrerequisiteStore.getState().missing).toEqual([]);
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("routes one low-priority inbox entry naming the missing tools", async () => {
+    healthCheckMock.mockResolvedValue(health([MISSING_GIT]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalled());
+    const payload = notifyMock.mock.calls[0]?.[0];
+    expect(payload.priority).toBe("low");
+    expect(payload.supersedeKey).toBeTruthy();
+    expect(payload.message).toContain("Git");
+  });
+
+  it("does not re-notify on a later re-check", async () => {
+    healthCheckMock.mockResolvedValue(health([MISSING_GIT]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+
+    await focusWindow();
+
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalledTimes(2));
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("forces a re-probe when the window regains focus", async () => {
+    healthCheckMock.mockResolvedValue(health([MISSING_GIT]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalledTimes(1));
+
+    await focusWindow();
+
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalledTimes(2));
+    expect(healthCheckMock).toHaveBeenLastCalledWith({ fatalOnly: true, force: true });
+  });
+
+  it("clears the banner when a focus re-check finds the tool installed", async () => {
+    healthCheckMock.mockResolvedValueOnce(health([MISSING_GIT]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+    await waitFor(() => expect(useMissingPrerequisiteStore.getState().missing).toHaveLength(1));
+
+    healthCheckMock.mockResolvedValue(health([result()]));
+    await focusWindow();
+
+    await waitFor(() => expect(useMissingPrerequisiteStore.getState().missing).toHaveLength(0));
+  });
+
+  it("ignores a focus event that arrives while the window is not focused", async () => {
+    healthCheckMock.mockResolvedValue(health([result()]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalledTimes(1));
+
+    vi.mocked(document.hasFocus).mockReturnValue(false);
+    await focusWindow();
+
+    expect(healthCheckMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the last known state alone when a probe fails", async () => {
+    healthCheckMock.mockResolvedValueOnce(health([MISSING_GIT]));
+
+    renderHook(() => useMissingPrerequisiteWarning(true));
+    await waitFor(() => expect(useMissingPrerequisiteStore.getState().missing).toHaveLength(1));
+
+    healthCheckMock.mockRejectedValue(new Error("probe blew up"));
+    await focusWindow();
+
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalledTimes(2));
+    expect(useMissingPrerequisiteStore.getState().missing).toHaveLength(1);
+  });
+
+  it("stops listening for focus after unmount", async () => {
+    healthCheckMock.mockResolvedValue(health([result()]));
+
+    const { unmount } = renderHook(() => useMissingPrerequisiteWarning(true));
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalledTimes(1));
+
+    unmount();
+    await focusWindow();
+
+    expect(healthCheckMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not write to the store after unmount", async () => {
+    let release: (value: SystemHealthCheckResult) => void = () => {};
+    healthCheckMock.mockReturnValue(
+      new Promise<SystemHealthCheckResult>((resolve) => {
+        release = resolve;
+      })
+    );
+
+    const { unmount } = renderHook(() => useMissingPrerequisiteWarning(true));
+    await waitFor(() => expect(healthCheckMock).toHaveBeenCalled());
+
+    unmount();
+    await act(async () => {
+      release(health([MISSING_GIT]));
+      await Promise.resolve();
+    });
+
+    expect(useMissingPrerequisiteStore.getState().missing).toEqual([]);
+  });
+});

--- a/src/hooks/app/useAppBootstrap.ts
+++ b/src/hooks/app/useAppBootstrap.ts
@@ -13,6 +13,7 @@ import { useClearSwitchBusyStateOnReveal } from "./useClearSwitchBusyStateOnReve
 import { usePluginDeepLink } from "./usePluginDeepLink";
 import { usePluginArchiveInstallIntent } from "./usePluginArchiveInstallIntent";
 import { useNotificationHistoryPruning } from "./useNotificationHistoryPruning";
+import { useMissingPrerequisiteWarning } from "./useMissingPrerequisiteWarning";
 import { useUpdateListener } from "@/hooks/useUpdateListener";
 import { removeStartupSkeleton } from "@/utils/removeStartupSkeleton";
 import { useNotificationSettingsStore, usePluginManagerStore } from "@/store";
@@ -136,6 +137,10 @@ export function useAppBootstrap() {
   useAgentWaitingNudge(isStateLoaded);
   useForgeEnableRecommendation(isStateLoaded && idleHousekeepingReady);
   useNotificationHistoryPruning();
+  // Gated on the idle flag so the prerequisite probe — which spawns
+  // subprocesses and awaits refreshPath()'s 10s budget — lands after first
+  // paint rather than on the boot path (#11763).
+  useMissingPrerequisiteWarning(isStateLoaded && idleHousekeepingReady);
 
   useEffect(() => {
     if (!isStateLoaded) return;

--- a/src/hooks/app/useMissingPrerequisiteWarning.ts
+++ b/src/hooks/app/useMissingPrerequisiteWarning.ts
@@ -85,12 +85,16 @@ export function useMissingPrerequisiteWarning(enabled: boolean) {
     let frame = 0;
     const handleFocus = () => {
       // document.hasFocus() is stale when read synchronously inside the focus
-      // handler on Chromium 148 (#10230), so the read is deferred a frame. The
-      // guard keeps a project-view switch inside the same window from forcing a
-      // re-probe; main's in-flight dedup covers whatever slips through.
+      // handler on Chromium 148 (#10230), so the read is deferred a frame. It
+      // only rules out a window that lost focus — a project-view switch calls
+      // webContents.focus() on the incoming view, so it passes too. What keeps
+      // this off the switch path is having something to re-confirm: a forced
+      // probe bypasses main's cache for a login shell plus a spawn per tool, and
+      // with nothing missing there is no banner for it to clear.
       cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
         if (!document.hasFocus()) return;
+        if (useMissingPrerequisiteStore.getState().missing.length === 0) return;
         void runCheck(true);
       });
     };

--- a/src/hooks/app/useMissingPrerequisiteWarning.ts
+++ b/src/hooks/app/useMissingPrerequisiteWarning.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef } from "react";
+import { systemClient } from "@/clients";
+import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
+import { notify } from "@/lib/notify";
+import { logWarn } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+function isMissing(result: { available: boolean; meetsMinVersion: boolean }): boolean {
+  return !result.available || !result.meetsMinVersion;
+}
+
+/**
+ * Surfaces missing fatal prerequisites (Git, Node) as a global banner. The
+ * baseline check already existed but was only reachable from Settings and the
+ * Agent Setup wizard, and the wizard is deliberately skipped on first run — so
+ * a fresh install learned Git was missing from a raw `spawn git ENOENT` part
+ * way into its first clone (#11763).
+ *
+ * Deliberately off the boot path: the probe spawns subprocesses and
+ * `refreshPath()` carries a 10s budget, so it runs after first paint. Main
+ * caches the fatal-only result, which is what keeps this to one probe rather
+ * than one per open project view.
+ */
+export function useMissingPrerequisiteWarning(enabled: boolean) {
+  const activeRef = useRef(true);
+  const inboxedRef = useRef(false);
+  const inFlightRef = useRef(false);
+
+  const runCheck = useCallback(async (force: boolean) => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      const result = await systemClient.healthCheck({ fatalOnly: true, force });
+      if (!activeRef.current) return;
+
+      const missing = result.prerequisites.filter(isMissing);
+      useMissingPrerequisiteStore.getState().setMissing(missing);
+
+      // Inbox entry once per session — the banner is the live surface, but a
+      // higher-priority global banner can hold the slot, and the entry is the
+      // audit trail that survives that. priority:"low" keeps it inbox-only.
+      if (missing.length > 0 && !inboxedRef.current) {
+        inboxedRef.current = true;
+        const names = missing.map((m) => m.label).join(", ");
+        notify({
+          type: "warning",
+          priority: "low",
+          title: "Missing required tools",
+          message: `${names} ${missing.length === 1 ? "is" : "are"} not installed or not on PATH. Git operations and agent launches will fail until ${missing.length === 1 ? "it's" : "they're"} available.`,
+          supersedeKey: "missing-prerequisites",
+          countable: false,
+          context: { eventKind: "host" },
+        });
+      }
+    } catch (err) {
+      // A failed probe must not invent a missing prerequisite — leave the last
+      // known state alone and stay quiet; the next focus re-check retries.
+      logWarn("Prerequisite health check failed", {
+        error: formatErrorMessage(err, "Health check failed"),
+      });
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void runCheck(false);
+  }, [enabled, runCheck]);
+
+  // Re-check when the user comes back to Daintree, so installing Git while
+  // Daintree is running clears the banner without a restart. refreshPath()
+  // re-reads the registry Path on Windows and the fallback paths already cover
+  // the standard Git install locations, so a mid-session install is visible.
+  useEffect(() => {
+    if (!enabled) return;
+
+    let frame = 0;
+    const handleFocus = () => {
+      // document.hasFocus() is stale when read synchronously inside the focus
+      // handler on Chromium 148 (#10230), so the read is deferred a frame. The
+      // guard keeps a project-view switch inside the same window from forcing a
+      // re-probe; main's in-flight dedup covers whatever slips through.
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        if (!document.hasFocus()) return;
+        void runCheck(true);
+      });
+    };
+
+    window.addEventListener("focus", handleFocus);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [enabled, runCheck]);
+
+  return runCheck;
+}

--- a/src/lib/agentInstall.ts
+++ b/src/lib/agentInstall.ts
@@ -58,7 +58,19 @@ export function extractInspectUrl(command: string): string | undefined {
   return match[0].replace(/[)\]'">]+$/, "");
 }
 
+/**
+ * A leading `sudo` has no pipe for `isManualOnlyCommand` to catch, but running
+ * it with piped stdio hangs forever on a password prompt the user can never
+ * see. Kept separate from `isManualOnlyCommand` so `extractInspectUrl` keeps
+ * meaning "pipes a remote script into a shell". Mirrors the main-side gate in
+ * `AgentInstallService`; this copy only decides whether to render a button,
+ * main refuses independently.
+ */
+export function requiresElevation(command: string): boolean {
+  return /^\s*sudo\b/i.test(command);
+}
+
 export function isBlockExecutable(block: AgentInstallBlock): boolean {
   if (!block.commands || block.commands.length === 0) return false;
-  return block.commands.every((cmd) => !isManualOnlyCommand(cmd));
+  return block.commands.every((cmd) => !isManualOnlyCommand(cmd) && !requiresElevation(cmd));
 }

--- a/src/store/missingPrerequisiteStore.ts
+++ b/src/store/missingPrerequisiteStore.ts
@@ -1,0 +1,56 @@
+import { create } from "zustand";
+import type { PrerequisiteCheckResult } from "@shared/types";
+
+/** Progress of a one-click install job for a single prerequisite. */
+export interface PrerequisiteInstallJob {
+  tool: string;
+  status: "running" | "handed-off" | "error";
+  /** Latest scrubbed output line, shown as the banner's live status. */
+  statusLine: string;
+  error: string | null;
+}
+
+interface MissingPrerequisiteState {
+  /** Fatal prerequisites that came back unavailable or below their minimum. */
+  missing: PrerequisiteCheckResult[];
+  /** Session-only — never persisted, so it returns on the next launch. */
+  dismissed: boolean;
+  /**
+   * Count of mounted surfaces already showing prerequisite state (the Setup
+   * wizard's health step, the Settings troubleshooting tab). A counter rather
+   * than a boolean because both can be mounted at once and each unmount must
+   * only retract its own claim.
+   */
+  inlineSurfaceCount: number;
+  install: PrerequisiteInstallJob | null;
+  setMissing: (missing: PrerequisiteCheckResult[]) => void;
+  dismiss: () => void;
+  claimInlineSurface: () => () => void;
+  setInstall: (install: PrerequisiteInstallJob | null) => void;
+}
+
+export const useMissingPrerequisiteStore = create<MissingPrerequisiteState>((set) => ({
+  missing: [],
+  dismissed: false,
+  inlineSurfaceCount: 0,
+  install: null,
+  setMissing: (missing) => set({ missing }),
+  dismiss: () => set({ dismissed: true }),
+  claimInlineSurface: () => {
+    set((s) => ({ inlineSurfaceCount: s.inlineSurfaceCount + 1 }));
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      set((s) => ({ inlineSurfaceCount: Math.max(0, s.inlineSurfaceCount - 1) }));
+    };
+  },
+  setInstall: (install) => set({ install }),
+}));
+
+/** True when the banner has something to say and nothing is shadowing it. */
+export function selectMissingPrerequisiteVisible(s: MissingPrerequisiteState): boolean {
+  return s.missing.length > 0 && !s.dismissed && s.inlineSurfaceCount === 0;
+}
+
+export type { MissingPrerequisiteState };

--- a/src/store/missingPrerequisiteStore.ts
+++ b/src/store/missingPrerequisiteStore.ts
@@ -3,6 +3,8 @@ import type { PrerequisiteCheckResult } from "@shared/types";
 
 /** Progress of a one-click install job for a single prerequisite. */
 export interface PrerequisiteInstallJob {
+  /** Correlates streamed progress; a superseded job's output is ignored. */
+  jobId: string;
   tool: string;
   status: "running" | "handed-off" | "error";
   /** Latest scrubbed output line, shown as the banner's live status. */


### PR DESCRIPTION
## Summary

On a fresh install with no Git, Daintree only ever surfaced the problem as a raw `spawn git ENOENT` the first time the user opened the clone dialog, after they'd already filled in the form. The prerequisite check for this already existed (`BASELINE_PREREQUISITES` marks `git` as `fatal`), but it was only reachable from Settings > Troubleshooting and the Agent Setup wizard, and the wizard is deliberately skipped on first run. A fresh install never ran the check at all.

This resolves that by fixing the check itself and running the fatal subset at startup, with a global banner and a one-click install path where it's safe.

Resolves #11763

## The problem

`checkPrerequisite()` decided availability from a `which`/`where` probe, then ran the version command in a separate try whose catch only nulled `version`. It never touched `available`. Git has no `minVersion`, so `meetsMinVersion` stayed `true` and the macOS `/usr/bin/git` shim reported perfectly healthy on a machine where every git call fails. That's fixed first: a failed execution now means unavailable, while a successful run with an unparseable version string still doesn't.

## What changed

1. **Never executes the CLT shim blind.** On macOS, `xcode-select -p` is probed first, but only when the PATH lookup actually resolved to `/usr/bin/<tool>` and the spec opts in via `macosCommandLineTool`, so a Homebrew git isn't gated behind Command Line Tools it doesn't need. Without this, a background startup probe pops Apple's installer dialog and hangs until the 5s timeout.
2. **Async, and off the boot path.** The probe moved to `execFile`, dropping the `setImmediate` wrappers that only deferred synchronous blocking. The fatal-only subset runs after first paint and is cached in main, since every project view is its own `WebContentsView` and without the cache it would spawn once per open project. A forced re-check bypasses the cache but is ordered so it can never resolve from a probe that started before it.
3. **New `missing-prerequisite` global banner slot**, above `forge-token` and below `restore-confirmation`: an expired token breaks one panel's data, but a missing Git breaks every git operation. Dismissal is session-only, unlike Rosetta's, since this condition can change, and the banner is suppressed while the Setup wizard or the Troubleshooting tab is already showing the same thing.
4. **Re-check on window focus**, so installing Git while Daintree is running clears the banner without a restart. The `document.hasFocus()` read is deferred a frame, since it reads stale inside the focus handler on Chromium 148.
5. **One-click install** where it's safe: `runAgentInstall` is generalised so the renderer names a tool and main resolves the command from `BASELINE_PREREQUISITES`. Three gates cover it: the existing pipe-to-shell refusal, a new leading-`sudo` refusal (the baseline Linux git block is `sudo apt-get install git`, which has no pipe and would otherwise hang on an invisible password prompt), and a package-manager presence probe so a button that can only ENOENT never renders. macOS Command Line Tools is a separate shape: `xcode-select --install` returns as soon as the GUI installer opens, so exit 0 is reported as "finish it, then re-check" rather than success. Success is only ever confirmed by a fresh probe, never by the exit code.

## Worth calling out for review

- The winget commands gained `--accept-source-agreements --accept-package-agreements` so the copy-paste and one-click paths run the same string. Deliberately not `--silent`, since that would suppress the output being streamed.
- On Windows, the version command runs through a shell only when the resolved path is genuinely a `.cmd`/`.bat` shim. Node refuses to spawn those directly, and now that a failed version command means unavailable, npm and every npm-installed agent CLI would otherwise have started reading as missing.
- Installs are guarded in main, keyed by target, since the renderer guard can't see other project views.
- `BASELINE_PREREQUISITES` moved to its own module so consumers of the data don't pull in the health check's Electron dependencies.

## Known follow-up (not addressed here)

`system:check-tool` accepts a renderer-supplied `PrerequisiteSpec` (including `command` and `versionArgs`) and executes it. That predates this branch and is unchanged by it. The Windows shell retry above was deliberately narrowed to main-identified shims so as not to widen it. Worth its own issue.

## Testing

Unit only, per the issue: nothing runs a real install. Coverage includes: a nonzero version-command exit classifies the tool as unavailable; the CLT shim is never executed when the tools are absent; Homebrew git skips the CLT probe; the sudo and pipe-to-shell gates never spawn; out-of-range install methods are rejected rather than silently running method 0; the new banner slot's precedence in both directions; the banner clearing after a re-check resolves; and the install state machine, including progress correlation, the handed-off state, and success only after a re-check.
