### PR TITLE
fix(ipc): stop agent.listAvailable hanging on an un-serializable registry payload

### DIFF
--- a/electron/ipc/handlers/__tests__/agentCapabilities.serialization.test.ts
+++ b/electron/ipc/handlers/__tests__/agentCapabilities.serialization.test.ts
@@ -34,17 +34,38 @@ function callOp(name: OpName, ...args: unknown[]): Promise<unknown> {
 /**
  * Derived from the live registry rather than hardcoded, so renaming or dropping
  * a built-in agent can't leave this suite probing an id that no longer exists.
+ * Throws at construction so a missing fixture fails once, loudly, instead of
+ * surfacing as a confusing assertion failure in every case below.
  */
-const sampleAgentId = Object.keys(getEffectiveRegistry())[0];
+const sampleAgentId = (() => {
+  const [first] = Object.keys(getEffectiveRegistry());
+  if (!first) throw new Error("effective registry is empty — no agent id to probe with");
+  return first;
+})();
+
+/** Own-property function values are what the IPC serializer chokes on. */
+function hasFunctionValue(value: unknown): boolean {
+  if (typeof value === "function") return true;
+  if (typeof value !== "object" || value === null) return false;
+  return Object.values(value).some(hasFunctionValue);
+}
 
 describe("agentCapabilities getRegistry serialization (issue #11795)", () => {
+  it("still holds live functions in the raw registry the projection guards against", () => {
+    // Names the actual hazard rather than only its symptom. If configs ever
+    // become pure data this fails with "the historical cause is gone", not with
+    // a vague clone error — and the projection stays justified on its own terms
+    // (a narrow wire contract), so the right response is to update this test,
+    // never to widen the handler back to raw configs.
+    const raw = getEffectiveRegistry();
+
+    expect(Object.values(raw).some(hasFunctionValue)).toBe(true);
+  });
+
   it("cannot put the raw effective registry on the wire", () => {
-    // The premise of the fix. Every `AgentResume` variant holds a live function
-    // (`args`, `argsForTarget`, `assignSessionIdArgs`), and structuredClone is
-    // the same algorithm Electron's IPC serializer uses — so returning the raw
-    // registry could never reach the renderer. If this ever stops throwing the
-    // projection below has become dead weight and should be revisited, not
-    // silently kept. The message is runtime-specific, so it isn't asserted.
+    // structuredClone is the same algorithm Electron's IPC serializer uses, so
+    // this is the fix's premise: returning the raw registry could never reach
+    // the renderer. The thrown message is runtime-specific and isn't asserted.
     expect(() => structuredClone(getEffectiveRegistry())).toThrow();
   });
 
@@ -69,16 +90,18 @@ describe("agentCapabilities getRegistry serialization (issue #11795)", () => {
     const projected = (await callOp("getRegistry")) as Record<string, object>;
 
     for (const [agentId, entry] of Object.entries(projected)) {
-      // Locking the wire shape is the point: a generic deep function-stripper
-      // would clone cleanly while quietly promoting every other config field
-      // onto the wire. Widening this is a deliberate edit, never a side effect.
-      expect(Object.keys(entry)).toEqual(["name"]);
+      // A generic deep function-stripper would clone cleanly while quietly
+      // promoting every other config field onto the wire. One field, strictly
+      // fewer than the config has — paired with the name check above, that
+      // pins the payload to exactly the field the consumer reads, without
+      // restating the projection's own key list.
+      expect(Object.keys(entry)).toHaveLength(1);
       expect(Object.keys(entry).length).toBeLessThan(Object.keys(raw[agentId]!).length);
     }
   });
 });
 
-describe("agentCapabilities namespace wire safety", () => {
+describe("agentCapabilities representative happy-path wire safety", () => {
   // Exhaustive by construction: `satisfies` fails to compile when an op is
   // added without deciding what arguments exercise it, so a new op can't slip
   // onto the wire unchecked the way getRegistry did.
@@ -90,10 +113,6 @@ describe("agentCapabilities namespace wire safety", () => {
     getCcrPresets: [],
     getResolvedModelList: [sampleAgentId],
   } satisfies Record<OpName, unknown[]>;
-
-  it("has a sample agent id to probe with", () => {
-    expect(sampleAgentId).toBeTruthy();
-  });
 
   it.each(Object.keys(opArgs) as OpName[])(
     "%s resolves to a structured-cloneable value",

--- a/electron/ipc/handlers/__tests__/agentCapabilities.serialization.test.ts
+++ b/electron/ipc/handlers/__tests__/agentCapabilities.serialization.test.ts
@@ -43,11 +43,17 @@ const sampleAgentId = (() => {
   return first;
 })();
 
-/** Own-property function values are what the IPC serializer chokes on. */
-function hasFunctionValue(value: unknown): boolean {
+/**
+ * Own-property function values are what the IPC serializer chokes on. Tracks
+ * visited objects so a cyclic config fails the assertion below rather than
+ * overflowing the stack with an unrelated error.
+ */
+function hasFunctionValue(value: unknown, seen = new WeakSet<object>()): boolean {
   if (typeof value === "function") return true;
   if (typeof value !== "object" || value === null) return false;
-  return Object.values(value).some(hasFunctionValue);
+  if (seen.has(value)) return false;
+  seen.add(value);
+  return Object.values(value).some((nested) => hasFunctionValue(nested, seen));
 }
 
 describe("agentCapabilities getRegistry serialization (issue #11795)", () => {
@@ -59,7 +65,7 @@ describe("agentCapabilities getRegistry serialization (issue #11795)", () => {
     // never to widen the handler back to raw configs.
     const raw = getEffectiveRegistry();
 
-    expect(Object.values(raw).some(hasFunctionValue)).toBe(true);
+    expect(Object.values(raw).some((config) => hasFunctionValue(config))).toBe(true);
   });
 
   it("cannot put the raw effective registry on the wire", () => {

--- a/electron/ipc/handlers/__tests__/agentCapabilities.serialization.test.ts
+++ b/electron/ipc/handlers/__tests__/agentCapabilities.serialization.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+const storeMock = vi.hoisted(() => ({
+  get: vi.fn(() => ({ agents: {} })),
+}));
+
+const ccrConfigServiceMock = vi.hoisted(() => ({
+  loadAndApply: vi.fn(() => []),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn(), getAllWindows: vi.fn(() => []) },
+}));
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+vi.mock("../../../services/CcrConfigService.js", () => ({
+  CcrConfigService: { getInstance: () => ccrConfigServiceMock },
+}));
+
+import { agentCapabilitiesNamespace } from "../agentCapabilities.js";
+import { getEffectiveRegistry } from "../../../../shared/config/agentRegistry.js";
+
+type OpName = keyof typeof agentCapabilitiesNamespace.ops;
+
+function callOp(name: OpName, ...args: unknown[]): Promise<unknown> {
+  const handler = agentCapabilitiesNamespace.ops[name].handler as (
+    ...a: unknown[]
+  ) => Promise<unknown>;
+  return handler(...args);
+}
+
+/**
+ * Derived from the live registry rather than hardcoded, so renaming or dropping
+ * a built-in agent can't leave this suite probing an id that no longer exists.
+ */
+const sampleAgentId = Object.keys(getEffectiveRegistry())[0];
+
+describe("agentCapabilities getRegistry serialization (issue #11795)", () => {
+  it("cannot put the raw effective registry on the wire", () => {
+    // The premise of the fix. Every `AgentResume` variant holds a live function
+    // (`args`, `argsForTarget`, `assignSessionIdArgs`), and structuredClone is
+    // the same algorithm Electron's IPC serializer uses — so returning the raw
+    // registry could never reach the renderer. If this ever stops throwing the
+    // projection below has become dead weight and should be revisited, not
+    // silently kept. The message is runtime-specific, so it isn't asserted.
+    expect(() => structuredClone(getEffectiveRegistry())).toThrow();
+  });
+
+  it("returns a payload the IPC serializer can carry", async () => {
+    const projected = await callOp("getRegistry");
+
+    expect(() => structuredClone(projected)).not.toThrow();
+  });
+
+  it("preserves every agent id and display name", async () => {
+    const raw = getEffectiveRegistry();
+    const projected = (await callOp("getRegistry")) as Record<string, { name: string }>;
+
+    expect(Object.keys(projected)).toEqual(Object.keys(raw));
+    for (const [agentId, entry] of Object.entries(projected)) {
+      expect(entry.name).toBe(raw[agentId]!.name);
+    }
+  });
+
+  it("stays a reduction rather than a passthrough", async () => {
+    const raw = getEffectiveRegistry();
+    const projected = (await callOp("getRegistry")) as Record<string, object>;
+
+    for (const [agentId, entry] of Object.entries(projected)) {
+      // Locking the wire shape is the point: a generic deep function-stripper
+      // would clone cleanly while quietly promoting every other config field
+      // onto the wire. Widening this is a deliberate edit, never a side effect.
+      expect(Object.keys(entry)).toEqual(["name"]);
+      expect(Object.keys(entry).length).toBeLessThan(Object.keys(raw[agentId]!).length);
+    }
+  });
+});
+
+describe("agentCapabilities namespace wire safety", () => {
+  // Exhaustive by construction: `satisfies` fails to compile when an op is
+  // added without deciding what arguments exercise it, so a new op can't slip
+  // onto the wire unchecked the way getRegistry did.
+  const opArgs = {
+    getRegistry: [],
+    getAgentIds: [],
+    getAgentMetadata: [sampleAgentId],
+    isAgentEnabled: [sampleAgentId],
+    getCcrPresets: [],
+    getResolvedModelList: [sampleAgentId],
+  } satisfies Record<OpName, unknown[]>;
+
+  it("has a sample agent id to probe with", () => {
+    expect(sampleAgentId).toBeTruthy();
+  });
+
+  it.each(Object.keys(opArgs) as OpName[])(
+    "%s resolves to a structured-cloneable value",
+    async (name) => {
+      const value = await callOp(name, ...opArgs[name]);
+
+      expect(() => structuredClone(value)).not.toThrow();
+    }
+  );
+});

--- a/electron/ipc/handlers/agentCapabilities.ts
+++ b/electron/ipc/handlers/agentCapabilities.ts
@@ -11,6 +11,7 @@ import {
 import type {
   AgentMetadata,
   AgentRegistry,
+  AgentRegistryEntry,
   ResolvedModelCatalog,
 } from "../../../shared/types/ipc/agentCapabilities.js";
 import type { AgentPreset } from "../../../shared/config/agentRegistry.js";
@@ -40,13 +41,34 @@ function toAgentMetadata(config: AgentConfig, agentId: string): AgentMetadata {
   };
 }
 
+/**
+ * Reduce a config to the fields `getRegistry` puts on the wire.
+ *
+ * The raw `AgentConfig` is not structured-cloneable — every `AgentResume`
+ * variant holds a live function — so returning the effective registry whole
+ * stalled the renderer instead of resolving (#11795). Explicit by design: a
+ * generic function-stripper would keep working while silently promoting each
+ * new config field onto the wire.
+ */
+function toAgentRegistryEntry(config: AgentConfig): AgentRegistryEntry {
+  return { name: config.name };
+}
+
 export const agentCapabilitiesNamespace = defineIpcNamespace({
   name: "agentCapabilities",
   ops: {
     getRegistry: op(
       AGENT_CAPABILITIES_METHOD_CHANNELS.getRegistry,
       async (): Promise<AgentRegistry> => {
-        return getEffectiveRegistry();
+        // `fromEntries` rather than index assignment: it defines own properties,
+        // so a plugin-contributed `__proto__` id lands as a key instead of
+        // reassigning the result's prototype.
+        return Object.fromEntries(
+          Object.entries(getEffectiveRegistry()).map(([agentId, config]) => [
+            agentId,
+            toAgentRegistryEntry(config),
+          ])
+        );
       }
     ),
     getAgentIds: op(AGENT_CAPABILITIES_METHOD_CHANNELS.getAgentIds, async (): Promise<string[]> => {

--- a/shared/types/ipc/agentCapabilities.ts
+++ b/shared/types/ipc/agentCapabilities.ts
@@ -1,6 +1,21 @@
-import type { AgentConfig, AgentModelConfig } from "../../config/agentRegistry.js";
+import type { AgentModelConfig } from "../../config/agentRegistry.js";
 
-export type AgentRegistry = Record<string, AgentConfig>;
+/**
+ * One registry entry as it crosses IPC. Deliberately NOT `AgentConfig`: every
+ * `AgentResume` variant carries a live function (`args`, `argsForTarget`,
+ * `assignSessionIdArgs`), and the structured-clone serializer behind
+ * `ipcRenderer.invoke` cannot encode a function — returning raw configs left
+ * the caller's promise unsettled rather than rejecting, so `agent.listAvailable`
+ * burned the full 30s MCP dispatch timeout on every call (#11795).
+ *
+ * Only widen this with plain data, and only for a field a caller actually
+ * reads: it is the wire contract, not a view of the config.
+ */
+export interface AgentRegistryEntry {
+  name: string;
+}
+
+export type AgentRegistry = Record<string, AgentRegistryEntry>;
 
 export interface AgentMetadata {
   id: string;

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -1270,6 +1270,36 @@ describe("agent.listAvailable", () => {
     expect(second.agents.map((row) => row.id)).toEqual(["claude"]);
     expect(clientsMock.agentCapabilitiesClient.getRegistry).toHaveBeenCalledTimes(2);
   });
+
+  it("settles instead of hanging when a discovery read never resolves (#11795)", async () => {
+    setStores({ agents: {} }, { claude: "ready" });
+    clientsMock.agentCapabilitiesClient.getRegistry.mockResolvedValue({
+      claude: { name: "Claude" },
+    });
+    clientsMock.userAgentRegistryClient.get.mockResolvedValue({});
+    const actions = setupActions(makeCallbacks());
+    // Warm `readAgentDiscoveryState`'s dynamic store imports under real timers;
+    // resolving a dynamic import while fake timers are installed can stall the
+    // module runner, which would make this test hang for the wrong reason.
+    await callAction(actions, "agent.listAvailable");
+
+    // Exactly the shape that shipped broken: an IPC leg that never settles
+    // rather than rejecting. Main abandons the dispatch at 30s without
+    // cancelling the renderer, so before the deadline this promise stayed
+    // pending indefinitely and held its focus-suppression lease with it.
+    clientsMock.agentCapabilitiesClient.getRegistry.mockReturnValueOnce(new Promise(() => {}));
+    vi.useFakeTimers();
+    try {
+      const pending = callAction(actions, "agent.listAvailable");
+      // Assert before advancing: attaching the handler afterwards races the
+      // rejection and trips vitest's unhandled-rejection guard.
+      const rejects = expect(pending).rejects.toThrow(/still waiting on: agentRegistry/);
+      await vi.advanceTimersToNextTimerAsync();
+      await rejects;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("agentSessionHistory.list (#10854)", () => {

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -1271,34 +1271,93 @@ describe("agent.listAvailable", () => {
     expect(clientsMock.agentCapabilitiesClient.getRegistry).toHaveBeenCalledTimes(2);
   });
 
-  it("settles instead of hanging when a discovery read never resolves (#11795)", async () => {
-    setStores({ agents: {} }, { claude: "ready" });
-    clientsMock.agentCapabilitiesClient.getRegistry.mockResolvedValue({
-      claude: { name: "Claude" },
-    });
-    clientsMock.userAgentRegistryClient.get.mockResolvedValue({});
-    const actions = setupActions(makeCallbacks());
-    // Warm `readAgentDiscoveryState`'s dynamic store imports under real timers;
-    // resolving a dynamic import while fake timers are installed can stall the
-    // module runner, which would make this test hang for the wrong reason.
-    await callAction(actions, "agent.listAvailable");
-
-    // Exactly the shape that shipped broken: an IPC leg that never settles
-    // rather than rejecting. Main abandons the dispatch at 30s without
-    // cancelling the renderer, so before the deadline this promise stayed
-    // pending indefinitely and held its focus-suppression lease with it.
-    clientsMock.agentCapabilitiesClient.getRegistry.mockReturnValueOnce(new Promise(() => {}));
-    vi.useFakeTimers();
-    try {
-      const pending = callAction(actions, "agent.listAvailable");
-      // Assert before advancing: attaching the handler afterwards races the
-      // rejection and trips vitest's unhandled-rejection guard.
-      const rejects = expect(pending).rejects.toThrow(/still waiting on: agentRegistry/);
-      await vi.advanceTimersToNextTimerAsync();
-      await rejects;
-    } finally {
+  describe("discovery-read deadline (#11795)", () => {
+    // Belt and braces with the per-test `finally`: if the deadline regresses,
+    // `advanceTimersToNextTimerAsync` no-ops, the awaited assertion never
+    // settles, and vitest kills the test externally — which unwinds nothing, so
+    // the local `finally` never runs and fake timers would leak into the rest
+    // of the file.
+    afterEach(() => {
       vi.useRealTimers();
+      clientsMock.agentCapabilitiesClient.getRegistry.mockReset();
+    });
+
+    /**
+     * Prime the dynamic `import()`s inside `readAgentDiscoveryState` under real
+     * timers. They are mocked, but vitest registers mocks lazily and the first
+     * import still traverses the module runner, which can stall under fake
+     * timers — the hazard `fakeTimersImportOrder.contract.test.ts` exists for.
+     * Importing the modules directly rather than running the whole action keeps
+     * the warm-up from arming a real 25s timer.
+     */
+    async function primeDiscoveryImports(): Promise<void> {
+      await Promise.all([
+        import("@/store/agentSettingsStore"),
+        import("@/store/cliAvailabilityStore"),
+      ]);
     }
+
+    it("settles instead of hanging when a discovery read never resolves", async () => {
+      await primeDiscoveryImports();
+      setStores({ agents: {} }, { claude: "ready" });
+      clientsMock.userAgentRegistryClient.get.mockResolvedValue({});
+      // Exactly the shape that shipped broken: an IPC leg that never settles
+      // rather than rejecting. Main abandons the dispatch at 30s without
+      // cancelling the renderer, so this promise stayed pending indefinitely
+      // and held its focus-suppression lease with it.
+      clientsMock.agentCapabilitiesClient.getRegistry.mockReturnValue(new Promise(() => {}));
+      const actions = setupActions(makeCallbacks());
+
+      vi.useFakeTimers();
+      try {
+        const startedAt = Date.now();
+        const pending = callAction(actions, "agent.listAvailable");
+        // Assert before advancing: attaching the handler afterwards races the
+        // rejection and trips vitest's unhandled-rejection guard.
+        const rejects = expect(pending).rejects.toThrow(/still waiting on: agentRegistry$/);
+        // The deadline must be the only timer in flight, so advancing to "next"
+        // provably lands on it rather than on something scheduled nearby.
+        expect(vi.getTimerCount()).toBe(1);
+
+        await vi.advanceTimersToNextTimerAsync();
+        await rejects;
+
+        // The bound is only correct relative to two constants in other files;
+        // pinning the elapsed window catches drift in either direction that a
+        // bare "it rejected" assertion would sail past. Lower bound: the real
+        // cold-read ceiling, refreshPath's 10s (electron/setup/environment.ts
+        // REFRESH_TIMEOUT_MS) plus CliAvailabilityService's 10s CHECK_TIMEOUT_MS,
+        // below which a slow cold start fails spuriously. Upper bound:
+        // MCP_DISPATCH_TIMEOUT_MS (electron/services/mcp-server/shared.ts), past
+        // which main has already abandoned the dispatch and the bound is moot.
+        const elapsed = Date.now() - startedAt;
+        expect(elapsed).toBeGreaterThan(20_000);
+        expect(elapsed).toBeLessThan(30_000);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("disarms the deadline once the reads succeed", async () => {
+      await primeDiscoveryImports();
+      setStores({ agents: {} }, { claude: "ready" });
+      clientsMock.agentCapabilitiesClient.getRegistry.mockResolvedValue({
+        claude: { name: "Claude" },
+      });
+      clientsMock.userAgentRegistryClient.get.mockResolvedValue({});
+      const actions = setupActions(makeCallbacks());
+
+      vi.useFakeTimers();
+      try {
+        await callAction(actions, "agent.listAvailable");
+
+        // A deadline that resolves the action but leaves its timer armed would
+        // keep the renderer awake for 25s after every call.
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });
 

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -160,6 +160,21 @@ function keepRepresentableRecords(records: AgentSessionRecord[]): AgentSessionRe
   return records.filter((record) => AgentFacingSessionRecordSchema.safeParse(record).success);
 }
 
+/**
+ * Deadline for `agent.listAvailable`'s discovery reads.
+ *
+ * Main abandons an MCP dispatch after `MCP_DISPATCH_TIMEOUT_MS` (30s) without
+ * cancelling the renderer-side action, so an IPC leg that never settles used to
+ * hold its `mcpSpawnFocusGuard` lease indefinitely — long past the 45s TTL, and
+ * observed pending for over 13 hours (#11795). Settling first keeps that lease
+ * bounded and turns a stall into a diagnosable error.
+ *
+ * Sits above `CliAvailabilityService`'s own 10s probe ceiling, which
+ * `readAgentDiscoveryState` can reach before the stores hydrate, and below both
+ * the 30s dispatch timeout and the 45s lease TTL.
+ */
+const AGENT_DISCOVERY_READ_TIMEOUT_MS = 15_000;
+
 export function registerAgentActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   const readAgentDiscoveryState = async () => {
     // These are the same normalized renderer stores the toolbar reads. Fall back to
@@ -183,6 +198,47 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     // which renders from the same hydrating store.
     const availabilityLive = availabilityStore.isInitialized === true;
     return { settings, availability, availabilityLive };
+  };
+
+  /**
+   * Read the three sources `agent.listAvailable` needs, under a deadline.
+   *
+   * Each leg is tracked by name so a timeout says which one is still
+   * outstanding — the whole difficulty of #11795 was that a bare dispatch
+   * timeout gave no hint which await had stalled. The deadline only stops
+   * waiting; `ipcRenderer.invoke` takes no `AbortSignal`, so an in-flight
+   * invoke keeps running and its late settle is absorbed below.
+   */
+  const readAvailableAgentSources = async () => {
+    const pending = new Set(["agentDiscoveryState", "agentRegistry", "userAgentRegistry"]);
+    const track = <T>(leg: string, work: Promise<T>): Promise<T> =>
+      work.finally(() => pending.delete(leg));
+
+    const sources = Promise.all([
+      track("agentDiscoveryState", readAgentDiscoveryState()),
+      track("agentRegistry", agentCapabilitiesClient.getRegistry()),
+      track("userAgentRegistry", userAgentRegistryClient.get()),
+    ]);
+    // A leg that rejects after the deadline fired would otherwise surface as an
+    // unhandled rejection — by then the race has stopped listening.
+    sources.catch(() => {});
+
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      deadlineTimer = setTimeout(() => {
+        reject(
+          new Error(
+            `Timed out after ${AGENT_DISCOVERY_READ_TIMEOUT_MS}ms reading agent discovery data; still waiting on: ${[...pending].join(", ")}`
+          )
+        );
+      }, AGENT_DISCOVERY_READ_TIMEOUT_MS);
+    });
+
+    try {
+      return await Promise.race([sources, deadline]);
+    } finally {
+      clearTimeout(deadlineTimer);
+    }
   };
 
   actions.set("agent.launch", () => ({
@@ -1019,11 +1075,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     mcpOutputSchema: true,
     run: async () => {
       const [{ settings, availability, availabilityLive }, registry, userRegistry] =
-        await Promise.all([
-          readAgentDiscoveryState(),
-          agentCapabilitiesClient.getRegistry(),
-          userAgentRegistryClient.get(),
-        ]);
+        await readAvailableAgentSources();
       const registryIds = [
         ...LAUNCHABLE_AGENT_IDS.filter((id) => Object.hasOwn(registry, id)),
         ...Object.keys(registry)

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -169,11 +169,15 @@ function keepRepresentableRecords(records: AgentSessionRecord[]): AgentSessionRe
  * observed pending for over 13 hours (#11795). Settling first keeps that lease
  * bounded and turns a stall into a diagnosable error.
  *
- * Sits above `CliAvailabilityService`'s own 10s probe ceiling, which
- * `readAgentDiscoveryState` can reach before the stores hydrate, and below both
- * the 30s dispatch timeout and the 45s lease TTL.
+ * Sized above the slowest LEGITIMATE cold read, which is ~20s rather than the
+ * 10s it first looks like: before the stores hydrate `readAgentDiscoveryState`
+ * calls `getCliAvailability`, which on an empty cache falls through to
+ * `CliAvailabilityService.checkAvailability()` — and that awaits `refreshPath()`
+ * (its own 10s budget) BEFORE starting its 10s probe timer. Undershooting turns
+ * a slow cold start into a spurious failure. Still clears main's 30s dispatch
+ * timeout and the guard's 45s lease TTL.
  */
-const AGENT_DISCOVERY_READ_TIMEOUT_MS = 15_000;
+const AGENT_DISCOVERY_READ_TIMEOUT_MS = 25_000;
 
 export function registerAgentActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   const readAgentDiscoveryState = async () => {
@@ -207,7 +211,9 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
    * outstanding — the whole difficulty of #11795 was that a bare dispatch
    * timeout gave no hint which await had stalled. The deadline only stops
    * waiting; `ipcRenderer.invoke` takes no `AbortSignal`, so an in-flight
-   * invoke keeps running and its late settle is absorbed below.
+   * invoke keeps running. A late rejection needs no extra guard: `Promise.race`
+   * leaves its handlers attached, so the leg stays handled after the deadline
+   * has already won.
    */
   const readAvailableAgentSources = async () => {
     const pending = new Set(["agentDiscoveryState", "agentRegistry", "userAgentRegistry"]);
@@ -219,9 +225,6 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       track("agentRegistry", agentCapabilitiesClient.getRegistry()),
       track("userAgentRegistry", userAgentRegistryClient.get()),
     ]);
-    // A leg that rejects after the deadline fired would otherwise surface as an
-    // unhandled rejection — by then the race has stopped listening.
-    sources.catch(() => {});
 
     let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
     const deadline = new Promise<never>((_resolve, reject) => {


### PR DESCRIPTION
## Root cause

`agentCapabilities.getRegistry` was returning `getEffectiveRegistry()` raw, typed as `AgentRegistry = Record<string, AgentConfig>`. Every `AgentResume` variant in `shared/config/agentRegistry.ts` carries a live arrow function (`args`, `argsForTarget`, `assignSessionIdArgs`), and that's populated in 15+ shipped agent configs: claude, codex, gemini, amp, aider, kiro, kimi, qwen, opencode, grok, copilot, mistral, goose, antigravity, interpreter. Electron's IPC uses the V8 structured-clone serializer, which can't encode a function. I confirmed this by running `structuredClone()` over the real 18-entry effective registry: it throws `DataCloneError`.

`agent.listAvailable` is the only production caller of `getRegistry()` in the repo, which is exactly why it was the only action affected. `agent.listToolbar` answered in 56ms from the same view, because it does zero live IPC once the stores hydrate. The sibling op `getAgentMetadata` already reduces its config through `toAgentMetadata()`, flattening the un-serializable parts to booleans. `getRegistry` was the odd one out in its own namespace.

Worth stating explicitly: PR #11793 was ruled out. None of its four commits touch this path, and the `Promise.all` shape predates it, introduced in `56dba0d10`.

Resolves #11795

## The fix

1. Narrowed the IPC type to `AgentRegistry = Record<string, AgentRegistryEntry>` with `AgentRegistryEntry = { name: string }`. That's everything the one consumer reads: it uses `Object.keys`, `Object.hasOwn`, and `registry[id]?.name`. Kept the `AgentRegistry` symbol name so the generated invoke map references it unchanged, so `codegen:ipc` and `codegen:ipc-renderer` are both no-ops.
2. Project explicitly in the handler via `toAgentRegistryEntry`, matching the `toAgentMetadata` precedent. Deliberately not a generic deep function-stripper, since that would keep cloning cleanly while silently promoting every future config field onto the wire. Uses `Object.fromEntries`, which defines own properties, so an id of `__proto__` lands as a plain key rather than reassigning the prototype.
3. Bounded `agent.listAvailable`'s discovery reads at 25s, tracking which legs are still outstanding so the error names them. Main abandons an MCP dispatch at 30s without cancelling the renderer action, so a leg that never settles used to hold its `mcpSpawnFocusGuard` lease indefinitely. Production logs show 49 of those warnings, all labelled `agent.listAvailable`, with a max `heldMs` of 47,848,623 (13.3 hours). 25s is sized above the real cold-read ceiling of about 20s: on an empty cache, `getCliAvailability` falls through to `CliAvailabilityService.checkAvailability()`, which awaits `refreshPath()` (its own 10s budget) before starting its own 10s probe timer. It still clears the 30s dispatch timeout and the 45s lease TTL.

## Testing

New `electron/ipc/handlers/__tests__/agentCapabilities.serialization.test.ts` asserts the raw registry still holds live functions, that `structuredClone` of it throws, that the projected payload clones cleanly, that ids and names are preserved, and that the projection stays a strict reduction rather than a passthrough, plus a representative wire-safety sweep across every op in the namespace, made exhaustive by a `satisfies Record<OpName, unknown[]>` constraint so a new op can't be added without deciding how it's exercised.

The existing adversarial suite mocked both clients with `mockResolvedValue`, so a never-settling promise was structurally invisible to it. Added a regression test where a client never resolves and the action must reject, asserting the elapsed window sits above the cold-read ceiling and below the MCP dispatch timeout, plus a happy-path test that the deadline timer is disposed.

## Not covered

There's still no e2e coverage of the MCP dispatch path, and the assistant-side 5s budget in `daintree-assistant` is shorter than this renderer deadline, so a future stall would surface there as its own generic timeout rather than this new diagnostic message.

## Local verification

383 targeted tests green. Prettier and eslint clean on all changed files, no new warnings.
