### PR TITLE
fix(mcp): fail closed when a session is revoked mid-request

### DIFF
--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -265,10 +265,18 @@ Two distinct mechanisms widen what a session can do past its baseline:
 
 ## End-to-end `tools/call` flow (`sessionServer.ts`)
 
-The `CallTool` handler is a fixed-order gate chain. Each gate that denies writes an audit record and returns a structured tool-error (`buildToolError`) — never a silent skip.
+The `CallTool` handler is a fixed-order gate chain. Each gate that denies writes an audit record and returns a structured tool-error (`buildToolError`) — never a silent skip. Gate 0 is the exception: a request whose session is already gone is refused without an audit record, because there is no tier it could honestly be recorded under.
+
+**`getTier` returns `McpTier | null`, and `null` means "no live transport" (#11799).** `workbench` is not a floor — `TIER_ALLOWLISTS` gives `external` its own allowlist rather than a subset of `workbench`, so defaulting a vanished session to `workbench` _widened_ a revoked external bearer onto 46 tools its allowlist withholds. Every authorization path (`tools/list`, `tools/call`, and all four resource handlers) resolves the tier once at entry and fails closed on `null` with `SESSION_GONE`. Discovery throws rather than answering with an empty list, which would read as a legitimate empty surface.
+
+**Authorization has one lifetime per call.** The tier is captured once, at admission, and reused for the rest of the handler — through the manifest fetch, the native-grant charge, and dispatch. Revocation stops the _next_ request; it does not retroactively refuse a call the gate already admitted, and re-reading mid-handler would only make the response disagree with the gate and the audit record.
 
 ```
 tools/call(actionId, args)
+  │
+  ├─0 Session liveness: sessionStore.getTier(sessionId) → null?
+  │      └─ yes → return SESSION_GONE (business, do not retry) before any audit,
+  │               denial counter, grant lookup, dedup entry or dispatch
   │
   ├─1 Tier floor: isTierPermitted(tier, actionId)?
   │      └─ no → grantCache.check(sessionId, actionId)

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -251,9 +251,10 @@ async function initializeClient(server: ReturnType<typeof createSessionServer>) 
 function seedLiveSession(
   store: RealSessionStore,
   sessionId: string,
-  tier: "workbench" | "action" | "system" | "external"
+  tier: "workbench" | "action" | "system" | "external",
+  transport: "sse" | "http" = "sse"
 ): void {
-  store.sessions.set(sessionId, {
+  const entry = {
     transport: {
       close: vi.fn().mockResolvedValue(undefined),
     },
@@ -261,7 +262,12 @@ function seedLiveSession(
       sendToolListChanged: vi.fn().mockResolvedValue(undefined),
     },
     idleTimer: setTimeout(() => {}, 1_000_000),
-  } as unknown as NonNullable<ReturnType<RealSessionStore["sessions"]["get"]>>);
+  } as unknown as NonNullable<ReturnType<RealSessionStore["sessions"]["get"]>>;
+  if (transport === "sse") {
+    store.sessions.set(sessionId, entry);
+  } else {
+    store.httpSessions.set(sessionId, entry as never);
+  }
   store.sessionTierMap.set(sessionId, tier);
 }
 
@@ -4072,12 +4078,19 @@ describe("mcp.surface short-circuit (#11549)", () => {
     // no tier at all afterwards (#11799), and re-reading would either refuse a
     // call the gate already admitted or disagree with the audit record that
     // logs the admitted tier. The gate's tier is the only coherent answer.
+    // The witness has to be a tool `workbench` grants and `external` does not,
+    // or its absence proves nothing — a tool neither tier reaches is missing
+    // either way. Derived rather than named so it cannot rot into a tautology.
+    const workbenchOnly = [...TIER_ALLOWLISTS.workbench].find(
+      (id) => !TIER_ALLOWLISTS.external.has(id)
+    );
+    expect(workbenchOnly).toBeDefined();
     const sessionStore = fakeSessionStore("external");
     const deps = fakeDeps({
       sessionStore,
       requestManifest: vi.fn().mockImplementation(async () => {
         vi.mocked(sessionStore.getTier).mockReturnValue(null);
-        return surfaceManifest();
+        return [...surfaceManifest(), makeManifestEntry(workbenchOnly!)];
       }),
     });
     const server = createSessionServer("session-surface-revoked", deps);
@@ -4090,9 +4103,8 @@ describe("mcp.surface short-circuit (#11549)", () => {
     };
 
     expect(reported.tier).toBe("external");
-    // `git.commit` is workbench-unreachable but system-tier in-app, and is not
-    // on the external allowlist — the concrete tool the leak would have added.
-    expect(reported.tools.map((t) => t.id)).not.toContain("git.commit");
+    // The concrete tool a workbench re-read would have added to the report.
+    expect(reported.tools.map((t) => t.id)).not.toContain(workbenchOnly);
     // Resolved once, at the gate — the re-read this guards against would show
     // up here as a second call.
     expect(sessionStore.getTier).toHaveBeenCalledTimes(1);
@@ -4514,6 +4526,25 @@ describe("workspace-bound external sessions (#11789)", () => {
 });
 
 describe("session-liveness gate (#11799)", () => {
+  const liveStores: RealSessionStore[] = [];
+
+  function makeStore(): RealSessionStore {
+    const store = new RealSessionStore(() => {});
+    liveStores.push(store);
+    return store;
+  }
+
+  afterEach(() => {
+    // Teardown here, not at the end of each test body: a failing assertion
+    // throws past an inline dispose and leaks the seeded idle timer plus the
+    // grant cache's sweep interval into the rest of the file.
+    while (liveStores.length > 0) {
+      const store = liveStores.pop()!;
+      store.drain();
+      store.grantCache.dispose();
+    }
+  });
+
   function invoke(
     server: ReturnType<typeof createSessionServer>,
     method: string,
@@ -4543,73 +4574,99 @@ describe("session-liveness gate (#11799)", () => {
     return JSON.parse(block.text) as Record<string, unknown>;
   }
 
-  /** `file.read` is the issue's own example: workbench-permitted, external-withheld. */
-  const WORKBENCH_ONLY_TOOL = "file.read";
+  /**
+   * A tool `workbench` permits and `external` does not — derived, not named, so
+   * this cannot drift into restating the allowlist. Its existence IS the issue's
+   * premise: if the two tiers were a ladder there would be no such tool, and
+   * falling back to workbench would be a narrowing rather than an escalation.
+   */
+  const WORKBENCH_ONLY_TOOL = [...TIER_ALLOWLISTS.workbench].find(
+    (id) => !TIER_ALLOWLISTS.external.has(id)
+  );
 
-  it("puts file.read on the workbench surface but not the external one", () => {
-    // Pins the premise the widening depends on. If these two ever agree,
-    // falling back to workbench would stop being an escalation and the tests
-    // below would pass for the wrong reason.
-    expect(isTierPermitted("workbench", WORKBENCH_ONLY_TOOL)).toBe(true);
-    expect(isTierPermitted("external", WORKBENCH_ONLY_TOOL)).toBe(false);
+  it("has at least one tool workbench permits and external withholds", () => {
+    // Guards the derivation above rather than a literal: were this to come back
+    // undefined, every escalation test below would silently lose its teeth.
+    expect(WORKBENCH_ONLY_TOOL).toBeDefined();
   });
 
-  it("refuses a revoked external session's tools/call instead of dispatching it at workbench", async () => {
-    // The issue verbatim: an external bearer's session is revoked while its
-    // request is in flight, and the tier read that follows used to resolve to
-    // `workbench` — a peer allowlist that permits `file.read`.
-    const store = new RealSessionStore(() => {});
-    seedLiveSession(store, "revoked-external", "external");
-    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
-    const appendAuditRecord = vi.fn();
-    const notifyTierMismatch = vi.fn();
-    const deps = fakeDeps({ sessionStore: store, dispatchAction, appendAuditRecord });
-    const server = createSessionServer("revoked-external", deps);
+  it.each([["sse"], ["http"]] as const)(
+    "refuses a revoked external session's tools/call over %s instead of dispatching it at workbench",
+    async (transport) => {
+      // The issue verbatim: an external bearer's session is revoked while its
+      // request is in flight, and the tier read that follows used to resolve to
+      // `workbench` — a peer allowlist that permits this tool.
+      const store = makeStore();
+      seedLiveSession(store, "revoked-external", "external", transport);
+      const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+      const appendAuditRecord = vi.fn();
+      const notifyTierMismatch = vi.fn();
+      const recordDenial = vi.fn(() => ({ tripped: false }));
+      const deps = fakeDeps({
+        sessionStore: store,
+        dispatchAction,
+        appendAuditRecord,
+        notifyTierMismatch,
+        recordDenial,
+      });
+      const server = createSessionServer("revoked-external", deps);
 
-    store.revokeSession("revoked-external");
+      store.revokeSession("revoked-external");
 
-    const result = await callTool(server, {
-      name: WORKBENCH_ONLY_TOOL,
-      arguments: { path: "/etc/passwd" },
-    });
+      const result = await callTool(server, {
+        name: WORKBENCH_ONLY_TOOL!,
+        arguments: { path: "/etc/passwd" },
+      });
 
-    expect((result as { isError?: boolean }).isError).toBe(true);
-    expect(parseToolErrorPayload(result)).toEqual({
-      code: "SESSION_GONE",
-      message: expect.stringContaining("no longer active"),
-      retriable: false,
-      errorCategory: "business",
-    });
-    // Refused before anything observable: no dispatch, and no audit row under a
-    // tier the caller never held.
-    expect(dispatchAction).not.toHaveBeenCalled();
-    expect(appendAuditRecord).not.toHaveBeenCalled();
-    expect(notifyTierMismatch).not.toHaveBeenCalled();
-    store.grantCache.dispose();
-  });
+      expect((result as { isError?: boolean }).isError).toBe(true);
+      expect(parseToolErrorPayload(result)).toEqual({
+        code: "SESSION_GONE",
+        message: expect.stringContaining("no longer active"),
+        retriable: false,
+        errorCategory: "business",
+      });
+      // Refused at the gate, before anything observable: no dispatch, no audit
+      // row under a tier the caller never held, no denial bookkeeping.
+      expect(dispatchAction).not.toHaveBeenCalled();
+      expect(appendAuditRecord).not.toHaveBeenCalled();
+      expect(notifyTierMismatch).not.toHaveBeenCalled();
+      expect(recordDenial).not.toHaveBeenCalled();
+    }
+  );
 
   it("leaves no dedup bookkeeping behind for a session refused at the gate", async () => {
-    const store = new RealSessionStore(() => {});
+    // The tier row is left behind deliberately while the transport is removed.
+    // Revoking would delete both, and the un-gated read would then resolve to
+    // `workbench`, which does not permit `terminal.new` — the call would exit at
+    // the tier gate before dedup and this would pass without the fix. An orphan
+    // `system` row makes the un-gated path actually dispatch and populate dedup,
+    // so the assertion has something to catch.
+    const store = makeStore();
     seedLiveSession(store, "gone-dedup", "system");
-    const deps = fakeDeps({ sessionStore: store });
+    const dispatchAction = vi
+      .fn()
+      .mockResolvedValue({ result: { ok: true, result: { terminalId: "t-1" } } });
+    const deps = fakeDeps({ sessionStore: store, dispatchAction });
     const server = createSessionServer("gone-dedup", deps);
 
-    store.revokeSession("gone-dedup");
-    await callTool(server, {
+    store.sessions.delete("gone-dedup");
+
+    const result = await callTool(server, {
       name: "terminal.new",
       arguments: { spawnedBy: { kind: "user" } },
     });
 
+    expect(parseToolErrorPayload(result).code).toBe("SESSION_GONE");
+    expect(dispatchAction).not.toHaveBeenCalled();
     expect(store.dedupInFlight.size).toBe(0);
     expect(store.dedupResultCache.size).toBe(0);
-    store.grantCache.dispose();
   });
 
   it("refuses tools/list before it costs a manifest fetch", async () => {
     // Gated ahead of `resolveManifest` on purpose: that fetch can throw
     // SESSION_BINDING_GONE, which would answer "your workspace went away" to a
     // caller whose session is what actually went away.
-    const store = new RealSessionStore(() => {});
+    const store = makeStore();
     seedLiveSession(store, "gone-list", "external");
     const requestManifest = vi.fn().mockResolvedValue([]);
     const getCachedManifest = vi.fn(() => null);
@@ -4618,36 +4675,38 @@ describe("session-liveness gate (#11799)", () => {
 
     store.revokeSession("gone-list");
 
-    await expect(listTools(server)).rejects.toThrow(McpError);
     await expect(listTools(server)).rejects.toMatchObject({
       data: { code: "SESSION_GONE", retriable: false, errorCategory: "business" },
     });
     expect(requestManifest).not.toHaveBeenCalled();
     expect(getCachedManifest).not.toHaveBeenCalled();
-    store.grantCache.dispose();
   });
 
   it("throws rather than answering discovery with an empty surface", async () => {
     // `{ tools: [] }` / `{ resources: [] }` are well-formed, cacheable answers
     // that read as "you legitimately have nothing" and carry no hint that
     // reconnecting is the fix.
-    const store = new RealSessionStore(() => {});
+    const store = makeStore();
     seedLiveSession(store, "gone-empty", "system");
     const deps = fakeDeps({ sessionStore: store });
     const server = createSessionServer("gone-empty", deps);
 
     store.revokeSession("gone-empty");
 
-    for (const method of ["tools/list", "resources/list", "resources/templates/list"]) {
+    for (const method of [
+      "tools/list",
+      "resources/list",
+      "resources/templates/list",
+      "prompts/list",
+    ]) {
       await expect(invoke(server, method)).rejects.toMatchObject({
         data: { code: "SESSION_GONE" },
       });
     }
-    store.grantCache.dispose();
   });
 
   it("refuses resources/read for a revoked session without dispatching the backing action", async () => {
-    const store = new RealSessionStore(() => {});
+    const store = makeStore();
     seedLiveSession(store, "gone-read", "system");
     const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
     const deps = fakeDeps({ sessionStore: store, dispatchAction });
@@ -4659,13 +4718,12 @@ describe("session-liveness gate (#11799)", () => {
       invoke(server, "resources/read", { uri: "daintree://worktree/wt-1/pulse" })
     ).rejects.toMatchObject({ data: { code: "SESSION_GONE" } });
     expect(dispatchAction).not.toHaveBeenCalled();
-    store.grantCache.dispose();
   });
 
   it("refuses resources/subscribe for a revoked session and installs no listener", async () => {
     // Subscribing a dead session would leave an event listener pushing updates
     // at a transport that is already gone.
-    const store = new RealSessionStore(() => {});
+    const store = makeStore();
     seedLiveSession(store, "gone-sub", "system");
     const deps = fakeDeps({ sessionStore: store });
     const server = createSessionServer("gone-sub", deps);
@@ -4676,14 +4734,76 @@ describe("session-liveness gate (#11799)", () => {
       invoke(server, "resources/subscribe", { uri: "daintree://worktree/wt-1/pulse" })
     ).rejects.toMatchObject({ data: { code: "SESSION_GONE" } });
     expect(store.resourceSubscriptions.get("gone-sub")).toBeUndefined();
-    store.grantCache.dispose();
+  });
+
+  it("refuses prompts/get for a revoked session without reading worktree or terminal state", async () => {
+    // Prompts render from live IDE state, so `collectPromptContext` dispatches
+    // `worktree.getCurrent` and `terminal.getOutput`. Ungated, that is the same
+    // leak as the tool path reached through the prompt surface.
+    const store = makeStore();
+    seedLiveSession(store, "gone-prompt", "external");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const deps = fakeDeps({ sessionStore: store, dispatchAction });
+    const server = createSessionServer("gone-prompt", deps);
+
+    store.revokeSession("gone-prompt");
+
+    await expect(
+      invoke(server, "prompts/get", {
+        name: "triage_failed_agent",
+        arguments: { terminal_id: "t-1" },
+      })
+    ).rejects.toMatchObject({ data: { code: "SESSION_GONE" } });
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  it("refuses the next call after an abuse trip revokes the session mid-call", async () => {
+    // The one revocation source that fires from inside a tools/call. The
+    // triggering call still answers from its captured tier — it was admitted —
+    // but the session is gone by the time the next request arrives.
+    const store = makeStore();
+    seedLiveSession(store, "abuse", "external");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const appendAuditRecord = vi.fn();
+    const notifySessionRevoked = vi.fn();
+    const deps = fakeDeps({
+      sessionStore: store,
+      dispatchAction,
+      appendAuditRecord,
+      recordDenial: vi.fn(() => ({ tripped: true })),
+      notifySessionRevoked,
+      clearDenialState: vi.fn(),
+    });
+    const server = createSessionServer("abuse", deps);
+
+    const denied = await callTool(server, {
+      name: WORKBENCH_ONLY_TOOL!,
+      arguments: { path: "/etc/passwd" },
+    });
+
+    // Admitted, then denied on its own captured tier — not retroactively
+    // rewritten into SESSION_GONE by the revocation it just triggered.
+    expect(parseToolErrorPayload(denied)).toMatchObject({ code: TIER_NOT_PERMITTED_CODE });
+    expect(parseToolErrorPayload(denied).message).toContain("external");
+    expect(notifySessionRevoked).toHaveBeenCalledTimes(1);
+    expect(store.getTier("abuse")).toBeNull();
+
+    appendAuditRecord.mockClear();
+    const afterRevoke = await callTool(server, {
+      name: WORKBENCH_ONLY_TOOL!,
+      arguments: { path: "/etc/passwd" },
+    });
+
+    expect(parseToolErrorPayload(afterRevoke).code).toBe("SESSION_GONE");
+    expect(appendAuditRecord).not.toHaveBeenCalled();
+    expect(dispatchAction).not.toHaveBeenCalled();
   });
 
   it("lets an already-admitted call finish on its captured tier when revocation lands mid-dispatch", async () => {
     // The one-lifetime rule: revocation stops the NEXT request, it does not
     // rewrite a call the gate already admitted. The admitted call still must
     // not resurrect dedup state for the torn-down session.
-    const store = new RealSessionStore(() => {});
+    const store = makeStore();
     seedLiveSession(store, "admitted", "system");
     let resolveDispatch: ((envelope: unknown) => void) | undefined;
     const dispatchAction = vi.fn().mockImplementation(
@@ -4706,7 +4826,6 @@ describe("session-liveness gate (#11799)", () => {
     expect(store.dedupInFlight.get("admitted")?.size).toBe(1);
 
     store.revokeSession("admitted");
-    expect(store.getTier("admitted")).toBeNull();
 
     resolveDispatch!({ result: { ok: true, result: { terminalId: "t-admitted" } } });
     const result = await inFlight;
@@ -4717,6 +4836,5 @@ describe("session-liveness gate (#11799)", () => {
     // ...but writes nothing back into the torn-down session.
     expect(store.dedupInFlight.size).toBe(0);
     expect(store.dedupResultCache.size).toBe(0);
-    store.grantCache.dispose();
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -24,6 +24,7 @@ import {
   TIER_NOT_PERMITTED_CODE,
   EXECUTION_ERROR_CODE,
   SESSION_BINDING_GONE,
+  SESSION_GONE,
   CONFIRMATION_TIMEOUT_CODE,
   USER_REJECTED_CODE,
   MCP_DEDUP_KEY_COLLISION_CODE,
@@ -238,6 +239,30 @@ async function initializeClient(server: ReturnType<typeof createSessionServer>) 
   } finally {
     await client.close();
   }
+}
+
+/**
+ * Register a live SSE transport plus its tier row on a real `SessionStore`.
+ *
+ * `getTier` gates on transport membership (#11799), so seeding `sessionTierMap`
+ * alone no longer produces a session any request handler will serve — a real
+ * store needs the transport too.
+ */
+function seedLiveSession(
+  store: RealSessionStore,
+  sessionId: string,
+  tier: "workbench" | "action" | "system" | "external"
+): void {
+  store.sessions.set(sessionId, {
+    transport: {
+      close: vi.fn().mockResolvedValue(undefined),
+    },
+    server: {
+      sendToolListChanged: vi.fn().mockResolvedValue(undefined),
+    },
+    idleTimer: setTimeout(() => {}, 1_000_000),
+  } as unknown as NonNullable<ReturnType<RealSessionStore["sessions"]["get"]>>);
+  store.sessionTierMap.set(sessionId, tier);
 }
 
 function makeManifestEntry(id: string): ActionManifestEntry {
@@ -1210,7 +1235,10 @@ describe("CallTool idempotency dedup", () => {
 
   it("does not resurrect dedup state when drain() runs during an in-flight dispatch", async () => {
     const realStore = new RealSessionStore(() => {});
-    realStore.sessionTierMap.set("dedup-resurrect", "system");
+    // A live transport, not just a tier row: `getTier` gates on transport
+    // membership (#11799), so a tier-map-only session is refused before it can
+    // reach dispatch at all.
+    seedLiveSession(realStore, "dedup-resurrect", "system");
 
     let resolveDispatch: ((envelope: unknown) => void) | undefined;
     const dispatchAction = vi.fn().mockImplementation(
@@ -1394,6 +1422,19 @@ describe("buildMcpErrorPayload", () => {
     expect(RETRIABLE_ERROR_CODES.has(EXECUTION_ERROR_CODE)).toBe(true);
     expect(RETRIABLE_ERROR_CODES.has(CONFIRMATION_TIMEOUT_CODE)).toBe(true);
     expect(RETRIABLE_ERROR_CODES.has(TIER_NOT_PERMITTED_CODE)).toBe(false);
+  });
+
+  it("classifies SESSION_GONE as a non-retriable business failure (#11799)", () => {
+    // Retrying is pointless — the session is what went away, so recovery is a
+    // new session rather than the same call again.
+    const payload = buildMcpErrorPayload({ code: SESSION_GONE, message: "gone" });
+    expect(payload).toEqual({
+      code: SESSION_GONE,
+      message: "gone",
+      retriable: false,
+      errorCategory: "business",
+    });
+    expect(RETRIABLE_ERROR_CODES.has(SESSION_GONE)).toBe(false);
   });
 });
 
@@ -4027,15 +4068,15 @@ describe("mcp.surface short-circuit (#11549)", () => {
   });
 
   it("builds against the tier the call was authorized at, not a later re-read", async () => {
-    // A session revoked mid-fetch makes `getTier` fall back to `workbench`, and
-    // workbench is a PEER of `external`, not a subset. Re-reading the tier after
-    // the await would hand this external caller a workbench report naming tools
-    // its own allowlist withholds. The gate's tier is the only coherent answer.
+    // Authorization has one lifetime per call: a session revoked mid-fetch has
+    // no tier at all afterwards (#11799), and re-reading would either refuse a
+    // call the gate already admitted or disagree with the audit record that
+    // logs the admitted tier. The gate's tier is the only coherent answer.
     const sessionStore = fakeSessionStore("external");
     const deps = fakeDeps({
       sessionStore,
       requestManifest: vi.fn().mockImplementation(async () => {
-        vi.mocked(sessionStore.getTier).mockReturnValue("workbench");
+        vi.mocked(sessionStore.getTier).mockReturnValue(null);
         return surfaceManifest();
       }),
     });
@@ -4052,6 +4093,9 @@ describe("mcp.surface short-circuit (#11549)", () => {
     // `git.commit` is workbench-unreachable but system-tier in-app, and is not
     // on the external allowlist — the concrete tool the leak would have added.
     expect(reported.tools.map((t) => t.id)).not.toContain("git.commit");
+    // Resolved once, at the gate — the re-read this guards against would show
+    // up here as a second call.
+    expect(sessionStore.getTier).toHaveBeenCalledTimes(1);
   });
 
   it("writes one audit record and settles the activity strip exactly once", async () => {
@@ -4466,5 +4510,213 @@ describe("workspace-bound external sessions (#11789)", () => {
         await client.close();
       }
     });
+  });
+});
+
+describe("session-liveness gate (#11799)", () => {
+  function invoke(
+    server: ReturnType<typeof createSessionServer>,
+    method: string,
+    params: Record<string, unknown> = {}
+  ) {
+    const handlers = (
+      server as unknown as {
+        _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+      }
+    )._requestHandlers;
+    const handler = handlers.get(method);
+    if (!handler) throw new Error(`${method} handler not found`);
+    return handler(
+      { method, params, jsonrpc: "2.0", id: 1 },
+      {
+        signal: new AbortController().signal,
+        _meta: {},
+        sendNotification: vi.fn(),
+        requestId: 1,
+      }
+    );
+  }
+
+  function parseToolErrorPayload(result: unknown): Record<string, unknown> {
+    const block = (result as { content: Array<{ type: string; text: string }> }).content[0];
+    if (block.type !== "text") throw new Error("Expected a text block");
+    return JSON.parse(block.text) as Record<string, unknown>;
+  }
+
+  /** `file.read` is the issue's own example: workbench-permitted, external-withheld. */
+  const WORKBENCH_ONLY_TOOL = "file.read";
+
+  it("puts file.read on the workbench surface but not the external one", () => {
+    // Pins the premise the widening depends on. If these two ever agree,
+    // falling back to workbench would stop being an escalation and the tests
+    // below would pass for the wrong reason.
+    expect(isTierPermitted("workbench", WORKBENCH_ONLY_TOOL)).toBe(true);
+    expect(isTierPermitted("external", WORKBENCH_ONLY_TOOL)).toBe(false);
+  });
+
+  it("refuses a revoked external session's tools/call instead of dispatching it at workbench", async () => {
+    // The issue verbatim: an external bearer's session is revoked while its
+    // request is in flight, and the tier read that follows used to resolve to
+    // `workbench` — a peer allowlist that permits `file.read`.
+    const store = new RealSessionStore(() => {});
+    seedLiveSession(store, "revoked-external", "external");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const appendAuditRecord = vi.fn();
+    const notifyTierMismatch = vi.fn();
+    const deps = fakeDeps({ sessionStore: store, dispatchAction, appendAuditRecord });
+    const server = createSessionServer("revoked-external", deps);
+
+    store.revokeSession("revoked-external");
+
+    const result = await callTool(server, {
+      name: WORKBENCH_ONLY_TOOL,
+      arguments: { path: "/etc/passwd" },
+    });
+
+    expect((result as { isError?: boolean }).isError).toBe(true);
+    expect(parseToolErrorPayload(result)).toEqual({
+      code: "SESSION_GONE",
+      message: expect.stringContaining("no longer active"),
+      retriable: false,
+      errorCategory: "business",
+    });
+    // Refused before anything observable: no dispatch, and no audit row under a
+    // tier the caller never held.
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(appendAuditRecord).not.toHaveBeenCalled();
+    expect(notifyTierMismatch).not.toHaveBeenCalled();
+    store.grantCache.dispose();
+  });
+
+  it("leaves no dedup bookkeeping behind for a session refused at the gate", async () => {
+    const store = new RealSessionStore(() => {});
+    seedLiveSession(store, "gone-dedup", "system");
+    const deps = fakeDeps({ sessionStore: store });
+    const server = createSessionServer("gone-dedup", deps);
+
+    store.revokeSession("gone-dedup");
+    await callTool(server, {
+      name: "terminal.new",
+      arguments: { spawnedBy: { kind: "user" } },
+    });
+
+    expect(store.dedupInFlight.size).toBe(0);
+    expect(store.dedupResultCache.size).toBe(0);
+    store.grantCache.dispose();
+  });
+
+  it("refuses tools/list before it costs a manifest fetch", async () => {
+    // Gated ahead of `resolveManifest` on purpose: that fetch can throw
+    // SESSION_BINDING_GONE, which would answer "your workspace went away" to a
+    // caller whose session is what actually went away.
+    const store = new RealSessionStore(() => {});
+    seedLiveSession(store, "gone-list", "external");
+    const requestManifest = vi.fn().mockResolvedValue([]);
+    const getCachedManifest = vi.fn(() => null);
+    const deps = fakeDeps({ sessionStore: store, requestManifest, getCachedManifest });
+    const server = createSessionServer("gone-list", deps);
+
+    store.revokeSession("gone-list");
+
+    await expect(listTools(server)).rejects.toThrow(McpError);
+    await expect(listTools(server)).rejects.toMatchObject({
+      data: { code: "SESSION_GONE", retriable: false, errorCategory: "business" },
+    });
+    expect(requestManifest).not.toHaveBeenCalled();
+    expect(getCachedManifest).not.toHaveBeenCalled();
+    store.grantCache.dispose();
+  });
+
+  it("throws rather than answering discovery with an empty surface", async () => {
+    // `{ tools: [] }` / `{ resources: [] }` are well-formed, cacheable answers
+    // that read as "you legitimately have nothing" and carry no hint that
+    // reconnecting is the fix.
+    const store = new RealSessionStore(() => {});
+    seedLiveSession(store, "gone-empty", "system");
+    const deps = fakeDeps({ sessionStore: store });
+    const server = createSessionServer("gone-empty", deps);
+
+    store.revokeSession("gone-empty");
+
+    for (const method of ["tools/list", "resources/list", "resources/templates/list"]) {
+      await expect(invoke(server, method)).rejects.toMatchObject({
+        data: { code: "SESSION_GONE" },
+      });
+    }
+    store.grantCache.dispose();
+  });
+
+  it("refuses resources/read for a revoked session without dispatching the backing action", async () => {
+    const store = new RealSessionStore(() => {});
+    seedLiveSession(store, "gone-read", "system");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const deps = fakeDeps({ sessionStore: store, dispatchAction });
+    const server = createSessionServer("gone-read", deps);
+
+    store.revokeSession("gone-read");
+
+    await expect(
+      invoke(server, "resources/read", { uri: "daintree://worktree/wt-1/pulse" })
+    ).rejects.toMatchObject({ data: { code: "SESSION_GONE" } });
+    expect(dispatchAction).not.toHaveBeenCalled();
+    store.grantCache.dispose();
+  });
+
+  it("refuses resources/subscribe for a revoked session and installs no listener", async () => {
+    // Subscribing a dead session would leave an event listener pushing updates
+    // at a transport that is already gone.
+    const store = new RealSessionStore(() => {});
+    seedLiveSession(store, "gone-sub", "system");
+    const deps = fakeDeps({ sessionStore: store });
+    const server = createSessionServer("gone-sub", deps);
+
+    store.revokeSession("gone-sub");
+
+    await expect(
+      invoke(server, "resources/subscribe", { uri: "daintree://worktree/wt-1/pulse" })
+    ).rejects.toMatchObject({ data: { code: "SESSION_GONE" } });
+    expect(store.resourceSubscriptions.get("gone-sub")).toBeUndefined();
+    store.grantCache.dispose();
+  });
+
+  it("lets an already-admitted call finish on its captured tier when revocation lands mid-dispatch", async () => {
+    // The one-lifetime rule: revocation stops the NEXT request, it does not
+    // rewrite a call the gate already admitted. The admitted call still must
+    // not resurrect dedup state for the torn-down session.
+    const store = new RealSessionStore(() => {});
+    seedLiveSession(store, "admitted", "system");
+    let resolveDispatch: ((envelope: unknown) => void) | undefined;
+    const dispatchAction = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDispatch = resolve as (envelope: unknown) => void;
+        })
+    );
+    const deps = fakeDeps({ sessionStore: store, dispatchAction });
+    const server = createSessionServer("admitted", deps);
+
+    const inFlight = callTool(server, {
+      name: "terminal.new",
+      arguments: { spawnedBy: { kind: "user" } },
+    });
+    for (let i = 0; i < 50 && !resolveDispatch; i++) {
+      await Promise.resolve();
+    }
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(store.dedupInFlight.get("admitted")?.size).toBe(1);
+
+    store.revokeSession("admitted");
+    expect(store.getTier("admitted")).toBeNull();
+
+    resolveDispatch!({ result: { ok: true, result: { terminalId: "t-admitted" } } });
+    const result = await inFlight;
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+
+    // Admitted work completes rather than being retroactively refused...
+    expect((result as { isError?: boolean }).isError).toBeUndefined();
+    // ...but writes nothing back into the torn-down session.
+    expect(store.dedupInFlight.size).toBe(0);
+    expect(store.dedupResultCache.size).toBe(0);
+    store.grantCache.dispose();
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -254,6 +254,12 @@ function seedLiveSession(
   tier: "workbench" | "action" | "system" | "external",
   transport: "sse" | "http" = "sse"
 ): void {
+  // Unref'd because the store's own `clearTimeout` is reachable only through
+  // the map entry: a test that drops the entry directly — to orphan a tier row,
+  // say — loses the only handle, and a referenced 1,000,000 ms timer then holds
+  // the Vitest worker open past the suite.
+  const idleTimer = setTimeout(() => {}, 1_000_000);
+  idleTimer.unref?.();
   const entry = {
     transport: {
       close: vi.fn().mockResolvedValue(undefined),
@@ -261,7 +267,7 @@ function seedLiveSession(
     server: {
       sendToolListChanged: vi.fn().mockResolvedValue(undefined),
     },
-    idleTimer: setTimeout(() => {}, 1_000_000),
+    idleTimer,
   } as unknown as NonNullable<ReturnType<RealSessionStore["sessions"]["get"]>>;
   if (transport === "sse") {
     store.sessions.set(sessionId, entry);
@@ -1280,6 +1286,7 @@ describe("CallTool idempotency dedup", () => {
 
     expect(realStore.dedupResultCache.size).toBe(0);
     expect(realStore.dedupInFlight.size).toBe(0);
+    realStore.grantCache.dispose();
   });
 
   it("rejects requestKey strings beyond the length cap (falls back to auto-hash)", async () => {

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -627,6 +627,80 @@ describe("SessionStore dropBearerState wiring (#8778)", () => {
   });
 });
 
+describe("SessionStore.getTier liveness gate (#11799)", () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    store = new SessionStore(() => {});
+  });
+
+  afterEach(() => {
+    store.grantCache.dispose();
+    store.drain();
+    vi.useRealTimers();
+  });
+
+  it("resolves the recorded tier while an SSE transport is live", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "external");
+
+    expect(store.getTier("s")).toBe("external");
+  });
+
+  it("resolves the recorded tier while a Streamable-HTTP transport is live", () => {
+    store.httpSessions.set("h", fakeHttpSession());
+    store.sessionTierMap.set("h", "external");
+
+    expect(store.getTier("h")).toBe("external");
+  });
+
+  it("returns null for a session id no transport map has ever seen", () => {
+    expect(store.getTier("never-connected")).toBeNull();
+  });
+
+  it("returns null when a tier row outlives both transports", () => {
+    // The precise shape of the bug: teardown removes the transport, and until
+    // the tier row goes too, a read would answer from a session that is gone.
+    // `external` makes the stakes explicit — the old default resolved this to
+    // `workbench`, a peer allowlist holding tools `external` withholds.
+    store.sessionTierMap.set("orphan", "external");
+
+    expect(store.getTier("orphan")).toBeNull();
+  });
+
+  it("returns null once revokeSession has torn the session down", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "external");
+    expect(store.getTier("s")).toBe("external");
+
+    store.revokeSession("s");
+
+    expect(store.getTier("s")).toBeNull();
+  });
+
+  it("returns null for every session after drain()", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "system");
+    store.httpSessions.set("h", fakeHttpSession());
+    store.sessionTierMap.set("h", "action");
+
+    store.drain();
+
+    expect(store.getTier("s")).toBeNull();
+    expect(store.getTier("h")).toBeNull();
+  });
+
+  it("keeps the workbench fallback for a live session with no tier row", () => {
+    // Liveness and tier are separate signals: a live transport whose tier row
+    // is missing is not the revocation case, and must not be answered with the
+    // refusal reserved for it.
+    store.sessions.set("s", fakeSseSession());
+
+    expect(store.getTier("s")).toBe("workbench");
+  });
+});
+
 describe("SessionStore tier-elevation decay (#8462)", () => {
   let store: SessionStore;
   let decayed: string[];

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -45,6 +45,7 @@ import {
   minimumPermittingTier,
   EXECUTION_ERROR_CODE,
   SESSION_BINDING_GONE,
+  SESSION_GONE,
   INVALID_URL_CODE,
   buildToolError,
   buildMcpErrorPayload,
@@ -353,6 +354,30 @@ export interface SessionServerDeps {
   }) => void;
 }
 
+/**
+ * Refusal for a request whose session no longer exists (#11799). Static, and
+ * names the only recovery there is: nothing about this session can be retried,
+ * so a client must open a new one.
+ */
+const SESSION_GONE_MESSAGE =
+  "This MCP session is no longer active. Reconnect to start a new session before retrying.";
+
+/**
+ * The `McpError` form of {@link SESSION_GONE_MESSAGE}, for the request paths
+ * that signal failure by throwing (discovery and resources) rather than by
+ * returning an `isError` tool result. `InternalError` matches how the sibling
+ * structural failure `SESSION_BINDING_GONE` is already raised on `tools/list`,
+ * so a client reads one JSON-RPC shape for both — the `data.code` is what
+ * separates them.
+ */
+function sessionGoneError(): McpError {
+  return new McpError(
+    ErrorCode.InternalError,
+    SESSION_GONE_MESSAGE,
+    buildMcpErrorPayload({ code: SESSION_GONE, message: SESSION_GONE_MESSAGE })
+  );
+}
+
 export function createSessionServer(sessionId: string, deps: SessionServerDeps): Server {
   const {
     sessionStore,
@@ -484,8 +509,18 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
   };
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const manifest = await resolveManifest("tools/list");
+    // Resolve the tier before fetching anything (#11799). Two reasons to gate
+    // here rather than after the await: a dead session should not cost a
+    // manifest fetch, and `resolveManifest` can itself throw
+    // SESSION_BINDING_GONE — which would answer "your workspace went away" to a
+    // caller whose actual problem is that its session did.
     const tier = sessionStore.getTier(sessionId);
+    // Throw rather than answer with an empty list: `{ tools: [] }` is a
+    // well-formed, cacheable "you have no tools", indistinguishable from a
+    // legitimately empty surface and carrying no hint that reconnecting is the
+    // fix.
+    if (tier === null) throw sessionGoneError();
+    const manifest = await resolveManifest("tools/list");
     const tools = manifest
       .filter((entry) => shouldExposeTool(entry, tier, sessionSurface))
       .map((entry) => {
@@ -510,6 +545,19 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     const { args, requestKey } = parseToolArguments(request.params.arguments);
     const startedAt = Date.now();
     const tier = sessionStore.getTier(sessionId);
+    // Gate 0 (#11799): no live session, no authorization. The SDK's own
+    // transport await — body parse and JSON-RPC routing — sits between "the
+    // request arrived on a live session" and this handler, so an idle-timer
+    // expiry or an abuse trip on a concurrent call can revoke the session in
+    // between. Refusing here, before the tier gate, keeps a revoked external
+    // bearer off the workbench surface its own allowlist withholds.
+    //
+    // Returns before anything observable happens: no audit record (there is no
+    // honest tier to record it under), no denial counter, no tier-mismatch
+    // banner, no grant lookup, no dedup entry, and no dispatch.
+    if (tier === null) {
+      return buildToolError({ code: SESSION_GONE, message: SESSION_GONE_MESSAGE });
+    }
     // Snapshot the turn id once, at dispatch start, before any guard or await
     // can yield to an active→passive FSM transition that would clear it (#10067).
     // Every consumer below — the started/settled strip events and all audit
@@ -1047,16 +1095,14 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             const manifest = await resolveManifest(MCP_SURFACE_TOOL_ID);
             // Build against the tier captured at dispatch start — the one the
             // permission gate above actually authorized this call at — rather
-            // than re-reading after the await. Re-reading looks fresher but is
-            // not safe: `getTier` falls back to `workbench` once a revoked
-            // session's entry is gone, and workbench is a PEER of `external`,
-            // not a subset, so an external caller whose session was revoked
-            // mid-fetch would be handed a report naming workbench tools its own
-            // allowlist deliberately withholds. Using the gate's tier makes the
-            // report describe exactly what the caller was authorized against,
-            // and keeps it consistent with the audit record, which logs the
-            // same value. A tier that changes mid-call fires
-            // `notifications/tools/list_changed`, so a client re-reads anyway.
+            // than re-reading after the await. Authorization has one lifetime
+            // per call: revocation stops the *next* request, but does not
+            // rewrite a call already admitted, and an elevation or decay landing
+            // mid-fetch belongs to the next request too. Re-reading would make
+            // the report disagree with both the gate that admitted the call and
+            // the audit record, which logs this same value. A tier that changes
+            // mid-call fires `notifications/tools/list_changed`, so a client
+            // re-reads anyway.
             const result = buildSurfaceManifest(
               manifest,
               tier,
@@ -1540,22 +1586,31 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     return await dispatchPromise;
   });
 
+  // Each resource handler resolves the tier once at entry and threads it down
+  // (#11799). One capture per request: the listing helpers await dispatches
+  // mid-enumeration, and re-reading across those awaits would let one response
+  // mix two authorization lifetimes.
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    return { resources: await listConcreteResources(sessionId, deps) };
+    const tier = sessionStore.getTier(sessionId);
+    if (tier === null) throw sessionGoneError();
+    return { resources: await listConcreteResources(tier, deps) };
   });
 
   server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-    return { resourceTemplates: listResourceTemplates(sessionId, deps) };
+    const tier = sessionStore.getTier(sessionId);
+    if (tier === null) throw sessionGoneError();
+    return { resourceTemplates: listResourceTemplates(tier) };
   });
 
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const tier = sessionStore.getTier(sessionId);
+    if (tier === null) throw sessionGoneError();
     const uri = request.params.uri;
     const parsed = parseResourceUri(uri);
     if (!parsed) {
       throw new McpError(ErrorCode.InvalidRequest, `Unknown resource URI: ${uri}`);
     }
-    if (!isResourcePermitted(sessionId, deps, parsed.kind)) {
-      const tier = sessionStore.getTier(sessionId);
+    if (!isResourcePermitted(tier, parsed.kind)) {
       const message = `Resource '${uri}' is not permitted for the '${tier}' tier.`;
       throw new McpError(
         ErrorCode.InvalidRequest,
@@ -1568,13 +1623,17 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
   });
 
   server.setRequestHandler(SubscribeRequestSchema, async (request) => {
+    // Gated before `subscribeResource` can install an event listener, so a
+    // revoked session never leaves a subscription behind for a transport that
+    // is already gone.
+    const tier = sessionStore.getTier(sessionId);
+    if (tier === null) throw sessionGoneError();
     const uri = request.params.uri;
     const parsed = parseResourceUri(uri);
     if (!parsed) {
       throw new McpError(ErrorCode.InvalidRequest, `Unknown resource URI: ${uri}`);
     }
-    if (!isResourcePermitted(sessionId, deps, parsed.kind)) {
-      const tier = sessionStore.getTier(sessionId);
+    if (!isResourcePermitted(tier, parsed.kind)) {
       const message = `Resource '${uri}' is not permitted for the '${tier}' tier.`;
       throw new McpError(
         ErrorCode.InvalidRequest,
@@ -1654,12 +1713,12 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
 // --- Resource helpers ---
 
 async function listConcreteResources(
-  sessionId: string,
+  tier: McpTier,
   deps: SessionServerDeps
 ): Promise<Array<{ uri: string; name: string; mimeType: string; description?: string }>> {
   const resources: Array<{ uri: string; name: string; mimeType: string; description?: string }> =
     [];
-  if (isResourcePermitted(sessionId, deps, "issues")) {
+  if (isResourcePermitted(tier, "issues")) {
     resources.push({
       uri: "daintree://project/current/issues",
       name: "Current project — open issues",
@@ -1667,7 +1726,7 @@ async function listConcreteResources(
       description: "Open issues for the active project.",
     });
   }
-  if (isResourcePermitted(sessionId, deps, "pulse")) {
+  if (isResourcePermitted(tier, "pulse")) {
     const worktrees = await tryDispatchList("worktree.list", deps.dispatchAction);
     for (const wt of worktrees) {
       const id = readStringField(wt, ["id", "worktreeId"]);
@@ -1681,15 +1740,12 @@ async function listConcreteResources(
       });
     }
   }
-  if (
-    isResourcePermitted(sessionId, deps, "scrollback") ||
-    isResourcePermitted(sessionId, deps, "agentState")
-  ) {
+  if (isResourcePermitted(tier, "scrollback") || isResourcePermitted(tier, "agentState")) {
     const terminals = await tryDispatchList("terminal.list", deps.dispatchAction);
     for (const term of terminals) {
       const id = readStringField(term, ["id", "terminalId"]);
       const label = readStringField(term, ["title", "name"]) ?? id;
-      if (id && isResourcePermitted(sessionId, deps, "scrollback")) {
+      if (id && isResourcePermitted(tier, "scrollback")) {
         resources.push({
           uri: `daintree://terminal/${encodeURIComponent(id)}/scrollback`,
           name: `Terminal scrollback — ${label ?? id}`,
@@ -1698,7 +1754,7 @@ async function listConcreteResources(
         });
       }
       const agentId = readStringField(term, ["agentId"]);
