### PR TITLE
fix(logger): normalize Errors found anywhere in a log context

### DIFF
--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -285,7 +285,9 @@ describe("getErrorDetails", () => {
 
   it("forwards the diagnostics a serialized error arrived with", () => {
     const serialized = serializeError(
-      new GitOperationError("push-rejected-outdated", "push rejected", { command: "git push" })
+      new GitOperationError("push-rejected-outdated", "push rejected", {
+        context: { command: "git push" },
+      })
     );
     // Simulate the IPC hop: only own-enumerable properties survive it.
     const overWire = JSON.parse(JSON.stringify(serialized)) as Record<string, unknown>;

--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -282,4 +282,40 @@ describe("getErrorDetails", () => {
     expect(details.name).toBeUndefined();
     expect(details.stack).toBeUndefined();
   });
+
+  it("forwards the diagnostics a serialized error arrived with", () => {
+    const serialized = serializeError(
+      new GitOperationError("push-rejected-outdated", "push rejected", { command: "git push" })
+    );
+    // Simulate the IPC hop: only own-enumerable properties survive it.
+    const overWire = JSON.parse(JSON.stringify(serialized)) as Record<string, unknown>;
+
+    const details = getErrorDetails(overWire);
+    expect(details.gitReason).toBe(serialized.gitReason);
+    expect(details.context).toEqual(serialized.context);
+  });
+
+  it("does not let a throwing accessor escape", () => {
+    const hostile = {
+      message: "original failure",
+      get name(): string {
+        throw new Error("name trap");
+      },
+    };
+
+    let details: Record<string, unknown> = {};
+    expect(() => {
+      details = getErrorDetails(hostile);
+    }).not.toThrow();
+    expect(details.message).toBe("original failure");
+    expect(details.name).toBeUndefined();
+  });
+
+  it("carries the cause of a plain Error, which is non-enumerable", () => {
+    const err = new Error("outer", { cause: new Error("inner") });
+    expect(Object.keys(err)).not.toContain("cause");
+
+    const details = getErrorDetails(err);
+    expect((details.cause as Error).message).toBe("inner");
+  });
 });

--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -311,6 +311,42 @@ describe("getErrorDetails", () => {
     expect(details.name).toBeUndefined();
   });
 
+  it("survives a real Error whose message accessor throws", () => {
+    // `getUserMessage` reads `.message` directly for an `instanceof Error`, so
+    // this is the one field that escapes without its own guard.
+    const err = new Error("replaced below");
+    Object.defineProperty(err, "message", {
+      get: () => {
+        throw new Error("message trap");
+      },
+    });
+
+    let details: Record<string, unknown> = {};
+    expect(() => {
+      details = getErrorDetails(err);
+    }).not.toThrow();
+    expect(details.message).toBeTypeOf("string");
+    expect(details.name).toBe("Error");
+  });
+
+  it("survives a throwing Node errno accessor", () => {
+    const err = Object.assign(new Error("io failed"), { syscall: "open" });
+    Object.defineProperty(err, "code", {
+      get: () => {
+        throw new Error("code trap");
+      },
+    });
+
+    let details: Record<string, unknown> = {};
+    expect(() => {
+      details = getErrorDetails(err);
+    }).not.toThrow();
+    // The unreadable field costs only itself; its siblings still report.
+    expect(details.code).toBeUndefined();
+    expect(details.syscall).toBe("open");
+    expect(details.message).toBe("io failed");
+  });
+
   it("carries the cause of a plain Error, which is non-enumerable", () => {
     const err = new Error("outer", { cause: new Error("inner") });
     expect(Object.keys(err)).not.toContain("cause");

--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -9,6 +9,7 @@ import {
   toGitOperationError,
   getUserMessage,
   getRetryability,
+  getErrorDetails,
 } from "../errorTypes.js";
 import { serializeError, deserializeError } from "../../../shared/utils/ipcErrorSerialization.js";
 
@@ -240,5 +241,45 @@ describe("getRetryability", () => {
     expect(getRetryability(null)).toBe("none");
     expect(getRetryability(undefined)).toBe("none");
     expect(getRetryability(new Error("plain"))).toBe("none");
+  });
+});
+
+describe("getErrorDetails", () => {
+  it("captures name, message and stack from a real Error", () => {
+    const err = new TypeError("boom");
+    const details = getErrorDetails(err);
+    expect(details.name).toBe(err.name);
+    expect(details.message).toBe(err.message);
+    expect(details.stack).toBe(err.stack);
+  });
+
+  it("keeps name and stack from an error already flattened for IPC", () => {
+    // What `dispatchRendererLog` hands us: the contextBridge strips the Error
+    // prototype, so the value fails `instanceof Error` but still carries the
+    // fields worth logging.
+    const flattened = {
+      name: "TypeError",
+      message: "renderer failure",
+      stack: "TypeError: renderer failure\n    at Component",
+    };
+    expect(flattened).not.toBeInstanceOf(Error);
+
+    const details = getErrorDetails(flattened);
+    expect(details.name).toBe(flattened.name);
+    expect(details.message).toBe(flattened.message);
+    expect(details.stack).toBe(flattened.stack);
+  });
+
+  it("ignores non-string name and stack values", () => {
+    const details = getErrorDetails({ message: "m", name: 42, stack: { frames: [] } });
+    expect(details.name).toBeUndefined();
+    expect(details.stack).toBeUndefined();
+  });
+
+  it("does not treat a primitive as carrying error fields", () => {
+    const details = getErrorDetails("just a string");
+    expect(details.message).toBe("just a string");
+    expect(details.name).toBeUndefined();
+    expect(details.stack).toBeUndefined();
   });
 });

--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -741,6 +741,34 @@ describe("logger", () => {
       expect(content).not.toContain('"error": {}');
     });
 
+    it("degrades instead of throwing when an Error field is unreadable", () => {
+      const error = new Error("still-know-this");
+      Object.defineProperty(error, "stack", {
+        get: () => {
+          throw new Error("hostile getter");
+        },
+      });
+
+      expect(() => logWarn("hostile", { error })).not.toThrow();
+      const captured = lastContext()?.error as Record<string, unknown>;
+      expect(captured.message).toBe("still-know-this");
+    });
+
+    it("does not throw when a context value's prototype trap throws", () => {
+      // `instanceof` runs `getPrototypeOf`, so Error detection itself has to be
+      // safe against a hostile value.
+      const trapped = new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf trap");
+          },
+        }
+      );
+
+      expect(() => logWarn("trapped", { trapped })).not.toThrow();
+    });
+
     it("keeps name and stack when an already-flattened error arrives from the renderer", () => {
       // `dispatchRendererLog` forwards `context.error` — a plain object by the
       // time it crosses the contextBridge — as logError's dedicated argument.
@@ -755,6 +783,28 @@ describe("logger", () => {
       expect(captured.name).toBe(fromRenderer.name);
       expect(captured.message).toBe(fromRenderer.message);
       expect(captured.stack).toBe(fromRenderer.stack);
+    });
+
+    it("keeps the classification and cause of a rich error flattened by the renderer", () => {
+      // What `serializeError` produces for a GitOperationError in the renderer.
+      const fromRenderer = {
+        name: "GitOperationError",
+        message: "push rejected",
+        stack: "GitOperationError: push rejected\n    at push",
+        gitReason: "push-rejected-outdated",
+        branchName: "feature/x",
+        context: { command: "git push" },
+        cause: { name: "Error", message: "remote ref moved" },
+      };
+      logError("git said no", fromRenderer, { source: "Renderer" });
+
+      const captured = lastContext()?.error as Record<string, unknown>;
+      // Without forwarding these, a renderer git failure reached the log file
+      // as a bare message with no way to tell what kind of failure it was.
+      expect(captured.gitReason).toBe(fromRenderer.gitReason);
+      expect(captured.branchName).toBe(fromRenderer.branchName);
+      expect(captured.context).toEqual(fromRenderer.context);
+      expect((captured.cause as { message?: string }).message).toBe("remote ref moved");
     });
   });
 

--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -648,6 +648,116 @@ describe("logger", () => {
     });
   });
 
