### PR TITLE
feat(pilot): run parking with notes, gated release and fleet scan cues

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -244,6 +244,8 @@ export const CHANNELS = {
   PROJECT_STATS_UPDATED: "project:stats-updated",
   FLEET_SNAPSHOT_UPDATED: "fleet:snapshot-updated",
   FLEET_GET_SNAPSHOT: "fleet:get-snapshot",
+  FLEET_PARK_RUN: "fleet:park-run",
+  FLEET_UNPARK_RUN: "fleet:unpark-run",
   PROJECT_HISTORY_PEEK: "project-history:peek",
   PROJECT_CREATE_FOLDER: "project:create-folder",
   PROJECT_INIT_GIT: "project:init-git",

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -66,6 +66,10 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   // close paths and bridged from the pty-host's trash-expiry capture)
   "agent-session:recorded": "bus",
 
+  // A gated park auto-released (emitted by RunAttentionService; the renderer's
+  // release notification rides this)
+  "terminal:park-released": "bus",
+
   // Global broadcasts emitted externally (no TypedEventBus counterpart).
   "resource:profile-changed": "external",
   "sound:cancel": "external",

--- a/electron/ipc/handlers/fleet.preload.ts
+++ b/electron/ipc/handlers/fleet.preload.ts
@@ -2,6 +2,8 @@ import type { IpcInvokeMap } from "../../types/index.js";
 
 export const FLEET_METHOD_CHANNELS = {
   getSnapshot: "fleet:get-snapshot",
+  parkRun: "fleet:park-run",
+  unparkRun: "fleet:unpark-run",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof FLEET_METHOD_CHANNELS;

--- a/electron/ipc/handlers/fleet.ts
+++ b/electron/ipc/handlers/fleet.ts
@@ -1,7 +1,44 @@
-import type { FleetSnapshot } from "../../../shared/types/ipc/fleet.js";
-import { getFleetSnapshotService } from "./projectCrud/index.js";
+import type { FleetSnapshot, RunParkRecord } from "../../../shared/types/ipc/fleet.js";
+import { getFleetSnapshotService, getRunAttentionService } from "./projectCrud/index.js";
+import { MAX_PARK_NOTE_LENGTH } from "../../services/RunAttentionService.js";
+import { checkRateLimit } from "../utils.js";
+import { CHANNELS } from "../channels.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { FLEET_METHOD_CHANNELS } from "./fleet.preload.js";
+
+/**
+ * Renderer input is untrusted: ids are bounded strings, and the options bag
+ * must actually be a plain object — `null`, arrays and primitives are rejected
+ * rather than treated as "no options", so a type-confused caller hears about
+ * it instead of silently parking with defaults it didn't choose.
+ */
+function assertRunId(value: unknown, what: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0 || value.length > 200) {
+    throw new Error(`Invalid ${what}`);
+  }
+}
+
+/**
+ * Both ids must name runs the fleet can currently see. This is what makes a
+ * park addressable and a gate releasable: an id the snapshot doesn't know is
+ * either hostile, mistyped, or already trashed — and a gate that was trashed
+ * before the park existed would otherwise never fire its gate-closed release,
+ * hiding the run forever. The check requires a healthy snapshot on purpose;
+ * while the fleet is unreadable the park surfaces can't be trusted either.
+ * (A gate trashed in the instant between this check and the service commit
+ * still slips through — the 14-day expiry and manual unpark bound that gap.)
+ */
+function assertKnownRuns(runId: string, gateRunId: string | undefined): void {
+  const snapshot = getFleetSnapshotService()?.getLastBroadcast();
+  if (!snapshot || snapshot.degraded) {
+    throw new Error("Fleet state is unavailable right now — try again in a moment");
+  }
+  const known = new Set(snapshot.runs.map((run) => run.runId));
+  if (!known.has(runId)) throw new Error("Run not found in the current fleet");
+  if (gateRunId !== undefined && !known.has(gateRunId)) {
+    throw new Error("Gate terminal not found in the current fleet");
+  }
+}
 
 export const fleetNamespace = defineIpcNamespace({
   name: "fleet",
@@ -29,6 +66,63 @@ export const fleetNamespace = defineIpcNamespace({
       async (): Promise<FleetSnapshot | null> =>
         getFleetSnapshotService()?.getLastBroadcast() ?? null
     ),
+
+    /**
+     * Park a run — record that it doesn't need the user, optionally until the
+     * gate terminal next comes free. Reversible in one keystroke and local to
+     * attention surfaces (D0), so no confirmation tier applies.
+     *
+     * The note length check here is a size guard against a hostile payload;
+     * the exact semantics (trim, cap at {@link MAX_PARK_NOTE_LENGTH} UTF-16
+     * code units, surrogate tidy-up) belong to the service, which is the one
+     * authority on what a stored note looks like.
+     */
+    parkRun: op(
+      FLEET_METHOD_CHANNELS.parkRun,
+      async (
+        runId: string,
+        options?: { note?: string; gateRunId?: string }
+      ): Promise<RunParkRecord> => {
+        checkRateLimit(CHANNELS.FLEET_PARK_RUN, 20, 10_000);
+        assertRunId(runId, "run id");
+        if (options !== undefined) {
+          if (typeof options !== "object" || options === null || Array.isArray(options)) {
+            throw new Error("Invalid park options");
+          }
+        }
+        const note = options?.note;
+        if (
+          note !== undefined &&
+          (typeof note !== "string" || note.length > MAX_PARK_NOTE_LENGTH * 4)
+        ) {
+          throw new Error("Invalid park note");
+        }
+        const gateRunId = options?.gateRunId;
+        if (gateRunId !== undefined) assertRunId(gateRunId, "gate run id");
+        assertKnownRuns(runId, gateRunId);
+
+        const service = getRunAttentionService();
+        if (!service) throw new Error("Run attention service unavailable");
+        return service.park(runId, {
+          ...(note !== undefined ? { note } : {}),
+          ...(gateRunId !== undefined ? { gateRunId } : {}),
+        });
+      }
+    ),
+
+    /**
+     * Lift a park by hand. Resolves false when the run wasn't parked. No
+     * snapshot check: removing a record is safe whether or not the fleet is
+     * currently readable, and blocking the way OUT of a park on host health
+     * would hide runs behind a degradation the user can't fix.
+     */
+    unparkRun: op(FLEET_METHOD_CHANNELS.unparkRun, async (runId: string): Promise<boolean> => {
+      checkRateLimit(CHANNELS.FLEET_UNPARK_RUN, 20, 10_000);
+      assertRunId(runId, "run id");
+      const service = getRunAttentionService();
+      if (!service) throw new Error("Run attention service unavailable");
+      return service.unpark(runId);
+    }),
   },
 });
 

--- a/electron/ipc/handlers/projectCrud/index.ts
+++ b/electron/ipc/handlers/projectCrud/index.ts
@@ -19,7 +19,11 @@ import { registerGitInitHandlers } from "./gitInit.js";
 import { registerGitCloneHandlers } from "./gitClone.js";
 import { registerProjectPrefetchHandlers } from "./prefetch.js";
 
-export { getProjectStatsService, getFleetSnapshotService } from "./stats.js";
+export {
+  getProjectStatsService,
+  getFleetSnapshotService,
+  getRunAttentionService,
+} from "./stats.js";
 
 export function registerProjectCrudHandlers(deps: HandlerDependencies): () => void {
   const cleanups = [

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -5,6 +5,9 @@ import type { BulkProjectStats } from "../../../../shared/types/ipc/project.js";
 import type { MemoryRollup, MemoryRollupProject } from "../../../../shared/types/pty-host.js";
 import { ProjectStatsService } from "../../../services/ProjectStatsService.js";
 import { FleetSnapshotService } from "../../../services/FleetSnapshotService.js";
+import { RunAttentionService } from "../../../services/RunAttentionService.js";
+import { isCleaningUp } from "../../../lifecycle/shutdownCoordinator.js";
+import { store } from "../../../store.js";
 import { registerDeferredTask } from "../../../window/deferredInitQueue.js";
 import { computeProjectAgentCounts } from "../../../services/projectAgentCounts.js";
 import { projectStore } from "../../../services/ProjectStore.js";
@@ -16,6 +19,7 @@ import { BrowserWindow } from "electron";
 
 let projectStatsServiceInstance: ProjectStatsService | null = null;
 let fleetSnapshotServiceInstance: FleetSnapshotService | null = null;
+let runAttentionServiceInstance: RunAttentionService | null = null;
 
 export function getProjectStatsService(): ProjectStatsService | null {
   return projectStatsServiceInstance;
@@ -23,6 +27,10 @@ export function getProjectStatsService(): ProjectStatsService | null {
 
 export function getFleetSnapshotService(): FleetSnapshotService | null {
   return fleetSnapshotServiceInstance;
+}
+
+export function getRunAttentionService(): RunAttentionService | null {
+  return runAttentionServiceInstance;
 }
 
 export function registerProjectStatsHandlers(deps: HandlerDependencies): () => void {
@@ -45,11 +53,34 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
     projectStatsServiceInstance = null;
   });
 
+  // Park intent lives beside the snapshot that projects it: the attention
+  // service owns the records, the snapshot decorates rows with them, and a
+  // park-changed event drives the same refresh path as an agent transition.
+  // `isCleaningUp` freezes releases during graceful shutdown — the chain kills
+  // every terminal, and those kills would otherwise read as busy→ready edges
+  // and wipe the very parks persistence is carrying across the restart.
+  const runAttentionService = new RunAttentionService(
+    {
+      load: () => store.get("parkedRuns"),
+      save: (records) => store.set("parkedRuns", records),
+    },
+    { isQuitting: isCleaningUp }
+  );
+  runAttentionServiceInstance = runAttentionService;
+  handlers.push(() => {
+    runAttentionService.dispose();
+    // Identity-guarded: a stale cleanup from a superseded registration must
+    // not null out a newer instance's global.
+    if (runAttentionServiceInstance === runAttentionService) {
+      runAttentionServiceInstance = null;
+    }
+  });
+
   // The run-grained sibling of the counts above, on the same source and the
   // same cadence. Registered here so the two can never be started apart, and so
   // one lifecycle owns both. They sample independently, so a surface reading
   // runs and one reading counts can differ across a single transition.
-  const fleetSnapshotService = new FleetSnapshotService(deps.ptyClient);
+  const fleetSnapshotService = new FleetSnapshotService(deps.ptyClient, runAttentionService);
   fleetSnapshotServiceInstance = fleetSnapshotService;
   fleetSnapshotService.start();
   registerDeferredTask({

--- a/electron/services/FleetSnapshotService.ts
+++ b/electron/services/FleetSnapshotService.ts
@@ -13,6 +13,20 @@ const DEFAULT_POLL_INTERVAL_MS = 5_000;
 const DEBOUNCE_MS = 200;
 
 /**
+ * How long a working run must be silent before the row says so.
+ *
+ * Ten minutes is deliberately far past any agent's thinking pauses — the cue
+ * exists for the wedge, not the lull, and a threshold that fires during
+ * ordinary long tool calls would train the user to ignore it. Detection runs
+ * on the poll, so the crossing lands within one poll interval of the
+ * threshold; the value put on the wire is the silence's ANCHOR (last output
+ * or entry into the working stint, whichever is later — a constant while the
+ * silence lasts), which is what keeps a stalled run from defeating
+ * unchanged-payload suppression.
+ */
+export const STALL_QUIET_MS = 10 * 60_000;
+
+/**
  * The fleet's live run list, pushed to every view.
  *
  * A deliberate structural sibling of {@link ProjectStatsService}: same aligned
@@ -208,7 +222,8 @@ export class FleetSnapshotService {
         x.agentPresetColor !== y.agentPresetColor ||
         x.park?.parkedAt !== y.park?.parkedAt ||
         x.park?.note !== y.park?.note ||
-        x.park?.gateRunId !== y.park?.gateRunId
+        x.park?.gateRunId !== y.park?.gateRunId ||
+        x.quietSince !== y.quietSince
       ) {
         return false;
       }
@@ -242,6 +257,7 @@ export class FleetSnapshotService {
 
       const availability = getAgentAvailabilityStore();
       const parkRecords = this.runAttention?.getAll();
+      const stallCutoff = Date.now() - STALL_QUIET_MS;
       const runs: FleetRunRow[] = [];
 
       for (const terminal of allTerminals) {
@@ -286,6 +302,23 @@ export class FleetSnapshotService {
           // User intent decorates the row here so every surface reads park
           // state and agent state in one payload, never joining two feeds.
           ...(park !== undefined ? { park } : {}),
+          // Stall cue: only for a working run, and only once the CURRENT
+          // working stint has been silent past the threshold. Anchored on the
+          // later of last output, the transition into this state and the
+          // spawn — a run resumed after waiting quietly for twenty minutes
+          // enters `working` with an ancient lastOutputTime, and anchoring on
+          // output alone stamped it "quiet 20m" before it had a chance to
+          // make a sound. The raw lastOutputTime must never ride the row —
+          // see the wire type's own doc for the churn argument.
+          ...(() => {
+            if (terminal.agentState !== "working") return {};
+            const quietAnchor = Math.max(
+              typeof terminal.lastOutputTime === "number" ? terminal.lastOutputTime : 0,
+              typeof terminal.lastStateChange === "number" ? terminal.lastStateChange : 0,
+              terminal.spawnedAt
+            );
+            return quietAnchor > 0 && quietAnchor <= stallCutoff ? { quietSince: quietAnchor } : {};
+          })(),
         });
       }
 

--- a/electron/services/FleetSnapshotService.ts
+++ b/electron/services/FleetSnapshotService.ts
@@ -4,6 +4,7 @@ import { events } from "./events.js";
 import { classifyRun } from "./projectAgentCounts.js";
 import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
 import type { PtyClient } from "./PtyClient.js";
+import type { RunAttentionService } from "./RunAttentionService.js";
 import type { FleetRunRow, FleetSnapshot } from "../../shared/types/ipc/fleet.js";
 import { MutableDisposable, toDisposable, type IDisposable } from "../utils/lifecycle.js";
 import { setAlignedInterval } from "../utils/setAlignedInterval.js";
@@ -48,7 +49,10 @@ export class FleetSnapshotService {
    */
   private lastSuccessfulReadAt: number | null = null;
 
-  constructor(private ptyClient: PtyClient | undefined | null) {}
+  constructor(
+    private ptyClient: PtyClient | undefined | null,
+    private runAttention?: RunAttentionService | null
+  ) {}
 
   get isStarted(): boolean {
     return this.started;
@@ -70,6 +74,9 @@ export class FleetSnapshotService {
     subscribe("agent:state-changed");
     subscribe("terminal:trashed");
     subscribe("terminal:restored");
+    // Park records ride the rows, so a park set or lifted is a fleet change
+    // even though no agent state moved.
+    subscribe("terminal:park-changed");
   }
 
   updatePollInterval(ms: number): void {
@@ -198,7 +205,10 @@ export class FleetSnapshotService {
         x.cwd !== y.cwd ||
         x.launchAgentId !== y.launchAgentId ||
         x.everDetectedAgent !== y.everDetectedAgent ||
-        x.agentPresetColor !== y.agentPresetColor
+        x.agentPresetColor !== y.agentPresetColor ||
+        x.park?.parkedAt !== y.park?.parkedAt ||
+        x.park?.note !== y.park?.note ||
+        x.park?.gateRunId !== y.park?.gateRunId
       ) {
         return false;
       }
@@ -231,6 +241,7 @@ export class FleetSnapshotService {
       }
 
       const availability = getAgentAvailabilityStore();
+      const parkRecords = this.runAttention?.getAll();
       const runs: FleetRunRow[] = [];
 
       for (const terminal of allTerminals) {
@@ -239,6 +250,7 @@ export class FleetSnapshotService {
         if (!terminal.projectId) continue;
         if (classifyRun(terminal, (id) => availability.isHelpTerminal(id)) !== null) continue;
 
+        const park = parkRecords?.get(terminal.id);
         runs.push({
           runId: terminal.id,
           workspaceId: terminal.projectId,
@@ -271,6 +283,9 @@ export class FleetSnapshotService {
           ...(terminal.agentPresetColor !== undefined
             ? { agentPresetColor: terminal.agentPresetColor }
             : {}),
+          // User intent decorates the row here so every surface reads park
+          // state and agent state in one payload, never joining two feeds.
+          ...(park !== undefined ? { park } : {}),
         });
       }
 

--- a/electron/services/RunAttentionService.ts
+++ b/electron/services/RunAttentionService.ts
@@ -1,0 +1,340 @@
+import { events } from "./events.js";
+import type { AgentState } from "../../shared/types/agent.js";
+import type { RunParkRecord } from "../../shared/types/ipc/fleet.js";
+
+/** Longest note a park may carry, in UTF-16 code units (the cap the slice enforces). */
+export const MAX_PARK_NOTE_LENGTH = 500;
+
+/**
+ * Cardinality bound on the whole park set. Far beyond any real workflow — this
+ * exists so a hostile renderer looping `parkRun` with fresh ids cannot grow the
+ * persisted store without bound, not to constrain a user. Re-parking an
+ * already-parked run never counts against it.
+ */
+export const MAX_PARKED_RUNS = 200;
+
+/**
+ * Parks expire after two weeks — a deliberate product contract, not just
+ * orphan hygiene. A park nobody has looked at in fourteen days is stale
+ * intent: the note has lost its context and silently honouring it forever
+ * would hide a run behind a decision the user no longer remembers making.
+ * Enforced at load, which is the only moment the whole set is re-read anyway.
+ */
+const STALE_PARK_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+/** A loaded `parkedAt` this far past "now" is corrupt, not early. */
+const FUTURE_SKEW_MS = 60_000;
+
+const BUSY_STATES: ReadonlySet<AgentState> = new Set(["working", "directing"]);
+const READY_STATES: ReadonlySet<AgentState> = new Set(["idle", "waiting", "completed", "exited"]);
+
+export interface RunAttentionPersistence {
+  load(): Record<string, RunParkRecord>;
+  save(records: Record<string, RunParkRecord>): void;
+}
+
+export interface ParkRunOptions {
+  note?: string;
+  gateRunId?: string;
+}
+
+export interface RunAttentionDeps {
+  now?: () => number;
+  /**
+   * True while the app's graceful-shutdown chain is running. The chain kills
+   * every project terminal, and each kill lands as a busy→ready edge while
+   * this service is still subscribed — without the guard, quitting the app
+   * released every gated park and persisted the release, which is the exact
+   * opposite of intent that survives a restart.
+   */
+  isQuitting?: () => boolean;
+}
+
+/**
+ * Trim, cap and tidy a note. Returns undefined when nothing usable remains.
+ * The cap is UTF-16 code units; a slice landing inside a surrogate pair drops
+ * the orphaned half rather than persisting a malformed string.
+ */
+function normalizeNote(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  let note = value.trim().slice(0, MAX_PARK_NOTE_LENGTH);
+  const last = note.charCodeAt(note.length - 1);
+  if (last >= 0xd800 && last <= 0xdbff) note = note.slice(0, -1);
+  return note.length > 0 ? note : undefined;
+}
+
+/**
+ * The user's attention decisions about runs, starting with parking.
+ *
+ * Agent state says what a run is doing; this service records what the user
+ * decided about it. The two are deliberately separate: parking must never feed
+ * back into the FSM, and the FSM must never clear a park except through the one
+ * documented release path below.
+ *
+ * Release semantics are edge-triggered AND time-fenced: a park gated on
+ * terminal B lifts when B transitions busy → ready (`working`/`directing` →
+ * `idle`/`waiting`/`completed`/`exited`) with an event timestamp strictly
+ * after the park was created. The edge requirement makes the common flow work
+ * without a race — "park A until B is free" is usually said while B is
+ * waiting, just before handing B the work whose completion the park is about.
+ * The time fence closes the other half of that race: a busy→ready edge that
+ * happened before the park but was still crossing from the pty-host must not
+ * count as the gate "next" coming free, and neither may a stale edge from an
+ * earlier process incarnation under the same terminal id. The corollary is
+ * honest and documented: if the gate never runs again, the park holds until
+ * lifted by hand (or the 14-day expiry).
+ *
+ * Ready is `idle | waiting`, the codebase's own automation-safe readiness
+ * predicate (`waitUntilIdle`, the command queue), plus the terminal states.
+ * `completed` alone would be wrong: completion is pattern-detected and most
+ * agents end a stint in `waiting`, never `completed`.
+ *
+ * A gate that is trashed releases its parks too ("gate-closed") — a park that
+ * can no longer release must resurface, not hide its run forever. The parked
+ * run's OWN trashing does not unpark it: trash is restorable, and restoring a
+ * run should restore the intent recorded against it.
+ *
+ * Every mutation commits in one order — apply, persist, then announce — and a
+ * persistence failure rolls the memory state back and suppresses the events,
+ * so no surface is ever told about a change that would not survive a restart.
+ */
+export class RunAttentionService {
+  private records = new Map<string, RunParkRecord>();
+  private unsubscribers: Array<() => void> = [];
+  private now: () => number;
+  private isQuitting: () => boolean;
+
+  constructor(
+    private persistence: RunAttentionPersistence,
+    deps: RunAttentionDeps = {}
+  ) {
+    this.now = deps.now ?? Date.now;
+    this.isQuitting = deps.isQuitting ?? (() => false);
+    this.loadAndPrune();
+
+    this.unsubscribers.push(
+      events.on("agent:state-changed", (payload) => {
+        const terminalId = payload.terminalId;
+        if (!terminalId) return;
+        if (!READY_STATES.has(payload.state)) return;
+        if (!BUSY_STATES.has(payload.previousState)) return;
+        this.releaseGatedOn(terminalId, "gate-ready", payload.timestamp);
+      })
+    );
+
+    this.unsubscribers.push(
+      events.on("terminal:trashed", (payload) => {
+        this.releaseGatedOn(payload.id, "gate-closed");
+      })
+    );
+  }
+
+  getParkRecord(runId: string): RunParkRecord | undefined {
+    return this.records.get(runId);
+  }
+
+  getAll(): ReadonlyMap<string, RunParkRecord> {
+    return this.records;
+  }
+
+  /**
+   * Park a run. Re-parking replaces the record wholesale — a new note or a new
+   * gate is a new decision, so `parkedAt` restarts too.
+   *
+   * Trusts the caller to have checked the ids against the live fleet — the IPC
+   * handler validates both against the current snapshot. This layer enforces
+   * only what it can know by itself: shape, the self-gate rule, and the bound.
+   */
+  park(runId: string, options: ParkRunOptions = {}): RunParkRecord {
+    if (this.isQuitting()) {
+      throw new Error("Cannot park a run while the app is shutting down");
+    }
+    if (typeof runId !== "string" || runId.length === 0) {
+      throw new Error("Cannot park a run without a terminal id");
+    }
+    const gateRunId =
+      typeof options.gateRunId === "string" && options.gateRunId.length > 0
+        ? options.gateRunId
+        : undefined;
+    if (gateRunId === runId) {
+      throw new Error("A run cannot gate its own park");
+    }
+    if (!this.records.has(runId) && this.records.size >= MAX_PARKED_RUNS) {
+      throw new Error(`Cannot park more than ${MAX_PARKED_RUNS} runs`);
+    }
+    const note = normalizeNote(options.note);
+
+    const record: RunParkRecord = {
+      parkedAt: this.now(),
+      ...(note !== undefined ? { note } : {}),
+      ...(gateRunId !== undefined ? { gateRunId } : {}),
+    };
+
+    const previous = this.records.get(runId);
+    this.records.set(runId, record);
+    try {
+      this.persist();
+    } catch (error) {
+      // The park would not survive a restart, so it must not exist now either:
+      // reporting success for a non-durable park is the lie this rollback
+      // exists to prevent.
+      if (previous !== undefined) this.records.set(runId, previous);
+      else this.records.delete(runId);
+      throw error;
+    }
+    events.emit("terminal:park-changed", { id: runId, parked: true, timestamp: this.now() });
+    return record;
+  }
+
+  /** Lift a park by hand. Returns false when the run wasn't parked. */
+  unpark(runId: string): boolean {
+    if (this.isQuitting()) {
+      throw new Error("Cannot unpark a run while the app is shutting down");
+    }
+    const previous = this.records.get(runId);
+    if (previous === undefined) return false;
+    this.records.delete(runId);
+    try {
+      this.persist();
+    } catch (error) {
+      this.records.set(runId, previous);
+      throw error;
+    }
+    events.emit("terminal:park-changed", { id: runId, parked: false, timestamp: this.now() });
+    return true;
+  }
+
+  /**
+   * Release every park gated on a terminal, in one committed batch.
+   *
+   * Matches are snapshotted before anything is emitted, so a listener that
+   * synchronously re-parks on the same gate cannot be revisited by this pass,
+   * and a throwing listener cannot leave the set half-deleted: by the time the
+   * first event fires, the whole batch is already applied and persisted. A
+   * persistence failure keeps every park in place — announcing a release that
+   * would resurrect after restart is worse than releasing late.
+   */
+  private releaseGatedOn(
+    gateRunId: string,
+    reason: "gate-ready" | "gate-closed",
+    edgeTimestamp?: number
+  ): void {
+    // The shutdown chain gracefully kills every terminal, and each kill lands
+    // here as a busy→ready edge (and later a trash). Releasing on those would
+    // wipe every gated park at the exact moment persistence is supposed to be
+    // carrying them across the restart.
+    if (this.isQuitting()) return;
+
+    const released: Array<[string, RunParkRecord]> = [];
+    for (const [runId, record] of this.records) {
+      if (record.gateRunId !== gateRunId) continue;
+      // Time fence, gate-ready only: the edge must postdate the park. A trash
+      // is not fenced — it is delivered once, from the user's own present.
+      if (reason === "gate-ready") {
+        if (typeof edgeTimestamp !== "number" || !Number.isFinite(edgeTimestamp)) continue;
+        if (edgeTimestamp <= record.parkedAt) continue;
+      }
+      released.push([runId, record]);
+    }
+    if (released.length === 0) return;
+
+    for (const [runId] of released) this.records.delete(runId);
+    try {
+      this.persist();
+    } catch (error) {
+      for (const [runId, record] of released) this.records.set(runId, record);
+      console.error(
+        "[RunAttentionService] Failed to persist a gate release, keeping parks:",
+        error
+      );
+      return;
+    }
+
+    for (const [runId, record] of released) {
+      events.emit("terminal:park-released", {
+        id: runId,
+        gateRunId,
+        ...(record.note !== undefined ? { note: record.note } : {}),
+        reason,
+        timestamp: this.now(),
+      });
+      events.emit("terminal:park-changed", { id: runId, parked: false, timestamp: this.now() });
+    }
+  }
+
+  /**
+   * Hydrate from disk, treating the stored blob as untrusted: every record is
+   * rebuilt field-by-field into a fresh object, and anything malformed —
+   * wrong types, a self-gate, a timestamp from the future — is dropped rather
+   * than repaired, because a repaired guess would still be presented as the
+   * user's own words.
+   */
+  private loadAndPrune(): void {
+    let stored: unknown;
+    try {
+      stored = this.persistence.load() ?? {};
+    } catch (error) {
+      console.error("[RunAttentionService] Failed to load park records:", error);
+      stored = {};
+    }
+    if (typeof stored !== "object" || stored === null || Array.isArray(stored)) stored = {};
+
+    const now = this.now();
+    const cutoff = now - STALE_PARK_TTL_MS;
+    let pruned = false;
+    for (const [runId, raw] of Object.entries(stored as Record<string, unknown>)) {
+      const record = this.rebuildRecord(runId, raw, cutoff, now);
+      if (record === null) {
+        pruned = true;
+        continue;
+      }
+      this.records.set(runId, record);
+    }
+    if (pruned) {
+      try {
+        this.persist();
+      } catch (error) {
+        console.error("[RunAttentionService] Failed to persist pruned park records:", error);
+      }
+    }
+  }
+
+  private rebuildRecord(
+    runId: string,
+    raw: unknown,
+    cutoff: number,
+    now: number
+  ): RunParkRecord | null {
+    if (typeof runId !== "string" || runId.length === 0) return null;
+    if (typeof raw !== "object" || raw === null) return null;
+    const candidate = raw as Record<string, unknown>;
+
+    const parkedAt = candidate.parkedAt;
+    if (typeof parkedAt !== "number" || !Number.isFinite(parkedAt)) return null;
+    if (parkedAt < cutoff || parkedAt > now + FUTURE_SKEW_MS) return null;
+
+    const note = normalizeNote(candidate.note);
+    const gateRunId =
+      typeof candidate.gateRunId === "string" &&
+      candidate.gateRunId.length > 0 &&
+      candidate.gateRunId !== runId
+        ? candidate.gateRunId
+        : undefined;
+
+    return {
+      parkedAt,
+      ...(note !== undefined ? { note } : {}),
+      ...(gateRunId !== undefined ? { gateRunId } : {}),
+    };
+  }
+
+  private persist(): void {
+    this.persistence.save(Object.fromEntries(this.records));
+  }
+
+  dispose(): void {
+    for (const unsubscribe of this.unsubscribers) unsubscribe();
+    this.unsubscribers = [];
+    this.records.clear();
+  }
+}

--- a/electron/services/RunAttentionService.ts
+++ b/electron/services/RunAttentionService.ts
@@ -1,9 +1,8 @@
 import { events } from "./events.js";
 import type { AgentState } from "../../shared/types/agent.js";
-import type { RunParkRecord } from "../../shared/types/ipc/fleet.js";
+import { MAX_PARK_NOTE_LENGTH, type RunParkRecord } from "../../shared/types/ipc/fleet.js";
 
-/** Longest note a park may carry, in UTF-16 code units (the cap the slice enforces). */
-export const MAX_PARK_NOTE_LENGTH = 500;
+export { MAX_PARK_NOTE_LENGTH };
 
 /**
  * Cardinality bound on the whole park set. Far beyond any real workflow — this

--- a/electron/services/__tests__/FleetSnapshotService.test.ts
+++ b/electron/services/__tests__/FleetSnapshotService.test.ts
@@ -574,6 +574,65 @@ describe("FleetSnapshotService", () => {
     expect(wc.send).not.toHaveBeenCalled();
   });
 
+  it("decorates a run with its park record", async () => {
+    const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
+    const park = { parkedAt: NOW - 5_000, note: "after the migration", gateRunId: "t9" };
+    const attention = { getAll: () => new Map([["t1", park]]) };
+    const service = new FleetSnapshotService(client as never, attention as never);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(lastSnapshot().runs[0].park).toEqual(park);
+    service.stop();
+  });
+
+  it("treats a park change as a fleet change even though no agent state moved", async () => {
+    const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
+    let parks = new Map();
+    const attention = { getAll: () => parks };
+    const service = new FleetSnapshotService(client as never, attention as never);
+    service.start();
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+    expect(lastSnapshot().runs[0].park).toBeUndefined();
+
+    parks = new Map([["t1", { parkedAt: NOW }]]);
+    eventEmitter.emit("terminal:park-changed", { id: "t1", parked: true, timestamp: NOW });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(broadcastMock).toHaveBeenCalledTimes(2);
+    expect(lastSnapshot().runs[0].park).toEqual({ parkedAt: NOW });
+    service.stop();
+  });
+
+  it("re-broadcasts on a note-only park change, advancing changedAt", async () => {
+    const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
+    let parks = new Map([["t1", { parkedAt: NOW - 10_000, note: "before" }]]);
+    const attention = { getAll: () => parks };
+    const service = new FleetSnapshotService(client as never, attention as never);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    const firstChangedAt = lastSnapshot().changedAt;
+
+    // An unchanged park is not a fleet change — suppression must hold.
+    vi.setSystemTime(NOW + 5_000);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+
+    // The note is the row's user-facing intent, so editing it alone is news.
+    parks = new Map([["t1", { parkedAt: NOW - 10_000, note: "after" }]]);
+    vi.setSystemTime(NOW + 10_000);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(broadcastMock).toHaveBeenCalledTimes(2);
+    expect(lastSnapshot().runs[0].park?.note).toBe("after");
+    expect(lastSnapshot().changedAt).toBeGreaterThan(firstChangedAt);
+    service.stop();
+  });
+
   it("broadcasts a genuinely empty fleet so a cleared queue reaches every view", async () => {
     const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
     const service = new FleetSnapshotService(client as never);

--- a/electron/services/__tests__/FleetSnapshotService.test.ts
+++ b/electron/services/__tests__/FleetSnapshotService.test.ts
@@ -27,7 +27,7 @@ vi.mock("../AgentAvailabilityStore.js", () => ({
   getAgentAvailabilityStore: () => availabilityMock,
 }));
 
-import { FleetSnapshotService } from "../FleetSnapshotService.js";
+import { FleetSnapshotService, STALL_QUIET_MS } from "../FleetSnapshotService.js";
 import type { FleetSnapshot } from "../../../shared/types/ipc/fleet.js";
 
 const NOW = 1_830_001;
@@ -630,6 +630,97 @@ describe("FleetSnapshotService", () => {
     expect(broadcastMock).toHaveBeenCalledTimes(2);
     expect(lastSnapshot().runs[0].park?.note).toBe("after");
     expect(lastSnapshot().changedAt).toBeGreaterThan(firstChangedAt);
+    service.stop();
+  });
+
+  it("reports a working run as quiet only past the stall threshold", async () => {
+    const longAgo = NOW - 2 * STALL_QUIET_MS;
+    const stalledAt = NOW - STALL_QUIET_MS - 60_000;
+    const client = makePtyClient([
+      terminal({
+        id: "stalled",
+        agentState: "working",
+        spawnedAt: longAgo,
+        lastStateChange: stalledAt,
+        lastOutputTime: stalledAt,
+      }),
+      terminal({
+        id: "busy",
+        agentState: "working",
+        spawnedAt: longAgo,
+        lastStateChange: longAgo,
+        lastOutputTime: NOW - 1_000,
+      }),
+      // Silence is only a symptom while the agent claims to be WORKING — a
+      // waiting run is supposed to be quiet.
+      terminal({
+        id: "waiting",
+        agentState: "waiting",
+        spawnedAt: longAgo,
+        lastStateChange: stalledAt,
+        lastOutputTime: stalledAt,
+      }),
+    ]);
+    const service = new FleetSnapshotService(client as never);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+
+    const byId = new Map(lastSnapshot().runs.map((r) => [r.runId, r]));
+    expect(byId.get("stalled")?.quietSince).toBe(stalledAt);
+    expect(byId.get("busy")?.quietSince).toBeUndefined();
+    expect(byId.get("waiting")?.quietSince).toBeUndefined();
+    service.stop();
+  });
+
+  it("anchors the stall on the working stint, not on output alone", async () => {
+    // A run resumed after waiting quietly for twenty minutes enters `working`
+    // with an ancient lastOutputTime. Judging by output alone would stamp it
+    // "quiet 20m" before it had a chance to make a sound.
+    const ancientOutput = NOW - 2 * STALL_QUIET_MS;
+    const client = makePtyClient([
+      terminal({
+        agentState: "working",
+        spawnedAt: ancientOutput,
+        lastStateChange: NOW - 5_000,
+        lastOutputTime: ancientOutput,
+      }),
+    ]);
+    const service = new FleetSnapshotService(client as never);
+    service.start();
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    expect(lastSnapshot().runs[0].quietSince).toBeUndefined();
+
+    // The stint itself going silent past the threshold IS the stall, and the
+    // armed poll notices the crossing without any event.
+    await vi.advanceTimersByTimeAsync(STALL_QUIET_MS + 30_000);
+    expect(lastSnapshot().runs[0].quietSince).toBe(NOW - 5_000);
+    service.stop();
+  });
+
+  it("stays suppressed while a stall persists — the cue costs one broadcast, not one per poll", async () => {
+    const longAgo = NOW - 2 * STALL_QUIET_MS;
+    const stalledAt = NOW - STALL_QUIET_MS - 60_000;
+    const client = makePtyClient([
+      terminal({
+        agentState: "working",
+        spawnedAt: longAgo,
+        lastStateChange: stalledAt,
+        lastOutputTime: stalledAt,
+      }),
+    ]);
+    const service = new FleetSnapshotService(client as never);
+
+    for (let i = 0; i < 4; i++) {
+      service.refresh();
+      await vi.runOnlyPendingTimersAsync();
+      vi.setSystemTime(NOW + (i + 1) * 5_000);
+    }
+
+    // The wire value is a constant anchor while the silence lasts — a
+    // "quiet for Nms" duration would re-broadcast every poll.
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+    expect(lastSnapshot().runs[0].quietSince).toBe(stalledAt);
     service.stop();
   });
 

--- a/electron/services/__tests__/RunAttentionService.test.ts
+++ b/electron/services/__tests__/RunAttentionService.test.ts
@@ -1,0 +1,436 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const eventEmitter = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(payload?: unknown) => void>>();
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  return {
+    on: (event: string, cb: (payload?: unknown) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(cb);
+      return () => listeners.get(event)?.delete(cb);
+    },
+    emit: (event: string, payload?: unknown) => {
+      emitted.push({ event, payload });
+      for (const cb of listeners.get(event) ?? []) cb(payload);
+    },
+    emitted,
+    _reset: () => {
+      listeners.clear();
+      emitted.length = 0;
+    },
+  };
+});
+
+vi.mock("../events.js", () => ({ events: eventEmitter }));
+
+import {
+  MAX_PARK_NOTE_LENGTH,
+  MAX_PARKED_RUNS,
+  RunAttentionService,
+} from "../RunAttentionService.js";
+import type { RunParkRecord } from "../../../shared/types/ipc/fleet.js";
+
+const NOW = 1_900_000_000_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makePersistence(initial: Record<string, RunParkRecord> = {}) {
+  return {
+    load: vi.fn(() => initial),
+    save: vi.fn<(records: Record<string, RunParkRecord>) => void>(),
+  };
+}
+
+function makeService(
+  persistence = makePersistence(),
+  deps: { now?: () => number; isQuitting?: () => boolean } = {}
+) {
+  return new RunAttentionService(persistence, { now: () => NOW, ...deps });
+}
+
+function emittedOf(event: string) {
+  return eventEmitter.emitted.filter((e) => e.event === event).map((e) => e.payload);
+}
+
+/** A gate edge that postdates every park created at NOW, unless overridden. */
+function gateBecomesReady(
+  gateId: string,
+  state = "waiting",
+  previousState = "working",
+  timestamp = NOW + 1_000
+) {
+  eventEmitter.emit("agent:state-changed", {
+    terminalId: gateId,
+    state,
+    previousState,
+    timestamp,
+  });
+}
+
+beforeEach(() => {
+  eventEmitter._reset();
+});
+
+describe("RunAttentionService", () => {
+  it("parks a run, persists it and announces the change", () => {
+    const persistence = makePersistence();
+    const service = makeService(persistence);
+
+    const record = service.park("t1", { note: "start after the refactor lands" });
+
+    expect(record).toEqual({ parkedAt: NOW, note: "start after the refactor lands" });
+    expect(service.getParkRecord("t1")).toEqual(record);
+    expect(persistence.save).toHaveBeenCalledWith({ t1: record });
+    expect(emittedOf("terminal:park-changed")).toEqual([
+      { id: "t1", parked: true, timestamp: NOW },
+    ]);
+    service.dispose();
+  });
+
+  it("trims the note, caps its length, and drops a blank one entirely", () => {
+    const service = makeService();
+
+    expect(service.park("a", { note: "  padded  " }).note).toBe("padded");
+    expect(service.park("b", { note: "x".repeat(MAX_PARK_NOTE_LENGTH + 50) }).note).toHaveLength(
+      MAX_PARK_NOTE_LENGTH
+    );
+    expect(service.park("c", { note: "   " }).note).toBeUndefined();
+    service.dispose();
+  });
+
+  it("never caps a note in the middle of a surrogate pair", () => {
+    const service = makeService();
+    // 249 chars then emoji: the astral pair straddles the 500-unit boundary,
+    // so a naive slice would keep a lone high surrogate as the last unit.
+    const note = "x".repeat(MAX_PARK_NOTE_LENGTH - 1) + "🚀";
+    const stored = service.park("a", { note }).note!;
+    expect(stored).toHaveLength(MAX_PARK_NOTE_LENGTH - 1);
+    const lastCode = stored.charCodeAt(stored.length - 1);
+    expect(lastCode < 0xd800 || lastCode > 0xdbff).toBe(true);
+    service.dispose();
+  });
+
+  it("rejects a park with no run id and a run gating on itself", () => {
+    const service = makeService();
+
+    expect(() => service.park("")).toThrow();
+    expect(() => service.park("t1", { gateRunId: "t1" })).toThrow();
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    service.dispose();
+  });
+
+  it("bounds the park set, while re-parking never counts against the cap", () => {
+    const service = makeService();
+    for (let i = 0; i < MAX_PARKED_RUNS; i++) service.park(`run-${i}`);
+
+    expect(() => service.park("one-too-many")).toThrow();
+    // An existing park may still be replaced at the cap — it is not growth.
+    expect(() => service.park("run-0", { note: "updated" })).not.toThrow();
+    expect(service.getParkRecord("run-0")?.note).toBe("updated");
+    service.dispose();
+  });
+
+  it("re-parking replaces the record wholesale, restarting the clock", () => {
+    let now = NOW;
+    const service = new RunAttentionService(makePersistence(), { now: () => now });
+
+    service.park("t1", { note: "first", gateRunId: "g1" });
+    now = NOW + 60_000;
+    const second = service.park("t1", { note: "second" });
+
+    expect(second).toEqual({ parkedAt: NOW + 60_000, note: "second" });
+    expect(service.getParkRecord("t1")?.gateRunId).toBeUndefined();
+    // The old gate no longer owns this park: its edge must not release it.
+    gateBecomesReady("g1", "waiting", "working", now + 1_000);
+    expect(service.getParkRecord("t1")).toBeDefined();
+    service.dispose();
+  });
+
+  it("unparks by hand and reports whether anything was lifted", () => {
+    const persistence = makePersistence();
+    const service = makeService(persistence);
+    service.park("t1");
+
+    expect(service.unpark("t1")).toBe(true);
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    expect(persistence.save).toHaveBeenLastCalledWith({});
+    expect(service.unpark("t1")).toBe(false);
+    expect(emittedOf("terminal:park-changed")).toEqual([
+      { id: "t1", parked: true, timestamp: NOW },
+      { id: "t1", parked: false, timestamp: NOW },
+    ]);
+    service.dispose();
+  });
+
+  it("rolls a park back when persistence fails, and reports the failure", () => {
+    const persistence = makePersistence();
+    persistence.save.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const service = makeService(persistence);
+
+    expect(() => service.park("t1", { note: "will not survive" })).toThrow("disk full");
+    // A park that would not survive a restart must not exist now either, and
+    // no surface may be told about it.
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    expect(emittedOf("terminal:park-changed")).toEqual([]);
+    service.dispose();
+  });
+
+  it("restores the record when an unpark fails to persist", () => {
+    const persistence = makePersistence();
+    const service = makeService(persistence);
+    service.park("t1", { note: "keep me" });
+    persistence.save.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    expect(() => service.unpark("t1")).toThrow("disk full");
+    expect(service.getParkRecord("t1")?.note).toBe("keep me");
+    service.dispose();
+  });
+
+  it("releases a gated park when the gate transitions busy → ready", () => {
+    const persistence = makePersistence();
+    const service = makeService(persistence);
+    service.park("t1", { note: "kick off once the migration agent is done", gateRunId: "gate" });
+
+    gateBecomesReady("gate");
+
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    expect(persistence.save).toHaveBeenLastCalledWith({});
+    expect(emittedOf("terminal:park-released")).toEqual([
+      {
+        id: "t1",
+        gateRunId: "gate",
+        note: "kick off once the migration agent is done",
+        reason: "gate-ready",
+        timestamp: NOW,
+      },
+    ]);
+    // The snapshot refresh path rides park-changed, so the release must also
+    // announce the park going away.
+    expect(emittedOf("terminal:park-changed")).toEqual([
+      { id: "t1", parked: true, timestamp: NOW },
+      { id: "t1", parked: false, timestamp: NOW },
+    ]);
+    service.dispose();
+  });
+
+  it("requires the busy → ready EDGE: ready → ready and idle → busy release nothing", () => {
+    const service = makeService();
+    service.park("t1", { gateRunId: "gate" });
+
+    // The gate flapping between ready states (waiting → idle) is not it
+    // finishing a stint of work, and the gate STARTING work must never fire.
+    gateBecomesReady("gate", "idle", "waiting");
+    gateBecomesReady("gate", "working", "idle");
+    expect(service.getParkRecord("t1")).toBeDefined();
+
+    // A different terminal reaching ready is someone else's news.
+    gateBecomesReady("other");
+    expect(service.getParkRecord("t1")).toBeDefined();
+    service.dispose();
+  });
+
+  it("ignores an edge that predates the park — stale events cannot release it", () => {
+    const service = makeService();
+    service.park("t1", { gateRunId: "gate" });
+
+    // An edge generated before the park but delivered after (pty-host → main
+    // is async), and the ambiguous same-millisecond edge, both hold.
+    gateBecomesReady("gate", "waiting", "working", NOW - 5);
+    gateBecomesReady("gate", "waiting", "working", NOW);
+    expect(service.getParkRecord("t1")).toBeDefined();
+
+    // A malformed timestamp is not evidence the edge is new.
+    gateBecomesReady("gate", "waiting", "working", Number.NaN);
+    expect(service.getParkRecord("t1")).toBeDefined();
+
+    gateBecomesReady("gate", "waiting", "working", NOW + 1);
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    service.dispose();
+  });
+
+  it("releases on every ready-family state, from either busy state", () => {
+    const service = makeService();
+    for (const state of ["idle", "waiting", "completed", "exited"]) {
+      service.park(`run-${state}`, { gateRunId: `gate-${state}` });
+      gateBecomesReady(`gate-${state}`, state);
+      expect(service.getParkRecord(`run-${state}`)).toBeUndefined();
+    }
+    service.park("t-directing", { gateRunId: "gate-d" });
+    gateBecomesReady("gate-d", "waiting", "directing");
+    expect(service.getParkRecord("t-directing")).toBeUndefined();
+    service.dispose();
+  });
+
+  it("releases as gate-closed when the gate terminal is trashed", () => {
+    const service = makeService();
+    service.park("t1", { gateRunId: "gate" });
+
+    eventEmitter.emit("terminal:trashed", { id: "gate", expiresAt: NOW + 1000 });
+
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    expect(emittedOf("terminal:park-released")).toEqual([
+      { id: "t1", gateRunId: "gate", reason: "gate-closed", timestamp: NOW },
+    ]);
+    service.dispose();
+  });
+
+  it("keeps the park when the parked run ITSELF is trashed — trash is restorable", () => {
+    const service = makeService();
+    service.park("t1", { note: "keep me" });
+
+    eventEmitter.emit("terminal:trashed", { id: "t1", expiresAt: NOW + 1000 });
+
+    expect(service.getParkRecord("t1")?.note).toBe("keep me");
+    service.dispose();
+  });
+
+  it("releases every run sharing the gate in one pass", () => {
+    const persistence = makePersistence();
+    const service = makeService(persistence);
+    service.park("t1", { gateRunId: "gate" });
+    service.park("t2", { gateRunId: "gate" });
+    service.park("t3", { gateRunId: "elsewhere" });
+
+    gateBecomesReady("gate");
+
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    expect(service.getParkRecord("t2")).toBeUndefined();
+    expect(service.getParkRecord("t3")).toBeDefined();
+    expect(persistence.save).toHaveBeenLastCalledWith({
+      t3: { parkedAt: NOW, gateRunId: "elsewhere" },
+    });
+    service.dispose();
+  });
+
+  it("keeps every park when a gate release cannot be persisted", () => {
+    const persistence = makePersistence();
+    const service = makeService(persistence);
+    service.park("t1", { gateRunId: "gate" });
+    persistence.save.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    gateBecomesReady("gate");
+
+    // Announcing a release that resurrects after restart is worse than
+    // releasing late, so the park stays and nothing is emitted.
+    expect(service.getParkRecord("t1")).toBeDefined();
+    expect(emittedOf("terminal:park-released")).toEqual([]);
+    service.dispose();
+  });
+
+  it("does not re-visit a park created by a release listener on the same gate", () => {
+    const service = makeService();
+    service.park("t1", { gateRunId: "gate" });
+    eventEmitter.on("terminal:park-released", () => {
+      // A listener that immediately re-parks on the same gate must need a NEW
+      // edge — the pass that released t1 already snapshotted its batch.
+      if (service.getParkRecord("t2") === undefined) {
+        service.park("t2", { gateRunId: "gate" });
+      }
+    });
+
+    gateBecomesReady("gate");
+
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    expect(service.getParkRecord("t2")).toBeDefined();
+    service.dispose();
+  });
+
+  it("freezes entirely while the app is shutting down", () => {
+    let quitting = false;
+    const persistence = makePersistence();
+    const service = makeService(persistence, { isQuitting: () => quitting });
+    service.park("t1", { gateRunId: "gate" });
+    quitting = true;
+
+    // The shutdown chain kills every terminal, which lands as busy→ready
+    // edges and trashes — none of it may touch the parks being carried
+    // across the restart, and no new intent can be recorded mid-teardown.
+    gateBecomesReady("gate");
+    eventEmitter.emit("terminal:trashed", { id: "gate", expiresAt: NOW + 1000 });
+    expect(service.getParkRecord("t1")).toBeDefined();
+    expect(() => service.park("t2")).toThrow();
+    expect(() => service.unpark("t1")).toThrow();
+    expect(service.getParkRecord("t1")).toBeDefined();
+    service.dispose();
+  });
+
+  it("hydrates from persistence, pruning stale and malformed records", () => {
+    const fresh: RunParkRecord = { parkedAt: NOW - DAY_MS, note: "fresh" };
+    const persistence = makePersistence({
+      fresh,
+      stale: { parkedAt: NOW - 20 * DAY_MS },
+      malformed: { parkedAt: Number.NaN },
+      fromTheFuture: { parkedAt: NOW + DAY_MS },
+      broken: undefined as unknown as RunParkRecord,
+    });
+    const service = makeService(persistence);
+
+    expect(service.getParkRecord("fresh")).toEqual(fresh);
+    expect(service.getParkRecord("stale")).toBeUndefined();
+    expect(service.getParkRecord("malformed")).toBeUndefined();
+    expect(service.getParkRecord("fromTheFuture")).toBeUndefined();
+    // Pruning rewrote the store so the dead records don't reload forever.
+    expect(persistence.save).toHaveBeenCalledWith({ fresh });
+    service.dispose();
+  });
+
+  it("rebuilds loaded records field-by-field, dropping what fails validation", () => {
+    const persistence = makePersistence({
+      t1: {
+        parkedAt: NOW - DAY_MS,
+        note: 42,
+        gateRunId: "t1",
+        smuggled: "extra",
+      } as unknown as RunParkRecord,
+      t2: { parkedAt: NOW - DAY_MS, note: "  ok  ", gateRunId: "" } as RunParkRecord,
+    });
+    const service = makeService(persistence);
+
+    // Non-string note dropped, self-gate dropped, unknown fields not copied.
+    expect(service.getParkRecord("t1")).toEqual({ parkedAt: NOW - DAY_MS });
+    // Note re-normalized on the way in; empty gate treated as no gate.
+    expect(service.getParkRecord("t2")).toEqual({ parkedAt: NOW - DAY_MS, note: "ok" });
+    service.dispose();
+  });
+
+  it("releases a park hydrated from disk when its gate comes free", () => {
+    const service = makeService(
+      makePersistence({ t1: { parkedAt: NOW - DAY_MS, gateRunId: "gate" } })
+    );
+
+    gateBecomesReady("gate");
+
+    expect(service.getParkRecord("t1")).toBeUndefined();
+    service.dispose();
+  });
+
+  it("starts empty when persistence itself fails", () => {
+    const persistence = {
+      load: vi.fn(() => {
+        throw new Error("corrupt store");
+      }),
+      save: vi.fn(),
+    };
+    const service = new RunAttentionService(persistence, { now: () => NOW });
+    expect([...service.getAll()]).toEqual([]);
+    service.dispose();
+  });
+
+  it("stops listening after dispose", () => {
+    const service = makeService();
+    service.park("t1", { gateRunId: "gate" });
+    const before = service.getParkRecord("t1");
+    service.dispose();
+
+    gateBecomesReady("gate");
+
+    // Dispose cleared the map; the point is no release event fired afterwards.
+    expect(before).toBeDefined();
+    expect(emittedOf("terminal:park-released")).toEqual([]);
+  });
+});

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -276,6 +276,18 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: false,
     description: "Terminal restored from trash",
   },
+  "terminal:park-changed": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "A run was parked or unparked (user intent, not agent state)",
+  },
+  "terminal:park-released": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "A parked run was released because its gate terminal came free or closed",
+  },
   "agent-session:captured": {
     category: "agent",
     requiresContext: false,
@@ -768,6 +780,33 @@ export type DaintreeEventMap = {
   };
 
   /**
+   * Emitted whenever a run's park record is created, replaced or removed —
+   * by the user or by an automatic release. Attention projections
+   * (`FleetSnapshotService`) subscribe to recompute; the payload deliberately
+   * carries only the id so no consumer is tempted to bypass the service as the
+   * single reader of park state.
+   */
+  "terminal:park-changed": {
+    id: string;
+    parked: boolean;
+    timestamp: number;
+  };
+
+  /**
+   * Emitted when a park is lifted automatically rather than by hand: the gate
+   * terminal finished its stint (busy → ready) or was closed. Carries the note
+   * so the "this run is ready for you again" surface can say why the run was
+   * waiting without a second read.
+   */
+  "terminal:park-released": {
+    id: string;
+    gateRunId: string;
+    note?: string;
+    reason: "gate-ready" | "gate-closed";
+    timestamp: number;
+  };
+
+  /**
    * Emitted in the pty-host when trash expiry captures a resumable session,
    * and re-emitted on the Main bus by PtyEventsBridge. Main persists the
    * record (single journal writer — the pty-host writing the file itself
@@ -931,6 +970,8 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "action:dispatched",
   "terminal:trashed",
   "terminal:restored",
+  "terminal:park-changed",
+  "terminal:park-released",
   "agent-session:captured",
   "agent-session:recorded",
   "terminal:activity",

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -28,6 +28,7 @@ import type { PluginMcpConsentRecord } from "../shared/types/pluginMcpConsent.js
 import type { PluginCapabilityConsentRecord } from "../shared/types/pluginCapabilityConsent.js";
 import { PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION } from "../shared/types/ipc/pluginMcp.js";
 import type { ForgeAuditRecord } from "../shared/types/ipc/forge.js";
+import type { RunParkRecord } from "../shared/types/ipc/fleet.js";
 import type { RunHistoryRecord } from "../shared/types/ipc/runHistory.js";
 import type { SuggestedDictionaryEntry } from "../shared/types/ipc/api.js";
 import { FORGE_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/forge.js";
@@ -95,6 +96,13 @@ export interface StoreSchema {
   };
   idleTerminalDismissals: Record<string, number>;
   idleTerminalNotifiedAt: Record<string, number>;
+  /**
+   * Park records keyed by terminal id (`RunAttentionService` is the sole
+   * reader/writer). Terminal ids survive app restart — panels rehydrate and
+   * respawn under the same ids — so a park set before quitting still holds
+   * after relaunch. Records for ids that never come back are pruned by age.
+   */
+  parkedRuns: Record<string, RunParkRecord>;
   idleBackgroundAutoClose: {
     enabled: boolean;
     thresholdMinutes: number;
@@ -555,6 +563,7 @@ const storeOptions = {
     },
     idleTerminalDismissals: {},
     idleTerminalNotifiedAt: {},
+    parkedRuns: {},
     // Auto-close defaults OFF: it's a structural change to project lifecycle
     // (frees the renderer + workspace host), so users opt in. 15-min default
     // threshold matches the issue spec.

--- a/shared/types/ipc/fleet.ts
+++ b/shared/types/ipc/fleet.ts
@@ -44,13 +44,14 @@ export interface RunParkRecord {
  * Every field here is already on the pty-host's terminal record, so the whole
  * row is free: main fetches exactly this data today and discards it.
  *
- * Deliberately excludes the terminal's `lastOutputTime`. It is rewritten on
- * every PTY data chunk (`PtyDataPipeline`), so carrying it would change the
+ * Deliberately excludes the terminal's raw `lastOutputTime`. It is rewritten
+ * on every PTY data chunk (`PtyDataPipeline`), so carrying it would change the
  * payload many times a second for any working agent and defeat the snapshot's
- * unchanged-payload suppression exactly when the fleet is busiest. Stall
- * detection wants that signal, but it needs per-run calibration against the
- * run's own output rhythm and belongs beside the agent FSM, not on a list
- * projection whose whole cost model depends on changing rarely.
+ * unchanged-payload suppression exactly when the fleet is busiest. What rides
+ * instead is {@link quietSince}: the same signal, but only once a working run
+ * has been silent long enough to be worth saying — a value that is absent for
+ * a healthy busy agent and CONSTANT for a stalled one, so it costs one
+ * broadcast at the threshold crossing and nothing after.
  */
 export interface FleetRunRow {
   /** Terminal id. The run's identity, and the handle any action takes. */
@@ -109,6 +110,17 @@ export interface FleetRunRow {
    * the note travels with it.
    */
   park?: RunParkRecord;
+  /**
+   * When a WORKING run last showed signs of life — the later of its last
+   * output and its entry into the current working stint — present only once
+   * that silence has crossed main's stall threshold. "Working · 47m" and
+   * "working but wedged for 12 minutes" are different facts, and without this
+   * field they render identically. Anchoring on the stint and not output
+   * alone keeps a freshly resumed run from inheriting its old waiting silence
+   * as a stall. Absent means healthy (or not working at all), never merely
+   * unknown.
+   */
+  quietSince?: number;
 }
 
 /**

--- a/shared/types/ipc/fleet.ts
+++ b/shared/types/ipc/fleet.ts
@@ -3,6 +3,28 @@ import type { BuiltInAgentId } from "../../config/agentIds.js";
 import type { PanelTitleMode } from "../panel.js";
 
 /**
+ * A user's decision that a run does not need them right now.
+ *
+ * Parking is intent, not state: the agent underneath keeps doing whatever it
+ * was doing, and every attention surface (bands, demand counts, filters) treats
+ * the run as shelved until the record is removed — by hand, or automatically
+ * when the gate terminal next comes free. Owned by Main
+ * (`RunAttentionService`) for the same reason the snapshot is: intent must
+ * survive view eviction and app restart, and terminal ids do.
+ */
+export interface RunParkRecord {
+  /** When the user parked the run (epoch ms). */
+  parkedAt: number;
+  /** Why it's parked — the user's own words, shown wherever the run is listed. */
+  note?: string;
+  /**
+   * Terminal id whose next busy→ready transition releases this park. Absent
+   * means the park holds until the user lifts it.
+   */
+  gateRunId?: string;
+}
+
+/**
  * One agent run: a single agent terminal living in a single worktree.
  *
  * The run — not the project — is the unit here, and that is the whole point of
@@ -73,6 +95,12 @@ export interface FleetRunRow {
   everDetectedAgent?: boolean;
   /** User-chosen preset colour, which outranks the agent's default brand hue. */
   agentPresetColor?: string;
+  /**
+   * Present iff the user parked this run. Rides the row so every surface reads
+   * one source of truth; the band logic demotes a parked run below the fold and
+   * the note travels with it.
+   */
+  park?: RunParkRecord;
 }
 
 /**

--- a/shared/types/ipc/fleet.ts
+++ b/shared/types/ipc/fleet.ts
@@ -3,6 +3,14 @@ import type { BuiltInAgentId } from "../../config/agentIds.js";
 import type { PanelTitleMode } from "../panel.js";
 
 /**
+ * Longest note a park may carry, in UTF-16 code units. Lives on the shared
+ * wire type because both ends enforce it: the service caps what it stores,
+ * and the editor caps what can be typed — two limits that drift apart would
+ * let a user write a note the store then silently shortens.
+ */
+export const MAX_PARK_NOTE_LENGTH = 500;
+
+/**
  * A user's decision that a run does not need them right now.
  *
  * Parking is intent, not state: the agent underneath keeps doing whatever it

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -176,6 +176,12 @@ export interface GeneratedElectronAPI {
     getSnapshot(
       ...args: IpcInvokeMap["fleet:get-snapshot"]["args"]
     ): Promise<IpcInvokeMap["fleet:get-snapshot"]["result"]>;
+    parkRun(
+      ...args: IpcInvokeMap["fleet:park-run"]["args"]
+    ): Promise<IpcInvokeMap["fleet:park-run"]["result"]>;
+    unparkRun(
+      ...args: IpcInvokeMap["fleet:unpark-run"]["args"]
+    ): Promise<IpcInvokeMap["fleet:unpark-run"]["result"]>;
   };
   forgeAudit: {
     clearLog(

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -373,6 +373,17 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./fleet.js").FleetSnapshot | null;
   };
+  "fleet:park-run": {
+    args: [
+      runId: string,
+      options?: { note?: string | undefined; gateRunId?: string | undefined } | undefined,
+    ];
+    result: import("./fleet.js").RunParkRecord;
+  };
+  "fleet:unpark-run": {
+    args: [runId: string];
+    result: boolean;
+  };
   "forge-audit:clear-log": {
     args: [];
     result: void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1381,6 +1381,16 @@ export interface IpcEventMap {
   "terminal:error": [id: string, error: string];
   "terminal:trashed": { id: string; expiresAt: number };
   "terminal:restored": { id: string };
+  // A gated park lifted itself: the gate terminal came free ("gate-ready") or
+  // was closed ("gate-closed"). Carries the note so the hand-back surface can
+  // say why the run was waiting without a second read.
+  "terminal:park-released": {
+    id: string;
+    gateRunId: string;
+    note?: string;
+    reason: "gate-ready" | "gate-closed";
+    timestamp: number;
+  };
   // A close path journaled a resumable agent session (trash expiry, kill,
   // gracefulKill). Signal-only for resume surfaces to refetch the journal.
   "agent-session:recorded": {
@@ -2098,6 +2108,8 @@ export type IpcEventBusMap = Pick<
   | "terminal:status"
   // Agent session journaled — resume surfaces refetch (global broadcast)
   | "agent-session:recorded"
+  // A gated park auto-released — the ready-again hand-back (global broadcast)
+  | "terminal:park-released"
   // Watchdog deadlock detector — emitted once on cap-hit; global broadcast.
   | "watchdog:disabled"
   | "watchdog:active"

--- a/src/__tests__/PostHydrationListeners.test.tsx
+++ b/src/__tests__/PostHydrationListeners.test.tsx
@@ -8,6 +8,7 @@ import { PERF_MARKS } from "@shared/perf/marks";
 
 const hibernation = vi.fn();
 const idleTerminal = vi.fn();
+const parkRelease = vi.fn();
 const diskSpace = vi.fn();
 const tokenHealth = vi.fn();
 const rateLimit = vi.fn();
@@ -23,6 +24,9 @@ vi.mock("@/hooks/useHibernationNotifications", () => ({
 }));
 vi.mock("@/hooks/useIdleTerminalNotifications", () => ({
   useIdleTerminalNotifications: () => idleTerminal(),
+}));
+vi.mock("@/hooks/useParkReleaseNotifications", () => ({
+  useParkReleaseNotifications: () => parkRelease(),
 }));
 vi.mock("@/hooks/useDiskSpaceWarnings", () => ({
   useDiskSpaceWarnings: () => diskSpace(),
@@ -53,6 +57,7 @@ vi.mock("@/utils/performance", () => ({
 const allHooks = [
   hibernation,
   idleTerminal,
+  parkRelease,
   diskSpace,
   tokenHealth,
   rateLimit,

--- a/src/components/Pilot/PilotFilterBar.tsx
+++ b/src/components/Pilot/PilotFilterBar.tsx
@@ -45,6 +45,13 @@ const SEGMENT_TONE: Record<
     tone: "text-category-blue",
     toneFaded: "text-category-blue/40",
   },
+  // Parked never earns a hue: it is the user's own quiet, and a coloured
+  // segment would re-demand the attention parking just released.
+  parked: {
+    Icon: BAND_GLYPH.parked,
+    tone: NEUTRAL_TONE,
+    toneFaded: NEUTRAL_TONE_FADED,
+  },
 };
 
 /**

--- a/src/components/Pilot/PilotParkEditor.tsx
+++ b/src/components/Pilot/PilotParkEditor.tsx
@@ -1,0 +1,355 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { cn } from "@/lib/utils";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { PilotRunState } from "./PilotRunState";
+import type { PilotProjectGroup, PilotRow } from "./pilotRows";
+import { MAX_PARK_NOTE_LENGTH, type RunParkRecord } from "@shared/types/ipc/fleet";
+
+/**
+ * A run another run's park can gate on, carried with enough of its identity
+ * (title, workspace, state) for the picker to name it the way Pilot's own
+ * rows do.
+ */
+export interface PilotGateCandidate {
+  row: PilotRow;
+  group: PilotProjectGroup;
+}
+
+export interface PilotParkTarget {
+  row: PilotRow;
+  group: PilotProjectGroup;
+  existingPark: RunParkRecord | undefined;
+}
+
+const GATE_NONE = "__none__";
+
+function gateOptionDomId(runId: string): string {
+  return `pilot-park-gate-${runId}`;
+}
+
+/**
+ * The in-palette parking form: one note, one optional gate, two keys.
+ *
+ * Deliberately a mode of the Pilot dialog rather than a second dialog — the
+ * user is already inside a keyboard surface, and stacking a modal on a modal
+ * would re-teach focus, Escape and dismissal semantics for one input and a
+ * list. Escape pops back to the list because PilotView delegates the DIALOG's
+ * own onClose here while the editor is open — the palette's Escape handling
+ * runs at a document-level backstop that fires before any inner listener, so
+ * intercepting the key locally can never win; redirecting what "close" means
+ * can. Enter commits from anywhere except the buttons that mean something
+ * else.
+ *
+ * The gate list is a radiogroup, not a combobox: the candidates are few, the
+ * choice is single, and selection-follows-focus is the pattern the filter bar
+ * directly above it already taught.
+ */
+export function PilotParkEditor({
+  target,
+  candidates,
+  onClose,
+}: {
+  target: PilotParkTarget;
+  candidates: PilotGateCandidate[];
+  /** `changed` is true when a park was created, replaced or lifted. */
+  onClose: (changed: boolean) => void;
+}) {
+  const [note, setNote] = useState(target.existingPark?.note ?? "");
+  const [gateId, setGateId] = useState<string>(target.existingPark?.gateRunId ?? GATE_NONE);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const noteRef = useRef<HTMLInputElement>(null);
+  const gateRefs = useRef(new Map<string, HTMLButtonElement | null>());
+
+  useEffect(() => {
+    noteRef.current?.focus();
+  }, []);
+
+  // A gate that stopped existing (its run closed while the editor was open)
+  // silently degrades to "no gate" rather than submitting an id the handler
+  // will reject.
+  const gateOptions = useMemo<Array<{ id: string; candidate: PilotGateCandidate | null }>>(
+    () => [
+      { id: GATE_NONE, candidate: null },
+      ...candidates.map((candidate) => ({ id: candidate.row.run.runId, candidate })),
+    ],
+    [candidates]
+  );
+  useEffect(() => {
+    if (gateId !== GATE_NONE && !candidates.some((c) => c.row.run.runId === gateId)) {
+      setGateId(GATE_NONE);
+    }
+  }, [gateId, candidates]);
+  /**
+   * What the radiogroup RENDERS from, never the raw state: the sync effect
+   * above lands one commit late, and a frame whose checked id points at a
+   * removed option is a radiogroup with no checked radio and no tab stop —
+   * focus falls out of the form if that radio held it.
+   */
+  const effectiveGateId = gateOptions.some((option) => option.id === gateId) ? gateId : GATE_NONE;
+
+  const confirm = useCallback(() => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    const trimmed = note.trim();
+    window.electron.fleet
+      .parkRun(target.row.run.runId, {
+        ...(trimmed.length > 0 ? { note: trimmed } : {}),
+        ...(effectiveGateId !== GATE_NONE ? { gateRunId: effectiveGateId } : {}),
+      })
+      .then(() => onClose(true))
+      .catch((cause: unknown) => {
+        setBusy(false);
+        setError(formatErrorMessage(cause, "Couldn't park the run"));
+      });
+  }, [busy, note, effectiveGateId, target.row.run.runId, onClose]);
+
+  const unpark = useCallback(() => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    window.electron.fleet
+      .unparkRun(target.row.run.runId)
+      .then(() => onClose(true))
+      .catch((cause: unknown) => {
+        setBusy(false);
+        setError(formatErrorMessage(cause, "Couldn't unpark the run"));
+      });
+  }, [busy, target.row.run.runId, onClose]);
+
+  /**
+   * Enter commits from the note input and the gate list. Buttons that mean
+   * something else (Cancel, Unpark, and each gate radio, whose Enter already
+   * selects it natively) opt out via the data attribute so one keypress never
+   * fires two verbs.
+   */
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
+      // Unmodified, non-repeat Enter only: the Alt+Enter chord that OPENED
+      // the editor can key-repeat straight into the autofocused note input,
+      // and a submit fired by the opening gesture would park with an
+      // untouched form.
+      if (event.altKey || event.metaKey || event.ctrlKey || event.shiftKey || event.repeat) return;
+      if (!(event.target instanceof HTMLElement)) return;
+      if (event.target.closest("[data-no-submit]") !== null) return;
+      event.preventDefault();
+      confirm();
+    },
+    [confirm]
+  );
+
+  const moveGate = useCallback((to: string) => {
+    setGateId(to);
+    gateRefs.current.get(to)?.focus();
+  }, []);
+
+  const handleGateKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const index = gateOptions.findIndex((option) => option.id === effectiveGateId);
+      if (index === -1) return;
+
+      let next: string | undefined;
+      switch (event.key) {
+        case "ArrowDown":
+        case "ArrowRight":
+          next = gateOptions[(index + 1) % gateOptions.length]?.id;
+          break;
+        case "ArrowUp":
+        case "ArrowLeft":
+          next = gateOptions[(index - 1 + gateOptions.length) % gateOptions.length]?.id;
+          break;
+        case "Home":
+          next = gateOptions[0]?.id;
+          break;
+        case "End":
+          next = gateOptions[gateOptions.length - 1]?.id;
+          break;
+        default:
+          return;
+      }
+      if (next === undefined) return;
+      event.preventDefault();
+      event.stopPropagation();
+      moveGate(next);
+    },
+    [gateOptions, effectiveGateId, moveGate]
+  );
+
+  const isReparking = target.existingPark !== undefined;
+
+  return (
+    <div
+      data-testid="pilot-park-editor"
+      className="flex flex-col gap-3 px-3 py-2"
+      onKeyDown={handleKeyDown}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <TerminalIcon
+          chrome={target.row.chrome}
+          className="h-4 w-4 shrink-0"
+          brandColor={target.row.presetColor ?? target.row.chrome.color}
+          userChosen={target.row.presetColor !== undefined}
+        />
+        <span className="min-w-0 truncate text-sm text-daintree-text">{target.row.title}</span>
+        <span className="shrink-0 text-xs text-daintree-text/40">{target.group.name}</span>
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-[10px] font-medium tracking-wide text-daintree-text/50 uppercase">
+          Note
+        </span>
+        <input
+          ref={noteRef}
+          type="text"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          maxLength={MAX_PARK_NOTE_LENGTH}
+          disabled={busy}
+          placeholder="Why is this parked? (optional)"
+          data-testid="pilot-park-note"
+          className={cn(
+            "w-full rounded-[var(--radius-sm)] border border-border-default bg-transparent px-2 py-1.5",
+            "text-sm text-daintree-text placeholder:text-daintree-text/35"
+          )}
+        />
+      </label>
+
+      <div className="flex flex-col gap-1">
+        <span
+          id="pilot-park-gate-label"
+          className="text-[10px] font-medium tracking-wide text-daintree-text/50 uppercase"
+        >
+          Park until
+        </span>
+        <div
+          role="radiogroup"
+          aria-labelledby="pilot-park-gate-label"
+          aria-orientation="vertical"
+          data-testid="pilot-park-gates"
+          onKeyDown={handleGateKeyDown}
+          className="flex max-h-56 flex-col overflow-y-auto rounded-[var(--radius-sm)] border border-border-default"
+        >
+          {gateOptions.map(({ id, candidate }) => {
+            const isActive = id === effectiveGateId;
+            return (
+              <button
+                key={id}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                tabIndex={isActive ? 0 : -1}
+                disabled={busy}
+                // The glyph and brand icon are aria-hidden decoration, so the
+                // radio spells its whole identity out: two same-titled runs on
+                // different agents or in different states must not be one
+                // string to a screen reader.
+                {...(candidate !== null
+                  ? {
+                      "aria-label": `${candidate.row.title}, ${candidate.row.chrome.label}, ${candidate.row.statusLabel}, ${candidate.group.name}`,
+                    }
+                  : {})}
+                data-no-submit
+                id={gateOptionDomId(id)}
+                ref={(el) => {
+                  gateRefs.current.set(id, el);
+                }}
+                onClick={() => setGateId(id)}
+                className={cn(
+                  "flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent",
+                  isActive
+                    ? "bg-overlay-subtle text-daintree-text"
+                    : "text-daintree-text/70 hover:bg-tint/[0.04]"
+                )}
+              >
+                {candidate === null ? (
+                  <span className="text-daintree-text/70">I unpark it myself</span>
+                ) : (
+                  <>
+                    <span className="flex size-3.5 shrink-0 items-center justify-center">
+                      <PilotRunState
+                        band={candidate.row.band}
+                        agentState={candidate.row.run.agentState}
+                      />
+                    </span>
+                    <TerminalIcon
+                      chrome={candidate.row.chrome}
+                      className="h-4 w-4 shrink-0"
+                      brandColor={candidate.row.presetColor ?? candidate.row.chrome.color}
+                      userChosen={candidate.row.presetColor !== undefined}
+                    />
+                    <span className="min-w-0 flex-1 truncate">{candidate.row.title}</span>
+                    <span className="shrink-0 text-xs text-daintree-text/40">
+                      {candidate.group.name}
+                    </span>
+                  </>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-[11px] leading-snug text-daintree-text/40">
+          Gated parks lift when that agent next finishes working — the run pops back into Waiting
+          with your note.
+        </p>
+      </div>
+
+      {error !== null && (
+        <p role="alert" className="text-xs text-status-danger">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={confirm}
+          disabled={busy}
+          data-testid="pilot-park-confirm"
+          className={cn(
+            "rounded-[var(--radius-sm)] bg-overlay-subtle px-3 py-1 text-sm text-daintree-text transition-colors",
+            "hover:bg-tint/[0.08] disabled:opacity-50",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+          )}
+        >
+          {isReparking ? "Update park" : "Park"}
+        </button>
+        {isReparking && (
+          <button
+            type="button"
+            onClick={unpark}
+            disabled={busy}
+            data-no-submit
+            data-testid="pilot-park-unpark"
+            className={cn(
+              "rounded-[var(--radius-sm)] px-3 py-1 text-sm text-daintree-text/70 transition-colors",
+              "hover:bg-overlay-subtle hover:text-daintree-text disabled:opacity-50",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+            )}
+          >
+            Unpark
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => onClose(false)}
+          disabled={busy}
+          data-no-submit
+          data-testid="pilot-park-cancel"
+          className={cn(
+            "ml-auto rounded-[var(--radius-sm)] px-3 py-1 text-sm text-daintree-text/50 transition-colors",
+            "hover:bg-overlay-subtle hover:text-daintree-text disabled:opacity-50",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+          )}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -73,11 +73,12 @@ export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>
  * `done` and `idle` stay neutral: an acknowledged completion and an exited
  * shell are not news.
  *
- * Module-private: the collapsed-group pip cluster that used to draw from it is
- * gone, and the filter bar spells its own segment tones out in full because
- * Tailwind's scanner cannot see an assembled `${tone}/40`.
+ * Exported for the group header's demand chip, which has to speak the same
+ * hue as the rows it summarises. The filter bar still spells its own segment
+ * tones out in full because Tailwind's scanner cannot see an assembled
+ * `${tone}/40`.
  */
-const BAND_GLYPH_TONE: Record<FleetBand, string> = {
+export const BAND_GLYPH_TONE: Record<FleetBand, string> = {
   blocked: "text-status-danger",
   "needs-you": "text-state-waiting",
   review: "text-category-blue",

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -5,6 +5,7 @@ import {
   InteractingCircle,
   ExitedCircle,
   CircleCheck,
+  CirclePause,
   CircleSlash,
 } from "@/components/icons";
 import type { FleetBand } from "@/lib/fleetAttention";
@@ -49,6 +50,7 @@ export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>
   review: CircleCheck,
   running: SpinnerCircle,
   done: CircleCheck,
+  parked: CirclePause,
   idle: HollowCircle,
 };
 
@@ -81,6 +83,9 @@ const BAND_GLYPH_TONE: Record<FleetBand, string> = {
   review: "text-category-blue",
   running: "text-state-working",
   done: NEUTRAL_TONE,
+  // Parked is the user's own quiet, so it takes the quiet tone: hued parked
+  // rows would re-demand the attention parking just released.
+  parked: NEUTRAL_TONE,
   idle: NEUTRAL_TONE,
 };
 
@@ -96,10 +101,10 @@ const BAND_GLYPH_TONE: Record<FleetBand, string> = {
  * ordering beside it: an acknowledged completion has to stop looking like a
  * hand-back at the same moment it stops being counted as one.
  *
- * The three demand bands and `running` are hued; the two quiet ones are not.
- * Shape still carries the state as a second channel for all six — spinner,
- * hollow circle, prohibition, check and exited stay distinct — and the row
- * keeps the state in text in its accessible name either way. Never colour
+ * The three demand bands and `running` are hued; the quiet ones are not.
+ * Shape still carries the state as a second channel for every band — spinner,
+ * hollow circle, prohibition, check, pause and exited stay distinct — and the
+ * row keeps the state in text in its accessible name either way. Never colour
  * alone, and never colour where there is nothing happening.
  */
 export function PilotRunState({ band, agentState }: PilotRunStateProps) {

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -26,6 +26,8 @@ import {
 } from "./pilotRows";
 import { PilotRunState } from "./PilotRunState";
 import { PilotFilterBar } from "./PilotFilterBar";
+import { PilotParkEditor, type PilotGateCandidate, type PilotParkTarget } from "./PilotParkEditor";
+import { isMac } from "@/lib/platform";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
 import { PALETTE_ROW_CLASS, PALETTE_SECTION_LABEL_CLASS } from "@/components/ui/paletteRowStyles";
@@ -281,6 +283,7 @@ function RunRow({
     row.title,
     agentLabel,
     row.statusLabel,
+    row.parkNote,
     row.age !== null ? agoPhrase(row.age) : null,
   ]
     .filter((part): part is string => part !== null)
@@ -333,6 +336,20 @@ function RunRow({
       </span>
 
       {/*
+        The park's note — the one line of intent that justifies the row still
+        being listed. Capped so it shares the row with the title instead of
+        starving it; the row's accessible name above carries it in full.
+      */}
+      {row.parkNote !== null && (
+        <span
+          aria-hidden="true"
+          className="max-w-[45%] min-w-0 shrink truncate text-xs leading-tight text-daintree-text/45"
+        >
+          {row.parkNote}
+        </span>
+      )}
+
+      {/*
         The scan column, now a single fact wide.
 
         `aria-hidden` — the row's own label above says this in order and with
@@ -376,11 +393,14 @@ function RunRow({
  */
 function PilotFooter({
   actionLabel,
+  parkLabel,
   summary,
   demandCount,
   onShowDemand,
 }: {
   actionLabel: string | null;
+  /** The park verb for the highlighted row, or null while no row is selected. */
+  parkLabel: string | null;
   summary: string;
   demandCount: number;
   onShowDemand: () => void;
@@ -392,6 +412,12 @@ function PilotFooter({
           <span>
             <kbd className={KBD_CLASS}>↵</kbd>
             <span className="ml-1.5">{actionLabel}</span>
+          </span>
+        )}
+        {parkLabel !== null && (
+          <span data-testid="pilot-park-hint">
+            <kbd className={KBD_CLASS}>{isMac() ? "⌥↵" : "Alt+↵"}</kbd>
+            <span className="ml-1.5">{parkLabel}</span>
           </span>
         )}
       </div>
@@ -614,10 +640,62 @@ export function PilotView() {
     [visibleGroups]
   );
 
+  /**
+   * The run whose park is being edited, held by id so the pane always renders
+   * live data: titles, bands and the candidate list keep updating underneath
+   * the editor exactly as they do under the list.
+   */
+  const [parkTargetId, setParkTargetId] = useState<string | null>(null);
+
+  const parkTarget = useMemo<PilotParkTarget | null>(() => {
+    if (parkTargetId === null) return null;
+    for (const group of liveGroups) {
+      const row = group.rows.find((r) => r.run.runId === parkTargetId);
+      if (row) return { row, group, existingPark: row.run.park };
+    }
+    return null;
+  }, [parkTargetId, liveGroups]);
+
+  const gateCandidates = useMemo<PilotGateCandidate[]>(() => {
+    if (parkTargetId === null) return [];
+    const out: PilotGateCandidate[] = [];
+    for (const group of liveGroups) {
+      for (const row of group.rows) {
+        if (row.run.runId === parkTargetId) continue;
+        out.push({ row, group });
+      }
+    }
+    return out;
+  }, [parkTargetId, liveGroups]);
+
+  // The run closed (or the fleet became unreadable) while its editor was open
+  // — there is nothing left to park, so fall back to the list.
+  useEffect(() => {
+    if (parkTargetId !== null && parkTarget === null) setParkTargetId(null);
+  }, [parkTargetId, parkTarget]);
+
+  const parkEditing = parkTarget !== null;
+
+  const closeParkEditor = useCallback((_changed: boolean) => {
+    setParkTargetId(null);
+  }, []);
+
+  // The editor unmounts with focus inside it, and the search box only
+  // REMOUNTS on the same commit — so the hand-back has to happen after that
+  // commit, not inside the close handler, where the ref is still null.
+  const wasParkEditingRef = useRef(false);
+  useEffect(() => {
+    if (wasParkEditingRef.current && !parkEditing && isOpen) {
+      searchRef.current?.focus();
+    }
+    wasParkEditingRef.current = parkEditing;
+  }, [parkEditing, isOpen]);
+
   useEffect(() => {
     if (!isOpen) {
       setQuery("");
       setBandFilter("all");
+      setParkTargetId(null);
       // Closing takes focus with it without a blur ever reaching the bar.
       setIsFilterFocused(false);
     }
@@ -717,20 +795,46 @@ export function PilotView() {
     if (event.defaultPrevented) setPointerOrder(null);
   }, []);
 
+  /**
+   * Alt+Enter on the highlighted row opens the park editor — a second verb on
+   * the same selection, so it lives beside Enter in both key paths rather
+   * than in the navigation model, which owns structure and not actions.
+   */
+  const interceptParkKey = useCallback(
+    (event: KeyboardEvent<HTMLElement>): boolean => {
+      if (event.key !== "Enter" || !event.altKey || event.defaultPrevented) return false;
+      if (selectedRow === null || selectedRow.kind !== "item") return false;
+      // No parking from retained data: Main rejects a park it cannot validate
+      // against a healthy snapshot, so offering the editor over a stale fleet
+      // would collect a note and then bounce it.
+      if (snapshot === null || snapshot.degraded) return false;
+      event.preventDefault();
+      setParkTargetId(selectedRow.item.run.runId);
+      return true;
+    },
+    [selectedRow, snapshot]
+  );
+
   const handleInputKeyDown = useCallback<KeyboardEventHandler<HTMLInputElement>>(
     (event) => {
+      if (interceptParkKey(event)) return;
       navigation.handleInputKeyDown(event);
       releaseOnConsumedKey(event);
     },
-    [navigation, releaseOnConsumedKey]
+    [interceptParkKey, navigation, releaseOnConsumedKey]
   );
 
   const handleBodyKeyDown = useCallback<KeyboardEventHandler<HTMLElement>>(
     (event) => {
+      // While the editor owns the body, the list's navigation must stand down
+      // entirely: its selection is live underneath, and an Enter bubbling out
+      // of the note input would otherwise OPEN the highlighted run.
+      if (parkEditing) return;
+      if (interceptParkKey(event)) return;
       navigation.handleBodyKeyDown(event);
       releaseOnConsumedKey(event);
     },
-    [navigation, releaseOnConsumedKey]
+    [parkEditing, interceptParkKey, navigation, releaseOnConsumedKey]
   );
 
   /**
@@ -849,56 +953,98 @@ export function PilotView() {
   // never gets its blur, and the flag alone would suppress the hints for good.
   const actionLabel = selectedRow === null || (isFilterFocused && showFilterBar) ? null : "Open";
 
-  return (
-    <AppPaletteDialog isOpen={isOpen} onClose={close} ariaLabel="All agents" tier="command">
-      <AppPaletteDialog.Header label="All agents" shortcut={pilotShortcut}>
-        <AppPaletteDialog.Input
-          inputRef={searchRef}
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={handleInputKeyDown}
-          placeholder="Search agents…"
-          aria-label="Search agents"
-          // The role is constant, not conditional on there being results. A
-          // control that changes role underneath a screen reader as rows come
-          // and go is not re-announced, so it silently stops being what the
-          // user was told it was. The tree container below is always mounted,
-          // which is what keeps `aria-controls` resolving.
-          role="combobox"
-          aria-expanded={hasTree}
-          aria-haspopup="listbox"
-          aria-controls={LIST_ID}
-          aria-activedescendant={activeDescendantId}
-          data-testid="pilot-search"
-        />
+  // The second verb rides the same gating as the first — no selection or a
+  // focused filter segment drops both hints — plus one of its own: parking
+  // needs a healthy snapshot (Main validates the ids against it), so the hint
+  // disappears with the data that would back it.
+  const parkLabel =
+    actionLabel === null ||
+    selectedRow === null ||
+    selectedRow.kind !== "item" ||
+    status.kind !== "live"
+      ? null
+      : selectedRow.item.band === "parked"
+        ? "Edit park"
+        : "Park";
 
+  return (
+    // While the park editor is open, "close" means "back to the list": the
+    // palette's Escape runs through a document-level backstop that fires
+    // before any inner listener can, so the only reliable way to layer the
+    // editor under Escape is to redirect what closing does — not to race the
+    // key. Backdrop clicks follow the same rule, which is also the right
+    // gesture reading: dismissing the editor, not the surface under it.
+    <AppPaletteDialog
+      isOpen={isOpen}
+      onClose={parkEditing ? () => closeParkEditor(false) : close}
+      ariaLabel="All agents"
+      tier="command"
+    >
+      <AppPaletteDialog.Header label="All agents" shortcut={pilotShortcut}>
         {/*
-          Inside the header, under the input, so the two narrowing controls read
-          as one unit and the header's own rule closes the block. Full-bleed
-          against the header's padding, matching the sidebar's bar exactly.
-          After the input in DOM order, which is also the tab order: input →
-          active segment → results.
+          The search-and-narrow controls belong to the list. While the park
+          editor owns the body they unmount — a query box filtering an
+          invisible list is a control acting somewhere the user cannot see.
         */}
-        {showFilterBar && (
-          <div className="-mx-3 -mb-2 mt-2 border-t border-border-default">
-            <PilotFilterBar
-              value={bandFilter}
-              counts={filterCounts}
-              bands={fleet.bands}
-              onChange={setBandFilter}
-              onFocusChange={setIsFilterFocused}
+        {!parkEditing && (
+          <>
+            <AppPaletteDialog.Input
+              inputRef={searchRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleInputKeyDown}
+              placeholder="Search agents…"
+              aria-label="Search agents"
+              // The role is constant, not conditional on there being results. A
+              // control that changes role underneath a screen reader as rows come
+              // and go is not re-announced, so it silently stops being what the
+              // user was told it was. The tree container below is always mounted,
+              // which is what keeps `aria-controls` resolving.
+              role="combobox"
+              aria-expanded={hasTree}
+              aria-haspopup="listbox"
+              aria-controls={LIST_ID}
+              aria-activedescendant={activeDescendantId}
+              data-testid="pilot-search"
             />
-          </div>
+
+            {/*
+              Inside the header, under the input, so the two narrowing controls read
+              as one unit and the header's own rule closes the block. Full-bleed
+              against the header's padding, matching the sidebar's bar exactly.
+              After the input in DOM order, which is also the tab order: input →
+              active segment → results.
+            */}
+            {showFilterBar && (
+              <div className="-mx-3 -mb-2 mt-2 border-t border-border-default">
+                <PilotFilterBar
+                  value={bandFilter}
+                  counts={filterCounts}
+                  bands={fleet.bands}
+                  onChange={setBandFilter}
+                  onFocusChange={setIsFilterFocused}
+                />
+              </div>
+            )}
+          </>
         )}
       </AppPaletteDialog.Header>
 
       <AppPaletteDialog.Body
         className="p-0"
         ariaLabel="Agents"
-        activeDescendant={activeDescendantId}
+        activeDescendant={parkEditing ? undefined : activeDescendantId}
         onNavigationKeyDown={handleBodyKeyDown}
       >
-        {showSkeleton && (
+        {parkEditing && parkTarget !== null && (
+          <PilotParkEditor
+            target={parkTarget}
+            candidates={gateCandidates}
+            onClose={closeParkEditor}
+          />
+        )}
+
+        {!parkEditing && showSkeleton && (
           /*
            * Gated at the Doherty threshold — a fleet read that resolves in
            * 80ms must not flash a skeleton on the way. The hint is a SIBLING of
@@ -917,7 +1063,7 @@ export function PilotView() {
           </>
         )}
 
-        {status.kind === "unavailable" && (
+        {!parkEditing && status.kind === "unavailable" && (
           <div className="px-3 py-8 text-center" role="status" data-testid="pilot-unavailable">
             <p className="text-sm text-daintree-text/70">Can&apos;t reach the agent host</p>
             {/*
@@ -931,7 +1077,7 @@ export function PilotView() {
           </div>
         )}
 
-        {status.kind === "stale" && (
+        {!parkEditing && status.kind === "stale" && (
           <div data-testid="pilot-stale" className="px-3 py-1.5 text-[11px] text-activity-waiting">
             {/*
               The announced copy is fixed and the ticking age is hidden from it.
@@ -947,7 +1093,7 @@ export function PilotView() {
           </div>
         )}
 
-        {showEmpty && (
+        {!parkEditing && showEmpty && (
           /*
            * Names the next action rather than the absence. This is not the
            * completed-work state it first looks like: a finished agent stays in
@@ -996,11 +1142,13 @@ export function PilotView() {
 
         {/*
           Always mounted so `aria-controls` on the combobox above always
-          resolves, even while loading or empty. No padding of its own: the
-          palette body's scroller already carries `p-2`.
+          resolves, even while loading or empty — except while the park editor
+          owns the body, when the combobox itself is unmounted too. No padding
+          of its own: the palette body's scroller already carries `p-2`.
         */}
         <div
           id={LIST_ID}
+          hidden={parkEditing}
           {...(hasTree ? { role: "listbox", "aria-label": "Agents by project" } : {})}
           // The pointer stops working the list the moment it leaves it, so the
           // ranking goes back to being true. On the container rather than the
@@ -1053,10 +1201,11 @@ export function PilotView() {
         strip under the empty state. Drop the whole footer instead of shipping a
         divider with nothing beneath it.
       */}
-      {(actionLabel !== null || summary !== "") && (
+      {!parkEditing && (actionLabel !== null || summary !== "") && (
         <AppPaletteDialog.Footer>
           <PilotFooter
             actionLabel={actionLabel}
+            parkLabel={parkLabel}
             summary={summary}
             demandCount={needsYou}
             onShowDemand={() => {

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -12,6 +12,7 @@ import { actionService } from "@/services/ActionService";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { agoPhrase, formatWaitAge } from "@/lib/projectRowStatus";
+import { isDemandBand } from "@/lib/fleetAttention";
 import {
   buildPilotGroups,
   countPilotBands,
@@ -24,7 +25,7 @@ import {
   type PilotRow,
   type PilotWorkspaceMeta,
 } from "./pilotRows";
-import { PilotRunState } from "./PilotRunState";
+import { BAND_GLYPH, BAND_GLYPH_TONE, PilotRunState } from "./PilotRunState";
 import { PilotFilterBar } from "./PilotFilterBar";
 import { PilotParkEditor, type PilotGateCandidate, type PilotParkTarget } from "./PilotParkEditor";
 import { isMac } from "@/lib/platform";
@@ -229,6 +230,32 @@ function GroupHeader({ group, className }: { group: PilotProjectGroup; className
           <span className="shrink-0 text-[10px] leading-none text-daintree-text/30">Current</span>
         )}
       </div>
+
+      {/*
+        The group's demand, at a glance: glyph and hue come from the worst row
+        beneath (which is always a demand band whenever the count is non-zero,
+        since demands outrank everything else), so five headers answer "which
+        project is on fire" without reading a single row. Hidden with the rest
+        of the header — the group's aria-label carries the same fact in words.
+      */}
+      {group.demandCount > 0 &&
+        (() => {
+          const chipBand = isDemandBand(group.topBand) ? group.topBand : "needs-you";
+          const ChipGlyph = BAND_GLYPH[chipBand];
+          return (
+            <span
+              aria-hidden="true"
+              data-testid="pilot-group-demand"
+              className={cn(
+                "flex shrink-0 items-center gap-1 text-[10px] leading-none tabular-nums",
+                BAND_GLYPH_TONE[chipBand]
+              )}
+            >
+              <ChipGlyph className="h-2.5 w-2.5" />
+              {group.demandCount}
+            </span>
+          );
+        })()}
     </div>
   );
 }
@@ -284,6 +311,7 @@ function RunRow({
     agentLabel,
     row.statusLabel,
     row.parkNote,
+    row.quietFor !== null ? `quiet for ${row.quietFor}` : null,
     row.age !== null ? agoPhrase(row.age) : null,
   ]
     .filter((part): part is string => part !== null)
@@ -346,6 +374,22 @@ function RunRow({
           className="max-w-[45%] min-w-0 shrink truncate text-xs leading-tight text-daintree-text/45"
         >
           {row.parkNote}
+        </span>
+      )}
+
+      {/*
+        The stall cue: a working glyph beside ten minutes of silence is the
+        one combination the age column cannot express — "Working · 47m" and
+        "working but wedged" render identically without it. Amber because it
+        is a live fact that may need a hand, worded because the hue alone
+        must never carry it (the accessible name says "quiet for 12m").
+      */}
+      {row.quietFor !== null && (
+        <span
+          aria-hidden="true"
+          className="shrink-0 text-[11px] leading-none text-state-waiting/80"
+        >
+          quiet {row.quietFor}
         </span>
       )}
 
@@ -1172,7 +1216,7 @@ export function PilotView() {
               key={header.domId}
               id={header.domId}
               role="group"
-              aria-label={`${header.group.name}${header.group.isCurrent ? ", current workspace" : ""}`}
+              aria-label={`${header.group.name}${header.group.isCurrent ? ", current workspace" : ""}${header.group.demandCount > 0 ? `, ${demandPhrase(header.group.demandCount)}` : ""}`}
               // The scroller spaces siblings equally, so after a long run list
               // the next project arrives with no more separation than one more
               // agent. Only between groups — a leading gap would push the list

--- a/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
+++ b/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
@@ -7,7 +7,7 @@ import type { PilotBandFilter, PilotBandFilterCounts } from "../pilotRows";
 import { emptyBandCounts, type FleetBandCounts } from "@/lib/fleetAttention";
 
 function counts(overrides: Partial<PilotBandFilterCounts> = {}): PilotBandFilterCounts {
-  return { all: 0, "needs-you": 0, working: 0, finished: 0, ...overrides };
+  return { all: 0, "needs-you": 0, working: 0, finished: 0, parked: 0, ...overrides };
 }
 
 function bands(overrides: Partial<FleetBandCounts> = {}): FleetBandCounts {
@@ -60,13 +60,13 @@ function segmentNames(): string[] {
 }
 
 describe("PilotFilterBar", () => {
-  it("offers the four states as one mutually exclusive choice", () => {
+  it("offers the states as one mutually exclusive choice", () => {
     // A radiogroup, not the sidebar's toolbar of toggles: these segments are
     // exclusive with All as the null option, which is what a radiogroup IS.
     renderBar();
 
     expect(screen.getByRole("radiogroup")).toBeTruthy();
-    expect(screen.getAllByRole("radio")).toHaveLength(4);
+    expect(screen.getAllByRole("radio")).toHaveLength(5);
   });
 
   it("reports exactly one checked segment", () => {
@@ -91,13 +91,14 @@ describe("PilotFilterBar", () => {
   });
 
   it("carries the count in each segment's name, so it is never colour-and-digit alone", () => {
-    renderBar("all", counts({ all: 7, "needs-you": 2, working: 4, finished: 1 }));
+    renderBar("all", counts({ all: 7, "needs-you": 2, working: 4, finished: 1, parked: 3 }));
 
     expect(segmentNames()).toEqual([
       "All, 7 agents",
       "Waiting, 2 agents",
       "Working, 4 agents",
       "Finished, 1 agent",
+      "Parked, 3 agents",
     ]);
   });
 
@@ -153,11 +154,11 @@ describe("PilotFilterBar", () => {
 
       press("ArrowLeft");
 
-      expect(liveState().checked).toBe("Finished");
+      expect(liveState().checked).toBe("Parked");
     });
 
     it("wraps forwards off the last segment", () => {
-      render(<StatefulBar initial="finished" />);
+      render(<StatefulBar initial="parked" />);
 
       press("ArrowRight");
 
@@ -171,7 +172,7 @@ describe("PilotFilterBar", () => {
       expect(liveState().checked).toBe("All");
 
       press("End");
-      expect(liveState().checked).toBe("Finished");
+      expect(liveState().checked).toBe("Parked");
     });
 
     it("keeps exactly one tab stop through every move", () => {

--- a/src/components/Pilot/__tests__/PilotRunState.test.tsx
+++ b/src/components/Pilot/__tests__/PilotRunState.test.tsx
@@ -42,8 +42,8 @@ function shapeOf(band: FleetBand, agentState?: AgentState): string {
 }
 
 const DEMAND_BANDS = FLEET_BANDS.filter(isDemandBand);
-/** Nothing in flight and nothing being asked — the two states that stay grey. */
-const QUIET_BANDS: FleetBand[] = ["done", "idle"];
+/** Nothing in flight and nothing being asked — the states that stay grey. */
+const QUIET_BANDS: FleetBand[] = ["done", "parked", "idle"];
 
 describe("PilotRunState", () => {
   it("paints one shared neutral tone across the states that are not news", () => {
@@ -98,6 +98,7 @@ describe("PilotRunState", () => {
       shapeOf("running"),
       shapeOf("running", "directing"),
       shapeOf("done"),
+      shapeOf("parked"),
       shapeOf("idle"),
       shapeOf("idle", "exited"),
     ];

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -1526,4 +1526,214 @@ describe("PilotView", () => {
       expect(order()).toEqual(["first s", "second s"]);
     });
   });
+
+  describe("parking", () => {
+    const parkRunMock = vi.fn();
+    const unparkRunMock = vi.fn();
+
+    beforeEach(() => {
+      parkRunMock.mockReset().mockResolvedValue({ parkedAt: NOW });
+      unparkRunMock.mockReset().mockResolvedValue(true);
+      window.electron = {
+        fleet: { parkRun: parkRunMock, unparkRun: unparkRunMock },
+      } as unknown as typeof window.electron;
+    });
+
+    afterEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).electron;
+    });
+
+    function altEnter() {
+      fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "Enter", altKey: true });
+    }
+
+    it("advertises the park verb for the highlighted row", () => {
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })]);
+      render(<PilotView />);
+
+      expect(screen.getByTestId("pilot-park-hint").textContent).toContain("Park");
+    });
+
+    it("renames the verb when the highlighted row is already parked", () => {
+      seed([
+        run({
+          agentState: "waiting",
+          title: "auth spike",
+          since: NOW - 60_000,
+          park: { parkedAt: NOW - 30_000 },
+        }),
+      ]);
+      render(<PilotView />);
+
+      expect(screen.getByTestId("pilot-park-hint").textContent).toContain("Edit park");
+    });
+
+    it("shows the park note on the row itself", () => {
+      seed([
+        run({
+          agentState: "waiting",
+          title: "auth spike",
+          since: NOW - 60_000,
+          park: { parkedAt: NOW - 30_000, note: "after the migration lands" },
+        }),
+      ]);
+      render(<PilotView />);
+
+      expect(screen.getByText("after the migration lands")).toBeTruthy();
+    });
+
+    it("opens the editor with Alt+Enter, replacing the list and its controls", () => {
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })]);
+      render(<PilotView />);
+
+      altEnter();
+
+      expect(screen.getByTestId("pilot-park-editor")).toBeTruthy();
+      // A query box filtering an invisible list would be a control acting
+      // somewhere the user cannot see.
+      expect(screen.queryByTestId("pilot-search")).toBeNull();
+      expect(screen.queryByTestId("pilot-filter-bar")).toBeNull();
+    });
+
+    it("parks the highlighted run with the typed note", async () => {
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })]);
+      render(<PilotView />);
+      altEnter();
+
+      const note = screen.getByTestId("pilot-park-note");
+      fireEvent.change(note, { target: { value: "  waiting on studio-02  " } });
+      await act(async () => {
+        fireEvent.keyDown(note, { key: "Enter" });
+      });
+
+      // Trimmed before it crosses the wire — the service would re-trim, but
+      // the renderer should not knowingly send padding.
+      expect(parkRunMock).toHaveBeenCalledWith("t1", { note: "waiting on studio-02" });
+      expect(screen.queryByTestId("pilot-park-editor")).toBeNull();
+      // Back on the list, with focus at the palette's home position.
+      expect(document.activeElement).toBe(screen.getByTestId("pilot-search"));
+    });
+
+    it("parks until a chosen gate", async () => {
+      seed([
+        run({ runId: "t1", agentState: "waiting", title: "downstream", since: NOW - 60_000 }),
+        run({ runId: "t2", agentState: "working", title: "upstream", since: NOW - 30_000 }),
+      ]);
+      render(<PilotView />);
+      altEnter();
+
+      // The waiting run ranks first, so the editor targets t1 and offers t2.
+      fireEvent.click(screen.getByRole("radio", { name: /upstream/ }));
+      await act(async () => {
+        fireEvent.keyDown(screen.getByTestId("pilot-park-note"), { key: "Enter" });
+      });
+
+      expect(parkRunMock).toHaveBeenCalledWith("t1", { gateRunId: "t2" });
+    });
+
+    it("unparks from the editor of an already-parked run", async () => {
+      seed([
+        run({
+          agentState: "waiting",
+          title: "auth spike",
+          since: NOW - 60_000,
+          park: { parkedAt: NOW - 30_000, note: "old note" },
+        }),
+      ]);
+      render(<PilotView />);
+      altEnter();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("pilot-park-unpark"));
+      });
+
+      expect(unparkRunMock).toHaveBeenCalledWith("t1");
+      expect(parkRunMock).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("pilot-park-editor")).toBeNull();
+    });
+
+    it("cancel returns to the list without touching the park", async () => {
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })]);
+      render(<PilotView />);
+      altEnter();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("pilot-park-cancel"));
+      });
+
+      expect(parkRunMock).not.toHaveBeenCalled();
+      expect(unparkRunMock).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("pilot-park-editor")).toBeNull();
+      expect(screen.getByTestId("pilot-search")).toBeTruthy();
+    });
+
+    it("surfaces a rejected park inline and stays open", async () => {
+      parkRunMock.mockRejectedValue(new Error("Fleet state is unavailable right now"));
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })]);
+      render(<PilotView />);
+      altEnter();
+
+      await act(async () => {
+        fireEvent.keyDown(screen.getByTestId("pilot-park-note"), { key: "Enter" });
+      });
+
+      expect(screen.getByRole("alert").textContent).toContain("Fleet state is unavailable");
+      expect(screen.getByTestId("pilot-park-editor")).toBeTruthy();
+    });
+
+    it("closes only the editor on Escape, leaving the palette open", () => {
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })]);
+      render(<PilotView />);
+      altEnter();
+      expect(screen.getByTestId("pilot-park-editor")).toBeTruthy();
+
+      // A real bubbled Escape, which the palette's document-level backstop
+      // sees first — the dialog's onClose is delegated to the editor while it
+      // is open, so the key must pop the mode and not the surface.
+      fireEvent.keyDown(screen.getByTestId("pilot-park-note"), { key: "Escape" });
+
+      expect(screen.queryByTestId("pilot-park-editor")).toBeNull();
+      expect(screen.getByTestId("pilot-search")).toBeTruthy();
+    });
+
+    it("ignores the opening chord's key-repeat — a modified Enter never submits", () => {
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })]);
+      render(<PilotView />);
+      altEnter();
+
+      const note = screen.getByTestId("pilot-park-note");
+      fireEvent.keyDown(note, { key: "Enter", altKey: true });
+      fireEvent.keyDown(note, { key: "Enter", repeat: true });
+
+      expect(parkRunMock).not.toHaveBeenCalled();
+      expect(screen.getByTestId("pilot-park-editor")).toBeTruthy();
+    });
+
+    it("offers no parking over retained data — Main would reject it anyway", () => {
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })], {
+        degraded: true,
+        lastSuccessfulAt: NOW - 60_000,
+      });
+      render(<PilotView />);
+
+      expect(screen.queryByTestId("pilot-park-hint")).toBeNull();
+      altEnter();
+      expect(screen.queryByTestId("pilot-park-editor")).toBeNull();
+    });
+
+    it("falls back to the list when the run being parked disappears", async () => {
+      seed([run({ agentState: "waiting", title: "auth spike", since: NOW - 60_000 })]);
+      render(<PilotView />);
+      altEnter();
+      expect(screen.getByTestId("pilot-park-editor")).toBeTruthy();
+
+      act(() => {
+        seed([]);
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(screen.queryByTestId("pilot-park-editor")).toBeNull();
+    });
+  });
 });

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -1527,6 +1527,91 @@ describe("PilotView", () => {
     });
   });
 
+  describe("group demand chips", () => {
+    it("summarises each project's demand on its header, worst band first", () => {
+      seed([
+        run({ runId: "a", workspaceId: "p1", agentState: "waiting", since: NOW - 60_000 }),
+        run({ runId: "b", workspaceId: "p1", agentState: "working", since: NOW - 60_000 }),
+        run({ runId: "c", workspaceId: "s1", agentState: "working", since: NOW - 60_000 }),
+      ]);
+      render(<PilotView />);
+
+      // One chip, on the one project with a demand — a busy-but-quiet project
+      // earns nothing, or the chip stops meaning "needs you".
+      const chips = screen.getAllByTestId("pilot-group-demand");
+      expect(chips).toHaveLength(1);
+      expect(chips[0]!.textContent).toContain("1");
+
+      // The group's accessible name says the same thing in words.
+      expect(screen.getByRole("group", { name: /daintree, Agent needs you/ })).toBeTruthy();
+    });
+
+    it("drops the chip when the query filters the demand away", () => {
+      // The chip summarises the rows actually beneath the header — a header
+      // still announcing a demand its own list no longer shows would be the
+      // false signal this surface exists to remove.
+      seed([
+        run({
+          runId: "a",
+          workspaceId: "p1",
+          agentState: "waiting",
+          title: "auth spike",
+          since: NOW,
+        }),
+        run({
+          runId: "b",
+          workspaceId: "p1",
+          agentState: "working",
+          title: "docs pass",
+          since: NOW,
+        }),
+      ]);
+      render(<PilotView />);
+      expect(screen.getByTestId("pilot-group-demand")).toBeTruthy();
+
+      fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "docs" } });
+
+      expect(screen.queryByTestId("pilot-group-demand")).toBeNull();
+      expect(screen.queryByRole("group", { name: /needs you/ })).toBeNull();
+    });
+
+    it("counts every demand band, not just waiting", () => {
+      seed([
+        run({
+          runId: "a",
+          workspaceId: "p1",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW,
+        }),
+        run({ runId: "b", workspaceId: "p1", agentState: "waiting", since: NOW }),
+        run({ runId: "c", workspaceId: "p1", agentState: "completed", since: NOW }),
+      ]);
+      render(<PilotView />);
+
+      expect(screen.getByTestId("pilot-group-demand").textContent).toContain("3");
+    });
+  });
+
+  describe("stall cue", () => {
+    it("marks a working run that main flagged as quiet", () => {
+      seed([
+        run({
+          agentState: "working",
+          title: "long migration",
+          since: NOW - 3_600_000,
+          quietSince: NOW - 12 * 60_000,
+        }),
+      ]);
+      render(<PilotView />);
+
+      expect(screen.getByText("quiet 12m")).toBeTruthy();
+      // And the fact reaches the accessible name, since the cue itself is
+      // decoration.
+      expect(screen.getByRole("option", { name: /quiet for 12m/ })).toBeTruthy();
+    });
+  });
+
   describe("parking", () => {
     const parkRunMock = vi.fn();
     const unparkRunMock = vi.fn();

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -910,6 +910,45 @@ describe("parked rows", () => {
   });
 });
 