-      if (agentId && isResourcePermitted(sessionId, deps, "agentState")) {
+      if (agentId && isResourcePermitted(tier, "agentState")) {
         resources.push({
           uri: `daintree://agent/${encodeURIComponent(agentId)}/state`,
           name: `Agent state — ${label ?? agentId}`,
@@ -1712,8 +1768,7 @@ async function listConcreteResources(
 }
 
 function listResourceTemplates(
-  sessionId: string,
-  deps: SessionServerDeps
+  tier: McpTier
 ): Array<{ uriTemplate: string; name: string; mimeType: string; description?: string }> {
   const templates: Array<{
     uriTemplate: string;
@@ -1721,7 +1776,7 @@ function listResourceTemplates(
     mimeType: string;
     description?: string;
   }> = [];
-  if (isResourcePermitted(sessionId, deps, "pulse")) {
+  if (isResourcePermitted(tier, "pulse")) {
     templates.push({
       uriTemplate: "daintree://worktree/{id}/pulse",
       name: "Worktree pulse",
@@ -1729,7 +1784,7 @@ function listResourceTemplates(
       description: "Git status summary, recent commits, and pull-request signal.",
     });
   }
-  if (isResourcePermitted(sessionId, deps, "scrollback")) {
+  if (isResourcePermitted(tier, "scrollback")) {
     templates.push({
       uriTemplate: "daintree://terminal/{id}/scrollback",
       name: "Terminal scrollback",
@@ -1737,7 +1792,7 @@ function listResourceTemplates(
       description: `Last ${RESOURCE_SCROLLBACK_TAIL_LINES} lines of terminal output.`,
     });
   }
-  if (isResourcePermitted(sessionId, deps, "agentState")) {
+  if (isResourcePermitted(tier, "agentState")) {
     templates.push({
       uriTemplate: "daintree://agent/{id}/state",
       name: "Agent state",
@@ -1825,8 +1880,14 @@ async function tryDispatchList(
   }
 }
 
-function isResourcePermitted(sessionId: string, deps: SessionServerDeps, kind: string): boolean {
-  const tier = deps.sessionStore.getTier(sessionId);
+/**
+ * Pure tier check — takes the tier its caller already resolved rather than
+ * reading the store again (#11799). The resource handlers resolve liveness once
+ * at entry, so this helper is only ever reached for a live session, and the
+ * twelve call sites across the two listing helpers share that one capture
+ * instead of racing the store twelve separate times.
+ */
+function isResourcePermitted(tier: McpTier, kind: string): boolean {
   return isTierPermitted(tier, (RESOURCE_BACKING_ACTIONS as Record<string, string>)[kind]);
 }
 

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -1651,6 +1651,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
   });
 
   server.setRequestHandler(ListPromptsRequestSchema, async () => {
+    if (sessionStore.getTier(sessionId) === null) throw sessionGoneError();
     return {
       prompts: PROMPT_DEFINITIONS.map((def) => ({
         name: def.name,
@@ -1661,6 +1662,13 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
   });
 
   server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    // Prompts render from live IDE state: `collectPromptContext` dispatches
+    // `worktree.getCurrent`, and `triage_failed_agent` also reads terminal
+    // output. That is a renderer dispatch on behalf of the session, so it
+    // belongs behind the same liveness gate as `tools/call` — otherwise a
+    // revoked bearer still reads worktree and terminal data through the prompt
+    // surface, which is the leak this issue is about wearing a different hat.
+    if (sessionStore.getTier(sessionId) === null) throw sessionGoneError();
     const name = request.params.name;
     const definition = PROMPT_DEFINITIONS.find((def) => def.name === name);
     if (!definition) {

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -615,7 +615,31 @@ export class SessionStore {
     this.tierElevationBaseline.delete(sessionId);
   }
 
-  getTier(sessionId: string): McpTier {
+  /**
+   * The tier a *live* session is authorized at, or `null` when no live
+   * transport owns `sessionId` (#11799).
+   *
+   * The liveness check comes first on purpose. `workbench` is not a floor:
+   * `TIER_ALLOWLISTS` gives `external` its own allowlist rather than a subset
+   * of `workbench`, so the two are peers. Returning the `workbench` default for
+   * a session that no longer exists therefore *widens* a revoked external
+   * bearer onto 46 tools its own allowlist withholds — `file.read`,
+   * `files.search`, `copyTree.generate` and `git.getFileDiff` among them —
+   * instead of refusing it. Revocation tears down `sessions`/`httpSessions`
+   * before it deletes the tier row, so transport membership is the signal that
+   * outlives nothing.
+   *
+   * `null` rather than a throw or a sentinel tier: there is no tier value that
+   * means "deny everything", and the nullable return makes the compiler
+   * enumerate every authorization site, so no caller can quietly inherit the
+   * old fail-open default. Callers fail closed — see `SESSION_GONE`.
+   *
+   * The `workbench` fallback survives only for a session that *is* live but has
+   * no tier row, which handshake ordering makes unreachable in production
+   * (every connect path stamps the tier before registering the transport).
+   */
+  getTier(sessionId: string): McpTier | null {
+    if (!this.sessions.has(sessionId) && !this.httpSessions.has(sessionId)) return null;
     return this.sessionTierMap.get(sessionId) ?? "workbench";
   }
 
@@ -662,9 +686,10 @@ export class SessionStore {
       }
       // The tier map can briefly outlive the transport during teardown; require
       // a live transport so a decaying session never reports as connected.
-      if (!this.sessions.has(transportSessionId) && !this.httpSessions.has(transportSessionId)) {
-        continue;
-      }
+      // `getTier` carries that liveness check itself (#11799), so its `null` is
+      // the same "no live transport" signal this scan used to test by hand.
+      const tier = this.getTier(transportSessionId);
+      if (tier === null) continue;
       // getActiveGrants is lazy-eviction only — a grant past expiresAt can
       // linger until the periodic sweep (~5min). Filter those out so the
       // snapshot never reports a logically-expired grant as active; the next
@@ -689,7 +714,7 @@ export class SessionStore {
         remainingUses: g.remainingUses,
       }));
       return {
-        tier: this.getTier(transportSessionId),
+        tier,
         activeGrants: [...activeGrants, ...nativeGrants],
       };
     }

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -232,6 +232,18 @@ export const CONFIRMATION_TIMEOUT_CODE = "CONFIRMATION_TIMEOUT";
 export const EXECUTION_ERROR_CODE = "EXECUTION_ERROR";
 export const BINDING_STALE = "BINDING_STALE";
 export const SESSION_BINDING_GONE = "SESSION_BINDING_GONE";
+/**
+ * The session itself no longer exists — revoked, idled out, or closed — so the
+ * request cannot be authorized against any tier (#11799).
+ *
+ * Distinct from {@link SESSION_BINDING_GONE}, which describes a session that is
+ * still live but can no longer reach the workspace it bound to at handshake.
+ * That one says "your target went away"; this one says "you went away". A
+ * client can recover from a binding failure by rebinding, but the only recovery
+ * from this is a new session, so conflating them would tell a client to retry a
+ * route it no longer has any session to route.
+ */
+export const SESSION_GONE = "SESSION_GONE";
 export const MCP_DEDUP_KEY_COLLISION_CODE = "MCP_DEDUP_KEY_COLLISION";
 export const PRE_AUTH_FAILED_CODE = "PRE_AUTH_FAILED";
 export const INVALID_URL_CODE = "INVALID_URL";
@@ -365,7 +377,11 @@ export function buildMcpErrorPayload(input: {
     message: input.message,
     retriable: RETRIABLE_ERROR_CODES.has(input.code),
   };
-  if (input.code === BINDING_STALE || input.code === SESSION_BINDING_GONE) {
+  if (
+    input.code === BINDING_STALE ||
+    input.code === SESSION_BINDING_GONE ||
+    input.code === SESSION_GONE
+  ) {
     payload.errorCategory = "business";
   }
   if (input.details !== undefined) {


### PR DESCRIPTION
**The bug.** `SessionStore.getTier()` returned the `workbench` default for a session id it didn't know. That would be fine if `workbench` were the floor, but it isn't: `TIER_ALLOWLISTS` maps `external` to its own independent allowlist rather than a superset of `workbench`, so the two are peers, not rungs on a ladder. `revokeSession()` deletes the tier row, and the `tools/call` handler read the tier with no liveness check ahead of it — so a request whose session was revoked while the SDK was still parsing and routing it resumed on the `workbench` surface instead of the one its bearer authenticated into, and the tier gate passed it. 46 tools are in `WORKBENCH_TIER_TOOLS` and not in `MCP_EXTERNAL_TIER_TOOLS`, including `file.read`, `files.search`, `copyTree.generate` and `git.getFileDiff`. Revocation widened the surface instead of closing it.

**The fix.** `getTier` now returns `McpTier | null`, checking transport liveness (`sessions.has(id) || httpSessions.has(id)` — the predicate the store already used in four other places) *before* it reads the tier map. `null` rather than a throw or a different default value: there is no tier that means "deny everything", and a nullable return makes the compiler enumerate every authorization site so no caller can quietly inherit the old fail-open behaviour. Both the issue and PR #11793's follow-up note ruled out simply changing the default.

Every authorization path now resolves the tier once at entry and fails closed on `null` with a new `SESSION_GONE` error — `tools/call` returns it as a tool error, and `tools/list`, the four resource handlers and the two prompt handlers throw it. Discovery throws rather than answering with an empty list, which would read as a legitimately empty surface and carry no hint that reconnecting is the fix.

`SESSION_GONE` is deliberately distinct from `SESSION_BINDING_GONE`: that one means a live session can no longer reach its bound workspace ("your target went away"), this one means the session itself is gone ("you went away"). A client recovers from the first by rebinding and from the second only by opening a new session, so conflating them would tell a client to retry a route it has no session to route. Non-retriable, business category.

**Two things worth calling out.**

`prompts/get` was in scope and wasn't obvious. It renders from live IDE state, so `collectPromptContext` dispatches `worktree.getCurrent` and, for `triage_failed_agent`, `terminal.getOutput`. Ungated, that's the same read a revoked bearer was never entitled to, reached through the prompt surface instead of the tool surface. Both prompt handlers are gated now. `resources/unsubscribe` is deliberately left ungated — it only tears down local state, and refusing cleanup for a dead session would be the wrong direction.

Authorization keeps its one lifetime per call. The tier is captured once, at admission, and reused for the rest of the handler — through the manifest fetch, the native-grant charge and dispatch. Revocation stops the *next* request; it does not retroactively refuse a call the gate already admitted, and re-reading mid-handler would only make the response disagree with the gate and the audit record that logs the same value. That convention is why the `mcp.surface` short-circuit captured the tier in the first place — its comment cited the `workbench` fallback as the reason, which this change makes false, so the rationale is reworded while the behaviour stands.

`isResourcePermitted` became a pure `(tier, kind)` function. It was reading the store on each of twelve calls across the two listing helpers; they now share the handler's single capture.

**Testing.** 693 tests pass across the six affected mcp-server suites, with typecheck and format clean on the changed files. The new coverage is mutation-checked: commenting out the single liveness line fails 14 tests, including the revoked-external-bearer dispatch attempt over both SSE and Streamable HTTP, all four discovery surfaces, the resource read/subscribe paths, `prompts/get`, and the abuse-trip path — the one revocation source that fires from inside a `tools/call`. The tier witness is derived from `TIER_ALLOWLISTS` rather than hardcoded, so it can't rot into a tautology.

**Out of scope, deliberately.** `httpLifecycle.ts`'s four inline cleanup blocks duplicate `revokeSession`'s teardown, but they correctly maintain the `sessions`/`httpSessions` membership this fix depends on, so de-duplicating them is separable follow-up rather than part of this change.

Resolves #11799