### PR TITLE
feat(switcher): surface assistant presence for assistant-only projects

### DIFF
--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import os from "os";
 
 const ipcMainMock = vi.hoisted(() => ({
@@ -142,6 +142,7 @@ import { registerDeferredTask } from "../../../window/deferredInitQueue.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { createProjectCrudRegistrar } from "./helpers/projectCrudLifecycle.js";
+import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
 
 // Disposes the stats/fleet pollers after each test; see the helper for why
 // dropping the disposer is what produced this file's CI flake. Still returns
@@ -880,5 +881,88 @@ describe("bulk stats and acknowledgement for scratch workspaces", () => {
       lastCompletionSeenAt: 7_000,
     });
     expect(scratchStore.markCompletionSeen).not.toHaveBeenCalled();
+  });
+});
+
+describe("bulk stats assistant presence (#11806)", () => {
+  const PROJECT_ID = "b".repeat(64);
+  const HELP_TERMINAL_ID = "help-1";
+
+  function helpTerminal(over: Record<string, unknown> = {}) {
+    return {
+      id: HELP_TERMINAL_ID,
+      projectId: PROJECT_ID,
+      kind: "terminal",
+      launchAgentId: "daintree-assistant",
+      hasPty: true,
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The real availability store, because that is what decides `"help"` and
+    // this test exists to prove the seed reads the same verdict the push does.
+    getAgentAvailabilityStore().markAsHelp(HELP_TERMINAL_ID);
+  });
+
+  afterEach(() => {
+    // The store is a module singleton — a mark left behind would make every
+    // later test in this process treat that id as the assistant.
+    getAgentAvailabilityStore().unmarkAsHelp(HELP_TERMINAL_ID);
+  });
+
+  it("seeds the same assistant facts the pushed status map reports", async () => {
+    const ptyClient = makePtyClient({
+      getAllTerminalsAsync: vi
+        .fn()
+        .mockResolvedValue([
+          helpTerminal({ agentState: "waiting", waitingReason: "error", lastStateChange: 3_000 }),
+        ]),
+      getProjectStats: vi.fn().mockResolvedValue({
+        terminalCount: 1,
+        terminalTypes: { terminal: 1 },
+        processIds: [100],
+      }),
+    });
+    registerProjectCrudHandlers(makeDeps(ptyClient));
+
+    const result = (await getBulkStatsHandler()(fakeEvent, [PROJECT_ID])) as Record<
+      string,
+      {
+        assistantState?: string;
+        assistantWaitingReason?: string;
+        assistantStateSince?: number;
+        activeAgentCount: number;
+        waitingAgentCount: number;
+        processCount: number;
+      }
+    >;
+
+    const entry = result[PROJECT_ID]!;
+    expect(entry.assistantState).toBe("waiting");
+    expect(entry.assistantWaitingReason).toBe("error");
+    expect(entry.assistantStateSince).toBe(3_000);
+    // A seed that let the assistant into these would reintroduce exactly the
+    // seed-vs-push disagreement #10989 removed.
+    expect(entry.waitingAgentCount).toBe(0);
+    expect(entry.activeAgentCount).toBe(0);
+    expect(entry.processCount).toBe(0);
+  });
+
+  it("omits the assistant fields when the project has no live assistant", async () => {
+    const ptyClient = makePtyClient({
+      getAllTerminalsAsync: vi.fn().mockResolvedValue([]),
+    });
+    registerProjectCrudHandlers(makeDeps(ptyClient));
+
+    const result = (await getBulkStatsHandler()(fakeEvent, [PROJECT_ID])) as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(result[PROJECT_ID]).not.toHaveProperty("assistantState");
+    expect(result[PROJECT_ID]).not.toHaveProperty("assistantWaitingReason");
+    expect(result[PROJECT_ID]).not.toHaveProperty("assistantStateSince");
   });
 });

--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -143,6 +143,10 @@ import { projectStore } from "../../../services/ProjectStore.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { createProjectCrudRegistrar } from "./helpers/projectCrudLifecycle.js";
 import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
+import {
+  ASSISTANT_PROJECTION_PARITY,
+  PARITY_ASSISTANT_TERMINAL,
+} from "../../../services/__tests__/helpers/assistantProjectionParity.js";
 
 // Disposes the stats/fleet pollers after each test; see the helper for why
 // dropping the disposer is what produced this file's CI flake. Still returns
@@ -914,11 +918,7 @@ describe("bulk stats assistant presence (#11806)", () => {
 
   it("seeds the same assistant facts the pushed status map reports", async () => {
     const ptyClient = makePtyClient({
-      getAllTerminalsAsync: vi
-        .fn()
-        .mockResolvedValue([
-          helpTerminal({ agentState: "waiting", waitingReason: "error", lastStateChange: 3_000 }),
-        ]),
+      getAllTerminalsAsync: vi.fn().mockResolvedValue([helpTerminal(PARITY_ASSISTANT_TERMINAL)]),
       getProjectStats: vi.fn().mockResolvedValue({
         terminalCount: 1,
         terminalTypes: { terminal: 1 },
@@ -929,25 +929,22 @@ describe("bulk stats assistant presence (#11806)", () => {
 
     const result = (await getBulkStatsHandler()(fakeEvent, [PROJECT_ID])) as Record<
       string,
-      {
-        assistantState?: string;
-        assistantWaitingReason?: string;
-        assistantStateSince?: number;
-        activeAgentCount: number;
-        waitingAgentCount: number;
-        processCount: number;
-      }
+      Record<string, unknown>
     >;
 
     const entry = result[PROJECT_ID]!;
-    expect(entry.assistantState).toBe("waiting");
-    expect(entry.assistantWaitingReason).toBe("error");
-    expect(entry.assistantStateSince).toBe(3_000);
-    // A seed that let the assistant into these would reintroduce exactly the
-    // seed-vs-push disagreement #10989 removed.
-    expect(entry.waitingAgentCount).toBe(0);
-    expect(entry.activeAgentCount).toBe(0);
-    expect(entry.processCount).toBe(0);
+    // The same expectation `ProjectStatsService.adversarial.test.ts` asserts
+    // against the push producer for the same terminal — a seed that let the
+    // assistant into the worker counts, or dropped a presence field the push
+    // keeps, is the seed-vs-push disagreement #10989 removed.
+    expect({
+      assistantState: entry.assistantState,
+      assistantWaitingReason: entry.assistantWaitingReason,
+      assistantStateSince: entry.assistantStateSince,
+      activeAgentCount: entry.activeAgentCount,
+      waitingAgentCount: entry.waitingAgentCount,
+      processCount: entry.processCount,
+    }).toEqual(ASSISTANT_PROJECTION_PARITY);
   });
 
   it("omits the assistant fields when the project has no live assistant", async () => {

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -267,6 +267,17 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
           ...(counts.nextSnoozeWakeAt !== null
             ? { nextSnoozeWakeAt: counts.nextSnoozeWakeAt }
             : {}),
+          // Assistant presence, projected exactly as the pushed status map
+          // does (#11806). A seed that omitted it would render an
+          // assistant-only project as dormant until the next push moved
+          // something else — the same seed-vs-push disagreement as #10989.
+          ...(counts.assistantState !== null ? { assistantState: counts.assistantState } : {}),
+          ...(counts.assistantWaitingReason !== null
+            ? { assistantWaitingReason: counts.assistantWaitingReason }
+            : {}),
+          ...(counts.assistantStateSince !== null
+            ? { assistantStateSince: counts.assistantStateSince }
+            : {}),
           terminalMemoryMB: hasMeasured ? Math.round(measured!.memoryKb / 1024) : undefined,
           topProcess: top
             ? { name: top.comm, memoryMB: Math.round(top.memoryKb / 1024) }

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -171,7 +171,15 @@ export class ProjectStatsService {
         ea.latestCompletionAt !== eb.latestCompletionAt ||
         ea.latestWorkingSince !== eb.latestWorkingSince ||
         ea.snoozedAgentCount !== eb.snoozedAgentCount ||
-        ea.nextSnoozeWakeAt !== eb.nextSnoozeWakeAt
+        ea.nextSnoozeWakeAt !== eb.nextSnoozeWakeAt ||
+        // Assistant presence is compared here for the same reason every count
+        // above is: this gate decides whether a broadcast happens at all, so a
+        // field it doesn't know about can change without anyone hearing. An
+        // assistant that started working would sit invisible in an already-open
+        // switcher until some unrelated worker tally moved (#11806).
+        ea.assistantState !== eb.assistantState ||
+        ea.assistantWaitingReason !== eb.assistantWaitingReason ||
+        ea.assistantStateSince !== eb.assistantStateSince
       ) {
         return false;
       }
@@ -266,6 +274,16 @@ export class ProjectStatsService {
             snoozedAgentCount: counts.snoozed,
             ...(counts.nextSnoozeWakeAt !== null
               ? { nextSnoozeWakeAt: counts.nextSnoozeWakeAt }
+              : {}),
+            // Presence, carried beside the tallies and never inside them
+            // (#11806). The bulk stats handler projects these identically —
+            // the two paths answering differently is exactly #10989.
+            ...(counts.assistantState !== null ? { assistantState: counts.assistantState } : {}),
+            ...(counts.assistantWaitingReason !== null
+              ? { assistantWaitingReason: counts.assistantWaitingReason }
+              : {}),
+            ...(counts.assistantStateSince !== null
+              ? { assistantStateSince: counts.assistantStateSince }
               : {}),
           };
         }

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -39,6 +39,10 @@ vi.mock("../AgentAvailabilityStore.js", () => ({
 }));
 
 import { ProjectStatsService } from "../ProjectStatsService.js";
+import {
+  ASSISTANT_PROJECTION_PARITY,
+  PARITY_ASSISTANT_TERMINAL,
+} from "./helpers/assistantProjectionParity.js";
 
 type FakePtyClient = {
   getAllTerminalsAsync: ReturnType<typeof vi.fn>;
@@ -1022,11 +1026,62 @@ describe("ProjectStatsService assistant presence (#11806)", () => {
     svc.refresh();
     await vi.runAllTimersAsync();
     const firstCount = broadcastMock.mock.calls.length;
+    // The control. Without it this passes against a build that projects no
+    // assistant facts at all, proving only that two empty payloads are equal.
+    expect(lastPayload().p1.assistantWaitingReason).toBe("prompt");
 
     svc.refresh();
     await vi.runAllTimersAsync();
 
     expect(broadcastMock.mock.calls.length).toBe(firstCount);
+    svc.stop();
+  });
+
+  it("clears every assistant field when the assistant goes away", async () => {
+    // Starts from a fully-populated assistant so all three fields have
+    // something to lose — a fixture with no waiting reason cannot prove the
+    // reason is cleared.
+    const ptyClient = makePtyClient();
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      helpTerminal({ agentState: "waiting", waitingReason: "error", lastStateChange: 1_000 }),
+    ]);
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+    expect(lastPayload().p1.assistantWaitingReason).toBe("error");
+
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([]);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    expect(lastPayload().p1).not.toHaveProperty("assistantState");
+    expect(lastPayload().p1).not.toHaveProperty("assistantWaitingReason");
+    expect(lastPayload().p1).not.toHaveProperty("assistantStateSince");
+    svc.stop();
+  });
+
+  it("projects exactly the assistant subobject the bulk seed projects", async () => {
+    // The #10989 shape: two hand-written projections of the same reducer
+    // output. `project.bulkStats.test.ts` asserts this identical expectation
+    // against the other producer, so either one drifting fails its own suite.
+    const ptyClient = makePtyClient();
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([helpTerminal(PARITY_ASSISTANT_TERMINAL)]);
+    ptyClient.getProjectStats.mockResolvedValue({ projectId: "p1", terminalCount: 1 });
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const p1 = lastPayload().p1 as Record<string, unknown>;
+    expect({
+      assistantState: p1.assistantState,
+      assistantWaitingReason: p1.assistantWaitingReason,
+      assistantStateSince: p1.assistantStateSince,
+      activeAgentCount: p1.activeAgentCount,
+      waitingAgentCount: p1.waitingAgentCount,
+      processCount: p1.processCount,
+    }).toEqual(ASSISTANT_PROJECTION_PARITY);
     svc.stop();
   });
 });

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -891,3 +891,142 @@ describe("ProjectStatsService scratch workspaces", () => {
     svc.stop();
   });
 });
+
+describe("ProjectStatsService assistant presence (#11806)", () => {
+  function helpTerminal(over: Record<string, unknown> = {}) {
+    return {
+      id: "help-1",
+      projectId: "p1",
+      kind: "terminal",
+      launchAgentId: "daintree-assistant",
+      ...over,
+    };
+  }
+
+  function lastPayload() {
+    return broadcastMock.mock.calls.at(-1)![1] as Record<
+      string,
+      {
+        assistantState?: string;
+        assistantWaitingReason?: string;
+        assistantStateSince?: number;
+        activeAgentCount: number;
+        waitingAgentCount: number;
+        processCount: number;
+      }
+    >;
+  }
+
+  beforeEach(() => {
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+    availabilityMock.isHelpTerminal.mockImplementation((id: string) => id.startsWith("help"));
+  });
+
+  it("pushes the assistant's state while still keeping it out of every count", async () => {
+    const ptyClient = makePtyClient();
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      helpTerminal({ agentState: "working", lastStateChange: 1_000 }),
+    ]);
+    ptyClient.getProjectStats.mockResolvedValue({ projectId: "p1", terminalCount: 1 });
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const p1 = lastPayload().p1;
+    expect(p1.assistantState).toBe("working");
+    expect(p1.assistantStateSince).toBe(1_000);
+    expect(p1.activeAgentCount).toBe(0);
+    expect(p1.waitingAgentCount).toBe(0);
+    // Still netted out of the host's count — presence is not residency.
+    expect(p1.processCount).toBe(0);
+    svc.stop();
+  });
+
+  it("omits the assistant fields entirely when no assistant is live", async () => {
+    const ptyClient = makePtyClient();
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([]);
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    expect(lastPayload().p1).not.toHaveProperty("assistantState");
+    expect(lastPayload().p1).not.toHaveProperty("assistantWaitingReason");
+    expect(lastPayload().p1).not.toHaveProperty("assistantStateSince");
+    svc.stop();
+  });
+
+  // The change gate is hand-enumerated, so each field needs its own proof: one
+  // left out of `shallowEqual` would leave an already-open switcher showing
+  // stale assistant state until some unrelated worker tally happened to move.
+  it.each([
+    {
+      field: "assistantState",
+      before: { agentState: "working", lastStateChange: 1_000 },
+      after: { agentState: "waiting", lastStateChange: 1_000 },
+    },
+    {
+      field: "assistantWaitingReason",
+      before: { agentState: "waiting", waitingReason: "prompt", lastStateChange: 1_000 },
+      after: { agentState: "waiting", waitingReason: "error", lastStateChange: 1_000 },
+    },
+    {
+      field: "assistantStateSince",
+      before: { agentState: "waiting", waitingReason: "prompt", lastStateChange: 1_000 },
+      after: { agentState: "waiting", waitingReason: "prompt", lastStateChange: 2_000 },
+    },
+  ])("broadcasts when only $field changes", async ({ before, after }) => {
+    const ptyClient = makePtyClient();
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([helpTerminal(before)]);
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+    const firstCount = broadcastMock.mock.calls.length;
+
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([helpTerminal(after)]);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    expect(broadcastMock.mock.calls.length).toBeGreaterThan(firstCount);
+    svc.stop();
+  });
+
+  it("broadcasts the assistant going away so the row can stop reporting it", async () => {
+    const ptyClient = makePtyClient();
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      helpTerminal({ agentState: "working", lastStateChange: 1_000 }),
+    ]);
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+    expect(lastPayload().p1.assistantState).toBe("working");
+
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([]);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    expect(lastPayload().p1).not.toHaveProperty("assistantState");
+    svc.stop();
+  });
+
+  it("still suppresses a payload whose assistant state did not move", async () => {
+    const ptyClient = makePtyClient();
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      helpTerminal({ agentState: "waiting", waitingReason: "prompt", lastStateChange: 1_000 }),
+    ]);
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+    const firstCount = broadcastMock.mock.calls.length;
+
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    expect(broadcastMock.mock.calls.length).toBe(firstCount);
+    svc.stop();
+  });
+});

