### PR TITLE
feat(mcp): distinguish assistant-launched runs from external MCP spawns

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -18,6 +18,7 @@ import type {
   McpRuntimeSnapshot,
   McpGrantLifecyclePayload,
   McpBearerIdentity,
+  McpSessionOrigin,
   McpToolCallStartedPayload,
   McpToolCallSettledPayload,
   McpHelpDisplayImagePayload,
@@ -2996,6 +2997,7 @@ function buildElectronApi(): ElectronAPI {
           confirmed?: boolean;
           context?: ActionContext;
           callerInfo?: McpBearerIdentity;
+          sessionOrigin?: McpSessionOrigin;
         }) => void
       ) => _typedOn(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, callback),
 

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -205,15 +205,35 @@ export class McpServerService {
       turnOutcomeService: this.turnOutcomeService,
       abusePolicy,
       requestManifest: () => this.bridge.requestManifest(),
-      dispatchAction: (actionId, args, confirmed, callerInfo) =>
-        this.bridge.dispatchAction(actionId, args, confirmed, callerInfo),
+      dispatchAction: (actionId, args, confirmed, callerInfo, sessionOrigin) =>
+        this.bridge.dispatchAction(actionId, args, confirmed, callerInfo, sessionOrigin),
       requestManifestForWebContents: (id) => this.bridge.requestManifestForWebContents(id),
-      dispatchActionForWebContents: (id, actionId, args, confirmed, contextOverride) =>
-        this.bridge.dispatchActionForWebContents(id, actionId, args, confirmed, contextOverride),
+      dispatchActionForWebContents: (
+        id,
+        actionId,
+        args,
+        confirmed,
+        contextOverride,
+        sessionOrigin
+      ) =>
+        this.bridge.dispatchActionForWebContents(
+          id,
+          actionId,
+          args,
+          confirmed,
+          contextOverride,
+          sessionOrigin
+        ),
       requestManifestForWorkspace: (workspaceId) =>
         this.bridge.requestManifestForWorkspace(workspaceId),
-      dispatchActionForWorkspace: (workspaceId, actionId, args, confirmed) =>
-        this.bridge.dispatchActionForWorkspace(workspaceId, actionId, args, confirmed),
+      dispatchActionForWorkspace: (workspaceId, actionId, args, confirmed, sessionOrigin) =>
+        this.bridge.dispatchActionForWorkspace(
+          workspaceId,
+          actionId,
+          args,
+          confirmed,
+          sessionOrigin
+        ),
       resolveWorkspaceBinding: (workspaceId) => this.bridge.resolveWorkspaceBinding(workspaceId),
       handleWaitUntilIdle: (rawArgs, signal, options) =>
         handleWaitUntilIdle(rawArgs, signal, options),

--- a/electron/services/__tests__/McpServerService.authAndToolSurface.test.ts
+++ b/electron/services/__tests__/McpServerService.authAndToolSurface.test.ts
@@ -933,6 +933,48 @@ describe("McpServerService", () => {
     expect(after.status).toBe(401);
   });
 
+  it("carries the assistant's session origin all the way to the renderer dispatch payload (#11808)", async () => {
+    // The unit tests either side of this one stop at a mock: HttpLifecycle is
+    // checked against a fake dispatcher, and the bridge is checked against a
+    // hand-passed origin. Neither covers the adapter lambdas in
+    // `McpServerService` that wire the two together — and because the bridge
+    // defaults a missing origin to "external", dropping the argument there
+    // would leave every one of those tests green while silently relabelling
+    // every assistant-launched run as an external client's. Only a real
+    // handshake through the whole chain catches that.
+    const win = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "terminal.list",
+          title: "List Terminals",
+          description: "Read the terminal list",
+          kind: "query",
+        }),
+      ],
+      dispatchAction: () => ({ ok: true, result: "ok" }),
+    });
+    await service.start(win.window);
+    service.setHelpTokenValidator((token) => (token === "help-token" ? "action" : false));
+    service.setHelpSessionWebContentsResolver((token) =>
+      token === "help-token" ? win.webContents.id : null
+    );
+
+    const helped = await connectClient(service.currentPort!, {
+      Authorization: "Bearer help-token",
+    });
+    transports.push(helped.transport);
+    await helped.client.callTool({ name: "terminal.list", arguments: {} });
+
+    const dispatchPayloads = win.webContents.send.mock.calls
+      .filter(([channel]) => channel === CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST)
+      .map(([, payload]) => payload as { sessionOrigin?: string });
+
+    expect(dispatchPayloads).toHaveLength(1);
+    // "help", not the "external" default — the value had to survive the
+    // handshake, the build-time snapshot, and both adapter hops to get here.
+    expect(dispatchPayloads[0]!.sessionOrigin).toBe("help");
+  });
+
   it("pins each help-session bearer to its own renderer WebContents — tool calls never cross windows (#7002)", async () => {
     // Two windows, each with a distinct project-view WebContents. Two
     // help-session bearers — one minted from each. Without per-session

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -1252,10 +1252,13 @@ describe("HttpLifecycle", () => {
 
       await sessionDeps.dispatchAction("terminal.kill", { id: "t-1" }, false);
 
-      expect(deps.dispatchAction).toHaveBeenCalledWith("terminal.kill", { id: "t-1" }, false, {
-        token4LastChars: "1234",
-        userAgent: "Claude Code",
-      });
+      expect(deps.dispatchAction).toHaveBeenCalledWith(
+        "terminal.kill",
+        { id: "t-1" },
+        false,
+        { token4LastChars: "1234", userAgent: "Claude Code" },
+        "external"
+      );
     });
 
     it("passes callerInfo: undefined when the session has no tracked bearer", async () => {
@@ -1272,7 +1275,96 @@ describe("HttpLifecycle", () => {
 
       await sessionDeps.dispatchAction("actions.list", {}, false);
 
-      expect(deps.dispatchAction).toHaveBeenCalledWith("actions.list", {}, false, undefined);
+      expect(deps.dispatchAction).toHaveBeenCalledWith(
+        "actions.list",
+        {},
+        false,
+        undefined,
+        "external"
+      );
+    });
+  });
+
+  describe("buildSessionServerDeps — spawn provenance origin (#11808)", () => {
+    type OriginHandle = {
+      buildSessionServerDeps: (
+        sessionId: string
+      ) => import("../sessionServer.js").SessionServerDeps;
+    };
+
+    /** Pinned-route fixture: `fakeDeps` leaves the pinned dispatcher unwired. */
+    function pinnedOriginDeps(): HttpLifecycleDeps {
+      return fakeDeps({
+        dispatchActionForWebContents: vi
+          .fn()
+          .mockResolvedValue({ result: { ok: true, result: null } }),
+      } as unknown as Partial<HttpLifecycleDeps>);
+    }
+
+    it.each(["help", "assistant-pane", "external"] as const)(
+      "forwards a %s session's origin on the pinned dispatch route",
+      async (origin) => {
+        const deps = pinnedOriginDeps();
+        const lc = new HttpLifecycle(deps);
+        deps.sessionStore.sessionOriginMap.set("sess-origin", origin);
+        deps.sessionStore.sessionWebContentsMap.set("sess-origin", 42);
+
+        const sessionDeps = (lc as unknown as OriginHandle).buildSessionServerDeps("sess-origin");
+        await sessionDeps.dispatchAction("agent.launch", {}, false);
+
+        expect(deps.dispatchActionForWebContents).toHaveBeenCalledWith(
+          42,
+          "agent.launch",
+          {},
+          false,
+          undefined,
+          origin
+        );
+      }
+    );
+
+    it("keeps the build-time origin after the session's binding is torn down", async () => {
+      const deps = pinnedOriginDeps();
+      const lc = new HttpLifecycle(deps);
+      deps.sessionStore.sessionOriginMap.set("sess-teardown", "assistant-pane");
+      deps.sessionStore.sessionWebContentsMap.set("sess-teardown", 7);
+
+      const sessionDeps = (lc as unknown as OriginHandle).buildSessionServerDeps("sess-teardown");
+
+      // `clearSessionBinding` runs on teardown while a dispatch can still be in
+      // flight, and `getOrigin` fails closed to "external" once the entry is
+      // gone. Reading origin inside the closure would therefore relabel the
+      // assistant's own spawn as an external client's the moment its session
+      // ended — the build-time snapshot is what stops that. The pin is cleared
+      // by the same call, so this asserts through the unpinned route.
+      deps.sessionStore.clearSessionBinding("sess-teardown");
+      await sessionDeps.dispatchAction("agent.launch", {}, false);
+
+      expect(deps.dispatchAction).toHaveBeenCalledWith(
+        "agent.launch",
+        {},
+        false,
+        undefined,
+        "assistant-pane"
+      );
+    });
+
+    it("falls back to external for a session that never recorded an origin", async () => {
+      const deps = pinnedOriginDeps();
+      const lc = new HttpLifecycle(deps);
+      deps.sessionStore.sessionWebContentsMap.set("sess-no-origin", 9);
+
+      const sessionDeps = (lc as unknown as OriginHandle).buildSessionServerDeps("sess-no-origin");
+      await sessionDeps.dispatchAction("agent.launch", {}, false);
+
+      expect(deps.dispatchActionForWebContents).toHaveBeenCalledWith(
+        9,
+        "agent.launch",
+        {},
+        false,
+        undefined,
+        "external"
+      );
     });
   });
 
@@ -1803,11 +1895,15 @@ describe("HttpLifecycle", () => {
         await sessionDeps.dispatchAction("terminal.list", {}, false);
 
         expect(deps.requestManifestForWorkspace).toHaveBeenCalledWith("ws-a");
+        // Only external sessions may bind a workspace — a selector from a
+        // pinned bearer is refused at handshake — so the origin threaded here
+        // is always "external" (#11808).
         expect(deps.dispatchActionForWorkspace).toHaveBeenCalledWith(
           "ws-a",
           "terminal.list",
           {},
-          false
+          false,
+          "external"
         );
         // Never the focus-following path — that is the retargeting this removes.
         expect(deps.dispatchAction).not.toHaveBeenCalled();

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -238,6 +238,39 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
     expect(sentPayload?.context).toBeUndefined();
   });
 
+  it("threads the session's authenticated origin into the dispatch IPC payload (#11808)", async () => {
+    const wc = makeWebContents(901);
+    mockWebContentsRegistry.set(901, wc);
+
+    const sentOrigins: unknown[] = [];
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+      sentOrigins.push((payload as { sessionOrigin?: unknown }).sessionOrigin);
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: 901 } },
+          { requestId: payload.requestId, result: { ok: true, result: "ok" } }
+        );
+      });
+    });
+
+    await bridge.dispatchActionForWebContents(
+      901,
+      "agent.launch",
+      {},
+      false,
+      undefined,
+      "assistant-pane"
+    );
+    // Omitted entirely — a WebContents route proves where to send, not who owns
+    // the session, so only HttpLifecycle can positively establish that this is
+    // one of Daintree's own surfaces. Everything else lands as external.
+    await bridge.dispatchActionForWebContents(901, "agent.launch", {}, false);
+
+    expect(sentOrigins).toEqual(["assistant-pane", "external"]);
+  });
+
   it("fails closed when the pinned view has been destroyed (#7002 — never silently re-routes)", async () => {
     // No entry for id=999 → webContents.fromId returns undefined.
     await expect(bridge.requestManifestForWebContents(999)).rejects.toBeInstanceOf(
@@ -592,6 +625,31 @@ describe("rendererBridge — requesting-bearer identity passthrough (#9157)", ()
 
     expect(sentPayload).toBeDefined();
     expect(sentPayload?.callerInfo).toBeUndefined();
+  });
+
+  it("defaults the unpinned dispatch payload to an external origin (#11808)", async () => {
+    const wc = makeWebContents(804);
+    const bridge = makeActiveBridge(wc);
+
+    let sentPayload: { requestId: string; sessionOrigin?: unknown } | undefined;
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+      sentPayload = payload as { requestId: string; sessionOrigin?: unknown };
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: 804 } },
+          { requestId: payload.requestId, result: { ok: true, result: "ok" } }
+        );
+      });
+    });
+
+    // Unlike `callerInfo`, which is legitimately absent, origin is never
+    // absent — a caller that forgets it gets the least-privileged answer
+    // rather than an undefined the renderer would have to interpret.
+    await bridge.dispatchAction("actions.list", {}, false);
+
+    expect(sentPayload?.sessionOrigin).toBe("external");
   });
 
   it("the pinned dispatch path leaves callerInfo undefined (provenance-free)", async () => {

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -1154,6 +1154,34 @@ describe("rendererBridge — workspace-bound routing (#11789)", () => {
     expect((mockWebContentsRegistry.get(202) as FakeWebContents).send).not.toHaveBeenCalled();
   });
 
+  it("forwards a supplied origin, and defaults to external without one (#11808)", async () => {
+    const wc = registerView("ws-a", 101);
+
+    // Workspace binding is refused for pinned bearers today, so this route only
+    // ever sees external sessions — but httpLifecycle threads origin here
+    // anyway rather than leaning on the default. That is a forward-compat
+    // claim, so it gets asserted rather than just commented.
+    const promiseOne = bridge.dispatchActionForWorkspace(
+      "ws-a",
+      "terminal.list",
+      {},
+      false,
+      "assistant-pane"
+    );
+    await settleDispatch();
+    await promiseOne;
+
+    const promiseTwo = bridge.dispatchActionForWorkspace("ws-a", "terminal.list", {}, false);
+    await settleDispatch();
+    await promiseTwo;
+
+    const origins = wc.send.mock.calls
+      .filter(([channel]) => channel === CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST)
+      .map(([, payload]) => (payload as { sessionOrigin?: unknown }).sessionOrigin);
+
+    expect(origins).toEqual(["assistant-pane", "external"]);
+  });
+
   it("keeps routing to its workspace after another workspace's view is registered", async () => {
     // The isolation the whole feature is for: nothing about workspace B
     // appearing (or being focused) may move workspace A's session.

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -82,7 +82,8 @@ export interface HttpLifecycleDeps {
     actionId: string,
     args: unknown,
     confirmed?: boolean,
-    callerInfo?: McpBearerIdentity
+    callerInfo?: McpBearerIdentity,
+    sessionOrigin?: McpSessionOrigin
   ) => Promise<import("./shared.js").DispatchEnvelope>;
   // Pinned variants used for help-session bearers — route to the renderer
   // WebContents that minted the bearer at provision time (#7002). Optional
@@ -95,7 +96,8 @@ export interface HttpLifecycleDeps {
     actionId: string,
     args: unknown,
     confirmed?: boolean,
-    contextOverride?: import("../../../shared/types/actions.js").ActionContext
+    contextOverride?: import("../../../shared/types/actions.js").ActionContext,
+    sessionOrigin?: McpSessionOrigin
   ) => Promise<import("./shared.js").DispatchEnvelope>;
   // Workspace-bound variants used for external sessions that named a workspace
   // at handshake (#11789). They resolve the workspace's current view per call,
@@ -109,7 +111,8 @@ export interface HttpLifecycleDeps {
     workspaceId: string,
     actionId: string,
     args: unknown,
-    confirmed?: boolean
+    confirmed?: boolean,
+    sessionOrigin?: McpSessionOrigin
   ) => Promise<import("./shared.js").DispatchEnvelope>;
   getCachedManifestForWorkspace?: (
     workspaceId: string
@@ -1504,6 +1507,12 @@ export class HttpLifecycle {
     // per-WebContents cache, so a session torn down mid-call can never flip to
     // the shared cache and leak another window's tool surface (#7003 / #9887).
     const pinnedWebContentsId = this.deps.sessionStore.sessionWebContentsMap.get(sessionId) ?? null;
+    // Snapshotted for the same reason as the pin: `clearSessionBinding` deletes
+    // the origin entry on teardown, and `getOrigin` fails closed to `external`
+    // — so an in-flight dispatch settling after that would downgrade one of the
+    // assistant's own spawns to "an external client did this" (#11808). Read
+    // here, before the closure, never inside it.
+    const sessionOrigin = this.deps.sessionStore.getOrigin(sessionId);
 
     /**
      * A bound session whose workspace route is unwired must fail, never fall
@@ -1543,8 +1552,13 @@ export class HttpLifecycle {
         // No `callerInfo` either: it exists solely to name the requesting client
         // in the confirm dialog (#9157), and a bound session's surface excludes
         // every confirm-gated tool, so nothing could ever read it.
+        //
+        // `sessionOrigin` is threaded even though only `external` sessions may
+        // bind — a selector from a pinned bearer is refused at handshake — so
+        // the payload is built the same way on all three routes rather than one
+        // of them relying on a default that a later binding rule could falsify.
         return workspaceDispatch
-          ? workspaceDispatch(boundWorkspaceId, actionId, args, confirmed)
+          ? workspaceDispatch(boundWorkspaceId, actionId, args, confirmed, sessionOrigin)
           : Promise.reject(missingWorkspaceRoute());
       }
       const id = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
@@ -1555,14 +1569,14 @@ export class HttpLifecycle {
         // the model's turn (#8317). Absent for context-less sessions, in
         // which case pinned dispatch falls back to live renderer context.
         const boundContext = this.deps.sessionStore.sessionContextMap.get(sessionId);
-        return pinnedDispatch(id, actionId, args, confirmed, boundContext);
+        return pinnedDispatch(id, actionId, args, confirmed, boundContext, sessionOrigin);
       }
       // Unpinned external/api-key dispatch — surface the requesting bearer's
       // identity so the confirm dialog can name the client (#9157). Returns
       // null (→ undefined) for help-session bearers, so callerInfo never
       // reaches the renderer for the assistant's own dispatches.
       const callerInfo = this.getBearerInfoForSession(sessionId) ?? undefined;
-      return this.deps.dispatchAction(actionId, args, confirmed, callerInfo);
+      return this.deps.dispatchAction(actionId, args, confirmed, callerInfo, sessionOrigin);
     };
 
     const getCachedManifest: import("./sessionServer.js").SessionServerDeps["getCachedManifest"] =

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -6,7 +6,7 @@ import { getWebContentsForProject } from "../../window/webContentsRegistry.js";
 import { unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
 import type { WorkspaceViewLeaseRegistry } from "./workspaceViewLease.js";
 import type { ActionContext, ActionManifestEntry } from "../../../shared/types/actions.js";
-import type { McpBearerIdentity } from "../../../shared/types/ipc/mcpServer.js";
+import type { McpBearerIdentity, McpSessionOrigin } from "../../../shared/types/ipc/mcpServer.js";
 import { CHANNELS } from "../../ipc/channels.js";
 import type {
   PendingRequest,
@@ -431,6 +431,7 @@ export function createRendererBridge(
     actionId: string,
     args: unknown,
     confirmed: boolean,
+    sessionOrigin: McpSessionOrigin,
     contextOverride?: ActionContext,
     callerInfo?: McpBearerIdentity,
     route?: BridgeRoute
@@ -506,6 +507,11 @@ export function createRendererBridge(
             // (#9157). Only the unpinned external path supplies it; absent for
             // pinned help-session dispatch so the dialog stays provenance-free.
             callerInfo,
+            // How the dispatching session authenticated (#11808), so the
+            // renderer can stamp a spawn it creates as assistant-launched
+            // rather than lumping every MCP-borne spawn under one origin.
+            // Always present: main resolves it, the caller never sends it.
+            sessionOrigin,
           });
         } catch (err) {
           clearTimeout(timer);
@@ -536,13 +542,15 @@ export function createRendererBridge(
     actionId: string,
     args: unknown,
     confirmed = false,
-    callerInfo?: McpBearerIdentity
+    callerInfo?: McpBearerIdentity,
+    sessionOrigin: McpSessionOrigin = "external"
   ): Promise<DispatchEnvelope> {
     return sendDispatchRequest(
       () => getActiveProjectWebContents(),
       actionId,
       args,
       confirmed,
+      sessionOrigin,
       undefined,
       callerInfo
     );
@@ -633,13 +641,15 @@ export function createRendererBridge(
     actionId: string,
     args: unknown,
     confirmed = false,
-    contextOverride?: ActionContext
+    contextOverride?: ActionContext,
+    sessionOrigin: McpSessionOrigin = "external"
   ): Promise<DispatchEnvelope> {
     return sendDispatchRequest(
       () => getPinnedWebContents(id),
       actionId,
       args,
       confirmed,
+      sessionOrigin,
       contextOverride,
       undefined,
       { kind: "pinned", webContentsId: id }
@@ -683,13 +693,15 @@ export function createRendererBridge(
     workspaceId: string,
     actionId: string,
     args: unknown,
-    confirmed = false
+    confirmed = false,
+    sessionOrigin: McpSessionOrigin = "external"
   ): Promise<DispatchEnvelope> {
     return sendDispatchRequest(
       () => getWorkspaceWebContents(workspaceId),
       actionId,
       args,
       confirmed,
+      sessionOrigin,
       undefined,
       undefined,
       { kind: "workspace", workspaceId }

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -249,19 +249,12 @@ export const PRE_AUTH_FAILED_CODE = "PRE_AUTH_FAILED";
 export const INVALID_URL_CODE = "INVALID_URL";
 
 /**
- * How a session's bearer was authenticated, recorded explicitly at handshake
- * (#11789). Before this, "which renderer owns this session" was inferred from
- * presence in `sessionWebContentsMap` — but that map is simultaneously the
- * routing table and the authorization gate for `issueGrant` / `setSessionTier`,
- * so binding an external session to a workspace would have made it eligible for
- * renderer-driven privilege elevation it must never have.
- *
- * Routing reads the WebContents / workspace maps. Authorization, notifications
- * and external-client inventory read this. `external` covers api-key bearers,
- * unauthenticated loopback, and generic pane tokens — everything that is not one
- * of Daintree's own assistant surfaces.
+ * Re-exported from its canonical home in `shared/types/ipc/mcpServer.ts`, which
+ * is where it had to move once the renderer needed it too (#11808). Kept
+ * exported from here so the main-process modules that have always imported it
+ * from this file keep working — one definition, two spellings of the path.
  */
-export type McpSessionOrigin = "help" | "assistant-pane" | "external";
+export type { McpSessionOrigin } from "../../../shared/types/ipc/mcpServer.js";
 
 /**
  * Lookup key for the workspace-selector header on an incoming request (#11789).

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1921,6 +1921,18 @@ export interface ElectronAPI extends GeneratedElectronAPI {
          * provenance-free.
          */
         callerInfo?: import("./mcpServer.js").McpBearerIdentity;
+        /**
+         * How the dispatching session authenticated (#11808), resolved in main
+         * from the session store — never sent by the client. Lets the renderer
+         * stamp a spawn it creates as assistant-launched rather than lumping
+         * every MCP-borne spawn under one origin.
+         *
+         * Optional because nothing type-checks the `webContents.send` side of
+         * this channel: main always sends it, but the renderer cannot prove
+         * that, so the consumer treats an absent value as `external` rather
+         * than trusting the declaration. That fallback is the real guarantee.
+         */
+        sessionOrigin?: import("./mcpServer.js").McpSessionOrigin;
       }) => void
     ): () => void;
     /** Send action dispatch result to main process */

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -722,12 +722,43 @@ export interface HelpSessionBearerRecord {
 }
 
 /**
+ * How a session's bearer was authenticated, recorded explicitly at handshake
+ * (#11789). Before this, "which renderer owns this session" was inferred from
+ * presence in `sessionWebContentsMap` — but that map is simultaneously the
+ * routing table and the authorization gate for `issueGrant` / `setSessionTier`,
+ * so binding an external session to a workspace would have made it eligible for
+ * renderer-driven privilege elevation it must never have.
+ *
+ * Routing reads the WebContents / workspace maps. Authorization, notifications
+ * and external-client inventory read this. `external` covers api-key bearers,
+ * unauthenticated loopback, and generic pane tokens — everything that is not one
+ * of Daintree's own assistant surfaces.
+ *
+ * Lives here rather than in `electron/services/mcp-server/shared.ts` (which
+ * re-exports it) because it now crosses the contextBridge on every dispatch
+ * request, so the renderer can tell an assistant-launched run from an external
+ * one (#11808). Mirroring it renderer-side instead would leave two unions free
+ * to drift, silently reclassifying a surface as external the day they did.
+ *
+ * The same two Daintree-own surfaces this splits out are the ones
+ * {@link McpGrantActorType} names; that type classifies who a grant was issued
+ * to, this one classifies how the session itself authenticated.
+ */
+export type McpSessionOrigin = "help" | "assistant-pane" | "external";
+
+/**
  * Display-only provenance for the external bearer behind a `danger: "confirm"`
  * dispatch, threaded into the MCP confirm dialog so the user can see which
  * client is asking before approving (#9157). Carries only the non-sensitive
  * fields — the 4-char token suffix and the client user-agent. Absent for
  * pinned help-session dispatch (the assistant's own panel is the context), so
  * the dialog stays provenance-free there.
+ *
+ * Distinct from {@link McpSessionOrigin}, which rides the same payload: this
+ * names *which external client* is asking, for a pre-dispatch approval prompt;
+ * that records *which class of surface* the session is, for post-dispatch run
+ * provenance. An assistant session has no meaningful `callerInfo` and still has
+ * an origin.
  */
 export interface McpBearerIdentity {
   token4LastChars: string;

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -172,8 +172,17 @@ export type PersistableFlowStatus = Exclude<TerminalFlowStatus, "data-loss" | Fu
  *  `FutureSABFlowStatus` set never appear here. */
 export type TerminalRuntimeStatus = PersistableFlowStatus | "background" | "exited" | "error";
 
-/** Origin that spawned a terminal */
-export type TerminalSpawnSource = "quickrun" | "recipe" | "agent" | "palette" | "mcp";
+/**
+ * Origin that spawned a terminal.
+ *
+ * `assistant` and `mcp` both arrive over the MCP bridge and are split apart by
+ * the session's authenticated origin, not by anything the caller sends (#11808).
+ * `assistant` is one of Daintree's own surfaces — the assistant panel or an
+ * assistant pane — starting work the user did not ask for directly; `mcp` is an
+ * arbitrary external client. Collapsing them left a terminal the user never
+ * started looking identical to one they did.
+ */
+export type TerminalSpawnSource = "quickrun" | "recipe" | "agent" | "palette" | "mcp" | "assistant";
 
 /** Focus policy for newly-created panels — orthogonal to provenance. */
 export type AddPanelFocusPolicy = "auto" | "preserve" | "take";

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -204,7 +204,14 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   const worktreeId = panel?.worktreeId ?? info?.worktreeId;
   const titleMode = panel?.titleMode ?? info?.titleMode;
   const spawnSource = panel?.spawnedBy;
-  const startedViaMcp = spawnSource === "mcp" ? "Yes" : spawnSource ? "No" : "Unknown";
+  // An assistant-launched run arrives over the MCP bridge like any other, so
+  // the transport answer stays "Yes" — what changed is that we can now say who
+  // was on the other end of it (#11808). Kept as two rows rather than one:
+  // folding the actor into the transport row would drop the fact that this is
+  // still an MCP dispatch, which is the useful half when debugging routing.
+  const startedByAssistant = spawnSource === "assistant";
+  const startedViaMcp =
+    spawnSource === "mcp" || startedByAssistant ? "Yes" : spawnSource ? "No" : "Unknown";
   const uiStartedAt = panel?.startedAt;
   const spawnStatus = panel?.spawnStatus;
   const location = panel?.location;
@@ -276,7 +283,7 @@ Session Metadata:
   CWD: ${info.cwd}
   Location: ${location ?? "N/A"}
   Spawn Source: ${spawnSource ?? "N/A"}
-  Started via MCP: ${startedViaMcp}
+${startedByAssistant ? "  Started By: Daintree Assistant\n" : ""}  Started via MCP: ${startedViaMcp}
   Spawn Status: ${spawnStatus ?? "N/A"}
   UI Created At: ${uiStartedAt != null ? formatTimestamp(uiStartedAt) : "N/A"}
 
@@ -359,6 +366,7 @@ Performance & Diagnostics:
               <InfoRow label="Current Directory" value={info.cwd} mono />
               <InfoRow label="Location" value={location} />
               <InfoRow label="Spawn Source" value={spawnSource} />
+              {startedByAssistant && <InfoRow label="Started By" value="Daintree Assistant" />}
               <InfoRow label="Started via MCP" value={startedViaMcp} />
               <InfoRow label="Spawn Status" value={spawnStatus} />
               {uiStartedAt != null && (

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -288,11 +288,64 @@ describe("TerminalInfoDialog", () => {
     expect(clipboardText).toContain("Location: dock");
     expect(clipboardText).toContain("Spawn Source: mcp");
     expect(clipboardText).toContain("Started via MCP: Yes");
+    // An external client gets no initiator line — there is no Daintree surface
+    // to name, and claiming one would be worse than saying nothing (#11808).
+    expect(clipboardText).not.toContain("Started By:");
     expect(clipboardText).toContain("Spawn Status: spawning");
     expect(clipboardText).toContain("Command: claude --model claude-sonnet-4-5");
     expect(clipboardText).toContain("Launch Agent: claude");
     expect(clipboardText).toContain("Preset Color: #123456");
     expect(clipboardText).toContain("Session ID: agent-session-1");
+  });
+
+  it("names the assistant as the initiator for assistant-launched runs (#11808)", async () => {
+    mockPanelsById = {
+      "test-id": { id: "test-id", spawnedBy: "assistant", location: "grid" },
+    };
+    dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Session Metadata")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Started By:")).toBeTruthy();
+    expect(screen.getByText("Daintree Assistant")).toBeTruthy();
+    // Still an MCP dispatch — the actor is the new fact, not a replacement for
+    // the transport one.
+    expect(screen.getByText("Started via MCP:")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Copy to Clipboard"));
+    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
+    expect(clipboardText).toContain("Spawn Source: assistant");
+    expect(clipboardText).toContain("Started By: Daintree Assistant");
+    expect(clipboardText).toContain("Started via MCP: Yes");
+  });
+
+  it("omits the initiator row for external MCP and user-started runs (#11808)", async () => {
+    mockPanelsById = {
+      "test-id": { id: "test-id", spawnedBy: "quickrun", location: "grid" },
+    };
+    dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Session Metadata")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Started By:")).toBeNull();
+
+    fireEvent.click(screen.getByText("Copy to Clipboard"));
+    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
+    expect(clipboardText).toContain("Spawn Source: quickrun");
+    expect(clipboardText).not.toContain("Started By:");
+    expect(clipboardText).toContain("Started via MCP: No");
   });
 
   it("renders Launch Context and Live State sections for agent terminals", async () => {

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -348,6 +348,29 @@ describe("TerminalInfoDialog", () => {
     expect(clipboardText).toContain("Started via MCP: No");
   });
 
+  it("reports unknown provenance for a panel with no spawn source (#11808)", async () => {
+    // `spawnedBy` is runtime-only and never serialized, so every panel restored
+    // across a restart lands here — this is the common case, not an edge one.
+    mockPanelsById = { "test-id": { id: "test-id", location: "grid" } };
+    dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Session Metadata")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Started By:")).toBeNull();
+
+    fireEvent.click(screen.getByText("Copy to Clipboard"));
+    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
+    expect(clipboardText).toContain("Spawn Source: N/A");
+    expect(clipboardText).toContain("Started via MCP: Unknown");
+    expect(clipboardText).not.toContain("Started By:");
+  });
+
   it("renders Launch Context and Live State sections for agent terminals", async () => {
     const payload = makePayload({
       kind: "terminal",

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -48,7 +48,9 @@ import {
   useMcpBridge,
   buildMcpConfirmPreview,
   resolveMcpConfirmPreviewTarget,
+  tagMcpSpawnSource,
 } from "../useMcpBridge";
+import { TerminalSpawnSourceSchema } from "@/services/actions/definitions/schemas";
 
 function safeManifestEntry(overrides: Partial<ActionManifestEntry> = {}): ActionManifestEntry {
   return {
@@ -540,20 +542,29 @@ describe("useMcpBridge", () => {
       }
     );
 
-    it("falls back to 'mcp' when the dispatch carries no origin at all", async () => {
+    it.each([
+      ["absent", undefined],
+      ["unrecognized", "assistant" as unknown],
+      ["garbage", "'; DROP TABLE" as unknown],
+    ])("falls back to 'mcp' when the origin is %s", async (_label, sessionOrigin) => {
       mocks.get.mockReturnValue(safeManifestEntry({ id: "agent.launch", danger: "safe" }));
       mocks.dispatch.mockResolvedValue({ ok: true, result: { terminalId: "t-no-origin" } });
 
       renderHook(() => useMcpBridge());
 
-      // Nothing type-checks the `webContents.send` side of this channel, so an
-      // origin-less payload has to resolve somewhere. It resolves away from
-      // assistant provenance: under-claiming is recoverable, mislabelling an
-      // external client's spawn as the user's own assistant is not.
+      // Nothing type-checks the `webContents.send` side of this channel, so a
+      // payload carrying no origin — or a value the union doesn't contain —
+      // has to resolve somewhere. It resolves away from assistant provenance:
+      // under-claiming is recoverable, mislabelling an external client's spawn
+      // as the user's own assistant is not. Note the "unrecognized" case sends
+      // the *terminal source* spelling rather than an origin, which is exactly
+      // the kind of near-miss that a substring or truthiness check would let
+      // through.
       await dispatchHandler?.({
-        requestId: "req-origin-absent",
+        requestId: "req-origin-fallback",
         actionId: "agent.launch",
         args: { agentId: "claude" },
+        sessionOrigin: sessionOrigin as never,
       });
 
       expect(mocks.dispatch).toHaveBeenCalledWith(
@@ -561,6 +572,47 @@ describe("useMcpBridge", () => {
         { agentId: "claude", spawnedBy: "mcp", focusPolicy: "preserve" },
         { source: "agent", confirmed: undefined }
       );
+    });
+
+    it("keeps the assistant's provenance across the confirm-gated await", async () => {
+      mocks.get.mockReturnValue(confirmManifestEntry({ id: "recipe.run", title: "Run Recipe" }));
+      mocks.dispatch.mockResolvedValue({ ok: true, result: { terminalId: "t-confirm" } });
+
+      renderHook(() => useMcpBridge());
+
+      // A confirm-gated spawn parks on the approval modal for as long as the
+      // user takes. Origin is read once, up front, so nothing about that wait
+      // can relabel who asked — the risk being a later refactor that re-reads
+      // provenance after the await, when the session may be gone.
+      const dispatched = dispatchHandler?.({
+        requestId: "req-confirm-origin",
+        actionId: "recipe.run",
+        args: { recipeId: "recipe-1" },
+        sessionOrigin: "assistant-pane",
+      });
+
+      await Promise.resolve();
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+
+      useMcpConfirmStore.getState().resolveCurrent("approved");
+      await dispatched;
+
+      expect(mocks.dispatch).toHaveBeenCalledWith(
+        "recipe.run",
+        { recipeId: "recipe-1", spawnedBy: "assistant", focusPolicy: "preserve" },
+        { source: "agent", confirmed: true }
+      );
+    });
+
+    it("stamps a spawnedBy the real action schema accepts", () => {
+      // The bridge writes this field; action argsSchemas validate it. Nothing
+      // in the tests above would notice them drifting apart, because they mock
+      // `actionService.dispatch` — and the production symptom of a drift is
+      // every assistant-launched spawn failing validation before it launches.
+      for (const origin of ["help", "assistant-pane", "external"] as const) {
+        const tagged = tagMcpSpawnSource("agent.launch", {}, origin) as { spawnedBy: unknown };
+        expect(TerminalSpawnSourceSchema.safeParse(tagged.spawnedBy).success).toBe(true);
+      }
     });
 
     it("leaves non-spawning actions untouched regardless of origin", async () => {

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -90,6 +90,7 @@ describe("useMcpBridge", () => {
         confirmed?: boolean;
         context?: Record<string, unknown>;
         callerInfo?: { token4LastChars: string; userAgent: string };
+        sessionOrigin?: "help" | "assistant-pane" | "external";
       }) => void | Promise<void>)
     | undefined;
   let cleanupManifest: ReturnType<typeof vi.fn>;
@@ -511,6 +512,78 @@ describe("useMcpBridge", () => {
     expect(cleanupDispatch).toHaveBeenCalledTimes(1);
   });
 
+  describe("assistant vs external spawn provenance (#11808)", () => {
+    it.each([
+      ["help", "assistant"],
+      ["assistant-pane", "assistant"],
+      ["external", "mcp"],
+    ] as const)(
+      "resolves a %s-origin dispatch to spawnedBy: '%s'",
+      async (sessionOrigin, expectedSource) => {
+        mocks.get.mockReturnValue(safeManifestEntry({ id: "agent.launch", danger: "safe" }));
+        mocks.dispatch.mockResolvedValue({ ok: true, result: { terminalId: "t-origin" } });
+
+        renderHook(() => useMcpBridge());
+
+        await dispatchHandler?.({
+          requestId: `req-${sessionOrigin}`,
+          actionId: "agent.launch",
+          args: { agentId: "claude" },
+          sessionOrigin,
+        });
+
+        expect(mocks.dispatch).toHaveBeenCalledWith(
+          "agent.launch",
+          { agentId: "claude", spawnedBy: expectedSource, focusPolicy: "preserve" },
+          { source: "agent", confirmed: undefined }
+        );
+      }
+    );
+
+    it("falls back to 'mcp' when the dispatch carries no origin at all", async () => {
+      mocks.get.mockReturnValue(safeManifestEntry({ id: "agent.launch", danger: "safe" }));
+      mocks.dispatch.mockResolvedValue({ ok: true, result: { terminalId: "t-no-origin" } });
+
+      renderHook(() => useMcpBridge());
+
+      // Nothing type-checks the `webContents.send` side of this channel, so an
+      // origin-less payload has to resolve somewhere. It resolves away from
+      // assistant provenance: under-claiming is recoverable, mislabelling an
+      // external client's spawn as the user's own assistant is not.
+      await dispatchHandler?.({
+        requestId: "req-origin-absent",
+        actionId: "agent.launch",
+        args: { agentId: "claude" },
+      });
+
+      expect(mocks.dispatch).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", spawnedBy: "mcp", focusPolicy: "preserve" },
+        { source: "agent", confirmed: undefined }
+      );
+    });
+
+    it("leaves non-spawning actions untouched regardless of origin", async () => {
+      mocks.get.mockReturnValue(safeManifestEntry({ id: "actions.list", danger: "safe" }));
+      mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+      renderHook(() => useMcpBridge());
+
+      await dispatchHandler?.({
+        requestId: "req-list-assistant",
+        actionId: "actions.list",
+        args: { query: "worktree" },
+        sessionOrigin: "assistant-pane",
+      });
+
+      expect(mocks.dispatch).toHaveBeenCalledWith(
+        "actions.list",
+        { query: "worktree" },
+        { source: "agent", confirmed: undefined }
+      );
+    });
+  });
+
   describe("MCP spawn source tagging (#6959)", () => {
     it("stamps spawnedBy: 'mcp' onto agent.launch dispatches and preserves caller args", async () => {
       mocks.get.mockReturnValue(safeManifestEntry({ id: "agent.launch", danger: "safe" }));
@@ -593,6 +666,29 @@ describe("useMcpBridge", () => {
         requestId: "req-claude",
         actionId: "agent.claude",
         args: { spawnedBy: "quickrun" },
+      });
+
+      expect(mocks.dispatch).toHaveBeenCalledWith(
+        "agent.claude",
+        { spawnedBy: "mcp", focusPolicy: "preserve" },
+        { source: "agent", confirmed: undefined }
+      );
+    });
+
+    it("cannot be talked into claiming assistant provenance from an external session", async () => {
+      mocks.get.mockReturnValue(safeManifestEntry({ id: "agent.claude", danger: "safe" }));
+      mocks.dispatch.mockResolvedValue({ ok: true, result: { terminalId: "t-spoof" } });
+
+      renderHook(() => useMcpBridge());
+
+      // The session's authenticated origin decides, not the args — otherwise
+      // any external client could dress its spawns up as the user's own
+      // assistant, which is exactly the confusion #11808 removes.
+      await dispatchHandler?.({
+        requestId: "req-spoof",
+        actionId: "agent.claude",
+        args: { spawnedBy: "assistant" },
+        sessionOrigin: "external",
       });
 
       expect(mocks.dispatch).toHaveBeenCalledWith(

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -542,29 +542,20 @@ describe("useMcpBridge", () => {
       }
     );
 
-    it.each([
-      ["absent", undefined],
-      ["unrecognized", "assistant" as unknown],
-      ["garbage", "'; DROP TABLE" as unknown],
-    ])("falls back to 'mcp' when the origin is %s", async (_label, sessionOrigin) => {
+    it("falls back to 'mcp' when the dispatch carries no origin at all", async () => {
       mocks.get.mockReturnValue(safeManifestEntry({ id: "agent.launch", danger: "safe" }));
       mocks.dispatch.mockResolvedValue({ ok: true, result: { terminalId: "t-no-origin" } });
 
       renderHook(() => useMcpBridge());
 
-      // Nothing type-checks the `webContents.send` side of this channel, so a
-      // payload carrying no origin — or a value the union doesn't contain —
-      // has to resolve somewhere. It resolves away from assistant provenance:
-      // under-claiming is recoverable, mislabelling an external client's spawn
-      // as the user's own assistant is not. Note the "unrecognized" case sends
-      // the *terminal source* spelling rather than an origin, which is exactly
-      // the kind of near-miss that a substring or truthiness check would let
-      // through.
+      // Nothing type-checks the `webContents.send` side of this channel, so an
+      // origin-less payload has to resolve somewhere. It resolves away from
+      // assistant provenance: under-claiming is recoverable, mislabelling an
+      // external client's spawn as the user's own assistant is not.
       await dispatchHandler?.({
-        requestId: "req-origin-fallback",
+        requestId: "req-origin-absent",
         actionId: "agent.launch",
         args: { agentId: "claude" },
-        sessionOrigin: sessionOrigin as never,
       });
 
       expect(mocks.dispatch).toHaveBeenCalledWith(
@@ -609,9 +600,12 @@ describe("useMcpBridge", () => {
       // in the tests above would notice them drifting apart, because they mock
       // `actionService.dispatch` — and the production symptom of a drift is
       // every assistant-launched spawn failing validation before it launches.
+      const readSpawnedBy = (args: unknown): unknown =>
+        typeof args === "object" && args !== null ? Reflect.get(args, "spawnedBy") : undefined;
+
       for (const origin of ["help", "assistant-pane", "external"] as const) {
-        const tagged = tagMcpSpawnSource("agent.launch", {}, origin) as { spawnedBy: unknown };
-        expect(TerminalSpawnSourceSchema.safeParse(tagged.spawnedBy).success).toBe(true);
+        const spawnedBy = readSpawnedBy(tagMcpSpawnSource("agent.launch", {}, origin));
+        expect(TerminalSpawnSourceSchema.safeParse(spawnedBy).success).toBe(true);
       }
     });
 

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -16,7 +16,8 @@ import {
   type WorktreeLocationArgs,
 } from "@/services/actions/definitions/locationArgs";
 import type { ActionContext, ActionDispatchResult, ActionId } from "@shared/types/actions";
-import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
+import type { McpConfirmationDecision, McpSessionOrigin } from "@shared/types/ipc/mcpServer";
+import type { TerminalSpawnSource } from "@shared/types/panel";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { summarizeMcpArgs } from "@shared/utils/mcpArgsSummary";
 
@@ -227,23 +228,50 @@ function withPreviewedGitCwd(args: unknown, target: McpConfirmPreviewTarget | un
 }
 
 /**
- * Stamp `spawnedBy: "mcp"` and `focusPolicy: "preserve"` onto actions that
- * can create panels. `spawnedBy` records provenance (MCP bridge is the
- * dispatch source); `focusPolicy` declares the caller's intent to keep focus
- * where it is (#6959). We override any caller-supplied values because the
- * dispatch source is authoritative — an MCP client cannot claim a different
- * origin or focus policy.
+ * Which spawn source a dispatch from this session should be stamped with
+ * (#11808).
+ *
+ * `help` and `assistant-pane` are both Daintree's own assistant surfaces — one
+ * is the assistant panel, the other a `daintree-assistant` CLI pane — so both
+ * read as `"assistant"`. Splitting them apart in the terminal's provenance
+ * would classify the implementation surface rather than the actor, and the user
+ * question this answers is "did I ask for this run, or did the assistant start
+ * it on its own?".
+ *
+ * Anything else, including an absent origin, is `"mcp"`. That mirrors
+ * `SessionStore.getOrigin`'s own fail-closed default: an unknown or torn-down
+ * session must never be promoted into one of Daintree's own surfaces, and the
+ * safe direction here is to under-claim assistant provenance rather than label
+ * an external client's spawn as ours.
+ */
+function spawnSourceForOrigin(sessionOrigin: McpSessionOrigin | undefined): TerminalSpawnSource {
+  return sessionOrigin === "help" || sessionOrigin === "assistant-pane" ? "assistant" : "mcp";
+}
+
+/**
+ * Stamp the dispatching session's spawn source and `focusPolicy: "preserve"`
+ * onto actions that can create panels. `spawnedBy` records provenance — which
+ * surface asked for this spawn; `focusPolicy` declares the caller's intent to
+ * keep focus where it is (#6959). We override any caller-supplied values
+ * because the dispatch source is authoritative — an MCP client cannot claim a
+ * different origin or focus policy, and in particular cannot claim to be the
+ * assistant.
  *
  * Exported for unit tests; importing modules should not call this directly —
  * the bridge is the only authoritative caller.
  */
-export function tagMcpSpawnSource(actionId: string, args: unknown): unknown {
+export function tagMcpSpawnSource(
+  actionId: string,
+  args: unknown,
+  sessionOrigin?: McpSessionOrigin
+): unknown {
   if (!shouldTagMcpSpawn(actionId)) return args;
+  const spawnedBy = spawnSourceForOrigin(sessionOrigin);
   if (args && typeof args === "object" && !Array.isArray(args)) {
-    return { ...(args as Record<string, unknown>), spawnedBy: "mcp", focusPolicy: "preserve" };
+    return { ...(args as Record<string, unknown>), spawnedBy, focusPolicy: "preserve" };
   }
   if (args === undefined || args === null) {
-    return { spawnedBy: "mcp", focusPolicy: "preserve" };
+    return { spawnedBy, focusPolicy: "preserve" };
   }
   return args;
 }
@@ -276,7 +304,7 @@ export function useMcpBridge(): void {
     });
 
     const cleanupDispatch = window.electron.mcpBridge.onDispatchActionRequest(
-      async ({ requestId, actionId, args, confirmed, context, callerInfo }) => {
+      async ({ requestId, actionId, args, confirmed, context, callerInfo, sessionOrigin }) => {
         let confirmationDecision: McpConfirmationDecision | undefined;
         // Declared outside the confirm block so the approved dispatch can pin
         // itself to the previewed cwd. Stays undefined for pre-granted
@@ -364,7 +392,8 @@ export function useMcpBridge(): void {
 
           const dispatchArgs = tagMcpSpawnSource(
             actionId,
-            withPreviewedGitCwd(args, previewTarget)
+            withPreviewedGitCwd(args, previewTarget),
+            sessionOrigin
           );
           const result = await runWithMcpSpawnFocusSuppressed(
             () =>

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -24,11 +24,13 @@ export const LaunchLocationSchema = z
 /**
  * Mirror of `TerminalSpawnSource` from `shared/types/panel.ts`. Kept in lockstep
  * with that union so action argsSchemas can validate the field. The MCP bridge
- * stamps `"mcp"` on spawn-producing dispatches; user surfaces stamp their own
- * origin (`"quickrun"`, `"recipe"`, `"agent"`, `"palette"`).
+ * stamps `"assistant"` or `"mcp"` on spawn-producing dispatches — whichever the
+ * session's authenticated origin resolves to (#11808) — and overrides whatever
+ * the caller sent, so neither value can be claimed. User surfaces stamp their
+ * own origin (`"quickrun"`, `"recipe"`, `"agent"`, `"palette"`).
  */
 export const TerminalSpawnSourceSchema = z
-  .enum(["quickrun", "recipe", "agent", "palette", "mcp"])
+  .enum(["quickrun", "recipe", "agent", "palette", "mcp", "assistant"])
   .describe(
     "Records which surface asked for the spawn, for provenance and run history only; it never changes what is launched. Leave it unset when dispatching over MCP — the bridge stamps its own origin."
   );


### PR DESCRIPTION
Resolves #11808

## The problem

`TerminalSpawnSource` had one value, `mcp`, for everything that came in over the MCP bridge. A run the Daintree Assistant started on its own schedule looked exactly like one an arbitrary external client started, so a terminal could appear that the user didn't ask for with nothing on it saying where it came from. External session binding (#11788) made that worse by putting both down the same path.

The information already existed — `McpSessionOrigin` (`help` | `assistant-pane` | `external`) is recorded at handshake and read through `SessionStore.getOrigin()`. It just never crossed the IPC boundary, so the renderer had nothing to distinguish on.

## What changed

`TerminalSpawnSource` gains `assistant`. `buildSessionServerDeps` snapshots the session's authenticated origin and threads it through all three dispatch routes into the `MCP_SERVER_DISPATCH_ACTION_REQUEST` payload; the renderer maps `help`/`assistant-pane` to `assistant` and everything else to `mcp`. `TerminalInfoDialog` picks up a `Started By: Daintree Assistant` row (and the matching clipboard line), and its `Started via MCP` derivation now covers both values instead of silently reporting "No" for assistant runs.

Both assistant surfaces map to one value on purpose. `help` vs `assistant-pane` is an implementation detail of which surface is running; the question the label answers is "did I ask for this, or did the assistant start it on its own". The full origin still crosses the boundary, so a future consumer that wants the finer split has it.

`McpSessionOrigin` moved to `shared/types/ipc/mcpServer.ts` (the old location re-exports it) because the renderer needs it now. Mirroring it renderer-side would have left two unions free to drift, which is how a surface silently gets reclassified as external.

## Fail-closed

Origin is resolved in main from the authenticated bearer and overrides whatever the caller sent, so an external client cannot claim to be the assistant — there's a test for exactly that. `getOrigin()` already defaults to `external`, the bridge defaults to `external`, and the renderer maps an absent or unrecognized origin to `mcp`. Every unknown resolves away from assistant provenance: under-claiming is recoverable, mislabelling an external client's spawn as the user's own is not.

The origin is snapshotted at `buildSessionServerDeps` time rather than read live in the dispatch closure. `clearSessionBinding` deletes the entry on teardown and `getOrigin` fails closed, so a live read would relabel the assistant's own in-flight spawn as external the moment its session ended.

## Deliberately not in scope

The issue also asks that a run be traceable back to the specific assistant session that started it. That isn't here. Help sessions have a public id, but assistant-pane sessions have no id in `SessionStore`, so it would land asymmetrically — and `spawnedBy` is runtime-only and never serialized, so a stored session id wouldn't survive a restart anyway. Carrying one properly means a new panel field threaded through all five action schemas and the creation factories. Worth doing separately if the coarse label turns out not to be enough.

Panel tab/header chrome is also untouched. Doing it consistently spans tab buttons, panel headers, dock chips, grouped tabs, tooltips and accessibility names; putting it on one header variant would just be inconsistent.

## Testing

593 tests pass across the MCP server, bridge, hook and dialog suites, plus typecheck. New coverage: the origin→source mapping for all three origins, spoof resistance, origin survival across the confirm-gated await, the build-time snapshot surviving teardown, the fail-closed default for an unknown session, the restored-panel unknown case, and an end-to-end handshake test proving the `McpServerService` adapter lambdas actually forward the origin — the bridge defaults a missing one to `external`, so without that test dropping the argument there would have left every other test green.