### PR TITLE
fix(actions): settle terminal.close before it acks to an automated caller

### DIFF
--- a/e2e/full/terminal/agent-launch-perf.spec.ts
+++ b/e2e/full/terminal/agent-launch-perf.spec.ts
@@ -270,7 +270,6 @@ perfDescribe("Perf: agent-terminal launch latency", () => {
             { terminalId: id, confirmed: true },
             { source: "test" }
           );
-          await dispatch?.("terminal.close", { terminalId: id }, { source: "test" });
         }
       });
       await expect

--- a/e2e/full/terminal/agent-launch-perf.spec.ts
+++ b/e2e/full/terminal/agent-launch-perf.spec.ts
@@ -257,8 +257,8 @@ perfDescribe("Perf: agent-terminal launch latency", () => {
       // agent into later rounds. `confirmed: true` matters: an unconfirmed
       // kill of a running-agent panel doesn't kill — it opens a pending
       // destructive-action confirm that lingers over the app and pollutes
-      // subsequent rounds with overlay renders. The close is a fallback for
-      // a panel the kill already removed (no-op) or an already-exited agent.
+      // subsequent rounds with overlay renders. The kill removes the panel
+      // outright, so no close is needed after it.
       await page.evaluate(async () => {
         const dispatch = (window as any).__daintreeDispatchAction;
         const ids = Array.from(document.querySelectorAll('[data-panel-location="grid"]'))

--- a/e2e/full/worktree/recipe-fanout-perf.spec.ts
+++ b/e2e/full/worktree/recipe-fanout-perf.spec.ts
@@ -1469,8 +1469,9 @@ async function cleanupCase(
           if (titleSet.has(terminal.title)) targetIds.add(terminal.id);
         }
         for (const terminalId of targetIds) {
+          // No close after the kill: `terminal.kill` removes the panel outright,
+          // and `terminal.close` now rejects an id it can no longer find.
           await run("terminal.kill", { terminalId, confirmed: true });
-          await run("terminal.close", { terminalId });
         }
 
         if (mode === "new-worktree" && targetWorktreeId) {
@@ -1808,7 +1809,6 @@ async function closeInitialPanels(page: Page): Promise<void> {
         { terminalId: terminal.id, confirmed: true },
         { source: "test" }
       );
-      await dispatch?.("terminal.close", { terminalId: terminal.id }, { source: "test" });
     }
   });
   await expect.poll(() => page.locator(SEL.panel.gridPanel).count(), { timeout: T_LONG }).toBe(0);
@@ -1894,7 +1894,6 @@ async function cleanupRemainingResources(): Promise<void> {
               { terminalId: terminal.id, confirmed: true },
               { source: "test" }
             );
-            await dispatch?.("terminal.close", { terminalId: terminal.id }, { source: "test" });
           }
           await dispatch?.("worktree.select", { worktreeId: mainWorktreeId }, { source: "test" });
           for (const worktreeId of worktreeIds) {

--- a/e2e/full/worktree/worktree-agent-ready-perf.spec.ts
+++ b/e2e/full/worktree/worktree-agent-ready-perf.spec.ts
@@ -371,7 +371,6 @@ async function measureDelete(branch: string, worktreeId: string): Promise<Delete
       .filter((id): id is string => !!id);
     for (const id of ids) {
       await dispatch?.("terminal.kill", { terminalId: id, confirmed: true }, { source: "test" });
-      await dispatch?.("terminal.close", { terminalId: id }, { source: "test" });
     }
   });
   return await page.evaluate(

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -4177,7 +4177,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Close a panel, usually moving it to the trash where it stays briefly recoverable before its process is killed. Recovery is not universal — panels set to remove on exit, and dialog panels, are discarded outright. This is not limited to terminals. Identify the panel explicitly: an automated caller cannot see what the user has focused, and closing the wrong one discards their work.",
+    "description": "Close a panel, usually moving it to the trash where it stays briefly recoverable before its process is killed. Recovery is not universal — panels set to remove on exit, and dialog panels, are discarded outright. This is not limited to terminals. Name the panel you mean; closing the wrong one discards someone's work. An untracked panel is rejected rather than reported closed, and the result names what actually closed — already gone from the listing when an automated caller sees it.",
     "examples": undefined,
     "id": "terminal.close",
     "keywords": [

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.optimisticClose.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.optimisticClose.test.ts
@@ -41,6 +41,10 @@ interface MockPanel {
 // `@/store/panelStore` while the coordinator reads `@/store`. Two separate
 // mocks would let the action see a trash that the coordinator never wrote.
 const store = vi.hoisted(() => {
+  // Lets a test swap in the real `trashPanel`'s other two outcomes: removing the
+  // record outright (remove-on-exit / dialog panels route to `removePanel`), and
+  // failing (the coordinator swallows a commit that throws).
+  const override = { trash: null as null | ((id: string) => void) };
   const state = {
     focusedId: null as string | null,
     panelIds: [] as string[],
@@ -52,11 +56,15 @@ const store = vi.hoisted(() => {
     // Mirrors the real `trashPanel`: the record survives, its location becomes
     // "trash", and `terminal.list` filters on exactly that.
     trashPanel: vi.fn((id: string) => {
+      if (override.trash) {
+        override.trash(id);
+        return;
+      }
       const panel = state.panelsById[id];
       if (panel) state.panelsById[id] = { ...panel, location: "trash" };
     }),
   };
-  return { state };
+  return { state, override };
 });
 
 vi.mock("@/store", () => ({ panelStoreApi: { getState: () => store.state } }));
@@ -101,6 +109,7 @@ import {
 const WORKTREE = "wt1";
 
 function seed(panels: MockPanel[], focusedId: string | null = null): void {
+  store.override.trash = null;
   store.state.panelIds = panels.map((p) => p.id);
   store.state.panelsById = {};
   for (const panel of panels) {
@@ -161,19 +170,27 @@ describe("terminal.close read-your-writes against the real coordinator (#11805)"
     expect(await listedIds(service)).toEqual(["b"]);
   });
 
-  it("still defers the teardown for a foreground close", async () => {
+  it("still defers the teardown for a foreground close, and names what it accepted", async () => {
     seed([
       { id: "a", kind: "terminal", location: "grid" },
       { id: "b", kind: "terminal", location: "grid" },
     ]);
     const service = buildService();
 
-    await service.dispatch("terminal.close", { terminalId: "a" }, { source: "keybinding" });
+    const closed = await service.dispatch<{ closedIds: string[] }>(
+      "terminal.close",
+      { terminalId: "a" },
+      { source: "keybinding" }
+    );
 
     // The paint-frame protection the optimistic path exists for is intact: the
-    // canonical trash has not run yet.
+    // canonical trash has not run yet. The result still names the panel, so a
+    // foreground caller is not told the close was a no-op.
+    expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
     expect(await listedIds(service)).toEqual(["a", "b"]);
-    await vi.advanceTimersByTimeAsync(200);
+    // Advance to the queued commit rather than a literal delay — the coordinator
+    // owns the wait, and this asserts only that it eventually runs.
+    await vi.runOnlyPendingTimersAsync();
     expect(await listedIds(service)).toEqual(["b"]);
   });
 
@@ -184,9 +201,23 @@ describe("terminal.close read-your-writes against the real coordinator (#11805)"
     // ActionService defaults an omitted source to "user", so the in-app close
     // paths that pass no source keep the deferral rather than paying for a
     // synchronous teardown on every Cmd+W.
-    await service.dispatch("terminal.close", { terminalId: "a" });
+    const closed = await service.dispatch<{ closedIds: string[] }>("terminal.close", {
+      terminalId: "a",
+    });
 
+    expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
     expect(await listedIds(service)).toEqual(["a"]);
+  });
+
+  it("closes synchronously for plugin dispatch too, not just agent", async () => {
+    seed([{ id: "a", kind: "terminal", location: "grid" }]);
+    const service = buildService();
+
+    // The gate is an allowlist of foreground sources, so "plugin" gets the same
+    // read-your-writes guarantee without being named anywhere.
+    await service.dispatch("terminal.close", { terminalId: "a" }, { source: "plugin" });
+
+    expect(await listedIds(service)).toEqual([]);
   });
 
   it("resolves truthfully when the panel is already mid-close", async () => {
@@ -207,6 +238,96 @@ describe("terminal.close read-your-writes against the real coordinator (#11805)"
     expect(commit).toHaveBeenCalledTimes(1);
     expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
     expect(await listedIds(service)).toEqual([]);
+  });
+
+  it("reports a panel removed outright as closed", async () => {
+    seed([{ id: "a", kind: "terminal", location: "grid" }]);
+    // Remove-on-exit and dialog panels bypass trash: `trashPanel` routes them to
+    // `removePanel`, so the record is gone rather than relocated. Judging that by
+    // location alone would report the close as a no-op.
+    store.override.trash = (id) => {
+      delete store.state.panelsById[id];
+      store.state.panelIds = store.state.panelIds.filter((panelId) => panelId !== id);
+    };
+    const service = buildService();
+
+    const closed = await service.dispatch<{ closedIds: string[] }>(
+      "terminal.close",
+      { terminalId: "a" },
+      { source: "agent" }
+    );
+
+    expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
+    expect(await listedIds(service)).toEqual([]);
+  });
+
+  it("reports nothing closed when the teardown fails", async () => {
+    seed([{ id: "a", kind: "terminal", location: "grid" }]);
+    // The coordinator catches a commit that throws so one failure cannot take
+    // out the rest of the batch. The panel is still open, so the ack must not
+    // claim otherwise.
+    store.override.trash = () => {
+      throw new Error("trash failed");
+    };
+    const service = buildService();
+
+    const closed = await service.dispatch<{ closedIds: string[] }>(
+      "terminal.close",
+      { terminalId: "a" },
+      { source: "agent" }
+    );
+
+    expect(closed.ok && closed.result).toEqual({ closedIds: [] });
+    expect(await listedIds(service)).toEqual(["a"]);
+  });
+
+  it("closes nothing when focus points at a panel that is gone", async () => {
+    seed([{ id: "a", kind: "terminal", location: "grid" }], "stale");
+    const service = buildService();
+
+    // No explicit id, so the target resolves from focus — which can outlive the
+    // panel it names. Reporting that as a close would be a false positive.
+    const closed = await service.dispatch<{ closedIds: string[] }>("terminal.close", undefined, {
+      source: "keybinding",
+    });
+
+    expect(closed.ok && closed.result).toEqual({ closedIds: [] });
+    expect(await listedIds(service)).toEqual(["a"]);
+  });
+
+  it.each(["constructor", "__proto__", "toString"])(
+    "rejects the inherited key %s rather than trashing it",
+    async (terminalId) => {
+      seed([{ id: "a", kind: "terminal", location: "grid" }]);
+      const service = buildService();
+
+      // `panelsById` is a plain object, so a truthiness check would resolve these
+      // off Object.prototype and run the whole trash flow on a panel that never
+      // existed.
+      const closed = await service.dispatch("terminal.close", { terminalId }, { source: "agent" });
+
+      expect(closed.ok).toBe(false);
+      expect(!closed.ok && closed.error.code).toBe("EXECUTION_ERROR");
+      expect(store.state.trashPanel).not.toHaveBeenCalled();
+      expect(await listedIds(service)).toEqual(["a"]);
+    }
+  );
+
+  it("closes a tracked panel that has not reached panelIds yet", async () => {
+    seed([]);
+    // Hydration commits `panelsById` before `panelIds`, so membership in the id
+    // list is not what makes a panel real. Gating the guard on `panelIds` would
+    // reject a genuinely tracked panel during that window.
+    store.state.panelsById = { a: { id: "a", kind: "terminal", location: "grid" } };
+    const service = buildService();
+
+    const closed = await service.dispatch<{ closedIds: string[] }>(
+      "terminal.close",
+      { terminalId: "a" },
+      { source: "agent" }
+    );
+
+    expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
   });
 
   it("rejects an id that is not tracked instead of acking it", async () => {

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.optimisticClose.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.optimisticClose.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionId } from "@shared/types/actions";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+
+/**
+ * The read-your-writes half of #11805, run against the REAL optimistic-close
+ * coordinator.
+ *
+ * terminalLifecycleActions.test.ts mocks that coordinator so its commit runs
+ * synchronously, which makes it structurally unable to catch this bug: the
+ * whole defect is that the commit does NOT run before `terminal.close`
+ * resolves. Asserting there that a mocked `flushOptimisticCloses` was called
+ * proves the call, not the postcondition. So this file wires the real
+ * coordinator to a real ActionService and asserts what an MCP caller actually
+ * observes — whether the panel is still in `terminal.list` the moment the close
+ * acks — with timers frozen so any reliance on the deferred flush fails.
+ */
+
+// ActionService pulls in the shortcut-hint store, keybinding service, and
+// notify at module load / dispatch time; none are under test here.
+vi.mock("../../../../store/shortcutHintStore", () => ({
+  shortcutHintStore: {
+    getState: vi.fn(() => ({ counts: {}, show: vi.fn(), incrementCount: vi.fn() })),
+  },
+}));
+vi.mock("../../../KeybindingService", () => ({
+  keybindingService: { getEffectiveCombo: vi.fn(() => null), getDisplayCombo: vi.fn(() => "") },
+}));
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+interface MockPanel {
+  id: string;
+  kind: string;
+  location: "grid" | "dock" | "trash" | "background";
+  worktreeId?: string;
+  title?: string;
+}
+
+// One store object behind both module specifiers: the action reads
+// `@/store/panelStore` while the coordinator reads `@/store`. Two separate
+// mocks would let the action see a trash that the coordinator never wrote.
+const store = vi.hoisted(() => {
+  const state = {
+    focusedId: null as string | null,
+    panelIds: [] as string[],
+    panelsById: {} as Record<string, { id: string; kind: string; location: string }>,
+    setFocused: vi.fn((id: string | null) => {
+      state.focusedId = id;
+    }),
+    getTabGroups: undefined,
+    // Mirrors the real `trashPanel`: the record survives, its location becomes
+    // "trash", and `terminal.list` filters on exactly that.
+    trashPanel: vi.fn((id: string) => {
+      const panel = state.panelsById[id];
+      if (panel) state.panelsById[id] = { ...panel, location: "trash" };
+    }),
+  };
+  return { state };
+});
+
+vi.mock("@/store", () => ({ panelStoreApi: { getState: () => store.state } }));
+vi.mock("@/store/panelStore", () => ({ usePanelStore: { getState: () => store.state } }));
+vi.mock("@/store/fleetArmingStore", () => ({
+  useFleetArmingStore: { getState: () => ({ armedIds: new Set<string>() }) },
+}));
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: { focus: vi.fn() },
+}));
+vi.mock("@/services/terminal/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    focus: vi.fn(),
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    resetRenderer: vi.fn(),
+  },
+}));
+vi.mock("@/clients", () => ({
+  terminalClient: { submit: vi.fn(), killTerminal: vi.fn(), forceResume: vi.fn() },
+}));
+vi.mock("@/lib/watchNotification", () => ({ fireWatchNotification: vi.fn() }));
+vi.mock("@/store/terminalPendingDestructiveActionStore", () => ({
+  useTerminalPendingDestructiveActionStore: {
+    getState: () => ({ pending: null, request: vi.fn(), clear: vi.fn() }),
+  },
+}));
+const PTY_KINDS = new Set(["terminal", "agent"]);
+vi.mock("@shared/config/panelKindRegistry", () => ({
+  panelKindHasPty: (kind: string) => PTY_KINDS.has(kind),
+}));
+
+import { ActionService } from "../../../ActionService";
+import { registerTerminalLifecycleActions } from "../terminalLifecycleActions";
+import { registerTerminalQueryActions } from "../terminalQueryActions";
+import {
+  requestPanelClose,
+  __resetOptimisticPanelCloseForTests,
+} from "@/services/terminal/optimisticPanelClose";
+
+const WORKTREE = "wt1";
+
+function seed(panels: MockPanel[], focusedId: string | null = null): void {
+  store.state.panelIds = panels.map((p) => p.id);
+  store.state.panelsById = {};
+  for (const panel of panels) {
+    store.state.panelsById[panel.id] = {
+      worktreeId: WORKTREE,
+      title: panel.id,
+      ...panel,
+    } as MockPanel & { id: string; kind: string; location: string };
+  }
+  store.state.focusedId = focusedId;
+}
+
+function buildService(): ActionService {
+  const registry: ActionRegistry = new Map();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- ActionCallbacks has ~40 members; terminal.closeAll reads only this one.
+  const callbacks = { getActiveWorktreeId: () => WORKTREE } as ActionCallbacks;
+  registerTerminalLifecycleActions(registry, callbacks);
+  registerTerminalQueryActions(registry, callbacks);
+  const service = new ActionService();
+  for (const [, factory] of registry) {
+    service.register(factory() as AnyActionDefinition);
+  }
+  return service;
+}
+
+/** The ids an MCP caller would see in `terminal.list` right now. */
+async function listedIds(service: ActionService): Promise<string[]> {
+  const listed = await service.dispatch<{ terminals: Array<{ id: string }> }>("terminal.list");
+  if (!listed.ok) throw new Error(`terminal.list failed: ${listed.error.code}`);
+  return listed.result.terminals.map((t) => t.id);
+}
+
+describe("terminal.close read-your-writes against the real coordinator (#11805)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __resetOptimisticPanelCloseForTests();
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("has already left terminal.list when an agent close resolves", async () => {
+    seed([
+      { id: "a", kind: "terminal", location: "grid" },
+      { id: "b", kind: "terminal", location: "grid" },
+    ]);
+    const service = buildService();
+
+    const closed = await service.dispatch(
+      "terminal.close",
+      { terminalId: "a" },
+      { source: "agent" }
+    );
+
+    // No timer advance anywhere in this test: the deferred flush is exactly what
+    // must NOT be load-bearing for an automated caller.
+    expect(closed.ok).toBe(true);
+    expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
+    expect(await listedIds(service)).toEqual(["b"]);
+  });
+
+  it("still defers the teardown for a foreground close", async () => {
+    seed([
+      { id: "a", kind: "terminal", location: "grid" },
+      { id: "b", kind: "terminal", location: "grid" },
+    ]);
+    const service = buildService();
+
+    await service.dispatch("terminal.close", { terminalId: "a" }, { source: "keybinding" });
+
+    // The paint-frame protection the optimistic path exists for is intact: the
+    // canonical trash has not run yet.
+    expect(await listedIds(service)).toEqual(["a", "b"]);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(await listedIds(service)).toEqual(["b"]);
+  });
+
+  it("treats a source-less dispatch as foreground, matching ActionService's default", async () => {
+    seed([{ id: "a", kind: "terminal", location: "grid" }]);
+    const service = buildService();
+
+    // ActionService defaults an omitted source to "user", so the in-app close
+    // paths that pass no source keep the deferral rather than paying for a
+    // synchronous teardown on every Cmd+W.
+    await service.dispatch("terminal.close", { terminalId: "a" });
+
+    expect(await listedIds(service)).toEqual(["a"]);
+  });
+
+  it("resolves truthfully when the panel is already mid-close", async () => {
+    seed([{ id: "a", kind: "terminal", location: "grid" }]);
+    const service = buildService();
+    const commit = vi.fn(() => store.state.trashPanel("a"));
+    // A foreground close is already queued for this panel, so the agent's own
+    // requestPanelClose is dropped as a duplicate and queues nothing. The flush
+    // still has to commit the earlier request for the ack to be honest.
+    requestPanelClose({ hideIds: ["a"], commit });
+
+    const closed = await service.dispatch(
+      "terminal.close",
+      { terminalId: "a" },
+      { source: "agent" }
+    );
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
+    expect(await listedIds(service)).toEqual([]);
+  });
+
+  it("rejects an id that is not tracked instead of acking it", async () => {
+    seed([{ id: "a", kind: "terminal", location: "grid" }]);
+    const service = buildService();
+
+    const closed = await service.dispatch(
+      "terminal.close",
+      { terminalId: "ghost" },
+      { source: "agent" }
+    );
+
+    expect(closed.ok).toBe(false);
+    expect(!closed.ok && closed.error.code).toBe("EXECUTION_ERROR");
+    expect(await listedIds(service)).toEqual(["a"]);
+  });
+
+  it("clears the active worktree when an agent closes all", async () => {
+    seed([
+      { id: "a", kind: "terminal", location: "grid" },
+      { id: "b", kind: "terminal", location: "grid" },
+    ]);
+    const service = buildService();
+
+    const closed = await service.dispatch("terminal.closeAll", undefined, { source: "agent" });
+
+    expect(closed.ok && closed.result).toEqual({ closedIds: ["a", "b"] });
+    expect(await listedIds(service)).toEqual([]);
+  });
+
+  it("advertises an object outputSchema carrying closedIds for both close actions", () => {
+    const service = buildService();
+
+    for (const id of ["terminal.close", "terminal.closeAll"]) {
+      // buildToolOutputSchema (tierAuth) forwards only object-typed schemas, so
+      // a non-object root would silently drop structuredContent rather than
+      // fail. Asserting the generated schema catches that; asserting the
+      // `mcpOutputSchema` flag would not.
+      const schema = service.get(id as ActionId)?.outputSchema as
+        { type?: string; properties?: Record<string, unknown> } | undefined;
+      expect(schema?.type, id).toBe("object");
+      expect(schema?.properties?.closedIds, id).toBeDefined();
+    }
+  });
+});

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.optimisticClose.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.optimisticClose.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActionId } from "@shared/types/actions";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 
@@ -97,6 +97,9 @@ const PTY_KINDS = new Set(["terminal", "agent"]);
 vi.mock("@shared/config/panelKindRegistry", () => ({
   panelKindHasPty: (kind: string) => PTY_KINDS.has(kind),
 }));
+// The coordinator logs a commit that throws; one test provokes that on purpose,
+// and the real logger would print the stack as if the run had broken.
+vi.mock("@/utils/logger", () => ({ logError: vi.fn(), logWarn: vi.fn(), logDebug: vi.fn() }));
 
 import { ActionService } from "../../../ActionService";
 import { registerTerminalLifecycleActions } from "../terminalLifecycleActions";
@@ -147,7 +150,14 @@ describe("terminal.close read-your-writes against the real coordinator (#11805)"
     vi.useFakeTimers();
     __resetOptimisticPanelCloseForTests();
     vi.clearAllMocks();
+    // Reset here as well as in `seed()`, so a test that never seeds cannot
+    // inherit the previous one's trash behavior.
+    store.override.trash = null;
     document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("has already left terminal.list when an agent close resolves", async () => {
@@ -215,8 +225,13 @@ describe("terminal.close read-your-writes against the real coordinator (#11805)"
 
     // The gate is an allowlist of foreground sources, so "plugin" gets the same
     // read-your-writes guarantee without being named anywhere.
-    await service.dispatch("terminal.close", { terminalId: "a" }, { source: "plugin" });
+    const closed = await service.dispatch<{ closedIds: string[] }>(
+      "terminal.close",
+      { terminalId: "a" },
+      { source: "plugin" }
+    );
 
+    expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
     expect(await listedIds(service)).toEqual([]);
   });
 
@@ -240,24 +255,28 @@ describe("terminal.close read-your-writes against the real coordinator (#11805)"
     expect(await listedIds(service)).toEqual([]);
   });
 
-  it("reports a panel removed outright as closed", async () => {
-    seed([{ id: "a", kind: "terminal", location: "grid" }]);
+  // "constructor" is a real panel id here (an own key shadowing the prototype),
+  // which is what makes this a regression test for the projection rather than
+  // just the happy path: judging "gone" by `panelsById[id] === undefined` finds
+  // the inherited function instead and reports the close as a no-op.
+  it.each(["a", "constructor"])("reports the panel %s removed outright as closed", async (id) => {
+    seed([{ id, kind: "terminal", location: "grid" }]);
     // Remove-on-exit and dialog panels bypass trash: `trashPanel` routes them to
     // `removePanel`, so the record is gone rather than relocated. Judging that by
     // location alone would report the close as a no-op.
-    store.override.trash = (id) => {
-      delete store.state.panelsById[id];
-      store.state.panelIds = store.state.panelIds.filter((panelId) => panelId !== id);
+    store.override.trash = (target) => {
+      delete store.state.panelsById[target];
+      store.state.panelIds = store.state.panelIds.filter((panelId) => panelId !== target);
     };
     const service = buildService();
 
     const closed = await service.dispatch<{ closedIds: string[] }>(
       "terminal.close",
-      { terminalId: "a" },
+      { terminalId: id },
       { source: "agent" }
     );
 
-    expect(closed.ok && closed.result).toEqual({ closedIds: ["a"] });
+    expect(closed.ok && closed.result).toEqual({ closedIds: [id] });
     expect(await listedIds(service)).toEqual([]);
   });
 
@@ -281,19 +300,25 @@ describe("terminal.close read-your-writes against the real coordinator (#11805)"
     expect(await listedIds(service)).toEqual(["a"]);
   });
 
-  it("closes nothing when focus points at a panel that is gone", async () => {
-    seed([{ id: "a", kind: "terminal", location: "grid" }], "stale");
-    const service = buildService();
+  it.each(["stale", "constructor"])(
+    "closes nothing when focus points at the missing panel %s",
+    async (focusedId) => {
+      seed([{ id: "a", kind: "terminal", location: "grid" }], focusedId);
+      const service = buildService();
 
-    // No explicit id, so the target resolves from focus — which can outlive the
-    // panel it names. Reporting that as a close would be a false positive.
-    const closed = await service.dispatch<{ closedIds: string[] }>("terminal.close", undefined, {
-      source: "keybinding",
-    });
+      // No explicit id, so the target resolves from focus — which can outlive
+      // the panel it names. "constructor" additionally proves the focus branch
+      // does its own own-property check: a plain lookup resolves it off the
+      // prototype and trashes a panel that never existed.
+      const closed = await service.dispatch<{ closedIds: string[] }>("terminal.close", undefined, {
+        source: "keybinding",
+      });
 
-    expect(closed.ok && closed.result).toEqual({ closedIds: [] });
-    expect(await listedIds(service)).toEqual(["a"]);
-  });
+      expect(closed.ok && closed.result).toEqual({ closedIds: [] });
+      expect(store.state.trashPanel).not.toHaveBeenCalled();
+      expect(await listedIds(service)).toEqual(["a"]);
+    }
+  );
 
   it.each(["constructor", "__proto__", "toString"])(
     "rejects the inherited key %s rather than trashing it",

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -243,8 +243,11 @@ describe("terminal.close result contract (#11805)", () => {
     await expect(run("terminal.close")).resolves.toEqual({ closedIds: [] });
   });
 
-  it.each(["agent", "plugin", undefined] as const)(
-    "settles the close before resolving for %s dispatch",
+  // Routing only — the mocked coordinator settles nothing. That the panel is
+  // genuinely gone by the time the call resolves is proved against the real
+  // coordinator in terminalLifecycleActions.optimisticClose.test.ts.
+  it.each(["agent", "plugin"] as const)(
+    "routes %s dispatch through the synchronous flush",
     async (dispatchSource) => {
       setPanelState({ focusedId: "p1", panels: [{ id: "p1", location: "grid" }] });
       const run = setupActions();
@@ -262,8 +265,10 @@ describe("terminal.close result contract (#11805)", () => {
       const run = setupActions();
 
       // The paint-frame protection is the whole point of the optimistic path;
-      // a person is watching this one land.
-      await run("terminal.close", { terminalId: "p1" }, { dispatchSource });
+      // a person is watching this one land. The result still names the panel.
+      await expect(
+        run("terminal.close", { terminalId: "p1" }, { dispatchSource })
+      ).resolves.toEqual({ closedIds: ["p1"] });
 
       expect(optimisticPanelCloseMock.requestPanelClose).toHaveBeenCalled();
       expect(optimisticPanelCloseMock.flushOptimisticCloses).not.toHaveBeenCalled();
@@ -310,7 +315,11 @@ describe("terminal.closeAll result contract (#11805)", () => {
     optimisticPanelCloseMock.flushOptimisticCloses.mockClear();
     setPanelState({ panels: [{ id: "b", location: "grid", worktreeId: "wt1" }] });
 
-    await inWorktree("wt1")("terminal.closeAll", undefined, { dispatchSource: "keybinding" });
+    // Foreground keeps the deferral but still names what it accepted, so a
+    // keybinding caller is not told the close was a no-op.
+    await expect(
+      inWorktree("wt1")("terminal.closeAll", undefined, { dispatchSource: "keybinding" })
+    ).resolves.toEqual({ closedIds: ["b"] });
     expect(optimisticPanelCloseMock.flushOptimisticCloses).not.toHaveBeenCalled();
   });
 });

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -48,15 +48,22 @@ vi.mock("@/store/terminalPendingDestructiveActionStore", () => ({
 
 // Run the optimistic-close commit synchronously so these tests assert the
 // canonical trash outcome directly; the deferral is covered by
-// optimisticPanelClose.test.ts.
-vi.mock("@/services/terminal/optimisticPanelClose", () => ({
+// optimisticPanelClose.test.ts, and the read-your-writes contract that depends
+// on it by terminalLifecycleActions.optimisticClose.test.ts.
+const optimisticPanelCloseMock = vi.hoisted(() => ({
   requestPanelClose: vi.fn((req: { commit: () => void }) => req.commit()),
   flushOptimisticCloses: vi.fn(),
 }));
+vi.mock("@/services/terminal/optimisticPanelClose", () => optimisticPanelCloseMock);
 
 import { registerTerminalLifecycleActions } from "../terminalLifecycleActions";
 
-type MockPanel = { id: string; location: "grid" | "dock" | "trash" | "background" };
+type MockPanel = {
+  id: string;
+  location: "grid" | "dock" | "trash" | "background";
+  worktreeId?: string;
+  excludeFromPersistence?: boolean;
+};
 
 function setPanelState(options: {
   focusedId?: string | null;
@@ -70,7 +77,12 @@ function setPanelState(options: {
   let focusedId = options.focusedId ?? null;
   const trashPanel =
     options.trashPanel ??
-    vi.fn(() => {
+    vi.fn((id: string) => {
+      // Mirror the real `trashPanel`: the record survives, its location becomes
+      // "trash". `closedIds` is derived from exactly that, so a mock leaving the
+      // panel in the grid would make every close report it closed nothing.
+      const panel = panelsById[id];
+      if (panel) panel.location = "trash";
       if (options.postTrashFocusedId !== undefined) {
         focusedId = options.postTrashFocusedId;
       }
@@ -84,10 +96,9 @@ function setPanelState(options: {
   return { trashPanel };
 }
 
-function setupActions() {
+function setupActions(callbacks: Partial<ActionCallbacks> = {}) {
   const actions: ActionRegistry = new Map();
-  const callbacks = {} as unknown as ActionCallbacks;
-  registerTerminalLifecycleActions(actions, callbacks);
+  registerTerminalLifecycleActions(actions, callbacks as ActionCallbacks);
   return async (id: string, args?: unknown, ctx?: unknown): Promise<unknown> => {
     const factory = actions.get(id);
     if (!factory) throw new Error(`missing ${id}`);
@@ -177,6 +188,130 @@ describe("terminal.close", () => {
     await run("terminal.close");
 
     expect(trashPanel).not.toHaveBeenCalled();
+  });
+});
+
+// An MCP caller reads the roster straight after the ack, so the close has to be
+// canonical before it resolves and a bad id has to fail rather than report "OK"
+// (#11805). The store postcondition itself is covered end-to-end against the
+// real coordinator in terminalLifecycleActions.optimisticClose.test.ts.
+describe("terminal.close result contract (#11805)", () => {
+  it("names the panel it closed", async () => {
+    setPanelState({
+      focusedId: "p1",
+      panels: [
+        { id: "p1", location: "grid" },
+        { id: "p2", location: "grid" },
+      ],
+      postTrashFocusedId: "p2",
+    });
+    const run = setupActions();
+
+    await expect(run("terminal.close", { terminalId: "p1" })).resolves.toEqual({
+      closedIds: ["p1"],
+    });
+  });
+
+  it("rejects a named panel that is not tracked instead of reporting success", async () => {
+    const { trashPanel } = setPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", location: "grid" }],
+    });
+    const run = setupActions();
+
+    await expect(run("terminal.close", { terminalId: "ghost" })).rejects.toThrow(/ghost/);
+    expect(trashPanel).not.toHaveBeenCalled();
+    expect(optimisticPanelCloseMock.requestPanelClose).not.toHaveBeenCalled();
+  });
+
+  it("closes nothing when the named panel is already trashed", async () => {
+    const { trashPanel } = setPanelState({
+      focusedId: null,
+      panels: [{ id: "p1", location: "trash" }],
+    });
+    const run = setupActions();
+
+    // Re-trashing would reset the recovery TTL and rewrite the restore target.
+    await expect(run("terminal.close", { terminalId: "p1" })).resolves.toEqual({ closedIds: [] });
+    expect(trashPanel).not.toHaveBeenCalled();
+  });
+
+  it("closes nothing when there is no panel to act on", async () => {
+    setPanelState({ focusedId: null, panels: [{ id: "p1", location: "trash" }] });
+    const run = setupActions();
+
+    await expect(run("terminal.close")).resolves.toEqual({ closedIds: [] });
+  });
+
+  it.each(["agent", "plugin", undefined] as const)(
+    "settles the close before resolving for %s dispatch",
+    async (dispatchSource) => {
+      setPanelState({ focusedId: "p1", panels: [{ id: "p1", location: "grid" }] });
+      const run = setupActions();
+
+      await run("terminal.close", { terminalId: "p1" }, { dispatchSource });
+
+      expect(optimisticPanelCloseMock.flushOptimisticCloses).toHaveBeenCalled();
+    }
+  );
+
+  it.each(["user", "keybinding", "menu", "context-menu"] as const)(
+    "leaves the deferral intact for %s dispatch",
+    async (dispatchSource) => {
+      setPanelState({ focusedId: "p1", panels: [{ id: "p1", location: "grid" }] });
+      const run = setupActions();
+
+      // The paint-frame protection is the whole point of the optimistic path;
+      // a person is watching this one land.
+      await run("terminal.close", { terminalId: "p1" }, { dispatchSource });
+
+      expect(optimisticPanelCloseMock.requestPanelClose).toHaveBeenCalled();
+      expect(optimisticPanelCloseMock.flushOptimisticCloses).not.toHaveBeenCalled();
+    }
+  );
+});
+
+describe("terminal.closeAll result contract (#11805)", () => {
+  const inWorktree = (id: string) => setupActions({ getActiveWorktreeId: () => id });
+
+  it("names every panel it closed in the active worktree", async () => {
+    setPanelState({
+      panels: [
+        { id: "a", location: "grid", worktreeId: "wt1" },
+        { id: "b", location: "grid", worktreeId: "wt1" },
+        { id: "elsewhere", location: "grid", worktreeId: "wt2" },
+        { id: "gone", location: "trash", worktreeId: "wt1" },
+        { id: "internal", location: "grid", worktreeId: "wt1", excludeFromPersistence: true },
+      ],
+    });
+    const run = inWorktree("wt1");
+
+    await expect(run("terminal.closeAll", undefined, { dispatchSource: "agent" })).resolves.toEqual(
+      { closedIds: ["a", "b"] }
+    );
+  });
+
+  it("closes nothing when the active worktree has no eligible panels", async () => {
+    setPanelState({ panels: [{ id: "elsewhere", location: "grid", worktreeId: "wt2" }] });
+    const run = inWorktree("wt1");
+
+    await expect(run("terminal.closeAll", undefined, { dispatchSource: "agent" })).resolves.toEqual(
+      { closedIds: [] }
+    );
+    expect(optimisticPanelCloseMock.requestPanelClose).not.toHaveBeenCalled();
+  });
+
+  it("settles before resolving for agent dispatch but not for a keybinding", async () => {
+    setPanelState({ panels: [{ id: "a", location: "grid", worktreeId: "wt1" }] });
+
+    await inWorktree("wt1")("terminal.closeAll", undefined, { dispatchSource: "agent" });
+    expect(optimisticPanelCloseMock.flushOptimisticCloses).toHaveBeenCalled();
+
+    optimisticPanelCloseMock.flushOptimisticCloses.mockClear();
+    setPanelState({ panels: [{ id: "b", location: "grid", worktreeId: "wt1" }] });
+
+    await inWorktree("wt1")("terminal.closeAll", undefined, { dispatchSource: "keybinding" });
+    expect(optimisticPanelCloseMock.flushOptimisticCloses).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -1,8 +1,9 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import type { ActionSource } from "@shared/types/actions";
 import { z } from "zod";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
-import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
+import { flushOptimisticCloses, requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
@@ -29,6 +30,50 @@ function clearPendingIf(kind: TerminalPendingDestructiveActionKind): void {
     useTerminalPendingDestructiveActionStore.getState().clear();
   }
 }
+
+const PanelCloseResultSchema = z.object({
+  closedIds: z
+    .array(z.string())
+    .describe(
+      "The panels this call closed. Empty means nothing closed — there was no panel to act on, or the one named was already in the trash."
+    ),
+});
+
+/**
+ * Which of `ids` have actually left the open roster, read after the canonical
+ * teardown ran. `trashPanel` keeps the record and moves it to `location:
+ * "trash"`, but remove-on-exit and dialog panels bypass trash entirely and are
+ * removed outright, so a missing record counts as closed too.
+ */
+function closedPanelIds(ids: readonly string[]): string[] {
+  const { panelsById } = usePanelStore.getState();
+  return ids.filter((id) => {
+    const panel = panelsById[id];
+    return panel === undefined || panel.location === "trash";
+  });
+}
+
+/**
+ * Resolve a close before returning when nobody is watching the screen.
+ *
+ * The optimistic coordinator defers the canonical teardown past paint, which is
+ * right for a click and wrong for an automated caller: it has no frame to
+ * protect and it reads the roster straight after the ack, so a deferred commit
+ * hands back the panel it just closed (#11805). Flushing drains *every* queued
+ * close rather than just this one — the same trade `terminal.reopenLast`
+ * already makes, and the reason a duplicate close still resolves truthfully:
+ * `requestPanelClose` drops it as already-closing, but the flush commits the
+ * earlier request that owns it.
+ */
+function settleCloseForDispatch(ids: readonly string[], ctx: { dispatchSource?: ActionSource }) {
+  if (isForegroundDispatch(ctx?.dispatchSource)) {
+    // The commit is still queued, so this names what was accepted for close.
+    // A person watching the grid is the real feedback channel here.
+    return { closedIds: [...ids] };
+  }
+  flushOptimisticCloses();
+  return { closedIds: closedPanelIds(ids) };
+}
 export function registerTerminalLifecycleActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -37,13 +82,24 @@ export function registerTerminalLifecycleActions(
     id: "terminal.close",
     title: "Close Terminal",
     description:
-      "Close a panel, usually moving it to the trash where it stays briefly recoverable before its process is killed. Recovery is not universal — panels set to remove on exit, and dialog panels, are discarded outright. This is not limited to terminals. Identify the panel explicitly: an automated caller cannot see what the user has focused, and closing the wrong one discards their work.",
+      "Close a panel, usually moving it to the trash where it stays briefly recoverable before its process is killed. Recovery is not universal — panels set to remove on exit, and dialog panels, are discarded outright. This is not limited to terminals. Name the panel you mean; closing the wrong one discards someone's work. An untracked panel is rejected rather than reported closed, and the result names what actually closed — already gone from the listing when an automated caller sees it.",
     category: "terminal",
     kind: "command",
     danger: "safe",
     scope: "renderer",
     keywords: ["trash", "hide", "dismiss", "remove"],
-    argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
+    argsSchema: z
+      .object({
+        terminalId: z
+          .string()
+          .optional()
+          .describe(
+            "The panel to close, as an `id` from the terminal listing. An automated caller must pass this; omitted, the close falls back to whatever the user has focused."
+          ),
+      })
+      .optional(),
+    resultSchema: PanelCloseResultSchema,
+    mcpOutputSchema: true,
     run: async (args: unknown, ctx) => {
       const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
       // Guard before the store read: this chain falls past focus all the way to
@@ -51,6 +107,14 @@ export function registerTerminalLifecycleActions(
       // essentially at random.
       requireExplicitTerminalIdForAgentDispatch("terminal.close", terminalId, ctx);
       const state = usePanelStore.getState();
+      // A named panel that isn't tracked is a caller mistake, not a no-op:
+      // `trashPanel` ignores an unknown id silently, so without this the call
+      // reports success for a typo (#11805).
+      if (terminalId !== undefined && !state.panelsById[terminalId]) {
+        throw new Error(
+          `terminal.close: no panel with id "${terminalId}" — pass an \`id\` from the terminal listing.`
+        );
+      }
       const targetId =
         terminalId ??
         state.focusedId ??
@@ -59,7 +123,12 @@ export function registerTerminalLifecycleActions(
             state.panelsById[id]?.location !== "trash" &&
             state.panelsById[id]?.location !== "background"
         );
-      if (!targetId) return;
+      if (!targetId) return { closedIds: [] };
+      const target = state.panelsById[targetId];
+      // A stale `focusedId`, or a panel already trashed. Re-trashing resets the
+      // recovery TTL and rewrites the recorded restore location, so leave it be
+      // and report that nothing closed.
+      if (!target || target.location === "trash") return { closedIds: [] };
       // Optimistic close: hide the panel now, trash it after the removal has
       // painted. The coordinator advances focus synchronously so a rapid Cmd+W
       // stream keeps closing fresh panels instead of re-targeting this one.
@@ -67,6 +136,7 @@ export function registerTerminalLifecycleActions(
         hideIds: [targetId],
         commit: () => usePanelStore.getState().trashPanel(targetId),
       });
+      return settleCloseForDispatch([targetId], ctx);
     },
   }));
 
@@ -462,7 +532,9 @@ export function registerTerminalLifecycleActions(
     danger: "safe",
     scope: "renderer",
     keywords: ["trash", "hide", "clear", "cleanup"],
-    run: async () => {
+    resultSchema: PanelCloseResultSchema,
+    mcpOutputSchema: true,
+    run: async (_args: unknown, ctx) => {
       const state = usePanelStore.getState();
       const activeWorktreeId = callbacks.getActiveWorktreeId();
       // Skip tooling-internal panels — the Daintree Assistant's own dock
@@ -477,7 +549,7 @@ export function registerTerminalLifecycleActions(
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
       });
-      if (idsToClose.length === 0) return;
+      if (idsToClose.length === 0) return { closedIds: [] };
       requestPanelClose({
         hideIds: idsToClose,
         commit: () => {
@@ -485,6 +557,7 @@ export function registerTerminalLifecycleActions(
           idsToClose.forEach((id) => latest.trashPanel(id));
         },
       });
+      return settleCloseForDispatch(idsToClose, ctx);
     },
   }));
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -35,7 +35,7 @@ const PanelCloseResultSchema = z.object({
   closedIds: z
     .array(z.string())
     .describe(
-      "The panels this call closed. Empty means nothing closed — there was no panel to act on, or the one named was already in the trash."
+      "The panels this call closed. Empty means nothing closed: there was no panel to act on, the one named was already in the trash, or its teardown did not complete. Treat an empty array as a failed close rather than a quiet success."
     ),
 });
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -48,8 +48,8 @@ const PanelCloseResultSchema = z.object({
 function closedPanelIds(ids: readonly string[]): string[] {
   const { panelsById } = usePanelStore.getState();
   return ids.filter((id) => {
-    const panel = panelsById[id];
-    return panel === undefined || panel.location === "trash";
+    if (!Object.hasOwn(panelsById, id)) return true;
+    return panelsById[id]?.location === "trash";
   });
 }
 
@@ -109,8 +109,11 @@ export function registerTerminalLifecycleActions(
       const state = usePanelStore.getState();
       // A named panel that isn't tracked is a caller mistake, not a no-op:
       // `trashPanel` ignores an unknown id silently, so without this the call
-      // reports success for a typo (#11805).
-      if (terminalId !== undefined && !state.panelsById[terminalId]) {
+      // reports success for a typo (#11805). `Object.hasOwn` rather than a
+      // truthiness check: `panelsById` is a plain object, so an id like
+      // "constructor" would otherwise resolve off the prototype and get trashed
+      // as if it were a real panel.
+      if (terminalId !== undefined && !Object.hasOwn(state.panelsById, terminalId)) {
         throw new Error(
           `terminal.close: no panel with id "${terminalId}" — pass an \`id\` from the terminal listing.`
         );
@@ -124,7 +127,9 @@ export function registerTerminalLifecycleActions(
             state.panelsById[id]?.location !== "background"
         );
       if (!targetId) return { closedIds: [] };
-      const target = state.panelsById[targetId];
+      const target = Object.hasOwn(state.panelsById, targetId)
+        ? state.panelsById[targetId]
+        : undefined;
       // A stale `focusedId`, or a panel already trashed. Re-trashing resets the
       // recovery TTL and rewrites the recorded restore location, so leave it be
       // and report that nothing closed.


### PR DESCRIPTION
## What was wrong

`terminal.close` was returning before the panel actually left `panelStore`. It calls `requestPanelClose()`, and the real teardown (`trashPanel`) is deferred through `requestIdleCallback(cb, { timeout: 160 })`. That means an MCP ack could land up to 160ms before the panel actually left the store, and in a real session log a `terminal.list` call 3ms after the `terminal.close` ack handed back the terminal that had just been closed.

The assistant CLI carries a whole `rosterTombstones` subsystem to work around exactly this.

Separately, `terminal.close` with an id that doesn't exist also returned `"OK"`. `trashPanel` silently no-ops on an unknown id, so `run()` returned `undefined`, which the MCP layer serializes as `"OK"`. A caller had no way to tell a real close from a typo.

## What changed

- On non-foreground dispatch, `terminal.close` now calls the synchronous `flushOptimisticCloses()` before resolving, so an MCP result means the panel is actually gone. Foreground closes keep the deferral: the paint-frame protection is the whole point of the optimistic path, and a click has a frame to protect.
- The gate is `!isForegroundDispatch(ctx?.dispatchSource)`, an allowlist rather than an equality check against `"agent"`. `"plugin"` and any dispatch source added later get the correct behavior by default. No UI path is affected: `ActionService` defaults an omitted dispatch source to `"user"`, and both real dispatch sites pass `source: "keybinding"`.
- An explicitly named panel that isn't tracked is now rejected instead of reported closed.
- Both `terminal.close` and `terminal.closeAll` now return `{ closedIds }` with `mcpOutputSchema: true`, so a caller gets the ids that actually closed rather than the string `"OK"`. `terminal.closeAll` had the same ack race and is equally reachable from the assistant tier.

## A bug the review caught

`panelsById` is a plain object, so a truthiness check on `panelsById[terminalId]` resolved ids like `"constructor"` off `Object.prototype`. That passed the existence guard, ran the whole trash flow including the `terminalClient.trash` IPC call, wrote a bogus record, and reported `closedIds: ["constructor"]`. All three lookups now use `Object.hasOwn`.

## E2E

Five perf specs dispatched a confirmed `terminal.kill` and then `terminal.close` on the same id. `kill` already calls `removePanel`, so that close is redundant, and it now rejects. In `recipe-fanout-perf.spec.ts` the local `run` helper records non-ok results, so the benchmark would have failed deterministically. Those redundant closes are gone.

## Known, not fixed (deliberate)

`terminal.trash`, `terminal.kill`, `terminal.restart`, `terminal.watch`, and `terminal.rename` all read `panelsById[id]` unguarded and share the same inherited-key weakness. Those reads are already on `develop` and aren't regressions from this branch. The agent-reachable ones are confirmation-gated. Worth its own issue rather than widening this one.

## Testing

The existing lifecycle suite mocks the optimistic-close coordinator so its commit runs synchronously, which makes it structurally unable to catch this bug. There's a new `terminalLifecycleActions.optimisticClose.test.ts` that wires the real coordinator to a real `ActionService` and asserts what an MCP caller actually observes: whether the panel is still in `terminal.list` the moment the close acks, with timers frozen.

Locally: 296 tests pass across the lifecycle, coordinator, action-manifest, schema, and output-schema suites. `npm run typecheck` is clean. Prettier and eslint are clean on changed files (0 errors, and the new file adds 0 warnings so the lint ratchet is unmoved).

Resolves #11805

## Files changed

- `src/services/actions/definitions/terminalLifecycleActions.ts`
- `src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts`
- `src/services/actions/definitions/__tests__/terminalLifecycleActions.optimisticClose.test.ts` (new)
- `src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap`
- `e2e/full/terminal/agent-launch-perf.spec.ts`
- `e2e/full/worktree/recipe-fanout-perf.spec.ts`
- `e2e/full/worktree/worktree-agent-ready-perf.spec.ts`
