### PR TITLE
fix(terminal): recover from a failed xterm attach instead of retrying into a wall

### DIFF
--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -385,6 +385,11 @@ export interface PtyPanelData extends BasePanelData {
   reconnectError?: TerminalReconnectError;
   /** Scrollback restore failure - set when deferred scrollback replay fails */
   scrollbackRestoreError?: TerminalScrollbackRestoreError;
+  /** Renderer attach failure (#11776) — the xterm instance could not be opened,
+   *  so the pane cannot paint even though the PTY is healthy and streaming.
+   *  Deliberately not persisted: a restart builds a fresh terminal anyway, and
+   *  a restored banner would describe a failure that no longer exists. */
+  attachError?: string;
   /** Error that occurred when spawning the PTY process */
   spawnError?: import("./pty-host.js").SpawnError;
   /** Flow control status - indicates if terminal is paused/suspended due to backpressure or safety policy.

--- a/src/components/Terminal/TerminalAttachErrorBanner.tsx
+++ b/src/components/Terminal/TerminalAttachErrorBanner.tsx
@@ -1,0 +1,57 @@
+import { MonitorX, RotateCcw } from "lucide-react";
+import { InlineStatusBanner } from "./InlineStatusBanner";
+import { boundedErrorText } from "@/utils/errorText";
+
+export interface TerminalAttachErrorBannerProps {
+  terminalId: string;
+  error: string;
+  onRetry: (id: string) => void;
+  isRetrying?: boolean;
+  className?: string;
+}
+
+/**
+ * T3 inline error banner for a pane whose xterm instance could not be opened
+ * (#11776).
+ *
+ * Severity is "error", not "warning", and the distinction is the whole point:
+ * the scrollback banner's terminal still works and is only missing history,
+ * whereas this pane paints *nothing* while its agent keeps running and the PTY
+ * keeps streaming. That is a data-visibility failure — the user is blind to a
+ * live process — so it earns the error tier and a recovery action, per the
+ * runtime-signal tiers in CLAUDE.md. It stays inline rather than routing
+ * through notify() because both the signal and its recovery live in this one
+ * pane.
+ *
+ * Copy leads with the reassurance that nothing is lost, because the failure
+ * looks exactly like a hung agent and that is the wrong conclusion to draw.
+ */
+export function TerminalAttachErrorBanner({
+  terminalId,
+  error,
+  onRetry,
+  isRetrying = false,
+  className,
+}: TerminalAttachErrorBannerProps) {
+  const sanitized = boundedErrorText(error);
+  const tail = "The process is still running and its output is being recorded.";
+  return (
+    <InlineStatusBanner
+      icon={MonitorX}
+      title="Terminal display failed"
+      description={sanitized ? `${sanitized} ${tail}` : tail}
+      severity="error"
+      action={{
+        id: "retry-attach",
+        label: "Retry",
+        icon: RotateCcw,
+        variant: "primary",
+        onClick: () => onRetry(terminalId),
+        title: "Rebuild the terminal display and replay its output",
+        ariaLabel: "Retry",
+        loading: isRetrying,
+      }}
+      className={className}
+    />
+  );
+}

--- a/src/components/Terminal/TerminalAttachErrorBanner.tsx
+++ b/src/components/Terminal/TerminalAttachErrorBanner.tsx
@@ -48,7 +48,10 @@ export function TerminalAttachErrorBanner({
         variant: "primary",
         onClick: () => onRetry(terminalId),
         title: "Rebuild the terminal display and replay its output",
-        ariaLabel: "Retry",
+        // Visible label stays the bare recovery verb per CLAUDE.md; the
+        // accessible name carries the context a screen-reader user has no
+        // other way to recover from a button announced as just "Retry".
+        ariaLabel: "Retry terminal display",
         loading: isRetrying,
       }}
       className={className}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -974,15 +974,22 @@ function TerminalPaneComponent({
 
   // No dismiss counterpart on purpose (#11776): the banner is the only sign
   // the pane is dead, so it clears when the rebuild actually succeeds, not
-  // when the user waves it away. `isRebuildingDisplay` keeps the button
-  // spinning for the rebuild's duration — it awaits an addon load, an open and
-  // a scrollback replay, well past the Doherty threshold.
-  const [isRebuildingDisplay, setIsRebuildingDisplay] = useState(false);
+  // when the user waves it away. The busy state keeps the button spinning for
+  // the rebuild's duration — it awaits a write drain, an addon load, an open
+  // and a scrollback replay, well past the Doherty threshold.
+  //
+  // Stored as the id being rebuilt rather than a bare boolean: this component
+  // is reused across tab switches within a group, so a plain flag would let a
+  // retry on one terminal disable the Retry button of whichever terminal the
+  // pane shows next — and let the first terminal's late settlement clear the
+  // second one's busy state.
+  const [retryingAttachId, setRetryingAttachId] = useState<string | null>(null);
+  const isRebuildingDisplay = retryingAttachId === id;
   const handleRetryAttach = useCallback(() => {
-    setIsRebuildingDisplay(true);
+    setRetryingAttachId(id);
     void terminalInstanceService
       .recoverPoisonedTerminal(id, { manual: true })
-      .finally(() => setIsRebuildingDisplay(false));
+      .finally(() => setRetryingAttachId((current) => (current === id ? null : current)));
   }, [id]);
 
   useEffect(() => {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -40,6 +40,7 @@ import { TerminalErrorBanner } from "./TerminalErrorBanner";
 import { SpawnErrorBanner } from "./SpawnErrorBanner";
 import { ReconnectErrorBanner } from "./ReconnectErrorBanner";
 import { ScrollbackRestoreErrorBanner } from "./ScrollbackRestoreErrorBanner";
+import { TerminalAttachErrorBanner } from "./TerminalAttachErrorBanner";
 import { useShouldSuppressLocalError } from "@/components/Recovery/useShouldSuppressLocalError";
 import { UpdateCwdDialog } from "./UpdateCwdDialog";
 import { ErrorBanner } from "../Errors/ErrorBanner";
@@ -308,6 +309,8 @@ export interface TerminalPaneProps {
   reconnectError?: TerminalReconnectError;
   spawnError?: SpawnError;
   scrollbackRestoreError?: TerminalScrollbackRestoreError;
+  /** Renderer attach failure (#11776) — the pane cannot paint at all. */
+  attachError?: string;
   isMultiPanelGrid?: boolean;
   detectedProcessId?: string;
   // Group-level ambient state: highest-urgency state across all tabs, for container border styling
@@ -354,6 +357,7 @@ function TerminalPaneComponent({
   reconnectError,
   spawnError,
   scrollbackRestoreError,
+  attachError,
   isMultiPanelGrid = true,
   detectedProcessId,
   ambientAgentState,
@@ -968,6 +972,19 @@ function TerminalPaneComponent({
     clearScrollbackRestoreError(id);
   };
 
+  // No dismiss counterpart on purpose (#11776): the banner is the only sign
+  // the pane is dead, so it clears when the rebuild actually succeeds, not
+  // when the user waves it away. `isRebuildingDisplay` keeps the button
+  // spinning for the rebuild's duration — it awaits an addon load, an open and
+  // a scrollback replay, well past the Doherty threshold.
+  const [isRebuildingDisplay, setIsRebuildingDisplay] = useState(false);
+  const handleRetryAttach = useCallback(() => {
+    setIsRebuildingDisplay(true);
+    void terminalInstanceService
+      .recoverPoisonedTerminal(id, { manual: true })
+      .finally(() => setIsRebuildingDisplay(false));
+  }, [id]);
+
   useEffect(() => {
     terminalInstanceService.setFocused(id, isFocused);
 
@@ -1348,6 +1365,17 @@ function TerminalPaneComponent({
             onDismiss={handleDismissScrollbackRestoreError}
             onRestart={handleRestart}
             isRestarting={isRestarting}
+          />
+        )}
+      </BannerSlot>
+
+      <BannerSlot visible={Boolean(attachError)}>
+        {attachError && (
+          <TerminalAttachErrorBanner
+            terminalId={id}
+            error={attachError}
+            onRetry={handleRetryAttach}
+            isRetrying={isRebuildingDisplay}
           />
         )}
       </BannerSlot>

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -349,7 +349,7 @@ export function XtermAdapter({
           return false;
         };
 
-        managed.terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+        const customKeyEventHandler = (event: KeyboardEvent): boolean => {
           // Only process keydown events to avoid double-firing
           if (event.type !== "keydown") {
             return true;
@@ -583,7 +583,16 @@ export function XtermAdapter({
             return false;
           }
           return true;
-        });
+        };
+
+        // Recorded on the instance as well as attached: this effect runs once
+        // per mount and does NOT re-run when a poisoned terminal is rebuilt
+        // underneath it (#11776), so the service re-attaches this exact handler
+        // to the replacement. Without it `keyHandlerInstalled` would stay true
+        // against a fresh Terminal that has no handler, and the rebuilt pane
+        // would silently stop accepting keyboard input.
+        managed.customKeyEventHandler = customKeyEventHandler;
+        managed.terminal.attachCustomKeyEventHandler(customKeyEventHandler);
         managed.keyHandlerInstalled = true;
       }
 

--- a/src/components/Terminal/__tests__/TerminalAttachErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalAttachErrorBanner.test.tsx
@@ -48,7 +48,7 @@ describe("TerminalAttachErrorBanner", () => {
   it("passes the terminal id to the retry handler", () => {
     const { onRetry } = renderBanner({ terminalId: "term-42" });
 
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry terminal display" }));
 
     expect(onRetry).toHaveBeenCalledWith("term-42");
   });
@@ -73,7 +73,7 @@ describe("TerminalAttachErrorBanner", () => {
     renderBanner({ error: "" });
 
     expect(screen.getByRole("alert").textContent).toMatch(/process is still running/i);
-    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry terminal display" })).toBeTruthy();
   });
 
   it("strips terminal escape sequences out of the error text", () => {
@@ -92,7 +92,7 @@ describe("TerminalAttachErrorBanner", () => {
     // second click mid-flight would queue a redundant teardown.
     const { onRetry } = renderBanner({ isRetrying: true });
 
-    const button = screen.getByRole("button", { name: "Retry" });
+    const button = screen.getByRole("button", { name: "Retry terminal display" });
     expect(button.hasAttribute("disabled")).toBe(true);
 
     fireEvent.click(button);

--- a/src/components/Terminal/__tests__/TerminalAttachErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalAttachErrorBanner.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { TerminalAttachErrorBanner } from "../TerminalAttachErrorBanner";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderBanner(overrides: Partial<React.ComponentProps<typeof TerminalAttachErrorBanner>>) {
+  const onRetry = vi.fn();
+  render(
+    <TerminalAttachErrorBanner
+      terminalId="term-1"
+      error="Cannot read properties of undefined (reading 'setRenderer')"
+      onRetry={onRetry}
+      {...overrides}
+    />
+  );
+  return { onRetry };
+}
+
+describe("TerminalAttachErrorBanner", () => {
+  it("passes the terminal id to the retry handler", () => {
+    const { onRetry } = renderBanner({ terminalId: "term-42" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(onRetry).toHaveBeenCalledWith("term-42");
+  });
+
+  it("reassures the user the process is still alive", () => {
+    // The failure looks exactly like a hung agent from the outside, and that is
+    // the wrong conclusion — the PTY is healthy and still recording.
+    renderBanner({});
+
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /process is still running and its output is being recorded/i
+    );
+  });
+
+  it("surfaces the underlying error text", () => {
+    renderBanner({ error: "boom-specific-detail" });
+
+    expect(screen.getByRole("alert").textContent).toContain("boom-specific-detail");
+  });
+
+  it("renders without an error detail when the message is empty", () => {
+    renderBanner({ error: "" });
+
+    expect(screen.getByRole("alert").textContent).toMatch(/process is still running/i);
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("strips terminal escape sequences out of the error text", () => {
+    // The message can originate from terminal output, so it is untrusted.
+    const esc = String.fromCharCode(27);
+    renderBanner({ error: `${esc}[31mred${esc}[0m failure` });
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("red failure");
+    expect(alert.textContent).not.toContain(esc);
+    expect(alert.textContent).not.toContain("[31m");
+  });
+
+  it("disables the retry button while a rebuild is in flight", () => {
+    // The rebuild awaits an addon load, an open and a scrollback replay, so a
+    // second click mid-flight would queue a redundant teardown.
+    const { onRetry } = renderBanner({ isRetrying: true });
+
+    const button = screen.getByRole("button", { name: "Retry" });
+    expect(button.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(button);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("offers exactly one action and no dismiss", () => {
+    // CLAUDE.md: an error banner carries at most ONE contextual recovery
+    // action. Dismiss is deliberately absent — the banner is the only sign the
+    // pane is dead, so it clears when the rebuild succeeds, not on a wave-away.
+    renderBanner({});
+
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+});

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -94,6 +94,10 @@ const PTY_FIELD_CLASSIFICATION = {
   restartError: false,
   reconnectError: false,
   scrollbackRestoreError: false,
+  // Renderer attach failure (#11776) — a live signal about the CURRENT xterm
+  // instance. A restart builds a fresh one, so persisting it would resurrect a
+  // banner for a failure that no longer exists.
+  attachError: false,
   flowStatus: false,
   runtimeStatus: false,
   flowStatusTimestamp: false,

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1601,12 +1601,15 @@ class TerminalInstanceService {
   async recoverPoisonedTerminal(id: string, options?: { manual?: boolean }): Promise<boolean> {
     const managed = this.instances.get(id);
     if (!managed) return false;
-    if (managed.attachRecoveryInFlight) return managed.attachRecoveryInFlight;
-
     // A manual Retry is the user telling us conditions changed (they resized,
     // un-occluded the pane, or simply want another go), so it refills the
-    // automatic budget rather than being blocked by it.
+    // automatic budget rather than being blocked by it. Applied BEFORE the
+    // in-flight check: the loop re-reads the budget each iteration, so a click
+    // landing during the final automatic attempt still buys more attempts
+    // instead of being swallowed by the shared promise.
     if (options?.manual === true) managed.attachRecoveryAttempts = 0;
+
+    if (managed.attachRecoveryInFlight) return managed.attachRecoveryInFlight;
 
     const run = this.runRecoveryAttempts(id, managed)
       // The loop is started with `void` from a synchronous open failure, so an
@@ -1669,12 +1672,39 @@ class TerminalInstanceService {
    * would open cleanly and then sit there receiving nothing, which is a worse
    * bug than the one being fixed.
    *
-   * Parsing does not need a renderer, so a poisoned terminal still drains
-   * normally; the timeout only exists so a genuinely wedged parser degrades to
-   * "try again later" instead of taking the dispose path anyway.
+   * One sentinel is not enough. A poisoned terminal is usually still receiving
+   * output at full rate, so fresh batches land BEHIND the sentinel while it
+   * waits — their callbacks would be exactly the ones dropped. Re-arm until the
+   * ack-bearing queue is actually empty, bounded by one shared deadline.
+   *
+   * Parsing does not need a renderer, so a poisoned terminal does drain; the
+   * deadline only exists so a terminal streaming without pause degrades to "try
+   * again later" rather than taking the dispose path anyway.
    */
-  private drainWritesBeforeDispose(id: string, managed: ManagedTerminal): Promise<boolean> {
-    if ((managed.pendingWrites ?? 0) === 0) return Promise.resolve(true);
+  private async drainWritesBeforeDispose(id: string, managed: ManagedTerminal): Promise<boolean> {
+    const deadline = Date.now() + ATTACH_RECOVERY_DRAIN_TIMEOUT_MS;
+    // At least one pass runs unconditionally: `pendingWrites` counts only
+    // ack-bearing batches, and untracked writes (scrollback replay, the
+    // data-loss marker) can still be sitting in the buffer ahead of us.
+    for (;;) {
+      if (!(await this.queueDrainSentinel(id, managed, deadline))) return false;
+      if ((managed.pendingWrites ?? 0) === 0) return true;
+      if (Date.now() >= deadline) {
+        logWarn("[TIS] Writes kept arriving during the pre-rebuild drain", {
+          id,
+          pendingWrites: managed.pendingWrites ?? 0,
+        });
+        return false;
+      }
+    }
+  }
+
+  /** One FIFO barrier through xterm's write queue. */
+  private queueDrainSentinel(
+    id: string,
+    managed: ManagedTerminal,
+    deadline: number
+  ): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       let settled = false;
       const finish = (drained: boolean) => {
@@ -1683,19 +1713,24 @@ class TerminalInstanceService {
         clearTimeout(timer);
         resolve(drained);
       };
-      const timer = setTimeout(() => {
-        logWarn("[TIS] Timed out draining writes before rebuild", {
-          id,
-          pendingWrites: managed.pendingWrites ?? 0,
-        });
-        finish(false);
-      }, ATTACH_RECOVERY_DRAIN_TIMEOUT_MS);
+      const timer = setTimeout(
+        () => {
+          logWarn("[TIS] Timed out draining writes before rebuild", {
+            id,
+            pendingWrites: managed.pendingWrites ?? 0,
+          });
+          finish(false);
+        },
+        Math.max(0, deadline - Date.now())
+      );
       try {
         // An empty write parses to nothing but still queues behind everything
         // already in the buffer, so its callback fires only once the backlog —
         // and every ack riding those earlier callbacks — has landed.
         managed.terminal.write("", () => finish(true));
       } catch (error) {
+        // Over the discard watermark, or already disposed. Either way we cannot
+        // establish the barrier, so we must not dispose.
         logWarn("[TIS] Could not queue a drain write before rebuild", { id, error });
         finish(false);
       }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -44,6 +44,7 @@ import {
   type TerminalListenerInstallDeps,
 } from "./TerminalListenerInstaller";
 import { reduceScrollback, restoreScrollback } from "./TerminalScrollbackController";
+import { hasUsableRenderer } from "./xtermRendererProbe";
 import { DEFAULT_TERMINAL_FONT_FAMILY, onTerminalFontArrivedLate } from "@/config/terminalFont";
 import { isPtyPanel } from "@shared/types/panel";
 import { isValidTerminalGeometry, type TerminalGeometry } from "@shared/types/terminal";
@@ -52,6 +53,7 @@ import { applyXtermReflowFastpath } from "@shared/utils/xtermReflowFastpath";
 import { usePanelStore } from "@/store/panelStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { logDebug, logWarn, logError } from "@/utils/logger";
+import { getErrorMessage } from "@/utils/errorContext";
 import { PaintFabricCompositor } from "./paintFabric/PaintFabricCompositor";
 import type { PaintSurface } from "./paintFabric/PaintSurfaceRegistry";
 import { createRoundRobinPlacement } from "./paintFabric/placementPolicies";
@@ -65,6 +67,14 @@ import { TerminalWorkerIngestController } from "./TerminalWorkerIngestController
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { stripAnsiAndOscCodes } from "@shared/utils/urlUtils";
+
+/**
+ * Automatic rebuild budget for a terminal that cannot be opened (#11776).
+ * Three is enough to ride out a transient cause (a view mid-teardown, a host
+ * that was momentarily unmeasurable) without turning a genuinely unrenderable
+ * pane into a rebuild loop. The user's Retry resets it.
+ */
+const MAX_ATTACH_RECOVERY_ATTEMPTS = 3;
 
 export { isNonKeyboardInput } from "./inputUtils";
 // Re-exported so existing consumers (notably tests) that import
@@ -953,26 +963,10 @@ class TerminalInstanceService {
     onInput: ((data: string) => void) | undefined,
     getCwd: (() => string) | undefined
   ): Promise<ManagedTerminal> {
-    const openLink = (url: string, event?: MouseEvent) => {
-      this.linkHandler.openLink(url, id, event);
-    };
-
-    const setHoveredLink = (link: TerminalLink | null) => {
-      const current = this.instances.get(id);
-      if (!current) return;
-      current.hoveredLink = link;
-    };
-
     const terminalOptions = {
       ...options,
       rescaleOverlappingGlyphs: true,
-      linkHandler: {
-        activate: (event: MouseEvent, text: string) => openLink(text, event),
-        hover: (_event: MouseEvent, text: string, range: IBufferRange) => {
-          setHoveredLink(this.makeSyntheticLink(text, range, id));
-        },
-        leave: () => setHoveredLink(null),
-      },
+      linkHandler: this.makeTerminalLinkHandler(id),
     };
 
     if (launchAgentId !== undefined) {
@@ -1376,14 +1370,34 @@ class TerminalInstanceService {
     // concurrently (the cold-open path in ensureOpened() and the BACKGROUND→
     // active tier-upgrade path), so re-check the slot after the await and dispose
     // the loser to avoid loading two addons onto one terminal.
-    if (!managed.imageAddon) {
+    // ImageAddon is the one deferred addon that must NOT be built against a
+    // terminal without a live renderer (#11776). Its ImageRenderer constructor
+    // monkey-patches `_core.open` with a wrapper that unconditionally reads
+    // `_core._renderService.setRenderer`, and that wrapper runs even on xterm's
+    // silent early-return path. Installed on a never-opened terminal — which
+    // `onTierApplied` does on any non-BACKGROUND tier — it converts a single
+    // failed open into a permanent, self-re-throwing wedge: every subsequent
+    // open() attempt dies in the patch instead of rebuilding the renderer.
+    // Deferring it until the terminal actually paints keeps the thrower out of
+    // open() entirely; the tier-upgrade path rebuilds it once the pane opens.
+    if (!managed.imageAddon && managed.isOpened && hasUsableRenderer(managed.terminal)) {
+      // Captured before the await: a rebuild swaps `managed.terminal` while
+      // keeping the same ManagedTerminal, so the instances-map check below
+      // cannot see it. Without this, an import that resolves after a rebuild
+      // would load the old terminal's addon onto the new one.
+      const builtFor = managed.terminal;
       try {
         const imageAddon = await createImageAddon(managed.terminal);
         // Dispose the loser rather than leak it if, during the async import, a
         // concurrent caller already populated the slot OR the terminal was
         // destroyed/replaced (its instance is no longer the one in the map, so
-        // its own teardown will never dispose this addon).
-        if (managed.imageAddon || this.instances.get(id) !== managed) {
+        // its own teardown will never dispose this addon), OR this terminal was
+        // rebuilt out from under us.
+        if (
+          managed.imageAddon ||
+          this.instances.get(id) !== managed ||
+          managed.terminal !== builtFor
+        ) {
           imageAddon.dispose();
         } else {
           managed.imageAddon = imageAddon;
@@ -1424,12 +1438,39 @@ class TerminalInstanceService {
       typeof performance !== "undefined" ? performance.now() : Date.now();
     managed.hasEmittedFirstWriteMark = false;
     markRendererPerformance(PERF_MARKS.TERMINAL_OPEN_START, { terminalId: id });
+    // Was try/finally (#11776). A throw out of open() propagated all the way to
+    // XtermAdapter's IIFE catch, which aborted the REST of attach — the exit
+    // listener and the scrollback restore never registered — and surfaced
+    // nowhere but a console line. Classify the failure here instead: the caller
+    // gets a terminal that is honestly "not opened", and the recovery path
+    // below owns getting it painting again.
+    let openError: unknown;
     try {
       managed.terminal.open(managed.hostElement);
+    } catch (err) {
+      openError = err;
     } finally {
       markRendererPerformance(PERF_MARKS.TERMINAL_OPEN_END, { terminalId: id });
     }
+
+    // A clean return is not proof of success. On an already-poisoned instance
+    // xterm's re-entry guard early-returns *silently* (no throw) while
+    // `_renderService` stays undefined, so trusting the absence of an
+    // exception is exactly how `isOpened` ends up true on a pane that can
+    // never paint. Verify the renderer actually exists before claiming it.
+    if (openError === undefined && !hasUsableRenderer(managed.terminal)) {
+      openError = new Error(
+        "xterm.open() returned without building a renderer (terminal is unpaintable)"
+      );
+    }
+
+    if (openError !== undefined) {
+      this.handleFailedOpen(id, managed, openError);
+      return;
+    }
+
     managed.isOpened = true;
+    this.clearAttachError(id, managed);
     logDebug(`[TIS] Opened terminal ${id}`);
     // Build the deferred Image/link addons now that the terminal is live.
     // EXPERIMENT (hibernation removal, Codex review fix — Finding 3): build them
@@ -1441,6 +1482,298 @@ class TerminalInstanceService {
     if (this.webGLPolicy.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
       this.webGLManager.ensureContext(id, managed);
     }
+  }
+
+  /**
+   * The xterm `linkHandler` option, keyed by terminal id. Shared by the
+   * creation path and the #11776 rebuild so a replacement terminal links
+   * exactly like the one it replaces — the handlers close over `id` and read
+   * the live instance, never a captured `ManagedTerminal`, so they stay correct
+   * across a swap.
+   */
+  private makeTerminalLinkHandler(id: string) {
+    const setHoveredLink = (link: TerminalLink | null) => {
+      const current = this.instances.get(id);
+      if (!current) return;
+      current.hoveredLink = link;
+    };
+
+    return {
+      activate: (event: MouseEvent, text: string) => this.linkHandler.openLink(text, id, event),
+      hover: (_event: MouseEvent, text: string, range: IBufferRange) => {
+        setHoveredLink(this.makeSyntheticLink(text, range, id));
+      },
+      leave: () => setHoveredLink(null),
+    };
+  }
+
+  /**
+   * Options for a replacement terminal (#11776). Sourced from the live
+   * instance's own `options` rather than a remembered creation snapshot, so
+   * everything applied since — font changes, agent promotion's cursorBlink
+   * clamp, theme updates — carries across the rebuild. The link handler is
+   * rebuilt rather than copied: the old one is fine, but re-deriving keeps the
+   * two construction paths on one definition.
+   */
+  private rebuildOptionsFor(managed: ManagedTerminal): ConstructorParameters<typeof Terminal>[0] {
+    let inherited: Partial<Terminal["options"]> = {};
+    try {
+      inherited = { ...managed.terminal.options };
+    } catch (error) {
+      logWarn("[TIS] Could not read options off the terminal being rebuilt", {
+        id: managed.id,
+        error,
+      });
+    }
+    return {
+      ...inherited,
+      rescaleOverlappingGlyphs: true,
+      linkHandler: this.makeTerminalLinkHandler(managed.id),
+    };
+  }
+
+  /**
+   * Record a failed open and schedule recovery (#11776).
+   *
+   * Deliberately does NOT rethrow. The previous behaviour let the error escape
+   * `attach()` into XtermAdapter's catch, which skipped every remaining attach
+   * step and left the user with a blank pane and no signal. Failing quietly
+   * here, publishing the error to the panel store, and rebuilding in the
+   * background is strictly more recoverable.
+   */
+  private handleFailedOpen(id: string, managed: ManagedTerminal, error: unknown): void {
+    const message = getErrorMessage(error);
+    managed.isOpened = false;
+    managed.lastAttachError = message;
+    logError("[TIS] Terminal open failed", error, { id });
+    // Optional-called: many suites stub usePanelStore with a partial action
+    // surface, and a missing banner setter must not turn a recoverable open
+    // failure into a thrown one.
+    usePanelStore.getState().setTerminalAttachError?.(id, message);
+    void this.recoverPoisonedTerminal(id);
+  }
+
+  /** Drop a resolved attach failure from both the instance and the pane. */
+  private clearAttachError(id: string, managed: ManagedTerminal): void {
+    managed.attachRecoveryAttempts = 0;
+    if (managed.lastAttachError === undefined) return;
+    managed.lastAttachError = undefined;
+    usePanelStore.getState().clearTerminalAttachError?.(id);
+  }
+
+  /**
+   * Rebuild a terminal whose xterm instance can no longer be opened (#11776).
+   *
+   * Retrying `open()` is structurally incapable of working: xterm's re-entry
+   * guard is satisfied by fields assigned before `_renderService`, so a
+   * half-opened instance early-returns forever. The only way back is a fresh
+   * `Terminal`. The `ManagedTerminal` itself survives — same id, same host
+   * element, same PTY, same subscribers — so the panel store, the agent state
+   * machine and the backend never see a lifecycle event; only the renderer-side
+   * object is swapped underneath.
+   *
+   * Scoped strictly to the terminal. Anything keyed on the PTY or the pane's
+   * identity (the leading `listeners` entries, exit/agent-state/alt-buffer
+   * subscribers, the restore controller's deferred-output ledger, the port-ack
+   * FIFO) is left alone — tearing those down is what `destroy()` is for, and
+   * doing it here would drop output the rebuild is meant to preserve.
+   *
+   * Bounded and deduplicated: concurrent triggers (attach, reveal, the
+   * watchdog, the banner's Retry) share one in-flight rebuild, and automatic
+   * attempts stop after {@link MAX_ATTACH_RECOVERY_ATTEMPTS} so a host that is
+   * genuinely never renderable degrades to a banner instead of looping.
+   */
+  async recoverPoisonedTerminal(id: string, options?: { manual?: boolean }): Promise<boolean> {
+    const managed = this.instances.get(id);
+    if (!managed) return false;
+    if (managed.attachRecoveryInFlight) return managed.attachRecoveryInFlight;
+
+    const isManual = options?.manual === true;
+    const attempts = managed.attachRecoveryAttempts ?? 0;
+    if (!isManual && attempts >= MAX_ATTACH_RECOVERY_ATTEMPTS) {
+      logWarn("[TIS] Terminal rebuild attempts exhausted — leaving the banner up", {
+        id,
+        attempts,
+      });
+      return false;
+    }
+    // A manual Retry is the user telling us the conditions changed (they
+    // resized, un-occluded, or simply want another go), so it resets the
+    // automatic budget rather than being blocked by it.
+    managed.attachRecoveryAttempts = isManual ? 1 : attempts + 1;
+
+    const run = this.rebuildTerminalInstance(id, managed).finally(() => {
+      managed.attachRecoveryInFlight = undefined;
+    });
+    managed.attachRecoveryInFlight = run;
+    return run;
+  }
+
+  private async rebuildTerminalInstance(id: string, managed: ManagedTerminal): Promise<boolean> {
+    // Opening against a zero-box host is a plausible cause of the original
+    // failure, so a rebuild that ignored it would just poison the fresh
+    // instance too. Leave the banner up; the reveal pass retries once the pane
+    // has real layout.
+    if (!this.hostHasRenderableDims(managed)) {
+      logDebug(`[TIS] Deferring rebuild of ${id} — host has no renderable box yet`);
+      return false;
+    }
+
+    logWarn("[TIS] Rebuilding unpaintable terminal", { id, error: managed.lastAttachError });
+
+    try {
+      this.teardownTerminalForRebuild(id, managed);
+    } catch (error) {
+      logError("[TIS] Failed to tear down terminal for rebuild", error, { id });
+      return false;
+    }
+
+    let terminal: Terminal;
+    try {
+      terminal = new Terminal(this.rebuildOptionsFor(managed));
+      applyXtermReflowFastpath(terminal);
+      const addons = await setupTerminalAddons(terminal);
+      // The instance can be destroyed while we await the (module-cached, but
+      // still async) addon setup. Bail before publishing the new terminal.
+      if (this.instances.get(id) !== managed) {
+        terminal.dispose();
+        return false;
+      }
+      Object.assign(managed, addons);
+      managed.terminal = terminal;
+    } catch (error) {
+      logError("[TIS] Failed to construct replacement terminal", error, { id });
+      return false;
+    }
+
+    // Same shared installer every other construction path uses — never a
+    // hand-rolled subset, or the rebuilt pane silently loses copy-on-select,
+    // title forwarding and the agent-state hooks.
+    managed.parserHandler = new TerminalParserHandler(
+      managed,
+      () => this.resizeController.applyDeferredResize(id),
+      (droppedBytes) => this.drawDataLossMarker(id, droppedBytes)
+    );
+    installTerminalBoundListeners(terminal, managed, id, this.makeListenerInstallDeps());
+
+    // XtermAdapter installs this once per mount and will not re-run for a
+    // rebuild, so re-attach it here; `keyHandlerInstalled` staying true against
+    // a handler-less Terminal would leave the pane unable to take input.
+    if (managed.customKeyEventHandler) {
+      terminal.attachCustomKeyEventHandler(managed.customKeyEventHandler);
+    } else {
+      managed.keyHandlerInstalled = false;
+    }
+
+    // Geometry dedup caches describe the disposed instance's grid.
+    managed.lastWidth = 0;
+    managed.lastHeight = 0;
+    managed.pendingWrites = 0;
+    managed.writeChain = Promise.resolve();
+    managed.isOpened = false;
+
+    this.ensureOpened(id, managed);
+    if (!managed.isOpened) {
+      // ensureOpened already recorded the failure and re-armed recovery.
+      logWarn("[TIS] Replacement terminal failed to open", { id });
+      return false;
+    }
+
+    this.rendererPolicy.applyRendererPolicy(
+      id,
+      managed.getRefreshTier?.() ?? managed.lastAppliedTier ?? TerminalRefreshTier.FOCUSED
+    );
+
+    // Repopulate from the headless mirror. The disposed instance's buffer went
+    // with it, and it never painted anything the user saw anyway, so this is
+    // the scrollback — not a nicety.
+    try {
+      await this.restoreController.fetchAndRestore(id);
+    } catch (error) {
+      logWarn("[TIS] Rebuilt terminal could not restore scrollback", {
+        id,
+        error: getErrorMessage(error),
+      });
+    }
+
+    logDebug(`[TIS] Rebuilt terminal ${id}`);
+    return true;
+  }
+
+  /**
+   * Terminal-scoped teardown for {@link rebuildTerminalInstance} — the subset
+   * of `destroy()` that belongs to the xterm instance rather than to the pane.
+   */
+  private teardownTerminalForRebuild(id: string, managed: ManagedTerminal): void {
+    this.cancelAttachReveal(managed);
+    this.resizeController.clearResizeJob(managed);
+    this.resizeController.clearSettledTimer(id);
+    this.writeController.forget(id);
+    this.cancelWebGLHideTimer(managed);
+    if (managed.webGLRestoreTimer !== undefined) {
+      clearTimeout(managed.webGLRestoreTimer);
+      managed.webGLRestoreTimer = undefined;
+    }
+    if (managed.tierChangeTimer !== undefined) {
+      clearTimeout(managed.tierChangeTimer);
+      managed.tierChangeTimer = undefined;
+    }
+
+    // Only the xterm-bound tail. The leading entries unsubscribe the PTY data
+    // and exit streams, which must keep running across the swap — dropping them
+    // would silently detach the pane from its process.
+    const boundStart = managed.ipcListenerCount;
+    for (const unsub of managed.listeners.slice(boundStart)) {
+      try {
+        unsub();
+      } catch (error) {
+        logWarn("Error unsubscribing terminal-bound listener during rebuild", { id, error });
+      }
+    }
+    managed.listeners.length = boundStart;
+
+    managed.parserHandler?.dispose();
+    managed.parserHandler = undefined;
+
+    managed.lastActivityMarker?.dispose();
+    managed.lastActivityMarker = undefined;
+    managed.postCompleteMarker?.dispose();
+    managed.postCompleteMarker = undefined;
+
+    // ImageAddon first and by name: its dispose() is what restores the
+    // `_core.open` it monkey-patched. Disposing the terminal with the patch
+    // still installed is how the wedge survives a rebuild.
+    for (const [label, disposable] of [
+      ["image addon", managed.imageAddon],
+      ["file links", managed.fileLinksDisposable],
+      ["image links", managed.imageLinksDisposable],
+      ["web links", managed.webLinksAddon],
+    ] as const) {
+      try {
+        disposable?.dispose();
+      } catch (error) {
+        logWarn(`Error disposing ${label} during rebuild`, { id, error });
+      }
+    }
+    managed.imageAddon = null;
+    managed.fileLinksDisposable = null;
+    managed.imageLinksDisposable = null;
+    managed.webLinksAddon = null;
+
+    // Before dispose: the manager holds pool/lease references to this exact
+    // Terminal, and releasing them afterwards would touch a dead object.
+    this.webGLManager.onTerminalDestroyed(id);
+
+    try {
+      managed.terminal.dispose();
+    } catch (error) {
+      logWarn("Error disposing terminal during rebuild", { id, error });
+    }
+
+    // xterm removes its own `.xterm` element on dispose, but a terminal that
+    // threw partway through open() may have left one behind — the host is
+    // reused as-is for the new open(), so clear any orphan.
+    managed.hostElement.replaceChildren();
   }
 
   /**

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1546,19 +1546,42 @@ class TerminalInstanceService {
    * Deliberately does NOT rethrow. The previous behaviour let the error escape
    * `attach()` into XtermAdapter's catch, which skipped every remaining attach
    * step and left the user with a blank pane and no signal. Failing quietly
-   * here, publishing the error to the panel store, and rebuilding in the
-   * background is strictly more recoverable.
+   * here and rebuilding in the background is strictly more recoverable.
+   *
+   * The diagnostic (`lastAttachError`) is recorded immediately; the T3 pane
+   * banner is NOT. A failed open is an auto-recovering state, and publishing it
+   * here made every self-healing attach flash a red "Terminal display failed"
+   * that `clearAttachError` retracted a few frames later — the rebuild always
+   * crosses a drain sentinel, an addon await and an `open()` reflow, so React
+   * gets to paint it. {@link publishUnrecoveredAttachError} raises the banner
+   * once recovery has actually failed to restore the pane, per the runtime-signal
+   * tiering rule (auto-recovering stays quiet until recovery is exhausted).
    */
   private handleFailedOpen(id: string, managed: ManagedTerminal, error: unknown): void {
-    const message = getErrorMessage(error);
     managed.isOpened = false;
-    managed.lastAttachError = message;
+    managed.lastAttachError = getErrorMessage(error);
     logError("[TIS] Terminal open failed", error, { id });
+    void this.recoverPoisonedTerminal(id);
+  }
+
+  /**
+   * Escalate an attach failure to the pane once rebuilding has given up.
+   *
+   * Called from every path where recovery resolves false — a failed attempt, a
+   * deferred one (no measurable host yet), or the exhausted budget. Guarded on
+   * the pane still being broken and still being the instance we started with, so
+   * a rebuild that succeeded on a later attempt, or a terminal destroyed/replaced
+   * mid-recovery, never raises a banner for a pane that is painting fine.
+   */
+  private publishUnrecoveredAttachError(id: string, managed: ManagedTerminal): void {
+    if (this.instances.get(id) !== managed) return;
+    if (managed.isOpened) return;
+    const message = managed.lastAttachError;
+    if (message === undefined) return;
     // Optional-called: many suites stub usePanelStore with a partial action
     // surface, and a missing banner setter must not turn a recoverable open
     // failure into a thrown one.
     usePanelStore.getState().setTerminalAttachError?.(id, message);
-    void this.recoverPoisonedTerminal(id);
   }
 
   /**
@@ -1621,6 +1644,14 @@ class TerminalInstanceService {
       })
       .finally(() => {
         managed.attachRecoveryInFlight = undefined;
+      })
+      // The single escalation point: recovery is over and, on false, the pane is
+      // still unpaintable — a failed attempt, one deferred for want of a
+      // measurable host, or the exhausted budget. Raising the banner here rather
+      // than on the first failed open is what keeps a self-healing attach silent.
+      .then((recovered) => {
+        if (!recovered) this.publishUnrecoveredAttachError(id, managed);
+        return recovered;
       });
     managed.attachRecoveryInFlight = run;
     return run;
@@ -1820,8 +1851,26 @@ class TerminalInstanceService {
     // The worker-ingest resize bridge is an xterm-bound listener that the
     // shared installer does not own, so the teardown dropped it and nothing
     // else would put it back — leaving the background mirror parsing at a
-    // frozen geometry.
+    // frozen geometry. Bind only here; the mirror's geometry seed waits for the
+    // open below, or it would park at the construction grid.
     this.workerIngestController.rebindTerminal(id, managed);
+
+    // The replacement was CONSTRUCTED at whatever cols/rows the dead instance's
+    // options carried, which is NOT its live grid: xterm copies the grid into
+    // `options.cols/rows` only in `reset()`, never in `resize()`, so anything
+    // resized since construction hands over a stale size — 80x24 for the common
+    // case. Seed the open-time target so `ensureOpened` sizes the grid before
+    // `open()`, and before the replay below reads it as the grid to reflow back
+    // to (a wrong seed there is the #11718/#11552 corruption family: a pane
+    // parsing a ~200-column agent at 80 columns, and a snapshot replayed then
+    // snapped to a width it was never captured at). Same idiom as
+    // `detachForProjectSwitch`: background-tier resizes only ever write
+    // latestCols/latestRows, so those are the only record of the real grid.
+    const seededTargetGeometry = !managed.targetCols && managed.latestCols > 0;
+    if (seededTargetGeometry) {
+      managed.targetCols = managed.latestCols;
+      managed.targetRows = managed.latestRows;
+    }
 
     this.ensureOpened(id, managed);
     if (!managed.isOpened) {
@@ -1831,10 +1880,31 @@ class TerminalInstanceService {
       return "failed";
     }
 
+    // Consumed by the open above. Leaving a target we invented behind would make
+    // the next reparent-attach apply it instead of fitting, pinning the pane to
+    // this grid after its container had changed size.
+    if (seededTargetGeometry) {
+      managed.targetCols = undefined;
+      managed.targetRows = undefined;
+    }
+
+    this.workerIngestController.reseedMirrorGeometry(id, managed);
+
     this.rendererPolicy.applyRendererPolicy(
       id,
       managed.getRefreshTier?.() ?? managed.lastAppliedTier ?? TerminalRefreshTier.FOCUSED
     );
+
+    // Measure against the host now that the pane can paint. Nothing else will:
+    // `attach()`'s nested-rAF fit is gated on `isOpened`, which the failed open
+    // had already set false, and the ResizeObserver stays quiet because the host
+    // box never changed. Without this a rebuild triggered from a cold attach —
+    // no measured grid to seed from above — would sit on xterm's 80x24 default
+    // until the user happened to resize the window. Runs BEFORE the replay so
+    // the restore's geometry seed reads the settled grid; a no-op while resizes
+    // are locked or the host is unmeasurable, and idempotent when the seed
+    // already landed the right size.
+    this.resizeController.fit(id);
 
     // Repopulate from the headless mirror. The disposed instance's buffer went
     // with it, and it never painted anything the user saw anyway, so this is

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -76,6 +76,14 @@ import { stripAnsiAndOscCodes } from "@shared/utils/urlUtils";
  */
 const MAX_ATTACH_RECOVERY_ATTEMPTS = 3;
 
+/**
+ * How long a rebuild waits for xterm's write queue to settle before giving up
+ * on the attempt. Generous on purpose: exceeding it means abandoning the
+ * rebuild entirely (disposing with writes in flight would strand flow-control
+ * credit), so a slow drain should wait rather than skip.
+ */
+const ATTACH_RECOVERY_DRAIN_TIMEOUT_MS = 2000;
+
 export { isNonKeyboardInput } from "./inputUtils";
 // Re-exported so existing consumers (notably tests) that import
 // `forceXtermReflow` from this module don't need to update their imports.
@@ -1553,10 +1561,17 @@ class TerminalInstanceService {
     void this.recoverPoisonedTerminal(id);
   }
 
-  /** Drop a resolved attach failure from both the instance and the pane. */
+  /**
+   * Drop a resolved attach failure from both the instance and the pane.
+   *
+   * The store write is unconditional, NOT gated on this instance having
+   * recorded an error. A restart or any same-id recreation hands us a brand-new
+   * ManagedTerminal with a clean `lastAttachError` while the pane still carries
+   * the previous instance's banner — gating on the local flag would leave that
+   * banner up forever behind a terminal that is painting fine.
+   */
   private clearAttachError(id: string, managed: ManagedTerminal): void {
     managed.attachRecoveryAttempts = 0;
-    if (managed.lastAttachError === undefined) return;
     managed.lastAttachError = undefined;
     usePanelStore.getState().clearTerminalAttachError?.(id);
   }
@@ -1588,36 +1603,123 @@ class TerminalInstanceService {
     if (!managed) return false;
     if (managed.attachRecoveryInFlight) return managed.attachRecoveryInFlight;
 
-    const isManual = options?.manual === true;
-    const attempts = managed.attachRecoveryAttempts ?? 0;
-    if (!isManual && attempts >= MAX_ATTACH_RECOVERY_ATTEMPTS) {
-      logWarn("[TIS] Terminal rebuild attempts exhausted — leaving the banner up", {
-        id,
-        attempts,
-      });
-      return false;
-    }
-    // A manual Retry is the user telling us the conditions changed (they
-    // resized, un-occluded, or simply want another go), so it resets the
+    // A manual Retry is the user telling us conditions changed (they resized,
+    // un-occluded the pane, or simply want another go), so it refills the
     // automatic budget rather than being blocked by it.
-    managed.attachRecoveryAttempts = isManual ? 1 : attempts + 1;
+    if (options?.manual === true) managed.attachRecoveryAttempts = 0;
 
-    const run = this.rebuildTerminalInstance(id, managed).finally(() => {
-      managed.attachRecoveryInFlight = undefined;
-    });
+    const run = this.runRecoveryAttempts(id, managed)
+      // The loop is started with `void` from a synchronous open failure, so an
+      // escaping rejection would surface as an unhandled promise rejection with
+      // no owner. Contain it here and report the honest boolean.
+      .catch((error: unknown) => {
+        logError("[TIS] Terminal rebuild threw", error, { id });
+        return false;
+      })
+      .finally(() => {
+        managed.attachRecoveryInFlight = undefined;
+      });
     managed.attachRecoveryInFlight = run;
     return run;
   }
 
-  private async rebuildTerminalInstance(id: string, managed: ManagedTerminal): Promise<boolean> {
+  /**
+   * Drive rebuild attempts until one paints or the budget runs out.
+   *
+   * The loop lives here rather than relying on the failure path re-triggering
+   * itself: a replacement that also fails calls `handleFailedOpen`, which
+   * re-enters `recoverPoisonedTerminal` and gets handed the very promise this
+   * loop is running under. Without an explicit loop that re-entry is a no-op
+   * and the advertised budget silently collapses to a single attempt.
+   */
+  private async runRecoveryAttempts(id: string, managed: ManagedTerminal): Promise<boolean> {
+    for (;;) {
+      const attempts = managed.attachRecoveryAttempts ?? 0;
+      if (attempts >= MAX_ATTACH_RECOVERY_ATTEMPTS) {
+        logWarn("[TIS] Terminal rebuild attempts exhausted — leaving the banner up", {
+          id,
+          attempts,
+        });
+        return false;
+      }
+
+      const outcome = await this.rebuildTerminalInstance(id, managed);
+      if (outcome === "rebuilt") return true;
+      // Deferred is not a failed attempt — the host simply had no layout box
+      // yet, so it must not burn budget. A later attach/reveal/watchdog pass
+      // retries once the pane is measurable.
+      if (outcome === "deferred") return false;
+
+      managed.attachRecoveryAttempts = attempts + 1;
+      // Destroyed or replaced while we were awaiting — there is nothing left to
+      // rebuild, and looping would resurrect a dead id.
+      if (this.instances.get(id) !== managed) return false;
+    }
+  }
+
+  /**
+   * Settle xterm's write queue before the instance is disposed.
+   *
+   * Disposing with writes still queued is silently destructive: xterm's
+   * `WriteBuffer` drops its pending callbacks on dispose rather than invoking
+   * them, and those callbacks are what send the port ack, return flow-control
+   * credit to the pty-host, and decrement the ingest's in-flight byte count.
+   * Losing them leaves the backend believing this terminal is still chewing
+   * through a batch, so it throttles or stops streaming — the rebuilt pane
+   * would open cleanly and then sit there receiving nothing, which is a worse
+   * bug than the one being fixed.
+   *
+   * Parsing does not need a renderer, so a poisoned terminal still drains
+   * normally; the timeout only exists so a genuinely wedged parser degrades to
+   * "try again later" instead of taking the dispose path anyway.
+   */
+  private drainWritesBeforeDispose(id: string, managed: ManagedTerminal): Promise<boolean> {
+    if ((managed.pendingWrites ?? 0) === 0) return Promise.resolve(true);
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (drained: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(drained);
+      };
+      const timer = setTimeout(() => {
+        logWarn("[TIS] Timed out draining writes before rebuild", {
+          id,
+          pendingWrites: managed.pendingWrites ?? 0,
+        });
+        finish(false);
+      }, ATTACH_RECOVERY_DRAIN_TIMEOUT_MS);
+      try {
+        // An empty write parses to nothing but still queues behind everything
+        // already in the buffer, so its callback fires only once the backlog —
+        // and every ack riding those earlier callbacks — has landed.
+        managed.terminal.write("", () => finish(true));
+      } catch (error) {
+        logWarn("[TIS] Could not queue a drain write before rebuild", { id, error });
+        finish(false);
+      }
+    });
+  }
+
+  private async rebuildTerminalInstance(
+    id: string,
+    managed: ManagedTerminal
+  ): Promise<"rebuilt" | "deferred" | "failed"> {
     // Opening against a zero-box host is a plausible cause of the original
     // failure, so a rebuild that ignored it would just poison the fresh
     // instance too. Leave the banner up; the reveal pass retries once the pane
     // has real layout.
     if (!this.hostHasRenderableDims(managed)) {
       logDebug(`[TIS] Deferring rebuild of ${id} — host has no renderable box yet`);
-      return false;
+      return "deferred";
     }
+
+    // Before anything is torn down: an undrainable buffer means we must not
+    // dispose at all (see drainWritesBeforeDispose).
+    if (!(await this.drainWritesBeforeDispose(id, managed))) return "deferred";
+    // Destroyed while draining.
+    if (this.instances.get(id) !== managed) return "failed";
 
     logWarn("[TIS] Rebuilding unpaintable terminal", { id, error: managed.lastAttachError });
 
@@ -1625,10 +1727,10 @@ class TerminalInstanceService {
       this.teardownTerminalForRebuild(id, managed);
     } catch (error) {
       logError("[TIS] Failed to tear down terminal for rebuild", error, { id });
-      return false;
+      return "failed";
     }
 
-    let terminal: Terminal;
+    let terminal: Terminal | undefined;
     try {
       terminal = new Terminal(this.rebuildOptionsFor(managed));
       applyXtermReflowFastpath(terminal);
@@ -1637,13 +1739,21 @@ class TerminalInstanceService {
       // still async) addon setup. Bail before publishing the new terminal.
       if (this.instances.get(id) !== managed) {
         terminal.dispose();
-        return false;
+        return "failed";
       }
       Object.assign(managed, addons);
       managed.terminal = terminal;
     } catch (error) {
       logError("[TIS] Failed to construct replacement terminal", error, { id });
-      return false;
+      // The old instance is already disposed and `managed.terminal` may still
+      // point at it, so drop the half-built replacement rather than leaking a
+      // Terminal nothing will ever dispose.
+      try {
+        terminal?.dispose();
+      } catch {
+        /* the replacement never got far enough to need disposing */
+      }
+      return "failed";
     }
 
     // Same shared installer every other construction path uses — never a
@@ -1672,11 +1782,18 @@ class TerminalInstanceService {
     managed.writeChain = Promise.resolve();
     managed.isOpened = false;
 
+    // The worker-ingest resize bridge is an xterm-bound listener that the
+    // shared installer does not own, so the teardown dropped it and nothing
+    // else would put it back — leaving the background mirror parsing at a
+    // frozen geometry.
+    this.workerIngestController.rebindTerminal(id, managed);
+
     this.ensureOpened(id, managed);
     if (!managed.isOpened) {
-      // ensureOpened already recorded the failure and re-armed recovery.
+      // ensureOpened already recorded the failure; the recovery loop owns the
+      // next attempt.
       logWarn("[TIS] Replacement terminal failed to open", { id });
-      return false;
+      return "failed";
     }
 
     this.rendererPolicy.applyRendererPolicy(
@@ -1696,8 +1813,14 @@ class TerminalInstanceService {
       });
     }
 
+    // This rebuild IS an attach settling. `attach()`'s own failure path already
+    // released the waiters it knew about, but anything that registered between
+    // that failure and now is waiting on a terminal that has only just become
+    // paintable.
+    this.settleWaiters.notifyAttachSettledWaiters(id);
+
     logDebug(`[TIS] Rebuilt terminal ${id}`);
-    return true;
+    return "rebuilt";
   }
 
   /**
@@ -2998,6 +3121,11 @@ class TerminalInstanceService {
     if (!managed) return;
 
     this.settleWaiters.rejectAll(id);
+
+    // The attach banner describes an xterm instance that is about to stop
+    // existing (#11776). Its Retry would target a terminal this service no
+    // longer has, so drop the signal with the thing it described.
+    this.clearAttachError(id, managed);
 
     this.cancelAttachReveal(managed);
     this.agentStateController.destroy(id);

--- a/src/services/terminal/TerminalWorkerIngestController.ts
+++ b/src/services/terminal/TerminalWorkerIngestController.ts
@@ -145,14 +145,39 @@ export class TerminalWorkerIngestController {
       },
     });
 
-    // Geometry follows the mirror in every mode so demotion re-seeds at the
-    // right size (session forwards resizes only while in worker mode).
+    this.bindTerminalResize(managed, ingest);
+
+    return ingest;
+  }
+
+  /**
+   * Geometry follows the mirror in every mode so demotion re-seeds at the right
+   * size (the session forwards resizes only while in worker mode).
+   *
+   * Extracted so the #11776 rebuild can re-establish it: this is an
+   * xterm-bound listener, so a terminal swap disposes it along with the rest of
+   * the tail, but it is owned here rather than by
+   * `installTerminalBoundListeners` — nothing in the shared installer would put
+   * it back.
+   */
+  private bindTerminalResize(managed: ManagedTerminal, ingest: LiveWorkerIngest): void {
     const resizeDisposable = managed.terminal.onResize(({ cols, rows }) =>
       ingest.resize(cols, rows)
     );
     managed.listeners.push(() => resizeDisposable.dispose());
+  }
 
-    return ingest;
+  /**
+   * Re-attach this controller's terminal-bound listener after the xterm
+   * instance behind `id` was replaced (#11776). No-op when the terminal never
+   * had a worker ingest. Re-seeds the mirror geometry from the replacement,
+   * whose grid may differ from the one the old listener last reported.
+   */
+  rebindTerminal(id: string, managed: ManagedTerminal): void {
+    const ingest = this.workerIngest.get(id);
+    if (!ingest) return;
+    this.bindTerminalResize(managed, ingest);
+    ingest.resize(managed.terminal.cols, managed.terminal.rows);
   }
 
   // Worker ingest dies with the terminal: dispose terminates the Worker and

--- a/src/services/terminal/TerminalWorkerIngestController.ts
+++ b/src/services/terminal/TerminalWorkerIngestController.ts
@@ -170,13 +170,30 @@ export class TerminalWorkerIngestController {
   /**
    * Re-attach this controller's terminal-bound listener after the xterm
    * instance behind `id` was replaced (#11776). No-op when the terminal never
-   * had a worker ingest. Re-seeds the mirror geometry from the replacement,
-   * whose grid may differ from the one the old listener last reported.
+   * had a worker ingest.
+   *
+   * Binding only. The geometry re-seed is a separate call because the
+   * replacement terminal is still on its construction grid at this point —
+   * seeding here would park the headless mirror at xterm's 80x24 default and
+   * every subsequent snapshot would come back at that width. See
+   * {@link reseedMirrorGeometry}.
    */
   rebindTerminal(id: string, managed: ManagedTerminal): void {
     const ingest = this.workerIngest.get(id);
     if (!ingest) return;
     this.bindTerminalResize(managed, ingest);
+  }
+
+  /**
+   * Point the mirror at the replacement terminal's real grid (#11776). Called
+   * once the rebuilt terminal has actually opened and been sized, since only
+   * then does `terminal.cols/rows` describe the grid the pane is on — the
+   * `onResize` listener {@link rebindTerminal} installed reports later changes,
+   * but never the one the open itself applied.
+   */
+  reseedMirrorGeometry(id: string, managed: ManagedTerminal): void {
+    const ingest = this.workerIngest.get(id);
+    if (!ingest) return;
     ingest.resize(managed.terminal.cols, managed.terminal.rows);
   }
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.attachRecovery.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attachRecovery.test.ts
@@ -1,0 +1,469 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedTerminal } from "../types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({ visualBuffers: [], signalBuffer: null })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+// The replacement Terminal the rebuild constructs. Faked so the test controls
+// whether the fresh instance paints, which is the branch under test — a real
+// xterm in jsdom would decide that for us.
+//
+// Built inside vi.hoisted: vi.mock factories are hoisted above the module body,
+// so a class declared here normally would still be in its temporal dead zone
+// when the factory runs.
+const xtermHarness = vi.hoisted(() => {
+  const rebuiltTerminals: XtermFake[] = [];
+  const control = { opensCleanly: true, disposeCounter: 0 };
+
+  class XtermFake {
+    open = vi.fn(() => {
+      this.opened = true;
+    });
+    dispose = vi.fn(() => {
+      this.disposeOrder = ++control.disposeCounter;
+    });
+    resize = vi.fn();
+    refresh = vi.fn();
+    blur = vi.fn();
+    attachCustomKeyEventHandler = vi.fn();
+    loadAddon = vi.fn();
+    onRender = vi.fn(() => ({ dispose: vi.fn() }));
+    element = document.createElement("div");
+    rows = 24;
+    cols = 80;
+    options: Record<string, unknown> = { fontSize: 13 };
+    buffer = { active: { length: 0 } };
+    opened = false;
+    disposeOrder = 0;
+    opensCleanly = control.opensCleanly;
+
+    constructor() {
+      rebuiltTerminals.push(this);
+    }
+
+    get dimensions(): unknown {
+      return this.opened && this.opensCleanly
+        ? { css: { cell: { width: 8, height: 16 } } }
+        : undefined;
+    }
+  }
+
+  return { rebuiltTerminals, control, XtermFake };
+});
+
+const { rebuiltTerminals, control } = xtermHarness;
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: xtermHarness.XtermFake,
+}));
+
+vi.mock("@shared/utils/xtermReflowFastpath", () => ({
+  applyXtermReflowFastpath: vi.fn(),
+}));
+
+vi.mock("../TerminalListenerInstaller", () => ({
+  installTerminalBoundListeners: vi.fn(
+    (_terminal: unknown, managed: ManagedTerminal, _id: string) => {
+      managed.listeners.push(() => {});
+    }
+  ),
+}));
+
+vi.mock("../TerminalParserHandler", () => ({
+  // A class, not vi.fn(() => ...): the service calls it with `new`, and an
+  // arrow function is not constructible.
+  TerminalParserHandler: class {
+    dispose = vi.fn();
+  },
+}));
+
+const createImageAddonMock = vi.fn(async () => ({ dispose: vi.fn() }));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(async () => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: null,
+    searchAddon: {},
+    fileLinksDisposable: null,
+    imageLinksDisposable: null,
+    webLinksAddon: null,
+  })),
+  createImageAddon: createImageAddonMock,
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createImageLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+const setAttachError = vi.fn();
+const clearAttachError = vi.fn();
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: {
+    getState: () => ({
+      setTerminalAttachError: setAttachError,
+      clearTerminalAttachError: clearAttachError,
+      panelsById: {},
+    }),
+  },
+}));
+
+interface RecoveryTestService {
+  instances: Map<string, ManagedTerminal>;
+  attach: (id: string, container: HTMLElement) => ManagedTerminal | null;
+  recoverPoisonedTerminal: (id: string, options?: { manual?: boolean }) => Promise<boolean>;
+  restoreController: { fetchAndRestore: (id: string) => Promise<boolean> };
+  rendererPolicy: { applyRendererPolicy: (id: string, tier: number) => void };
+  webGLManager: { onTerminalDestroyed: (id: string) => void };
+  resizeController: { fit: (id: string) => void };
+}
+
+describe("TerminalInstanceService attach failure recovery (#11776)", () => {
+  let service: RecoveryTestService;
+
+  /**
+   * A terminal whose `open()` behaves like the poisoned instance: it may or may
+   * not throw, but either way it never produces dimensions — exactly what
+   * xterm's early-return path leaves behind once `_renderService` is missing.
+   */
+  const makeManaged = (
+    id: string,
+    terminalOverrides: Record<string, unknown> = {}
+  ): ManagedTerminal => {
+    const hostElement = document.createElement("div");
+    const ptyUnsubA = vi.fn();
+    const ptyUnsubB = vi.fn();
+    return {
+      id,
+      terminal: {
+        open: vi.fn(),
+        dispose: vi.fn(),
+        resize: vi.fn(),
+        refresh: vi.fn(),
+        blur: vi.fn(),
+        attachCustomKeyEventHandler: vi.fn(),
+        onRender: vi.fn(() => ({ dispose: vi.fn() })),
+        element: document.createElement("div"),
+        rows: 24,
+        options: { fontSize: 13 },
+        buffer: { active: { length: 0 } },
+        get dimensions() {
+          return undefined;
+        },
+        ...terminalOverrides,
+      },
+      hostElement,
+      isOpened: false,
+      // Two PTY-bound listeners then, conceptually, the terminal-bound tail.
+      listeners: [ptyUnsubA, ptyUnsubB],
+      ipcListenerCount: 2,
+      isVisible: true,
+      isDetached: false,
+      lastAttachAt: 0,
+      lastDetachAt: 0,
+      lastWidth: 0,
+      lastHeight: 0,
+      latestCols: 80,
+      latestRows: 24,
+      attachGeneration: 0,
+      attachRevealToken: 0,
+      exitSubscribers: new Set(),
+      agentStateSubscribers: new Set(),
+      altBufferListeners: new Set(),
+      keyHandlerInstalled: true,
+    } as unknown as ManagedTerminal;
+  };
+
+  /** Give the host a real layout box so the rebuild is allowed to proceed. */
+  const makeHostRenderable = (managed: ManagedTerminal) => {
+    const el = managed.hostElement;
+    document.body.appendChild(el);
+    Object.defineProperty(el, "clientWidth", { value: 800, configurable: true });
+    Object.defineProperty(el, "clientHeight", { value: 600, configurable: true });
+    el.checkVisibility = () => true;
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    rebuiltTerminals.length = 0;
+    control.disposeCounter = 0;
+    control.opensCleanly = true;
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: RecoveryTestService;
+      });
+    service.instances.clear();
+    vi.spyOn(service.restoreController, "fetchAndRestore").mockResolvedValue(true);
+    vi.spyOn(service.rendererPolicy, "applyRendererPolicy").mockImplementation(() => {});
+    vi.spyOn(service.resizeController, "fit").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    service.instances.clear();
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  describe("classifying the open", () => {
+    it("does not mark a terminal opened when open() throws", () => {
+      const managed = makeManaged("t1", {
+        open: vi.fn(() => {
+          throw new TypeError("Cannot read properties of undefined (reading 'setRenderer')");
+        }),
+      });
+      service.instances.set("t1", managed);
+
+      service.attach("t1", document.createElement("div"));
+
+      expect(managed.isOpened).toBe(false);
+      expect(managed.lastAttachError).toContain("setRenderer");
+    });
+
+    it("does not mark a terminal opened when open() returns but builds no renderer", () => {
+      // The silent half of #11776. xterm's re-entry guard early-returns without
+      // throwing on an already-poisoned instance, so "no exception" is NOT
+      // evidence the pane can paint — trusting it is what set isOpened=true on
+      // a terminal that stayed blank forever.
+      const managed = makeManaged("t2");
+      service.instances.set("t2", managed);
+
+      service.attach("t2", document.createElement("div"));
+
+      expect(managed.terminal.open).toHaveBeenCalled();
+      expect(managed.isOpened).toBe(false);
+      expect(managed.lastAttachError).toBeDefined();
+    });
+
+    it("marks a terminal opened when it produces a renderer", () => {
+      const managed = makeManaged("t3", {
+        get dimensions() {
+          return { css: { cell: { width: 8, height: 16 } } };
+        },
+      });
+      service.instances.set("t3", managed);
+
+      service.attach("t3", document.createElement("div"));
+
+      expect(managed.isOpened).toBe(true);
+      expect(managed.lastAttachError).toBeUndefined();
+    });
+
+    it("publishes the failure to the pane and clears it once an open succeeds", () => {
+      const failing = makeManaged("t4");
+      service.instances.set("t4", failing);
+      service.attach("t4", document.createElement("div"));
+      expect(setAttachError).toHaveBeenCalledWith("t4", expect.any(String));
+
+      const healthy = makeManaged("t5", {
+        get dimensions() {
+          return { css: { cell: { width: 8, height: 16 } } };
+        },
+      });
+      healthy.lastAttachError = "stale failure";
+      service.instances.set("t5", healthy);
+      service.attach("t5", document.createElement("div"));
+
+      expect(clearAttachError).toHaveBeenCalledWith("t5");
+      expect(healthy.lastAttachError).toBeUndefined();
+    });
+  });
+
+  describe("rebuilding", () => {
+    it("replaces the xterm instance and disposes the old one", async () => {
+      const managed = makeManaged("r1");
+      makeHostRenderable(managed);
+      service.instances.set("r1", managed);
+      const original = managed.terminal;
+
+      const rebuilt = await service.recoverPoisonedTerminal("r1", { manual: true });
+
+      expect(rebuilt).toBe(true);
+      expect(original.dispose).toHaveBeenCalled();
+      expect(managed.terminal).not.toBe(original);
+      expect(managed.isOpened).toBe(true);
+    });
+
+    it("keeps the PTY listeners and re-installs only the terminal-bound ones", async () => {
+      const managed = makeManaged("r2");
+      makeHostRenderable(managed);
+      // A terminal-bound listener sitting past the PTY prefix.
+      const boundUnsub = vi.fn();
+      managed.listeners.push(boundUnsub);
+      const [ptyA, ptyB] = managed.listeners;
+      service.instances.set("r2", managed);
+
+      await service.recoverPoisonedTerminal("r2", { manual: true });
+
+      // The xterm-bound tail is torn down; the PTY prefix is untouched, because
+      // dropping it would silently detach the pane from its live process.
+      expect(boundUnsub).toHaveBeenCalled();
+      expect(ptyA).not.toHaveBeenCalled();
+      expect(ptyB).not.toHaveBeenCalled();
+      expect(managed.listeners[0]).toBe(ptyA);
+      expect(managed.listeners[1]).toBe(ptyB);
+      expect(managed.listeners).not.toContain(boundUnsub);
+    });
+
+    it("disposes the image addon before the terminal it patched", async () => {
+      // ImageAddon.dispose() is what restores the `_core.open` it monkey-patched.
+      // Disposing the terminal first would strand the patch on a dead object.
+      const managed = makeManaged("r3");
+      makeHostRenderable(managed);
+      let imageAddonDisposeOrder = 0;
+      const staleAddon = {
+        dispose: vi.fn(() => {
+          imageAddonDisposeOrder = ++control.disposeCounter;
+        }),
+      } as unknown as ManagedTerminal["imageAddon"];
+      managed.imageAddon = staleAddon;
+      const original = managed.terminal as unknown as { dispose: ReturnType<typeof vi.fn> };
+      let terminalDisposeOrder = 0;
+      original.dispose = vi.fn(() => {
+        terminalDisposeOrder = ++control.disposeCounter;
+      });
+      service.instances.set("r3", managed);
+
+      await service.recoverPoisonedTerminal("r3", { manual: true });
+
+      expect(imageAddonDisposeOrder).toBeGreaterThan(0);
+      expect(terminalDisposeOrder).toBeGreaterThan(imageAddonDisposeOrder);
+      // The slot may be repopulated for the NEW terminal, but it must never
+      // still hold the addon bound to the disposed one.
+      expect(managed.imageAddon).not.toBe(staleAddon);
+    });
+
+    it("re-attaches the custom key handler to the replacement terminal", async () => {
+      // Without this the rebuilt pane accepts no keyboard input: XtermAdapter's
+      // effect does not re-run, so nothing else would ever install one.
+      const managed = makeManaged("r4");
+      makeHostRenderable(managed);
+      const handler = vi.fn(() => true);
+      managed.customKeyEventHandler = handler;
+      service.instances.set("r4", managed);
+
+      await service.recoverPoisonedTerminal("r4", { manual: true });
+
+      expect(managed.terminal.attachCustomKeyEventHandler).toHaveBeenCalledWith(handler);
+      expect(managed.keyHandlerInstalled).toBe(true);
+    });
+
+    it("replays scrollback from the headless mirror after rebuilding", async () => {
+      const managed = makeManaged("r5");
+      makeHostRenderable(managed);
+      service.instances.set("r5", managed);
+
+      await service.recoverPoisonedTerminal("r5", { manual: true });
+
+      expect(service.restoreController.fetchAndRestore).toHaveBeenCalledWith("r5");
+    });
+
+    it("defers while the host has no measurable box", async () => {
+      // Opening against a zero-box host is a plausible cause of the original
+      // failure, so rebuilding into one would just poison the fresh instance.
+      const managed = makeManaged("r6");
+      service.instances.set("r6", managed);
+      const original = managed.terminal;
+
+      const rebuilt = await service.recoverPoisonedTerminal("r6", { manual: true });
+
+      expect(rebuilt).toBe(false);
+      expect(original.dispose).not.toHaveBeenCalled();
+      expect(managed.terminal).toBe(original);
+    });
+
+    it("shares one rebuild between concurrent callers", async () => {
+      const managed = makeManaged("r7");
+      makeHostRenderable(managed);
+      service.instances.set("r7", managed);
+
+      const [a, b] = await Promise.all([
+        service.recoverPoisonedTerminal("r7", { manual: true }),
+        service.recoverPoisonedTerminal("r7", { manual: true }),
+      ]);
+
+      expect(a).toBe(true);
+      expect(b).toBe(true);
+      // One replacement, not two — a second Terminal would leave an orphan
+      // holding the PTY's listeners.
+      expect(rebuiltTerminals).toHaveLength(1);
+    });
+
+    it("stops automatic rebuilds once the budget is spent but still honours Retry", async () => {
+      control.opensCleanly = false; // every replacement stays unpaintable
+      const managed = makeManaged("r8");
+      makeHostRenderable(managed);
+      service.instances.set("r8", managed);
+
+      for (let i = 0; i < 6; i++) {
+        await service.recoverPoisonedTerminal("r8");
+      }
+      const automaticBuilds = rebuiltTerminals.length;
+
+      // The automatic budget is bounded — a pane that cannot be rebuilt must
+      // degrade to a banner rather than loop forever.
+      expect(automaticBuilds).toBeLessThanOrEqual(3);
+
+      // A manual Retry is the user asserting something changed, so it is not
+      // blocked by the exhausted automatic budget.
+      await service.recoverPoisonedTerminal("r8", { manual: true });
+      expect(rebuiltTerminals.length).toBeGreaterThan(automaticBuilds);
+    });
+  });
+
+  describe("preventing the poisoning", () => {
+    it("does not build the image addon against a terminal with no renderer", async () => {
+      // ImageAddon's constructor patches `_core.open` with a wrapper that
+      // dereferences `_renderService` unconditionally. Installed pre-open it
+      // turns one failed open into a permanent, self-re-throwing wedge.
+      const managed = makeManaged("p1");
+      service.instances.set("p1", managed);
+
+      service.attach("p1", document.createElement("div"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(managed.isOpened).toBe(false);
+      expect(createImageAddonMock).not.toHaveBeenCalled();
+    });
+
+    it("builds the image addon once the terminal actually paints", async () => {
+      const managed = makeManaged("p2", {
+        get dimensions() {
+          return { css: { cell: { width: 8, height: 16 } } };
+        },
+      });
+      service.instances.set("p2", managed);
+
+      service.attach("p2", document.createElement("div"));
+      await vi.waitFor(() => expect(createImageAddonMock).toHaveBeenCalled());
+    });
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.attachRecovery.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attachRecovery.test.ts
@@ -54,6 +54,9 @@ const xtermHarness = vi.hoisted(() => {
     refresh = vi.fn();
     blur = vi.fn();
     attachCustomKeyEventHandler = vi.fn();
+    // Settles the rebuild's drain barrier immediately — a fresh terminal has
+    // nothing queued.
+    write = vi.fn((_data: string, callback?: () => void) => callback?.());
     loadAddon = vi.fn();
     onRender = vi.fn(() => ({ dispose: vi.fn() }));
     element = document.createElement("div");
@@ -484,7 +487,11 @@ describe("TerminalInstanceService attach failure recovery (#11776)", () => {
         dispose: ReturnType<typeof vi.fn>;
       };
       original.write = vi.fn((_data: string, callback?: () => void) => {
-        releaseDrain = callback;
+        releaseDrain = () => {
+          // Settling the barrier is what drains the ack-bearing batches.
+          managed.pendingWrites = 0;
+          callback?.();
+        };
       });
       service.instances.set("d1", managed);
 
@@ -499,6 +506,35 @@ describe("TerminalInstanceService attach failure recovery (#11776)", () => {
 
       expect(original.dispose).toHaveBeenCalled();
       expect(managed.isOpened).toBe(true);
+    });
+
+    it("re-arms the drain when output lands behind the sentinel", async () => {
+      // A poisoned terminal is usually still streaming at full rate, so a batch
+      // can be queued BEHIND the drain sentinel while it waits — and its
+      // callback is exactly the ack that disposing would drop. One barrier is
+      // not enough; the drain has to keep going until the queue is really idle.
+      const managed = makeManaged("d3");
+      makeHostRenderable(managed);
+      managed.pendingWrites = 1;
+      const original = managed.terminal as unknown as {
+        write: ReturnType<typeof vi.fn>;
+        dispose: ReturnType<typeof vi.fn>;
+      };
+      let sentinels = 0;
+      original.write = vi.fn((_data: string, callback?: () => void) => {
+        sentinels++;
+        // The first barrier completes with a newly-arrived batch still pending;
+        // only by the second has the terminal actually gone quiet.
+        if (sentinels >= 2) managed.pendingWrites = 0;
+        callback?.();
+      });
+      service.instances.set("d3", managed);
+
+      await service.recoverPoisonedTerminal("d3", { manual: true });
+
+      expect(sentinels).toBeGreaterThan(1);
+      expect(original.dispose).toHaveBeenCalled();
+      expect(managed.pendingWrites).toBe(0);
     });
 
     it("abandons the rebuild rather than disposing a terminal whose writes never drain", async () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.attachRecovery.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attachRecovery.test.ts
@@ -50,7 +50,12 @@ const xtermHarness = vi.hoisted(() => {
     dispose = vi.fn(() => {
       this.disposeOrder = ++control.disposeCounter;
     });
-    resize = vi.fn();
+    // Tracks the grid like the real thing: the rebuild's geometry seed is only
+    // observable through cols/rows, and a no-op resize would hide it.
+    resize = vi.fn((cols: number, rows: number) => {
+      this.cols = cols;
+      this.rows = rows;
+    });
     refresh = vi.fn();
     blur = vi.fn();
     attachCustomKeyEventHandler = vi.fn();
@@ -147,6 +152,9 @@ interface RecoveryTestService {
   rendererPolicy: { applyRendererPolicy: (id: string, tier: number) => void };
   webGLManager: { onTerminalDestroyed: (id: string) => void };
   resizeController: { fit: (id: string) => void };
+  workerIngestController: {
+    reseedMirrorGeometry: (id: string, managed: ManagedTerminal) => void;
+  };
 }
 
 describe("TerminalInstanceService attach failure recovery (#11776)", () => {
@@ -280,11 +288,15 @@ describe("TerminalInstanceService attach failure recovery (#11776)", () => {
       expect(managed.lastAttachError).toBeUndefined();
     });
 
-    it("publishes the failure to the pane and clears it once an open succeeds", () => {
+    it("publishes the failure to the pane and clears it once an open succeeds", async () => {
       const failing = makeManaged("t4");
       service.instances.set("t4", failing);
       service.attach("t4", document.createElement("div"));
-      expect(setAttachError).toHaveBeenCalledWith("t4", expect.any(String));
+      // Not on the failed open itself — a failure is auto-recovering, so the
+      // banner waits for the rebuild to give up. This host is never measurable,
+      // so recovery defers immediately and the escalation lands a microtask on.
+      expect(setAttachError).not.toHaveBeenCalled();
+      await vi.waitFor(() => expect(setAttachError).toHaveBeenCalledWith("t4", expect.any(String)));
 
       const healthy = makeManaged("t5", {
         get dimensions() {
@@ -389,6 +401,87 @@ describe("TerminalInstanceService attach failure recovery (#11776)", () => {
       expect(service.restoreController.fetchAndRestore).toHaveBeenCalledWith("r5");
     });
 
+    it("opens the replacement on the pre-failure grid, not xterm's default", async () => {
+      // The replacement is CONSTRUCTED from the dead instance's `options`, and
+      // xterm copies the live grid into options only in reset() — never in
+      // resize() — so the fresh Terminal starts at the size the old one was
+      // built at. Left uncorrected, the pane parses live output at 80x24 and the
+      // replay below reflows the restored scrollback down to it: #11718 and
+      // #11552 reproduced together on one terminal.
+      const managed = makeManaged("g1");
+      makeHostRenderable(managed);
+      // Only ever resized while backgrounded, so the measured grid lives in
+      // latestCols/latestRows with no attach target recorded.
+      managed.latestCols = 203;
+      managed.latestRows = 51;
+      managed.targetCols = undefined;
+      managed.targetRows = undefined;
+      service.instances.set("g1", managed);
+
+      let gridAtReplay: { cols: number; rows: number } | undefined;
+      vi.spyOn(service.restoreController, "fetchAndRestore").mockImplementation(async () => {
+        gridAtReplay = { cols: managed.terminal.cols, rows: managed.terminal.rows };
+        return true;
+      });
+
+      await service.recoverPoisonedTerminal("g1", { manual: true });
+
+      const replacement = rebuiltTerminals.at(-1);
+      expect(replacement).toBeDefined();
+      // Sized BEFORE the open: xterm measures its cell grid inside open(), and
+      // anything parsed against the interim grid is already corrupted.
+      const resizeOrder = replacement?.resize.mock.invocationCallOrder[0] ?? Infinity;
+      const openOrder = replacement?.open.mock.invocationCallOrder[0] ?? 0;
+      expect(resizeOrder).toBeLessThan(openOrder);
+      expect(gridAtReplay).toEqual({ cols: 203, rows: 51 });
+      // The invented target is consumed, not left behind for the next attach to
+      // apply in place of a fresh fit.
+      expect(managed.targetCols).toBeUndefined();
+      expect(managed.targetRows).toBeUndefined();
+    });
+
+    it("re-measures the rebuilt pane against its host before replaying", async () => {
+      // attach()'s nested-rAF fit is gated on isOpened, which the failed open
+      // had already set false, and the host box never changed so the
+      // ResizeObserver stays quiet — nothing else would ever size a pane
+      // rebuilt from a cold attach with no measured grid to seed from.
+      const managed = makeManaged("g2");
+      makeHostRenderable(managed);
+      service.instances.set("g2", managed);
+
+      await service.recoverPoisonedTerminal("g2", { manual: true });
+
+      const fitSpy = vi.mocked(service.resizeController.fit);
+      expect(fitSpy).toHaveBeenCalledWith("g2");
+      const replacement = rebuiltTerminals.at(-1);
+      // After the open (a fit against an unopened terminal measures nothing) and
+      // before the replay (the restore seeds its target from the live grid).
+      expect(fitSpy.mock.invocationCallOrder[0]).toBeGreaterThan(
+        replacement?.open.mock.invocationCallOrder[0] ?? Infinity
+      );
+      expect(fitSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(service.restoreController.fetchAndRestore).mock.invocationCallOrder[0] ?? 0
+      );
+    });
+
+    it("re-seeds the headless worker mirror only after the real grid is applied", async () => {
+      // The mirror's geometry comes from `terminal.cols/rows`, so seeding it
+      // during the rebind — before the open — would park the background parse at
+      // the construction grid and every snapshot would come back at that width.
+      const managed = makeManaged("g3");
+      makeHostRenderable(managed);
+      service.instances.set("g3", managed);
+      const reseed = vi.spyOn(service.workerIngestController, "reseedMirrorGeometry");
+
+      await service.recoverPoisonedTerminal("g3", { manual: true });
+
+      expect(reseed).toHaveBeenCalledWith("g3", managed);
+      const replacement = rebuiltTerminals.at(-1);
+      expect(reseed.mock.invocationCallOrder[0]).toBeGreaterThan(
+        replacement?.open.mock.invocationCallOrder[0] ?? Infinity
+      );
+    });
+
     it("defers while the host has no measurable box", async () => {
       // Opening against a zero-box host is a plausible cause of the original
       // failure, so rebuilding into one would just poison the fresh instance.
@@ -442,9 +535,39 @@ describe("TerminalInstanceService attach failure recovery (#11776)", () => {
         expect(managed.terminal).not.toBe(original);
         expect(managed.isOpened).toBe(true);
       });
-      // The banner raised by the failure is retracted once the pane paints.
+      // The pane never saw a banner: the rebuild always crosses a drain
+      // sentinel, an addon await and an open() reflow, so a T3 published on the
+      // first failed open is a red flash the user gets to see for nothing.
+      expect(setAttachError).not.toHaveBeenCalled();
       expect(clearAttachError).toHaveBeenCalledWith("auto1");
       expect(managed.lastAttachError).toBeUndefined();
+    });
+
+    it("raises the banner only once the rebuild budget is exhausted", async () => {
+      // The other half of the tiering rule: recovery that genuinely cannot fix
+      // the pane must escalate rather than stay silent forever.
+      control.opensCleanly = false;
+      const managed = makeManaged("auto2", {
+        open: vi.fn(() => {
+          throw new TypeError("Cannot read properties of undefined (reading 'setRenderer')");
+        }),
+      });
+      makeHostRenderable(managed);
+      service.instances.set("auto2", managed);
+
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      service.attach("auto2", container);
+
+      expect(setAttachError).not.toHaveBeenCalled();
+
+      await vi.waitFor(() =>
+        expect(setAttachError).toHaveBeenCalledWith("auto2", expect.any(String))
+      );
+      // Every replacement failed too, so the escalation came from the plateau —
+      // not from a single attempt that never got a second chance.
+      expect(rebuiltTerminals.length).toBeGreaterThan(1);
+      expect(managed.isOpened).toBe(false);
     });
 
     it("keeps retrying, then plateaus, and lets Retry resume", async () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.attachRecovery.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attachRecovery.test.ts
@@ -170,6 +170,7 @@ describe("TerminalInstanceService attach failure recovery (#11776)", () => {
         refresh: vi.fn(),
         blur: vi.fn(),
         attachCustomKeyEventHandler: vi.fn(),
+        write: vi.fn((_data: string, callback?: () => void) => callback?.()),
         onRender: vi.fn(() => ({ dispose: vi.fn() })),
         element: document.createElement("div"),
         rows: 24,
@@ -416,25 +417,116 @@ describe("TerminalInstanceService attach failure recovery (#11776)", () => {
       expect(rebuiltTerminals).toHaveLength(1);
     });
 
-    it("stops automatic rebuilds once the budget is spent but still honours Retry", async () => {
-      control.opensCleanly = false; // every replacement stays unpaintable
+    it("rebuilds automatically when attach() hits an unpaintable terminal", async () => {
+      // The end-to-end path, and the one that actually fixes #11776: nothing
+      // in the app calls recovery directly. If handleFailedOpen stopped
+      // scheduling it, every other test here would still pass while a real
+      // pane stayed blank forever.
+      const managed = makeManaged("auto1", {
+        open: vi.fn(() => {
+          throw new TypeError("Cannot read properties of undefined (reading 'setRenderer')");
+        }),
+      });
+      makeHostRenderable(managed);
+      service.instances.set("auto1", managed);
+      const original = managed.terminal;
+
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      service.attach("auto1", container);
+
+      await vi.waitFor(() => {
+        expect(managed.terminal).not.toBe(original);
+        expect(managed.isOpened).toBe(true);
+      });
+      // The banner raised by the failure is retracted once the pane paints.
+      expect(clearAttachError).toHaveBeenCalledWith("auto1");
+      expect(managed.lastAttachError).toBeUndefined();
+    });
+
+    it("keeps retrying, then plateaus, and lets Retry resume", async () => {
+      // Every replacement stays unpaintable, so the loop exhausts its budget.
+      control.opensCleanly = false;
       const managed = makeManaged("r8");
       makeHostRenderable(managed);
       service.instances.set("r8", managed);
 
-      for (let i = 0; i < 6; i++) {
-        await service.recoverPoisonedTerminal("r8");
-      }
-      const automaticBuilds = rebuiltTerminals.length;
+      await service.recoverPoisonedTerminal("r8");
+      const afterAutomatic = rebuiltTerminals.length;
 
-      // The automatic budget is bounded — a pane that cannot be rebuilt must
-      // degrade to a banner rather than loop forever.
-      expect(automaticBuilds).toBeLessThanOrEqual(3);
+      // More than one: a failed replacement must schedule the NEXT attempt
+      // itself. Re-entering through the failure path cannot do that — it is
+      // handed the in-flight promise — so a single build here would mean the
+      // budget silently collapsed to one attempt.
+      expect(afterAutomatic).toBeGreaterThan(1);
 
-      // A manual Retry is the user asserting something changed, so it is not
-      // blocked by the exhausted automatic budget.
+      // Then it stops rather than looping forever.
+      await service.recoverPoisonedTerminal("r8");
+      await service.recoverPoisonedTerminal("r8");
+      expect(rebuiltTerminals).toHaveLength(afterAutomatic);
+
+      // The user asserting something changed refills the budget.
       await service.recoverPoisonedTerminal("r8", { manual: true });
-      expect(rebuiltTerminals.length).toBeGreaterThan(automaticBuilds);
+      expect(rebuiltTerminals.length).toBeGreaterThan(afterAutomatic);
+    });
+
+    it("settles queued writes before disposing the old terminal", async () => {
+      // xterm drops its pending write callbacks on dispose instead of running
+      // them, and those callbacks are what return flow-control credit to the
+      // pty-host. Disposing mid-write would leave the backend throttling a
+      // terminal that has already been replaced.
+      const managed = makeManaged("d1");
+      makeHostRenderable(managed);
+      managed.pendingWrites = 2;
+      let releaseDrain: (() => void) | undefined;
+      const original = managed.terminal as unknown as {
+        write: ReturnType<typeof vi.fn>;
+        dispose: ReturnType<typeof vi.fn>;
+      };
+      original.write = vi.fn((_data: string, callback?: () => void) => {
+        releaseDrain = callback;
+      });
+      service.instances.set("d1", managed);
+
+      const recovery = service.recoverPoisonedTerminal("d1", { manual: true });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(original.dispose).not.toHaveBeenCalled();
+
+      releaseDrain?.();
+      await recovery;
+
+      expect(original.dispose).toHaveBeenCalled();
+      expect(managed.isOpened).toBe(true);
+    });
+
+    it("abandons the rebuild rather than disposing a terminal whose writes never drain", async () => {
+      vi.useFakeTimers();
+      try {
+        const managed = makeManaged("d2");
+        makeHostRenderable(managed);
+        managed.pendingWrites = 1;
+        const original = managed.terminal as unknown as {
+          write: ReturnType<typeof vi.fn>;
+          dispose: ReturnType<typeof vi.fn>;
+        };
+        original.write = vi.fn(() => {
+          /* never invokes the drain callback */
+        });
+        service.instances.set("d2", managed);
+
+        const recovery = service.recoverPoisonedTerminal("d2", { manual: true });
+        await vi.advanceTimersByTimeAsync(5000);
+
+        await expect(recovery).resolves.toBe(false);
+        // Left intact: a stranded ledger is worse than a pane that is still
+        // blank but still correctly accounted for.
+        expect(original.dispose).not.toHaveBeenCalled();
+        expect(managed.terminal).toBe(original as unknown as typeof managed.terminal);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/services/terminal/__tests__/revealUntilStable.test.ts
+++ b/src/services/terminal/__tests__/revealUntilStable.test.ts
@@ -124,9 +124,13 @@ describe("revealUntilStable", () => {
 
     await expect(result).resolves.toBe(false);
     expect(attempt).toHaveBeenCalledTimes(1);
+    // The MESSAGE, not the Error (#11776). `Error.message` is non-enumerable,
+    // so logging the object itself serialised the whole context to
+    // `{"error":{}}` — the one line that could explain a wedged terminal said
+    // nothing at all in the diagnostics bundle.
     expect(logWarnMock).toHaveBeenCalledWith("[assistantReveal] reveal failed", {
       id: "t-1",
-      error: boom,
+      error: "renderer gone",
     });
   });
 

--- a/src/services/terminal/__tests__/xtermRendererProbe.test.ts
+++ b/src/services/terminal/__tests__/xtermRendererProbe.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { Terminal } from "@xterm/xterm";
+import { hasUsableRenderer } from "../xtermRendererProbe";
+
+type Probed = Pick<Terminal, "dimensions">;
+
+/** An object carrying a `dimensions` accessor that yields whatever is given. */
+function withDimensions(produce: () => Terminal["dimensions"]): Probed {
+  return {
+    get dimensions() {
+      return produce();
+    },
+  };
+}
+
+const SOME_DIMENSIONS = {
+  css: { canvas: { width: 800, height: 600 }, cell: { width: 8, height: 16 } },
+  device: { canvas: { width: 800, height: 600 }, cell: { width: 8, height: 16 } },
+} as unknown as NonNullable<Terminal["dimensions"]>;
+
+describe("hasUsableRenderer", () => {
+  it("reports healthy when the terminal exposes real dimensions", () => {
+    expect(hasUsableRenderer(withDimensions(() => SOME_DIMENSIONS))).toBe(true);
+  });
+
+  it("reports broken when the accessor yields undefined", () => {
+    // This is the poisoned state from #11776: xterm's `dimensions` getter
+    // returns undefined precisely when `_renderService` was never built, which
+    // is what a throw between CoreBrowserService and RenderService leaves
+    // behind.
+    expect(hasUsableRenderer(withDimensions(() => undefined))).toBe(false);
+  });
+
+  it("reports broken when reading dimensions throws", () => {
+    // RenderService.dimensions dereferences its renderer, so a throw means
+    // there is a service but nothing that can paint — just as unusable.
+    expect(
+      hasUsableRenderer(
+        withDimensions(() => {
+          throw new Error("Cannot read properties of undefined (reading 'dimensions')");
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("reports healthy when the terminal has no dimensions accessor at all", () => {
+    // The unknown-shape bias. An xterm without the accessor (a different
+    // version, or a hand-built test double) must not be treated as broken —
+    // guessing "poisoned" here would push healthy terminals into the rebuild
+    // path on every single open.
+    expect(hasUsableRenderer({} as Probed)).toBe(true);
+  });
+
+  it("distinguishes a missing accessor from a present-but-undefined one", () => {
+    // The two cases are one `in` check apart and resolve to OPPOSITE verdicts,
+    // so a refactor that collapses them would silently break one of them.
+    const absent = {} as Probed;
+    const presentButEmpty = withDimensions(() => undefined);
+
+    expect(absent.dimensions).toBeUndefined();
+    expect(presentButEmpty.dimensions).toBeUndefined();
+    expect(hasUsableRenderer(absent)).not.toBe(hasUsableRenderer(presentButEmpty));
+  });
+});

--- a/src/services/terminal/paintFabric/PaintFabricCompositor.ts
+++ b/src/services/terminal/paintFabric/PaintFabricCompositor.ts
@@ -1138,6 +1138,17 @@ export class PaintFabricCompositor implements TerminalPaintPlane {
     return this.plane(id).fetchAndRestore(id);
   }
 
+  /**
+   * Per-terminal, never fanned out (#11776). The rebuild disposes and replaces
+   * one xterm instance, and only the surface that owns it holds the
+   * ManagedTerminal to swap — broadcasting would have every other surface look
+   * up an id it does not have and no-op, which reads like recovery ran
+   * everywhere when it ran nowhere.
+   */
+  recoverPoisonedTerminal(id: string, options?: { manual?: boolean }): Promise<boolean> {
+    return this.plane(id).recoverPoisonedTerminal(id, options);
+  }
+
   restoreFromSerialized(
     id: string,
     serializedState: string,

--- a/src/services/terminal/revealUntilStable.ts
+++ b/src/services/terminal/revealUntilStable.ts
@@ -1,4 +1,5 @@
 import { logWarn } from "@/utils/logger";
+import { getErrorMessage } from "@/utils/errorContext";
 
 // Upper bound on frames a single terminal will keep retrying its reveal before
 // the caller gives up on it. A warm project-view return that's settling its
@@ -95,7 +96,10 @@ export async function revealUntilStable(
     } catch (error) {
       // One broken terminal must not abort the caller's wider sweep — the next
       // visible terminal still needs its post-reveal repaint.
-      logWarn(`${logContext} reveal failed`, { id, error });
+      // getErrorMessage, not the Error itself: `message` is non-enumerable, so
+      // a nested Error serialises to `{}` in the log context and the one line
+      // that could explain a wedged terminal says nothing at all (#11776).
+      logWarn(`${logContext} reveal failed`, { id, error: getErrorMessage(error) });
       return false;
     }
     if (paintable) painted++;

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -317,7 +317,31 @@ export interface ManagedTerminal {
   attachRevealTimer?: ReturnType<typeof setTimeout>;
   attachRevealDisposable?: { dispose: () => void };
 
+  // Count of PTY-bound entries at the head of `listeners`, recorded before
+  // installTerminalBoundListeners appends the xterm-bound ones. The split
+  // point matters for the #11776 rebuild: the tail belongs to the disposed
+  // Terminal and must be re-installed, the head belongs to the PTY and must
+  // survive.
   ipcListenerCount: number;
+
+  // Attach failure state (#11776). Deliberately NOT folded into `isOpened`:
+  // that flag answers "has open() been completed", and overloading it with
+  // "did open() succeed" is what let a permanently-unpaintable terminal look
+  // healthy to every retry path. Message only — the Error itself would pin the
+  // whole poisoned instance graph via its stack.
+  lastAttachError?: string;
+  // Consecutive automatic rebuild attempts. Bounds recovery so a terminal that
+  // cannot be rebuilt (a host that is genuinely never renderable) degrades to a
+  // banner rather than looping.
+  attachRecoveryAttempts?: number;
+  // In-flight rebuild, so concurrent triggers (attach, reveal, watchdog, the
+  // banner's Retry) share one rebuild instead of racing several.
+  attachRecoveryInFlight?: Promise<boolean>;
+  // The custom key handler XtermAdapter installed on the current Terminal.
+  // Recorded so a rebuild can re-attach it: `keyHandlerInstalled` would
+  // otherwise stay true against a fresh Terminal that has no handler, leaving
+  // the rebuilt pane unable to accept keyboard input.
+  customKeyEventHandler?: (event: KeyboardEvent) => boolean;
 
   // Visibility-driven WebGL restore debounce. Show path waits ~100ms before
   // re-ensuring the addon, so rapid tab/panel toggles don't repeatedly

--- a/src/services/terminal/xtermRendererProbe.ts
+++ b/src/services/terminal/xtermRendererProbe.ts
@@ -1,0 +1,47 @@
+import type { Terminal } from "@xterm/xterm";
+
+/**
+ * Whether an xterm instance actually owns a live render service — the thing
+ * that makes a pane capable of painting at all.
+ *
+ * Why this exists (#11776): `CoreBrowserTerminal.open()` is not transactional.
+ * It assigns `element` (L462) and `_coreBrowserService` (L505) BEFORE
+ * `_renderService` (L536), and its own re-entry guard tests only the first
+ * two:
+ *
+ *   if (this.element?.ownerDocument.defaultView && this._coreBrowserService) return;
+ *
+ * So any throw in the L505-L536 window (CharSizeService / ThemeService /
+ * CoreBrowserService / the RenderService constructor itself) leaves the
+ * instance permanently "already opened" from xterm's point of view while it
+ * has no renderer and never will — every later `open()` early-returns without
+ * building one. `isOpened` alone cannot see that state, which is exactly how a
+ * pane ends up blank forever while its PTY keeps streaming.
+ *
+ * The probe is the public, documented `dimensions` accessor rather than a
+ * `_core._renderService` reach-through. xterm's own typings say "*This will be
+ * undefined before {@link open} is called*", and the implementation is literally
+ * `if (!this._renderService) return undefined`, so it answers the question
+ * without depending on a private field name surviving a beta bump.
+ *
+ * Both failure modes are deliberately biased the same way — **when we cannot
+ * tell, report healthy**:
+ *
+ *  - No `dimensions` accessor at all (an older/newer xterm, or a hand-built
+ *    test double) → `true`. A probe that guessed "broken" here would send
+ *    perfectly good terminals into the rebuild path on every open.
+ *  - The accessor throws → `false`. `RenderService.dimensions` dereferences its
+ *    renderer, so a throw means there is a service but no usable renderer,
+ *    which is just as unpaintable.
+ *
+ * Reporting healthy on an unknown shape preserves today's behaviour; reporting
+ * broken on one would invent a new failure. Cheap to call — a property read.
+ */
+export function hasUsableRenderer(terminal: Pick<Terminal, "dimensions">): boolean {
+  if (!("dimensions" in terminal)) return true;
+  try {
+    return terminal.dimensions !== undefined;
+  } catch {
+    return false;
+  }
+}

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -36,6 +36,8 @@ export const createBrowserActions = (
   | "clearReconnectError"
   | "setScrollbackRestoreError"
   | "clearScrollbackRestoreError"
+  | "setTerminalAttachError"
+  | "clearTerminalAttachError"
 > => ({
   setBrowserUrl: (id, url) => {
     set((state) => {
@@ -324,6 +326,41 @@ export const createBrowserActions = (
         panelsById: {
           ...state.panelsById,
           [id]: { ...terminal, scrollbackRestoreError: undefined },
+        },
+      };
+    });
+  },
+
+  // Renderer attach failure (#11776). Unlike the scrollback banner above this
+  // one IS an error: the pane paints nothing at all while its agent keeps
+  // working, so the user is blind to a running process rather than missing
+  // history. No debounce — the service only writes it after it has already
+  // classified the open as failed.
+  setTerminalAttachError: (id, error) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal || !isPtyPanel(terminal)) return state;
+      if (terminal.attachError === error) return state;
+
+      return {
+        panelsById: {
+          ...state.panelsById,
+          [id]: { ...terminal, attachError: error },
+        },
+      };
+    });
+  },
+
+  clearTerminalAttachError: (id) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal || !isPtyPanel(terminal)) return state;
+      if (terminal.attachError === undefined) return state;
+
+      return {
+        panelsById: {
+          ...state.panelsById,
+          [id]: { ...terminal, attachError: undefined },
         },
       };
     });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -273,10 +273,12 @@ export const createRestartActions = (
           reconnectError: undefined,
           spawnError: undefined,
           scrollbackRestoreError: undefined,
-          // A restart builds a brand-new xterm instance, so a paint failure
-          // recorded against the old one describes something that no longer
-          // exists (#11776) — leaving it set would strand the banner.
-          attachError: undefined,
+          // attachError is deliberately NOT cleared here: this reset runs
+          // before the restart is validated, so clearing it would hide the
+          // banner while the old unpaintable terminal is still on screen
+          // (#11776). The service clears it when a terminal actually opens, and
+          // destroy() clears it when one is torn down — both strictly after the
+          // point of no return.
           // A restart spins up a fresh PTY process; flow state from the previous
           // process must not survive into it or the paused pill would linger
           // (#9899). The host only re-emits flow status on a pause/resume

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -273,6 +273,10 @@ export const createRestartActions = (
           reconnectError: undefined,
           spawnError: undefined,
           scrollbackRestoreError: undefined,
+          // A restart builds a brand-new xterm instance, so a paint failure
+          // recorded against the old one describes something that no longer
+          // exists (#11776) — leaving it set would strand the banner.
+          attachError: undefined,
           // A restart spins up a fresh PTY process; flow state from the previous
           // process must not survive into it or the paused pill would linger
           // (#9899). The host only re-emits flow status on a pause/resume
@@ -867,6 +871,7 @@ export const createRestartActions = (
         ...t,
         restartError: undefined,
         scrollbackRestoreError: undefined,
+        attachError: undefined,
       }))
     );
   },

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -269,6 +269,9 @@ export interface PanelRegistrySlice {
   clearReconnectError: (id: string) => void;
   setScrollbackRestoreError: (id: string, error: TerminalScrollbackRestoreError) => void;
   clearScrollbackRestoreError: (id: string) => void;
+  /** Renderer attach failure (#11776) — the pane cannot paint at all. */
+  setTerminalAttachError: (id: string, error: string) => void;
+  clearTerminalAttachError: (id: string) => void;
   /**
    * Acknowledge the "Session no longer reachable" signal for one panel by
    * clearing `sessionLostOnRestore` (issue #11589). Lives in the store rather

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -4,6 +4,7 @@ import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { logWarn } from "@/utils/logger";
+import { getErrorMessage } from "@/utils/errorContext";
 import { notifyWarmReactivationComplete } from "@/utils/warmReactivationGate";
 
 const WAKE_CONCURRENCY = 2;
@@ -141,7 +142,13 @@ async function wakeActiveWorktreeTerminalsInner(): Promise<void> {
     } catch (error) {
       // One broken terminal must not abort the fan-out — the next visible
       // terminal still needs its missed range pulled from the headless mirror.
-      logWarn("[wakeActiveWorktreeTerminals] wake failed", { id, error });
+      // getErrorMessage, not the Error itself: `message` is non-enumerable, so
+      // a nested Error serialises to `{}` in the log context and the one line
+      // that could explain a wedged terminal says nothing at all (#11776).
+      logWarn("[wakeActiveWorktreeTerminals] wake failed", {
+        id,
+        error: getErrorMessage(error),
+      });
     }
   };
 

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -109,6 +109,7 @@ export function buildPanelProps({
     reconnectError: pty?.reconnectError,
     spawnError: pty?.spawnError,
     scrollbackRestoreError: pty?.scrollbackRestoreError,
+    attachError: pty?.attachError,
     detectedProcessId: pty?.detectedProcessId,
 
     // Extension state


### PR DESCRIPTION
## Summary

- A terminal pane could go permanently blank while its agent kept running: the PTY was healthy and streaming at 30-50 events/sec with ~1.9MB queued, nothing painted, and no error surfaced anywhere. Switching projects away and back made no difference.
- Root cause: in the pinned `@xterm/xterm` `6.1.0-beta.300`, `CoreBrowserTerminal.open()` assigns `element` (L462) and `_coreBrowserService` (L505) before `_renderService` (L536), but the library's own re-entry guard only checks the first two fields. A throw anywhere in that window leaves an instance that reports itself as already opened but has no renderer and never will, so every later `open()` silently early-returns.
- Fixed prevention-first, per the issue: stop the throw from reaching `open()`, detect the unpaintable state if it ever does anyway, rebuild the terminal instead of retrying into a wall, and surface a T3 error banner so the user isn't staring at a dead pane with no explanation.

Resolves #11776

## Root cause

The throw came from `@xterm/addon-image`'s `ImageRenderer`, which monkey-patches `_core.open` with a wrapper that dereferences `_renderService` unconditionally. Daintree was installing that addon on terminals that had never been opened yet, through `getOrCreate` → `applyRendererPolicy` → `onTierApplied` → `ensureDeferredAddons`.

`ensureOpened()` treated the `open()` call as retryable, so attach, wake, reveal, and the reconciliation watchdog all kept re-calling a function that could never succeed once the instance was poisoned.

## Changes

**Prevention**
- Detect the unpaintable state through xterm's public, documented `terminal.dimensions` accessor, whose own implementation just returns `undefined` when there's no render service. Biased toward "healthy" on an unknown shape so it can never invent a failure (`src/services/terminal/xtermRendererProbe.ts`).
- `ensureOpened()` now catches the thrown error and also verifies a renderer actually exists before marking the terminal opened, so a silent early return can no longer pass as success.
- The `ImageAddon` is no longer built against a terminal with no renderer, removing the source of the throw from `open()` entirely.

**Recovery**
- When attach fails, rebuild rather than retry: dispose the poisoned instance and construct a replacement on the same `ManagedTerminal`, preserving the PTY listener prefix, re-running the shared listener installer, re-attaching the custom key handler, rebinding the worker-ingest resize bridge, and replaying scrollback from the headless mirror. Bounded and deduplicated so it can't become its own wedge (`src/services/terminal/TerminalInstanceService.ts`).

**Surfacing**
- A T3 inline error banner on the affected pane with a single Retry action (`TerminalAttachErrorBanner.tsx`, wired into `TerminalPane.tsx`). The pane painted nothing at all while the agent kept working, so this is a data-visibility failure, not a cosmetic one.

**Diagnostics fix**
- The wake and reveal paths were logging the `Error` object nested inside a context object. Since `Error.message` is non-enumerable, those lines serialized down to `{"error":{}}`, so the only log lines that could have explained a wedged terminal said nothing useful.

**Review catch worth calling out**
xterm's `WriteBuffer.dispose()` clears its pending callbacks instead of running them, and those callbacks are what send the port ack, return flow-control credit to the pty-host, and decrement the ingest's in-flight byte count. Disposing mid-write would have left the backend throttling a terminal that had already been replaced, so the rebuilt pane would open cleanly and then receive nothing. The rebuild now drains xterm's write queue to genuine quiescence first, re-arming the drain check since a streaming terminal queues new batches behind a single sentinel, and abandons the attempt rather than disposing if it can't reach quiescence (`TerminalWorkerIngestController.ts`).

**Deliberately not done:** `TerminalRuntimeStatus` has an unused `"error"` member this could flip, but wiring it in ripples into chrome derivation and its contract tests for no real gain beyond the banner that's already there.

## Testing

- 446 tests pass across 20 targeted suites, including 3 new files: `xtermRendererProbe.test.ts`, `TerminalInstanceService.attachRecovery.test.ts`, `TerminalAttachErrorBanner.test.tsx`
- Typecheck clean
- 0 eslint errors on changed files
- Prettier clean
- Lint ratchet improved (1090 vs 1092 baseline)
- No new E2E coverage: the failure needs a renderer-internal throw that can't be provoked from Playwright
