### PR TITLE
fix(terminal): re-read the Windows registry PATH per terminal spawn

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -55,6 +55,7 @@ const refreshWindowsPathForSpawnMock = vi.hoisted(() => vi.fn().mockResolvedValu
 vi.mock("../../../../setup/windowsPath.js", () => ({
   refreshWindowsPathForSpawn: refreshWindowsPathForSpawnMock,
   resolveWindowsRegistryPath: vi.fn().mockResolvedValue(null),
+  applyWindowsExtraPaths: vi.fn((p: string) => p),
   expandWindowsEnvVars: vi.fn((s: string) => s),
   __resetWindowsPathStateForTests: vi.fn(),
 }));
@@ -2661,9 +2662,11 @@ describe("terminal spawn handler - Windows PATH refresh", () => {
     const handler = spawnHandlerForTest();
 
     await handler({} as Electron.IpcMainInvokeEvent, {
+      // Deliberately an odd spelling: Windows resolves it the same, so the skip
+      // has to fold case rather than recognise a few known variants.
       cols: 80,
       rows: 24,
-      env: { Path: "C:\\Custom" },
+      env: { pAtH: "C:\\Custom" },
     });
 
     // The caller's PATH wins downstream, so the registry read would be pure latency.

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -57,6 +57,7 @@ vi.mock("../../../../setup/windowsPath.js", () => ({
   resolveWindowsRegistryPath: vi.fn().mockResolvedValue(null),
   applyWindowsExtraPaths: vi.fn((p: string) => p),
   expandWindowsEnvVars: vi.fn((s: string) => s),
+  deduplicatePath: vi.fn((p: string) => p),
   __resetWindowsPathStateForTests: vi.fn(),
 }));
 

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -48,6 +48,17 @@ vi.mock("../../../../services/pty/agentSessionHistory.js", () => ({
 
 // Retention is read from the electron-store singleton, which isn't wired in
 // this unit test; stub the accessor so the journaling paths get a plain value.
+const refreshWindowsPathForSpawnMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+// Full surface, not just the one export lifecycle.ts uses: a factory that omits
+// an export throws for every consumer of the module at collection time.
+vi.mock("../../../../setup/windowsPath.js", () => ({
+  refreshWindowsPathForSpawn: refreshWindowsPathForSpawnMock,
+  resolveWindowsRegistryPath: vi.fn().mockResolvedValue(null),
+  expandWindowsEnvVars: vi.fn((s: string) => s),
+  __resetWindowsPathStateForTests: vi.fn(),
+}));
+
 vi.mock("../../../../services/pty/agentSessionRetention.js", () => ({
   getAgentSessionRetentionDays: vi.fn(() => 30),
 }));
@@ -2579,5 +2590,114 @@ describe("terminal close handlers - resume journaling", () => {
     await getKillHandler()({}, "term-1");
 
     expect(persistAgentSessionMock.mock.calls[0][0].branch).toBeUndefined();
+  });
+});
+
+describe("terminal spawn handler - Windows PATH refresh", () => {
+  const realPlatform = process.platform;
+  const setPlatform = (platform: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  };
+
+  let ptyClient: {
+    spawn: ReturnType<typeof vi.fn>;
+    hasTerminal: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refreshWindowsPathForSpawnMock.mockResolvedValue(undefined);
+    ptyClient = {
+      spawn: vi.fn(),
+      hasTerminal: vi.fn(() => false),
+      write: vi.fn(),
+    };
+    mockGetCurrentProject.mockReturnValue({ id: "p1", name: "P", path: "/projects/p" });
+    mockGetProjectById.mockReturnValue(null);
+    mockGetProjectSettings.mockResolvedValue({});
+  });
+
+  afterEach(() => setPlatform(realPlatform));
+
+  function spawnHandlerForTest() {
+    registerTerminalLifecycleHandlers({ ptyClient } as unknown as HandlerDependencies);
+    return getSpawnHandler();
+  }
+
+  it("refreshes the registry PATH before spawning on Windows", async () => {
+    setPlatform("win32");
+    const handler = spawnHandlerForTest();
+
+    await handler({} as Electron.IpcMainInvokeEvent, { cols: 80, rows: 24 });
+
+    expect(refreshWindowsPathForSpawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds the spawn until the refresh settles", async () => {
+    setPlatform("win32");
+    let release!: () => void;
+    refreshWindowsPathForSpawnMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = () => resolve();
+        })
+    );
+    const handler = spawnHandlerForTest();
+
+    const pending = handler({} as Electron.IpcMainInvokeEvent, { cols: 80, rows: 24 });
+    await vi.waitFor(() => expect(refreshWindowsPathForSpawnMock).toHaveBeenCalled());
+
+    // A terminal spawned against the pre-refresh PATH is exactly the bug.
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
+
+    release();
+    await pending;
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the refresh when the caller already supplies a PATH", async () => {
+    setPlatform("win32");
+    const handler = spawnHandlerForTest();
+
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cols: 80,
+      rows: 24,
+      env: { Path: "C:\\Custom" },
+    });
+
+    // The caller's PATH wins downstream, so the registry read would be pure latency.
+    expect(refreshWindowsPathForSpawnMock).not.toHaveBeenCalled();
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refreshes for restore spawns, leaving the throttle to suppress the burst", async () => {
+    setPlatform("win32");
+    const handler = spawnHandlerForTest();
+
+    await handler({} as Electron.IpcMainInvokeEvent, { cols: 80, rows: 24, restore: true });
+
+    expect(refreshWindowsPathForSpawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch the spawn path on macOS or Linux", async () => {
+    setPlatform("darwin");
+    const handler = spawnHandlerForTest();
+
+    await handler({} as Electron.IpcMainInvokeEvent, { cols: 80, rows: 24 });
+
+    expect(refreshWindowsPathForSpawnMock).not.toHaveBeenCalled();
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("spawns anyway when the refresh rejects", async () => {
+    setPlatform("win32");
+    refreshWindowsPathForSpawnMock.mockRejectedValue(new Error("reg query exploded"));
+    const handler = spawnHandlerForTest();
+
+    await expect(
+      handler({} as Electron.IpcMainInvokeEvent, { cols: 80, rows: 24 })
+    ).resolves.toBeTruthy();
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -168,6 +168,8 @@ import {
 import { getLifecycleLedger } from "../../../services/pty/lifecycleLedger.js";
 import type { WorkspaceClient } from "../../../services/WorkspaceClient.js";
 import { getDefaultShell } from "../../../services/pty/terminalShell.js";
+import { hasEnvVar } from "../../../services/pty/EnvironmentFilter.js";
+import { refreshWindowsPathForSpawn } from "../../../setup/windowsPath.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { quoteCommandArg } from "../../../../shared/utils/shellEscape.js";
 import { MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH } from "../../../../shared/utils/recipeSanitizer.js";
@@ -438,6 +440,38 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(
         "Daintree Assistant session token is invalid or already displaced; refusing to spawn"
       );
+    }
+
+    // Re-read the Windows registry PATH so a tool installed since app start is
+    // on this terminal's PATH (#11773). Main's PATH is what `PtyClient` stamps
+    // onto the spawn message, and that message is the only thing that crosses
+    // into the long-lived pty-host, which still holds the env it was forked
+    // with. Throttled to one `reg.exe` pair every few seconds, so a recipe
+    // opening six panes or a session restore replaying a grid pays it once.
+    //
+    // Awaited HERE for the same reason the worktree-ownership check above is:
+    // everything below binds resources to this terminal id (help-session token,
+    // MCP pane config), and an await between those bindings and the spawn lets
+    // a competing provision revoke them against a PTY that does not exist yet.
+    // Placed after the invalid-token rejection so that path doesn't pay for it.
+    //
+    // Skipped when the caller already supplies a PATH: it wins over anything we
+    // resolve (see `withCurrentWindowsPath`), so the registry read would be
+    // pure latency. Nothing below adds one — the later `spawnEnv` merges carry
+    // scratch dirs, MCP coordinates and assistant flags only.
+    //
+    // The platform guard is duplicated here even though the helper no-ops off
+    // Windows: it keeps macOS and Linux free of an extra microtask on the spawn
+    // path, where they already resolve PATH through the startup shell probe.
+    if (process.platform === "win32" && !hasEnvVar(spawnEnv ?? {}, "PATH")) {
+      // Enrichment, like the MCP env block below: a PATH that couldn't be
+      // refreshed means the terminal opens with the one it would have had
+      // anyway, never that it fails to open. The helper already degrades
+      // internally; this keeps that promise from being the spawn's problem if
+      // it ever stops holding.
+      await refreshWindowsPathForSpawn().catch((err) => {
+        console.warn("[TerminalSpawn] Windows PATH refresh failed; using the current PATH:", err);
+      });
     }
 
     if (isHelpLaunch && launchAgentId) {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -455,6 +455,10 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // a competing provision revoke them against a PTY that does not exist yet.
     // Placed after the invalid-token rejection so that path doesn't pay for it.
     //
+    // The wait is bounded inside the helper — a wedged `reg.exe` hands this
+    // spawn the PATH it already had and finishes in the background — so the
+    // await costs a read that lands quickly, never a stalled terminal.
+    //
     // Skipped when the caller already supplies a PATH: it wins over anything we
     // resolve (see `withCurrentWindowsPath`), so the registry read would be
     // pure latency. Nothing below adds one — the later `spawnEnv` merges carry

--- a/electron/services/AgentUpdateHandler.ts
+++ b/electron/services/AgentUpdateHandler.ts
@@ -60,7 +60,12 @@ export class AgentUpdateHandler {
     // Daintree to update a CLI through it. `PtyClient` stamps whatever main
     // holds onto the spawn, so refreshing here is what makes it the fresh one
     // (#11773). Windows-only and throttled; failure just uses the current PATH.
-    await refreshWindowsPathForSpawn().catch(() => {});
+    await refreshWindowsPathForSpawn().catch((err) => {
+      console.warn(
+        "[AgentUpdateHandler] Windows PATH refresh failed; using the current PATH:",
+        err
+      );
+    });
 
     this.ptyClient.spawn(terminalId, {
       cwd: os.homedir(),

--- a/electron/services/AgentUpdateHandler.ts
+++ b/electron/services/AgentUpdateHandler.ts
@@ -9,6 +9,7 @@ import type {
 import type { PtyClient } from "./PtyClient.js";
 import { AgentVersionService } from "./AgentVersionService.js";
 import { CliAvailabilityService } from "./CliAvailabilityService.js";
+import { refreshWindowsPathForSpawn } from "../setup/windowsPath.js";
 
 export class AgentUpdateHandler {
   constructor(
@@ -53,6 +54,13 @@ export class AgentUpdateHandler {
     const terminalId = crypto.randomUUID();
     const cols = 120;
     const rows = 30;
+
+    // An update command is the case that most needs a current PATH: the user
+    // often installs the runtime (Node, a package manager) and immediately asks
+    // Daintree to update a CLI through it. `PtyClient` stamps whatever main
+    // holds onto the spawn, so refreshing here is what makes it the fresh one
+    // (#11773). Windows-only and throttled; failure just uses the current PATH.
+    await refreshWindowsPathForSpawn().catch(() => {});
 
     this.ptyClient.spawn(terminalId, {
       cwd: os.homedir(),

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -73,6 +73,7 @@ import { getTrashedPidTracker } from "./TrashedPidTracker.js";
 import { helpSessionService } from "./HelpSessionService.js";
 import { helpSessionJobService } from "./HelpSessionJobService.js";
 import { getLifecycleLedger, ledgerFactsFromSpawnOptions } from "./pty/lifecycleLedger.js";
+import { getEnvVar, hasEnvVar } from "./pty/EnvironmentFilter.js";
 import { BrokerError } from "./rpc/index.js";
 import { routeHostEvent, type PtyEventRouterDeps } from "./pty/PtyEventRouter.js";
 import { sendPtyHostRpc } from "./pty/PtyHostRpcFacade.js";
@@ -249,6 +250,38 @@ function readPersistedOverrides(): Record<string, string> {
   } catch {
     return {};
   }
+}
+
+/**
+ * Stamp main's current PATH onto a Windows spawn message.
+ *
+ * The pty-host is forked once with a snapshot of main's `process.env`
+ * (`PtyHostLifecycle.start`) and lives for the rest of the session, so
+ * `buildTerminalEnv` over there reads a PATH frozen at fork time. Nothing main
+ * does to its own `process.env` afterwards crosses that boundary — which is why
+ * installing a tool and opening a new pane surfaced nothing until the app was
+ * restarted (#11773). The spawn message's `env` is the one channel that does
+ * cross, and the host merges it over its stale base, so stamping the PATH here
+ * is what actually delivers the refresh.
+ *
+ * Applied at send time rather than in `spawn()` so it never enters
+ * `pendingSpawns`: every replay (pre-ready, crash respawn, crash-budget
+ * migration) re-runs this and picks up main's PATH as of the replay instead of
+ * resurrecting the value that was current when the terminal was first opened.
+ *
+ * A caller-supplied PATH always wins — project env settings may set it
+ * deliberately, and an explicit empty value is a choice, not an absence. Returns
+ * `options` unchanged off Windows and clones rather than mutating, so the
+ * caller's object and the lifecycle ledger's env provenance are untouched.
+ */
+function withCurrentWindowsPath(options: PtyHostSpawnOptions): PtyHostSpawnOptions {
+  if (process.platform !== "win32") return options;
+  if (options.env && hasEnvVar(options.env, "PATH")) return options;
+
+  const currentPath = getEnvVar(process.env as Record<string, string | undefined>, "PATH");
+  if (!currentPath) return options;
+
+  return { ...options, env: { ...(options.env ?? {}), PATH: currentPath } };
 }
 
 export class PtyClient extends EventEmitter {
@@ -827,6 +860,7 @@ export class PtyClient extends EventEmitter {
    * the command into a pre-existing live PTY.
    */
   private sendSpawnWithPostInput(shard: PtyShard, id: string, options: PtyHostSpawnOptions): void {
+    // (see `withCurrentWindowsPath` for why the PATH is stamped at send time)
     // Never deliver into a shard that isn't ready yet. A post-fork/pre-ready
     // send is dropped here AND re-sent by the first-ready replay below, which
     // for a command launch would run the command (and any resume) twice. The
@@ -835,7 +869,7 @@ export class PtyClient extends EventEmitter {
     // This makes the "double-spawn-safe" invariant explicit rather than relying
     // on the pre-fork transport drop.
     if (!shard.isRunning()) return;
-    shard.send({ type: "spawn", id, options });
+    shard.send({ type: "spawn", id, options: withCurrentWindowsPath(options) });
   }
 
   private respawnPendingForShard(shard: PtyShard): void {

--- a/electron/services/__tests__/AgentUpdateHandler.test.ts
+++ b/electron/services/__tests__/AgentUpdateHandler.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../setup/windowsPath.js", () => ({
   resolveWindowsRegistryPath: vi.fn().mockResolvedValue(null),
   applyWindowsExtraPaths: vi.fn((p: string) => p),
   expandWindowsEnvVars: vi.fn((s: string) => s),
+  deduplicatePath: vi.fn((p: string) => p),
   __resetWindowsPathStateForTests: vi.fn(),
 }));
 

--- a/electron/services/__tests__/AgentUpdateHandler.test.ts
+++ b/electron/services/__tests__/AgentUpdateHandler.test.ts
@@ -2,6 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setUserRegistry } from "../../../shared/config/agentRegistry.js";
 import { AgentUpdateHandler } from "../AgentUpdateHandler.js";
 
+const refreshWindowsPathForSpawnMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+// Full export surface: a factory that omits one throws for every consumer of the
+// module at collection while vitest still exits 0.
+vi.mock("../../setup/windowsPath.js", () => ({
+  refreshWindowsPathForSpawn: refreshWindowsPathForSpawnMock,
+  resolveWindowsRegistryPath: vi.fn().mockResolvedValue(null),
+  applyWindowsExtraPaths: vi.fn((p: string) => p),
+  expandWindowsEnvVars: vi.fn((s: string) => s),
+  __resetWindowsPathStateForTests: vi.fn(),
+}));
+
 type Listener = (...args: unknown[]) => void;
 
 function createPtyClientMock() {
@@ -278,5 +290,67 @@ describe("AgentUpdateHandler", () => {
 
     // brew has higher priority than cargo, so it wins auto-selection.
     expect(result.command).toBe("brew upgrade cargo-agent");
+  });
+});
+
+describe("AgentUpdateHandler Windows PATH refresh", () => {
+  const realPlatform = process.platform;
+  const setPlatform = (platform: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    refreshWindowsPathForSpawnMock.mockClear();
+    refreshWindowsPathForSpawnMock.mockResolvedValue(undefined);
+    setUserRegistry({
+      "test-agent": {
+        id: "test-agent",
+        name: "Test Agent",
+        command: "test-agent",
+        color: "#000000",
+        iconId: "terminal",
+        supportsContextInjection: false,
+        update: { npm: "npm install -g test-agent@latest" },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    setUserRegistry({});
+    setPlatform(realPlatform);
+  });
+
+  function createHandler() {
+    const { ptyClient } = createPtyClientMock();
+    const handler = new AgentUpdateHandler(
+      ptyClient as never,
+      { clearCache: vi.fn() } as never,
+      { refresh: vi.fn() } as never
+    );
+    return { handler, ptyClient };
+  }
+
+  it("refreshes the registry PATH before spawning the update terminal", async () => {
+    setPlatform("win32");
+    const { handler, ptyClient } = createHandler();
+
+    await handler.startUpdate({ agentId: "test-agent" as never });
+
+    // The user typically installs the runtime, then asks Daintree to update a
+    // CLI through it — the update command needs the PATH that install created.
+    expect(refreshWindowsPathForSpawnMock).toHaveBeenCalledTimes(1);
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("spawns anyway when the refresh fails", async () => {
+    setPlatform("win32");
+    refreshWindowsPathForSpawnMock.mockRejectedValue(new Error("reg query exploded"));
+    const { handler, ptyClient } = createHandler();
+
+    await expect(handler.startUpdate({ agentId: "test-agent" as never })).resolves.toBeTruthy();
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/services/__tests__/PtyClient.windowsPath.test.ts
+++ b/electron/services/__tests__/PtyClient.windowsPath.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { EventEmitter } from "events";
+import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
+
+const shared = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+  const appEmitter = new EventEmitter();
+  const appMock = Object.assign(appEmitter, {
+    getPath: vi.fn().mockReturnValue("/mock/user/data"),
+  });
+  return {
+    forkMock: vi.fn(),
+    tracker: {
+      removeTrashed: vi.fn(),
+      persistTrashed: vi.fn(),
+      clearAll: vi.fn(),
+    },
+    appMock,
+  };
+});
+
+vi.mock("electron", () => ({
+  utilityProcess: {
+    fork: shared.forkMock,
+  },
+  UtilityProcess: EventEmitter,
+  MessagePortMain: class {},
+  app: shared.appMock,
+}));
+
+vi.mock("../TrashedPidTracker.js", () => ({
+  getTrashedPidTracker: () => shared.tracker,
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  isValidLogOverrideLevel: vi.fn(() => true),
+}));
+
+interface MockUtilityProcess extends EventEmitter {
+  postMessage: Mock;
+  kill: Mock;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  pid?: number;
+}
+
+function createMockChild(): MockUtilityProcess {
+  return Object.assign(new EventEmitter(), {
+    postMessage: vi.fn(),
+    kill: vi.fn(),
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    pid: 321,
+  });
+}
+
+function spawnMessages(
+  child: MockUtilityProcess
+): Array<{ id: string; options: PtyHostSpawnOptions }> {
+  return child.postMessage.mock.calls
+    .map(
+      (call: unknown[]) => call[0] as { type?: string; id?: string; options?: PtyHostSpawnOptions }
+    )
+    .filter((msg) => msg?.type === "spawn")
+    .map((msg) => ({ id: msg.id!, options: msg.options! }));
+}
+
+/**
+ * The pty-host holds the environment it was forked with for its whole life, so
+ * the spawn message is the only carrier for a PATH that changed since (#11773).
+ * These assert what actually goes on the wire.
+ */
+describe("PtyClient Windows PATH stamping", () => {
+  const realPlatform = process.platform;
+  const setPlatform = (platform: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  };
+
+  let mockChild: MockUtilityProcess;
+  let PtyClientClass: typeof import("../PtyClient.js").PtyClient;
+  let disposeLifecycleLedger: typeof import("../pty/lifecycleLedger.js").disposeLifecycleLedger;
+  let getLifecycleLedger: typeof import("../pty/lifecycleLedger.js").getLifecycleLedger;
+  let originalPath: string | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    shared.appMock.removeAllListeners();
+    mockChild = createMockChild();
+    shared.forkMock.mockReturnValue(mockChild);
+    originalPath = process.env.PATH;
+
+    ({ PtyClient: PtyClientClass } = await import("../PtyClient.js"));
+    ({ getLifecycleLedger, disposeLifecycleLedger } = await import("../pty/lifecycleLedger.js"));
+
+    // Install after imports: fake timers can stall module re-execution (#11661).
+    vi.useFakeTimers();
+    disposeLifecycleLedger();
+  });
+
+  afterEach(() => {
+    disposeLifecycleLedger();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    setPlatform(realPlatform);
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+  });
+
+  // Constructed on the real platform so host-fork wiring behaves normally; the
+  // stamp is read at send time, which is all these exercise.
+  function createReadyClient(): import("../PtyClient.js").PtyClient {
+    const client = new PtyClientClass();
+    mockChild.emit("message", { type: "ready" });
+    return client;
+  }
+
+  const baseOptions: PtyHostSpawnOptions = { cwd: "C:\\repo", cols: 80, rows: 24 };
+
+  it("stamps main's current PATH onto a Windows spawn", () => {
+    const client = createReadyClient();
+    process.env.PATH = "C:\\Windows;C:\\Python313";
+    setPlatform("win32");
+
+    client.spawn("t1", baseOptions);
+
+    expect(spawnMessages(mockChild)[0]?.options.env).toEqual({ PATH: "C:\\Windows;C:\\Python313" });
+  });
+
+  it("merges the PATH alongside a caller's other env vars", () => {
+    const client = createReadyClient();
+    process.env.PATH = "C:\\Windows";
+    setPlatform("win32");
+
+    client.spawn("t1", { ...baseOptions, env: { ANTHROPIC_BASE_URL: "https://proxy.example" } });
+
+    expect(spawnMessages(mockChild)[0]?.options.env).toEqual({
+      ANTHROPIC_BASE_URL: "https://proxy.example",
+      PATH: "C:\\Windows",
+    });
+  });
+
+  it("yields to a caller-supplied PATH under any casing", () => {
+    const client = createReadyClient();
+    process.env.PATH = "C:\\Windows";
+    setPlatform("win32");
+
+    client.spawn("t1", { ...baseOptions, env: { Path: "C:\\Custom" } });
+
+    const env = spawnMessages(mockChild)[0]?.options.env;
+    expect(env).toEqual({ Path: "C:\\Custom" });
+  });
+
+  it("treats a deliberately empty PATH as a choice, not an absence", () => {
+    const client = createReadyClient();
+    process.env.PATH = "C:\\Windows";
+    setPlatform("win32");
+
+    client.spawn("t1", { ...baseOptions, env: { PATH: "" } });
+
+    expect(spawnMessages(mockChild)[0]?.options.env).toEqual({ PATH: "" });
+  });
+
+  it("does not mutate the caller's options or env object", () => {
+    const client = createReadyClient();
+    process.env.PATH = "C:\\Windows";
+    setPlatform("win32");
+    const callerEnv = { ANTHROPIC_BASE_URL: "https://proxy.example" };
+    const callerOptions = { ...baseOptions, env: callerEnv };
+
+    client.spawn("t1", callerOptions);
+
+    expect(callerEnv).toEqual({ ANTHROPIC_BASE_URL: "https://proxy.example" });
+    expect(callerOptions.env).toBe(callerEnv);
+  });
+
+  it("keeps the implicit PATH out of lifecycle-ledger env provenance", () => {
+    const client = createReadyClient();
+    process.env.PATH = "C:\\Windows";
+    setPlatform("win32");
+
+    client.spawn("t1", { ...baseOptions, env: { ANTHROPIC_BASE_URL: "https://proxy.example" } });
+
+    expect(getLifecycleLedger().getEntry("t1")?.facts.env?.keys).toEqual(["ANTHROPIC_BASE_URL"]);
+  });
+
+  it("re-stamps a changed PATH when a crashed host replays the spawn", () => {
+    const client = createReadyClient();
+    process.env.PATH = "C:\\Windows";
+    setPlatform("win32");
+    client.spawn("t1", baseOptions);
+
+    const restartedChild = createMockChild();
+    shared.forkMock.mockReturnValue(restartedChild);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    mockChild.emit("exit", 1);
+    vi.advanceTimersByTime(200);
+
+    // The tool the user installed while the host was down must be on the PATH
+    // of the replayed terminal, not the one captured when it first opened.
+    process.env.PATH = "C:\\Windows;C:\\Python313";
+    restartedChild.emit("message", { type: "ready" });
+
+    const replayed = spawnMessages(restartedChild);
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0]?.options.env?.PATH).toBe("C:\\Windows;C:\\Python313");
+  });
+
+  it("leaves POSIX spawns untouched", () => {
+    const client = createReadyClient();
+    process.env.PATH = "/usr/bin";
+    setPlatform("darwin");
+
+    client.spawn("t1", { ...baseOptions, env: { ANTHROPIC_BASE_URL: "https://proxy.example" } });
+    client.spawn("t2", baseOptions);
+
+    const spawns = spawnMessages(mockChild);
+    expect(spawns[0]?.options.env).toEqual({ ANTHROPIC_BASE_URL: "https://proxy.example" });
+    expect(spawns[1]?.options.env).toBeUndefined();
+  });
+});

--- a/electron/services/__tests__/PtyClient.windowsPath.test.ts
+++ b/electron/services/__tests__/PtyClient.windowsPath.test.ts
@@ -149,15 +149,16 @@ describe("PtyClient Windows PATH stamping", () => {
     });
   });
 
-  it("yields to a caller-supplied PATH under any casing", () => {
+  it.each(["Path", "PATH", "pAtH"])("yields to a caller-supplied %s", (key) => {
     const client = createReadyClient();
     process.env.PATH = "C:\\Windows";
     setPlatform("win32");
 
-    client.spawn("t1", { ...baseOptions, env: { Path: "C:\\Custom" } });
+    client.spawn("t1", { ...baseOptions, env: { [key]: "C:\\Custom" } });
 
-    const env = spawnMessages(mockChild)[0]?.options.env;
-    expect(env).toEqual({ Path: "C:\\Custom" });
+    // Windows resolves every spelling to the same variable, so the skip has to
+    // fold case rather than recognise a handful of known forms.
+    expect(spawnMessages(mockChild)[0]?.options.env).toEqual({ [key]: "C:\\Custom" });
   });
 
   it("treats a deliberately empty PATH as a choice, not an absence", () => {

--- a/electron/services/pty/EnvironmentFilter.ts
+++ b/electron/services/pty/EnvironmentFilter.ts
@@ -144,7 +144,14 @@ export function mergeEnvVars(
   base: Readonly<Record<string, string>>,
   overrides: Readonly<Record<string, string>>
 ): Record<string, string> {
-  const result: Record<string, string> = { ...base };
+  // Both sides fold into an empty object. Seeding with `{ ...base }` would
+  // normalize only the overrides, so a base that already carried two spellings
+  // of one name would keep both — the guarantee has to be structural, not a
+  // bet on the inputs being clean.
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(base)) {
+    setEnvVar(result, key, value);
+  }
   for (const [key, value] of Object.entries(overrides)) {
     setEnvVar(result, key, value);
   }
@@ -171,7 +178,7 @@ export function filterEnvironment(env: Record<string, string | undefined>): Reco
     // same variable.
     if (foldEnvKey(key).startsWith(DAINTREE_PREFIX)) continue;
     if (isSensitiveVar(key)) continue;
-    result[key] = value;
+    setEnvVar(result, key, value);
   }
   return result;
 }
@@ -193,7 +200,7 @@ export function filterSensitiveOnly(
   for (const [key, value] of Object.entries(env)) {
     if (value === undefined) continue;
     if (isSensitiveVar(key)) continue;
-    result[key] = value;
+    setEnvVar(result, key, value);
   }
   return result;
 }

--- a/electron/services/pty/EnvironmentFilter.ts
+++ b/electron/services/pty/EnvironmentFilter.ts
@@ -73,6 +73,85 @@ export function isSensitiveVar(name: string): boolean {
 }
 
 /**
+ * Windows environment variables are case-insensitive; POSIX ones are not.
+ *
+ * These filters and merges build plain JS objects, which are always
+ * case-sensitive, and node-pty emits every key verbatim into the child's
+ * environment block (`Terminal._parseEnv`). So on Windows a base env carrying
+ * `Path` merged with an override carrying `PATH` produces two entries for what
+ * the OS considers one variable, and the base one — being first — is the one
+ * `CreateProcess` resolves. That silently defeats any override we inject
+ * (#11773). The helpers below give the whole spawn-env pipeline one key per
+ * Windows equivalence class; on POSIX they degrade to plain object semantics,
+ * where `Path` and `PATH` really are different variables.
+ */
+function isCaseInsensitiveEnv(): boolean {
+  return process.platform === "win32";
+}
+
+/** Normalize an env key for comparison — identity on POSIX, upper-cased on Windows. */
+function foldEnvKey(key: string): string {
+  return isCaseInsensitiveEnv() ? key.toUpperCase() : key;
+}
+
+/** Find the key in `env` that names `name`, honouring Windows case-insensitivity. */
+function findEnvKey(env: Readonly<Record<string, unknown>>, name: string): string | undefined {
+  if (Object.prototype.hasOwnProperty.call(env, name)) return name;
+  if (!isCaseInsensitiveEnv()) return undefined;
+  const folded = name.toUpperCase();
+  return Object.keys(env).find((key) => key.toUpperCase() === folded);
+}
+
+/**
+ * Whether `env` defines `name`. Presence, not truthiness — an explicit
+ * `PATH=""` is a deliberate override and must not be treated as absent.
+ */
+export function hasEnvVar(
+  env: Readonly<Record<string, string | undefined>>,
+  name: string
+): boolean {
+  const key = findEnvKey(env, name);
+  return key !== undefined && env[key] !== undefined;
+}
+
+/** Read `name` from `env`, honouring Windows case-insensitivity. */
+export function getEnvVar(
+  env: Readonly<Record<string, string | undefined>>,
+  name: string
+): string | undefined {
+  const key = findEnvKey(env, name);
+  return key === undefined ? undefined : env[key];
+}
+
+/**
+ * Assign `name` in `env`, writing through an existing differently-cased key
+ * rather than adding a second one. Mutates `env`.
+ *
+ * The existing key's casing wins so the environment block a Windows child sees
+ * keeps the OS's own spelling (`Path`, `ComSpec`, `ProgramFiles`) instead of
+ * being rewritten to whatever casing our injection site happened to use.
+ */
+export function setEnvVar(env: Record<string, string>, name: string, value: string): void {
+  env[findEnvKey(env, name) ?? name] = value;
+}
+
+/**
+ * Merge `overrides` onto `base`, collapsing Windows case-variant keys.
+ *
+ * Later values win, first-seen casing is kept, and neither input is mutated.
+ */
+export function mergeEnvVars(
+  base: Readonly<Record<string, string>>,
+  overrides: Readonly<Record<string, string>>
+): Record<string, string> {
+  const result: Record<string, string> = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    setEnvVar(result, key, value);
+  }
+  return result;
+}
+
+/**
  * Filter an environment object, removing sensitive variables and DAINTREE_* vars.
  * Undefined values are also stripped (node-pty requires Record<string, string>).
  *
@@ -86,7 +165,11 @@ export function filterEnvironment(env: Record<string, string | undefined>): Reco
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
     if (value === undefined) continue;
-    if (key.startsWith(DAINTREE_PREFIX)) continue;
+    // Case-folded on Windows: a `daintree_pane_id` exported from PowerShell
+    // would otherwise survive this anti-spoofing strip and then sit beside the
+    // `DAINTREE_PANE_ID` injected below as a second key the OS treats as the
+    // same variable.
+    if (foldEnvKey(key).startsWith(DAINTREE_PREFIX)) continue;
     if (isSensitiveVar(key)) continue;
     result[key] = value;
   }
@@ -145,10 +228,13 @@ const UTF8_PATTERN = /utf-?8/i;
  * Ensure the environment has a UTF-8 locale set in LANG.
  */
 export function ensureUtf8Locale(env: Record<string, string>): Record<string, string> {
-  if (env.LANG && UTF8_PATTERN.test(env.LANG)) {
-    return { ...env };
+  const result = { ...env };
+  const lang = getEnvVar(result, "LANG");
+  if (lang && UTF8_PATTERN.test(lang)) {
+    return result;
   }
-  return { ...env, LANG: "en_US.UTF-8" };
+  setEnvVar(result, "LANG", "en_US.UTF-8");
+  return result;
 }
 
 /**
@@ -160,9 +246,9 @@ export function injectDaintreeMetadata(
   metadata: DaintreeTerminalMetadata
 ): Record<string, string> {
   const result: Record<string, string> = { ...env };
-  result.DAINTREE_PANE_ID = metadata.paneId;
-  result.DAINTREE_CWD = metadata.cwd;
-  if (metadata.projectId) result.DAINTREE_PROJECT_ID = metadata.projectId;
-  if (metadata.worktreeId) result.DAINTREE_WORKTREE_ID = metadata.worktreeId;
+  setEnvVar(result, "DAINTREE_PANE_ID", metadata.paneId);
+  setEnvVar(result, "DAINTREE_CWD", metadata.cwd);
+  if (metadata.projectId) setEnvVar(result, "DAINTREE_PROJECT_ID", metadata.projectId);
+  if (metadata.worktreeId) setEnvVar(result, "DAINTREE_WORKTREE_ID", metadata.worktreeId);
   return result;
 }

--- a/electron/services/pty/__tests__/EnvironmentFilter.test.ts
+++ b/electron/services/pty/__tests__/EnvironmentFilter.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import {
   isSensitiveVar,
   filterEnvironment,
   injectDaintreeMetadata,
   ensureUtf8Locale,
   shouldInjectForceColor,
+  getEnvVar,
+  hasEnvVar,
+  mergeEnvVars,
+  setEnvVar,
 } from "../EnvironmentFilter.js";
 
 describe("shouldInjectForceColor", () => {
@@ -342,5 +346,133 @@ describe("filterEnvironment + injectDaintreeMetadata integration", () => {
     expect(final.DAINTREE_PANE_ID).toBe("new-pane-id");
     expect(final.DAINTREE_CWD).toBe("/Users/dev/project");
     expect(final.DAINTREE_PROJECT_ID).toBe("proj-1");
+  });
+});
+
+describe("case-aware environment primitives", () => {
+  const realPlatform = process.platform;
+  const setPlatform = (platform: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  };
+
+  afterEach(() => setPlatform(realPlatform));
+
+  describe("on Windows, where env names are case-insensitive", () => {
+    beforeEach(() => setPlatform("win32"));
+
+    it("collapses a case-variant override onto the existing key", () => {
+      const merged = mergeEnvVars({ Path: "C:\\Windows" }, { PATH: "C:\\Windows;C:\\Python313" });
+
+      expect(Object.keys(merged)).toEqual(["Path"]);
+      expect(merged.Path).toBe("C:\\Windows;C:\\Python313");
+    });
+
+    it("leaves exactly one key per name however many spellings arrive", () => {
+      const merged = mergeEnvVars({ Path: "a", Temp: "t" }, { PATH: "b", TEMP: "u", path: "c" });
+
+      expect(
+        Object.keys(merged)
+          .map((k) => k.toUpperCase())
+          .sort()
+      ).toEqual(["PATH", "TEMP"]);
+      expect(merged.Path).toBe("c");
+      expect(merged.Temp).toBe("u");
+    });
+
+    it("mutates neither input", () => {
+      const base = { Path: "C:\\Windows" };
+      const overrides = { PATH: "C:\\Python313" };
+
+      mergeEnvVars(base, overrides);
+
+      expect(base).toEqual({ Path: "C:\\Windows" });
+      expect(overrides).toEqual({ PATH: "C:\\Python313" });
+    });
+
+    it("finds a value stored under different casing", () => {
+      expect(getEnvVar({ Path: "C:\\Windows" }, "PATH")).toBe("C:\\Windows");
+      expect(hasEnvVar({ Path: "C:\\Windows" }, "PATH")).toBe(true);
+    });
+
+    it("treats an explicitly empty value as present", () => {
+      expect(hasEnvVar({ Path: "" }, "PATH")).toBe(true);
+    });
+
+    it("reports a genuinely absent name as absent", () => {
+      expect(hasEnvVar({ Temp: "t" }, "PATH")).toBe(false);
+      expect(getEnvVar({ Temp: "t" }, "PATH")).toBeUndefined();
+    });
+
+    it("writes through the existing key rather than adding a second", () => {
+      const env = { Path: "C:\\Windows" };
+
+      setEnvVar(env, "PATH", "C:\\Python313");
+
+      expect(env).toEqual({ Path: "C:\\Python313" });
+    });
+
+    it("adds the name as spelled when nothing matches it", () => {
+      const env: Record<string, string> = { Temp: "t" };
+
+      setEnvVar(env, "PATH", "C:\\Windows");
+
+      expect(env.PATH).toBe("C:\\Windows");
+    });
+
+    it("strips a lower-cased DAINTREE_ var that would survive the spoofing guard", () => {
+      const filtered = filterEnvironment({ daintree_pane_id: "spoofed", Path: "C:\\Windows" });
+
+      expect(filtered.daintree_pane_id).toBeUndefined();
+      expect(filtered.Path).toBe("C:\\Windows");
+    });
+
+    it("overwrites case-variant metadata in place instead of duplicating it", () => {
+      const injected = injectDaintreeMetadata(
+        { daintree_pane_id: "stale" },
+        { paneId: "fresh", cwd: "C:\\repo" }
+      );
+
+      expect(injected.daintree_pane_id).toBe("fresh");
+      expect(injected.DAINTREE_PANE_ID).toBeUndefined();
+    });
+
+    it("recognises a mixed-case LANG that already states UTF-8", () => {
+      const result = ensureUtf8Locale({ Lang: "en_GB.UTF-8" });
+
+      expect(result).toEqual({ Lang: "en_GB.UTF-8" });
+    });
+
+    it("replaces a mixed-case non-UTF-8 LANG under its own key", () => {
+      const result = ensureUtf8Locale({ Lang: "C" });
+
+      expect(result).toEqual({ Lang: "en_US.UTF-8" });
+    });
+  });
+
+  describe("on POSIX, where env names are case-sensitive", () => {
+    beforeEach(() => setPlatform("darwin"));
+
+    it("keeps differently-cased names as the distinct variables they are", () => {
+      const merged = mergeEnvVars({ Path: "/a" }, { PATH: "/b" });
+
+      expect(merged).toEqual({ Path: "/a", PATH: "/b" });
+    });
+
+    it("does not resolve a name through another casing", () => {
+      expect(hasEnvVar({ Path: "/a" }, "PATH")).toBe(false);
+      expect(getEnvVar({ Path: "/a" }, "PATH")).toBeUndefined();
+    });
+
+    it("keeps a lower-cased daintree_ var, which is not the reserved prefix", () => {
+      const filtered = filterEnvironment({ daintree_pane_id: "mine" });
+
+      expect(filtered.daintree_pane_id).toBe("mine");
+    });
+
+    it("leaves a mixed-case Lang alone and sets LANG separately", () => {
+      const result = ensureUtf8Locale({ Lang: "C" });
+
+      expect(result).toEqual({ Lang: "C", LANG: "en_US.UTF-8" });
+    });
   });
 });

--- a/electron/services/pty/__tests__/EnvironmentFilter.test.ts
+++ b/electron/services/pty/__tests__/EnvironmentFilter.test.ts
@@ -379,6 +379,22 @@ describe("case-aware environment primitives", () => {
       expect(merged.Temp).toBe("u");
     });
 
+    it("collapses a base that already carries two spellings of one name", () => {
+      // Seeding with `{ ...base }` would normalize only the overrides and leave
+      // the stale `Path` in place beside the updated `PATH`.
+      const merged = mergeEnvVars({ Path: "old", PATH: "older" }, { PATH: "new" });
+
+      expect(Object.keys(merged)).toEqual(["Path"]);
+      expect(merged.Path).toBe("new");
+    });
+
+    it("collapses duplicates while filtering an inherited environment", () => {
+      const filtered = filterEnvironment({ Path: "first", PATH: "second" });
+
+      expect(Object.keys(filtered)).toEqual(["Path"]);
+      expect(filtered.Path).toBe("second");
+    });
+
     it("mutates neither input", () => {
       const base = { Path: "C:\\Windows" };
       const overrides = { PATH: "C:\\Python313" };

--- a/electron/services/pty/__tests__/terminalSpawn.env.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.env.test.ts
@@ -181,3 +181,91 @@ describe("buildTerminalEnv colour hints", () => {
     expect(env.COLORTERM).toBe("24bit");
   });
 });
+
+describe("buildTerminalEnv Windows PATH override", () => {
+  const realPlatform = process.platform;
+  const setPlatform = (platform: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  };
+
+  let originalPath: string | undefined;
+  let originalColorterm: string | undefined;
+
+  beforeEach(() => {
+    originalPath = process.env.PATH;
+    // buildTerminalEnv inherits process.env, and the shell running these tests
+    // almost certainly exports COLORTERM — which would decide the casing
+    // assertions below for us rather than the code under test.
+    originalColorterm = process.env.COLORTERM;
+    delete process.env.COLORTERM;
+  });
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalColorterm === undefined) delete process.env.COLORTERM;
+    else process.env.COLORTERM = originalColorterm;
+  });
+
+  /**
+   * node-pty emits `Object.keys(env)` verbatim into the child's environment
+   * block, so a stale `Path` sitting beside a fresh `PATH` is two entries for
+   * one variable and the first one wins. Counting keys by folded name is the
+   * assertion that the block a Windows shell actually receives is unambiguous.
+   */
+  const pathKeysOf = (env: Record<string, string>) =>
+    Object.keys(env).filter((key) => key.toUpperCase() === "PATH");
+
+  it("overwrites the inherited Path in place, leaving one PATH key", () => {
+    setPlatform("win32");
+    process.env.PATH = "C:\\Windows";
+    const env = buildTerminalEnv(
+      { ...baseOptions, env: { PATH: "C:\\Windows;C:\\Python313" } },
+      "pane-1",
+      "powershell.exe"
+    );
+
+    expect(pathKeysOf(env)).toHaveLength(1);
+    expect(env[pathKeysOf(env)[0]]).toBe("C:\\Windows;C:\\Python313");
+  });
+
+  it("leaves no case-insensitive duplicate key anywhere in the spawn env", () => {
+    setPlatform("win32");
+    const env = buildTerminalEnv(
+      {
+        ...baseOptions,
+        env: { PATH: "C:\\Python313", COLORTERM: "24bit", NODE_COMPILE_CACHE: "C:\\cache" },
+      },
+      "pane-1",
+      "powershell.exe"
+    );
+
+    const folded = Object.keys(env).map((key) => key.toUpperCase());
+    expect(folded).toHaveLength(new Set(folded).size);
+  });
+
+  it("honours a lower-cased override against an upper-cased inherited value", () => {
+    setPlatform("win32");
+    const env = buildTerminalEnv(
+      { ...baseOptions, env: { colorterm: "24bit" } },
+      "pane-1",
+      "powershell.exe"
+    );
+
+    expect(pathKeysOf(env).length).toBeLessThanOrEqual(1);
+    expect(env.colorterm).toBe("24bit");
+    expect(env.COLORTERM).toBeUndefined();
+  });
+
+  it("keeps Path and PATH distinct on POSIX, where they are different variables", () => {
+    setPlatform("darwin");
+    const env = buildTerminalEnv(
+      { ...baseOptions, env: { PATH: "/opt/bin" } },
+      "pane-1",
+      "/bin/bash"
+    );
+
+    expect(env.PATH).toBe("/opt/bin");
+  });
+});

--- a/electron/services/pty/__tests__/terminalSpawn.env.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.env.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { buildTerminalEnv } from "../terminalSpawn.js";
+import { buildTerminalEnv, computeSpawnContext } from "../terminalSpawn.js";
 import type { PtySpawnOptions } from "../types.js";
 
 const baseOptions: PtySpawnOptions = {
@@ -188,84 +188,97 @@ describe("buildTerminalEnv Windows PATH override", () => {
     Object.defineProperty(process, "platform", { value: platform, configurable: true });
   };
 
-  let originalPath: string | undefined;
-  let originalColorterm: string | undefined;
+  // Windows reports PATH as `Path`, so the env the pty-host inherited carries
+  // that spelling while our override uses `PATH`. On a POSIX test host those
+  // really are two variables, which is precisely what lets us reproduce the
+  // Windows collision here: seed `Path` alongside the runner's own `PATH` and
+  // `process.env` presents the same two-key shape a Windows process would.
+  const STALE = "C:\\Windows";
+  const FRESH = "C:\\Windows;C:\\Python313";
+  const AMBIENT = ["Path", "COLORTERM", "colorterm", "Lang", "daintree_pane_id"] as const;
+  const saved = new Map<string, string | undefined>();
 
   beforeEach(() => {
-    originalPath = process.env.PATH;
-    // buildTerminalEnv inherits process.env, and the shell running these tests
-    // almost certainly exports COLORTERM — which would decide the casing
-    // assertions below for us rather than the code under test.
-    originalColorterm = process.env.COLORTERM;
-    delete process.env.COLORTERM;
+    for (const key of AMBIENT) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    process.env.Path = STALE;
   });
 
   afterEach(() => {
     setPlatform(realPlatform);
-    if (originalPath === undefined) delete process.env.PATH;
-    else process.env.PATH = originalPath;
-    if (originalColorterm === undefined) delete process.env.COLORTERM;
-    else process.env.COLORTERM = originalColorterm;
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    saved.clear();
   });
 
   /**
    * node-pty emits `Object.keys(env)` verbatim into the child's environment
-   * block, so a stale `Path` sitting beside a fresh `PATH` is two entries for
-   * one variable and the first one wins. Counting keys by folded name is the
-   * assertion that the block a Windows shell actually receives is unambiguous.
+   * block — no dedup, no case folding — so a stale `Path` sitting beside a
+   * fresh `PATH` is two entries for one variable and the first one wins.
+   * Counting keys by folded name is the assertion that the block a Windows
+   * shell actually receives is unambiguous.
    */
-  const pathKeysOf = (env: Record<string, string>) =>
-    Object.keys(env).filter((key) => key.toUpperCase() === "PATH");
+  const foldedKeysNamed = (env: Record<string, string>, name: string) =>
+    Object.keys(env).filter((key) => key.toUpperCase() === name);
 
-  it("overwrites the inherited Path in place, leaving one PATH key", () => {
+  const foldedDuplicates = (env: Record<string, string>) => {
+    const seen = new Set<string>();
+    return Object.keys(env).filter((key) => {
+      const folded = key.toUpperCase();
+      if (seen.has(folded)) return true;
+      seen.add(folded);
+      return false;
+    });
+  };
+
+  it("collapses the inherited Path onto the fresh PATH instead of emitting both", () => {
     setPlatform("win32");
-    process.env.PATH = "C:\\Windows";
-    const env = buildTerminalEnv(
-      { ...baseOptions, env: { PATH: "C:\\Windows;C:\\Python313" } },
-      "pane-1",
-      "powershell.exe"
-    );
+    const env = buildTerminalEnv({ ...baseOptions, env: { PATH: FRESH } }, "p1", "powershell.exe");
 
-    expect(pathKeysOf(env)).toHaveLength(1);
-    expect(env[pathKeysOf(env)[0]]).toBe("C:\\Windows;C:\\Python313");
+    const keys = foldedKeysNamed(env, "PATH");
+    expect(keys).toHaveLength(1);
+    expect(env[keys[0]]).toBe(FRESH);
   });
 
-  it("leaves no case-insensitive duplicate key anywhere in the spawn env", () => {
+  it("collapses an override spelled in any casing", () => {
     setPlatform("win32");
-    const env = buildTerminalEnv(
-      {
-        ...baseOptions,
-        env: { PATH: "C:\\Python313", COLORTERM: "24bit", NODE_COMPILE_CACHE: "C:\\cache" },
-      },
-      "pane-1",
-      "powershell.exe"
-    );
+    const env = buildTerminalEnv({ ...baseOptions, env: { pAtH: FRESH } }, "p1", "powershell.exe");
 
-    const folded = Object.keys(env).map((key) => key.toUpperCase());
-    expect(folded).toHaveLength(new Set(folded).size);
+    const keys = foldedKeysNamed(env, "PATH");
+    expect(keys).toHaveLength(1);
+    expect(env[keys[0]]).toBe(FRESH);
   });
 
-  it("honours a lower-cased override against an upper-cased inherited value", () => {
+  it("hands pty.spawn an env with no case-insensitive duplicate key at all", () => {
     setPlatform("win32");
-    const env = buildTerminalEnv(
-      { ...baseOptions, env: { colorterm: "24bit" } },
-      "pane-1",
-      "powershell.exe"
-    );
+    process.env.colorterm = "16bit";
+    process.env.Lang = "C";
+    process.env.daintree_pane_id = "spoofed";
 
-    expect(pathKeysOf(env).length).toBeLessThanOrEqual(1);
-    expect(env.colorterm).toBe("24bit");
-    expect(env.COLORTERM).toBeUndefined();
+    // computeSpawnContext, not buildTerminalEnv: this is the object that
+    // reaches `pty.spawn`, after metadata, locale, colour and profiling have
+    // all had their turn at writing into it.
+    const { env } = computeSpawnContext("p1", {
+      ...baseOptions,
+      env: { PATH: FRESH, COLORTERM: "24bit", LANG: "en_US.UTF-8" },
+    });
+
+    expect(foldedDuplicates(env)).toEqual([]);
+    expect(env[foldedKeysNamed(env, "PATH")[0]]).toBe(FRESH);
+    expect(env[foldedKeysNamed(env, "DAINTREE_PANE_ID")[0]]).toBe("p1");
   });
 
   it("keeps Path and PATH distinct on POSIX, where they are different variables", () => {
     setPlatform("darwin");
-    const env = buildTerminalEnv(
-      { ...baseOptions, env: { PATH: "/opt/bin" } },
-      "pane-1",
-      "/bin/bash"
-    );
+    const env = buildTerminalEnv({ ...baseOptions, env: { PATH: "/opt/bin" } }, "p1", "/bin/bash");
 
+    // Both survive, unfolded: on POSIX these name two unrelated variables and
+    // collapsing them would silently drop one.
     expect(env.PATH).toBe("/opt/bin");
+    expect(env.Path).toBe(STALE);
   });
 });

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -5,6 +5,10 @@ import {
   injectDaintreeMetadata,
   ensureUtf8Locale,
   shouldInjectForceColor,
+  getEnvVar,
+  hasEnvVar,
+  mergeEnvVars,
+  setEnvVar,
 } from "./EnvironmentFilter.js";
 import { getDefaultShell, getDefaultShellArgs } from "./terminalShell.js";
 import { computePoolEnvHash } from "./ptyPoolEnvHash.js";
@@ -65,8 +69,12 @@ function injectAgentStartupProfiling(env: Record<string, string>, options: PtySp
 
   const profileDir = path.join(userData, "agent-profiles");
   const injection = `--cpu-prof --cpu-prof-dir=${profileDir}`;
-  const existing = env.NODE_OPTIONS;
-  env.NODE_OPTIONS = existing && existing.length > 0 ? `${existing} ${injection}` : injection;
+  const existing = getEnvVar(env, "NODE_OPTIONS");
+  setEnvVar(
+    env,
+    "NODE_OPTIONS",
+    existing && existing.length > 0 ? `${existing} ${injection}` : injection
+  );
 }
 
 /**
@@ -95,14 +103,16 @@ export function buildTerminalEnv(
         string
       >)
     : {};
-  const mergedEnv = injectDaintreeMetadata(
-    { ...filteredBaseEnv, ...intentionalEnv },
-    {
-      paneId: id,
-      cwd: options.cwd,
-      projectId: options.projectId,
-    }
-  );
+  // Case-collapsing merge, not a spread: on Windows the inherited base carries
+  // the OS's own casing (`Path`) while our overrides use the JS convention
+  // (`PATH`). A plain spread keeps both, node-pty writes both into the child's
+  // environment block, and the base one wins — which would silently defeat the
+  // refreshed PATH main stamps onto every spawn (#11773).
+  const mergedEnv = injectDaintreeMetadata(mergeEnvVars(filteredBaseEnv, intentionalEnv), {
+    paneId: id,
+    cwd: options.cwd,
+    projectId: options.projectId,
+  });
 
   // Universal colour hints — xterm.js supports truecolor, and most CLIs
   // (chalk, supports-color, termenv, ink) honour these. The FORCE_COLOR default
@@ -110,9 +120,11 @@ export function buildTerminalEnv(
   // COLORTERM stays unconditional: it feeds depth detection behind NO_COLOR's
   // own check, so it cannot resurrect colour the user opted out of.
   if (shouldInjectForceColor(mergedEnv)) {
-    mergedEnv.FORCE_COLOR = "3";
+    setEnvVar(mergedEnv, "FORCE_COLOR", "3");
   }
-  mergedEnv.COLORTERM = mergedEnv.COLORTERM ?? "truecolor";
+  if (!hasEnvVar(mergedEnv, "COLORTERM")) {
+    setEnvVar(mergedEnv, "COLORTERM", "truecolor");
+  }
 
   // V8 bytecode cache for Node-based agent CLIs. Path is per-agent to
   // avoid cross-CLI cache invalidation; Node also auto-isolates by
@@ -127,10 +139,10 @@ export function buildTerminalEnv(
     userData &&
     launchAgentId &&
     NODE_COMPILE_CACHE_AGENTS.has(launchAgentId) &&
-    mergedEnv.NODE_COMPILE_CACHE === undefined
+    !hasEnvVar(mergedEnv, "NODE_COMPILE_CACHE")
   ) {
     const cacheDir = getAgentCompileCacheDir(userData, launchAgentId);
-    if (cacheDir) mergedEnv.NODE_COMPILE_CACHE = cacheDir;
+    if (cacheDir) setEnvVar(mergedEnv, "NODE_COMPILE_CACHE", cacheDir);
   }
 
   return ensureUtf8Locale(mergedEnv);

--- a/electron/setup/__tests__/windowsPath.test.ts
+++ b/electron/setup/__tests__/windowsPath.test.ts
@@ -37,12 +37,37 @@ type ExecFileCallback = (err: Error | null, stdout: string) => void;
 function stubRegistry(values: { hklm: string | null; hkcu: string | null }): void {
   execFileMock.mockImplementation(
     (_cmd: string, args: string[], _opts: unknown, cb: ExecFileCallback) => {
-      const key = args[1];
-      const value = key.startsWith("HKLM") ? values.hklm : values.hkcu;
-      if (value === null) return cb(new Error("reg query failed"), "");
-      cb(null, `\r\n${key}\r\n    Path    REG_SZ    ${value}\r\n\r\n`);
+      respond(args[1], values, cb);
     }
   );
+}
+
+/**
+ * Like `stubRegistry`, but holds every `reg query` open until the returned
+ * `settle()` runs. `stubRegistry` answers synchronously, which leaves a read
+ * "in flight" for barely a microtask — too short to test what a caller does
+ * while one is genuinely outstanding.
+ */
+function stubRegistryDeferred(values: { hklm: string | null; hkcu: string | null }): () => void {
+  const pending: Array<() => void> = [];
+  execFileMock.mockImplementation(
+    (_cmd: string, args: string[], _opts: unknown, cb: ExecFileCallback) => {
+      pending.push(() => respond(args[1], values, cb));
+    }
+  );
+  return () => {
+    for (const respondNow of pending.splice(0)) respondNow();
+  };
+}
+
+function respond(
+  key: string,
+  values: { hklm: string | null; hkcu: string | null },
+  cb: ExecFileCallback
+): void {
+  const value = key.startsWith("HKLM") ? values.hklm : values.hkcu;
+  if (value === null) return cb(new Error("reg query failed"), "");
+  cb(null, `\r\n${key}\r\n    Path    REG_SZ    ${value}\r\n\r\n`);
 }
 
 /** Registry key reads issued so far, ignoring which key each targeted. */
@@ -57,6 +82,12 @@ async function importWindowsPath() {
 describe("windowsPath", () => {
   const originalPlatform = process.platform;
   const originalPath = process.env.PATH;
+
+  // Both derived from the module's throttle window rather than restated: what
+  // matters is which side of it a call lands on, not the number itself.
+  const WITHIN_THROTTLE_MS = 1_000;
+  const BEYOND_THROTTLE_MS = 30_000;
+
   let now = 1_000_000;
 
   beforeEach(() => {
@@ -64,16 +95,19 @@ describe("windowsPath", () => {
     execFileMock.mockReset();
     spawnMock.mockReset();
     now = 1_000_000;
-    // Date.now rather than fake timers: the module is loaded via a dynamic
-    // import inside each test, and installing fake timers before one of those
-    // hangs the hook.
-    vi.spyOn(Date, "now").mockImplementation(() => now);
-    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    // Stubbing the clock rather than installing fake timers: the module is
+    // loaded via a dynamic import inside each test, and fake timers installed
+    // before one of those hang the hook (#11661).
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    // configurable, NOT writable: Node ships `platform` as non-writable, and
+    // flipping that leaks the loosened descriptor into whichever file reuses
+    // this worker. Restoring the value alone would not put it back.
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;
   });
@@ -136,7 +170,7 @@ describe("windowsPath", () => {
 
   describe("refreshWindowsPathForSpawn", () => {
     it("does nothing off Windows", async () => {
-      Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
       process.env.PATH = "/usr/bin";
       stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
       const { refreshWindowsPathForSpawn } = await importWindowsPath();
@@ -163,7 +197,7 @@ describe("windowsPath", () => {
 
       await refreshWindowsPathForSpawn();
       const afterFirst = registryReadCount();
-      now += 4_000;
+      now += WITHIN_THROTTLE_MS;
       await refreshWindowsPathForSpawn();
 
       expect(registryReadCount()).toBe(afterFirst);
@@ -177,7 +211,7 @@ describe("windowsPath", () => {
       expect(process.env.PATH).toBe("C:\\Windows");
 
       stubRegistry({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
-      now += 6_000;
+      now += BEYOND_THROTTLE_MS;
       await refreshWindowsPathForSpawn();
 
       expect(process.env.PATH).toBe("C:\\Windows;C:\\Python313");
@@ -196,23 +230,39 @@ describe("windowsPath", () => {
       expect(registryReadCount()).toBe(afterStartup);
     });
 
-    it("joins an in-flight read rather than skipping on the previous stamp", async () => {
+    it("joins an in-flight read even though the previous stamp is still fresh", async () => {
       stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
       const { resolveWindowsRegistryPath, refreshWindowsPathForSpawn } = await importWindowsPath();
-
       await resolveWindowsRegistryPath();
-      now += 6_000;
-      stubRegistry({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
+      const afterStartup = registryReadCount();
 
-      // A refresh already in flight is strictly newer than the stamp it has not
-      // written yet, so the spawn must await it instead of reading the old one.
+      // Inside the throttle window, so the TTL alone would say "skip" — but a
+      // read is outstanding, and it is by definition newer than the stamp it
+      // has not written yet. Skipping here would hand this spawn the previous
+      // answer while a fresher one was moments away.
+      now += WITHIN_THROTTLE_MS;
+      const settle = stubRegistryDeferred({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
       const inFlight = resolveWindowsRegistryPath();
-      await refreshWindowsPathForSpawn();
-      await inFlight;
+      const joined = refreshWindowsPathForSpawn();
 
-      // Two reads for the startup refresh, two for the in-flight one the spawn
-      // joined — not six, which is what a spawn issuing its own would cost.
-      expect(registryReadCount()).toBe(4);
+      settle();
+      await Promise.all([inFlight, joined]);
+
+      expect(registryReadCount()).toBe(afterStartup * 2);
+      expect(process.env.PATH).toBe("C:\\Windows;C:\\Python313");
+    });
+
+    it("collapses concurrent spawns onto a single registry read", async () => {
+      const settle = stubRegistryDeferred({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      // Six panes opening at once — a recipe launch — must not mean six
+      // `reg.exe` pairs.
+      const spawns = Array.from({ length: 6 }, () => refreshWindowsPathForSpawn());
+      settle();
+      await Promise.all(spawns);
+
+      expect(registryReadCount()).toBe(2);
       expect(process.env.PATH).toBe("C:\\Windows;C:\\Python313");
     });
 
@@ -233,11 +283,11 @@ describe("windowsPath", () => {
       await refreshWindowsPathForSpawn();
       const afterFailure = registryReadCount();
 
-      now += 1_000;
+      now += WITHIN_THROTTLE_MS;
       await refreshWindowsPathForSpawn();
       expect(registryReadCount()).toBe(afterFailure);
 
-      now += 6_000;
+      now += BEYOND_THROTTLE_MS;
       await refreshWindowsPathForSpawn();
       expect(registryReadCount()).toBeGreaterThan(afterFailure);
     });
@@ -251,6 +301,41 @@ describe("windowsPath", () => {
 
       await expect(refreshWindowsPathForSpawn()).resolves.toBeUndefined();
       expect(process.env.PATH).toBe("C:\\Windows");
+    });
+
+    it("throttles a throwing registry read too, rather than retrying per pane", async () => {
+      execFileMock.mockImplementation(() => {
+        throw new Error("spawn ENOENT");
+      });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await refreshWindowsPathForSpawn();
+      const afterThrow = registryReadCount();
+
+      // A missing or broken `reg.exe` is a persistent condition; paying for it
+      // on every terminal open would be the worst version of this feature.
+      now += WITHIN_THROTTLE_MS;
+      await refreshWindowsPathForSpawn();
+
+      expect(registryReadCount()).toBe(afterThrow);
+    });
+
+    it("throttles on monotonic time, not the wall clock", async () => {
+      stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await refreshWindowsPathForSpawn();
+      const afterFirst = registryReadCount();
+
+      // The wall clock jumps backwards (NTP correction, a timezone fix) while
+      // monotonic time moves on past the throttle window. A `Date.now()` gate
+      // would compute negative elapsed, read it as "just refreshed", and
+      // suppress every registry read until real time caught up.
+      vi.spyOn(Date, "now").mockReturnValue(0);
+      now += BEYOND_THROTTLE_MS;
+      await refreshWindowsPathForSpawn();
+
+      expect(registryReadCount()).toBeGreaterThan(afterFirst);
     });
   });
 });

--- a/electron/setup/__tests__/windowsPath.test.ts
+++ b/electron/setup/__tests__/windowsPath.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Full surface for every mocked builtin: a factory missing an export throws for
+// each consumer at collection while vitest still exits 0.
+vi.mock("fs", () => ({
+  default: { existsSync: vi.fn(() => false) },
+  existsSync: vi.fn(() => false),
+}));
+
+vi.mock("os", () => ({
+  default: { homedir: () => "/home/testuser" },
+  homedir: () => "/home/testuser",
+}));
+
+// The module under test parses and joins Windows PATH strings, so it needs
+// Windows path semantics — above all `delimiter === ";"`. On a POSIX host the
+// real module splits `C:\Windows;C:\Tools` on ":" and shreds it, which would
+// make every assertion below about merged output meaningless.
+vi.mock("path", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("path")>();
+  return { ...actual.win32, default: actual.win32 };
+});
+
+const execFileMock = vi.fn();
+const spawnMock = vi.fn();
+vi.mock("child_process", () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+type ExecFileCallback = (err: Error | null, stdout: string) => void;
+
+/**
+ * Stand in for `reg query <key> /v Path`, keyed on the registry key so the two
+ * concurrent reads can return different values. `null` makes that key fail.
+ */
+function stubRegistry(values: { hklm: string | null; hkcu: string | null }): void {
+  execFileMock.mockImplementation(
+    (_cmd: string, args: string[], _opts: unknown, cb: ExecFileCallback) => {
+      const key = args[1];
+      const value = key.startsWith("HKLM") ? values.hklm : values.hkcu;
+      if (value === null) return cb(new Error("reg query failed"), "");
+      cb(null, `\r\n${key}\r\n    Path    REG_SZ    ${value}\r\n\r\n`);
+    }
+  );
+}
+
+/** Registry key reads issued so far, ignoring which key each targeted. */
+function registryReadCount(): number {
+  return execFileMock.mock.calls.length;
+}
+
+async function importWindowsPath() {
+  return import("../windowsPath.js");
+}
+
+describe("windowsPath", () => {
+  const originalPlatform = process.platform;
+  const originalPath = process.env.PATH;
+  let now = 1_000_000;
+
+  beforeEach(() => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    spawnMock.mockReset();
+    now = 1_000_000;
+    // Date.now rather than fake timers: the module is loaded via a dynamic
+    // import inside each test, and installing fake timers before one of those
+    // hangs the hook.
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+  });
+
+  describe("resolveWindowsRegistryPath", () => {
+    it("merges the machine and user PATH, machine first", async () => {
+      stubRegistry({ hklm: "C:\\Windows;C:\\Windows\\System32", hkcu: "C:\\Users\\me\\bin" });
+      const { resolveWindowsRegistryPath } = await importWindowsPath();
+
+      expect(await resolveWindowsRegistryPath()).toBe(
+        "C:\\Windows;C:\\Windows\\System32;C:\\Users\\me\\bin"
+      );
+    });
+
+    it("drops case-insensitive duplicate entries", async () => {
+      stubRegistry({ hklm: "C:\\Windows;C:\\Tools", hkcu: "c:\\windows;C:\\Users\\me\\bin" });
+      const { resolveWindowsRegistryPath } = await importWindowsPath();
+
+      expect(await resolveWindowsRegistryPath()).toBe("C:\\Windows;C:\\Tools;C:\\Users\\me\\bin");
+    });
+
+    it("keeps the surviving key when the other one errors", async () => {
+      stubRegistry({ hklm: null, hkcu: "C:\\Users\\me\\bin" });
+      const { resolveWindowsRegistryPath } = await importWindowsPath();
+
+      expect(await resolveWindowsRegistryPath()).toBe("C:\\Users\\me\\bin");
+    });
+
+    it("returns null when neither key yields a value", async () => {
+      stubRegistry({ hklm: null, hkcu: null });
+      const { resolveWindowsRegistryPath } = await importWindowsPath();
+
+      expect(await resolveWindowsRegistryPath()).toBeNull();
+    });
+
+    it("collapses concurrent callers onto one pair of registry reads", async () => {
+      stubRegistry({ hklm: "C:\\Windows", hkcu: "C:\\Users\\me\\bin" });
+      const { resolveWindowsRegistryPath } = await importWindowsPath();
+
+      const [a, b, c] = await Promise.all([
+        resolveWindowsRegistryPath(),
+        resolveWindowsRegistryPath(),
+        resolveWindowsRegistryPath(),
+      ]);
+
+      expect(registryReadCount()).toBe(2);
+      expect(a).toBe(b);
+      expect(b).toBe(c);
+    });
+
+    it("re-reads once the previous call has settled", async () => {
+      stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
+      const { resolveWindowsRegistryPath } = await importWindowsPath();
+
+      await resolveWindowsRegistryPath();
+      stubRegistry({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
+      expect(await resolveWindowsRegistryPath()).toBe("C:\\Windows;C:\\Python313");
+    });
+  });
+
+  describe("refreshWindowsPathForSpawn", () => {
+    it("does nothing off Windows", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+      process.env.PATH = "/usr/bin";
+      stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await refreshWindowsPathForSpawn();
+
+      expect(registryReadCount()).toBe(0);
+      expect(process.env.PATH).toBe("/usr/bin");
+    });
+
+    it("adopts the registry PATH on the first call", async () => {
+      process.env.PATH = "C:\\Windows";
+      stubRegistry({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await refreshWindowsPathForSpawn();
+
+      expect(process.env.PATH).toBe("C:\\Windows;C:\\Python313");
+    });
+
+    it("skips the registry entirely for a second spawn inside the TTL", async () => {
+      stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await refreshWindowsPathForSpawn();
+      const afterFirst = registryReadCount();
+      now += 4_000;
+      await refreshWindowsPathForSpawn();
+
+      expect(registryReadCount()).toBe(afterFirst);
+    });
+
+    it("re-reads once the TTL has elapsed, picking up a newly installed tool", async () => {
+      stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await refreshWindowsPathForSpawn();
+      expect(process.env.PATH).toBe("C:\\Windows");
+
+      stubRegistry({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
+      now += 6_000;
+      await refreshWindowsPathForSpawn();
+
+      expect(process.env.PATH).toBe("C:\\Windows;C:\\Python313");
+    });
+
+    it("counts a startup registry read against the TTL", async () => {
+      stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
+      const { resolveWindowsRegistryPath, refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      // Stands in for the app-start refresh, which resolves through the same
+      // single-flight; a restore burst right after it must not re-query.
+      await resolveWindowsRegistryPath();
+      const afterStartup = registryReadCount();
+      await refreshWindowsPathForSpawn();
+
+      expect(registryReadCount()).toBe(afterStartup);
+    });
+
+    it("joins an in-flight read rather than skipping on the previous stamp", async () => {
+      stubRegistry({ hklm: "C:\\Windows", hkcu: "" });
+      const { resolveWindowsRegistryPath, refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await resolveWindowsRegistryPath();
+      now += 6_000;
+      stubRegistry({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
+
+      // A refresh already in flight is strictly newer than the stamp it has not
+      // written yet, so the spawn must await it instead of reading the old one.
+      const inFlight = resolveWindowsRegistryPath();
+      await refreshWindowsPathForSpawn();
+      await inFlight;
+
+      // Two reads for the startup refresh, two for the in-flight one the spawn
+      // joined — not six, which is what a spawn issuing its own would cost.
+      expect(registryReadCount()).toBe(4);
+      expect(process.env.PATH).toBe("C:\\Windows;C:\\Python313");
+    });
+
+    it("leaves PATH alone when the registry yields nothing", async () => {
+      process.env.PATH = "C:\\Windows";
+      stubRegistry({ hklm: null, hkcu: null });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await refreshWindowsPathForSpawn();
+
+      expect(process.env.PATH).toBe("C:\\Windows");
+    });
+
+    it("throttles a failing registry read, then retries after the TTL", async () => {
+      stubRegistry({ hklm: null, hkcu: null });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await refreshWindowsPathForSpawn();
+      const afterFailure = registryReadCount();
+
+      now += 1_000;
+      await refreshWindowsPathForSpawn();
+      expect(registryReadCount()).toBe(afterFailure);
+
+      now += 6_000;
+      await refreshWindowsPathForSpawn();
+      expect(registryReadCount()).toBeGreaterThan(afterFailure);
+    });
+
+    it("never rejects when the registry read throws", async () => {
+      process.env.PATH = "C:\\Windows";
+      execFileMock.mockImplementation(() => {
+        throw new Error("spawn ENOENT");
+      });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      await expect(refreshWindowsPathForSpawn()).resolves.toBeUndefined();
+      expect(process.env.PATH).toBe("C:\\Windows");
+    });
+  });
+});

--- a/electron/setup/__tests__/windowsPath.test.ts
+++ b/electron/setup/__tests__/windowsPath.test.ts
@@ -88,6 +88,11 @@ describe("windowsPath", () => {
   const WITHIN_THROTTLE_MS = 1_000;
   const BEYOND_THROTTLE_MS = 30_000;
 
+  // Longer than any budget a terminal spawn could reasonably hold for. What is
+  // asserted is that the wait ends while the read is still outstanding, not
+  // where the module draws the line.
+  const WEDGED_REGISTRY_READ_MS = 30_000;
+
   let now = 1_000_000;
 
   beforeEach(() => {
@@ -106,6 +111,9 @@ describe("windowsPath", () => {
   });
 
   afterEach(() => {
+    // Before `restoreAllMocks`: uninstalling the fake clock puts back whatever
+    // `performance.now` it captured — the spy — so restoring has to come after.
+    vi.useRealTimers();
     vi.restoreAllMocks();
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     if (originalPath === undefined) delete process.env.PATH;
@@ -263,6 +271,34 @@ describe("windowsPath", () => {
       await Promise.all(spawns);
 
       expect(registryReadCount()).toBe(2);
+      expect(process.env.PATH).toBe("C:\\Windows;C:\\Python313");
+    });
+
+    it("stops waiting on a wedged registry read, then adopts it for the next spawn", async () => {
+      process.env.PATH = "C:\\Windows";
+      const settle = stubRegistryDeferred({ hklm: "C:\\Windows;C:\\Python313", hkcu: "" });
+      const { refreshWindowsPathForSpawn } = await importWindowsPath();
+
+      // Fake timers go in here rather than in `beforeEach`: installed before the
+      // dynamic import above, they hang the hook (#11661).
+      vi.useFakeTimers();
+      let spawnProceeded = false;
+      void refreshWindowsPathForSpawn().then(() => {
+        spawnProceeded = true;
+      });
+
+      // `reg.exe` is still outstanding — nothing has answered it. An unbounded
+      // await would still be sitting here, holding the terminal open request.
+      await vi.advanceTimersByTimeAsync(WEDGED_REGISTRY_READ_MS);
+
+      expect(spawnProceeded).toBe(true);
+      expect(process.env.PATH).toBe("C:\\Windows");
+
+      // The read is not abandoned when the spawn walks away: it lands afterwards
+      // and the next terminal opens against the fresh value.
+      settle();
+      await vi.advanceTimersByTimeAsync(1);
+
       expect(process.env.PATH).toBe("C:\\Windows;C:\\Python313");
     });
 

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -24,7 +24,11 @@ import path from "path";
 import fs from "fs";
 import { existsSync } from "fs";
 import os from "os";
-import { applyWindowsExtraPaths, resolveWindowsRegistryPath } from "./windowsPath.js";
+import {
+  applyWindowsExtraPaths,
+  deduplicatePath,
+  resolveWindowsRegistryPath,
+} from "./windowsPath.js";
 import { isLinuxWaylandHybridGpu } from "../utils/gpuDetection.js";
 import { getMaxWebGLContextCeiling } from "../utils/webglContextBudget.js";
 // Deliberately the tiny pure-fs module, NOT GpuCrashMonitorService — importing
@@ -230,20 +234,6 @@ const SHELL_PROBE_KILL_GRACE_MS = 500;
 // transient failure for the entire session is worse than the bounded cost
 // of one extra probe.
 let shellProbePromise: Promise<string | null> | null = null;
-
-function deduplicatePath(pathStr: string, caseInsensitive: boolean): string {
-  const entries = pathStr.split(path.delimiter).filter(Boolean);
-  const seen = new Set<string>();
-  const unique: string[] = [];
-  for (const entry of entries) {
-    const key = caseInsensitive ? entry.toLowerCase() : entry;
-    if (!seen.has(key)) {
-      seen.add(key);
-      unique.push(entry);
-    }
-  }
-  return unique.join(path.delimiter);
-}
 
 /**
  * Fallback shim/bin directories to add to PATH on macOS/Linux when the

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -17,7 +17,7 @@ for (const stream of [process.stdout, process.stderr]) {
 
 import nodeV8 from "node:v8";
 import vm from "node:vm";
-import { execFile, spawn } from "child_process";
+import { spawn } from "child_process";
 import { randomBytes } from "crypto";
 import { app } from "electron";
 import path from "path";

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -24,6 +24,7 @@ import path from "path";
 import fs from "fs";
 import { existsSync } from "fs";
 import os from "os";
+import { applyWindowsExtraPaths, resolveWindowsRegistryPath } from "./windowsPath.js";
 import { isLinuxWaylandHybridGpu } from "../utils/gpuDetection.js";
 import { getMaxWebGLContextCeiling } from "../utils/webglContextBudget.js";
 // Deliberately the tiny pure-fs module, NOT GpuCrashMonitorService — importing
@@ -208,14 +209,10 @@ app.commandLine.appendSwitch("force-gpu-mem-available-mb", getGpuTileMemoryCapMb
 app.commandLine.appendSwitch("max-active-webgl-contexts", String(getMaxWebGLContextCeiling()));
 
 if (process.platform === "win32") {
-  const extraPaths = getWindowsExtraPaths();
   const current = process.env.PATH || "";
-  const existingEntries = current.split(path.delimiter).map((e) => e.toLowerCase());
-  const missing = extraPaths.filter(
-    (p) => !existingEntries.includes(p.toLowerCase()) && existsSync(p)
-  );
-  if (missing.length) {
-    process.env.PATH = [...missing, current].join(path.delimiter);
+  const augmented = applyWindowsExtraPaths(current);
+  if (augmented !== current) {
+    process.env.PATH = augmented;
   }
 }
 
@@ -246,10 +243,6 @@ function deduplicatePath(pathStr: string, caseInsensitive: boolean): string {
     }
   }
   return unique.join(path.delimiter);
-}
-
-export function expandWindowsEnvVars(str: string): string {
-  return str.replace(/%([^%]+)%/g, (match, name: string) => process.env[name] ?? match);
 }
 
 /**
@@ -319,76 +312,6 @@ function applyUnixFallbackPaths(currentPath: string): string {
   const extraPaths = getUnixFallbackPaths();
   const existingEntries = currentPath.split(path.delimiter);
   const missing = extraPaths.filter((p) => !existingEntries.includes(p));
-  return missing.length ? [...missing, currentPath].join(path.delimiter) : currentPath;
-}
-
-function getWindowsExtraPaths(): string[] {
-  const programFiles = process.env["ProgramFiles"] || "C:\\Program Files";
-  const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
-  const chocoInstall = process.env["ChocolateyInstall"] || "C:\\ProgramData\\chocolatey";
-  const home = os.homedir();
-
-  const paths = [
-    path.join(home, "AppData", "Roaming", "npm"),
-    path.join(home, "AppData", "Local", "Programs", "Git", "cmd"),
-    path.join(programFiles, "Git", "cmd"),
-    path.join(programFilesX86, "Git", "cmd"),
-    path.join(home, "scoop", "shims"),
-    path.join(chocoInstall, "bin"),
-  ];
-
-  // Volta: env var first, hardcoded fallback
-  if (process.env["VOLTA_HOME"]) {
-    paths.push(path.join(process.env["VOLTA_HOME"], "bin"));
-  } else {
-    paths.push(path.join(home, "AppData", "Local", "Volta", "bin"));
-  }
-
-  // pnpm: env var only
-  if (process.env["PNPM_HOME"]) {
-    paths.push(process.env["PNPM_HOME"]);
-  }
-
-  // fnm: env var only (dynamic per session)
-  if (process.env["FNM_MULTISHELL_PATH"]) {
-    paths.push(process.env["FNM_MULTISHELL_PATH"]);
-  }
-
-  // nvm-windows: env var only
-  if (process.env["NVM_SYMLINK"]) {
-    paths.push(process.env["NVM_SYMLINK"]);
-  }
-
-  return paths;
-}
-
-function readWindowsRegistryPath(): Promise<string> {
-  const keys = [
-    "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment",
-    "HKCU\\Environment",
-  ];
-
-  return Promise.all(
-    keys.map(
-      (key) =>
-        new Promise<string>((resolve) => {
-          execFile("reg", ["query", key, "/v", "Path"], { timeout: 3_000 }, (err, stdout) => {
-            if (err || !stdout) return resolve("");
-            const match = stdout.match(/Path\s+REG_(?:EXPAND_)?SZ\s+(.+)/i);
-            resolve(expandWindowsEnvVars(match?.[1]?.trim() ?? ""));
-          });
-        })
-    )
-  ).then((paths) => paths.filter(Boolean).join(path.delimiter));
-}
-
-function applyWindowsExtraPaths(currentPath: string): string {
-  const extraPaths = getWindowsExtraPaths();
-  const existingEntries = currentPath.split(path.delimiter).map((e) => e.toLowerCase());
-  const missing = extraPaths.filter(
-    (p) => !existingEntries.includes(p.toLowerCase()) && existsSync(p)
-  );
-
   return missing.length ? [...missing, currentPath].join(path.delimiter) : currentPath;
 }
 
@@ -555,10 +478,14 @@ async function runRefreshPath(): Promise<void> {
     const result = await Promise.race([
       (async () => {
         if (process.platform === "win32") {
-          const registryPath = await readWindowsRegistryPath();
-          if (!registryPath || timedOut) return;
-          const withExtras = applyWindowsExtraPaths(registryPath);
-          process.env.PATH = deduplicatePath(withExtras, true);
+          // Registry read + shim-dir merge live in the dependency-free
+          // `windowsPath.ts` leaf so the terminal spawn path can re-run them
+          // per pane without importing this module's startup machinery
+          // (#11773). Its single-flight is shared, so a spawn refresh landing
+          // mid-startup joins this read instead of racing a second `reg.exe`.
+          const resolved = await resolveWindowsRegistryPath();
+          if (!resolved || timedOut) return;
+          process.env.PATH = resolved;
         } else if (process.env.DAINTREE_SHELL_PROBE === "1") {
           // Opt-in markered shell-probe path (#6063). Replaces shell-env
           // with a real `$SHELL -i -l -c` invocation so lazy-loaded version
@@ -658,6 +585,11 @@ export function getEarlyPathRefreshPromise(): Promise<void> | null {
 // as local bindings (not a bare `export ... from`) because environment.ts uses
 // isSmokeTest internally below.
 export { isDemoMode, isSmokeTest, smokeTestStart };
+
+// Same deal for the Windows PATH helpers, which moved to ./windowsPath.js so
+// the terminal spawn path can reach them without this module's `app.*` and
+// SQLite module-scope work. A bare re-export because nothing here uses it.
+export { expandWindowsEnvVars } from "./windowsPath.js";
 
 if (isSmokeTest) {
   console.error("[SMOKE] Smoke test mode enabled");

--- a/electron/setup/windowsPath.ts
+++ b/electron/setup/windowsPath.ts
@@ -1,0 +1,203 @@
+// Windows PATH resolution, read straight from the registry.
+//
+// Kept separate from the heavy `environment.ts` (which runs `app.getPath`/
+// `setPath`, `app.commandLine`, fs, and SQLite work at module load) so
+// importers that only need a PATH refresh — the terminal spawn handler — don't
+// pull that startup machinery into their graph. Same rationale as
+// `runtimeFlags.ts` and `deepLinkUrlQueue.ts`. Node builtins only.
+//
+// `deduplicatePath` lives here rather than in `environment.ts` because this is
+// the dependency-free leaf: `environment.ts` imports it back for its POSIX
+// branch, and the reverse direction would be a cycle.
+
+import { execFile } from "child_process";
+import { existsSync } from "fs";
+import os from "os";
+import path from "path";
+
+// A terminal spawn re-reads the registry at most this often. `reg.exe` is two
+// process spawns (30-100ms+ each on Windows once Defender inspects them), which
+// is real latency on the spawn path, so a burst — a recipe opening six panes, a
+// session restore replaying a grid — collapses onto one read. Anything longer
+// than a few seconds and "install a tool, open a terminal" would still miss it,
+// which is the whole point of #11773.
+const SPAWN_PATH_REFRESH_TTL_MS = 5_000;
+
+// Single-flight for the registry read itself, shared by every caller (startup
+// refresh, CLI availability probes, terminal spawns). Cleared on settlement so
+// a later call re-queries rather than pinning a stale answer.
+let registryReadPromise: Promise<string | null> | null = null;
+
+// When the last registry read *settled*, success or failure. Stamped on both
+// outcomes on purpose: this is a short cooldown so a failing `reg.exe` can't be
+// hammered once per pane, not a success cache. `0` means "never read".
+let lastRegistryReadAt = 0;
+
+function deduplicatePath(pathStr: string, caseInsensitive: boolean): string {
+  const entries = pathStr.split(path.delimiter).filter(Boolean);
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const entry of entries) {
+    const key = caseInsensitive ? entry.toLowerCase() : entry;
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(entry);
+    }
+  }
+  return unique.join(path.delimiter);
+}
+
+export function expandWindowsEnvVars(str: string): string {
+  return str.replace(/%([^%]+)%/g, (match, name: string) => process.env[name] ?? match);
+}
+
+function getWindowsExtraPaths(): string[] {
+  const programFiles = process.env["ProgramFiles"] || "C:\\Program Files";
+  const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+  const chocoInstall = process.env["ChocolateyInstall"] || "C:\\ProgramData\\chocolatey";
+  const home = os.homedir();
+
+  const paths = [
+    path.join(home, "AppData", "Roaming", "npm"),
+    path.join(home, "AppData", "Local", "Programs", "Git", "cmd"),
+    path.join(programFiles, "Git", "cmd"),
+    path.join(programFilesX86, "Git", "cmd"),
+    path.join(home, "scoop", "shims"),
+    path.join(chocoInstall, "bin"),
+  ];
+
+  // Volta: env var first, hardcoded fallback
+  if (process.env["VOLTA_HOME"]) {
+    paths.push(path.join(process.env["VOLTA_HOME"], "bin"));
+  } else {
+    paths.push(path.join(home, "AppData", "Local", "Volta", "bin"));
+  }
+
+  // pnpm: env var only
+  if (process.env["PNPM_HOME"]) {
+    paths.push(process.env["PNPM_HOME"]);
+  }
+
+  // fnm: env var only (dynamic per session)
+  if (process.env["FNM_MULTISHELL_PATH"]) {
+    paths.push(process.env["FNM_MULTISHELL_PATH"]);
+  }
+
+  // nvm-windows: env var only
+  if (process.env["NVM_SYMLINK"]) {
+    paths.push(process.env["NVM_SYMLINK"]);
+  }
+
+  return paths;
+}
+
+function readWindowsRegistryPath(): Promise<string> {
+  const keys = [
+    "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment",
+    "HKCU\\Environment",
+  ];
+
+  return Promise.all(
+    keys.map(
+      (key) =>
+        new Promise<string>((resolve) => {
+          execFile("reg", ["query", key, "/v", "Path"], { timeout: 3_000 }, (err, stdout) => {
+            if (err || !stdout) return resolve("");
+            const match = stdout.match(/Path\s+REG_(?:EXPAND_)?SZ\s+(.+)/i);
+            resolve(expandWindowsEnvVars(match?.[1]?.trim() ?? ""));
+          });
+        })
+    )
+  ).then((paths) => paths.filter(Boolean).join(path.delimiter));
+}
+
+export function applyWindowsExtraPaths(currentPath: string): string {
+  const extraPaths = getWindowsExtraPaths();
+  const existingEntries = currentPath.split(path.delimiter).map((e) => e.toLowerCase());
+  const missing = extraPaths.filter(
+    (p) => !existingEntries.includes(p.toLowerCase()) && existsSync(p)
+  );
+
+  return missing.length ? [...missing, currentPath].join(path.delimiter) : currentPath;
+}
+
+async function runResolveWindowsRegistryPath(): Promise<string | null> {
+  try {
+    const registryPath = await readWindowsRegistryPath();
+    if (!registryPath) return null;
+    return deduplicatePath(applyWindowsExtraPaths(registryPath), true);
+  } finally {
+    // Inside the run, not on a `.then` chain hung off it: a derived promise's
+    // handler lands a microtask AFTER the awaiting caller resumes, which would
+    // leave the settled read installed as "in flight" long enough for the very
+    // next call to join it and get the previous answer.
+    lastRegistryReadAt = Date.now();
+    registryReadPromise = null;
+  }
+}
+
+/**
+ * Read the machine + user PATH out of the registry and merge it with the
+ * version-manager shim dirs that never appear there.
+ *
+ * Returns the merged value; does NOT write `process.env`. Callers decide
+ * whether to adopt it — `refreshPath()` has a timeout race to honour first.
+ * `null` means the registry read yielded nothing (both keys errored or were
+ * empty), in which case the caller keeps whatever PATH it already had.
+ *
+ * Single-flight: concurrent callers share one `reg.exe` pair.
+ */
+export function resolveWindowsRegistryPath(): Promise<string | null> {
+  if (registryReadPromise) return registryReadPromise;
+
+  const promise = runResolveWindowsRegistryPath();
+  registryReadPromise = promise;
+  // Swallow on a detached branch so a rejection can't surface as an unhandled
+  // rejection when the only awaiter is a caller that already try/catches.
+  void promise.catch(() => null);
+  return promise;
+}
+
+/**
+ * Refresh `process.env.PATH` from the registry on behalf of a terminal spawn.
+ *
+ * The pty-host is forked with a one-time spread of Main's `process.env`
+ * (`PtyHostLifecycle.start`), so a PATH that changed after that fork is
+ * invisible to every terminal the host spawns — installing a tool and opening a
+ * new pane surfaced nothing until the app was restarted (#11773). Main re-reads
+ * the registry here and `PtyClient` stamps the result onto each spawn message,
+ * which is what actually crosses the process boundary.
+ *
+ * No-op off Windows: macOS/Linux resolve their PATH through the shell probe at
+ * startup and have no equivalent registry to drift against.
+ *
+ * Never throws and never rejects — a registry read that fails must degrade to
+ * "spawn with the PATH we already have", not block terminal creation.
+ */
+export async function refreshWindowsPathForSpawn(): Promise<void> {
+  if (process.platform !== "win32") return;
+
+  // Join an in-flight read before consulting the TTL: a refresh that started
+  // moments ago is strictly fresher than the timestamp it hasn't stamped yet,
+  // and skipping on the old stamp would hand this spawn the previous answer.
+  if (
+    !registryReadPromise &&
+    lastRegistryReadAt !== 0 &&
+    Date.now() - lastRegistryReadAt < SPAWN_PATH_REFRESH_TTL_MS
+  ) {
+    return;
+  }
+
+  try {
+    const resolved = await resolveWindowsRegistryPath();
+    if (resolved) process.env.PATH = resolved;
+  } catch {
+    // Keep the existing PATH.
+  }
+}
+
+/** Test seam — module-level single-flight and TTL state outlive `vi.resetModules()` consumers. */
+export function __resetWindowsPathStateForTests(): void {
+  registryReadPromise = null;
+  lastRegistryReadAt = 0;
+}

--- a/electron/setup/windowsPath.ts
+++ b/electron/setup/windowsPath.ts
@@ -30,8 +30,13 @@ let registryReadPromise: Promise<string | null> | null = null;
 
 // When the last registry read *settled*, success or failure. Stamped on both
 // outcomes on purpose: this is a short cooldown so a failing `reg.exe` can't be
-// hammered once per pane, not a success cache. `0` means "never read".
-let lastRegistryReadAt = 0;
+// hammered once per pane, not a success cache. `null` means "never read".
+//
+// `performance.now()` rather than `Date.now()`: the wall clock can step
+// backwards (NTP correction, the user fixing their timezone), which would make
+// the elapsed comparison negative and suppress every refresh until real time
+// caught up — a stale PATH for as long as the jump.
+let lastRegistryReadAt: number | null = null;
 
 function deduplicatePath(pathStr: string, caseInsensitive: boolean): string {
   const entries = pathStr.split(path.delimiter).filter(Boolean);
@@ -101,7 +106,12 @@ function readWindowsRegistryPath(): Promise<string> {
     keys.map(
       (key) =>
         new Promise<string>((resolve) => {
-          execFile("reg", ["query", key, "/v", "Path"], { timeout: 3_000 }, (err, stdout) => {
+          // windowsHide, as everywhere else this repo shells out: `reg.exe` is a
+          // console-subsystem binary and a GUI Electron process has no console
+          // to inherit, so without it Windows opens a real window. Tolerable
+          // once at startup; this now runs per terminal-open.
+          const options = { timeout: 3_000, windowsHide: true };
+          execFile("reg", ["query", key, "/v", "Path"], options, (err, stdout) => {
             if (err || !stdout) return resolve("");
             const match = stdout.match(/Path\s+REG_(?:EXPAND_)?SZ\s+(.+)/i);
             resolve(expandWindowsEnvVars(match?.[1]?.trim() ?? ""));
@@ -131,7 +141,7 @@ async function runResolveWindowsRegistryPath(): Promise<string | null> {
     // handler lands a microtask AFTER the awaiting caller resumes, which would
     // leave the settled read installed as "in flight" long enough for the very
     // next call to join it and get the previous answer.
-    lastRegistryReadAt = Date.now();
+    lastRegistryReadAt = performance.now();
     registryReadPromise = null;
   }
 }
@@ -182,8 +192,8 @@ export async function refreshWindowsPathForSpawn(): Promise<void> {
   // and skipping on the old stamp would hand this spawn the previous answer.
   if (
     !registryReadPromise &&
-    lastRegistryReadAt !== 0 &&
-    Date.now() - lastRegistryReadAt < SPAWN_PATH_REFRESH_TTL_MS
+    lastRegistryReadAt !== null &&
+    performance.now() - lastRegistryReadAt < SPAWN_PATH_REFRESH_TTL_MS
   ) {
     return;
   }
@@ -199,5 +209,5 @@ export async function refreshWindowsPathForSpawn(): Promise<void> {
 /** Test seam — module-level single-flight and TTL state outlive `vi.resetModules()` consumers. */
 export function __resetWindowsPathStateForTests(): void {
   registryReadPromise = null;
-  lastRegistryReadAt = 0;
+  lastRegistryReadAt = null;
 }

--- a/electron/setup/windowsPath.ts
+++ b/electron/setup/windowsPath.ts
@@ -23,6 +23,15 @@ import path from "path";
 // which is the whole point of #11773.
 const SPAWN_PATH_REFRESH_TTL_MS = 5_000;
 
+// How long a spawn is willing to wait on that read before opening the terminal
+// with the PATH it already has. The read is normally tens of milliseconds, but
+// a `reg.exe` wedged behind Defender or a stalled registry sits there for its
+// full 3s exec timeout — once per throttle window, on the path the user is
+// waiting on. The read is not cancelled: it keeps going and its value lands for
+// the next spawn, so a slow registry costs freshness on one terminal rather
+// than latency on every one.
+const SPAWN_PATH_REFRESH_BUDGET_MS = 700;
+
 // Single-flight for the registry read itself, shared by every caller (startup
 // refresh, CLI availability probes, terminal spawns). Cleared on settlement so
 // a later call re-queries rather than pinning a stale answer.
@@ -38,7 +47,7 @@ let registryReadPromise: Promise<string | null> | null = null;
 // caught up — a stale PATH for as long as the jump.
 let lastRegistryReadAt: number | null = null;
 
-function deduplicatePath(pathStr: string, caseInsensitive: boolean): string {
+export function deduplicatePath(pathStr: string, caseInsensitive: boolean): string {
   const entries = pathStr.split(path.delimiter).filter(Boolean);
   const seen = new Set<string>();
   const unique: string[] = [];
@@ -181,8 +190,10 @@ export function resolveWindowsRegistryPath(): Promise<string | null> {
  * No-op off Windows: macOS/Linux resolve their PATH through the shell probe at
  * startup and have no equivalent registry to drift against.
  *
- * Never throws and never rejects — a registry read that fails must degrade to
- * "spawn with the PATH we already have", not block terminal creation.
+ * Bounded by `SPAWN_PATH_REFRESH_BUDGET_MS`: resolves once the read lands or
+ * the budget expires, whichever comes first. Never throws and never rejects — a
+ * registry read that fails, or merely drags, must degrade to "spawn with the
+ * PATH we already have", not block terminal creation.
  */
 export async function refreshWindowsPathForSpawn(): Promise<void> {
   if (process.platform !== "win32") return;
@@ -198,11 +209,36 @@ export async function refreshWindowsPathForSpawn(): Promise<void> {
     return;
   }
 
+  let budgetTimer: NodeJS.Timeout | undefined;
   try {
-    const resolved = await resolveWindowsRegistryPath();
-    if (resolved) process.env.PATH = resolved;
+    // Adopting the value is the read's own continuation rather than something
+    // this caller does after awaiting it: once the budget wins the race nobody
+    // is awaiting any more, and the result still has to reach `process.env` for
+    // the next spawn. Both settlement branches are handled right here, so the
+    // continuation outliving its caller can't surface as an unhandled
+    // rejection. The single-flight and the settlement stamp are untouched — the
+    // budget only decides how long this caller waits, never what runs.
+    const adopted = resolveWindowsRegistryPath().then(
+      (resolved) => {
+        if (resolved) process.env.PATH = resolved;
+      },
+      (err: unknown) => {
+        console.warn("[windowsPath] Registry PATH read failed; keeping the current PATH:", err);
+      }
+    );
+
+    await Promise.race([
+      adopted,
+      new Promise<void>((resolve) => {
+        budgetTimer = setTimeout(resolve, SPAWN_PATH_REFRESH_BUDGET_MS);
+        // A PATH refresh must never be the reason the process stays alive.
+        budgetTimer.unref();
+      }),
+    ]);
   } catch {
     // Keep the existing PATH.
+  } finally {
+    if (budgetTimer) clearTimeout(budgetTimer);
   }
 }
 


### PR DESCRIPTION
On Windows, installing a tool (Python, Node, anything) and then opening a new terminal pane didn't surface the new PATH entries. Only a full app restart picked it up.

## Root cause

The issue's own writeup was slightly off, worth correcting here. The pty-host `UtilityProcess` is forked once with a spread of main's `process.env` (`PtyHostLifecycle.start`) and lives for the whole session. `buildTerminalEnv()` runs inside that host and reads its own frozen `process.env`. So main's existing `refreshPath()` calls (`CliAvailabilityService`, `SystemHealthCheck`, the startup `kickOffEarlyPathRefresh()` one-shot) provably never reached a terminal spawn: nothing main does to its own environment crosses that process boundary. The spawn IPC message's `options.env` is the only channel that does.

## The fix

Four parts.

**1. `electron/setup/windowsPath.ts` (new).** Pulls the registry read (`reg query` on `HKLM` and `HKCU`), the shim-dir merge, and the dedup into a Node-builtins-only leaf module. It had to leave `environment.ts`: that module runs `app.commandLine`, `app.enableSandbox()`, `app.getPath()`, GPU-flag filesystem reads, and SQLite setup at module scope (it carries an `eager-import-allow` marker), so importing it from the terminal IPC handler would have dragged all of that into the spawn path's dependency graph and broken collection in every test file under `electron/ipc/handlers/terminal/__tests__/`. Same rationale `runtimeFlags.ts` already documents. `environment.ts` now delegates its win32 branch to the new module, so there's one registry-read implementation and one single-flight shared by startup and spawns.

**2. Throttled** to one `reg.exe` pair per 5 seconds on monotonic time, shared with the startup refresh. A recipe opening six panes, or a session restore replaying a grid, pays for one read, not one per pane. `reg.exe` is two process spawns at 30-100ms+ each on Windows once Defender inspects them.

**3. `PtyClient.sendSpawnWithPostInput`** stamps main's current PATH onto the spawn message. Done at send time rather than in `spawn()`, so it never enters `pendingSpawns`: every replay (pre-ready, crash respawn, crash-budget migration) re-stamps with main's PATH as of the replay instead of resurrecting whatever was current when the terminal first opened. A caller-supplied PATH always wins, under any casing, including an explicit empty one.

**4. Case-collapsing env merge.** This one is load-bearing, not polish. Windows reports PATH as `Path`; our override uses `PATH`. node-pty's `_parseEnv` emits `Object.keys(env)` verbatim with no dedup and no case folding, so a plain spread put both into the child's environment block, and the stale `Path` sorted first and won. Without this the rest of the fix does nothing. Applied to the whole spawn-env pipeline (metadata, `LANG`, `COLORTERM`, `FORCE_COLOR`, `NODE_COMPILE_CACHE`, `NODE_OPTIONS`, and the `DAINTREE_*` anti-spoofing strip) so the object handed to `pty.spawn` has exactly one key per case-insensitive name. POSIX is untouched: there `Path` and `PATH` really are different variables.

Also added `windowsHide: true` to the `reg query`, matching every other `execFile` call in the repo. It's a console-subsystem binary and a GUI Electron process has no console to inherit, which was tolerable for a one-time startup call and isn't once it runs per terminal-open.

## Scope notes

Deliberate exclusions worth flagging:

- The agent-update terminal also gets the refresh. Installing a runtime and then updating a CLI through it is the case that most needs a current PATH.
- Dev-preview spawns do NOT actively trigger a registry read. I tried it and reverted it: it broke two crash-loop-guard tests, and `spawnSessionTerminal` has an `isDisposed()` guard right after its existing `await` that the new one would have sat after, unguarded. They still improve, since the send-time stamp gives them main's current PATH instead of the pty-host's fork-time one.
- The raw plugin-PTY lane (`PluginPtyProcessManager` to `minimalSpawnEnv`) has the same two problems (no refresh, plain-spread env merge that double-keys on Windows). It's a documented separate lane ("not a terminal panel"), so it's out of scope here and worth its own issue.

## Testing

766 targeted tests pass. The case-collision tests are verified load-bearing: neutralizing the case fold makes 14 of them fail, including all three PATH ones. That check mattered, since the first version of those tests passed with the fix reverted too, because on POSIX CI both sides were spelled `PATH`. They now seed a genuine `Path`/`PATH` collision and assert on the env `computeSpawnContext` hands `pty.spawn`. Also covered: concurrent spawns collapsing to one read, the join-in-flight-vs-throttle branch (with a deferred registry stub, so it actually exercises that branch), a throwing `reg.exe`, the monotonic-clock gate, and POSIX behaviour staying byte-for-byte unchanged.

This goes beyond VS Code, which hasn't solved it: [microsoft/vscode#47816](https://github.com/microsoft/vscode/issues/47816) is still open.

Resolves #11773
