### PR TITLE
fix(terminal): select the pane a file was dropped on

### DIFF
--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -15,6 +15,7 @@ import { terminalInstanceService } from "../../services/TerminalInstanceService"
 import { TerminalRefreshTier } from "@/types";
 import type { DevPreviewStatus } from "@/hooks/useDevServer";
 import { useConsoleCaptureStore, ZERO_COUNTS } from "@/store/consoleCaptureStore";
+import { usePanelStore } from "@/store/panelStore";
 import { ConsolePanel } from "./ConsolePanel";
 import { DiagnosticsPanel } from "./DiagnosticsPanel";
 
@@ -425,6 +426,12 @@ export function ConsoleDrawer({
                   terminalId={terminalId}
                   getRefreshTier={getRefreshTier}
                   restoreOnAttach={true}
+                  // The console runs its own PTY inside this panel, so a drop
+                  // has to select the panel rather than the terminal it landed
+                  // in — `terminalId` names nothing the grid can select
+                  // (#11809). Without this the drop would move DOM focus here
+                  // while the selection stayed on whatever pane had it.
+                  onDropSelect={() => usePanelStore.getState().setFocused(paneId)}
                   className="!rounded-none !px-0 !pt-0 !pb-0"
                 />
               </Suspense>

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -272,8 +272,13 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       themeCompartmentRef,
     } = compartments;
 
+    // `onActivate` is the same pane-selection callback the pointer handlers
+    // below fire, so a drop lands the pane in exactly the state a click on the
+    // bar would (#11809). Called with no argument, which is what keeps the
+    // shift/cmd fleet gestures a click carries out of a drop. Absent for the
+    // Assistant, whose input bar owns no selectable pane.
     const { handleDragEnter, handleDragOver, handleDragLeave, handleDrop, isDragOverFiles } =
-      useDragDrop(editorViewRef, cwd);
+      useDragDrop(editorViewRef, cwd, onActivate);
 
     const { imagePasteExtension, filePasteExtension, plainPasteKeymap } = usePasteExtensions(cwd);
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1494,6 +1494,11 @@ function TerminalPaneComponent({
                     onReady={handleReady}
                     onExit={handleExit}
                     onInput={handleInput}
+                    // Same selection path as a click on the pane, minus the
+                    // event — which is exactly what leaves the shift/cmd fleet
+                    // gestures behind, since those only fire for a real click
+                    // that landed in pane chrome (#11809).
+                    onDropSelect={handleClick}
                     onAttached={handleAttached}
                     className="absolute inset-0"
                     getRefreshTier={getRefreshTierCallback}

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -44,6 +44,12 @@ export interface XtermAdapterProps {
   onExit?: (exitCode: number) => void;
   onInput?: (data: string) => void;
   /**
+   * Selects the panel that owns this terminal after a file drop writes to it.
+   * Omitted by consumers whose xterm is not a selectable panel of its own —
+   * the Assistant overlay and the Dev Preview console (#11809).
+   */
+  onDropSelect?: () => void;
+  /**
    * Fired once per live `attach()`, after the service has been told the
    * terminal is visible. Lets the owning pane re-arm anything that captured an
    * attach generation before this async setup landed (#11445).
@@ -69,6 +75,7 @@ export function XtermAdapter({
   onReady,
   onExit,
   onInput,
+  onDropSelect,
   onAttached,
   className,
   getRefreshTier,
@@ -167,6 +174,7 @@ export function XtermAdapter({
     terminalId,
     isInputLocked,
     onInput: stableOnInput,
+    onDropSelect,
     // The same stable reader the instance service gets, so a drop relativizes
     // its `@file` token against the cwd the terminal is in when it lands.
     cwdProvider: stableCwdProvider,

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -177,8 +177,9 @@ vi.mock("@/utils/logger", () => ({
   logError: vi.fn(),
 }));
 
-function renderAdapter(props: Partial<React.ComponentProps<typeof XtermAdapter>> = {}) {
-  return render(
+/** The element `renderAdapter` mounts, so `rerender` can rebuild it verbatim. */
+function adapterElement(props: Partial<React.ComponentProps<typeof XtermAdapter>> = {}) {
+  return (
     <Suspense fallback={null}>
       <XtermAdapter
         terminalId="term-1"
@@ -192,6 +193,10 @@ function renderAdapter(props: Partial<React.ComponentProps<typeof XtermAdapter>>
       />
     </Suspense>
   );
+}
+
+function renderAdapter(props: Partial<React.ComponentProps<typeof XtermAdapter>> = {}) {
+  return render(adapterElement(props));
 }
 
 describe("XtermAdapter lifecycle", () => {
@@ -1017,6 +1022,26 @@ describe("XtermAdapter lifecycle", () => {
         launchAgentId: "claude",
         detectedAgentId: "codex",
         agentState: "working",
+      });
+    });
+
+    // The hook can only select the panel a drop landed on if the owner's
+    // callback reaches it — and the option is optional, so losing this wiring
+    // would compile, leave every hook-level test green, and quietly restore
+    // #11809. Consumers whose xterm owns no selectable panel (the Assistant,
+    // the Dev Preview console) pass nothing, so absence has to survive too.
+    it("forwards the owner's drop-selection callback, and its absence", async () => {
+      const onDropSelect = vi.fn();
+      const { rerender } = renderAdapter({ onDropSelect });
+      await waitFor(() => expect(mocks.useTerminalFileTransfer).toHaveBeenCalled());
+
+      const [, withOwner] = mocks.useTerminalFileTransfer.mock.calls.at(-1)!;
+      expect(withOwner.onDropSelect).toBe(onDropSelect);
+
+      rerender(adapterElement({}));
+      await waitFor(() => {
+        const [, withoutOwner] = mocks.useTerminalFileTransfer.mock.calls.at(-1)!;
+        expect(withoutOwner.onDropSelect).toBeUndefined();
       });
     });
   });

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -24,12 +24,21 @@ vi.mock("@/clients", () => ({
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     notifyUserInput: vi.fn(),
+    focus: vi.fn(),
     get: vi.fn(() =>
       instanceState.hasManagedInstance
         ? { terminal: { modes: { bracketedPasteMode: instanceState.bracketedPasteMode } } }
         : null
     ),
   },
+}));
+
+// The real store constructs the terminal-instance singleton and several
+// controllers at module scope. Only the focus-preference setter is exercised
+// here, so the mock stays that narrow — a wider fake would drift.
+const setPreferredTerminalFocusTarget = vi.hoisted(() => vi.fn<(target: string) => void>());
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ setPreferredTerminalFocusTarget }) },
 }));
 
 import type { EditorView } from "@codemirror/view";
