### PR TITLE
feat(switcher): mark recently active projects with a decaying dot

### DIFF
--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -212,6 +212,11 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     // `gitBacked` joins them: it decides whether the workspace host enumerates
     // worktrees at all, and only `addProject` — which actually looked for a
     // repository — may set it (#11405).
+    // `recentlyClosedAt`/`recentlyActiveUntil` join them: the recency mark is
+    // main-owned derived state, stamped and cleared off real lifecycle
+    // transitions (#11791). A renderer that could write either could hand any
+    // project a mark it never earned, and the deadline is computed on read
+    // anyway, so accepting it would only ever be a lie.
     const {
       id: _id,
       path: _path,
@@ -219,6 +224,8 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
       frecencyScore: _fs,
       lastAccessedAt: _lat,
       gitBacked: _gitBacked,
+      recentlyClosedAt: _rca,
+      recentlyActiveUntil: _rau,
       ...safeUpdates
     } = updates;
     const updated = projectStore.updateProject(projectId, safeUpdates);

--- a/electron/services/IdleBackgroundAutoCloseService.ts
+++ b/electron/services/IdleBackgroundAutoCloseService.ts
@@ -448,7 +448,13 @@ export class IdleBackgroundAutoCloseService {
     // Keep the project in the list as `closed` WITHOUT clearProjectState, so its
     // panel/terminal layout survives a non-destructive reopen. The autoParkedAt
     // marker distinguishes this from a manual close in the switcher.
-    projectStore.updateProjectStatus(projectId, "closed", { autoParkedAt: now });
+    // No recency stamp: the sweep closes projects precisely because they have
+    // been idle, so "recently active" is the one thing this close does not mean
+    // (#11791). The row says "Suspended to free memory" instead.
+    projectStore.updateProjectStatus(projectId, "closed", {
+      autoParkedAt: now,
+      recentlyClosedAt: null,
+    });
     const updated = projectStore.getProjectById(projectId);
     if (updated) {
       try {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -134,9 +134,9 @@ function rowToRepoStats(row: ProjectRow): ProjectRepoStats | null {
  * `active`/`background` rows still on disk at boot ARE the set that was open
  * when the app went away. That makes a separate persisted checkpoint redundant.
  *
- * A late capture is safe for the same reason: the only transitions a launch
- * performs are active/background, and both stay in the set. Only a genuine
- * close or a missing folder removes a project, and both are correct.
+ * Taken before `getAllProjects()` performs its status repair, which promotes
+ * the current project to `active`: a row that was `closed` on disk must not be
+ * pulled into the previous session's open set on the way past.
  */
 let launchSnapshot: { atMs: number; openProjectIds: ReadonlySet<string> } | null = null;
 
@@ -1075,12 +1075,13 @@ export class ProjectStore {
       // Pass null straight through to clear; updateProject writes NULL for it.
       updates.autoParkedAt = options.autoParkedAt;
     }
-    // Stamped here rather than at the three close call sites (#11791). This is
-    // the only path that writes `closed` — `setCurrentProject` moves projects
-    // between active and background and never closes one — so centralizing it
-    // means no future close site can forget to mark its own recency. An
-    // explicit `recentlyClosedAt` in the options still wins, so a caller that
-    // already holds the operation's clock can pass it rather than re-reading it.
+    // Stamped here rather than at the three close call sites (#11791). Every
+    // transition to `closed` goes through this method — `setCurrentProject`
+    // only ever moves a project between active and background, and clears the
+    // stamp itself on both sides — so centralizing it means no future close
+    // site can forget to mark its own recency. An explicit `recentlyClosedAt`
+    // in the options still wins, so a caller that has a reason not to stamp
+    // (or already holds the operation's clock) can say so.
     if (options && "recentlyClosedAt" in options) {
       updates.recentlyClosedAt = options.recentlyClosedAt;
     } else if (status === "closed") {
@@ -1095,6 +1096,9 @@ export class ProjectStore {
   }
 
   getAllProjects(): Project[] {
+    // Before the repair below, which can promote a row to `active` — the
+    // snapshot has to see the statuses as they were persisted (#11791).
+    ensureLaunchSnapshot();
     const db = getSharedDb();
     const rows = db
       .select()

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -27,7 +27,8 @@ import {
   appState as appStateTable,
   type ProjectRow,
 } from "./persistence/schema.js";
-import { eq, desc } from "drizzle-orm";
+import { eq, desc, inArray } from "drizzle-orm";
+import { RECENTLY_ACTIVE_WINDOW_MS } from "../../shared/config/recentlyActive.js";
 import {
   generateProjectId,
   mintProjectId,
@@ -123,6 +124,64 @@ function rowToRepoStats(row: ProjectRow): ProjectRepoStats | null {
   };
 }
 
+/**
+ * The previous session's open projects, plus the moment this one started
+ * (#11791).
+ *
+ * Captured once per main process, from the persisted statuses themselves —
+ * nothing in the shutdown chain closes a project, and the only status repair
+ * `getAllProjects()` performs demotes a stray `active` to `background`, so the
+ * `active`/`background` rows still on disk at boot ARE the set that was open
+ * when the app went away. That makes a separate persisted checkpoint redundant.
+ *
+ * A late capture is safe for the same reason: the only transitions a launch
+ * performs are active/background, and both stay in the set. Only a genuine
+ * close or a missing folder removes a project, and both are correct.
+ */
+let launchSnapshot: { atMs: number; openProjectIds: ReadonlySet<string> } | null = null;
+
+function ensureLaunchSnapshot(): { atMs: number; openProjectIds: ReadonlySet<string> } {
+  if (launchSnapshot) return launchSnapshot;
+  let openProjectIds: ReadonlySet<string> = new Set();
+  try {
+    const rows = getSharedDb()
+      .select({ id: projectsTable.id })
+      .from(projectsTable)
+      .where(inArray(projectsTable.status, ["active", "background"]))
+      .all();
+    openProjectIds = new Set(rows.map((r) => r.id));
+  } catch {
+    // The mark is a hint, never session state. A DB that can't be read here
+    // costs the user some grey dots, not a launch.
+  }
+  launchSnapshot = { atMs: Date.now(), openProjectIds };
+  return launchSnapshot;
+}
+
+/** Test-only: the snapshot is module state that outlives a per-test DB. */
+export function resetLaunchSnapshotForTests(): void {
+  launchSnapshot = null;
+}
+
+/**
+ * The later of the two deadlines that can apply, or undefined when neither
+ * does. Open-at-shutdown runs from launch rather than from the close that never
+ * happened; a hand-closed project runs from its own close and decays across
+ * restarts. A project in both populations — closed this session after being
+ * restored from the last one — takes whichever reaches further.
+ */
+function resolveRecentlyActiveUntil(row: ProjectRow): number | undefined {
+  const snapshot = ensureLaunchSnapshot();
+  const deadlines: number[] = [];
+  if (snapshot.openProjectIds.has(row.id)) {
+    deadlines.push(snapshot.atMs + RECENTLY_ACTIVE_WINDOW_MS);
+  }
+  if (typeof row.recentlyClosedAt === "number") {
+    deadlines.push(row.recentlyClosedAt + RECENTLY_ACTIVE_WINDOW_MS);
+  }
+  return deadlines.length > 0 ? Math.max(...deadlines) : undefined;
+}
+
 function rowToProject(row: ProjectRow): Project {
   const project: Project = {
     id: row.id,
@@ -144,6 +203,12 @@ function rowToProject(row: ProjectRow): Project {
   if (typeof row.lastCompletionSeenAt === "number")
     project.lastCompletionSeenAt = row.lastCompletionSeenAt;
   if (typeof row.autoParkedAt === "number") project.autoParkedAt = row.autoParkedAt;
+  if (typeof row.recentlyClosedAt === "number") project.recentlyClosedAt = row.recentlyClosedAt;
+  // Derived here rather than at the call sites so every path that hands a
+  // project out — list reads, single lookups, and the update broadcasts —
+  // carries the same deadline.
+  const recentlyActiveUntil = resolveRecentlyActiveUntil(row);
+  if (recentlyActiveUntil !== undefined) project.recentlyActiveUntil = recentlyActiveUntil;
   // Only `false` is carried: null means git-backed, and so does absence.
   if (row.gitBacked === false) project.gitBacked = false;
   const lastKnownStats = rowToRepoStats(row);
@@ -197,6 +262,10 @@ export class ProjectStore {
   }
 
   async initialize(): Promise<void> {
+    // Pin the previous session's open set before this one starts changing it
+    // (#11791). Idempotent, and safe this early — the shared DB is already open
+    // by the time initialize() runs.
+    ensureLaunchSnapshot();
     if (!existsSync(this.projectsConfigDir)) {
       await fs.mkdir(this.projectsConfigDir, { recursive: true });
     }
@@ -836,7 +905,10 @@ export class ProjectStore {
     // number sets it; omitting the key leaves it untouched. Don't route the clear
     // through `undefined` — a callee that strips undefined keys would silently
     // drop the clear (review #4).
-    updates: Partial<Omit<Project, "autoParkedAt">> & { autoParkedAt?: number | null }
+    updates: Partial<Omit<Project, "autoParkedAt" | "recentlyClosedAt">> & {
+      autoParkedAt?: number | null;
+      recentlyClosedAt?: number | null;
+    }
   ): Project {
     const db = getSharedDb();
 
@@ -854,6 +926,7 @@ export class ProjectStore {
       lastAccessedAt: number;
       lastCompletionSeenAt: number;
       autoParkedAt: number | null;
+      recentlyClosedAt: number | null;
       gitBacked: boolean | null;
     }> = {};
     if (updates.name !== undefined) set.name = updates.name;
@@ -871,6 +944,7 @@ export class ProjectStore {
     if (updates.lastCompletionSeenAt !== undefined)
       set.lastCompletionSeenAt = updates.lastCompletionSeenAt;
     if ("autoParkedAt" in updates) set.autoParkedAt = updates.autoParkedAt ?? null;
+    if ("recentlyClosedAt" in updates) set.recentlyClosedAt = updates.recentlyClosedAt ?? null;
     // Keyed on presence, not on `!== undefined`: promoting a lightweight
     // workspace clears the flag by passing `undefined`, which an existence-blind
     // check would silently drop and leave the row lightweight forever.
@@ -989,14 +1063,33 @@ export class ProjectStore {
   updateProjectStatus(
     projectId: string,
     status: ProjectStatus,
-    options?: { autoParkedAt?: number | null }
+    options?: { autoParkedAt?: number | null; recentlyClosedAt?: number | null }
   ): Project {
-    const updates: Partial<Omit<Project, "autoParkedAt">> & { autoParkedAt?: number | null } = {
+    const updates: Partial<Omit<Project, "autoParkedAt" | "recentlyClosedAt">> & {
+      autoParkedAt?: number | null;
+      recentlyClosedAt?: number | null;
+    } = {
       status,
     };
     if (options && "autoParkedAt" in options) {
       // Pass null straight through to clear; updateProject writes NULL for it.
       updates.autoParkedAt = options.autoParkedAt;
+    }
+    // Stamped here rather than at the three close call sites (#11791). This is
+    // the only path that writes `closed` — `setCurrentProject` moves projects
+    // between active and background and never closes one — so centralizing it
+    // means no future close site can forget to mark its own recency. An
+    // explicit `recentlyClosedAt` in the options still wins, so a caller that
+    // already holds the operation's clock can pass it rather than re-reading it.
+    if (options && "recentlyClosedAt" in options) {
+      updates.recentlyClosedAt = options.recentlyClosedAt;
+    } else if (status === "closed") {
+      updates.recentlyClosedAt = Date.now();
+    } else {
+      // Live again, or gone. Either way the old close is no longer the last
+      // thing that happened here, and leaving it would resurrect the mark on
+      // the next transition.
+      updates.recentlyClosedAt = null;
     }
     return this.updateProject(projectId, updates);
   }
@@ -1154,8 +1247,14 @@ export class ProjectStore {
         } else if (exists && project.status === "missing") {
           // Clear any stale auto-parked marker — a project that went missing and
           // came back wasn't suspended by the idle sweep, so the switcher must
-          // not label it "Suspended to free memory".
-          this.updateProjectStatus(project.id, "closed", { autoParkedAt: null });
+          // not label it "Suspended to free memory". `recentlyClosedAt` is
+          // cleared explicitly for the same reason: a folder reappearing on disk
+          // is not the user having just worked in it, so this `closed` must not
+          // stamp a recency it never earned (#11791).
+          this.updateProjectStatus(project.id, "closed", {
+            autoParkedAt: null,
+            recentlyClosedAt: null,
+          });
         }
       })
     );
@@ -1388,8 +1487,18 @@ export class ProjectStore {
           // Bump the departing project's lastOpened to just before `now` so it
           // becomes the top MRU candidate on the next switch — gives the
           // Cmd+Alt+= shortcut Alt+Tab-style toggle behavior.
-          const previousUpdate: { status: "background"; lastOpened?: number } = {
+          // `recentlyClosedAt` is cleared on both sides of the switch: this
+          // transaction writes status directly rather than through
+          // `updateProjectStatus`, so it owns its own clears (#11791). Switching
+          // away is not closing — the project stays open in the background and
+          // must not start decaying yet.
+          const previousUpdate: {
+            status: "background";
+            lastOpened?: number;
+            recentlyClosedAt: number | null;
+          } = {
             status: "background",
+            recentlyClosedAt: null,
           };
           if (!writesSuppressed) {
             previousUpdate.lastOpened = now - 1;
@@ -1409,9 +1518,12 @@ export class ProjectStore {
           frecencyScore?: number;
           lastAccessedAt?: number;
           autoParkedAt: number | null;
+          recentlyClosedAt: number | null;
           // Reopening a project clears any background-idle "parked" marker so the
           // switcher stops showing "Suspended to free memory" once it's live again.
-        } = { status: "active", autoParkedAt: null };
+          // The recency stamp goes with it: the project is live, so the dot that
+          // stands in for it has nothing left to say (#11791).
+        } = { status: "active", autoParkedAt: null, recentlyClosedAt: null };
         if (!writesSuppressed && newScore !== null) {
           activeUpdate.lastOpened = now;
           activeUpdate.frecencyScore = newScore;

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1075,13 +1075,19 @@ export class ProjectStore {
       // Pass null straight through to clear; updateProject writes NULL for it.
       updates.autoParkedAt = options.autoParkedAt;
     }
-    // Stamped here rather than at the three close call sites (#11791). Every
-    // transition to `closed` goes through this method — `setCurrentProject`
-    // only ever moves a project between active and background, and clears the
-    // stamp itself on both sides — so centralizing it means no future close
-    // site can forget to mark its own recency. An explicit `recentlyClosedAt`
-    // in the options still wins, so a caller that has a reason not to stamp
-    // (or already holds the operation's clock) can say so.
+    // Stamped here rather than at the three close call sites (#11791): every
+    // close the USER performs — close, free memory, idle sweep — goes through
+    // this method, so centralizing it means no future one can forget to mark
+    // its own recency. An explicit `recentlyClosedAt` in the options still
+    // wins, so a caller that has a reason not to stamp (the idle sweep) or
+    // already holds the operation's clock can say so.
+    //
+    // The other writers of `closed` deliberately leave the mark alone by going
+    // through `updateProject` instead: folder adoption, relocation, and the
+    // invalid-status repair are bookkeeping about where a project IS, not the
+    // user putting it down, and none of them should light up the switcher.
+    // `setCurrentProject` is the reverse case — it only moves a project between
+    // active and background, and clears the stamp itself on both sides.
     if (options && "recentlyClosedAt" in options) {
       updates.recentlyClosedAt = options.recentlyClosedAt;
     } else if (status === "closed") {

--- a/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
+++ b/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
@@ -218,6 +218,7 @@ describe("IdleBackgroundAutoCloseService", () => {
       expect(workspaceClientMock.evictProject).toHaveBeenCalledWith("/projects/proj-1");
       expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed", {
         autoParkedAt: expect.any(Number),
+        recentlyClosedAt: null,
       });
       // PROJECT_UPDATED drives the switcher row → "Suspended to free memory".
       expect(broadcastToRendererMock).toHaveBeenCalledWith(
@@ -253,6 +254,7 @@ describe("IdleBackgroundAutoCloseService", () => {
       // The assistant PTY did not block the reclaim…
       expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed", {
         autoParkedAt: expect.any(Number),
+        recentlyClosedAt: null,
       });
       // …and its session was capture-revoked (conversation preserved via the
       // pending-hibernation entry) BEFORE the project-wide kill.
@@ -291,6 +293,7 @@ describe("IdleBackgroundAutoCloseService", () => {
 
       expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed", {
         autoParkedAt: expect.any(Number),
+        recentlyClosedAt: null,
       });
       expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
     });
@@ -331,6 +334,7 @@ describe("IdleBackgroundAutoCloseService", () => {
       });
       expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed", {
         autoParkedAt: expect.any(Number),
+        recentlyClosedAt: null,
       });
     });
 

--- a/electron/services/__tests__/ProjectStore.autoParkedAt.test.ts
+++ b/electron/services/__tests__/ProjectStore.autoParkedAt.test.ts
@@ -24,6 +24,7 @@ const CREATE_TABLES_SQL = `
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
     last_completion_seen_at INTEGER,
     auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
     stats_commit_count INTEGER,
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,

--- a/electron/services/__tests__/ProjectStore.diskPressure.test.ts
+++ b/electron/services/__tests__/ProjectStore.diskPressure.test.ts
@@ -23,6 +23,7 @@ const CREATE_TABLES_SQL = `
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
     last_completion_seen_at INTEGER,
     auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
     stats_commit_count INTEGER,
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -22,6 +22,7 @@ const CREATE_TABLES_SQL = `
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
     last_completion_seen_at INTEGER,
     auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
     stats_commit_count INTEGER,
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,

--- a/electron/services/__tests__/ProjectStore.lightweight.test.ts
+++ b/electron/services/__tests__/ProjectStore.lightweight.test.ts
@@ -22,6 +22,7 @@ const CREATE_TABLES_SQL = `
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
     last_completion_seen_at INTEGER,
     auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
     stats_commit_count INTEGER,
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,

--- a/electron/services/__tests__/ProjectStore.mruSwitch.test.ts
+++ b/electron/services/__tests__/ProjectStore.mruSwitch.test.ts
@@ -23,6 +23,7 @@ const CREATE_TABLES_SQL = `
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
     last_completion_seen_at INTEGER,
     auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
     stats_commit_count INTEGER,
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,

--- a/electron/services/__tests__/ProjectStore.openFailures.test.ts
+++ b/electron/services/__tests__/ProjectStore.openFailures.test.ts
@@ -31,6 +31,7 @@ const CREATE_TABLES_SQL = `
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
     last_completion_seen_at INTEGER,
     auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
     stats_commit_count INTEGER,
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,

--- a/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
+++ b/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
@@ -203,6 +203,25 @@ describe("ProjectStore recently-active marker (#11791)", () => {
       expect(store.getProjectById(projectId)?.recentlyClosedAt).toBe(LONG_AGO);
     });
 
+    it("keeps the stamp through an unrelated update to the same row", () => {
+      store.updateProjectStatus(projectId, "closed");
+      const stamped = store.getProjectById(projectId)?.recentlyClosedAt;
+
+      store.updateProject(projectId, { name: "Renamed" });
+
+      // A rename is not a lifecycle transition; only those move the mark.
+      expect(store.getProjectById(projectId)?.recentlyClosedAt).toBe(stamped);
+    });
+
+    it("re-stamps on a second close after the project was reopened", async () => {
+      store.updateProjectStatus(projectId, "closed", { recentlyClosedAt: LONG_AGO });
+      await store.setCurrentProject(projectId);
+      store.updateProjectStatus(projectId, "closed");
+
+      // The stale stamp must not survive the round trip and win the Math.max.
+      expect(store.getProjectById(projectId)?.recentlyActiveUntil).toBeGreaterThan(Date.now());
+    });
+
     it("does not mark a project whose folder merely reappeared on disk", async () => {
       db.update(schema.projects)
         .set({ status: "missing" })
@@ -254,6 +273,39 @@ describe("ProjectStore recently-active marker (#11791)", () => {
     it("does not extend the mark to projects that were already closed at shutdown", () => {
       resetLaunchSnapshotForTests();
       expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeUndefined();
+    });
+
+    it("holds the open set fixed once taken, so closing during the session cannot join it", () => {
+      db.update(schema.projects)
+        .set({ status: "background" })
+        .where(eq(schema.projects.id, projectId))
+        .run();
+      resetLaunchSnapshotForTests();
+      // Take the snapshot while only `projectId` is open.
+      expect(store.getProjectById(projectId)?.recentlyActiveUntil).toBeGreaterThan(Date.now());
+
+      // `otherId` opens and closes afterwards; it belongs to the close clock, so
+      // a stale close of its own must still read as expired.
+      store.updateProjectStatus(otherId, "closed", { recentlyClosedAt: LONG_AGO });
+      expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeLessThan(Date.now());
+    });
+
+    it("does not pull a closed current project into the open set via the status repair", () => {
+      db.update(schema.projects)
+        .set({ status: "closed" })
+        .where(eq(schema.projects.id, projectId))
+        .run();
+      db.insert(schema.appState)
+        .values({ key: "currentProjectId", value: projectId })
+        .onConflictDoUpdate({ target: schema.appState.key, set: { value: projectId } })
+        .run();
+      resetLaunchSnapshotForTests();
+
+      // getAllProjects() promotes the current row to `active`; the snapshot has
+      // to have been taken from the persisted statuses before that happens.
+      const listed = store.getAllProjects().find((p) => p.id === projectId);
+      expect(listed?.status).toBe("active");
+      expect(listed?.recentlyActiveUntil).toBeUndefined();
     });
   });
 

--- a/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
+++ b/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { eq } from "drizzle-orm";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import * as schema from "../persistence/schema.js";
+
+const CREATE_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    emoji TEXT NOT NULL,
+    last_opened INTEGER NOT NULL,
+    color TEXT,
+    status TEXT,
+    daintree_config_present INTEGER,
+    in_repo_settings INTEGER,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    frecency_score REAL NOT NULL DEFAULT 3.0,
+    last_accessed_at INTEGER NOT NULL DEFAULT 0,
+    last_completion_seen_at INTEGER,
+    auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
+    stats_commit_count INTEGER,
+    stats_issue_count INTEGER,
+    stats_pr_count INTEGER,
+    stats_provider_id TEXT,
+    stats_last_updated INTEGER,
+    git_backed INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`;
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+vi.mock("../persistence/db.js", () => ({
+  getSharedDb: () => db,
+  openDb: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp/daintree-recent-active-test" },
+}));
+
+vi.mock("../GitService.js", () => ({
+  GitService: class {
+    async getRepositoryRoot(p: string): Promise<string> {
+      return p;
+    }
+  },
+}));
+
+vi.mock("../ProjectSettingsManager.js", () => ({
+  ProjectSettingsManager: class {
+    deleteAllEnvForProject() {}
+    migrateEnvForProject() {}
+    getEffectiveNotificationSettings() {
+      return {};
+    }
+  },
+}));
+
+vi.mock("../ProjectStateManager.js", () => ({
+  ProjectStateManager: class {
+    invalidateProjectStateCache() {}
+  },
+}));
+
+vi.mock("../ProjectFileStore.js", () => ({ ProjectFileStore: class {} }));
+vi.mock("../GlobalFileStore.js", () => ({ GlobalFileStore: class {} }));
+vi.mock("../ProjectIdentityFiles.js", () => ({
+  ProjectIdentityFiles: class {
+    async readInRepoProjectIdentity() {
+      return { found: false };
+    }
+  },
+}));
+vi.mock("../projectQuarantineCleanup.js", () => ({
+  cleanupQuarantinedProjectFiles: vi.fn(),
+}));
+
+import { ProjectStore, resetLaunchSnapshotForTests } from "../ProjectStore.js";
+
+/** Comfortably outside the recency window, without naming its length. */
+const LONG_AGO = Date.now() - 24 * 60 * 60 * 1000;
+
+describe("ProjectStore recently-active marker (#11791)", () => {
+  let store: ProjectStore;
+  let projectDir: string;
+  let projectId: string;
+  let otherDir: string;
+  let otherId: string;
+
+  const seed = (
+    id: string,
+    p: string,
+    name: string,
+    row: { status: string; recentlyClosedAt?: number }
+  ) => {
+    db.insert(schema.projects)
+      .values({
+        id,
+        path: p,
+        name,
+        emoji: "🌲",
+        lastOpened: LONG_AGO,
+        status: row.status,
+        frecencyScore: 3.0,
+        lastAccessedAt: LONG_AGO,
+        ...(row.recentlyClosedAt !== undefined ? { recentlyClosedAt: row.recentlyClosedAt } : {}),
+      })
+      .run();
+  };
+
+  beforeEach(async () => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-recent-"));
+    otherDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-recent-other-"));
+    const canonical = await fs.promises.realpath(projectDir);
+    const otherCanonical = await fs.promises.realpath(otherDir);
+    const { generateProjectId } = await import("../projectStorePaths.js");
+    projectId = generateProjectId(canonical);
+    otherId = generateProjectId(otherCanonical);
+
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+
+    seed(projectId, canonical, "Recent", { status: "closed" });
+    seed(otherId, otherCanonical, "Other", { status: "closed" });
+
+    // The launch snapshot is module state deliberately captured once per
+    // process; each test seeds its own DB, so it has to be re-taken.
+    resetLaunchSnapshotForTests();
+    store = new ProjectStore();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(otherDir, { recursive: true, force: true });
+  });
+
+  describe("the close clock", () => {
+    it("marks a project the user just closed, and stamps when it happened", () => {
+      const before = Date.now();
+      store.updateProjectStatus(projectId, "closed");
+
+      const project = store.getProjectById(projectId);
+      expect(project?.recentlyClosedAt).toBeGreaterThanOrEqual(before);
+      // Still ahead of the clock, so the row would draw the dot.
+      expect(project?.recentlyActiveUntil).toBeGreaterThan(Date.now());
+    });
+
+    it("lets the mark expire on its own once the close is old enough", () => {
+      store.updateProjectStatus(projectId, "closed");
+      // Rewrite the stamp rather than advancing time: the deadline is derived
+      // from it, so this is the same arithmetic the decay performs.
+      db.update(schema.projects)
+        .set({ recentlyClosedAt: LONG_AGO })
+        .where(eq(schema.projects.id, projectId))
+        .run();
+
+      const project = store.getProjectById(projectId);
+      expect(project?.recentlyActiveUntil).toBeLessThan(Date.now());
+    });
+
+    it("leaves a project that was never closed unmarked", () => {
+      const project = store.getProjectById(projectId);
+      expect(project?.recentlyClosedAt).toBeUndefined();
+      expect(project?.recentlyActiveUntil).toBeUndefined();
+    });
+
+    it("clears the stamp when the project is reopened", async () => {
+      store.updateProjectStatus(projectId, "closed");
+      expect(store.getProjectById(projectId)?.recentlyClosedAt).toEqual(expect.any(Number));
+
+      await store.setCurrentProject(projectId);
+
+      const project = store.getProjectById(projectId);
+      expect(project?.status).toBe("active");
+      expect(project?.recentlyClosedAt).toBeUndefined();
+    });
+
+    it("does not stamp a project that was merely switched away from", async () => {
+      await store.setCurrentProject(projectId);
+      await store.setCurrentProject(otherId);
+
+      const previous = store.getProjectById(projectId);
+      // Backgrounded is still open — the decay must not start here.
+      expect(previous?.status).toBe("background");
+      expect(previous?.recentlyClosedAt).toBeUndefined();
+    });
+
+    it("honours an explicit stamp from a caller that already holds the clock", () => {
+      store.updateProjectStatus(projectId, "closed", { recentlyClosedAt: LONG_AGO });
+      expect(store.getProjectById(projectId)?.recentlyClosedAt).toBe(LONG_AGO);
+    });
+
+    it("does not mark a project whose folder merely reappeared on disk", async () => {
+      db.update(schema.projects)
+        .set({ status: "missing" })
+        .where(eq(schema.projects.id, projectId))
+        .run();
+      resetLaunchSnapshotForTests();
+
+      await store.checkMissingProjects();
+
+      const project = store.getProjectById(projectId);
+      expect(project?.status).toBe("closed");
+      // A folder coming back is not the user having just worked in it.
+      expect(project?.recentlyClosedAt).toBeUndefined();
+      expect(project?.recentlyActiveUntil).toBeUndefined();
+    });
+  });
+
+  describe("the launch clock", () => {
+    it("marks a project that was still open when the app went away", () => {
+      db.update(schema.projects)
+        .set({ status: "background" })
+        .where(eq(schema.projects.id, projectId))
+        .run();
+      resetLaunchSnapshotForTests();
+
+      const project = store.getProjectById(projectId);
+      // No close ever happened, so only the launch clock can be marking it.
+      expect(project?.recentlyClosedAt).toBeUndefined();
+      expect(project?.recentlyActiveUntil).toBeGreaterThan(Date.now());
+    });
+
+    it("keeps the two populations apart: a stale close stays expired, an open project does not", () => {
+      db.update(schema.projects)
+        .set({ status: "background", recentlyClosedAt: LONG_AGO })
+        .where(eq(schema.projects.id, projectId))
+        .run();
+      db.update(schema.projects)
+        .set({ status: "closed", recentlyClosedAt: LONG_AGO })
+        .where(eq(schema.projects.id, otherId))
+        .run();
+      resetLaunchSnapshotForTests();
+
+      // Same stale stamp on both rows; only the one that was open at shutdown
+      // gets the launch clock, which is the whole point of the two populations.
+      expect(store.getProjectById(projectId)?.recentlyActiveUntil).toBeGreaterThan(Date.now());
+      expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeLessThan(Date.now());
+    });
+
+    it("does not extend the mark to projects that were already closed at shutdown", () => {
+      resetLaunchSnapshotForTests();
+      expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeUndefined();
+    });
+  });
+
+  it("carries the deadline on every project the list hands out", () => {
+    store.updateProjectStatus(projectId, "closed");
+
+    const listed = store.getAllProjects().find((p) => p.id === projectId);
+    const single = store.getProjectById(projectId);
+    // The list read and the single lookup must not disagree about recency.
+    expect(listed?.recentlyActiveUntil).toBe(single?.recentlyActiveUntil);
+    expect(listed?.recentlyActiveUntil).toBeGreaterThan(Date.now());
+  });
+});

--- a/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
+++ b/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
@@ -284,8 +284,14 @@ describe("ProjectStore recently-active marker (#11791)", () => {
       // Take the snapshot while only `projectId` is open.
       expect(store.getProjectById(projectId)?.recentlyActiveUntil).toBeGreaterThan(Date.now());
 
-      // `otherId` opens and closes afterwards; it belongs to the close clock, so
-      // a stale close of its own must still read as expired.
+      // `otherId` opens AFTER the snapshot was taken. It must not join the
+      // launch population — that set is the previous session's, and a set
+      // recomputed on read would wrongly hand it the launch clock here.
+      store.updateProjectStatus(otherId, "background");
+      expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeUndefined();
+
+      // Closing it puts it on the close clock instead, where a stale stamp
+      // reads as expired.
       store.updateProjectStatus(otherId, "closed", { recentlyClosedAt: LONG_AGO });
       expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeLessThan(Date.now());
     });

--- a/electron/services/__tests__/ProjectStore.repoStats.test.ts
+++ b/electron/services/__tests__/ProjectStore.repoStats.test.ts
@@ -25,6 +25,7 @@ const CREATE_TABLES_SQL = `
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
     last_completion_seen_at INTEGER,
     auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
     stats_commit_count INTEGER,
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,

--- a/electron/services/__tests__/ProjectStore.test.ts
+++ b/electron/services/__tests__/ProjectStore.test.ts
@@ -571,6 +571,7 @@ const CREATE_TABLES_SQL = `
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
     last_completion_seen_at INTEGER,
     auto_parked_at INTEGER,
+    recently_closed_at INTEGER,
     stats_commit_count INTEGER,
     stats_issue_count INTEGER,
     stats_pr_count INTEGER,

--- a/electron/services/persistence/migrations/0011_add_project_recently_closed_at.sql
+++ b/electron/services/persistence/migrations/0011_add_project_recently_closed_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `projects` ADD `recently_closed_at` integer;

--- a/electron/services/persistence/migrations/meta/_journal.json
+++ b/electron/services/persistence/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785468253694,
       "tag": "0010_add_scratch_completion_seen",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1786786208480,
+      "tag": "0011_add_project_recently_closed_at",
+      "breakpoints": true
     }
   ]
 }

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -27,6 +27,11 @@ export const projects = sqliteTable(
     // "Suspended to free memory" label in the project switcher. Cleared when the
     // project is reopened (`setCurrentProject`).
     autoParkedAt: integer("auto_parked_at"),
+    // Timestamp (ms) this project stopped being active, stamped on the
+    // transition to `closed` and cleared when it goes active/background again
+    // (#11791). Drives the switcher's decaying "recently active" dot. Null for
+    // a project still open and for every row predating the field.
+    recentlyClosedAt: integer("recently_closed_at"),
     // False for a folder adopted without git (issue #11405). Null for every
     // legacy row and every repository-backed project — absence means
     // git-backed, so no backfill is needed.

--- a/shared/config/recentlyActive.ts
+++ b/shared/config/recentlyActive.ts
@@ -1,0 +1,8 @@
+/**
+ * How long a project keeps its "recently active" mark in the switcher (#11791).
+ *
+ * Shared because the deadline is computed in main (ProjectStore stamps an
+ * absolute `recentlyActiveUntil` on every project it returns) and compared in
+ * the renderer against a ticking clock — one constant, two processes.
+ */
+export const RECENTLY_ACTIVE_WINDOW_MS = 15 * 60 * 1000;

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -569,6 +569,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
   // Palette selected-row indicator (#11686) — the outline is the whole non-text
   // signal there, so it carries 1.4.11 on its own.
   warnings.push(...getPaletteSelectionWarnings(scheme));
+  warnings.push(...getRecentActivityDotWarnings(scheme));
 
   // Terminal ANSI / syntax legibility and distinctness — OKLab-based because
   // the terminal background is always dark and WCAG ratios are unreliable there.
@@ -625,6 +626,9 @@ function resolvePaletteSurfaces(scheme: AppColorScheme): string[] | null {
 
 const SELECTION_OUTLINE_MIN_CONTRAST = 3.0;
 
+/** WCAG 1.4.11's non-text floor, same basis as the selection outline above. */
+const RECENT_ACTIVITY_DOT_MIN_CONTRAST = 3.0;
+
 // The pixel a token actually paints when it lands on `backdrop`. Tokens reach us
 // as an opaque hex, an alpha hex (`#RGBA`/`#RRGGBBAA`, which `isHexColor` accepts
 // and `relativeLuminance` would otherwise read as opaque and pass on a ratio the
@@ -669,6 +673,79 @@ function splitHexAlpha(hex: string): { hex: string; opacity: number } | null {
 // neighbours it touches. The fill is the binding one — on dark the row lifts
 // *towards* the outline, so the pair that looks safe against the surrounding
 // surface can still fail against the row it encloses.
+/**
+ * The switcher's "recently active" dot is a filled `activity-idle` disc drawn in
+ * the project row's status slot (#11791).
+ *
+ * It gets its own gate rather than a CONTRAST_PAIRS entry because the palette
+ * row is not one of DISPLAY_SURFACES: rows are transparent until selected, so
+ * the dot lands on the composited palette surface, and on the selected row it
+ * lands on `overlay-raised` over that surface. Both are backgrounds it can
+ * actually paint on, and a dot that clears one but not the other is invisible
+ * exactly half the time it matters.
+ *
+ * `activity-idle` is also checked light-only and advisory-only by the matrix
+ * pass; this promotes it to the hard-fail gate for the surfaces it now has to
+ * hold. Nothing here relies on the dot being the sole carrier of the fact — the
+ * row says "recently active" in its accessible name too — but a mark quiet
+ * enough to miss is not a subtle mark, it is an absent one.
+ */
+function getRecentActivityDotWarnings(scheme: AppColorScheme): AppThemeValidationWarning[] {
+  const warnings: AppThemeValidationWarning[] = [];
+  const dotToken = scheme.tokens["activity-idle"];
+  const fillToken = scheme.tokens["overlay-raised"];
+
+  const surfaces = resolvePaletteSurfaces(scheme);
+  if (surfaces === null) {
+    warnings.push({
+      kind: "unevaluable",
+      message: `Cannot evaluate recent-activity dot contrast: the palette surface for a ${scheme.type} theme is not a hex color`,
+    });
+    return warnings;
+  }
+
+  const worstByLabel = new Map<string, number>();
+
+  for (const surface of surfaces) {
+    const fill = resolveOverBackdrop(fillToken, surface);
+    if (fill === null) {
+      warnings.push({
+        kind: "unevaluable",
+        message: `Cannot evaluate recent-activity dot contrast: overlay-raised="${fillToken}" is neither hex nor rgba()`,
+      });
+      return warnings;
+    }
+
+    for (const [label, against] of [
+      ["the selected row fill", fill],
+      ["the surrounding palette surface", surface],
+    ] as const) {
+      const dot = resolveOverBackdrop(dotToken, against);
+      if (dot === null) {
+        warnings.push({
+          kind: "unevaluable",
+          message: `Cannot evaluate recent-activity dot contrast: activity-idle="${dotToken}" is neither hex nor rgba()`,
+        });
+        return warnings;
+      }
+      const ratio = contrastRatio(dot, against);
+      const seen = worstByLabel.get(label);
+      if (seen === undefined || ratio < seen) worstByLabel.set(label, ratio);
+    }
+  }
+
+  for (const [label, ratio] of worstByLabel) {
+    if (ratio < RECENT_ACTIVITY_DOT_MIN_CONTRAST) {
+      warnings.push({
+        kind: "low-contrast",
+        message: `activity-idle (recent-activity dot) against ${label} is ${ratio.toFixed(2)}:1; target is ${RECENT_ACTIVITY_DOT_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
+      });
+    }
+  }
+
+  return warnings;
+}
+
 function getPaletteSelectionWarnings(scheme: AppColorScheme): AppThemeValidationWarning[] {
   const warnings: AppThemeValidationWarning[] = [];
   const outlineToken = scheme.tokens["selection-outline"];

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -674,8 +674,8 @@ function splitHexAlpha(hex: string): { hex: string; opacity: number } | null {
 // *towards* the outline, so the pair that looks safe against the surrounding
 // surface can still fail against the row it encloses.
 /**
- * The switcher's "recently active" dot is a filled `activity-idle` disc drawn in
- * the project row's status slot (#11791).
+ * The switcher's "recently active" dot is a filled `text-secondary` disc drawn
+ * in the project row's status slot (#11791).
  *
  * It gets its own gate rather than a CONTRAST_PAIRS entry because the palette
  * row is not one of DISPLAY_SURFACES: rows are transparent until selected, so
@@ -684,15 +684,19 @@ function splitHexAlpha(hex: string): { hex: string; opacity: number } | null {
  * actually paint on, and a dot that clears one but not the other is invisible
  * exactly half the time it matters.
  *
- * `activity-idle` is also checked light-only and advisory-only by the matrix
- * pass; this promotes it to the hard-fail gate for the surfaces it now has to
- * hold. Nothing here relies on the dot being the sole carrier of the fact — the
- * row says "recently active" in its accessible name too — but a mark quiet
- * enough to miss is not a subtle mark, it is an absent one.
+ * `text-secondary` rather than the semantically tempting `activity-idle`:
+ * measured against these surfaces, `activity-idle` lands between 2.18:1 and
+ * 2.94:1 on five of the dark built-ins (daintree included), because it was
+ * calibrated as a cursor/ring hue rather than as a filled indicator.
+ * `text-secondary` is the palette's quiet-but-legible tier and already holds a
+ * 3.0 floor against every display surface. Nothing here relies on the dot being
+ * the sole carrier of the fact — the row says "recently active" in its
+ * accessible name too — but a mark quiet enough to miss is not a subtle mark,
+ * it is an absent one.
  */
 function getRecentActivityDotWarnings(scheme: AppColorScheme): AppThemeValidationWarning[] {
   const warnings: AppThemeValidationWarning[] = [];
-  const dotToken = scheme.tokens["activity-idle"];
+  const dotToken = scheme.tokens["text-secondary"];
   const fillToken = scheme.tokens["overlay-raised"];
 
   const surfaces = resolvePaletteSurfaces(scheme);
@@ -724,7 +728,7 @@ function getRecentActivityDotWarnings(scheme: AppColorScheme): AppThemeValidatio
       if (dot === null) {
         warnings.push({
           kind: "unevaluable",
-          message: `Cannot evaluate recent-activity dot contrast: activity-idle="${dotToken}" is neither hex nor rgba()`,
+          message: `Cannot evaluate recent-activity dot contrast: text-secondary="${dotToken}" is neither hex nor rgba()`,
         });
         return warnings;
       }
@@ -738,7 +742,7 @@ function getRecentActivityDotWarnings(scheme: AppColorScheme): AppThemeValidatio
     if (ratio < RECENT_ACTIVITY_DOT_MIN_CONTRAST) {
       warnings.push({
         kind: "low-contrast",
-        message: `activity-idle (recent-activity dot) against ${label} is ${ratio.toFixed(2)}:1; target is ${RECENT_ACTIVITY_DOT_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
+        message: `text-secondary (recent-activity dot) against ${label} is ${ratio.toFixed(2)}:1; target is ${RECENT_ACTIVITY_DOT_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
       });
     }
   }

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -99,6 +99,27 @@ export interface Project {
    */
   autoParkedAt?: number;
   /**
+   * Timestamp (ms) this project stopped being active — stamped on the
+   * transition to `closed`, cleared the moment it goes active or background
+   * again (#11791). Anchored to the END of an interaction rather than
+   * `lastOpened`: a project worked in for three hours and then stopped would
+   * otherwise carry no recency at the moment that recency is most useful.
+   */
+  recentlyClosedAt?: number;
+  /**
+   * Epoch ms until which this project counts as recently active, or absent when
+   * it doesn't (#11791). Main owns the arithmetic so the renderer holds an
+   * absolute deadline it can compare against its own clock, rather than a
+   * duration it would have to re-base every render.
+   *
+   * Two populations feed it, on deliberately different clocks: a project the
+   * user closed runs from {@link Project.recentlyClosedAt}, while one still open
+   * at the previous shutdown runs from app launch — the app went away, not the
+   * project, so anchoring it to shutdown would show nothing the next morning,
+   * which is the case the mark exists for.
+   */
+  recentlyActiveUntil?: number;
+  /**
    * Last-known repository counts, persisted so switch-back seeds the toolbar
    * immediately instead of shifting its pill widths (issue #11078). Main owns
    * the write; absent until the project's first clean stats poll.

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -54,6 +54,7 @@ import {
 } from "@/lib/projectRowStatus";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useModifierKeys } from "@/hooks/useModifierKeys";
+import { useGlobalMinuteClock } from "@/hooks/useGlobalMinuteTicker";
 import { useScratchDeletionProgress } from "@/hooks/useScratchDeletionProgress";
 import { useOverlayClaim } from "@/hooks";
 // Leaf import, not the `@/hooks` barrel: several palette suites mock that barrel
@@ -192,6 +193,17 @@ export interface ProjectSwitcherPaletteProps {
 interface ProjectListItemProps {
   project: ProjectSwitcherProjectRow;
   isSelected: boolean;
+  /**
+   * The clock this row renders against, passed rather than read (#11791).
+   *
+   * React Compiler auto-memoizes these rows, so a re-render of the palette root
+   * does not re-run this component's body while its props are referentially
+   * unchanged — an ambient `Date.now()` inside it would simply freeze. Ages and
+   * the recency deadline both derive from this prop instead, so the tick that
+   * changes it is what invalidates the row. `ScratchSection` already threads its
+   * `now` the same way.
+   */
+  nowMs: number;
   onSelect: (row: ProjectSwitcherProjectRow) => void;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
@@ -215,7 +227,13 @@ interface ProjectListItemProps {
  * omitted dot would pull every quiet row 14px left of the busy ones, and a list
  * that is mostly quiet would read as the ragged edge rather than the tidy one.
  */
-function StatusDot({ status }: { status: ProjectRowStatus }) {
+function StatusDot({
+  status,
+  showRecentDot = false,
+}: {
+  status: ProjectRowStatus;
+  showRecentDot?: boolean;
+}) {
   return (
     <div className="w-1.5 shrink-0" data-testid="workspace-status-slot">
       {!status.isDormantFallback && (
@@ -224,8 +242,37 @@ function StatusDot({ status }: { status: ProjectRowStatus }) {
           data-testid="workspace-status-dot"
         />
       )}
+      {showRecentDot && (
+        // Hidden from assistive tech, which hears the row's own "recently
+        // active" phrase instead — a live region per row would re-announce the
+        // whole list on every render, and colour must not be the only carrier.
+        <div
+          className="w-1.5 h-1.5 rounded-full bg-activity-idle"
+          data-testid="workspace-recent-dot"
+          aria-hidden="true"
+        />
+      )}
     </div>
   );
+}
+
+/**
+ * Whether the row should carry the decaying "recently active" mark (#11791).
+ *
+ * Gated on the dormant fallback because a live status always outranks a recency
+ * hint: the coloured dot says what the project is doing now, the grey one only
+ * says someone was here lately. So the mark lands exactly where the slot was
+ * already empty — the dormant rows #11692 cleared — and never displaces a mark
+ * that means more. Keyed off the deadline rather than which band the row sorts
+ * into, so a pinned project keeps it too.
+ */
+function showRecentlyActiveMark(
+  status: ProjectRowStatus,
+  project: SearchableProject,
+  nowMs: number
+): boolean {
+  if (status.isDormantFallback !== true) return false;
+  return project.recentlyActiveUntil !== undefined && nowMs < project.recentlyActiveUntil;
 }
 
 /** Matches the resolution of the wait ages on screen — they change by the minute. */
@@ -255,6 +302,7 @@ function useWaitAgeTick(active: boolean): void {
 function ProjectListItem({
   project,
   isSelected,
+  nowMs,
   onSelect,
   onStopProject,
   onCloseProject,
@@ -279,7 +327,8 @@ function ProjectListItem({
   );
   const isProjectNotificationsMuted = areProjectNotificationsMuted(notificationOverrides);
 
-  const status = getProjectRowStatus(project);
+  const status = getProjectRowStatus(project, nowMs);
+  const showRecentDot = showRecentlyActiveMark(status, project, nowMs);
 
   const row = (
     <div
@@ -315,7 +364,7 @@ function ProjectListItem({
       onPointerEnter={onHoverProject ? (e) => onHoverProject(project.id, e.pointerType) : undefined}
       onPointerLeave={onHoverProjectEnd ? (e) => onHoverProjectEnd(e.pointerType) : undefined}
     >
-      <StatusDot status={status} />
+      <StatusDot status={status} showRecentDot={showRecentDot} />
 
       <div
         className={cn(
@@ -354,6 +403,14 @@ function ProjectListItem({
            * attach itself to the wrong noun.
            */}
           {project.isActive && <span className="sr-only">, current</span>}
+          {/*
+           * The grey dot's meaning, said rather than shown (#11791). The dot
+           * itself is `aria-hidden`, so without this the row would carry the
+           * fact in colour alone. Same shape as `, current` above — part of the
+           * accessible name, not a live region, so a list render doesn't
+           * announce every recently-active row.
+           */}
+          {showRecentDot && <span className="sr-only">, recently active</span>}
           {isProjectNotificationsMuted && (
             <>
               {/*
@@ -742,6 +799,13 @@ function ProjectListContent({
 }: ProjectListContentProps) {
   const isSearching = query.trim().length > 0;
 
+  // Held here, once for the whole list, and handed to each row as a prop
+  // (#11791). It has to live in a component that renders the rows rather than at
+  // the palette root: the clock is state, so a tick re-runs THIS body, and the
+  // changed `nowMs` is then what invalidates each auto-memoized row. A tick held
+  // further up re-renders the root and stops there.
+  const nowMs = useGlobalMinuteClock();
+
   // Mounted here, once for the whole list, rather than per row: sixty timers in
   // a hundred-project list would all fire for the same reason.
 
@@ -792,6 +856,7 @@ function ProjectListContent({
           <ProjectListItem
             project={row}
             isSelected={isSelected}
+            nowMs={nowMs}
             onSelect={onSelect}
             onStopProject={onStopProject}
             onCloseProject={onCloseProject}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -265,12 +265,19 @@ function StatusDot({
  * already empty — the dormant rows #11692 cleared — and never displaces a mark
  * that means more. Keyed off the deadline rather than which band the row sorts
  * into, so a pinned project keeps it too.
+ *
+ * The current project is excluded outright. Its deadline is real — it was open
+ * at the last shutdown, so main hands it the launch clock — but an idle current
+ * row falls through to the same dormant fallback as any other quiet row, and
+ * "recently" is the wrong word for where you are standing. Without this the row
+ * would read ", current, recently active".
  */
 function showRecentlyActiveMark(
   status: ProjectRowStatus,
   project: SearchableProject,
   nowMs: number
 ): boolean {
+  if (project.isActive) return false;
   if (status.isDormantFallback !== true) return false;
   return project.recentlyActiveUntil !== undefined && nowMs < project.recentlyActiveUntil;
 }
@@ -799,15 +806,12 @@ function ProjectListContent({
 }: ProjectListContentProps) {
   const isSearching = query.trim().length > 0;
 
-  // Held here, once for the whole list, and handed to each row as a prop
-  // (#11791). It has to live in a component that renders the rows rather than at
-  // the palette root: the clock is state, so a tick re-runs THIS body, and the
-  // changed `nowMs` is then what invalidates each auto-memoized row. A tick held
-  // further up re-renders the root and stops there.
-  const nowMs = useGlobalMinuteClock();
-
   // Mounted here, once for the whole list, rather than per row: sixty timers in
-  // a hundred-project list would all fire for the same reason.
+  // a hundred-project list would all fire for the same reason. It has to be a
+  // component that renders the rows, too — the clock is state, so a tick re-runs
+  // THIS body and the changed `nowMs` is what invalidates each auto-memoized
+  // row. A tick held at the palette root re-renders the root and stops there.
+  const nowMs = useGlobalMinuteClock();
 
   // Bands are contiguous runs of `results`, never a re-filter of it. The hook
   // has already sorted by section, so walking the array once and cutting where

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -247,7 +247,7 @@ function StatusDot({
         // active" phrase instead — a live region per row would re-announce the
         // whole list on every render, and colour must not be the only carrier.
         <div
-          className="w-1.5 h-1.5 rounded-full bg-activity-idle"
+          className="w-1.5 h-1.5 rounded-full bg-text-secondary"
           data-testid="workspace-recent-dot"
           aria-hidden="true"
         />

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -1272,3 +1272,92 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
     ).toBeTruthy();
   });
 });
+
+/**
+ * The decaying "recently active" mark (#11791). It exists to give the Other
+ * Projects band a mark again without reintroducing the permanent ring #11692
+ * removed: it lands only where the slot was already empty, and clears itself.
+ */
+describe("ProjectSwitcherPalette recently-active dot", () => {
+  const QUIET = { lastOpened: Date.now() - 2 * 3600000 };
+  const soon = () => Date.now() + 5 * 60_000;
+
+  it("marks a quiet row whose recency has not run out yet", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[makeProject({ ...QUIET, recentlyActiveUntil: soon() })]}
+      />
+    );
+    expect(screen.getByTestId("workspace-recent-dot")).toBeTruthy();
+  });
+
+  it("leaves the row unmarked once the deadline has passed", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[makeProject({ ...QUIET, recentlyActiveUntil: Date.now() - 1 })]}
+      />
+    );
+    expect(screen.queryByTestId("workspace-recent-dot")).toBeNull();
+  });
+
+  it("leaves a row with no recency at all unmarked", () => {
+    render(<ProjectSwitcherPalette {...baseProps} results={[makeProject(QUIET)]} />);
+    expect(screen.queryByTestId("workspace-recent-dot")).toBeNull();
+  });
+
+  it("yields to a row that has a real status to report", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[makeProject({ waitingAgentCount: 1, recentlyActiveUntil: soon() })]}
+      />
+    );
+    // The status dot says what the project is doing; recency only says someone
+    // was here. Two dots in a one-dot slot would be the regression.
+    expect(screen.getByTestId("workspace-status-dot")).toBeTruthy();
+    expect(screen.queryByTestId("workspace-recent-dot")).toBeNull();
+  });
+
+  it("keys off recency rather than the band, so a pinned row keeps the mark", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({ ...QUIET, isPinned: true, section: "pinned", recentlyActiveUntil: soon() }),
+        ]}
+      />
+    );
+    expect(screen.getByTestId("workspace-recent-dot")).toBeTruthy();
+  });
+
+  it("says it in the row's name too, rather than in colour alone", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[makeProject({ ...QUIET, name: "Marked", recentlyActiveUntil: soon() })]}
+      />
+    );
+    // Reachable by accessible name, so the fact survives without the hue.
+    expect(screen.getByRole("option", { name: /recently active/i })).toBeTruthy();
+    expect(screen.getByTestId("workspace-recent-dot").getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("does not widen the slot it shares with the status dot", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({ ...QUIET, id: "recent", name: "Recent", recentlyActiveUntil: soon() }),
+          makeProject({ ...QUIET, id: "quiet", name: "Quiet" }),
+        ]}
+      />
+    );
+    const slotIn = (row: HTMLElement) => row.querySelector("[data-testid='workspace-status-slot']");
+    const marked = slotIn(screen.getByRole("option", { name: /Recent/ }));
+    const unmarked = slotIn(screen.getByRole("option", { name: /Quiet/ }));
+    // Same slot element, same classes — the mark goes inside it, not beside it.
+    expect(marked?.className).toBe(unmarked?.className);
+  });
+});

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -1357,7 +1357,55 @@ describe("ProjectSwitcherPalette recently-active dot", () => {
     const slotIn = (row: HTMLElement) => row.querySelector("[data-testid='workspace-status-slot']");
     const marked = slotIn(screen.getByRole("option", { name: /Recent/ }));
     const unmarked = slotIn(screen.getByRole("option", { name: /Quiet/ }));
-    // Same slot element, same classes — the mark goes inside it, not beside it.
+
+    // The mark goes inside the reserved slot, not beside it — so the slot has to
+    // both contain the dot and stay the same element it is on an unmarked row.
+    expect(marked?.querySelector("[data-testid='workspace-recent-dot']")).toBeTruthy();
+    expect(unmarked?.querySelector("[data-testid='workspace-recent-dot']")).toBeNull();
     expect(marked?.className).toBe(unmarked?.className);
+  });
+
+  it("never marks the project you are already in", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({
+            ...QUIET,
+            name: "Here",
+            isActive: true,
+            status: "active",
+            // Open at the last shutdown, so main really does hand it a deadline.
+            recentlyActiveUntil: soon(),
+          }),
+        ]}
+      />
+    );
+    // The row is otherwise exactly the quiet shape the mark applies to — no
+    // status dot of its own — so the suppression is what this proves, rather
+    // than a real status having displaced the mark.
+    expect(screen.queryByTestId("workspace-status-dot")).toBeNull();
+    expect(screen.queryByTestId("workspace-recent-dot")).toBeNull();
+    // "…, current, recently active" would be the nonsense this rules out.
+    expect(screen.queryByRole("option", { name: /recently active/i })).toBeNull();
+  });
+
+  it("clears itself as the deadline passes, without the row's props changing", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      // One fixed deadline, then let the shared ticker carry the clock past it —
+      // the decay has to come from the tick, not from a re-render with new props.
+      const results = [makeProject({ ...QUIET, recentlyActiveUntil: Date.now() + 60_000 })];
+      render(<ProjectSwitcherPalette {...baseProps} results={results} />);
+      expect(screen.getByTestId("workspace-recent-dot")).toBeTruthy();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(120_000);
+      });
+
+      expect(screen.queryByTestId("workspace-recent-dot")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/hooks/useGlobalMinuteTicker.ts
+++ b/src/hooks/useGlobalMinuteTicker.ts
@@ -56,3 +56,24 @@ export function useGlobalMinuteTicker(): number {
 
   return tick;
 }
+
+/**
+ * The shared ticker as a wall-clock timestamp, held in state (#11791).
+ *
+ * The distinction from reading `Date.now()` during render is the whole point.
+ * React Compiler auto-memoizes components, so a clock read in a render body can
+ * be cached and silently freeze; a clock kept in state is a tracked value, which
+ * both re-runs the holder's own body on every tick and invalidates the memo of
+ * any child it is passed to. Callers thread the result down as a prop rather
+ * than re-reading the time further in.
+ */
+export function useGlobalMinuteClock(): number {
+  const tick = useGlobalMinuteTicker();
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    setNowMs(Date.now());
+  }, [tick]);
+
+  return nowMs;
+}

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -161,6 +161,12 @@ export interface SearchableProject extends WorkspaceRowStatusFields {
   status: Project["status"];
   /** Set when the project was auto-closed by the background-idle sweep (#10830). */
   autoParkedAt?: number;
+  /**
+   * Epoch ms until which this project reads as recently active (#11791). Main
+   * resolves which clock applies and hands down an absolute deadline, so the
+   * row only ever compares it against the current time.
+   */
+  recentlyActiveUntil?: number;
   isActive: boolean;
   isBackground: boolean;
   isMissing: boolean;
@@ -772,6 +778,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         lastOpened: p.lastOpened ?? 0,
         status: p.status,
         autoParkedAt: p.autoParkedAt,
+        recentlyActiveUntil: p.recentlyActiveUntil,
         isActive,
         isBackground,
         isMissing,


### PR DESCRIPTION
A small grey dot in the project switcher's existing status-dot slot marks a project as recently active, then clears itself after 15 minutes. It only lands on rows that were already dot-free, specifically the dormant "Other Projects" band that #11692 deliberately cleared, so it never competes with the filled dots that carry real meaning.

Resolves #11791

## Two clocks, two populations

There are two different ways a project earns this mark:

- A project the user closes decays from its own close time, persisted so it survives a restart.
- A project still open at the previous shutdown decays from app launch instead. There's no close event for it: the app quit, but the project didn't. Anchoring to shutdown time would show nothing the next morning, which is exactly the case this feature exists for.

## How it's built

- A new nullable `recently_closed_at` column on `projects` (migration `0011`), stamped centrally in `ProjectStore.updateProjectStatus` when a project transitions to closed, and cleared when it goes active again. Folder adoption, relocation, and the invalid-status repair also write `closed`, but deliberately leave this mark alone: they're bookkeeping about where a project lives, not the user putting it down. The idle sweep's auto-park passes an explicit `null` for this field, since it closes projects precisely because they were idle.
- The previous session's open set is derived at boot from the persisted `active`/`background` statuses rather than a second persisted checkpoint: nothing in the shutdown chain closes a project, and the only status repair demotes a stray `active` down to `background`. It's captured once per process, before `getAllProjects()` can promote the current row.
- Main resolves an absolute `recentlyActiveUntil` deadline inside `rowToProject`, so every path that hands a project out, list reads and update broadcasts alike, carries the same value, and the renderer just compares it to a clock. No new IPC namespace needed.

## The compiler trap

`useWaitAgeTick` in this file re-renders the palette root on an interval and expects that to cascade down to the rows. Under `babel-plugin-react-compiler`, the rows get auto-memoized, so the row body never actually re-runs, and an ambient `Date.now()` call inside it freezes at whatever it first captured.

The fix threads a `nowMs` prop down from a new `useGlobalMinuteClock()`, a shared, visibility-aware ticker that holds its timestamp in React state. It's called inside the component that renders the rows, since a component's own state change forces its body to re-run regardless of memoization. The same fix corrects the wait-age display, which was reading an ambient clock inside `getProjectRowStatus(project)`. Vitest runs without the compiler, so this class of bug can't be caught by the test suite either way.

## Colour

The dot uses `text-secondary`, not `activity-idle`. `activity-idle` looks like the obvious semantic choice, but it was calibrated for use as a cursor or ring hue, not a small filled shape. Rendered as a 6px filled disc, it measures a contrast ratio of only 2.18:1 to 2.94:1 against the palette surface colour on five of the dark built-in themes, including the default Daintree theme, which fails accessibility requirements. `text-secondary` already holds a contrast floor of 3.0 against every display surface.

I added a new hard-fail contrast gate that checks the dot's colour against both the resting palette surface and the selected-row fill, across all fourteen built-in themes: the row background is transparent until selected, so both states need to pass.

## Accessibility

The dot is `aria-hidden`. Instead, the row's accessible name gets ", recently active" appended, alongside the existing ", current" text for the current project, so screen reader users get the same information without relying on colour. No `role="status"` on the dot: that would create a live region announcement for every row, which is excessive.

The current project is excluded from this mark outright. Its launch deadline is real and meaningful, but an idle current row would otherwise hit the same dormant fallback and read as ", current, recently active", which is redundant and confusing.

## Testing

1,340 tests across 59 files pass locally, covering the `ProjectStore` suites, the switcher render and hook suites, the persistence and migration suites, and the theme contrast gate. New coverage includes both clocks, the immutability of the previous session's open set, the re-close path, the auto-park and folder-reappeared exclusions, and a fake-timer test that advances the shared ticker past a fixed deadline to prove the mark clears itself without any of the row's props changing.