--- a/electron/services/__tests__/helpers/assistantProjectionParity.ts
+++ b/electron/services/__tests__/helpers/assistantProjectionParity.ts
@@ -1,0 +1,32 @@
+/**
+ * The one expectation both producers of assistant presence are held to.
+ *
+ * `ProjectStatsService` (the pushed status map) and `handleProjectGetBulkStats`
+ * (the palette's cold seed) each hand-write their own projection of the same
+ * `computeProjectAgentCounts` output. That duplication is exactly the shape of
+ * #10989, where the two answered "is this an agent?" independently and drifted
+ * — and because the push suppresses unchanged payloads, nothing corrected the
+ * disagreement until agent state next moved.
+ *
+ * Both suites assert this same object against {@link PARITY_ASSISTANT_TERMINAL},
+ * so either producer drifting fails its own file with a diff that names the
+ * field. Shared as a constant rather than duplicated because two copies of the
+ * expectation could drift in precisely the way it exists to catch.
+ */
+export const ASSISTANT_PROJECTION_PARITY = {
+  assistantState: "waiting",
+  assistantWaitingReason: "error",
+  assistantStateSince: 3_000,
+  // The assistant contributes to none of these. `processCount` is the host's
+  // raw terminal count minus the assistant PTY it already counted.
+  activeAgentCount: 0,
+  waitingAgentCount: 0,
+  processCount: 0,
+} as const;
+
+/** The terminal fields both suites must feed their producer to get the above. */
+export const PARITY_ASSISTANT_TERMINAL = {
+  agentState: "waiting",
+  waitingReason: "error",
+  lastStateChange: 3_000,
+} as const;

--- a/electron/services/__tests__/projectAgentCounts.test.ts
+++ b/electron/services/__tests__/projectAgentCounts.test.ts
@@ -148,9 +148,11 @@ describe("computeProjectAgentCounts", () => {
     const p1 = counts.get("p1")!;
     // #10989: the assistant is tooling-internal — it must never surface as an
     // agent, and callers subtract `helpTerminals` from the host's raw count.
+    // #11806: its state is reported alongside, never inside, those tallies.
     expect(p1.waiting).toBe(0);
     expect(p1.active).toBe(1);
     expect(p1.helpTerminals).toBe(1);
+    expect(p1.assistantState).toBe("waiting");
   });
 
   it("excludes trashed, dev-preview, PTY-less, and non-agent terminals", () => {
@@ -488,5 +490,162 @@ describe("computeProjectAgentCounts — snooze", () => {
     );
 
     expect(counts.get("p1")!.snoozed).toBe(0);
+  });
+});
+
+describe("computeProjectAgentCounts — assistant presence (#11806)", () => {
+  beforeEach(() => {
+    availabilityMock.isHelpTerminal.mockImplementation((id: string) => id.startsWith("help"));
+  });
+
+  it("carries the assistant's state, reason and transition without touching any tally", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [
+        agent({
+          id: "help",
+          agentState: "waiting",
+          waitingReason: "error",
+          lastStateChange: 5_000,
+        }),
+      ]
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.assistantState).toBe("waiting");
+    expect(p1.assistantWaitingReason).toBe("error");
+    expect(p1.assistantStateSince).toBe(5_000);
+    // The whole point: presence without membership. A project whose only
+    // terminal is the assistant still has nothing the user launched.
+    expect(p1.active + p1.waiting + p1.blocked + p1.completed + p1.snoozed).toBe(0);
+  });
+
+  it("reports nothing for a project with no live assistant", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "real", agentState: "working", lastStateChange: 1_000 })]
+    );
+
+    const p1 = counts.get("p1")!;
+    expect(p1.assistantState).toBeNull();
+    expect(p1.assistantWaitingReason).toBeNull();
+    expect(p1.assistantStateSince).toBeNull();
+  });
+
+  it("drops a waiting reason that outlived the state it belonged to", () => {
+    // A terminal record can keep the reason from a wait it has since left. A
+    // working assistant carrying a stale "error" would read as blocked on
+    // every row it reaches.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "help", agentState: "working", waitingReason: "error" })]
+    );
+
+    expect(counts.get("p1")!.assistantState).toBe("working");
+    expect(counts.get("p1")!.assistantWaitingReason).toBeNull();
+  });
+
+  it("refuses an unusable transition time rather than dating the state to epoch", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "help", agentState: "waiting", lastStateChange: 0 })]
+    );
+
+    expect(counts.get("p1")!.assistantStateSince).toBeNull();
+  });
+
+  it("stays silent for a trashed or dead assistant", () => {
+    // Both are already excluded from `helpTerminals`; reporting state for them
+    // would leave a killed assistant working forever on every other project's
+    // switcher.
+    const counts = computeProjectAgentCounts(
+      ["p1", "p2"],
+      [
+        agent({ id: "help-trashed", agentState: "working", isTrashed: true }),
+        agent({ id: "help-dead", projectId: "p2", agentState: "working", hasPty: false }),
+      ]
+    );
+
+    expect(counts.get("p1")!.assistantState).toBeNull();
+    expect(counts.get("p2")!.assistantState).toBeNull();
+  });
+
+  it("keeps each project's assistant to its own entry", () => {
+    const counts = computeProjectAgentCounts(
+      ["p1", "p2"],
+      [
+        agent({ id: "help-1", agentState: "working" }),
+        agent({ id: "help-2", projectId: "p2", agentState: "waiting", waitingReason: "prompt" }),
+      ]
+    );
+
+    expect(counts.get("p1")!.assistantState).toBe("working");
+    expect(counts.get("p2")!.assistantState).toBe("waiting");
+  });
+
+  it("picks the live session over a displaced one regardless of listing order", () => {
+    // `HelpSessionService` allows at most one assistant per project, but a
+    // replacement is provisioned while the old PTY is still being killed. The
+    // record still moving is the live one; order must not decide it.
+    const displaced = agent({ id: "help-old", agentState: "waiting", lastStateChange: 1_000 });
+    const live = agent({ id: "help-new", agentState: "working", lastStateChange: 2_000 });
+
+    const forward = computeProjectAgentCounts(["p1"], [displaced, live]);
+    const reverse = computeProjectAgentCounts(["p1"], [live, displaced]);
+
+    expect(forward.get("p1")!.assistantState).toBe("working");
+    expect(forward.get("p1")!.assistantStateSince).toBe(2_000);
+    expect(reverse.get("p1")!.assistantState).toBe("working");
+    expect(reverse.get("p1")!.assistantStateSince).toBe(2_000);
+    // Both are live PTYs, so both still have to be netted out of the process
+    // count even though only one speaks for the project.
+    expect(forward.get("p1")!.helpTerminals).toBe(2);
+  });
+
+  it("prefers the newest record when two assistants share a liveness rank", () => {
+    const older = agent({ id: "help-a", agentState: "waiting", lastStateChange: 1_000 });
+    const newer = agent({ id: "help-b", agentState: "waiting", lastStateChange: 9_000 });
+
+    expect(computeProjectAgentCounts(["p1"], [newer, older]).get("p1")!.assistantStateSince).toBe(
+      9_000
+    );
+    expect(computeProjectAgentCounts(["p1"], [older, newer]).get("p1")!.assistantStateSince).toBe(
+      9_000
+    );
+  });
+
+  it("resolves a dead heat by terminal id so the answer never depends on order", () => {
+    const a = agent({ id: "help-a", agentState: "waiting", waitingReason: "prompt" });
+    const b = agent({ id: "help-b", agentState: "waiting", waitingReason: "error" });
+
+    expect(computeProjectAgentCounts(["p1"], [a, b]).get("p1")!.assistantWaitingReason).toBe(
+      "prompt"
+    );
+    expect(computeProjectAgentCounts(["p1"], [b, a]).get("p1")!.assistantWaitingReason).toBe(
+      "prompt"
+    );
+  });
+
+  it("lets a settled assistant be spoken for by a working one", () => {
+    const settled = agent({ id: "help-a", agentState: "exited", lastStateChange: 9_000 });
+    const working = agent({ id: "help-b", agentState: "working", lastStateChange: 1_000 });
+
+    // Liveness outranks recency: a newer "exited" must not silence an older
+    // session that is genuinely still working.
+    expect(computeProjectAgentCounts(["p1"], [settled, working]).get("p1")!.assistantState).toBe(
+      "working"
+    );
+  });
+
+  it("reports a settled assistant faithfully rather than inventing an absence", () => {
+    // The reducer carries what is there; deciding that "idle" is not worth a
+    // status line belongs to the one renderer-side classifier, not here.
+    const counts = computeProjectAgentCounts(
+      ["p1"],
+      [agent({ id: "help", agentState: "idle", lastStateChange: 4_000 })]
+    );
+
+    expect(counts.get("p1")!.assistantState).toBe("idle");
+    expect(counts.get("p1")!.assistantStateSince).toBe(4_000);
   });
 });