@@ -542,6 +551,7 @@ describe("useTerminalFileTransfer hook", () => {
       current: {
         state: { selection: { main: { head: 0 } } },
         dispatch,
+        focus: vi.fn(),
       } as unknown as EditorView,
     };
 
@@ -1156,5 +1166,131 @@ describe("useTerminalFileTransfer hook", () => {
     expect(over.defaultPrevented).toBe(false);
     expect(dataTransfer.dropEffect).toBe("copy");
     expect(terminalClient.write).not.toHaveBeenCalled();
+  });
+
+  // --- The drop leaves the pane selected and ready to type into (#11809) ---
+  describe("selection", () => {
+    it("records the surface, selects the pane, then focuses the xterm", () => {
+      const onDropSelect = vi.fn();
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect });
+      dropFiles([fileAt("App.tsx", `${CWD}/src/App.tsx`)]);
+
+      // The order is load-bearing, not incidental: the pane's focus effect reads
+      // the preference to route the keyboard when selection lands, so leaving it
+      // on "hybridInput" would send focus to the input bar the paths bypassed.
+      expect(setPreferredTerminalFocusTarget).toHaveBeenCalledWith("xterm");
+      expect(setPreferredTerminalFocusTarget.mock.invocationCallOrder[0]!).toBeLessThan(
+        onDropSelect.mock.invocationCallOrder[0]!
+      );
+      expect(onDropSelect.mock.invocationCallOrder[0]!).toBeLessThan(
+        vi.mocked(terminalInstanceService.focus).mock.invocationCallOrder[0]!
+      );
+      expect(terminalInstanceService.focus).toHaveBeenCalledWith("term-1");
+    });
+
+    // The gesture is one drop however many files rode on it, so the pane is
+    // selected once — not once per path, which would be invisible here but real
+    // in the wake and MRU stamping `setFocused` drives.
+    it("selects once per drop, not once per path", () => {
+      const onDropSelect = vi.fn();
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect });
+      dropInternalPaths([`${CWD}/a.ts`, `${CWD}/b.ts`, `${CWD}/c.ts`]);
+
+      expect(terminalClient.write).toHaveBeenCalledTimes(1);
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it("selects the pane for an in-app drag exactly as it does for an OS drop", () => {
+      const onDropSelect = vi.fn();
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(setPreferredTerminalFocusTarget).toHaveBeenCalledWith("xterm");
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+      expect(terminalInstanceService.focus).toHaveBeenCalledWith("term-1");
+    });
+
+    /**
+     * Nothing about the pane moved. Each caller renders its own hook: the hook
+     * binds to the shared container, so two live at once would both answer the
+     * same drop.
+     */
+    function expectNothingSelected(onDropSelect: ReturnType<typeof vi.fn>) {
+      expect(terminalClient.write).not.toHaveBeenCalled();
+      expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
+      expect(onDropSelect).not.toHaveBeenCalled();
+      expect(terminalInstanceService.focus).not.toHaveBeenCalled();
+    }
+
+    // A terminal that took nothing has not been pointed at in any sense that
+    // should move the selection off whatever the user was already typing into.
+    it("selects nothing when the input is locked", () => {
+      const onDropSelect = vi.fn();
+      renderFileTransferHook({ isInputLocked: true, cwdProvider: () => CWD, onDropSelect });
+      dropFiles([fileAt("App.tsx", `${CWD}/src/App.tsx`)]);
+
+      expectNothingSelected(onDropSelect);
+    });
+
+    // The OS declined to resolve a path, so there is nothing referenceable.
+    it("selects nothing when no dropped file resolves to a path", () => {
+      const onDropSelect = vi.fn();
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect });
+      dropFiles([fileAt("no-path.txt")]);
+
+      expectNothingSelected(onDropSelect);
+    });
+
+    // A relative path names nothing the agent could open, so the whole payload
+    // is rejected rather than partially delivered.
+    it("selects nothing when the in-app payload is rejected", () => {
+      const onDropSelect = vi.fn();
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect });
+      dropInternalPaths(["relative/App.tsx"]);
+
+      expectNothingSelected(onDropSelect);
+    });
+
+    // Pasting an image writes the same kind of reference, but the pointer never
+    // pointed anywhere — the pane the user is typing into is already the target.
+    it("does not select the pane for an image paste", async () => {
+      const onDropSelect = vi.fn();
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect });
+      await pasteImage();
+
+      expect(terminalClient.write).toHaveBeenCalledTimes(1);
+      expect(onDropSelect).not.toHaveBeenCalled();
+      expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
+    });
+
+    // The owning pane rebuilds this callback every render. Reading it through a
+    // ref is what lets the listeners stay registered across those renders, so a
+    // stale capture would only ever show up after one.
+    it("calls the callback the latest render supplied", () => {
+      const stale = vi.fn();
+      const fresh = vi.fn();
+      const { rerender } = renderFileTransferHook({
+        detectedAgentId: "claude",
+        cwdProvider: () => CWD,
+        onDropSelect: stale,
+      });
+      rerender({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect: fresh });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(stale).not.toHaveBeenCalled();
+      expect(fresh).toHaveBeenCalledTimes(1);
+    });
+
+    // The Assistant overlay and the Dev Preview console both run this hook over
+    // a PTY that owns no selectable pane, so they pass no callback. Their own
+    // surface still takes the keyboard; what they must never do is reach for a
+    // panel id they don't have.
+    it("still focuses the xterm when no pane owns the terminal", () => {
+      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(terminalClient.write).toHaveBeenCalledTimes(1);
+      expect(terminalInstanceService.focus).toHaveBeenCalledWith("term-1");
+    });
   });
 });

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -1002,13 +1002,20 @@ describe("useTerminalFileTransfer hook", () => {
     // delimiters as literal input.
     it("falls back to identity when no managed instance answers", () => {
       instanceState.hasManagedInstance = false;
-      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD });
+      const { rerender } = renderFileTransferHook({
+        detectedAgentId: "claude",
+        cwdProvider: () => CWD,
+      });
       dropInternalPaths([`${CWD}/src/App.tsx`]);
       expect(lastWrittenPayload()).toBe(formatWithBracketedPaste("@src/App.tsx "));
 
+      // Drops the agent identity on the same hook rather than rendering a
+      // second one: both would bind to the shared container and answer the
+      // drop below, and reading only the last payload would hide it.
       vi.mocked(terminalClient.write).mockClear();
-      renderFileTransferHook({ cwdProvider: () => CWD });
+      rerender({ cwdProvider: () => CWD });
       dropInternalPaths([`${CWD}/src/App.tsx`]);
+      expect(vi.mocked(terminalClient.write)).toHaveBeenCalledTimes(1);
       expect(lastWrittenPayload()).toBe(`${escapeShellArgOptional(`${CWD}/src/App.tsx`)} `);
     });
 
