### PR TITLE
fix(projects): mark only the previous session's projects as recently active

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -116,10 +116,7 @@ import {
   readSessionOpenProjectsSync,
 } from "./services/persistence/readLastProjectId.js";
 import { writeSessionOpenProjects } from "./services/persistence/sessionOpenProjectsStore.js";
-import {
-  flushSessionOpenProjects,
-  initSessionOpenProjectsTracker,
-} from "./services/sessionOpenProjectsTracker.js";
+import { initSessionOpenProjectsTracker } from "./services/sessionOpenProjectsTracker.js";
 import {
   initOpenWindowsTracker,
   resumeOpenWindowsSaves,
@@ -720,14 +717,18 @@ if (!gotTheLock) {
       // manifest should describe it.
       initOpenWindowsTracker({ registry: windowRegistry, readOnly: launchIntent === "recovery" });
 
-      // Freeze the previous session's open projects before anything can join
-      // this one's set (#11794). Read unconditionally — a targeted or recovery
-      // launch still draws the dot for what the last session had open, it just
-      // doesn't get to rewrite the checkpoint. This must precede every
-      // `registerInitialView()` and `setCurrentProject()` below, which write
-      // into the same key as the fleet comes up.
+      // Take the previous session's open projects before anything can join this
+      // one's set (#11794). Read on every launch — a targeted or recovery launch
+      // still draws the dot for what the last session had open. Consumed rather
+      // than merely read, so a session that opens nothing leaves an empty set
+      // behind instead of the previous one; recovery is the exception, because
+      // safe mode's single window must not become the user's remembered set.
+      // This must precede every `registerInitialView()` and `setCurrentProject()`
+      // below, which write into the same key as the fleet comes up.
       initSessionOpenProjectsTracker({
-        previousSessionProjectIds: readSessionOpenProjectsSync(),
+        previousSessionProjectIds: readSessionOpenProjectsSync({
+          clear: launchIntent !== "recovery",
+        }),
         launchAtMs: Date.now(),
         readOnly: launchIntent === "recovery",
         write: writeSessionOpenProjects,
@@ -779,15 +780,6 @@ if (!gotTheLock) {
           console.error("[MAIN] Restoring a background window failed:", reason);
         },
       });
-
-      // Every open/close already persists the checkpoint, so this only matters
-      // for the session that opens nothing — picker window, then quit. Without
-      // it the previous session's value would survive on disk and the launch
-      // after would light up its projects a second time (#11794). Deliberately
-      // here rather than before the fleet comes up: it writes whatever has
-      // accumulated, so it needs no ordering guarantee, and running it after
-      // keeps the shared DB (and its migrations) off the first-paint path.
-      flushSessionOpenProjects();
     } catch (error) {
       console.error("[MAIN] Startup failed:", error);
       // Startup crashes hard-exit without running before-quit, which means

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -116,7 +116,10 @@ import {
   readSessionOpenProjectsSync,
 } from "./services/persistence/readLastProjectId.js";
 import { writeSessionOpenProjects } from "./services/persistence/sessionOpenProjectsStore.js";
-import { initSessionOpenProjectsTracker } from "./services/sessionOpenProjectsTracker.js";
+import {
+  initSessionOpenProjectsTracker,
+  retrySessionOpenProjectsIfDirty,
+} from "./services/sessionOpenProjectsTracker.js";
 import {
   initOpenWindowsTracker,
   resumeOpenWindowsSaves,
@@ -780,6 +783,11 @@ if (!gotTheLock) {
           console.error("[MAIN] Restoring a background window failed:", reason);
         },
       });
+
+      // The restore's checkpoint writes are the only ones a session might make,
+      // so a transient failure there has nothing later to retry it (#11794).
+      // No-op unless one actually failed.
+      retrySessionOpenProjectsIfDirty();
     } catch (error) {
       console.error("[MAIN] Startup failed:", error);
       // Startup crashes hard-exit without running before-quit, which means

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -113,7 +113,13 @@ import { initializeGpuCrashMonitor } from "./services/GpuCrashMonitorService.js"
 import {
   readLastActiveProjectIdSync,
   readOpenWindowsManifestSync,
+  readSessionOpenProjectsSync,
 } from "./services/persistence/readLastProjectId.js";
+import { writeSessionOpenProjects } from "./services/persistence/sessionOpenProjectsStore.js";
+import {
+  flushSessionOpenProjects,
+  initSessionOpenProjectsTracker,
+} from "./services/sessionOpenProjectsTracker.js";
 import {
   initOpenWindowsTracker,
   resumeOpenWindowsSaves,
@@ -714,6 +720,19 @@ if (!gotTheLock) {
       // manifest should describe it.
       initOpenWindowsTracker({ registry: windowRegistry, readOnly: launchIntent === "recovery" });
 
+      // Freeze the previous session's open projects before anything can join
+      // this one's set (#11794). Read unconditionally — a targeted or recovery
+      // launch still draws the dot for what the last session had open, it just
+      // doesn't get to rewrite the checkpoint. This must precede every
+      // `registerInitialView()` and `setCurrentProject()` below, which write
+      // into the same key as the fleet comes up.
+      initSessionOpenProjectsTracker({
+        previousSessionProjectIds: readSessionOpenProjectsSync(),
+        launchAtMs: Date.now(),
+        readOnly: launchIntent === "recovery",
+        write: writeSessionOpenProjects,
+      });
+
       const { hadManifest, records: restoreRecords } = shouldRestoreWindowFleet(launchIntent)
         ? readOpenWindowsManifestSync()
         : { hadManifest: false, records: [] };
@@ -760,6 +779,15 @@ if (!gotTheLock) {
           console.error("[MAIN] Restoring a background window failed:", reason);
         },
       });
+
+      // Every open/close already persists the checkpoint, so this only matters
+      // for the session that opens nothing — picker window, then quit. Without
+      // it the previous session's value would survive on disk and the launch
+      // after would light up its projects a second time (#11794). Deliberately
+      // here rather than before the fleet comes up: it writes whatever has
+      // accumulated, so it needs no ordering guarantee, and running it after
+      // keeps the shared DB (and its migrations) off the first-paint path.
+      flushSessionOpenProjects();
     } catch (error) {
       console.error("[MAIN] Startup failed:", error);
       // Startup crashes hard-exit without running before-quit, which means

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -27,8 +27,13 @@ import {
   appState as appStateTable,
   type ProjectRow,
 } from "./persistence/schema.js";
-import { eq, desc, inArray } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 import { RECENTLY_ACTIVE_WINDOW_MS } from "../../shared/config/recentlyActive.js";
+import {
+  addSessionOpenProject,
+  getPreviousSessionOpenProjects,
+  removeSessionOpenProject,
+} from "./sessionOpenProjectsTracker.js";
 import {
   generateProjectId,
   mintProjectId,
@@ -125,55 +130,21 @@ function rowToRepoStats(row: ProjectRow): ProjectRepoStats | null {
 }
 
 /**
- * The previous session's open projects, plus the moment this one started
- * (#11791).
- *
- * Captured once per main process, from the persisted statuses themselves —
- * nothing in the shutdown chain closes a project, and the only status repair
- * `getAllProjects()` performs demotes a stray `active` to `background`, so the
- * `active`/`background` rows still on disk at boot ARE the set that was open
- * when the app went away. That makes a separate persisted checkpoint redundant.
- *
- * Taken before `getAllProjects()` performs its status repair, which promotes
- * the current project to `active`: a row that was `closed` on disk must not be
- * pulled into the previous session's open set on the way past.
- */
-let launchSnapshot: { atMs: number; openProjectIds: ReadonlySet<string> } | null = null;
-
-function ensureLaunchSnapshot(): { atMs: number; openProjectIds: ReadonlySet<string> } {
-  if (launchSnapshot) return launchSnapshot;
-  let openProjectIds: ReadonlySet<string> = new Set();
-  try {
-    const rows = getSharedDb()
-      .select({ id: projectsTable.id })
-      .from(projectsTable)
-      .where(inArray(projectsTable.status, ["active", "background"]))
-      .all();
-    openProjectIds = new Set(rows.map((r) => r.id));
-  } catch {
-    // The mark is a hint, never session state. A DB that can't be read here
-    // costs the user some grey dots, not a launch.
-  }
-  launchSnapshot = { atMs: Date.now(), openProjectIds };
-  return launchSnapshot;
-}
-
-/** Test-only: the snapshot is module state that outlives a per-test DB. */
-export function resetLaunchSnapshotForTests(): void {
-  launchSnapshot = null;
-}
-
-/**
  * The later of the two deadlines that can apply, or undefined when neither
  * does. Open-at-shutdown runs from launch rather than from the close that never
  * happened; a hand-closed project runs from its own close and decays across
  * restarts. A project in both populations — closed this session after being
  * restored from the last one — takes whichever reaches further.
+ *
+ * The open-at-shutdown half comes from the persisted session-open checkpoint,
+ * frozen at boot before any window could touch it. It was originally inferred
+ * from `active`/`background` rows instead, which read as a lifetime "opened at
+ * least once" latch and marked the entire project list every launch (#11794).
  */
 function resolveRecentlyActiveUntil(row: ProjectRow): number | undefined {
-  const snapshot = ensureLaunchSnapshot();
+  const snapshot = getPreviousSessionOpenProjects();
   const deadlines: number[] = [];
-  if (snapshot.openProjectIds.has(row.id)) {
+  if (snapshot?.projectIds.has(row.id)) {
     deadlines.push(snapshot.atMs + RECENTLY_ACTIVE_WINDOW_MS);
   }
   if (typeof row.recentlyClosedAt === "number") {
@@ -262,10 +233,6 @@ export class ProjectStore {
   }
 
   async initialize(): Promise<void> {
-    // Pin the previous session's open set before this one starts changing it
-    // (#11791). Idempotent, and safe this early — the shared DB is already open
-    // by the time initialize() runs.
-    ensureLaunchSnapshot();
     if (!existsSync(this.projectsConfigDir)) {
       await fs.mkdir(this.projectsConfigDir, { recursive: true });
     }
@@ -874,6 +841,12 @@ export class ProjectStore {
     const db = getSharedDb();
     db.delete(projectsTable).where(eq(projectsTable.id, projectId)).run();
 
+    // No status write happens on this path — the row is gone — so the session
+    // set has to be told directly (#11794). Ids are derived from the project
+    // path, so a project later re-added at the same folder would otherwise
+    // inherit the deleted one's membership.
+    removeSessionOpenProject(projectId);
+
     if (project) {
       this.pruneInRepoRecipeHashes(project.path);
     }
@@ -1098,13 +1071,33 @@ export class ProjectStore {
       // the next transition.
       updates.recentlyClosedAt = null;
     }
-    return this.updateProject(projectId, updates);
+
+    const project = this.updateProject(projectId, updates);
+
+    // The session-open checkpoint moves with the same transitions, and for the
+    // same reason it is centralized here rather than at the call sites: every
+    // close the user performs reaches this method, so no future one can forget
+    // to leave the set (#11794).
+    //
+    // `background` removes, which is the one mapping that isn't self-evident.
+    // Only the close-without-killing-terminals branch of `project:close`
+    // writes it through here, and that is the same "Close Project" gesture as
+    // the killing branch — `background` there means "keep the processes", not
+    // "the user still considers this open". Switching away also backgrounds a
+    // project, but `setCurrentProject` writes that status inside its own
+    // transaction and never reaches this method, so a switch keeps membership.
+    if (status === "active") {
+      addSessionOpenProject(projectId);
+    } else {
+      // closed, missing, or anything a corrupt row repair collapses: the
+      // project is no longer one the user has open.
+      removeSessionOpenProject(projectId);
+    }
+
+    return project;
   }
 
   getAllProjects(): Project[] {
-    // Before the repair below, which can promote a row to `active` — the
-    // snapshot has to see the statuses as they were persisted (#11791).
-    ensureLaunchSnapshot();
     const db = getSharedDb();
     const rows = db
       .select()
@@ -1543,6 +1536,12 @@ export class ProjectStore {
       },
       { behavior: "immediate" }
     );
+
+    // After the transaction, not inside it: the dot is auxiliary state, and a
+    // checkpoint write that failed must not roll back a real project switch
+    // (#11794). Only the incoming project joins — the departing one is
+    // backgrounded, not closed, and stays in the set.
+    addSessionOpenProject(projectId);
 
     if (process.env.DAINTREE_VERBOSE) {
       const updatedPrevious = previousProjectId ? this.getProjectById(previousProjectId) : null;

--- a/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
+++ b/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
@@ -86,7 +86,17 @@ vi.mock("../projectQuarantineCleanup.js", () => ({
   cleanupQuarantinedProjectFiles: vi.fn(),
 }));
 
-import { ProjectStore, resetLaunchSnapshotForTests } from "../ProjectStore.js";
+import { ProjectStore } from "../ProjectStore.js";
+import {
+  initSessionOpenProjectsTracker,
+  resetSessionOpenProjectsTrackerForTests,
+} from "../sessionOpenProjectsTracker.js";
+import { writeSessionOpenProjects } from "../persistence/sessionOpenProjectsStore.js";
+import {
+  SESSION_OPEN_PROJECTS_KEY,
+  parseSessionOpenProjects,
+  serializeSessionOpenProjects,
+} from "../persistence/sessionOpenProjects.js";
 
 /** Comfortably outside the recency window, without naming its length. */
 const LONG_AGO = Date.now() - 24 * 60 * 60 * 1000;
@@ -97,6 +107,39 @@ describe("ProjectStore recently-active marker (#11791)", () => {
   let projectId: string;
   let otherDir: string;
   let otherId: string;
+
+  /** Write a previous session's checkpoint the way a real shutdown left one. */
+  const seedCheckpoint = (ids: string[]) => {
+    const value = serializeSessionOpenProjects(ids);
+    db.insert(schema.appState)
+      .values({ key: SESSION_OPEN_PROJECTS_KEY, value })
+      .onConflictDoUpdate({ target: schema.appState.key, set: { value } })
+      .run();
+  };
+
+  /** The checkpoint as it now stands on disk, for the next launch to read. */
+  const storedCheckpoint = (): string[] => {
+    const row = db
+      .select()
+      .from(schema.appState)
+      .where(eq(schema.appState.key, SESSION_OPEN_PROJECTS_KEY))
+      .get();
+    return parseSessionOpenProjects(row?.value ?? null);
+  };
+
+  /**
+   * Boot the tracker the way main.ts does: read whatever is persisted, freeze
+   * it, and start this session's set empty.
+   */
+  const launch = (opts?: { readOnly?: boolean }) => {
+    resetSessionOpenProjectsTrackerForTests();
+    initSessionOpenProjectsTracker({
+      previousSessionProjectIds: storedCheckpoint(),
+      launchAtMs: Date.now(),
+      readOnly: opts?.readOnly ?? false,
+      write: writeSessionOpenProjects,
+    });
+  };
 
   const seed = (
     id: string,
@@ -135,13 +178,14 @@ describe("ProjectStore recently-active marker (#11791)", () => {
     seed(projectId, canonical, "Recent", { status: "closed" });
     seed(otherId, otherCanonical, "Other", { status: "closed" });
 
-    // The launch snapshot is module state deliberately captured once per
-    // process; each test seeds its own DB, so it has to be re-taken.
-    resetLaunchSnapshotForTests();
+    // The tracker is module state deliberately held for the life of a process;
+    // each test seeds its own DB, so the launch has to be replayed.
+    launch();
     store = new ProjectStore();
   });
 
   afterEach(() => {
+    resetSessionOpenProjectsTrackerForTests();
     sqlite.close();
     fs.rmSync(projectDir, { recursive: true, force: true });
     fs.rmSync(otherDir, { recursive: true, force: true });
@@ -227,7 +271,6 @@ describe("ProjectStore recently-active marker (#11791)", () => {
         .set({ status: "missing" })
         .where(eq(schema.projects.id, projectId))
         .run();
-      resetLaunchSnapshotForTests();
 
       await store.checkMissingProjects();
 
@@ -240,12 +283,9 @@ describe("ProjectStore recently-active marker (#11791)", () => {
   });
 
   describe("the launch clock", () => {
-    it("marks a project that was still open when the app went away", () => {
-      db.update(schema.projects)
-        .set({ status: "background" })
-        .where(eq(schema.projects.id, projectId))
-        .run();
-      resetLaunchSnapshotForTests();
+    it("marks a project the previous session's checkpoint names", () => {
+      seedCheckpoint([projectId]);
+      launch();
 
       const project = store.getProjectById(projectId);
       // No close ever happened, so only the launch clock can be marking it.
@@ -253,16 +293,39 @@ describe("ProjectStore recently-active marker (#11791)", () => {
       expect(project?.recentlyActiveUntil).toBeGreaterThan(Date.now());
     });
 
-    it("keeps the two populations apart: a stale close stays expired, an open project does not", () => {
+    it("leaves every project unmarked when no checkpoint has been written yet", () => {
+      // The first launch after upgrading, and the #11794 regression: both rows
+      // are `background`, which used to be read as "open at shutdown" and lit
+      // up the entire list. Nothing may substitute for the missing checkpoint.
+      db.update(schema.projects).set({ status: "background" }).run();
+      launch();
+
+      expect(store.getProjectById(projectId)?.recentlyActiveUntil).toBeUndefined();
+      expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeUndefined();
+    });
+
+    it("ignores status entirely — a checkpointed project is marked whatever its row says", () => {
       db.update(schema.projects)
-        .set({ status: "background", recentlyClosedAt: LONG_AGO })
+        .set({ status: "closed" })
         .where(eq(schema.projects.id, projectId))
         .run();
       db.update(schema.projects)
-        .set({ status: "closed", recentlyClosedAt: LONG_AGO })
+        .set({ status: "background" })
         .where(eq(schema.projects.id, otherId))
         .run();
-      resetLaunchSnapshotForTests();
+      seedCheckpoint([projectId]);
+      launch();
+
+      // The checkpoint names `projectId` and not `otherId`; the statuses say
+      // the opposite. Membership is the user's intent, not the row's state.
+      expect(store.getProjectById(projectId)?.recentlyActiveUntil).toBeGreaterThan(Date.now());
+      expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeUndefined();
+    });
+
+    it("keeps the two populations apart: a stale close stays expired, a checkpointed project does not", () => {
+      db.update(schema.projects).set({ recentlyClosedAt: LONG_AGO }).run();
+      seedCheckpoint([projectId]);
+      launch();
 
       // Same stale stamp on both rows; only the one that was open at shutdown
       // gets the launch clock, which is the whole point of the two populations.
@@ -270,24 +333,15 @@ describe("ProjectStore recently-active marker (#11791)", () => {
       expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeLessThan(Date.now());
     });
 
-    it("does not extend the mark to projects that were already closed at shutdown", () => {
-      resetLaunchSnapshotForTests();
-      expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeUndefined();
-    });
-
-    it("holds the open set fixed once taken, so closing during the session cannot join it", () => {
-      db.update(schema.projects)
-        .set({ status: "background" })
-        .where(eq(schema.projects.id, projectId))
-        .run();
-      resetLaunchSnapshotForTests();
-      // Take the snapshot while only `projectId` is open.
+    it("holds the previous set fixed, so opening a project now cannot join it", async () => {
+      seedCheckpoint([projectId]);
+      launch();
       expect(store.getProjectById(projectId)?.recentlyActiveUntil).toBeGreaterThan(Date.now());
 
-      // `otherId` opens AFTER the snapshot was taken. It must not join the
-      // launch population — that set is the previous session's, and a set
-      // recomputed on read would wrongly hand it the launch clock here.
-      store.updateProjectStatus(otherId, "background");
+      // `otherId` opens during THIS session. It must not join the launch
+      // population — that set is the previous session's, and a set recomputed
+      // on read would wrongly hand it the launch clock here.
+      await store.setCurrentProject(otherId);
       expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeUndefined();
 
       // Closing it puts it on the close clock instead, where a stale stamp
@@ -296,22 +350,97 @@ describe("ProjectStore recently-active marker (#11791)", () => {
       expect(store.getProjectById(otherId)?.recentlyActiveUntil).toBeLessThan(Date.now());
     });
 
-    it("does not pull a closed current project into the open set via the status repair", () => {
-      db.update(schema.projects)
-        .set({ status: "closed" })
-        .where(eq(schema.projects.id, projectId))
-        .run();
+    it("does not pull a project into the set via the status repair", () => {
       db.insert(schema.appState)
         .values({ key: "currentProjectId", value: projectId })
         .onConflictDoUpdate({ target: schema.appState.key, set: { value: projectId } })
         .run();
-      resetLaunchSnapshotForTests();
+      launch();
 
-      // getAllProjects() promotes the current row to `active`; the snapshot has
-      // to have been taken from the persisted statuses before that happens.
+      // getAllProjects() promotes the current row to `active`. That repair is
+      // bookkeeping about which row is current, never evidence of last session.
       const listed = store.getAllProjects().find((p) => p.id === projectId);
       expect(listed?.status).toBe("active");
       expect(listed?.recentlyActiveUntil).toBeUndefined();
+    });
+  });
+
+  describe("the checkpoint this session leaves behind", () => {
+    it("starts empty, so last session's projects never carry over", async () => {
+      seedCheckpoint([projectId, otherId]);
+      launch();
+
+      await store.setCurrentProject(projectId);
+
+      // Persisting the union with the previous set is the lifetime latch that
+      // made every project look recently active (#11794).
+      expect(storedCheckpoint()).toEqual([projectId]);
+    });
+
+    it("accumulates the union across switches — backgrounding is not closing", async () => {
+      await store.setCurrentProject(projectId);
+      await store.setCurrentProject(otherId);
+
+      expect(store.getProjectById(projectId)?.status).toBe("background");
+      expect(storedCheckpoint().sort()).toEqual([projectId, otherId].sort());
+    });
+
+    it("drops a project the user closed", async () => {
+      await store.setCurrentProject(projectId);
+      await store.setCurrentProject(otherId);
+
+      store.updateProjectStatus(projectId, "closed");
+
+      expect(storedCheckpoint()).toEqual([otherId]);
+    });
+
+    it("drops a project closed without killing its terminals", async () => {
+      await store.setCurrentProject(projectId);
+
+      // The `killTerminals: false` branch of project:close writes `background`.
+      // Same gesture as the killing branch — the status only says the processes
+      // were kept, not that the user still considers the project open.
+      store.updateProjectStatus(projectId, "background");
+
+      expect(storedCheckpoint()).toEqual([]);
+    });
+
+    it("drops a project whose folder went missing", async () => {
+      await store.setCurrentProject(projectId);
+
+      store.updateProjectStatus(projectId, "missing");
+
+      expect(storedCheckpoint()).toEqual([]);
+    });
+
+    it("drops a project that was removed outright", async () => {
+      await store.setCurrentProject(projectId);
+      await store.setCurrentProject(otherId);
+
+      await store.removeProject(projectId);
+
+      // Ids are derived from the path, so leaving it would let a project later
+      // re-added at the same folder inherit the deleted one's membership.
+      expect(storedCheckpoint()).toEqual([otherId]);
+    });
+
+    it("is left untouched by a recovery launch, whose reduced set must not overwrite it", async () => {
+      seedCheckpoint([projectId, otherId]);
+      launch({ readOnly: true });
+
+      await store.setCurrentProject(projectId);
+      store.updateProjectStatus(otherId, "closed");
+
+      // Safe mode opens one window on purpose; rolling that over would lose the
+      // fleet the user actually had.
+      expect(storedCheckpoint().sort()).toEqual([projectId, otherId].sort());
+    });
+
+    it("still marks the previous session's projects during a recovery launch", () => {
+      seedCheckpoint([projectId]);
+      launch({ readOnly: true });
+
+      expect(store.getProjectById(projectId)?.recentlyActiveUntil).toBeGreaterThan(Date.now());
     });
   });
 

--- a/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
+++ b/electron/services/__tests__/ProjectStore.recentlyActive.test.ts
@@ -395,22 +395,34 @@ describe("ProjectStore recently-active marker (#11791)", () => {
     });
 
     it("drops a project closed without killing its terminals", async () => {
+      await store.setCurrentProject(otherId);
       await store.setCurrentProject(projectId);
+      expect(storedCheckpoint().sort()).toEqual([projectId, otherId].sort());
 
       // The `killTerminals: false` branch of project:close writes `background`.
       // Same gesture as the killing branch — the status only says the processes
       // were kept, not that the user still considers the project open.
       store.updateProjectStatus(projectId, "background");
 
-      expect(storedCheckpoint()).toEqual([]);
+      // `otherId` is background too, from the switch — and stays, because
+      // switching away is not closing.
+      expect(store.getProjectById(otherId)?.status).toBe("background");
+      expect(storedCheckpoint()).toEqual([otherId]);
     });
 
     it("drops a project whose folder went missing", async () => {
+      await store.setCurrentProject(otherId);
       await store.setCurrentProject(projectId);
+      // Only the current project is skipped by the sweep, so hand the pointer
+      // to `otherId` and let the real sweep find `projectId`'s folder gone.
+      await store.setCurrentProject(otherId);
+      fs.rmSync(projectDir, { recursive: true, force: true });
+      expect(storedCheckpoint().sort()).toEqual([projectId, otherId].sort());
 
-      store.updateProjectStatus(projectId, "missing");
+      await store.checkMissingProjects();
 
-      expect(storedCheckpoint()).toEqual([]);
+      expect(store.getProjectById(projectId)?.status).toBe("missing");
+      expect(storedCheckpoint()).toEqual([otherId]);
     });
 
     it("drops a project that was removed outright", async () => {

--- a/electron/services/__tests__/sessionOpenProjectsTracker.test.ts
+++ b/electron/services/__tests__/sessionOpenProjectsTracker.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
   addSessionOpenProject,
   getPreviousSessionOpenProjects,
@@ -6,6 +6,7 @@ import {
   removeSessionOpenProject,
   resetSessionOpenProjectsTrackerForTests,
   retrySessionOpenProjectsIfDirty,
+  type SessionOpenProjectsWriter,
 } from "../sessionOpenProjectsTracker.js";
 
 /**
@@ -21,7 +22,7 @@ describe("session-open projects tracker", () => {
    * on exactly that distinction.
    */
   let stored: string[] | null;
-  let write: ReturnType<typeof vi.fn>;
+  let write: Mock<SessionOpenProjectsWriter>;
   let warn: ReturnType<typeof vi.spyOn>;
 
   const init = (opts?: { previous?: string[]; readOnly?: boolean; launchAtMs?: number }) => {
@@ -36,7 +37,7 @@ describe("session-open projects tracker", () => {
 
   beforeEach(() => {
     stored = null;
-    write = vi.fn((ids: ReadonlySet<string>) => {
+    write = vi.fn<SessionOpenProjectsWriter>((ids) => {
       stored = [...ids].sort();
     });
     warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/electron/services/__tests__/sessionOpenProjectsTracker.test.ts
+++ b/electron/services/__tests__/sessionOpenProjectsTracker.test.ts
@@ -5,6 +5,7 @@ import {
   initSessionOpenProjectsTracker,
   removeSessionOpenProject,
   resetSessionOpenProjectsTrackerForTests,
+  retrySessionOpenProjectsIfDirty,
 } from "../sessionOpenProjectsTracker.js";
 
 /**
@@ -16,8 +17,8 @@ describe("session-open projects tracker", () => {
   /**
    * A stand-in for the app_state row, seeded with a previous session's value.
    * Stateful on purpose: asserting on the writer's arguments alone cannot tell
-   * "wrote an empty set" apart from "never wrote", which is exactly the
-   * distinction the flush exists to make.
+   * "wrote an empty set" apart from "never wrote", and the read-only gate turns
+   * on exactly that distinction.
    */
   let stored: string[] | null;
   let write: ReturnType<typeof vi.fn>;
@@ -179,11 +180,12 @@ describe("session-open projects tracker", () => {
     });
 
     it("retries the whole set on the next mutation, even a duplicate add", () => {
-      init({ previous: ["proj-a"] });
+      init();
       failNextWrite();
       addSessionOpenProject("proj-a");
-      // The failed attempt left last session's value on disk.
-      expect(stored).toEqual(["proj-a"]);
+      // The boot read already emptied the row, and the failed write left it
+      // that way — the checkpoint no longer describes what is open.
+      expect(stored).toBeNull();
       expect(write).toHaveBeenCalledTimes(1);
 
       // Normally a no-op — but the stored value is known stale, so this has to
@@ -204,6 +206,37 @@ describe("session-open projects tracker", () => {
       addSessionOpenProject("proj-a");
 
       expect(write).toHaveBeenCalledTimes(2);
+    });
+
+    it("repairs a restore-only session, whose failed write has nothing later to retry it", () => {
+      init();
+      failNextWrite();
+      // The startup restore's add is the only write this session makes.
+      addSessionOpenProject("proj-a");
+      expect(stored).toBeNull();
+
+      retrySessionOpenProjectsIfDirty();
+
+      expect(stored).toEqual(["proj-a"]);
+    });
+
+    it("does not re-write when the last write succeeded", () => {
+      init();
+      addSessionOpenProject("proj-a");
+
+      retrySessionOpenProjectsIfDirty();
+
+      expect(write).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays inert on a recovery launch", () => {
+      init({ previous: ["proj-a"], readOnly: true });
+      addSessionOpenProject("proj-b");
+
+      retrySessionOpenProjectsIfDirty();
+
+      expect(write).not.toHaveBeenCalled();
+      expect(stored).toEqual(["proj-a"]);
     });
   });
 

--- a/electron/services/__tests__/sessionOpenProjectsTracker.test.ts
+++ b/electron/services/__tests__/sessionOpenProjectsTracker.test.ts
@@ -1,14 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   addSessionOpenProject,
-  flushSessionOpenProjects,
   getPreviousSessionOpenProjects,
   initSessionOpenProjectsTracker,
   removeSessionOpenProject,
   resetSessionOpenProjectsTrackerForTests,
 } from "../sessionOpenProjectsTracker.js";
-
-vi.mock("../../utils/logger.js", () => ({ logError: vi.fn() }));
 
 /**
  * The tracker owns two sets that must never contaminate each other: the
@@ -16,15 +13,18 @@ vi.mock("../../utils/logger.js", () => ({ logError: vi.fn() }));
  * live membership (what gets persisted for next time) — #11794.
  */
 describe("session-open projects tracker", () => {
+  /**
+   * A stand-in for the app_state row, seeded with a previous session's value.
+   * Stateful on purpose: asserting on the writer's arguments alone cannot tell
+   * "wrote an empty set" apart from "never wrote", which is exactly the
+   * distinction the flush exists to make.
+   */
+  let stored: string[] | null;
   let write: ReturnType<typeof vi.fn>;
-
-  /** The set the writer was handed on its most recent call. */
-  const lastWritten = (): string[] => {
-    const call = write.mock.calls.at(-1);
-    return call ? [...(call[0] as ReadonlySet<string>)].sort() : [];
-  };
+  let warn: ReturnType<typeof vi.spyOn>;
 
   const init = (opts?: { previous?: string[]; readOnly?: boolean; launchAtMs?: number }) => {
+    stored = opts?.previous ? [...opts.previous].sort() : null;
     initSessionOpenProjectsTracker({
       previousSessionProjectIds: opts?.previous ?? [],
       launchAtMs: opts?.launchAtMs ?? 1_000,
@@ -34,11 +34,16 @@ describe("session-open projects tracker", () => {
   };
 
   beforeEach(() => {
-    write = vi.fn();
+    stored = null;
+    write = vi.fn((ids: ReadonlySet<string>) => {
+      stored = [...ids].sort();
+    });
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     resetSessionOpenProjectsTrackerForTests();
   });
 
   afterEach(() => {
+    warn.mockRestore();
     resetSessionOpenProjectsTrackerForTests();
   });
 
@@ -53,7 +58,6 @@ describe("session-open projects tracker", () => {
       expect(() => {
         addSessionOpenProject("proj-a");
         removeSessionOpenProject("proj-a");
-        flushSessionOpenProjects();
       }).not.toThrow();
       expect(write).not.toHaveBeenCalled();
     });
@@ -76,7 +80,7 @@ describe("session-open projects tracker", () => {
       // The whole point of the two sets: `proj-b` was opened now, so it was not
       // open last time and must not inherit the launch clock.
       expect([...(getPreviousSessionOpenProjects()?.projectIds ?? [])]).toEqual(["proj-a"]);
-      expect(lastWritten()).toEqual(["proj-b"]);
+      expect(stored).toEqual(["proj-b"]);
     });
 
     it("does not shrink when a project it names is closed this session", () => {
@@ -92,9 +96,9 @@ describe("session-open projects tracker", () => {
 
       addSessionOpenProject("proj-c");
 
-      // Persisting the union with the previous set is exactly the lifetime
-      // latch #11794 was about.
-      expect(lastWritten()).toEqual(["proj-c"]);
+      // Persisting the union with the previous set is the lifetime latch that
+      // made every project look recently active (#11794).
+      expect(stored).toEqual(["proj-c"]);
     });
   });
 
@@ -105,28 +109,26 @@ describe("session-open projects tracker", () => {
       addSessionOpenProject("proj-a");
       addSessionOpenProject("proj-b");
 
-      expect(lastWritten()).toEqual(["proj-a", "proj-b"]);
+      expect(stored).toEqual(["proj-a", "proj-b"]);
     });
 
     it("skips the write when a project already in the set is re-added", () => {
       init();
       addSessionOpenProject("proj-a");
-      const writes = write.mock.calls.length;
 
       // A second window restoring the same project, or a switch back to it.
       addSessionOpenProject("proj-a");
 
-      expect(write.mock.calls.length).toBe(writes);
+      expect(write).toHaveBeenCalledTimes(1);
     });
 
     it("skips the write when removing a project that was never in the set", () => {
       init();
       addSessionOpenProject("proj-a");
-      const writes = write.mock.calls.length;
 
       removeSessionOpenProject("proj-unrelated");
 
-      expect(write.mock.calls.length).toBe(writes);
+      expect(write).toHaveBeenCalledTimes(1);
     });
 
     it("persists what remains after a close", () => {
@@ -136,7 +138,7 @@ describe("session-open projects tracker", () => {
 
       removeSessionOpenProject("proj-a");
 
-      expect(lastWritten()).toEqual(["proj-b"]);
+      expect(stored).toEqual(["proj-b"]);
     });
 
     it("ignores an empty project id on both sides", () => {
@@ -150,41 +152,58 @@ describe("session-open projects tracker", () => {
   });
 
   describe("write failures", () => {
-    it("swallows the error rather than failing the operation that triggered it", () => {
-      init();
-      write.mockImplementation(() => {
+    /** Fail the next write outright, leaving `stored` untouched. */
+    const failNextWrite = () => {
+      write.mockImplementationOnce(() => {
         throw new Error("database is locked");
       });
+    };
+
+    it("swallows the error rather than failing the operation that triggered it", () => {
+      init();
+      failNextWrite();
 
       expect(() => addSessionOpenProject("proj-a")).not.toThrow();
     });
 
-    it("retries the whole set on the next mutation, even a duplicate add", () => {
+    it("logs the underlying cause so a persistently stale checkpoint is diagnosable", () => {
       init();
-      write.mockImplementationOnce(() => {
-        throw new Error("database is locked");
-      });
+      failNextWrite();
+
       addSessionOpenProject("proj-a");
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[1]).toEqual(
+        expect.objectContaining({ message: "database is locked" })
+      );
+    });
+
+    it("retries the whole set on the next mutation, even a duplicate add", () => {
+      init({ previous: ["proj-a"] });
+      failNextWrite();
+      addSessionOpenProject("proj-a");
+      // The failed attempt left last session's value on disk.
+      expect(stored).toEqual(["proj-a"]);
+      expect(write).toHaveBeenCalledTimes(1);
 
       // Normally a no-op — but the stored value is known stale, so this has to
       // reach the disk or the checkpoint stays diverged for the session.
       addSessionOpenProject("proj-a");
 
-      expect(lastWritten()).toEqual(["proj-a"]);
+      expect(write).toHaveBeenCalledTimes(2);
+      expect(stored).toEqual(["proj-a"]);
     });
 
     it("stops retrying once a write lands", () => {
       init();
-      write.mockImplementationOnce(() => {
-        throw new Error("database is locked");
-      });
+      failNextWrite();
       addSessionOpenProject("proj-a");
       addSessionOpenProject("proj-a");
-      const writes = write.mock.calls.length;
+      expect(write).toHaveBeenCalledTimes(2);
 
       addSessionOpenProject("proj-a");
 
-      expect(write.mock.calls.length).toBe(writes);
+      expect(write).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -200,30 +219,9 @@ describe("session-open projects tracker", () => {
 
       addSessionOpenProject("proj-b");
       removeSessionOpenProject("proj-a");
-      flushSessionOpenProjects();
 
       expect(write).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("the flush", () => {
-    it("clears a stale checkpoint for a session that opened nothing", () => {
-      init({ previous: ["proj-a"] });
-
-      flushSessionOpenProjects();
-
-      // Picker window, then quit. Without this the launch after would light up
-      // `proj-a` a second time.
-      expect(lastWritten()).toEqual([]);
-    });
-
-    it("writes whatever has accumulated, so its ordering does not matter", () => {
-      init({ previous: ["proj-a"] });
-      addSessionOpenProject("proj-b");
-
-      flushSessionOpenProjects();
-
-      expect(lastWritten()).toEqual(["proj-b"]);
+      expect(stored).toEqual(["proj-a"]);
     });
   });
 });

--- a/electron/services/__tests__/sessionOpenProjectsTracker.test.ts
+++ b/electron/services/__tests__/sessionOpenProjectsTracker.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addSessionOpenProject,
+  flushSessionOpenProjects,
+  getPreviousSessionOpenProjects,
+  initSessionOpenProjectsTracker,
+  removeSessionOpenProject,
+  resetSessionOpenProjectsTrackerForTests,
+} from "../sessionOpenProjectsTracker.js";
+
+vi.mock("../../utils/logger.js", () => ({ logError: vi.fn() }));
+
+/**
+ * The tracker owns two sets that must never contaminate each other: the
+ * previous session's frozen membership (what the dot marks) and this session's
+ * live membership (what gets persisted for next time) — #11794.
+ */
+describe("session-open projects tracker", () => {
+  let write: ReturnType<typeof vi.fn>;
+
+  /** The set the writer was handed on its most recent call. */
+  const lastWritten = (): string[] => {
+    const call = write.mock.calls.at(-1);
+    return call ? [...(call[0] as ReadonlySet<string>)].sort() : [];
+  };
+
+  const init = (opts?: { previous?: string[]; readOnly?: boolean; launchAtMs?: number }) => {
+    initSessionOpenProjectsTracker({
+      previousSessionProjectIds: opts?.previous ?? [],
+      launchAtMs: opts?.launchAtMs ?? 1_000,
+      readOnly: opts?.readOnly ?? false,
+      write,
+    });
+  };
+
+  beforeEach(() => {
+    write = vi.fn();
+    resetSessionOpenProjectsTrackerForTests();
+  });
+
+  afterEach(() => {
+    resetSessionOpenProjectsTrackerForTests();
+  });
+
+  describe("before the tracker is initialized", () => {
+    it("reports no previous session rather than an empty one", () => {
+      // Null and "the previous session had nothing open" are different claims:
+      // a unit suite or a failed boot must not be able to hand out deadlines.
+      expect(getPreviousSessionOpenProjects()).toBeNull();
+    });
+
+    it("absorbs every mutation without throwing or writing", () => {
+      expect(() => {
+        addSessionOpenProject("proj-a");
+        removeSessionOpenProject("proj-a");
+        flushSessionOpenProjects();
+      }).not.toThrow();
+      expect(write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the frozen previous session", () => {
+    it("carries the launch instant the deadline is measured from", () => {
+      init({ previous: ["proj-a"], launchAtMs: 12_345 });
+
+      const snapshot = getPreviousSessionOpenProjects();
+      expect(snapshot?.atMs).toBe(12_345);
+      expect([...(snapshot?.projectIds ?? [])]).toEqual(["proj-a"]);
+    });
+
+    it("does not grow when this session opens something new", () => {
+      init({ previous: ["proj-a"] });
+
+      addSessionOpenProject("proj-b");
+
+      // The whole point of the two sets: `proj-b` was opened now, so it was not
+      // open last time and must not inherit the launch clock.
+      expect([...(getPreviousSessionOpenProjects()?.projectIds ?? [])]).toEqual(["proj-a"]);
+      expect(lastWritten()).toEqual(["proj-b"]);
+    });
+
+    it("does not shrink when a project it names is closed this session", () => {
+      init({ previous: ["proj-a"] });
+
+      removeSessionOpenProject("proj-a");
+
+      expect([...(getPreviousSessionOpenProjects()?.projectIds ?? [])]).toEqual(["proj-a"]);
+    });
+
+    it("starts this session's set empty, so last session's ids never carry over", () => {
+      init({ previous: ["proj-a", "proj-b"] });
+
+      addSessionOpenProject("proj-c");
+
+      // Persisting the union with the previous set is exactly the lifetime
+      // latch #11794 was about.
+      expect(lastWritten()).toEqual(["proj-c"]);
+    });
+  });
+
+  describe("this session's membership", () => {
+    it("accumulates a deduplicated union across windows", () => {
+      init();
+
+      addSessionOpenProject("proj-a");
+      addSessionOpenProject("proj-b");
+
+      expect(lastWritten()).toEqual(["proj-a", "proj-b"]);
+    });
+
+    it("skips the write when a project already in the set is re-added", () => {
+      init();
+      addSessionOpenProject("proj-a");
+      const writes = write.mock.calls.length;
+
+      // A second window restoring the same project, or a switch back to it.
+      addSessionOpenProject("proj-a");
+
+      expect(write.mock.calls.length).toBe(writes);
+    });
+
+    it("skips the write when removing a project that was never in the set", () => {
+      init();
+      addSessionOpenProject("proj-a");
+      const writes = write.mock.calls.length;
+
+      removeSessionOpenProject("proj-unrelated");
+
+      expect(write.mock.calls.length).toBe(writes);
+    });
+
+    it("persists what remains after a close", () => {
+      init();
+      addSessionOpenProject("proj-a");
+      addSessionOpenProject("proj-b");
+
+      removeSessionOpenProject("proj-a");
+
+      expect(lastWritten()).toEqual(["proj-b"]);
+    });
+
+    it("ignores an empty project id on both sides", () => {
+      init();
+
+      addSessionOpenProject("");
+      removeSessionOpenProject("");
+
+      expect(write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("write failures", () => {
+    it("swallows the error rather than failing the operation that triggered it", () => {
+      init();
+      write.mockImplementation(() => {
+        throw new Error("database is locked");
+      });
+
+      expect(() => addSessionOpenProject("proj-a")).not.toThrow();
+    });
+
+    it("retries the whole set on the next mutation, even a duplicate add", () => {
+      init();
+      write.mockImplementationOnce(() => {
+        throw new Error("database is locked");
+      });
+      addSessionOpenProject("proj-a");
+
+      // Normally a no-op — but the stored value is known stale, so this has to
+      // reach the disk or the checkpoint stays diverged for the session.
+      addSessionOpenProject("proj-a");
+
+      expect(lastWritten()).toEqual(["proj-a"]);
+    });
+
+    it("stops retrying once a write lands", () => {
+      init();
+      write.mockImplementationOnce(() => {
+        throw new Error("database is locked");
+      });
+      addSessionOpenProject("proj-a");
+      addSessionOpenProject("proj-a");
+      const writes = write.mock.calls.length;
+
+      addSessionOpenProject("proj-a");
+
+      expect(write.mock.calls.length).toBe(writes);
+    });
+  });
+
+  describe("a recovery launch", () => {
+    it("still reports the previous session, so the dots survive safe mode", () => {
+      init({ previous: ["proj-a"], readOnly: true });
+
+      expect([...(getPreviousSessionOpenProjects()?.projectIds ?? [])]).toEqual(["proj-a"]);
+    });
+
+    it("never writes, so the reduced fleet cannot overwrite the real set", () => {
+      init({ previous: ["proj-a"], readOnly: true });
+
+      addSessionOpenProject("proj-b");
+      removeSessionOpenProject("proj-a");
+      flushSessionOpenProjects();
+
+      expect(write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the flush", () => {
+    it("clears a stale checkpoint for a session that opened nothing", () => {
+      init({ previous: ["proj-a"] });
+
+      flushSessionOpenProjects();
+
+      // Picker window, then quit. Without this the launch after would light up
+      // `proj-a` a second time.
+      expect(lastWritten()).toEqual([]);
+    });
+
+    it("writes whatever has accumulated, so its ordering does not matter", () => {
+      init({ previous: ["proj-a"] });
+      addSessionOpenProject("proj-b");
+
+      flushSessionOpenProjects();
+
+      expect(lastWritten()).toEqual(["proj-b"]);
+    });
+  });
+});

--- a/electron/services/persistence/__tests__/readSessionOpenProjects.test.ts
+++ b/electron/services/persistence/__tests__/readSessionOpenProjects.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   SESSION_OPEN_PROJECTS_KEY,
   SESSION_OPEN_PROJECTS_VERSION,
+  parseSessionOpenProjects,
 } from "../sessionOpenProjects.js";
 
 // Explicit factories throughout — spreading importOriginal() here would load the
@@ -19,6 +20,7 @@ vi.mock("electron", () => ({
 interface Statement {
   get: (...args: unknown[]) => unknown;
   all: (...args: unknown[]) => unknown;
+  run: (...args: unknown[]) => unknown;
 }
 
 const prepare = vi.fn<(sql: string) => Statement>();
@@ -36,93 +38,194 @@ import { readSessionOpenProjectsSync } from "../readLastProjectId.js";
 const checkpointJson = (projectIds: unknown[]): string =>
   JSON.stringify({ version: SESSION_OPEN_PROJECTS_VERSION, projectIds });
 
-/** Wire the single app_state lookup the reader issues. */
+/** Every INSERT/UPDATE the reader issued, as [sql, ...bindings]. */
+let writes: unknown[][];
+
+/**
+ * Stand in for the whole `app_state` table, plus a populated `projects` table.
+ *
+ * The projects rows matter: they are what a status-inferred fallback would find
+ * if one were ever reintroduced at this boundary, so a reader that quietly
+ * started answering from `active`/`background` rows would show up here as a
+ * non-empty result instead of passing on an empty stub.
+ */
 function withStoredValue(value: string | undefined) {
-  prepare.mockImplementation(() => ({
-    get: (key: unknown) =>
-      key === SESSION_OPEN_PROJECTS_KEY && value !== undefined ? { value } : undefined,
-    all: () => [],
-  }));
+  const table = new Map<string, string>();
+  if (value !== undefined) table.set(SESSION_OPEN_PROJECTS_KEY, value);
+
+  prepare.mockImplementation((sql: string) => {
+    const isWrite = /^\s*(INSERT|UPDATE|DELETE)/i.test(sql);
+    return {
+      get: (...args: unknown[]) => {
+        if (/from\s+projects/i.test(sql)) return { id: "status-inferred-project" };
+        const stored = table.get(String(args[0]));
+        return stored === undefined ? undefined : { value: stored };
+      },
+      all: () => {
+        if (/from\s+projects/i.test(sql)) {
+          // What `status IN ('active','background')` used to return — #11794.
+          return [{ id: "status-inferred-a" }, { id: "status-inferred-b" }];
+        }
+        return [];
+      },
+      run: (...args: unknown[]) => {
+        if (isWrite) {
+          writes.push([sql, ...args]);
+          table.set(String(args[0]), String(args[1]));
+        }
+        return { changes: 1 };
+      },
+    };
+  });
+  return table;
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  writes = [];
   existsSync.mockReturnValue(true);
   withStoredValue(undefined);
 });
 
 /**
  * The eager, pre-window read of the session-open checkpoint (#11794). It runs
- * before `app.whenReady()` finishes and before any window can write the same
- * key, on its own throwaway read-only connection.
+ * before any window can write the same key, on its own throwaway connection,
+ * and hands the row over rather than merely reading it.
  */
 describe("readSessionOpenProjectsSync", () => {
-  it("returns the stored set", () => {
-    withStoredValue(checkpointJson(["proj-a", "proj-b"]));
+  describe("reading", () => {
+    it("returns the stored set", () => {
+      withStoredValue(checkpointJson(["proj-a", "proj-b"]));
 
-    expect(readSessionOpenProjectsSync().sort()).toEqual(["proj-a", "proj-b"]);
-  });
+      expect(readSessionOpenProjectsSync({ clear: false }).sort()).toEqual(["proj-a", "proj-b"]);
+    });
 
-  it("opens the database read-only, so the boot read can never mutate it", () => {
-    withStoredValue(checkpointJson(["proj-a"]));
+    it("closes its throwaway connection", () => {
+      withStoredValue(checkpointJson(["proj-a"]));
 
-    readSessionOpenProjectsSync();
+      readSessionOpenProjectsSync({ clear: false });
 
-    expect(databaseCtor).toHaveBeenCalledWith(expect.stringContaining("daintree.db"), {
-      readonly: true,
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the connection even when the query throws", () => {
+      prepare.mockImplementation(() => {
+        throw new Error("no such table: app_state");
+      });
+
+      expect(readSessionOpenProjectsSync({ clear: true })).toEqual([]);
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports nothing on first launch, without opening a database", () => {
+      existsSync.mockReturnValue(false);
+
+      expect(readSessionOpenProjectsSync({ clear: true })).toEqual([]);
+      expect(databaseCtor).not.toHaveBeenCalled();
+    });
+
+    it("reports nothing when the key has never been written, even with open projects on disk", () => {
+      // The first launch after upgrading. The mock's `projects` table is full of
+      // rows a status query would happily return; the reader must not have one.
+      withStoredValue(undefined);
+
+      expect(readSessionOpenProjectsSync({ clear: false })).toEqual([]);
+    });
+
+    it("reports nothing when the stored value is corrupt", () => {
+      withStoredValue("{not json");
+
+      expect(readSessionOpenProjectsSync({ clear: false })).toEqual([]);
+    });
+
+    it("reports nothing when the database cannot be opened at all", () => {
+      databaseCtor.mockImplementationOnce(() => {
+        throw new Error("SQLITE_CORRUPT");
+      });
+
+      expect(readSessionOpenProjectsSync({ clear: true })).toEqual([]);
+    });
+
+    it("keeps the readable ids out of a partly corrupt list", () => {
+      withStoredValue(checkpointJson(["proj-a", 7, null, "proj-b"]));
+
+      expect(readSessionOpenProjectsSync({ clear: false }).sort()).toEqual(["proj-a", "proj-b"]);
     });
   });
 
-  it("closes its throwaway connection", () => {
-    withStoredValue(checkpointJson(["proj-a"]));
+  describe("consuming the row", () => {
+    it("hands back the previous set and leaves an empty one behind", () => {
+      const table = withStoredValue(checkpointJson(["proj-a", "proj-b"]));
 
-    readSessionOpenProjectsSync();
+      const previous = readSessionOpenProjectsSync({ clear: true });
 
-    expect(close).toHaveBeenCalledTimes(1);
-  });
-
-  it("closes the connection even when the query throws", () => {
-    prepare.mockImplementation(() => {
-      throw new Error("no such table: app_state");
+      // The value belongs to the session that just ended; this one starts with
+      // nothing open, so a picker-only session cannot relight `proj-a` twice.
+      expect(previous.sort()).toEqual(["proj-a", "proj-b"]);
+      expect(parseSessionOpenProjects(table.get(SESSION_OPEN_PROJECTS_KEY))).toEqual([]);
     });
 
-    expect(readSessionOpenProjectsSync()).toEqual([]);
-    expect(close).toHaveBeenCalledTimes(1);
-  });
+    it("opens the database writable only when it is going to clear", () => {
+      withStoredValue(checkpointJson(["proj-a"]));
 
-  it("reports nothing on first launch, without opening a database", () => {
-    existsSync.mockReturnValue(false);
+      readSessionOpenProjectsSync({ clear: true });
 
-    expect(readSessionOpenProjectsSync()).toEqual([]);
-    expect(databaseCtor).not.toHaveBeenCalled();
-  });
-
-  it("reports nothing when the key has never been written", () => {
-    // The first launch after upgrading: no checkpoint yet, and deliberately no
-    // fallback to project `status` — inferring it from `active`/`background`
-    // rows IS the bug this replaces.
-    withStoredValue(undefined);
-
-    expect(readSessionOpenProjectsSync()).toEqual([]);
-  });
-
-  it("reports nothing when the stored value is corrupt", () => {
-    withStoredValue("{not json");
-
-    expect(readSessionOpenProjectsSync()).toEqual([]);
-  });
-
-  it("reports nothing when the database cannot be opened at all", () => {
-    databaseCtor.mockImplementationOnce(() => {
-      throw new Error("SQLITE_CORRUPT");
+      expect(databaseCtor).toHaveBeenCalledWith(expect.stringContaining("daintree.db"), {
+        readonly: false,
+      });
     });
 
-    expect(readSessionOpenProjectsSync()).toEqual([]);
-  });
+    it("opens read-only when it is not clearing, so a recovery boot cannot mutate", () => {
+      withStoredValue(checkpointJson(["proj-a"]));
 
-  it("keeps the readable ids out of a partly corrupt list", () => {
-    withStoredValue(checkpointJson(["proj-a", 7, null, "proj-b"]));
+      readSessionOpenProjectsSync({ clear: false });
 
-    expect(readSessionOpenProjectsSync().sort()).toEqual(["proj-a", "proj-b"]);
+      expect(databaseCtor).toHaveBeenCalledWith(expect.stringContaining("daintree.db"), {
+        readonly: true,
+      });
+      expect(writes).toEqual([]);
+    });
+
+    it("leaves the row intact for a recovery launch", () => {
+      const table = withStoredValue(checkpointJson(["proj-a"]));
+
+      readSessionOpenProjectsSync({ clear: false });
+
+      // Safe mode opens one window on purpose; consuming here would throw away
+      // the set the user actually had.
+      expect(parseSessionOpenProjects(table.get(SESSION_OPEN_PROJECTS_KEY))).toEqual(["proj-a"]);
+    });
+
+    it("clears even when there was nothing readable to hand back", () => {
+      // A corrupt value has to be replaced too, or it is re-parsed every launch.
+      const table = withStoredValue("{not json");
+
+      readSessionOpenProjectsSync({ clear: true });
+
+      expect(parseSessionOpenProjects(table.get(SESSION_OPEN_PROJECTS_KEY))).toEqual([]);
+      expect(writes).toHaveLength(1);
+    });
+
+    it("fails closed and still closes up when the clear itself throws", () => {
+      withStoredValue(checkpointJson(["proj-a"]));
+      const base = prepare.getMockImplementation()!;
+      prepare.mockImplementation((sql: string) => {
+        const stmt = base(sql);
+        if (/^\s*INSERT/i.test(sql)) {
+          return {
+            ...stmt,
+            run: () => {
+              throw new Error("attempt to write a readonly database");
+            },
+          };
+        }
+        return stmt;
+      });
+
+      // A database this launch cannot write is not one to hand out dots from:
+      // fewer marks is the safe direction, and the launch itself is unaffected.
+      expect(readSessionOpenProjectsSync({ clear: true })).toEqual([]);
+      expect(close).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/electron/services/persistence/__tests__/readSessionOpenProjects.test.ts
+++ b/electron/services/persistence/__tests__/readSessionOpenProjects.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  SESSION_OPEN_PROJECTS_KEY,
+  SESSION_OPEN_PROJECTS_VERSION,
+} from "../sessionOpenProjects.js";
+
+// Explicit factories throughout — spreading importOriginal() here would load the
+// real better-sqlite3 binding and electron, which passes locally and fails on CI.
+const existsSync = vi.fn<(p: string) => boolean>(() => true);
+vi.mock("node:fs", () => ({
+  default: { existsSync: (p: string) => existsSync(p) },
+  existsSync: (p: string) => existsSync(p),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/userData" },
+}));
+
+interface Statement {
+  get: (...args: unknown[]) => unknown;
+  all: (...args: unknown[]) => unknown;
+}
+
+const prepare = vi.fn<(sql: string) => Statement>();
+const close = vi.fn();
+const databaseCtor = vi.fn(() => ({ prepare, close }));
+
+vi.mock("better-sqlite3", () => ({
+  default: function Database(this: unknown, ...args: unknown[]) {
+    return databaseCtor(...(args as []));
+  },
+}));
+
+import { readSessionOpenProjectsSync } from "../readLastProjectId.js";
+
+const checkpointJson = (projectIds: unknown[]): string =>
+  JSON.stringify({ version: SESSION_OPEN_PROJECTS_VERSION, projectIds });
+
+/** Wire the single app_state lookup the reader issues. */
+function withStoredValue(value: string | undefined) {
+  prepare.mockImplementation(() => ({
+    get: (key: unknown) =>
+      key === SESSION_OPEN_PROJECTS_KEY && value !== undefined ? { value } : undefined,
+    all: () => [],
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  existsSync.mockReturnValue(true);
+  withStoredValue(undefined);
+});
+
+/**
+ * The eager, pre-window read of the session-open checkpoint (#11794). It runs
+ * before `app.whenReady()` finishes and before any window can write the same
+ * key, on its own throwaway read-only connection.
+ */
+describe("readSessionOpenProjectsSync", () => {
+  it("returns the stored set", () => {
+    withStoredValue(checkpointJson(["proj-a", "proj-b"]));
+
+    expect(readSessionOpenProjectsSync().sort()).toEqual(["proj-a", "proj-b"]);
+  });
+
+  it("opens the database read-only, so the boot read can never mutate it", () => {
+    withStoredValue(checkpointJson(["proj-a"]));
+
+    readSessionOpenProjectsSync();
+
+    expect(databaseCtor).toHaveBeenCalledWith(expect.stringContaining("daintree.db"), {
+      readonly: true,
+    });
+  });
+
+  it("closes its throwaway connection", () => {
+    withStoredValue(checkpointJson(["proj-a"]));
+
+    readSessionOpenProjectsSync();
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the connection even when the query throws", () => {
+    prepare.mockImplementation(() => {
+      throw new Error("no such table: app_state");
+    });
+
+    expect(readSessionOpenProjectsSync()).toEqual([]);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports nothing on first launch, without opening a database", () => {
+    existsSync.mockReturnValue(false);
+
+    expect(readSessionOpenProjectsSync()).toEqual([]);
+    expect(databaseCtor).not.toHaveBeenCalled();
+  });
+
+  it("reports nothing when the key has never been written", () => {
+    // The first launch after upgrading: no checkpoint yet, and deliberately no
+    // fallback to project `status` — inferring it from `active`/`background`
+    // rows IS the bug this replaces.
+    withStoredValue(undefined);
+
+    expect(readSessionOpenProjectsSync()).toEqual([]);
+  });
+
+  it("reports nothing when the stored value is corrupt", () => {
+    withStoredValue("{not json");
+
+    expect(readSessionOpenProjectsSync()).toEqual([]);
+  });
+
+  it("reports nothing when the database cannot be opened at all", () => {
+    databaseCtor.mockImplementationOnce(() => {
+      throw new Error("SQLITE_CORRUPT");
+    });
+
+    expect(readSessionOpenProjectsSync()).toEqual([]);
+  });
+
+  it("keeps the readable ids out of a partly corrupt list", () => {
+    withStoredValue(checkpointJson(["proj-a", 7, null, "proj-b"]));
+
+    expect(readSessionOpenProjectsSync().sort()).toEqual(["proj-a", "proj-b"]);
+  });
+});

--- a/electron/services/persistence/__tests__/sessionOpenProjects.test.ts
+++ b/electron/services/persistence/__tests__/sessionOpenProjects.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  SESSION_OPEN_PROJECTS_VERSION,
+  parseSessionOpenProjects,
+  serializeSessionOpenProjects,
+} from "../sessionOpenProjects.js";
+
+/**
+ * The corruption matrix for the session-open checkpoint (#11794). Pure — no DB,
+ * no Electron — because every one of these shapes has to fail toward "the
+ * previous session named nothing" rather than toward marking projects the user
+ * never had open.
+ */
+describe("session-open checkpoint payload", () => {
+  const store = (value: unknown) => JSON.stringify(value);
+
+  describe("round trip", () => {
+    it("recovers exactly the set it was given", () => {
+      const ids = ["proj-b", "proj-a", "proj-c"];
+      expect(new Set(parseSessionOpenProjects(serializeSessionOpenProjects(ids)))).toEqual(
+        new Set(ids)
+      );
+    });
+
+    it("survives far more projects than the window manifest would restore", () => {
+      // The cap that is right for spawning windows is wrong for a decoration:
+      // truncating here would silently under-report the set the dot describes.
+      const ids = Array.from({ length: 50 }, (_, i) => `proj-${i}`);
+      expect(parseSessionOpenProjects(serializeSessionOpenProjects(ids))).toHaveLength(50);
+    });
+
+    it("is byte-identical for the same set in a different order", () => {
+      expect(serializeSessionOpenProjects(["b", "a"])).toBe(
+        serializeSessionOpenProjects(["a", "b"])
+      );
+    });
+
+    it("collapses duplicates on the way in and on the way out", () => {
+      expect(serializeSessionOpenProjects(["a", "a", "b"])).toBe(
+        serializeSessionOpenProjects(["a", "b"])
+      );
+      expect(parseSessionOpenProjects(store({ version: 1, projectIds: ["a", "a"] }))).toEqual([
+        "a",
+      ]);
+    });
+
+    it("drops empty ids rather than storing an id that matches no row", () => {
+      expect(parseSessionOpenProjects(serializeSessionOpenProjects(["a", ""]))).toEqual(["a"]);
+    });
+  });
+
+  describe("unreadable input reads as an empty set", () => {
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["an empty string", ""],
+      ["invalid JSON", "{not json"],
+      ["a bare array", '["a"]'],
+      ["a JSON scalar", "42"],
+      ["a JSON null", "null"],
+    ])("%s", (_label, raw) => {
+      expect(parseSessionOpenProjects(raw as string | null | undefined)).toEqual([]);
+    });
+
+    it("refuses a version this build does not know", () => {
+      const future = store({ version: SESSION_OPEN_PROJECTS_VERSION + 1, projectIds: ["a"] });
+      // A future shape is unreadable, not merely unsupported — guessing at its
+      // fields is how you resurrect ids that mean something else.
+      expect(parseSessionOpenProjects(future)).toEqual([]);
+    });
+
+    it("refuses a payload with no version at all", () => {
+      expect(parseSessionOpenProjects(store({ projectIds: ["a"] }))).toEqual([]);
+    });
+
+    it("refuses a projectIds field that is not an array", () => {
+      expect(parseSessionOpenProjects(store({ version: 1, projectIds: "a" }))).toEqual([]);
+    });
+  });
+
+  describe("partial corruption", () => {
+    it("keeps the valid ids and drops the malformed entries beside them", () => {
+      const mixed = store({
+        version: 1,
+        projectIds: ["good-a", 42, null, "", { id: "nope" }, ["nested"], "good-b"],
+      });
+      expect(parseSessionOpenProjects(mixed)).toEqual(["good-a", "good-b"]);
+    });
+
+    it("reads an all-malformed list as empty rather than inventing ids", () => {
+      expect(parseSessionOpenProjects(store({ version: 1, projectIds: [1, null, ""] }))).toEqual(
+        []
+      );
+    });
+
+    it("ignores unknown fields inside a version it does recognize", () => {
+      const extra = store({ version: 1, projectIds: ["a"], writtenAt: 123, windows: 4 });
+      expect(parseSessionOpenProjects(extra)).toEqual(["a"]);
+    });
+  });
+
+  it("stores an empty set as a readable checkpoint, not as absence", () => {
+    // The session that closed everything has to be able to say so — otherwise
+    // the previous session's ids would be indistinguishable from "cleared".
+    const serialized = serializeSessionOpenProjects([]);
+    expect(JSON.parse(serialized)).toEqual({
+      version: SESSION_OPEN_PROJECTS_VERSION,
+      projectIds: [],
+    });
+    expect(parseSessionOpenProjects(serialized)).toEqual([]);
+  });
+});

--- a/electron/services/persistence/__tests__/sessionOpenProjects.test.ts
+++ b/electron/services/persistence/__tests__/sessionOpenProjects.test.ts
@@ -39,9 +39,11 @@ describe("session-open checkpoint payload", () => {
       expect(serializeSessionOpenProjects(["a", "a", "b"])).toBe(
         serializeSessionOpenProjects(["a", "b"])
       );
-      expect(parseSessionOpenProjects(store({ version: 1, projectIds: ["a", "a"] }))).toEqual([
-        "a",
-      ]);
+      expect(
+        parseSessionOpenProjects(
+          store({ version: SESSION_OPEN_PROJECTS_VERSION, projectIds: ["a", "a"] })
+        )
+      ).toEqual(["a"]);
     });
 
     it("drops empty ids rather than storing an id that matches no row", () => {
@@ -74,27 +76,36 @@ describe("session-open checkpoint payload", () => {
     });
 
     it("refuses a projectIds field that is not an array", () => {
-      expect(parseSessionOpenProjects(store({ version: 1, projectIds: "a" }))).toEqual([]);
+      expect(
+        parseSessionOpenProjects(store({ version: SESSION_OPEN_PROJECTS_VERSION, projectIds: "a" }))
+      ).toEqual([]);
     });
   });
 
   describe("partial corruption", () => {
     it("keeps the valid ids and drops the malformed entries beside them", () => {
       const mixed = store({
-        version: 1,
+        version: SESSION_OPEN_PROJECTS_VERSION,
         projectIds: ["good-a", 42, null, "", { id: "nope" }, ["nested"], "good-b"],
       });
       expect(parseSessionOpenProjects(mixed)).toEqual(["good-a", "good-b"]);
     });
 
     it("reads an all-malformed list as empty rather than inventing ids", () => {
-      expect(parseSessionOpenProjects(store({ version: 1, projectIds: [1, null, ""] }))).toEqual(
-        []
-      );
+      expect(
+        parseSessionOpenProjects(
+          store({ version: SESSION_OPEN_PROJECTS_VERSION, projectIds: [1, null, ""] })
+        )
+      ).toEqual([]);
     });
 
     it("ignores unknown fields inside a version it does recognize", () => {
-      const extra = store({ version: 1, projectIds: ["a"], writtenAt: 123, windows: 4 });
+      const extra = store({
+        version: SESSION_OPEN_PROJECTS_VERSION,
+        projectIds: ["a"],
+        writtenAt: 123,
+        windows: 4,
+      });
       expect(parseSessionOpenProjects(extra)).toEqual(["a"]);
     });
   });

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -22,6 +22,7 @@ import {
   parseOpenWindowsManifest,
   type OpenWindowRecord,
 } from "./windowManifest.js";
+import { SESSION_OPEN_PROJECTS_KEY, parseSessionOpenProjects } from "./sessionOpenProjects.js";
 
 export function readLastActiveProjectIdSync(): string | null {
   try {
@@ -162,5 +163,46 @@ export function readOpenWindowsManifestSync(): OpenWindowsManifestRead {
   } catch {
     // Any error (corrupt DB, missing table, etc.) — restore a single window.
     return NO_MANIFEST;
+  }
+}
+
+/**
+ * Synchronous, standalone reader for the session-open checkpoint (#11794) — the
+ * projects that were open when the app last ran, which the switcher's
+ * recently-active dot marks.
+ *
+ * Reads on the same throwaway read-only connection idiom as its siblings above,
+ * and for a sharper reason than they have: the restore fan-out writes into this
+ * same key as each window comes up, so the previous session's set has to be
+ * captured before any window exists. Read it lazily on the first DB query
+ * instead and a project opened fresh this session — a CLI-targeted launch, a
+ * restore that fell back to the last-active project — would leak into the set
+ * that is supposed to be frozen from last time.
+ *
+ * Missing DB, missing row, corrupt JSON, or an unreadable version all report an
+ * empty set, which costs one launch's dots rather than marking projects the
+ * user never had open. There is deliberately no fallback to project `status`:
+ * inferring the set from `active`/`background` rows IS #11794.
+ */
+export function readSessionOpenProjectsSync(): string[] {
+  try {
+    const dbPath = path.join(app.getPath("userData"), "daintree.db");
+
+    if (!fs.existsSync(dbPath)) {
+      return []; // First launch — no database yet
+    }
+
+    const sqlite = new Database(dbPath, { readonly: true });
+    try {
+      const row = sqlite
+        .prepare("SELECT value FROM app_state WHERE key = ?")
+        .get(SESSION_OPEN_PROJECTS_KEY) as { value: string } | undefined;
+      return parseSessionOpenProjects(row?.value ?? null);
+    } finally {
+      sqlite.close();
+    }
+  } catch {
+    // Any error (corrupt DB, missing table, etc.) — no dots for one session.
+    return [];
   }
 }

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -3,9 +3,12 @@
  * Synchronous, standalone readers for the last-active project.
  *
  * Called BEFORE app.whenReady() / on the early-renderer boot path. Each uses its
- * own read-only better-sqlite3 connection — they do not depend on getSharedDb()
- * or ProjectStore.initialize() (the shared DB is not open yet at this point in
+ * own better-sqlite3 connection — they do not depend on getSharedDb() or
+ * ProjectStore.initialize() (the shared DB is not open yet at this point in
  * boot, and opening it would run migrations on the loadURL-dispatch path).
+ *
+ * Read-only, with one exception: the session-open checkpoint is consumed rather
+ * than merely read, and says so at its own definition.
  *
  * Returns null on first launch, corrupt DB, or any error (safe fallback).
  */
@@ -15,6 +18,7 @@ import { app } from "electron";
 import fs from "node:fs";
 import path from "path";
 import type { Project } from "../../../shared/types/project.js";
+import { tightenFilePermissionsSync } from "../../utils/fs.js";
 import {
   OPEN_WINDOWS_KEY,
   filterRestorableWindows,
@@ -210,6 +214,13 @@ export function readSessionOpenProjectsSync(opts: { clear: boolean }): string[] 
     if (!fs.existsSync(dbPath)) {
       return []; // First launch — no database yet
     }
+
+    // Before opening writable, never after: bundled SQLite derives the
+    // -wal/-shm sidecar mode from the main file's, so a legacy 0o644 database
+    // would otherwise get world-readable sidecars created here — ahead of the
+    // chmod `openDb()` performs for exactly this reason. Best-effort and
+    // POSIX-gated, like its counterpart there.
+    if (opts.clear) tightenFilePermissionsSync(dbPath);
 
     const sqlite = new Database(dbPath, { readonly: !opts.clear });
     try {

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -22,7 +22,11 @@ import {
   parseOpenWindowsManifest,
   type OpenWindowRecord,
 } from "./windowManifest.js";
-import { SESSION_OPEN_PROJECTS_KEY, parseSessionOpenProjects } from "./sessionOpenProjects.js";
+import {
+  SESSION_OPEN_PROJECTS_KEY,
+  parseSessionOpenProjects,
+  serializeSessionOpenProjects,
+} from "./sessionOpenProjects.js";
 
 export function readLastActiveProjectIdSync(): string | null {
   try {
@@ -167,24 +171,39 @@ export function readOpenWindowsManifestSync(): OpenWindowsManifestRead {
 }
 
 /**
- * Synchronous, standalone reader for the session-open checkpoint (#11794) — the
- * projects that were open when the app last ran, which the switcher's
- * recently-active dot marks.
+ * Take the session-open checkpoint off disk (#11794) — the projects that were
+ * open when the app last ran, which the switcher's recently-active dot marks.
  *
- * Reads on the same throwaway read-only connection idiom as its siblings above,
- * and for a sharper reason than they have: the restore fan-out writes into this
- * same key as each window comes up, so the previous session's set has to be
- * captured before any window exists. Read it lazily on the first DB query
- * instead and a project opened fresh this session — a CLI-targeted launch, a
- * restore that fell back to the last-active project — would leak into the set
- * that is supposed to be frozen from last time.
+ * Reads on the same throwaway connection idiom as its siblings above, and for a
+ * sharper reason than they have: the restore fan-out writes into this same key
+ * as each window comes up, so the previous session's set has to be captured
+ * before any window exists. Read it lazily on the first DB query instead and a
+ * project opened fresh this session — a CLI-targeted launch, a restore that
+ * fell back to the last-active project — would leak into the set that is
+ * supposed to be frozen from last time.
+ *
+ * `clear` hands over the row as well as reading it: the value belongs to the
+ * session that just ended, and this one starts with nothing open. Clearing here
+ * rather than on the way out is what makes a session that opens nothing —
+ * picker window, then quit or crash — leave an empty set behind instead of the
+ * previous session's, which would otherwise light its projects up a second
+ * time. It writes on the same throwaway connection deliberately: routing it
+ * through `getSharedDb()` would force the shared database (and its drizzle
+ * migrations) open ahead of the first window, which is the cost this whole
+ * idiom exists to avoid.
+ *
+ * Recovery launches pass `clear: false`. Safe mode opens one window on purpose,
+ * and consuming the checkpoint there would throw away the set the user actually
+ * had — the same reason the window manifest goes read-only on that path.
  *
  * Missing DB, missing row, corrupt JSON, or an unreadable version all report an
  * empty set, which costs one launch's dots rather than marking projects the
  * user never had open. There is deliberately no fallback to project `status`:
- * inferring the set from `active`/`background` rows IS #11794.
+ * inferring the set from `active`/`background` rows IS #11794. A failed clear
+ * is swallowed for the same reason — a stale checkpoint costs one launch's
+ * accuracy, never the launch.
  */
-export function readSessionOpenProjectsSync(): string[] {
+export function readSessionOpenProjectsSync(opts: { clear: boolean }): string[] {
   try {
     const dbPath = path.join(app.getPath("userData"), "daintree.db");
 
@@ -192,12 +211,23 @@ export function readSessionOpenProjectsSync(): string[] {
       return []; // First launch — no database yet
     }
 
-    const sqlite = new Database(dbPath, { readonly: true });
+    const sqlite = new Database(dbPath, { readonly: !opts.clear });
     try {
       const row = sqlite
         .prepare("SELECT value FROM app_state WHERE key = ?")
         .get(SESSION_OPEN_PROJECTS_KEY) as { value: string } | undefined;
-      return parseSessionOpenProjects(row?.value ?? null);
+      const projectIds = parseSessionOpenProjects(row?.value ?? null);
+
+      if (opts.clear) {
+        sqlite
+          .prepare(
+            "INSERT INTO app_state (key, value) VALUES (?, ?) " +
+              "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+          )
+          .run(SESSION_OPEN_PROJECTS_KEY, serializeSessionOpenProjects([]));
+      }
+
+      return projectIds;
     } finally {
       sqlite.close();
     }

--- a/electron/services/persistence/sessionOpenProjects.ts
+++ b/electron/services/persistence/sessionOpenProjects.ts
@@ -1,0 +1,88 @@
+/**
+ * The session-open checkpoint: which projects the user had open when the app
+ * last ran, so the switcher's recently-active dot marks that set and nothing
+ * else (#11794).
+ *
+ * Stored as a single JSON value under `app_state.sessionOpenProjects`, beside
+ * the `currentProjectId` scalar and the `openWindows` manifest. That table is a
+ * schemaless key/value store, so this needs no drizzle migration.
+ *
+ * Membership is user intent, not resource state: a project joins when it is
+ * opened or switched to and leaves when it is closed, removed, or goes missing.
+ * It is deliberately NOT derived from `status`, which is what #11794 was —
+ * `background` is written on every "no longer current" transition and cleared
+ * only by an explicit close, so it latches on for the life of the install.
+ *
+ * Order carries no meaning. Ids are serialized deduplicated and sorted so the
+ * stored value is stable for a given set and nothing downstream can start
+ * reading the array as a ranking.
+ *
+ * Uncapped, unlike the window manifest's MAX_RESTORED_WINDOWS: these ids spawn
+ * nothing, and truncating them would silently under-report the set the dot is
+ * supposed to describe. There is no truthful entry to drop either — the payload
+ * has no timestamps to order by.
+ *
+ * Deliberately dependency-free: the reader that consumes it runs before
+ * `app.whenReady()`, and keeping the shape and its validation clear of the DB
+ * and Electron lets the corruption matrix be unit-tested without either.
+ * The write side lives in sessionOpenProjectsStore.ts.
+ */
+
+export const SESSION_OPEN_PROJECTS_KEY = "sessionOpenProjects";
+export const SESSION_OPEN_PROJECTS_VERSION = 1;
+
+export interface SessionOpenProjectsCheckpoint {
+  version: number;
+  projectIds: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parse and validate a stored checkpoint. Pure — no IO, no DB — so the
+ * corruption matrix is unit-testable.
+ *
+ * Every failure mode collapses to `[]`, which the caller reads as "the previous
+ * session named nothing", i.e. no dots for one launch. Being wrong in that
+ * direction costs a decoration; being wrong in the other marks projects the
+ * user never had open, which is the bug this replaces.
+ *
+ * An empty list and a missing row are deliberately indistinguishable here: both
+ * mean the same thing to every caller, unlike the window manifest where "named
+ * zero windows" and "no manifest" drive different restore decisions.
+ */
+export function parseSessionOpenProjects(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (!isRecord(parsed)) return [];
+  // A future version's shape is unknown, so it is not merely unsupported — it
+  // is unreadable. Refuse it rather than guessing at fields.
+  if (parsed.version !== SESSION_OPEN_PROJECTS_VERSION) return [];
+  if (!Array.isArray(parsed.projectIds)) return [];
+
+  const ids = new Set<string>();
+  for (const entry of parsed.projectIds) {
+    // Anything that isn't a non-empty string is malformed. Coercing it would
+    // invent a project id, and an invented id can collide with a real row.
+    if (typeof entry === "string" && entry.length > 0) ids.add(entry);
+  }
+
+  return [...ids].sort();
+}
+
+export function serializeSessionOpenProjects(projectIds: Iterable<string>): string {
+  const checkpoint: SessionOpenProjectsCheckpoint = {
+    version: SESSION_OPEN_PROJECTS_VERSION,
+    projectIds: [...new Set(projectIds)].filter((id) => id.length > 0).sort(),
+  };
+  return JSON.stringify(checkpoint);
+}

--- a/electron/services/persistence/sessionOpenProjectsStore.ts
+++ b/electron/services/persistence/sessionOpenProjectsStore.ts
@@ -1,0 +1,29 @@
+/**
+ * Write side of the session-open checkpoint (#11794).
+ *
+ * Split from sessionOpenProjects.ts so the shape and its validation stay free
+ * of the DB — the sync reader on the pre-`whenReady()` boot path imports the
+ * pure half, and only this module pulls in drizzle.
+ *
+ * The tracker takes this as an injected writer rather than importing it, which
+ * is what keeps the tracker itself loadable (and inert) in the node-environment
+ * unit suites that never open a database.
+ */
+
+import { getSharedDb } from "./db.js";
+import { appState as appStateTable } from "./schema.js";
+import { SESSION_OPEN_PROJECTS_KEY, serializeSessionOpenProjects } from "./sessionOpenProjects.js";
+
+/**
+ * Persist the checkpoint. Synchronous — better-sqlite3 writes inline, so a
+ * close or a switch leaves no unawaited promise behind for a force-quit to
+ * drop. Callers own the decision to write at all; this just performs it.
+ */
+export function writeSessionOpenProjects(projectIds: ReadonlySet<string>): void {
+  const value = serializeSessionOpenProjects(projectIds);
+  getSharedDb()
+    .insert(appStateTable)
+    .values({ key: SESSION_OPEN_PROJECTS_KEY, value })
+    .onConflictDoUpdate({ target: appStateTable.key, set: { value } })
+    .run();
+}

--- a/electron/services/sessionOpenProjectsTracker.ts
+++ b/electron/services/sessionOpenProjectsTracker.ts
@@ -19,10 +19,11 @@
  * `app.exit(0)`, which skips `before-quit`, and a main-process crash skips
  * everything. Those are exactly the exits after which you want the set back.
  *
- * No shutdown gate, unlike openWindowsTracker: every mutator here is reached
- * from a ProjectStore method that has already written the same shared database
- * on the line before, so a write during teardown cannot be the call that
- * reopens a closed connection.
+ * No shutdown gate, unlike openWindowsTracker: every mutator here runs after a
+ * synchronous shared-database access in the same call — the ProjectStore write
+ * that prompted it, or the `getProjectById()` the restore path resolved its
+ * project with — so a write during teardown cannot be the call that reopens a
+ * closed connection.
  *
  * Membership is NOT residency. `ProjectViewManager` evicts views under memory
  * pressure, and that is a decision the user never sees — it must not silently
@@ -124,6 +125,21 @@ export function removeSessionOpenProject(projectId: string): void {
   if (!state || !projectId) return;
   const removed = state.current.delete(projectId);
   if (!removed && !state.dirty) return;
+  persist();
+}
+
+/**
+ * Re-persist the set if the last write failed, otherwise do nothing.
+ *
+ * Ordinary mutations retry on their own, because a failed write leaves the
+ * tracker dirty and the next add or remove writes the whole set again. That
+ * covers everything except the session whose only write was the startup
+ * restore: with nothing further to trigger a retry, a transient failure there
+ * would leave the boot-cleared checkpoint empty for the next launch. Called
+ * once the fleet is up, where the shared database is certainly open.
+ */
+export function retrySessionOpenProjectsIfDirty(): void {
+  if (!state || !state.dirty) return;
   persist();
 }
 

--- a/electron/services/sessionOpenProjectsTracker.ts
+++ b/electron/services/sessionOpenProjectsTracker.ts
@@ -1,0 +1,144 @@
+/**
+ * Keeps the persisted session-open checkpoint in step with the projects the
+ * user actually has open, and freezes the previous session's copy of it for the
+ * switcher's recently-active dot (#11794).
+ *
+ * Two sets, and the split is the whole point:
+ *
+ *  - `previous` is the checkpoint as it was read off disk at boot, frozen with
+ *    the launch time. Nothing this session does may change it — the dot means
+ *    "you had this open last time", so a project opened during THIS session
+ *    must not join it.
+ *  - `current` is what this session has open, a deduplicated union across every
+ *    window. It starts empty, so the first mutation already overwrites last
+ *    session's stored value; membership never carries over.
+ *
+ * Continuous persistence rather than a snapshot at quit, for the same reason
+ * the window manifest does it (#11492): our own force-quit goes through
+ * `app.exit(0)`, which skips `before-quit`, and a main-process crash skips
+ * everything. Those are exactly the exits after which you want the set back.
+ *
+ * Membership is NOT residency. `ProjectViewManager` evicts views under memory
+ * pressure, and that is a decision the user never sees — it must not silently
+ * drop a project out of the set.
+ *
+ * Recovery launches read but never write. Safe mode opens one window on
+ * purpose; rolling the checkpoint over there would overwrite the user's real
+ * set with it, the same reason openWindowsTracker goes read-only on that path.
+ *
+ * Electron-free and DB-free by construction: the writer is injected. That keeps
+ * the module importable from ProjectStore's node-environment unit suites, where
+ * it is simply never initialized and every mutator is a no-op.
+ */
+
+import { logError } from "../utils/logger.js";
+
+export interface PreviousSessionOpenProjects {
+  /** When this launch captured the set, the anchor for the dot's deadline. */
+  readonly atMs: number;
+  readonly projectIds: ReadonlySet<string>;
+}
+
+export type SessionOpenProjectsWriter = (projectIds: ReadonlySet<string>) => void;
+
+interface TrackerState {
+  previous: PreviousSessionOpenProjects;
+  current: Set<string>;
+  /** Recovery launches observe but never write. */
+  readOnly: boolean;
+  write: SessionOpenProjectsWriter;
+  /**
+   * A write failed, so the stored value no longer matches `current`. Set here
+   * rather than swallowed, so the next mutation persists the full set even when
+   * it would otherwise be a no-op (re-adding a project already in the union).
+   */
+  dirty: boolean;
+}
+
+let state: TrackerState | null = null;
+
+/**
+ * Freeze the previous session's set and start tracking this one.
+ *
+ * Performs no write: this runs on the boot path before the shared DB is open,
+ * and forcing it open here would move drizzle's migrations ahead of the
+ * renderer load. The first `add`/`remove` persists the whole current set, which
+ * overwrites the stored value on its own; {@link flushSessionOpenProjects}
+ * covers the session that never opens anything.
+ */
+export function initSessionOpenProjectsTracker(opts: {
+  previousSessionProjectIds: Iterable<string>;
+  launchAtMs: number;
+  readOnly: boolean;
+  write: SessionOpenProjectsWriter;
+}): void {
+  state = {
+    previous: {
+      atMs: opts.launchAtMs,
+      projectIds: new Set(opts.previousSessionProjectIds),
+    },
+    current: new Set(),
+    readOnly: opts.readOnly,
+    write: opts.write,
+    dirty: false,
+  };
+}
+
+/**
+ * The previous session's open set, or null when this process never captured one
+ * — a unit suite, or a boot path that failed before the read. Null means no
+ * project gets a launch-clock deadline, which is the safe direction: the dot is
+ * a hint, and being absent costs less than marking projects that were closed.
+ */
+export function getPreviousSessionOpenProjects(): PreviousSessionOpenProjects | null {
+  return state?.previous ?? null;
+}
+
+function persist(): void {
+  if (!state || state.readOnly) return;
+  try {
+    state.write(state.current);
+    state.dirty = false;
+  } catch (error) {
+    // Losing the checkpoint costs the user some grey dots next launch. It must
+    // never take down a project switch, a close, or a project deletion.
+    state.dirty = true;
+    logError("[sessionOpenProjects] Failed to persist the session-open checkpoint", error);
+  }
+}
+
+/** A project the user opened or switched to joins the session's set. */
+export function addSessionOpenProject(projectId: string): void {
+  if (!state || !projectId) return;
+  if (state.current.has(projectId) && !state.dirty) return;
+  state.current.add(projectId);
+  persist();
+}
+
+/** A project the user closed, removed, or that went missing leaves the set. */
+export function removeSessionOpenProject(projectId: string): void {
+  if (!state || !projectId) return;
+  const removed = state.current.delete(projectId);
+  if (!removed && !state.dirty) return;
+  persist();
+}
+
+/**
+ * Write the current set once, whatever it holds.
+ *
+ * Ordinary mutations already persist, so this exists for the session that
+ * performs none: open the picker, quit. Without it the previous session's value
+ * would still be on disk and the launch after would light up its projects a
+ * second time. Order-independent — it writes whatever has accumulated, so it is
+ * safe to call after windows are up rather than before, keeping the shared DB
+ * off the first-paint path.
+ */
+export function flushSessionOpenProjects(): void {
+  if (!state) return;
+  persist();
+}
+
+/** Test-only: the module singleton outlives tests that don't reset modules. */
+export function resetSessionOpenProjectsTrackerForTests(): void {
+  state = null;
+}

--- a/electron/services/sessionOpenProjectsTracker.ts
+++ b/electron/services/sessionOpenProjectsTracker.ts
@@ -10,13 +10,19 @@
  *    "you had this open last time", so a project opened during THIS session
  *    must not join it.
  *  - `current` is what this session has open, a deduplicated union across every
- *    window. It starts empty, so the first mutation already overwrites last
- *    session's stored value; membership never carries over.
+ *    window. It starts empty, and the boot read that produced `previous`
+ *    cleared the stored row on its way past, so membership never carries over
+ *    and a session that opens nothing leaves an empty set behind.
  *
  * Continuous persistence rather than a snapshot at quit, for the same reason
  * the window manifest does it (#11492): our own force-quit goes through
  * `app.exit(0)`, which skips `before-quit`, and a main-process crash skips
  * everything. Those are exactly the exits after which you want the set back.
+ *
+ * No shutdown gate, unlike openWindowsTracker: every mutator here is reached
+ * from a ProjectStore method that has already written the same shared database
+ * on the line before, so a write during teardown cannot be the call that
+ * reopens a closed connection.
  *
  * Membership is NOT residency. `ProjectViewManager` evicts views under memory
  * pressure, and that is a decision the user never sees — it must not silently
@@ -30,8 +36,6 @@
  * the module importable from ProjectStore's node-environment unit suites, where
  * it is simply never initialized and every mutator is a no-op.
  */
-
-import { logError } from "../utils/logger.js";
 
 export interface PreviousSessionOpenProjects {
   /** When this launch captured the set, the anchor for the dot's deadline. */
@@ -60,11 +64,11 @@ let state: TrackerState | null = null;
 /**
  * Freeze the previous session's set and start tracking this one.
  *
- * Performs no write: this runs on the boot path before the shared DB is open,
- * and forcing it open here would move drizzle's migrations ahead of the
- * renderer load. The first `add`/`remove` persists the whole current set, which
- * overwrites the stored value on its own; {@link flushSessionOpenProjects}
- * covers the session that never opens anything.
+ * Performs no write, and needs none: the boot-path read that produced
+ * `previousSessionProjectIds` also cleared the stored row, so disk already
+ * reads as "nothing open this session" and every later add/remove keeps it in
+ * step. Writing here instead would force the shared database — and its drizzle
+ * migrations — open ahead of the first window.
  */
 export function initSessionOpenProjectsTracker(opts: {
   previousSessionProjectIds: Iterable<string>;
@@ -103,7 +107,7 @@ function persist(): void {
     // Losing the checkpoint costs the user some grey dots next launch. It must
     // never take down a project switch, a close, or a project deletion.
     state.dirty = true;
-    logError("[sessionOpenProjects] Failed to persist the session-open checkpoint", error);
+    console.warn("[sessionOpenProjects] Failed to persist the session-open checkpoint:", error);
   }
 }
 
@@ -120,21 +124,6 @@ export function removeSessionOpenProject(projectId: string): void {
   if (!state || !projectId) return;
   const removed = state.current.delete(projectId);
   if (!removed && !state.dirty) return;
-  persist();
-}
-
-/**
- * Write the current set once, whatever it holds.
- *
- * Ordinary mutations already persist, so this exists for the session that
- * performs none: open the picker, quit. Without it the previous session's value
- * would still be on disk and the launch after would light up its projects a
- * second time. Order-independent — it writes whatever has accumulated, so it is
- * safe to call after windows are up rather than before, keeping the shared DB
- * off the first-paint path.
- */
-export function flushSessionOpenProjects(): void {
-  if (!state) return;
   persist();
 }
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -9,6 +9,7 @@ import { getWorkspaceClient } from "../services/WorkspaceClient.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { createApplicationMenu, handleDirectoryOpen } from "../menu.js";
 import { refreshProjectMenuState } from "../projectMenuState.js";
+import { addSessionOpenProject } from "../services/sessionOpenProjectsTracker.js";
 import { notificationService } from "../services/NotificationService.js";
 import { getMainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
 import { projectStore } from "../services/ProjectStore.js";
@@ -641,6 +642,12 @@ export async function setupWindowServices(
       restoreProject.id,
       restoreProject.path
     );
+    // A restored window never goes through `setCurrentProject`, so it has to
+    // join the session's open set here or the fleet would vanish from next
+    // launch's recently-active set (#11794). Membership is a deduplicated union
+    // across windows, so every restored window adds its own project and the
+    // repeats collapse.
+    addSessionOpenProject(restoreProject.id);
     // The menu was built before this binding existed, so its project gates
     // resolved against a PVM with no active project. Converge them now (#11136).
     refreshProjectMenuState();


### PR DESCRIPTION
## Summary

- The recently active dot added in #11792 for #11791 was lighting up nearly every project on every launch. `ProjectStore.ensureLaunchSnapshot()` inferred the previous session's open set by querying rows with `status IN ('active','background')`, but `background` is written on every "no longer current" transition and only cleared by an explicit close, free-memory, or an idle sweep (disabled by default). It behaves as a lifetime "opened at least once" latch, not session state.
- On the reporter's install: 1 active, 14 background, 0 closed, every `recently_closed_at` NULL. All 14 dots came from the launch snapshot, one of them for a project last opened months earlier.
- Fix: an explicit session-open checkpoint, persisted as versioned JSON under a new `app_state.sessionOpenProjects` key (schemaless table, no drizzle migration needed), written continuously through the session and consumed once at boot.

Resolves #11794

## Changes

- `electron/services/persistence/sessionOpenProjects.ts` (new): pure shape plus parse/serialize, no DB or Electron dependency so the corruption matrix is unit testable. Versioned envelope; ids deduplicated and sorted, so array order is explicitly not a ranking. Deliberately uncapped, unlike the window manifest's `MAX_RESTORED_WINDOWS` cap, that cap is right for spawning windows and wrong for a recency mark.
- `electron/services/persistence/sessionOpenProjectsStore.ts` (new): the drizzle upsert, split off the same way as `windowManifestStore.ts`.
- `electron/services/sessionOpenProjectsTracker.ts` (new): holds two sets that never mix, the previous session's set (frozen at boot with the launch instant) and this session's live set (unioned across windows). The writer is injected, so the module stays inert in unit suites that never open a database.
- `readSessionOpenProjectsSync({ clear })` in `readLastProjectId.ts`: reads on the same throwaway-connection pattern as its siblings, and consumes the row rather than merely reading it, so a session that opens nothing leaves an empty set behind instead of carrying over the previous session's. Recovery launches pass `clear: false` and stay read-only. Deliberately not routed through `getSharedDb()`, that would pull drizzle's migrations ahead of the first window.
- Membership transitions are centralized in `ProjectStore.updateProjectStatus`, mirroring how #11791 centralized `recentlyClosedAt` there so no future close path can forget it: `active` adds, `closed`/`missing`/`background` remove. `background` removes because the only caller reaching this method with it is the close-without-killing-terminals branch of `project:close`, the same user gesture as the killing branch. Switching away also backgrounds a project, but `setCurrentProject` writes that status inside its own transaction and never calls this method, so a switch keeps membership. Restored windows bypass `setCurrentProject` entirely, so `registerInitialView` adds them explicitly.

Constraints honoured: membership never derives from `ProjectViewManager` residency (LRU eviction under memory pressure can't drop it), writes are continuous rather than at shutdown (`app.exit(0)` skips `before-quit`, and crashes skip everything), recovery launches read but never write, and there's no backfill from `status` on the first upgraded launch, an absent checkpoint means zero dots for one session, never a fallback to the old behaviour.

## Testing

711 tests pass across the ProjectStore, project-lifecycle IPC, persistence, and window-services suites, plus a clean `npm run typecheck`. New suites cover the parse/serialize corruption matrix, the eager reader (including a SQL-aware DB mock that would catch a status fallback relocated into the reader), and the tracker's lifecycle: frozen previous set, cross-window union, recovery read-only, and dirty-retry after a failed write. The launch-clock block of `ProjectStore.recentlyActive.test.ts` was rewritten, it had been seeded through `status`, the exact thing this removes. The core regression test asserts that with no checkpoint on disk, `active`/`background` rows get no launch-clock deadline.

Known and deliberate: `project:update` still accepts `status` directly and so bypasses membership, pre-existing and intentional (`crud.ts` branches on it to refresh window titles), and it bypasses #11791's `recentlyClosedAt` stamping the same way, so it's out of scope here.