--- a/electron/services/__tests__/projectAgentCounts.test.ts
+++ b/electron/services/__tests__/projectAgentCounts.test.ts
@@ -545,15 +545,6 @@ describe("computeProjectAgentCounts — assistant presence (#11806)", () => {
     expect(counts.get("p1")!.assistantWaitingReason).toBeNull();
   });
 
-  it("refuses an unusable transition time rather than dating the state to epoch", () => {
-    const counts = computeProjectAgentCounts(
-      ["p1"],
-      [agent({ id: "help", agentState: "waiting", lastStateChange: 0 })]
-    );
-
-    expect(counts.get("p1")!.assistantStateSince).toBeNull();
-  });
-
   it("stays silent for a trashed or dead assistant", () => {
     // Both are already excluded from `helpTerminals`; reporting state for them
     // would leave a killed assistant working forever on every other project's
@@ -614,17 +605,76 @@ describe("computeProjectAgentCounts — assistant presence (#11806)", () => {
     );
   });
 
-  it("resolves a dead heat by terminal id so the answer never depends on order", () => {
+  it("resolves a dead heat identically whichever way the terminals are listed", () => {
+    // The contract is permutation invariance, not which id happens to win —
+    // asserting the winner would pin an arbitrary tie-break rule in place.
     const a = agent({ id: "help-a", agentState: "waiting", waitingReason: "prompt" });
     const b = agent({ id: "help-b", agentState: "waiting", waitingReason: "error" });
 
-    expect(computeProjectAgentCounts(["p1"], [a, b]).get("p1")!.assistantWaitingReason).toBe(
-      "prompt"
-    );
-    expect(computeProjectAgentCounts(["p1"], [b, a]).get("p1")!.assistantWaitingReason).toBe(
-      "prompt"
-    );
+    const forward = computeProjectAgentCounts(["p1"], [a, b]).get("p1")!;
+    const reverse = computeProjectAgentCounts(["p1"], [b, a]).get("p1")!;
+
+    expect(forward.assistantWaitingReason).toBe(reverse.assistantWaitingReason);
+    expect(forward.assistantState).toBe(reverse.assistantState);
+    expect(forward.assistantStateSince).toBe(reverse.assistantStateSince);
   });
+
+  it("lets the newest session win a displacement even while the old one still reads working", () => {
+    // The displaced PTY keeps its last state until the kill lands, so an
+    // outgoing "working" would otherwise outrank the live session's real
+    // state and hide a blocked assistant behind a Running band.
+    const displaced = agent({
+      id: "help-old",
+      spawnedAt: 1_000,
+      agentState: "working",
+      lastStateChange: 5_000,
+    });
+    const live = agent({
+      id: "help-new",
+      spawnedAt: 9_000,
+      agentState: "waiting",
+      waitingReason: "error",
+      lastStateChange: 2_000,
+    });
+
+    for (const listing of [
+      [displaced, live],
+      [live, displaced],
+    ]) {
+      const p1 = computeProjectAgentCounts(["p1"], listing).get("p1")!;
+      expect(p1.assistantState).toBe("waiting");
+      expect(p1.assistantWaitingReason).toBe("error");
+    }
+  });
+
+  it("stays order-independent when a transition time is unusable", () => {
+    // Every comparison against NaN is false, so an unscreened one would leave
+    // whichever record arrived first as the winner.
+    const a = agent({ id: "help-a", agentState: "waiting", lastStateChange: Number.NaN });
+    const b = agent({ id: "help-b", agentState: "waiting", lastStateChange: 4_000 });
+
+    const forward = computeProjectAgentCounts(["p1"], [a, b]).get("p1")!;
+    const reverse = computeProjectAgentCounts(["p1"], [b, a]).get("p1")!;
+
+    expect(forward.assistantStateSince).toBe(reverse.assistantStateSince);
+    expect(forward.assistantStateSince).toBe(4_000);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1, 0])(
+    "refuses the unusable transition time %p",
+    (lastStateChange) => {
+      // An infinite or wildly-future stamp would read as a wait that began
+      // after every possible observation — permanently unseen, while the age
+      // beside it rendered "just now".
+      const counts = computeProjectAgentCounts(
+        ["p1"],
+        [agent({ id: "help", agentState: "waiting", lastStateChange })]
+      );
+
+      expect(counts.get("p1")!.assistantStateSince).toBeNull();
+      expect(counts.get("p1")!.assistantState).toBe("waiting");
+    }
+  );
 
   it("lets a settled assistant be spoken for by a working one", () => {
     const settled = agent({ id: "help-a", agentState: "exited", lastStateChange: 9_000 });

--- a/electron/services/__tests__/projectAgentCounts.test.ts
+++ b/electron/services/__tests__/projectAgentCounts.test.ts
@@ -614,6 +614,11 @@ describe("computeProjectAgentCounts — assistant presence (#11806)", () => {
     const forward = computeProjectAgentCounts(["p1"], [a, b]).get("p1")!;
     const reverse = computeProjectAgentCounts(["p1"], [b, a]).get("p1")!;
 
+    // The control: without it, two builds reporting nothing at all would also
+    // agree, and this would pass with the feature removed.
+    expect(forward.assistantState).toBe("waiting");
+    expect(["prompt", "error"]).toContain(forward.assistantWaitingReason);
+
     expect(forward.assistantWaitingReason).toBe(reverse.assistantWaitingReason);
     expect(forward.assistantState).toBe(reverse.assistantState);
     expect(forward.assistantStateSince).toBe(reverse.assistantStateSince);

--- a/electron/services/projectAgentCounts.ts
+++ b/electron/services/projectAgentCounts.ts
@@ -55,6 +55,27 @@ export interface ProjectAgentCounts {
    * subtract this from any process count they report (#10989).
    */
   helpTerminals: number;
+  /**
+   * What the live Daintree Assistant is doing, or null when this project has
+   * no live assistant PTY (#11806).
+   *
+   * Reported beside the tallies and never folded into them: the assistant is
+   * not a run the user launched, so it must not read as one. It is here at all
+   * because the `"help"` exclusion is what made a project whose assistant was
+   * working indistinguishable from a dormant one on every cross-project
+   * surface — the state was on the terminal record the whole time and simply
+   * went unread.
+   */
+  assistantState: AgentState | null;
+  /**
+   * Why the assistant is waiting. Null unless {@link assistantState} is
+   * `"waiting"` — a terminal record can carry a stale reason out of the state
+   * it belonged to, and a working assistant holding a leftover `"error"` would
+   * report as blocked.
+   */
+  assistantWaitingReason: WaitingReason | null;
+  /** The assistant's transition into {@link assistantState}, or null. */
+  assistantStateSince: number | null;
 }
 
 /**
@@ -82,10 +103,11 @@ export interface CountableTerminal {
 /**
  * Why a terminal is not a countable agent run, or null when it is one.
  *
- * Exported as a reason rather than a boolean because one caller has to act on
+ * Exported as a reason rather than a boolean because callers have to act on
  * the distinction: `"help"` is the assistant PTY, which the host already
  * tallied into `terminalCount` and which therefore has to be netted back out
- * (#10989), while every other reason is simply "not an agent".
+ * (#10989), and whose state is reported separately as presence (#11806).
+ * Every other reason is simply "not an agent", with nothing left to say.
  */
 export type RunExclusionReason = "trashed" | "help" | "dev-preview" | "no-pty" | "not-an-agent";
 
@@ -105,8 +127,9 @@ export function classifyRun(
   if (terminal.isTrashed) return "trashed";
 
   // The assistant help terminal is a real PTY but tooling-internal: it never
-  // counts as an agent, and is reported here only so callers can net it out of
-  // a process count the host already included it in.
+  // counts as an agent. Named rather than silently dropped so callers can net
+  // it out of a process count the host already included it in, and so its
+  // state can be carried as presence instead of vanishing (#11806).
   if (terminal.id !== undefined && isHelpTerminal(terminal.id)) return "help";
 
   if (terminal.kind === "dev-preview") return "dev-preview";
@@ -138,7 +161,51 @@ function empty(): ProjectAgentCounts {
     snoozed: 0,
     nextSnoozeWakeAt: null,
     helpTerminals: 0,
+    assistantState: null,
+    assistantWaitingReason: null,
+    assistantStateSince: null,
   };
+}
+
+/**
+ * Liveness rank for picking which assistant record speaks for a project.
+ * Lower wins: actively doing something, then waiting, then settled.
+ */
+function assistantLiveness(state: AgentState | undefined): number {
+  if (state === "working" || state === "directing") return 0;
+  if (state === "waiting") return 1;
+  return 2;
+}
+
+/**
+ * Whether `candidate` should replace `incumbent` as the project's reported
+ * assistant.
+ *
+ * `HelpSessionService` enforces at most one assistant PTY per project, so in
+ * steady state there is nothing to choose between. The window this exists for
+ * is displacement: a new backend is provisioned while the old one is still
+ * being killed, and for those moments two terminals answer to the same
+ * project. The newest transition wins that tie, because the record still
+ * moving is the live session and the one left behind is the corpse.
+ *
+ * Terminal id breaks a dead-heat so the answer can never depend on the order
+ * the host happened to list terminals in.
+ */
+function beatsIncumbent(
+  candidate: CountableTerminal,
+  incumbent: CountableTerminal | null
+): boolean {
+  if (incumbent === null) return true;
+
+  const candidateRank = assistantLiveness(candidate.agentState);
+  const incumbentRank = assistantLiveness(incumbent.agentState);
+  if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
+
+  const candidateSince = candidate.lastStateChange ?? 0;
+  const incumbentSince = incumbent.lastStateChange ?? 0;
+  if (candidateSince !== incumbentSince) return candidateSince > incumbentSince;
+
+  return (candidate.id ?? "") < (incumbent.id ?? "");
 }
 
 /**
@@ -179,6 +246,10 @@ export function computeProjectAgentCounts(
   for (const id of projectIds) counts.set(id, empty());
 
   const availability = getAgentAvailabilityStore();
+  // Which assistant terminal currently speaks for each project. Held aside
+  // rather than written straight into `counts` so the winner is decided by
+  // `beatsIncumbent` alone and never by which terminal happened to come first.
+  const assistantByProject = new Map<string, CountableTerminal>();
 
   for (const terminal of terminals) {
     if (!terminal.projectId) continue;
@@ -186,7 +257,15 @@ export function computeProjectAgentCounts(
     if (!entry) continue;
     const exclusion = classifyRun(terminal, (id) => availability.isHelpTerminal(id));
     if (exclusion === "help") {
-      if (terminal.hasPty !== false) entry.helpTerminals += 1;
+      // Same liveness gate the process-count netting uses: a help terminal
+      // with no PTY is a record, not a running assistant, and must neither be
+      // subtracted from the host's count nor speak for the project.
+      if (terminal.hasPty !== false) {
+        entry.helpTerminals += 1;
+        if (beatsIncumbent(terminal, assistantByProject.get(terminal.projectId) ?? null)) {
+          assistantByProject.set(terminal.projectId, terminal);
+        }
+      }
       continue;
     }
     if (exclusion !== null) continue;
@@ -261,6 +340,18 @@ export function computeProjectAgentCounts(
         }
       }
     }
+  }
+
+  // Assistant presence, written last so it can never be mistaken for a tally
+  // that accumulated alongside the worker states above.
+  for (const [projectId, assistant] of assistantByProject) {
+    const entry = counts.get(projectId);
+    if (!entry) continue;
+    entry.assistantState = assistant.agentState ?? null;
+    entry.assistantWaitingReason =
+      assistant.agentState === "waiting" ? (assistant.waitingReason ?? null) : null;
+    const since = assistant.lastStateChange;
+    entry.assistantStateSince = typeof since === "number" && since > 0 ? since : null;
   }
 
   return counts;

--- a/electron/services/projectAgentCounts.ts
+++ b/electron/services/projectAgentCounts.ts
@@ -98,6 +98,13 @@ export interface CountableTerminal {
   detectedAgentId?: string;
   launchAgentId?: string;
   everDetectedAgent?: boolean;
+  /**
+   * When this PTY was spawned. Read only to tell one assistant session from
+   * another during a displacement — `AgentStateService` already treats it as
+   * the live-session identity token, so it is the fact that says which of two
+   * overlapping records is the current one.
+   */
+  spawnedAt?: number;
 }
 
 /**
@@ -168,6 +175,18 @@ function empty(): ProjectAgentCounts {
 }
 
 /**
+ * A timestamp that can be compared and reported, or 0 when it cannot be.
+ *
+ * Zero, negatives, `NaN` and the infinities are all rejected together. `NaN`
+ * in particular has to be screened before any comparison: every comparison
+ * against it is false, so it would silently make "which record is newer"
+ * depend on the order the host happened to list terminals in.
+ */
+function usableTimestamp(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
  * Liveness rank for picking which assistant record speaks for a project.
  * Lower wins: actively doing something, then waiting, then settled.
  */
@@ -185,11 +204,17 @@ function assistantLiveness(state: AgentState | undefined): number {
  * steady state there is nothing to choose between. The window this exists for
  * is displacement: a new backend is provisioned while the old one is still
  * being killed, and for those moments two terminals answer to the same
- * project. The newest transition wins that tie, because the record still
- * moving is the live session and the one left behind is the corpse.
+ * project.
  *
- * Terminal id breaks a dead-heat so the answer can never depend on the order
- * the host happened to list terminals in.
+ * Spawn time decides it, because that is the fact that actually identifies the
+ * session — `AgentStateService` uses the same stamp to reject state updates
+ * from a superseded run. Liveness cannot lead here: a displaced PTY whose kill
+ * has not landed yet still reads `working`, so ranking activity first would let
+ * the corpse keep reporting over a new session that is genuinely blocked.
+ *
+ * The remaining tie-breaks only matter when spawn times are missing or equal,
+ * and terminal id closes the last gap, so the answer never depends on listing
+ * order.
  */
 function beatsIncumbent(
   candidate: CountableTerminal,
@@ -197,12 +222,16 @@ function beatsIncumbent(
 ): boolean {
   if (incumbent === null) return true;
 
+  const candidateSpawn = usableTimestamp(candidate.spawnedAt);
+  const incumbentSpawn = usableTimestamp(incumbent.spawnedAt);
+  if (candidateSpawn !== incumbentSpawn) return candidateSpawn > incumbentSpawn;
+
   const candidateRank = assistantLiveness(candidate.agentState);
   const incumbentRank = assistantLiveness(incumbent.agentState);
   if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
 
-  const candidateSince = candidate.lastStateChange ?? 0;
-  const incumbentSince = incumbent.lastStateChange ?? 0;
+  const candidateSince = usableTimestamp(candidate.lastStateChange);
+  const incumbentSince = usableTimestamp(incumbent.lastStateChange);
   if (candidateSince !== incumbentSince) return candidateSince > incumbentSince;
 
   return (candidate.id ?? "") < (incumbent.id ?? "");
@@ -350,8 +379,12 @@ export function computeProjectAgentCounts(
     entry.assistantState = assistant.agentState ?? null;
     entry.assistantWaitingReason =
       assistant.agentState === "waiting" ? (assistant.waitingReason ?? null) : null;
-    const since = assistant.lastStateChange;
-    entry.assistantStateSince = typeof since === "number" && since > 0 ? since : null;
+    // Same screen the selection used, so an unusable stamp can neither pick the
+    // winner nor be reported as one. An infinite or wildly-future value would
+    // read as a wait that began after every possible observation, holding the
+    // row in the attention band while the age beside it rendered "just now".
+    const since = usableTimestamp(assistant.lastStateChange);
+    entry.assistantStateSince = since > 0 ? since : null;
   }
 
   return counts;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -180,6 +180,7 @@ export type {
   ProjectStats,
   BulkProjectStatsEntry,
   BulkProjectStats,
+  AssistantPresenceEntry,
   ProjectStatusEntry,
   ProjectStatusMap,
   ForgeRateLimitKind,

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -1,7 +1,49 @@
 import type { Project, TerminalSnapshot } from "../project.js";
 import type { TabGroup } from "../panel.js";
+import type { AgentState, WaitingReason } from "../agent.js";
 import type { IdArrayDelta } from "../../utils/layoutMerge.js";
 import type { HydrateResult } from "./app.js";
+
+/**
+ * Live Daintree Assistant presence for one workspace — what the assistant is
+ * doing, not a run the user launched (#11806).
+ *
+ * Carried beside the worker tallies and never inside them. The assistant is a
+ * tooling-internal PTY: it is excluded from `activeAgentCount`,
+ * `waitingAgentCount` and `completedAgentCount`, netted out of `processCount`,
+ * and absent from the fleet run list. Before these fields existed that
+ * exclusion also made it invisible cross-project, so a project whose assistant
+ * was working read as dormant.
+ *
+ * Raw facts, deliberately: whether a given state means "present", "running" or
+ * "needs someone" is a presentation decision, and it is made in exactly one
+ * place on the renderer side (`classifyAssistantActivity`). Shipping the
+ * verdict instead would put that judgement in the producer and let the two
+ * drift, which is the whole failure mode #10989 came from.
+ */
+export interface AssistantPresenceEntry {
+  /**
+   * The assistant terminal's `agentState`. Absent when the workspace has no
+   * live assistant PTY. Settled states (`idle`, `completed`, `exited`) are
+   * reported as faithfully as live ones — the consumer decides which of them
+   * are worth a status line.
+   */
+  assistantState?: AgentState;
+  /**
+   * Why the assistant is waiting. Present only when
+   * {@link AssistantPresenceEntry.assistantState} is `"waiting"` — a terminal
+   * record can keep a stale reason after leaving the state, and a working
+   * assistant carrying a leftover `"error"` would read as blocked.
+   */
+  assistantWaitingReason?: WaitingReason;
+  /**
+   * Epoch ms of the assistant's transition into the reported state, so a wait
+   * can be aged and compared against when the user last had the project on
+   * screen. Absent when no transition has been recorded yet (a pre-detection
+   * boot window).
+   */
+  assistantStateSince?: number;
+}
 
 /**
  * Outgoing state passed alongside project switch/reopen IPC calls.
@@ -113,7 +155,7 @@ export interface ProjectStats {
 }
 
 /** Per-project entry in bulk stats response, includes agent counts */
-export interface BulkProjectStatsEntry extends ProjectStats {
+export interface BulkProjectStatsEntry extends ProjectStats, AssistantPresenceEntry {
   activeAgentCount: number;
   waitingAgentCount: number;
   /**
@@ -166,7 +208,7 @@ export interface BulkProjectStatsEntry extends ProjectStats {
 export type BulkProjectStats = Record<string, BulkProjectStatsEntry>;
 
 /** Minimal per-project status entry for push-based updates */
-export interface ProjectStatusEntry {
+export interface ProjectStatusEntry extends AssistantPresenceEntry {
   activeAgentCount: number;
   waitingAgentCount: number;
   processCount: number;

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -37,7 +37,14 @@ const {
   const projectStatsState = {
     stats: {} as Record<
       string,
-      { activeAgentCount: number; waitingAgentCount: number; processCount: number }
+      {
+        activeAgentCount: number;
+        waitingAgentCount: number;
+        processCount: number;
+        assistantState?: "idle" | "working" | "waiting" | "directing" | "completed" | "exited";
+        assistantWaitingReason?: "prompt" | "question" | "approval" | "error";
+        assistantStateSince?: number;
+      }
     >,
   };
 
@@ -1190,6 +1197,32 @@ describe("scratch agent-status join", () => {
     const row = scratchRow(result, "scratch-1");
     for (const field of STATS_FIELDS) expect(row[field]).toBe(0);
     expect(row.oldestWaitingSince).toBeUndefined();
+  });
+
+  it("carries assistant presence onto the row without touching its counts", async () => {
+    // A help session is provisioned against an opaque workspace id, so a
+    // scratch can host one. Its row projection is hand-written separately from
+    // the project one and would otherwise go unexercised.
+    seedScratches(1);
+    projectStatsState.stats = {
+      "scratch-1": {
+        activeAgentCount: 0,
+        waitingAgentCount: 0,
+        processCount: 0,
+        assistantState: "waiting",
+        assistantWaitingReason: "error",
+        assistantStateSince: 6_000,
+      },
+    };
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await waitFor(() => expect(result.current.scratchResults).toHaveLength(1));
+
+    const row = scratchRow(result, "scratch-1");
+    expect(row.assistantState).toBe("waiting");
+    expect(row.assistantWaitingReason).toBe("error");
+    expect(row.assistantStateSince).toBe(6_000);
+    for (const field of STATS_FIELDS) expect(row[field]).toBe(0);
   });
 
   it("carries the map's counts onto the row", async () => {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -3138,8 +3138,8 @@ describe("assistant presence banding (#11806)", () => {
     });
   });
 
-  it("never lets assistant presence inflate the worker tallies or the badge", async () => {
-    const result = await openWithStats({
+  it("never lets assistant presence reach the tray badge", async () => {
+    const assistantOnly = await openWithStats({
       ...idle,
       assistantState: "waiting",
       assistantWaitingReason: "error",
@@ -3147,16 +3147,27 @@ describe("assistant presence banding (#11806)", () => {
     });
 
     await waitFor(() => {
-      const row = asProject(result.current.results[0]);
-      expect(row.activeAgentCount).toBe(0);
-      expect(row.waitingAgentCount).toBe(0);
-      expect(row.blockedAgentCount).toBe(0);
+      // The row IS escalated — so the zeros below are the badge declining to
+      // count it, not the fixture simply being empty.
+      expect(asProject(assistantOnly.current.results[0]).section).toBe("attention");
     });
-    // The tray/toolbar badge answers "how many places are waiting on me?" —
-    // the assistant is not an interruption the user is owed.
-    expect(result.current.nonActiveAgentCounts.waitingAgentCount).toBe(0);
-    expect(result.current.nonActiveAgentCounts.waitingProjectCount).toBe(0);
-    expect(result.current.nonActiveAgentCounts.activeAgentCount).toBe(0);
+    // The badge answers "how many places are waiting on me?" — the assistant
+    // is not an interruption the user is owed.
+    expect(assistantOnly.current.nonActiveAgentCounts.waitingAgentCount).toBe(0);
+    expect(assistantOnly.current.nonActiveAgentCounts.waitingProjectCount).toBe(0);
+    expect(assistantOnly.current.nonActiveAgentCounts.activeAgentCount).toBe(0);
+
+    // The control: the same badge does count a real worker, so the machinery
+    // under test is live rather than inert.
+    const withWorker = await openWithStats({
+      ...idle,
+      waitingAgentCount: 1,
+      assistantState: "working",
+    });
+    await waitFor(() => {
+      expect(withWorker.current.nonActiveAgentCounts.waitingAgentCount).toBe(1);
+    });
+    expect(withWorker.current.nonActiveAgentCounts.waitingProjectCount).toBe(1);
   });
 
   it("carries the assistant fields off the push store onto the row", async () => {
@@ -3181,7 +3192,8 @@ describe("assistant presence banding (#11806)", () => {
     getBulkStatsMock.mockResolvedValue({
       "project-1": {
         ...emptyBulkStats(["project-1"])["project-1"],
-        assistantState: "working",
+        assistantState: "waiting",
+        assistantWaitingReason: "approval",
         assistantStateSince: 7_000,
       },
     });
@@ -3195,7 +3207,8 @@ describe("assistant presence banding (#11806)", () => {
       expect(setStatsMock).toHaveBeenCalled();
     });
     const seeded = setStatsMock.mock.calls.at(-1)![0] as typeof projectStatsState.stats;
-    expect(seeded["project-1"]!.assistantState).toBe("working");
+    expect(seeded["project-1"]!.assistantState).toBe("waiting");
+    expect(seeded["project-1"]!.assistantWaitingReason).toBe("approval");
     expect(seeded["project-1"]!.assistantStateSince).toBe(7_000);
   });
 
@@ -3222,6 +3235,127 @@ describe("assistant presence banding (#11806)", () => {
 
     await waitFor(() => {
       expect(asProject(result.current.results[0]).section).toBe("attention");
+    });
+  });
+
+  describe("ordering", () => {
+    const THREE: ProjectFixture[] = [
+      {
+        id: "p-a",
+        name: "Alpha",
+        path: "/a",
+        emoji: "🌲",
+        lastOpened: LAST_OPENED,
+        status: "background",
+      },
+      {
+        id: "p-b",
+        name: "Bravo",
+        path: "/b",
+        emoji: "🌲",
+        lastOpened: LAST_OPENED,
+        status: "background",
+      },
+      {
+        id: "p-c",
+        name: "Charlie",
+        path: "/c",
+        emoji: "🌲",
+        lastOpened: LAST_OPENED,
+        status: "background",
+      },
+    ];
+
+    async function openWithMany(stats: Record<string, (typeof projectStatsState.stats)[string]>) {
+      projectState.projects = THREE;
+      projectStatsState.stats = stats;
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(["p-a", "p-b", "p-c"]));
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open();
+      });
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+      return result;
+    }
+
+    it("sorts a blocked assistant above an unseen wait above a completion", async () => {
+      const result = await openWithMany({
+        "p-a": {
+          ...idle,
+          unacknowledgedCompletedAgentCount: 1,
+          oldestUnacknowledgedCompletionAt: 1,
+        },
+        "p-b": {
+          ...idle,
+          assistantState: "waiting",
+          assistantWaitingReason: "prompt",
+          assistantStateSince: LAST_OPENED + 60_000,
+        },
+        "p-c": { ...idle, assistantState: "waiting", assistantWaitingReason: "error" },
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.every((r) => asProject(r).section === "attention")).toBe(
+          true
+        );
+      });
+      expect(result.current.results.map((r) => r.id)).toEqual(["p-c", "p-b", "p-a"]);
+    });
+
+    it("puts the assistant stuck longest at the top of the unseen-wait tier", async () => {
+      const result = await openWithMany({
+        "p-a": { ...idle, assistantState: "waiting", assistantStateSince: LAST_OPENED + 60_000 },
+        "p-b": { ...idle, assistantState: "waiting", assistantStateSince: LAST_OPENED + 10_000 },
+        "p-c": { ...idle, assistantState: "waiting", assistantStateSince: LAST_OPENED + 30_000 },
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+      // Oldest wait first — the one nobody has come for the longest.
+      expect(result.current.results.map((r) => r.id)).toEqual(["p-b", "p-c", "p-a"]);
+    });
+
+    it("keeps a project with real workers above an assistant-only one in Running", async () => {
+      // Charlie is the NEWER assistant but the later name, so a build without
+      // the assistant fallback would tie both at zero and sort them
+      // alphabetically — the two orders differ, which is what makes this bite.
+      const result = await openWithMany({
+        "p-a": { ...idle, assistantState: "working", assistantStateSince: 5_000 },
+        "p-b": { ...idle, activeAgentCount: 1, latestWorkingSince: 1_000 },
+        "p-c": { ...idle, assistantState: "working", assistantStateSince: 9_000 },
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.every((r) => asProject(r).section === "running")).toBe(true);
+      });
+      // Worker first, then the assistant-only rows newest-active first — which
+      // is only possible if the assistant supplies the ordering timestamp.
+      expect(result.current.results.map((r) => r.id)).toEqual(["p-b", "p-c", "p-a"]);
+    });
+
+    it("orders an attention row by its worker's wait when it has both", async () => {
+      // The line and the tier both resolve to the worker, so the clock must too
+      // — dating the row by the assistant would sort it by a reason it never
+      // states.
+      const result = await openWithMany({
+        "p-a": { ...idle, waitingAgentCount: 1, oldestWaitingSince: LAST_OPENED + 90_000 },
+        "p-b": {
+          ...idle,
+          waitingAgentCount: 1,
+          oldestWaitingSince: LAST_OPENED + 95_000,
+          assistantState: "waiting",
+          assistantStateSince: LAST_OPENED + 1,
+        },
+        "p-c": { ...idle, waitingAgentCount: 1, oldestWaitingSince: LAST_OPENED + 80_000 },
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+      expect(result.current.results.map((r) => r.id)).toEqual(["p-c", "p-a", "p-b"]);
     });
   });
 

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -52,6 +52,9 @@ const {
         latestWorkingSince?: number;
         snoozedAgentCount?: number;
         nextSnoozeWakeAt?: number;
+        assistantState?: "idle" | "working" | "waiting" | "directing" | "completed" | "exited";
+        assistantWaitingReason?: "prompt" | "question" | "approval" | "error";
+        assistantStateSince?: number;
         processCount: number;
       }
     >,
@@ -3024,6 +3027,215 @@ describe("useProjectSwitcherPalette", () => {
       expect(byId.get("unknown")).toBeUndefined();
       expect(byId.get("zero")).toBe(0);
       expect(byId.get("some")).toBe(3);
+    });
+  });
+});
+
+describe("assistant presence banding (#11806)", () => {
+  // Well in the past, so a wait stamped after it counts as unseen and one
+  // stamped before it counts as already looked at.
+  const LAST_OPENED = 1_000_000;
+
+  const assistantProjects: ProjectFixture[] = [
+    {
+      id: "project-1",
+      name: "Project One",
+      path: "/repo/one",
+      emoji: "🌲",
+      lastOpened: LAST_OPENED,
+      frecencyScore: 3.0,
+      status: "background",
+    },
+  ];
+
+  let savedProjects: typeof projectState.projects;
+
+  beforeEach(() => {
+    savedProjects = projectState.projects;
+    projectState.projects = assistantProjects;
+    vi.clearAllMocks();
+    projectState.currentProject = null;
+    projectStatsState.stats = {};
+    getBulkStatsMock.mockResolvedValue(emptyBulkStats(["project-1"]));
+    setStatsMock.mockImplementation((stats: typeof projectStatsState.stats) => {
+      projectStatsState.stats = stats;
+    });
+    usePaletteStore.setState({ activePaletteId: null });
+  });
+
+  afterEach(() => {
+    projectState.projects = savedProjects;
+  });
+
+  async function openWithStats(stats: (typeof projectStatsState.stats)[string]) {
+    projectStatsState.stats = { "project-1": stats };
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+    act(() => {
+      result.current.open();
+    });
+    await waitFor(() => {
+      expect(result.current.results).toHaveLength(1);
+    });
+    return result;
+  }
+
+  const idle = { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 };
+
+  it("lifts a project whose only live thing is a working assistant into Running", async () => {
+    const result = await openWithStats({ ...idle, assistantState: "working" });
+
+    await waitFor(() => {
+      expect(asProject(result.current.results[0]).section).toBe("running");
+    });
+  });
+
+  it("leaves it dormant when the assistant is idle", async () => {
+    const result = await openWithStats({ ...idle, assistantState: "idle" });
+
+    await waitFor(() => {
+      expect(asProject(result.current.results[0]).section).toBe("other");
+    });
+  });
+
+  it("keeps an assistant parked at its prompt out of Needs attention", async () => {
+    // Its resting state. A band that fills up with these stops meaning
+    // anything, which is the whole point of the restraint.
+    const result = await openWithStats({
+      ...idle,
+      assistantState: "waiting",
+      assistantWaitingReason: "prompt",
+      assistantStateSince: LAST_OPENED - 60_000,
+    });
+
+    await waitFor(() => {
+      expect(asProject(result.current.results[0]).section).toBe("other");
+    });
+  });
+
+  it("escalates a wait that started after the user was last in the project", async () => {
+    const result = await openWithStats({
+      ...idle,
+      assistantState: "waiting",
+      assistantWaitingReason: "prompt",
+      assistantStateSince: LAST_OPENED + 60_000,
+    });
+
+    await waitFor(() => {
+      expect(asProject(result.current.results[0]).section).toBe("attention");
+    });
+  });
+
+  it("escalates an errored assistant however recently the project was seen", async () => {
+    const result = await openWithStats({
+      ...idle,
+      assistantState: "waiting",
+      assistantWaitingReason: "error",
+      assistantStateSince: LAST_OPENED - 60_000,
+    });
+
+    await waitFor(() => {
+      expect(asProject(result.current.results[0]).section).toBe("attention");
+    });
+  });
+
+  it("never lets assistant presence inflate the worker tallies or the badge", async () => {
+    const result = await openWithStats({
+      ...idle,
+      assistantState: "waiting",
+      assistantWaitingReason: "error",
+      assistantStateSince: LAST_OPENED + 60_000,
+    });
+
+    await waitFor(() => {
+      const row = asProject(result.current.results[0]);
+      expect(row.activeAgentCount).toBe(0);
+      expect(row.waitingAgentCount).toBe(0);
+      expect(row.blockedAgentCount).toBe(0);
+    });
+    // The tray/toolbar badge answers "how many places are waiting on me?" —
+    // the assistant is not an interruption the user is owed.
+    expect(result.current.nonActiveAgentCounts.waitingAgentCount).toBe(0);
+    expect(result.current.nonActiveAgentCounts.waitingProjectCount).toBe(0);
+    expect(result.current.nonActiveAgentCounts.activeAgentCount).toBe(0);
+  });
+
+  it("carries the assistant fields off the push store onto the row", async () => {
+    const result = await openWithStats({
+      ...idle,
+      assistantState: "waiting",
+      assistantWaitingReason: "question",
+      assistantStateSince: 4_242,
+    });
+
+    await waitFor(() => {
+      const row = asProject(result.current.results[0]);
+      expect(row.assistantState).toBe("waiting");
+      expect(row.assistantWaitingReason).toBe("question");
+      expect(row.assistantStateSince).toBe(4_242);
+    });
+  });
+
+  it("seeds the assistant fields from bulk stats when no push has landed", async () => {
+    // The cold-start path. A seed that dropped these would render an
+    // assistant-only project as dormant until some unrelated tally moved.
+    getBulkStatsMock.mockResolvedValue({
+      "project-1": {
+        ...emptyBulkStats(["project-1"])["project-1"],
+        assistantState: "working",
+        assistantStateSince: 7_000,
+      },
+    });
+
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+    act(() => {
+      result.current.open();
+    });
+
+    await waitFor(() => {
+      expect(setStatsMock).toHaveBeenCalled();
+    });
+    const seeded = setStatsMock.mock.calls.at(-1)![0] as typeof projectStatsState.stats;
+    expect(seeded["project-1"]!.assistantState).toBe("working");
+    expect(seeded["project-1"]!.assistantStateSince).toBe(7_000);
+  });
+
+  it("keeps a pinned project pinned when its assistant is merely working", async () => {
+    // Same rule a running worker gets: an explicit pin outranks the
+    // operational fact that something is executing.
+    projectState.projects = [{ ...assistantProjects[0]!, pinned: true }];
+
+    const result = await openWithStats({ ...idle, assistantState: "working" });
+
+    await waitFor(() => {
+      expect(asProject(result.current.results[0]).section).toBe("pinned");
+    });
+  });
+
+  it("still escalates a pinned project whose assistant is blocked", async () => {
+    projectState.projects = [{ ...assistantProjects[0]!, pinned: true }];
+
+    const result = await openWithStats({
+      ...idle,
+      assistantState: "waiting",
+      assistantWaitingReason: "error",
+    });
+
+    await waitFor(() => {
+      expect(asProject(result.current.results[0]).section).toBe("attention");
+    });
+  });
+
+  it("leaves the current project in its own band whatever its assistant is doing", async () => {
+    projectState.currentProject = { id: "project-1" };
+
+    const result = await openWithStats({
+      ...idle,
+      assistantState: "waiting",
+      assistantWaitingReason: "error",
+    });
+
+    await waitFor(() => {
+      expect(asProject(result.current.results[0]).section).toBe("current");
     });
   });
 });

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -3336,6 +3336,29 @@ describe("assistant presence banding (#11806)", () => {
       expect(result.current.results.map((r) => r.id)).toEqual(["p-b", "p-c", "p-a"]);
     });
 
+    it("keeps the clock on an undated worker wait rather than borrowing the assistant's", async () => {
+      // A worker wait with no recorded transition is still what the tier and
+      // the line name. Bravo would jump to the front on the assistant's very
+      // old stamp if the clock fell through to it.
+      const result = await openWithMany({
+        "p-a": { ...idle, waitingAgentCount: 1, oldestWaitingSince: LAST_OPENED + 50_000 },
+        "p-b": {
+          ...idle,
+          waitingAgentCount: 1,
+          assistantState: "waiting",
+          assistantWaitingReason: "error",
+          assistantStateSince: 1,
+        },
+        "p-c": { ...idle, waitingAgentCount: 1, oldestWaitingSince: LAST_OPENED + 20_000 },
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+      // Dated waits first, oldest-first; the undated one sorts last.
+      expect(result.current.results.map((r) => r.id)).toEqual(["p-c", "p-a", "p-b"]);
+    });
+
     it("orders an attention row by its worker's wait when it has both", async () => {
       // The line and the tier both resolve to the worker, so the clock must too
       // — dating the row by the assistant would sort it by a reason it never

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -535,7 +535,14 @@ function attentionClass(project: SearchableProject): number {
  * clock, matching the tier and the line it will actually show.
  */
 function waitOrderingSince(project: SearchableProject): number {
-  if (project.oldestWaitingSince !== undefined) return project.oldestWaitingSince;
+  // Gated on the counts, not on whether a timestamp arrived. A worker wait
+  // whose transition was never recorded is still a worker wait — it is what
+  // the tier and the line both name — so it has to keep the clock even though
+  // it cannot supply one. Reading the timestamp first let such a row borrow the
+  // assistant's, dating it by something it never mentions.
+  if (project.waitingAgentCount > 0 || project.blockedAgentCount > 0) {
+    return project.oldestWaitingSince ?? Number.POSITIVE_INFINITY;
+  }
   if (!assistantNeedsAttention(classifyAssistantActivity(project))) {
     return Number.POSITIVE_INFINITY;
   }

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -14,7 +14,9 @@ import { closeAndAnnounce } from "@/lib/accessibility";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { logError } from "@/utils/logger";
 import type { Project, Scratch } from "@shared/types";
+import type { AgentState, WaitingReason } from "@shared/types/agent";
 import type { ProjectStatusMap } from "@shared/types/ipc/project";
+import { assistantNeedsAttention, classifyAssistantActivity } from "@/lib/projectAssistantActivity";
 import { decayFrecencyScore, FRECENCY_COLD_START } from "@shared/utils/frecency";
 import { projectClient, scratchClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -58,6 +60,28 @@ export interface WorkspaceRowStatusFields {
    */
   nextSnoozeWakeAt?: number;
   processCount: number;
+  /**
+   * What the live Daintree Assistant is doing, absent when there is no live
+   * assistant here (#11806). Raw state, not a verdict — `classifyAssistantActivity`
+   * is the one place that decides what it means, so the band, the ordering and
+   * the status line cannot disagree about it.
+   *
+   * Never a member of the counts above. The assistant is not a run the user
+   * launched, and folding it in would make every worker tally a lie.
+   */
+  assistantState?: AgentState;
+  /** Why the assistant is waiting; only ever set alongside a `waiting` state. */
+  assistantWaitingReason?: WaitingReason;
+  /** The assistant's transition into its current state, absent when unrecorded. */
+  assistantStateSince?: number;
+  /**
+   * When the user last had this workspace as their current one — stamped both
+   * on arrival and on departure, so it dates the last time they actually had
+   * it on screen. Shared by both kinds because both can host an assistant, and
+   * it is what decides whether a wait has gone unseen.
+   */
+  lastOpened: number;
+  isActive: boolean;
 }
 
 /** Lightweight searchable scratch view-model for the palette section. */
@@ -66,8 +90,6 @@ export interface SearchableScratch extends WorkspaceRowStatusFields {
   name: string;
   path: string;
   createdAt: number;
-  lastOpened: number;
-  isActive: boolean;
 }
 
 /**
@@ -157,7 +179,6 @@ export interface SearchableProject extends WorkspaceRowStatusFields {
   path: string;
   emoji: string;
   color?: string;
-  lastOpened: number;
   status: Project["status"];
   /** Set when the project was auto-closed by the background-idle sweep (#10830). */
   autoParkedAt?: number;
@@ -168,7 +189,6 @@ export interface SearchableProject extends WorkspaceRowStatusFields {
    * which is an answer.
    */
   resumableAgentCount?: number;
-  isActive: boolean;
   isBackground: boolean;
   isMissing: boolean;
   isPinned: boolean;
@@ -450,19 +470,28 @@ function resortOtherBand(
  *   stays in Pinned; its status line still says "Agent running".
  * - `running` requires live agents. Bare leftover processes are residency, not
  *   intent — those projects fall through to Pinned/Other.
+ *
+ * The assistant joins both ends of that without joining any tally (#11806). A
+ * working assistant is live activity, so it earns Running the same way a
+ * worker does; an assistant that is blocked or has been waiting since before
+ * the user last looked is someone waiting on nobody, so it earns attention. An
+ * assistant merely parked at its prompt earns neither — it still gets a status
+ * line where it lands, exactly as a project with only bare processes does.
  */
 function sectionForProject(project: SearchableProject): ProjectSectionKey {
   if (project.isActive) return "current";
   if (project.isMissing) return "unavailable";
+  const assistant = classifyAssistantActivity(project);
   if (
     project.waitingAgentCount > 0 ||
     project.blockedAgentCount > 0 ||
-    project.unacknowledgedCompletedAgentCount > 0
+    project.unacknowledgedCompletedAgentCount > 0 ||
+    assistantNeedsAttention(assistant)
   ) {
     return "attention";
   }
   if (project.isPinned) return "pinned";
-  if (project.activeAgentCount > 0) return "running";
+  if (project.activeAgentCount > 0 || assistant === "working") return "running";
   // Last stop before the residual band. Below `pinned` and `running` for the
   // same reason a pinned running project stays in Pinned: snooze withdraws a
   // demand, it does not override an explicit pin or the fact that something is
@@ -476,11 +505,44 @@ function sectionForProject(project: SearchableProject): ProjectSectionKey {
  * Severity tier inside the attention band: blocked outranks waiting outranks
  * ready-for-review. Blocked agents may not restart on input; waiting agents
  * are stalled on the user; completed agents are done and can wait their turn.
+ *
+ * An escalated assistant is tiered by the same rule rather than given one of
+ * its own: a blocked assistant is a blocked thing and an unseen wait is a
+ * wait. Without this a project escalated purely by its assistant would fall to
+ * the review tier and sort below completions it has nothing to do with.
  */
 function attentionClass(project: SearchableProject): number {
-  if (project.blockedAgentCount > 0) return 0;
-  if (project.waitingAgentCount > 0) return 1;
+  const assistant = classifyAssistantActivity(project);
+  if (project.blockedAgentCount > 0 || assistant === "blocked") return 0;
+  if (project.waitingAgentCount > 0 || assistant === "waiting-unseen") return 1;
   return 2;
+}
+
+/**
+ * The transition that dates a row's wait, whichever kind of wait it has.
+ *
+ * Assistant-only rows have no `oldestWaitingSince`, so without this they would
+ * all tie at infinity and fall through to an ordering that has nothing to do
+ * with how long anyone has been stuck.
+ */
+function waitOrderingSince(project: SearchableProject): number {
+  const worker = project.oldestWaitingSince;
+  const assistant = assistantNeedsAttention(classifyAssistantActivity(project))
+    ? project.assistantStateSince
+    : undefined;
+  if (worker === undefined) return assistant ?? Number.POSITIVE_INFINITY;
+  if (assistant === undefined) return worker;
+  return Math.min(worker, assistant);
+}
+
+/**
+ * The transition that orders a row inside the Running band. Falls back to the
+ * assistant's own so assistant-only rows are ordered by how recently they came
+ * alive, rather than tying at zero and sorting on unrelated recency.
+ */
+function runningOrderingSince(project: SearchableProject): number {
+  if (project.latestWorkingSince !== undefined) return project.latestWorkingSince;
+  return classifyAssistantActivity(project) === "working" ? (project.assistantStateSince ?? 0) : 0;
 }
 
 /**
@@ -521,8 +583,8 @@ function compareWithinSection(
       if (a.blockedAgentCount !== b.blockedAgentCount) {
         return b.blockedAgentCount - a.blockedAgentCount;
       }
-      const aSince = a.oldestWaitingSince ?? Number.POSITIVE_INFINITY;
-      const bSince = b.oldestWaitingSince ?? Number.POSITIVE_INFINITY;
+      const aSince = waitOrderingSince(a);
+      const bSince = waitOrderingSince(b);
       if (aSince !== bSince) return aSince - bSince;
       if (a.waitingAgentCount !== b.waitingAgentCount) {
         return b.waitingAgentCount - a.waitingAgentCount;
@@ -539,8 +601,8 @@ function compareWithinSection(
     if (a.activeAgentCount !== b.activeAgentCount) {
       return b.activeAgentCount - a.activeAgentCount;
     }
-    const aWorking = a.latestWorkingSince ?? 0;
-    const bWorking = b.latestWorkingSince ?? 0;
+    const aWorking = runningOrderingSince(a);
+    const bWorking = runningOrderingSince(b);
     if (aWorking !== bWorking) return bWorking - aWorking;
   } else if (section === "other") {
     // `frecencyScore` is already read-time decayed here (see `searchableProjects`),
@@ -733,6 +795,15 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
               ...(entry.nextSnoozeWakeAt !== undefined
                 ? { nextSnoozeWakeAt: entry.nextSnoozeWakeAt }
                 : {}),
+              ...(entry.assistantState !== undefined
+                ? { assistantState: entry.assistantState }
+                : {}),
+              ...(entry.assistantWaitingReason !== undefined
+                ? { assistantWaitingReason: entry.assistantWaitingReason }
+                : {}),
+              ...(entry.assistantStateSince !== undefined
+                ? { assistantStateSince: entry.assistantStateSince }
+                : {}),
               processCount: entry.processCount,
             };
             changed = true;
@@ -805,6 +876,9 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         snoozedAgentCount: stats?.snoozedAgentCount ?? 0,
         nextSnoozeWakeAt: stats?.nextSnoozeWakeAt,
         processCount: stats?.processCount ?? 0,
+        assistantState: stats?.assistantState,
+        assistantWaitingReason: stats?.assistantWaitingReason,
+        assistantStateSince: stats?.assistantStateSince,
         displayPath: displayPathById.get(p.id) ?? p.path,
         section: "other",
       };
@@ -1069,6 +1143,12 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         snoozedAgentCount: stats?.snoozedAgentCount ?? 0,
         nextSnoozeWakeAt: stats?.nextSnoozeWakeAt,
         processCount: stats?.processCount ?? 0,
+        // A scratch can host an assistant too — the session is provisioned
+        // against an opaque workspace id — so it gets the same status line. It
+        // never gets a band: scratches live in the pinned section regardless.
+        assistantState: stats?.assistantState,
+        assistantWaitingReason: stats?.assistantWaitingReason,
+        assistantStateSince: stats?.assistantStateSince,
       };
     });
     list.sort((a, b) => b.lastOpened - a.lastOpened);

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -510,11 +510,19 @@ function sectionForProject(project: SearchableProject): ProjectSectionKey {
  * its own: a blocked assistant is a blocked thing and an unseen wait is a
  * wait. Without this a project escalated purely by its assistant would fall to
  * the review tier and sort below completions it has nothing to do with.
+ *
+ * Consulted only once no worker is asking, because the status line resolves
+ * the same contest that way. A row tiered as blocked by its assistant while
+ * its line reads "Agent needs input" would be sorted by a reason it never
+ * states — the row would look mis-ranked, and the explanation would be
+ * invisible.
  */
 function attentionClass(project: SearchableProject): number {
+  if (project.blockedAgentCount > 0) return 0;
+  if (project.waitingAgentCount > 0) return 1;
   const assistant = classifyAssistantActivity(project);
-  if (project.blockedAgentCount > 0 || assistant === "blocked") return 0;
-  if (project.waitingAgentCount > 0 || assistant === "waiting-unseen") return 1;
+  if (assistant === "blocked") return 0;
+  if (assistant === "waiting-unseen") return 1;
   return 2;
 }
 
@@ -523,16 +531,15 @@ function attentionClass(project: SearchableProject): number {
  *
  * Assistant-only rows have no `oldestWaitingSince`, so without this they would
  * all tie at infinity and fall through to an ordering that has nothing to do
- * with how long anyone has been stuck.
+ * with how long anyone has been stuck. A row with both falls to the worker's
+ * clock, matching the tier and the line it will actually show.
  */
 function waitOrderingSince(project: SearchableProject): number {
-  const worker = project.oldestWaitingSince;
-  const assistant = assistantNeedsAttention(classifyAssistantActivity(project))
-    ? project.assistantStateSince
-    : undefined;
-  if (worker === undefined) return assistant ?? Number.POSITIVE_INFINITY;
-  if (assistant === undefined) return worker;
-  return Math.min(worker, assistant);
+  if (project.oldestWaitingSince !== undefined) return project.oldestWaitingSince;
+  if (!assistantNeedsAttention(classifyAssistantActivity(project))) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return project.assistantStateSince ?? Number.POSITIVE_INFINITY;
 }
 
 /**

--- a/src/lib/__tests__/projectAssistantActivity.test.ts
+++ b/src/lib/__tests__/projectAssistantActivity.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  assistantNeedsAttention,
+  classifyAssistantActivity,
+  type AssistantActivityFields,
+} from "../projectAssistantActivity";
+
+const LAST_OPENED = 1_700_000_000_000;
+
+function workspace(overrides: Partial<AssistantActivityFields> = {}): AssistantActivityFields {
+  return {
+    lastOpened: LAST_OPENED,
+    isActive: false,
+    ...overrides,
+  };
+}
+
+describe("classifyAssistantActivity", () => {
+  it("reports nothing when no assistant is live", () => {
+    expect(classifyAssistantActivity(workspace())).toBeNull();
+  });
+
+  it.each(["idle", "completed", "exited"] as const)(
+    "reports nothing for the settled state %s",
+    (assistantState) => {
+      expect(classifyAssistantActivity(workspace({ assistantState }))).toBeNull();
+    }
+  );
+
+  it.each(["working", "directing"] as const)("reads %s as working", (assistantState) => {
+    expect(classifyAssistantActivity(workspace({ assistantState }))).toBe("working");
+  });
+
+  it("never escalates a working assistant, however long it has been going", () => {
+    const activity = classifyAssistantActivity(
+      workspace({ assistantState: "working", assistantStateSince: LAST_OPENED + 60 * 60_000 })
+    );
+    expect(assistantNeedsAttention(activity)).toBe(false);
+  });
+
+  it("reads an errored wait as blocked even when the user is looking at it", () => {
+    expect(
+      classifyAssistantActivity(
+        workspace({
+          assistantState: "waiting",
+          assistantWaitingReason: "error",
+          isActive: true,
+          assistantStateSince: LAST_OPENED - 60_000,
+        })
+      )
+    ).toBe("blocked");
+  });
+
+  it.each(["prompt", "question", "approval"] as const)(
+    "leaves a %s wait unescalated when it began before the user was last here",
+    (assistantWaitingReason) => {
+      const activity = classifyAssistantActivity(
+        workspace({
+          assistantState: "waiting",
+          assistantWaitingReason,
+          assistantStateSince: LAST_OPENED - 60_000,
+        })
+      );
+      expect(activity).toBe("waiting");
+      expect(assistantNeedsAttention(activity)).toBe(false);
+    }
+  );
+
+  it("escalates a wait that began after the user was last here", () => {
+    const activity = classifyAssistantActivity(
+      workspace({ assistantState: "waiting", assistantStateSince: LAST_OPENED + 1 })
+    );
+    expect(activity).toBe("waiting-unseen");
+    expect(assistantNeedsAttention(activity)).toBe(true);
+  });
+
+  it("treats a wait that began exactly when the user was last here as seen", () => {
+    // Strictly-after: the transition landed while they were on the row, so it
+    // was there to be noticed. Equality escalating would make every project
+    // switch escalate the wait it switched away from.
+    expect(
+      classifyAssistantActivity(
+        workspace({ assistantState: "waiting", assistantStateSince: LAST_OPENED })
+      )
+    ).toBe("waiting");
+  });
+
+  it("never escalates a wait in the workspace the view is showing", () => {
+    expect(
+      classifyAssistantActivity(
+        workspace({
+          assistantState: "waiting",
+          assistantStateSince: LAST_OPENED + 60_000,
+          isActive: true,
+        })
+      )
+    ).toBe("waiting");
+  });
+
+  it("does not escalate a wait it cannot date", () => {
+    // An undatable wait has no way back down: nothing about it would ever
+    // change, so it would hold the row in the attention band forever.
+    expect(classifyAssistantActivity(workspace({ assistantState: "waiting", lastOpened: 0 }))).toBe(
+      "waiting"
+    );
+  });
+
+  it("escalates an unseen wait even in a workspace that has never been opened", () => {
+    expect(
+      classifyAssistantActivity(
+        workspace({ assistantState: "waiting", assistantStateSince: 1, lastOpened: 0 })
+      )
+    ).toBe("waiting-unseen");
+  });
+
+  it("ignores a waiting reason left behind by a state the assistant has left", () => {
+    // Producers normalize this, but a stale "error" surviving into a working
+    // state would paint a healthy assistant as failed on every row it reaches.
+    expect(
+      classifyAssistantActivity(
+        workspace({ assistantState: "working", assistantWaitingReason: "error" })
+      )
+    ).toBe("working");
+  });
+});
+
+describe("assistantNeedsAttention", () => {
+  it("admits only the two states nobody is coming for", () => {
+    expect(assistantNeedsAttention("blocked")).toBe(true);
+    expect(assistantNeedsAttention("waiting-unseen")).toBe(true);
+    expect(assistantNeedsAttention("working")).toBe(false);
+    expect(assistantNeedsAttention("waiting")).toBe(false);
+    expect(assistantNeedsAttention(null)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -627,3 +627,187 @@ describe("snoozed rows", () => {
     expect(snoozed.tone).not.toBe(settled.tone);
   });
 });
+
+describe("assistant presence status lines (#11806)", () => {
+  const SEEN = NOW - 10 * 60_000;
+
+  it("names the assistant instead of claiming an agent count", () => {
+    const status = getProjectRowStatus(
+      project({ assistantState: "working", assistantStateSince: NOW - 60_000 }),
+      NOW
+    );
+
+    expect(status.text).toBe("Assistant working");
+    // The row must not read as a run the user launched.
+    expect(status.text).not.toMatch(/agent/i);
+    expect(status.isDormantFallback).toBeUndefined();
+  });
+
+  it("reads a directing assistant as working too", () => {
+    expect(getProjectRowStatus(project({ assistantState: "directing" }), NOW).text).toBe(
+      "Assistant working"
+    );
+  });
+
+  it("ages a wait so a fresh one and an old one stop rendering identically", () => {
+    const fresh = getProjectRowStatus(
+      project({
+        assistantState: "waiting",
+        assistantStateSince: NOW - 30_000,
+        lastOpened: SEEN,
+      }),
+      NOW
+    );
+    const old = getProjectRowStatus(
+      project({
+        assistantState: "waiting",
+        assistantStateSince: NOW - 42 * 60_000,
+        lastOpened: SEEN,
+      }),
+      NOW
+    );
+
+    expect(fresh.text).toBe("Assistant waiting · just now");
+    expect(old.text).toBe("Assistant waiting · 42m");
+  });
+
+  it("says blocked, in the danger tone, when the assistant failed", () => {
+    const status = getProjectRowStatus(
+      project({
+        assistantState: "waiting",
+        assistantWaitingReason: "error",
+        assistantStateSince: NOW - 5 * 60_000,
+      }),
+      NOW
+    );
+
+    expect(status.text).toBe("Assistant blocked · 5m");
+    expect(status.tone).toBe("assistant-blocked");
+  });
+
+  it("keeps every assistant tone out of the worker vocabulary", () => {
+    // The worker dot is the thing the issue says must keep meaning what it
+    // means. Assistant rows must never borrow one of its tones.
+    const workerTones = ["working", "waiting", "blocked", "review", "running", "snoozed"];
+    for (const assistantState of ["working", "waiting"] as const) {
+      const status = getProjectRowStatus(project({ assistantState, lastOpened: NOW }), NOW);
+      expect(workerTones).not.toContain(status.tone);
+    }
+  });
+
+  it.each(["idle", "completed", "exited"] as const)(
+    "says nothing for a settled assistant in state %s",
+    (assistantState) => {
+      const status = getProjectRowStatus(project({ assistantState, lastOpened: SEEN }), NOW);
+
+      // Falls all the way through to the dormant line, drawing no dot.
+      expect(status.isDormantFallback).toBe(true);
+      expect(status.text).not.toMatch(/assistant/i);
+    }
+  );
+
+  it("lets an assistant failure outrank an unreviewed completion", () => {
+    const status = getProjectRowStatus(
+      project({
+        assistantState: "waiting",
+        assistantWaitingReason: "error",
+        unacknowledgedCompletedAgentCount: 1,
+        latestUnacknowledgedCompletionAt: NOW - 60_000,
+      }),
+      NOW
+    );
+
+    expect(status.text).toContain("Assistant blocked");
+  });
+
+  it("keeps workers waiting on the user above the assistant", () => {
+    // Both land the row in the attention band; the people stalled on a run
+    // they started are the louder ask.
+    const status = getProjectRowStatus(
+      project({
+        waitingAgentCount: 2,
+        assistantState: "waiting",
+        assistantWaitingReason: "error",
+      }),
+      NOW
+    );
+
+    expect(status.text).toContain("agents need input");
+  });
+
+  it("reports a working assistant rather than the snooze beneath it", () => {
+    // A working assistant is why this row is in Running at all — announcing
+    // "Agent snoozed" from that band would contradict its own placement.
+    const status = getProjectRowStatus(
+      project({ assistantState: "working", snoozedAgentCount: 1 }),
+      NOW
+    );
+
+    expect(status.text).toBe("Assistant working");
+  });
+
+  it("leaves a running worker's line alone", () => {
+    const status = getProjectRowStatus(
+      project({ activeAgentCount: 2, assistantState: "working" }),
+      NOW
+    );
+
+    expect(status.text).toBe("2 agents running");
+    expect(status.tone).toBe("working");
+  });
+
+  it("puts a seen wait below the snooze but above the settled lines", () => {
+    const snoozed = getProjectRowStatus(
+      project({
+        snoozedAgentCount: 1,
+        assistantState: "waiting",
+        assistantStateSince: SEEN - 60_000,
+        lastOpened: SEEN,
+      }),
+      NOW
+    );
+    const settled = getProjectRowStatus(
+      project({
+        completedAgentCount: 1,
+        latestCompletionAt: NOW - 60_000,
+        assistantState: "waiting",
+        assistantStateSince: SEEN - 60_000,
+        lastOpened: SEEN,
+      }),
+      NOW
+    );
+
+    expect(snoozed.text).toContain("snoozed");
+    expect(settled.text).toContain("Assistant waiting");
+  });
+
+  it("outranks a bare process count", () => {
+    const status = getProjectRowStatus(
+      project({ processCount: 3, assistantState: "working" }),
+      NOW
+    );
+
+    expect(status.text).toBe("Assistant working");
+  });
+
+  it("gives a scratch the same assistant line a project gets", () => {
+    // A help session is provisioned against an opaque workspace id, so a
+    // scratch can host one and must not render it differently.
+    const status = getScratchRowStatus(
+      scratch({ assistantState: "working", assistantStateSince: NOW - 60_000 }),
+      NOW
+    );
+
+    expect(status.text).toBe("Assistant working");
+    expect(status.tone).toBe("assistant");
+  });
+
+  it("still names the assistant when the wait has no recorded start", () => {
+    const status = getProjectRowStatus(project({ assistantState: "waiting" }), NOW);
+
+    // No age to state, but the presence is still the most useful fact here —
+    // and an undatable wait must not render as an epoch-old one.
+    expect(status.text).toBe("Assistant waiting");
+    expect(status.text).not.toContain("·");
+  });
+});

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -687,10 +687,14 @@ describe("assistant presence status lines (#11806)", () => {
 
   it("keeps every assistant tone out of the worker vocabulary", () => {
     // The worker dot is the thing the issue says must keep meaning what it
-    // means. Assistant rows must never borrow one of its tones.
+    // means. Assistant rows must never borrow one of its tones — and must earn
+    // a line of their own rather than falling through to the dormant fallback,
+    // which would satisfy the first half of this while saying nothing.
     const workerTones = ["working", "waiting", "blocked", "review", "running", "snoozed"];
     for (const assistantState of ["working", "waiting"] as const) {
       const status = getProjectRowStatus(project({ assistantState, lastOpened: NOW }), NOW);
+      expect(status.text).toContain("Assistant");
+      expect(status.isDormantFallback).toBeUndefined();
       expect(workerTones).not.toContain(status.tone);
     }
   });

--- a/src/lib/projectAssistantActivity.ts
+++ b/src/lib/projectAssistantActivity.ts
@@ -1,0 +1,87 @@
+import type { AgentState, WaitingReason } from "@shared/types/agent";
+
+/**
+ * What a live Daintree Assistant means for the row it sits on.
+ *
+ * - `blocked` — settled after a failure; input may not restart it.
+ * - `waiting-unseen` — waiting, and the user has not had this workspace on
+ *   screen since the wait began. Nobody is coming.
+ * - `working` — actively doing something.
+ * - `waiting` — at its prompt, already seen. Its normal resting state.
+ *
+ * Null means the assistant has nothing to say: no live session, or a settled
+ * one (`idle`, `completed`, `exited`).
+ */
+export type AssistantActivity = "blocked" | "waiting-unseen" | "working" | "waiting";
+
+/**
+ * The fields this classification reads, declared structurally rather than
+ * imported from the switcher's row model.
+ *
+ * Both row kinds satisfy it, and keeping the dependency pointing this way
+ * means the hook can call this helper without the type import looping back
+ * through it.
+ */
+export interface AssistantActivityFields {
+  assistantState?: AgentState;
+  assistantWaitingReason?: WaitingReason;
+  assistantStateSince?: number;
+  /**
+   * When the user last had this workspace as their current one. Stamped on the
+   * way in AND on the way out — `ProjectStore` sets the departing project's
+   * `lastOpened` to just before the switch — so it reads as "last had this on
+   * screen" rather than merely "last opened it".
+   */
+  lastOpened: number;
+  /** Whether this workspace is the one the view is showing right now. */
+  isActive: boolean;
+}
+
+/**
+ * The one definition of what the assistant's state means for a row (#11806).
+ *
+ * Shared by the switcher's banding, its within-band ordering, and its status
+ * line, because those three disagreeing is how a project ends up sorted into
+ * "Needs attention" while its own status line says something else.
+ *
+ * Escalation is deliberately narrow. An assistant parked at its prompt is what
+ * an idle assistant looks like, and a band that fills up with them stops
+ * meaning anything — so `waiting` only escalates when the user has not been
+ * back since the wait started, and `working` never escalates at all.
+ *
+ * Known limits of `lastOpened` as the observation watermark, both erring
+ * toward escalating a wait the user may already have seen: switching from a
+ * project into a scratch clears the current-project pointer without stamping
+ * the project it left, and the stamp is skipped entirely while disk writes are
+ * suppressed. Both are rarer than the case this catches, and an over-eager
+ * status line is a smaller failure than an assistant stuck where nobody looks.
+ */
+export function classifyAssistantActivity(
+  workspace: AssistantActivityFields
+): AssistantActivity | null {
+  const state = workspace.assistantState;
+
+  if (state === "working" || state === "directing") return "working";
+  if (state !== "waiting") return null;
+
+  // An error outranks the observation check: it is not waiting on the user in
+  // the ordinary sense, and having glanced at the project does not unstick it.
+  if (workspace.assistantWaitingReason === "error") return "blocked";
+
+  // The user is looking at it right now — there is nothing to escalate to.
+  if (workspace.isActive) return "waiting";
+
+  const since = workspace.assistantStateSince;
+  // No recorded transition means the wait cannot be dated, and an undatable
+  // wait must not escalate: it would have no way back down.
+  if (since === undefined) return "waiting";
+
+  // Strictly after: a wait that began at the moment the user was last here
+  // was on screen for them to see.
+  return since > workspace.lastOpened ? "waiting-unseen" : "waiting";
+}
+
+/** Whether this activity belongs in the switcher's attention band. */
+export function assistantNeedsAttention(activity: AssistantActivity | null): boolean {
+  return activity === "blocked" || activity === "waiting-unseen";
+}

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -209,9 +209,13 @@ function getWorkspaceActivityStatus(
   project: WorkspaceRowStatusFields,
   nowMs: number
 ): WorkspaceActivityStatus | null {
-  // Classified once, consumed at three different heights below. The same
-  // helper decides the row's band, so a row can never be filed under "Needs
-  // attention" while this function tells it a different story.
+  // Classified once, consumed at three different heights below. Sharing the
+  // helper with `sectionForProject` is what keeps a row's band and its line
+  // telling the same story about the assistant. Not an absolute guarantee: the
+  // palette freezes band membership while it is open (#11071) and lets the
+  // facts stay live, so a state change mid-session can move this line under a
+  // heading chosen a moment earlier. That is the anti-jump policy working, and
+  // it resolves the next time the palette opens.
   const assistant = classifyAssistantActivity(project);
   const age =
     project.oldestWaitingSince !== undefined

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -3,11 +3,20 @@ import type {
   SearchableScratch,
   WorkspaceRowStatusFields,
 } from "@/hooks/useProjectSwitcherPalette";
+import { classifyAssistantActivity, type AssistantActivity } from "@/lib/projectAssistantActivity";
 import { formatTimeAgo } from "@/utils/timeAgo";
 
 /** Visual weight of a row's status line. Maps to status tokens, never the accent. */
 export type ProjectRowTone =
-  "blocked" | "waiting" | "review" | "working" | "running" | "snoozed" | "muted";
+  | "blocked"
+  | "waiting"
+  | "review"
+  | "working"
+  | "running"
+  | "snoozed"
+  | "muted"
+  | "assistant"
+  | "assistant-blocked";
 
 /**
  * Text colour for a status line, by tone.
@@ -32,6 +41,13 @@ export const ROW_TONE_CLASS: Record<ProjectRowTone, string> = {
   // be the loudest thing in the list on the way out.
   snoozed: "text-daintree-text/50",
   muted: "text-daintree-text/50",
+  // Machine-initiated work the user didn't launch, so it reads at the same
+  // weight as the settled states rather than competing with the runs they
+  // started (#11806).
+  assistant: "text-daintree-text/50",
+  // An assistant that failed says so in the danger hue — the severity is real
+  // — while its dot stays hollow, so it never reads as a worker run.
+  "assistant-blocked": "text-status-danger/80",
 };
 
 export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
@@ -51,6 +67,15 @@ export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
   // that mean something — dormant rows draw no dot at all now (#11692), so the
   // ring is back to marking the two muted states that earned a line.
   muted: "border border-daintree-text/20",
+  // Hollow, and that is the whole point: the filled dot means a run the user
+  // launched, and the assistant is the machine acting on its own. It is the
+  // convention for machine-initiated background work, and it leaves the worker
+  // dot meaning exactly what it meant before (#11806). Stronger than `muted`'s
+  // ring because this one marks something live rather than something finished.
+  assistant: "border border-daintree-text/40",
+  // Same hollow shape carrying the danger hue: still not a worker run, but a
+  // failure the row should not have to be read closely to notice.
+  "assistant-blocked": "border border-status-danger",
 };
 
 /**
@@ -137,6 +162,34 @@ export function formatWakeTime(wakeAtMs: number): string {
 type WorkspaceActivityStatus = Omit<ProjectRowStatus, "pathHint">;
 
 /**
+ * The assistant's line: it says what the assistant is, never a count (#11806).
+ *
+ * "Assistant working", not "1 agent running" — the assistant is one thing and
+ * always has been, so a number would be inventing a plural that cannot exist,
+ * and calling it an agent would claim a run the user never launched. Waits
+ * carry their age for the same reason worker waits do: one that started forty
+ * seconds ago and one that started forty minutes ago are different situations.
+ *
+ * A wait reads the same whether or not it has gone unseen. Escalation moves the
+ * row into "Needs attention", which is a louder statement than any adjective
+ * this line could add.
+ */
+function assistantStatus(
+  activity: Exclude<AssistantActivity, null>,
+  since: number | undefined,
+  nowMs: number
+): WorkspaceActivityStatus {
+  if (activity === "working") {
+    return { text: "Assistant working", tone: "assistant" };
+  }
+
+  const lead = activity === "blocked" ? "Assistant blocked" : "Assistant waiting";
+  const tone: ProjectRowTone = activity === "blocked" ? "assistant-blocked" : "assistant";
+  const age = since !== undefined ? formatWaitAge(since, nowMs) : null;
+  return { text: age ? `${lead} · ${age}` : lead, tone };
+}
+
+/**
  * The activity half of a row's status line — everything derived purely from
  * agent counts, and so identical for a project and a scratch.
  *
@@ -156,6 +209,10 @@ function getWorkspaceActivityStatus(
   project: WorkspaceRowStatusFields,
   nowMs: number
 ): WorkspaceActivityStatus | null {
+  // Classified once, consumed at three different heights below. The same
+  // helper decides the row's band, so a row can never be filed under "Needs
+  // attention" while this function tells it a different story.
+  const assistant = classifyAssistantActivity(project);
   const age =
     project.oldestWaitingSince !== undefined
       ? formatWaitAge(project.oldestWaitingSince, nowMs)
@@ -208,6 +265,15 @@ function getWorkspaceActivityStatus(
     };
   }
 
+  // The two assistant states that put a row in the attention band, reported
+  // here so the band and the line agree about why it is there. Below the
+  // worker waits above — those are people stalled on a run they started, which
+  // outranks the assistant asking — and above review, because both of these
+  // are stuck and a finished agent is not.
+  if (assistant === "blocked" || assistant === "waiting-unseen") {
+    return assistantStatus(assistant, project.assistantStateSince, nowMs);
+  }
+
   // Finished work the user hasn't seen — the hand-back the attention band
   // exists for. States the action ("ready for review") and how fresh the
   // hand-back is, so a 3-minute-old completion and a 2-hour-old one stop
@@ -255,6 +321,13 @@ function getWorkspaceActivityStatus(
     };
   }
 
+  // A working assistant, above the snooze line because it is the reason the
+  // row is in Running at all when no worker is: a project whose assistant is
+  // working would otherwise announce "Agent snoozed" from the Running band.
+  if (assistant === "working") {
+    return assistantStatus(assistant, project.assistantStateSince, nowMs);
+  }
+
   // Everything here is snoozed and nothing is running. Below `active` on
   // purpose — a project with one snoozed agent and one working one is Running,
   // because something genuinely is. Above the completed/dormant lines because a
@@ -271,6 +344,14 @@ function getWorkspaceActivityStatus(
     // deliver.
     if (wakeAt === undefined) return { text: lead, tone: "snoozed" };
     return { text: `${lead} · until ${formatWakeTime(wakeAt)}`, tone: "snoozed" };
+  }
+
+  // An assistant parked at its prompt, already seen. Its resting state, so it
+  // sits below everything that is actually asking for something — but above
+  // the settled lines, because a live session is a better answer to "what is
+  // this project doing" than a completion that was reviewed hours ago.
+  if (assistant === "waiting") {
+    return assistantStatus(assistant, project.assistantStateSince, nowMs);
   }
 
   // Everything completed has been seen: drop the action phrase and mute. The


### PR DESCRIPTION
## Summary

- A project whose only running agent was the Daintree Assistant read as idle in the project switcher. It sat in "Other projects" next to genuinely dormant repos, no status line, for as long as the assistant was working. `classifyRun()` returns the exclusion reason `"help"` for the assistant terminal, and that single verdict removed it from every cross-project surface. The state was already sitting on the terminal record, it was only ever withheld.
- Fix carries the assistant's `agentState`, `waitingReason`, and `lastStateChange` forward out of the existing `"help"` branch in `computeProjectAgentCounts`, the same shared reducer both producers already read, so the pushed status map and the bulk stats seed can't drift apart (the #10989 failure mode). The renderer only gets raw facts. A single new classifier, `src/lib/projectAssistantActivity.ts`, is the one definition of what those states mean, shared by the switcher's banding, its within-band ordering, and its status line, so those three can never disagree.

Resolves #11806

## Behaviour

- A working assistant lifts its project into the Running band with the line "Assistant working".
- Attention stays restrained. An assistant parked at its prompt is its normal resting state and doesn't escalate. Only an assistant blocked on an error, or one waiting since before the user was last in that project, reaches "Needs attention".
- The dot is hollow, never the saturated worker dot. That's the convention for machine-initiated background work, and it leaves the worker dot meaning exactly what it meant before. An errored assistant carries the danger hue in the same hollow shape.
- Scratches get the same status line, since a help session is provisioned against an opaque workspace id.

## Non-goals held

- No entry in the active/waiting/completed/blocked tallies.
- No peer row in the Pilot/fleet run list (`FleetSnapshotService` untouched).
- No entry in `agent.listAvailable` or the launcher picker (`agentActions.adversarial.test.ts` passes unmodified).
- Tray/toolbar badge stays worker-only.
- `helpTerminals` is still netted out of `processCount`.

## Known limitations

Both documented in code comments:

- `lastOpened` is the observation watermark. It's stamped on both arrival and departure of a project switch, but a project-to-scratch switch clears the pointer without stamping, and the stamp is skipped under disk-write suppression. Both err toward escalating a wait the user may already have seen. An exact signal would need a new main-owned observation watermark, out of scope here.
- A degraded PTY-host read momentarily clears assistant presence, identical to how every existing worker tally already behaves on a degraded read.

## Review

Ran three adversarial Codex passes and applied their findings. Assistant selection now keys on `spawnedAt`, the live-session identity token, so a displaced PTY still reading `working` can't outrank the live session. Non-finite timestamps are screened so selection is listing-order independent. Attention tier and wait-ordering clock now follow the same precedence the status line uses. Both producers are held to one shared parity fixture.

## Testing

- 1082 tests across 36 files pass: every suite the branch touched, the modules it changed, and the repo-wide contract scans.
- Typecheck clean on root, electron, and preload projects.
- Lint ratchet passes and improved (1090 vs baseline 1092).
- Prettier and eslint clean on all 16 changed files, 0 errors.