@@ -1178,7 +1185,11 @@ describe("useTerminalFileTransfer hook", () => {
       // The order is load-bearing, not incidental: the pane's focus effect reads
       // the preference to route the keyboard when selection lands, so leaving it
       // on "hybridInput" would send focus to the input bar the paths bypassed.
+      // And nothing about the pane moves until the paths are actually delivered.
       expect(setPreferredTerminalFocusTarget).toHaveBeenCalledWith("xterm");
+      expect(vi.mocked(terminalClient.write).mock.invocationCallOrder[0]!).toBeLessThan(
+        setPreferredTerminalFocusTarget.mock.invocationCallOrder[0]!
+      );
       expect(setPreferredTerminalFocusTarget.mock.invocationCallOrder[0]!).toBeLessThan(
         onDropSelect.mock.invocationCallOrder[0]!
       );
@@ -1211,44 +1222,64 @@ describe("useTerminalFileTransfer hook", () => {
     });
 
     /**
-     * Nothing about the pane moved. Each caller renders its own hook: the hook
-     * binds to the shared container, so two live at once would both answer the
-     * same drop.
+     * Nothing about the pane moved, and then a drop that IS accepted moves it —
+     * so the absence above is the guard doing its job rather than a hook that
+     * never selects anything. Renders its own hook per call: the hook binds to
+     * the shared container, so two live at once would both answer one drop.
      */
-    function expectNothingSelected(onDropSelect: ReturnType<typeof vi.fn>) {
+    function expectRejectedThenAcceptedDrop(
+      options: HookProps,
+      rejectedDrop: () => void,
+      accept: (hook: ReturnType<typeof renderFileTransferHook>, onDropSelect: () => void) => void
+    ) {
+      const onDropSelect = vi.fn();
+      const hook = renderFileTransferHook({ cwdProvider: () => CWD, onDropSelect, ...options });
+      rejectedDrop();
+
       expect(terminalClient.write).not.toHaveBeenCalled();
       expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
       expect(onDropSelect).not.toHaveBeenCalled();
       expect(terminalInstanceService.focus).not.toHaveBeenCalled();
+
+      accept(hook, onDropSelect);
+
+      expect(setPreferredTerminalFocusTarget).toHaveBeenCalledWith("xterm");
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+      expect(terminalInstanceService.focus).toHaveBeenCalledWith("term-1");
     }
 
     // A terminal that took nothing has not been pointed at in any sense that
     // should move the selection off whatever the user was already typing into.
-    it("selects nothing when the input is locked", () => {
-      const onDropSelect = vi.fn();
-      renderFileTransferHook({ isInputLocked: true, cwdProvider: () => CWD, onDropSelect });
-      dropFiles([fileAt("App.tsx", `${CWD}/src/App.tsx`)]);
-
-      expectNothingSelected(onDropSelect);
+    it("selects nothing while the input is locked", () => {
+      expectRejectedThenAcceptedDrop(
+        { isInputLocked: true },
+        () => dropFiles([fileAt("App.tsx", `${CWD}/src/App.tsx`)]),
+        (hook, onDropSelect) => {
+          // Unlocking reuses the same hook rather than rendering a second one,
+          // which would leave two listener sets answering the one drop below.
+          hook.rerender({ cwdProvider: () => CWD, onDropSelect, isInputLocked: false });
+          dropInternalPaths([`${CWD}/src/App.tsx`]);
+        }
+      );
     });
 
     // The OS declined to resolve a path, so there is nothing referenceable.
     it("selects nothing when no dropped file resolves to a path", () => {
-      const onDropSelect = vi.fn();
-      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect });
-      dropFiles([fileAt("no-path.txt")]);
-
-      expectNothingSelected(onDropSelect);
+      expectRejectedThenAcceptedDrop(
+        { detectedAgentId: "claude" },
+        () => dropFiles([fileAt("no-path.txt")]),
+        () => dropFiles([fileAt("App.tsx", `${CWD}/src/App.tsx`)])
+      );
     });
 
     // A relative path names nothing the agent could open, so the whole payload
     // is rejected rather than partially delivered.
     it("selects nothing when the in-app payload is rejected", () => {
-      const onDropSelect = vi.fn();
-      renderFileTransferHook({ detectedAgentId: "claude", cwdProvider: () => CWD, onDropSelect });
-      dropInternalPaths(["relative/App.tsx"]);
-
-      expectNothingSelected(onDropSelect);
+      expectRejectedThenAcceptedDrop(
+        { detectedAgentId: "claude" },
+        () => dropInternalPaths(["relative/App.tsx"]),
+        () => dropInternalPaths([`${CWD}/src/App.tsx`])
+      );
     });
 
     // Pasting an image writes the same kind of reference, but the pointer never
@@ -1261,6 +1292,13 @@ describe("useTerminalFileTransfer hook", () => {
       expect(terminalClient.write).toHaveBeenCalledTimes(1);
       expect(onDropSelect).not.toHaveBeenCalled();
       expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
+      expect(terminalInstanceService.focus).not.toHaveBeenCalled();
+
+      // The same hook, now given a gesture that did point somewhere.
+      dropInternalPaths([`${CWD}/src/App.tsx`]);
+
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+      expect(terminalInstanceService.focus).toHaveBeenCalledWith("term-1");
     });
 
     // The owning pane rebuilds this callback every render. Reading it through a

--- a/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
@@ -671,9 +671,48 @@ describe("useDragDrop", () => {
       );
     });
 
-    // The whole point of the gesture is typing straight after the chip, so the
-    // caret the insertion parked must survive being focused. Routing through
-    // the panel focus registry instead would dispatch it to the end of the draft.
+    // An image waits on a thumbnail over IPC before it can be inserted, and
+    // that is exactly the drop the user has time to start typing after. The
+    // whole gesture has to be committed before the wait, not after it — the
+    // insertion is allowed to arrive late, the keyboard is not.
+    it("selects the pane before an image drop waits on its thumbnail", async () => {
+      const onDropSelect = vi.fn();
+      const { ref, focus, dispatch } = fakeView();
+      let releaseThumbnail!: () => void;
+      thumbnailFromPath.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            releaseThumbnail = () => resolve({ thumbnailDataUrl: "data:image/png;base64,x" });
+          })
+      );
+      const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
+
+      let pending!: Promise<void>;
+      act(() => {
+        pending = result.current.handleDrop(internalDrop([`${CWD}/shot.png`]));
+      });
+
+      // Nothing is inserted yet, but the keyboard already belongs here.
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(setPreferredTerminalFocusTarget).toHaveBeenCalledWith("hybridInput");
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+      expect(focus).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        releaseThumbnail();
+        await pending;
+      });
+
+      // …and the late insertion neither repeats nor re-takes the selection.
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+      expect(focus).toHaveBeenCalledTimes(1);
+    });
+
+    // The whole point of the gesture is typing straight after the chip, so
+    // focusing must not carry a caret move of its own. Routing through the
+    // panel focus registry instead would dispatch the caret to the end of the
+    // draft, overriding where the insertion parks it.
     it("leaves the caret the insertion parked rather than moving it", async () => {
       const { ref, dispatch, focus, head } = fakeView(6);
       const { result } = renderHook(() => useDragDrop(ref, CWD, vi.fn()));
@@ -689,8 +728,10 @@ describe("useDragDrop", () => {
     });
 
     // A pane that took nothing has not been pointed at in any sense that should
-    // move the selection off whatever the user was already typing into.
-    it("selects nothing when the drop resolves no paths", async () => {
+    // move the selection off whatever the user was already typing into. Each
+    // case ends with a drop that IS accepted, so the assertion is about the
+    // guard rather than about selection being absent everywhere.
+    it("selects nothing for a drop carrying nothing referenceable", async () => {
       const onDropSelect = vi.fn();
       const { ref, focus, dispatch } = fakeView();
       const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
@@ -703,10 +744,18 @@ describe("useDragDrop", () => {
       expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
       expect(onDropSelect).not.toHaveBeenCalled();
       expect(focus).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
+      });
+
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+      expect(focus).toHaveBeenCalledTimes(1);
     });
 
     it("selects nothing when the editor is gone before the drop lands", async () => {
       const onDropSelect = vi.fn();
+      const view = fakeView();
       const ref = { current: null } as React.RefObject<EditorView | null>;
       const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
 
@@ -716,30 +765,23 @@ describe("useDragDrop", () => {
 
       expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
       expect(onDropSelect).not.toHaveBeenCalled();
-    });
 
-    // A destroyed view rejects the transaction; nothing was inserted, so
-    // nothing about the pane should move either.
-    it("selects nothing when the insertion itself fails", async () => {
-      const onDropSelect = vi.fn();
-      const { ref, dispatch, focus } = fakeView();
-      dispatch.mockImplementation(() => {
-        throw new Error("view destroyed");
-      });
-      const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
-
+      // The same drop once an editor is mounted, proving the absence above was
+      // the missing view and not a hook that never selects anything.
+      ref.current = view.view;
       await act(async () => {
         await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
       });
 
-      expect(onDropSelect).not.toHaveBeenCalled();
-      expect(focus).not.toHaveBeenCalled();
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+      expect(view.focus).toHaveBeenCalledTimes(1);
     });
 
     // A thumbnail resolves asynchronously, so the pane can remount underneath a
-    // dropped image. Committing then would insert into a detached editor — inert
-    // on its own — and drag the selection to a pane that shows none of it.
-    it("selects nothing when the pane remounts while an image resolves", async () => {
+    // dropped image. The gesture was aimed at this pane and already selected it;
+    // what must not happen is the late insertion landing in a document neither
+    // the old nor the new editor is showing.
+    it("inserts into neither editor when the pane remounts while an image resolves", async () => {
       const onDropSelect = vi.fn();
       const { ref, dispatch, focus } = fakeView();
       let releaseThumbnail!: () => void;
@@ -756,16 +798,20 @@ describe("useDragDrop", () => {
         pending = result.current.handleDrop(internalDrop([`${CWD}/shot.png`]));
       });
       // The replacement a remount installs — same ref, different view.
-      ref.current = fakeView().view;
+      const replacement = fakeView();
+      ref.current = replacement.view;
       await act(async () => {
         releaseThumbnail();
         await pending;
       });
 
       expect(dispatch).not.toHaveBeenCalled();
-      expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
-      expect(onDropSelect).not.toHaveBeenCalled();
-      expect(focus).not.toHaveBeenCalled();
+      expect(replacement.dispatch).not.toHaveBeenCalled();
+      expect(replacement.focus).not.toHaveBeenCalled();
+      // The pane it was dropped on was selected when the gesture landed, which
+      // is before the editor underneath it was replaced.
+      expect(onDropSelect).toHaveBeenCalledTimes(1);
+      expect(focus).toHaveBeenCalledTimes(1);
     });
 
     // The Assistant's input bar runs this hook over a PTY that owns no

--- a/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useDragDrop.test.ts
@@ -11,6 +11,14 @@ vi.mock("../../useTerminalFileTransfer", () => ({
   IMAGE_EXTENSIONS: /\.(png|jpe?g|bmp|tiff?|avif|heic)$/i,
 }));
 
+// Same reason: the real store constructs `terminalInstanceService` and several
+// controllers at module scope. Only the focus-preference setter is exercised
+// here, so the mock stays that narrow — a wider fake would drift.
+const setPreferredTerminalFocusTarget = vi.hoisted(() => vi.fn<(target: string) => void>());
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ setPreferredTerminalFocusTarget }) },
+}));
+
 const { useDragDrop } = await import("../useDragDrop");
 const { FILE_DRAG_MIME, encodeFileDragPaths } = await import("@/lib/fileDragPayload");
 
@@ -18,11 +26,19 @@ const CWD = "/Users/greg/Projects/daintree";
 
 function fakeView(head = 0) {
   const dispatch = vi.fn();
+  const focus = vi.fn();
   const view = {
     state: { selection: { main: { head } } },
     dispatch,
+    focus,
   } as unknown as EditorView;
-  return { view, dispatch, head, ref: { current: view } as React.RefObject<EditorView | null> };
+  return {
+    view,
+    dispatch,
+    focus,
+    head,
+    ref: { current: view } as React.RefObject<EditorView | null>,
+  };
 }
 
 /**
@@ -98,6 +114,7 @@ let pathForFile: ReturnType<typeof vi.fn>;
 let thumbnailFromPath: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  setPreferredTerminalFocusTarget.mockClear();
   pathForFile = vi.fn((file: File) => `${CWD}/${file.name}`);
   thumbnailFromPath = vi.fn(async () => ({ thumbnailDataUrl: "data:image/png;base64,x" }));
   (window as unknown as { electron: unknown }).electron = {
@@ -628,6 +645,142 @@ describe("useDragDrop", () => {
       expect(event.dataTransfer.getData).not.toHaveBeenCalled();
       expect(thumbnailFromPath).not.toHaveBeenCalled();
       expect(result.current.isDragOverFiles).toBe(false);
+    });
+  });
+
+  // --- The drop leaves the pane selected and ready to type into (#11809) ---
+  describe("selection", () => {
+    it("records the surface, selects the pane, then focuses the editor", async () => {
+      const onDropSelect = vi.fn();
+      const { ref, focus } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
+      });
+
+      // The order is load-bearing, not incidental: the pane's focus effect
+      // reads the preference to route the keyboard when selection lands, so
+      // recording it after `onDropSelect` would send focus to the xterm first.
+      expect(setPreferredTerminalFocusTarget).toHaveBeenCalledWith("hybridInput");
+      expect(setPreferredTerminalFocusTarget.mock.invocationCallOrder[0]!).toBeLessThan(
+        onDropSelect.mock.invocationCallOrder[0]!
+      );
+      expect(onDropSelect.mock.invocationCallOrder[0]!).toBeLessThan(
+        focus.mock.invocationCallOrder[0]!
+      );
+    });
+
+    // The whole point of the gesture is typing straight after the chip, so the
+    // caret the insertion parked must survive being focused. Routing through
+    // the panel focus registry instead would dispatch it to the end of the draft.
+    it("leaves the caret the insertion parked rather than moving it", async () => {
+      const { ref, dispatch, focus, head } = fakeView(6);
+      const { result } = renderHook(() => useDragDrop(ref, CWD, vi.fn()));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
+      });
+
+      const insert = dispatch.mock.calls[0]![0].changes.insert as string;
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch.mock.calls[0]![0].selection).toEqual({ anchor: head + insert.length });
+      expect(focus).toHaveBeenCalledTimes(1);
+    });
+
+    // A pane that took nothing has not been pointed at in any sense that should
+    // move the selection off whatever the user was already typing into.
+    it("selects nothing when the drop resolves no paths", async () => {
+      const onDropSelect = vi.fn();
+      const { ref, focus, dispatch } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([]));
+      });
+
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
+      expect(onDropSelect).not.toHaveBeenCalled();
+      expect(focus).not.toHaveBeenCalled();
+    });
+
+    it("selects nothing when the editor is gone before the drop lands", async () => {
+      const onDropSelect = vi.fn();
+      const ref = { current: null } as React.RefObject<EditorView | null>;
+      const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
+      });
+
+      expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
+      expect(onDropSelect).not.toHaveBeenCalled();
+    });
+
+    // A destroyed view rejects the transaction; nothing was inserted, so
+    // nothing about the pane should move either.
+    it("selects nothing when the insertion itself fails", async () => {
+      const onDropSelect = vi.fn();
+      const { ref, dispatch, focus } = fakeView();
+      dispatch.mockImplementation(() => {
+        throw new Error("view destroyed");
+      });
+      const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
+      });
+
+      expect(onDropSelect).not.toHaveBeenCalled();
+      expect(focus).not.toHaveBeenCalled();
+    });
+
+    // A thumbnail resolves asynchronously, so the pane can remount underneath a
+    // dropped image. Committing then would insert into a detached editor — inert
+    // on its own — and drag the selection to a pane that shows none of it.
+    it("selects nothing when the pane remounts while an image resolves", async () => {
+      const onDropSelect = vi.fn();
+      const { ref, dispatch, focus } = fakeView();
+      let releaseThumbnail!: () => void;
+      thumbnailFromPath.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            releaseThumbnail = () => resolve({ thumbnailDataUrl: "data:image/png;base64,x" });
+          })
+      );
+      const { result } = renderHook(() => useDragDrop(ref, CWD, onDropSelect));
+
+      let pending!: Promise<void>;
+      act(() => {
+        pending = result.current.handleDrop(internalDrop([`${CWD}/shot.png`]));
+      });
+      // The replacement a remount installs — same ref, different view.
+      ref.current = fakeView().view;
+      await act(async () => {
+        releaseThumbnail();
+        await pending;
+      });
+
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(setPreferredTerminalFocusTarget).not.toHaveBeenCalled();
+      expect(onDropSelect).not.toHaveBeenCalled();
+      expect(focus).not.toHaveBeenCalled();
+    });
+
+    // The Assistant's input bar runs this hook over a PTY that owns no
+    // selectable pane, so it passes no callback. Its own surface still takes the
+    // caret; what it must never do is reach for a panel id it doesn't have.
+    it("still focuses the editor when no pane owns the input", async () => {
+      const { ref, focus, dispatch } = fakeView();
+      const { result } = renderHook(() => useDragDrop(ref, CWD));
+
+      await act(async () => {
+        await result.current.handleDrop(internalDrop([`${CWD}/src/App.tsx`]));
+      });
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(focus).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/Terminal/hooks/useDragDrop.ts
+++ b/src/components/Terminal/hooks/useDragDrop.ts
@@ -110,6 +110,32 @@ export function useDragDrop(
 
       if (dropped.length === 0) return;
 
+      // The gesture already pointed at this input, so it ends the same way a
+      // click on it does: pane selected, caret here, ready to type about the
+      // file that just landed (#11809). A drop carrying nothing referenceable
+      // returned above and leaves the selection alone.
+      //
+      // Committed here rather than after the insertion, because an image drop
+      // waits on a thumbnail over IPC first. Selecting only once that resolved
+      // would leave the keystrokes typed in between going to the pane the user
+      // just navigated away from — the very bug this fixes, still present for
+      // exactly the drops with the longest gap. It would also let a slow
+      // thumbnail pull the selection back long after the user moved on.
+      //
+      // Order matters. The preference is what `TerminalPane`'s focus effect
+      // reads to decide which sub-surface the newly selected pane hands the
+      // keyboard to, so a stale "xterm" would yank focus straight back out.
+      //
+      // `view.focus()` rather than the panel focus registry: the registry
+      // routes to `focusWithCursorAtEnd`, which drags the caret to the end of
+      // the draft whenever the editor doesn't already hold focus — undoing the
+      // caret the insertion below parks after the chip. Focusing directly keeps
+      // it, and makes the pane effect's own later call a no-op, since it
+      // preserves an editor that already owns DOM focus.
+      usePanelStore.getState().setPreferredTerminalFocusTarget("hybridInput");
+      onDropSelect?.();
+      view.focus();
+
       type ResolvedFile =
         | { type: "image"; filePath: string; thumbnailDataUrl: string }
         | {
@@ -147,8 +173,8 @@ export function useDragDrop(
 
       // A thumbnail await above can outlive the editor it started in: the pane
       // can unmount or remount (`useEditorFactory` destroys the view and nulls
-      // the ref) while an image resolves. Inserting into a detached view was
-      // already inert, but selecting a panel off the back of one would not be.
+      // the ref) while an image resolves. Dispatching into the detached view
+      // would insert into a document nothing is showing any more.
       if (editorViewRef.current !== view) return;
 
       try {
@@ -192,25 +218,6 @@ export function useDragDrop(
           effects: [...imageEffects, ...fileEffects],
           selection: { anchor: cursor + insertText.length },
         });
-
-        // The gesture already pointed at this input, so it ends the same way a
-        // click on it does: pane selected, caret here, ready to type about the
-        // file that just landed (#11809). Only a drop that inserted something
-        // earns that — the early returns above leave selection alone.
-        //
-        // Order matters. The preference is what `TerminalPane`'s focus effect
-        // reads to decide which sub-surface the newly selected pane hands the
-        // keyboard to, so a stale "xterm" would yank focus straight back out.
-        //
-        // `view.focus()` rather than the panel focus registry: the registry
-        // routes to `focusWithCursorAtEnd`, which drags the caret to the end of
-        // the draft whenever the editor doesn't already hold focus — undoing
-        // the caret this dispatch just parked after the chip. Focusing directly
-        // keeps it, and makes the pane effect's own later call a no-op, since
-        // it preserves an editor that already owns DOM focus.
-        usePanelStore.getState().setPreferredTerminalFocusTarget("hybridInput");
-        onDropSelect?.();
-        view.focus();
       } catch {
         // Editor may have been destroyed
       }

--- a/src/components/Terminal/hooks/useDragDrop.ts
+++ b/src/components/Terminal/hooks/useDragDrop.ts
@@ -10,6 +10,7 @@ import {
 import { IMAGE_EXTENSIONS } from "../useTerminalFileTransfer";
 import { formatAtFileTokenForCwd } from "../hybridInputParsing";
 import { addImageChip, addFileDropChip } from "../inputEditorExtensions";
+import { usePanelStore } from "@/store/panelStore";
 
 /**
  * A dropped entry, normalized across the two provenances before anything is
@@ -23,7 +24,19 @@ interface DroppedEntry {
   fileSize: number | undefined;
 }
 
-export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, cwd: string) {
+/**
+ * @param onDropSelect Selects the panel that owns this input, invoked only once
+ *   a drop has actually inserted something. The hook knows which *surface* was
+ *   dropped on but not which panel owns it — `terminalId` is a PTY id, and the
+ *   Assistant's input bar has one without being a selectable panel at all. So
+ *   panel selection is delegated to the caller and simply absent where there is
+ *   no panel to select.
+ */
+export function useDragDrop(
+  editorViewRef: React.RefObject<EditorView | null>,
+  cwd: string,
+  onDropSelect?: () => void
+) {
   const dragDepthRef = useRef(0);
   const [isDragOverFiles, setIsDragOverFiles] = useState(false);
 
@@ -132,6 +145,12 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, c
 
       if (resolved.length === 0) return;
 
+      // A thumbnail await above can outlive the editor it started in: the pane
+      // can unmount or remount (`useEditorFactory` destroys the view and nulls
+      // the ref) while an image resolves. Inserting into a detached view was
+      // already inert, but selecting a panel off the back of one would not be.
+      if (editorViewRef.current !== view) return;
+
       try {
         const cursor = view.state.selection.main.head;
         const imageEffects: ReturnType<typeof addImageChip.of>[] = [];
@@ -173,11 +192,30 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>, c
           effects: [...imageEffects, ...fileEffects],
           selection: { anchor: cursor + insertText.length },
         });
+
+        // The gesture already pointed at this input, so it ends the same way a
+        // click on it does: pane selected, caret here, ready to type about the
+        // file that just landed (#11809). Only a drop that inserted something
+        // earns that — the early returns above leave selection alone.
+        //
+        // Order matters. The preference is what `TerminalPane`'s focus effect
+        // reads to decide which sub-surface the newly selected pane hands the
+        // keyboard to, so a stale "xterm" would yank focus straight back out.
+        //
+        // `view.focus()` rather than the panel focus registry: the registry
+        // routes to `focusWithCursorAtEnd`, which drags the caret to the end of
+        // the draft whenever the editor doesn't already hold focus — undoing
+        // the caret this dispatch just parked after the chip. Focusing directly
+        // keeps it, and makes the pane effect's own later call a no-op, since
+        // it preserves an editor that already owns DOM focus.
+        usePanelStore.getState().setPreferredTerminalFocusTarget("hybridInput");
+        onDropSelect?.();
+        view.focus();
       } catch {
         // Editor may have been destroyed
       }
     },
