### PR TITLE
feat(fleet): snooze an agent so it stops flagging the project

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -246,6 +246,8 @@ export const CHANNELS = {
   FLEET_GET_SNAPSHOT: "fleet:get-snapshot",
   FLEET_PARK_RUN: "fleet:park-run",
   FLEET_UNPARK_RUN: "fleet:unpark-run",
+  FLEET_SNOOZE_RUN: "fleet:snooze-run",
+  FLEET_UNSNOOZE_RUN: "fleet:unsnooze-run",
   PROJECT_HISTORY_PEEK: "project-history:peek",
   PROJECT_CREATE_FOLDER: "project:create-folder",
   PROJECT_INIT_GIT: "project:init-git",

--- a/electron/ipc/handlers/fleet.preload.ts
+++ b/electron/ipc/handlers/fleet.preload.ts
@@ -4,6 +4,8 @@ export const FLEET_METHOD_CHANNELS = {
   getSnapshot: "fleet:get-snapshot",
   parkRun: "fleet:park-run",
   unparkRun: "fleet:unpark-run",
+  snoozeRun: "fleet:snooze-run",
+  unsnoozeRun: "fleet:unsnooze-run",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof FLEET_METHOD_CHANNELS;

--- a/electron/ipc/handlers/fleet.ts
+++ b/electron/ipc/handlers/fleet.ts
@@ -1,4 +1,12 @@
-import type { FleetSnapshot, RunParkRecord } from "../../../shared/types/ipc/fleet.js";
+import type {
+  FleetSnapshot,
+  RunParkRecord,
+  RunSnoozeRecord,
+} from "../../../shared/types/ipc/fleet.js";
+import {
+  isAgentSnoozeDurationOption,
+  type AgentSnoozeDurationOption,
+} from "../../../shared/utils/agentSnoozeDurations.js";
 import { getFleetSnapshotService, getRunAttentionService } from "./projectCrud/index.js";
 import { MAX_PARK_NOTE_LENGTH } from "../../services/RunAttentionService.js";
 import { checkRateLimit } from "../utils.js";
@@ -122,6 +130,49 @@ export const fleetNamespace = defineIpcNamespace({
       const service = getRunAttentionService();
       if (!service) throw new Error("Run attention service unavailable");
       return service.unpark(runId);
+    }),
+
+    /**
+     * Snooze a run — drop it out of the project's attention roll-up until the
+     * chosen ceiling passes or the user types at it. Reversible in one
+     * keystroke and local to attention surfaces (D0), so no confirmation tier
+     * applies.
+     *
+     * The duration is validated as a member of the ladder rather than accepted
+     * as a raw number of milliseconds: an arbitrary expiry from the renderer
+     * would be a wake time no menu could ever show, and the four options are
+     * the whole product surface.
+     */
+    snoozeRun: op(
+      FLEET_METHOD_CHANNELS.snoozeRun,
+      async (runId: string, option: AgentSnoozeDurationOption): Promise<RunSnoozeRecord> => {
+        checkRateLimit(CHANNELS.FLEET_SNOOZE_RUN, 20, 10_000);
+        assertRunId(runId, "run id");
+        if (!isAgentSnoozeDurationOption(option)) {
+          throw new Error("Invalid snooze duration");
+        }
+        // Same liveness requirement parking has: a run the snapshot cannot see
+        // is hostile, mistyped or already gone, and snoozing it would persist
+        // intent against an id nothing will ever clear.
+        assertKnownRuns(runId, undefined);
+
+        const service = getRunAttentionService();
+        if (!service) throw new Error("Run attention service unavailable");
+        return service.snooze(runId, option);
+      }
+    ),
+
+    /**
+     * Lift a snooze by hand. Resolves false when the run wasn't snoozed. No
+     * snapshot check, for the same reason unpark has none: the way OUT of a
+     * suppression must not depend on the fleet being readable.
+     */
+    unsnoozeRun: op(FLEET_METHOD_CHANNELS.unsnoozeRun, async (runId: string): Promise<boolean> => {
+      checkRateLimit(CHANNELS.FLEET_UNSNOOZE_RUN, 20, 10_000);
+      assertRunId(runId, "run id");
+      const service = getRunAttentionService();
+      if (!service) throw new Error("Run attention service unavailable");
+      return service.unsnooze(runId);
     }),
   },
 });

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -77,7 +77,7 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
   });
   handlers.push(() => {
     projectStatsService.stop();
-    // Identity-guarded like the attention service below: a late cleanup from a
+    // Identity-guarded like the attention service above: a late cleanup from a
     // superseded registration must not null out a newer instance's global,
     // which would leave the getters reporting "unavailable" while a live
     // service is still polling.

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -77,7 +77,13 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
   });
   handlers.push(() => {
     projectStatsService.stop();
-    projectStatsServiceInstance = null;
+    // Identity-guarded like the attention service below: a late cleanup from a
+    // superseded registration must not null out a newer instance's global,
+    // which would leave the getters reporting "unavailable" while a live
+    // service is still polling.
+    if (projectStatsServiceInstance === projectStatsService) {
+      projectStatsServiceInstance = null;
+    }
   });
 
   // The run-grained sibling of the counts above, on the same source and the
@@ -95,7 +101,9 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
   });
   handlers.push(() => {
     fleetSnapshotService.stop();
-    fleetSnapshotServiceInstance = null;
+    if (fleetSnapshotServiceInstance === fleetSnapshotService) {
+      fleetSnapshotServiceInstance = null;
+    }
   });
 
   // Acknowledgement watermark for completed agents: the project the user has

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -36,7 +36,34 @@ export function getRunAttentionService(): RunAttentionService | null {
 export function registerProjectStatsHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const projectStatsService = new ProjectStatsService(deps.ptyClient);
+  // Park and snooze intent lives beside the projections that read it: the
+  // attention service owns the records, the stats counts and the fleet snapshot
+  // both consult it, and a park- or snooze-changed event drives the same
+  // refresh path as an agent transition. Constructed FIRST because both
+  // projections take it as a dependency.
+  // `isCleaningUp` freezes releases during graceful shutdown — the chain kills
+  // every terminal, and those kills would otherwise read as busy→ready edges
+  // and wipe the very parks persistence is carrying across the restart.
+  const runAttentionService = new RunAttentionService(
+    {
+      load: () => store.get("parkedRuns"),
+      save: (records) => store.set("parkedRuns", records),
+      loadSnoozes: () => store.get("snoozedRuns"),
+      saveSnoozes: (records) => store.set("snoozedRuns", records),
+    },
+    { isQuitting: isCleaningUp }
+  );
+  runAttentionServiceInstance = runAttentionService;
+  handlers.push(() => {
+    runAttentionService.dispose();
+    // Identity-guarded: a stale cleanup from a superseded registration must
+    // not null out a newer instance's global.
+    if (runAttentionServiceInstance === runAttentionService) {
+      runAttentionServiceInstance = null;
+    }
+  });
+
+  const projectStatsService = new ProjectStatsService(deps.ptyClient, runAttentionService);
   projectStatsServiceInstance = projectStatsService;
   projectStatsService.start();
   // Defer the initial compute off the first-interactive critical path. The
@@ -51,29 +78,6 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
   handlers.push(() => {
     projectStatsService.stop();
     projectStatsServiceInstance = null;
-  });
-
-  // Park intent lives beside the snapshot that projects it: the attention
-  // service owns the records, the snapshot decorates rows with them, and a
-  // park-changed event drives the same refresh path as an agent transition.
-  // `isCleaningUp` freezes releases during graceful shutdown — the chain kills
-  // every terminal, and those kills would otherwise read as busy→ready edges
-  // and wipe the very parks persistence is carrying across the restart.
-  const runAttentionService = new RunAttentionService(
-    {
-      load: () => store.get("parkedRuns"),
-      save: (records) => store.set("parkedRuns", records),
-    },
-    { isQuitting: isCleaningUp }
-  );
-  runAttentionServiceInstance = runAttentionService;
-  handlers.push(() => {
-    runAttentionService.dispose();
-    // Identity-guarded: a stale cleanup from a superseded registration must
-    // not null out a newer instance's global.
-    if (runAttentionServiceInstance === runAttentionService) {
-      runAttentionServiceInstance = null;
-    }
   });
 
   // The run-grained sibling of the counts above, on the same source and the
@@ -198,7 +202,17 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
       ...projectStore.getLastCompletionSeenMap(),
       ...scratchStore.getLastCompletionSeenMap(),
     ]);
-    const agentCounts = computeProjectAgentCounts(uniqueIds, allTerminals, seenMap);
+    // Same snooze view the pushed status map uses. Omitting it here would
+    // recreate exactly the drift this shared helper exists to prevent: opening
+    // the palette would hydrate rows that still counted snoozed agents as
+    // waiting, and the push path suppresses unchanged payloads, so nothing
+    // would correct them until agent state next moved.
+    const agentCounts = computeProjectAgentCounts(
+      uniqueIds,
+      allTerminals,
+      seenMap,
+      runAttentionServiceInstance?.getActiveSnoozes()
+    );
 
     const result: BulkProjectStats = {};
     for (const entry of statsResults) {
@@ -240,6 +254,10 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
             : {}),
           ...(counts.latestWorkingSince !== null
             ? { latestWorkingSince: counts.latestWorkingSince }
+            : {}),
+          snoozedAgentCount: counts.snoozed,
+          ...(counts.nextSnoozeWakeAt !== null
+            ? { nextSnoozeWakeAt: counts.nextSnoozeWakeAt }
             : {}),
           terminalMemoryMB: hasMeasured ? Math.round(measured!.memoryKb / 1024) : undefined,
           topProcess: top

