### PR TITLE
fix(settings): use Spinner for the diagnostics collecting state

### DIFF
--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -137,7 +137,7 @@ export function DownloadDiagnosticsSection() {
         disabled={isCollecting}
         className="text-daintree-text border-daintree-border hover:bg-daintree-border hover:text-daintree-text mb-3"
       >
-        {isCollecting ? <Spinner size="md" /> : <Download className="w-4 h-4" />}
+        {isCollecting ? <Spinner size="sm" /> : <Download className="w-4 h-4" />}
         {isCollecting ? "Collecting…" : "Download diagnostics"}
       </Button>
       {downloadError && <p className="text-xs text-status-error mb-3">{downloadError}</p>}

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -16,6 +16,7 @@ import {
   Square,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Spinner } from "@/components/ui/Spinner";
 import { appClient, systemClient, logsClient } from "@/clients";
 import type { AppState, SystemHealthCheckResult } from "@shared/types";
 import { actionService } from "@/services/ActionService";
@@ -111,7 +112,7 @@ function SystemHealthSection() {
   );
 }
 
-function DownloadDiagnosticsSection() {
+export function DownloadDiagnosticsSection() {
   const isCollecting = useDiagnosticsReviewStore((s) => s.isCollecting);
   const downloadError = useDiagnosticsReviewStore((s) => s.downloadError);
 
@@ -136,8 +137,8 @@ function DownloadDiagnosticsSection() {
         disabled={isCollecting}
         className="text-daintree-text border-daintree-border hover:bg-daintree-border hover:text-daintree-text mb-3"
       >
-        <Download className={cn("w-4 h-4", isCollecting && "animate-spin")} />
-        {isCollecting ? "Collecting..." : "Download Diagnostics"}
+        {isCollecting ? <Spinner size="md" /> : <Download className="w-4 h-4" />}
+        {isCollecting ? "Collecting…" : "Download diagnostics"}
       </Button>
       {downloadError && <p className="text-xs text-status-error mb-3">{downloadError}</p>}
     </SettingsSection>

--- a/src/components/Settings/__tests__/DownloadDiagnosticsSection.test.tsx
+++ b/src/components/Settings/__tests__/DownloadDiagnosticsSection.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { DownloadDiagnosticsSection } from "../TroubleshootingTab";
+import { Spinner } from "@/components/ui/Spinner";
 import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
 
 const mockDispatch = vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue({
@@ -15,13 +16,14 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
-// Marked so the busy glyph can be identified by component identity rather than
-// by its class strings — asserting `animate-spin` would just copy the literal
-// back out of Spinner.tsx. Button imports Spinner too, but only for its
-// `loading` overlay, which this section never enables.
-vi.mock("@/components/ui/Spinner", () => ({
-  Spinner: () => <span data-testid="busy-spinner" />,
-}));
+// Spied, not replaced: the real Spinner still renders its SVG, so the busy glyph
+// is identified by component identity rather than by class strings (asserting
+// `animate-spin` would just copy the literal back out of Spinner.tsx). Button
+// imports this same module for its `loading` overlay, which this section never
+// enables — so every recorded call belongs to the section under test.
+vi.mock("@/components/ui/Spinner", { spy: true });
+
+const spinner = () => vi.mocked(Spinner);
 
 const setCollecting = (isCollecting: boolean) => {
   act(() => {
@@ -30,10 +32,9 @@ const setCollecting = (isCollecting: boolean) => {
 };
 
 const getButton = () => screen.getByRole<HTMLButtonElement>("button");
-const spinner = () => screen.queryByTestId("busy-spinner");
 // Scoped to the button: SettingsSection renders its own Download glyph in the
 // section heading, which is not part of the busy state under test.
-const glyph = () => getButton().querySelector("svg");
+const glyphCount = () => getButton().querySelectorAll("svg").length;
 
 describe("DownloadDiagnosticsSection — collecting state", () => {
   beforeEach(() => {
@@ -41,30 +42,32 @@ describe("DownloadDiagnosticsSection — collecting state", () => {
     useDiagnosticsReviewStore.setState({ isCollecting: false, downloadError: null });
   });
 
-  it("shows an action glyph and no spinner while idle", () => {
+  it("shows the action glyph and no spinner while idle", () => {
     render(<DownloadDiagnosticsSection />);
 
-    expect(glyph()).not.toBeNull();
-    expect(spinner()).toBeNull();
+    expect(spinner()).not.toHaveBeenCalled();
+    expect(glyphCount()).toBe(1);
   });
 
   it("swaps the action glyph for the spinner while collecting", () => {
     render(<DownloadDiagnosticsSection />);
     setCollecting(true);
 
-    // The bug being fixed was a single glyph that spun in place. The two
-    // indicators must be mutually exclusive, not layered.
-    expect(spinner()).not.toBeNull();
-    expect(glyph()).toBeNull();
+    // The bug being fixed was one glyph spinning in place. The spinner must be
+    // rendered (not the Download glyph animating), and the two must be mutually
+    // exclusive rather than layered — hence exactly one SVG either way.
+    expect(spinner()).toHaveBeenCalled();
+    expect(glyphCount()).toBe(1);
   });
 
   it("restores the action glyph once collecting ends", () => {
     render(<DownloadDiagnosticsSection />);
     setCollecting(true);
+    spinner().mockClear();
     setCollecting(false);
 
-    expect(spinner()).toBeNull();
-    expect(glyph()).not.toBeNull();
+    expect(spinner()).not.toHaveBeenCalled();
+    expect(glyphCount()).toBe(1);
   });
 
   it("swaps the label when collecting starts", () => {
@@ -83,16 +86,6 @@ describe("DownloadDiagnosticsSection — collecting state", () => {
     const busyLabel = getButton().textContent ?? "";
     expect(busyLabel).toMatch(/…$/);
     expect(busyLabel).not.toContain("...");
-  });
-
-  it("writes the idle label in sentence case", () => {
-    render(<DownloadDiagnosticsSection />);
-
-    // Sentence case as an invariant, not a copy of the literal: every word
-    // after the first stays lowercase.
-    const words = (getButton().textContent ?? "").trim().split(/\s+/);
-    expect(words.length).toBeGreaterThan(1);
-    expect(words.slice(1).every((word) => word === word.toLowerCase())).toBe(true);
   });
 
   it("disables the button only while collecting", () => {

--- a/src/components/Settings/__tests__/DownloadDiagnosticsSection.test.tsx
+++ b/src/components/Settings/__tests__/DownloadDiagnosticsSection.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { render, screen, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { DownloadDiagnosticsSection } from "../TroubleshootingTab";
+import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
+
+const mockDispatch = vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue({
+  ok: true,
+  result: undefined,
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => mockDispatch(...args),
+  },
+}));
+
+// Marked so the busy glyph can be identified by component identity rather than
+// by its class strings — asserting `animate-spin` would just copy the literal
+// back out of Spinner.tsx. Button imports Spinner too, but only for its
+// `loading` overlay, which this section never enables.
+vi.mock("@/components/ui/Spinner", () => ({
+  Spinner: () => <span data-testid="busy-spinner" />,
+}));
+
+const setCollecting = (isCollecting: boolean) => {
+  act(() => {
+    useDiagnosticsReviewStore.setState({ isCollecting });
+  });
+};
+
+const getButton = () => screen.getByRole<HTMLButtonElement>("button");
+const spinner = () => screen.queryByTestId("busy-spinner");
+// Scoped to the button: SettingsSection renders its own Download glyph in the
+// section heading, which is not part of the busy state under test.
+const glyph = () => getButton().querySelector("svg");
+
+describe("DownloadDiagnosticsSection — collecting state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDiagnosticsReviewStore.setState({ isCollecting: false, downloadError: null });
+  });
+
+  it("shows an action glyph and no spinner while idle", () => {
+    render(<DownloadDiagnosticsSection />);
+
+    expect(glyph()).not.toBeNull();
+    expect(spinner()).toBeNull();
+  });
+
+  it("swaps the action glyph for the spinner while collecting", () => {
+    render(<DownloadDiagnosticsSection />);
+    setCollecting(true);
+
+    // The bug being fixed was a single glyph that spun in place. The two
+    // indicators must be mutually exclusive, not layered.
+    expect(spinner()).not.toBeNull();
+    expect(glyph()).toBeNull();
+  });
+
+  it("restores the action glyph once collecting ends", () => {
+    render(<DownloadDiagnosticsSection />);
+    setCollecting(true);
+    setCollecting(false);
+
+    expect(spinner()).toBeNull();
+    expect(glyph()).not.toBeNull();
+  });
+
+  it("swaps the label when collecting starts", () => {
+    render(<DownloadDiagnosticsSection />);
+    const idleLabel = getButton().textContent;
+
+    setCollecting(true);
+
+    expect(getButton().textContent).not.toBe(idleLabel);
+  });
+
+  it("ends the busy label with a real ellipsis rather than three periods", () => {
+    render(<DownloadDiagnosticsSection />);
+    setCollecting(true);
+
+    const busyLabel = getButton().textContent ?? "";
+    expect(busyLabel).toMatch(/…$/);
+    expect(busyLabel).not.toContain("...");
+  });
+
+  it("writes the idle label in sentence case", () => {
+    render(<DownloadDiagnosticsSection />);
+
+    // Sentence case as an invariant, not a copy of the literal: every word
+    // after the first stays lowercase.
+    const words = (getButton().textContent ?? "").trim().split(/\s+/);
+    expect(words.length).toBeGreaterThan(1);
+    expect(words.slice(1).every((word) => word === word.toLowerCase())).toBe(true);
+  });
+
+  it("disables the button only while collecting", () => {
+    render(<DownloadDiagnosticsSection />);
+    expect(getButton().disabled).toBe(false);
+
+    setCollecting(true);
+    expect(getButton().disabled).toBe(true);
+
+    setCollecting(false);
+    expect(getButton().disabled).toBe(false);
+  });
+
+  it("renders the collection failure message from the store", () => {
+    render(<DownloadDiagnosticsSection />);
+    act(() => {
+      useDiagnosticsReviewStore.setState({ downloadError: "disk full" });
+    });
+
+    expect(screen.getByText("disk full")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- In Settings > Troubleshooting, the "Download diagnostics" button spun its `Download` icon in place while a diagnostics snapshot was being collected. That read as a glitch rather than a loading indicator.
- The button now shows the app's standard `Spinner` while collecting, and the static `Download` icon otherwise, so only one indicator is ever showing rather than one icon animating in place.
- Two microcopy fixes on the same lines: the label is sentence case (`Download diagnostics`, not `Download Diagnostics`), and the busy label uses a real ellipsis character (`Collecting…`, not `Collecting...`), matching how `HostCrashBanner` already renders this same store state.

Resolves #11775

## Changes

- `src/components/Settings/TroubleshootingTab.tsx`: swap the spinning `Download` icon for a conditional `Spinner`/`Download` render, and fix the label casing and ellipsis.
- `src/components/Settings/__tests__/DownloadDiagnosticsSection.test.tsx` (new): 7 tests covering the state mapping.

A few notes on choices worth calling out:

- Didn't use `Button`'s built in `loading` prop. It overlays a centered spinner and dims the label to `opacity-30` without swapping the text, so it can't show the `Collecting…` label. Used the same manual icon+text conditional already used twice elsewhere in this file (`SystemHealthSection`, `RendererCpuProfileSection`).
- No Doherty/`useDeferredLoading` gate here. `UI_FEEDBACK_HINT_MS` in `src/lib/animationUtils.ts` is explicit that it's for direct user-action feedback, not a Doherty-gated background placeholder, and says outright it "is not used as a visibility gate."
- `Spinner size="sm"` matches `SPINNER_SIZE_MAP` for a `size="sm"` button. Cosmetically it's moot since the button's `[&_svg]:size-3.5` rule overrides the icon's own sizing anyway, but it's the semantically correct value.
- `DownloadDiagnosticsSection` is now exported solely so the test can render it in isolation, following the same precedent as `ApplicationLogsSection` in the same file.
- `RotateCw` on `SystemHealthSection` is untouched, per the issue. A rotating refresh glyph is conventional; a rotating download arrow isn't.

## Testing

New unit test `DownloadDiagnosticsSection.test.tsx` spies on `Spinner` (pass-through, so the real SVG still renders) to assert component identity, checks exactly one glyph renders per state, checks the busy label ends in the ellipsis character and never contains `...`, and checks `disabled` tracks the store.

Ran locally: 18 tests across `DownloadDiagnosticsSection.test.tsx`, `ApplicationLogsSection.test.tsx`, and `SettingsSection.test.tsx`; 387 tests in `src/config/__tests__` (repo-wide source-contract suites); `eslint` and `prettier --check` clean on both changed files. `TroubleshootingTab.tsx` carries 8 pre-existing `no-floating-promises`/`no-unsafe-type-assertion` warnings (no errors) in untouched code, confirmed identical on `develop`.