### PR TITLE
fix(mcp): keep a bound session's view thawed and leased against eviction

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -79,7 +79,7 @@ import {
   setStopDiskSpaceMonitor,
   getMainProcessWatchdogClientRef,
 } from "./window/windowServices.js";
-import { getResourceProfileService } from "./window/serviceRefs.js";
+import { getMcpServerServiceRef, getResourceProfileService } from "./window/serviceRefs.js";
 import {
   setupPowerMonitor,
   setupWindowFocusThrottle,
@@ -392,6 +392,19 @@ if (!gotTheLock) {
       // async, and a shard that times out comes back as an empty list, which
       // would read as "the assistant is gone" and unprotect a live one.
       isTerminalLive: (terminalId) => getPtyClient()?.hasTerminal(terminalId) === true,
+      // Keeps a workspace an MCP session is bound to out of the freeze sweep,
+      // and out of eviction entirely while a dispatch is in flight (#11790).
+      // A bound session drives a *background* workspace by design, and a frozen
+      // renderer can't run JS — the dispatch IPC would sit in Mojo until the
+      // bridge deadline turned it into an opaque failure.
+      //
+      // Read through serviceRefs rather than imported: the MCP service sits
+      // behind a dynamic import to stay off the eager boot graph, and it
+      // publishes itself there at module scope. Before anything loads it the
+      // ref is null, which is the right answer anyway — no server, no sessions,
+      // nothing to protect.
+      mcpViewActivity: (workspaceId, webContentsId) =>
+        getMcpServerServiceRef()?.getWorkspaceViewActivity(workspaceId, webContentsId) ?? null,
       onViewEvicted: (wcId) => {
         // Each cleanup is isolated: if removeDirectPort throws, the worktree
         // port must still close. Partial cleanup leaves a live producer

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -33,6 +33,8 @@ import { handleProjectRunCheck } from "./mcp-server/projectCheck.js";
 import { cleanupResourceSubscriptions } from "./mcp-server/sessionServer.js";
 import { HttpLifecycle } from "./mcp-server/httpLifecycle.js";
 import { AbusePolicy } from "./mcp-server/abusePolicy.js";
+import { WorkspaceViewLeaseRegistry } from "./mcp-server/workspaceViewLease.js";
+import { setMcpServerServiceRef } from "../window/serviceRefs.js";
 import type {
   PendingRequest,
   DispatchEnvelope,
@@ -80,6 +82,12 @@ export class McpServerService {
    */
   private readonly persistentListeners: Array<() => void> = [];
   private readonly bridge;
+  /**
+   * Views with an MCP operation in flight (#11790). Instance-owned rather than
+   * module-global so the service-class suites, which construct several
+   * instances, cannot leak leases into one another.
+   */
+  private readonly viewLeases = new WorkspaceViewLeaseRegistry();
   private readonly statusListeners = new Set<(running: boolean) => void>();
   private readonly runtimeStateListeners = new Set<(snapshot: McpRuntimeSnapshot) => void>();
 
@@ -187,7 +195,8 @@ export class McpServerService {
     this.bridge = createRendererBridge(
       this.pendingManifests,
       this.pendingDispatches,
-      () => this._registry
+      () => this._registry,
+      this.viewLeases
     );
 
     this.httpLifecycle = new HttpLifecycle({
@@ -434,6 +443,42 @@ export class McpServerService {
 
   async stop(): Promise<void> {
     await this.httpLifecycle.stop();
+    // The stop rejects every pending request, so the leases those requests own
+    // have no one left to release them. Holding them would pin their views
+    // against eviction for renderers that will never answer (#11790).
+    this.viewLeases.clear();
+  }
+
+  /**
+   * Why a project view must not be frozen or evicted right now, from MCP's side
+   * (#11790). Read synchronously by `ProjectViewManager`'s freeze and eviction
+   * policies through the `mcpViewActivity` callback `main.ts` injects.
+   *
+   * Two answers, deliberately separate because they earn different protection:
+   *
+   * - `dispatchLease` — an MCP request is in flight against this exact view.
+   *   Destroying it strands the request and breaks the session's route, so the
+   *   view is excluded from eviction outright, like a paint-gate bridge. Safe
+   *   as an absolute exclusion only because it is self-expiring: every lease is
+   *   held by a pending request, and those are capped by the bridge deadlines.
+   * - `liveBinding` — a live session is bound to this workspace but is not
+   *   mid-call. Enough to skip the efficiency freeze (a frozen renderer cannot
+   *   answer at all, and skipping costs one optimization on one cached view),
+   *   but NOT enough to survive memory pressure: a quiet bound view stays an
+   *   eviction candidate, just the last one.
+   *
+   * Keyed by workspace id for the binding and WebContents id for the lease —
+   * the workspace id outlives the view, the WebContents id is what identifies
+   * the exact renderer a request is waiting on.
+   */
+  getWorkspaceViewActivity(
+    workspaceId: string,
+    webContentsId: number
+  ): { dispatchLease: boolean; liveBinding: boolean } {
+    return {
+      dispatchLease: this.viewLeases.has(webContentsId),
+      liveBinding: this.sessionStore.hasLiveWorkspaceBinding(workspaceId),
+    };
   }
 
   listActiveClients(): import("../../shared/types/ipc/mcpServer.js").McpActiveClientInfo[] {
@@ -772,3 +817,13 @@ export const mcpServerService = new McpServerService();
 // the server, so the registry's onStatusChange subscription always lands
 // before the first status event.
 wireMcpServerToConnectivityRegistry(mcpServerService);
+
+// Publish the singleton for the project-view freeze/eviction policies (#11790).
+// Same reasoning as the wiring above — at module scope, so every load path
+// covers it — but the direction matters more here: `electron/window/` must
+// never import this module, which sits behind a dynamic import precisely to
+// keep the MCP graph off eager boot. `serviceRefs` is a zero-runtime-import
+// leaf, so publishing into it costs nothing and cannot cycle, and until some
+// path loads this module the getter reads null and both policies fail closed
+// to "not protected" — the pre-#11790 behaviour.
+setMcpServerServiceRef(mcpServerService);

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -806,6 +806,9 @@ export class McpServerService {
   get _bridge() {
     return this.bridge;
   }
+  get _viewLeases() {
+    return this.viewLeases;
+  }
 }
 
 export const mcpServerService = new McpServerService();

--- a/electron/services/__tests__/McpServerService.viewActivity.test.ts
+++ b/electron/services/__tests__/McpServerService.viewActivity.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The composition seam #11790 depends on spans three layers that are otherwise
+// only ever tested in isolation: SessionStore's binding predicate, the bridge's
+// lease registry, and the accessor ProjectViewManager reads through the
+// callback main.ts injects. Every layer can be correct while the seam is wired
+// backwards, so this suite exercises the seam itself.
+
+const testHomeDir = vi.hoisted(
+  () => `${process.cwd()}/.vitest-mcp-activity-${Math.random().toString(36).slice(2)}`
+);
+
+vi.mock("electron", () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => testHomeDir),
+    setPath: vi.fn(),
+    getVersion: vi.fn(() => "0.0.0-test"),
+    commandLine: { appendSwitch: vi.fn() },
+    on: vi.fn(),
+    once: vi.fn(),
+    whenReady: vi.fn(() => Promise.resolve()),
+  },
+  ipcMain: { on: vi.fn(), off: vi.fn(), removeListener: vi.fn(), handle: vi.fn() },
+  webContents: { fromId: vi.fn(() => null), getAllWebContents: vi.fn(() => []) },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false) },
+}));
+
+vi.mock("../../window/windowRef.js", () => ({
+  getProjectViewManager: () => null,
+  getWindowRegistry: () => null,
+  setWindowRegistry: vi.fn(),
+}));
+
+vi.mock("../../window/webContentsRegistry.js", () => ({
+  getWebContentsForProject: () => [],
+  getProjectForWebContents: () => null,
+}));
+
+import { McpServerService, mcpServerService } from "../McpServerService.js";
+import { getMcpServerServiceRef } from "../../window/serviceRefs.js";
+import type { McpHttpSession } from "../mcp-server/shared.js";
+
+function fakeHttpSession(): McpHttpSession {
+  return {
+    transport: {
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as McpHttpSession["transport"],
+    server: {} as McpHttpSession["server"],
+    idleTimer: setTimeout(() => {}, 1_000_000),
+  };
+}
+
+describe("McpServerService.getWorkspaceViewActivity (#11790)", () => {
+  let service: McpServerService;
+
+  beforeEach(() => {
+    service = new McpServerService();
+  });
+
+  afterEach(() => {
+    service._sessionStore.drain();
+    service._sessionStore.grantCache.dispose();
+  });
+
+  /** Register a live, workspace-bound external session the way a handshake does. */
+  function bindLiveSession(sessionId: string, workspaceId: string): void {
+    service._sessionStore.httpSessions.set(sessionId, fakeHttpSession());
+    service._sessionStore.sessionOriginMap.set(sessionId, "external");
+    service._sessionStore.sessionWorkspaceMap.set(sessionId, workspaceId);
+  }
+
+  it("reports nothing protected when there are no sessions and no calls", () => {
+    expect(service.getWorkspaceViewActivity("ws-a", 101)).toEqual({
+      dispatchLease: false,
+      liveBinding: false,
+    });
+  });
+
+  it("surfaces a live binding, keyed by workspace id", () => {
+    bindLiveSession("s1", "ws-a");
+
+    expect(service.getWorkspaceViewActivity("ws-a", 101).liveBinding).toBe(true);
+    // Keyed by workspace, so an unrelated workspace on the same view is unaffected.
+    expect(service.getWorkspaceViewActivity("ws-b", 101).liveBinding).toBe(false);
+  });
+
+  it("surfaces a dispatch lease, keyed by WebContents id", () => {
+    const release = service._viewLeases.acquire(101);
+
+    // The two halves must not be crossed: the lease answers for the view, the
+    // binding for the workspace.
+    expect(service.getWorkspaceViewActivity("ws-a", 101).dispatchLease).toBe(true);
+    expect(service.getWorkspaceViewActivity("ws-a", 202).dispatchLease).toBe(false);
+    expect(service.getWorkspaceViewActivity("ws-a", 101).liveBinding).toBe(false);
+
+    release();
+    expect(service.getWorkspaceViewActivity("ws-a", 101).dispatchLease).toBe(false);
+  });
+
+  it("reports both halves independently for the same workspace and view", () => {
+    bindLiveSession("s1", "ws-a");
+    service._viewLeases.acquire(101);
+
+    expect(service.getWorkspaceViewActivity("ws-a", 101)).toEqual({
+      dispatchLease: true,
+      liveBinding: true,
+    });
+  });
+
+  it("drops the binding when the session is revoked, without touching leases", () => {
+    bindLiveSession("s1", "ws-a");
+    service._viewLeases.acquire(101);
+
+    service._sessionStore.revokeSession("s1");
+
+    expect(service.getWorkspaceViewActivity("ws-a", 101)).toEqual({
+      dispatchLease: true,
+      liveBinding: false,
+    });
+  });
+
+  it("stop() drops leases so a view is not pinned for a renderer that will never answer", async () => {
+    service._viewLeases.acquire(101);
+
+    await service.stop();
+
+    expect(service.getWorkspaceViewActivity("ws-a", 101).dispatchLease).toBe(false);
+  });
+
+  it("publishes the singleton to serviceRefs at module scope", () => {
+    // main.ts reads the activity callback through this ref. If the publication
+    // is dropped, every ProjectViewManager silently sees "not protected" and
+    // both defects come back with the whole suite still green.
+    expect(getMcpServerServiceRef()).toBe(mcpServerService);
+  });
+});

--- a/electron/services/__tests__/McpServerService.viewActivity.test.ts
+++ b/electron/services/__tests__/McpServerService.viewActivity.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The composition seam #11790 depends on spans three layers that are otherwise
 // only ever tested in isolation: SessionStore's binding predicate, the bridge's
@@ -52,13 +52,18 @@ function fakeHttpSession(): McpHttpSession {
 }
 
 describe("McpServerService.getWorkspaceViewActivity (#11790)", () => {
-  let service: McpServerService;
+  // One service for the suite, reset between tests. Construction subscribes to
+  // the global event bus and the sleep service, and `stop()` deliberately keeps
+  // those (they must survive a server restart) — so a fresh instance per test
+  // would leave every previous one subscribed and reachable.
+  const service: McpServerService = new McpServerService();
 
   beforeEach(() => {
-    service = new McpServerService();
+    service._sessionStore.drain();
+    service._viewLeases.clear();
   });
 
-  afterEach(() => {
+  afterAll(() => {
     service._sessionStore.drain();
     service._sessionStore.grantCache.dispose();
   });

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -51,14 +51,32 @@ vi.mock("../../../window/webContentsRegistry.js", () => ({
   getWebContentsForProject: (projectId: string) => mockProjectViews.get(projectId) ?? [],
 }));
 
+// `unfreezeWebContents` is the only member the bridge imports. Mocked so the
+// routed paths' thaw is observable and so the real CDP helper doesn't warn its
+// way through every test against a WebContents fake with no `debugger`.
+vi.mock("../../../utils/webContentsLifecycle.js", () => ({
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
 import {
   createRendererBridge,
   SessionBindingError,
   WorkspaceBindingError,
   McpRouteBindingError,
 } from "../rendererBridge.js";
+import { unfreezeWebContents } from "../../../utils/webContentsLifecycle.js";
+import { WorkspaceViewLeaseRegistry } from "../workspaceViewLease.js";
 import type { PendingRequest, DispatchEnvelope } from "../shared.js";
 import type { ActionManifestEntry } from "../../../../shared/types/actions.js";
+
+/**
+ * Drain the microtask chain a routed send awaits before it reaches
+ * `webContents.send` (#11790). A routed operation thaws its target first — a
+ * real await — so a test that answers as the renderer would before that
+ * settles clears the pending entry, and the send then (correctly) never
+ * happens. A macrotask hop drains the whole chain regardless of its length.
+ */
+const flushThaw = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
 
 interface FakeWebContents {
   id: number;
@@ -263,7 +281,11 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
     await Promise.resolve();
     wc.triggerDestroyed();
 
-    await expect(promise).rejects.toThrow(/MCP renderer bridge destroyed/);
+    // Same classification as a view already gone before the send (#11790):
+    // "destroyed a moment later" is still the route dying, so it must not
+    // degrade to an opaque retriable EXECUTION_ERROR.
+    await expect(promise).rejects.toBeInstanceOf(SessionBindingError);
+    await expect(promise).rejects.toThrow(/Do not retry/);
   });
 });
 
@@ -409,9 +431,11 @@ describe("rendererBridge — per-WebContents manifest cache (#9887)", () => {
       manual: true,
     });
 
-    // Kick off a fetch that stays in flight.
+    // Kick off a fetch that stays in flight. The routed paths thaw before they
+    // send (#11790), so the request only reaches the renderer a chain of
+    // microtasks later.
     const inflight = bridge.requestManifestForWebContents(161);
-    await Promise.resolve();
+    await flushThaw();
     expect(requestIds).toHaveLength(1);
 
     // The server clears all caches (stop/restart) while the fetch is pending.
@@ -454,7 +478,7 @@ describe("rendererBridge — per-WebContents manifest cache (#9887)", () => {
     await Promise.resolve();
     wc.triggerDestroyed();
 
-    await expect(inflight).rejects.toThrow(/MCP renderer bridge destroyed/);
+    await expect(inflight).rejects.toBeInstanceOf(SessionBindingError);
     expect(bridge.getCachedManifestForWebContents(181)).toBeNull();
   });
 
@@ -1047,7 +1071,8 @@ describe("rendererBridge — workspace-bound routing (#11789)", () => {
   }
 
   /** Settle whichever dispatch the bridge just sent, as the renderer would. */
-  function settleDispatch(): void {
+  async function settleDispatch(): Promise<void> {
+    await flushThaw();
     const [requestId] = [...pendingDispatches.keys()];
     mockIpcMain.emit(
       CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
@@ -1061,7 +1086,7 @@ describe("rendererBridge — workspace-bound routing (#11789)", () => {
     registerView("ws-b", 202);
 
     const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
-    settleDispatch();
+    await settleDispatch();
     await promise;
 
     expect(wc.send).toHaveBeenCalledWith(
@@ -1076,12 +1101,12 @@ describe("rendererBridge — workspace-bound routing (#11789)", () => {
     // appearing (or being focused) may move workspace A's session.
     const wcA = registerView("ws-a", 101);
     const promiseOne = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
-    settleDispatch();
+    await settleDispatch();
     await promiseOne;
 
     registerView("ws-b", 202);
     const promiseTwo = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
-    settleDispatch();
+    await settleDispatch();
     await promiseTwo;
 
     expect(wcA.send).toHaveBeenCalledTimes(2);
@@ -1101,7 +1126,7 @@ describe("rendererBridge — workspace-bound routing (#11789)", () => {
 
     const replacement = registerView("ws-a", 303);
     const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
-    settleDispatch();
+    await settleDispatch();
     await promise;
 
     expect(replacement.send).toHaveBeenCalled();
@@ -1166,5 +1191,288 @@ describe("rendererBridge — workspace-bound routing (#11789)", () => {
     // are unresolvable — losing a label must never cost a working binding.
     registerView("ws-a", 101);
     expect(bridge.resolveWorkspaceBinding("ws-a")).toEqual({ workspaceId: "ws-a" });
+  });
+});
+
+describe("rendererBridge — thaw and eviction lease for routed operations (#11790)", () => {
+  let pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>;
+  let pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>;
+  let leases: WorkspaceViewLeaseRegistry;
+  let bridge: ReturnType<typeof createRendererBridge>;
+
+  beforeEach(() => {
+    mockIpcMain.removeAllListeners();
+    mockWebContentsRegistry.clear();
+    mockProjectViews.clear();
+    vi.mocked(unfreezeWebContents).mockClear();
+    vi.mocked(unfreezeWebContents).mockResolvedValue(undefined);
+    pendingManifests = new Map();
+    pendingDispatches = new Map();
+    leases = new WorkspaceViewLeaseRegistry();
+    bridge = createRendererBridge(pendingManifests, pendingDispatches, () => null, leases);
+    bridge.setupListeners([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function registerView(workspaceId: string, id: number): FakeWebContents {
+    const wc = makeWebContents(id);
+    mockWebContentsRegistry.set(id, wc);
+    mockProjectViews.set(workspaceId, [...(mockProjectViews.get(workspaceId) ?? []), wc]);
+    return wc;
+  }
+
+  function settlePendingDispatch(webContentsId: number): void {
+    const [requestId] = [...pendingDispatches.keys()];
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: webContentsId } },
+      { requestId, result: { ok: true, result: "done" } }
+    );
+  }
+
+  it("thaws the bound view before the dispatch IPC, not after", async () => {
+    // The whole defect: a CDP-frozen renderer cannot run JS, so the dispatch
+    // sits in Mojo unanswered until the 30s bridge deadline. Sending first and
+    // thawing after would not fix it — the ordering is the fix.
+    const wc = registerView("ws-a", 101);
+    let thawedBeforeSend: boolean | null = null;
+    wc.send.mockImplementation(() => {
+      thawedBeforeSend = vi.mocked(unfreezeWebContents).mock.calls.length > 0;
+    });
+
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    await flushThaw();
+
+    expect(thawedBeforeSend).toBe(true);
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(wc);
+
+    settlePendingDispatch(101);
+    await promise;
+  });
+
+  it("thaws a pinned view too — a help session's view is an ordinary cached view", async () => {
+    const wc = makeWebContents(505);
+    mockWebContentsRegistry.set(505, wc);
+
+    const promise = bridge.dispatchActionForWebContents(505, "actions.list", {}, false);
+    await flushThaw();
+
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(wc);
+
+    settlePendingDispatch(505);
+    await promise;
+  });
+
+  it("thaws before the manifest IPC as well — tools/list has the shorter deadline", async () => {
+    const wc = registerView("ws-a", 101);
+
+    const promise = bridge.requestManifestForWorkspace("ws-a");
+    await flushThaw();
+
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(wc);
+
+    const [requestId] = [...pendingManifests.keys()];
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
+      { sender: { id: 101 } },
+      { requestId, manifest: [] }
+    );
+    await promise;
+  });
+
+  it("does not thaw the unpinned focused-window path", async () => {
+    // That path resolves the ACTIVE view, which is never frozen and never an
+    // eviction candidate. Thawing it would spend a CDP round trip per tool
+    // call for nothing.
+    await expect(bridge.dispatchAction("actions.list", {}, false)).rejects.toThrow(
+      /renderer bridge unavailable/
+    );
+    expect(vi.mocked(unfreezeWebContents)).not.toHaveBeenCalled();
+  });
+
+  it("holds a lease for the life of the dispatch and releases it on the response", async () => {
+    registerView("ws-a", 101);
+
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    // Taken synchronously, before the thaw round trip — an eviction pass
+    // landing inside that window would otherwise destroy the view we just
+    // resolved.
+    expect(leases.has(101)).toBe(true);
+
+    await flushThaw();
+    expect(leases.has(101)).toBe(true);
+
+    settlePendingDispatch(101);
+    await promise;
+
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("releases the lease when the dispatch times out", async () => {
+    vi.useFakeTimers();
+    registerView("ws-a", 101);
+
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    const assertion = expect(promise).rejects.toThrow(/Action dispatch timed out/);
+    expect(leases.has(101)).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    await assertion;
+
+    // A leaked lease would pin the view for the rest of the session, quietly
+    // recreating the permanent eviction floor this design avoids.
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("names the unreachable workspace in the timeout message", async () => {
+    vi.useFakeTimers();
+    registerView("ws-a", 101);
+
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    const assertion = expect(promise).rejects.toThrow(
+      /Action dispatch timed out: terminal\.list.*workspace ws-a.*30s/
+    );
+    await vi.advanceTimersByTimeAsync(31_000);
+    await assertion;
+  });
+
+  it("releases the lease when the view is destroyed mid-dispatch", async () => {
+    const wc = registerView("ws-a", 101);
+
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    expect(leases.has(101)).toBe(true);
+
+    wc.triggerDestroyed();
+
+    await expect(promise).rejects.toBeInstanceOf(WorkspaceBindingError);
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("reports a view destroyed mid-dispatch as a workspace route loss, not a dead pin", async () => {
+    // "Do not retry" is right for a help session whose window closed, and wrong
+    // for a workspace binding: the workspace id outlives the view, so reopening
+    // it makes the very same call work.
+    const wc = registerView("ws-a", 101);
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    wc.triggerDestroyed();
+
+    await expect(promise).rejects.toMatchObject({
+      code: "SESSION_BINDING_GONE",
+      reason: "not-found",
+    });
+    await expect(promise).rejects.toThrow(/Reopen that workspace and retry/);
+  });
+
+  it("reports a workspace manifest fetch destroyed mid-flight as a workspace route loss", async () => {
+    const wc = registerView("ws-a", 101);
+    const promise = bridge.requestManifestForWorkspace("ws-a");
+    wc.triggerDestroyed();
+
+    await expect(promise).rejects.toBeInstanceOf(WorkspaceBindingError);
+    await expect(promise).rejects.toThrow(/Reopen that workspace and retry/);
+  });
+
+  it("releases the lease when the send throws", async () => {
+    const wc = registerView("ws-a", 101);
+    wc.send.mockImplementation(() => {
+      throw new Error("send blew up");
+    });
+
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    // `normalizeError` passes a real Error straight through, so the renderer's
+    // own failure is what surfaces — the fallback text is for non-Error throws.
+    await expect(promise).rejects.toThrow(/send blew up/);
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("keeps the view leased until the last of several concurrent dispatches settles", async () => {
+    registerView("ws-a", 101);
+
+    const first = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    const second = bridge.dispatchActionForWorkspace("ws-a", "worktree.list", {}, false);
+    await flushThaw();
+
+    const [firstId, secondId] = [...pendingDispatches.keys()];
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 101 } },
+      { requestId: firstId, result: { ok: true, result: "one" } }
+    );
+    await first;
+    expect(leases.has(101)).toBe(true);
+
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 101 } },
+      { requestId: secondId, result: { ok: true, result: "two" } }
+    );
+    await second;
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("takes no lease when the target cannot be resolved at all", async () => {
+    await expect(
+      bridge.dispatchActionForWorkspace("ws-missing", "terminal.list", {}, false)
+    ).rejects.toBeInstanceOf(WorkspaceBindingError);
+    expect(vi.mocked(unfreezeWebContents)).not.toHaveBeenCalled();
+  });
+
+  it("does not send after a deadline that fired while the thaw was outstanding", async () => {
+    vi.useFakeTimers();
+    const wc = registerView("ws-a", 101);
+    // A thaw that never settles until we let it — the window in which the
+    // request can time out underneath.
+    let releaseThaw: () => void = () => {};
+    vi.mocked(unfreezeWebContents).mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseThaw = resolve;
+      })
+    );
+
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    const assertion = expect(promise).rejects.toThrow(/Action dispatch timed out/);
+    await vi.advanceTimersByTimeAsync(31_000);
+    await assertion;
+
+    releaseThaw();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Sending now would emit an IPC for a requestId nothing is waiting on.
+    expect(wc.send).not.toHaveBeenCalled();
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("still sends when the thaw itself fails — a hiccup must not guarantee a timeout", async () => {
+    const wc = registerView("ws-a", 101);
+    vi.mocked(unfreezeWebContents).mockRejectedValue(new Error("CDP exploded"));
+
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    await flushThaw();
+
+    expect(wc.send).toHaveBeenCalled();
+
+    settlePendingDispatch(101);
+    await promise;
+  });
+
+  it("takes no lease when the bridge was built without a registry", async () => {
+    // Older construction paths and focused unit tests keep the pre-#11790
+    // behavior: views stay ordinary eviction candidates.
+    const bare = createRendererBridge(pendingManifests, pendingDispatches, () => null);
+    bare.setupListeners([]);
+    const wc = registerView("ws-bare", 909);
+
+    const promise = bare.dispatchActionForWorkspace("ws-bare", "terminal.list", {}, false);
+    await flushThaw();
+
+    expect(leases.has(909)).toBe(false);
+    // The thaw is independent of the lease and still happens.
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(wc);
+
+    settlePendingDispatch(909);
+    await promise;
   });
 });

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -1233,21 +1233,32 @@ describe("rendererBridge — thaw and eviction lease for routed operations (#117
     );
   }
 
-  it("thaws the bound view before the dispatch IPC, not after", async () => {
+  it("waits for the thaw to RESOLVE before the dispatch IPC, not merely to start", async () => {
     // The whole defect: a CDP-frozen renderer cannot run JS, so the dispatch
-    // sits in Mojo unanswered until the 30s bridge deadline. Sending first and
-    // thawing after would not fix it — the ordering is the fix.
+    // sits in Mojo unanswered until the 30s bridge deadline. Issuing the thaw
+    // and sending in the same turn would not fix it — the send has to be
+    // downstream of the thaw completing.
     const wc = registerView("ws-a", 101);
-    let thawedBeforeSend: boolean | null = null;
-    wc.send.mockImplementation(() => {
-      thawedBeforeSend = vi.mocked(unfreezeWebContents).mock.calls.length > 0;
-    });
+    let completeThaw: () => void = () => {};
+    vi.mocked(unfreezeWebContents).mockReturnValue(
+      new Promise<void>((resolve) => {
+        completeThaw = resolve;
+      })
+    );
 
     const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
     await flushThaw();
 
-    expect(thawedBeforeSend).toBe(true);
     expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(wc);
+    expect(wc.send).not.toHaveBeenCalled();
+
+    completeThaw();
+    await flushThaw();
+
+    expect(wc.send).toHaveBeenCalledWith(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST,
+      expect.objectContaining({ actionId: "terminal.list" })
+    );
 
     settlePendingDispatch(101);
     await promise;
@@ -1283,14 +1294,39 @@ describe("rendererBridge — thaw and eviction lease for routed operations (#117
     await promise;
   });
 
-  it("does not thaw the unpinned focused-window path", async () => {
+  it("does not thaw or lease the unpinned focused-window path, even with a live target", async () => {
     // That path resolves the ACTIVE view, which is never frozen and never an
     // eviction candidate. Thawing it would spend a CDP round trip per tool
-    // call for nothing.
-    await expect(bridge.dispatchAction("actions.list", {}, false)).rejects.toThrow(
-      /renderer bridge unavailable/
+    // call for nothing. The target must actually resolve, or an implementation
+    // that thaws every resolved active view would pass this too.
+    const activeWc = makeWebContents(707);
+    const registryBridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () =>
+        ({
+          focusOrder: () => [
+            {
+              browserWindow: { isDestroyed: () => false },
+              services: {
+                projectViewManager: { getActiveView: () => ({ webContents: activeWc }) },
+              },
+            },
+          ],
+        }) as never,
+      leases
     );
+    registryBridge.setupListeners([]);
+
+    const promise = registryBridge.dispatchAction("actions.list", {}, false);
+    await flushThaw();
+
+    expect(activeWc.send).toHaveBeenCalled();
     expect(vi.mocked(unfreezeWebContents)).not.toHaveBeenCalled();
+    expect(leases.has(707)).toBe(false);
+
+    settlePendingDispatch(707);
+    await promise;
   });
 
   it("holds a lease for the life of the dispatch and releases it on the response", async () => {
@@ -1458,21 +1494,167 @@ describe("rendererBridge — thaw and eviction lease for routed operations (#117
     await promise;
   });
 
-  it("takes no lease when the bridge was built without a registry", async () => {
-    // Older construction paths and focused unit tests keep the pre-#11790
-    // behavior: views stay ordinary eviction candidates.
-    const bare = createRendererBridge(pendingManifests, pendingDispatches, () => null);
-    bare.setupListeners([]);
+  it("still dispatches when built without a lease registry, taking no lease", async () => {
+    // Differential against the leased bridge on the same workspace, so the
+    // "no lease" half is pinned to the missing registry rather than being
+    // trivially true of an object nothing writes to.
     const wc = registerView("ws-bare", 909);
 
-    const promise = bare.dispatchActionForWorkspace("ws-bare", "terminal.list", {}, false);
+    const leasedRun = bridge.dispatchActionForWorkspace("ws-bare", "terminal.list", {}, false);
+    await flushThaw();
+    expect(leases.has(909)).toBe(true);
+    settlePendingDispatch(909);
+    await leasedRun;
+    expect(leases.has(909)).toBe(false);
+
+    const bare = createRendererBridge(pendingManifests, pendingDispatches, () => null);
+    bare.setupListeners([]);
+    wc.send.mockClear();
+
+    const bareRun = bare.dispatchActionForWorkspace("ws-bare", "terminal.list", {}, false);
     await flushThaw();
 
-    expect(leases.has(909)).toBe(false);
-    // The thaw is independent of the lease and still happens.
+    // Same call, same target, no registry: dispatch still works and the thaw
+    // still happens — only the lease is absent.
+    expect(wc.send).toHaveBeenCalled();
     expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(wc);
+    expect(leases.has(909)).toBe(false);
 
     settlePendingDispatch(909);
+    await bareRun;
+  });
+
+  it("keeps the lease when a spoofed sender answers, and releases it on the real response", async () => {
+    // The mismatch branch deliberately leaves the pending entry alone so the
+    // legitimate renderer can still answer. Releasing the lease there would let
+    // any wrong-sender message expose the view mid-call.
+    const wc = registerView("ws-a", 101);
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    await flushThaw();
+
+    const [requestId] = [...pendingDispatches.keys()];
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: 999 } },
+      { requestId, result: { ok: true, result: "spoofed" } }
+    );
+
+    expect(leases.has(101)).toBe(true);
+    expect(pendingDispatches.has(requestId)).toBe(true);
+
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+      { sender: { id: wc.id } },
+      { requestId, result: { ok: true, result: "real" } }
+    );
+    const envelope = await promise;
+
+    expect(envelope.result).toEqual({ ok: true, result: "real" });
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("releases the lease when server teardown rejects the pending request", async () => {
+    // What HttpLifecycle does on stop and on unexpected close: it reaches into
+    // the pending maps and settles them itself, so the release has to ride the
+    // pending entry's own cleanup rather than the bridge's normal paths.
+    registerView("ws-a", 101);
+    const promise = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    const assertion = expect(promise).rejects.toThrow(/MCP server stopped/);
+    expect(leases.has(101)).toBe(true);
+
+    for (const [id, pending] of pendingDispatches) {
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
+      pending.reject(new Error("MCP server stopped"));
+      pendingDispatches.delete(id);
+    }
+    await assertion;
+
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("holds and releases a lease around a workspace manifest fetch", async () => {
+    registerView("ws-a", 101);
+
+    const promise = bridge.requestManifestForWorkspace("ws-a");
+    expect(leases.has(101)).toBe(true);
+    await flushThaw();
+
+    const [requestId] = [...pendingManifests.keys()];
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
+      { sender: { id: 101 } },
+      { requestId, manifest: [] }
+    );
     await promise;
+
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("releases the manifest lease when the 5s deadline fires", async () => {
+    vi.useFakeTimers();
+    registerView("ws-a", 101);
+
+    const promise = bridge.requestManifestForWorkspace("ws-a");
+    const assertion = expect(promise).rejects.toThrow(/Manifest request timed out/);
+    expect(leases.has(101)).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    await assertion;
+
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("releases the manifest lease when the view is destroyed mid-fetch", async () => {
+    const wc = registerView("ws-a", 101);
+
+    const promise = bridge.requestManifestForWorkspace("ws-a");
+    expect(leases.has(101)).toBe(true);
+    wc.triggerDestroyed();
+
+    await expect(promise).rejects.toBeInstanceOf(WorkspaceBindingError);
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("coalesced manifest callers share one lease, released once the shared fetch settles", async () => {
+    // Singleflight: the lease covers the fetch, not the caller, so a joiner
+    // must neither add a second reference nor be left unprotected.
+    registerView("ws-a", 101);
+
+    const first = bridge.requestManifestForWorkspace("ws-a");
+    const second = bridge.requestManifestForWorkspace("ws-a");
+    await flushThaw();
+
+    expect(pendingManifests.size).toBe(1);
+    expect(leases.has(101)).toBe(true);
+
+    const [requestId] = [...pendingManifests.keys()];
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
+      { sender: { id: 101 } },
+      { requestId, manifest: [{ id: "terminal.list" }] }
+    );
+    await Promise.all([first, second]);
+
+    expect(leases.has(101)).toBe(false);
+  });
+
+  it("releases the manifest lease even when clearCache drops the singleflight mid-fetch", async () => {
+    registerView("ws-a", 101);
+
+    const promise = bridge.requestManifestForWorkspace("ws-a");
+    await flushThaw();
+    // Drops the inflight/cache bookkeeping but not the pending request itself.
+    bridge.clearCache();
+
+    const [requestId] = [...pendingManifests.keys()];
+    mockIpcMain.emit(
+      CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
+      { sender: { id: 101 } },
+      { requestId, manifest: [] }
+    );
+    await promise;
+
+    expect(leases.has(101)).toBe(false);
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -1317,3 +1317,113 @@ describe("SessionStore session origin and workspace binding (#11789)", () => {
     }
   });
 });
+
+describe("SessionStore.hasLiveWorkspaceBinding (#11790)", () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore(() => {});
+  });
+
+  afterEach(() => {
+    store.grantCache.dispose();
+  });
+
+  function bindLiveExternal(sessionId: string, workspaceId: string): void {
+    store.httpSessions.set(sessionId, fakeHttpSession());
+    store.sessionOriginMap.set(sessionId, "external");
+    store.sessionWorkspaceMap.set(sessionId, workspaceId);
+  }
+
+  it("reports a live external session bound to the workspace", () => {
+    bindLiveExternal("s1", "ws-a");
+    expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(true);
+  });
+
+  it("scopes the answer to the asked-for workspace", () => {
+    bindLiveExternal("s1", "ws-a");
+    expect(store.hasLiveWorkspaceBinding("ws-b")).toBe(false);
+  });
+
+  it("answers for an SSE-transport session too, not just Streamable HTTP", () => {
+    // Only Streamable HTTP can bind today, but liveness must not be
+    // transport-specific — nothing here should need changing when SSE can.
+    store.sessions.set("s1", fakeSseSession());
+    store.sessionOriginMap.set("s1", "external");
+    store.sessionWorkspaceMap.set("s1", "ws-a");
+
+    expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(true);
+  });
+
+  it("does not report a workspace routing record whose session is no longer live", () => {
+    // Presence in sessionWorkspaceMap is routing, not liveness. Without the
+    // liveness half, a dropped session would pin its view against freeze and
+    // deprioritize it for eviction for the rest of the app's life.
+    store.sessionOriginMap.set("s1", "external");
+    store.sessionWorkspaceMap.set("s1", "ws-a");
+
+    expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(false);
+  });
+
+  it("does not treat a routing record with no recorded origin as external", () => {
+    // getOrigin() defaults an unknown session to "external", so reading through
+    // it would let a half-torn-down record — origin already dropped, workspace
+    // row not yet — read as a live binding. The origin map is read directly for
+    // exactly this case.
+    store.httpSessions.set("s1", fakeHttpSession());
+    store.sessionWorkspaceMap.set("s1", "ws-a");
+
+    expect(store.getOrigin("s1")).toBe("external");
+    expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(false);
+  });
+
+  it("ignores a renderer-owned session that somehow carries a workspace row", () => {
+    store.httpSessions.set("s1", fakeHttpSession());
+    store.sessionOriginMap.set("s1", "help");
+    store.sessionWorkspaceMap.set("s1", "ws-a");
+
+    expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(false);
+  });
+
+  it("still reports the workspace while a second session is bound to it", () => {
+    bindLiveExternal("s1", "ws-a");
+    bindLiveExternal("s2", "ws-a");
+
+    store.revokeSession("s1");
+
+    expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(true);
+  });
+
+  it("releases the workspace once its last session is revoked", () => {
+    bindLiveExternal("s1", "ws-a");
+    bindLiveExternal("s2", "ws-a");
+
+    store.revokeSession("s1");
+    store.revokeSession("s2");
+
+    expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(false);
+  });
+
+  it("releases the workspace on drain", () => {
+    bindLiveExternal("s1", "ws-a");
+
+    store.drain();
+
+    expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(false);
+  });
+
+  it("releases the workspace when the session idles out", () => {
+    vi.useFakeTimers();
+    try {
+      setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
+      bindLiveExternal("s1", "ws-a");
+      store.httpSessions.get("s1")!.idleTimer = store.createHttpIdleTimer("s1");
+
+      vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 10);
+
+      expect(store.hasLiveWorkspaceBinding("ws-a")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/electron/services/mcp-server/__tests__/workspaceViewLease.test.ts
+++ b/electron/services/mcp-server/__tests__/workspaceViewLease.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { WorkspaceViewLeaseRegistry } from "../workspaceViewLease.js";
+
+describe("WorkspaceViewLeaseRegistry (#11790)", () => {
+  it("reports no lease for a view nothing is dispatching to", () => {
+    const leases = new WorkspaceViewLeaseRegistry();
+    expect(leases.has(42)).toBe(false);
+  });
+
+  it("holds the view until the last of several concurrent requests releases", () => {
+    const leases = new WorkspaceViewLeaseRegistry();
+    const releaseFirst = leases.acquire(42);
+    const releaseSecond = leases.acquire(42);
+
+    releaseFirst();
+    // A bound session can have more than one call in flight; the first one
+    // finishing must not expose the view to the pass that would strand the
+    // second.
+    expect(leases.has(42)).toBe(true);
+
+    releaseSecond();
+    expect(leases.has(42)).toBe(false);
+  });
+
+  it("keeps leases on different views independent", () => {
+    const leases = new WorkspaceViewLeaseRegistry();
+    const releaseOne = leases.acquire(1);
+    leases.acquire(2);
+
+    releaseOne();
+
+    expect(leases.has(1)).toBe(false);
+    expect(leases.has(2)).toBe(true);
+  });
+
+  it("ignores a repeated release instead of dropping another caller's lease", () => {
+    // A request settles through several paths (response, deadline, WebContents
+    // destruction), and more than one can run for the same request. A
+    // double-decrement would unprotect a view another in-flight call is still
+    // waiting on.
+    const leases = new WorkspaceViewLeaseRegistry();
+    const release = leases.acquire(7);
+    leases.acquire(7);
+
+    release();
+    release();
+    release();
+
+    expect(leases.has(7)).toBe(true);
+  });
+
+  it("does not resurrect a lease when a stale release runs after a new acquire", () => {
+    const leases = new WorkspaceViewLeaseRegistry();
+    const staleRelease = leases.acquire(9);
+    staleRelease();
+
+    // A later request takes the same view — an earlier request's release must
+    // not cancel it.
+    leases.acquire(9);
+    staleRelease();
+
+    expect(leases.has(9)).toBe(true);
+  });
+
+  it("clear() drops every lease", () => {
+    // Server stop rejects the pending requests that own these leases, so
+    // nothing is left to release them one by one.
+    const leases = new WorkspaceViewLeaseRegistry();
+    leases.acquire(1);
+    leases.acquire(1);
+    leases.acquire(2);
+
+    leases.clear();
+
+    expect(leases.has(1)).toBe(false);
+    expect(leases.has(2)).toBe(false);
+  });
+
+  it("takes fresh leases normally after a clear", () => {
+    const leases = new WorkspaceViewLeaseRegistry();
+    leases.acquire(3);
+    leases.clear();
+
+    const release = leases.acquire(3);
+    expect(leases.has(3)).toBe(true);
+    release();
+    expect(leases.has(3)).toBe(false);
+  });
+});

--- a/electron/services/mcp-server/__tests__/workspaceViewLease.test.ts
+++ b/electron/services/mcp-server/__tests__/workspaceViewLease.test.ts
@@ -76,6 +76,22 @@ describe("WorkspaceViewLeaseRegistry (#11790)", () => {
     expect(leases.has(2)).toBe(false);
   });
 
+  it("a release issued before a clear cannot cancel a lease taken after it", () => {
+    // Server stop snapshots and rejects the pending requests, then clears. A
+    // request that reached the bridge inside the drain window still holds a
+    // release handle; when its stale deadline fires after a restart, that
+    // handle must not decrement the restarted request's lease and expose the
+    // view it is waiting on.
+    const leases = new WorkspaceViewLeaseRegistry();
+    const staleRelease = leases.acquire(5);
+
+    leases.clear();
+    leases.acquire(5);
+    staleRelease();
+
+    expect(leases.has(5)).toBe(true);
+  });
+
   it("takes fresh leases normally after a clear", () => {
     const leases = new WorkspaceViewLeaseRegistry();
     leases.acquire(3);

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "node:crypto";
 import type { WindowRegistry } from "../../window/WindowRegistry.js";
 import { getProjectViewManager } from "../../window/windowRef.js";
 import { getWebContentsForProject } from "../../window/webContentsRegistry.js";
+import { unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
+import type { WorkspaceViewLeaseRegistry } from "./workspaceViewLease.js";
 import type { ActionContext, ActionManifestEntry } from "../../../shared/types/actions.js";
 import type { McpBearerIdentity } from "../../../shared/types/ipc/mcpServer.js";
 import { CHANNELS } from "../../ipc/channels.js";
@@ -79,10 +81,106 @@ export class RendererBridgeUnavailableError extends Error {
   }
 }
 
+/**
+ * Which binding a bridge operation is routed by, or `undefined` for the
+ * unpinned focused-window path (#11790).
+ *
+ * A routed operation targets a view the user is not looking at, which is what
+ * makes it different in three ways at once, all handled off this one value:
+ *
+ * 1. The target may be CDP-frozen by the efficiency profile, so it must be
+ *    thawed before the dispatch IPC — a frozen renderer cannot run JS and the
+ *    message would sit in Mojo until the bridge deadline fired.
+ * 2. It must hold an eviction lease while the request is outstanding, or a
+ *    memory-pressure pass can destroy the very view being awaited.
+ * 3. Losing the target is a *binding* failure (`SESSION_BINDING_GONE`), not a
+ *    generic retriable execution error — the same classification the resolver
+ *    already applies when the target is gone before the send.
+ *
+ * The unpinned path opts out of all three: it resolves the active view, which
+ * is never frozen and never an eviction candidate, so thawing it would spend a
+ * CDP round trip per tool call for nothing.
+ */
+type BridgeRoute =
+  { kind: "workspace"; workspaceId: string } | { kind: "pinned"; webContentsId: number };
+
+/**
+ * The error a routed operation should fail with when its target dies while the
+ * request is in flight. Mirrors what the resolver throws when the target is
+ * already gone, so "destroyed just before" and "destroyed just after" report
+ * the same thing instead of the second one degrading to `EXECUTION_ERROR`.
+ */
+function routeLostError(route: BridgeRoute): McpRouteBindingError {
+  return route.kind === "workspace"
+    ? new WorkspaceBindingError(route.workspaceId, "not-found")
+    : new SessionBindingError(route.webContentsId);
+}
+
+/** Names the unreachable target in a deadline message, so a timeout says which view went quiet. */
+function routeTimeoutSuffix(route: BridgeRoute | undefined, timeoutMs: number): string {
+  if (!route) return "";
+  const target =
+    route.kind === "workspace"
+      ? `workspace ${route.workspaceId}`
+      : `pinned view ${route.webContentsId}`;
+  return ` — the view bound to ${target} did not answer within ${Math.round(timeoutMs / 1000)}s`;
+}
+
+/**
+ * Thaw a routed target, then send — the fix for the stranded-dispatch half of
+ * #11790.
+ *
+ * Under the efficiency profile a cached background view is CDP-frozen, and a
+ * frozen renderer cannot run JS: the dispatch IPC queues in Mojo and nothing
+ * ever answers it, so the caller waits out the full bridge deadline for what
+ * looks like an execution failure. Chromium never auto-resumes a frozen
+ * renderer on focus or re-attach, so an explicit `"active"` is the only thing
+ * that rescues it.
+ *
+ * Awaited, unlike the fire-and-forget `void unfreezeWebContents(...)` at the
+ * lifecycle call sites: those only need the view running again eventually,
+ * whereas the IPC queued here is precisely what the thaw has to precede.
+ *
+ * CPU throttling is deliberately left in place, matching `unfreezeActiveAgentViews`.
+ * `Emulation.setCPUThrottlingRate` is orthogonal to lifecycle state and slows
+ * JS without suspending it, so a thawed-but-throttled view still answers — and
+ * clearing it would hand a background workspace the CPU budget of a foreground
+ * one. Nothing here attaches, shows, focuses, or activates the view either: a
+ * bound session driving project A must never disturb what the user is looking at.
+ */
+function thawThenSend(
+  webContents: Electron.WebContents,
+  isStillPending: () => boolean,
+  send: () => void
+): void {
+  void unfreezeWebContents(webContents)
+    .catch(() => {
+      // `unfreezeWebContents` already swallows the expected teardown/navigation
+      // CDP errors, so anything landing here is unexpected. Refusing to send
+      // would convert a thaw hiccup into a guaranteed deadline failure; sending
+      // anyway leaves a genuinely-still-frozen view failing exactly as it did
+      // before this path existed, and costs nothing when the thaw did work.
+    })
+    .then(() => {
+      // The deadline may have fired, or the view may have been destroyed, while
+      // the CDP round trip was outstanding. Either way the request is already
+      // settled and its lease released, so sending now would emit an IPC for a
+      // requestId nothing is waiting on.
+      if (!isStillPending() || webContents.isDestroyed()) return;
+      send();
+    });
+}
+
 export function createRendererBridge(
   pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>,
   pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>,
-  getRegistry: () => WindowRegistry | null
+  getRegistry: () => WindowRegistry | null,
+  /**
+   * Eviction leases for routed operations (#11790). Optional so a bridge built
+   * without one (tests, older construction paths) simply takes no leases —
+   * views then stay ordinary eviction candidates, the pre-#11790 behavior.
+   */
+  viewLeases?: WorkspaceViewLeaseRegistry
 ) {
   let cachedManifest: ActionManifestEntry[] | null = null;
 
@@ -236,7 +334,8 @@ export function createRendererBridge(
 
   function sendManifestRequest(
     resolveWebContents: () => Electron.WebContents,
-    onResolved: (manifest: ActionManifestEntry[]) => void
+    onResolved: (manifest: ActionManifestEntry[]) => void,
+    route?: BridgeRoute
   ): Promise<ActionManifestEntry[]> {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
@@ -249,11 +348,21 @@ export function createRendererBridge(
 
       const requestId = randomUUID();
       const webContentsId = webContents.id;
+      // Taken before the thaw round trip below, so the window between picking
+      // this view and sending to it is covered too — an eviction pass landing
+      // inside a CDP round trip would otherwise destroy the target we just
+      // resolved. `tools/list` is usually a bound session's first operation and
+      // has the shorter deadline of the two, so it is the more exposed one.
+      const releaseLease = route ? (viewLeases?.acquire(webContentsId) ?? null) : null;
       const timer = setTimeout(() => {
         const pending = pendingManifests.get(requestId);
         pending?.destroyedCleanup?.();
         pendingManifests.delete(requestId);
-        reject(new Error("Manifest request timed out"));
+        reject(
+          new Error(
+            `Manifest request timed out${routeTimeoutSuffix(route, MCP_MANIFEST_REQUEST_TIMEOUT_MS)}`
+          )
+        );
       }, MCP_MANIFEST_REQUEST_TIMEOUT_MS);
 
       const onDestroyed = () => {
@@ -261,15 +370,26 @@ export function createRendererBridge(
         if (!pending) return;
         clearTimeout(pending.timer);
         pendingManifests.delete(requestId);
-        pending.reject(new Error("MCP renderer bridge destroyed"));
+        settle();
+        pending.reject(route ? routeLostError(route) : new Error("MCP renderer bridge destroyed"));
       };
       webContents.once("destroyed", onDestroyed);
-      const destroyedCleanup = () => {
+      // Idempotent: a request can settle through the response, the deadline,
+      // WebContents destruction, or a synchronous `send()` throw, and more than
+      // one of those can run for the same request. A double release would
+      // decrement another caller's lease; a missed one would pin the view for
+      // the rest of the session, quietly recreating the permanent eviction
+      // floor #11790 exists to avoid.
+      let settled = false;
+      const settle = () => {
+        if (settled) return;
+        settled = true;
         try {
           webContents.removeListener("destroyed", onDestroyed);
         } catch {
           // best-effort cleanup; webContents may already be gone
         }
+        releaseLease?.();
       };
 
       pendingManifests.set(requestId, {
@@ -280,16 +400,24 @@ export function createRendererBridge(
         reject,
         timer,
         webContentsId,
-        destroyedCleanup,
+        destroyedCleanup: settle,
       });
 
-      try {
-        webContents.send(CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST, { requestId });
-      } catch (err) {
-        clearTimeout(timer);
-        destroyedCleanup();
-        pendingManifests.delete(requestId);
-        reject(normalizeError(err, "Failed to request action manifest"));
+      const send = () => {
+        try {
+          webContents.send(CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST, { requestId });
+        } catch (err) {
+          clearTimeout(timer);
+          settle();
+          pendingManifests.delete(requestId);
+          reject(normalizeError(err, "Failed to request action manifest"));
+        }
+      };
+
+      if (route) {
+        thawThenSend(webContents, () => pendingManifests.has(requestId), send);
+      } else {
+        send();
       }
     });
   }
@@ -300,7 +428,8 @@ export function createRendererBridge(
     args: unknown,
     confirmed: boolean,
     contextOverride?: ActionContext,
-    callerInfo?: McpBearerIdentity
+    callerInfo?: McpBearerIdentity,
+    route?: BridgeRoute
   ): Promise<DispatchEnvelope> {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
@@ -313,11 +442,18 @@ export function createRendererBridge(
 
       const requestId = randomUUID();
       const webContentsId = webContents.id;
+      // See sendManifestRequest: acquired before the thaw so the resolve → send
+      // window is covered, released by `settle()` on every outcome.
+      const releaseLease = route ? (viewLeases?.acquire(webContentsId) ?? null) : null;
       const timer = setTimeout(() => {
         const pending = pendingDispatches.get(requestId);
         pending?.destroyedCleanup?.();
         pendingDispatches.delete(requestId);
-        reject(new Error(`Action dispatch timed out: ${actionId}`));
+        reject(
+          new Error(
+            `Action dispatch timed out: ${actionId}${routeTimeoutSuffix(route, MCP_DISPATCH_TIMEOUT_MS)}`
+          )
+        );
       }, MCP_DISPATCH_TIMEOUT_MS);
 
       const onDestroyed = () => {
@@ -325,15 +461,20 @@ export function createRendererBridge(
         if (!pending) return;
         clearTimeout(pending.timer);
         pendingDispatches.delete(requestId);
-        pending.reject(new Error("MCP renderer bridge destroyed"));
+        settle();
+        pending.reject(route ? routeLostError(route) : new Error("MCP renderer bridge destroyed"));
       };
       webContents.once("destroyed", onDestroyed);
-      const destroyedCleanup = () => {
+      let settled = false;
+      const settle = () => {
+        if (settled) return;
+        settled = true;
         try {
           webContents.removeListener("destroyed", onDestroyed);
         } catch {
           // best-effort cleanup; webContents may already be gone
         }
+        releaseLease?.();
       };
 
       pendingDispatches.set(requestId, {
@@ -341,29 +482,37 @@ export function createRendererBridge(
         reject,
         timer,
         webContentsId,
-        destroyedCleanup,
+        destroyedCleanup: settle,
       });
 
-      try {
-        webContents.send(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, {
-          requestId,
-          actionId,
-          args,
-          confirmed,
-          // Only pinned help-session dispatch passes a contextOverride; the
-          // unpinned external/api-key path leaves this undefined so the
-          // renderer keeps its live focused-window context (#8317).
-          context: contextOverride,
-          // Display-only requesting-bearer identity for the confirm dialog
-          // (#9157). Only the unpinned external path supplies it; absent for
-          // pinned help-session dispatch so the dialog stays provenance-free.
-          callerInfo,
-        });
-      } catch (err) {
-        clearTimeout(timer);
-        destroyedCleanup();
-        pendingDispatches.delete(requestId);
-        reject(normalizeError(err, `Failed to dispatch action: ${actionId}`));
+      const send = () => {
+        try {
+          webContents.send(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, {
+            requestId,
+            actionId,
+            args,
+            confirmed,
+            // Only pinned help-session dispatch passes a contextOverride; the
+            // unpinned external/api-key path leaves this undefined so the
+            // renderer keeps its live focused-window context (#8317).
+            context: contextOverride,
+            // Display-only requesting-bearer identity for the confirm dialog
+            // (#9157). Only the unpinned external path supplies it; absent for
+            // pinned help-session dispatch so the dialog stays provenance-free.
+            callerInfo,
+          });
+        } catch (err) {
+          clearTimeout(timer);
+          settle();
+          pendingDispatches.delete(requestId);
+          reject(normalizeError(err, `Failed to dispatch action: ${actionId}`));
+        }
+      };
+
+      if (route) {
+        thawThenSend(webContents, () => pendingDispatches.has(requestId), send);
+      } else {
+        send();
       }
     });
   }
@@ -447,7 +596,13 @@ export function createRendererBridge(
           perWebContentsCache.set(id, manifest);
           perWebContentsInflight.delete(id);
         }
-      }
+      },
+      // A pinned view is a project view like any other: it can be cached,
+      // frozen and evicted while its help session is still live (#11790).
+      // Callers that coalesce onto this in-flight fetch inherit its thaw and
+      // its lease — the lease covers the fetch, not the caller, so one is
+      // enough for all of them.
+      { kind: "pinned", webContentsId: id }
     );
     perWebContentsInflight.set(id, { token, promise: fetchPromise });
     // Drop the inflight marker on failure so the next call retries — never cache
@@ -479,7 +634,9 @@ export function createRendererBridge(
       actionId,
       args,
       confirmed,
-      contextOverride
+      contextOverride,
+      undefined,
+      { kind: "pinned", webContentsId: id }
     );
   }
 
@@ -497,7 +654,16 @@ export function createRendererBridge(
     } catch (err) {
       return Promise.reject(normalizeError(err, "MCP workspace binding unavailable"));
     }
-    return requestManifestForWebContents(id);
+    return requestManifestForWebContents(id).catch((err: unknown) => {
+      // The shared fetch reports a mid-flight teardown as a dead *pin* — "do
+      // not retry", which is right for a help session whose window closed but
+      // wrong for a workspace binding. The workspace id outlives the view, so
+      // reopening it makes the very same call work (#11790).
+      if (err instanceof SessionBindingError) {
+        throw new WorkspaceBindingError(workspaceId, "not-found");
+      }
+      throw err;
+    });
   }
 
   /**
@@ -517,7 +683,10 @@ export function createRendererBridge(
       () => getWorkspaceWebContents(workspaceId),
       actionId,
       args,
-      confirmed
+      confirmed,
+      undefined,
+      undefined,
+      { kind: "workspace", workspaceId }
     );
   }
 

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -348,12 +348,6 @@ export function createRendererBridge(
 
       const requestId = randomUUID();
       const webContentsId = webContents.id;
-      // Taken before the thaw round trip below, so the window between picking
-      // this view and sending to it is covered too — an eviction pass landing
-      // inside a CDP round trip would otherwise destroy the target we just
-      // resolved. `tools/list` is usually a bound session's first operation and
-      // has the shorter deadline of the two, so it is the more exposed one.
-      const releaseLease = route ? (viewLeases?.acquire(webContentsId) ?? null) : null;
       const timer = setTimeout(() => {
         const pending = pendingManifests.get(requestId);
         pending?.destroyedCleanup?.();
@@ -391,6 +385,16 @@ export function createRendererBridge(
         }
         releaseLease?.();
       };
+
+      // Taken after every listener that could throw is wired, so a failed setup
+      // can never strand a lease with no settle path left to release it — and
+      // still synchronously, before the thaw round trip below, so the window
+      // between picking this view and sending to it is covered. An eviction
+      // pass landing inside that CDP round trip would otherwise destroy the
+      // target we just resolved. `tools/list` is usually a bound session's
+      // first operation and has the shorter deadline, so it is the more
+      // exposed of the two.
+      const releaseLease = route ? (viewLeases?.acquire(webContentsId) ?? null) : null;
 
       pendingManifests.set(requestId, {
         resolve: (manifest) => {
@@ -442,9 +446,6 @@ export function createRendererBridge(
 
       const requestId = randomUUID();
       const webContentsId = webContents.id;
-      // See sendManifestRequest: acquired before the thaw so the resolve → send
-      // window is covered, released by `settle()` on every outcome.
-      const releaseLease = route ? (viewLeases?.acquire(webContentsId) ?? null) : null;
       const timer = setTimeout(() => {
         const pending = pendingDispatches.get(requestId);
         pending?.destroyedCleanup?.();
@@ -476,6 +477,11 @@ export function createRendererBridge(
         }
         releaseLease?.();
       };
+
+      // See sendManifestRequest: after the listener wiring so a throwing setup
+      // can't strand it, before the thaw so the resolve → send window is
+      // covered. Released by `settle()` on every outcome.
+      const releaseLease = route ? (viewLeases?.acquire(webContentsId) ?? null) : null;
 
       pendingDispatches.set(requestId, {
         resolve,

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -194,6 +194,37 @@ export class SessionStore {
   }
 
   /**
+   * Whether any live session is bound to this workspace (#11790).
+   *
+   * Read by the project-view freeze and eviction policies through the injected
+   * `mcpViewActivity` callback: a bound workspace's view is usually the
+   * background one, and freezing it strands every dispatch (a frozen renderer
+   * cannot run JS) while evicting it breaks the binding outright.
+   *
+   * Two halves, both load-bearing:
+   *
+   * 1. Explicit `external` origin, read straight off `sessionOriginMap` rather
+   *    than through `getOrigin()`. That accessor defaults an *unknown* session
+   *    to `"external"`, so a stale `sessionWorkspaceMap` row whose origin was
+   *    already torn down would read as a live external binding and pin the view
+   *    forever. Presence in the routing map is routing, never ownership
+   *    (#11789) — the two must be asked separately.
+   * 2. Transport liveness. The binding outlives nothing on its own; a session
+   *    that dropped is reaped from `sessions`/`httpSessions` before (or
+   *    alongside) `clearSessionBinding`, so this is what makes protection
+   *    release itself. Transport-agnostic on purpose: only Streamable HTTP can
+   *    bind today, but nothing here should have to change when SSE can.
+   */
+  hasLiveWorkspaceBinding(workspaceId: string): boolean {
+    for (const [sessionId, boundWorkspaceId] of this.sessionWorkspaceMap) {
+      if (boundWorkspaceId !== workspaceId) continue;
+      if (this.sessionOriginMap.get(sessionId) !== "external") continue;
+      if (this.sessions.has(sessionId) || this.httpSessions.has(sessionId)) return true;
+    }
+    return false;
+  }
+
+  /**
    * Drop every per-session routing/ownership record in one place.
    *
    * The four maps must die together: a stale origin would let a recycled

--- a/electron/services/mcp-server/workspaceViewLease.ts
+++ b/electron/services/mcp-server/workspaceViewLease.ts
@@ -29,6 +29,13 @@
  */
 export class WorkspaceViewLeaseRegistry {
   private readonly counts = new Map<number, number>();
+  /**
+   * Bumped by `clear()`. A release handle remembers the generation it was
+   * issued under and does nothing once that generation is stale — otherwise a
+   * request straggling across a server stop/start could decrement a *new*
+   * request's lease and expose the view it is waiting on.
+   */
+  private generation = 0;
 
   /**
    * Take a lease on `webContentsId` and return its release.
@@ -41,10 +48,11 @@ export class WorkspaceViewLeaseRegistry {
    * must wire the release into every settle path — not just the happy one.
    */
   acquire(webContentsId: number): () => void {
+    const issuedAt = this.generation;
     this.counts.set(webContentsId, (this.counts.get(webContentsId) ?? 0) + 1);
     let released = false;
     return () => {
-      if (released) return;
+      if (released || issuedAt !== this.generation) return;
       released = true;
       const remaining = (this.counts.get(webContentsId) ?? 0) - 1;
       if (remaining > 0) {
@@ -66,6 +74,7 @@ export class WorkspaceViewLeaseRegistry {
    * would pin views for renderers that will never answer.
    */
   clear(): void {
+    this.generation++;
     this.counts.clear();
   }
 }

--- a/electron/services/mcp-server/workspaceViewLease.ts
+++ b/electron/services/mcp-server/workspaceViewLease.ts
@@ -12,11 +12,17 @@
  * eviction pass can skip it, alongside the paint-gate and cold-switch
  * exclusions. Deliberately NOT the unconditional floor a live assistant backend
  * gets (#11157): that floor exists because eviction there kills a PTY process
- * tree, and the argument does not transfer. A lease is bounded by construction —
- * every holder is a pending bridge request, and those are capped by
- * `MCP_MANIFEST_REQUEST_TIMEOUT_MS` / `MCP_DISPATCH_TIMEOUT_MS` — so enough
- * concurrent bound sessions can never defeat the pressure policy the way a
- * permanent floor would. A bound session that goes quiet holds nothing.
+ * tree, and the argument does not transfer. Every individual lease is bounded by
+ * construction — each holder is a pending bridge request, capped by
+ * `MCP_MANIFEST_REQUEST_TIMEOUT_MS` / `MCP_DISPATCH_TIMEOUT_MS`.
+ *
+ * That bound is per-lease, not aggregate: a session dispatching back-to-back
+ * renews protection for as long as it keeps working. That is the intended
+ * reading of "keep the view alive while a bound session is actually working" —
+ * destroying the exact renderer a valid request is awaiting is the failure this
+ * exists to prevent, and a deadline is not a reason to allow it. What keeps it
+ * from being a floor is the other half: a bound session that goes quiet holds
+ * nothing at all, and its view is an ordinary eviction candidate again.
  *
  * Keyed by `webContentsId`, not workspace id: the id is what eviction has in
  * hand for each candidate entry, and it is the exact view the request is

--- a/electron/services/mcp-server/workspaceViewLease.ts
+++ b/electron/services/mcp-server/workspaceViewLease.ts
@@ -1,0 +1,71 @@
+/**
+ * Reference-counted eviction leases for renderer views with an MCP operation in
+ * flight (#11790).
+ *
+ * A workspace-bound external session dispatches into a *background* view — that
+ * is the point of the binding. Memory-pressure eviction destroys the WebContents
+ * (`cleanupEntry`), so a pass landing mid-dispatch strands the in-flight request
+ * until its 30s deadline and leaves every later call failing
+ * `SESSION_BINDING_GONE`.
+ *
+ * A lease marks "this exact view is answering an MCP request right now" so the
+ * eviction pass can skip it, alongside the paint-gate and cold-switch
+ * exclusions. Deliberately NOT the unconditional floor a live assistant backend
+ * gets (#11157): that floor exists because eviction there kills a PTY process
+ * tree, and the argument does not transfer. A lease is bounded by construction —
+ * every holder is a pending bridge request, and those are capped by
+ * `MCP_MANIFEST_REQUEST_TIMEOUT_MS` / `MCP_DISPATCH_TIMEOUT_MS` — so enough
+ * concurrent bound sessions can never defeat the pressure policy the way a
+ * permanent floor would. A bound session that goes quiet holds nothing.
+ *
+ * Keyed by `webContentsId`, not workspace id: the id is what eviction has in
+ * hand for each candidate entry, and it is the exact view the request is
+ * awaiting. A workspace whose view was replaced by a cold start gets a new id,
+ * so a stale lease can never protect the wrong renderer.
+ *
+ * Leaf module — no imports, so both `electron/services/mcp-server/` (writer) and
+ * `electron/window/` (reader, via the injected activity callback) can reach it
+ * without a cycle or an eager-graph cost.
+ */
+export class WorkspaceViewLeaseRegistry {
+  private readonly counts = new Map<number, number>();
+
+  /**
+   * Take a lease on `webContentsId` and return its release.
+   *
+   * The release is idempotent: bridge requests settle through several paths
+   * (response, timeout, WebContents destruction, a synchronous `send()` throw)
+   * and more than one can run for the same request, so a double release must
+   * not decrement another caller's reference. A leaked lease would quietly
+   * recreate the permanent floor this design exists to avoid, so the caller
+   * must wire the release into every settle path — not just the happy one.
+   */
+  acquire(webContentsId: number): () => void {
+    this.counts.set(webContentsId, (this.counts.get(webContentsId) ?? 0) + 1);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const remaining = (this.counts.get(webContentsId) ?? 0) - 1;
+      if (remaining > 0) {
+        this.counts.set(webContentsId, remaining);
+      } else {
+        this.counts.delete(webContentsId);
+      }
+    };
+  }
+
+  /** Whether an MCP request is currently awaiting this exact view. */
+  has(webContentsId: number): boolean {
+    return (this.counts.get(webContentsId) ?? 0) > 0;
+  }
+
+  /**
+   * Drop every lease. Called when the MCP server stops: `HttpLifecycle.stop()`
+   * rejects the pending requests that own these leases, so keeping the counts
+   * would pin views for renderers that will never answer.
+   */
+  clear(): void {
+    this.counts.clear();
+  }
+}

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -380,11 +380,10 @@ export function evictStaleViews(
   // rather than the active view alone is now the expected outcome, and it is
   // exactly the case where an unexplained over-cap cache would read as a leak.
   //
-  // MCP dispatch leases are included in the gate, not just in the counts
-  // (#11790). A lease is self-expiring per request, but a session dispatching
-  // continuously can renew one indefinitely, so a lease-only stall is exactly
-  // the case where an over-cap cache would otherwise sit in the logs with
-  // nothing explaining it.
+  // MCP dispatch leases open the gate too (#11790). A lease is self-expiring
+  // per request, but a session dispatching continuously renews one, so a
+  // lease-only stall can persist — exactly the case where an over-cap cache
+  // would otherwise sit in the logs with nothing explaining it.
   if (
     host.views.size > effectiveMax &&
     candidates.length === 0 &&
@@ -402,10 +401,6 @@ export function evictStaleViews(
         (id): id is string => id !== null && id !== host.activeProjectId
       )
     );
-    // MCP dispatch leases belong with the paint-gate/cold-switch bridges, not
-    // with the assistant floor: all three resolve on their own, so a reader
-    // seeing them here knows the over-cap cache is temporary (#11790).
-    for (const projectId of mcpLeasedProjectIds) transientlyExcludedProjectIds.add(projectId);
     logInfo("projectview.eviction-skipped", {
       reason: effectiveReason,
       forced: criticalPressure,
@@ -414,6 +409,13 @@ export function evictStaleViews(
       overflow: host.views.size - effectiveMax,
       protectedCount: assistantProtected.length,
       transientlyExcludedCount: transientlyExcludedProjectIds.size,
+      // Reported as its own reason rather than folded into the transient count
+      // (#11790). A lease resolves on its own like the two bridges above, but
+      // it is excluded BEFORE assistant protection is evaluated, so folding
+      // them together would report an assistant-backed view that happens to be
+      // mid-dispatch as transient when its floor outlives the call. Kept apart,
+      // each count means exactly one thing.
+      mcpLeasedCount: mcpLeasedProjectIds.size,
       protectedProjectIds: assistantProtected.map(({ projectId }) => projectId),
     });
   }

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -239,13 +239,17 @@ export function evictStaleViews(
   // `SESSION_BINDING_GONE`, since eviction destroys the WebContents the binding
   // resolves to and nothing recreates it.
   //
-  // An absolute exclusion is safe here only because it is self-expiring: each
-  // lease is held by one pending bridge request, capped at 5s (manifest) or 30s
-  // (dispatch), and released on the response, the deadline, and the view's own
-  // destruction alike. That is what makes this a bounded lease rather than the
-  // unconditional floor a live assistant backend gets — enough concurrent bound
-  // sessions could defeat the pressure policy outright if it were permanent, so
-  // "bound but quiet" is deliberately NOT excluded here (see the tiers below).
+  // Each individual lease is self-expiring — held by one pending bridge
+  // request, capped at 5s (manifest) or 30s (dispatch), released on the
+  // response, the deadline and the view's own destruction alike — which is what
+  // makes this a bounded lease rather than the unconditional floor a live
+  // assistant backend gets. Note the bound is per-lease, not aggregate: a
+  // session dispatching back-to-back can keep one view's refcount above zero
+  // indefinitely. That is the intended reading of "keep the view alive while a
+  // bound session is actually working", but it does mean sustained traffic can
+  // hold the cache over its cap, so the skipped-eviction log below reports it.
+  // A session that goes quiet holds nothing, which is the property that keeps
+  // this from becoming a floor.
   const mcpLeasedProjectIds = new Set<string>();
 
   const evictable = Array.from(host.views.entries())
@@ -319,7 +323,11 @@ export function evictStaleViews(
   const assistantProtected: EvictionCandidate[] = [];
   for (const [projectId, entry] of evictable) {
     const activeAgent = hasActiveAgent(host, projectId);
-    const boundMcpSession = host.mcpActivityFor(projectId, entry.view.webContents).liveBinding;
+    const mcp = host.mcpActivityFor(projectId, entry.view.webContents);
+    // `unknown` (the activity callback threw) deprioritizes but never protects:
+    // it must not reach the exclusion set above, or one broken callback would
+    // pin every cached view straight through critical pressure.
+    const boundMcpSession = mcp.liveBinding || mcp.unknown;
     const base = { projectId, entry, activeAgent, boundMcpSession };
     if (hasLiveAssistantBackend(host, projectId, entry)) {
       assistantProtected.push({ ...base, liveAssistantBackend: true });
@@ -371,7 +379,17 @@ export function evictStaleViews(
   // tier-2 reclaim that converges to "active view + protected assistants"
   // rather than the active view alone is now the expected outcome, and it is
   // exactly the case where an unexplained over-cap cache would read as a leak.
-  if (host.views.size > effectiveMax && candidates.length === 0 && assistantProtected.length > 0) {
+  //
+  // MCP dispatch leases are included in the gate, not just in the counts
+  // (#11790). A lease is self-expiring per request, but a session dispatching
+  // continuously can renew one indefinitely, so a lease-only stall is exactly
+  // the case where an over-cap cache would otherwise sit in the logs with
+  // nothing explaining it.
+  if (
+    host.views.size > effectiveMax &&
+    candidates.length === 0 &&
+    (assistantProtected.length > 0 || mcpLeasedProjectIds.size > 0)
+  ) {
     // `overflow` counts views over target; the two counts beside it say what is
     // holding them, so a reader can tell a pinned assistant (persistent, this
     // pass will never take it) from a paint-gate/cold-switch bridge (temporary,

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -14,8 +14,14 @@ import type { EvictionReason, ViewEntry } from "./ProjectViewManagerTypes.js";
 import { readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 import { memoryPressureTarget } from "../utils/cachedProjectViews.js";
 
-/** `[projectId, entry, activeAgent, liveAssistantBackend]` — the last two are carried into the eviction log line. */
-type EvictionCandidate = [string, ViewEntry, boolean, boolean];
+/** A view eligible for eviction; the flags beyond the entry are carried into the eviction log line. */
+type EvictionCandidate = {
+  projectId: string;
+  entry: ViewEntry;
+  activeAgent: boolean;
+  liveAssistantBackend: boolean;
+  boundMcpSession: boolean;
+};
 
 /**
  * workingSetSize is the only cross-platform field — privateBytes is
@@ -226,13 +232,37 @@ export function evictStaleViews(
   // real on-screen window.
   const switchOutgoingProjectId = host.pendingColdSwitch?.outgoingProjectId ?? null;
 
+  // Views an MCP request is currently awaiting (#11790). Excluded outright,
+  // like the two bridges above and for the same reason: destroying one does not
+  // just cost a reload, it strands an operation nothing can retry — the caller
+  // waits out the bridge deadline and every later call on that session fails
+  // `SESSION_BINDING_GONE`, since eviction destroys the WebContents the binding
+  // resolves to and nothing recreates it.
+  //
+  // An absolute exclusion is safe here only because it is self-expiring: each
+  // lease is held by one pending bridge request, capped at 5s (manifest) or 30s
+  // (dispatch), and released on the response, the deadline, and the view's own
+  // destruction alike. That is what makes this a bounded lease rather than the
+  // unconditional floor a live assistant backend gets — enough concurrent bound
+  // sessions could defeat the pressure policy outright if it were permanent, so
+  // "bound but quiet" is deliberately NOT excluded here (see the tiers below).
+  const mcpLeasedProjectIds = new Set<string>();
+
   const evictable = Array.from(host.views.entries())
-    .filter(
-      ([id]) =>
-        id !== host.activeProjectId &&
-        id !== gateOutgoingProjectId &&
-        id !== switchOutgoingProjectId
-    )
+    .filter(([id, entry]) => {
+      if (
+        id === host.activeProjectId ||
+        id === gateOutgoingProjectId ||
+        id === switchOutgoingProjectId
+      ) {
+        return false;
+      }
+      if (host.mcpActivityFor(id, entry.view.webContents).dispatchLease) {
+        mcpLeasedProjectIds.add(id);
+        return false;
+      }
+      return true;
+    })
     // Oldest lastUsed first — pure LRU. Sequential switchTo calls stamp
     // distinct millisecond timestamps so equal-lastUsed ties don't arise
     // in practice; Array.sort stability handles them deterministically.
@@ -272,25 +302,42 @@ export function evictStaleViews(
   // per project, and another window's view of the same project remains an
   // ordinary candidate. The ceiling is the number of assistants actually
   // running — reported below so the over-cap cache is attributable.
+  //
+  // A view backing a live-but-idle MCP session binding sits between the two
+  // (#11790): evicting it breaks the binding with no recovery path, so it
+  // outranks an active-agent view — an ordinary grid terminal's PTY lives in
+  // the pty-host and reconnects on switch-back, while a destroyed bound view
+  // leaves the session `SESSION_BINDING_GONE` until the user reopens that
+  // workspace. But it stays in `candidates`, unlike the assistant floor: the
+  // issue is explicit that a hard floor is the wrong answer here, because
+  // nothing dies with the renderer the way an assistant's process tree does,
+  // and enough concurrent bound sessions would otherwise defeat the pressure
+  // policy. So it yields under real pressure, just last.
   const safeToEvict: EvictionCandidate[] = [];
   const activeAgentFallback: EvictionCandidate[] = [];
+  const boundMcpSessionFallback: EvictionCandidate[] = [];
   const assistantProtected: EvictionCandidate[] = [];
   for (const [projectId, entry] of evictable) {
-    const active = hasActiveAgent(host, projectId);
+    const activeAgent = hasActiveAgent(host, projectId);
+    const boundMcpSession = host.mcpActivityFor(projectId, entry.view.webContents).liveBinding;
+    const base = { projectId, entry, activeAgent, boundMcpSession };
     if (hasLiveAssistantBackend(host, projectId, entry)) {
-      assistantProtected.push([projectId, entry, active, true]);
-    } else if (active) {
-      activeAgentFallback.push([projectId, entry, true, false]);
+      assistantProtected.push({ ...base, liveAssistantBackend: true });
+    } else if (boundMcpSession) {
+      boundMcpSessionFallback.push({ ...base, liveAssistantBackend: false });
+    } else if (activeAgent) {
+      activeAgentFallback.push({ ...base, liveAssistantBackend: false });
     } else {
-      safeToEvict.push([projectId, entry, false, false]);
+      safeToEvict.push({ ...base, liveAssistantBackend: false });
     }
   }
 
-  const candidates = [...safeToEvict, ...activeAgentFallback];
+  const candidates = [...safeToEvict, ...activeAgentFallback, ...boundMcpSessionFallback];
 
   let evictedCount = 0;
   while (host.views.size > effectiveMax && candidates.length > 0 && evictedCount < evictionBudget) {
-    const [projectId, entry, activeAgent, liveAssistantBackend] = candidates.shift()!;
+    const { projectId, entry, activeAgent, liveAssistantBackend, boundMcpSession } =
+      candidates.shift()!;
     const ageMs = Date.now() - entry.lastUsed;
     const memoryKb = memoryFor(entry);
     const guestMemoryKb = guestMemoryFor(entry);
@@ -301,6 +348,10 @@ export function evictStaleViews(
       activeAgent,
     };
     if (liveAssistantBackend) ctx.liveAssistantBackend = true;
+    // Recorded so a bound session going `SESSION_BINDING_GONE` is traceable to
+    // the pass that took its view, rather than looking like the binding broke
+    // on its own.
+    if (boundMcpSession) ctx.boundMcpSession = true;
     if (memoryKb > 0) ctx.memoryKb = memoryKb;
     if (guestMemoryKb > 0) ctx.guestMemoryKb = guestMemoryKb;
     if (availableMb != null) ctx.memoryAvailableMb = availableMb;
@@ -333,6 +384,10 @@ export function evictStaleViews(
         (id): id is string => id !== null && id !== host.activeProjectId
       )
     );
+    // MCP dispatch leases belong with the paint-gate/cold-switch bridges, not
+    // with the assistant floor: all three resolve on their own, so a reader
+    // seeing them here knows the over-cap cache is temporary (#11790).
+    for (const projectId of mcpLeasedProjectIds) transientlyExcludedProjectIds.add(projectId);
     logInfo("projectview.eviction-skipped", {
       reason: effectiveReason,
       forced: criticalPressure,
@@ -341,7 +396,7 @@ export function evictStaleViews(
       overflow: host.views.size - effectiveMax,
       protectedCount: assistantProtected.length,
       transientlyExcludedCount: transientlyExcludedProjectIds.size,
-      protectedProjectIds: assistantProtected.map(([projectId]) => projectId),
+      protectedProjectIds: assistantProtected.map(({ projectId }) => projectId),
     });
   }
 

--- a/electron/window/ProjectViewLifecycleController.ts
+++ b/electron/window/ProjectViewLifecycleController.ts
@@ -162,7 +162,7 @@ export function deactivateEntry(host: ProjectViewManager, current: ViewEntry): v
       !AgentStateCache.hasActiveAgent(host, capturedProjectId)
     ) {
       const mcp = host.mcpActivityFor(capturedProjectId, vc);
-      if (!mcp.liveBinding && !mcp.dispatchLease) {
+      if (!mcp.liveBinding && !mcp.dispatchLease && !mcp.unknown) {
         void freezeWebContents(vc);
       }
     }

--- a/electron/window/ProjectViewLifecycleController.ts
+++ b/electron/window/ProjectViewLifecycleController.ts
@@ -152,13 +152,19 @@ export function deactivateEntry(host: ProjectViewManager, current: ViewEntry): v
     // if we froze first (lesson #4684). Skip the freeze for a project with a
     // live agent: a frozen renderer can't apply queued agent:state-changed
     // events, stranding the background dashboard on a stale state (mirrors
-    // the freezeAllCached guard).
+    // the freezeAllCached guard). A live MCP session binding earns the same
+    // skip for the same reason — a frozen renderer can't answer the dispatch
+    // IPC either, and this is the path that would freeze a bound workspace the
+    // moment the user switches away from it (#11790).
     if (
       host.efficiencyFreezeEnabled &&
       !vc.isDestroyed() &&
       !AgentStateCache.hasActiveAgent(host, capturedProjectId)
     ) {
-      void freezeWebContents(vc);
+      const mcp = host.mcpActivityFor(capturedProjectId, vc);
+      if (!mcp.liveBinding && !mcp.dispatchLease) {
+        void freezeWebContents(vc);
+      }
     }
 
     schedulePurge(host, current, CACHED_VIEW_PURGE_DELAY_MS);

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -195,7 +195,33 @@ export interface ProjectViewManagerOptions {
    * eviction protection needs a liveness source that tracks exits.
    */
   isTerminalLive?: (terminalId: string) => boolean;
+  /**
+   * Why MCP needs this view kept running right now (#11790) — a live session
+   * binding, an in-flight dispatch, or neither. Injected from the composition
+   * root for the same reason as `assistantBackendForProject`: electron/window/
+   * stays free of the service, and here it also keeps the MCP module graph off
+   * eager boot, since it is deliberately behind a dynamic import.
+   *
+   * Absent — as in tests that don't exercise MCP — every workspace reads as
+   * unprotected, which is the pre-#11790 behavior.
+   */
+  mcpViewActivity?: (workspaceId: string, webContentsId: number) => McpViewActivity | null;
 }
+
+/**
+ * What MCP is doing with a project view, as read by the freeze and eviction
+ * policies (#11790). The two fields earn different protection — see
+ * `McpServerService.getWorkspaceViewActivity` for why one is an outright
+ * eviction exclusion and the other only a deprioritization.
+ */
+export interface McpViewActivity {
+  /** An MCP request is in flight against this exact view. */
+  dispatchLease: boolean;
+  /** A live MCP session is bound to this workspace, call or no call. */
+  liveBinding: boolean;
+}
+
+const NO_MCP_ACTIVITY: McpViewActivity = { dispatchLease: false, liveBinding: false };
 
 export class ProjectViewManager {
   // The fields below are intentionally not `private`: sibling
@@ -221,6 +247,7 @@ export class ProjectViewManager {
     webContentsId: number;
   } | null;
   isTerminalLive?: (terminalId: string) => boolean;
+  mcpViewActivity?: (workspaceId: string, webContentsId: number) => McpViewActivity | null;
   windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
   private switchChain: Promise<void> = Promise.resolve();
   private resizeHandler: (() => void) | null = null;
@@ -286,6 +313,7 @@ export class ProjectViewManager {
     this.onViewCrashed = opts.onViewCrashed;
     this.assistantBackendForProject = opts.assistantBackendForProject;
     this.isTerminalLive = opts.isTerminalLive;
+    this.mcpViewActivity = opts.mcpViewActivity;
     this.windowRegistry = opts.windowRegistry;
     if (opts.cachedProjectViews != null) {
       this.maxCachedViews = opts.cachedProjectViews;
@@ -835,6 +863,29 @@ export class ProjectViewManager {
     }
   }
 
+  /**
+   * What MCP is doing with `workspaceId`'s view right now (#11790).
+   *
+   * Never throws and never returns null: the callback reaches a service behind
+   * a dynamic import, and a freeze or eviction pass must not be abandoned
+   * halfway through the view map because that service was mid-teardown. Every
+   * failure — no callback wired, MCP never loaded, the call threw, the view
+   * already destroyed — reads as "not protected", the same conservative answer
+   * `hasActiveAgent` gives before its cache is seeded.
+   *
+   * Takes a workspace id, not a project id: `views` is keyed by the opaque
+   * workspace identity (a project's 64-hex id or a scratch workspace's UUID),
+   * which is the same vocabulary the MCP session binding stores.
+   */
+  mcpActivityFor(workspaceId: string, wc: Electron.WebContents): McpViewActivity {
+    if (!this.mcpViewActivity || wc.isDestroyed()) return NO_MCP_ACTIVITY;
+    try {
+      return this.mcpViewActivity(workspaceId, wc.id) ?? NO_MCP_ACTIVITY;
+    } catch {
+      return NO_MCP_ACTIVITY;
+    }
+  }
+
   private freezeAllCached(): void {
     for (const [projectId, entry] of this.views) {
       if (projectId === this.activeProjectId) continue;
@@ -846,6 +897,20 @@ export class ProjectViewManager {
       if (hasActiveAgent(this, projectId)) continue;
       const wc = entry.view.webContents;
       if (wc.isDestroyed()) continue;
+      // A live MCP session binding is the same argument (#11790): the whole
+      // point of binding is to drive this workspace while the user works
+      // elsewhere, so its view is a background one by design, and freezing it
+      // strands every dispatch until the bridge deadline fires. The bridge also
+      // thaws on demand, which covers a session that binds after this pass;
+      // this guard is what stops a later pass from re-freezing underneath a
+      // session that is already using the view.
+      //
+      // Unlike eviction, skipping the freeze needs no bounded lease. It costs
+      // one optimization on one cached view — CPU throttling and the periodic
+      // memory purge still apply — rather than the memory a resident renderer
+      // holds, so a quiet binding can hold it for as long as the session lives.
+      const mcp = this.mcpActivityFor(projectId, wc);
+      if (mcp.liveBinding || mcp.dispatchLease) continue;
       void freezeWebContents(wc);
     }
   }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -940,6 +940,15 @@ export class ProjectViewManager {
   private freezeAllCached(): void {
     for (const [projectId, entry] of this.views) {
       if (projectId === this.activeProjectId) continue;
+      // The outgoing anti-flash bridge is still attached and on-screen even
+      // though `activeProjectId` already names the incoming project, so it is
+      // as un-freezable as the active view (the eviction guard excludes it for
+      // the same reason). This pass is periodic now, not just the profile
+      // transition, so a sampler tick can land inside any switch: freezing
+      // there suspends the renderer painting the frame the user is looking at,
+      // and it would also beat `deactivateEntry` to the view, freezing before
+      // its requestIdleCallback GC is ever scheduled (lesson #4684).
+      if (projectId === this.getOutgoingBridgeProjectId()) continue;
       // Never freeze a view whose project has a live agent. A frozen renderer
       // cannot run JS, so the queued agent:state-changed IPC sits in Mojo and
       // the background dashboard stays stuck on its pre-freeze state (e.g.

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -987,6 +987,12 @@ export class ProjectViewManager {
    */
   refreezeUnprotectedCachedViews(): void {
     if (!this.efficiencyFreezeEnabled) return;
+    // A freeze-entry debounce is still pending — let its trailing edge do the
+    // work. `setEfficiencyFreeze(true)` flips the flag immediately but delays
+    // the sweep, precisely so a profile that flips back inside the window
+    // freezes nothing at all; a sampler tick landing in that window would
+    // freeze early and defeat it.
+    if (this.efficiencyFreezeTimer !== null) return;
     this.freezeAllCached();
   }
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -221,7 +221,38 @@ export interface McpViewActivity {
   liveBinding: boolean;
 }
 
-const NO_MCP_ACTIVITY: McpViewActivity = { dispatchLease: false, liveBinding: false };
+/**
+ * What the freeze and eviction policies actually read: the activity, plus
+ * whether the answer could be obtained at all.
+ */
+export interface McpViewActivityReading extends McpViewActivity {
+  /**
+   * The wired callback threw, so protection state is genuinely unavailable.
+   *
+   * Deliberately distinct from the two "definitely not protected" cases — no
+   * callback wired, and a callback returning null because MCP has not loaded —
+   * because the two policies resolve real uncertainty in OPPOSITE directions.
+   * Freezing treats unknown as protected: the cost is one missed optimization
+   * on one cached view, against re-creating the 30s stranded dispatch. Eviction
+   * must not: an unknown that granted the absolute lease exclusion would let a
+   * single broken callback pin every cached view through critical pressure and
+   * turn a wiring bug into an OOM. It deprioritizes instead — reclaimable, just
+   * last.
+   */
+  unknown: boolean;
+}
+
+const NO_MCP_ACTIVITY: McpViewActivityReading = {
+  dispatchLease: false,
+  liveBinding: false,
+  unknown: false,
+};
+
+const UNKNOWN_MCP_ACTIVITY: McpViewActivityReading = {
+  dispatchLease: false,
+  liveBinding: false,
+  unknown: true,
+};
 
 export class ProjectViewManager {
   // The fields below are intentionally not `private`: sibling
@@ -291,6 +322,8 @@ export class ProjectViewManager {
     intent: ProjectFocusOnActivateIntent;
   } | null = null;
   disposed = false;
+  /** One-shot latch so a persistently broken activity callback can't flood the log. */
+  private warnedMcpActivityFailure = false;
   private cachedMemoryTimerCleanup: (() => void) | null = null;
 
   // Agent-state cache for hasActiveAgent(). The main-process getPtyManager()
@@ -402,6 +435,13 @@ export class ProjectViewManager {
         } catch (error) {
           logWarn("projectview.pressure-check.error", {
             error: formatErrorMessage(error, "maybeEvictUnderPressure threw"),
+          });
+        }
+        try {
+          this.refreezeUnprotectedCachedViews();
+        } catch (error) {
+          logWarn("projectview.refreeze.error", {
+            error: formatErrorMessage(error, "refreezeUnprotectedCachedViews threw"),
           });
         }
         scheduleSample(CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS);
@@ -866,23 +906,34 @@ export class ProjectViewManager {
   /**
    * What MCP is doing with `workspaceId`'s view right now (#11790).
    *
-   * Never throws and never returns null: the callback reaches a service behind
-   * a dynamic import, and a freeze or eviction pass must not be abandoned
-   * halfway through the view map because that service was mid-teardown. Every
-   * failure — no callback wired, MCP never loaded, the call threw, the view
-   * already destroyed — reads as "not protected", the same conservative answer
-   * `hasActiveAgent` gives before its cache is seeded.
+   * Never throws: the callback reaches a service behind a dynamic import, and a
+   * freeze or eviction pass must not be abandoned halfway through the view map
+   * because that service was mid-teardown.
+   *
+   * Three outcomes, not two. No callback wired, a destroyed view, or a null
+   * answer (MCP has not loaded, so there are no sessions) are all *known* to be
+   * unprotected — the pre-#11790 behavior. A callback that throws is not: that
+   * is reported as `unknown` so each policy can resolve it in its own safe
+   * direction, and warned once so a broken composition seam is distinguishable
+   * from "MCP simply isn't running" in the logs.
    *
    * Takes a workspace id, not a project id: `views` is keyed by the opaque
    * workspace identity (a project's 64-hex id or a scratch workspace's UUID),
    * which is the same vocabulary the MCP session binding stores.
    */
-  mcpActivityFor(workspaceId: string, wc: Electron.WebContents): McpViewActivity {
+  mcpActivityFor(workspaceId: string, wc: Electron.WebContents): McpViewActivityReading {
     if (!this.mcpViewActivity || wc.isDestroyed()) return NO_MCP_ACTIVITY;
     try {
-      return this.mcpViewActivity(workspaceId, wc.id) ?? NO_MCP_ACTIVITY;
-    } catch {
-      return NO_MCP_ACTIVITY;
+      const activity = this.mcpViewActivity(workspaceId, wc.id);
+      return activity ? { ...activity, unknown: false } : NO_MCP_ACTIVITY;
+    } catch (error) {
+      if (!this.warnedMcpActivityFailure) {
+        this.warnedMcpActivityFailure = true;
+        logWarn("projectview.mcp-activity.error", {
+          error: formatErrorMessage(error, "mcpViewActivity threw"),
+        });
+      }
+      return UNKNOWN_MCP_ACTIVITY;
     }
   }
 
@@ -910,9 +961,33 @@ export class ProjectViewManager {
       // memory purge still apply — rather than the memory a resident renderer
       // holds, so a quiet binding can hold it for as long as the session lives.
       const mcp = this.mcpActivityFor(projectId, wc);
-      if (mcp.liveBinding || mcp.dispatchLease) continue;
+      if (mcp.liveBinding || mcp.dispatchLease || mcp.unknown) continue;
       void freezeWebContents(wc);
     }
+  }
+
+  /**
+   * Re-freeze cached views that were thawed for MCP but are no longer
+   * protected (#11790).
+   *
+   * The bridge thaws a bound or pinned view on demand, and nothing puts it
+   * back: `freezeAllCached` runs only on the transition INTO the efficiency
+   * profile, and `setEfficiencyFreeze(true)` while already enabled is an early
+   * no-op. Without this, one dispatch into a cached view leaves it running JS
+   * and timers for the rest of the efficiency period, and a session that
+   * disconnects never gives its view back — repeated across workspaces, the
+   * profile quietly stops doing its job.
+   *
+   * Piggybacked on the cached-view memory sampler for the same reason
+   * `maybeEvictUnderPressure` is: it needs a trigger that doesn't depend on the
+   * user switching projects or the profile toggling. Reusing `freezeAllCached`
+   * keeps one copy of the guard set, and re-freezing an already-frozen view is
+   * a harmless no-op, so this converges rather than tracking which views it
+   * personally thawed. A strict no-op outside the efficiency profile.
+   */
+  refreezeUnprotectedCachedViews(): void {
+    if (!this.efficiencyFreezeEnabled) return;
+    this.freezeAllCached();
   }
 
   // Wake any cached background view whose project gained a live agent after it

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -3490,14 +3490,14 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       expect(mgr.getAllViews().length).toBe(3);
       const skipped = skippedLog();
       expect(skipped?.protectedCount).toBe(0);
-      expect(skipped?.transientlyExcludedCount).toBe(2);
+      expect(skipped?.mcpLeasedCount).toBe(2);
     });
 
-    it("counts a lease as a transient exclusion, not as part of the assistant floor", async () => {
+    it("reports a lease separately from the assistant floor holding the same cache open", async () => {
       // The over-cap log exists so extra resident renderers are attributable
-      // rather than reading as a leak. A lease resolves on its own, like the
-      // paint-gate and cold-switch bridges, so it must not inflate the
-      // persistent `protectedCount` a pinned assistant reports.
+      // rather than reading as a leak, which means each count has to mean one
+      // thing: a pinned assistant is persistent, a lease is not, and neither
+      // may be reported as the other.
       const mgr = makeManager(3);
       await seedThreeViews(mgr);
       const wcA = mgr.getAllViews().find((v) => v.projectId === "proj-a")!.view.webContents;
@@ -3511,7 +3511,9 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       const skipped = skippedLog();
       expect(skipped?.protectedCount).toBe(1);
       expect(skipped?.protectedProjectIds).toEqual(["proj-a"]);
-      expect(skipped?.transientlyExcludedCount).toBe(1);
+      expect(skipped?.mcpLeasedCount).toBe(1);
+      // Paint-gate / cold-switch bridges only — a lease is not one of those.
+      expect(skipped?.transientlyExcludedCount).toBe(0);
     });
 
     it("leases only the exact view, not every view of the workspace's project id", async () => {
@@ -3687,6 +3689,10 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       assistantBackendForProject,
       isTerminalLive,
     });
+    // Built directly rather than via makeManager (the point is the missing
+    // option), so it still has to join the teardown list or its sampler
+    // outlives the test.
+    managers.push(mgr);
     await seedThreeViews(mgr);
 
     mgr.setCachedViewLimit(1);

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -3318,3 +3318,309 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
   });
 });
+
+describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)", () => {
+  let win: ReturnType<typeof createMockWindow>;
+  /** Workspaces a live MCP session is bound to, and views with a call in flight. */
+  let boundWorkspaces: Set<string>;
+  let leasedWebContentsIds: Set<number>;
+
+  type MemInfo = { free: number; purgeable?: number; total: number };
+  const originalSystemMemoryInfo = (process as unknown as { getSystemMemoryInfo?: () => MemInfo })
+    .getSystemMemoryInfo;
+
+  function setAvailableMb(availableMb: number) {
+    Object.defineProperty(process, "getSystemMemoryInfo", {
+      configurable: true,
+      value: () => ({ free: availableMb * 1024, purgeable: 0, total: 8 * 1024 * 1024 }),
+    });
+  }
+
+  const BAND = { criticalMb: 1000, warningMb: 2000 };
+
+  const evictedProjectIds = () =>
+    vi
+      .mocked(logInfo)
+      .mock.calls.filter(([event]) => event === "projectview.eviction")
+      .map(([, ctx]) => (ctx as { projectId: string }).projectId);
+
+  const evictionLogFor = (projectId: string) =>
+    vi
+      .mocked(logInfo)
+      .mock.calls.find(
+        ([event, ctx]) =>
+          event === "projectview.eviction" && (ctx as { projectId: string }).projectId === projectId
+      )?.[1] as Record<string, unknown> | undefined;
+
+  const skippedLog = (): Record<string, unknown> | undefined =>
+    vi
+      .mocked(logInfo)
+      .mock.calls.filter(([event]) => event === "projectview.eviction-skipped")
+      .pop()?.[1] as Record<string, unknown> | undefined;
+
+  function makeManager(cachedProjectViews: number) {
+    return new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews,
+      assistantBackendForProject,
+      isTerminalLive,
+      mcpViewActivity: (workspaceId: string, webContentsId: number) => ({
+        liveBinding: boundWorkspaces.has(workspaceId),
+        dispatchLease: leasedWebContentsIds.has(webContentsId),
+      }),
+    });
+  }
+
+  /** Three views: proj-a and proj-b cached (oldest-first), proj-c active. */
+  async function seedThreeViews(mgr: ProjectViewManager) {
+    const wcA = createMockWebContents();
+    mgr.registerInitialView({ webContents: wcA, setBounds: vi.fn() } as never, "proj-a", "/path/a");
+    await mgr.switchTo("proj-b", "/path/b");
+    await flushImmediates();
+    await mgr.switchTo("proj-c", "/path/c");
+    await flushImmediates();
+  }
+
+  const webContentsIdFor = (mgr: ProjectViewManager, projectId: string): number =>
+    mgr.getAllViews().find((v) => v.projectId === projectId)!.view.webContents.id;
+
+  const tickPressureCheck = (mgr: ProjectViewManager) =>
+    (mgr as unknown as { maybeEvictUnderPressure(): void }).maybeEvictUnderPressure();
+
+  beforeEach(() => {
+    nextWebContentsId = 100;
+    nextOsProcessId = 1000;
+    vi.clearAllMocks();
+    mockGetAllTerminals.mockReset();
+    mockGetAllTerminals.mockResolvedValue([]);
+    mockGetAppMetrics.mockReset();
+    mockGetAppMetrics.mockReturnValue([]);
+    assistantBackends.clear();
+    liveTerminals.clear();
+    boundWorkspaces = new Set();
+    leasedWebContentsIds = new Set();
+    win = createMockWindow();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "getSystemMemoryInfo", {
+      configurable: true,
+      value: originalSystemMemoryInfo,
+    });
+  });
+
+  describe("in-flight dispatch leases", () => {
+    it("evicts a newer view rather than the LRU one that is answering a dispatch", async () => {
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      leasedWebContentsIds.add(webContentsIdFor(mgr, "proj-a"));
+
+      mgr.setCachedViewLimit(2);
+
+      // Destroying proj-a would strand the in-flight call and leave every later
+      // one on that session failing SESSION_BINDING_GONE.
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-a", "proj-c"]);
+      expect(evictedProjectIds()).toEqual(["proj-b"]);
+    });
+
+    it("survives the forced tier-2 reclaim, which collapses everything else", async () => {
+      // The lease is an absolute exclusion, safe only because it self-expires
+      // with the request that owns it.
+      const mgr = makeManager(3);
+      mgr.setMemoryPressurePolicy(BAND);
+      setAvailableMb(2500);
+      await seedThreeViews(mgr);
+      leasedWebContentsIds.add(webContentsIdFor(mgr, "proj-a"));
+
+      mgr.reclaimCachedViewsUnderPressure();
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-a", "proj-c"]);
+    });
+
+    it("becomes an ordinary candidate again the moment the dispatch settles", async () => {
+      const mgr = makeManager(3);
+      mgr.setMemoryPressurePolicy(BAND);
+      setAvailableMb(2500);
+      await seedThreeViews(mgr);
+      const wcIdA = webContentsIdFor(mgr, "proj-a");
+      leasedWebContentsIds.add(wcIdA);
+
+      mgr.reclaimCachedViewsUnderPressure();
+      expect(mgr.getAllViews().map((v) => v.projectId)).toContain("proj-a");
+
+      // Bounded, not permanent: this is the difference from the assistant floor.
+      leasedWebContentsIds.delete(wcIdA);
+      mgr.reclaimCachedViewsUnderPressure();
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+
+    it("counts a lease as a transient exclusion, not as part of the assistant floor", async () => {
+      // The over-cap log exists so extra resident renderers are attributable
+      // rather than reading as a leak. A lease resolves on its own, like the
+      // paint-gate and cold-switch bridges, so it must not inflate the
+      // persistent `protectedCount` a pinned assistant reports.
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      const wcA = mgr.getAllViews().find((v) => v.projectId === "proj-a")!.view.webContents;
+      assistantBackends.set("proj-a", { terminalId: "t-help-a", webContentsId: wcA.id });
+      liveTerminals.add("t-help-a");
+      leasedWebContentsIds.add(webContentsIdFor(mgr, "proj-b"));
+
+      mgr.setCachedViewLimit(1);
+
+      expect(mgr.getAllViews().length).toBe(3);
+      const skipped = skippedLog();
+      expect(skipped?.protectedCount).toBe(1);
+      expect(skipped?.protectedProjectIds).toEqual(["proj-a"]);
+      expect(skipped?.transientlyExcludedCount).toBe(1);
+    });
+
+    it("leases only the exact view, not every view of the workspace's project id", async () => {
+      // Keyed by WebContents id because that is what a pending request awaits;
+      // a replacement view after a cold start gets a new id and no stale
+      // protection.
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      leasedWebContentsIds.add(webContentsIdFor(mgr, "proj-a") + 9999);
+
+      mgr.setCachedViewLimit(1);
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+  });
+
+  describe("quiet bound sessions", () => {
+    it("evicts an active-agent view before a quiet bound one", async () => {
+      // An agent view is cheap to lose — its PTY lives in the pty-host and
+      // reconnects on switch-back. A bound view's destruction breaks the
+      // session's route with no recovery path, so it goes last.
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      boundWorkspaces.add("proj-a");
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-b", projectId: "proj-b", agentState: "working" },
+      ]);
+      await mgr.initAgentStateCache(mockPtyClient as never);
+
+      mgr.setCachedViewLimit(2);
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-a", "proj-c"]);
+      expect(evictedProjectIds()).toEqual(["proj-b"]);
+    });
+
+    it("evicts an ordinary idle view before a quiet bound one", async () => {
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      // proj-a is the LRU view, so pure LRU would take it first.
+      boundWorkspaces.add("proj-a");
+
+      mgr.setCachedViewLimit(2);
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-a", "proj-c"]);
+    });
+
+    it("still evicts a quiet bound view once nothing safer is left", async () => {
+      // The issue is explicit that this must NOT become a hard floor: enough
+      // concurrent bound sessions would otherwise defeat the pressure policy.
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      boundWorkspaces.add("proj-a");
+      boundWorkspaces.add("proj-b");
+
+      mgr.setCachedViewLimit(1);
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+      expect(evictedProjectIds()).toEqual(["proj-a", "proj-b"]);
+    });
+
+    it("yields to the forced tier-2 reclaim", async () => {
+      const mgr = makeManager(3);
+      mgr.setMemoryPressurePolicy(BAND);
+      setAvailableMb(2500);
+      await seedThreeViews(mgr);
+      boundWorkspaces.add("proj-a");
+      boundWorkspaces.add("proj-b");
+
+      mgr.reclaimCachedViewsUnderPressure();
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+
+    it("yields one at a time under graduated pressure, bound views last", async () => {
+      const mgr = makeManager(3);
+      mgr.setMemoryPressurePolicy(BAND);
+      setAvailableMb(2500);
+      await seedThreeViews(mgr);
+      boundWorkspaces.add("proj-a");
+
+      setAvailableMb(1200);
+      tickPressureCheck(mgr);
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-a", "proj-c"]);
+
+      tickPressureCheck(mgr);
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+
+    it("records the binding on the eviction log line so a broken session is traceable", async () => {
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      boundWorkspaces.add("proj-a");
+      boundWorkspaces.add("proj-b");
+
+      mgr.setCachedViewLimit(1);
+
+      expect(evictionLogFor("proj-a")?.boundMcpSession).toBe(true);
+    });
+
+    it("leaves the assistant floor above it — a bound view goes first", async () => {
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      const wcA = mgr.getAllViews().find((v) => v.projectId === "proj-a")!.view.webContents;
+      assistantBackends.set("proj-a", { terminalId: "t-help-a", webContentsId: wcA.id });
+      liveTerminals.add("t-help-a");
+      boundWorkspaces.add("proj-b");
+
+      mgr.setCachedViewLimit(1);
+
+      // proj-a holds a live assistant (unconditional floor) so the bound-but-quiet
+      // proj-b is what the pass can actually take.
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-a", "proj-c"]);
+      expect(evictedProjectIds()).toEqual(["proj-b"]);
+    });
+
+    it("never protects the workspace the user is actively looking at from being active", async () => {
+      // The active view is excluded before any tiering, bound or not — a
+      // binding must not change which view is on screen.
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      boundWorkspaces.add("proj-c");
+
+      mgr.setCachedViewLimit(1);
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+  });
+
+  it("behaves exactly as before when no mcpViewActivity callback is wired", async () => {
+    const mgr = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 3,
+      assistantBackendForProject,
+      isTerminalLive,
+    });
+    await seedThreeViews(mgr);
+
+    mgr.setCachedViewLimit(1);
+
+    expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+  });
+});

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -3358,8 +3358,13 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       .mock.calls.filter(([event]) => event === "projectview.eviction-skipped")
       .pop()?.[1] as Record<string, unknown> | undefined;
 
+  /** Every manager built here, so the randomized sampler each one starts is torn down. */
+  let managers: ProjectViewManager[];
+  /** Workspaces the injected activity callback throws for, exercising the unknown path. */
+  let activityThrowsFor: Set<string>;
+
   function makeManager(cachedProjectViews: number) {
-    return new ProjectViewManager(win as never, {
+    const mgr = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
       paintGateHardTimeoutMs: 0,
@@ -3368,11 +3373,16 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       cachedProjectViews,
       assistantBackendForProject,
       isTerminalLive,
-      mcpViewActivity: (workspaceId: string, webContentsId: number) => ({
-        liveBinding: boundWorkspaces.has(workspaceId),
-        dispatchLease: leasedWebContentsIds.has(webContentsId),
-      }),
+      mcpViewActivity: (workspaceId: string, webContentsId: number) => {
+        if (activityThrowsFor.has(workspaceId)) throw new Error("MCP service mid-teardown");
+        return {
+          liveBinding: boundWorkspaces.has(workspaceId),
+          dispatchLease: leasedWebContentsIds.has(webContentsId),
+        };
+      },
     });
+    managers.push(mgr);
+    return mgr;
   }
 
   /** Three views: proj-a and proj-b cached (oldest-first), proj-c active. */
@@ -3403,10 +3413,17 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
     liveTerminals.clear();
     boundWorkspaces = new Set();
     leasedWebContentsIds = new Set();
+    activityThrowsFor = new Set();
+    managers = [];
     win = createMockWindow();
   });
 
   afterEach(() => {
+    // Each manager starts a randomly-phased memory sampler. Left running, a
+    // previous test's tick can fire mid-test, write into the shared logInfo
+    // mock, and read the sets after they have been rebound for another case.
+    for (const mgr of managers) mgr.dispose();
+    managers = [];
     Object.defineProperty(process, "getSystemMemoryInfo", {
       configurable: true,
       value: originalSystemMemoryInfo,
@@ -3457,6 +3474,23 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       mgr.reclaimCachedViewsUnderPressure();
 
       expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+
+    it("reports a lease-only over-cap cache, which nothing else would explain", async () => {
+      // A lease is self-expiring per request, but a session dispatching
+      // continuously renews one, so this stall can persist. Without the log it
+      // reads as a leak in the memory logs.
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      leasedWebContentsIds.add(webContentsIdFor(mgr, "proj-a"));
+      leasedWebContentsIds.add(webContentsIdFor(mgr, "proj-b"));
+
+      mgr.setCachedViewLimit(1);
+
+      expect(mgr.getAllViews().length).toBe(3);
+      const skipped = skippedLog();
+      expect(skipped?.protectedCount).toBe(0);
+      expect(skipped?.transientlyExcludedCount).toBe(2);
     });
 
     it("counts a lease as a transient exclusion, not as part of the assistant floor", async () => {
@@ -3603,6 +3637,42 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       mgr.setCachedViewLimit(1);
 
       expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+  });
+
+  describe("an activity callback that throws", () => {
+    it("never becomes an absolute exclusion — a broken callback must not pin the cache", async () => {
+      // The dangerous direction: if unknown granted the lease exclusion, one
+      // failing callback would make every cached view unreclaimable straight
+      // through critical pressure and turn a wiring bug into an OOM.
+      const mgr = makeManager(3);
+      mgr.setMemoryPressurePolicy(BAND);
+      setAvailableMb(2500);
+      await seedThreeViews(mgr);
+      activityThrowsFor.add("proj-a");
+      activityThrowsFor.add("proj-b");
+
+      mgr.reclaimCachedViewsUnderPressure();
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+
+    it("deprioritizes like a quiet binding rather than reading as unprotected", async () => {
+      // proj-a is LRU, so pure LRU would take it first. An agent-active proj-b
+      // is the cheaper loss, so an unknown proj-a should outlive it. Scoped to
+      // one workspace on purpose: if every view read as unknown the tiers would
+      // flatten back to plain LRU and there would be no differential to observe.
+      const mgr = makeManager(3);
+      await seedThreeViews(mgr);
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-b", projectId: "proj-b", agentState: "working" },
+      ]);
+      await mgr.initAgentStateCache(mockPtyClient as never);
+      activityThrowsFor.add("proj-a");
+
+      mgr.setCachedViewLimit(2);
+
+      expect(evictedProjectIds()).toEqual(["proj-b"]);
     });
   });
 

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -772,11 +772,29 @@ describe("ProjectViewManager — MCP session bindings stay thawed (#11790)", () 
     expect(frozeProjA()).toBe(false);
   });
 
+  it("freezes inline on deactivation when nothing is bound (positive control)", async () => {
+    // Establishes that this setup — efficiency on, still inside the batch
+    // sweep's debounce window, so only the deactivation path can freeze —
+    // really does freeze. Without it the guard test below would pass just as
+    // well if inline freezing were deleted entirely.
+    manager.setEfficiencyFreeze(true);
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(frozeProjA()).toBe(true);
+  });
+
   it("skips the inline deactivation freeze for a workspace backing a live session", async () => {
-    // The path that would freeze a bound workspace the instant the user
-    // switches away from it — inside the batch sweep's debounce window, so the
-    // sweep is not what is being tested here.
+    // Same setup as the control above, one variable changed.
     boundWorkspaces.add("proj-a");
+
+    manager.setEfficiencyFreeze(true);
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(frozeProjA()).toBe(false);
+  });
+
+  it("skips the inline deactivation freeze while a dispatch is in flight", async () => {
+    leasedWebContentsIds.add(initialWc.id);
 
     manager.setEfficiencyFreeze(true);
     await manager.switchTo("proj-b", "/path/b");
@@ -834,9 +852,11 @@ describe("ProjectViewManager — MCP session bindings stay thawed (#11790)", () 
     expect(mcpViewActivity).toHaveBeenCalledWith("proj-a", initialWc.id);
   });
 
-  it("freezes as usual when the callback throws — a broken service can't stall the sweep", async () => {
-    // The callback reaches a service behind a dynamic import. An exception
-    // escaping here would abandon the freeze pass partway through the view map.
+  it("does not freeze when the callback throws — unknown protection resolves as protected here", async () => {
+    // The callback reaches a service behind a dynamic import, so a throw means
+    // protection state is genuinely unavailable rather than false. Freezing on
+    // that would re-create the 30s stranded dispatch for the cost of one
+    // missed optimization, so this policy resolves unknown as protected.
     await manager.switchTo("proj-b", "/path/b");
     mcpViewActivity.mockImplementation(() => {
       throw new Error("MCP service mid-teardown");
@@ -845,10 +865,27 @@ describe("ProjectViewManager — MCP session bindings stay thawed (#11790)", () 
     manager.setEfficiencyFreeze(true);
     vi.advanceTimersByTime(500);
 
-    expect(frozeProjA()).toBe(true);
+    expect(frozeProjA()).toBe(false);
   });
 
-  it("freezes as usual when the callback answers null", async () => {
+  it("keeps sweeping the rest of the view map after the callback throws", async () => {
+    // An exception escaping the accessor would abandon the pass partway
+    // through, silently leaving later views unfrozen for an unrelated reason.
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+    mcpViewActivity.mockImplementation(() => {
+      throw new Error("MCP service mid-teardown");
+    });
+
+    expect(() => {
+      manager.setEfficiencyFreeze(true);
+      vi.advanceTimersByTime(500);
+    }).not.toThrow();
+  });
+
+  it("freezes as usual when the callback answers null — MCP simply isn't running", async () => {
+    // Distinct from a throw: null is a definite "no server, so no sessions",
+    // not an unavailable answer.
     await manager.switchTo("proj-b", "/path/b");
     mcpViewActivity.mockReturnValue(null);
 
@@ -856,6 +893,42 @@ describe("ProjectViewManager — MCP session bindings stay thawed (#11790)", () 
     vi.advanceTimersByTime(500);
 
     expect(frozeProjA()).toBe(true);
+  });
+
+  it("re-freezes a view thawed for a dispatch once the lease is gone", async () => {
+    // The bridge thaws on demand and nothing puts the view back: freezeAllCached
+    // runs only on the transition INTO efficiency, and re-entering while already
+    // enabled is an early no-op. Without the sampler's re-freeze pass, one
+    // dispatch leaves the view running JS for the rest of the profile.
+    await manager.switchTo("proj-b", "/path/b");
+    leasedWebContentsIds.add(initialWc.id);
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    expect(frozeProjA()).toBe(false);
+
+    leasedWebContentsIds.delete(initialWc.id);
+    manager.refreezeUnprotectedCachedViews();
+
+    expect(frozeProjA()).toBe(true);
+  });
+
+  it("leaves a still-bound view thawed when the re-freeze pass runs", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    boundWorkspaces.add("proj-a");
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    manager.refreezeUnprotectedCachedViews();
+
+    expect(frozeProjA()).toBe(false);
+  });
+
+  it("the re-freeze pass is a no-op outside the efficiency profile", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    manager.refreezeUnprotectedCachedViews();
+
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
   });
 
   it("never freezes the active view, bound or not", async () => {

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -931,6 +931,22 @@ describe("ProjectViewManager — MCP session bindings stay thawed (#11790)", () 
     expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
   });
 
+  it("the re-freeze pass defers to a pending freeze-entry debounce", async () => {
+    // The periodic sampler can tick inside the debounce window. Freezing there
+    // would defeat the trailing edge, which exists so a profile that flips back
+    // within the window freezes nothing at all — and would make every
+    // call-count assertion in this file depend on the sampler's random phase.
+    await manager.switchTo("proj-b", "/path/b");
+    manager.setEfficiencyFreeze(true);
+
+    manager.refreezeUnprotectedCachedViews();
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+
+    manager.setEfficiencyFreeze(false);
+    vi.advanceTimersByTime(500);
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+  });
+
   it("never freezes the active view, bound or not", async () => {
     boundWorkspaces.add("proj-b");
     await manager.switchTo("proj-b", "/path/b");

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 
 let nextWebContentsId = 100;
 
@@ -710,5 +710,164 @@ describe("ProjectViewManager — cached-view memory purge", () => {
     initialWc.isDestroyed.mockReturnValue(true);
     vi.advanceTimersByTime(120_000);
     expect(vi.mocked(purgeMemoryWebContents)).toHaveBeenCalledTimes(1);
+  });
+});
+
+type McpActivityFn = (
+  workspaceId: string,
+  webContentsId: number
+) => import("../ProjectViewManager.js").McpViewActivity | null;
+
+describe("ProjectViewManager — MCP session bindings stay thawed (#11790)", () => {
+  let manager: ProjectViewManager;
+  let win: ReturnType<typeof createMockWindow>;
+  let initialWc: ReturnType<typeof createMockWebContents>;
+  /** Workspaces a live MCP session is bound to, and views with a call in flight. */
+  let boundWorkspaces: Set<string>;
+  let leasedWebContentsIds: Set<number>;
+  let mcpViewActivity: Mock<McpActivityFn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    nextWebContentsId = 300;
+    boundWorkspaces = new Set();
+    leasedWebContentsIds = new Set();
+    mcpViewActivity = vi.fn<McpActivityFn>((workspaceId, webContentsId) => ({
+      liveBinding: boundWorkspaces.has(workspaceId),
+      dispatchLease: leasedWebContentsIds.has(webContentsId),
+    }));
+    win = createMockWindow();
+    manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      mcpViewActivity,
+    });
+    (manager as unknown as { waitForPaint: () => Promise<string> }).waitForPaint = () =>
+      Promise.resolve("signal");
+    initialWc = createMockWebContents();
+    manager.registerInitialView(
+      { webContents: initialWc, setBounds: vi.fn() } as never,
+      "proj-a",
+      "/path/a"
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const frozeProjA = () =>
+    vi.mocked(freezeWebContents).mock.calls.some((call) => (call[0] as unknown) === initialWc);
+
+  it("does not batch-freeze a cached view whose workspace backs a live session", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    boundWorkspaces.add("proj-a");
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(frozeProjA()).toBe(false);
+  });
+
+  it("skips the inline deactivation freeze for a workspace backing a live session", async () => {
+    // The path that would freeze a bound workspace the instant the user
+    // switches away from it — inside the batch sweep's debounce window, so the
+    // sweep is not what is being tested here.
+    boundWorkspaces.add("proj-a");
+
+    manager.setEfficiencyFreeze(true);
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(frozeProjA()).toBe(false);
+  });
+
+  it("does not freeze a view with a dispatch in flight even with no standing binding", async () => {
+    // Belt and braces: the lease alone is enough, so a call that outlives its
+    // session's liveness record still can't have its renderer suspended.
+    await manager.switchTo("proj-b", "/path/b");
+    leasedWebContentsIds.add(initialWc.id);
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(frozeProjA()).toBe(false);
+  });
+
+  it("freezes the view again once the binding is gone", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    boundWorkspaces.add("proj-a");
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    expect(frozeProjA()).toBe(false);
+
+    // Protection is only as long-lived as the session: a disconnected client
+    // must not cost the efficiency profile a view for the rest of the run.
+    boundWorkspaces.clear();
+    manager.setEfficiencyFreeze(false);
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(frozeProjA()).toBe(true);
+  });
+
+  it("still freezes an unbound cached view — protection is not blanket", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    boundWorkspaces.add("some-other-workspace");
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(frozeProjA()).toBe(true);
+  });
+
+  it("asks about the workspace id the view is keyed by", async () => {
+    // ProjectViewManager keys views by an opaque WORKSPACE id (a project's hex
+    // id or a scratch UUID), which is the same vocabulary the MCP binding
+    // stores. Asking with anything else would never match.
+    await manager.switchTo("proj-b", "/path/b");
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(mcpViewActivity).toHaveBeenCalledWith("proj-a", initialWc.id);
+  });
+
+  it("freezes as usual when the callback throws — a broken service can't stall the sweep", async () => {
+    // The callback reaches a service behind a dynamic import. An exception
+    // escaping here would abandon the freeze pass partway through the view map.
+    await manager.switchTo("proj-b", "/path/b");
+    mcpViewActivity.mockImplementation(() => {
+      throw new Error("MCP service mid-teardown");
+    });
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(frozeProjA()).toBe(true);
+  });
+
+  it("freezes as usual when the callback answers null", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    mcpViewActivity.mockReturnValue(null);
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(frozeProjA()).toBe(true);
+  });
+
+  it("never freezes the active view, bound or not", async () => {
+    boundWorkspaces.add("proj-b");
+    await manager.switchTo("proj-b", "/path/b");
+    const activeWc = manager.getActiveView()!.webContents;
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(vi.mocked(freezeWebContents).mock.calls.every((call) => call[0] !== activeWc)).toBe(
+      true
+    );
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -947,6 +947,33 @@ describe("ProjectViewManager — MCP session bindings stay thawed (#11790)", () 
     expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
   });
 
+  it("never freezes the outgoing bridge view when a sampler tick lands mid-switch", async () => {
+    // The re-freeze pass runs on the periodic sampler, so it can tick inside a
+    // switch. `activeProjectId` already names the incoming project by then,
+    // while the outgoing view is still attached as the anti-flash bridge —
+    // freezing it suspends the renderer painting the visible frame.
+    await manager.switchTo("proj-b", "/path/b");
+    const bridgeWc = manager.getActiveView()!.webContents;
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    vi.mocked(freezeWebContents).mockClear();
+
+    const switchPromise = manager.switchTo("proj-c", "/path/c");
+    await Promise.resolve();
+    expect(manager.getOutgoingBridgeProjectId()).toBe("proj-b");
+
+    manager.refreezeUnprotectedCachedViews();
+
+    expect(vi.mocked(freezeWebContents).mock.calls.some((call) => call[0] === bridgeWc)).toBe(
+      false
+    );
+    // The pass still swept the genuinely cached view — the guard is targeted,
+    // not a blanket bail-out on any switch being in flight.
+    expect(frozeProjA()).toBe(true);
+
+    await switchPromise;
+  });
+
   it("never freezes the active view, bound or not", async () => {
     boundWorkspaces.add("proj-b");
     await manager.switchTo("proj-b", "/path/b");

--- a/electron/window/serviceRefs.ts
+++ b/electron/window/serviceRefs.ts
@@ -17,6 +17,7 @@ import type { CcrConfigService } from "../services/CcrConfigService.js";
 import type { autoUpdaterService as AutoUpdaterServiceType } from "../services/AutoUpdaterService.js";
 import type { agentNotificationService as AgentNotificationServiceType } from "../services/AgentNotificationService.js";
 import type { windowsStoreNotifierService as WindowsStoreNotifierServiceType } from "../services/WindowsStoreNotifierService.js";
+import type { mcpServerService as McpServerServiceType } from "../services/McpServerService.js";
 
 // Guard: process.argv CLI path should only be consumed by the first window
 let processArgvCliHandled = false;
@@ -57,6 +58,14 @@ let ccrConfigService: CcrConfigService | null = null;
 let autoUpdaterServiceRef: typeof AutoUpdaterServiceType | null = null;
 let agentNotificationServiceRef: typeof AgentNotificationServiceType | null = null;
 let windowsStoreNotifierServiceRef: typeof WindowsStoreNotifierServiceType | null = null;
+// Published by McpServerService at module scope, so it lands on whichever load
+// path reaches that module first (#11790). Read by main.ts to hand each
+// ProjectViewManager its `mcpViewActivity` callback: the MCP graph is behind a
+// dynamic import to stay off eager boot, and electron/window/ must not drag it
+// back on by importing the service directly. Null until something loads it,
+// which reads as "no view is protected" — the correct answer when there is no
+// server and therefore no session.
+let mcpServerServiceRef: typeof McpServerServiceType | null = null;
 
 // ── Public getters/setters (consumed by main.ts, menu.ts, shutdown.ts) ──
 export function getPtyClient(): PtyClient | null {
@@ -186,6 +195,12 @@ export function getCcrConfigService(): CcrConfigService | null {
 }
 export function setCcrConfigService(v: CcrConfigService | null): void {
   ccrConfigService = v;
+}
+export function getMcpServerServiceRef(): typeof McpServerServiceType | null {
+  return mcpServerServiceRef;
+}
+export function setMcpServerServiceRef(v: typeof McpServerServiceType | null): void {
+  mcpServerServiceRef = v;
 }
 export function getAutoUpdaterServiceRef(): typeof AutoUpdaterServiceType | null {
   return autoUpdaterServiceRef;


### PR DESCRIPTION
Issue #11790 has two halves, and they need different answers.

## Frozen views

Under the efficiency resource profile, cached background project views get CDP-frozen. A frozen renderer can't run JS, so a dispatched MCP tool call just queues in Mojo and nothing ever answers it. The caller waits out main's 30 second bridge deadline and gets a generic `EXECUTION_ERROR`. Chromium never auto-resumes a frozen renderer on focus, so nothing rescues it.

The fix: routed bridge operations (workspace-bound and pinned) now await an explicit thaw before the IPC call, and a workspace backing a live session is skipped by both freeze paths, the batch sweep and the deactivation-time freeze. CPU throttling is deliberately left in place. It slows JS down without suspending it.

## Evicted views

Memory-pressure eviction only hard-protected views with a live assistant backend, so a bound workspace's view could be destroyed mid-session, and every call after that failed with `SESSION_BINDING_GONE`. The issue is explicit that a hard floor is the wrong answer here: nothing dies with the renderer the way an assistant's PTY process tree does.

So this is a bounded lease instead: a refcount held for the life of each in-flight routed request, released on the response, the deadline, the view's own destruction, and a synchronous send throw alike. A leased view is excluded from eviction outright. A bound-but-quiet view is only deprioritized to the last candidate tier, so pressure can still reclaim it.

## Other details worth knowing

- The thaw is one-way on its own, so the periodic cached-view sampler now re-freezes views once their protection lapses. Otherwise one dispatch would leave a view running JS for the rest of the efficiency profile.
- An activity callback that throws is treated as unknown rather than unprotected, and the two policies resolve that in opposite directions: freezing treats unknown as protected (it's cheap), eviction only deprioritizes it (a broken callback must never pin the cache through critical pressure).
- A routed target destroyed mid-flight is now classified as `SESSION_BINDING_GONE` instead of a generic retriable error, matching what the resolver already reports when the target is gone before the send. Bridge timeout messages now name the unreachable target.

## Testing

652 tests passed across the branch's own suites and every module it touches. Electron typecheck is clean. Prettier and eslint are clean on all changed files, with two pre-existing no-explicit-any warnings on untouched lines remaining.

No E2E was run locally. The existing LRU eviction spec has no MCP session to bind, so it exercises none of this.

Resolves #11790
