### PR TITLE
fix(terminal): resume paused xterm renderer instead of retrying forever

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -36,6 +36,7 @@ import {
   TerminalReflowController,
   forceXtermReflow,
   forceXtermRendererUnpause,
+  resetRendererUnpauseBreaker,
 } from "./TerminalReflowController";
 import { TerminalReconciliationWatchdog } from "./TerminalReconciliationWatchdog";
 import { TerminalWriteController } from "./TerminalWriteController";
@@ -336,7 +337,6 @@ class TerminalInstanceService {
       isWebGLActive: (id) => this.webGLManager.isActive(id),
       shouldHaveWebGL: (managed) => this.webGLPolicy.shouldHaveActiveWebGL(managed),
       ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),
-      forceUnpauseRenderer: (terminal) => forceXtermRendererUnpause(terminal),
       reconcileRevealGeometry: (id) => this.reconcileRevealGeometry(id),
       isStoreBackgrounded: (id) => usePanelStore.getState().backgroundedTerminals.has(id),
       isStoreHidden: (id) => usePanelStore.getState().panelsById[id]?.isVisible === false,
@@ -1813,6 +1813,12 @@ class TerminalInstanceService {
       }
       Object.assign(managed, addons);
       managed.terminal = terminal;
+      // A replacement Terminal brings a brand-new RenderService with its own
+      // pause state. attachGeneration doesn't move here, so without this the
+      // fresh renderer inherits the old one's give-up latch and — since it
+      // starts paused and only an observed unpause re-arms — would be denied
+      // its first repair forever (#11800).
+      resetRendererUnpauseBreaker(managed);
     } catch (error) {
       logError("[TIS] Failed to construct replacement terminal", error, { id });
       // The old instance is already disposed and `managed.terminal` may still
@@ -2985,18 +2991,25 @@ class TerminalInstanceService {
       logError(`resetRenderer failed for ${id}`, error);
     }
 
-    // Force IO re-evaluation so a DOM-renderer terminal that got stuck
-    // with _isPaused=true actually resumes drawing. Runs independently of
-    // the refresh/fit block so the user-invokable escape hatch works even
-    // when fit() throws. Clear the throttle so any follow-up automatic
-    // reflow (onWriteParsed, heartbeat, focus) fires immediately.
+    // Resume a renderer stuck at _isPaused=true so the pane actually redraws.
+    // Runs independently of the refresh/fit block so the user-invokable escape
+    // hatch works even when fit() throws. Clear the throttle so any follow-up
+    // automatic repair (onWriteParsed, heartbeat, focus) fires immediately.
     const termEl = managed.terminal.element;
     if (termEl) {
       try {
+        // The layout flush the reveal/wake sequences rely on. It cannot unpause
+        // anything on its own (#11800) — the real repair is below.
         forceXtermReflow(termEl);
       } catch (error) {
         logWarn(`forceXtermReflow failed for ${id}`, { error });
       }
+      // Redraw is the user's explicit "this pane is broken" signal, so it re-arms
+      // the breaker before repairing: a latch accrued by autonomous sweeps must
+      // not make the manual escape hatch a no-op, and one user-initiated attempt
+      // can't recreate a retry loop.
+      resetRendererUnpauseBreaker(managed);
+      forceXtermRendererUnpause(managed.terminal);
       managed.lastReflowAt = 0;
     }
     return true;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -32,7 +32,11 @@ import { TerminalWebGLPolicy } from "./TerminalWebGLPolicy";
 import { TerminalRevealController } from "./TerminalRevealController";
 import { TerminalAgentStateController } from "./TerminalAgentStateController";
 import { TerminalRestoreController } from "./TerminalRestoreController";
-import { TerminalReflowController, forceXtermReflow } from "./TerminalReflowController";
+import {
+  TerminalReflowController,
+  forceXtermReflow,
+  forceXtermRendererUnpause,
+} from "./TerminalReflowController";
 import { TerminalReconciliationWatchdog } from "./TerminalReconciliationWatchdog";
 import { TerminalWriteController } from "./TerminalWriteController";
 import { TerminalSettleWaiterRegistry } from "./TerminalSettleWaiterRegistry";
@@ -332,7 +336,7 @@ class TerminalInstanceService {
       isWebGLActive: (id) => this.webGLManager.isActive(id),
       shouldHaveWebGL: (managed) => this.webGLPolicy.shouldHaveActiveWebGL(managed),
       ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),
-      forceReflow: (element) => forceXtermReflow(element),
+      forceUnpauseRenderer: (terminal) => forceXtermRendererUnpause(terminal),
       reconcileRevealGeometry: (id) => this.reconcileRevealGeometry(id),
       isStoreBackgrounded: (id) => usePanelStore.getState().backgroundedTerminals.has(id),
       isStoreHidden: (id) => usePanelStore.getState().panelsById[id]?.isVisible === false,

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -34,6 +34,7 @@ import { TerminalAgentStateController } from "./TerminalAgentStateController";
 import { TerminalRestoreController } from "./TerminalRestoreController";
 import {
   TerminalReflowController,
+  attemptRendererUnpause,
   forceXtermReflow,
   forceXtermRendererUnpause,
   resetRendererUnpauseBreaker,
@@ -3004,12 +3005,20 @@ class TerminalInstanceService {
       } catch (error) {
         logWarn(`forceXtermReflow failed for ${id}`, { error });
       }
-      // Redraw is the user's explicit "this pane is broken" signal, so it re-arms
-      // the breaker before repairing: a latch accrued by autonomous sweeps must
-      // not make the manual escape hatch a no-op, and one user-initiated attempt
-      // can't recreate a retry loop.
-      resetRendererUnpauseBreaker(managed);
-      forceXtermRendererUnpause(managed.terminal);
+      if (options.force) {
+        // A PERSON asked for this — the same foreground gate #11638 uses below.
+        // Their explicit "this pane is broken" signal re-arms the breaker, so a
+        // latch accrued by autonomous sweeps can't make the manual escape hatch
+        // a no-op. One user-initiated attempt can't become a retry loop.
+        resetRendererUnpauseBreaker(managed);
+        forceXtermRendererUnpause(managed.terminal);
+      } else {
+        // Automatic callers — backend recovery, the project-switch reveal, and
+        // the post-drag repair — stay inside the shared cap. Re-arming for them
+        // would clear the latch on a timer and hand the periodic sweeps a fresh
+        // budget forever, which is the loop this whole change removes.
+        attemptRendererUnpause(managed);
+      }
       managed.lastReflowAt = 0;
     }
     return true;

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -251,7 +251,7 @@ export class TerminalReconciliationWatchdog {
       // Before the cooldown gate on purpose: verifying a prior unpause repair is
       // a private-field read, and gating it behind the 6s cooldown would delay
       // re-arming the breaker past the sweep that can actually see the outcome.
-      this.observeRendererUnpauseOutcome(id, managed);
+      this.observeRendererUnpauseOutcome(id, managed, now);
       if (now - (managed.lastWatchdogRepairAt ?? 0) < WATCHDOG_REPAIR_COOLDOWN_MS) continue;
       heavyBudget -= this.reconcile(id, managed, now, heavyBudget, resizeTransitioning);
     }
@@ -740,9 +740,15 @@ export class TerminalReconciliationWatchdog {
    * missing private field as proof of recovery and wipe the accrued attempts,
    * turning the one signal that bounds the loop into a fail-open.
    */
-  private observeRendererUnpauseOutcome(id: string, managed: ManagedTerminal): void {
+  private observeRendererUnpauseOutcome(id: string, managed: ManagedTerminal, now: number): void {
     if (!managed.rendererUnpauseAttempts) return;
     if (managed.rendererUnpauseGeneration !== managed.attachGeneration) return;
+    // The reflow controller registers its visibilitychange/reveal listeners
+    // BEFORE this class does, so on those events its repair runs in the same
+    // event turn, immediately ahead of this read. Requiring a full sweep to have
+    // elapsed is what makes the observation about the renderer rather than about
+    // a sibling's just-landed write.
+    if (now - (managed.rendererUnpauseAttemptedAt ?? 0) < WATCHDOG_INTERVAL_MS) return;
     if (readXtermRenderPaused(managed.terminal) !== false) return;
     logDebug("[TerminalReconciliationWatchdog] xterm render pause no longer set after repair", {
       id,

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -5,6 +5,12 @@ import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCa
 import { logDebug, logWarn } from "@/utils/logger";
 import { normalizeTerminalGridDimension } from "@shared/types/terminal";
 import { hasStreamingWrites } from "./TerminalResizeController";
+import {
+  MAX_RENDERER_UNPAUSE_ATTEMPTS,
+  attemptRendererUnpause,
+  readXtermRenderPaused,
+  resetRendererUnpauseBreaker,
+} from "./TerminalReflowController";
 import type { ManagedTerminal } from "./types";
 
 // Sweep cadence. Matches the TerminalReflowController heartbeat — slow enough
@@ -31,14 +37,6 @@ export const WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK = 2;
 // converge, stop repairing and log once, matching TerminalWebGLManager's
 // LOSS_THRESHOLD one-way-trip pattern. Reset on genuine convergence or re-attach.
 export const WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS = 3;
-
-// Renderer-unpause repairs allowed for one terminal before its breaker trips
-// (#11800). xterm's `_isPaused` is only ever written by its own
-// IntersectionObserver, so the repair forces the flag and repaints; if
-// something re-pauses the pane on every sweep, retrying forever just burns a
-// full-grid repaint each time and logs a repair that never took. Reset when a
-// later sweep observes the renderer unpaused, or on re-attach.
-export const WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS = 3;
 
 /** Narrow structural type for the private xterm.js render-pause flag. */
 interface XtermCoreRenderPause {
@@ -85,13 +83,6 @@ export interface ReconciliationWatchdogDeps {
   isWebGLActive: (id: string) => boolean;
   shouldHaveWebGL: (managed: ManagedTerminal) => boolean;
   ensureWebGL: (id: string, managed: ManagedTerminal) => void;
-  /**
-   * Repair (#11800): clear xterm's IntersectionObserver-driven render pause and
-   * repaint. Returns whether the repair was ISSUED — a `false` (drifted private
-   * API, or a throwing refresh) still counts as an attempt so a dependency that
-   * can never succeed can't restart the unbounded retry loop this replaced.
-   */
-  forceUnpauseRenderer: (terminal: Terminal) => boolean;
   /**
    * Repair (#10632): alt-buffer-safe atomic reveal reconcile — a FRESH fit
    * (xterm + PTY resized together) plus a local WebGL-atlas repair, with NO
@@ -700,43 +691,32 @@ export class TerminalReconciliationWatchdog {
    * its cost on their own.
    */
   private repairRenderPause(id: string, managed: ManagedTerminal, now: number): boolean {
-    // A fresh incarnation reusing this id starts clean — a previous instance's
-    // give-up can't describe a renderer it never owned (mirrors the geometry
-    // breaker's generation guard).
-    if (managed.rendererUnpauseGeneration !== managed.attachGeneration) {
-      managed.rendererUnpauseGeneration = managed.attachGeneration;
-      managed.rendererUnpauseAttempts = 0;
-      managed.rendererUnpauseGaveUp = false;
-    }
-    if (managed.rendererUnpauseGaveUp) return false;
-
-    const attempts = managed.rendererUnpauseAttempts ?? 0;
-    if (attempts >= WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS) {
-      managed.rendererUnpauseGaveUp = true;
+    // Accounting lives in attemptRendererUnpause because the reflow controller's
+    // write/heartbeat/focus paths share this same cap — see its doc comment.
+    const outcome = attemptRendererUnpause(managed);
+    if (outcome === "capped") return false;
+    if (outcome === "exhausted") {
       logWarn(
         "[TerminalReconciliationWatchdog] xterm renderer still paused after repeated unpause repairs — giving up (circuit breaker)",
         {
           id,
-          attempts,
-          limit: WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS,
+          limit: MAX_RENDERER_UNPAUSE_ATTEMPTS,
           isAltBuffer: managed.isAltBuffer === true,
         }
       );
       return false;
     }
 
-    managed.rendererUnpauseAttempts = attempts + 1;
     managed.lastWatchdogRepairAt = now;
-    // Counted even when the repair reports it could not run: a drifted or
-    // throwing primitive is precisely the case that must not retry forever.
-    const repairIssued = this.deps.forceUnpauseRenderer(managed.terminal);
     logWarn(
       "[TerminalReconciliationWatchdog] xterm render service paused for on-screen terminal — forcing unpause",
       {
         id,
         attempt: managed.rendererUnpauseAttempts,
-        limit: WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS,
-        repairIssued,
+        limit: MAX_RENDERER_UNPAUSE_ATTEMPTS,
+        // The real outcome, not an assertion of success: `false` means the
+        // private API drifted or the repaint threw.
+        repairIssued: outcome === "issued",
         isAltBuffer: managed.isAltBuffer === true,
       }
     );
@@ -753,18 +733,23 @@ export class TerminalReconciliationWatchdog {
    * and xterm's observer a chance to re-pause, so it is the only honest signal
    * available — and it proves the pause is no longer set, NOT that pixels
    * appeared. The log says exactly that.
+   *
+   * Uses the THREE-state read deliberately. `isXtermRenderPaused` collapses API
+   * drift to `false` — correct for deciding whether to repair (skip the check,
+   * let the other layers reconcile) but catastrophic here: it would read a
+   * missing private field as proof of recovery and wipe the accrued attempts,
+   * turning the one signal that bounds the loop into a fail-open.
    */
   private observeRendererUnpauseOutcome(id: string, managed: ManagedTerminal): void {
     if (!managed.rendererUnpauseAttempts) return;
     if (managed.rendererUnpauseGeneration !== managed.attachGeneration) return;
-    if (isXtermRenderPaused(managed.terminal)) return;
+    if (readXtermRenderPaused(managed.terminal) !== false) return;
     logDebug("[TerminalReconciliationWatchdog] xterm render pause no longer set after repair", {
       id,
       attempts: managed.rendererUnpauseAttempts,
       gaveUp: managed.rendererUnpauseGaveUp === true,
     });
-    managed.rendererUnpauseAttempts = 0;
-    managed.rendererUnpauseGaveUp = false;
+    resetRendererUnpauseBreaker(managed);
   }
 
   /**

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -32,6 +32,14 @@ export const WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK = 2;
 // LOSS_THRESHOLD one-way-trip pattern. Reset on genuine convergence or re-attach.
 export const WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS = 3;
 
+// Renderer-unpause repairs allowed for one terminal before its breaker trips
+// (#11800). xterm's `_isPaused` is only ever written by its own
+// IntersectionObserver, so the repair forces the flag and repaints; if
+// something re-pauses the pane on every sweep, retrying forever just burns a
+// full-grid repaint each time and logs a repair that never took. Reset when a
+// later sweep observes the renderer unpaused, or on re-attach.
+export const WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS = 3;
+
 /** Narrow structural type for the private xterm.js render-pause flag. */
 interface XtermCoreRenderPause {
   _renderService?: { _isPaused?: boolean };
@@ -77,7 +85,13 @@ export interface ReconciliationWatchdogDeps {
   isWebGLActive: (id: string) => boolean;
   shouldHaveWebGL: (managed: ManagedTerminal) => boolean;
   ensureWebGL: (id: string, managed: ManagedTerminal) => void;
-  forceReflow: (element: HTMLElement) => void;
+  /**
+   * Repair (#11800): clear xterm's IntersectionObserver-driven render pause and
+   * repaint. Returns whether the repair was ISSUED — a `false` (drifted private
+   * API, or a throwing refresh) still counts as an attempt so a dependency that
+   * can never succeed can't restart the unbounded retry loop this replaced.
+   */
+  forceUnpauseRenderer: (terminal: Terminal) => boolean;
   /**
    * Repair (#10632): alt-buffer-safe atomic reveal reconcile — a FRESH fit
    * (xterm + PTY resized together) plus a local WebGL-atlas repair, with NO
@@ -243,6 +257,10 @@ export class TerminalReconciliationWatchdog {
     for (const { id, managed } of onScreen) {
       const resizeTransitioning = this.deps.isResizeTransitioning(id);
       if (!resizeTransitioning) this.diagnoseGeometryDivergence(id, managed);
+      // Before the cooldown gate on purpose: verifying a prior unpause repair is
+      // a private-field read, and gating it behind the 6s cooldown would delay
+      // re-arming the breaker past the sweep that can actually see the outcome.
+      this.observeRendererUnpauseOutcome(id, managed);
       if (now - (managed.lastWatchdogRepairAt ?? 0) < WATCHDOG_REPAIR_COOLDOWN_MS) continue;
       heavyBudget -= this.reconcile(id, managed, now, heavyBudget, resizeTransitioning);
     }
@@ -499,7 +517,7 @@ export class TerminalReconciliationWatchdog {
           // a synchronized block, also unpause so convergence completes in one
           // tick (resetRenderer reflows too). Safe here — the synchronized guard
           // above is the only mid-block hazard.
-          this.unpauseIfNeeded(managed, element);
+          this.unpauseIfNeeded(id, managed, element, now);
           managed.revealPendingRepair = false;
           managed.revealPendingGeneration = undefined;
         }
@@ -602,7 +620,7 @@ export class TerminalReconciliationWatchdog {
                 }
               );
               if (this.deps.reconcileRevealGeometry(id)) {
-                this.unpauseIfNeeded(managed, element);
+                this.unpauseIfNeeded(id, managed, element, now);
               }
               return 1;
             }
@@ -611,27 +629,23 @@ export class TerminalReconciliationWatchdog {
       }
     }
 
-    // xterm render service paused on an on-screen terminal — force an IO
-    // re-evaluation so a renderer paused while the view was occluded resumes
-    // drawing. This now covers alt-buffer agent TUIs too (#10632): the old
-    // `!managed.isAltBuffer` exclusion was over-broad — the real hazard is
-    // interleaving a paint into an open DEC 2026 synchronized-output block, which
-    // `inSynchronizedBlock` already guards. A paused renderer repaints from
-    // NOTHING until unpaused, so excluding the very agent TUIs that break was the
-    // structural gap behind the recurring switch-back garble.
+    // xterm render service paused on an on-screen terminal — clear the pause so
+    // a renderer paused while the view was occluded resumes drawing. This covers
+    // alt-buffer agent TUIs too (#10632): the old `!managed.isAltBuffer`
+    // exclusion was over-broad — the real hazard is interleaving a paint into an
+    // open DEC 2026 synchronized-output block, which `inSynchronizedBlock`
+    // already guards. A paused renderer repaints from NOTHING until unpaused, so
+    // excluding the very agent TUIs that break was the structural gap behind the
+    // recurring switch-back garble.
     if (
       element &&
       element.isConnected &&
       !inSynchronizedBlock &&
       isXtermRenderPaused(managed.terminal)
     ) {
-      managed.lastWatchdogRepairAt = now;
-      logWarn(
-        "[TerminalReconciliationWatchdog] xterm render service paused for on-screen terminal — reflowing",
-        { id, isAltBuffer: managed.isAltBuffer === true }
-      );
-      this.deps.forceReflow(element);
-      return 0;
+      // Falls through to the WebGL layer when the breaker has latched — the
+      // breaker disables only this repair, not the rest of the chain.
+      if (this.repairRenderPause(id, managed, now)) return 0;
     }
 
     if (this.deps.shouldHaveWebGL(managed) && !this.deps.isWebGLActive(id)) {
@@ -652,15 +666,105 @@ export class TerminalReconciliationWatchdog {
    * Unpause a still-paused renderer right after a successful reveal reconcile
    * (#10632). Only called from the reveal-pending / geometry branches, which
    * have already established we are NOT inside a DEC 2026 synchronized-output
-   * block — so the reflow can't interleave a paint with a buffered range. This
-   * is what makes the watchdog's reveal recovery single-tick (geometry re-fit +
-   * unpause together), matching a manual Redraw rather than dribbling the two
-   * halves across separate cooldown windows.
+   * block — so the repaint can't interleave with a buffered range. This is what
+   * makes the watchdog's reveal recovery single-tick (geometry re-fit + unpause
+   * together), matching a manual Redraw rather than dribbling the two halves
+   * across separate cooldown windows.
+   *
+   * Shares the standalone branch's attempt counter (#11800). The geometry repair
+   * that just ran IS a real, frame-persisted change that may eventually drive a
+   * legitimate IO delivery — but waiting on one is exactly what left panes blank,
+   * and an escalation outside the cap would just be a second unbounded loop.
    */
-  private unpauseIfNeeded(managed: ManagedTerminal, element: HTMLElement | undefined): void {
+  private unpauseIfNeeded(
+    id: string,
+    managed: ManagedTerminal,
+    element: HTMLElement | undefined,
+    now: number
+  ): void {
     if (!element || !element.isConnected) return;
     if (!isXtermRenderPaused(managed.terminal)) return;
-    this.deps.forceReflow(element);
+    this.repairRenderPause(id, managed, now);
+  }
+
+  /**
+   * Bounded renderer-unpause repair (#11800). Returns whether this branch handled
+   * the tick; `false` means the breaker has latched and the caller should fall
+   * through to the cheaper layers below.
+   *
+   * Stays a LIGHT repair (the caller returns 0). It marks rows dirty and
+   * repaints, but triggers no wake/restore IPC, no WebGL context attach, no PTY
+   * resize and no scrollback re-wrap — the things the heavy budget exists to
+   * ration. Charging it heavy would cap recovery at two blank panes per tick and
+   * spend budget the WebGL layer needs; the cooldown and the attempt cap bound
+   * its cost on their own.
+   */
+  private repairRenderPause(id: string, managed: ManagedTerminal, now: number): boolean {
+    // A fresh incarnation reusing this id starts clean — a previous instance's
+    // give-up can't describe a renderer it never owned (mirrors the geometry
+    // breaker's generation guard).
+    if (managed.rendererUnpauseGeneration !== managed.attachGeneration) {
+      managed.rendererUnpauseGeneration = managed.attachGeneration;
+      managed.rendererUnpauseAttempts = 0;
+      managed.rendererUnpauseGaveUp = false;
+    }
+    if (managed.rendererUnpauseGaveUp) return false;
+
+    const attempts = managed.rendererUnpauseAttempts ?? 0;
+    if (attempts >= WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS) {
+      managed.rendererUnpauseGaveUp = true;
+      logWarn(
+        "[TerminalReconciliationWatchdog] xterm renderer still paused after repeated unpause repairs — giving up (circuit breaker)",
+        {
+          id,
+          attempts,
+          limit: WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS,
+          isAltBuffer: managed.isAltBuffer === true,
+        }
+      );
+      return false;
+    }
+
+    managed.rendererUnpauseAttempts = attempts + 1;
+    managed.lastWatchdogRepairAt = now;
+    // Counted even when the repair reports it could not run: a drifted or
+    // throwing primitive is precisely the case that must not retry forever.
+    const repairIssued = this.deps.forceUnpauseRenderer(managed.terminal);
+    logWarn(
+      "[TerminalReconciliationWatchdog] xterm render service paused for on-screen terminal — forcing unpause",
+      {
+        id,
+        attempt: managed.rendererUnpauseAttempts,
+        limit: WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS,
+        repairIssued,
+        isAltBuffer: managed.isAltBuffer === true,
+      }
+    );
+    return true;
+  }
+
+  /**
+   * Closed-loop half of the renderer-unpause repair (#11800). Runs before the
+   * repair cooldown so recovery is observed on the very next 3s sweep instead of
+   * waiting out the 6s window.
+   *
+   * A same-tick re-read after the repair would only confirm our own write. A
+   * later sweep is the first point at which Chromium has had frames to render
+   * and xterm's observer a chance to re-pause, so it is the only honest signal
+   * available — and it proves the pause is no longer set, NOT that pixels
+   * appeared. The log says exactly that.
+   */
+  private observeRendererUnpauseOutcome(id: string, managed: ManagedTerminal): void {
+    if (!managed.rendererUnpauseAttempts) return;
+    if (managed.rendererUnpauseGeneration !== managed.attachGeneration) return;
+    if (isXtermRenderPaused(managed.terminal)) return;
+    logDebug("[TerminalReconciliationWatchdog] xterm render pause no longer set after repair", {
+      id,
+      attempts: managed.rendererUnpauseAttempts,
+      gaveUp: managed.rendererUnpauseGaveUp === true,
+    });
+    managed.rendererUnpauseAttempts = 0;
+    managed.rendererUnpauseGaveUp = false;
   }
 
   /**

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -27,10 +27,17 @@ function readXtermRenderPaused(terminal: Terminal): boolean | undefined {
 }
 
 /**
- * Force a synchronous reflow that triggers xterm.js's IntersectionObserver
- * re-evaluation without pausing the renderer. Using display:none would set
- * isIntersecting=false, causing xterm to set _isPaused=true and halt rendering.
- * Sub-pixel padding jitter keeps the element in the layout tree throughout.
+ * Sub-pixel padding jitter that forces a synchronous layout while keeping the
+ * element in the layout tree (display:none would set isIntersecting=false and
+ * pause the renderer instead).
+ *
+ * Does NOT resume a paused renderer, despite what #5085 assumed: the mutation
+ * and its revert both happen in one task, while IntersectionObserver records
+ * are computed in the per-frame "update the rendering" step that runs only
+ * after the task and microtask queues drain — so the observer never sees
+ * anything but the reverted state (#11800). Reveal and wake paths still call
+ * it for the layout flush, alongside the real geometry changes that do drive
+ * IO. To actually unpause, use {@link forceXtermRendererUnpause}.
  */
 export function forceXtermReflow(element: HTMLElement): void {
   const prev = element.style.paddingTop;
@@ -39,8 +46,40 @@ export function forceXtermReflow(element: HTMLElement): void {
   element.style.paddingTop = prev;
 }
 
-// Throttle per-terminal reflows to bound layout cost under write bursts while
-// still recovering a paused DOM renderer within one write cadence window.
+/**
+ * Resume xterm's core RenderService after its IntersectionObserver paused it.
+ *
+ * In xterm 6 `_isPaused` is written in exactly one place — the observer
+ * callback — and no public API resets it, so a pane whose observer never
+ * redelivers (occluded reveal, long backgrounding) stays paused with every
+ * `refreshRows` call short-circuiting. Clearing the flag and issuing a
+ * full-range `refresh()` is precisely what xterm's own unpause path does
+ * (`refreshRows(0, rows - 1)`), just driven manually.
+ *
+ * Fails closed on API drift: the flag must already read `true`, so a future
+ * xterm that renames or drops it never gets a synthetic property written.
+ * Returns whether the repair was ISSUED — not whether the pane visibly
+ * recovered, which only a later observation can establish.
+ */
+export function forceXtermRendererUnpause(terminal: Terminal): boolean {
+  let renderService: { _isPaused?: boolean } | undefined;
+  try {
+    renderService = (terminal as Terminal & { _core?: XtermCoreRenderPause })._core?._renderService;
+    if (renderService?._isPaused !== true) return false;
+    renderService._isPaused = false;
+    terminal.refresh(0, Math.max(0, terminal.rows - 1));
+    return true;
+  } catch (err) {
+    // Leave the flag as we found it so the watchdog re-detects the pause and
+    // retries under its attempt cap, rather than believing this pane recovered.
+    if (renderService?._isPaused === false) renderService._isPaused = true;
+    logWarn("forceXtermRendererUnpause failed", { error: err });
+    return false;
+  }
+}
+
+// Throttle per-terminal repairs to bound repaint cost under write bursts while
+// still recovering a paused renderer within one write cadence window.
 const REFLOW_THROTTLE_MS = 250;
 
 // Periodic heartbeat interval — low frequency is enough to recover a paused
@@ -59,14 +98,16 @@ export interface ReflowControllerDeps {
 }
 
 /**
- * Owns the three layered IO-unpause recovery paths for visible terminals:
- *  1. Per-write reflow via `maybeReflow()` (called from `onWriteParsedReflow`)
+ * Owns the three layered unpause-recovery triggers for visible terminals:
+ *  1. Per-write via `maybeReflow()` (called from `onWriteParsedReflow`)
  *  2. 3 s heartbeat sweep — recovers a paused renderer with no writes
  *  3. Window focus / document visibilitychange — the moments a user is most
  *     likely to notice a blank terminal
  *
- * Co-locating all three layers preserves the recovery invariant from #5092:
- * removing any one path silently breaks recovery in some scenarios.
+ * Co-locating all three preserves the trigger invariant from #5092: removing
+ * any one path silently breaks recovery in some scenarios. The repair they
+ * share used to be a padding jitter that could never unpause anything (#11800);
+ * they now drive `forceXtermRendererUnpause` instead.
  */
 export class TerminalReflowController {
   private deps: ReflowControllerDeps;
@@ -150,16 +191,16 @@ export class TerminalReflowController {
   }
 
   /**
-   * Force an IntersectionObserver reflow on a terminal if it's eligible —
-   * used by onWriteParsed, the periodic heartbeat, and visibility/focus
-   * recovery paths. All guards live here so every caller stays consistent.
+   * Resume a paused renderer if this terminal is eligible — used by
+   * onWriteParsed, the periodic heartbeat, and the visibility/focus recovery
+   * paths. All guards live here so every caller stays consistent.
    *
    * Applies to agent terminals too: xterm 6's pause gate lives in the core
    * RenderService, so a WebGL-rendered terminal is just as susceptible as a
    * DOM one (and after a webglcontextlost it falls back to the DOM renderer
    * with no requeue). Skips: invisible/attaching terminals, alt-buffer (TUI)
-   * sessions, and terminals without a rendered element. Throttled per
-   * terminal.
+   * sessions, terminals without a connected element, an occluded window, and
+   * an open synchronized-output block. Throttled per terminal.
    */
   maybeReflow(managed: ManagedTerminal): void {
     // The decisive gate lives here rather than only on the heartbeat: the
@@ -183,22 +224,32 @@ export class TerminalReflowController {
     // IntersectionObserver jitter mid-block would interleave a paint with
     // the buffered range. Skip without stamping the throttle so we reflow
     // on the next tick after ESU.
+    // The per-write path reaches this method directly, so the heartbeat's own
+    // document check can't cover it: forcing a repaint while the window is
+    // occluded paints nothing (rAF is suspended there) and the visibilitychange
+    // sweep already recovers the moment it returns.
+    if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
     if (managed.terminal.modes?.synchronizedOutputMode === true) return;
-    // Renderer is provably unpaused — the jitter would be a wasted forced
-    // layout. Skip without stamping lastReflowAt so a pause detected on the
-    // next write reflows immediately. `true` or `undefined` (API drift)
-    // falls through to keep all three #5092 recovery layers working.
-    if (readXtermRenderPaused(managed.terminal) === false) return;
+    // Only a readable `true` is actionable. The repair clears xterm's private
+    // pause flag, so an unpaused renderer needs nothing and API drift
+    // (`undefined`) leaves no flag to clear — falling through on drift, as the
+    // reflow era did for #5092, would stamp the throttle for a guaranteed no-op.
+    if (readXtermRenderPaused(managed.terminal) !== true) return;
+    // The watchdog owns the breaker because it's the layer that can observe
+    // whether a repair took (#11800). Honour its give-up so this path can't
+    // restart a retry loop it already bounded.
+    if (
+      managed.rendererUnpauseGaveUp === true &&
+      managed.rendererUnpauseGeneration === managed.attachGeneration
+    ) {
+      return;
+    }
 
     const now = typeof performance !== "undefined" ? performance.now() : Date.now();
     if (now - (managed.lastReflowAt ?? 0) < REFLOW_THROTTLE_MS) return;
     managed.lastReflowAt = now;
 
-    try {
-      forceXtermReflow(element);
-    } catch (err) {
-      logWarn("forceXtermReflow failed", { error: err });
-    }
+    forceXtermRendererUnpause(managed.terminal);
   }
 
   dispose(): void {

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -144,6 +144,7 @@ export function attemptRendererUnpause(managed: ManagedTerminal): RendererUnpaus
   }
 
   managed.rendererUnpauseAttempts = attempts + 1;
+  managed.rendererUnpauseAttemptedAt = Date.now();
   // A `false` still consumed an attempt: a drifted or throwing primitive is
   // precisely the case that must not retry forever.
   return forceXtermRendererUnpause(managed.terminal) ? "issued" : "failed";
@@ -160,6 +161,7 @@ export function resetRendererUnpauseBreaker(managed: ManagedTerminal): void {
   managed.rendererUnpauseGeneration = managed.attachGeneration;
   managed.rendererUnpauseAttempts = 0;
   managed.rendererUnpauseGaveUp = false;
+  managed.rendererUnpauseAttemptedAt = undefined;
 }
 
 // Throttle per-terminal repairs to bound repaint cost under write bursts while

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -143,10 +143,16 @@ export function attemptRendererUnpause(managed: ManagedTerminal): RendererUnpaus
     return "exhausted";
   }
 
+  // A healthy renderer has nothing to repair, so it must not spend budget:
+  // `resetRenderer`'s automatic branch calls this with no pause check, and three
+  // such calls would otherwise latch the breaker on a working pane and deny the
+  // repair a genuine pause needs later. Only a readable `false` is proof —
+  // `undefined` (API drift) and the throwing case still consume an attempt,
+  // because a drifted primitive is precisely what must not retry forever.
+  if (readXtermRenderPaused(managed.terminal) === false) return "failed";
+
   managed.rendererUnpauseAttempts = attempts + 1;
   managed.rendererUnpauseAttemptedAt = Date.now();
-  // A `false` still consumed an attempt: a drifted or throwing primitive is
-  // precisely the case that must not retry forever.
   return forceXtermRendererUnpause(managed.terminal) ? "issued" : "failed";
 }
 

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -3,20 +3,32 @@ import type { ManagedTerminal } from "./types";
 import { logWarn } from "@/utils/logger";
 import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 
-type XtermCoreRenderPause = {
-  _renderService?: {
-    _isPaused?: boolean;
-  };
+type XtermRenderServicePause = {
+  _isPaused?: boolean;
+  /** xterm's own resume transition — see forceXtermRendererUnpause. */
+  _handleIntersectionChange?: (entry: IntersectionObserverEntry) => void;
 };
+
+type XtermCoreRenderPause = {
+  _renderService?: XtermRenderServicePause;
+};
+
+// Automatic renderer-unpause repairs allowed for one terminal before the
+// breaker trips (#11800). xterm's `_isPaused` is written only by its own
+// IntersectionObserver, so the repair forces the resume; if something re-pauses
+// the pane every sweep, retrying forever just burns a full-grid repaint each
+// time. Mirrors WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS and
+// TerminalWebGLManager's LOSS_THRESHOLD one-way-trip pattern.
+export const MAX_RENDERER_UNPAUSE_ATTEMPTS = 3;
 
 /**
  * Three-state read of xterm's private IntersectionObserver pause flag (same
  * `_core` escape hatch as `getXtermCellDimensions` / `isXtermRenderPaused`).
- * Returns `undefined` when the field is missing (API drift) so callers can
- * fall back to the unconditional reflow path — unlike the watchdog's
- * boolean read, which treats drift as not-paused.
+ * Returns `undefined` when the field is missing (API drift), which callers must
+ * treat as "don't know" — unlike the watchdog's boolean read, which collapses
+ * drift to not-paused so the rest of the chain keeps reconciling.
  */
-function readXtermRenderPaused(terminal: Terminal): boolean | undefined {
+export function readXtermRenderPaused(terminal: Terminal): boolean | undefined {
   try {
     const isPaused = (terminal as Terminal & { _core?: XtermCoreRenderPause })._core?._renderService
       ?._isPaused;
@@ -62,20 +74,92 @@ export function forceXtermReflow(element: HTMLElement): void {
  * recovered, which only a later observation can establish.
  */
 export function forceXtermRendererUnpause(terminal: Terminal): boolean {
-  let renderService: { _isPaused?: boolean } | undefined;
+  let renderService: XtermRenderServicePause | undefined;
   try {
     renderService = (terminal as Terminal & { _core?: XtermCoreRenderPause })._core?._renderService;
     if (renderService?._isPaused !== true) return false;
-    renderService._isPaused = false;
+    // Prefer driving xterm's OWN resume transition. Clearing the flag and
+    // repainting is not equivalent: `_handleIntersectionChange` also notifies
+    // the renderer of visibility, measures char dimensions if they were never
+    // valid, and — the one that actually bites — flushes `_pausedResizeTask`,
+    // the renderer resize queued when `resize()` ran while paused. That is
+    // exactly the reveal case (geometry re-fit, then unpause), so skipping it
+    // would repaint at the old surface size.
+    const resume = renderService._handleIntersectionChange;
+    if (typeof resume === "function") {
+      resume.call(renderService, {
+        isIntersecting: true,
+        intersectionRatio: 1,
+      } as IntersectionObserverEntry);
+    } else {
+      renderService._isPaused = false;
+    }
+    // Belt and braces: the handler only repaints when `_needsFullRefresh` was
+    // set, and the fallback above repaints nothing at all.
     terminal.refresh(0, Math.max(0, terminal.rows - 1));
     return true;
   } catch (err) {
     // Leave the flag as we found it so the watchdog re-detects the pause and
-    // retries under its attempt cap, rather than believing this pane recovered.
-    if (renderService?._isPaused === false) renderService._isPaused = true;
+    // retries under the attempt cap, rather than believing this pane recovered.
+    // Read defensively — a throwing getter is how we got here in the first place.
+    try {
+      if (renderService?._isPaused === false) renderService._isPaused = true;
+    } catch {
+      // Nothing more to do; the breaker bounds the retries either way.
+    }
     logWarn("forceXtermRendererUnpause failed", { error: err });
     return false;
   }
+}
+
+/**
+ * Outcome of a bounded unpause attempt. `capped` means the breaker was already
+ * latched (silent); `exhausted` means THIS call tripped it.
+ */
+export type RendererUnpauseOutcome = "issued" | "failed" | "exhausted" | "capped";
+
+/**
+ * The single bounded entry point for every AUTOMATIC renderer-unpause repair —
+ * the watchdog sweep, the per-write path, the 3s heartbeat, and focus/visibility
+ * recovery (#11800).
+ *
+ * Accounting lives here rather than in any one caller because a cap only bounds
+ * the loop if every autonomous path goes through it. The reflow controller's
+ * heartbeat runs at the watchdog's own 3s cadence and its write path at 250ms,
+ * so an uncounted repair there would keep a pane that IO re-pauses in exactly
+ * the full-grid repaint loop this cap exists to stop.
+ */
+export function attemptRendererUnpause(managed: ManagedTerminal): RendererUnpauseOutcome {
+  // A fresh incarnation reusing this id starts clean — a previous instance's
+  // give-up can't describe a renderer it never owned.
+  if (managed.rendererUnpauseGeneration !== managed.attachGeneration) {
+    resetRendererUnpauseBreaker(managed);
+  }
+  if (managed.rendererUnpauseGaveUp === true) return "capped";
+
+  const attempts = managed.rendererUnpauseAttempts ?? 0;
+  if (attempts >= MAX_RENDERER_UNPAUSE_ATTEMPTS) {
+    managed.rendererUnpauseGaveUp = true;
+    return "exhausted";
+  }
+
+  managed.rendererUnpauseAttempts = attempts + 1;
+  // A `false` still consumed an attempt: a drifted or throwing primitive is
+  // precisely the case that must not retry forever.
+  return forceXtermRendererUnpause(managed.terminal) ? "issued" : "failed";
+}
+
+/**
+ * Re-arm the breaker. Called on an observed unpause, on re-attach, when the
+ * terminal instance is replaced (a new RenderService has its own pause state and
+ * must not inherit a latch), and on an explicit user Redraw — the events that
+ * genuinely change whether a repair could succeed. Deliberately NOT time-based:
+ * a periodic re-arm would just restore the slow repaint loop.
+ */
+export function resetRendererUnpauseBreaker(managed: ManagedTerminal): void {
+  managed.rendererUnpauseGeneration = managed.attachGeneration;
+  managed.rendererUnpauseAttempts = 0;
+  managed.rendererUnpauseGaveUp = false;
 }
 
 // Throttle per-terminal repairs to bound repaint cost under write bursts while
@@ -235,21 +319,21 @@ export class TerminalReflowController {
     // (`undefined`) leaves no flag to clear — falling through on drift, as the
     // reflow era did for #5092, would stamp the throttle for a guaranteed no-op.
     if (readXtermRenderPaused(managed.terminal) !== true) return;
-    // The watchdog owns the breaker because it's the layer that can observe
-    // whether a repair took (#11800). Honour its give-up so this path can't
-    // restart a retry loop it already bounded.
-    if (
-      managed.rendererUnpauseGaveUp === true &&
-      managed.rendererUnpauseGeneration === managed.attachGeneration
-    ) {
-      return;
-    }
 
     const now = typeof performance !== "undefined" ? performance.now() : Date.now();
     if (now - (managed.lastReflowAt ?? 0) < REFLOW_THROTTLE_MS) return;
     managed.lastReflowAt = now;
 
-    forceXtermRendererUnpause(managed.terminal);
+    // Shares the watchdog's cap: this path fires far more often (every write,
+    // every 3s heartbeat, every focus), so leaving it uncounted would let a pane
+    // that IO keeps re-pausing repaint forever no matter what the watchdog
+    // decided (#11800).
+    if (attemptRendererUnpause(managed) === "exhausted") {
+      logWarn(
+        "[TerminalReflowController] xterm renderer still paused after repeated unpause repairs — giving up (circuit breaker)",
+        { id: managed.id, limit: MAX_RENDERER_UNPAUSE_ATTEMPTS }
+      );
+    }
   }
 
   dispose(): void {

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -94,36 +94,17 @@ function makeHostElement(): HTMLDivElement {
 }
 
 function makeTerminalElement(): HTMLDivElement {
-  const element = document.createElement("div");
-  const history: string[] = [];
-  const style = element.style;
-  const original = Object.getOwnPropertyDescriptor(style, "paddingTop");
-  Object.defineProperty(style, "paddingTop", {
-    configurable: true,
-    get(): string {
-      return original?.get?.call(style) ?? "";
-    },
-    set(value: string): void {
-      history.push(value);
-      original?.set?.call(style, value);
-    },
-  });
-  (
-    element as HTMLDivElement & {
-      __paddingTopHistory: string[];
-    }
-  ).__paddingTopHistory = history;
-  return element;
+  return document.createElement("div");
 }
 
-function paddingHistory(managed: ManagedTerminal): string[] {
-  return (
-    (
-      managed.terminal.element as HTMLDivElement & {
-        __paddingTopHistory?: string[];
-      }
-    ).__paddingTopHistory ?? []
-  );
+function renderService(managed: ManagedTerminal): { _isPaused: boolean } {
+  return (managed.terminal as unknown as { _core: { _renderService: { _isPaused: boolean } } })
+    ._core._renderService;
+}
+
+/** Put the renderer in the paused state — the only one a repair acts on. */
+function pauseRenderer(managed: ManagedTerminal): void {
+  renderService(managed)._isPaused = true;
 }
 
 function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
@@ -135,6 +116,8 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
     terminal: {
       element: terminalElement,
       rows: 24,
+      // Starts unpaused; the reflow tests below opt in via `pauseRenderer`.
+      _core: { _renderService: { _isPaused: false } },
       buffer: { active: { length: 100, type: "normal", baseY: 0, viewportY: 0 } },
       open: vi.fn(),
       write: vi.fn(),
@@ -243,6 +226,8 @@ describe("TerminalInstanceService adversarial", () => {
   it("CONCURRENT_REFLOW_IS_PER_TERMINAL_NOT_GLOBAL", () => {
     const managedA = makeManaged({ lastReflowAt: 2990 });
     const managedB = makeManaged({ lastReflowAt: 0 });
+    pauseRenderer(managedA);
+    pauseRenderer(managedB);
     document.body.appendChild(managedA.hostElement);
     document.body.appendChild(managedB.hostElement);
     service.instances.set("a", managedA);
@@ -250,8 +235,10 @@ describe("TerminalInstanceService adversarial", () => {
 
     vi.advanceTimersByTime(3000);
 
-    expect(paddingHistory(managedA)).toHaveLength(0);
-    expect(paddingHistory(managedB)).toContain("0.01px");
+    // A sits inside its 250ms throttle window and B does not, so B recovers on
+    // this sweep while A waits — one terminal's throttle must never gate another's.
+    expect(renderService(managedA)._isPaused).toBe(true);
+    expect(renderService(managedB)._isPaused).toBe(false);
     expect(managedA.lastReflowAt).toBe(2990);
     expect(managedB.lastReflowAt).toBeGreaterThan(0);
   });

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -120,8 +120,9 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
   // attach to the document by default. Individual tests can detach the host
   // to assert the disconnected-short-circuit path.
   document.body.appendChild(hostElement);
-  // Force offsetHeight to be readable (jsdom returns 0, but the read still
-  // forces layout — we observe the side-effect via paddingTop jitter).
+  // Padding jitter is still the observable for the paths that legitimately call
+  // forceXtermReflow for its forced layout (resetRenderer, reveal, wake) — it
+  // just no longer unpauses anything (#11800).
   const paddingTopHistory: string[] = [];
   const style = termEl.style;
   const orig = Object.getOwnPropertyDescriptor(style, "paddingTop");
@@ -138,9 +139,36 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
   (termEl as HTMLDivElement & { __paddingTopHistory: string[] }).__paddingTopHistory =
     paddingTopHistory;
 
+  // Count renderer-unpause repairs by watching the private pause flag clear —
+  // the one effect every trigger path shares, and robust against tests that
+  // reassign `terminal.refresh`. Terminals start PAUSED because that is the
+  // only state in which a repair has anything to do.
+  let unpauses = 0;
+  let paused = true;
+  const renderService = {
+    get _isPaused(): boolean {
+      return paused;
+    },
+    set _isPaused(next: boolean) {
+      if (paused && !next) unpauses += 1;
+      paused = next;
+    },
+  };
+  const probe = termEl as HTMLDivElement & {
+    __unpauses: () => number;
+    __repause: () => void;
+  };
+  probe.__unpauses = () => unpauses;
+  probe.__repause = () => {
+    paused = true;
+  };
+
   const managed = {
     terminal: {
       element: termEl,
+      rows: 24,
+      refresh: vi.fn(),
+      _core: { _renderService: renderService },
       modes: { synchronizedOutputMode: false },
     } as unknown as ManagedTerminal["terminal"],
     type: "terminal",
@@ -192,6 +220,20 @@ function paddingHistory(managed: ManagedTerminal): string[] {
   return el.__paddingTopHistory;
 }
 
+/** Renderer-unpause repairs issued against this terminal. */
+function unpauseCount(managed: ManagedTerminal): number {
+  return (managed.terminal.element as unknown as { __unpauses: () => number }).__unpauses();
+}
+
+/**
+ * Re-arm the pause. A successful repair clears the flag, so without this a
+ * follow-up trigger would skip because the renderer is already running rather
+ * than for the reason under test.
+ */
+function repause(managed: ManagedTerminal): void {
+  (managed.terminal.element as unknown as { __repause: () => void }).__repause();
+}
+
 // Test-fixture mutation helpers. The terminal mock isn't a full xterm Terminal,
 // so these consolidate the partial-shape casts in one place.
 type MutableModes = { modes?: { synchronizedOutputMode: boolean } | undefined };
@@ -233,66 +275,64 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     document.body.innerHTML = "";
   });
 
-  it("reflows a visible standard terminal and records lastReflowAt", () => {
+  it("unpauses a visible standard terminal and records lastReflowAt", () => {
     const managed = makeManaged();
     service.maybeReflowTerminal(managed);
 
-    // paddingTop was set to "0.01px" then restored
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
-  it("throttles per-terminal reflows within 250ms", () => {
+  it("throttles per-terminal repairs within 250ms", () => {
     const managed = makeManaged();
     service.maybeReflowTerminal(managed);
-    const history1 = paddingHistory(managed).length;
 
+    // Re-arm: otherwise the second call would skip because the renderer is
+    // already running, not because of the throttle.
+    repause(managed);
     service.maybeReflowTerminal(managed);
-    const history2 = paddingHistory(managed).length;
 
-    // Second call short-circuited — no additional jitter writes
-    expect(history2).toBe(history1);
+    expect(unpauseCount(managed)).toBe(1);
   });
 
-  it("allows reflow again after the throttle window", () => {
+  it("allows a repair again after the throttle window", () => {
     const managed = makeManaged();
     service.maybeReflowTerminal(managed);
-    const history1 = paddingHistory(managed).length;
 
+    repause(managed);
     // Simulate throttle window passing
     managed.lastReflowAt = (managed.lastReflowAt ?? 0) - 500;
     service.maybeReflowTerminal(managed);
-    const history2 = paddingHistory(managed).length;
 
-    expect(history2).toBeGreaterThan(history1);
+    expect(unpauseCount(managed)).toBe(2);
   });
 
-  it("reflows agent terminals — the xterm pause gate is renderer-agnostic", () => {
+  it("unpauses agent terminals — the xterm pause gate is renderer-agnostic", () => {
     const managed = makeManaged({ kind: "terminal", launchAgentId: "claude" });
     expect(managed.runtimeAgentId).toBe("claude");
 
     service.maybeReflowTerminal(managed);
 
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
   it("skips invisible terminals", () => {
     const managed = makeManaged({ isVisible: false });
     service.maybeReflowTerminal(managed);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips alt-buffer (TUI) terminals", () => {
     const managed = makeManaged({ isAltBuffer: true });
     service.maybeReflowTerminal(managed);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips terminals that are mid-attach", () => {
     const managed = makeManaged({ isAttaching: true });
     service.maybeReflowTerminal(managed);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips when terminal has no rendered element yet", () => {
@@ -310,10 +350,10 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect((managed.terminal.element as HTMLElement).isConnected).toBe(false);
 
     service.maybeReflowTerminal(managed);
-    // Throttle must NOT be stamped — otherwise the next legitimate reflow
+    // Throttle must NOT be stamped — otherwise the next legitimate repair
     // after reattachment would be suppressed for 250ms.
     expect(managed.lastReflowAt).toBe(0);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips — and does not stamp throttle — when synchronized output mode is active", () => {
@@ -321,34 +361,34 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     setSyncMode(managed, true);
 
     service.maybeReflowTerminal(managed);
-    // BSU is open — refreshing now would interleave with xterm's buffered
-    // range. Throttle must not stamp so we reflow on the next tick after ESU.
+    // BSU is open — repainting now would interleave with xterm's buffered
+    // range. Throttle must not stamp so we repair on the next tick after ESU.
     expect(managed.lastReflowAt).toBe(0);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
-  it("reflows when synchronized output mode is false", () => {
+  it("unpauses when synchronized output mode is false", () => {
     const managed = makeManaged();
     setSyncMode(managed, false);
 
     service.maybeReflowTerminal(managed);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
-  it("does not throttle the post-ESU reflow after a BSU skip", () => {
+  it("does not throttle the post-ESU repair after a BSU skip", () => {
     const managed = makeManaged();
     setSyncMode(managed, true);
     service.maybeReflowTerminal(managed);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
     expect(managed.lastReflowAt).toBe(0);
 
-    // ESU closes — the next reflow must fire immediately, not be eaten by
+    // ESU closes — the next repair must fire immediately, not be eaten by
     // the 250ms throttle. This is the invariant that justifies the
     // no-stamp branch in the guard.
     setSyncMode(managed, false);
     service.maybeReflowTerminal(managed);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
@@ -759,47 +799,47 @@ describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
     });
   });
 
-  it("skips reflows while document is hidden", () => {
+  it("skips repairs while document is hidden", () => {
     visibilityState = "hidden";
     const managed = makeManaged();
     service.instances.set("t1", managed);
 
     vi.advanceTimersByTime(3000);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
     expect(managed.lastReflowAt).toBe(0);
   });
 
-  it("performs reflows on heartbeat when visible", () => {
+  it("performs repairs on heartbeat when visible", () => {
     const managed = makeManaged();
     service.instances.set("t1", managed);
 
     vi.advanceTimersByTime(3000);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
-  it("heartbeat does not reflow or stamp throttle while sync block is open", () => {
+  it("heartbeat does not repair or stamp throttle while sync block is open", () => {
     const managed = makeManaged();
     setSyncMode(managed, true);
     service.instances.set("t1", managed);
 
     vi.advanceTimersByTime(3000);
     // Heartbeat tick fired but the sync-mode guard skipped without
-    // stamping — so the next post-ESU heartbeat will reflow immediately.
-    expect(paddingHistory(managed).length).toBe(0);
+    // stamping — so the next post-ESU heartbeat repairs immediately.
+    expect(unpauseCount(managed)).toBe(0);
     expect(managed.lastReflowAt).toBe(0);
   });
 
-  it("resumes reflows when visibility transitions hidden → visible", () => {
+  it("resumes repairs when visibility transitions hidden → visible", () => {
     visibilityState = "hidden";
     const managed = makeManaged();
     service.instances.set("t1", managed);
 
     vi.advanceTimersByTime(3000);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
 
     visibilityState = "visible";
     vi.advanceTimersByTime(3000);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ManagedTerminal } from "../types";
+import { MAX_RENDERER_UNPAUSE_ATTEMPTS } from "../TerminalReflowController";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -488,6 +489,38 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(service.resetRenderer("manual", { force: true })).toBe(true);
     expect(manual.rendererUnpauseGaveUp).toBe(false);
     expect(unpauseCount(manual)).toBe(1);
+  });
+
+  it("automatic resetRenderer spends no unpause budget on a healthy renderer (#11800)", () => {
+    // The automatic branch has no pause check of its own — post-drag reparent,
+    // backend recovery and the project-switch clear all reach it on panes that
+    // are rendering fine. If those calls consumed the budget, a handful of them
+    // would latch the breaker and deny the repair a real pause needs later.
+    vi.spyOn(service.resizeController, "fit").mockImplementation(() => null);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+
+    const managed = makeManaged();
+    for (const [prop, value] of [
+      ["clientWidth", 200],
+      ["clientHeight", 200],
+    ] as const) {
+      Object.defineProperty(managed.hostElement, prop, { value, configurable: true });
+    }
+    service.instances.set("healthy", managed);
+
+    for (let call = 0; call <= MAX_RENDERER_UNPAUSE_ATTEMPTS; call += 1) {
+      expect(service.resetRenderer("healthy")).toBe(true);
+    }
+
+    expect(managed.rendererUnpauseAttempts ?? 0).toBe(0);
+    expect(managed.rendererUnpauseGaveUp).toBeFalsy();
+
+    // The consequence that matters: a genuine pause arriving afterwards is
+    // still repaired instead of being refused by a breaker those healthy calls
+    // had no business latching.
+    pauseRenderer(managed);
+    expect(service.resetRenderer("healthy")).toBe(true);
+    expect(unpauseCount(managed)).toBe(1);
   });
 
   it("resetRenderer uses the local WebGL repair and skips the fallback refresh when a pool entry is repaired", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -453,6 +453,43 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(managed.lastReflowAt).toBe(0);
   });
 
+  it("only a user-initiated Redraw re-arms the unpause breaker (#11800)", () => {
+    // resetRenderer has automatic callers too — backend recovery, the
+    // project-switch reveal, the post-drag repair. If they re-armed, they would
+    // clear the latch on a timer and hand the periodic sweeps a fresh budget
+    // forever. `force` is the same foreground gate #11638 uses.
+    vi.spyOn(service.resizeController, "fit").mockImplementation(() => null);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+
+    const latch = (managed: ManagedTerminal): ManagedTerminal => {
+      // resetRenderer bails out below 50x50, so give the host a real box or
+      // both halves of this test would pass without reaching the code at all.
+      for (const [prop, value] of [
+        ["clientWidth", 200],
+        ["clientHeight", 200],
+      ] as const) {
+        Object.defineProperty(managed.hostElement, prop, { value, configurable: true });
+      }
+      pauseRenderer(managed);
+      managed.rendererUnpauseGaveUp = true;
+      managed.rendererUnpauseGeneration = managed.attachGeneration;
+      managed.rendererUnpauseAttempts = 3;
+      return managed;
+    };
+
+    const automatic = latch(makeManaged());
+    service.instances.set("auto", automatic);
+    expect(service.resetRenderer("auto")).toBe(true);
+    expect(automatic.rendererUnpauseGaveUp).toBe(true);
+    expect(unpauseCount(automatic)).toBe(0);
+
+    const manual = latch(makeManaged());
+    service.instances.set("manual", manual);
+    expect(service.resetRenderer("manual", { force: true })).toBe(true);
+    expect(manual.rendererUnpauseGaveUp).toBe(false);
+    expect(unpauseCount(manual)).toBe(1);
+  });
+
   it("resetRenderer uses the local WebGL repair and skips the fallback refresh when a pool entry is repaired", () => {
     const managed = makeManaged({ lastReflowAt: 99999 });
     Object.defineProperty(managed.hostElement, "clientWidth", { value: 200, configurable: true });

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -141,10 +141,11 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
 
   // Count renderer-unpause repairs by watching the private pause flag clear —
   // the one effect every trigger path shares, and robust against tests that
-  // reassign `terminal.refresh`. Terminals start PAUSED because that is the
-  // only state in which a repair has anything to do.
+  // reassign `terminal.refresh`. Terminals start UNPAUSED (the healthy state
+  // this mixed fixture's resetRenderer tests need); repair tests call
+  // `pauseRenderer` so their guards are proven, not assumed.
   let unpauses = 0;
-  let paused = true;
+  let paused = false;
   const renderService = {
     get _isPaused(): boolean {
       return paused;
@@ -220,17 +221,30 @@ function paddingHistory(managed: ManagedTerminal): string[] {
   return el.__paddingTopHistory;
 }
 
+/**
+ * Assert a forced layout flush ran: forceXtermReflow writes a temporary padding
+ * value and writes the original back. Checks that invariant rather than the
+ * specific jitter literal, which would just restate the implementation.
+ */
+function expectLayoutFlush(managed: ManagedTerminal): void {
+  const history = paddingHistory(managed);
+  expect(history.length).toBeGreaterThanOrEqual(2);
+  const [temporary, restored] = history.slice(-2);
+  expect(temporary).not.toBe(restored);
+}
+
 /** Renderer-unpause repairs issued against this terminal. */
 function unpauseCount(managed: ManagedTerminal): number {
   return (managed.terminal.element as unknown as { __unpauses: () => number }).__unpauses();
 }
 
 /**
- * Re-arm the pause. A successful repair clears the flag, so without this a
- * follow-up trigger would skip because the renderer is already running rather
- * than for the reason under test.
+ * Put the renderer in the paused state — the only one in which a repair has
+ * anything to do. Also used to RE-ARM between calls: a successful repair clears
+ * the flag, so without it a follow-up trigger would skip because the renderer is
+ * already running rather than for the reason under test.
  */
-function repause(managed: ManagedTerminal): void {
+function pauseRenderer(managed: ManagedTerminal): void {
   (managed.terminal.element as unknown as { __repause: () => void }).__repause();
 }
 
@@ -277,6 +291,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("unpauses a visible standard terminal and records lastReflowAt", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     service.maybeReflowTerminal(managed);
 
     expect(unpauseCount(managed)).toBe(1);
@@ -285,11 +300,12 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("throttles per-terminal repairs within 250ms", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     service.maybeReflowTerminal(managed);
 
     // Re-arm: otherwise the second call would skip because the renderer is
     // already running, not because of the throttle.
-    repause(managed);
+    pauseRenderer(managed);
     service.maybeReflowTerminal(managed);
 
     expect(unpauseCount(managed)).toBe(1);
@@ -297,9 +313,10 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("allows a repair again after the throttle window", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     service.maybeReflowTerminal(managed);
 
-    repause(managed);
+    pauseRenderer(managed);
     // Simulate throttle window passing
     managed.lastReflowAt = (managed.lastReflowAt ?? 0) - 500;
     service.maybeReflowTerminal(managed);
@@ -309,6 +326,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("unpauses agent terminals — the xterm pause gate is renderer-agnostic", () => {
     const managed = makeManaged({ kind: "terminal", launchAgentId: "claude" });
+    pauseRenderer(managed);
     expect(managed.runtimeAgentId).toBe("claude");
 
     service.maybeReflowTerminal(managed);
@@ -319,24 +337,28 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("skips invisible terminals", () => {
     const managed = makeManaged({ isVisible: false });
+    pauseRenderer(managed);
     service.maybeReflowTerminal(managed);
     expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips alt-buffer (TUI) terminals", () => {
     const managed = makeManaged({ isAltBuffer: true });
+    pauseRenderer(managed);
     service.maybeReflowTerminal(managed);
     expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips terminals that are mid-attach", () => {
     const managed = makeManaged({ isAttaching: true });
+    pauseRenderer(managed);
     service.maybeReflowTerminal(managed);
     expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips when terminal has no rendered element yet", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     (managed.terminal as unknown as { element: HTMLElement | undefined }).element = undefined;
     service.maybeReflowTerminal(managed);
     // lastReflowAt not set because we short-circuited on missing element
@@ -345,6 +367,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("skips — and does not stamp throttle — when element is detached", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     // Disconnect from document
     managed.hostElement.remove();
     expect((managed.terminal.element as HTMLElement).isConnected).toBe(false);
@@ -358,6 +381,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("skips — and does not stamp throttle — when synchronized output mode is active", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     setSyncMode(managed, true);
 
     service.maybeReflowTerminal(managed);
@@ -369,6 +393,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("unpauses when synchronized output mode is false", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     setSyncMode(managed, false);
 
     service.maybeReflowTerminal(managed);
@@ -378,6 +403,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("does not throttle the post-ESU repair after a BSU skip", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     setSyncMode(managed, true);
     service.maybeReflowTerminal(managed);
     expect(unpauseCount(managed)).toBe(0);
@@ -421,7 +447,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(repair).toHaveBeenCalledWith("t1");
     // DOM-renderer fallback still repaints the targeted pane.
     expect(term.refresh).toHaveBeenCalledWith(0, 23);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expectLayoutFlush(managed);
     // Throttle is cleared so the next onWriteParsed/heartbeat tick
     // reflows immediately.
     expect(managed.lastReflowAt).toBe(0);
@@ -454,7 +480,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(term.clearTextureAtlas).not.toHaveBeenCalled();
     expect(term.refresh).not.toHaveBeenCalled();
     // forceXtermReflow still fires and the throttle is still cleared.
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expectLayoutFlush(managed);
     expect(managed.lastReflowAt).toBe(0);
   });
 
@@ -479,7 +505,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
     expect(() => service.resetRenderer("t1")).not.toThrow();
     // The escape hatch — forceXtermReflow — must still run even if fit throws.
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expectLayoutFlush(managed);
     expect(managed.lastReflowAt).toBe(0);
     // Even on the error path, Redraw never flushes the shared atlas.
     expect(term.clearTextureAtlas).not.toHaveBeenCalled();
@@ -595,7 +621,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     // settled-strategy split.
     expect(fit).not.toHaveBeenCalled();
     // The escape hatch still runs so a paused renderer resumes drawing.
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expectLayoutFlush(managed);
   });
 
   it("forced resetRenderer still runs forceXtermReflow when the reconcile throws", () => {
@@ -615,7 +641,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     // either way rather than dropped.
     expect(managed.revealPendingRepair).toBe(true);
     expect(managed.revealPendingGeneration).toBe(managed.attachGeneration);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expectLayoutFlush(managed);
     expect(managed.lastReflowAt).toBe(0);
   });
 
@@ -802,6 +828,7 @@ describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
   it("skips repairs while document is hidden", () => {
     visibilityState = "hidden";
     const managed = makeManaged();
+    pauseRenderer(managed);
     service.instances.set("t1", managed);
 
     vi.advanceTimersByTime(3000);
@@ -811,6 +838,7 @@ describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
 
   it("performs repairs on heartbeat when visible", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     service.instances.set("t1", managed);
 
     vi.advanceTimersByTime(3000);
@@ -820,6 +848,7 @@ describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
 
   it("heartbeat does not repair or stamp throttle while sync block is open", () => {
     const managed = makeManaged();
+    pauseRenderer(managed);
     setSyncMode(managed, true);
     service.instances.set("t1", managed);
 
@@ -833,6 +862,7 @@ describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
   it("resumes repairs when visibility transitions hidden → visible", () => {
     visibilityState = "hidden";
     const managed = makeManaged();
+    pauseRenderer(managed);
     service.instances.set("t1", managed);
 
     vi.advanceTimersByTime(3000);

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -719,6 +719,30 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(attemptLogs[0]?.[1]).toMatchObject({ repairIssued: false, attempt: 1 });
     });
 
+    it("does not accept a same-turn sibling write as recovery", () => {
+      // The reflow controller registers its visibilitychange listener first, so
+      // on that event its repair lands immediately before the watchdog's sweep.
+      // Treating that write as durable recovery would re-arm the breaker on a
+      // renderer nothing actually fixed — the loop would never terminate.
+      const managed = makeManaged();
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.rendererUnpauseAttempts).toBe(1);
+
+      // Stand in for the sibling: clear the flag, then sweep within the same
+      // interval the repair was issued in.
+      setRenderPaused(managed, false);
+      watchdog.tick();
+      expect(managed.rendererUnpauseAttempts).toBe(1);
+
+      // A full sweep later, the same `false` IS believable.
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.rendererUnpauseAttempts).toBe(0);
+    });
+
     it("shares one attempt budget between the standalone branch and the reveal path", () => {
       // unpauseIfNeeded (reveal-pending / geometry) routes through the same cap.
       // Two independent budgets would let a stuck pane repaint twice as often.

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -13,6 +13,7 @@ import {
   WATCHDOG_INTERVAL_MS,
   WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS,
   WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK,
+  WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS,
   WATCHDOG_REPAIR_COOLDOWN_MS,
   isXtermRenderPaused,
   type ReconciliationWatchdogDeps,
@@ -100,6 +101,22 @@ function setRenderPaused(managed: ManagedTerminal, paused: boolean): void {
 }
 
 /**
+ * A `forceUnpauseRenderer` that behaves like the real primitive: it clears the
+ * private pause flag. Recovery is only observable to the watchdog on a LATER
+ * sweep, so tests using this must advance at least one more interval before
+ * asserting the breaker re-armed.
+ */
+function unpauseWith(): ReconciliationWatchdogDeps["forceUnpauseRenderer"] {
+  return vi.fn((terminal: ManagedTerminal["terminal"]) => {
+    const svc = (terminal as unknown as { _core?: { _renderService?: { _isPaused?: boolean } } })
+      ._core?._renderService;
+    if (svc?._isPaused !== true) return false;
+    svc._isPaused = false;
+    return true;
+  });
+}
+
+/**
  * Wire the xterm grid and the fit-addon proposal so the watchdog's geometry
  * convergence check (#10632) has real numbers. A mismatch models the garbled
  * "wrong column wrapping" a pane shows after a warm switch-back.
@@ -135,7 +152,10 @@ function makeDeps(
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
-    forceReflow: vi.fn(),
+    // Models a pane that stays paused: the repair is issued but the flag does
+    // not clear, which is the #11800 production case. Tests that need a genuine
+    // recovery override this with `unpauseWith(instances)`.
+    forceUnpauseRenderer: vi.fn(() => true),
     reconcileRevealGeometry: vi.fn(() => true),
     isStoreBackgrounded: vi.fn(() => false),
     isStoreHidden: vi.fn(() => false),
@@ -485,7 +505,7 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.resumeFlush).not.toHaveBeenCalled();
     });
 
-    it("reflows a terminal whose xterm render service is paused", () => {
+    it("unpauses a terminal whose xterm render service is paused", () => {
       const managed = makeManaged();
       setRenderPaused(managed, true);
       instances.set("t1", managed);
@@ -493,10 +513,10 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledWith(managed.terminal);
     });
 
-    it("reflows a paused alt-buffer (agent TUI) terminal when no synchronized block is open (#10632)", () => {
+    it("unpauses a paused alt-buffer (agent TUI) terminal when no synchronized block is open (#10632)", () => {
       // Regression: the watchdog used to EXCLUDE alt-buffer agents from the
       // render-pause repair (`!managed.isAltBuffer`), so exactly the agent TUIs
       // that break on switch-back had no closed-loop recovery. The only real
@@ -508,10 +528,10 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledWith(managed.terminal);
     });
 
-    it("does not reflow while DEC 2026 synchronized output is active (alt-buffer included)", () => {
+    it("does not unpause while DEC 2026 synchronized output is active (alt-buffer included)", () => {
       const managed = makeManaged({ isAltBuffer: true });
       (
         managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
@@ -522,8 +542,114 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceReflow).not.toHaveBeenCalled();
+      expect(deps.forceUnpauseRenderer).not.toHaveBeenCalled();
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    });
+
+    it("stops repairing a renderer that stays paused, after a bounded number of attempts (#11800)", () => {
+      // The bug: the branch reissued the repair on every eligible tick forever,
+      // logging success each time while the pane stayed blank.
+      const managed = makeManaged();
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
+
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(
+        WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS
+      );
+      expect(managed.rendererUnpauseGaveUp).toBe(true);
+      const giveUps = vi
+        .mocked(logWarn)
+        .mock.calls.filter(([msg]) => typeof msg === "string" && msg.includes("giving up"));
+      expect(giveUps).toHaveLength(1);
+    });
+
+    it("keeps reconciling the WebGL layer after the unpause breaker trips", () => {
+      // The breaker disables one repair, not the whole chain.
+      const managed = makeManaged();
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances, {
+        shouldHaveWebGL: vi.fn(() => true),
+        isWebGLActive: vi.fn(() => false),
+      });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
+
+      expect(managed.rendererUnpauseGaveUp).toBe(true);
+      expect(deps.ensureWebGL).toHaveBeenCalledWith("t1", managed);
+    });
+
+    it("re-arms the breaker once a later sweep observes the renderer unpaused", () => {
+      // Recovery is only observable on a LATER sweep — re-reading the flag in the
+      // same tick would just confirm the repair's own write.
+      const managed = makeManaged();
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances, { forceUnpauseRenderer: unpauseWith() });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(1);
+      expect(managed.rendererUnpauseAttempts).toBe(1);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.rendererUnpauseAttempts).toBe(0);
+      expect(managed.rendererUnpauseGaveUp).toBe(false);
+      expect(vi.mocked(logDebug).mock.calls.some(([msg]) => msg.includes("no longer set"))).toBe(
+        true
+      );
+
+      // A fresh pause after recovery gets the full budget again.
+      setRenderPaused(managed, true);
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 4);
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(2);
+    });
+
+    it("re-arms a latched breaker when the terminal re-attaches", () => {
+      const managed = makeManaged();
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
+      expect(managed.rendererUnpauseGaveUp).toBe(true);
+
+      // A new incarnation reusing this id must not inherit the give-up state.
+      managed.attachGeneration += 1;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(
+        WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS + 1
+      );
+      expect(managed.rendererUnpauseGaveUp).toBe(false);
+    });
+
+    it("counts an attempt even when the repair reports it could not run", () => {
+      // A drifted private API or a throwing refresh returns false. If those did
+      // not consume the budget, the unbounded retry loop would be back.
+      const managed = makeManaged();
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances, { forceUnpauseRenderer: vi.fn(() => false) });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
+
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(
+        WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS
+      );
+      expect(managed.rendererUnpauseGaveUp).toBe(true);
+      const attemptLogs = vi
+        .mocked(logWarn)
+        .mock.calls.filter(([msg]) => typeof msg === "string" && msg.includes("forcing unpause"));
+      expect(attemptLogs).toHaveLength(WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS);
+      // The log must report the real outcome, not assert success.
+      expect(attemptLogs[0]?.[1]).toMatchObject({ repairIssued: false, attempt: 1 });
     });
 
     it("reattaches a missing WebGL context for an eligible terminal", () => {
@@ -552,7 +678,7 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
       expect(deps.reassertActiveBackendTier).not.toHaveBeenCalled();
       expect(deps.resumeFlush).not.toHaveBeenCalled();
-      expect(deps.forceReflow).not.toHaveBeenCalled();
+      expect(deps.forceUnpauseRenderer).not.toHaveBeenCalled();
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
       expect(deps.ensureWebGL).not.toHaveBeenCalled();
       expect(managed.lastWatchdogRepairAt).toBeUndefined();
@@ -632,7 +758,7 @@ describe("TerminalReconciliationWatchdog", () => {
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
-      expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledWith(managed.terminal);
     });
 
     it("reconciles an on-screen terminal whose grid disagrees with the container (garbled wrapping)", () => {
@@ -901,7 +1027,7 @@ describe("TerminalReconciliationWatchdog", () => {
 
     it("falls through to the paused-render recovery on a streaming-deferred tick", () => {
       // Deferring the geometry repair must not starve the cheaper layers: a
-      // streaming pane whose renderer is paused still needs the unpause reflow.
+      // streaming pane whose renderer is paused still needs the unpause.
       const managed = makeManaged({ isAltBuffer: false });
       setRenderPaused(managed, true);
       setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
@@ -912,7 +1038,7 @@ describe("TerminalReconciliationWatchdog", () => {
       managed.lastWriteAt = Date.now() + WATCHDOG_INTERVAL_MS;
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
-      expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledWith(managed.terminal);
     });
 
     it("still issues the reveal-pending repair for a streaming ALT-buffer pane (quiescence gate is main-buffer only)", () => {
@@ -1082,7 +1208,9 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.setVisible).toHaveBeenCalledTimes(WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1);
     });
 
-    it("does not count light repairs against the heavy budget", () => {
+    it("does not count renderer-unpause repairs against the heavy budget", () => {
+      // Three blank panes must all recover on the same tick. Charging the unpause
+      // heavy would fix two and leave the third blank for another 3s (#11800).
       const pausedA = makeManaged();
       const pausedB = makeManaged();
       const pausedC = makeManaged();
@@ -1096,7 +1224,7 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceReflow).toHaveBeenCalledTimes(3);
+      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -13,11 +13,11 @@ import {
   WATCHDOG_INTERVAL_MS,
   WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS,
   WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK,
-  WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS,
   WATCHDOG_REPAIR_COOLDOWN_MS,
   isXtermRenderPaused,
   type ReconciliationWatchdogDeps,
 } from "../TerminalReconciliationWatchdog";
+import { MAX_RENDERER_UNPAUSE_ATTEMPTS } from "../TerminalReflowController";
 import type { ManagedTerminal } from "../types";
 import { MAX_TERMINAL_GRID_DIMENSION } from "@shared/types/terminal";
 
@@ -47,6 +47,8 @@ function makeManaged(overrides: ManagedOverrides = {}): ManagedTerminal {
   const managed = {
     terminal: {
       element: termEl,
+      rows: 24,
+      refresh: vi.fn(),
       modes: { synchronizedOutputMode: false },
     } as unknown as ManagedTerminal["terminal"],
     kind: "terminal",
@@ -101,19 +103,28 @@ function setRenderPaused(managed: ManagedTerminal, paused: boolean): void {
 }
 
 /**
- * A `forceUnpauseRenderer` that behaves like the real primitive: it clears the
- * private pause flag. Recovery is only observable to the watchdog on a LATER
- * sweep, so tests using this must advance at least one more interval before
- * asserting the breaker re-armed.
+ * Model the #11800 production case: the repair runs, but the renderer is paused
+ * again by the time anyone looks. Backed by a setter that refuses to go false,
+ * which is what a terminal whose IntersectionObserver keeps reporting
+ * not-intersecting looks like from the outside.
  */
-function unpauseWith(): ReconciliationWatchdogDeps["forceUnpauseRenderer"] {
-  return vi.fn((terminal: ManagedTerminal["terminal"]) => {
-    const svc = (terminal as unknown as { _core?: { _renderService?: { _isPaused?: boolean } } })
-      ._core?._renderService;
-    if (svc?._isPaused !== true) return false;
-    svc._isPaused = false;
-    return true;
-  });
+function setRenderPausedSticky(managed: ManagedTerminal): void {
+  (managed.terminal as unknown as { _core: unknown })._core = {
+    _renderService: {
+      get _isPaused(): boolean {
+        return true;
+      },
+      set _isPaused(_next: boolean) {
+        // Swallowed — IO re-pauses it before the next observation.
+      },
+    },
+  };
+}
+
+/** Count of full-grid repaints the real unpause primitive issued. */
+function refreshCount(managed: ManagedTerminal): number {
+  return (managed.terminal as unknown as { refresh: { mock: { calls: unknown[] } } }).refresh.mock
+    .calls.length;
 }
 
 /**
@@ -152,10 +163,6 @@ function makeDeps(
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
-    // Models a pane that stays paused: the repair is issued but the flag does
-    // not clear, which is the #11800 production case. Tests that need a genuine
-    // recovery override this with `unpauseWith(instances)`.
-    forceUnpauseRenderer: vi.fn(() => true),
     reconcileRevealGeometry: vi.fn(() => true),
     isStoreBackgrounded: vi.fn(() => false),
     isStoreHidden: vi.fn(() => false),
@@ -513,7 +520,7 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledWith(managed.terminal);
+      expect(refreshCount(managed)).toBe(1);
     });
 
     it("unpauses a paused alt-buffer (agent TUI) terminal when no synchronized block is open (#10632)", () => {
@@ -528,7 +535,7 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledWith(managed.terminal);
+      expect(refreshCount(managed)).toBe(1);
     });
 
     it("does not unpause while DEC 2026 synchronized output is active (alt-buffer included)", () => {
@@ -542,24 +549,23 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceUnpauseRenderer).not.toHaveBeenCalled();
+      expect(refreshCount(managed)).toBe(0);
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
     });
 
     it("stops repairing a renderer that stays paused, after a bounded number of attempts (#11800)", () => {
       // The bug: the branch reissued the repair on every eligible tick forever,
-      // logging success each time while the pane stayed blank.
+      // logging success each time while the pane stayed blank. Sticky pause
+      // models a renderer IO keeps re-pausing — the production case.
       const managed = makeManaged();
-      setRenderPaused(managed, true);
+      setRenderPausedSticky(managed);
       instances.set("t1", managed);
       const deps = makeDeps(instances);
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
 
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(
-        WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS
-      );
+      expect(refreshCount(managed)).toBe(MAX_RENDERER_UNPAUSE_ATTEMPTS);
       expect(managed.rendererUnpauseGaveUp).toBe(true);
       const giveUps = vi
         .mocked(logWarn)
@@ -570,7 +576,7 @@ describe("TerminalReconciliationWatchdog", () => {
     it("keeps reconciling the WebGL layer after the unpause breaker trips", () => {
       // The breaker disables one repair, not the whole chain.
       const managed = makeManaged();
-      setRenderPaused(managed, true);
+      setRenderPausedSticky(managed);
       instances.set("t1", managed);
       const deps = makeDeps(instances, {
         shouldHaveWebGL: vi.fn(() => true),
@@ -590,12 +596,14 @@ describe("TerminalReconciliationWatchdog", () => {
       const managed = makeManaged();
       setRenderPaused(managed, true);
       instances.set("t1", managed);
-      const deps = makeDeps(instances, { forceUnpauseRenderer: unpauseWith() });
+      const deps = makeDeps(instances);
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(1);
+      expect(refreshCount(managed)).toBe(1);
       expect(managed.rendererUnpauseAttempts).toBe(1);
+      // Same-tick: NOT yet reset, because that would be verifying our own write.
+      expect(isXtermRenderPaused(managed.terminal)).toBe(false);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(managed.rendererUnpauseAttempts).toBe(0);
@@ -607,12 +615,72 @@ describe("TerminalReconciliationWatchdog", () => {
       // A fresh pause after recovery gets the full budget again.
       setRenderPaused(managed, true);
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 4);
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(2);
+      expect(refreshCount(managed)).toBe(2);
+    });
+
+    it("re-arms a genuinely latched breaker when the renderer is later seen unpaused", () => {
+      // Distinct from the test above, which only ever reset attempts===1: this
+      // one trips `rendererUnpauseGaveUp` first, then proves the latch clears.
+      const managed = makeManaged();
+      setRenderPausedSticky(managed);
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
+      expect(managed.rendererUnpauseGaveUp).toBe(true);
+      const afterLatch = refreshCount(managed);
+
+      // Whatever was re-pausing it stops; the renderer now reads unpaused.
+      setRenderPaused(managed, false);
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.rendererUnpauseGaveUp).toBe(false);
+      expect(managed.rendererUnpauseAttempts).toBe(0);
+
+      // And a fresh pause is repaired again rather than being permanently barred.
+      setRenderPaused(managed, true);
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 4);
+      expect(refreshCount(managed)).toBe(afterLatch + 1);
+    });
+
+    it("preserves accrued attempts when the private pause flag drifts away", () => {
+      // isXtermRenderPaused collapses drift to `false`; if the observation used
+      // it, a missing field would read as proof of recovery and wipe the counter.
+      const managed = makeManaged();
+      setRenderPaused(managed, true);
+      instances.set("t1", managed);
+      watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.rendererUnpauseAttempts).toBe(1);
+
+      // API drift: the field disappears entirely.
+      delete (managed.terminal as unknown as { _core: { _renderService: { _isPaused?: boolean } } })
+        ._core._renderService._isPaused;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 4);
+      expect(managed.rendererUnpauseAttempts).toBe(1);
+    });
+
+    it("keeps each terminal's breaker state independent", () => {
+      const stuck = makeManaged();
+      const recovers = makeManaged();
+      setRenderPausedSticky(stuck);
+      setRenderPaused(recovers, true);
+      instances.set("stuck", stuck);
+      instances.set("recovers", recovers);
+      watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
+
+      expect(stuck.rendererUnpauseGaveUp).toBe(true);
+      expect(recovers.rendererUnpauseGaveUp).toBe(false);
+      expect(recovers.rendererUnpauseAttempts).toBe(0);
+      expect(refreshCount(recovers)).toBe(1);
     });
 
     it("re-arms a latched breaker when the terminal re-attaches", () => {
       const managed = makeManaged();
-      setRenderPaused(managed, true);
+      setRenderPausedSticky(managed);
       instances.set("t1", managed);
       const deps = makeDeps(instances);
       watchdog = new TerminalReconciliationWatchdog(deps);
@@ -623,33 +691,46 @@ describe("TerminalReconciliationWatchdog", () => {
       // A new incarnation reusing this id must not inherit the give-up state.
       managed.attachGeneration += 1;
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(
-        WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS + 1
-      );
+      expect(refreshCount(managed)).toBe(MAX_RENDERER_UNPAUSE_ATTEMPTS + 1);
       expect(managed.rendererUnpauseGaveUp).toBe(false);
     });
 
     it("counts an attempt even when the repair reports it could not run", () => {
-      // A drifted private API or a throwing refresh returns false. If those did
-      // not consume the budget, the unbounded retry loop would be back.
+      // A render service whose pause flag reads true but cannot be resumed —
+      // refresh throws, so the primitive restores the flag and returns false. If
+      // that did not consume the budget, the unbounded retry loop would be back.
       const managed = makeManaged();
       setRenderPaused(managed, true);
+      (managed.terminal as unknown as { refresh: ReturnType<typeof vi.fn> }).refresh = vi.fn(() => {
+        throw new Error("renderer gone");
+      });
       instances.set("t1", managed);
-      const deps = makeDeps(instances, { forceUnpauseRenderer: vi.fn(() => false) });
-      watchdog = new TerminalReconciliationWatchdog(deps);
+      watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
 
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(
-        WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS
-      );
+      expect(refreshCount(managed)).toBe(MAX_RENDERER_UNPAUSE_ATTEMPTS);
       expect(managed.rendererUnpauseGaveUp).toBe(true);
       const attemptLogs = vi
         .mocked(logWarn)
         .mock.calls.filter(([msg]) => typeof msg === "string" && msg.includes("forcing unpause"));
-      expect(attemptLogs).toHaveLength(WATCHDOG_MAX_RENDERER_UNPAUSE_ATTEMPTS);
+      expect(attemptLogs).toHaveLength(MAX_RENDERER_UNPAUSE_ATTEMPTS);
       // The log must report the real outcome, not assert success.
       expect(attemptLogs[0]?.[1]).toMatchObject({ repairIssued: false, attempt: 1 });
+    });
+
+    it("shares one attempt budget between the standalone branch and the reveal path", () => {
+      // unpauseIfNeeded (reveal-pending / geometry) routes through the same cap.
+      // Two independent budgets would let a stuck pane repaint twice as often.
+      const managed = makeManaged({ revealPendingRepair: true });
+      setRenderPausedSticky(managed);
+      instances.set("t1", managed);
+      watchdog = new TerminalReconciliationWatchdog(makeDeps(instances));
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 20);
+
+      expect(refreshCount(managed)).toBe(MAX_RENDERER_UNPAUSE_ATTEMPTS);
+      expect(managed.rendererUnpauseGaveUp).toBe(true);
     });
 
     it("reattaches a missing WebGL context for an eligible terminal", () => {
@@ -678,7 +759,7 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
       expect(deps.reassertActiveBackendTier).not.toHaveBeenCalled();
       expect(deps.resumeFlush).not.toHaveBeenCalled();
-      expect(deps.forceUnpauseRenderer).not.toHaveBeenCalled();
+      expect(refreshCount(managed)).toBe(0);
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
       expect(deps.ensureWebGL).not.toHaveBeenCalled();
       expect(managed.lastWatchdogRepairAt).toBeUndefined();
@@ -758,7 +839,7 @@ describe("TerminalReconciliationWatchdog", () => {
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledWith(managed.terminal);
+      expect(refreshCount(managed)).toBe(1);
     });
 
     it("reconciles an on-screen terminal whose grid disagrees with the container (garbled wrapping)", () => {
@@ -1038,7 +1119,7 @@ describe("TerminalReconciliationWatchdog", () => {
       managed.lastWriteAt = Date.now() + WATCHDOG_INTERVAL_MS;
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledWith(managed.terminal);
+      expect(refreshCount(managed)).toBe(1);
     });
 
     it("still issues the reveal-pending repair for a streaming ALT-buffer pane (quiescence gate is main-buffer only)", () => {
@@ -1224,7 +1305,9 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceUnpauseRenderer).toHaveBeenCalledTimes(3);
+      expect(refreshCount(pausedA)).toBe(1);
+      expect(refreshCount(pausedB)).toBe(1);
+      expect(refreshCount(pausedC)).toBe(1);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -4,6 +4,7 @@ import {
   REFLOW_HEARTBEAT_MS,
   TerminalReflowController,
   forceXtermReflow,
+  forceXtermRendererUnpause,
 } from "../TerminalReflowController";
 import { __resetProjectViewCacheStateForTests } from "@/lib/viewCacheState";
 import type { ManagedTerminal } from "../types";
@@ -20,26 +21,15 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
   hostElement.appendChild(termEl);
   document.body.appendChild(hostElement);
 
-  // Track padding writes — the only observable effect of forceXtermReflow.
-  const paddingTopHistory: string[] = [];
-  const style = termEl.style;
-  const orig = Object.getOwnPropertyDescriptor(style, "paddingTop");
-  Object.defineProperty(style, "paddingTop", {
-    configurable: true,
-    get(): string {
-      return orig?.get?.call(style) ?? "";
-    },
-    set(value: string): void {
-      paddingTopHistory.push(value);
-      orig?.set?.call(style, value);
-    },
-  });
-  (termEl as HTMLDivElement & { __paddingTopHistory: string[] }).__paddingTopHistory =
-    paddingTopHistory;
-
   const managed = {
     terminal: {
       element: termEl,
+      rows: 24,
+      // The observable effect of a repair: the pause flag clears and xterm is
+      // told to repaint. Terminals start PAUSED because that is the only state
+      // in which the controller has anything to do.
+      refresh: vi.fn(),
+      _core: { _renderService: { _isPaused: true } },
       modes: { synchronizedOutputMode: false },
     } as unknown as ManagedTerminal["terminal"],
     kind: "terminal",
@@ -86,12 +76,37 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
   return managed;
 }
 
-function paddingHistory(managed: ManagedTerminal): string[] {
-  const el = managed.terminal.element as unknown as { __paddingTopHistory: string[] };
-  return el.__paddingTopHistory;
+/** Repairs issued against this terminal — one refresh per unpause. */
+function unpauseCount(managed: ManagedTerminal): number {
+  return (managed.terminal as unknown as { refresh: { mock: { calls: unknown[] } } }).refresh.mock
+    .calls.length;
+}
+
+function renderService(managed: ManagedTerminal): { _isPaused?: boolean } {
+  return (managed.terminal as unknown as { _core: { _renderService: { _isPaused?: boolean } } })
+    ._core._renderService;
+}
+
+/**
+ * Re-arm the pause. A successful repair clears the flag, so without this a
+ * follow-up call would skip because the renderer is already running — making
+ * throttle assertions pass for the wrong reason.
+ */
+function repause(managed: ManagedTerminal): void {
+  renderService(managed)._isPaused = true;
+}
+
+function setDocumentVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
 }
 
 describe("forceXtermReflow", () => {
+  // Retained only as coverage for the legacy layout primitive — the reveal and
+  // wake paths still call it for its forced layout. It cannot unpause a
+  // renderer (#11800); that is forceXtermRendererUnpause's job.
   it("toggles paddingTop to 0.01px and restores it", () => {
     const el = document.createElement("div");
     el.style.paddingTop = "5px";
@@ -101,12 +116,82 @@ describe("forceXtermReflow", () => {
   });
 });
 
+describe("forceXtermRendererUnpause", () => {
+  function makeTerminal(renderServiceValue: object | undefined, rows = 24) {
+    return {
+      rows,
+      refresh: vi.fn(),
+      ...(renderServiceValue === undefined
+        ? {}
+        : { _core: { _renderService: renderServiceValue } }),
+    } as unknown as ManagedTerminal["terminal"];
+  }
+
+  it("clears the pause flag and repaints every row", () => {
+    const svc = { _isPaused: true };
+    const terminal = makeTerminal(svc, 40);
+
+    expect(forceXtermRendererUnpause(terminal)).toBe(true);
+    expect(svc._isPaused).toBe(false);
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 39);
+  });
+
+  it("no-ops on an already-running renderer", () => {
+    const svc = { _isPaused: false };
+    const terminal = makeTerminal(svc);
+
+    expect(forceXtermRendererUnpause(terminal)).toBe(false);
+    expect(terminal.refresh).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on API drift without synthesizing the flag", () => {
+    // A future xterm that renames or drops _isPaused must not get a new
+    // property written onto its render service.
+    const svc: { _isPaused?: boolean } = {};
+    const terminal = makeTerminal(svc);
+
+    expect(forceXtermRendererUnpause(terminal)).toBe(false);
+    expect("_isPaused" in svc).toBe(false);
+    expect(terminal.refresh).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the private core is absent entirely", () => {
+    const terminal = makeTerminal(undefined);
+    expect(forceXtermRendererUnpause(terminal)).toBe(false);
+    expect(terminal.refresh).not.toHaveBeenCalled();
+  });
+
+  it("restores the pause flag when the repaint throws", () => {
+    // Reporting success on a half-applied repair would stop the watchdog
+    // retrying a terminal that is still blank.
+    const svc = { _isPaused: true };
+    const terminal = makeTerminal(svc);
+    (terminal.refresh as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("renderer gone");
+    });
+
+    expect(forceXtermRendererUnpause(terminal)).toBe(false);
+    expect(svc._isPaused).toBe(true);
+  });
+
+  it("clamps the repaint range for a zero-row terminal", () => {
+    const svc = { _isPaused: true };
+    const terminal = makeTerminal(svc, 0);
+
+    expect(forceXtermRendererUnpause(terminal)).toBe(true);
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 0);
+  });
+});
+
 describe("TerminalReflowController.maybeReflow", () => {
   let controller: TerminalReflowController;
   let instances: ManagedTerminal[];
 
   beforeEach(() => {
     instances = [];
+    // Explicit, for the same reason the cached-view suite below stubs it: an
+    // inherited stub from another test would make these order-dependent.
+    setDocumentVisibility("visible");
     controller = new TerminalReflowController({
       getInstances: () => instances,
     });
@@ -117,59 +202,62 @@ describe("TerminalReflowController.maybeReflow", () => {
     document.body.innerHTML = "";
   });
 
-  it("reflows a visible standard terminal and stamps lastReflowAt", () => {
+  it("unpauses a visible standard terminal and stamps lastReflowAt", () => {
     const managed = makeManaged();
     controller.maybeReflow(managed);
 
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
+    expect(renderService(managed)._isPaused).toBe(false);
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
-  it("throttles a second reflow inside the 250ms window", () => {
+  it("throttles a second repair inside the 250ms window", () => {
     const managed = makeManaged();
     controller.maybeReflow(managed);
-    const before = paddingHistory(managed).length;
 
+    // Re-arm: otherwise the second call would skip because the renderer is
+    // already running, not because of the throttle.
+    repause(managed);
     controller.maybeReflow(managed);
-    expect(paddingHistory(managed).length).toBe(before);
+    expect(unpauseCount(managed)).toBe(1);
   });
 
-  it("allows a reflow once the throttle window has passed", () => {
+  it("allows a repair once the throttle window has passed", () => {
     const managed = makeManaged();
     controller.maybeReflow(managed);
-    const before = paddingHistory(managed).length;
 
+    repause(managed);
     managed.lastReflowAt = (managed.lastReflowAt ?? 0) - 500;
     controller.maybeReflow(managed);
-    expect(paddingHistory(managed).length).toBeGreaterThan(before);
+    expect(unpauseCount(managed)).toBe(2);
   });
 
-  it("reflows agent terminals — the xterm pause gate is renderer-agnostic", () => {
+  it("unpauses agent terminals — the xterm pause gate is renderer-agnostic", () => {
     const managed = makeManaged({ launchAgentId: "claude" });
     expect(managed.runtimeAgentId).toBe("claude");
 
     controller.maybeReflow(managed);
 
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
   it("skips invisible terminals", () => {
     const managed = makeManaged({ isVisible: false });
     controller.maybeReflow(managed);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips alt-buffer (TUI) terminals", () => {
     const managed = makeManaged({ isAltBuffer: true });
     controller.maybeReflow(managed);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips terminals that are mid-attach", () => {
     const managed = makeManaged({ isAttaching: true });
     controller.maybeReflow(managed);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips when terminal element is missing", () => {
@@ -186,40 +274,55 @@ describe("TerminalReflowController.maybeReflow", () => {
 
     controller.maybeReflow(managed);
     expect(managed.lastReflowAt).toBe(0);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
   it("skips without stamping the throttle when the renderer is provably unpaused", () => {
     const managed = makeManaged();
-    (managed.terminal as unknown as { _core: object })._core = {
-      _renderService: { _isPaused: false },
-    };
+    renderService(managed)._isPaused = false;
 
     controller.maybeReflow(managed);
     expect(managed.lastReflowAt).toBe(0);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
-  it("reflows when the renderer is paused", () => {
+  it("skips without stamping the throttle when the pause flag is missing (API drift)", () => {
+    // Inverted from the reflow era (#11800): the repair clears a flag, so with
+    // no readable flag there is nothing to clear. Falling through would stamp
+    // the throttle for a guaranteed no-op.
     const managed = makeManaged();
-    (managed.terminal as unknown as { _core: object })._core = {
-      _renderService: { _isPaused: true },
-    };
+    delete renderService(managed)._isPaused;
 
     controller.maybeReflow(managed);
-    expect(paddingHistory(managed)).toContain("0.01px");
-    expect(managed.lastReflowAt).toBeGreaterThan(0);
+    expect(managed.lastReflowAt).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 
-  it("reflows when the pause flag is missing (API drift)", () => {
+  it("skips while the document is hidden", () => {
+    // The per-write path reaches maybeReflow directly, so the heartbeat's own
+    // document check cannot cover it.
     const managed = makeManaged();
-    (managed.terminal as unknown as { _core: object })._core = {
-      _renderService: {},
-    };
+    setDocumentVisibility("hidden");
 
     controller.maybeReflow(managed);
-    expect(paddingHistory(managed)).toContain("0.01px");
-    expect(managed.lastReflowAt).toBeGreaterThan(0);
+    expect(managed.lastReflowAt).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
+  });
+
+  it("honours a latched watchdog give-up for the current generation", () => {
+    // The watchdog owns the breaker because it is the layer that can observe
+    // whether a repair took; this path must not restart a bounded retry loop.
+    const managed = makeManaged();
+    managed.rendererUnpauseGaveUp = true;
+    managed.rendererUnpauseGeneration = managed.attachGeneration;
+
+    controller.maybeReflow(managed);
+    expect(unpauseCount(managed)).toBe(0);
+
+    // A give-up from a previous incarnation does not apply.
+    managed.rendererUnpauseGeneration = managed.attachGeneration - 1;
+    controller.maybeReflow(managed);
+    expect(unpauseCount(managed)).toBe(1);
   });
 
   it("does not stamp the throttle while synchronized output mode is active", () => {
@@ -230,7 +333,7 @@ describe("TerminalReflowController.maybeReflow", () => {
 
     controller.maybeReflow(managed);
     expect(managed.lastReflowAt).toBe(0);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
   });
 });
 
@@ -268,34 +371,36 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
     winRemove.mockRestore();
   });
 
-  it("heartbeat fires every 3 s and reflows visible standard terminals", () => {
+  it("heartbeat fires every 3 s and unpauses visible standard terminals", () => {
     vi.useFakeTimers();
+    setDocumentVisibility("visible");
 
     const managed = makeManaged();
     instances = [managed];
     controller = new TerminalReflowController({ getInstances: () => instances });
 
     // Heartbeat hasn't fired yet.
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
 
     vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
 
     controller.dispose();
     vi.useRealTimers();
   });
 
-  it("heartbeat reflows agent terminals too", () => {
+  it("heartbeat unpauses agent terminals too", () => {
     vi.useFakeTimers();
+    setDocumentVisibility("visible");
 
     const managed = makeManaged({ launchAgentId: "claude" });
     instances = [managed];
     controller = new TerminalReflowController({ getInstances: () => instances });
 
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
 
     vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
 
     controller.dispose();
     vi.useRealTimers();
@@ -303,23 +408,25 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
 
   it("heartbeat stops firing after dispose", () => {
     vi.useFakeTimers();
+    setDocumentVisibility("visible");
 
     const managed = makeManaged();
     instances = [managed];
     controller = new TerminalReflowController({ getInstances: () => instances });
 
     vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
-    const reflowsAfterFirstTick = paddingHistory(managed).length;
-    expect(reflowsAfterFirstTick).toBeGreaterThan(0);
+    const afterFirstTick = unpauseCount(managed);
+    expect(afterFirstTick).toBeGreaterThan(0);
 
     controller.dispose();
 
-    // Reset the throttle so a second heartbeat would fire if the interval
-    // were still active.
+    // Re-arm the pause and reset the throttle so a second heartbeat would fire
+    // if the interval were still active.
+    repause(managed);
     managed.lastReflowAt = 0;
     vi.advanceTimersByTime(10_000);
 
-    expect(paddingHistory(managed).length).toBe(reflowsAfterFirstTick);
+    expect(unpauseCount(managed)).toBe(afterFirstTick);
     vi.useRealTimers();
   });
 
@@ -330,27 +437,22 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
     instances = [managed];
     controller = new TerminalReflowController({ getInstances: () => instances });
 
-    Object.defineProperty(document, "visibilityState", {
-      configurable: true,
-      get: () => "hidden",
-    });
+    setDocumentVisibility("hidden");
     vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
 
-    Object.defineProperty(document, "visibilityState", {
-      configurable: true,
-      get: () => "visible",
-    });
+    setDocumentVisibility("visible");
     // Reset throttle in case the visibilitychange listener fired one already.
     managed.lastReflowAt = 0;
     vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBeGreaterThan(0);
 
     controller.dispose();
     vi.useRealTimers();
   });
 
-  it("focus listener reflows every visible standard terminal", () => {
+  it("focus listener unpauses every visible standard terminal", () => {
+    setDocumentVisibility("visible");
     const a = makeManaged();
     const b = makeManaged();
     instances = [a, b];
@@ -358,20 +460,21 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
     controller = new TerminalReflowController({ getInstances: () => instances });
     window.dispatchEvent(new FocusEvent("focus"));
 
-    expect(paddingHistory(a)).toContain("0.01px");
-    expect(paddingHistory(b)).toContain("0.01px");
+    expect(unpauseCount(a)).toBe(1);
+    expect(unpauseCount(b)).toBe(1);
 
     controller.dispose();
   });
 
-  it("focus listener reflows agent terminals too", () => {
+  it("focus listener unpauses agent terminals too", () => {
+    setDocumentVisibility("visible");
     const managed = makeManaged({ launchAgentId: "claude" });
     instances = [managed];
 
     controller = new TerminalReflowController({ getInstances: () => instances });
     window.dispatchEvent(new FocusEvent("focus"));
 
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
 
     controller.dispose();
   });
@@ -382,38 +485,29 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
 
     controller = new TerminalReflowController({ getInstances: () => instances });
 
-    Object.defineProperty(document, "visibilityState", {
-      configurable: true,
-      get: () => "hidden",
-    });
+    setDocumentVisibility("hidden");
     document.dispatchEvent(new Event("visibilitychange"));
 
-    expect(paddingHistory(managed).length).toBe(0);
+    expect(unpauseCount(managed)).toBe(0);
 
-    Object.defineProperty(document, "visibilityState", {
-      configurable: true,
-      get: () => "visible",
-    });
+    setDocumentVisibility("visible");
     document.dispatchEvent(new Event("visibilitychange"));
 
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
 
     controller.dispose();
   });
 
-  it("visibilitychange listener reflows agent terminals too", () => {
+  it("visibilitychange listener unpauses agent terminals too", () => {
     const managed = makeManaged({ launchAgentId: "claude" });
     instances = [managed];
 
     controller = new TerminalReflowController({ getInstances: () => instances });
 
-    Object.defineProperty(document, "visibilityState", {
-      configurable: true,
-      get: () => "visible",
-    });
+    setDocumentVisibility("visible");
     document.dispatchEvent(new Event("visibilitychange"));
 
-    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(unpauseCount(managed)).toBe(1);
 
     controller.dispose();
   });
@@ -426,10 +520,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
   let controller: TerminalReflowController | undefined;
   let latchedCached = false;
 
-  function reflowCount(managed: ManagedTerminal): number {
-    // forceXtermReflow writes paddingTop twice per reflow (jitter + restore).
-    return paddingHistory(managed).length;
-  }
+  const reflowCount = unpauseCount;
 
   beforeEach(() => {
     latchedCached = false;

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -107,11 +107,41 @@ describe("forceXtermReflow", () => {
   // Retained only as coverage for the legacy layout primitive — the reveal and
   // wake paths still call it for its forced layout. It cannot unpause a
   // renderer (#11800); that is forceXtermRendererUnpause's job.
-  it("toggles paddingTop to 0.01px and restores it", () => {
+  it("writes a temporary padding value, forces layout, and restores the original", () => {
     const el = document.createElement("div");
     el.style.paddingTop = "5px";
+
+    const writes: string[] = [];
+    // Back the property with a local rather than delegating to the original
+    // accessor: paddingTop lives on CSSStyleDeclaration.prototype, so an
+    // own-property descriptor lookup returns undefined and the getter would
+    // always read "".
+    let current = el.style.paddingTop;
+    Object.defineProperty(el.style, "paddingTop", {
+      configurable: true,
+      get: (): string => current,
+      set(value: string): void {
+        writes.push(value);
+        current = value;
+      },
+    });
+    let layoutReads = 0;
+    Object.defineProperty(el, "offsetHeight", {
+      configurable: true,
+      get: () => {
+        layoutReads += 1;
+        return 0;
+      },
+    });
+
     forceXtermReflow(el);
-    // Restored to original after the read.
+
+    // Invariants, not the jitter literal: a value DIFFERENT from the original
+    // must land, layout must be forced while it is applied, and the original
+    // must come back. Asserting "0.01px" would just restate the implementation.
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).not.toBe("5px");
+    expect(layoutReads).toBeGreaterThan(0);
     expect(el.style.paddingTop).toBe("5px");
   });
 });
@@ -319,8 +349,11 @@ describe("TerminalReflowController.maybeReflow", () => {
     controller.maybeReflow(managed);
     expect(unpauseCount(managed)).toBe(0);
 
-    // A give-up from a previous incarnation does not apply.
+    // A give-up from a previous incarnation does not apply. Clear the throttle
+    // too — the capped call above still stamped it, so without this the second
+    // call would be suppressed for the wrong reason.
     managed.rendererUnpauseGeneration = managed.attachGeneration - 1;
+    managed.lastReflowAt = 0;
     controller.maybeReflow(managed);
     expect(unpauseCount(managed)).toBe(1);
   });

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -206,7 +206,7 @@ function makeWatchdogDeps(instances: Map<string, ManagedTerminal>): Reconciliati
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
-    forceReflow: vi.fn(),
+    forceUnpauseRenderer: vi.fn(() => true),
     reconcileRevealGeometry: vi.fn(() => true),
     isStoreBackgrounded: vi.fn(() => false),
     isStoreHidden: vi.fn(() => false),

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -206,7 +206,6 @@ function makeWatchdogDeps(instances: Map<string, ManagedTerminal>): Reconciliati
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
-    forceUnpauseRenderer: vi.fn(() => true),
     reconcileRevealGeometry: vi.fn(() => true),
     isStoreBackgrounded: vi.fn(() => false),
     isStoreHidden: vi.fn(() => false),

--- a/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
+++ b/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
@@ -18,7 +18,7 @@
 // paint half here, with its grid owned by the app's SIGWINCH redraw and the
 // ResizeObserver-driven resize on reattach.
 //
-// The `reconcileRevealGeometry` / `forceReflow` deps mirror what the real
+// The `reconcileRevealGeometry` / `forceUnpauseRenderer` deps mirror what the real
 // TerminalInstanceService does, INCLUDING the present-ordering guarantee:
 // reconcileGeometryFresh only succeeds against a foreground-renderable host
 // (checkVisibility + non-zero box), so a repaint is never issued into an
@@ -46,6 +46,7 @@ import {
   unlockSidebarHydration,
 } from "@/lib/layoutTransitionLock";
 import type { ManagedTerminal } from "../types";
+import { forceXtermRendererUnpause } from "../TerminalReflowController";
 
 vi.mock("@/utils/logger", () => ({
   logDebug: vi.fn(),
@@ -121,6 +122,12 @@ function buildManaged(agent: FakeAgent, isAltBuffer: boolean): ManagedTerminal {
         get _isPaused() {
           return agent.paused;
         },
+        // Writable, because that is how the pause is actually cleared (#11800):
+        // xterm only ever writes this from its own IntersectionObserver, so the
+        // repair forces the flag and repaints.
+        set _isPaused(next: boolean) {
+          agent.paused = next;
+        },
       },
     },
   } as unknown as ManagedTerminal["terminal"];
@@ -192,12 +199,11 @@ function buildDeps(
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
-    forceReflow: vi.fn((_element: HTMLElement) => {
-      // Unpause: the IO re-evaluation resumes the paused renderer. We can't know
-      // which agent the element belongs to cheaply, so unpause any agent whose
-      // host owns it.
-      for (const agent of agents.values()) agent.paused = false;
-    }),
+    // The REAL primitive, not a stand-in: it is the half #11800 proved was a
+    // structural no-op, so driving it end-to-end here is the point.
+    forceUnpauseRenderer: vi.fn((terminal: ManagedTerminal["terminal"]) =>
+      forceXtermRendererUnpause(terminal)
+    ),
     // Mirror TerminalInstanceService.reconcileRevealGeometry +
     // TerminalResizeController.reconcileGeometryFresh: atomic xterm+PTY re-fit to
     // the FRESH container measurement plus a local atlas repair — but ONLY when
@@ -406,7 +412,7 @@ describe("#10632 switch-back redraw — closed-loop convergence", () => {
     vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
     // Deferred: a repaint now would interleave with the buffered range.
     expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
-    expect(deps.forceReflow).not.toHaveBeenCalled();
+    expect(deps.forceUnpauseRenderer).not.toHaveBeenCalled();
     expect(agent.cols).toBe(120);
 
     // Block closes — next tick converges.

--- a/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
+++ b/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
@@ -18,7 +18,7 @@
 // paint half here, with its grid owned by the app's SIGWINCH redraw and the
 // ResizeObserver-driven resize on reattach.
 //
-// The `reconcileRevealGeometry` / `forceUnpauseRenderer` deps mirror what the real
+// The `reconcileRevealGeometry` dep mirrors what the real
 // TerminalInstanceService does, INCLUDING the present-ordering guarantee:
 // reconcileGeometryFresh only succeeds against a foreground-renderable host
 // (checkVisibility + non-zero box), so a repaint is never issued into an
@@ -46,7 +46,6 @@ import {
   unlockSidebarHydration,
 } from "@/lib/layoutTransitionLock";
 import type { ManagedTerminal } from "../types";
-import { forceXtermRendererUnpause } from "../TerminalReflowController";
 
 vi.mock("@/utils/logger", () => ({
   logDebug: vi.fn(),
@@ -199,11 +198,6 @@ function buildDeps(
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
-    // The REAL primitive, not a stand-in: it is the half #11800 proved was a
-    // structural no-op, so driving it end-to-end here is the point.
-    forceUnpauseRenderer: vi.fn((terminal: ManagedTerminal["terminal"]) =>
-      forceXtermRendererUnpause(terminal)
-    ),
     // Mirror TerminalInstanceService.reconcileRevealGeometry +
     // TerminalResizeController.reconcileGeometryFresh: atomic xterm+PTY re-fit to
     // the FRESH container measurement plus a local atlas repair — but ONLY when
@@ -412,7 +406,7 @@ describe("#10632 switch-back redraw — closed-loop convergence", () => {
     vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
     // Deferred: a repaint now would interleave with the buffered range.
     expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
-    expect(deps.forceUnpauseRenderer).not.toHaveBeenCalled();
+    expect(agent.paused).toBe(true);
     expect(agent.cols).toBe(120);
 
     // Block closes — next tick converges.

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -92,8 +92,8 @@ export interface ManagedTerminal {
   keyHandlerInstalled: boolean;
   lastAttachAt: number;
   lastDetachAt: number;
-  // Last time forceXtermReflow() ran for this terminal — used to throttle the
-  // IntersectionObserver unpause reflow across write/heartbeat/focus triggers.
+  // Last time TerminalReflowController issued a renderer-unpause repair for this
+  // terminal — throttles the repair across write/heartbeat/focus triggers.
   lastReflowAt?: number;
   // Last time the reconciliation watchdog issued a repair for this terminal —
   // per-terminal cooldown so a persistently-diverging layer never repair-loops.
@@ -112,6 +112,17 @@ export interface ManagedTerminal {
   // the same id must not inherit a prior instance's give-up state (mirrors the
   // revealPendingGeneration guard).
   geometryRepairGeneration?: number;
+  // Circuit breaker for the watchdog's renderer-unpause repair (#11800). xterm's
+  // `_isPaused` is written only by its own IntersectionObserver callback, so the
+  // repair has to force the flag and repaint; if something re-pauses the pane
+  // every sweep, these bound the retry instead of forcing a repaint forever.
+  rendererUnpauseAttempts?: number;
+  // Once tripped, the paused-renderer branch stops issuing repairs — the WebGL
+  // layer below it still reconciles. Cleared when a later sweep observes the
+  // renderer unpaused, or when the terminal re-attaches.
+  rendererUnpauseGaveUp?: boolean;
+  // The attachGeneration the counter accrued under — mirrors geometryRepairGeneration.
+  rendererUnpauseGeneration?: number;
   // Geometry the PTY reported holding after its last resize (#11641). The only
   // view the renderer has of the backend grid — everything else here describes
   // xterm's side.

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -123,6 +123,13 @@ export interface ManagedTerminal {
   rendererUnpauseGaveUp?: boolean;
   // The attachGeneration the counter accrued under — mirrors geometryRepairGeneration.
   rendererUnpauseGeneration?: number;
+  // When the last unpause repair was issued. Recovery is only believable once
+  // real frames have had a chance since then: the reflow controller and the
+  // watchdog both listen for visibilitychange/reveal and run in the SAME event
+  // turn, so without this the watchdog would read its sibling's just-written
+  // `false` as durable recovery and re-arm the breaker on a renderer that
+  // nothing has actually fixed.
+  rendererUnpauseAttemptedAt?: number;
   // Geometry the PTY reported holding after its last resize (#11641). The only
   // view the renderer has of the backend grid — everything else here describes
   // xterm's side.


### PR DESCRIPTION
## Summary

- The watchdog's paused-renderer repair called `forceXtermReflow` every 3 seconds forever, with no attempt cap and a log line that unconditionally claimed success. Production telemetry showed 4 repair attempts over 19 seconds with the pane still blank.
- Reading the pinned `@xterm/xterm` 6.1.0-beta.300 source turned up the real cause: `_core._renderService._isPaused` is only ever written at runtime inside the IntersectionObserver callback `_handleIntersectionChange`. `forceXtermReflow` jitters an element's padding and reverts it within the same synchronous task, but Chromium computes IntersectionObserver entries in the per-frame update-the-rendering step, which runs after the task and microtask queues drain. The observer only ever saw the already-reverted state, so the old repair was structurally incapable of unpausing anything.
- Two things the issue got wrong: this isn't a backgrounding-throttle bug (all 4 failed repairs in the telemetry, 09:39:33 to 09:39:52, happened before `app.did-resign-active` fired at 09:39:56, while the app was foregrounded and producing frames), and #5085's claim that the helper worked but was called from too few places was never validated (that repro conflated the padding jitter with a real DOM reparent it happened to be wrapped in, and a reparent persists a genuine geometry change across frames, unlike a same-task revert).

Resolves #11800

## Changes

- New `forceXtermRendererUnpause(terminal)` drives xterm's own resume transition (`_handleIntersectionChange` with a synthetic intersecting entry) when available, falling back to writing the flag directly, then repaints with the public `terminal.refresh(0, rows - 1)`. Driving xterm's own path matters because it also flushes `_pausedResizeTask`, the renderer resize queued when `resize()` runs while paused, so a reveal that re-fits geometry before unpausing no longer repaints at the old surface size.
- `attemptRendererUnpause` is now the single bounded entry point every automatic trigger shares (watchdog sweep, per-write path, 3s heartbeat, focus/visibility, reveal), capped at 3 attempts per attach generation, mirroring the existing geometry-repair breaker. Centralizing it mattered because the reflow controller's write path fires every 250ms, so leaving it uncounted would let a pane that IntersectionObserver keeps re-pausing repaint far more often than the original bug did.
- Recovery is verified on a later sweep, not the same tick (a same-tick re-read would only confirm our own write), using a three-state pause read so API drift can't be misread as recovery. An attempt timestamp guards against the reflow controller's same-event-turn write being mistaken for durable recovery, since it registers its `visibilitychange`/reveal listeners before the watchdog.
- Logs now report the real outcome (`repairIssued`, attempt count, limit) instead of asserting success; the recovery log says "pause no longer set", not "recovered".
- The breaker re-arms on observed unpause, re-attach, terminal replacement in `rebuildTerminalInstance` (a fresh `RenderService` would otherwise inherit the latch with no way out), and an explicit user Redraw (`options.force`, the same foreground gate #11638 uses). Automatic `resetRenderer` callers stay inside the cap.
- Corrected `forceXtermReflow`'s doc comment, which claimed the IntersectionObserver re-evaluation this investigation disproves. Its 6 remaining call sites (reveal/wake sequences) keep using it for genuine layout flushes, which is still a legitimate use.

Files: `src/services/terminal/TerminalReflowController.ts`, `TerminalReconciliationWatchdog.ts`, `TerminalInstanceService.ts`, `types.ts`, plus 5 test suites (`TerminalReconciliationWatchdog.test.ts`, `TerminalReflowController.test.ts`, `TerminalInstanceService.reflow.test.ts`, `TerminalInstanceService.adversarial.test.ts`, `TerminalSwitchBackRedraw.regression.test.ts`, `TerminalResizeController.fitParity.test.ts`).

## Testing

- `vitest run src/services/terminal/`: 1679 tests across 84 files, all passing
- `npm run typecheck`: clean
- eslint + prettier on all changed files: clean, 0 errors
- Suites were converted from observing the padding jitter to observing the pause flag and repaint directly, since the jitter is no longer what the recovery paths do. New coverage: bounded attempts then latch, breaker re-arm on observed unpause / re-attach / renderer replacement / user Redraw, drift preserving accrued attempts, per-terminal independence, shared cap across the standalone and reveal paths, same-turn sibling write rejected.

## Follow-up

`TerminalRevealController`'s 4 `forceXtermReflow` call sites still have comments describing them as unpausing. Left out of scope here: they're sequencing-sensitive reveal paths bundled with real geometry changes that may legitimately drive IntersectionObserver, and the corrected comment at the definition now warns anyone reading them.
