### PR TITLE
fix(menu): reach the application menu from the toolbar on Windows and Linux

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -183,6 +183,7 @@ export const CHANNELS = {
   APP_DISMISS_ROSETTA_WARNING: "app:dismiss-rosetta-warning",
   MENU_ACTION: "menu:action",
   MENU_SHOW_CONTEXT: "menu:show-context",
+  MENU_SHOW_APPLICATION: "menu:show-application",
 
   LOGS_GET_ALL: "logs:get-all",
   LOGS_GET_SOURCES: "logs:get-sources",

--- a/electron/ipc/handlers/__tests__/menu.application.test.ts
+++ b/electron/ipc/handlers/__tests__/menu.application.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const getApplicationMenu = vi.fn();
+
+vi.mock("electron", () => ({
+  Menu: {
+    getApplicationMenu: () => getApplicationMenu(),
+    buildFromTemplate: vi.fn(),
+  },
+}));
+
+const getAppWebContents = vi.fn();
+const isCachedViewWebContents = vi.fn();
+
+vi.mock("../../../window/webContentsRegistry.js", () => ({
+  getAppWebContents: (...args: unknown[]) => getAppWebContents(...args),
+  isCachedViewWebContents: (...args: unknown[]) => isCachedViewWebContents(...args),
+}));
+
+const { menuNamespace, resolveApplicationMenuAnchor } = await import("../menu.js");
+
+const showApplication = menuNamespace.ops.showApplication.handler as (
+  ctx: unknown,
+  payload?: { x?: number; y?: number }
+) => Promise<void>;
+
+const realPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+interface MenuStub {
+  popup: ReturnType<typeof vi.fn>;
+}
+
+function makeMenu(): MenuStub {
+  return { popup: vi.fn() };
+}
+
+function makeWindow(bounds = { x: 0, y: 0, width: 1000, height: 800 }) {
+  return {
+    isDestroyed: () => false,
+    getContentBounds: () => bounds,
+  };
+}
+
+function makeCtx(win: unknown, webContentsId = 7) {
+  return { event: {}, webContentsId, senderWindow: win, projectId: null };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setPlatform("win32");
+  isCachedViewWebContents.mockReturnValue(false);
+  getAppWebContents.mockReturnValue({ isDestroyed: () => false, getZoomFactor: () => 1 });
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+});
+
+describe("resolveApplicationMenuAnchor", () => {
+  const bounds = { width: 1000, height: 800 };
+
+  it("scales the CSS-pixel anchor by the view's zoom factor", () => {
+    expect(resolveApplicationMenuAnchor({ x: 100, y: 40 }, bounds, 1.5)).toEqual({
+      x: 150,
+      y: 60,
+    });
+  });
+
+  it("clamps an anchor beyond the content area back inside it", () => {
+    const anchor = resolveApplicationMenuAnchor({ x: 900, y: 700 }, bounds, 2);
+    expect(anchor).toEqual({ x: bounds.width, y: bounds.height });
+  });
+
+  it("clamps a negative anchor to the content origin", () => {
+    expect(resolveApplicationMenuAnchor({ x: -50, y: -10 }, bounds, 1)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("rounds fractional device coordinates to integers", () => {
+    const anchor = resolveApplicationMenuAnchor({ x: 10.4, y: 20.6 }, bounds, 1.1);
+    expect(Number.isInteger(anchor!.x)).toBe(true);
+    expect(Number.isInteger(anchor!.y)).toBe(true);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "treats an unusable zoom factor (%s) as 1x rather than collapsing the anchor",
+    (zoom) => {
+      expect(resolveApplicationMenuAnchor({ x: 120, y: 48 }, bounds, zoom)).toEqual({
+        x: 120,
+        y: 48,
+      });
+    }
+  );
+
+  it.each([
+    ["a missing payload", undefined],
+    ["a payload with no coordinates", {}],
+    ["a partial payload", { x: 10 }],
+    ["non-finite coordinates", { x: Number.NaN, y: 10 }],
+    ["infinite coordinates", { x: 10, y: Number.POSITIVE_INFINITY }],
+  ])("returns null for %s so main falls back to the cursor default", (_label, payload) => {
+    expect(resolveApplicationMenuAnchor(payload, bounds, 1)).toBeNull();
+  });
+});
+
+describe("menu:show-application", () => {
+  it("pops up the exact installed menu object rather than a rebuilt template", async () => {
+    const menu = makeMenu();
+    getApplicationMenu.mockReturnValue(menu);
+    const win = makeWindow();
+
+    await showApplication(makeCtx(win), { x: 12, y: 48 });
+
+    expect(menu.popup).toHaveBeenCalledTimes(1);
+    expect(menu.popup.mock.calls[0]![0]).toMatchObject({ window: win });
+  });
+
+  it("re-resolves the current menu on every call, so a rebuild is picked up", async () => {
+    const first = makeMenu();
+    const second = makeMenu();
+    const win = makeWindow();
+
+    getApplicationMenu.mockReturnValue(first);
+    await showApplication(makeCtx(win), { x: 0, y: 0 });
+
+    // createApplicationMenu() installs a fresh Menu on project open, CLI
+    // install, and recent-project removal.
+    getApplicationMenu.mockReturnValue(second);
+    await showApplication(makeCtx(win), { x: 0, y: 0 });
+
+    expect(first.popup).toHaveBeenCalledTimes(1);
+    expect(second.popup).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the zoom-corrected anchor to popup", async () => {
+    const menu = makeMenu();
+    getApplicationMenu.mockReturnValue(menu);
+    getAppWebContents.mockReturnValue({ isDestroyed: () => false, getZoomFactor: () => 2 });
+
+    await showApplication(makeCtx(makeWindow()), { x: 30, y: 50 });
+
+    expect(menu.popup.mock.calls[0]![0]).toMatchObject({ x: 60, y: 100 });
+  });
+
+  it("still opens the menu at the cursor when the anchor cannot be resolved", async () => {
+    const menu = makeMenu();
+    getApplicationMenu.mockReturnValue(menu);
+    getAppWebContents.mockImplementation(() => {
+      throw new Error("view detached");
+    });
+
+    await showApplication(makeCtx(makeWindow()), { x: 30, y: 50 });
+
+    expect(menu.popup).toHaveBeenCalledTimes(1);
+    const options = menu.popup.mock.calls[0]![0] as Record<string, unknown>;
+    expect(options).not.toHaveProperty("x");
+    expect(options).not.toHaveProperty("y");
+  });
+
+  it("does nothing on macOS, which keeps its native system menu bar", async () => {
+    setPlatform("darwin");
+    const menu = makeMenu();
+    getApplicationMenu.mockReturnValue(menu);
+
+    await showApplication(makeCtx(makeWindow()), { x: 12, y: 48 });
+
+    expect(menu.popup).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for a backgrounded project view", async () => {
+    const menu = makeMenu();
+    getApplicationMenu.mockReturnValue(menu);
+    isCachedViewWebContents.mockReturnValue(true);
+
+    await showApplication(makeCtx(makeWindow()), { x: 12, y: 48 });
+
+    expect(menu.popup).not.toHaveBeenCalled();
+  });
+
+  it("scopes the cached-view check to the calling view", async () => {
+    getApplicationMenu.mockReturnValue(makeMenu());
+
+    await showApplication(makeCtx(makeWindow(), 42), { x: 1, y: 1 });
+
+    expect(isCachedViewWebContents).toHaveBeenCalledWith(42);
+  });
+
+  it.each([
+    ["no owning window", null],
+    ["a destroyed window", { isDestroyed: () => true, getContentBounds: () => ({}) }],
+  ])("does nothing when the sender has %s", async (_label, win) => {
+    const menu = makeMenu();
+    getApplicationMenu.mockReturnValue(menu);
+
+    await expect(showApplication(makeCtx(win), { x: 1, y: 1 })).resolves.toBeUndefined();
+    expect(menu.popup).not.toHaveBeenCalled();
+  });
+
+  it("resolves without throwing when no application menu is installed", async () => {
+    getApplicationMenu.mockReturnValue(null);
+
+    await expect(showApplication(makeCtx(makeWindow()), { x: 1, y: 1 })).resolves.toBeUndefined();
+  });
+});

--- a/electron/ipc/handlers/__tests__/menu.application.test.ts
+++ b/electron/ipc/handlers/__tests__/menu.application.test.ts
@@ -9,11 +9,9 @@ vi.mock("electron", () => ({
   },
 }));
 
-const getAppWebContents = vi.fn();
 const isCachedViewWebContents = vi.fn();
 
 vi.mock("../../../window/webContentsRegistry.js", () => ({
-  getAppWebContents: (...args: unknown[]) => getAppWebContents(...args),
   isCachedViewWebContents: (...args: unknown[]) => isCachedViewWebContents(...args),
 }));
 
@@ -41,19 +39,24 @@ function makeMenu(): MenuStub {
 function makeWindow(bounds = { x: 0, y: 0, width: 1000, height: 800 }) {
   return {
     isDestroyed: () => false,
+    isFocused: () => true,
     getContentBounds: () => bounds,
   };
 }
 
-function makeCtx(win: unknown, webContentsId = 7) {
-  return { event: {}, webContentsId, senderWindow: win, projectId: null };
+function makeCtx(win: unknown, webContentsId = 7, sender?: unknown) {
+  return {
+    event: { sender: sender ?? { isDestroyed: () => false, getZoomFactor: () => 1 } },
+    webContentsId,
+    senderWindow: win,
+    projectId: null,
+  };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   setPlatform("win32");
   isCachedViewWebContents.mockReturnValue(false);
-  getAppWebContents.mockReturnValue({ isDestroyed: () => false, getZoomFactor: () => 1 });
 });
 
 afterEach(() => {
@@ -135,12 +138,12 @@ describe("menu:show-application", () => {
     expect(second.popup).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards the zoom-corrected anchor to popup", async () => {
+  it("converts the anchor with the sending view's own zoom factor", async () => {
     const menu = makeMenu();
     getApplicationMenu.mockReturnValue(menu);
-    getAppWebContents.mockReturnValue({ isDestroyed: () => false, getZoomFactor: () => 2 });
+    const sender = { isDestroyed: () => false, getZoomFactor: () => 2 };
 
-    await showApplication(makeCtx(makeWindow()), { x: 30, y: 50 });
+    await showApplication(makeCtx(makeWindow(), 7, sender), { x: 30, y: 50 });
 
     expect(menu.popup.mock.calls[0]![0]).toMatchObject({ x: 60, y: 100 });
   });
@@ -148,11 +151,14 @@ describe("menu:show-application", () => {
   it("still opens the menu at the cursor when the anchor cannot be resolved", async () => {
     const menu = makeMenu();
     getApplicationMenu.mockReturnValue(menu);
-    getAppWebContents.mockImplementation(() => {
-      throw new Error("view detached");
-    });
+    const sender = {
+      isDestroyed: () => false,
+      getZoomFactor: () => {
+        throw new Error("view detached");
+      },
+    };
 
-    await showApplication(makeCtx(makeWindow()), { x: 30, y: 50 });
+    await showApplication(makeCtx(makeWindow(), 7, sender), { x: 30, y: 50 });
 
     expect(menu.popup).toHaveBeenCalledTimes(1);
     const options = menu.popup.mock.calls[0]![0] as Record<string, unknown>;
@@ -188,9 +194,35 @@ describe("menu:show-application", () => {
     expect(isCachedViewWebContents).toHaveBeenCalledWith(42);
   });
 
+  it("does nothing for an unfocused window, so a popup cannot be baited under the pointer", async () => {
+    const menu = makeMenu();
+    getApplicationMenu.mockReturnValue(menu);
+    const win = { ...makeWindow(), isFocused: () => false };
+
+    await showApplication(makeCtx(win), { x: 12, y: 48 });
+
+    expect(menu.popup).not.toHaveBeenCalled();
+  });
+
+  it("reports rather than rejects when the native popup fails during teardown", async () => {
+    const menu = makeMenu();
+    menu.popup.mockImplementation(() => {
+      throw new Error("window gone");
+    });
+    getApplicationMenu.mockReturnValue(menu);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(showApplication(makeCtx(makeWindow()), { x: 1, y: 1 })).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   it.each([
     ["no owning window", null],
-    ["a destroyed window", { isDestroyed: () => true, getContentBounds: () => ({}) }],
+    [
+      "a destroyed window",
+      { isDestroyed: () => true, isFocused: () => true, getContentBounds: () => ({}) },
+    ],
   ])("does nothing when the sender has %s", async (_label, win) => {
     const menu = makeMenu();
     getApplicationMenu.mockReturnValue(menu);

--- a/electron/ipc/handlers/menu.preload.ts
+++ b/electron/ipc/handlers/menu.preload.ts
@@ -2,6 +2,7 @@ import type { IpcInvokeMap } from "../../types/index.js";
 
 export const MENU_METHOD_CHANNELS = {
   showContext: "menu:show-context",
+  showApplication: "menu:show-application",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof MENU_METHOD_CHANNELS;

--- a/electron/ipc/handlers/menu.ts
+++ b/electron/ipc/handlers/menu.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../../shared/types/menu.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { MENU_METHOD_CHANNELS } from "./menu.preload.js";
-import { getAppWebContents, isCachedViewWebContents } from "../../window/webContentsRegistry.js";
+import { isCachedViewWebContents } from "../../window/webContentsRegistry.js";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -151,6 +151,12 @@ export const menuNamespace = defineIpcNamespace({
         const win = ctx.senderWindow;
         if (!win || win.isDestroyed()) return;
 
+        // The only legitimate caller is a click on the toolbar button of the
+        // window the user is looking at. Refusing unfocused windows keeps a
+        // renderer from summoning the real application menu under the pointer
+        // and baiting a click onto a privileged item such as Exit.
+        if (!win.isFocused()) return;
+
         // A backgrounded project view can still hold a queued click; without
         // this it would surface a popup over whichever view is now visible.
         if (isCachedViewWebContents(ctx.webContentsId)) return;
@@ -160,12 +166,15 @@ export const menuNamespace = defineIpcNamespace({
 
         let anchor: { x: number; y: number } | null = null;
         try {
-          const wc = getAppWebContents(win);
-          if (!wc.isDestroyed()) {
+          // The sender's own zoom factor, not the window's app view: the rect
+          // was measured in the sender's CSS pixels, so only that view's zoom
+          // converts it back to device-independent window coordinates.
+          const sender = ctx.event.sender;
+          if (!sender.isDestroyed()) {
             anchor = resolveApplicationMenuAnchor(
               payload,
               win.getContentBounds(),
-              wc.getZoomFactor()
+              sender.getZoomFactor()
             );
           }
         } catch {
@@ -173,7 +182,13 @@ export const menuNamespace = defineIpcNamespace({
           // menu entirely — reachability matters more than placement.
         }
 
-        menu.popup({ window: win, ...(anchor ?? {}) });
+        try {
+          menu.popup({ window: win, ...(anchor ?? {}) });
+        } catch (err) {
+          // Losing the window mid-teardown is a benign race, but an unhandled
+          // rejection here would reach the renderer's global error reporter.
+          console.error("[MAIN] Failed to open the application menu:", err);
+        }
       },
       { withContext: true }
     ),

--- a/electron/ipc/handlers/menu.ts
+++ b/electron/ipc/handlers/menu.ts
@@ -1,8 +1,13 @@
 import { Menu } from "electron";
 import type { HandlerDependencies } from "../types.js";
-import type { MenuItemOption, ShowContextMenuPayload } from "../../../shared/types/menu.js";
+import type {
+  MenuItemOption,
+  ShowApplicationMenuPayload,
+  ShowContextMenuPayload,
+} from "../../../shared/types/menu.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { MENU_METHOD_CHANNELS } from "./menu.preload.js";
+import { getAppWebContents, isCachedViewWebContents } from "../../window/webContentsRegistry.js";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -88,9 +93,90 @@ function sanitizeShowContextMenuPayload(value: unknown): ShowContextMenuPayload 
   };
 }
 
+/**
+ * Translate a sender-view CSS-pixel anchor into the window coordinates
+ * `Menu.popup` expects, clamped inside the window's content area.
+ *
+ * The project WebContentsView always fills the window's content area
+ * (`ProjectViewManager` sets `{x: 0, y: 0, width, height}`), so the only
+ * correction between the two spaces is the view's zoom factor — an app zoomed
+ * to 150% renders the button 1.5x further from the origin than its CSS rect
+ * reports. Non-finite input falls back to Electron's own default (the cursor).
+ */
+export function resolveApplicationMenuAnchor(
+  payload: ShowApplicationMenuPayload | undefined,
+  bounds: { width: number; height: number },
+  zoomFactor: number
+): { x: number; y: number } | null {
+  if (!payload) return null;
+  const { x, y } = payload;
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+
+  // A zero/negative/NaN zoom factor would collapse or invert the anchor.
+  const scale = Number.isFinite(zoomFactor) && zoomFactor > 0 ? zoomFactor : 1;
+  const clamp = (value: number, max: number) =>
+    Math.round(Math.min(Math.max(value * scale, 0), Math.max(max, 0)));
+
+  return { x: clamp(x as number, bounds.width), y: clamp(y as number, bounds.height) };
+}
+
 export const menuNamespace = defineIpcNamespace({
   name: "menu",
   ops: {
+    /**
+     * Pop up the installed application menu at a renderer-supplied anchor
+     * (#11813).
+     *
+     * Windows hides the native title bar for the Window Controls Overlay, which
+     * removes the frame region the menu bar would render into — Alt reveals
+     * nothing and every menu-only action becomes unreachable. Linux keeps a real
+     * frame (Alt works) but nothing advertises the menu.
+     *
+     * This pops up the exact object `Menu.getApplicationMenu()` returns rather
+     * than rebuilding a template, so the popup inherits every dynamic part of
+     * the menu for free: Open Recent, installed-agent items, plugin
+     * contributions, the live "Check for Updates…" label mutated by
+     * `applyUpdateMenuState`, and the project gates mutated by
+     * `refreshProjectMenuState`. Electron runs the items' own click handlers and
+     * roles, so there is no second source of truth to drift.
+     *
+     * macOS keeps its system menu bar and no-ops here even if a renderer calls
+     * this, so the native menu is never shadowed by a duplicate popup.
+     */
+    showApplication: op(
+      MENU_METHOD_CHANNELS.showApplication,
+      async (ctx, payload?: ShowApplicationMenuPayload): Promise<void> => {
+        if (process.platform === "darwin") return;
+
+        const win = ctx.senderWindow;
+        if (!win || win.isDestroyed()) return;
+
+        // A backgrounded project view can still hold a queued click; without
+        // this it would surface a popup over whichever view is now visible.
+        if (isCachedViewWebContents(ctx.webContentsId)) return;
+
+        const menu = Menu.getApplicationMenu();
+        if (!menu) return;
+
+        let anchor: { x: number; y: number } | null = null;
+        try {
+          const wc = getAppWebContents(win);
+          if (!wc.isDestroyed()) {
+            anchor = resolveApplicationMenuAnchor(
+              payload,
+              win.getContentBounds(),
+              wc.getZoomFactor()
+            );
+          }
+        } catch {
+          // Fall through to a cursor-anchored popup rather than dropping the
+          // menu entirely — reachability matters more than placement.
+        }
+
+        menu.popup({ window: win, ...(anchor ?? {}) });
+      },
+      { withContext: true }
+    ),
     showContext: op(
       MENU_METHOD_CHANNELS.showContext,
       async (ctx, payload: ShowContextMenuPayload): Promise<string | null> => {

--- a/electron/window/platformWindowOptions.ts
+++ b/electron/window/platformWindowOptions.ts
@@ -40,10 +40,13 @@ export function getPlatformWindowOptions(windowBg: string): PlatformWindowOption
         symbolColor: WINDOWS_CAPTION_SYMBOL_COLOR,
         height: WINDOWS_TITLEBAR_HEIGHT_PX,
       },
-      // Hide the native menu bar so the custom toolbar is the only chrome; Alt
-      // still reveals the menu. Must be set in the constructor — calling
-      // setAutoHideMenuBar after creation can cause Window Controls Overlay
-      // layout shifts.
+      // Hide the native menu bar so the custom toolbar is the only chrome.
+      // Alt does NOT reveal it here: titleBarStyle "hidden" removes the
+      // non-client frame region the menu bar would render into, so the menu is
+      // unreachable through native chrome entirely — the toolbar's
+      // AppMenuButton pops up the installed menu instead (#11813). Must be set
+      // in the constructor — calling setAutoHideMenuBar after creation can
+      // cause Window Controls Overlay layout shifts.
       autoHideMenuBar: true,
     };
   }

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -360,6 +360,9 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["mcp-server:set-session-tier"]["result"]>;
   };
   menu: {
+    showApplication(
+      ...args: IpcInvokeMap["menu:show-application"]["args"]
+    ): Promise<IpcInvokeMap["menu:show-application"]["result"]>;
     showContext(
       ...args: IpcInvokeMap["menu:show-context"]["args"]
     ): Promise<IpcInvokeMap["menu:show-context"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -881,6 +881,10 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: { sessionId: string; tier: "action" | "workbench" | "system" }];
     result: { sessionId: string; tier: "action" | "workbench" | "system" };
   };
+  "menu:show-application": {
+    args: [payload?: import("../menu.js").ShowApplicationMenuPayload | undefined];
+    result: void;
+  };
   "menu:show-context": {
     args: [payload: import("../menu.js").ShowContextMenuPayload];
     result: string | null;

--- a/shared/types/menu.ts
+++ b/shared/types/menu.ts
@@ -26,3 +26,16 @@ export interface ShowContextMenuPayload {
   x?: number;
   y?: number;
 }
+
+/**
+ * Anchor for popping up the installed application menu (#11813).
+ *
+ * Coordinates are CSS pixels relative to the sender view's viewport — the
+ * project WebContentsView is always sized to the window's full content area
+ * (ProjectViewManager sets `{x: 0, y: 0, width, height}`), so main only has to
+ * apply the view's zoom factor to reach window coordinates.
+ */
+export interface ShowApplicationMenuPayload {
+  x?: number;
+  y?: number;
+}

--- a/src/components/Layout/AppMenuButton.tsx
+++ b/src/components/Layout/AppMenuButton.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useRef } from "react";
+import { Menu } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { isMac } from "@/lib/platform";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+
+const APP_MENU_LABEL = "Application menu";
+const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
+
+/**
+ * In-app entry point to the native application menu on Windows and Linux
+ * (#11813).
+ *
+ * Windows hides the native title bar for the Window Controls Overlay, which
+ * removes the frame region the menu bar would render into — Alt reveals
+ * nothing, so every menu-only action is unreachable. Linux keeps a real frame
+ * (Alt works) but nothing advertises that the menu exists. Both get this
+ * button; macOS keeps its system menu bar and renders nothing here.
+ *
+ * The click asks main to pop up the installed `Menu` object itself rather than
+ * rendering a DOM replica, so the popup always matches the real menu — Open
+ * Recent, installed agents, plugin contributions and the live update label
+ * included — with no second source of truth to drift.
+ */
+export function AppMenuButton() {
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  // The element focus should return to before the menu opens. The Edit menu's
+  // items act on `webContents.getFocusedWebContents()`, which resolves against
+  // whatever DOM node holds focus — letting this button take focus would point
+  // Cut/Copy/Paste/Select All at the button instead of the user's input.
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Pointer activation: keep focus where it already is. `preventDefault` on
+  // pointerdown stops the browser's focus-on-press, so nothing to restore.
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.button !== 0) return;
+    previousFocusRef.current = null;
+    event.preventDefault();
+  }, []);
+
+  // Keyboard activation: focus genuinely moved here as the user tabbed in, so
+  // capture where it came from and hand it back before the menu opens.
+  const handleFocus = useCallback((event: React.FocusEvent<HTMLButtonElement>) => {
+    const from = event.relatedTarget;
+    previousFocusRef.current =
+      from instanceof HTMLElement && from !== event.currentTarget ? from : null;
+  }, []);
+
+  const handleClick = useCallback(() => {
+    const button = buttonRef.current;
+
+    const restoreTo = previousFocusRef.current;
+    previousFocusRef.current = null;
+    if (restoreTo?.isConnected) {
+      restoreTo.focus({ preventScroll: true });
+    }
+
+    // Anchor the popup under the button. Omitting the rect is survivable —
+    // main falls back to Electron's cursor default — so this never blocks.
+    const rect = button?.getBoundingClientRect();
+    safeFireAndForget(
+      window.electron.menu.showApplication(rect ? { x: rect.left, y: rect.bottom } : undefined),
+      { context: "Failed to open the application menu" }
+    );
+  }, []);
+
+  if (isMac()) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          ref={buttonRef}
+          variant="ghost"
+          size="icon"
+          data-toolbar-item=""
+          data-app-menu-button=""
+          onPointerDown={handlePointerDown}
+          onFocus={handleFocus}
+          onClick={handleClick}
+          className={toolbarIconButtonClass}
+          aria-label={APP_MENU_LABEL}
+          aria-haspopup="menu"
+        >
+          <Menu />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{APP_MENU_LABEL}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/Layout/AppMenuButton.tsx
+++ b/src/components/Layout/AppMenuButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Menu } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -25,40 +25,51 @@ const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative"
  */
 export function AppMenuButton() {
   const buttonRef = useRef<HTMLButtonElement | null>(null);
-  // The element focus should return to before the menu opens. The Edit menu's
+  // Where the caret was before the user reached for the menu. The Edit menu's
   // items act on `webContents.getFocusedWebContents()`, which resolves against
-  // whatever DOM node holds focus — letting this button take focus would point
-  // Cut/Copy/Paste/Select All at the button instead of the user's input.
-  const previousFocusRef = useRef<HTMLElement | null>(null);
+  // whatever DOM node holds focus — so Cut/Copy/Paste/Select All only work if
+  // focus is back on the user's editor when the popup opens.
+  const externalFocusRef = useRef<HTMLElement | null>(null);
 
-  // Pointer activation: keep focus where it already is. `preventDefault` on
-  // pointerdown stops the browser's focus-on-press, so nothing to restore.
+  // Tracked document-wide rather than from this button's own `relatedTarget`:
+  // the toolbar implements roving focus, so arrowing across it calls .focus()
+  // on each item in turn. `relatedTarget` would then be the neighbouring
+  // toolbar button, and restoring THAT would still leave Edit commands aimed
+  // at chrome. Ignoring everything inside the toolbar keeps the last genuine
+  // editing target instead, however the user travelled here.
+  useEffect(() => {
+    if (isMac()) return;
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      if (target.closest('[role="toolbar"]')) return;
+      externalFocusRef.current = target;
+    };
+
+    document.addEventListener("focusin", handleFocusIn);
+    return () => document.removeEventListener("focusin", handleFocusIn);
+  }, []);
+
+  // Pointer activation: keep focus exactly where it is. `preventDefault` on
+  // pointerdown suppresses the browser's focus-on-press, so the common case
+  // never disturbs the caret at all and the restore below is a no-op.
   const handlePointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
     if (event.button !== 0) return;
-    previousFocusRef.current = null;
     event.preventDefault();
   }, []);
 
-  // Keyboard activation: focus genuinely moved here as the user tabbed in, so
-  // capture where it came from and hand it back before the menu opens.
-  const handleFocus = useCallback((event: React.FocusEvent<HTMLButtonElement>) => {
-    const from = event.relatedTarget;
-    previousFocusRef.current =
-      from instanceof HTMLElement && from !== event.currentTarget ? from : null;
-  }, []);
-
   const handleClick = useCallback(() => {
-    const button = buttonRef.current;
-
-    const restoreTo = previousFocusRef.current;
-    previousFocusRef.current = null;
+    // Keyboard activation genuinely moved focus onto this button, so hand it
+    // back before main reads the focused element.
+    const restoreTo = externalFocusRef.current;
     if (restoreTo?.isConnected) {
       restoreTo.focus({ preventScroll: true });
     }
 
     // Anchor the popup under the button. Omitting the rect is survivable —
     // main falls back to Electron's cursor default — so this never blocks.
-    const rect = button?.getBoundingClientRect();
+    const rect = buttonRef.current?.getBoundingClientRect();
     safeFireAndForget(
       window.electron.menu.showApplication(rect ? { x: rect.left, y: rect.bottom } : undefined),
       { context: "Failed to open the application menu" }
@@ -77,7 +88,6 @@ export function AppMenuButton() {
           data-toolbar-item=""
           data-app-menu-button=""
           onPointerDown={handlePointerDown}
-          onFocus={handleFocus}
           onClick={handleClick}
           className={toolbarIconButtonClass}
           aria-label={APP_MENU_LABEL}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -2012,10 +2012,14 @@ export function Toolbar({
           )}
           {/* Fixed chrome, never part of buttonRegistry/overflow: this is the
               recovery surface for the application menu itself, so it must not
-              be hideable or reorderable into an overflow popover (#11813). */}
-          <div className="app-no-drag">
-            <AppMenuButton />
-          </div>
+              be hideable or reorderable into an overflow popover (#11813).
+              Gated here as well as inside the component so macOS doesn't keep
+              an empty flex item, which would add a stray gap-1.5 column. */}
+          {!isMac() && (
+            <div className="app-no-drag">
+              <AppMenuButton />
+            </div>
+          )}
           <div className="app-no-drag">{buttonRegistry["sidebar-toggle"]!.render()}</div>
 
           <div className={toolbarDividerClass} />

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -115,6 +115,7 @@ import { useUIStore } from "@/store/uiStore";
 import { ForgeStatsToolbarButton, type ForgeStatsHandle } from "./ForgeStatsToolbarButton";
 import { useResolvedForgeProvider } from "@/hooks/useResolvedForgeProvider";
 import { NotificationCenterToolbarButton } from "./NotificationCenterToolbarButton";
+import { AppMenuButton } from "./AppMenuButton";
 import { ToolbarLauncherButton } from "./ToolbarLauncherButton";
 import { ToolbarCommandPaletteButton } from "./ToolbarCommandPaletteButton";
 import { ResumeSessionsToolbarButton } from "./ResumeSessionsToolbarButton";
@@ -2009,6 +2010,12 @@ export function Toolbar({
               )}
             />
           )}
+          {/* Fixed chrome, never part of buttonRegistry/overflow: this is the
+              recovery surface for the application menu itself, so it must not
+              be hideable or reorderable into an overflow popover (#11813). */}
+          <div className="app-no-drag">
+            <AppMenuButton />
+          </div>
           <div className="app-no-drag">{buttonRegistry["sidebar-toggle"]!.render()}</div>
 
           <div className={toolbarDividerClass} />

--- a/src/components/Layout/__tests__/AppMenuButton.test.tsx
+++ b/src/components/Layout/__tests__/AppMenuButton.test.tsx
@@ -1,7 +1,24 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
+
+// The rejection path ends in this reporter. Mocking it keeps the assertion on
+// the observable hand-off (and keeps the real reporter's store/Sentry writes
+// out of a component suite).
+vi.mock("@/utils/rendererGlobalErrorHandlers", () => ({
+  reportRendererGlobalError: vi.fn(),
+}));
+
+import { reportRendererGlobalError } from "@/utils/rendererGlobalErrorHandlers";
 import { AppMenuButton } from "../AppMenuButton";
+
+const mockedReport = vi.mocked(reportRendererGlobalError);
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 3; i += 1) {
+    await Promise.resolve();
+  }
+}
 
 const isMacMock = vi.fn(() => false);
 vi.mock("@/lib/platform", () => ({
@@ -209,23 +226,53 @@ describe("AppMenuButton", () => {
   });
 
   it("stops tracking focus once unmounted", () => {
-    const { button, unmount } = renderInToolbar();
-    const editor = addEditor();
-    editor.focus();
-    button!.focus();
-    unmount();
+    // A leaked focusin listener is silent — it just keeps writing into a ref
+    // belonging to a dead component — so the only observable evidence of the
+    // teardown is the listener registration itself.
+    const addSpy = vi.spyOn(document, "addEventListener");
+    const removeSpy = vi.spyOn(document, "removeEventListener");
 
-    // A focusin after teardown must not be recorded — if the listener leaked,
-    // it would keep writing into a ref belonging to a dead component.
-    const late = addEditor();
-    expect(() => late.focus()).not.toThrow();
+    try {
+      const { unmount } = renderInToolbar();
+      const added = addSpy.mock.calls
+        .filter(([type]) => type === "focusin")
+        .map(([, listener]) => listener);
+      // Guards the spy itself: without this, a component that never listened
+      // would satisfy the empty-vs-empty comparison below.
+      expect(added).toHaveLength(1);
+
+      unmount();
+
+      const removed = removeSpy.mock.calls
+        .filter(([type]) => type === "focusin")
+        .map(([, listener]) => listener);
+      expect(removed).toHaveLength(1);
+      // Identity, not just a matching count: removeEventListener silently does
+      // nothing unless the function reference matches the registered one.
+      expect(removed[0]).toBe(added[0]);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
   });
 
   it("consumes an IPC rejection instead of surfacing an unhandled rejection", async () => {
-    showApplication.mockRejectedValueOnce(new Error("window disposed"));
+    const failure = new Error("window disposed");
+    showApplication.mockRejectedValueOnce(failure);
     const { button } = renderInToolbar();
 
-    expect(() => fireEvent.click(button!)).not.toThrow();
-    await Promise.resolve();
+    fireEvent.click(button!);
+    await flushMicrotasks();
+
+    // A bare `void promise` would leave this rejection to escape as an
+    // unhandled rejection; routing it through safeFireAndForget lands it here.
+    expect(mockedReport).toHaveBeenCalledTimes(1);
+    const [kind, error, metadata] = mockedReport.mock.calls[0]!;
+    expect(kind).toBe("unhandledrejection");
+    expect(error).toBe(failure);
+    // The call site supplies its own context rather than letting the raw IPC
+    // rejection text stand in as the user-facing message.
+    expect(metadata.message).toBeTruthy();
+    expect(metadata.message).not.toBe(failure.message);
   });
 });

--- a/src/components/Layout/__tests__/AppMenuButton.test.tsx
+++ b/src/components/Layout/__tests__/AppMenuButton.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { AppMenuButton } from "../AppMenuButton";
+
+const isMacMock = vi.fn(() => false);
+vi.mock("@/lib/platform", () => ({
+  isMac: () => isMacMock(),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ref,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    ref?: React.Ref<HTMLButtonElement>;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button ref={ref} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/icons", () => ({
+  Menu: () => <svg data-testid="menu-icon" />,
+}));
+
+const showApplication = vi.fn<(payload?: { x?: number; y?: number }) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+/** Records where DOM focus sat at the moment the IPC call was made. */
+let focusAtInvoke: Element | null = null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isMacMock.mockReturnValue(false);
+  focusAtInvoke = null;
+  // Testing Library only unmounts what it rendered; inputs appended by hand
+  // would otherwise survive and win document.activeElement in a later test.
+  document.body.innerHTML = "";
+  showApplication.mockImplementation(() => {
+    focusAtInvoke = document.activeElement;
+    return Promise.resolve();
+  });
+  (globalThis as unknown as { window: Window }).window.electron = {
+    menu: { showApplication: (payload?: { x?: number; y?: number }) => showApplication(payload) },
+  } as never;
+});
+
+function renderButton() {
+  const utils = render(<AppMenuButton />);
+  return { ...utils, button: utils.container.querySelector("button") };
+}
+
+function stubRect(button: HTMLButtonElement, rect: { left: number; bottom: number }) {
+  button.getBoundingClientRect = () =>
+    ({ left: rect.left, bottom: rect.bottom }) as unknown as DOMRect;
+}
+
+function addInput(): HTMLInputElement {
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  return input;
+}
+
+/**
+ * Reproduce a keyboard arrival: move real focus onto the button, then deliver
+ * the focus event carrying the element the user came from. `fireEvent.focus`
+ * alone never moves `document.activeElement`, and calling `button.focus()`
+ * afterwards would fire a second, relatedTarget-less focus event that clears
+ * what the component just recorded.
+ */
+function focusFrom(button: HTMLButtonElement, from: HTMLElement) {
+  button.focus();
+  fireEvent.focus(button, { relatedTarget: from });
+}
+
+describe("AppMenuButton", () => {
+  it("renders nothing on macOS, which keeps its native system menu bar", () => {
+    isMacMock.mockReturnValue(true);
+    const { container } = render(<AppMenuButton />);
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("renders a labelled menu trigger on the platforms that lost the native menu", () => {
+    const { button } = renderButton();
+    expect(button).not.toBeNull();
+    expect(button!.getAttribute("aria-haspopup")).toBe("menu");
+    expect(button!.getAttribute("aria-label")?.trim()).toBeTruthy();
+    // Must stay in the toolbar's roving-focus set to be keyboard reachable.
+    expect(button!.hasAttribute("data-toolbar-item")).toBe(true);
+  });
+
+  it("anchors the popup to the button's bottom-left corner", () => {
+    const { button } = renderButton();
+    stubRect(button as HTMLButtonElement, { left: 84, bottom: 44 });
+
+    fireEvent.click(button!);
+
+    expect(showApplication).toHaveBeenCalledWith({ x: 84, y: 44 });
+  });
+
+  it("keeps a primary press from stealing focus, so Edit commands keep their target", () => {
+    const { button } = renderButton();
+    const input = addInput();
+    input.focus();
+
+    const prevented = !fireEvent.pointerDown(button!, { button: 0 });
+
+    expect(prevented).toBe(true);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("does not swallow non-primary presses", () => {
+    const { button } = renderButton();
+    const prevented = !fireEvent.pointerDown(button!, { button: 2 });
+    expect(prevented).toBe(false);
+  });
+
+  it("restores the pre-focus element before asking main to open the menu", () => {
+    const { button } = renderButton();
+    stubRect(button as HTMLButtonElement, { left: 0, bottom: 0 });
+    const input = addInput();
+
+    // Keyboard route: focus really moved onto the button, so relatedTarget is
+    // the only record of where the user was.
+    focusFrom(button as HTMLButtonElement, input);
+    fireEvent.click(button!);
+
+    expect(focusAtInvoke).toBe(input);
+  });
+
+  it("does not restore focus to an element that has since left the DOM", () => {
+    const { button } = renderButton();
+    stubRect(button as HTMLButtonElement, { left: 0, bottom: 0 });
+    const input = addInput();
+
+    focusFrom(button as HTMLButtonElement, input);
+    input.remove();
+    fireEvent.click(button!);
+
+    expect(focusAtInvoke).toBe(button);
+  });
+
+  it("does not reuse a stale focus target on a later pointer press", () => {
+    const { button } = renderButton();
+    stubRect(button as HTMLButtonElement, { left: 0, bottom: 0 });
+    const input = addInput();
+
+    focusFrom(button as HTMLButtonElement, input);
+    fireEvent.click(button!);
+    expect(focusAtInvoke).toBe(input);
+
+    // A subsequent mouse press starts from a clean slate: pointerdown clears
+    // the remembered target, so focus is left wherever the user actually is.
+    const other = addInput();
+    other.focus();
+    fireEvent.pointerDown(button!, { button: 0 });
+    fireEvent.click(button!);
+
+    expect(focusAtInvoke).toBe(other);
+  });
+
+  it("consumes an IPC rejection instead of surfacing an unhandled rejection", async () => {
+    showApplication.mockRejectedValueOnce(new Error("window disposed"));
+    const { button } = renderButton();
+    stubRect(button as HTMLButtonElement, { left: 0, bottom: 0 });
+
+    expect(() => fireEvent.click(button!)).not.toThrow();
+    await Promise.resolve();
+  });
+});

--- a/src/components/Layout/__tests__/AppMenuButton.test.tsx
+++ b/src/components/Layout/__tests__/AppMenuButton.test.tsx
@@ -37,28 +37,46 @@ const showApplication = vi.fn<(payload?: { x?: number; y?: number }) => Promise<
   Promise.resolve()
 );
 
-/** Records where DOM focus sat at the moment the IPC call was made. */
+/** Where DOM focus sat at the exact moment the IPC call was made. */
 let focusAtInvoke: Element | null = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
   isMacMock.mockReturnValue(false);
   focusAtInvoke = null;
-  // Testing Library only unmounts what it rendered; inputs appended by hand
-  // would otherwise survive and win document.activeElement in a later test.
-  document.body.innerHTML = "";
   showApplication.mockImplementation(() => {
     focusAtInvoke = document.activeElement;
     return Promise.resolve();
   });
+  // Testing Library only unmounts what it rendered; nodes appended by hand
+  // would otherwise survive and win document.activeElement in a later test.
+  document.body.innerHTML = "";
   (globalThis as unknown as { window: Window }).window.electron = {
     menu: { showApplication: (payload?: { x?: number; y?: number }) => showApplication(payload) },
   } as never;
 });
 
-function renderButton() {
-  const utils = render(<AppMenuButton />);
-  return { ...utils, button: utils.container.querySelector("button") };
+/**
+ * Render the button inside a realistic toolbar: the component distinguishes
+ * "focus moved within the toolbar" from "focus moved to real content" via the
+ * role="toolbar" ancestor, so a bare render would not exercise that branch.
+ * The sibling stands in for any other roving-focus toolbar item.
+ */
+function renderInToolbar() {
+  const utils = render(
+    <div role="toolbar" aria-label="Main toolbar">
+      <button type="button" data-toolbar-item="" data-testid="sibling">
+        sibling
+      </button>
+      <AppMenuButton />
+    </div>
+  );
+  const button = utils.container.querySelector(
+    "[data-app-menu-button]"
+  ) as HTMLButtonElement | null;
+  const sibling = utils.container.querySelector("[data-testid=sibling]") as HTMLButtonElement;
+  if (button) stubRect(button, { left: 0, bottom: 0 });
+  return { ...utils, button, sibling };
 }
 
 function stubRect(button: HTMLButtonElement, rect: { left: number; bottom: number }) {
@@ -66,33 +84,22 @@ function stubRect(button: HTMLButtonElement, rect: { left: number; bottom: numbe
     ({ left: rect.left, bottom: rect.bottom }) as unknown as DOMRect;
 }
 
-function addInput(): HTMLInputElement {
+/** An editable target living outside the toolbar, like a real text input. */
+function addEditor(): HTMLInputElement {
   const input = document.createElement("input");
   document.body.appendChild(input);
   return input;
 }
 
-/**
- * Reproduce a keyboard arrival: move real focus onto the button, then deliver
- * the focus event carrying the element the user came from. `fireEvent.focus`
- * alone never moves `document.activeElement`, and calling `button.focus()`
- * afterwards would fire a second, relatedTarget-less focus event that clears
- * what the component just recorded.
- */
-function focusFrom(button: HTMLButtonElement, from: HTMLElement) {
-  button.focus();
-  fireEvent.focus(button, { relatedTarget: from });
-}
-
 describe("AppMenuButton", () => {
   it("renders nothing on macOS, which keeps its native system menu bar", () => {
     isMacMock.mockReturnValue(true);
-    const { container } = render(<AppMenuButton />);
-    expect(container.querySelector("button")).toBeNull();
+    const { button } = renderInToolbar();
+    expect(button).toBeNull();
   });
 
   it("renders a labelled menu trigger on the platforms that lost the native menu", () => {
-    const { button } = renderButton();
+    const { button } = renderInToolbar();
     expect(button).not.toBeNull();
     expect(button!.getAttribute("aria-haspopup")).toBe("menu");
     expect(button!.getAttribute("aria-label")?.trim()).toBeTruthy();
@@ -101,7 +108,7 @@ describe("AppMenuButton", () => {
   });
 
   it("anchors the popup to the button's bottom-left corner", () => {
-    const { button } = renderButton();
+    const { button } = renderInToolbar();
     stubRect(button as HTMLButtonElement, { left: 84, bottom: 44 });
 
     fireEvent.click(button!);
@@ -109,71 +116,113 @@ describe("AppMenuButton", () => {
     expect(showApplication).toHaveBeenCalledWith({ x: 84, y: 44 });
   });
 
-  it("keeps a primary press from stealing focus, so Edit commands keep their target", () => {
-    const { button } = renderButton();
-    const input = addInput();
-    input.focus();
-
+  it("cancels a primary press so the browser never moves focus onto the button", () => {
+    const { button } = renderInToolbar();
     const prevented = !fireEvent.pointerDown(button!, { button: 0 });
-
     expect(prevented).toBe(true);
-    expect(document.activeElement).toBe(input);
   });
 
   it("does not swallow non-primary presses", () => {
-    const { button } = renderButton();
+    const { button } = renderInToolbar();
     const prevented = !fireEvent.pointerDown(button!, { button: 2 });
     expect(prevented).toBe(false);
   });
 
-  it("restores the pre-focus element before asking main to open the menu", () => {
-    const { button } = renderButton();
-    stubRect(button as HTMLButtonElement, { left: 0, bottom: 0 });
-    const input = addInput();
+  it("returns focus to the editor before asking main to open the menu", () => {
+    const { button } = renderInToolbar();
+    const editor = addEditor();
 
-    // Keyboard route: focus really moved onto the button, so relatedTarget is
-    // the only record of where the user was.
-    focusFrom(button as HTMLButtonElement, input);
+    // Keyboard route: the user tabs from the editor onto the button, so focus
+    // really is on chrome by the time the menu opens.
+    editor.focus();
+    button!.focus();
     fireEvent.click(button!);
 
-    expect(focusAtInvoke).toBe(input);
+    expect(focusAtInvoke).toBe(editor);
   });
 
-  it("does not restore focus to an element that has since left the DOM", () => {
-    const { button } = renderButton();
-    stubRect(button as HTMLButtonElement, { left: 0, bottom: 0 });
-    const input = addInput();
+  it("restores the editor even when the user arrowed across the toolbar to get here", () => {
+    const { button, sibling } = renderInToolbar();
+    const editor = addEditor();
 
-    focusFrom(button as HTMLButtonElement, input);
-    input.remove();
+    // The toolbar's roving focus calls .focus() on each item in turn, so the
+    // button's immediate predecessor is a sibling button, not the editor.
+    // Restoring that sibling would still point Edit commands at chrome.
+    editor.focus();
+    sibling.focus();
+    button!.focus();
     fireEvent.click(button!);
 
-    expect(focusAtInvoke).toBe(button);
+    expect(focusAtInvoke).toBe(editor);
+    expect(focusAtInvoke).not.toBe(sibling);
   });
 
-  it("does not reuse a stale focus target on a later pointer press", () => {
-    const { button } = renderButton();
-    stubRect(button as HTMLButtonElement, { left: 0, bottom: 0 });
-    const input = addInput();
+  it("keeps the editor target across a press that follows keyboard focus", () => {
+    const { button } = renderInToolbar();
+    const editor = addEditor();
 
-    focusFrom(button as HTMLButtonElement, input);
-    fireEvent.click(button!);
-    expect(focusAtInvoke).toBe(input);
-
-    // A subsequent mouse press starts from a clean slate: pointerdown clears
-    // the remembered target, so focus is left wherever the user actually is.
-    const other = addInput();
-    other.focus();
+    editor.focus();
+    button!.focus();
+    // Clicking a button that already holds keyboard focus must not discard the
+    // remembered editor — preventDefault leaves focus on the button, so the
+    // restore is the only thing pointing Edit commands back at the caret.
     fireEvent.pointerDown(button!, { button: 0 });
     fireEvent.click(button!);
 
-    expect(focusAtInvoke).toBe(other);
+    expect(focusAtInvoke).toBe(editor);
+  });
+
+  it("tracks the most recent editor when focus moves between several", () => {
+    const { button } = renderInToolbar();
+    const first = addEditor();
+    const second = addEditor();
+
+    first.focus();
+    second.focus();
+    button!.focus();
+    fireEvent.click(button!);
+
+    expect(focusAtInvoke).toBe(second);
+  });
+
+  it("does not restore focus to an editor that has since left the DOM", () => {
+    const { button } = renderInToolbar();
+    const editor = addEditor();
+
+    editor.focus();
+    editor.remove();
+    button!.focus();
+    fireEvent.click(button!);
+
+    expect(focusAtInvoke).toBe(button);
+    expect(showApplication).toHaveBeenCalledTimes(1);
+  });
+
+  it("still opens the menu when nothing outside the toolbar was ever focused", () => {
+    const { button } = renderInToolbar();
+
+    button!.focus();
+    fireEvent.click(button!);
+
+    expect(showApplication).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops tracking focus once unmounted", () => {
+    const { button, unmount } = renderInToolbar();
+    const editor = addEditor();
+    editor.focus();
+    button!.focus();
+    unmount();
+
+    // A focusin after teardown must not be recorded — if the listener leaked,
+    // it would keep writing into a ref belonging to a dead component.
+    const late = addEditor();
+    expect(() => late.focus()).not.toThrow();
   });
 
   it("consumes an IPC rejection instead of surfacing an unhandled rejection", async () => {
     showApplication.mockRejectedValueOnce(new Error("window disposed"));
-    const { button } = renderButton();
-    stubRect(button as HTMLButtonElement, { left: 0, bottom: 0 });
+    const { button } = renderInToolbar();
 
     expect(() => fireEvent.click(button!)).not.toThrow();
     await Promise.resolve();

--- a/src/components/Layout/__tests__/AppMenuButton.test.tsx
+++ b/src/components/Layout/__tests__/AppMenuButton.test.tsx
@@ -51,9 +51,11 @@ beforeEach(() => {
   // Testing Library only unmounts what it rendered; nodes appended by hand
   // would otherwise survive and win document.activeElement in a later test.
   document.body.innerHTML = "";
-  (globalThis as unknown as { window: Window }).window.electron = {
-    menu: { showApplication: (payload?: { x?: number; y?: number }) => showApplication(payload) },
-  } as never;
+  Object.assign(window, {
+    electron: {
+      menu: { showApplication: (payload?: { x?: number; y?: number }) => showApplication(payload) },
+    },
+  });
 });
 
 /**
@@ -71,17 +73,16 @@ function renderInToolbar() {
       <AppMenuButton />
     </div>
   );
-  const button = utils.container.querySelector(
-    "[data-app-menu-button]"
-  ) as HTMLButtonElement | null;
-  const sibling = utils.container.querySelector("[data-testid=sibling]") as HTMLButtonElement;
+  const button = utils.container.querySelector<HTMLButtonElement>("[data-app-menu-button]");
+  const sibling = utils.container.querySelector<HTMLButtonElement>("[data-testid=sibling]")!;
   if (button) stubRect(button, { left: 0, bottom: 0 });
   return { ...utils, button, sibling };
 }
 
 function stubRect(button: HTMLButtonElement, rect: { left: number; bottom: number }) {
-  button.getBoundingClientRect = () =>
-    ({ left: rect.left, bottom: rect.bottom }) as unknown as DOMRect;
+  // Zero-sized rect anchored so that left/bottom are exactly the values under
+  // test — DOMRect derives bottom from y + height.
+  button.getBoundingClientRect = () => new DOMRect(rect.left, rect.bottom, 0, 0);
 }
 
 /** An editable target living outside the toolbar, like a real text input. */
@@ -109,7 +110,7 @@ describe("AppMenuButton", () => {
 
   it("anchors the popup to the button's bottom-left corner", () => {
     const { button } = renderInToolbar();
-    stubRect(button as HTMLButtonElement, { left: 84, bottom: 44 });
+    stubRect(button!, { left: 84, bottom: 44 });
 
     fireEvent.click(button!);
 

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -29,6 +29,7 @@ export {
   History, // resume closed session / session history
   Layers, // worktree overview (multiple worktrees, stacked)
   LayoutPanelTop, // workspace plugin category (panels, notes)
+  Menu, // the application menu, surfaced in-app where the native menu bar can't render
   Moon, // sleep a project — shut it down the way quitting does, restored on reopen
   Package, // plugin (a packaged extension) — plugin tray, unresolved plugin glyphs
   Plug, // agent (integration that plugs into the host system)


### PR DESCRIPTION
## Summary

- On Windows, `getPlatformWindowOptions()` sets `titleBarStyle: "hidden"` plus `titleBarOverlay` for the Window Controls Overlay. That removes the frame region the native menu bar would render into, so the application menu was unreachable. Any action that only lived in the menu had no route at all, and the code comment claiming "Alt still reveals the menu" was false.
- On Linux the frame is real and Alt does work, so the problem there is just discoverability. Nothing in the UI hints that a menu exists.
- Fixes it with a new IPC op that pops up the exact `Menu.getApplicationMenu()` object, not a rebuilt template, anchored under a new toolbar button.

Resolves #11813

## Approach

`menu:show-application` pops the installed menu object itself. Because it's the same menu instance `electron/menu.ts` builds and keeps live, the popup inherits everything dynamic for free: the Open Recent submenu, installed-agent items, plugin contributions, the "Check for Updates…" label `applyUpdateMenuState` mutates in place, and the project gates `refreshProjectMenuState` toggles. No second source of truth to drift, and `electron/menu.ts` itself is untouched.

I considered transcribing the menu into a Radix DOM menu instead, matching how panel-header menus already work. Rejected it: roughly 45% of the template is main-process-only with no renderer-callable equivalent (the Open Directory / `handleDirectoryOpen` pipeline, the Edit menu's `getFocusedWebContents()` calls, Reload/Zoom/Fullscreen, the CLI installer, About). A DOM replica would have been both a duplicate source of truth and structurally incomplete.

## Details worth flagging

- macOS is untouched. It keeps the native system menu bar, the button doesn't render there, and the main-process handler no-ops.
- The native menu stays installed on every platform. Nulling it would deregister the accelerators `electron/menu.ts` deliberately keeps natively registered.
- `platformWindowOptions.ts` behaviour is unchanged, I only corrected the false comment. `autoHideMenuBar` still has to stay in the constructor, or the Window Controls Overlay layout shifts. Linux keeps `autoHideMenuBar: true`, so Alt still works as a second route.
- The button must not take DOM focus. The Edit menu's items act on `webContents.getFocusedWebContents()`, so stealing focus would point Cut/Copy/Paste at the button instead of whatever the user was actually working in. I cancel the primary pointerdown and restore the last element focused *outside* the toolbar before opening the popup, tracked document-wide rather than via `relatedTarget`, because the toolbar's roving focus would otherwise hand focus back to the neighbouring toolbar button.
- The popup refuses to open from an unfocused window, so a renderer can't summon the real application menu under the pointer to bait a click onto a privileged item.
- The anchor is converted using the sending view's own zoom factor and clamped to the window's content bounds.

## Testing

Two new suites:
- `electron/ipc/handlers/__tests__/menu.application.test.ts`: anchor math, guard behaviour, popping the exact installed menu object, re-resolving after a menu rebuild.
- `src/components/Layout/__tests__/AppMenuButton.test.tsx`: platform gating, anchoring, and the focus-preservation invariant including the roving-focus route.

Locally green: 148 targeted tests, 423 contract tests, `npm run typecheck`, plus prettier/eslint on the changed files.

**Not done:** no E2E spec. The button doesn't render on macOS so I can't exercise it on this machine, and PR CI doesn't run E2E anyway, so an unverified spec would only fail later at release time. `e2e/full/platform/` looks like the right home if someone adds one on a Windows or Linux box.