+describe("stalled runs", () => {
+  it("carries the quiet duration only for a working run main flagged", () => {
+    const [group] = buildPilotGroups(
+      [
+        run({
+          runId: "stalled",
+          agentState: "working",
+          since: NOW - 3_600_000,
+          quietSince: NOW - 12 * 60_000,
+        }),
+        run({ runId: "busy", agentState: "working", since: NOW - 3_600_000 }),
+      ],
+      ctx()
+    );
+
+    const byId = new Map(group!.rows.map((r) => [r.run.runId, r]));
+    expect(byId.get("stalled")?.quietFor).toBe("12m");
+    expect(byId.get("busy")?.quietFor).toBeNull();
+  });
+
+  it("drops the cue when the run is no longer in the running band", () => {
+    // A stale quietSince arriving alongside a state change (one poll of skew)
+    // must not paint a waiting or parked row as a stalled worker.
+    const [group] = buildPilotGroups(
+      [
+        run({
+          agentState: "working",
+          since: NOW,
+          quietSince: NOW - 12 * 60_000,
+          park: { parkedAt: NOW },
+        }),
+      ],
+      ctx()
+    );
+
+    expect(group!.rows[0]!.quietFor).toBeNull();
+  });
+});
+
 describe("bandFilterHasDemand", () => {
   const bands = (overrides: Partial<Record<FleetBand, number>> = {}) => ({
     ...emptyBandCounts(),

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -722,7 +722,7 @@ describe("filterPilotGroups", () => {
 });
 
 describe("countPilotBands", () => {
-  /** One run in each of the six bands, spread over two projects. */
+  /** One run in each band, spread over two projects. */
   const wholeFleet = () =>
     buildPilotGroups(
       [
@@ -742,6 +742,13 @@ describe("countPilotBands", () => {
           agentState: "completed",
           since: NOW - 120_000,
         }),
+        run({
+          runId: "parked",
+          workspaceId: "p2",
+          agentState: "waiting",
+          since: NOW,
+          park: { parkedAt: NOW - 60_000 },
+        }),
         run({ runId: "idle", workspaceId: "p2", agentState: "exited", since: NOW }),
       ],
       ctx({
@@ -754,14 +761,18 @@ describe("countPilotBands", () => {
       })
     );
 
-  it("maps all six bands onto the four segments", () => {
+  it("maps every band onto the segments", () => {
     const counts = countPilotBands(wholeFleet());
 
-    expect(counts.all).toBe(6);
+    expect(counts.all).toBe(7);
     // Blocked and needs-you are one demand; review is a hand-back, not a block.
     expect(counts["needs-you"]).toBe(2);
     expect(counts.working).toBe(1);
     expect(counts.finished).toBe(2);
+    // Parked and exited live only under All: the run parked while waiting must
+    // NOT surface through the Waiting segment — hiding from that segment is
+    // the entire point of parking it.
+    expect(counts["needs-you"] + counts.working + counts.finished).toBe(counts.all - 2);
   });
 
   it("leaves an exited run out of every segment but All", () => {
@@ -786,6 +797,83 @@ describe("countPilotBands", () => {
 
     expect(countPilotBands(built)["needs-you"]).toBe(2);
     expect(countPilotBands(filterPilotGroups(built, "auth"))["needs-you"]).toBe(1);
+  });
+});
+
+describe("parked rows", () => {
+  it("ages a parked row from the park, not the underlying agent state", () => {
+    // A three-hour-old waiting run parked two minutes ago must read
+    // "Parked · 2m" — the row is now about the decision, not the wait.
+    const [group] = buildPilotGroups(
+      [
+        run({
+          agentState: "waiting",
+          since: NOW - 3 * 3_600_000,
+          park: { parkedAt: NOW - 120_000, note: "after the migration" },
+        }),
+      ],
+      ctx()
+    );
+    const row = group!.rows[0]!;
+
+    expect(row.statusLabel).toBe("Parked");
+    expect(row.age).toBe("2m");
+  });
+
+  it("orders parked rows by park age, oldest shelf first", () => {
+    // Within-band anti-starvation, on the timestamp the band is about: the
+    // agent-state `since` here would sort them the other way round.
+    const [group] = buildPilotGroups(
+      [
+        run({
+          runId: "recent",
+          agentState: "waiting",
+          since: NOW - 3_600_000,
+          park: { parkedAt: NOW - 60_000 },
+        }),
+        run({
+          runId: "ancient",
+          agentState: "waiting",
+          since: NOW - 60_000,
+          park: { parkedAt: NOW - 3_600_000 },
+        }),
+      ],
+      ctx()
+    );
+
+    expect(group!.rows.map((r) => r.run.runId)).toEqual(["ancient", "recent"]);
+  });
+
+  it("contributes nothing to a group's demand count, whatever the state under it", () => {
+    const [group] = buildPilotGroups(
+      [
+        run({
+          runId: "a",
+          agentState: "waiting",
+          waitingReason: "error",
+          since: NOW,
+          park: { parkedAt: NOW },
+        }),
+        run({ runId: "b", agentState: "waiting", since: NOW }),
+      ],
+      ctx()
+    );
+
+    expect(group!.demandCount).toBe(1);
+    // And it sorts below the live demand it would otherwise have been.
+    expect(group!.rows.map((r) => r.run.runId)).toEqual(["b", "a"]);
+  });
+
+  it("is admitted by no narrowing segment", () => {
+    const groups = buildPilotGroups(
+      [run({ agentState: "waiting", since: NOW, park: { parkedAt: NOW } })],
+      ctx()
+    );
+
+    for (const segment of ["needs-you", "working", "finished"] as const) {
+      expect(filterPilotBands(groups, segment)).toEqual([]);
+    }
+    expect(filterPilotBands(groups, "all")[0]!.rows).toHaveLength(1);
   });
 });
 

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -864,7 +864,7 @@ describe("parked rows", () => {
     expect(group!.rows.map((r) => r.run.runId)).toEqual(["b", "a"]);
   });
 
-  it("is admitted by no narrowing segment", () => {
+  it("is admitted by no state segment — hiding from Waiting is the point of parking", () => {
     const groups = buildPilotGroups(
       [run({ agentState: "waiting", since: NOW, park: { parkedAt: NOW } })],
       ctx()
@@ -874,6 +874,39 @@ describe("parked rows", () => {
       expect(filterPilotBands(groups, segment)).toEqual([]);
     }
     expect(filterPilotBands(groups, "all")[0]!.rows).toHaveLength(1);
+  });
+
+  it("gets a segment of its own that admits nothing else", () => {
+    const groups = buildPilotGroups(
+      [
+        run({ runId: "shelved", agentState: "waiting", since: NOW, park: { parkedAt: NOW } }),
+        run({ runId: "live", agentState: "waiting", since: NOW }),
+      ],
+      ctx()
+    );
+
+    const [parkedOnly] = filterPilotBands(groups, "parked");
+    expect(parkedOnly!.rows.map((r) => r.run.runId)).toEqual(["shelved"]);
+    expect(countPilotBands(groups).parked).toBe(1);
+  });
+
+  it("is findable by its note — the user's own words for the run", () => {
+    const groups = buildPilotGroups(
+      [
+        run({
+          runId: "shelved",
+          agentState: "waiting",
+          since: NOW,
+          title: "auth refactor",
+          park: { parkedAt: NOW, note: "resume after the migration lands" },
+        }),
+        run({ runId: "other", agentState: "waiting", since: NOW, title: "docs pass" }),
+      ],
+      ctx()
+    );
+
+    const [matched] = filterPilotGroups(groups, "migration");
+    expect(matched!.rows.map((r) => r.run.runId)).toEqual(["shelved"]);
   });
 });
 

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -49,6 +49,12 @@ export interface PilotRow {
    * type when hunting for the run you shelved behind it.
    */
   parkNote: string | null;
+  /**
+   * How long a working run has been silent, once main judged the silence
+   * worth reporting. Null for a healthy busy agent — so the row only ever
+   * says "quiet 12m" when there is genuinely something to look at.
+   */
+  quietFor: string | null;
 }
 
 export type PilotWorkspaceKind = "project" | "scratch" | "unknown";
@@ -292,6 +298,10 @@ export function buildPilotGroups(
               ? formatWaitAge(run.since, ctx.nowMs)
               : null,
         parkNote: run.park?.note ?? null,
+        quietFor:
+          band === "running" && run.quietSince !== undefined
+            ? formatWaitAge(run.quietSince, ctx.nowMs)
+            : null,
       };
     });
 

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -42,6 +42,13 @@ export interface PilotRow {
   worktreeLabel: string | null;
   /** Compact age of the current state, or null when the run never recorded one. */
   age: string | null;
+  /**
+   * The park's note, drawn on the row: a parked run's one line of intent is
+   * the whole reason to look at it. Null for everything unparked, and also on
+   * the row's search surface — "after the migration" is a plausible thing to
+   * type when hunting for the run you shelved behind it.
+   */
+  parkNote: string | null;
 }
 
 export type PilotWorkspaceKind = "project" | "scratch" | "unknown";
@@ -119,6 +126,47 @@ const BAND_RANK = new Map<FleetBand, number>(FLEET_BANDS.map((band, i) => [band,
 
 function rank(band: FleetBand): number {
   return BAND_RANK.get(band) ?? FLEET_BANDS.length;
+}
+
+/** The chrome the panel header and dock would derive for this run. */
+export function derivePilotRunChrome(run: FleetRunRow): TerminalChromeDescriptor {
+  return deriveTerminalChrome({
+    kind: "terminal",
+    ...(run.agentId !== undefined ? { detectedAgentId: run.agentId } : {}),
+    ...(run.launchAgentId !== undefined ? { launchAgentId: run.launchAgentId } : {}),
+    ...(run.everDetectedAgent !== undefined ? { everDetectedAgent: run.everDetectedAgent } : {}),
+    ...(run.agentState !== undefined ? { agentState: run.agentState } : {}),
+    ...(run.agentPresetColor !== undefined ? { agentPresetColor: run.agentPresetColor } : {}),
+  });
+}
+
+/**
+ * A run's display title, composed through the app's one title pipeline rather
+ * than assembled ad hoc. Reading `lastObservedTitle` directly is what made
+ * rows read "Claude Code" — the agent naming itself, which the pipeline
+ * recognises as an identity echo and suppresses. `compact` because every
+ * caller here pairs the string with the brand icon, so a prefix would only
+ * push the task out of the truncation window. Shared by the row build and the
+ * park surfaces (editor, release notification), which must all name a run the
+ * same way.
+ */
+export function composePilotRunTitle(run: FleetRunRow, chrome?: TerminalChromeDescriptor): string {
+  const resolved = chrome ?? derivePilotRunChrome(run);
+  return (
+    composeTitledPanel(
+      {
+        title: run.title ?? resolved.label,
+        ...(run.titleMode !== undefined ? { titleMode: run.titleMode } : {}),
+        ...(run.lastObservedTitle !== undefined
+          ? { lastObservedTitle: run.lastObservedTitle }
+          : {}),
+        ...(run.agentId !== undefined ? { detectedAgentId: run.agentId } : {}),
+        ...(run.agentState !== undefined ? { agentState: run.agentState } : {}),
+        cwd: run.cwd,
+      },
+      "compact"
+    ).trim() || resolved.label
+  );
 }
 
 /**
@@ -222,36 +270,8 @@ export function buildPilotGroups(
 
     const rows: PilotRow[] = sorted.map((run) => {
       const band = bandForRun(run, acknowledgedAt);
-      const chrome = deriveTerminalChrome({
-        kind: "terminal",
-        ...(run.agentId !== undefined ? { detectedAgentId: run.agentId } : {}),
-        ...(run.launchAgentId !== undefined ? { launchAgentId: run.launchAgentId } : {}),
-        ...(run.everDetectedAgent !== undefined
-          ? { everDetectedAgent: run.everDetectedAgent }
-          : {}),
-        ...(run.agentState !== undefined ? { agentState: run.agentState } : {}),
-        ...(run.agentPresetColor !== undefined ? { agentPresetColor: run.agentPresetColor } : {}),
-      });
-      // Composed through the app's one title pipeline, not assembled here.
-      // Reading `lastObservedTitle` directly is what made rows read "Claude
-      // Code" — the agent naming itself, which the pipeline recognises as an
-      // identity echo and suppresses. `compact` because the brand icon beside
-      // the title already carries identity, so a prefix would only push the
-      // task out of the truncation window.
-      const title =
-        composeTitledPanel(
-          {
-            title: run.title ?? chrome.label,
-            ...(run.titleMode !== undefined ? { titleMode: run.titleMode } : {}),
-            ...(run.lastObservedTitle !== undefined
-              ? { lastObservedTitle: run.lastObservedTitle }
-              : {}),
-            ...(run.agentId !== undefined ? { detectedAgentId: run.agentId } : {}),
-            ...(run.agentState !== undefined ? { agentState: run.agentState } : {}),
-            cwd: run.cwd,
-          },
-          "compact"
-        ).trim() || chrome.label;
+      const chrome = derivePilotRunChrome(run);
+      const title = composePilotRunTitle(run, chrome);
 
       return {
         run,
@@ -271,6 +291,7 @@ export function buildPilotGroups(
             : run.since !== undefined
               ? formatWaitAge(run.since, ctx.nowMs)
               : null,
+        parkNote: run.park?.note ?? null,
       };
     });
 
@@ -346,7 +367,10 @@ export function filterPilotGroups(
         (row.worktreeLabel !== null && isFilterMatch(needle, row.worktreeLabel)) ||
         // The agent's name is on the row as an icon rather than as text, but
         // "codex" is still a plausible thing to type when looking for one.
-        isFilterMatch(needle, row.chrome.label)
+        isFilterMatch(needle, row.chrome.label) ||
+        // A park note is the user's own words about the run — the string they
+        // are most likely to remember it by.
+        (row.parkNote !== null && isFilterMatch(needle, row.parkNote))
     );
     if (rows.length === 0) continue;
     // Recomputed, never inherited: a query that filters the blocked run out of
@@ -361,7 +385,7 @@ export function filterPilotGroups(
  * The state filter's vocabulary, declared beside the bands so a segment and the
  * count under it can never drift apart.
  */
-export type PilotBandFilter = "all" | "needs-you" | "working" | "finished";
+export type PilotBandFilter = "all" | "needs-you" | "working" | "finished" | "parked";
 
 /**
  * Which bands each segment admits.
@@ -374,11 +398,17 @@ export type PilotBandFilter = "all" | "needs-you" | "working" | "finished";
  * `isDemandBand` counts review as a demand. Review is a hand-back, not a
  * block — folding it in would make the footer's demand count promise more
  * agents than applying the filter actually reveals.
+ *
+ * "Parked" gets a segment of its own because it is the one band the user
+ * authored: "show me everything I shelved, with my notes" is a real question,
+ * and a run parked while waiting must be findable somewhere other than the
+ * bottom of All.
  */
 const BAND_FILTER_SETS: Record<Exclude<PilotBandFilter, "all">, ReadonlySet<FleetBand>> = {
   "needs-you": new Set<FleetBand>(["blocked", "needs-you"]),
   working: new Set<FleetBand>(["running"]),
   finished: new Set<FleetBand>(["review", "done"]),
+  parked: new Set<FleetBand>(["parked"]),
 };
 
 /** The narrowing segments, in the order the bar renders them after All. */
@@ -386,6 +416,7 @@ export const PILOT_BAND_FILTERS: readonly Exclude<PilotBandFilter, "all">[] = [
   "needs-you",
   "working",
   "finished",
+  "parked",
 ];
 
 /**
@@ -402,6 +433,7 @@ export const PILOT_BAND_FILTER_LABEL: Record<PilotBandFilter, string> = {
   "needs-you": "Waiting",
   working: "Working",
   finished: "Finished",
+  parked: "Parked",
 };
 
 export type PilotBandFilterCounts = Record<PilotBandFilter, number>;
@@ -416,7 +448,13 @@ export type PilotBandFilterCounts = Record<PilotBandFilter, number>;
  * nothing they can't see.
  */
 export function countPilotBands(groups: readonly PilotProjectGroup[]): PilotBandFilterCounts {
-  const counts: PilotBandFilterCounts = { all: 0, "needs-you": 0, working: 0, finished: 0 };
+  const counts: PilotBandFilterCounts = {
+    all: 0,
+    "needs-you": 0,
+    working: 0,
+    finished: 0,
+    parked: 0,
+  };
   for (const group of groups) {
     for (const row of group.rows) {
       counts.all++;

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -133,8 +133,8 @@ function rank(band: FleetBand): number {
  */
 function narrowGroup(group: PilotProjectGroup, rows: PilotRow[]): PilotProjectGroup {
   let topBand: FleetBand = "idle";
-  // Annotated: `FLEET_BANDS` is a const tuple, so its `length` narrows to the
-  // literal 6 and the accumulator would refuse every rank assigned below it.
+  // Annotated: `FLEET_BANDS` is a const tuple, so its `length` narrows to a
+  // literal and the accumulator would refuse every rank assigned below it.
   let best: number = FLEET_BANDS.length;
   let demandCount = 0;
   for (const row of rows) {
@@ -207,8 +207,17 @@ export function buildPilotGroups(
     const acknowledgedAt = meta?.lastCompletionSeenAt;
 
     const sorted = [...workspaceRuns].sort((a, b) => {
-      const byBand = rank(bandForRun(a, acknowledgedAt)) - rank(bandForRun(b, acknowledgedAt));
-      return byBand !== 0 ? byBand : compareWithinBand(a, b);
+      const bandA = bandForRun(a, acknowledgedAt);
+      const byBand = rank(bandA) - rank(bandForRun(b, acknowledgedAt));
+      if (byBand !== 0) return byBand;
+      // Parked rows order on the park, not the underlying state: `since` is
+      // whenever the agent last transitioned, which predates the decision the
+      // band is actually about. Oldest park first, same anti-starvation rule.
+      if (bandA === "parked" && a.park !== undefined && b.park !== undefined) {
+        if (a.park.parkedAt !== b.park.parkedAt) return a.park.parkedAt - b.park.parkedAt;
+        return a.runId < b.runId ? -1 : a.runId > b.runId ? 1 : 0;
+      }
+      return compareWithinBand(a, b);
     });
 
     const rows: PilotRow[] = sorted.map((run) => {
@@ -252,7 +261,16 @@ export function buildPilotGroups(
         presetColor: run.agentPresetColor,
         statusLabel: bandLabel(band, run),
         worktreeLabel: disambiguatingLabel(directoryLabel(run.cwd), name),
-        age: run.since !== undefined ? formatWaitAge(run.since, ctx.nowMs) : null,
+        // A parked row's age is the age of the PARK. Dating it from `since`
+        // read "Parked · 3h" the moment a three-hour-old waiting run was
+        // parked, which answers "how long has it waited" when the row is now
+        // about "how long ago did I shelve this".
+        age:
+          band === "parked" && run.park !== undefined
+            ? formatWaitAge(run.park.parkedAt, ctx.nowMs)
+            : run.since !== undefined
+              ? formatWaitAge(run.since, ctx.nowMs)
+              : null,
       };
     });
 

--- a/src/components/PostHydrationListeners.tsx
+++ b/src/components/PostHydrationListeners.tsx
@@ -4,6 +4,7 @@ import { markRendererPerformance } from "../utils/performance";
 import { useHibernationNotifications } from "../hooks/useHibernationNotifications";
 import { useIdleTerminalNotifications } from "../hooks/useIdleTerminalNotifications";
 import { useIdleBackgroundCloseNotifications } from "../hooks/useIdleBackgroundCloseNotifications";
+import { useParkReleaseNotifications } from "../hooks/useParkReleaseNotifications";
 import { useDiskSpaceWarnings } from "../hooks/useDiskSpaceWarnings";
 import { useForgeTokenHealth } from "../hooks/useForgeTokenHealth";
 import { useForgeRateLimit } from "../hooks/useForgeRateLimit";
@@ -29,6 +30,7 @@ export function PostHydrationListeners() {
   useHibernationNotifications();
   useIdleTerminalNotifications();
   useIdleBackgroundCloseNotifications();
+  useParkReleaseNotifications();
   useDiskSpaceWarnings();
   useForgeTokenHealth();
   useForgeRateLimit();

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -15,6 +15,7 @@ export {
   ChartNoAxesColumn, // frecency sort order ("Most used" — decayed access score)
   CircleCheck, // finished run awaiting review (Pilot's review band)
   CircleHelp, // workspace whose metadata is missing (removed while its agents ran)
+  CirclePause, // run the user parked — shelved on purpose (Pilot's parked band)
   CircleSlash, // agent stopped on an error, distinct in shape from a waiting one (Pilot's blocked band)
   Clock, // recency sort order (most recently opened first)
   FileText, // view selected file path in the read-only file viewer

--- a/src/hooks/__tests__/useParkReleaseNotifications.test.ts
+++ b/src/hooks/__tests__/useParkReleaseNotifications.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+interface NotifyArg {
+  title?: string;
+  message?: string;
+  supersedeKey?: string;
+  context?: { projectId?: string; panelId?: string };
+  action?: { label?: string; actionId?: string; actionArgs?: Record<string, unknown> };
+}
+
+const notifyCalls: NotifyArg[] = [];
+const notifyMock = vi.fn((payload: NotifyArg) => {
+  notifyCalls.push(payload);
+});
+vi.mock("@/lib/notify", () => ({
+  notify: (payload: NotifyArg) => notifyMock(payload),
+}));
+
+const dispatchMock = vi.fn();
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: dispatchMock } }));
+
+type ReleasePayload = {
+  id: string;
+  gateRunId: string;
+  note?: string;
+  reason: "gate-ready" | "gate-closed";
+  timestamp: number;
+};
+
+const onMock = vi.fn();
+let captured: ((payload: ReleasePayload) => void) | null = null;
+
+function notifyArg(n: number): NotifyArg {
+  const payload = notifyCalls[n];
+  if (!payload) throw new Error(`expected a notify call at index ${n}`);
+  return payload;
+}
+
+async function load() {
+  const [hookModule, storeModule] = await Promise.all([
+    import("../useParkReleaseNotifications"),
+    import("@/store/fleetSnapshotStore"),
+  ]);
+  return { ...hookModule, ...storeModule };
+}
+
+const NOW = 1_830_000_000_000;
+
+function seedRun(overrides: Record<string, unknown> = {}) {
+  return {
+    runId: "t1",
+    workspaceId: "p1",
+    spawnedAt: NOW - 3_600_000,
+    cwd: "/repo",
+    title: "Fix the auth redirect",
+    ...overrides,
+  };
+}
+
+describe("useParkReleaseNotifications", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    notifyMock.mockClear();
+    notifyCalls.length = 0;
+    dispatchMock.mockClear();
+    onMock.mockReset();
+    captured = null;
+    onMock.mockImplementation((name: string, cb: (payload: ReleasePayload) => void) => {
+      if (name === "terminal:park-released") captured = cb;
+      return vi.fn();
+    });
+
+    window.electron = {
+      events: { on: onMock },
+    } as unknown as typeof window.electron;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).electron;
+  });
+
+  it("subscribes exactly once across mount → unmount → remount", async () => {
+    const { useParkReleaseNotifications } = await load();
+
+    const first = renderHook(() => useParkReleaseNotifications());
+    expect(onMock).toHaveBeenCalledTimes(1);
+
+    first.unmount();
+    renderHook(() => useParkReleaseNotifications());
+
+    expect(onMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands the run back with its title, the note, and an Open action", async () => {
+    const { useParkReleaseNotifications, useFleetSnapshotStore } = await load();
+    useFleetSnapshotStore.setState({
+      snapshot: {
+        runs: [seedRun()] as never,
+        changedAt: NOW,
+        degraded: false,
+        lastSuccessfulAt: NOW,
+      },
+    });
+    renderHook(() => useParkReleaseNotifications());
+
+    act(() => {
+      captured!({
+        id: "t1",
+        gateRunId: "g1",
+        note: "resume once the migration lands",
+        reason: "gate-ready",
+        timestamp: NOW,
+      });
+    });
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    const payload = notifyArg(0);
+    // The note is the payoff — the reader must see their own words, not just
+    // that "something" released.
+    expect(payload.message).toContain("Fix the auth redirect");
+    expect(payload.message).toContain("resume once the migration lands");
+    expect(payload).toMatchObject({
+      supersedeKey: "park-released:t1",
+      context: { projectId: "p1", panelId: "t1" },
+    });
+    expect(payload.action).toMatchObject({
+      actionId: "pilot.openRun",
+      actionArgs: { runId: "t1", workspaceId: "p1" },
+    });
+  });
+
+  it("says so when the gate closed rather than finished — and still carries the note", async () => {
+    const { useParkReleaseNotifications, useFleetSnapshotStore } = await load();
+    useFleetSnapshotStore.setState({
+      snapshot: {
+        runs: [seedRun()] as never,
+        changedAt: NOW,
+        degraded: false,
+        lastSuccessfulAt: NOW,
+      },
+    });
+    renderHook(() => useParkReleaseNotifications());
+
+    act(() => {
+      captured!({
+        id: "t1",
+        gateRunId: "g1",
+        note: "kick off the release",
+        reason: "gate-closed",
+        timestamp: NOW,
+      });
+    });
+
+    // The note is the user's own context; a closed gate doesn't make it less
+    // theirs — dropping it here would hand back a run with the "why" missing.
+    expect(notifyArg(0).message).toContain("gate terminal closed");
+    expect(notifyArg(0).message).toContain("kick off the release");
+  });
+
+  it("degrades to a generic hand-back when the run is no longer in the snapshot", async () => {
+    const { useParkReleaseNotifications } = await load();
+    renderHook(() => useParkReleaseNotifications());
+
+    act(() => {
+      captured!({ id: "gone", gateRunId: "g1", reason: "gate-ready", timestamp: NOW });
+    });
+
+    const payload = notifyArg(0);
+    expect(payload.message).toContain("A parked agent");
+    // No run means no workspace to open — an action that cannot resolve its
+    // target is worse than none.
+    expect(payload.action).toBeUndefined();
+  });
+
+  it("does not subscribe when Electron is unavailable", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).electron;
+    const { useParkReleaseNotifications } = await load();
+
+    expect(() => renderHook(() => useParkReleaseNotifications())).not.toThrow();
+    expect(onMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useParkReleaseNotifications.ts
+++ b/src/hooks/useParkReleaseNotifications.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+import { isElectronAvailable } from "./useElectron";
+import { notify } from "@/lib/notify";
+import { actionService } from "@/services/ActionService";
+import { useFleetSnapshotStore } from "@/store/fleetSnapshotStore";
+import { composePilotRunTitle } from "@/components/Pilot/pilotRows";
+
+// One-way latch, same shape as the idle-terminal listener: the broadcast IPC
+// listener is an app-lifetime, notify-only singleton with no teardown, and
+// resetting the latch on remount would fire duplicate toasts (#10455).
+let ipcListenerAttached = false;
+
+/**
+ * The hand-back half of run parking.
+ *
+ * Main releases a gated park when the gate terminal comes free (or closes)
+ * and broadcasts `terminal:park-released`; this turns that into the one
+ * notification the whole feature was built to earn — "the run you shelved is
+ * ready, and here is the note you left on it". The parked run usually lives
+ * in ANOTHER project, so the row popping back into Pilot's Waiting band is
+ * not otherwise visible from where the user is working.
+ */
+export function useParkReleaseNotifications(): void {
+  useEffect(() => {
+    if (!isElectronAvailable() || ipcListenerAttached) return;
+
+    window.electron.events.on("terminal:park-released", (payload) => {
+      const run = useFleetSnapshotStore
+        .getState()
+        .snapshot?.runs.find((candidate) => candidate.runId === payload.id);
+      const title = run !== undefined ? composePilotRunTitle(run) : "A parked agent";
+
+      // Neutral about the RUN's own state on purpose: the release says the
+      // gate finished (or closed), not that the parked run is idle — it may
+      // still be working or blocked. The note travels on both reasons; it is
+      // the user's own context and a closed gate doesn't make it less theirs.
+      const reasonPhrase =
+        payload.reason === "gate-closed" ? "its gate terminal closed" : "its gate came free";
+      const message =
+        payload.note !== undefined
+          ? `${title} — ${reasonPhrase}. "${payload.note}"`
+          : `${title} — ${reasonPhrase}`;
+
+      notify({
+        type: "info",
+        title: "Park released",
+        message,
+        correlationId: `park-released:${payload.id}`,
+        // A re-park and re-release of the same run retires the older row
+        // rather than stacking near-duplicates in the inbox.
+        supersedeKey: `park-released:${payload.id}`,
+        context: {
+          eventKind: "agent",
+          panelId: payload.id,
+          ...(run !== undefined ? { projectId: run.workspaceId } : {}),
+        },
+        ...(run !== undefined
+          ? {
+              action: {
+                label: "Open",
+                successLabel: "Opened",
+                actionId: "pilot.openRun",
+                actionArgs: { runId: run.runId, workspaceId: run.workspaceId },
+                onClick: () => {
+                  void actionService.dispatch("pilot.openRun", {
+                    runId: run.runId,
+                    workspaceId: run.workspaceId,
+                  });
+                },
+              },
+            }
+          : {}),
+      });
+    });
+
+    // Latch only after a successful subscribe so a throwing preload doesn't
+    // wedge the latch and silently suppress all future notifications.
+    ipcListenerAttached = true;
+  }, []);
+}

--- a/src/lib/__tests__/fleetAttention.test.ts
+++ b/src/lib/__tests__/fleetAttention.test.ts
@@ -47,6 +47,40 @@ describe("bandForRun", () => {
   });
 });
 
+describe("parked runs", () => {
+  it("puts a parked run in the parked band regardless of agent state", () => {
+    // Parking is the user's promise to themselves; an attention model that
+    // overrides it the moment something looks urgent has to be re-checked
+    // constantly, which is the exact cost parking removes.
+    for (const agentState of [
+      "waiting",
+      "working",
+      "directing",
+      "completed",
+      "idle",
+      "exited",
+    ] as const) {
+      expect(bandForRun(run({ agentState, park: { parkedAt: NOW } }))).toBe("parked");
+    }
+    expect(
+      bandForRun(run({ agentState: "waiting", waitingReason: "error", park: { parkedAt: NOW } }))
+    ).toBe("parked");
+  });
+
+  it("never counts a parked run as a demand", () => {
+    const band = bandForRun(run({ agentState: "waiting", park: { parkedAt: NOW } }));
+    expect(isDemandBand(band)).toBe(false);
+  });
+
+  it("ranks parked below every live band but above idle", () => {
+    const rank = (band: (typeof FLEET_BANDS)[number]) => FLEET_BANDS.indexOf(band);
+    for (const live of ["blocked", "needs-you", "review", "running", "done"] as const) {
+      expect(rank("parked")).toBeGreaterThan(rank(live));
+    }
+    expect(rank("parked")).toBeLessThan(rank("idle"));
+  });
+});
+
 describe("acknowledged completions", () => {
   it("demotes a completion the user has already seen out of the demand bands", () => {
     // Without the watermark every finished run demands attention forever, and a
@@ -85,6 +119,12 @@ describe("bandLabel", () => {
     for (const band of FLEET_BANDS) {
       expect(bandLabel(band, run()).length).toBeGreaterThan(0);
     }
+  });
+
+  it("gives parked its own words — a shelved run must never read as idle", () => {
+    expect(bandLabel("parked", run({ agentState: "waiting", park: { parkedAt: NOW } }))).not.toBe(
+      bandLabel("idle", run({ agentState: "idle" }))
+    );
   });
 
   it("splits the bands that cover two situations a user can tell apart", () => {

--- a/src/lib/fleetAttention.ts
+++ b/src/lib/fleetAttention.ts
@@ -12,8 +12,20 @@ import type { FleetRunRow } from "@shared/types/ipc/fleet";
  * implies (`src/lib/projectRowStatus.ts`), one grain finer. Two surfaces
  * disagreeing about which agent is most urgent is worse than either ordering
  * being individually wrong.
+ *
+ * `parked` sits between `done` and `idle`: the user has explicitly shelved the
+ * run, so it must never read as a demand — but unlike an idle shell it carries
+ * intent (a note, maybe a gate) worth finding above the dead rows.
  */
-export const FLEET_BANDS = ["blocked", "needs-you", "review", "running", "done", "idle"] as const;
+export const FLEET_BANDS = [
+  "blocked",
+  "needs-you",
+  "review",
+  "running",
+  "done",
+  "parked",
+  "idle",
+] as const;
 
 export type FleetBand = (typeof FLEET_BANDS)[number];
 
@@ -36,8 +48,17 @@ export function isDemandBand(band: FleetBand): boolean {
  *
  * A completion with no `since` cannot be compared to the watermark and stays in
  * `review`: unknown is not evidence of having been seen.
+ *
+ * A park beats every state, including `blocked`. Parking is the user saying
+ * "this one does not need me until further notice", and an attention model
+ * that second-guesses that promise the moment something looks urgent is a
+ * model the user has to keep re-checking — the exact cost parking exists to
+ * remove. The release paths (manual unpark, gate coming free, gate closed)
+ * are the only ways back above the fold, and all of them are the user's own
+ * rules firing.
  */
 export function bandForRun(run: FleetRunRow, acknowledgedAt?: number): FleetBand {
+  if (run.park !== undefined) return "parked";
   switch (run.agentState) {
     case "waiting":
       return run.waitingReason === "error" ? "blocked" : "needs-you";
@@ -80,8 +101,15 @@ export function bandLabel(band: FleetBand, run: FleetRunRow): string {
       return run.agentState === "directing" ? "Directing" : "Working";
     case "done":
       return "Finished";
-    default:
+    case "parked":
+      return "Parked";
+    case "idle":
       return run.agentState === "exited" ? "Exited" : "Idle";
+    default: {
+      // Exhaustive: a new band must pick its words here, not inherit idle's.
+      const exhaustive: never = band;
+      return exhaustive;
+    }
   }
 }
 
@@ -121,5 +149,5 @@ export function compareWithinBand(a: FleetRunRow, b: FleetRunRow): number {
 export type FleetBandCounts = Record<FleetBand, number>;
 
 export function emptyBandCounts(): FleetBandCounts {
-  return { blocked: 0, "needs-you": 0, review: 0, running: 0, done: 0, idle: 0 };
+  return { blocked: 0, "needs-you": 0, review: 0, running: 0, done: 0, parked: 0, idle: 0 };
 }


### PR DESCRIPTION
When I'm running five projects at once, the Pilot overview (⌥⌘O) shows every waiting agent as needing me. The problem is that some of those agents are waiting on purpose. They're sitting idle until another agent finishes, and I have to keep remembering which ones are intentional every time I open the list. That memory load is exactly what the overview was supposed to remove.

This PR lets you park a run. Press Alt+Enter on the highlighted row in Pilot and you get a small in-dialog editor with an optional note and an optional gate.

When a run is parked, it drops into a new low `parked` band, stops counting as a demand everywhere (bands, demand counts, filter segments, the footer), and shows your note right on the row. If you pick a gate, the park releases automatically the next time that terminal goes from busy to ready, and a notification hands the run back with your note attached and an Open action that routes across projects.

A few smaller things landed alongside it:

- A new Parked filter segment, so "show me everything I shelved, with my notes" is one click.
- Park notes are searchable. Your own words are usually how you remember a run.
- Project group headers now show a small demand chip (count plus the worst band's glyph), so five projects scan without reading a single row.
- Working runs that have been silent for over ten minutes show a `quiet 12m` cue. "Working · 47m" and "working but wedged" used to render identically.

## Implementation notes

- Park records live in the main process (`RunAttentionService`) and persist across restarts, since terminal ids survive relaunch. The fleet snapshot decorates each row with its park record, so every surface reads one payload.
- Releases are edge-triggered and time-fenced: the gate has to transition busy to ready with an event timestamp after the park was created. A stale edge still crossing from the pty-host can't release a park you just set, and a respawned terminal under the same id can't either.
- The service freezes during graceful shutdown. The teardown chain kills every terminal, and each kill looks like a busy to ready edge, so without the freeze quitting the app would wipe every gated park.
- Mutations commit in one order: apply, persist, then announce. A persistence failure rolls back and suppresses the events, so no surface hears about a park that wouldn't survive a restart.
- The IPC surface validates both ids against the current fleet snapshot, is rate limited, and bounds the record set. Parking is only offered over a live snapshot; retained stale data shows no park affordances.
- The stall cue is anchored on the later of last output and entry into the current working stint, and the anchor is constant while the silence lasts, so it costs one broadcast at the threshold crossing and never defeats the snapshot's unchanged-payload suppression.

## Commits

Three commits, one per phase, each reviewed before landing:

1. `feat(pilot): add the run-parking primitive in Main`
2. `feat(pilot): surface run parking in the Pilot palette`
3. `feat(pilot): per-project demand chips and a stalled-while-working cue`

Tests cover both sides: `RunAttentionService` and `FleetSnapshotService` in main, and the band model, row building, filter bar, park editor flow and release notifications in the renderer.