+  describe("Errors inside a log context (#11777)", () => {
+    beforeEach(() => {
+      logBuffer.clear();
+    });
+
+    function lastContext(): Record<string, unknown> | undefined {
+      const entries = logBuffer.getAll();
+      return entries[entries.length - 1]?.context as Record<string, unknown> | undefined;
+    }
+
+    it("keeps the identity of an Error passed at a non-error level", () => {
+      const error = new TypeError("wake failed");
+      logWarn("wake failed", { id: "terminal-1", error });
+
+      const captured = lastContext()?.error as Record<string, unknown>;
+      // Own-property enumeration alone yields `{}` — that was the bug.
+      expect(Object.keys(error)).toHaveLength(0);
+      expect(captured.name).toBe(error.name);
+      expect(captured.message).toBe(error.message);
+      expect(captured.stack).toBeTypeOf("string");
+    });
+
+    it("reaches Errors nested in objects and inside arrays", () => {
+      logWarn("batch failed", {
+        task: { error: new Error("nested failure") },
+        failures: [new Error("listed failure")],
+      });
+
+      const context = lastContext() ?? {};
+      const task = context.task as { error: Record<string, unknown> };
+      expect(task.error.message).toBe("nested failure");
+      const failures = context.failures as Array<Record<string, unknown>>;
+      expect(failures[0]?.message).toBe("listed failure");
+    });
+
+    it("preserves the cause chain of a wrapped Error", () => {
+      const error = new Error("outer", { cause: new Error("root cause") });
+      logWarn("wrapped", { error });
+
+      const captured = lastContext()?.error as { cause?: { message?: string } };
+      expect(captured.cause?.message).toBe("root cause");
+    });
+
+    it("still redacts an Error stored under a sensitive key", () => {
+      logWarn("auth", { apiKey: new Error("s3cret-in-the-message") });
+      expect(lastContext()?.apiKey).toBe("[redacted]");
+    });
+
+    it("clamps a long stack instead of retaining it whole", () => {
+      const error = new Error("long trace");
+      error.stack = `Error: long trace\n${"    at frame\n".repeat(1000)}`;
+      logWarn("long", { error });
+
+      const captured = lastContext()?.error as { stack: string };
+      expect(captured.stack.length).toBeLessThan(error.stack.length);
+      const match = captured.stack.match(/\[…\+(\d+)\]$/);
+      expect(match).not.toBeNull();
+      // Invariant: the kept prefix plus the reported dropped count is the whole
+      // stack, so nothing is silently unaccounted for.
+      const dropped = Number(match![1]);
+      const kept = captured.stack.length - match![0].length;
+      expect(kept + dropped).toBe(error.stack.length);
+    });
+
+    it("scrubs a secret out of a stack before it is clamped", () => {
+      const secret = `ghp_${"b".repeat(36)}`;
+      const error = new Error("token leak");
+      error.stack = `Error: token leak\n    at auth (${secret})\n${"    at frame\n".repeat(500)}`;
+      logWarn("leaky", { error });
+
+      const captured = lastContext()?.error as { stack: string };
+      expect(captured.stack).not.toContain(secret);
+    });
+
+    it("does not throw on an Error whose cause chain is circular", () => {
+      const first = new Error("first");
+      const second = new Error("second", { cause: first });
+      (first as Error & { cause?: unknown }).cause = second;
+
+      expect(() => logWarn("cyclic", { error: first })).not.toThrow();
+      expect((lastContext()?.error as { message?: string }).message).toBe("first");
+    });
+
+    it("writes the flattened Error to the log file, not an empty object", async () => {
+      initializeLogger(TEST_LOG_DIR);
+      logWarn("disk trace", { error: new Error("landed-on-disk") });
+      await flushLogFileWritesForTesting();
+
+      const content = readFileSync(getLogFilePath(), "utf8");
+      expect(content).toContain("landed-on-disk");
+      expect(content).not.toContain('"error": {}');
+    });
+
+    it("keeps name and stack when an already-flattened error arrives from the renderer", () => {
+      // `dispatchRendererLog` forwards `context.error` — a plain object by the
+      // time it crosses the contextBridge — as logError's dedicated argument.
+      const fromRenderer = {
+        name: "TypeError",
+        message: "renderer failure",
+        stack: "TypeError: renderer failure\n    at Component",
+      };
+      logError("renderer said", fromRenderer, { source: "Renderer" });
+
+      const captured = lastContext()?.error as Record<string, unknown>;
+      expect(captured.name).toBe(fromRenderer.name);
+      expect(captured.message).toBe(fromRenderer.message);
+      expect(captured.stack).toBe(fromRenderer.stack);
+    });
+  });
+
   describe("pruneOldLogsAsync", () => {
     const logsDir = join(TEST_LOG_DIR, "logs");
     const debugDir = join(TEST_LOG_DIR, "debug");

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -237,13 +237,21 @@ const FORWARDED_SERIALIZED_FIELDS = [
   "properties",
 ] as const;
 
-/** Read one field without letting a throwing accessor escape into the log. */
-function readErrorField(error: object, key: string): unknown {
+/** Node's `ErrnoException` fields, reported whenever the error carries them. */
+const NODE_ERROR_FIELDS = ["code", "errno", "syscall", "path"] as const;
+
+/** Run a read that touches caller-supplied accessors, swallowing a throw. */
+function guardedRead<T>(read: () => T): T | undefined {
   try {
-    return (error as Record<string, unknown>)[key];
+    return read();
   } catch {
     return undefined;
   }
+}
+
+/** Read one field without letting a throwing accessor escape into the log. */
+function readErrorField(error: object, key: string): unknown {
+  return guardedRead(() => (error as Record<string, unknown>)[key]);
 }
 
 /**
@@ -253,8 +261,12 @@ export function getErrorDetails(
   error: unknown,
   seen = new WeakSet<Error>()
 ): Record<string, unknown> {
+  // Every field below is read under its own guard, because this feeds the
+  // logger: an error object with a throwing accessor must cost that one field,
+  // not turn the log call into a second failure. `getUserMessage` reads
+  // `error.message` unguarded for a real `Error`, so even it needs the net.
   const details: Record<string, unknown> = {
-    message: getUserMessage(error),
+    message: guardedRead(() => getUserMessage(error)) ?? "[unreadable error message]",
   };
 
   // Duck-typed rather than gated on `instanceof Error`, because errors that
@@ -262,8 +274,7 @@ export function getErrorDetails(
   // renderer flattens an Error before `logs.writeBatch` (the contextBridge
   // strips non-enumerable properties), so `dispatchRendererLog` hands this
   // function a serialized record and an `instanceof` gate silently dropped the
-  // name and stack of every renderer-side error (#11777). Every read is
-  // guarded — an accessor that throws must cost its own field, not the log.
+  // name and stack of every renderer-side error (#11777).
   if (error !== null && typeof error === "object") {
     for (const key of DUCK_TYPED_ERROR_FIELDS) {
       const value = readErrorField(error, key);
@@ -279,7 +290,10 @@ export function getErrorDetails(
     }
   }
 
-  if (isDaintreeError(error)) {
+  // `isDaintreeError` is an `instanceof` check, which runs a Proxy's
+  // `getPrototypeOf` trap, and the branch then reads `.context`/`.cause`.
+  guardedRead(() => {
+    if (!isDaintreeError(error)) return;
     details.context = error.context;
     if (error.cause) {
       if (error.cause instanceof Error && !seen.has(error.cause)) {
@@ -289,14 +303,13 @@ export function getErrorDetails(
         details.cause = getErrorDetails(error.cause, seen);
       }
     }
-  }
+  });
 
   if (error && typeof error === "object") {
-    const nodeError = error as NodeJS.ErrnoException;
-    if (nodeError.code) details.code = nodeError.code;
-    if (nodeError.errno) details.errno = nodeError.errno;
-    if (nodeError.syscall) details.syscall = nodeError.syscall;
-    if (nodeError.path) details.path = nodeError.path;
+    for (const key of NODE_ERROR_FIELDS) {
+      const value = readErrorField(error, key);
+      if (value) details[key] = value;
+    }
   }
 
   return details;

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -216,6 +216,36 @@ export function getUserMessage(error: unknown): string {
   return formatErrorMessage(error, "An unknown error occurred");
 }
 
+/** String-valued fields worth reporting from any error-shaped object. */
+const DUCK_TYPED_ERROR_FIELDS = ["name", "stack"] as const;
+
+/**
+ * Fields `serializeError` promotes onto a flattened error record. Forwarded as
+ * they are so an error that crossed IPC keeps the diagnostics it arrived with.
+ * A live `Error` reaching this function is read the same way, which is why a
+ * plain `new Error(msg, { cause })` now reports its cause too — `cause` is
+ * non-enumerable, so it used to be dropped for everything but a `DaintreeError`.
+ * The `isDaintreeError` branch below still wins for the classes it knows.
+ */
+const FORWARDED_SERIALIZED_FIELDS = [
+  "userMessage",
+  "gitReason",
+  "leaseSha",
+  "branchName",
+  "context",
+  "cause",
+  "properties",
+] as const;
+
+/** Read one field without letting a throwing accessor escape into the log. */
+function readErrorField(error: object, key: string): unknown {
+  try {
+    return (error as Record<string, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Handles circular references safely to prevent infinite recursion
  */
@@ -231,12 +261,22 @@ export function getErrorDetails(
   // have already crossed a process boundary arrive as plain objects: the
   // renderer flattens an Error before `logs.writeBatch` (the contextBridge
   // strips non-enumerable properties), so `dispatchRendererLog` hands this
-  // function `{ name, message, stack }` and an `instanceof` gate silently
-  // dropped the name and stack of every renderer-side error (#11777).
+  // function a serialized record and an `instanceof` gate silently dropped the
+  // name and stack of every renderer-side error (#11777). Every read is
+  // guarded — an accessor that throws must cost its own field, not the log.
   if (error !== null && typeof error === "object") {
-    const candidate = error as { name?: unknown; stack?: unknown };
-    if (typeof candidate.name === "string") details.name = candidate.name;
-    if (typeof candidate.stack === "string") details.stack = candidate.stack;
+    for (const key of DUCK_TYPED_ERROR_FIELDS) {
+      const value = readErrorField(error, key);
+      if (typeof value === "string") details[key] = value;
+    }
+    // A record that already carries the flattened chain keeps it: these are the
+    // fields `serializeError` promotes, and without them a renderer-side
+    // `GitOperationError` reached the log file having lost its classification,
+    // its context and its cause.
+    for (const key of FORWARDED_SERIALIZED_FIELDS) {
+      const value = readErrorField(error, key);
+      if (value !== undefined) details[key] = value;
+    }
   }
 
   if (isDaintreeError(error)) {

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -227,9 +227,16 @@ export function getErrorDetails(
     message: getUserMessage(error),
   };
 
-  if (error instanceof Error) {
-    details.name = error.name;
-    details.stack = error.stack;
+  // Duck-typed rather than gated on `instanceof Error`, because errors that
+  // have already crossed a process boundary arrive as plain objects: the
+  // renderer flattens an Error before `logs.writeBatch` (the contextBridge
+  // strips non-enumerable properties), so `dispatchRendererLog` hands this
+  // function `{ name, message, stack }` and an `instanceof` gate silently
+  // dropped the name and stack of every renderer-side error (#11777).
+  if (error !== null && typeof error === "object") {
+    const candidate = error as { name?: unknown; stack?: unknown };
+    if (typeof candidate.name === "string") details.name = candidate.name;
+    if (typeof candidate.stack === "string") details.stack = candidate.stack;
   }
 
   if (isDaintreeError(error)) {

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -19,7 +19,8 @@ import { logBuffer, type LogEntry } from "../services/LogBuffer.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { resilientRenameSync } from "./fs.js";
 import { scrubSecrets } from "../../shared/utils/secretScrubber.js";
-import { isErrorLike, serializeError } from "../../shared/utils/ipcErrorSerialization.js";
+import { isErrorLike } from "../../shared/utils/ipcErrorSerialization.js";
+import { serializeErrorForLog } from "../../shared/utils/logErrorNormalization.js";
 import { getWritesSuppressed } from "../services/diskPressureState.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -882,14 +883,10 @@ function writeToLogFile(level: string, message: string, contextStr: string): voi
  * a hot path that runs hundreds of times a second) costs one type check.
  */
 function toRedactableRecord(value: object): Record<string, unknown> {
-  if (!isErrorLike(value)) return value as Record<string, unknown>;
-  try {
-    return serializeError(value) as unknown as Record<string, unknown>;
-  } catch {
-    // A hostile getter on an Error subclass must not turn a log call into the
-    // throw it was reporting.
-    return { name: "Error", message: "[unserializable error]" };
-  }
+  // Both helpers are shared with the renderer's pre-bridge pass, so an Error
+  // logged from either process flattens to the same shape and degrades the same
+  // way when a hostile accessor makes it unserializable. Neither throws.
+  return isErrorLike(value) ? serializeErrorForLog(value) : (value as Record<string, unknown>);
 }
 
 function redactSensitiveData(

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -19,6 +19,7 @@ import { logBuffer, type LogEntry } from "../services/LogBuffer.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { resilientRenameSync } from "./fs.js";
 import { scrubSecrets } from "../../shared/utils/secretScrubber.js";
+import { isErrorLike, serializeError } from "../../shared/utils/ipcErrorSerialization.js";
 import { getWritesSuppressed } from "../services/diskPressureState.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -869,6 +870,28 @@ function writeToLogFile(level: string, message: string, contextStr: string): voi
   }
 }
 
+/**
+ * Flatten an Error into a plain record before redaction walks it.
+ *
+ * `redactSensitiveData` enumerates own properties, and an Error's `name`,
+ * `message` and `stack` are all non-enumerable — so every Error passed inside a
+ * context object was written to the log as `{}`, erasing the only record of the
+ * failure (#11777). Converting here rather than in a separate pre-pass means the
+ * flattened fields keep flowing through the existing scrubbing, string clamping,
+ * array caps and depth limits below, and the no-Error case (effectively all of
+ * a hot path that runs hundreds of times a second) costs one type check.
+ */
+function toRedactableRecord(value: object): Record<string, unknown> {
+  if (!isErrorLike(value)) return value as Record<string, unknown>;
+  try {
+    return serializeError(value) as unknown as Record<string, unknown>;
+  } catch {
+    // A hostile getter on an Error subclass must not turn a log call into the
+    // throw it was reporting.
+    return { name: "Error", message: "[unserializable error]" };
+  }
+}
+
 function redactSensitiveData(
   obj: Record<string, unknown>,
   visited = new WeakSet<object>(),
@@ -895,7 +918,7 @@ function redactSensitiveData(
     } else if (Array.isArray(value)) {
       result[key] = redactArrayWithCycleDetection(value, visited, depth + 1);
     } else if (value !== null && typeof value === "object") {
-      result[key] = redactSensitiveData(value as Record<string, unknown>, visited, depth + 1);
+      result[key] = redactSensitiveData(toRedactableRecord(value), visited, depth + 1);
     } else {
       result[key] = value;
     }
@@ -929,7 +952,7 @@ function redactArrayWithCycleDetection(
       return redactArrayWithCycleDetection(item, visited, depth + 1);
     }
     if (typeof item === "object") {
-      return redactSensitiveData(item as Record<string, unknown>, visited, depth + 1);
+      return redactSensitiveData(toRedactableRecord(item), visited, depth + 1);
     }
     return item;
   });

--- a/shared/utils/__tests__/ipcErrorSerialization.test.ts
+++ b/shared/utils/__tests__/ipcErrorSerialization.test.ts
@@ -1,11 +1,59 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   serializeError,
   deserializeError,
   wrapSuccess,
   wrapError,
 } from "../ipcErrorSerialization.js";
+import { isErrorLike } from "../ipcErrorSerialization.js";
 import { isIpcEnvelope } from "../../types/ipc/errors.js";
+import { runInNewContext } from "vm";
+
+describe("isErrorLike", () => {
+  it("recognizes an Error from another realm, which instanceof cannot", () => {
+    const foreign = runInNewContext("new TypeError('cross realm')") as Error;
+    expect(foreign instanceof Error).toBe(false);
+    expect(isErrorLike(foreign)).toBe(true);
+  });
+
+  it("recognizes a same-realm Error and rejects an ordinary object", () => {
+    expect(isErrorLike(new Error("local"))).toBe(true);
+    expect(isErrorLike({ name: "Error", message: "impostor" })).toBe(false);
+    expect(isErrorLike("a string")).toBe(false);
+    expect(isErrorLike(null)).toBe(false);
+  });
+
+  it("still detects a cross-realm Error on a runtime without Error.isError", async () => {
+    // The CI runtime does not have `Error.isError`, so a version-gated
+    // implementation would pass here and silently do nothing there. Remove it
+    // and re-import to exercise the fallback that has to carry those runtimes.
+    const original = Object.getOwnPropertyDescriptor(Error, "isError");
+    Reflect.deleteProperty(Error, "isError");
+    vi.resetModules();
+    try {
+      const fresh = await import("../ipcErrorSerialization.js");
+      const foreign = runInNewContext("new Error('no isError here')") as Error;
+      expect(fresh.isErrorLike(foreign)).toBe(true);
+      expect(fresh.serializeError(foreign).message).toBe("no isError here");
+    } finally {
+      if (original) Object.defineProperty(Error, "isError", original);
+      vi.resetModules();
+    }
+  });
+
+  it("does not throw on a Proxy whose prototype trap throws", () => {
+    const trapped = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("getPrototypeOf trap");
+        },
+      }
+    );
+    expect(() => isErrorLike(trapped)).not.toThrow();
+    expect(isErrorLike(trapped)).toBe(false);
+  });
+});
 
 describe("serializeError", () => {
   it("serializes a plain Error", () => {

--- a/shared/utils/__tests__/ipcErrorSerialization.test.ts
+++ b/shared/utils/__tests__/ipcErrorSerialization.test.ts
@@ -144,6 +144,29 @@ describe("serializeError", () => {
     expect(serializeError(null).message).toBe("null");
     expect(serializeError(undefined).message).toBe("undefined");
   });
+
+  it("preserves the members of an AggregateError, which own-key enumeration misses", () => {
+    const aggregate = new AggregateError(
+      [new Error("first failure"), new TypeError("second failure")],
+      "all attempts failed"
+    );
+
+    // Why an explicit branch is needed: `errors` is an own but non-enumerable
+    // property, so the generic own-key walk never reaches it.
+    expect(Object.keys(aggregate)).not.toContain("errors");
+
+    const serialized = serializeError(aggregate);
+    expect(serialized.message).toBe(aggregate.message);
+    const members = serialized.properties?.errors as Array<{ name: string; message: string }>;
+    expect(members.map((member) => member.message)).toEqual(["first failure", "second failure"]);
+    expect(members.map((member) => member.name)).toEqual(["Error", "TypeError"]);
+    expect(() => structuredClone(serialized)).not.toThrow();
+  });
+
+  it("keeps a custom enumerable `errors` value that is not an aggregate list", () => {
+    const err = Object.assign(new Error("partial"), { errors: { count: 2 } });
+    expect(serializeError(err).properties?.errors).toEqual({ count: 2 });
+  });
 });
 
 describe("deserializeError", () => {

--- a/shared/utils/__tests__/logErrorNormalization.test.ts
+++ b/shared/utils/__tests__/logErrorNormalization.test.ts
@@ -111,7 +111,7 @@ describe("normalizeErrorsInLogContext", () => {
     expect(asRecord(reachable.inner.error).message).toBe("hidden");
   });
 
-  it("degrades to a clone-safe payload when scanning itself throws", () => {
+  it("returns the context unchanged rather than throwing when the walk itself fails", () => {
     const hostile = new Proxy(
       { error: new Error("unreachable") },
       {
@@ -120,12 +120,29 @@ describe("normalizeErrorsInLogContext", () => {
         },
       }
     ) as unknown as Record<string, unknown>;
+    const context = { hostile };
 
-    let normalized: Record<string, unknown> = {};
-    expect(() => {
-      normalized = normalizeErrorsInLogContext({ hostile });
-    }).not.toThrow();
-    expect(normalized).toBeTypeOf("object");
+    // The documented trade-off: a context this pass cannot read is handed back
+    // as it came. It loses the Error flattening — the caller (`flushBatch`)
+    // is what keeps the failure from escaping.
+    expect(normalizeErrorsInLogContext(context)).toBe(context);
+  });
+
+  it("breaks a cycle that only closes past the depth bound", () => {
+    // The back-edge lands deeper than the walk descends. Truncating before
+    // consulting the memo would splice the caller's cycle into the result.
+    const root: Record<string, unknown> = { error: new Error("cyclic") };
+    let node = root;
+    for (let i = 0; i < 6; i++) {
+      const next: Record<string, unknown> = {};
+      node.child = next;
+      node = next;
+    }
+    node.back = root;
+
+    const normalized = normalizeErrorsInLogContext(root);
+    expect(normalized).not.toBe(root);
+    expect(() => JSON.stringify(normalized)).not.toThrow();
   });
 
   it("terminates on a chain far deeper than it walks, leaving the unreached Error alone", () => {

--- a/shared/utils/__tests__/logErrorNormalization.test.ts
+++ b/shared/utils/__tests__/logErrorNormalization.test.ts
@@ -155,6 +155,8 @@ describe("normalizeErrorsInLogContext", () => {
     expect(normalized).toBe(node);
   });
 
+  // Detection must not depend on `Error.isError`, which not every runtime we
+  // build on has yet — see `isErrorLike`.
   it("normalizes an Error from another realm, which instanceof cannot see", () => {
     const foreign = runInNewContext("new Error('cross realm')") as Error;
     expect(foreign instanceof Error).toBe(false);

--- a/shared/utils/__tests__/logErrorNormalization.test.ts
+++ b/shared/utils/__tests__/logErrorNormalization.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { runInNewContext } from "vm";
+import { normalizeErrorsInLogContext } from "../logErrorNormalization.js";
+
+/** The record an Error is expected to have been replaced by. */
+function asRecord(value: unknown): Record<string, unknown> {
+  expect(value).toBeTypeOf("object");
+  expect(value).not.toBeNull();
+  return value as Record<string, unknown>;
+}
+
+describe("normalizeErrorsInLogContext", () => {
+  it("replaces an Error with a record carrying the fields JSON.stringify drops", () => {
+    const error = new TypeError("wake failed");
+    const normalized = normalizeErrorsInLogContext({ id: "terminal-1", error });
+
+    // The bug being fixed: the raw Error survives none of its own identity.
+    expect(JSON.parse(JSON.stringify({ error }))).toEqual({ error: {} });
+
+    const record = asRecord(normalized.error);
+    expect(record.name).toBe(error.name);
+    expect(record.message).toBe(error.message);
+    expect(record.stack).toBe(error.stack);
+    expect(normalized.id).toBe("terminal-1");
+  });
+
+  it("survives a JSON round-trip with its message intact", () => {
+    const normalized = normalizeErrorsInLogContext({ error: new Error("boom") });
+    const roundTripped = JSON.parse(JSON.stringify(normalized)) as {
+      error: { message?: string };
+    };
+    expect(roundTripped.error.message).toBe("boom");
+  });
+
+  it("finds Errors nested in objects and inside arrays", () => {
+    const nested = new Error("deep");
+    const listed = new Error("in a list");
+    const normalized = normalizeErrorsInLogContext({
+      task: { attempt: 2, error: nested },
+      failures: [listed],
+    });
+
+    const task = asRecord(normalized.task);
+    expect(asRecord(task.error).message).toBe(nested.message);
+    const failures = normalized.failures as unknown[];
+    expect(asRecord(failures[0]).message).toBe(listed.message);
+  });
+
+  it("leaves the caller's context and Error untouched", () => {
+    const error = new Error("original");
+    const context = { error, nested: { error } };
+    normalizeErrorsInLogContext(context);
+
+    expect(context.error).toBe(error);
+    expect(context.nested.error).toBe(error);
+    expect(error.message).toBe("original");
+  });
+
+  it("returns the same reference when the context holds no Error", () => {
+    const context = { id: "x", nested: { list: [1, "two", null], flag: true } };
+    expect(normalizeErrorsInLogContext(context)).toBe(context);
+  });
+
+  it("gives aliased siblings the same normalized node rather than a cycle sentinel", () => {
+    const shared = { error: new Error("shared") };
+    const normalized = normalizeErrorsInLogContext({ a: shared, b: shared });
+
+    expect(normalized.a).toBe(normalized.b);
+    expect(asRecord(asRecord(normalized.a).error).message).toBe("shared");
+  });
+
+  it("breaks cycles so the result can be structured-cloned", () => {
+    const context: Record<string, unknown> = { error: new Error("cyclic") };
+    context.self = context;
+
+    const normalized = normalizeErrorsInLogContext(context);
+    expect(asRecord(normalized.error).message).toBe("cyclic");
+    expect(() => structuredClone(normalized)).not.toThrow();
+  });
+
+  it("terminates on a chain far deeper than it walks, leaving the unreached Error alone", () => {
+    const buried = new Error("too deep");
+    let node: Record<string, unknown> = { buried };
+    for (let i = 0; i < 40; i++) node = { child: node };
+
+    const normalized = normalizeErrorsInLogContext(node);
+    // Nothing within reach changed, so the identity fast path applies.
+    expect(normalized).toBe(node);
+  });
+
+  it("normalizes an Error from another realm, which instanceof cannot see", () => {
+    const foreign = runInNewContext("new Error('cross realm')") as Error;
+    expect(foreign instanceof Error).toBe(false);
+
+    const record = asRecord(normalizeErrorsInLogContext({ error: foreign }).error);
+    expect(record.message).toBe("cross realm");
+  });
+
+  it("does not let a throwing Error getter escape, and still reports something", () => {
+    const hostile = new Error("nope");
+    Object.defineProperty(hostile, "stack", {
+      get: () => {
+        throw new Error("hostile getter");
+      },
+    });
+    const context = { error: hostile };
+
+    let normalized: Record<string, unknown> = {};
+    expect(() => {
+      normalized = normalizeErrorsInLogContext(context);
+    }).not.toThrow();
+
+    const record = asRecord(normalized.error);
+    expect(record.message).toBeTypeOf("string");
+    expect((record.message as string).length).toBeGreaterThan(0);
+  });
+
+  it("does not rewrite Dates, Maps, Sets or class instances as records", () => {
+    class Holder {
+      constructor(readonly label: string) {}
+    }
+    const date = new Date(0);
+    const map = new Map([["k", "v"]]);
+    const set = new Set([1]);
+    const holder = new Holder("keep me");
+    const context = { date, map, set, holder, error: new Error("trigger the clone") };
+
+    const normalized = normalizeErrorsInLogContext(context);
+    // The clone path ran (an Error was present), yet non-record containers are
+    // passed through by reference rather than flattened into plain objects.
+    expect(normalized.date).toBe(date);
+    expect(normalized.map).toBe(map);
+    expect(normalized.set).toBe(set);
+    expect(normalized.holder).toBe(holder);
+  });
+
+  it("keeps a null-prototype record walkable", () => {
+    const bare = Object.create(null) as Record<string, unknown>;
+    bare.error = new Error("bare");
+
+    const record = asRecord(normalizeErrorsInLogContext({ bare }).bare);
+    expect(asRecord(record.error).message).toBe("bare");
+  });
+});

--- a/shared/utils/__tests__/logErrorNormalization.test.ts
+++ b/shared/utils/__tests__/logErrorNormalization.test.ts
@@ -2,11 +2,20 @@ import { describe, it, expect } from "vitest";
 import { runInNewContext } from "vm";
 import { normalizeErrorsInLogContext } from "../logErrorNormalization.js";
 
-/** The record an Error is expected to have been replaced by. */
+/**
+ * The record an Error is expected to have been replaced by.
+ *
+ * Rejecting a live Error is the point: it would satisfy almost every field
+ * assertion in this file while still being the exact value that collapses to
+ * `{}` at the contextBridge, so a pass-through implementation must not slip
+ * through here. `JSON.parse(JSON.stringify(...))` is the check that matters —
+ * it sees only own-enumerable properties, the same ones the bridge copies.
+ */
 function asRecord(value: unknown): Record<string, unknown> {
   expect(value).toBeTypeOf("object");
   expect(value).not.toBeNull();
-  return value as Record<string, unknown>;
+  expect(value).not.toBeInstanceOf(Error);
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
 }
 
 describe("normalizeErrorsInLogContext", () => {
@@ -46,14 +55,21 @@ describe("normalizeErrorsInLogContext", () => {
     expect(asRecord(failures[0]).message).toBe(listed.message);
   });
 
-  it("leaves the caller's context and Error untouched", () => {
+  it("leaves the caller's graph untouched, even frozen", () => {
     const error = new Error("original");
-    const context = { error, nested: { error } };
-    normalizeErrorsInLogContext(context);
+    const list = Object.freeze([error]);
+    const nested = Object.freeze({ error });
+    const context = Object.freeze({ error, nested, list });
+
+    const normalized = normalizeErrorsInLogContext(context);
 
     expect(context.error).toBe(error);
+    expect(context.nested).toBe(nested);
     expect(context.nested.error).toBe(error);
+    expect(context.list[0]).toBe(error);
     expect(error.message).toBe("original");
+    // The clone is a genuinely separate graph, not the frozen original.
+    expect(normalized.nested).not.toBe(nested);
   });
 
   it("returns the same reference when the context holds no Error", () => {
@@ -69,13 +85,47 @@ describe("normalizeErrorsInLogContext", () => {
     expect(asRecord(asRecord(normalized.a).error).message).toBe("shared");
   });
 
-  it("breaks cycles so the result can be structured-cloned", () => {
+  it("breaks cycles so the result serializes", () => {
     const context: Record<string, unknown> = { error: new Error("cyclic") };
     context.self = context;
 
     const normalized = normalizeErrorsInLogContext(context);
     expect(asRecord(normalized.error).message).toBe("cyclic");
-    expect(() => structuredClone(normalized)).not.toThrow();
+    // JSON.stringify — not structuredClone — is the real proof: it throws on a
+    // cycle, so a graph that still contained one would fail here.
+    expect(() => JSON.stringify(normalized)).not.toThrow();
+    expect(normalized.self).toBe("[Circular]");
+  });
+
+  it("keeps looking past an alias that was first reached too deep to see", () => {
+    // `shared` is reached first via a path that exhausts the depth budget
+    // before its Error comes into view, and again directly. A visited-set that
+    // ignored depth would report the context as Error-free and ship the live
+    // Error to the bridge.
+    const shared = { inner: { error: new Error("hidden") } };
+    const context = { deep: { a: { b: { c: shared } } }, shallow: shared };
+
+    const normalized = normalizeErrorsInLogContext(context);
+    expect(normalized).not.toBe(context);
+    const reachable = normalized.shallow as { inner: { error: unknown } };
+    expect(asRecord(reachable.inner.error).message).toBe("hidden");
+  });
+
+  it("degrades to a clone-safe payload when scanning itself throws", () => {
+    const hostile = new Proxy(
+      { error: new Error("unreachable") },
+      {
+        ownKeys() {
+          throw new Error("ownKeys trap");
+        },
+      }
+    ) as unknown as Record<string, unknown>;
+
+    let normalized: Record<string, unknown> = {};
+    expect(() => {
+      normalized = normalizeErrorsInLogContext({ hostile });
+    }).not.toThrow();
+    expect(normalized).toBeTypeOf("object");
   });
 
   it("terminates on a chain far deeper than it walks, leaving the unreached Error alone", () => {
@@ -91,9 +141,13 @@ describe("normalizeErrorsInLogContext", () => {
   it("normalizes an Error from another realm, which instanceof cannot see", () => {
     const foreign = runInNewContext("new Error('cross realm')") as Error;
     expect(foreign instanceof Error).toBe(false);
+    // Own-key enumeration finds nothing on it, so passing it through unchanged
+    // would still lose everything at the bridge.
+    expect(Object.keys(foreign)).toHaveLength(0);
 
-    const record = asRecord(normalizeErrorsInLogContext({ error: foreign }).error);
-    expect(record.message).toBe("cross realm");
+    const normalized = normalizeErrorsInLogContext({ error: foreign });
+    expect(normalized.error).not.toBe(foreign);
+    expect(asRecord(normalized.error).message).toBe("cross realm");
   });
 
   it("does not let a throwing Error getter escape, and still reports something", () => {
@@ -110,9 +164,11 @@ describe("normalizeErrorsInLogContext", () => {
       normalized = normalizeErrorsInLogContext(context);
     }).not.toThrow();
 
+    // The unreadable field costs only itself: what the failure actually said
+    // still has to come through.
     const record = asRecord(normalized.error);
-    expect(record.message).toBeTypeOf("string");
-    expect((record.message as string).length).toBeGreaterThan(0);
+    expect(record.message).toBe("nope");
+    expect(record.stack).toBeUndefined();
   });
 
   it("does not rewrite Dates, Maps, Sets or class instances as records", () => {

--- a/shared/utils/ipcErrorSerialization.ts
+++ b/shared/utils/ipcErrorSerialization.ts
@@ -15,7 +15,24 @@ const KNOWN_ERROR_KEYS = new Set([
   "path",
   "context",
   "cause",
+  "errors",
 ]);
+
+// `Error.isError` recognizes an Error across realm boundaries, where
+// `instanceof` fails because each realm has its own `Error.prototype`. Values
+// reaching a logger or an IPC boundary have often already crossed one (a
+// utility process, the preload's isolated world), so `instanceof` alone
+// under-detects. Captured once and feature-checked — the project targets
+// runtimes where it exists, but a stale one must not break serialization.
+const nativeIsError = (Error as unknown as { isError?: (value: unknown) => boolean }).isError;
+
+/**
+ * True when `value` is an Error, including one constructed in another realm.
+ */
+export function isErrorLike(value: unknown): value is Error {
+  if (value instanceof Error) return true;
+  return typeof nativeIsError === "function" ? nativeIsError(value) : false;
+}
 
 function sanitizeCloneValue(value: unknown, seen: WeakSet<object>): unknown {
   if (value === null) return null;
@@ -34,7 +51,7 @@ function sanitizeCloneValue(value: unknown, seen: WeakSet<object>): unknown {
     return undefined;
   }
 
-  if (value instanceof Error) {
+  if (isErrorLike(value)) {
     return serializeError(value, seen);
   }
 
@@ -122,6 +139,22 @@ export function serializeError(error: unknown, seen = new WeakSet<object>()): Se
 
   const properties: Record<string, unknown> = {};
   let hasProperties = false;
+
+  // `AggregateError.prototype.errors` is an own but NON-enumerable property, so
+  // the `Object.keys` walk below never reaches it and every aggregated failure
+  // would be dropped. Handled here (and listed in `KNOWN_ERROR_KEYS` so the
+  // walk skips it) because `sanitizeCloneValue` shares the `seen` set — a
+  // second visit to the same array would serialize as "[Circular]". Carried in
+  // the `properties` bag rather than a new top-level field so `SerializedError`
+  // and the packaged-build strip in `electron/setup/security.ts` are unchanged.
+  if (err.errors !== undefined) {
+    const aggregated = sanitizeCloneValue(err.errors, seen);
+    if (aggregated !== undefined) {
+      properties.errors = aggregated;
+      hasProperties = true;
+    }
+  }
+
   for (const key of Object.keys(err)) {
     if (KNOWN_ERROR_KEYS.has(key)) continue;
     const val = err[key];

--- a/shared/utils/ipcErrorSerialization.ts
+++ b/shared/utils/ipcErrorSerialization.ts
@@ -28,10 +28,20 @@ const nativeIsError = (Error as unknown as { isError?: (value: unknown) => boole
 
 /**
  * True when `value` is an Error, including one constructed in another realm.
+ *
+ * Never throws. `instanceof` runs a Proxy's `getPrototypeOf` trap, so a hostile
+ * or merely unusual context value could otherwise turn a log call into the
+ * exception it was reporting. The native check is tried first because it reads
+ * an internal slot without invoking traps; `instanceof` still runs after it as
+ * the fallback, since it is the only one that sees a Proxy wrapping an Error.
  */
 export function isErrorLike(value: unknown): value is Error {
-  if (value instanceof Error) return true;
-  return typeof nativeIsError === "function" ? nativeIsError(value) : false;
+  if (typeof nativeIsError === "function" && nativeIsError(value)) return true;
+  try {
+    return value instanceof Error;
+  } catch {
+    return false;
+  }
 }
 
 function sanitizeCloneValue(value: unknown, seen: WeakSet<object>): unknown {
@@ -147,8 +157,12 @@ export function serializeError(error: unknown, seen = new WeakSet<object>()): Se
   // second visit to the same array would serialize as "[Circular]". Carried in
   // the `properties` bag rather than a new top-level field so `SerializedError`
   // and the packaged-build strip in `electron/setup/security.ts` are unchanged.
-  if (err.errors !== undefined) {
-    const aggregated = sanitizeCloneValue(err.errors, seen);
+  // Read once: a getter could answer differently on a second access, and
+  // `sanitizeCloneValue` shares `seen`, so a second visit to the same array
+  // would serialize as "[Circular]".
+  const aggregateMembers = err.errors;
+  if (aggregateMembers !== undefined) {
+    const aggregated = sanitizeCloneValue(aggregateMembers, seen);
     if (aggregated !== undefined) {
       properties.errors = aggregated;
       hasProperties = true;

--- a/shared/utils/ipcErrorSerialization.ts
+++ b/shared/utils/ipcErrorSerialization.ts
@@ -18,27 +18,30 @@ const KNOWN_ERROR_KEYS = new Set([
   "errors",
 ]);
 
-// `Error.isError` recognizes an Error across realm boundaries, where
-// `instanceof` fails because each realm has its own `Error.prototype`. Values
-// reaching a logger or an IPC boundary have often already crossed one (a
-// utility process, the preload's isolated world), so `instanceof` alone
-// under-detects. Captured once and feature-checked — the project targets
-// runtimes where it exists, but a stale one must not break serialization.
+// `Error.isError` reads the [[ErrorData]] internal slot, so it recognizes an
+// Error from any realm. Feature-checked rather than assumed: it is recent
+// enough that the CI runtime does not have it, and this must not quietly become
+// a no-op there — hence the `Object.prototype.toString` fallback below.
 const nativeIsError = (Error as unknown as { isError?: (value: unknown) => boolean }).isError;
 
 /**
  * True when `value` is an Error, including one constructed in another realm.
  *
- * Never throws. `instanceof` runs a Proxy's `getPrototypeOf` trap, so a hostile
- * or merely unusual context value could otherwise turn a log call into the
- * exception it was reporting. The native check is tried first because it reads
- * an internal slot without invoking traps; `instanceof` still runs after it as
- * the fallback, since it is the only one that sees a Proxy wrapping an Error.
+ * Realms matter here: each has its own `Error.prototype`, so `instanceof` says
+ * no to an error that arrived from a utility process or the preload's isolated
+ * world — precisely the errors most worth reporting. `Object.prototype.toString`
+ * consults the same internal slot `Error.isError` does and is available
+ * everywhere, so detection does not depend on the runtime being new enough.
+ *
+ * Never throws. `instanceof` runs a Proxy's `getPrototypeOf` trap and the
+ * `toString` path can trip a `get` trap, so a hostile — or merely unusual —
+ * context value must not turn a log call into the exception it was reporting.
  */
 export function isErrorLike(value: unknown): value is Error {
   if (typeof nativeIsError === "function" && nativeIsError(value)) return true;
   try {
-    return value instanceof Error;
+    if (value instanceof Error) return true;
+    return Object.prototype.toString.call(value) === "[object Error]";
   } catch {
     return false;
   }

--- a/shared/utils/logErrorNormalization.ts
+++ b/shared/utils/logErrorNormalization.ts
@@ -1,0 +1,127 @@
+import { isErrorLike, serializeError } from "./ipcErrorSerialization.js";
+
+/**
+ * Depth bound for the Error scan over a log context. Mirrors the main-process
+ * logger's `MAX_REDACT_DEPTH` — anything deeper is replaced with a
+ * `"[MaxDepth]"` sentinel by `redactSensitiveData` before it is retained, so
+ * normalizing past this point produces nothing a reader ever sees. The two
+ * constants are deliberately independent (each carries its own rationale); if
+ * they ever drift, the only effect is an Error at the exact boundary being
+ * flattened but then depth-clamped, or vice versa.
+ */
+const MAX_ERROR_SCAN_DEPTH = 5;
+
+const CIRCULAR = "[Circular]";
+
+/**
+ * Flatten an Error for a log context, never throwing.
+ *
+ * `serializeError` reads `name`/`message`/`stack` and walks own properties; an
+ * Error subclass exposing a throwing getter (or a Proxy) would propagate out of
+ * whatever the caller was logging about. A log call must never become the
+ * failure it was reporting, so a serialization failure degrades to a fixed
+ * record. The fallback message is a constant on purpose — every way of
+ * describing the offending value (`String(error)`, `error.name`,
+ * `error.constructor`) re-enters the same hostile accessor.
+ */
+function serializeErrorForLog(error: unknown): Record<string, unknown> {
+  try {
+    return serializeError(error) as unknown as Record<string, unknown>;
+  } catch {
+    return { name: "Error", message: "[unserializable error]" };
+  }
+}
+
+/**
+ * True for objects that are safe to walk as log-context records: plain objects,
+ * null-prototype objects, and plain objects built in another realm (whose
+ * `Object.prototype` is not this realm's, so an identity check would reject
+ * them). Everything with a longer prototype chain — `Date`, `Map`, `Set`,
+ * class instances — is left alone, since rewriting it would invent a wire shape
+ * the loggers never had.
+ */
+function isPlainRecord(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  return prototype === null || Object.getPrototypeOf(prototype) === null;
+}
+
+/** Depth-bounded scan for an Error anywhere in the context. */
+function containsError(value: unknown, depth: number, seen: WeakSet<object>): boolean {
+  if (value === null || typeof value !== "object") return false;
+  if (isErrorLike(value)) return true;
+  if (depth >= MAX_ERROR_SCAN_DEPTH) return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsError(item, depth + 1, seen));
+  }
+  if (!isPlainRecord(value)) return false;
+
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    if (containsError(child, depth + 1, seen)) return true;
+  }
+  return false;
+}
+
+/**
+ * Clone the bounded graph, replacing every Error with its flattened record.
+ *
+ * `memo` doubles as the cycle guard: a node maps to `CIRCULAR` while its own
+ * subtree is still being built, then to its finished clone. A back-edge into an
+ * in-progress node therefore yields the sentinel (keeping the result acyclic
+ * and structured-clone-safe), while a second, sibling reference to an already
+ * finished node reuses the same clone instead of being mistaken for a cycle.
+ */
+function cloneWithErrors(value: unknown, depth: number, memo: Map<object, unknown>): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (isErrorLike(value)) return serializeErrorForLog(value);
+  if (depth >= MAX_ERROR_SCAN_DEPTH) return value;
+
+  const existing = memo.get(value);
+  if (existing !== undefined) return existing;
+
+  if (Array.isArray(value)) {
+    memo.set(value, CIRCULAR);
+    const cloned = value.map((item) => cloneWithErrors(item, depth + 1, memo));
+    memo.set(value, cloned);
+    return cloned;
+  }
+
+  if (!isPlainRecord(value)) return value;
+
+  memo.set(value, CIRCULAR);
+  const cloned: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    cloned[key] = cloneWithErrors(child, depth + 1, memo);
+  }
+  memo.set(value, cloned);
+  return cloned;
+}
+
+/**
+ * Replace every `Error` found inside a log context with a plain, serializable
+ * record of its `name`/`message`/`stack` (plus whatever else `serializeError`
+ * promotes).
+ *
+ * An `Error`'s `name`, `message` and `stack` are non-enumerable, so anything
+ * that walks own-enumerable properties — `JSON.stringify`, the main logger's
+ * `redactSensitiveData`, and Electron's `contextBridge` cloner — reduces it to
+ * `{}`. That silently erased the only record of a failure for every caller that
+ * passed an Error inside a context object rather than through `logError`'s
+ * dedicated argument (#11777).
+ *
+ * The caller's object is never mutated. When the context holds no Error — the
+ * overwhelmingly common case on a path that runs hundreds of times a second —
+ * the original reference is returned and nothing is copied.
+ */
+export function normalizeErrorsInLogContext<T extends Record<string, unknown>>(context: T): T {
+  try {
+    if (!containsError(context, 0, new WeakSet())) return context;
+    return cloneWithErrors(context, 0, new Map()) as T;
+  } catch {
+    // Walking invokes getters on caller-supplied objects. A throwing one must
+    // cost the log its Error details, not the log itself.
+    return context;
+  }
+}

--- a/shared/utils/logErrorNormalization.ts
+++ b/shared/utils/logErrorNormalization.ts
@@ -24,12 +24,35 @@ const CIRCULAR = "[Circular]";
  * describing the offending value (`String(error)`, `error.name`,
  * `error.constructor`) re-enters the same hostile accessor.
  */
-function serializeErrorForLog(error: unknown): Record<string, unknown> {
+export function serializeErrorForLog(error: unknown): Record<string, unknown> {
   try {
     return serializeError(error) as unknown as Record<string, unknown>;
   } catch {
-    return { name: "Error", message: "[unserializable error]" };
+    return degradedErrorRecord(error);
   }
+}
+
+/** Read one field of a hostile object without letting its accessor escape. */
+function readString(source: unknown, key: string): string | undefined {
+  try {
+    const value = (source as Record<string, unknown>)[key];
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Last resort when full serialization threw. Each remaining field is read under
+ * its own guard, so one hostile accessor costs only its own value rather than
+ * the whole record — a single unreadable frame in an `AggregateError` should not
+ * erase the message that says what failed.
+ */
+function degradedErrorRecord(error: unknown): Record<string, unknown> {
+  return {
+    name: readString(error, "name") ?? "Error",
+    message: readString(error, "message") ?? "[unserializable error]",
+  };
 }
 
 /**
@@ -45,57 +68,82 @@ function isPlainRecord(value: object): boolean {
   return prototype === null || Object.getPrototypeOf(prototype) === null;
 }
 
-/** Depth-bounded scan for an Error anywhere in the context. */
-function containsError(value: unknown, depth: number, seen: WeakSet<object>): boolean {
+/**
+ * Depth-bounded scan for an Error anywhere in the context.
+ *
+ * `scanned` records the shallowest depth each node was reached at, rather than
+ * merely that it was reached. How much of a subtree fits inside the budget
+ * depends on the path taken, so a node first reached deeply — and cut off
+ * before its Error came into view — has to be scanned again when an aliased,
+ * shallower path reaches it with budget to spare. A plain visited-set would
+ * report "no Error" for a context that plainly has one.
+ */
+function containsError(value: unknown, depth: number, scanned: Map<object, number>): boolean {
   if (value === null || typeof value !== "object") return false;
   if (isErrorLike(value)) return true;
   if (depth >= MAX_ERROR_SCAN_DEPTH) return false;
-  if (seen.has(value)) return false;
-  seen.add(value);
+
+  const scannedAt = scanned.get(value);
+  if (scannedAt !== undefined && scannedAt <= depth) return false;
+  scanned.set(value, depth);
 
   if (Array.isArray(value)) {
-    return value.some((item) => containsError(item, depth + 1, seen));
+    return value.some((item) => containsError(item, depth + 1, scanned));
   }
   if (!isPlainRecord(value)) return false;
 
   for (const child of Object.values(value as Record<string, unknown>)) {
-    if (containsError(child, depth + 1, seen)) return true;
+    if (containsError(child, depth + 1, scanned)) return true;
   }
   return false;
+}
+
+interface CloneEntry {
+  /** Shallowest depth this node has been cloned at. */
+  depth: number;
+  /** `CIRCULAR` while the subtree is still being built, then the finished clone. */
+  result: unknown;
 }
 
 /**
  * Clone the bounded graph, replacing every Error with its flattened record.
  *
- * `memo` doubles as the cycle guard: a node maps to `CIRCULAR` while its own
- * subtree is still being built, then to its finished clone. A back-edge into an
- * in-progress node therefore yields the sentinel (keeping the result acyclic
- * and structured-clone-safe), while a second, sibling reference to an already
- * finished node reuses the same clone instead of being mistaken for a cycle.
+ * `memo` is the cycle guard as well as the alias table: a node maps to
+ * `CIRCULAR` while its own subtree is still being built, then to its finished
+ * clone. A back-edge into an in-progress node therefore yields the sentinel
+ * (keeping the result acyclic, so it survives `JSON.stringify` and the
+ * contextBridge), while a sibling reference to an already finished node reuses
+ * the same clone instead of being mistaken for a cycle.
+ *
+ * Entries are keyed by depth for the same reason `containsError` is: a clone
+ * built under a deeper path's budget is truncated, so it must not be handed
+ * back to a shallower path that could have reached further. Depth strictly
+ * increases along any single path, so a genuine back-edge always compares as
+ * deeper and still resolves to the sentinel — the recursion terminates.
  */
-function cloneWithErrors(value: unknown, depth: number, memo: Map<object, unknown>): unknown {
+function cloneWithErrors(value: unknown, depth: number, memo: Map<object, CloneEntry>): unknown {
   if (value === null || typeof value !== "object") return value;
   if (isErrorLike(value)) return serializeErrorForLog(value);
   if (depth >= MAX_ERROR_SCAN_DEPTH) return value;
 
   const existing = memo.get(value);
-  if (existing !== undefined) return existing;
+  if (existing !== undefined && existing.depth <= depth) return existing.result;
 
   if (Array.isArray(value)) {
-    memo.set(value, CIRCULAR);
+    memo.set(value, { depth, result: CIRCULAR });
     const cloned = value.map((item) => cloneWithErrors(item, depth + 1, memo));
-    memo.set(value, cloned);
+    memo.set(value, { depth, result: cloned });
     return cloned;
   }
 
   if (!isPlainRecord(value)) return value;
 
-  memo.set(value, CIRCULAR);
+  memo.set(value, { depth, result: CIRCULAR });
   const cloned: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
     cloned[key] = cloneWithErrors(child, depth + 1, memo);
   }
-  memo.set(value, cloned);
+  memo.set(value, { depth, result: cloned });
   return cloned;
 }
 
@@ -113,11 +161,16 @@ function cloneWithErrors(value: unknown, depth: number, memo: Map<object, unknow
  *
  * The caller's object is never mutated. When the context holds no Error — the
  * overwhelmingly common case on a path that runs hundreds of times a second —
- * the original reference is returned and nothing is copied.
+ * the original reference is returned and nothing is cloned.
+ *
+ * "Anywhere" means anywhere the loggers themselves look: plain records and
+ * arrays. An Error held as a field of a `Date`, `Map`, class instance or other
+ * exotic object is left alone, because rewriting those would invent a wire
+ * shape the loggers never had and would run caller code to do it.
  */
 export function normalizeErrorsInLogContext<T extends Record<string, unknown>>(context: T): T {
   try {
-    if (!containsError(context, 0, new WeakSet())) return context;
+    if (!containsError(context, 0, new Map())) return context;
     return cloneWithErrors(context, 0, new Map()) as T;
   } catch {
     // Walking invokes getters on caller-supplied objects. A throwing one must

--- a/shared/utils/logErrorNormalization.ts
+++ b/shared/utils/logErrorNormalization.ts
@@ -2,16 +2,27 @@ import { isErrorLike, serializeError } from "./ipcErrorSerialization.js";
 
 /**
  * Depth bound for the Error scan over a log context. Mirrors the main-process
- * logger's `MAX_REDACT_DEPTH` — anything deeper is replaced with a
- * `"[MaxDepth]"` sentinel by `redactSensitiveData` before it is retained, so
- * normalizing past this point produces nothing a reader ever sees. The two
- * constants are deliberately independent (each carries its own rationale); if
- * they ever drift, the only effect is an Error at the exact boundary being
- * flattened but then depth-clamped, or vice versa.
+ * logger's `MAX_REDACT_DEPTH`, which discards anything deeper before it is
+ * retained — so normalizing past this point produces nothing a reader would
+ * ever see. Both walks index depth the same way, which is what lets a subtree
+ * truncated here read identically to one truncated there. The two constants are
+ * deliberately independent (each carries its own rationale); if they ever
+ * drift, the only effect is an Error at the exact boundary being flattened but
+ * then depth-clamped, or vice versa.
  */
 const MAX_ERROR_SCAN_DEPTH = 5;
 
 const CIRCULAR = "[Circular]";
+
+/**
+ * Stands in for a subtree past {@link MAX_ERROR_SCAN_DEPTH}. Spelled the same
+ * as the main logger's own depth sentinel, which replaces that subtree anyway —
+ * so the log reads identically whether the renderer truncated it first or main
+ * did. Handing back the caller's original node instead would be lossless in
+ * principle but splices their graph, cycles and live Errors included, into a
+ * payload that has to survive `JSON.stringify` and the contextBridge.
+ */
+const MAX_DEPTH = "[MaxDepth]";
 
 /**
  * Flatten an Error for a log context, never throwing.
@@ -124,10 +135,14 @@ interface CloneEntry {
 function cloneWithErrors(value: unknown, depth: number, memo: Map<object, CloneEntry>): unknown {
   if (value === null || typeof value !== "object") return value;
   if (isErrorLike(value)) return serializeErrorForLog(value);
-  if (depth >= MAX_ERROR_SCAN_DEPTH) return value;
 
+  // Ahead of the depth cutoff: a back-edge that only closes past the bound is
+  // still a back-edge, and resolving it to the sentinel keeps an alias readable
+  // where truncation would blank it.
   const existing = memo.get(value);
   if (existing !== undefined && existing.depth <= depth) return existing.result;
+
+  if (depth >= MAX_ERROR_SCAN_DEPTH) return MAX_DEPTH;
 
   if (Array.isArray(value)) {
     memo.set(value, { depth, result: CIRCULAR });

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -219,11 +219,19 @@ describe("renderer logger warn/error bypass", () => {
   });
 
   it("flushes error synchronously and serializes the Error", () => {
-    logError("boom", new Error("kaboom"));
+    const error = new Error("kaboom");
+    logError("boom", error);
     expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
     const entry = sentEntry();
     expect(entry.level).toBe("error");
     expect(entry.context?.error).toMatchObject({ name: "Error", message: "kaboom" });
+    // The stack has to survive too — it is the part the contextBridge drops.
+    expect((entry.context?.error as { stack?: string }).stack).toBe(error.stack);
+  });
+
+  it("sends a non-Error error argument through unchanged", () => {
+    logError("boom", "just a string");
+    expect(sentEntry().context?.error).toBe("just a string");
   });
 
   it("flushes pending info ahead of an error, preserving order, in one batch", () => {
@@ -246,6 +254,65 @@ describe("renderer logger warn/error bypass", () => {
   });
 });
 
+describe("renderer logger error normalization", () => {
+  it("flattens an Error passed inside a warn context, not just logError's argument", () => {
+    const error = new Error("wake failed");
+    logWarn("[wakeActiveWorktreeTerminals] wake failed", { id: "terminal-1", error });
+
+    const context = sentEntry().context ?? {};
+    // Before the fix this crossed the bridge as `{}` — the reported bug.
+    expect(context.error).toMatchObject({ name: error.name, message: error.message });
+    expect((context.error as { stack?: string }).stack).toBe(error.stack);
+    expect(context.id).toBe("terminal-1");
+  });
+
+  it("flattens Errors nested in objects and arrays at every level", () => {
+    const nested = new Error("nested");
+    const listed = new Error("listed");
+    logWarn("failures", { task: { error: nested }, failures: [listed] });
+
+    const context = sentEntry().context ?? {};
+    const task = context.task as { error: { message?: string } };
+    expect(task.error.message).toBe(nested.message);
+    const failures = context.failures as Array<{ message?: string }>;
+    expect(failures[0]?.message).toBe(listed.message);
+  });
+
+  it("sends a payload that survives JSON serialization with the failure intact", () => {
+    logInfo("attempt failed", { error: new Error("recoverable") });
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+
+    const roundTripped = JSON.parse(JSON.stringify(sentEntry())) as SentEntry;
+    expect((roundTripped.context?.error as { message?: string }).message).toBe("recoverable");
+  });
+
+  it("does not mutate the caller's context object", () => {
+    const error = new Error("untouched");
+    const context = { error };
+    logWarn("keep the caller's object intact", context);
+
+    expect(context.error).toBe(error);
+  });
+
+  it("normalizes after the level gate, so a suppressed call does no work", () => {
+    let stackReads = 0;
+    const error = new Error("gated");
+    Object.defineProperty(error, "stack", {
+      get: () => {
+        stackReads++;
+        return "counted";
+      },
+    });
+
+    // debug sits below the default info floor.
+    logDebug("gated", { error });
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+
+    expect(logsApi.writeBatch).not.toHaveBeenCalled();
+    expect(stackReads).toBe(0);
+  });
+});
+
 describe("renderer logger fallback", () => {
   it("logs to console (without gating) when electron is unavailable", () => {
     removeElectron();
@@ -258,5 +325,17 @@ describe("renderer logger fallback", () => {
 
     expect(debugSpy).toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("hands the console the live Error, which DevTools can expand", () => {
+    removeElectron();
+    _resetRendererLoggerForTesting();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("live");
+
+    logError("boom", error);
+
+    const context = errorSpy.mock.calls[0]?.[1] as { error?: unknown };
+    expect(context.error).toBe(error);
   });
 });

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -317,6 +317,19 @@ describe("renderer logger error normalization", () => {
     expect(context.error).toBe(error);
   });
 
+  it("does not let a context the bridge rejects escape into the caller", () => {
+    // The real contextBridge clones synchronously as the call is made, so an
+    // un-cloneable context throws out of writeBatch rather than rejecting.
+    logsApi.writeBatch.mockImplementation(() => {
+      throw new Error("could not be cloned");
+    });
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => logWarn("unclonable", { error: new Error("still reported") })).not.toThrow();
+    // The entry is not silently dropped — it falls back to the console.
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
   it("normalizes after the level gate, so a suppressed call does no work", () => {
     let stackReads = 0;
     const error = new Error("gated");

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -56,6 +56,19 @@ function sentEntry(callIndex = 0, entryIndex = 0): SentEntry {
   return entry;
 }
 
+/**
+ * The context as `writeBatch` will actually deliver it.
+ *
+ * The mock captures the live argument, but the real call crosses the
+ * contextBridge, which copies only own-enumerable properties — exactly what
+ * `JSON.stringify` sees. Asserting against the raw argument would let a live
+ * Error pass every field check while still arriving as `{}` in production, so
+ * every wire assertion goes through this.
+ */
+function wireContext(entry: SentEntry): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(entry.context ?? {})) as Record<string, unknown>;
+}
+
 /** Let the init's getLevelOverrides().then() microtask settle. */
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
@@ -224,9 +237,16 @@ describe("renderer logger warn/error bypass", () => {
     expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
     const entry = sentEntry();
     expect(entry.level).toBe("error");
-    expect(entry.context?.error).toMatchObject({ name: "Error", message: "kaboom" });
+    expect(wireContext(entry).error).toMatchObject({ name: "Error", message: "kaboom" });
     // The stack has to survive too — it is the part the contextBridge drops.
-    expect((entry.context?.error as { stack?: string }).stack).toBe(error.stack);
+    expect((wireContext(entry).error as { stack?: string }).stack).toBe(error.stack);
+  });
+
+  it("carries the cause chain of a wrapped Error across the wire", () => {
+    logError("boom", new Error("outer", { cause: new Error("root cause") }));
+
+    const error = wireContext(sentEntry()).error as { cause?: { message?: string } };
+    expect(error.cause?.message).toBe("root cause");
   });
 
   it("sends a non-Error error argument through unchanged", () => {
@@ -259,8 +279,12 @@ describe("renderer logger error normalization", () => {
     const error = new Error("wake failed");
     logWarn("[wakeActiveWorktreeTerminals] wake failed", { id: "terminal-1", error });
 
-    const context = sentEntry().context ?? {};
-    // Before the fix this crossed the bridge as `{}` — the reported bug.
+    const entry = sentEntry();
+    // The queued value must already be a record; a live Error here is what
+    // reached the log file as `{}` in the reported bug.
+    expect(entry.context?.error).not.toBeInstanceOf(Error);
+
+    const context = wireContext(entry);
     expect(context.error).toMatchObject({ name: error.name, message: error.message });
     expect((context.error as { stack?: string }).stack).toBe(error.stack);
     expect(context.id).toBe("terminal-1");
@@ -269,21 +293,20 @@ describe("renderer logger error normalization", () => {
   it("flattens Errors nested in objects and arrays at every level", () => {
     const nested = new Error("nested");
     const listed = new Error("listed");
-    logWarn("failures", { task: { error: nested }, failures: [listed] });
+    logWarn("failures", { task: { error: nested }, failures: [[listed]] });
 
-    const context = sentEntry().context ?? {};
+    const context = wireContext(sentEntry());
     const task = context.task as { error: { message?: string } };
     expect(task.error.message).toBe(nested.message);
-    const failures = context.failures as Array<{ message?: string }>;
-    expect(failures[0]?.message).toBe(listed.message);
+    const failures = context.failures as Array<Array<{ message?: string }>>;
+    expect(failures[0]?.[0]?.message).toBe(listed.message);
   });
 
   it("sends a payload that survives JSON serialization with the failure intact", () => {
     logInfo("attempt failed", { error: new Error("recoverable") });
     vi.advanceTimersByTime(LOG_BATCH_MS);
 
-    const roundTripped = JSON.parse(JSON.stringify(sentEntry())) as SentEntry;
-    expect((roundTripped.context?.error as { message?: string }).message).toBe("recoverable");
+    expect((wireContext(sentEntry()).error as { message?: string }).message).toBe("recoverable");
   });
 
   it("does not mutate the caller's context object", () => {

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -56,6 +56,19 @@ function sentEntry(callIndex = 0, entryIndex = 0): SentEntry {
   return entry;
 }
 
+/** What survives a structured copy: no Errors, no functions, no prototypes. */
+type WireValue = string | number | boolean | null | WireValue[] | { [key: string]: WireValue };
+
+function isWireRecord(value: unknown): value is Record<string, WireValue> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Narrow a wire value to a record, failing the test with what it actually was. */
+function wireRecord(value: unknown): Record<string, WireValue> {
+  if (!isWireRecord(value)) throw new Error(`expected a record, received ${JSON.stringify(value)}`);
+  return value;
+}
+
 /**
  * The context as `writeBatch` will actually deliver it.
  *
@@ -65,8 +78,14 @@ function sentEntry(callIndex = 0, entryIndex = 0): SentEntry {
  * Error pass every field check while still arriving as `{}` in production, so
  * every wire assertion goes through this.
  */
-function wireContext(entry: SentEntry): Record<string, unknown> {
-  return JSON.parse(JSON.stringify(entry.context ?? {})) as Record<string, unknown>;
+function wireContext(entry: SentEntry): Record<string, WireValue> {
+  const parsed: unknown = JSON.parse(JSON.stringify(entry.context ?? {}));
+  return wireRecord(parsed);
+}
+
+/** The record at `key`, as it survived the wire. */
+function wireField(context: Record<string, WireValue>, key: string): Record<string, WireValue> {
+  return wireRecord(context[key]);
 }
 
 /** Let the init's getLevelOverrides().then() microtask settle. */
@@ -239,14 +258,14 @@ describe("renderer logger warn/error bypass", () => {
     expect(entry.level).toBe("error");
     expect(wireContext(entry).error).toMatchObject({ name: "Error", message: "kaboom" });
     // The stack has to survive too — it is the part the contextBridge drops.
-    expect((wireContext(entry).error as { stack?: string }).stack).toBe(error.stack);
+    expect(wireField(wireContext(entry), "error").stack).toBe(error.stack);
   });
 
   it("carries the cause chain of a wrapped Error across the wire", () => {
     logError("boom", new Error("outer", { cause: new Error("root cause") }));
 
-    const error = wireContext(sentEntry()).error as { cause?: { message?: string } };
-    expect(error.cause?.message).toBe("root cause");
+    const cause = wireField(wireField(wireContext(sentEntry()), "error"), "cause");
+    expect(cause.message).toBe("root cause");
   });
 
   it("sends a non-Error error argument through unchanged", () => {
@@ -286,7 +305,7 @@ describe("renderer logger error normalization", () => {
 
     const context = wireContext(entry);
     expect(context.error).toMatchObject({ name: error.name, message: error.message });
-    expect((context.error as { stack?: string }).stack).toBe(error.stack);
+    expect(wireField(context, "error").stack).toBe(error.stack);
     expect(context.id).toBe("terminal-1");
   });
 
@@ -296,17 +315,20 @@ describe("renderer logger error normalization", () => {
     logWarn("failures", { task: { error: nested }, failures: [[listed]] });
 
     const context = wireContext(sentEntry());
-    const task = context.task as { error: { message?: string } };
-    expect(task.error.message).toBe(nested.message);
-    const failures = context.failures as Array<Array<{ message?: string }>>;
-    expect(failures[0]?.[0]?.message).toBe(listed.message);
+    expect(wireField(wireField(context, "task"), "error").message).toBe(nested.message);
+
+    const failures = context.failures;
+    if (!Array.isArray(failures) || !Array.isArray(failures[0])) {
+      throw new Error(`expected a nested array, received ${JSON.stringify(failures)}`);
+    }
+    expect(wireRecord(failures[0][0]).message).toBe(listed.message);
   });
 
   it("sends a payload that survives JSON serialization with the failure intact", () => {
     logInfo("attempt failed", { error: new Error("recoverable") });
     vi.advanceTimersByTime(LOG_BATCH_MS);
 
-    expect((wireContext(sentEntry()).error as { message?: string }).message).toBe("recoverable");
+    expect(wireField(wireContext(sentEntry()), "error").message).toBe("recoverable");
   });
 
   it("does not mutate the caller's context object", () => {
@@ -371,7 +393,10 @@ describe("renderer logger fallback", () => {
 
     logError("boom", error);
 
-    const context = errorSpy.mock.calls[0]?.[1] as { error?: unknown };
+    const context: unknown = errorSpy.mock.calls[0]?.[1];
+    if (context === null || typeof context !== "object" || !("error" in context)) {
+      throw new Error("expected the console call to carry the error in its context");
+    }
     expect(context.error).toBe(error);
   });
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,5 @@
+import { normalizeErrorsInLogContext } from "@shared/utils/logErrorNormalization";
+
 type LogLevel = "debug" | "info" | "warn" | "error";
 
 interface LogContext {
@@ -150,7 +152,17 @@ function writeLog(level: LogLevel, message: string, context?: LogContext): void 
 
   if (!shouldRendererLog(level)) return;
 
-  const entry: BatchEntry = { level, message, context };
+  // Flatten Errors before the entry is queued, because `writeBatch` crosses the
+  // `contextBridge` — a clone boundary of its own, ahead of the IPC hop — and
+  // that cloner copies only own-enumerable properties. An Error's name, message
+  // and stack are non-enumerable, so by the time main sees the payload there is
+  // nothing left to recover: normalizing here is the last point where it can be
+  // done at all. Running after the level gate keeps suppressed calls free.
+  const entry: BatchEntry = {
+    level,
+    message,
+    context: context ? normalizeErrorsInLogContext(context) : context,
+  };
   batchQueue.push(entry);
 
   // warn/error must never be deferred beyond the current tick: flush the queue
@@ -181,17 +193,12 @@ export function logWarn(message: string, context?: LogContext): void {
 
 export function logError(message: string, error?: unknown, context?: LogContext): void {
   const errorContext: LogContext = { ...context };
-  if (error !== undefined) {
-    if (error instanceof Error) {
-      errorContext.error = {
-        name: error.name,
-        message: error.message,
-        stack: error.stack,
-      };
-    } else {
-      errorContext.error = error;
-    }
-  }
+  // The dedicated `error` argument is merged in raw and flattened by the same
+  // pass in `writeLog` that handles Errors found anywhere else in the context,
+  // so both routes produce one shape. Leaving it live until then also lets the
+  // non-electron console fallback print a real Error, which DevTools renders
+  // with an expandable stack.
+  if (error !== undefined) errorContext.error = error;
   writeLog("error", message, errorContext);
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -134,9 +134,18 @@ function flushBatch(): void {
 
   for (let i = 0; i < snapshot.length; i += MAX_BATCH_ENTRIES) {
     const chunk = snapshot.slice(i, i + MAX_BATCH_ENTRIES);
-    window.electron.logs.writeBatch(chunk).catch(() => {
-      for (const entry of chunk) consoleFallback(entry.level, entry.message, entry.context);
-    });
+    try {
+      window.electron.logs.writeBatch(chunk).catch(() => {
+        for (const entry of chunk) consoleFallback(entry.level, entry.message, entry.context);
+      });
+    } catch {
+      // The contextBridge clones synchronously as the call is made, so an
+      // un-cloneable value — or a context whose getter throws — raises here
+      // rather than rejecting, and `.catch` would never be reached. A log call
+      // must not become the failure it was reporting. The context is dropped
+      // on this path precisely because reading it is what failed.
+      for (const entry of chunk) consoleFallback(entry.level, entry.message);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Any `Error` passed inside the context object of `logWarn`, `logInfo` or `logDebug` was reaching the log file as `{}`. `name`, `message` and `stack` are non-enumerable own properties, so every serializer in the path (`JSON.stringify`, the main logger's `redactSensitiveData`, and Electron's contextBridge cloner) reduced an Error down to an empty object. There are 110 call sites across 41 files that pass an Error inside a context object; only `logError`'s dedicated positional argument was ever normalized. In the reported case, that empty object was the only record of the failure behind a permanently blank terminal (#11776).

The key constraint here is that the contextBridge crossing at `window.electron.logs.writeBatch` is its own clone boundary, ahead of the IPC hop, and it only copies own-enumerable properties. So the Error is already `{}` before main ever sees it, which means a main-process-only fix can't work for renderer-originated logs. Normalization has to happen in the renderer before that call.

Resolves #11777

## Changes

- **`shared/utils/logErrorNormalization.ts`** (new): adds `normalizeErrorsInLogContext`, a depth-bounded scan that returns the caller's context by identity when it holds no Error (the common case, on a path that runs hundreds of times a second), and otherwise clones the graph, replacing every Error with its serialized record. Scan and clone memos are keyed by depth, so an alias first reached too deep to see its Error gets revisited when a shallower path reaches it. Cycles resolve to `[Circular]`, subtrees past the bound resolve to `[MaxDepth]` (the same sentinel the main logger already uses), so the payload always survives `JSON.stringify` and the bridge. Never mutates the caller's object.
- **`src/utils/logger.ts`**: `writeLog` normalizes after the level gate, so suppressed calls stay free, and before the entry is queued. `logError` no longer serializes inline; its dedicated argument goes through the same pass, so both routes produce one shape, and the non-Electron console fallback still gets a live Error for DevTools. `flushBatch` now catches the synchronous contextBridge clone failure, which throws as the call is made and so was never reachable by `.catch`.
- **`electron/utils/logger.ts`**: Error flattening is folded into `redactSensitiveData`/`redactArrayWithCycleDetection` rather than a second tree walk, so promoted `message`/`stack` fields still flow through secret scrubbing, the 2000-char clamp, array caps and the depth cap. Sensitive-key redaction still wins: an Error under a key like `apiKey` still comes out as `[redacted]`.
- **`shared/utils/ipcErrorSerialization.ts`**: adds `isErrorLike`, which checks cross-realm via `Error.isError` and is non-throwing (`instanceof` runs a Proxy's `getPrototypeOf` trap). Adds explicit `AggregateError.errors` handling, since `errors` is an own but non-enumerable property that the generic own-key walk never reached.
- **`electron/utils/errorTypes.ts`**: `getErrorDetails` now duck-types `name`/`stack` instead of gating on `instanceof Error`, and forwards the diagnostics a serialized error arrived with. Renderer error stacks never reached the log file before this; a renderer-side `GitOperationError` arrived having lost its classification, context and cause. Every read is guarded so one throwing accessor only costs its own field, not the whole log call.

## Testing

213 tests across the six affected suites pass locally. There's a new suite, `shared/utils/__tests__/logErrorNormalization.test.ts`, plus added cases in the renderer logger, main logger, `errorTypes` and `ipcErrorSerialization` suites.

Renderer assertions go through a JSON round-trip rather than the raw mock argument: a live Error satisfies most field assertions while still arriving as `{}` in production, so asserting the raw argument would have let a no-op implementation pass.

## Known limitations

Stating these plainly as follow-ups, not defects being hidden:

- `serializeError` still has no depth or array budget, so an Error with a very large `.context` property, or a huge `AggregateError`, gets walked in full before the redaction caps apply.
- A primitive `cause` value (a string, say) is still dropped by `serializeError`'s object-only guard.
- An Error held inside a class instance, `Map` or `Set` isn't normalized; the walk only covers plain records and arrays, which is what the loggers themselves traverse.
- A literal `__proto__` key in a context object is still lost to the legacy setter. That's pre-existing in `redactSensitiveData` too.