--- a/electron/services/FleetSnapshotService.ts
+++ b/electron/services/FleetSnapshotService.ts
@@ -91,6 +91,7 @@ export class FleetSnapshotService {
     // Park records ride the rows, so a park set or lifted is a fleet change
     // even though no agent state moved.
     subscribe("terminal:park-changed");
+    subscribe("terminal:snooze-changed");
   }
 
   updatePollInterval(ms: number): void {
@@ -223,6 +224,10 @@ export class FleetSnapshotService {
         x.park?.parkedAt !== y.park?.parkedAt ||
         x.park?.note !== y.park?.note ||
         x.park?.gateRunId !== y.park?.gateRunId ||
+        // Presence flips when a snooze lapses, so this is also what makes an
+        // expiry reach the renderer without an expiry event existing.
+        x.snooze?.snoozedAt !== y.snooze?.snoozedAt ||
+        x.snooze?.snoozedUntil !== y.snooze?.snoozedUntil ||
         x.quietSince !== y.quietSince
       ) {
         return false;
@@ -257,6 +262,10 @@ export class FleetSnapshotService {
 
       const availability = getAgentAvailabilityStore();
       const parkRecords = this.runAttention?.getAll();
+      // Expiry is resolved here, so only LIVE snoozes ever reach a row. That is
+      // what lets `bandForRun` decide on presence alone and keeps every
+      // renderer surface clock-free.
+      const snoozeRecords = this.runAttention?.getActiveSnoozes();
       const stallCutoff = Date.now() - STALL_QUIET_MS;
       const runs: FleetRunRow[] = [];
 
@@ -267,6 +276,7 @@ export class FleetSnapshotService {
         if (classifyRun(terminal, (id) => availability.isHelpTerminal(id)) !== null) continue;
 
         const park = parkRecords?.get(terminal.id);
+        const snooze = snoozeRecords?.get(terminal.id);
         runs.push({
           runId: terminal.id,
           workspaceId: terminal.projectId,
@@ -302,6 +312,7 @@ export class FleetSnapshotService {
           // User intent decorates the row here so every surface reads park
           // state and agent state in one payload, never joining two feeds.
           ...(park !== undefined ? { park } : {}),
+          ...(snooze !== undefined ? { snooze } : {}),
           // Stall cue: only for a working run, and only once the CURRENT
           // working stint has been silent past the threshold. Anchored on the
           // later of last output, the transition into this state and the

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -5,6 +5,7 @@ import { projectStore } from "./ProjectStore.js";
 import { scratchStore } from "./ScratchStore.js";
 import { computeProjectAgentCounts } from "./projectAgentCounts.js";
 import type { PtyClient } from "./PtyClient.js";
+import type { RunAttentionService } from "./RunAttentionService.js";
 import type { ProjectStatusMap } from "../../shared/types/ipc/project.js";
 import { MutableDisposable, toDisposable, type IDisposable } from "../utils/lifecycle.js";
 import { setAlignedInterval } from "../utils/setAlignedInterval.js";
@@ -21,7 +22,15 @@ export class ProjectStatsService {
   private pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
   private generation = 0;
 
-  constructor(private ptyClient: PtyClient | undefined | null) {}
+  /**
+   * `runAttention` is optional so the harness and any caller that only wants
+   * raw tallies can omit it — without it, snooze simply never suppresses
+   * anything, which is the correct reading of "no attention service".
+   */
+  constructor(
+    private ptyClient: PtyClient | undefined | null,
+    private runAttention?: RunAttentionService | null
+  ) {}
 
   get isStarted(): boolean {
     return this.started;
@@ -46,6 +55,11 @@ export class ProjectStatsService {
     subscribe("agent:state-changed");
     subscribe("terminal:trashed");
     subscribe("terminal:restored");
+    // Snoozing changes what a project's counts SAY without changing what any
+    // agent is doing, so no other event covers it. Only the taking and lifting
+    // of a snooze needs this — expiry rides the poll, since a lapsed snooze
+    // simply stops being returned by `getActiveSnoozes()`.
+    subscribe("terminal:snooze-changed");
   }
 
   updatePollInterval(ms: number): void {
@@ -155,7 +169,9 @@ export class ProjectStatsService {
         ea.oldestUnacknowledgedCompletionAt !== eb.oldestUnacknowledgedCompletionAt ||
         ea.latestUnacknowledgedCompletionAt !== eb.latestUnacknowledgedCompletionAt ||
         ea.latestCompletionAt !== eb.latestCompletionAt ||
-        ea.latestWorkingSince !== eb.latestWorkingSince
+        ea.latestWorkingSince !== eb.latestWorkingSince ||
+        ea.snoozedAgentCount !== eb.snoozedAgentCount ||
+        ea.nextSnoozeWakeAt !== eb.nextSnoozeWakeAt
       ) {
         return false;
       }
@@ -205,7 +221,17 @@ export class ProjectStatsService {
           seenMap.set(workspace.id, workspace.lastCompletionSeenAt);
         }
       }
-      const agentCounts = computeProjectAgentCounts(projectIds, allTerminals, seenMap);
+      // Snooze expiry is resolved here, once, against a single clock reading —
+      // the counting helper stays pure and never asks what time it is. This is
+      // also the whole of the feature's "timer": a lapsed snooze stops being
+      // returned, and the next poll (5s) recomputes without it.
+      const activeSnoozes = this.runAttention?.getActiveSnoozes();
+      const agentCounts = computeProjectAgentCounts(
+        projectIds,
+        allTerminals,
+        seenMap,
+        activeSnoozes
+      );
 
       const statusMap: ProjectStatusMap = {};
       for (const entry of statsResults) {
@@ -236,6 +262,10 @@ export class ProjectStatsService {
               : {}),
             ...(counts.latestWorkingSince !== null
               ? { latestWorkingSince: counts.latestWorkingSince }
+              : {}),
+            snoozedAgentCount: counts.snoozed,
+            ...(counts.nextSnoozeWakeAt !== null
+              ? { nextSnoozeWakeAt: counts.nextSnoozeWakeAt }
               : {}),
           };
         }

--- a/electron/services/RunAttentionService.ts
+++ b/electron/services/RunAttentionService.ts
@@ -1,6 +1,15 @@
 import { events } from "./events.js";
 import type { AgentState } from "../../shared/types/agent.js";
-import { MAX_PARK_NOTE_LENGTH, type RunParkRecord } from "../../shared/types/ipc/fleet.js";
+import {
+  MAX_PARK_NOTE_LENGTH,
+  type RunParkRecord,
+  type RunSnoozeRecord,
+} from "../../shared/types/ipc/fleet.js";
+import {
+  isAgentSnoozeDurationOption,
+  resolveAgentSnoozeDuration,
+  type AgentSnoozeDurationOption,
+} from "../../shared/utils/agentSnoozeDurations.js";
 
 export { MAX_PARK_NOTE_LENGTH };
 
@@ -24,12 +33,37 @@ const STALE_PARK_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 /** A loaded `parkedAt` this far past "now" is corrupt, not early. */
 const FUTURE_SKEW_MS = 60_000;
 
+/**
+ * Cardinality bound on the snooze set, for the same reason parks have one: a
+ * hostile renderer looping `snoozeRun` with fresh ids must not grow the
+ * persisted store without bound. Expired records are pruned before the check,
+ * so ordinary use can never hit it.
+ */
+export const MAX_SNOOZED_RUNS = 200;
+
+/**
+ * An unlimited snooze is cleared by input, not by a clock — but a run that
+ * never comes back would otherwise hold its record forever. Fourteen days
+ * matches the park TTL: intent nobody has revisited in two weeks is stale, and
+ * silently honouring it hides a run behind a decision the user no longer
+ * remembers making. Enforced at load, against `snoozedAt`.
+ */
+const STALE_SNOOZE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
 const BUSY_STATES: ReadonlySet<AgentState> = new Set(["working", "directing"]);
 const READY_STATES: ReadonlySet<AgentState> = new Set(["idle", "waiting", "completed", "exited"]);
 
 export interface RunAttentionPersistence {
   load(): Record<string, RunParkRecord>;
   save(records: Record<string, RunParkRecord>): void;
+  /**
+   * Snooze records live under their own store key rather than beside parks in
+   * one blob. They are written on a different cadence (a snooze is cleared by
+   * every stray keystroke), and a single blob would rewrite the whole park set
+   * on each of those.
+   */
+  loadSnoozes?(): Record<string, RunSnoozeRecord>;
+  saveSnoozes?(records: Record<string, RunSnoozeRecord>): void;
 }
 
 export interface ParkRunOptions {
@@ -60,6 +94,14 @@ function normalizeNote(value: unknown): string | undefined {
   const last = note.charCodeAt(note.length - 1);
   if (last >= 0xd800 && last <= 0xdbff) note = note.slice(0, -1);
   return note.length > 0 ? note : undefined;
+}
+
+/**
+ * Whether a snooze has lapsed. An absent `snoozedUntil` is the unlimited
+ * option, which no clock can expire — only typed input ends it.
+ */
+function isSnoozeExpired(record: RunSnoozeRecord, now: number): boolean {
+  return record.snoozedUntil !== undefined && record.snoozedUntil <= now;
 }
 
 /**
@@ -99,6 +141,7 @@ function normalizeNote(value: unknown): string | undefined {
  */
 export class RunAttentionService {
   private records = new Map<string, RunParkRecord>();
+  private snoozeRecords = new Map<string, RunSnoozeRecord>();
   private unsubscribers: Array<() => void> = [];
   private now: () => number;
   private isQuitting: () => boolean;
@@ -110,14 +153,35 @@ export class RunAttentionService {
     this.now = deps.now ?? Date.now;
     this.isQuitting = deps.isQuitting ?? (() => false);
     this.loadAndPrune();
+    this.loadAndPruneSnoozes();
 
     this.unsubscribers.push(
       events.on("agent:state-changed", (payload) => {
         const terminalId = payload.terminalId;
         if (!terminalId) return;
+        // Typed input is the primary way a snooze ends. On a snoozed run that
+        // is waiting/idle/completed, the input event transitions it to
+        // `working`, so the clear rides this event.
+        if (payload.trigger === "input") this.clearSnoozeOnInput(terminalId);
         if (!READY_STATES.has(payload.state)) return;
         if (!BUSY_STATES.has(payload.previousState)) return;
         this.releaseGatedOn(terminalId, "gate-ready", payload.timestamp);
+      })
+    );
+
+    // The other half of the input contract. Typing into a run that is ALREADY
+    // `working` produces no transition, and `AgentStateService` drops same-state
+    // updates without emitting `agent:state-changed` — so without this
+    // subscription, snoozing a working agent and then typing at it would leave
+    // the snooze in place. The dropped-transition event crosses the pty-host
+    // bridge carrying the same normalized trigger, which is exactly the signal
+    // needed and costs no new wire plumbing.
+    this.unsubscribers.push(
+      events.on("agent:state-transition-dropped", (payload) => {
+        if (payload.trigger !== "input") return;
+        const terminalId = payload.terminalId;
+        if (!terminalId) return;
+        this.clearSnoozeOnInput(terminalId);
       })
     );
 
@@ -201,6 +265,143 @@ export class RunAttentionService {
     }
     events.emit("terminal:park-changed", { id: runId, parked: false, timestamp: this.now() });
     return true;
+  }
+
+  /** The snooze record for a run, live or expired. */
+  getSnoozeRecord(runId: string): RunSnoozeRecord | undefined {
+    return this.snoozeRecords.get(runId);
+  }
+
+  /**
+   * Every snooze that is still live, expiry resolved against the caller's clock.
+   *
+   * This is the read every attention surface uses, and it is deliberately pure:
+   * expiry is decided here rather than by a timer, so a lapsed snooze needs no
+   * event to stop applying — the next read simply stops returning it. That is
+   * what makes the feature survive a restart and a machine sleeping through the
+   * window without owning a single `setTimeout`.
+   *
+   * Expired records are left in place rather than swept: this runs on the stats
+   * poll, and persisting from a hot read path would turn a query into a disk
+   * write every few seconds. They are dropped at load and whenever `snooze()`
+   * next writes.
+   */
+  getActiveSnoozes(now: number = this.now()): ReadonlyMap<string, RunSnoozeRecord> {
+    const active = new Map<string, RunSnoozeRecord>();
+    for (const [runId, record] of this.snoozeRecords) {
+      if (!isSnoozeExpired(record, now)) active.set(runId, record);
+    }
+    return active;
+  }
+
+  /** Whether a run is currently snoozed, expiry resolved against `now`. */
+  isSnoozed(runId: string, now: number = this.now()): boolean {
+    const record = this.snoozeRecords.get(runId);
+    return record !== undefined && !isSnoozeExpired(record, now);
+  }
+
+  /**
+   * Snooze a run for one of the ladder's durations.
+   *
+   * Re-snoozing replaces the record wholesale — a new duration is a new
+   * decision, so `snoozedAt` restarts too. Snoozing does NOT touch a park: the
+   * two intents are independent records, and clearing a park here would destroy
+   * the note that park exists to carry.
+   */
+  snooze(runId: string, option: AgentSnoozeDurationOption): RunSnoozeRecord {
+    if (this.isQuitting()) {
+      throw new Error("Cannot snooze a run while the app is shutting down");
+    }
+    if (typeof runId !== "string" || runId.length === 0) {
+      throw new Error("Cannot snooze a run without a terminal id");
+    }
+    if (!isAgentSnoozeDurationOption(option)) {
+      throw new Error("Invalid snooze duration");
+    }
+
+    const now = this.now();
+    // Sweep lapsed records before the bound so ordinary use can never be locked
+    // out by snoozes that stopped applying hours ago.
+    for (const [id, record] of this.snoozeRecords) {
+      if (isSnoozeExpired(record, now)) this.snoozeRecords.delete(id);
+    }
+    if (!this.snoozeRecords.has(runId) && this.snoozeRecords.size >= MAX_SNOOZED_RUNS) {
+      throw new Error(`Cannot snooze more than ${MAX_SNOOZED_RUNS} runs`);
+    }
+
+    const snoozedUntil = resolveAgentSnoozeDuration(option, now);
+    const record: RunSnoozeRecord = {
+      snoozedAt: now,
+      ...(snoozedUntil !== undefined ? { snoozedUntil } : {}),
+    };
+
+    const previous = this.snoozeRecords.get(runId);
+    this.snoozeRecords.set(runId, record);
+    try {
+      this.persistSnoozes();
+    } catch (error) {
+      // Same contract as park: a snooze that would not survive a restart must
+      // not be reported as taken. Only this run is restored — the sweep above
+      // dropped records that had already stopped applying, so leaving them out
+      // costs nothing and they are gone from disk at the next successful write.
+      if (previous !== undefined) this.snoozeRecords.set(runId, previous);
+      else this.snoozeRecords.delete(runId);
+      throw error;
+    }
+    events.emit("terminal:snooze-changed", { id: runId, snoozed: true, timestamp: now });
+    return record;
+  }
+
+  /** Lift a snooze by hand. Returns false when the run wasn't snoozed. */
+  unsnooze(runId: string): boolean {
+    if (this.isQuitting()) {
+      throw new Error("Cannot unsnooze a run while the app is shutting down");
+    }
+    const previous = this.snoozeRecords.get(runId);
+    if (previous === undefined) return false;
+    this.snoozeRecords.delete(runId);
+    try {
+      this.persistSnoozes();
+    } catch (error) {
+      this.snoozeRecords.set(runId, previous);
+      throw error;
+    }
+    events.emit("terminal:snooze-changed", { id: runId, snoozed: false, timestamp: this.now() });
+    return true;
+  }
+
+  /**
+   * Clear a snooze because the user typed at the run.
+   *
+   * The headline promise of the feature: whichever duration was picked, coming
+   * back and answering the agent ends the snooze. Deliberately silent when the
+   * run isn't snoozed — this fires on every input-triggered transition in the
+   * app, so the common case must cost one map lookup and nothing else.
+   *
+   * Unlike `unsnooze`, this never throws: it is driven by an event, not a user
+   * request, and there is nobody to report a failure to. A persistence failure
+   * keeps the snooze rather than announcing a clear that would come back after
+   * a restart.
+   */
+  private clearSnoozeOnInput(runId: string): void {
+    // The shutdown chain's terminal kills do not carry an `input` trigger, but
+    // the guard matches park's: nothing may quietly rewrite intent while
+    // persistence is trying to carry it across the restart.
+    if (this.isQuitting()) return;
+    const previous = this.snoozeRecords.get(runId);
+    if (previous === undefined) return;
+    this.snoozeRecords.delete(runId);
+    try {
+      this.persistSnoozes();
+    } catch (error) {
+      this.snoozeRecords.set(runId, previous);
+      console.error(
+        "[RunAttentionService] Failed to persist an input clear, keeping snooze:",
+        error
+      );
+      return;
+    }
+    events.emit("terminal:snooze-changed", { id: runId, snoozed: false, timestamp: this.now() });
   }
 
   /**
@@ -327,13 +528,83 @@ export class RunAttentionService {
     };
   }
 
+  /**
+   * Hydrate snoozes from disk, treating the blob as untrusted exactly as parks
+   * are. Records that already expired are dropped here rather than loaded and
+   * filtered forever after — load is the one moment the whole set is re-read,
+   * so it is the cheapest place to forget them.
+   */
+  private loadAndPruneSnoozes(): void {
+    if (!this.persistence.loadSnoozes) return;
+    let stored: unknown;
+    try {
+      stored = this.persistence.loadSnoozes() ?? {};
+    } catch (error) {
+      console.error("[RunAttentionService] Failed to load snooze records:", error);
+      stored = {};
+    }
+    if (typeof stored !== "object" || stored === null || Array.isArray(stored)) stored = {};
+
+    const now = this.now();
+    const cutoff = now - STALE_SNOOZE_TTL_MS;
+    let pruned = false;
+    for (const [runId, raw] of Object.entries(stored as Record<string, unknown>)) {
+      const record = this.rebuildSnoozeRecord(runId, raw, cutoff, now);
+      if (record === null) {
+        pruned = true;
+        continue;
+      }
+      this.snoozeRecords.set(runId, record);
+    }
+    if (pruned) {
+      try {
+        this.persistSnoozes();
+      } catch (error) {
+        console.error("[RunAttentionService] Failed to persist pruned snooze records:", error);
+      }
+    }
+  }
+
+  private rebuildSnoozeRecord(
+    runId: string,
+    raw: unknown,
+    cutoff: number,
+    now: number
+  ): RunSnoozeRecord | null {
+    if (typeof runId !== "string" || runId.length === 0) return null;
+    if (typeof raw !== "object" || raw === null) return null;
+    const candidate = raw as Record<string, unknown>;
+
+    const snoozedAt = candidate.snoozedAt;
+    if (typeof snoozedAt !== "number" || !Number.isFinite(snoozedAt)) return null;
+    if (snoozedAt < cutoff || snoozedAt > now + FUTURE_SKEW_MS) return null;
+
+    const rawUntil = candidate.snoozedUntil;
+    const snoozedUntil =
+      typeof rawUntil === "number" && Number.isFinite(rawUntil) ? rawUntil : undefined;
+    // A snooze whose wake time has already passed is not intent any more, it is
+    // history. Dropping it at load keeps the set from accumulating records that
+    // every later read would filter out anyway.
+    if (snoozedUntil !== undefined && snoozedUntil <= now) return null;
+
+    return {
+      snoozedAt,
+      ...(snoozedUntil !== undefined ? { snoozedUntil } : {}),
+    };
+  }
+
   private persist(): void {
     this.persistence.save(Object.fromEntries(this.records));
+  }
+
+  private persistSnoozes(): void {
+    this.persistence.saveSnoozes?.(Object.fromEntries(this.snoozeRecords));
   }
 
   dispose(): void {
     for (const unsubscribe of this.unsubscribers) unsubscribe();
     this.unsubscribers = [];
     this.records.clear();
+    this.snoozeRecords.clear();
   }
 }

--- a/electron/services/RunAttentionService.ts
+++ b/electron/services/RunAttentionService.ts
@@ -8,6 +8,7 @@ import {
 import {
   isAgentSnoozeDurationOption,
   resolveAgentSnoozeDuration,
+  MAX_AGENT_SNOOZE_MS,
   type AgentSnoozeDurationOption,
 } from "../../shared/utils/agentSnoozeDurations.js";
 
@@ -580,8 +581,20 @@ export class RunAttentionService {
     if (snoozedAt < cutoff || snoozedAt > now + FUTURE_SKEW_MS) return null;
 
     const rawUntil = candidate.snoozedUntil;
-    const snoozedUntil =
-      typeof rawUntil === "number" && Number.isFinite(rawUntil) ? rawUntil : undefined;
+    let snoozedUntil: number | undefined;
+    if (rawUntil !== undefined) {
+      // Present but unusable means the record is corrupt, and the whole thing
+      // is dropped rather than the field. Keeping the record without its wake
+      // time would silently PROMOTE a timed snooze to the unlimited option —
+      // turning damaged data into a stronger suppression than anything the user
+      // could have chosen, which is the wrong direction to fail in.
+      if (typeof rawUntil !== "number" || !Number.isFinite(rawUntil)) return null;
+      // A wake time past the longest ladder entry is corrupt, not generous:
+      // `snooze()` only ever resolves an option, so nothing legitimate can
+      // write one.
+      if (rawUntil > snoozedAt + MAX_AGENT_SNOOZE_MS) return null;
+      snoozedUntil = rawUntil;
+    }
     // A snooze whose wake time has already passed is not intent any more, it is
     // history. Dropping it at load keeps the set from accumulating records that
     // every later read would filter out anyway.
@@ -597,8 +610,21 @@ export class RunAttentionService {
     this.persistence.save(Object.fromEntries(this.records));
   }
 
+  /**
+   * Throws rather than no-opping when the host supplied no saver.
+   *
+   * The optional callbacks exist so a caller that only cares about parks need
+   * not know snooze exists. But silently skipping the write would report a
+   * snooze as taken and then lose it at restart — the exact lie the rollback
+   * paths are built to prevent. Failing loudly turns a wiring mistake into an
+   * error at the first snooze instead of a bug report about snoozes that
+   * "randomly" come back.
+   */
   private persistSnoozes(): void {
-    this.persistence.saveSnoozes?.(Object.fromEntries(this.snoozeRecords));
+    if (!this.persistence.saveSnoozes) {
+      throw new Error("Run attention persistence cannot save snoozes");
+    }
+    this.persistence.saveSnoozes(Object.fromEntries(this.snoozeRecords));
   }
 
   dispose(): void {

--- a/electron/services/__tests__/CompletionAcknowledgementService.test.ts
+++ b/electron/services/__tests__/CompletionAcknowledgementService.test.ts
@@ -17,6 +17,7 @@ function entry(overrides: Partial<ProjectStatusMap[string]>): ProjectStatusMap[s
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     ...overrides,
   };
 }

--- a/electron/services/__tests__/FleetSnapshotService.test.ts
+++ b/electron/services/__tests__/FleetSnapshotService.test.ts
@@ -577,7 +577,7 @@ describe("FleetSnapshotService", () => {
   it("decorates a run with its park record", async () => {
     const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
     const park = { parkedAt: NOW - 5_000, note: "after the migration", gateRunId: "t9" };
-    const attention = { getAll: () => new Map([["t1", park]]) };
+    const attention = { getAll: () => new Map([["t1", park]]), getActiveSnoozes: () => new Map() };
     const service = new FleetSnapshotService(client as never, attention as never);
     service.refresh();
     await vi.runOnlyPendingTimersAsync();
@@ -589,7 +589,7 @@ describe("FleetSnapshotService", () => {
   it("treats a park change as a fleet change even though no agent state moved", async () => {
     const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
     let parks = new Map();
-    const attention = { getAll: () => parks };
+    const attention = { getAll: () => parks, getActiveSnoozes: () => new Map() };
     const service = new FleetSnapshotService(client as never, attention as never);
     service.start();
     service.refresh();
@@ -609,7 +609,7 @@ describe("FleetSnapshotService", () => {
   it("re-broadcasts on a note-only park change, advancing changedAt", async () => {
     const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
     let parks = new Map([["t1", { parkedAt: NOW - 10_000, note: "before" }]]);
-    const attention = { getAll: () => parks };
+    const attention = { getAll: () => parks, getActiveSnoozes: () => new Map() };
     const service = new FleetSnapshotService(client as never, attention as never);
     service.refresh();
     await vi.runOnlyPendingTimersAsync();
@@ -630,6 +630,64 @@ describe("FleetSnapshotService", () => {
     expect(broadcastMock).toHaveBeenCalledTimes(2);
     expect(lastSnapshot().runs[0].park?.note).toBe("after");
     expect(lastSnapshot().changedAt).toBeGreaterThan(firstChangedAt);
+    service.stop();
+  });
+
+  it("decorates a run with its snooze record", async () => {
+    const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
+    const snooze = { snoozedAt: NOW - 5_000, snoozedUntil: NOW + 900_000 };
+    const attention = {
+      getAll: () => new Map(),
+      getActiveSnoozes: () => new Map([["t1", snooze]]),
+    };
+    const service = new FleetSnapshotService(client as never, attention as never);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(lastSnapshot().runs[0].snooze).toEqual(snooze);
+    service.stop();
+  });
+
+  it("treats a snooze change as a fleet change even though no agent state moved", async () => {
+    const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
+    let snoozes = new Map();
+    const attention = { getAll: () => new Map(), getActiveSnoozes: () => snoozes };
+    const service = new FleetSnapshotService(client as never, attention as never);
+    service.start();
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+    expect(lastSnapshot().runs[0].snooze).toBeUndefined();
+
+    snoozes = new Map([["t1", { snoozedAt: NOW }]]);
+    eventEmitter.emit("terminal:snooze-changed", { id: "t1", snoozed: true, timestamp: NOW });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(broadcastMock).toHaveBeenCalledTimes(2);
+    expect(lastSnapshot().runs[0].snooze).toEqual({ snoozedAt: NOW });
+    service.stop();
+  });
+
+  it("drops the snooze off the row when it lapses, with no event to announce it", async () => {
+    // Expiry owns no timer and emits nothing: the service simply stops being
+    // handed the record, and the next poll ships a row without it. This is the
+    // whole mechanism by which a lapsed snooze reaches the renderer.
+    const client = makePtyClient([terminal({ agentState: "waiting", lastStateChange: NOW })]);
+    let snoozes = new Map([["t1", { snoozedAt: NOW - 1_000, snoozedUntil: NOW + 1_000 }]]);
+    const attention = { getAll: () => new Map(), getActiveSnoozes: () => snoozes };
+    const service = new FleetSnapshotService(client as never, attention as never);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    expect(lastSnapshot().runs[0].snooze).toBeDefined();
+
+    // What `getActiveSnoozes` does once the wake time passes.
+    snoozes = new Map();
+    vi.setSystemTime(NOW + 5_000);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(broadcastMock).toHaveBeenCalledTimes(2);
+    expect(lastSnapshot().runs[0].snooze).toBeUndefined();
     service.stop();
   });
 

--- a/electron/services/__tests__/RunAttentionService.test.ts
+++ b/electron/services/__tests__/RunAttentionService.test.ts
@@ -26,9 +26,10 @@ vi.mock("../events.js", () => ({ events: eventEmitter }));
 import {
   MAX_PARK_NOTE_LENGTH,
   MAX_PARKED_RUNS,
+  MAX_SNOOZED_RUNS,
   RunAttentionService,
 } from "../RunAttentionService.js";
-import type { RunParkRecord } from "../../../shared/types/ipc/fleet.js";
+import type { RunParkRecord, RunSnoozeRecord } from "../../../shared/types/ipc/fleet.js";
 
 const NOW = 1_900_000_000_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -432,5 +433,273 @@ describe("RunAttentionService", () => {
     // Dispose cleared the map; the point is no release event fired afterwards.
     expect(before).toBeDefined();
     expect(emittedOf("terminal:park-released")).toEqual([]);
+  });
+});
+
+describe("snooze", () => {
+  function makeSnoozePersistence(
+    parks: Record<string, RunParkRecord> = {},
+    snoozes: Record<string, RunSnoozeRecord> = {}
+  ) {
+    return {
+      load: vi.fn(() => parks),
+      save: vi.fn<(records: Record<string, RunParkRecord>) => void>(),
+      loadSnoozes: vi.fn(() => snoozes),
+      saveSnoozes: vi.fn<(records: Record<string, RunSnoozeRecord>) => void>(),
+    };
+  }
+
+  function typedInput(terminalId: string, state = "working", previousState = "waiting") {
+    eventEmitter.emit("agent:state-changed", {
+      terminalId,
+      state,
+      previousState,
+      trigger: "input",
+      timestamp: NOW + 1_000,
+    });
+  }
+
+  /**
+   * What the pty-host emits when input lands on a run that is ALREADY working:
+   * the FSM produces no transition, so the change event never fires and only
+   * the dropped-transition event carries the signal.
+   */
+  function typedInputWhileWorking(terminalId: string) {
+    eventEmitter.emit("agent:state-transition-dropped", {
+      terminalId,
+      outcome: "no-op",
+      currentState: "working",
+      attemptedState: "working",
+      trigger: "input",
+      timestamp: NOW + 1_000,
+    });
+  }
+
+  it("resolves a timed option to a wake time in the future", () => {
+    const service = makeService(makeSnoozePersistence());
+    const record = service.snooze("run-1", "15m");
+
+    expect(record.snoozedAt).toBe(NOW);
+    expect(record.snoozedUntil).toBeGreaterThan(NOW);
+    expect(service.isSnoozed("run-1", NOW)).toBe(true);
+  });
+
+  it("gives the unlimited option no wake time, so no clock can end it", () => {
+    const service = makeService(makeSnoozePersistence());
+    const record = service.snooze("run-1", "unlimited");
+
+    expect(record.snoozedUntil).toBeUndefined();
+    // Far beyond any ladder entry: still snoozed, because only input ends it.
+    expect(service.isSnoozed("run-1", NOW + 400 * DAY_MS)).toBe(true);
+  });
+
+  it("stops reporting a timed snooze once its wake time passes", () => {
+    const service = makeService(makeSnoozePersistence());
+    const record = service.snooze("run-1", "15m");
+
+    expect(service.isSnoozed("run-1", record.snoozedUntil! - 1)).toBe(true);
+    expect(service.isSnoozed("run-1", record.snoozedUntil!)).toBe(false);
+    expect(service.getActiveSnoozes(record.snoozedUntil!).has("run-1")).toBe(false);
+  });
+
+  it("expires without emitting anything — expiry is resolved at read, not announced", () => {
+    const service = makeService(makeSnoozePersistence());
+    const record = service.snooze("run-1", "15m");
+    const before = emittedOf("terminal:snooze-changed").length;
+
+    service.getActiveSnoozes(record.snoozedUntil! + 1);
+
+    expect(emittedOf("terminal:snooze-changed").length).toBe(before);
+  });
+
+  it("clears the snooze when the user types at a waiting run", () => {
+    const service = makeService(makeSnoozePersistence());
+    service.snooze("run-1", "6h");
+
+    typedInput("run-1");
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
+  });
+
+  it("clears the snooze when the user types at a run that is already working", () => {
+    // The gap the dropped-transition subscription exists to close: no state
+    // change means no `agent:state-changed`, so this is the only signal.
+    const service = makeService(makeSnoozePersistence());
+    service.snooze("run-1", "6h");
+
+    typedInputWhileWorking("run-1");
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
+  });
+
+  it("clears an unlimited snooze on input, like every other duration", () => {
+    const service = makeService(makeSnoozePersistence());
+    service.snooze("run-1", "unlimited");
+
+    typedInput("run-1");
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
+  });
+
+  it("does NOT clear the snooze on a non-input transition", () => {
+    // Output, heuristics and activity all move agent state without the user
+    // being present. Only deliberate typing ends a snooze.
+    const service = makeService(makeSnoozePersistence());
+    service.snooze("run-1", "6h");
+
+    for (const trigger of ["output", "heuristic", "activity", "timeout", "title"]) {
+      eventEmitter.emit("agent:state-changed", {
+        terminalId: "run-1",
+        state: "waiting",
+        previousState: "working",
+        trigger,
+        timestamp: NOW + 1_000,
+      });
+    }
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(true);
+  });
+
+  it("only clears the run that was typed at", () => {
+    const service = makeService(makeSnoozePersistence());
+    service.snooze("run-1", "6h");
+    service.snooze("run-2", "6h");
+
+    typedInput("run-1");
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
+    expect(service.isSnoozed("run-2", NOW)).toBe(true);
+  });
+
+  it("persists a snooze so it survives a restart", () => {
+    const persistence = makeSnoozePersistence();
+    const service = makeService(persistence);
+    service.snooze("run-1", "6h");
+
+    const saved = persistence.saveSnoozes.mock.calls.at(-1)![0];
+    const revived = makeService(makeSnoozePersistence({}, saved));
+
+    expect(revived.isSnoozed("run-1", NOW)).toBe(true);
+  });
+
+  it("drops an already-lapsed snooze at load rather than carrying it forward", () => {
+    const stale: Record<string, RunSnoozeRecord> = {
+      "run-1": { snoozedAt: NOW - 60_000, snoozedUntil: NOW - 1 },
+    };
+    const service = makeService(makeSnoozePersistence({}, stale));
+
+    expect(service.getSnoozeRecord("run-1")).toBeUndefined();
+  });
+
+  it("drops a snooze older than the stale TTL even when it never expires", () => {
+    // An unlimited snooze on a run that never came back would otherwise be held
+    // forever, honouring a decision the user no longer remembers making.
+    const ancient: Record<string, RunSnoozeRecord> = {
+      "run-1": { snoozedAt: NOW - 20 * DAY_MS },
+    };
+    const service = makeService(makeSnoozePersistence({}, ancient));
+
+    expect(service.getSnoozeRecord("run-1")).toBeUndefined();
+  });
+
+  it("rejects a malformed stored record rather than repairing it", () => {
+    const corrupt = {
+      "run-1": { snoozedAt: "soon" },
+      "run-2": { snoozedAt: NOW + 10 * 60_000 },
+      "run-3": null,
+    } as unknown as Record<string, RunSnoozeRecord>;
+    const service = makeService(makeSnoozePersistence({}, corrupt));
+
+    // run-2's timestamp is far enough in the future to be corrupt, not early.
+    expect(service.getSnoozeRecord("run-1")).toBeUndefined();
+    expect(service.getSnoozeRecord("run-2")).toBeUndefined();
+    expect(service.getSnoozeRecord("run-3")).toBeUndefined();
+  });
+
+  it("rolls back and reports when the snooze cannot be persisted", () => {
+    const persistence = makeSnoozePersistence();
+    persistence.saveSnoozes.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const service = makeService(persistence);
+
+    expect(() => service.snooze("run-1", "6h")).toThrow("disk full");
+    // A snooze that would not survive a restart must not exist now either.
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
+    expect(emittedOf("terminal:snooze-changed")).toEqual([]);
+  });
+
+  it("keeps the snooze when an input-driven clear cannot be persisted", () => {
+    const persistence = makeSnoozePersistence();
+    const service = makeService(persistence);
+    service.snooze("run-1", "6h");
+    persistence.saveSnoozes.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    // Driven by an event, so it must not throw at the listener.
+    expect(() => typedInput("run-1")).not.toThrow();
+    expect(service.isSnoozed("run-1", NOW)).toBe(true);
+  });
+
+  it("re-snoozing replaces the record wholesale", () => {
+    const service = makeService(makeSnoozePersistence());
+    const first = service.snooze("run-1", "15m");
+    const second = service.snooze("run-1", "6h");
+
+    expect(second.snoozedUntil).toBeGreaterThan(first.snoozedUntil!);
+  });
+
+  it("unsnooze reports whether there was anything to lift", () => {
+    const service = makeService(makeSnoozePersistence());
+    expect(service.unsnooze("run-1")).toBe(false);
+
+    service.snooze("run-1", "6h");
+    expect(service.unsnooze("run-1")).toBe(true);
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
+  });
+
+  it("rejects a duration outside the ladder", () => {
+    const service = makeService(makeSnoozePersistence());
+    expect(() => service.snooze("run-1", "1h" as never)).toThrow(/Invalid snooze duration/);
+  });
+
+  it("refuses to mutate snoozes while the app is shutting down", () => {
+    const service = makeService(makeSnoozePersistence(), { isQuitting: () => true });
+    expect(() => service.snooze("run-1", "6h")).toThrow(/shutting down/);
+    expect(() => service.unsnooze("run-1")).toThrow(/shutting down/);
+  });
+
+  it("leaves a park untouched when the run is snoozed, and vice versa", () => {
+    // Independent intents: snoozing must not destroy the note a park carries.
+    const service = makeService(makeSnoozePersistence());
+    service.park("run-1", { note: "waiting on review" });
+    service.snooze("run-1", "6h");
+
+    expect(service.getParkRecord("run-1")?.note).toBe("waiting on review");
+    expect(service.isSnoozed("run-1", NOW)).toBe(true);
+
+    service.unsnooze("run-1");
+    expect(service.getParkRecord("run-1")).toBeDefined();
+  });
+
+  it("bounds the snooze set, but never counts lapsed records against the cap", () => {
+    let clock = NOW;
+    const service = makeService(makeSnoozePersistence(), { now: () => clock });
+    for (let i = 0; i < MAX_SNOOZED_RUNS; i++) service.snooze(`run-${i}`, "15m");
+
+    expect(() => service.snooze("overflow", "15m")).toThrow(/more than/);
+
+    // Once the first batch lapses, the slots come back.
+    clock = NOW + 60 * 60_000;
+    expect(() => service.snooze("overflow", "15m")).not.toThrow();
+  });
+
+  it("clears its snoozes on dispose", () => {
+    const service = makeService(makeSnoozePersistence());
+    service.snooze("run-1", "6h");
+    service.dispose();
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
   });
 });

--- a/electron/services/__tests__/RunAttentionService.test.ts
+++ b/electron/services/__tests__/RunAttentionService.test.ts
@@ -602,6 +602,28 @@ describe("snooze", () => {
     expect(service.getSnoozeRecord("run-1")).toBeUndefined();
   });
 
+  it("drops a stored wake time beyond anything the ladder could produce", () => {
+    // Nothing legitimate can write one, so it is corrupt rather than generous.
+    const forged: Record<string, RunSnoozeRecord> = {
+      "run-1": { snoozedAt: NOW, snoozedUntil: NOW + 365 * DAY_MS },
+    };
+    const service = makeService(makeSnoozePersistence({}, forged));
+
+    expect(service.getSnoozeRecord("run-1")).toBeUndefined();
+  });
+
+  it("drops the whole record rather than promoting a corrupt wake time to unlimited", () => {
+    // Keeping the record without its wake time would turn damaged data into a
+    // STRONGER suppression than any option the user could have picked — the
+    // wrong direction to fail in.
+    const corruptUntil = {
+      "run-1": { snoozedAt: NOW, snoozedUntil: "soon" },
+    } as unknown as Record<string, RunSnoozeRecord>;
+    const service = makeService(makeSnoozePersistence({}, corruptUntil));
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
+  });
+
   it("rejects a malformed stored record rather than repairing it", () => {
     const corrupt = {
       "run-1": { snoozedAt: "soon" },
@@ -681,6 +703,39 @@ describe("snooze", () => {
 
     service.unsnooze("run-1");
     expect(service.getParkRecord("run-1")).toBeDefined();
+  });
+
+  it("keeps a snooze through a park and unpark of the same run", () => {
+    // The two intents are independent records; neither release path may take
+    // the other's decision with it.
+    const service = makeService(makeSnoozePersistence());
+    service.snooze("run-1", "6h");
+    service.park("run-1");
+    service.unpark("run-1");
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(true);
+  });
+
+  it("keeps a park when typed input clears the run's snooze", () => {
+    const service = makeService(makeSnoozePersistence());
+    service.park("run-1", { note: "waiting on review" });
+    service.snooze("run-1", "6h");
+
+    typedInput("run-1");
+
+    expect(service.isSnoozed("run-1", NOW)).toBe(false);
+    expect(service.getParkRecord("run-1")?.note).toBe("waiting on review");
+  });
+
+  it("leaves a snooze alone when a gated park releases", () => {
+    const service = makeService(makeSnoozePersistence());
+    service.park("run-1", { gateRunId: "gate-1" });
+    service.snooze("run-1", "6h");
+
+    gateBecomesReady("gate-1");
+
+    expect(service.getParkRecord("run-1")).toBeUndefined();
+    expect(service.isSnoozed("run-1", NOW)).toBe(true);
   });
 
   it("bounds the snooze set, but never counts lapsed records against the cap", () => {

--- a/electron/services/__tests__/projectAgentCounts.test.ts
+++ b/electron/services/__tests__/projectAgentCounts.test.ts
@@ -341,8 +341,24 @@ describe("computeProjectAgentCounts — snooze", () => {
   });
 
   it("still counts a snoozed WORKING agent as active — snooze hides demand, not presence", () => {
-    // A project with a snoozed waiting agent and a working one must read as
-    // Running, which only holds if the working one still counts.
+    // The snooze is on the WORKING run itself. Snoozing a waiting sibling and
+    // asserting the unsnoozed worker counts would prove nothing: it passes just
+    // as well if snoozed workers are wrongly dropped from `active`.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "working", lastStateChange: 3_000 })],
+      undefined,
+      snoozes("t1")
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.active).toBe(1);
+    expect(p1.latestWorkingSince).toBe(3_000);
+    expect(p1.snoozed).toBe(1);
+  });
+
+  it("reads as Running when one agent is snoozed-waiting and another is working", () => {
+    // The issue's headline scenario, straight through the counts.
     const counts = computeProjectAgentCounts(
       ["p1"],
       [agent({ id: "t1", agentState: "waiting" }), agent({ id: "t2", agentState: "working" })],
@@ -353,6 +369,33 @@ describe("computeProjectAgentCounts — snooze", () => {
     const p1 = counts.get("p1")!;
     expect(p1.waiting).toBe(0);
     expect(p1.active).toBe(1);
+  });
+
+  it("keeps the subset invariants intact across a mixed snoozed/unsnoozed project", () => {
+    // blocked <= waiting and unacknowledgedCompleted <= completed have to hold
+    // whatever snooze suppresses, or a row renders a count it cannot explain.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [
+        agent({ id: "t1", agentState: "waiting", waitingReason: "error" }),
+        agent({ id: "t2", agentState: "waiting", waitingReason: "error" }),
+        agent({ id: "t3", agentState: "waiting" }),
+        agent({ id: "t4", agentState: "completed", lastStateChange: 5_000 }),
+        agent({ id: "t5", agentState: "completed", lastStateChange: 6_000 }),
+      ],
+      new Map([["p1", 1_000]]),
+      snoozes("t1", "t4")
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.blocked).toBeLessThanOrEqual(p1.waiting);
+    expect(p1.unacknowledgedCompleted).toBeLessThanOrEqual(p1.completed);
+    // And the suppression bit on exactly the snoozed runs, not more.
+    expect(p1.waiting).toBe(2);
+    expect(p1.blocked).toBe(1);
+    expect(p1.completed).toBe(2);
+    expect(p1.unacknowledgedCompleted).toBe(1);
+    expect(p1.snoozed).toBe(2);
   });
 
   it("counts a snoozed completed agent as completed but not as unacknowledged", () => {

--- a/electron/services/__tests__/projectAgentCounts.test.ts
+++ b/electron/services/__tests__/projectAgentCounts.test.ts
@@ -279,3 +279,171 @@ describe("computeProjectAgentCounts", () => {
     expect(counts.get("p1")!.latestWorkingSince).toBe(700);
   });
 });
+
+describe("computeProjectAgentCounts — snooze", () => {
+  const snoozes = (...ids: string[]) => new Map(ids.map((id) => [id, {}]));
+
+  it("withholds a snoozed waiting agent from the attention tallies", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting" })],
+      undefined,
+      snoozes("t1")
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.waiting).toBe(0);
+    expect(p1.snoozed).toBe(1);
+  });
+
+  it("withholds a snoozed blocked agent from both waiting and blocked", () => {
+    // `blocked` is a subset of `waiting`; suppressing one without the other
+    // would leave a project reading as blocked with nothing waiting.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting", waitingReason: "error" })],
+      undefined,
+      snoozes("t1")
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.waiting).toBe(0);
+    expect(p1.blocked).toBe(0);
+  });
+
+  it("does not let a snoozed wait contribute an age", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting", lastStateChange: 1_000 })],
+      undefined,
+      snoozes("t1")
+    );
+
+    expect(counts.get("p1")!.oldestWaitingSince).toBeNull();
+  });
+
+  it("keeps an unsnoozed sibling's wait fully counted", () => {
+    // The headline behaviour: one snoozed agent must not silence another.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [
+        agent({ id: "t1", agentState: "waiting", lastStateChange: 1_000 }),
+        agent({ id: "t2", agentState: "waiting", lastStateChange: 2_000 }),
+      ],
+      undefined,
+      snoozes("t1")
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.waiting).toBe(1);
+    expect(p1.oldestWaitingSince).toBe(2_000);
+    expect(p1.snoozed).toBe(1);
+  });
+
+  it("still counts a snoozed WORKING agent as active — snooze hides demand, not presence", () => {
+    // A project with a snoozed waiting agent and a working one must read as
+    // Running, which only holds if the working one still counts.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting" }), agent({ id: "t2", agentState: "working" })],
+      undefined,
+      snoozes("t1")
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.waiting).toBe(0);
+    expect(p1.active).toBe(1);
+  });
+
+  it("counts a snoozed completed agent as completed but not as unacknowledged", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "completed", lastStateChange: 5_000 })],
+      new Map([["p1", 1_000]]),
+      snoozes("t1")
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.completed).toBe(1);
+    expect(p1.unacknowledgedCompleted).toBe(0);
+    expect(p1.oldestUnacknowledgedCompletionAt).toBeNull();
+  });
+
+  it("reports the earliest wake time across snoozed runs", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting" }), agent({ id: "t2", agentState: "waiting" })],
+      undefined,
+      new Map([
+        ["t1", { snoozedUntil: 9_000 }],
+        ["t2", { snoozedUntil: 4_000 }],
+      ])
+    );
+
+    expect(counts.get("p1")!.nextSnoozeWakeAt).toBe(4_000);
+  });
+
+  it("reports no wake time when every snooze is unlimited", () => {
+    // Substituting one would promise a return no clock will deliver.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting" })],
+      undefined,
+      new Map([["t1", {}]])
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.snoozed).toBe(1);
+    expect(p1.nextSnoozeWakeAt).toBeNull();
+  });
+
+  it("ignores an unlimited snooze when picking the earliest wake time", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting" }), agent({ id: "t2", agentState: "waiting" })],
+      undefined,
+      new Map([
+        ["t1", {}],
+        ["t2", { snoozedUntil: 7_000 }],
+      ])
+    );
+
+    expect(counts.get("p1")!.nextSnoozeWakeAt).toBe(7_000);
+  });
+
+  it("counts nothing as snoozed when no snooze map is supplied", () => {
+    // Callers that don't consume snooze must see the pre-existing behaviour
+    // exactly, or the feature would change tallies it was never wired into.
+    const counts = computeProjectAgentCounts(["p1"], [agent({ id: "t1", agentState: "waiting" })]);
+
+    const p1 = counts.get("p1")!;
+    expect(p1.waiting).toBe(1);
+    expect(p1.snoozed).toBe(0);
+    expect(p1.nextSnoozeWakeAt).toBeNull();
+  });
+
+  it("does not snooze a run whose id merely resembles another project's", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting" })],
+      undefined,
+      snoozes("t2")
+    );
+
+    expect(counts.get("p1")!.waiting).toBe(1);
+    expect(counts.get("p1")!.snoozed).toBe(0);
+  });
+
+  it("never counts an excluded terminal as snoozed", () => {
+    // A trashed run is not an agent run at all; a snooze record left against
+    // its id must not resurrect it as a tally.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "t1", agentState: "waiting", isTrashed: true })],
+      undefined,
+      snoozes("t1")
+    );
+
+    expect(counts.get("p1")!.snoozed).toBe(0);
+  });
+});

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -288,6 +288,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "A parked run was released because its gate terminal came free or closed",
   },
+  "terminal:snooze-changed": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "A run was snoozed or unsnoozed (user intent, not agent state)",
+  },
   "agent-session:captured": {
     category: "agent",
     requiresContext: false,
@@ -793,6 +799,22 @@ export type DaintreeEventMap = {
   };
 
   /**
+   * Emitted whenever a run's snooze record is created, replaced or removed —
+   * by the user, or automatically when they typed at the run. Both attention
+   * projections subscribe: `ProjectStatsService` because a snooze changes the
+   * project's counts, `FleetSnapshotService` because it changes the row.
+   *
+   * Expiry deliberately emits NOTHING. A lapsed snooze stops applying because
+   * the next read resolves it against the clock, which is why the feature owns
+   * no timers; an expiry event would need one to fire.
+   */
+  "terminal:snooze-changed": {
+    id: string;
+    snoozed: boolean;
+    timestamp: number;
+  };
+
+  /**
    * Emitted when a park is lifted automatically rather than by hand: the gate
    * terminal finished its stint (busy → ready) or was closed. Carries the note
    * so the "this run is ready for you again" surface can say why the run was
@@ -972,6 +994,7 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "terminal:restored",
   "terminal:park-changed",
   "terminal:park-released",
+  "terminal:snooze-changed",
   "agent-session:captured",
   "agent-session:recorded",
   "terminal:activity",

--- a/electron/services/projectAgentCounts.ts
+++ b/electron/services/projectAgentCounts.ts
@@ -29,6 +29,27 @@ export interface ProjectAgentCounts {
   /** Latest transition into `working`, or null. Orders the Running band. */
   latestWorkingSince: number | null;
   /**
+   * Agents the user snoozed — counted whatever they are doing underneath, so
+   * this is NOT a subset of any single state above.
+   *
+   * A snoozed run keeps contributing to {@link active} and {@link completed}
+   * (snooze suppresses attention, not presence) but is withheld from
+   * {@link waiting}, {@link blocked} and {@link unacknowledgedCompleted}, which
+   * are the tallies that make a project read as needing someone. Without this
+   * field a project whose every agent is snoozed would be indistinguishable
+   * from one with nothing in it.
+   */
+  snoozed: number;
+  /**
+   * Earliest wake time among snoozed agents, or null when nothing is snoozed —
+   * or when every snooze is the unlimited option, which has no wake time.
+   *
+   * Lets a row say "until 3:45 PM" instead of drawing a countdown, which is the
+   * point: the wake time has to be discoverable without a ticking number
+   * pulling the eye back to the run the user just shelved.
+   */
+  nextSnoozeWakeAt: number | null;
+  /**
    * Live Daintree Assistant PTYs. The PTY host tallies these into
    * `terminalCount`, but the assistant is tooling-internal, so callers must
    * subtract this from any process count they report (#10989).
@@ -114,6 +135,8 @@ function empty(): ProjectAgentCounts {
     latestUnacknowledgedCompletionAt: null,
     latestCompletionAt: null,
     latestWorkingSince: null,
+    snoozed: 0,
+    nextSnoozeWakeAt: null,
     helpTerminals: 0,
   };
 }
@@ -139,7 +162,18 @@ export function computeProjectAgentCounts(
    * completion counts as unacknowledged. Omitting the map entirely means the
    * caller doesn't consume the acknowledgement split (same effect).
    */
-  lastCompletionSeenAt?: ReadonlyMap<string, number>
+  lastCompletionSeenAt?: ReadonlyMap<string, number>,
+  /**
+   * Runs the user has snoozed, keyed by terminal id, with expiry ALREADY
+   * resolved by the caller — a lapsed snooze must simply be absent.
+   *
+   * Resolving expiry here would mean taking a clock, and this function is
+   * deliberately pure: it is the one definition of what a project's agents are
+   * doing, and two callers that disagreed about "now" would reintroduce exactly
+   * the drift it exists to prevent. `RunAttentionService.getActiveSnoozes()` is
+   * the intended source.
+   */
+  activeSnoozes?: ReadonlyMap<string, { snoozedUntil?: number }>
 ): Map<string, ProjectAgentCounts> {
   const counts = new Map<string, ProjectAgentCounts>();
   for (const id of projectIds) counts.set(id, empty());
@@ -157,19 +191,45 @@ export function computeProjectAgentCounts(
     }
     if (exclusion !== null) continue;
 
-    if (terminal.agentState === "waiting") {
-      entry.waiting += 1;
-      // `"error"` means the agent settled after a blocking failure, where input
-      // may not unblock it — a materially different ask than an empty prompt.
-      // Counted as a subset of `waiting`, never in addition to it.
-      if (terminal.waitingReason === "error") entry.blocked += 1;
+    // The user's own decision about this run, which outranks what the run is
+    // doing when it comes to demanding their attention — and only then.
+    const snooze =
+      terminal.id !== undefined && activeSnoozes !== undefined
+        ? activeSnoozes.get(terminal.id)
+        : undefined;
+    const isSnoozed = snooze !== undefined;
+    if (isSnoozed) {
+      entry.snoozed += 1;
+      // An unlimited snooze carries no wake time and must not be allowed to
+      // stand in for one — a project mixing unlimited and timed snoozes reports
+      // the earliest real wake, and one holding only unlimited snoozes reports
+      // none at all rather than a misleading soonest.
+      if (snooze.snoozedUntil !== undefined) {
+        entry.nextSnoozeWakeAt =
+          entry.nextSnoozeWakeAt === null
+            ? snooze.snoozedUntil
+            : Math.min(entry.nextSnoozeWakeAt, snooze.snoozedUntil);
+      }
+    }
 
-      // Age the wait from the transition into `waiting`. Terminals that haven't
-      // recorded one yet still count toward `waiting` but can't contribute an age.
-      const since = terminal.lastStateChange;
-      if (typeof since === "number" && since > 0) {
-        entry.oldestWaitingSince =
-          entry.oldestWaitingSince === null ? since : Math.min(entry.oldestWaitingSince, since);
+    if (terminal.agentState === "waiting") {
+      // A snoozed wait is withheld from every attention tally — waiting, its
+      // blocked subset, and the age that dates them. The run is still there and
+      // still waiting; the user has said it does not need them yet.
+      if (!isSnoozed) {
+        entry.waiting += 1;
+        // `"error"` means the agent settled after a blocking failure, where input
+        // may not unblock it — a materially different ask than an empty prompt.
+        // Counted as a subset of `waiting`, never in addition to it.
+        if (terminal.waitingReason === "error") entry.blocked += 1;
+
+        // Age the wait from the transition into `waiting`. Terminals that haven't
+        // recorded one yet still count toward `waiting` but can't contribute an age.
+        const since = terminal.lastStateChange;
+        if (typeof since === "number" && since > 0) {
+          entry.oldestWaitingSince =
+            entry.oldestWaitingSince === null ? since : Math.min(entry.oldestWaitingSince, since);
+        }
       }
     } else if (terminal.agentState === "working") {
       entry.active += 1;
@@ -185,8 +245,10 @@ export function computeProjectAgentCounts(
         // Unacknowledged = finished after the user last saw this project.
         // Deliberately no elapsed-time cutoff: a completion that happened
         // while the user was away must stay surfaced until actually seen.
+        // A snoozed completion is exempt: the hand-back is real, but the user
+        // has already said they don't want to be reminded of it yet.
         const seenUpTo = lastCompletionSeenAt?.get(terminal.projectId) ?? 0;
-        if (at > seenUpTo) {
+        if (!isSnoozed && at > seenUpTo) {
           entry.unacknowledgedCompleted += 1;
           entry.oldestUnacknowledgedCompletionAt = Math.min(
             entry.oldestUnacknowledgedCompletionAt ?? Number.POSITIVE_INFINITY,

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -28,7 +28,7 @@ import type { PluginMcpConsentRecord } from "../shared/types/pluginMcpConsent.js
 import type { PluginCapabilityConsentRecord } from "../shared/types/pluginCapabilityConsent.js";
 import { PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION } from "../shared/types/ipc/pluginMcp.js";
 import type { ForgeAuditRecord } from "../shared/types/ipc/forge.js";
-import type { RunParkRecord } from "../shared/types/ipc/fleet.js";
+import type { RunParkRecord, RunSnoozeRecord } from "../shared/types/ipc/fleet.js";
 import type { RunHistoryRecord } from "../shared/types/ipc/runHistory.js";
 import type { SuggestedDictionaryEntry } from "../shared/types/ipc/api.js";
 import { FORGE_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/forge.js";
@@ -103,6 +103,14 @@ export interface StoreSchema {
    * after relaunch. Records for ids that never come back are pruned by age.
    */
   parkedRuns: Record<string, RunParkRecord>;
+  /**
+   * Snooze records keyed by terminal id (`RunAttentionService` is the sole
+   * reader/writer). Separate from {@link parkedRuns} because the two are
+   * written on very different cadences — a snooze is cleared by any typed
+   * input — and one blob would rewrite the park set on every keystroke that
+   * lands on a snoozed run. Expired records are pruned at load.
+   */
+  snoozedRuns: Record<string, RunSnoozeRecord>;
   idleBackgroundAutoClose: {
     enabled: boolean;
     thresholdMinutes: number;
@@ -564,6 +572,7 @@ const storeOptions = {
     idleTerminalDismissals: {},
     idleTerminalNotifiedAt: {},
     parkedRuns: {},
+    snoozedRuns: {},
     // Auto-close defaults OFF: it's a structural change to project lifecycle
     // (frees the renderer + workspace host), so users opt in. 15-min default
     // threshold matches the issue spec.

--- a/shared/types/ipc/fleet.ts
+++ b/shared/types/ipc/fleet.ts
@@ -33,6 +33,34 @@ export interface RunParkRecord {
 }
 
 /**
+ * A user's decision that a run does not need them *yet*.
+ *
+ * The sibling of {@link RunParkRecord}, and deliberately a separate record
+ * rather than a field on it: the two intents differ in what ends them. A park
+ * is "I've triaged this" and ends on a gate or by hand; a snooze is "remind me
+ * later, and definitely when I type" and ends on a clock or on the user's own
+ * keystrokes. Collapsing them would force one release mechanism to pretend to
+ * be the other.
+ *
+ * Snooze suppresses ATTENTION, not presence: a snoozed working agent still
+ * counts as running, and a snoozed completed agent is still completed. Only the
+ * demand it makes on the user is withdrawn.
+ */
+export interface RunSnoozeRecord {
+  /** When the user snoozed the run (epoch ms). */
+  snoozedAt: number;
+  /**
+   * Wake time (epoch ms). Absent means the "Unlimited (until I interact)"
+   * option — the snooze holds until typed input clears it, mirroring how an
+   * absent `gateRunId` already means a park holds until lifted by hand.
+   *
+   * Absolute rather than a duration so the snooze is wall-clock: a machine that
+   * sleeps through the window wakes up with the snooze already over.
+   */
+  snoozedUntil?: number;
+}
+
+/**
  * One agent run: a single agent terminal living in a single worktree.
  *
  * The run — not the project — is the unit here, and that is the whole point of
@@ -110,6 +138,15 @@ export interface FleetRunRow {
    * the note travels with it.
    */
   park?: RunParkRecord;
+  /**
+   * Present iff the user snoozed this run AND the snooze is still live.
+   *
+   * Main filters expired snoozes out before decorating the row, so a consumer
+   * never has to know what time it is to read this field — presence alone means
+   * "currently snoozed". That keeps every renderer surface clock-free and is
+   * what lets the whole feature ship without a countdown timer anywhere.
+   */
+  snooze?: RunSnoozeRecord;
   /**
    * When a WORKING run last showed signs of life — the later of its last
    * output and its entry into the current working stint — present only once

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -179,9 +179,15 @@ export interface GeneratedElectronAPI {
     parkRun(
       ...args: IpcInvokeMap["fleet:park-run"]["args"]
     ): Promise<IpcInvokeMap["fleet:park-run"]["result"]>;
+    snoozeRun(
+      ...args: IpcInvokeMap["fleet:snooze-run"]["args"]
+    ): Promise<IpcInvokeMap["fleet:snooze-run"]["result"]>;
     unparkRun(
       ...args: IpcInvokeMap["fleet:unpark-run"]["args"]
     ): Promise<IpcInvokeMap["fleet:unpark-run"]["result"]>;
+    unsnoozeRun(
+      ...args: IpcInvokeMap["fleet:unsnooze-run"]["args"]
+    ): Promise<IpcInvokeMap["fleet:unsnooze-run"]["result"]>;
   };
   forgeAudit: {
     clearLog(

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -380,7 +380,18 @@ export interface GeneratedIpcInvokeMap {
     ];
     result: import("./fleet.js").RunParkRecord;
   };
+  "fleet:snooze-run": {
+    args: [
+      runId: string,
+      option: import("../../utils/agentSnoozeDurations.js").AgentSnoozeDurationOption,
+    ];
+    result: import("./fleet.js").RunSnoozeRecord;
+  };
   "fleet:unpark-run": {
+    args: [runId: string];
+    result: boolean;
+  };
+  "fleet:unsnooze-run": {
     args: [runId: string];
     result: boolean;
   };

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -142,6 +142,15 @@ export interface BulkProjectStatsEntry extends ProjectStats {
   /** Latest transition into `working`, absent when nothing is working. */
   latestWorkingSince?: number;
   /**
+   * Agents the user snoozed. Carried for the same reason the blocked count is:
+   * a renderer seeded from bulk must reach the same reading the push would have
+   * given it, and without this a cold palette would band an all-snoozed project
+   * as dormant until agent state next moved.
+   */
+  snoozedAgentCount: number;
+  /** Earliest wake time among snoozed agents, absent when none has one. */
+  nextSnoozeWakeAt?: number;
+  /**
    * Measured resident memory (MB) of this project's terminal process trees —
    * each shell plus every descendant (dev servers, agents, language servers),
    * deduplicated by PID. Undefined when the OS process table couldn't be read;
@@ -206,6 +215,26 @@ export interface ProjectStatusEntry {
    * carried a `lastStateChange`.
    */
   latestWorkingSince?: number;
+  /**
+   * Agents the user snoozed, whatever they are doing underneath. NOT a subset
+   * of any single count above: a snoozed run still counts toward
+   * {@link ProjectStatusEntry.activeAgentCount} and
+   * {@link ProjectStatusEntry.completedAgentCount}, but is withheld from
+   * `waitingAgentCount`, `blockedAgentCount` and
+   * `unacknowledgedCompletedAgentCount` — snooze suppresses attention, not
+   * presence.
+   *
+   * The field the switcher needs to tell "every agent here is snoozed" apart
+   * from "nothing is here", which are the same zero on every other count.
+   */
+  snoozedAgentCount: number;
+  /**
+   * Earliest wake time among this project's snoozed agents (epoch ms). Absent
+   * when nothing is snoozed, and also when every snooze is the unlimited
+   * option — that one has no wake time, and reporting a substitute would date
+   * a snooze that no clock will ever end.
+   */
+  nextSnoozeWakeAt?: number;
 }
 
 /**

--- a/shared/utils/__tests__/agentSnoozeDurations.test.ts
+++ b/shared/utils/__tests__/agentSnoozeDurations.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  AGENT_SNOOZE_DURATION_OPTIONS,
+  AGENT_SNOOZE_LABEL,
+  isAgentSnoozeDurationOption,
+  resolveAgentSnoozeDuration,
+} from "../agentSnoozeDurations.js";
+
+const NOW = 1_700_000_000_000;
+
+describe("resolveAgentSnoozeDuration", () => {
+  it("orders the timed options strictly by length", () => {
+    const at15 = resolveAgentSnoozeDuration("15m", NOW)!;
+    const at30 = resolveAgentSnoozeDuration("30m", NOW)!;
+    const at6h = resolveAgentSnoozeDuration("6h", NOW)!;
+
+    expect(at15).toBeGreaterThan(NOW);
+    expect(at30).toBeGreaterThan(at15);
+    expect(at6h).toBeGreaterThan(at30);
+  });
+
+  it("makes 30m exactly twice the offset of 15m", () => {
+    // A relationship rather than a literal: this stays meaningful if the ladder
+    // is ever re-tuned, and fails if one option is edited without the other.
+    const at15 = resolveAgentSnoozeDuration("15m", NOW)! - NOW;
+    const at30 = resolveAgentSnoozeDuration("30m", NOW)! - NOW;
+    expect(at30).toBe(at15 * 2);
+  });
+
+  it("returns no wake time for the unlimited option", () => {
+    expect(resolveAgentSnoozeDuration("unlimited", NOW)).toBeUndefined();
+  });
+
+  it("is a pure offset from the injected clock, not from wall time", () => {
+    const early = resolveAgentSnoozeDuration("6h", NOW)!;
+    const later = resolveAgentSnoozeDuration("6h", NOW + 1_000)!;
+    expect(later - early).toBe(1_000);
+  });
+
+  it("resolves every listed option without falling through", () => {
+    for (const option of AGENT_SNOOZE_DURATION_OPTIONS) {
+      const resolved = resolveAgentSnoozeDuration(option, NOW);
+      // Unlimited is the only option allowed to produce no wake time.
+      if (option === "unlimited") expect(resolved).toBeUndefined();
+      else expect(resolved).toBeGreaterThan(NOW);
+    }
+  });
+});
+
+describe("isAgentSnoozeDurationOption", () => {
+  it("accepts every option the menu can offer", () => {
+    for (const option of AGENT_SNOOZE_DURATION_OPTIONS) {
+      expect(isAgentSnoozeDurationOption(option)).toBe(true);
+    }
+  });
+
+  it("rejects non-members, including the notification inbox's own ladder", () => {
+    // The two ladders are deliberately separate; an inbox option reaching the
+    // agent snooze path is a wiring mistake, not a valid duration.
+    for (const value of ["1h", "4h", "tomorrow-8am", "next-monday-8am"]) {
+      expect(isAgentSnoozeDurationOption(value)).toBe(false);
+    }
+  });
+
+  it("rejects non-string payloads from an untrusted caller", () => {
+    for (const value of [undefined, null, 15, {}, [], true]) {
+      expect(isAgentSnoozeDurationOption(value)).toBe(false);
+    }
+  });
+});
+
+describe("AGENT_SNOOZE_LABEL", () => {
+  it("labels every option distinctly", () => {
+    const labels = AGENT_SNOOZE_DURATION_OPTIONS.map((option) => AGENT_SNOOZE_LABEL[option]);
+    expect(new Set(labels).size).toBe(labels.length);
+    expect(labels.every((label) => label.length > 0)).toBe(true);
+  });
+
+  it("never ends a menu label with a period", () => {
+    // Microcopy rule: no trailing period on titles, buttons or labels.
+    for (const label of Object.values(AGENT_SNOOZE_LABEL)) {
+      expect(label.endsWith(".")).toBe(false);
+    }
+  });
+});

--- a/shared/utils/__tests__/agentSnoozeDurations.test.ts
+++ b/shared/utils/__tests__/agentSnoozeDurations.test.ts
@@ -48,11 +48,10 @@ describe("resolveAgentSnoozeDuration", () => {
 });
 
 describe("isAgentSnoozeDurationOption", () => {
-  it("accepts every option the menu can offer", () => {
-    for (const option of AGENT_SNOOZE_DURATION_OPTIONS) {
-      expect(isAgentSnoozeDurationOption(option)).toBe(true);
-    }
-  });
+  // Deliberately no "accepts every listed option" case: the predicate searches
+  // the same array such a test would iterate, so it passes no matter what the
+  // array contains — including after an option is deleted. The rejection cases
+  // below are the half that can actually fail.
 
   it("rejects non-members, including the notification inbox's own ladder", () => {
     // The two ladders are deliberately separate; an inbox option reaching the

--- a/shared/utils/agentSnoozeDurations.ts
+++ b/shared/utils/agentSnoozeDurations.ts
@@ -39,6 +39,19 @@ export const AGENT_SNOOZE_LABEL: Record<AgentSnoozeDurationOption, string> = {
 const MINUTE_MS = 60 * 1000;
 const HOUR_MS = 60 * MINUTE_MS;
 
+/**
+ * The longest wake time any option can produce, as an offset from when the
+ * snooze was taken.
+ *
+ * Derived from the ladder rather than written down, so re-tuning an option
+ * cannot leave a validator behind honouring a window nothing can produce. Used
+ * to reject stored records whose wake time is beyond anything the user could
+ * have chosen.
+ */
+export const MAX_AGENT_SNOOZE_MS = Math.max(
+  ...AGENT_SNOOZE_DURATION_OPTIONS.map((option) => resolveAgentSnoozeDuration(option, 0) ?? 0)
+);
+
 export function isAgentSnoozeDurationOption(value: unknown): value is AgentSnoozeDurationOption {
   return (
     typeof value === "string" &&

--- a/shared/utils/agentSnoozeDurations.ts
+++ b/shared/utils/agentSnoozeDurations.ts
@@ -1,0 +1,78 @@
+/**
+ * Snooze ladder for a single agent run.
+ *
+ * Deliberately NOT the notification inbox's ladder (`snoozeTimestamps.ts`).
+ * That one omits sub-hour slots on the reasoning that dev work happens in
+ * deep-work blocks — true for an inbox thread, wrong for an agent. An agent
+ * blocked on a question is a much shorter-lived thing than an inbox item, and
+ * 15- and 30-minute defers are the common case. Two ladders that mean different
+ * things are cheaper than one ladder bent to fit both.
+ *
+ * `unlimited` has no expiry at all. It is not "forever": every snooze is
+ * cleared by typed input, so the ladder is a ceiling on how long the run can
+ * stay quiet, not the mechanism that ends it. Most snoozes end because the user
+ * came back and answered the agent.
+ */
+export type AgentSnoozeDurationOption = "15m" | "30m" | "6h" | "unlimited";
+
+export const AGENT_SNOOZE_DURATION_OPTIONS: readonly AgentSnoozeDurationOption[] = [
+  "15m",
+  "30m",
+  "6h",
+  "unlimited",
+] as const;
+
+/**
+ * Menu copy, sentence case and no trailing period per the microcopy rule.
+ *
+ * "Unlimited (until I interact)" names the release condition out loud because
+ * it is the one option whose behaviour is not obvious from its own label — the
+ * other three read as ceilings, and this one would otherwise read as "never".
+ */
+export const AGENT_SNOOZE_LABEL: Record<AgentSnoozeDurationOption, string> = {
+  "15m": "15 minutes",
+  "30m": "30 minutes",
+  "6h": "6 hours",
+  unlimited: "Unlimited (until I interact)",
+};
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+export function isAgentSnoozeDurationOption(value: unknown): value is AgentSnoozeDurationOption {
+  return (
+    typeof value === "string" &&
+    (AGENT_SNOOZE_DURATION_OPTIONS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Resolve an option to an absolute wake time (epoch ms), or undefined for
+ * `unlimited`.
+ *
+ * Wall-clock by construction: the result is an absolute instant, so a machine
+ * that sleeps for eight hours wakes up with a 30-minute snooze already over.
+ * That is the contract — a snooze measured in "app uptime" would silently
+ * extend itself across every sleep, which is the opposite of what a ceiling is
+ * for.
+ *
+ * These are fixed offsets rather than wall-clock targets like the inbox's
+ * "tomorrow 8am", so they need no DST correction: adding six hours to an
+ * instant lands on the right instant regardless of what the local clock does in
+ * between. `now` is injectable for tests.
+ */
+export function resolveAgentSnoozeDuration(
+  option: AgentSnoozeDurationOption,
+  now: number = Date.now()
+): number | undefined {
+  switch (option) {
+    case "15m":
+      return now + 15 * MINUTE_MS;
+    case "30m":
+      return now + 30 * MINUTE_MS;
+    case "6h":
+      return now + 6 * HOUR_MS;
+    case "unlimited":
+      return undefined;
+  }
+}

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -5,6 +5,7 @@ import {
   InteractingCircle,
   ExitedCircle,
   CircleCheck,
+  CircleDashed,
   CirclePause,
   CircleSlash,
 } from "@/components/icons";
@@ -51,6 +52,11 @@ export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>
   running: SpinnerCircle,
   done: CircleCheck,
   parked: CirclePause,
+  // Dashed rather than paused: a park is held, a snooze is merely quiet for
+  // now, and the two must not share a shape when the row's only other
+  // difference between them is a word. The dash is the same signal the project
+  // switcher's snoozed dot uses, so one vocabulary covers both surfaces.
+  snoozed: CircleDashed,
   idle: HollowCircle,
 };
 
@@ -87,6 +93,9 @@ export const BAND_GLYPH_TONE: Record<FleetBand, string> = {
   // Parked is the user's own quiet, so it takes the quiet tone: hued parked
   // rows would re-demand the attention parking just released.
   parked: NEUTRAL_TONE,
+  // Snoozed is quiet for the same reason parked is: hueing a run the user just
+  // silenced would re-demand the attention the snooze exists to withdraw.
+  snoozed: NEUTRAL_TONE,
   idle: NEUTRAL_TONE,
 };
 

--- a/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
@@ -121,6 +121,7 @@ function makeBulkStatsEntry(overrides: Partial<BulkProjectStatsEntry> = {}): Bul
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     ...overrides,
   };
 }

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.bulkScratchDelete.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.bulkScratchDelete.test.tsx
@@ -218,6 +218,7 @@ function makeScratch(index: number): SearchableScratch {
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
   };
 }

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -187,6 +187,7 @@ function makeProject(overrides: Partial<SearchableProject> = {}): ProjectSwitche
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     section: "other",
     displayPath:
       (overrides.path ?? "/tmp/test").replace(/\\/g, "/").split("/").filter(Boolean).pop() ??
@@ -489,6 +490,7 @@ describe("ProjectSwitcherPalette keyboard on a scratch row", () => {
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
   };
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -167,6 +167,7 @@ function makeProject(overrides: Partial<SearchableProject> = {}): ProjectSwitche
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     section: "other",
     displayPath:
       (overrides.path ?? "/tmp/test").replace(/\\/g, "/").split("/").filter(Boolean).pop() ??
@@ -825,6 +826,7 @@ describe("ProjectSwitcherPalette scratch search rows", () => {
       blockedAgentCount: 0,
       completedAgentCount: 0,
       unacknowledgedCompletedAgentCount: 0,
+      snoozedAgentCount: 0,
       processCount: 0,
       ...overrides,
     };
@@ -1019,6 +1021,7 @@ describe("ProjectSwitcherPalette scratch section across search", () => {
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
   };
 
@@ -1101,6 +1104,7 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
   };
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
@@ -183,6 +183,7 @@ function makeScratch(overrides: Partial<SearchableScratch> = {}): SearchableScra
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
     ...overrides,
   };

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -128,6 +128,15 @@ export function TerminalContextMenu({
   // don't get the option, matching the gesture-level rules in
   // `multiSelectGestures`.
   const fleetEligible = isFleetArmEligible(terminal);
+  // Snooze needs more than fleet eligibility: that only means "live PTY in a
+  // grid location", while `snoozeRun` rejects any id the fleet snapshot can't
+  // see. A plain shell terminal is eligible and never on the snapshot, so
+  // without this the menu would offer a Snooze that always failed — and the
+  // rejection is fire-and-forget, so the user would see nothing at all. Gate on
+  // the same set the handler validates against.
+  const isKnownRun = useFleetSnapshotStore(
+    (s) => s.snapshot?.runs.some((run) => run.runId === terminalId) ?? false
+  );
   // Main strips expired snoozes before a row ships, so presence on the snapshot
   // IS "currently snoozed" — the menu needs no clock and never has to decide
   // whether a wake time has passed.
@@ -975,32 +984,34 @@ export function TerminalContextMenu({
                   Clear fleet
                 </ContextMenuItem>
               )}
-              <ContextMenuSub>
-                <ContextMenuSubTrigger>
-                  <BellOff className={ICON_CLASS} aria-hidden="true" />
-                  Snooze
-                </ContextMenuSubTrigger>
-                <ContextMenuSubContent>
-                  {AGENT_SNOOZE_DURATION_OPTIONS.map((option) => (
-                    <ContextMenuItem key={option} onSelect={() => handleSnooze(option)}>
-                      <BellOff className={ICON_CLASS} aria-hidden="true" />
-                      {AGENT_SNOOZE_LABEL[option]}
-                    </ContextMenuItem>
-                  ))}
-                  {/* Only once there is something to lift. An always-present
-                      "Wake now" would be a no-op the user has to read past on
-                      every run that was never snoozed. */}
-                  {isSnoozed && (
-                    <>
-                      <ContextMenuSeparator />
-                      <ContextMenuItem onSelect={handleUnsnooze}>
-                        <Bell className={ICON_CLASS} aria-hidden="true" />
-                        Wake now
+              {isKnownRun && (
+                <ContextMenuSub>
+                  <ContextMenuSubTrigger>
+                    <BellOff className={ICON_CLASS} aria-hidden="true" />
+                    Snooze
+                  </ContextMenuSubTrigger>
+                  <ContextMenuSubContent>
+                    {AGENT_SNOOZE_DURATION_OPTIONS.map((option) => (
+                      <ContextMenuItem key={option} onSelect={() => handleSnooze(option)}>
+                        <BellOff className={ICON_CLASS} aria-hidden="true" />
+                        {AGENT_SNOOZE_LABEL[option]}
                       </ContextMenuItem>
-                    </>
-                  )}
-                </ContextMenuSubContent>
-              </ContextMenuSub>
+                    ))}
+                    {/* Only once there is something to lift. An always-present
+                        "Wake now" would be a no-op the user has to read past on
+                        every run that was never snoozed. */}
+                    {isSnoozed && (
+                      <>
+                        <ContextMenuSeparator />
+                        <ContextMenuItem onSelect={handleUnsnooze}>
+                          <Bell className={ICON_CLASS} aria-hidden="true" />
+                          Wake now
+                        </ContextMenuItem>
+                      </>
+                    )}
+                  </ContextMenuSubContent>
+                </ContextMenuSub>
+              )}
               <ContextMenuSeparator />
             </>
           )}

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -7,6 +7,13 @@ import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
+import { useFleetSnapshotStore } from "@/store/fleetSnapshotStore";
+import {
+  AGENT_SNOOZE_DURATION_OPTIONS,
+  AGENT_SNOOZE_LABEL,
+  type AgentSnoozeDurationOption,
+} from "@shared/utils/agentSnoozeDurations";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
 import { panelKindHasPty, panelKindIsDockable } from "@shared/config/panelKindRegistry";
@@ -121,7 +128,29 @@ export function TerminalContextMenu({
   // don't get the option, matching the gesture-level rules in
   // `multiSelectGestures`.
   const fleetEligible = isFleetArmEligible(terminal);
+  // Main strips expired snoozes before a row ships, so presence on the snapshot
+  // IS "currently snoozed" — the menu needs no clock and never has to decide
+  // whether a wake time has passed.
+  const isSnoozed = useFleetSnapshotStore(
+    (s) =>
+      s.snapshot?.runs.some((run) => run.runId === terminalId && run.snooze !== undefined) ?? false
+  );
   const sourceRef = useRef<MenuActionSourceValue>("user");
+
+  const handleSnooze = useCallback(
+    (option: AgentSnoozeDurationOption) => {
+      safeFireAndForget(window.electron.fleet.snoozeRun(terminalId, option), {
+        context: "TerminalContextMenu snoozeRun",
+      });
+    },
+    [terminalId]
+  );
+
+  const handleUnsnooze = useCallback(() => {
+    safeFireAndForget(window.electron.fleet.unsnoozeRun(terminalId), {
+      context: "TerminalContextMenu unsnoozeRun",
+    });
+  }, [terminalId]);
 
   const pluginMenuContext = useMemo<WhenClauseContext>(
     () => ({ panelId: terminalId, panelKind: terminal?.kind }),
@@ -946,6 +975,32 @@ export function TerminalContextMenu({
                   Clear fleet
                 </ContextMenuItem>
               )}
+              <ContextMenuSub>
+                <ContextMenuSubTrigger>
+                  <BellOff className={ICON_CLASS} aria-hidden="true" />
+                  Snooze
+                </ContextMenuSubTrigger>
+                <ContextMenuSubContent>
+                  {AGENT_SNOOZE_DURATION_OPTIONS.map((option) => (
+                    <ContextMenuItem key={option} onSelect={() => handleSnooze(option)}>
+                      <BellOff className={ICON_CLASS} aria-hidden="true" />
+                      {AGENT_SNOOZE_LABEL[option]}
+                    </ContextMenuItem>
+                  ))}
+                  {/* Only once there is something to lift. An always-present
+                      "Wake now" would be a no-op the user has to read past on
+                      every run that was never snoozed. */}
+                  {isSnoozed && (
+                    <>
+                      <ContextMenuSeparator />
+                      <ContextMenuItem onSelect={handleUnsnooze}>
+                        <Bell className={ICON_CLASS} aria-hidden="true" />
+                        Wake now
+                      </ContextMenuItem>
+                    </>
+                  )}
+                </ContextMenuSubContent>
+              </ContextMenuSub>
               <ContextMenuSeparator />
             </>
           )}

--- a/src/components/Terminal/__tests__/TerminalContextMenu.snooze.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalContextMenu.snooze.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+/**
+ * The Snooze submenu on an agent terminal (#11783).
+ *
+ * Covers the two things the component decides that nothing else can: which
+ * durations it offers, and whether "Wake now" is present — the latter reads
+ * live snooze state off the fleet snapshot, so it is the one place the
+ * "presence means snoozed" contract is consumed rather than produced.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type React from "react";
+
+// Render menu content synchronously — Radix only mounts it behind a real
+// right-click into a portal, and the branch choice is what is under test.
+vi.mock("@/components/ui/context-menu", () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  const Item = ({ children, onSelect }: { children?: React.ReactNode; onSelect?: () => void }) => (
+    <button onClick={() => onSelect?.()}>{children}</button>
+  );
+  return {
+    ContextMenu: Passthrough,
+    ContextMenuTrigger: Passthrough,
+    ContextMenuContent: Passthrough,
+    ContextMenuItem: Item,
+    ContextMenuActionItem: Item,
+    ContextMenuCheckboxItem: Item,
+    ContextMenuRadioGroup: Passthrough,
+    ContextMenuRadioItem: Item,
+    ContextMenuSeparator: () => null,
+    ContextMenuLabel: Passthrough,
+    ContextMenuShortcut: Passthrough,
+    ContextMenuGroup: Passthrough,
+    ContextMenuPortal: Passthrough,
+    ContextMenuSub: Passthrough,
+    ContextMenuSubContent: Passthrough,
+    ContextMenuSubTrigger: Passthrough,
+  };
+});
+
+const dispatch = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch, get: () => undefined, list: () => [] },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: { getTerminal: () => undefined, getSelection: () => "" },
+}));
+
+vi.mock("@/hooks/useWorktrees", () => ({ useWorktrees: () => ({ worktrees: [] }) }));
+vi.mock("@/hooks/useIsHibernated", () => ({ useIsHibernated: () => false }));
+vi.mock("@/hooks/usePluginContextMenuItems", () => ({ usePluginContextMenuItems: () => [] }));
+
+vi.mock("@/store/voiceRecordingStore", () => ({
+  useVoiceRecordingStore: (selector: (s: unknown) => unknown) =>
+    selector({ lockedTarget: null, recentTargets: [] }),
+}));
+
+// Agent terminals only — the snooze submenu rides the same eligibility gate the
+// fleet items do, so this must be true for the branch to render at all.
+vi.mock("@/store/fleetArmingStore", () => ({
+  useFleetArmingStore: (selector: (s: { armedIds: Set<string> }) => unknown) =>
+    selector({ armedIds: new Set<string>() }),
+  isFleetArmEligible: () => true,
+}));
+
+const snapshotState = vi.hoisted(() => ({
+  current: null as { runs: Array<Record<string, unknown>> } | null,
+}));
+
+vi.mock("@/store/fleetSnapshotStore", () => ({
+  useFleetSnapshotStore: (selector: (s: { snapshot: unknown }) => unknown) =>
+    selector({ snapshot: snapshotState.current }),
+}));
+
+const panelsById = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock("@/store", () => ({
+  usePanelStore: (
+    selector: (s: {
+      panelsById: Record<string, unknown>;
+      maximizeTarget: null;
+      getPanelGroup: () => undefined;
+      watchedPanels: Set<string>;
+    }) => unknown
+  ) =>
+    selector({
+      panelsById: panelsById.current,
+      maximizeTarget: null,
+      getPanelGroup: () => undefined,
+      watchedPanels: new Set<string>(),
+    }),
+}));
+
+import { TerminalContextMenu } from "../TerminalContextMenu";
+import { AGENT_SNOOZE_LABEL } from "@shared/utils/agentSnoozeDurations";
+
+const snoozeRun = vi.fn(() => Promise.resolve({ snoozedAt: 0 }));
+const unsnoozeRun = vi.fn(() => Promise.resolve(true));
+
+const agentPanel = {
+  id: "panel-1",
+  title: "Claude",
+  kind: "terminal",
+  launchAgentId: "claude",
+  worktreeId: "wt-1",
+};
+
+function renderMenu() {
+  panelsById.current = { "panel-1": agentPanel };
+  return render(
+    <TerminalContextMenu terminalId="panel-1">
+      <div>Panel body</div>
+    </TerminalContextMenu>
+  );
+}
+
+beforeEach(() => {
+  snapshotState.current = null;
+  (window as unknown as { electron: unknown }).electron = { fleet: { snoozeRun, unsnoozeRun } };
+});
+
+afterEach(() => {
+  cleanup();
+  dispatch.mockReset();
+  snoozeRun.mockClear();
+  unsnoozeRun.mockClear();
+});
+
+describe("TerminalContextMenu — Snooze submenu", () => {
+  it("offers every duration on the ladder", () => {
+    renderMenu();
+
+    for (const label of Object.values(AGENT_SNOOZE_LABEL)) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
+
+  it("names the release condition on the unlimited option", () => {
+    // The one option whose behaviour isn't obvious from a bare label — without
+    // this it reads as "never".
+    renderMenu();
+
+    expect(screen.getByText(/until I interact/i)).toBeTruthy();
+  });
+
+  it("sends the picked duration to main rather than a resolved timestamp", () => {
+    // Main owns expiry; a renderer-computed wake time would be a second clock.
+    renderMenu();
+    fireEvent.click(screen.getByText(AGENT_SNOOZE_LABEL["30m"]));
+
+    expect(snoozeRun).toHaveBeenCalledWith("panel-1", "30m");
+  });
+
+  it("passes the unlimited option through unresolved", () => {
+    renderMenu();
+    fireEvent.click(screen.getByText(AGENT_SNOOZE_LABEL.unlimited));
+
+    expect(snoozeRun).toHaveBeenCalledWith("panel-1", "unlimited");
+  });
+
+  it("hides Wake now while the run is not snoozed", () => {
+    renderMenu();
+
+    expect(screen.queryByText("Wake now")).toBeNull();
+  });
+
+  it("offers Wake now once the snapshot carries a snooze for this run", () => {
+    // Presence on the row IS "currently snoozed" — main strips expired records
+    // before they ship, so the menu never checks a clock.
+    snapshotState.current = { runs: [{ runId: "panel-1", snooze: { snoozedAt: 1 } }] };
+    renderMenu();
+
+    expect(screen.getByText("Wake now")).toBeTruthy();
+  });
+
+  it("does not offer Wake now for a snooze belonging to a different run", () => {
+    snapshotState.current = { runs: [{ runId: "panel-2", snooze: { snoozedAt: 1 } }] };
+    renderMenu();
+
+    expect(screen.queryByText("Wake now")).toBeNull();
+  });
+
+  it("lifts the snooze for this run when Wake now is chosen", () => {
+    snapshotState.current = { runs: [{ runId: "panel-1", snooze: { snoozedAt: 1 } }] };
+    renderMenu();
+    fireEvent.click(screen.getByText("Wake now"));
+
+    expect(unsnoozeRun).toHaveBeenCalledWith("panel-1");
+  });
+});

--- a/src/components/Terminal/__tests__/TerminalContextMenu.snooze.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalContextMenu.snooze.test.tsx
@@ -2,10 +2,12 @@
 /**
  * The Snooze submenu on an agent terminal (#11783).
  *
- * Covers the two things the component decides that nothing else can: which
- * durations it offers, and whether "Wake now" is present — the latter reads
- * live snooze state off the fleet snapshot, so it is the one place the
- * "presence means snoozed" contract is consumed rather than produced.
+ * Covers the three things the component decides that nothing else can: whether
+ * the submenu is offered at all, which durations it lists, and whether "Wake
+ * now" is present. The first and last both read the fleet snapshot, so this is
+ * the one place the "presence on the snapshot" contract is consumed rather than
+ * produced — for membership (main rejects an id it can't see) and for snooze
+ * state (main strips expired records before they ship).
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
@@ -57,8 +59,9 @@ vi.mock("@/store/voiceRecordingStore", () => ({
     selector({ lockedTarget: null, recentTargets: [] }),
 }));
 
-// Agent terminals only — the snooze submenu rides the same eligibility gate the
-// fleet items do, so this must be true for the branch to render at all.
+// Fleet eligibility only means "live PTY in a grid location" — it says nothing
+// about the terminal being an agent. It gets the fleet items rendered; the
+// snooze submenu needs the run on the snapshot as well.
 vi.mock("@/store/fleetArmingStore", () => ({
   useFleetArmingStore: (selector: (s: { armedIds: Set<string> }) => unknown) =>
     selector({ armedIds: new Set<string>() }),
@@ -117,7 +120,8 @@ function renderMenu() {
 }
 
 beforeEach(() => {
-  snapshotState.current = null;
+  // The fleet can see this run, which is what makes it snoozable at all.
+  snapshotState.current = { runs: [{ runId: "panel-1" }] };
   Object.defineProperty(window, "electron", {
     value: { fleet: { snoozeRun, unsnoozeRun } },
     writable: true,
@@ -133,6 +137,28 @@ afterEach(() => {
 });
 
 describe("TerminalContextMenu — Snooze submenu", () => {
+  it("withholds the submenu when the fleet has no row for this panel", () => {
+    // Fleet eligibility is satisfied (a plain shell terminal clears it), but
+    // main rejects a snooze for an id the snapshot cannot see and the rejection
+    // never reaches the user — so the offer must not be made in the first place.
+    snapshotState.current = { runs: [{ runId: "panel-2" }] };
+    renderMenu();
+
+    expect(screen.queryByText("Snooze")).toBeNull();
+    for (const label of Object.values(AGENT_SNOOZE_LABEL)) {
+      expect(screen.queryByText(label)).toBeNull();
+    }
+  });
+
+  it("withholds the submenu before any snapshot has landed", () => {
+    // Null is "nothing reported yet", not "fleet is empty" — either way there
+    // is no row to validate against, so the menu waits.
+    snapshotState.current = null;
+    renderMenu();
+
+    expect(screen.queryByText("Snooze")).toBeNull();
+  });
+
   it("offers every duration on the ladder", () => {
     renderMenu();
 
@@ -180,7 +206,9 @@ describe("TerminalContextMenu — Snooze submenu", () => {
   });
 
   it("does not offer Wake now for a snooze belonging to a different run", () => {
-    snapshotState.current = { runs: [{ runId: "panel-2", snooze: { snoozedAt: 1 } }] };
+    snapshotState.current = {
+      runs: [{ runId: "panel-1" }, { runId: "panel-2", snooze: { snoozedAt: 1 } }],
+    };
     renderMenu();
 
     expect(screen.queryByText("Wake now")).toBeNull();

--- a/src/components/Terminal/__tests__/TerminalContextMenu.snooze.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalContextMenu.snooze.test.tsx
@@ -118,7 +118,11 @@ function renderMenu() {
 
 beforeEach(() => {
   snapshotState.current = null;
-  (window as unknown as { electron: unknown }).electron = { fleet: { snoozeRun, unsnoozeRun } };
+  Object.defineProperty(window, "electron", {
+    value: { fleet: { snoozeRun, unsnoozeRun } },
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -14,6 +14,7 @@ export {
   BellDot, // watch alert / notify on completion
   ChartNoAxesColumn, // frecency sort order ("Most used" — decayed access score)
   CircleCheck, // finished run awaiting review (Pilot's review band)
+  CircleDashed, // run the user snoozed — quiet until it wakes (Pilot's snoozed band)
   CircleHelp, // workspace whose metadata is missing (removed while its agents ran)
   CirclePause, // run the user parked — shelved on purpose (Pilot's parked band)
   CircleSlash, // agent stopped on an error, distinct in shape from a waiting one (Pilot's blocked band)

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -49,6 +49,8 @@ const {
         latestUnacknowledgedCompletionAt?: number;
         latestCompletionAt?: number;
         latestWorkingSince?: number;
+        snoozedAgentCount?: number;
+        nextSnoozeWakeAt?: number;
         processCount: number;
       }
     >,
@@ -1996,6 +1998,68 @@ describe("useProjectSwitcherPalette", () => {
         if (bands.at(-1) !== project.section) bands.push(project.section);
       }
       expect(bands).toEqual(["current", "attention", "pinned", "running", "other", "unavailable"]);
+    });
+
+    it("gives an all-snoozed project its own band instead of the dormant catch-all", async () => {
+      // The bug this feature exists to fix: a project holding three snoozed
+      // agents used to fall through to Other and read as if nothing were in it.
+      const projects = [
+        base("snoozedProj"),
+        base("emptyProj"),
+        base("runningWithSnooze"),
+        base("waitingWithSnooze"),
+        base("pinnedSnoozed", { pinned: true }),
+      ];
+      projectState.projects = projects;
+      projectState.currentProject = null;
+      projectStatsState.stats = {
+        snoozedProj: {
+          activeAgentCount: 0,
+          waitingAgentCount: 0,
+          processCount: 0,
+          snoozedAgentCount: 3,
+        },
+        // A snoozed agent alongside a genuinely working one: still Running,
+        // because something really is in flight.
+        runningWithSnooze: {
+          activeAgentCount: 1,
+          waitingAgentCount: 0,
+          processCount: 0,
+          snoozedAgentCount: 1,
+        },
+        // An unsnoozed wait still outranks everything — snooze demotes only the
+        // runs it actually covers.
+        waitingWithSnooze: {
+          activeAgentCount: 0,
+          waitingAgentCount: 1,
+          processCount: 0,
+          snoozedAgentCount: 1,
+        },
+        // An explicit pin is the stronger signal, exactly as it is for running.
+        pinnedSnoozed: {
+          activeAgentCount: 0,
+          waitingAgentCount: 0,
+          processCount: 0,
+          snoozedAgentCount: 2,
+        },
+      };
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(projects.map((p) => p.id)));
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(projects.length);
+      });
+
+      const sectionOf = (id: string) =>
+        result.current.results.map(asProject).find((p) => p.id === id)?.section;
+      expect(sectionOf("snoozedProj")).toBe("snoozed");
+      expect(sectionOf("emptyProj")).toBe("other");
+      expect(sectionOf("runningWithSnooze")).toBe("running");
+      expect(sectionOf("waitingWithSnooze")).toBe("attention");
+      expect(sectionOf("pinnedSnoozed")).toBe("pinned");
     });
 
     it("holds a project with unseen completed work in the attention band", async () => {

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -46,6 +46,17 @@ export interface WorkspaceRowStatusFields {
   latestUnacknowledgedCompletionAt?: number;
   /** Latest completion regardless of acknowledgement, absent when none. */
   latestCompletionAt?: number;
+  /**
+   * Agents the user snoozed. NOT a subset of the counts above — a snoozed run
+   * still counts as active or completed, but is withheld from the waiting,
+   * blocked and unacknowledged tallies that make a project read as demanding.
+   */
+  snoozedAgentCount: number;
+  /**
+   * Earliest wake time among snoozed agents, absent when nothing is snoozed or
+   * when every snooze is the unlimited option.
+   */
+  nextSnoozeWakeAt?: number;
   processCount: number;
 }
 
@@ -94,6 +105,7 @@ export const PROJECT_SECTION_ORDER = [
   "attention",
   "pinned",
   "running",
+  "snoozed",
   "other",
   "unavailable",
 ] as const;
@@ -122,6 +134,11 @@ export const PROJECT_SECTION_LABELS: Record<ProjectSectionKey, string> = {
   attention: "Needs attention",
   pinned: "Pinned",
   running: "Running",
+  // Its own band rather than a line inside Other, because the two mean opposite
+  // things: Other is the residual nothing-happening catch-all, and a snoozed
+  // project has live agents the user deliberately quieted. Sorting them
+  // together is what made a project with three snoozed agents read as dormant.
+  snoozed: "Snoozed",
   other: "Other projects",
   unavailable: "Unavailable",
 };
@@ -439,6 +456,12 @@ function sectionForProject(project: SearchableProject): ProjectSectionKey {
   }
   if (project.isPinned) return "pinned";
   if (project.activeAgentCount > 0) return "running";
+  // Last stop before the residual band. Below `pinned` and `running` for the
+  // same reason a pinned running project stays in Pinned: snooze withdraws a
+  // demand, it does not override an explicit pin or the fact that something is
+  // still executing. Above `other` because a project holding snoozed agents is
+  // not the dormant shell that band is for.
+  if (project.snoozedAgentCount > 0) return "snoozed";
   return "other";
 }
 
@@ -699,6 +722,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
               ...(entry.latestWorkingSince !== undefined
                 ? { latestWorkingSince: entry.latestWorkingSince }
                 : {}),
+              snoozedAgentCount: entry.snoozedAgentCount,
+              ...(entry.nextSnoozeWakeAt !== undefined
+                ? { nextSnoozeWakeAt: entry.nextSnoozeWakeAt }
+                : {}),
               processCount: entry.processCount,
             };
             changed = true;
@@ -764,6 +791,8 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         latestUnacknowledgedCompletionAt: stats?.latestUnacknowledgedCompletionAt,
         latestCompletionAt: stats?.latestCompletionAt,
         latestWorkingSince: stats?.latestWorkingSince,
+        snoozedAgentCount: stats?.snoozedAgentCount ?? 0,
+        nextSnoozeWakeAt: stats?.nextSnoozeWakeAt,
         processCount: stats?.processCount ?? 0,
         displayPath: displayPathById.get(p.id) ?? p.path,
         section: "other",
@@ -1026,6 +1055,8 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         oldestUnacknowledgedCompletionAt: stats?.oldestUnacknowledgedCompletionAt,
         latestUnacknowledgedCompletionAt: stats?.latestUnacknowledgedCompletionAt,
         latestCompletionAt: stats?.latestCompletionAt,
+        snoozedAgentCount: stats?.snoozedAgentCount ?? 0,
+        nextSnoozeWakeAt: stats?.nextSnoozeWakeAt,
         processCount: stats?.processCount ?? 0,
       };
     });

--- a/src/lib/__tests__/fleetAttention.test.ts
+++ b/src/lib/__tests__/fleetAttention.test.ts
@@ -210,3 +210,69 @@ describe("compareWithinBand", () => {
     expect([first, second].sort(compareWithinBand).map((r) => r.runId)).toEqual(["a", "b"]);
   });
 });
+
+describe("bandForRun — snooze", () => {
+  const snooze = { snoozedAt: NOW - 60_000, snoozedUntil: NOW + 900_000 };
+
+  it("bands a snoozed run as snoozed rather than by what it is doing", () => {
+    expect(bandForRun(run({ agentState: "waiting", snooze }))).toBe("snoozed");
+  });
+
+  it("keeps a snoozed run out of every demand band", () => {
+    // The whole point: a snoozed run must stop counting as a demand no matter
+    // how urgent its underlying state looks.
+    for (const state of ["waiting", "completed", "working"] as const) {
+      const band = bandForRun(run({ agentState: state, snooze }));
+      expect(isDemandBand(band)).toBe(false);
+    }
+  });
+
+  it("still bands an error-blocked run as snoozed when the user snoozed it", () => {
+    expect(bandForRun(run({ agentState: "waiting", waitingReason: "error", snooze }))).toBe(
+      "snoozed"
+    );
+  });
+
+  it("lets a park outrank a snooze when a run somehow carries both", () => {
+    const band = bandForRun(
+      run({ agentState: "waiting", snooze, park: { parkedAt: NOW - 60_000 } })
+    );
+    expect(band).toBe("parked");
+  });
+
+  it("ranks snoozed below parked, agreeing with the precedence check", () => {
+    // An ordering that disagreed with bandForRun's field-check order would be
+    // invisible from either site alone.
+    expect(FLEET_BANDS.indexOf("parked")).toBeLessThan(FLEET_BANDS.indexOf("snoozed"));
+  });
+
+  it("ranks snoozed above idle, so a shelved run outranks a dead one", () => {
+    expect(FLEET_BANDS.indexOf("snoozed")).toBeLessThan(FLEET_BANDS.indexOf("idle"));
+  });
+
+  it("ranks snoozed below every demand band", () => {
+    const snoozedIndex = FLEET_BANDS.indexOf("snoozed");
+    for (const band of FLEET_BANDS.filter(isDemandBand)) {
+      expect(FLEET_BANDS.indexOf(band)).toBeLessThan(snoozedIndex);
+    }
+  });
+
+  it("bands an unsnoozed run exactly as before", () => {
+    // Snooze is the only new demotion lever; nothing else may shift.
+    expect(bandForRun(run({ agentState: "waiting" }))).toBe("needs-you");
+    expect(bandForRun(run({ agentState: "working" }))).toBe("running");
+  });
+
+  it("gives the snoozed band its own label", () => {
+    const label = bandLabel("snoozed", run());
+    expect(label.length).toBeGreaterThan(0);
+    expect(label).not.toBe(bandLabel("parked", run()));
+    expect(label).not.toBe(bandLabel("idle", run()));
+  });
+
+  it("counts the snoozed band in an empty tally", () => {
+    const counts = emptyBandCounts();
+    // Every band must have a slot, or a snoozed run would increment undefined.
+    for (const band of FLEET_BANDS) expect(counts[band]).toBe(0);
+  });
+});

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -539,6 +539,32 @@ describe("snoozed rows", () => {
     expect(later).toBe(early);
   });
 
+  it("actually derives the line from the wake time, not a fixed string", () => {
+    // Paired with the stability test above: without this, a hard-coded or
+    // omitted time would satisfy "unchanged when read later" perfectly.
+    const early = getProjectRowStatus(
+      project({ snoozedAgentCount: 1, nextSnoozeWakeAt: WAKE_AT }),
+      NOW
+    ).text;
+    const late = getProjectRowStatus(
+      project({ snoozedAgentCount: 1, nextSnoozeWakeAt: WAKE_AT + 3 * 60 * 60_000 }),
+      NOW
+    ).text;
+
+    expect(late).not.toBe(early);
+  });
+
+  it("drops only the wake clause when the wake time is absent, keeping the count", () => {
+    const timed = getProjectRowStatus(
+      project({ snoozedAgentCount: 2, nextSnoozeWakeAt: WAKE_AT }),
+      NOW
+    ).text;
+    const unlimited = getProjectRowStatus(project({ snoozedAgentCount: 2 }), NOW).text;
+
+    expect(timed.startsWith(unlimited)).toBe(true);
+    expect(timed.length).toBeGreaterThan(unlimited.length);
+  });
+
   it("yields to a genuinely waiting agent", () => {
     // Snooze demotes only the runs it covers; an unsnoozed wait still wins.
     const status = getProjectRowStatus(

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -17,6 +17,7 @@ function scratch(overrides: Partial<SearchableScratch> = {}): SearchableScratch 
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
     ...overrides,
   };
@@ -40,6 +41,7 @@ function project(overrides: Partial<SearchableProject> = {}): SearchableProject 
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
     displayPath: "test",
     section: "other",
@@ -276,6 +278,7 @@ describe("getProjectRowStatus", () => {
       project({
         completedAgentCount: 1,
         unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
         latestCompletionAt: NOW - 2 * 3600_000,
       }),
       NOW
@@ -290,6 +293,7 @@ describe("getProjectRowStatus", () => {
       project({
         completedAgentCount: 3,
         unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
         latestCompletionAt: NOW - 2 * 3600_000,
       }),
       NOW
@@ -304,6 +308,7 @@ describe("getProjectRowStatus", () => {
         activeAgentCount: 1,
         completedAgentCount: 2,
         unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
         latestCompletionAt: NOW - 3600_000,
       }),
       NOW
@@ -492,5 +497,107 @@ describe("getScratchRowStatus", () => {
 
     expect(status.text).toContain("needs input");
     expect(status.tone).toBe("waiting");
+  });
+});
+
+describe("snoozed rows", () => {
+  const WAKE_AT = NOW + 15 * 60_000;
+
+  it("names the snoozed agents and their wake time", () => {
+    const status = getProjectRowStatus(
+      project({ snoozedAgentCount: 1, nextSnoozeWakeAt: WAKE_AT }),
+      NOW
+    );
+
+    expect(status.tone).toBe("snoozed");
+    expect(status.text).toContain("snoozed");
+    expect(status.text).toContain("until");
+  });
+
+  it("pluralises the count", () => {
+    const one = getProjectRowStatus(project({ snoozedAgentCount: 1 }), NOW).text;
+    const many = getProjectRowStatus(project({ snoozedAgentCount: 3 }), NOW).text;
+
+    expect(one).not.toContain("3");
+    expect(many).toContain("3");
+  });
+
+  it("states no wake time when every snooze is unlimited", () => {
+    const status = getProjectRowStatus(project({ snoozedAgentCount: 2 }), NOW);
+
+    expect(status.tone).toBe("snoozed");
+    expect(status.text).not.toContain("until");
+  });
+
+  it("renders the same wake time regardless of how much later it is read", () => {
+    // The anti-countdown contract: a static clock time stays true without being
+    // redrawn, so no timer is needed to keep the row honest.
+    const row = project({ snoozedAgentCount: 1, nextSnoozeWakeAt: WAKE_AT });
+    const early = getProjectRowStatus(row, NOW).text;
+    const later = getProjectRowStatus(row, NOW + 10 * 60_000).text;
+
+    expect(later).toBe(early);
+  });
+
+  it("yields to a genuinely waiting agent", () => {
+    // Snooze demotes only the runs it covers; an unsnoozed wait still wins.
+    const status = getProjectRowStatus(
+      project({ snoozedAgentCount: 1, waitingAgentCount: 1 }),
+      NOW
+    );
+
+    expect(status.tone).toBe("waiting");
+  });
+
+  it("yields to a running agent, so a project with work in flight reads as Running", () => {
+    const status = getProjectRowStatus(project({ snoozedAgentCount: 1, activeAgentCount: 1 }), NOW);
+
+    expect(status.tone).toBe("working");
+  });
+
+  it("yields to work awaiting review", () => {
+    const status = getProjectRowStatus(
+      project({ snoozedAgentCount: 1, unacknowledgedCompletedAgentCount: 1 }),
+      NOW
+    );
+
+    expect(status.tone).toBe("review");
+  });
+
+  it("outranks the seen-completion line", () => {
+    // A snoozed agent is live and coming back; "Agent finished" would deny that.
+    const status = getProjectRowStatus(
+      project({ snoozedAgentCount: 1, completedAgentCount: 1 }),
+      NOW
+    );
+
+    expect(status.tone).toBe("snoozed");
+  });
+
+  it("outranks the dormant opened-time fallback", () => {
+    const status = getProjectRowStatus(project({ snoozedAgentCount: 1, lastOpened: 1 }), NOW);
+
+    expect(status.isDormantFallback).toBeUndefined();
+    expect(status.tone).toBe("snoozed");
+  });
+
+  it("gives a scratch the same snoozed line a project gets", () => {
+    const status = getScratchRowStatus(scratch({ snoozedAgentCount: 1 }), NOW);
+
+    expect(status.tone).toBe("snoozed");
+    expect(status.text).toContain("snoozed");
+  });
+
+  it("is distinguishable from the muted settled states by more than colour", () => {
+    // Tone alone cannot separate snoozed from finished-and-seen, so the row's
+    // words have to — otherwise the two greys are the same row.
+    const snoozed = getProjectRowStatus(project({ snoozedAgentCount: 1 }), NOW);
+    const settled = getProjectRowStatus(
+      project({ completedAgentCount: 1, latestCompletionAt: NOW - 60_000 }),
+      NOW
+    );
+
+    expect(snoozed.text).not.toBe(settled.text);
+    expect(snoozed.tone).not.toBe(settled.tone);
   });
 });

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -20,6 +20,7 @@ function makeScratch(
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
     ...overrides,
   };
@@ -42,6 +43,7 @@ function makeProject(
     blockedAgentCount: 0,
     completedAgentCount: 0,
     unacknowledgedCompletedAgentCount: 0,
+    snoozedAgentCount: 0,
     processCount: 0,
     section: "other",
     displayPath: overrides.path.split("/").filter(Boolean).pop() ?? overrides.path,

--- a/src/lib/fleetAttention.ts
+++ b/src/lib/fleetAttention.ts
@@ -16,6 +16,13 @@ import type { FleetRunRow } from "@shared/types/ipc/fleet";
  * `parked` sits between `done` and `idle`: the user has explicitly shelved the
  * run, so it must never read as a demand — but unlike an idle shell it carries
  * intent (a note, maybe a gate) worth finding above the dead rows.
+ *
+ * `snoozed` sits just below `parked`, and the order encodes which decision is
+ * the stronger one rather than which is the more recent. A park is indefinite
+ * and carries a note; a snooze is a ceiling the user expects to lapse. Ranking
+ * park above snooze also keeps this list agreeing with `bandForRun`, which
+ * checks the park record first — an ordering that disagreed with the
+ * precedence check would be a bug nobody could see from either site alone.
  */
 export const FLEET_BANDS = [
   "blocked",
@@ -24,6 +31,7 @@ export const FLEET_BANDS = [
   "running",
   "done",
   "parked",
+  "snoozed",
   "idle",
 ] as const;
 
@@ -59,6 +67,10 @@ export function isDemandBand(band: FleetBand): boolean {
  */
 export function bandForRun(run: FleetRunRow, acknowledgedAt?: number): FleetBand {
   if (run.park !== undefined) return "parked";
+  // Presence alone, deliberately: main strips expired snoozes before the row is
+  // built, so this needs no clock. A run carrying both records reads as parked
+  // — the stronger, indefinite decision wins, matching FLEET_BANDS' order.
+  if (run.snooze !== undefined) return "snoozed";
   switch (run.agentState) {
     case "waiting":
       return run.waitingReason === "error" ? "blocked" : "needs-you";
@@ -103,6 +115,8 @@ export function bandLabel(band: FleetBand, run: FleetRunRow): string {
       return "Finished";
     case "parked":
       return "Parked";
+    case "snoozed":
+      return "Snoozed";
     case "idle":
       return run.agentState === "exited" ? "Exited" : "Idle";
     default: {
@@ -149,5 +163,14 @@ export function compareWithinBand(a: FleetRunRow, b: FleetRunRow): number {
 export type FleetBandCounts = Record<FleetBand, number>;
 
 export function emptyBandCounts(): FleetBandCounts {
-  return { blocked: 0, "needs-you": 0, review: 0, running: 0, done: 0, parked: 0, idle: 0 };
+  return {
+    blocked: 0,
+    "needs-you": 0,
+    review: 0,
+    running: 0,
+    done: 0,
+    parked: 0,
+    snoozed: 0,
+    idle: 0,
+  };
 }

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -40,16 +40,16 @@ export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
   review: "bg-activity-completed",
   working: "bg-activity-active animate-activity-pulse",
   running: "bg-status-success",
-  // Hollow, because "finished" and "suspended" are settled states rather than
-  // live ones. It used to sit on every dormant row too, which made a ring the
-  // most common mark in the list and left it competing with the filled dots
-  // that mean something — dormant rows draw no dot at all now (#11692), so the
-  // ring is back to marking the two muted states that earned a line.
   // Dashed rather than solid, because "snoozed" and "settled" are different
   // facts and the switcher's greys already carry the settled ones. Colour alone
   // could not separate them — a dashed ring reads as temporarily suspended at a
   // glance, and survives both high-contrast modes and a colour-blind reader.
   snoozed: "border border-dashed border-daintree-text/40",
+  // Hollow, because "finished" and "suspended" are settled states rather than
+  // live ones. It used to sit on every dormant row too, which made a ring the
+  // most common mark in the list and left it competing with the filled dots
+  // that mean something — dormant rows draw no dot at all now (#11692), so the
+  // ring is back to marking the two muted states that earned a line.
   muted: "border border-daintree-text/20",
 };
 

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -6,7 +6,8 @@ import type {
 import { formatTimeAgo } from "@/utils/timeAgo";
 
 /** Visual weight of a row's status line. Maps to status tokens, never the accent. */
-export type ProjectRowTone = "blocked" | "waiting" | "review" | "working" | "running" | "muted";
+export type ProjectRowTone =
+  "blocked" | "waiting" | "review" | "working" | "running" | "snoozed" | "muted";
 
 /**
  * Text colour for a status line, by tone.
@@ -26,6 +27,10 @@ export const ROW_TONE_CLASS: Record<ProjectRowTone, string> = {
   review: "text-activity-completed",
   working: "text-activity-working",
   running: "text-daintree-text/50",
+  // Muted like the other settled states, and deliberately NOT the accent: a
+  // snooze is the user telling this row to stop asking for them, so it must not
+  // be the loudest thing in the list on the way out.
+  snoozed: "text-daintree-text/50",
   muted: "text-daintree-text/50",
 };
 
@@ -40,6 +45,11 @@ export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
   // most common mark in the list and left it competing with the filled dots
   // that mean something — dormant rows draw no dot at all now (#11692), so the
   // ring is back to marking the two muted states that earned a line.
+  // Dashed rather than solid, because "snoozed" and "settled" are different
+  // facts and the switcher's greys already carry the settled ones. Colour alone
+  // could not separate them — a dashed ring reads as temporarily suspended at a
+  // glance, and survives both high-contrast modes and a colour-blind reader.
+  snoozed: "border border-dashed border-daintree-text/40",
   muted: "border border-daintree-text/20",
 };
 
@@ -107,6 +117,21 @@ export function agoPhrase(age: string): string {
 
 function pluralAgents(count: number, singular: string, plural: string): string {
   return count === 1 ? singular : `${count} ${plural}`;
+}
+
+/**
+ * A snooze's wake time as a wall clock reading ("3:45 PM"), in the user's own
+ * locale and hour convention.
+ *
+ * A clock time rather than a duration because it is the one form that stays
+ * true without being redrawn: "until 3:45 PM" is as correct ten minutes later
+ * as when it rendered, so the row never needs a ticking timer to stay honest.
+ */
+export function formatWakeTime(wakeAtMs: number): string {
+  return new Date(wakeAtMs).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 type WorkspaceActivityStatus = Omit<ProjectRowStatus, "pathHint">;
@@ -228,6 +253,24 @@ function getWorkspaceActivityStatus(
       text: pluralAgents(project.activeAgentCount, "Agent running", "agents running"),
       tone: "working",
     };
+  }
+
+  // Everything here is snoozed and nothing is running. Below `active` on
+  // purpose — a project with one snoozed agent and one working one is Running,
+  // because something genuinely is. Above the completed/dormant lines because a
+  // snoozed agent is live and coming back, which "Agent finished" would deny.
+  //
+  // The wake time is stated once, statically. A counting-down "in 12m" would
+  // pull the eye back to the row every minute, which is the precise thing the
+  // user snoozed it to stop.
+  if (project.snoozedAgentCount > 0) {
+    const lead = pluralAgents(project.snoozedAgentCount, "Agent snoozed", "agents snoozed");
+    const wakeAt = project.nextSnoozeWakeAt;
+    // Absent when every snooze is the unlimited option — there is no wake time
+    // to name, and inventing one would promise a return that no clock will
+    // deliver.
+    if (wakeAt === undefined) return { text: lead, tone: "snoozed" };
+    return { text: `${lead} · until ${formatWakeTime(wakeAt)}`, tone: "snoozed" };
   }
 
   // Everything completed has been seen: drop the action phrase and mute. The

--- a/src/store/__tests__/projectStatsStore.test.ts
+++ b/src/store/__tests__/projectStatsStore.test.ts
@@ -45,6 +45,7 @@ describe("projectStatsStore", () => {
         blockedAgentCount: 0,
         completedAgentCount: 0,
         unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
         processCount: 3,
       },
       "proj-2": {
@@ -53,6 +54,7 @@ describe("projectStatsStore", () => {
         blockedAgentCount: 0,
         completedAgentCount: 0,
         unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
         processCount: 0,
       },
     };
@@ -85,6 +87,7 @@ describe("projectStatsStore", () => {
         blockedAgentCount: 0,
         completedAgentCount: 0,
         unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
         processCount: 1,
       },
     };
@@ -95,6 +98,7 @@ describe("projectStatsStore", () => {
         blockedAgentCount: 0,
         completedAgentCount: 0,
         unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
         processCount: 4,
       },
     };


### PR DESCRIPTION
## Summary

- Adds a per-agent-terminal Snooze, so one agent sitting on a question stops making the whole project read as "needs attention". A `Snooze >` submenu on agent terminals (15 minutes / 30 minutes / 6 hours / Unlimited, until interaction) plus a "Wake now" item that only shows when a run is actually snoozed.
- A snoozed agent drops out of the project-level attention rollup: one agent snoozed-and-waiting alongside another genuinely working reads as Running, not Needs attention. An unsnoozed waiting agent still outranks a running one, snooze is the only new demotion lever.
- Any typed input clears the snooze regardless of duration, both terminal keystrokes and the hybrid input. Clicking or focusing a pane never clears it. When every agent in a project is snoozed and nothing is running, the project gets its own Snoozed state, distinct from Running and from the dormant "Other projects" bucket it used to fall into.

Resolves #11783

## Changes

- Built as a sibling intent inside the existing `RunAttentionService`, which already owns `park()`, rather than a parallel per-run store, per the issue's ask.
- Closed the harder half of the input contract: typing at an agent that's already `working` produces no FSM transition, so `agent:state-changed` never fires. Subscribed to the existing `agent:state-transition-dropped` bridge event too, since it carries the same normalized `trigger`, covering that path with no new wiring.
- Fixed the gap the issue called out: `computeProjectAgentCounts` had no knowledge of `RunAttentionService` at all, which is also why `park` never reached the switcher badge. Both producers of the counts, the pushed status map and the bulk-stats handler, are now wired, so a cold palette and a live one agree.
- Snooze suppresses attention, not presence: a snoozed run still counts toward active/completed, only withheld from waiting/blocked/unacknowledged.
- Expiry resolves lazily at read time against the existing 5s stats poll, so the feature owns no timers anywhere and survives restart and machine sleep on wall-clock time alone. The row shows a static wake time ("2 agents snoozed · until 3:45 PM"), not a ticking countdown, per the issue.
- The snoozed state is differentiated by shape (dashed ring / dashed circle glyph) and text, not color alone, and uses no accent token.

## Testing

- Typecheck clean, `npm run lint` 0 errors, prettier clean on all changed files.
- 587 tests passing across 19 targeted test files, including new suites for the duration ladder, the service, the counting layer, the bands, the row status, and the context menu.
- Re-ran IPC codegen (`codegen:ipc`, `codegen:ipc-renderer`).
- Scope note: the typed-input path is unit-tested at the main-process service boundary via its bridged events. The pty-host controller itself isn't reachable from a main-process unit test, so end-to-end coverage of the real keystroke path belongs in an e2e spec.