-    [editorViewRef, cwd]
+    [editorViewRef, cwd, onDropSelect]
   );
 
   return { handleDragEnter, handleDragOver, handleDragLeave, handleDrop, isDragOverFiles };

--- a/src/components/Terminal/useTerminalFileTransfer.ts
+++ b/src/components/Terminal/useTerminalFileTransfer.ts
@@ -12,6 +12,7 @@ import {
   hasInternalFileDrag,
 } from "@/lib/fileDragPayload";
 import { formatAtFileTokenForCwd } from "./hybridInputParsing";
+import { usePanelStore } from "@/store/panelStore";
 
 /**
  * Image file extension pattern shared with HybridInputBar.
@@ -63,6 +64,15 @@ interface UseTerminalFileTransferOptions extends TerminalFileTransferIdentity {
   isInputLocked?: boolean;
   onInput?: (data: string) => void;
   /**
+   * Selects the panel that owns this terminal, invoked only once a drop has
+   * actually written something. The hook knows which *surface* was dropped on
+   * but not which panel owns it: `terminalId` is a PTY id, and the Assistant
+   * and the Dev Preview console both run one inside a panel they do not name.
+   * So panel selection is delegated to the caller and simply absent where
+   * there is no panel to select.
+   */
+  onDropSelect?: () => void;
+  /**
    * Reads the terminal's live cwd, called at gesture time so a `cd` between
    * mount and drop relativizes against where the terminal actually is.
    * Omitted (or empty) leaves every path absolute, which is what
@@ -108,6 +118,7 @@ export function useTerminalFileTransfer(
     terminalId,
     isInputLocked,
     onInput,
+    onDropSelect,
     cwdProvider,
     launchAgentId,
     detectedAgentId,
@@ -136,11 +147,16 @@ export function useTerminalFileTransfer(
   const isInputLockedRef = useRef(isInputLocked);
   const cwdProviderRef = useRef(cwdProvider);
   const isMountedRef = useRef(true);
+  // Rides the same ref as the rest: the owning pane rebuilds this callback on
+  // every render, and putting it in the listener effect's deps would tear down
+  // and re-register all five DOM listeners that often.
+  const onDropSelectRef = useRef(onDropSelect);
 
   useLayoutEffect(() => {
     identityRef.current = { launchAgentId, detectedAgentId, agentState };
     isInputLockedRef.current = isInputLocked;
     cwdProviderRef.current = cwdProvider;
+    onDropSelectRef.current = onDropSelect;
   });
 
   useLayoutEffect(() => {
@@ -263,6 +279,24 @@ export function useTerminalFileTransfer(
       // Trailing space terminates the last token and leaves the caret ready for
       // the next argument or prompt word, matching the hybrid input's drop.
       writeToTerminal(`${formatted.join(" ")} `, isAgent);
+
+      // The gesture already pointed at this terminal, so it ends the same way a
+      // click on it does: pane selected, keyboard here, ready to type about the
+      // paths that just landed (#11809). Once per accepted batch, and never for
+      // a drop the guards above discarded.
+      //
+      // Order matters. The preference is what `TerminalPane`'s focus effect
+      // reads to decide which sub-surface the newly selected pane hands the
+      // keyboard to, so leaving it on "hybridInput" would route the keyboard to
+      // the input bar even though the paths went to the PTY.
+      //
+      // xterm is focused directly rather than through the panel focus registry:
+      // the drop proves this wrapper is mounted, the target is unambiguously
+      // xterm, and the Assistant and Dev Preview consoles have no registry
+      // entry under their PTY id to route through in the first place.
+      usePanelStore.getState().setPreferredTerminalFocusTarget("xterm");
+      onDropSelectRef.current?.();
+      terminalInstanceService.focus(terminalId);
     };
 
     // Use capture phase for paste so we intercept before xterm's own handler


### PR DESCRIPTION
## Summary
- Dropping a file onto an agent terminal inserted the file reference but never selected the pane, since a `drop` event doesn't fire the `onClick` handler that normally selects it, so anything typed right after went to whichever pane already had focus.
- Both drop surfaces had this problem: the hybrid input box and the raw terminal.
- A successful drop now ends in the same state a click would: pane selected, keyboard focus on the surface the file actually landed on.

Resolves #11809

## Changes
- Dropping onto the hybrid input records `preferredTerminalFocusTarget: "hybridInput"`, selects the owning pane, and focuses the CodeMirror editor directly, so the caret lands right after the inserted chip.
- Dropping onto the terminal records `"xterm"`, selects the owning pane, and focuses the terminal.
- `useDragDrop.ts` and `useTerminalFileTransfer.ts` now take an optional `onDropSelect` callback instead of selecting a pane directly. Both hooks are shared with the assistant overlay (`HelpPanel`) and the dev preview console (`ConsoleDrawer`), which run terminals that aren't selectable grid panels, so deriving the selection from the terminal id inside the hooks would have pushed invalid ids into the global focus state. `TerminalPane` passes its own `handleClick`, `ConsoleDrawer` selects its own pane id, and the assistant passes nothing, deliberately keeping its focus pinned.
- The pane-selection commit happens the moment the drop lands, not after the file finishes inserting. Image drops wait on a thumbnail round trip before inserting, which is exactly the kind of slow drop a user has time to start typing during. Committing selection only after insertion would have left the bug in place for the slowest drops.
- Fleet-arming (shift/cmd click for multi-select) is unaffected: the pane click handler only triggers those gestures on a real mouse event, and drops call it with none.

## Known limitations
Confirmed pre-existing during review, not introduced here:
- Changing `preferredTerminalFocusTarget` while a grid pane is already selected re-runs that pane's focus effect. Clicking the assistant panel's terminal or its input box already causes the same refocus today, so drops don't introduce anything a click couldn't already trigger. A proper fix means reworking how pane focus responds to preference changes generally, a bigger change than this issue.
- A drop can land while a terminal instance is still being created asynchronously, in which case the focus call silently no-ops. `TerminalPane`'s own focus effect has the same limitation; a durable retry-on-attach mechanism is broader than this fix.

## Testing
- 920 tests pass across the terminal, dev preview, help panel, and hybrid input suites.
- `npm run typecheck` is clean.
- Lint and formatting are clean on changed files.
- Mutation check: removing the three-line selection commit from both hooks fails 16 tests, so the new coverage is catching a real regression, not vacuous.
- No e2e spec was added. No e2e currently exercises either drop surface, and simulating a real file drop needs actual `File` objects carrying OS paths for `webUtils.getPathForFile`, so a synthetic drop test would only exercise a hand-built `DataTransfer`, not the real gesture. High effort for low signal over the existing hook-level coverage.