### PR TITLE
fix(services): stop idle auto-close from killing a working Daintree Assistant

### DIFF
--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1345,12 +1345,19 @@ export class HelpSessionService {
   }
 
   /**
-   * Idle-background auto-close (#10830): the assistant is tooling-internal,
-   * so its PTY must not keep an idle background project resident — and the
-   * renderer's own hibernate timer can't fire there (parked project views
-   * freeze timers, the #10739 class). The sweep capture-revokes the project's
-   * help sessions before reclaiming — the same conversation-preserving path
-   * as LRU eviction, so the next open resumes where the user left off.
+   * Idle-background auto-close (#10830): the sweep capture-revokes a project's
+   * help sessions before reclaiming it — the same conversation-preserving path
+   * as LRU eviction, so the next open resumes where the user left off. The
+   * renderer's own hibernate timer can't do this itself, because a parked
+   * project view freezes timers (the #10739 class).
+   *
+   * A LIVE assistant no longer reaches here: since #11807 the sweep treats one
+   * as a hard floor and skips the project entirely, because nothing tells main
+   * whether an idle-looking assistant is merely at its prompt or sitting on a
+   * scheduled wakeup. So the records this settles are the non-live ones — a
+   * terminal that exited under its own steam (nothing drops that binding), or
+   * a session provisioned but never bound. Only the former has a conversation
+   * to capture; an unbound record writes no pending-hibernation entry.
    */
   async revokeByProjectId(projectId: string): Promise<void> {
     const targets = [...this.sessionsById.values()].filter(

--- a/electron/services/IdleBackgroundAutoCloseService.ts
+++ b/electron/services/IdleBackgroundAutoCloseService.ts
@@ -139,6 +139,10 @@ export class IdleBackgroundAutoCloseService {
     const client = this.ptyClient;
     if (!client) return null;
     const snapshot = await client.getAllTerminalsWithCompletenessAsync();
+    // `stop()` may have landed while that request was in flight — app shutdown
+    // clears the client without touching `enabled`, so the config re-checks
+    // downstream would wave this through on a snapshot nobody owns any more.
+    if (this.ptyClient !== client) return null;
     if (snapshot.degraded) {
       logInfo("idle-background-auto-close-skip-degraded-snapshot", {
         shardsFailed: snapshot.shardsFailed,

--- a/electron/services/IdleBackgroundAutoCloseService.ts
+++ b/electron/services/IdleBackgroundAutoCloseService.ts
@@ -11,7 +11,6 @@ import { getPtyClient, getWorkspaceClientRef } from "../window/serviceRefs.js";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
 import { getHibernationService } from "./HibernationService.js";
-import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
 import { helpSessionService } from "./HelpSessionService.js";
 import { writeHibernatedMarker } from "./pty/terminalSessionPersistence.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
@@ -27,6 +26,12 @@ const DEFAULT_CONFIG: IdleBackgroundAutoCloseConfig = {
 const MIN_THRESHOLD_MINUTES = 15;
 const MAX_THRESHOLD_MINUTES = 1440; // 24h
 
+/** One entry of the live terminal snapshot PtyClient serves. */
+type AutoCloseTerminal = Awaited<ReturnType<PtyClient["getAllTerminalsAsync"]>>[number];
+
+/** Why a project must not be reclaimed this sweep. */
+type BlockingReason = "terminal" | "assistant";
+
 /**
  * IdleBackgroundAutoCloseService — Auto-closes background projects that have
  * been idle past a configurable threshold (default 15 min) AND hold zero
@@ -37,10 +42,13 @@ const MAX_THRESHOLD_MINUTES = 1440; // 24h
  *
  * Structurally mirrors {@link IdleTerminalNotificationService} (timer, startup
  * quiet, wake quiet, sleep/wake lifecycle) but ACTS instead of notifying:
- * - Gate is terminal presence only — any terminal means skip (never destroy
- *   agent scrollback silently). Exception: the Daintree Assistant's help PTY
- *   is tooling-internal and never blocks the reclaim; it's capture-revoked
- *   (conversation preserved via pending hibernation) before teardown.
+ * - Gate is terminal presence only — any live terminal means skip (never
+ *   destroy agent scrollback silently), and that includes the Daintree
+ *   Assistant's help PTY (#11807). A live assistant is floored a second time
+ *   by its session binding, so a pty-host snapshot that never listed it still
+ *   can't get it reclaimed out from under itself. Once the assistant's PTY is
+ *   gone the project is eligible again, and `closeProject` capture-revokes any
+ *   leftover binding (conversation preserved via pending hibernation).
  * - Never touches the foreground/active project in ANY window — the multi-window
  *   guard reads every per-window ProjectViewManager's active project, not just
  *   the SQLite-backed `getCurrentProjectId()` (which only reflects the
@@ -88,19 +96,45 @@ export class IdleBackgroundAutoCloseService {
   }
 
   /**
-   * Is this PTY the Daintree Assistant's tooling-internal help terminal?
-   * Checks BOTH registries: the renderer-fed availability mark (durable, but
-   * lands only after the renderer's `help.markTerminal` — a parked renderer
-   * may never send it) and main's own live session binding (set at spawn,
-   * dropped on revoke). Either alone has a blind window; together the
-   * assistant PTY can never masquerade as a real terminal and block sweeps
-   * indefinitely.
+   * Is a Daintree Assistant still running in this project?
+   *
+   * Binding + PTY liveness — the same pair `ProjectViewEvictionController` and
+   * `HibernationService` already gate on (#11477). The binding alone is NOT
+   * liveness: nothing drops it when the assistant exits under its own steam,
+   * so without the second half a quit assistant would pin its project forever.
+   * `hasTerminal` is PtyClient's main-local spawn registry, written
+   * synchronously by `spawn()` and dropped on both exit and kill, so it is
+   * authoritative from the assistant's first instant and — unlike
+   * `getAllTerminalsAsync` — cannot be silently truncated by a pty-host shard
+   * timeout.
+   *
+   * Agent state is deliberately NOT consulted. An assistant that scheduled a
+   * wakeup or dispatched a sub-agent reads `idle` while that work is still
+   * pending, and `help/CLAUDE.md` tells it to pace long work exactly that way.
+   * Nothing main-process-side separates "idle at its prompt" from "idle with
+   * work pending" (#11807, and #11157/#11477 before it), so the floor has to
+   * be unconditional; it lifts as soon as the PTY exits.
    */
-  private isHelpTerminal(terminalId: string): boolean {
-    return (
-      getAgentAvailabilityStore().isHelpTerminal(terminalId) ||
-      helpSessionService.isHelpTerminal(terminalId)
-    );
+  private hasLiveAssistantBackend(projectId: string): boolean {
+    const backend = helpSessionService.getAssistantBackend(projectId);
+    if (!backend) return false;
+    return this.ptyClient?.hasTerminal(backend.terminalId) === true;
+  }
+
+  /**
+   * Why this project must not be reclaimed right now, or `null` when it is
+   * free to close. ONE predicate behind all three gates — the sweep filter and
+   * both `closeProject` TOCTOU re-checks — so they cannot drift apart (#11800).
+   */
+  private blockingReason(
+    projectId: string,
+    terminals: readonly AutoCloseTerminal[]
+  ): BlockingReason | null {
+    if (terminals.some((t) => t.projectId === projectId && t.hasPty !== false)) {
+      return "terminal";
+    }
+    if (this.hasLiveAssistantBackend(projectId)) return "assistant";
+    return null;
   }
 
   private normalizeThreshold(value: unknown, fallback: number): number {
@@ -299,6 +333,8 @@ export class IdleBackgroundAutoCloseService {
     const activeIds = this.collectActiveProjectIds();
 
     const closed: IdleBackgroundClosedProjectEntry[] = [];
+    /** Projects held back purely by a live assistant — logged once per sweep. */
+    const assistantProtected: string[] = [];
 
     for (const project of projects) {
       if (!project.id) continue;
@@ -322,16 +358,17 @@ export class IdleBackgroundAutoCloseService {
       // Still within the idle threshold.
       if (now - project.lastOpened < thresholdMs) continue;
 
-      // Gate: terminal presence only. Any live PTY means skip — we never tear
-      // down a project that still has agent/terminal scrollback. The Daintree
-      // Assistant's help PTY is the one exception: it's tooling-internal (the
-      // switcher already hides it, #10989) and must not keep an idle project
-      // resident — `closeProject` capture-revokes it so the conversation
-      // still resumes on the next open.
-      const hasTerminal = allTerminals.some(
-        (t) => t.projectId === pid && t.hasPty !== false && !this.isHelpTerminal(t.id)
-      );
-      if (hasTerminal) continue;
+      // Gate: terminal presence. Any live PTY means skip — we never tear down a
+      // project that still has agent/terminal scrollback, and the Daintree
+      // Assistant's help PTY now counts too (#11807). It used to be waved
+      // through as tooling-internal, but the capture-revoke only preserves the
+      // conversation: whatever wakeup or sub-agent the assistant had in flight
+      // dies with the PTY, which is the reclaim this issue reports losing.
+      const blocked = this.blockingReason(pid, allTerminals);
+      if (blocked) {
+        if (blocked === "assistant") assistantProtected.push(pid);
+        continue;
+      }
 
       try {
         const result = await this.closeProject(pid, now, thresholdMs);
@@ -340,6 +377,15 @@ export class IdleBackgroundAutoCloseService {
         // Isolate per project — one teardown failure must not abort the sweep.
         logError("idle-background-auto-close-project-failed", error, { projectId: pid });
       }
+    }
+
+    // Mirrors HibernationService's `hibernate-skip-live-assistant`. Emitted from
+    // the sweep only — the two `closeProject` re-checks share the predicate, so
+    // logging there as well would just repeat this line.
+    if (assistantProtected.length > 0) {
+      logInfo("idle-background-auto-close-skip-live-assistant", {
+        projectIds: assistantProtected,
+      });
     }
 
     if (closed.length === 0) return;
@@ -388,22 +434,17 @@ export class IdleBackgroundAutoCloseService {
     if (this.collectActiveProjectIds().has(projectId)) return null;
 
     const liveTerminals = (await this.ptyClient?.getAllTerminalsAsync()) ?? [];
-    if (
-      liveTerminals.some(
-        (t) => t.projectId === projectId && t.hasPty !== false && !this.isHelpTerminal(t.id)
-      )
-    ) {
-      return null;
-    }
+    if (this.blockingReason(projectId, liveTerminals)) return null;
 
     const project = fresh;
 
-    // A still-running assistant help PTY must not survive the reclaim, and it
-    // must not lose the conversation either: capture-revoke it first (graceful
-    // kill + pending-hibernation entry — the LRU-eviction path), so the next
-    // panel open resumes the session. Await it so the PTY is down before the
-    // project-wide kill below; a failure degrades to that kill, losing only
-    // the resume entry, never blocking the reclaim.
+    // Reaching here means no assistant PTY is live (the gate above floors that),
+    // so this revoke is the cleanup for a session record whose terminal already
+    // exited — the binding survives a self-exited assistant, and nothing else
+    // drops it. Capture-revoking it writes the pending-hibernation entry, so the
+    // next panel open still resumes the conversation. Await it so the record is
+    // settled before the project-wide kill below; a failure degrades to that
+    // kill, losing only the resume entry, never blocking the reclaim.
     try {
       await helpSessionService.revokeByProjectId(projectId);
     } catch (error) {
@@ -411,21 +452,16 @@ export class IdleBackgroundAutoCloseService {
     }
 
     // The capture-revoke's gracefulKill can take seconds — long enough for the
-    // user to switch to this project or spawn a real terminal in it. Re-verify
-    // eligibility once more before the irreversible teardown; bailing here is
-    // safe because the revoke above already persisted the assistant's
-    // pending-hibernation entry, so a reopened panel still resumes.
+    // user to switch to this project, spawn a real terminal in it, or reopen the
+    // assistant panel. Re-verify eligibility once more before the irreversible
+    // teardown; bailing here is safe because the revoke above already persisted
+    // the assistant's pending-hibernation entry, so a reopened panel still
+    // resumes.
     if (this.collectActiveProjectIds().has(projectId)) return null;
     const refreshed = projectStore.getProjectById(projectId);
     if (!refreshed || refreshed.status !== "background") return null;
     const postRevokeTerminals = (await this.ptyClient?.getAllTerminalsAsync()) ?? [];
-    if (
-      postRevokeTerminals.some(
-        (t) => t.projectId === projectId && t.hasPty !== false && !this.isHelpTerminal(t.id)
-      )
-    ) {
-      return null;
-    }
+    if (this.blockingReason(projectId, postRevokeTerminals)) return null;
 
     // Graceful, session-preserving kill — scrollback survives via hibernation
     // markers so a later reopen restores panels instead of starting cold. For a

--- a/electron/services/IdleBackgroundAutoCloseService.ts
+++ b/electron/services/IdleBackgroundAutoCloseService.ts
@@ -122,18 +122,51 @@ export class IdleBackgroundAutoCloseService {
   }
 
   /**
+   * A terminal snapshot we can actually act on, or `null` when there isn't one.
+   *
+   * `getAllTerminalsAsync` substitutes `[]` for a shard that failed to answer,
+   * which makes a pty-host outage indistinguishable from a machine with no
+   * terminals. That is fine for a self-correcting count and disqualifying for
+   * this gate, whose whole contract is "empty means genuinely nothing running"
+   * — reporting a busy project as clear is the one wrong answer here, because
+   * the next step kills its processes. So read completeness explicitly and fail
+   * closed on a degraded snapshot; the sweep runs again in five minutes, and a
+   * deferred reclaim costs nothing next to a wrongly reclaimed one.
+   *
+   * Also `null` once `stop()` has cleared the client mid-sweep — same reasoning.
+   */
+  private async readTerminals(): Promise<AutoCloseTerminal[] | null> {
+    const client = this.ptyClient;
+    if (!client) return null;
+    const snapshot = await client.getAllTerminalsWithCompletenessAsync();
+    if (snapshot.degraded) {
+      logInfo("idle-background-auto-close-skip-degraded-snapshot", {
+        shardsFailed: snapshot.shardsFailed,
+        shardsTotal: snapshot.shardsTotal,
+      });
+      return null;
+    }
+    return snapshot.terminals;
+  }
+
+  /**
    * Why this project must not be reclaimed right now, or `null` when it is
    * free to close. ONE predicate behind all three gates — the sweep filter and
    * both `closeProject` TOCTOU re-checks — so they cannot drift apart (#11800).
+   *
+   * The assistant floor is consulted FIRST so that a live assistant is named as
+   * the reason even when its help PTY is also sitting in the snapshot as an
+   * ordinary terminal. Both answers block; only this order makes the skip log
+   * report the case operators actually hit.
    */
   private blockingReason(
     projectId: string,
     terminals: readonly AutoCloseTerminal[]
   ): BlockingReason | null {
+    if (this.hasLiveAssistantBackend(projectId)) return "assistant";
     if (terminals.some((t) => t.projectId === projectId && t.hasPty !== false)) {
       return "terminal";
     }
-    if (this.hasLiveAssistantBackend(projectId)) return "assistant";
     return null;
   }
 
@@ -322,11 +355,12 @@ export class IdleBackgroundAutoCloseService {
     const projects = projectStore.getAllProjects();
     if (projects.length === 0) return;
 
-    if (!this.ptyClient) return;
     // Read the live terminal registry every sweep — never cache it in the timer
     // closure, so a project that briefly held a terminal and dropped back to
-    // zero is re-evaluated fresh (lesson #8998).
-    const allTerminals = await this.ptyClient.getAllTerminalsAsync();
+    // zero is re-evaluated fresh (lesson #8998). A degraded read aborts the
+    // whole sweep: one silent shard would make every project on it look empty.
+    const allTerminals = await this.readTerminals();
+    if (!allTerminals) return;
 
     const now = Date.now();
     const thresholdMs = config.thresholdMinutes * 60 * 1000;
@@ -433,18 +467,23 @@ export class IdleBackgroundAutoCloseService {
     if (now - fresh.lastOpened < thresholdMs) return null;
     if (this.collectActiveProjectIds().has(projectId)) return null;
 
-    const liveTerminals = (await this.ptyClient?.getAllTerminalsAsync()) ?? [];
+    const liveTerminals = await this.readTerminals();
+    // Re-read `enabled` after the await too: `stop()` nulls the client, and
+    // without this a toggle-off landing mid-request would sail past every
+    // remaining guard on an empty snapshot and tear the project down anyway.
+    if (!liveTerminals || !this.getConfig().enabled) return null;
     if (this.blockingReason(projectId, liveTerminals)) return null;
 
     const project = fresh;
 
-    // Reaching here means no assistant PTY is live (the gate above floors that),
-    // so this revoke is the cleanup for a session record whose terminal already
-    // exited — the binding survives a self-exited assistant, and nothing else
-    // drops it. Capture-revoking it writes the pending-hibernation entry, so the
-    // next panel open still resumes the conversation. Await it so the record is
-    // settled before the project-wide kill below; a failure degrades to that
-    // kill, losing only the resume entry, never blocking the reclaim.
+    // The gate above floors a live assistant, so this revoke settles whatever
+    // non-live session records the project has left: one whose terminal exited
+    // under its own steam (nothing drops that binding), or one provisioned but
+    // never bound because the renderer crashed or the spawn failed. Only a
+    // previously bound record has a conversation to keep, and only that case
+    // writes the pending-hibernation entry that resumes on the next open. Await
+    // it so the records are settled before the project-wide kill below; a
+    // failure degrades to that kill, losing only the resume entry.
     try {
       await helpSessionService.revokeByProjectId(projectId);
     } catch (error) {
@@ -460,7 +499,8 @@ export class IdleBackgroundAutoCloseService {
     if (this.collectActiveProjectIds().has(projectId)) return null;
     const refreshed = projectStore.getProjectById(projectId);
     if (!refreshed || refreshed.status !== "background") return null;
-    const postRevokeTerminals = (await this.ptyClient?.getAllTerminalsAsync()) ?? [];
+    const postRevokeTerminals = await this.readTerminals();
+    if (!postRevokeTerminals || !this.getConfig().enabled) return null;
     if (this.blockingReason(projectId, postRevokeTerminals)) return null;
 
     // Graceful, session-preserving kill — scrollback survives via hibernation

--- a/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
+++ b/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
@@ -8,9 +8,10 @@ const storeMock = vi.hoisted(() => ({
   }),
 }));
 
-// getProjectById is consulted TWICE per close: the pre-teardown re-check (must
-// see a still-eligible background project) and the post-close PROJECT_UPDATED
-// broadcast. Default it to a background project idle well past the threshold.
+// getProjectById is consulted THREE times per close: the pre-revoke re-check,
+// the post-revoke re-check (both must see a still-eligible background project),
+// and the post-close PROJECT_UPDATED broadcast. Default it to a background
+// project idle well past the threshold.
 const projectStoreMock = vi.hoisted(() => ({
   getCurrentProjectId: vi.fn<() => string | null>(() => null),
   getAllProjects: vi.fn<() => Array<Record<string, unknown>>>(() => []),
@@ -29,6 +30,9 @@ const ptyClientMock = vi.hoisted(() => ({
   gracefulKillByProject: vi.fn<
     (projectId: string, opts?: { preserveSession?: boolean }) => Promise<Array<{ id: string }>>
   >(async () => []),
+  // PtyClient's main-local spawn registry — the liveness half of the assistant
+  // floor, independent of the (truncatable) pty-host terminal snapshot.
+  hasTerminal: vi.fn<(id: string) => boolean>((id: string) => liveTerminalIds.has(id)),
 }));
 
 const workspaceClientMock = vi.hoisted(() => ({
@@ -46,7 +50,8 @@ const broadcastToRendererMock = vi.hoisted(() => vi.fn());
 const writeHibernatedMarkerMock = vi.hoisted(() => vi.fn());
 const evictProjectRendererMock = vi.hoisted(() => vi.fn<(id: string) => number>(() => 1));
 
-vi.mock("../../utils/logger.js", () => ({ logInfo: vi.fn(), logError: vi.fn() }));
+const logInfoMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/logger.js", () => ({ logInfo: logInfoMock, logError: vi.fn() }));
 
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: broadcastToRendererMock,
@@ -76,22 +81,23 @@ vi.mock("../SystemSleepService.js", () => ({
   }),
 }));
 
-// The assistant help PTY never blocks auto-close; it's capture-revoked before
-// teardown. Terminal ids added to `helpTerminalIds` read as help terminals via
-// the availability store; `boundHelpTerminalIds` via main's session binding.
+// A live Daintree Assistant floors the reclaim (#11807). `assistantBackends`
+// maps a project to the terminal its help session bound; `liveTerminalIds` backs
+// PtyClient's spawn registry. A binding whose terminal is NOT in the live set
+// models an assistant that exited under its own steam — nothing drops the
+// binding, so only the liveness half distinguishes it from a running one.
+const assistantBackends = vi.hoisted(() => new Map<string, string>());
+const liveTerminalIds = vi.hoisted(() => new Set<string>());
+
 const helpSessionServiceMock = vi.hoisted(() => ({
   revokeByProjectId: vi.fn(async (_projectId: string) => {}),
-  isHelpTerminal: vi.fn((id: string) => boundHelpTerminalIds.has(id)),
-}));
-const helpTerminalIds = vi.hoisted(() => new Set<string>());
-const boundHelpTerminalIds = vi.hoisted(() => new Set<string>());
-
-vi.mock("../HelpSessionService.js", () => ({ helpSessionService: helpSessionServiceMock }));
-vi.mock("../AgentAvailabilityStore.js", () => ({
-  getAgentAvailabilityStore: () => ({
-    isHelpTerminal: (id: string) => helpTerminalIds.has(id),
+  getAssistantBackend: vi.fn((projectId: string) => {
+    const terminalId = assistantBackends.get(projectId);
+    return terminalId ? { terminalId, webContentsId: 42 } : null;
   }),
 }));
+
+vi.mock("../HelpSessionService.js", () => ({ helpSessionService: helpSessionServiceMock }));
 
 import { IdleBackgroundAutoCloseService } from "../IdleBackgroundAutoCloseService.js";
 import type { PtyClient } from "../PtyClient.js";
@@ -125,6 +131,23 @@ function makeTerminal(projectId: string, overrides: Record<string, unknown> = {}
   return { id: `t-${projectId}`, projectId, hasPty: true, ...overrides };
 }
 
+/** A bound assistant whose PTY is still running — floors the reclaim. */
+function liveAssistant(projectId: string, terminalId = `t-help-${projectId}`): string {
+  assistantBackends.set(projectId, terminalId);
+  liveTerminalIds.add(terminalId);
+  return terminalId;
+}
+
+/**
+ * A session binding whose PTY already exited. Nothing drops the binding on a
+ * self-exit, so this is the shape a quit assistant leaves behind — it must not
+ * block, and `closeProject` capture-revokes it on the way out.
+ */
+function staleAssistant(projectId: string, terminalId = `t-help-${projectId}`): string {
+  assistantBackends.set(projectId, terminalId);
+  return terminalId;
+}
+
 /** A ProjectViewManager mock whose active project is `activeId`. */
 function makePvm(activeId: string | null, outgoingId: string | null = null): ProjectViewManager {
   return {
@@ -154,8 +177,8 @@ describe("IdleBackgroundAutoCloseService", () => {
     ptyClientMock.gracefulKillByProject.mockResolvedValue([]);
     evictProjectRendererMock.mockReturnValue(1);
     workspaceClientMock.evictProject.mockReturnValue(true);
-    helpTerminalIds.clear();
-    boundHelpTerminalIds.clear();
+    assistantBackends.clear();
+    liveTerminalIds.clear();
   });
 
   afterEach(() => {
@@ -242,19 +265,87 @@ describe("IdleBackgroundAutoCloseService", () => {
       expect(broadcastToRendererMock).not.toHaveBeenCalled();
     });
 
-    it("closes a project whose only live PTY is the assistant, capture-revoking it first (#10989)", async () => {
+    it("a live assistant blocks the reclaim, and is never capture-revoked (#11807)", async () => {
       enable();
       projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
-      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal("proj-1")]);
-      helpTerminalIds.add("t-proj-1");
+      const helpId = liveAssistant("proj-1");
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([
+        { id: helpId, projectId: "proj-1", hasPty: true },
+      ]);
       const service = makeService();
       await runCheck(service);
 
-      // The assistant PTY did not block the reclaim…
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+      expect(ptyClientMock.gracefulKillByProject).not.toHaveBeenCalled();
+      expect(evictProjectRendererMock).not.toHaveBeenCalled();
+      expect(workspaceClientMock.evictProject).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+      expect(broadcastToRendererMock).not.toHaveBeenCalled();
+    });
+
+    it("blocks on an idle assistant — pending wakeups read as idle, so state is not consulted", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      const helpId = liveAssistant("proj-1");
+      // An assistant that scheduled a wakeup an hour out sits at "idle" with no
+      // output. That is precisely the state #11807 must not reclaim.
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([
+        { id: helpId, projectId: "proj-1", hasPty: true, agentState: "idle" },
+      ]);
+      const service = makeService();
+      await runCheck(service);
+
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+    });
+
+    it("floors on the session binding even when the terminal snapshot omits the help PTY", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      liveAssistant("proj-1");
+      // A truncated/stale pty-host snapshot never lists the assistant. The
+      // main-local spawn registry still knows it is alive.
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
+      const service = makeService();
+      await runCheck(service);
+
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+    });
+
+    it("logs the projects held back by a live assistant, once per sweep", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([
+        makeIdleProject("proj-1"),
+        makeIdleProject("proj-2"),
+      ]);
+      liveAssistant("proj-1");
+      liveAssistant("proj-2");
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
+      const service = makeService();
+      await runCheck(service);
+
+      const skipLogs = logInfoMock.mock.calls.filter(
+        ([event]) => event === "idle-background-auto-close-skip-live-assistant"
+      );
+      expect(skipLogs).toHaveLength(1);
+      expect(skipLogs[0]?.[1]).toEqual({ projectIds: ["proj-1", "proj-2"] });
+    });
+
+    it("a stale binding whose PTY already exited does not block, and is capture-revoked (#10989)", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      // Binding survives a self-exited assistant; `hasTerminal` is the half that
+      // knows it is gone.
+      staleAssistant("proj-1");
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
+      const service = makeService();
+      await runCheck(service);
+
       expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed", {
         autoParkedAt: expect.any(Number),
       });
-      // …and its session was capture-revoked (conversation preserved via the
+      // The leftover session is capture-revoked (conversation preserved via the
       // pending-hibernation entry) BEFORE the project-wide kill.
       expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
       const revokeOrder =
@@ -267,11 +358,11 @@ describe("IdleBackgroundAutoCloseService", () => {
     it("still skips when a real terminal coexists with the assistant help PTY", async () => {
       enable();
       projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      const helpId = liveAssistant("proj-1");
       ptyClientMock.getAllTerminalsAsync.mockResolvedValue([
         makeTerminal("proj-1"),
-        { id: "t-help", projectId: "proj-1", hasPty: true },
+        { id: helpId, projectId: "proj-1", hasPty: true },
       ]);
-      helpTerminalIds.add("t-help");
       const service = makeService();
       await runCheck(service);
 
@@ -279,33 +370,36 @@ describe("IdleBackgroundAutoCloseService", () => {
       expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
     });
 
-    it("recognizes the assistant via main's session binding when the renderer never marked it", async () => {
+    it("bails before the capture-revoke when an assistant appeared during the sweep", async () => {
       enable();
       projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
-      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal("proj-1")]);
-      // A parked renderer never sent help.markTerminal — only main's live
-      // session binding identifies the PTY as the assistant.
-      boundHelpTerminalIds.add("t-proj-1");
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
+      liveTerminalIds.add("t-help-late");
+      // The sweep gate saw no binding; the panel opened before the pre-revoke
+      // re-check ran, so the second look finds one. Queued per-call rather than
+      // via a persistent mockImplementation, which `clearAllMocks` would not
+      // undo and would poison later tests.
+      helpSessionServiceMock.getAssistantBackend
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce({ terminalId: "t-help-late", webContentsId: 42 });
       const service = makeService();
       await runCheck(service);
 
-      expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed", {
-        autoParkedAt: expect.any(Number),
-      });
-      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+      expect(ptyClientMock.gracefulKillByProject).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
 
     it("bails after the capture-revoke when a real terminal appeared during the await", async () => {
       enable();
       projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
-      helpTerminalIds.add("t-help");
-      const helpOnly = [{ id: "t-help", projectId: "proj-1", hasPty: true }];
-      // Sweep snapshot + pre-revoke recheck see only the assistant; the
-      // post-revoke recheck sees a real terminal spawned mid-await.
+      staleAssistant("proj-1");
+      // Sweep snapshot + pre-revoke recheck are clean; the post-revoke recheck
+      // sees a real terminal spawned mid-await.
       ptyClientMock.getAllTerminalsAsync
-        .mockResolvedValueOnce(helpOnly)
-        .mockResolvedValueOnce(helpOnly)
-        .mockResolvedValueOnce([...helpOnly, makeTerminal("proj-1")]);
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([makeTerminal("proj-1")]);
       const service = makeService();
       await runCheck(service);
 
@@ -316,11 +410,30 @@ describe("IdleBackgroundAutoCloseService", () => {
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
 
-    it("a failed assistant capture-revoke degrades gracefully and never blocks the reclaim", async () => {
+    it("bails after the capture-revoke when the assistant came back during the await", async () => {
       enable();
       projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
-      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([makeTerminal("proj-1")]);
-      helpTerminalIds.add("t-proj-1");
+      staleAssistant("proj-1", "t-help-returning");
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
+      // The revoke settles the dead record; the user reopens the panel during
+      // the multi-second await, so the post-revoke recheck must see it live.
+      helpSessionServiceMock.revokeByProjectId.mockImplementationOnce(async () => {
+        liveTerminalIds.add("t-help-returning");
+      });
+      const service = makeService();
+      await runCheck(service);
+
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
+      expect(ptyClientMock.gracefulKillByProject).not.toHaveBeenCalled();
+      expect(evictProjectRendererMock).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+    });
+
+    it("a failed capture-revoke of a dead session degrades gracefully and never blocks the reclaim", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      staleAssistant("proj-1");
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
       helpSessionServiceMock.revokeByProjectId.mockRejectedValueOnce(new Error("host gone"));
       const service = makeService();
       await runCheck(service);

--- a/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
+++ b/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
@@ -33,7 +33,19 @@ const ptyClientMock = vi.hoisted(() => ({
   // PtyClient's main-local spawn registry — the liveness half of the assistant
   // floor, independent of the (truncatable) pty-host terminal snapshot.
   hasTerminal: vi.fn<(id: string) => boolean>((id: string) => liveTerminalIds.has(id)),
+  // The service reads completeness so a silent shard can't read as "no
+  // terminals". Delegates to getAllTerminalsAsync so every fixture below still
+  // drives the snapshot through the one mock; flip `snapshotDegraded` to model
+  // a shard that failed to answer.
+  getAllTerminalsWithCompletenessAsync: vi.fn(async () => ({
+    terminals: await ptyClientMock.getAllTerminalsAsync(),
+    degraded: snapshotDegraded.value,
+    shardsTotal: 2,
+    shardsFailed: snapshotDegraded.value ? 1 : 0,
+  })),
 }));
+
+const snapshotDegraded = vi.hoisted(() => ({ value: false }));
 
 const workspaceClientMock = vi.hoisted(() => ({
   evictProject: vi.fn<(p: string) => boolean>(() => true),
@@ -179,6 +191,7 @@ describe("IdleBackgroundAutoCloseService", () => {
     workspaceClientMock.evictProject.mockReturnValue(true);
     assistantBackends.clear();
     liveTerminalIds.clear();
+    snapshotDegraded.value = false;
   });
 
   afterEach(() => {
@@ -319,9 +332,13 @@ describe("IdleBackgroundAutoCloseService", () => {
         makeIdleProject("proj-1"),
         makeIdleProject("proj-2"),
       ]);
-      liveAssistant("proj-1");
+      const helpId = liveAssistant("proj-1");
       liveAssistant("proj-2");
-      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
+      // proj-1's help PTY is listed in the snapshot the ordinary way, proj-2's
+      // is not — both must be attributed to the assistant, not to "a terminal".
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([
+        { id: helpId, projectId: "proj-1", hasPty: true },
+      ]);
       const service = makeService();
       await runCheck(service);
 
@@ -329,7 +346,41 @@ describe("IdleBackgroundAutoCloseService", () => {
         ([event]) => event === "idle-background-auto-close-skip-live-assistant"
       );
       expect(skipLogs).toHaveLength(1);
-      expect(skipLogs[0]?.[1]).toEqual({ projectIds: ["proj-1", "proj-2"] });
+      const logged = (skipLogs[0]?.[1] as { projectIds: string[] }).projectIds;
+      expect([...logged].sort()).toEqual(["proj-1", "proj-2"]);
+    });
+
+    it("a live assistant in one project does not hold back another project's reclaim", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([
+        makeIdleProject("proj-1"),
+        makeIdleProject("proj-2"),
+      ]);
+      liveAssistant("proj-1");
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
+      const service = makeService();
+      await runCheck(service);
+
+      // proj-1 is floored, proj-2 closes — the floor is per-project, not global.
+      expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledTimes(1);
+      expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith(
+        "proj-2",
+        "closed",
+        expect.anything()
+      );
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalledWith("proj-1");
+
+      const skipLogs = logInfoMock.mock.calls.filter(
+        ([event]) => event === "idle-background-auto-close-skip-live-assistant"
+      );
+      expect(skipLogs[0]?.[1]).toEqual({ projectIds: ["proj-1"] });
+
+      const closedBroadcast = broadcastToRendererMock.mock.calls.find(
+        ([channel]) => channel === "idle-background:closed"
+      );
+      expect(closedBroadcast?.[1].projects).toEqual([
+        { projectId: "proj-2", projectName: "proj-2" },
+      ]);
     });
 
     it("a stale binding whose PTY already exited does not block, and is capture-revoked (#10989)", async () => {
@@ -410,15 +461,18 @@ describe("IdleBackgroundAutoCloseService", () => {
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
 
-    it("bails after the capture-revoke when the assistant came back during the await", async () => {
+    it("bails after the capture-revoke when a FRESH assistant binding appeared during the await", async () => {
       enable();
       projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
-      staleAssistant("proj-1", "t-help-returning");
+      staleAssistant("proj-1", "t-help-old");
       ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
-      // The revoke settles the dead record; the user reopens the panel during
-      // the multi-second await, so the post-revoke recheck must see it live.
+      // The revoke settles the dead record and the user reopens the panel during
+      // the multi-second await, which binds a DIFFERENT terminal. The post-revoke
+      // gate has to re-resolve the project's backend — an implementation that
+      // reused the terminal id it saw before the await would sail past this.
       helpSessionServiceMock.revokeByProjectId.mockImplementationOnce(async () => {
-        liveTerminalIds.add("t-help-returning");
+        assistantBackends.delete("proj-1");
+        liveAssistant("proj-1", "t-help-new");
       });
       const service = makeService();
       await runCheck(service);
@@ -445,6 +499,51 @@ describe("IdleBackgroundAutoCloseService", () => {
       expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed", {
         autoParkedAt: expect.any(Number),
       });
+    });
+
+    it("never reclaims on a degraded terminal snapshot — a silent shard is not 'no terminals'", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      // A shard failed to answer, so the empty list proves nothing. Killing here
+      // is the one wrong answer: the project may be full of live agents.
+      snapshotDegraded.value = true;
+      ptyClientMock.getAllTerminalsAsync.mockResolvedValue([]);
+      const service = makeService();
+      await runCheck(service);
+
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+      expect(ptyClientMock.gracefulKillByProject).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+    });
+
+    it("bails when the snapshot degrades between the sweep and the pre-revoke re-check", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      ptyClientMock.getAllTerminalsWithCompletenessAsync
+        .mockResolvedValueOnce({ terminals: [], degraded: false, shardsTotal: 2, shardsFailed: 0 })
+        .mockResolvedValueOnce({ terminals: [], degraded: true, shardsTotal: 2, shardsFailed: 1 });
+      const service = makeService();
+      await runCheck(service);
+
+      // The revoke sits behind this gate, so nothing was touched at all.
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+    });
+
+    it("halts an in-flight close when the feature is toggled off during the snapshot await", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      ptyClientMock.getAllTerminalsWithCompletenessAsync
+        .mockResolvedValueOnce({ terminals: [], degraded: false, shardsTotal: 2, shardsFailed: 0 })
+        .mockImplementationOnce(async () => {
+          storeBacking.idleBackgroundAutoClose = { enabled: false, thresholdMinutes: 15 };
+          return { terminals: [], degraded: false, shardsTotal: 2, shardsFailed: 0 };
+        });
+      const service = makeService();
+      await runCheck(service);
+
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
 
     it("ignores ghost (hasPty===false) panels when gating on terminals", async () => {

--- a/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
+++ b/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
@@ -546,6 +546,44 @@ describe("IdleBackgroundAutoCloseService", () => {
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
 
+    it("bails when the snapshot degrades at the POST-revoke re-check", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      const clean = { terminals: [], degraded: false, shardsTotal: 2, shardsFailed: 0 };
+      ptyClientMock.getAllTerminalsWithCompletenessAsync
+        .mockResolvedValueOnce(clean)
+        .mockResolvedValueOnce(clean)
+        .mockResolvedValueOnce({ terminals: [], degraded: true, shardsTotal: 2, shardsFailed: 1 });
+      const service = makeService();
+      await runCheck(service);
+
+      // The revoke already ran, but the irreversible teardown must not.
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
+      expect(ptyClientMock.gracefulKillByProject).not.toHaveBeenCalled();
+      expect(evictProjectRendererMock).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+    });
+
+    it("halts an in-flight close when stop() clears the client mid-await", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);
+      const clean = { terminals: [], degraded: false, shardsTotal: 2, shardsFailed: 0 };
+      const service = makeService();
+      // Shutdown nulls the client without touching `enabled`, so the config
+      // re-checks cannot catch it — only the client-identity check can.
+      ptyClientMock.getAllTerminalsWithCompletenessAsync
+        .mockResolvedValueOnce(clean)
+        .mockImplementationOnce(async () => {
+          service.stop();
+          return clean;
+        });
+      await runCheck(service);
+
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+      expect(evictProjectRendererMock).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+    });
+
     it("ignores ghost (hasPty===false) panels when gating on terminals", async () => {
       enable();
       projectStoreMock.getAllProjects.mockReturnValue([makeIdleProject("proj-1")]);


### PR DESCRIPTION
## Summary

`IdleBackgroundAutoCloseService` was excluding the assistant's help PTY from the check for whether a project has a live terminal, then capture-revoking the assistant on the way out. So an assistant doing unattended work in a background project would get killed as soon as the idle threshold was crossed. This feature is default-off (`enabled: false`), so it wasn't live for most users, but it was a latent bug waiting for anyone who turned it on.

## The fix

Any live terminal now blocks the reclaim, help PTY included. A live assistant additionally gets a second floor: its session binding, plus `PtyClient.hasTerminal` (a main-local spawn registry), so a truncated pty-host snapshot can't get a running assistant reclaimed out from under it. All three gates, the sweep filter and both `closeProject` TOCTOU re-checks, now share one `blockingReason` predicate so they can't drift apart.

## Why agent state isn't consulted (read this part)

The issue asked for two things at once: an assistant that's actually working, or that has scheduled work pending, should count as live; an assistant idling at its prompt should still be reclaimable as before. Those can't both be honoured. Nothing on the main-process side distinguishes an assistant sitting at its prompt from one sitting on a scheduled wakeup. `agentState` reads `idle` in both cases, and `help/CLAUDE.md` explicitly tells the assistant to pace long work with `ScheduleWakeup` or a background timer, so the app is instructing the assistant into exactly the state that would read as reclaimable.

I considered `ACTIVE_AGENT_STATES` and rejected it. This repo already documents twice that it's the wrong signal for this actor, in `ProjectViewEvictionController.ts` and `HibernationService.ts` (both from #11477 and #11157): an assistant that dispatched a sub-agent or a background shell reads idle while that work keeps running.

I also considered `lastOutputTime` and rejected it too. It tracks raw output, not work, so a configured status line keeps it fresh while an assistant on a one-hour timer goes quiet.

So the floor here is unconditional, matching the two sibling reclaim paths. It lifts as soon as the assistant's PTY exits (quit it, `/exit`, or let it finish), and the next five-minute sweep reclaims the project normally. This deliberately does not honour the "idle assistant still reclaimable" line from the issue, for the reasons above.

## Second bug, found during review

All three gates were reading `getAllTerminalsAsync()`, which substitutes an empty array for a pty-host shard that failed to answer. Its own documentation says it's unsuitable for a caller whose contract is that an empty result means genuinely nothing is running, which is exactly the contract a destructive gate needs. A shard outage would have read as "no terminals" and closed a project full of live agents.

All three gates now read `getAllTerminalsWithCompletenessAsync()` and fail closed on a degraded snapshot; the sweep aborts rather than acting on a snapshot it can't trust. While I was in there I closed two related fail-open holes: a mid-sweep toggle-off, and `stop()` clearing the client during an awaited snapshot (app shutdown does this without touching `enabled`, so the config re-checks alone missed it).

## Pressure-eviction path

Checked, no change needed. `ProjectViewEvictionController.hasLiveAssistantBackend()` is already an unconditional hard floor from #11477 / PR #11480, and `HibernationService` has the same guard wired via `setHasLiveAssistantBackend`. Those two were already correct. Idle auto-close was the one reclaim path that never got the same treatment.

## Testing

The auto-close suite grew from 25 to 45 cases. New coverage: a live assistant blocks reclaim; an assistant that reads idle still blocks reclaim; the session binding floors reclaim even when the terminal snapshot omits the help PTY; a stale binding whose PTY already exited still lets the project close and the assistant get capture-revoked; per-project isolation, so one project's assistant doesn't hold back another; an assistant appearing at each of the two TOCTOU re-checks, including one where a different terminal gets bound during the await; a degraded snapshot at all three gates; and toggling the feature off or calling `stop()` mid-await.

Locally: that suite plus `HelpSessionService`, `ProjectViewManager.eviction`, and `HibernationService`, all 404 tests passing, and `npm run typecheck` clean.

## Follow-up worth filing separately (not filing it here)

`provisionSession` accepts a renderer-supplied `projectId` without checking it against the caller's own project context, and the terminal's `projectId` gets stamped separately. A malformed renderer could desync session project, terminal project, and pinned view. No normal UI path produces this, and it's IPC input-validation hardening rather than part of this bug, so it's out of scope here.

Resolves #11807
