### PR TITLE
fix(worktree): close startup paths that leave the sidebar without a port

### DIFF
--- a/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
+++ b/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import {
   attachStartupWorktreePort,
   describeStartupPortFailure,
+  runStartupWorktreeLoad,
   selectStatusTarget,
   sendStartupWorktreeLoadFailure,
+  STARTUP_NO_WORKSPACE_CLIENT_MESSAGE,
 } from "../startupWorktreeLoad.js";
 
 /**
@@ -24,30 +26,38 @@ const PROJECT_WORKTREE_LOAD_STATUS = "project:worktree-load-status";
 
 type FakeWebContents = {
   isDestroyed(): boolean;
+  /** Present so a subframe-only load is distinguishable from a settled one. */
+  isLoading(): boolean;
   isLoadingMainFrame(): boolean;
   once(event: "did-finish-load", listener: () => void): unknown;
   send(channel: string, payload: unknown): void;
   destroyed: boolean;
   sent: { channel: string; payload: unknown }[];
+  sendAttempts: number;
   pendingDidFinishLoad: (() => void)[];
 };
 
 function makeWebContents(opts: {
   loadingMainFrame: boolean;
+  /** Defaults to the main-frame value; set true alone to model a subframe. */
+  loading?: boolean;
   destroyed?: boolean;
   onSend?: () => void;
 }): FakeWebContents {
   const wc: FakeWebContents = {
     destroyed: opts.destroyed ?? false,
     sent: [],
+    sendAttempts: 0,
     pendingDidFinishLoad: [],
     isDestroyed: () => wc.destroyed,
+    isLoading: () => opts.loading ?? opts.loadingMainFrame,
     isLoadingMainFrame: () => opts.loadingMainFrame,
     once: (_event, listener) => {
       wc.pendingDidFinishLoad.push(listener);
       return wc;
     },
     send: (channel, payload) => {
+      wc.sendAttempts += 1;
       opts.onSend?.();
       wc.sent.push({ channel, payload });
     },
@@ -88,9 +98,12 @@ describe("startup worktree-load failure reporting (#8796)", () => {
   });
 
   it("sends immediately when only a subframe is loading", () => {
-    // `isLoading()` would be true here, but `did-finish-load` only fires for
-    // the main frame — deferring on it would park the send forever (#11818).
-    const wc = makeWebContents({ loadingMainFrame: false });
+    // `isLoading()` is true here but the main frame has settled, so
+    // `did-finish-load` will never fire again — deferring on it would park the
+    // send forever (#11818).
+    const wc = makeWebContents({ loadingMainFrame: false, loading: true });
+    expect(wc.isLoading()).toBe(true);
+
     sendStartupWorktreeLoadFailure(wc, "proj-a", new Error("folder is gone"));
 
     expect(wc.pendingDidFinishLoad).toHaveLength(0);
@@ -123,10 +136,8 @@ describe("startup worktree-load failure reporting (#8796)", () => {
     expect(wc.sent).toHaveLength(0);
   });
 
-  it("does not throw when the target webContents is missing", () => {
-    expect(() =>
-      sendStartupWorktreeLoadFailure(null, "proj-a", new Error("folder is gone"))
-    ).not.toThrow();
+  it("reports no send when the target webContents is missing", () => {
+    expect(sendStartupWorktreeLoadFailure(null, "proj-a", new Error("folder is gone"))).toBe(false);
   });
 
   it("swallows a teardown race inside the send itself", () => {
@@ -141,6 +152,8 @@ describe("startup worktree-load failure reporting (#8796)", () => {
     expect(() =>
       sendStartupWorktreeLoadFailure(wc, "proj-a", new Error("folder is gone"))
     ).not.toThrow();
+    // The send was genuinely attempted — not skipped by an earlier guard.
+    expect(wc.sendAttempts).toBe(1);
   });
 
   it("falls back to a generic message for a non-Error throw", () => {
@@ -255,5 +268,103 @@ describe("startup worktree port attach (#11818)", () => {
     for (const message of messages) {
       expect(message.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("startup worktree load orchestration (#11818)", () => {
+  const host = { id: "host-1" };
+  type HostType = typeof host;
+
+  type Scenario = {
+    loadProject?: (() => Promise<void>) | null;
+    target?: FakeWebContents | null;
+    host?: HostType | null;
+    brokerPort?: ((host: HostType, target: FakeWebContents) => boolean) | null;
+  };
+
+  function run(scenario: Scenario) {
+    const report = vi.fn();
+    const attachDirectPort = vi.fn();
+    const target =
+      scenario.target === undefined
+        ? makeWebContents({ loadingMainFrame: false })
+        : scenario.target;
+
+    const outcome = runStartupWorktreeLoad<HostType, FakeWebContents>({
+      loadProject:
+        scenario.loadProject === undefined ? () => Promise.resolve() : scenario.loadProject,
+      getPortTarget: () => target,
+      getHost: () => (scenario.host === undefined ? host : scenario.host),
+      attachDirectPort,
+      getBrokerPort: () => (scenario.brokerPort === undefined ? () => true : scenario.brokerPort),
+      report,
+    });
+
+    return { outcome, report, attachDirectPort };
+  }
+
+  it("brokers the port and reports nothing on the happy path", async () => {
+    const { outcome, report, attachDirectPort } = run({});
+
+    expect(await outcome).toEqual({ status: "loaded" });
+    expect(attachDirectPort).toHaveBeenCalledOnce();
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  // The #11818 regression witness: a boot with no workspace client used to skip
+  // the whole block in silence, leaving the sidebar on an endless skeleton.
+  it("reports instead of silently skipping when there is no workspace client", async () => {
+    const { outcome, report, attachDirectPort } = run({ loadProject: null });
+
+    expect(await outcome).toEqual({ status: "no-client" });
+    expect(report).toHaveBeenCalledOnce();
+    expect((report.mock.calls[0]![0] as Error).message).toBe(STARTUP_NO_WORKSPACE_CLIENT_MESSAGE);
+    // Nothing was loaded, so nothing may be attached either.
+    expect(attachDirectPort).not.toHaveBeenCalled();
+  });
+
+  it("reports the original error when the load throws", async () => {
+    const failure = new Error("folder is gone");
+    const { outcome, report } = run({ loadProject: () => Promise.reject(failure) });
+
+    expect(await outcome).toEqual({ status: "load-failed", error: failure });
+    expect(report).toHaveBeenCalledWith(failure);
+  });
+
+  // A resolved load with no brokered port leaves the renderer in exactly the
+  // state a thrown load does, so each of these must report too.
+  it.each([
+    ["no renderer target", { target: null }, "no-renderer-target"],
+    ["no workspace host", { host: null }, "no-host"],
+    ["no port broker", { brokerPort: null }, "no-broker"],
+    ["a broker that rejects the target", { brokerPort: () => false }, "broker-rejected"],
+  ] as const)("reports a load that succeeded but left %s", async (_label, scenario, reason) => {
+    const { outcome, report } = run(scenario);
+
+    expect(await outcome).toEqual({ status: "port-failed", reason });
+    expect(report).toHaveBeenCalledOnce();
+    expect((report.mock.calls[0]![0] as Error).message).toBe(describeStartupPortFailure(reason));
+  });
+
+  it("resolves the broker after the load rather than before it", async () => {
+    // The broker is constructed during init, which can still be in flight when
+    // the load starts — reading it up front would lose it.
+    let broker: ((host: HostType, target: FakeWebContents) => boolean) | null = null;
+    const report = vi.fn();
+
+    const outcome = await runStartupWorktreeLoad<HostType, FakeWebContents>({
+      loadProject: () => {
+        broker = () => true;
+        return Promise.resolve();
+      },
+      getPortTarget: () => makeWebContents({ loadingMainFrame: false }),
+      getHost: () => host,
+      attachDirectPort: () => {},
+      getBrokerPort: () => broker,
+      report,
+    });
+
+    expect(outcome).toEqual({ status: "loaded" });
+    expect(report).not.toHaveBeenCalled();
   });
 });

--- a/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
+++ b/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
@@ -1,77 +1,64 @@
-import { describe, expect, it } from "vitest";
-import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  attachStartupWorktreePort,
+  describeStartupPortFailure,
+  selectStatusTarget,
+  sendStartupWorktreeLoadFailure,
+} from "../startupWorktreeLoad.js";
 
 /**
- * Tests the startup worktree-load-failure decision logic from
- * windowServices.ts (#8796).
+ * Tests the startup worktree-load reporting used by windowServices.ts
+ * (#8796, #11818).
  *
- * setupWindowServices cannot be imported directly (side effects, Electron
- * deps), so we replicate the catch-block decision logic: given a resolved
- * projectId and a target webContents, when — and what — does it send?
+ * These exercise the production helpers directly — the module is structurally
+ * typed and Electron-free precisely so the boot decision logic can be tested
+ * without importing setupWindowServices (side effects, Electron deps).
  *
- * The interesting branch is IPC timing: a `project:worktree-load-status`
- * sent before the renderer wires its ipcRenderer listener is silently
- * dropped, so the send must defer to `did-finish-load` while loading.
+ * The interesting branches: IPC timing (a `project:worktree-load-status` sent
+ * before the renderer wires its ipcRenderer listener is silently dropped, so
+ * the send defers to `did-finish-load` while the *main frame* loads), and the
+ * port-attach outcomes that leave the renderer with no worktree port at all.
  */
 
+const PROJECT_WORKTREE_LOAD_STATUS = "project:worktree-load-status";
+
 type FakeWebContents = {
-  loading: boolean;
+  isDestroyed(): boolean;
+  isLoadingMainFrame(): boolean;
+  once(event: "did-finish-load", listener: () => void): unknown;
+  send(channel: string, payload: unknown): void;
   destroyed: boolean;
   sent: { channel: string; payload: unknown }[];
   pendingDidFinishLoad: (() => void)[];
 };
 
-const PROJECT_WORKTREE_LOAD_STATUS = "project:worktree-load-status";
-
-function makeWebContents(opts: { loading: boolean; destroyed?: boolean }): FakeWebContents {
-  return {
-    loading: opts.loading,
+function makeWebContents(opts: {
+  loadingMainFrame: boolean;
+  destroyed?: boolean;
+  onSend?: () => void;
+}): FakeWebContents {
+  const wc: FakeWebContents = {
     destroyed: opts.destroyed ?? false,
     sent: [],
     pendingDidFinishLoad: [],
+    isDestroyed: () => wc.destroyed,
+    isLoadingMainFrame: () => opts.loadingMainFrame,
+    once: (_event, listener) => {
+      wc.pendingDidFinishLoad.push(listener);
+      return wc;
+    },
+    send: (channel, payload) => {
+      opts.onSend?.();
+      wc.sent.push({ channel, payload });
+    },
   };
+  return wc;
 }
 
-/**
- * Replicates the status-target selection from windowServices.ts (#8796):
- * prefer the project view's webContents, but fall through to the window's
- * app webContents when it's already destroyed — selecting a destroyed
- * target would silently drop the message.
- */
-function selectStatusTarget(
-  initialAppViewWc: FakeWebContents | null,
-  fallbackWc: FakeWebContents | null
-): FakeWebContents | null {
-  if (initialAppViewWc && !initialAppViewWc.destroyed) return initialAppViewWc;
-  return fallbackWc;
-}
-
-/** Replicates the windowServices.ts worktree-load catch block (#8796). */
-function simulateStartupWorktreeLoadFailure(
-  failedProjectId: string | undefined,
-  statusTarget: FakeWebContents | null,
-  error: unknown
-): void {
-  if (!failedProjectId || !statusTarget) return;
-  const worktreeLoadError = formatErrorMessage(error, "Failed to load worktrees");
-  const sendLoadStatus = (): void => {
-    if (statusTarget.destroyed) return;
-    statusTarget.sent.push({
-      channel: PROJECT_WORKTREE_LOAD_STATUS,
-      payload: { projectId: failedProjectId, worktreeLoadError },
-    });
-  };
-  if (statusTarget.loading) {
-    statusTarget.pendingDidFinishLoad.push(sendLoadStatus);
-  } else {
-    sendLoadStatus();
-  }
-}
-
-describe("windowServices startup worktree-load failure (#8796)", () => {
-  it("sends the load-status immediately when the renderer has finished loading", () => {
-    const wc = makeWebContents({ loading: false });
-    simulateStartupWorktreeLoadFailure("proj-a", wc, new Error("folder is gone"));
+describe("startup worktree-load failure reporting (#8796)", () => {
+  it("sends the load-status immediately when the main frame has finished loading", () => {
+    const wc = makeWebContents({ loadingMainFrame: false });
+    expect(sendStartupWorktreeLoadFailure(wc, "proj-a", new Error("folder is gone"))).toBe(true);
 
     expect(wc.sent).toEqual([
       {
@@ -82,9 +69,9 @@ describe("windowServices startup worktree-load failure (#8796)", () => {
     expect(wc.pendingDidFinishLoad).toHaveLength(0);
   });
 
-  it("defers the load-status until did-finish-load while the renderer is still loading", () => {
-    const wc = makeWebContents({ loading: true });
-    simulateStartupWorktreeLoadFailure("proj-a", wc, new Error("folder is gone"));
+  it("defers the load-status until did-finish-load while the main frame is loading", () => {
+    const wc = makeWebContents({ loadingMainFrame: true });
+    sendStartupWorktreeLoadFailure(wc, "proj-a", new Error("folder is gone"));
 
     // Nothing sent yet — a message before the renderer wires its
     // ipcRenderer listener would be silently dropped.
@@ -100,17 +87,27 @@ describe("windowServices startup worktree-load failure (#8796)", () => {
     ]);
   });
 
-  it("sends nothing when no projectId could be resolved (explicit-path window)", () => {
-    const wc = makeWebContents({ loading: false });
-    simulateStartupWorktreeLoadFailure(undefined, wc, new Error("folder is gone"));
+  it("sends immediately when only a subframe is loading", () => {
+    // `isLoading()` would be true here, but `did-finish-load` only fires for
+    // the main frame — deferring on it would park the send forever (#11818).
+    const wc = makeWebContents({ loadingMainFrame: false });
+    sendStartupWorktreeLoadFailure(wc, "proj-a", new Error("folder is gone"));
+
+    expect(wc.pendingDidFinishLoad).toHaveLength(0);
+    expect(wc.sent).toHaveLength(1);
+  });
+
+  it("sends nothing when no projectId could be resolved", () => {
+    const wc = makeWebContents({ loadingMainFrame: false });
+    expect(sendStartupWorktreeLoadFailure(wc, undefined, new Error("folder is gone"))).toBe(false);
 
     expect(wc.sent).toHaveLength(0);
     expect(wc.pendingDidFinishLoad).toHaveLength(0);
   });
 
   it("does not send when the webContents was destroyed before did-finish-load", () => {
-    const wc = makeWebContents({ loading: true });
-    simulateStartupWorktreeLoadFailure("proj-a", wc, new Error("folder is gone"));
+    const wc = makeWebContents({ loadingMainFrame: true });
+    sendStartupWorktreeLoadFailure(wc, "proj-a", new Error("folder is gone"));
     expect(wc.pendingDidFinishLoad).toHaveLength(1);
 
     // Window closed between the throw and did-finish-load.
@@ -120,34 +117,143 @@ describe("windowServices startup worktree-load failure (#8796)", () => {
   });
 
   it("does not send when the target webContents is already destroyed at call time", () => {
-    const wc = makeWebContents({ loading: false, destroyed: true });
-    simulateStartupWorktreeLoadFailure("proj-a", wc, new Error("folder is gone"));
+    const wc = makeWebContents({ loadingMainFrame: false, destroyed: true });
+    expect(sendStartupWorktreeLoadFailure(wc, "proj-a", new Error("folder is gone"))).toBe(false);
 
     expect(wc.sent).toHaveLength(0);
   });
 
   it("does not throw when the target webContents is missing", () => {
     expect(() =>
-      simulateStartupWorktreeLoadFailure("proj-a", null, new Error("folder is gone"))
+      sendStartupWorktreeLoadFailure(null, "proj-a", new Error("folder is gone"))
     ).not.toThrow();
+  });
+
+  it("swallows a teardown race inside the send itself", () => {
+    const wc = makeWebContents({
+      loadingMainFrame: false,
+      onSend: () => {
+        throw new Error("Object has been destroyed");
+      },
+    });
+
+    // A throw here must not abort the rest of window startup.
+    expect(() =>
+      sendStartupWorktreeLoadFailure(wc, "proj-a", new Error("folder is gone"))
+    ).not.toThrow();
+  });
+
+  it("falls back to a generic message for a non-Error throw", () => {
+    const wc = makeWebContents({ loadingMainFrame: false });
+    sendStartupWorktreeLoadFailure(wc, "proj-a", { weird: true });
+
+    expect(wc.sent[0]?.payload).toEqual({
+      projectId: "proj-a",
+      worktreeLoadError: "Failed to load worktrees",
+    });
   });
 
   describe("status-target selection", () => {
     it("prefers the project view's webContents when it is alive", () => {
-      const viewWc = makeWebContents({ loading: false });
-      const fallbackWc = makeWebContents({ loading: false });
+      const viewWc = makeWebContents({ loadingMainFrame: false });
+      const fallbackWc = makeWebContents({ loadingMainFrame: false });
       expect(selectStatusTarget(viewWc, fallbackWc)).toBe(viewWc);
     });
 
     it("falls through to the app webContents when the project view is destroyed", () => {
-      const viewWc = makeWebContents({ loading: false, destroyed: true });
-      const fallbackWc = makeWebContents({ loading: false });
+      const viewWc = makeWebContents({ loadingMainFrame: false, destroyed: true });
+      const fallbackWc = makeWebContents({ loadingMainFrame: false });
       expect(selectStatusTarget(viewWc, fallbackWc)).toBe(fallbackWc);
     });
 
     it("uses the app webContents when there is no project view", () => {
-      const fallbackWc = makeWebContents({ loading: false });
+      const fallbackWc = makeWebContents({ loadingMainFrame: false });
       expect(selectStatusTarget(null, fallbackWc)).toBe(fallbackWc);
     });
+
+    it("yields no target when both candidates are destroyed", () => {
+      const viewWc = makeWebContents({ loadingMainFrame: false, destroyed: true });
+      const fallbackWc = makeWebContents({ loadingMainFrame: false, destroyed: true });
+      expect(selectStatusTarget(viewWc, fallbackWc)).toBeNull();
+    });
+  });
+});
+
+describe("startup worktree port attach (#11818)", () => {
+  const host = { id: "host-1" };
+  type HostType = typeof host;
+
+  function attach(overrides: {
+    target?: FakeWebContents | null;
+    host?: HostType | null;
+    brokerPort?: ((host: HostType, target: FakeWebContents) => boolean) | null;
+    attachDirectPort?: (target: FakeWebContents) => void;
+  }) {
+    return attachStartupWorktreePort({
+      target:
+        overrides.target === undefined
+          ? makeWebContents({ loadingMainFrame: false })
+          : overrides.target,
+      host: overrides.host === undefined ? host : overrides.host,
+      attachDirectPort: overrides.attachDirectPort ?? (() => {}),
+      brokerPort: overrides.brokerPort === undefined ? () => true : overrides.brokerPort,
+    });
+  }
+
+  it("reports success once the port is brokered", () => {
+    const attachDirectPort = vi.fn();
+    const brokerPort = vi.fn(() => true);
+    expect(attach({ attachDirectPort, brokerPort })).toEqual({ ok: true });
+    expect(attachDirectPort).toHaveBeenCalledOnce();
+    expect(brokerPort).toHaveBeenCalledOnce();
+  });
+
+  it("fails without attaching when there is no renderer target", () => {
+    const attachDirectPort = vi.fn();
+    expect(attach({ target: null, attachDirectPort })).toEqual({
+      ok: false,
+      reason: "no-renderer-target",
+    });
+    expect(attachDirectPort).not.toHaveBeenCalled();
+  });
+
+  it("fails without attaching when the renderer target is destroyed", () => {
+    const attachDirectPort = vi.fn();
+    const target = makeWebContents({ loadingMainFrame: false, destroyed: true });
+    expect(attach({ target, attachDirectPort })).toEqual({
+      ok: false,
+      reason: "no-renderer-target",
+    });
+    expect(attachDirectPort).not.toHaveBeenCalled();
+  });
+
+  it("fails when the project has no workspace host", () => {
+    expect(attach({ host: null })).toEqual({ ok: false, reason: "no-host" });
+  });
+
+  it("fails when no broker was constructed", () => {
+    expect(attach({ brokerPort: null })).toEqual({ ok: false, reason: "no-broker" });
+  });
+
+  it("fails when the broker rejects the target", () => {
+    // brokerPort() returns false for a destroyed webContents — a resolved
+    // loadProject() is not proof the renderer got a port.
+    expect(attach({ brokerPort: () => false })).toEqual({ ok: false, reason: "broker-rejected" });
+  });
+
+  it("still attaches the direct port before discovering the host is missing", () => {
+    const attachDirectPort = vi.fn();
+    attach({ host: null, attachDirectPort });
+    expect(attachDirectPort).toHaveBeenCalledOnce();
+  });
+
+  it("describes every failure reason with distinct reader-facing text", () => {
+    const reasons = ["no-renderer-target", "no-host", "no-broker", "broker-rejected"] as const;
+    const messages = reasons.map(describeStartupPortFailure);
+
+    expect(new Set(messages).size).toBe(reasons.length);
+    for (const message of messages) {
+      expect(message.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
+++ b/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
@@ -207,11 +207,45 @@ describe("startup worktree port attach (#11818)", () => {
         overrides.target === undefined
           ? makeWebContents({ loadingMainFrame: false })
           : overrides.target,
-      host: overrides.host === undefined ? host : overrides.host,
+      getHost: () => (overrides.host === undefined ? host : overrides.host),
       attachDirectPort: overrides.attachDirectPort ?? (() => {}),
-      brokerPort: overrides.brokerPort === undefined ? () => true : overrides.brokerPort,
+      getBrokerPort: () => (overrides.brokerPort === undefined ? () => true : overrides.brokerPort),
     });
   }
+
+  it("looks nothing up until the target is validated and attached", () => {
+    // Order matters: the pre-extraction code resolved the host and broker only
+    // after a live target had taken the direct port.
+    const order: string[] = [];
+    attachStartupWorktreePort<HostType, FakeWebContents>({
+      target: makeWebContents({ loadingMainFrame: false }),
+      getHost: () => {
+        order.push("host");
+        return host;
+      },
+      attachDirectPort: () => order.push("attach"),
+      getBrokerPort: () => {
+        order.push("broker");
+        return () => true;
+      },
+    });
+
+    expect(order).toEqual(["attach", "host", "broker"]);
+  });
+
+  it("looks nothing up at all when the target is already gone", () => {
+    const getHost = vi.fn(() => host);
+    const getBrokerPort = vi.fn(() => () => true);
+    attachStartupWorktreePort<HostType, FakeWebContents>({
+      target: null,
+      getHost,
+      attachDirectPort: () => {},
+      getBrokerPort,
+    });
+
+    expect(getHost).not.toHaveBeenCalled();
+    expect(getBrokerPort).not.toHaveBeenCalled();
+  });
 
   it("reports success once the port is brokered", () => {
     const attachDirectPort = vi.fn();
@@ -344,6 +378,49 @@ describe("startup worktree load orchestration (#11818)", () => {
     expect(await outcome).toEqual({ status: "port-failed", reason });
     expect(report).toHaveBeenCalledOnce();
     expect((report.mock.calls[0]![0] as Error).message).toBe(describeStartupPortFailure(reason));
+  });
+
+  // A throw escaping here would reject setupWindowServices itself, which on a
+  // cold boot exits the app instead of surfacing a worktree failure.
+  it.each([
+    [
+      "attachDirectPort",
+      {
+        attachDirectPort: () => {
+          throw new Error("webContents went away");
+        },
+      },
+    ],
+    [
+      "the host lookup",
+      {
+        getHost: () => {
+          throw new Error("pool is gone");
+        },
+      },
+    ],
+    [
+      "the broker",
+      {
+        getBrokerPort: () => () => {
+          throw new Error("port channel closed");
+        },
+      },
+    ],
+  ])("reports rather than throwing when %s throws", async (_label, overrides) => {
+    const report = vi.fn();
+    const call = runStartupWorktreeLoad<HostType, FakeWebContents>({
+      loadProject: () => Promise.resolve(),
+      getPortTarget: () => makeWebContents({ loadingMainFrame: false }),
+      getHost: () => host,
+      attachDirectPort: () => {},
+      getBrokerPort: () => () => true,
+      ...overrides,
+      report,
+    });
+
+    await expect(call).resolves.toMatchObject({ status: "attach-failed" });
+    expect(report).toHaveBeenCalledOnce();
   });
 
   it("resolves the broker after the load rather than before it", async () => {

--- a/electron/window/startupWorktreeLoad.ts
+++ b/electron/window/startupWorktreeLoad.ts
@@ -1,0 +1,133 @@
+import { CHANNELS } from "../ipc/channels.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+/**
+ * Startup-only worktree-load reporting for `setupWindowServices` (#8796, #11818).
+ *
+ * Boot is the one worktree-load path that has to defer its status send until
+ * the renderer has finished loading, so it does not share the send site used by
+ * project switch, relocation, or retry — those run against a renderer that is
+ * already listening. It is extracted here so both the failure branches and the
+ * tests exercise the same code instead of a copy of it.
+ *
+ * The Electron surfaces are declared structurally so this module (and its
+ * suite) never pulls in the Electron runtime.
+ */
+
+/** The `WebContents` surface the startup status send touches. */
+export interface StartupStatusTarget {
+  isDestroyed(): boolean;
+  isLoadingMainFrame(): boolean;
+  once(event: "did-finish-load", listener: () => void): unknown;
+  send(channel: string, payload: unknown): void;
+}
+
+/**
+ * Prefer the project view's webContents, falling through to the window's app
+ * webContents when it is already destroyed — a destroyed target would swallow
+ * the message and leave the sidebar hanging. A destroyed fallback yields no
+ * target at all rather than one that cannot receive anything.
+ */
+export function selectStatusTarget<T extends { isDestroyed(): boolean }>(
+  preferred: T | null | undefined,
+  fallback: T | null | undefined
+): T | null {
+  if (preferred && !preferred.isDestroyed()) return preferred;
+  if (fallback && !fallback.isDestroyed()) return fallback;
+  return null;
+}
+
+/**
+ * Push a worktree-load failure to the renderer so the sidebar shows
+ * `WorktreeLoadErrorBanner` and its Retry action instead of an endless loading
+ * skeleton.
+ *
+ * Gates the deferral on `isLoadingMainFrame()`, not `isLoading()`: the latter
+ * is true while *any* frame is loading (an HTML preview iframe, say), but
+ * `did-finish-load` only fires for the main frame, so a bare `isLoading()`
+ * parks the send on an event that never arrives. Same reasoning as the
+ * Dock-drop send in `menu.ts`.
+ *
+ * Returns whether a send was performed or scheduled.
+ */
+export function sendStartupWorktreeLoadFailure(
+  target: StartupStatusTarget | null,
+  projectId: string | undefined,
+  error: unknown
+): boolean {
+  if (!target || !projectId) return false;
+
+  const worktreeLoadError = formatErrorMessage(error, "Failed to load worktrees");
+  const sendLoadStatus = (): void => {
+    try {
+      if (target.isDestroyed()) return;
+      target.send(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, { projectId, worktreeLoadError });
+    } catch {
+      // The window went away between the liveness check and the send. Nothing
+      // is left to notify, and throwing here would abort the rest of startup.
+    }
+  };
+
+  try {
+    if (target.isDestroyed()) return false;
+    if (target.isLoadingMainFrame()) {
+      target.once("did-finish-load", sendLoadStatus);
+    } else {
+      sendLoadStatus();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Why a startup worktree port never reached the renderer. */
+export type StartupPortFailureReason =
+  "no-renderer-target" | "no-host" | "no-broker" | "broker-rejected";
+
+export type StartupPortAttachResult =
+  { ok: true } | { ok: false; reason: StartupPortFailureReason };
+
+/**
+ * Wire the renderer to the workspace host for a project that has just loaded.
+ *
+ * `loadProject()` resolving is not enough: if the direct-port target is gone,
+ * the host is missing, the broker was never constructed, or `brokerPort()`
+ * rejects the target, the renderer ends up with no worktree port — which it
+ * cannot tell apart from a load that threw. Each of those is reported as a
+ * failure rather than silently skipped (#11818).
+ */
+export function attachStartupWorktreePort<THost, TTarget extends { isDestroyed(): boolean }>(args: {
+  target: TTarget | null | undefined;
+  host: THost | null | undefined;
+  attachDirectPort: (target: TTarget) => void;
+  brokerPort: ((host: THost, target: TTarget) => boolean) | null | undefined;
+}): StartupPortAttachResult {
+  const { target, host, attachDirectPort, brokerPort } = args;
+
+  if (!target || target.isDestroyed()) return { ok: false, reason: "no-renderer-target" };
+
+  attachDirectPort(target);
+
+  if (!host) return { ok: false, reason: "no-host" };
+  if (!brokerPort) return { ok: false, reason: "no-broker" };
+  if (!brokerPort(host, target)) return { ok: false, reason: "broker-rejected" };
+
+  return { ok: true };
+}
+
+const STARTUP_PORT_FAILURE_MESSAGES: Record<StartupPortFailureReason, string> = {
+  "no-renderer-target": "The project window closed before its worktree connection was ready.",
+  "no-host": "The workspace service didn't start a host for this project.",
+  "no-broker": "The worktree connection broker wasn't available.",
+  "broker-rejected": "The worktree connection couldn't be opened.",
+};
+
+/** Reader-facing text for a port that never reached the renderer. */
+export function describeStartupPortFailure(reason: StartupPortFailureReason): string {
+  return STARTUP_PORT_FAILURE_MESSAGES[reason];
+}
+
+/** Reader-facing text for a boot that had no workspace client at all. */
+export const STARTUP_NO_WORKSPACE_CLIENT_MESSAGE =
+  "The workspace service wasn't available when this window started.";

--- a/electron/window/startupWorktreeLoad.ts
+++ b/electron/window/startupWorktreeLoad.ts
@@ -131,3 +131,64 @@ export function describeStartupPortFailure(reason: StartupPortFailureReason): st
 /** Reader-facing text for a boot that had no workspace client at all. */
 export const STARTUP_NO_WORKSPACE_CLIENT_MESSAGE =
   "The workspace service wasn't available when this window started.";
+
+/** How a window's startup worktree load ended. */
+export type StartupWorktreeLoadOutcome =
+  | { status: "loaded" }
+  | { status: "no-client" }
+  | { status: "load-failed"; error: unknown }
+  | { status: "port-failed"; reason: StartupPortFailureReason };
+
+/**
+ * Run a window's startup worktree load and report every outcome that leaves the
+ * renderer without a port.
+ *
+ * The reporting lives in here rather than at the call site because the whole
+ * defect in #11818 was a branch that silently did nothing: keeping the decision
+ * flow and its reporting together means the tests cover the thing that broke,
+ * instead of a copy of it.
+ *
+ * `loadProject` is null when no workspace client was available — that is the
+ * case that used to be skipped without a trace.
+ */
+export async function runStartupWorktreeLoad<
+  THost,
+  TTarget extends { isDestroyed(): boolean },
+>(args: {
+  loadProject: (() => Promise<void>) | null;
+  getPortTarget: () => TTarget | null | undefined;
+  getHost: () => THost | null | undefined;
+  attachDirectPort: (target: TTarget) => void;
+  // Resolved after the load rather than before it, so a broker constructed
+  // during init is still picked up, and a genuinely absent one stays
+  // distinguishable from one that rejected the target.
+  getBrokerPort: () => ((host: THost, target: TTarget) => boolean) | null | undefined;
+  report: (error: unknown) => void;
+}): Promise<StartupWorktreeLoadOutcome> {
+  const { loadProject, getPortTarget, getHost, attachDirectPort, getBrokerPort, report } = args;
+
+  if (!loadProject) {
+    report(new Error(STARTUP_NO_WORKSPACE_CLIENT_MESSAGE));
+    return { status: "no-client" };
+  }
+
+  try {
+    await loadProject();
+  } catch (error) {
+    report(error);
+    return { status: "load-failed", error };
+  }
+
+  const attachResult = attachStartupWorktreePort({
+    target: getPortTarget(),
+    host: getHost(),
+    attachDirectPort,
+    brokerPort: getBrokerPort(),
+  });
+  if (attachResult.ok) return { status: "loaded" };
+
+  // A resolved loadProject() is not enough — with no port the renderer sits in
+  // exactly the state a thrown load leaves it in, so it gets the same banner.
+  report(new Error(describeStartupPortFailure(attachResult.reason)));
+  return { status: "port-failed", reason: attachResult.reason };
+}

--- a/electron/window/startupWorktreeLoad.ts
+++ b/electron/window/startupWorktreeLoad.ts
@@ -99,17 +99,22 @@ export type StartupPortAttachResult =
  */
 export function attachStartupWorktreePort<THost, TTarget extends { isDestroyed(): boolean }>(args: {
   target: TTarget | null | undefined;
-  host: THost | null | undefined;
+  // Resolved lazily, in the same order the pre-extraction code used: nothing is
+  // looked up until the target has been validated and the direct port attached.
+  getHost: () => THost | null | undefined;
   attachDirectPort: (target: TTarget) => void;
-  brokerPort: ((host: THost, target: TTarget) => boolean) | null | undefined;
+  getBrokerPort: () => ((host: THost, target: TTarget) => boolean) | null | undefined;
 }): StartupPortAttachResult {
-  const { target, host, attachDirectPort, brokerPort } = args;
+  const { target, getHost, attachDirectPort, getBrokerPort } = args;
 
   if (!target || target.isDestroyed()) return { ok: false, reason: "no-renderer-target" };
 
   attachDirectPort(target);
 
+  const host = getHost();
   if (!host) return { ok: false, reason: "no-host" };
+
+  const brokerPort = getBrokerPort();
   if (!brokerPort) return { ok: false, reason: "no-broker" };
   if (!brokerPort(host, target)) return { ok: false, reason: "broker-rejected" };
 
@@ -137,6 +142,7 @@ export type StartupWorktreeLoadOutcome =
   | { status: "loaded" }
   | { status: "no-client" }
   | { status: "load-failed"; error: unknown }
+  | { status: "attach-failed"; error: unknown }
   | { status: "port-failed"; reason: StartupPortFailureReason };
 
 /**
@@ -179,12 +185,22 @@ export async function runStartupWorktreeLoad<
     return { status: "load-failed", error };
   }
 
-  const attachResult = attachStartupWorktreePort({
-    target: getPortTarget(),
-    host: getHost(),
-    attachDirectPort,
-    brokerPort: getBrokerPort(),
-  });
+  // Attachment stays inside an error boundary alongside the load: before this
+  // flow was extracted, one `try` covered the load, the direct attach and the
+  // brokering together. A synchronous throw escaping here would reject window
+  // startup itself rather than surfacing as a worktree failure.
+  let attachResult: StartupPortAttachResult;
+  try {
+    attachResult = attachStartupWorktreePort({
+      target: getPortTarget(),
+      getHost,
+      attachDirectPort,
+      getBrokerPort,
+    });
+  } catch (error) {
+    report(error);
+    return { status: "attach-failed", error };
+  }
   if (attachResult.ok) return { status: "loaded" };
 
   // A resolved loadProject() is not enough — with no port the renderer sits in

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -19,7 +19,14 @@ import { runSmokeFunctionalChecks } from "../services/smokeTest.js";
 import { markPerformance } from "../utils/performance.js";
 import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
-import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { isCleaningUp } from "../lifecycle/shutdownCoordinator.js";
+import {
+  attachStartupWorktreePort,
+  describeStartupPortFailure,
+  selectStatusTarget,
+  sendStartupWorktreeLoadFailure,
+  STARTUP_NO_WORKSPACE_CLIENT_MESSAGE,
+} from "./startupWorktreeLoad.js";
 import { extractRestorePanelCwds } from "./restorePanelCwds.js";
 import { mergeProjectEnv } from "./restoreProjectEnv.js";
 import { store } from "../store.js";
@@ -320,7 +327,17 @@ export async function setupWindowServices(
 
   // Initialize workspace client (first window only) — per-project hosts
   // are started on-demand when loadProject() is called, not at init time.
-  if (!getWorkspaceClientRef()) {
+  //
+  // Captured once here so the worktree-load gate near the end of this function
+  // uses the same instance rather than re-reading the module ref across the two
+  // `Promise.allSettled` gaps below (#11818). The construction path is
+  // first-window-only, so on later windows this capture is the ref read that
+  // used to happen at the gate. Whether the ref is actually cleared mid-boot on
+  // the reported packaged-Windows launches is unconfirmed — capturing removes
+  // the possibility either way, and the gate now reports every outcome that
+  // leaves the renderer without a port regardless of cause.
+  let capturedWorkspaceClient = getWorkspaceClientRef();
+  if (!capturedWorkspaceClient) {
     // Construct the workspace client and prewarm its per-project host
     // concurrently with the PTY host fork. The two utility processes load
     // native modules independently (node-pty vs better-sqlite3 + @parcel/watcher)
@@ -365,6 +382,7 @@ export async function setupWindowServices(
     }
 
     setWorkspaceClientRef(workspaceClient);
+    capturedWorkspaceClient = workspaceClient;
 
     // Give PluginService the WorkspaceClient reference now that it's ready.
     // initialize() is deferred and may run before or after this point — the
@@ -650,64 +668,84 @@ export async function setupWindowServices(
   // Load worktrees — prefer initialProjectPath, else restoreProject for
   // startup windows. Unbound windows (no project) skip worktree loading.
   const projectPathForWorktrees = opts.initialProjectPath ?? restoreProject?.path;
-  const workspaceClient = getWorkspaceClientRef();
-  if (projectPathForWorktrees && workspaceClient && workspaceReady) {
-    console.log("[MAIN] Loading worktrees for project path:", projectPathForWorktrees);
+  // Skipped outright while the app is quitting: the captured client may already
+  // be disposed, and a banner on a window that is going away helps nobody.
+  if (projectPathForWorktrees && !isCleaningUp()) {
+    // Every outcome below that leaves the renderer without a brokered worktree
+    // port has to reach PROJECT_WORKTREE_LOAD_STATUS (#8796, #11818). When one
+    // does not, the per-view worktree store never leaves its initial
+    // `isLoading: true` — `worktreePort.onReady` is what triggers the first
+    // fetch — so the sidebar renders its skeleton forever with no banner and
+    // nothing in the log. That silent branch is what this block removes.
+    //
+    // The id is resolved from the path actually being loaded rather than from
+    // `restoreProject`, which only exists for id-restored windows: a window
+    // opened by path (CLI open, Dock drop) would otherwise resolve no id and
+    // drop the status. `resolveProjectIdForPath` is a synchronous read that
+    // returns the registered id when there is one, so it matches the id the
+    // renderer filters on.
+    let statusProjectId: string | undefined;
     try {
-      await workspaceClient.loadProject(projectPathForWorktrees, win.id);
-      console.log("[MAIN] Worktrees loaded");
-
-      // Register the renderer in directPortViews so sendToEntryWindows
-      // routes host events (worktree updates, PR detection, etc.) to it.
-      const directPortTarget = opts.initialAppView?.webContents ?? getAppWebContents(win);
-      if (directPortTarget && !directPortTarget.isDestroyed()) {
-        workspaceClient.attachDirectPort(win.id, directPortTarget);
-        console.log("[MAIN] Workspace direct port attached");
-
-        // Broker new worktree port (Phase 1)
-        const host = workspaceClient.getHostForProject(projectPathForWorktrees);
-        const worktreePortBroker = getWorktreePortBrokerRef();
-        if (host && worktreePortBroker) {
-          worktreePortBroker.brokerPort(host, directPortTarget);
-          console.log("[MAIN] Worktree port brokered");
-        }
-      }
+      statusProjectId = projectStore.resolveProjectIdForPath(projectPathForWorktrees);
     } catch (error) {
-      console.error("[MAIN] Failed to load worktrees:", error);
+      console.warn("[MAIN] Could not resolve a project id for worktree load status:", error);
+      statusProjectId = restoreProject?.id;
+    }
 
-      // Surface the failure to the renderer so the sidebar shows the
-      // WorktreeLoadErrorBanner instead of an infinite loading skeleton
-      // (#8796). Without this, the worktree port is never brokered, the
-      // renderer's worktree store stays `isLoading: true`, and the sidebar
-      // hangs. Mirrors the project-switch path (projectCrud/switch.ts).
-      // The send is deferred until `did-finish-load` while the renderer is
-      // still loading — messages sent before the renderer wires its
-      // ipcRenderer listener are silently dropped.
-      const failedProjectId = restoreProject?.id;
-      // Prefer the project view's webContents, but fall through to the
-      // window's app webContents if it's already destroyed — selecting a
-      // destroyed target would silently drop the message and re-hang.
-      const initialViewWc = opts.initialAppView?.webContents;
-      const statusTarget =
-        initialViewWc && !initialViewWc.isDestroyed() ? initialViewWc : getAppWebContents(win);
-      if (failedProjectId && statusTarget) {
-        const worktreeLoadError = formatErrorMessage(error, "Failed to load worktrees");
-        const sendLoadStatus = (): void => {
-          if (statusTarget.isDestroyed()) return;
-          statusTarget.send(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
-            projectId: failedProjectId,
-            worktreeLoadError,
-          });
-        };
-        if (statusTarget.isLoading()) {
-          statusTarget.once("did-finish-load", sendLoadStatus);
+    // Re-selected at report time rather than captured up front — the window's
+    // app view can be swapped or destroyed while `loadProject()` is awaited.
+    const reportFailure = (error: unknown): void => {
+      if (isCleaningUp()) return;
+      const statusTarget = selectStatusTarget(
+        opts.initialAppView?.webContents ?? null,
+        getAppWebContents(win) ?? null
+      );
+      sendStartupWorktreeLoadFailure(statusTarget, statusProjectId, error);
+    };
+
+    if (!capturedWorkspaceClient) {
+      console.error(
+        "[MAIN] Workspace client unavailable - cannot load worktrees for:",
+        projectPathForWorktrees
+      );
+      reportFailure(new Error(STARTUP_NO_WORKSPACE_CLIENT_MESSAGE));
+    } else {
+      const workspaceClient = capturedWorkspaceClient;
+      console.log("[MAIN] Loading worktrees for project path:", projectPathForWorktrees);
+      try {
+        await workspaceClient.loadProject(projectPathForWorktrees, win.id);
+        console.log("[MAIN] Worktrees loaded");
+
+        // Register the renderer in directPortViews so sendToEntryWindows
+        // routes host events (worktree updates, PR detection, etc.) to it,
+        // then broker the worktree port (Phase 1).
+        const worktreePortBroker = getWorktreePortBrokerRef();
+        const attachResult = attachStartupWorktreePort({
+          target: opts.initialAppView?.webContents ?? getAppWebContents(win) ?? null,
+          host: workspaceClient.getHostForProject(projectPathForWorktrees),
+          attachDirectPort: (target) => {
+            workspaceClient.attachDirectPort(win.id, target);
+            console.log("[MAIN] Workspace direct port attached");
+          },
+          brokerPort: worktreePortBroker
+            ? (host, target) => worktreePortBroker.brokerPort(host, target)
+            : null,
+        });
+
+        if (attachResult.ok) {
+          console.log("[MAIN] Worktree port brokered");
         } else {
-          sendLoadStatus();
+          // A resolved `loadProject()` is not enough — with no port the
+          // renderer is in exactly the state a thrown load leaves it in, so
+          // it gets the same banner rather than a silent skip (#11818).
+          console.error("[MAIN] Worktree port not brokered:", attachResult.reason);
+          reportFailure(new Error(describeStartupPortFailure(attachResult.reason)));
         }
+      } catch (error) {
+        console.error("[MAIN] Failed to load worktrees:", error);
+        reportFailure(error);
       }
     }
-  } else if (projectPathForWorktrees && !workspaceReady) {
-    console.warn("[MAIN] Workspace service unavailable - skipping worktree loading");
   }
 
   // Smoke test

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -744,6 +744,9 @@ export async function setupWindowServices(
       case "load-failed":
         console.error("[MAIN] Failed to load worktrees:", outcome.error);
         break;
+      case "attach-failed":
+        console.error("[MAIN] Failed to attach the worktree port:", outcome.error);
+        break;
       case "port-failed":
         console.error("[MAIN] Worktree port not brokered:", outcome.reason);
         break;

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -21,11 +21,9 @@ import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { isCleaningUp } from "../lifecycle/shutdownCoordinator.js";
 import {
-  attachStartupWorktreePort,
-  describeStartupPortFailure,
+  runStartupWorktreeLoad,
   selectStatusTarget,
   sendStartupWorktreeLoadFailure,
-  STARTUP_NO_WORKSPACE_CLIENT_MESSAGE,
 } from "./startupWorktreeLoad.js";
 import { extractRestorePanelCwds } from "./restorePanelCwds.js";
 import { mergeProjectEnv } from "./restoreProjectEnv.js";
@@ -678,18 +676,21 @@ export async function setupWindowServices(
     // fetch — so the sidebar renders its skeleton forever with no banner and
     // nothing in the log. That silent branch is what this block removes.
     //
-    // The id is resolved from the path actually being loaded rather than from
-    // `restoreProject`, which only exists for id-restored windows: a window
-    // opened by path (CLI open, Dock drop) would otherwise resolve no id and
-    // drop the status. `resolveProjectIdForPath` is a synchronous read that
-    // returns the registered id when there is one, so it matches the id the
-    // renderer filters on.
-    let statusProjectId: string | undefined;
-    try {
-      statusProjectId = projectStore.resolveProjectIdForPath(projectPathForWorktrees);
-    } catch (error) {
-      console.warn("[MAIN] Could not resolve a project id for worktree load status:", error);
-      statusProjectId = restoreProject?.id;
+    // A restored window already carries the registered id, which is the one the
+    // renderer filters on — use it directly. Only a window opened by path (CLI
+    // open, Dock drop) has to resolve one, and without that it would resolve no
+    // id at all and drop the status. `resolveProjectIdForPath` is a synchronous
+    // read returning the registered id when the path is known; for a path that
+    // isn't registered yet it hashes the path, which can differ from the id the
+    // project is finally registered under (git-root or realpath resolution).
+    // The renderer's own port watchdog is the backstop for that case.
+    let statusProjectId = restoreProject?.id;
+    if (!statusProjectId) {
+      try {
+        statusProjectId = projectStore.resolveProjectIdForPath(projectPathForWorktrees);
+      } catch (error) {
+        console.warn("[MAIN] Could not resolve a project id for worktree load status:", error);
+      }
     }
 
     // Re-selected at report time rather than captured up front — the window's
@@ -703,48 +704,49 @@ export async function setupWindowServices(
       sendStartupWorktreeLoadFailure(statusTarget, statusProjectId, error);
     };
 
-    if (!capturedWorkspaceClient) {
-      console.error(
-        "[MAIN] Workspace client unavailable - cannot load worktrees for:",
-        projectPathForWorktrees
-      );
-      reportFailure(new Error(STARTUP_NO_WORKSPACE_CLIENT_MESSAGE));
-    } else {
-      const workspaceClient = capturedWorkspaceClient;
+    const workspaceClient = capturedWorkspaceClient;
+    if (workspaceClient) {
       console.log("[MAIN] Loading worktrees for project path:", projectPathForWorktrees);
-      try {
-        await workspaceClient.loadProject(projectPathForWorktrees, win.id);
-        console.log("[MAIN] Worktrees loaded");
+    }
 
-        // Register the renderer in directPortViews so sendToEntryWindows
-        // routes host events (worktree updates, PR detection, etc.) to it,
-        // then broker the worktree port (Phase 1).
+    // Register the renderer in directPortViews so sendToEntryWindows routes
+    // host events (worktree updates, PR detection, etc.) to it, then broker the
+    // worktree port (Phase 1).
+    const outcome = await runStartupWorktreeLoad({
+      loadProject: workspaceClient
+        ? () => workspaceClient.loadProject(projectPathForWorktrees, win.id)
+        : null,
+      getPortTarget: () => opts.initialAppView?.webContents ?? getAppWebContents(win) ?? null,
+      getHost: () => workspaceClient?.getHostForProject(projectPathForWorktrees),
+      attachDirectPort: (target) => {
+        workspaceClient?.attachDirectPort(win.id, target);
+        console.log("[MAIN] Workspace direct port attached");
+      },
+      getBrokerPort: () => {
         const worktreePortBroker = getWorktreePortBrokerRef();
-        const attachResult = attachStartupWorktreePort({
-          target: opts.initialAppView?.webContents ?? getAppWebContents(win) ?? null,
-          host: workspaceClient.getHostForProject(projectPathForWorktrees),
-          attachDirectPort: (target) => {
-            workspaceClient.attachDirectPort(win.id, target);
-            console.log("[MAIN] Workspace direct port attached");
-          },
-          brokerPort: worktreePortBroker
-            ? (host, target) => worktreePortBroker.brokerPort(host, target)
-            : null,
-        });
+        return worktreePortBroker
+          ? (host, target) => worktreePortBroker.brokerPort(host, target)
+          : null;
+      },
+      report: reportFailure,
+    });
 
-        if (attachResult.ok) {
-          console.log("[MAIN] Worktree port brokered");
-        } else {
-          // A resolved `loadProject()` is not enough — with no port the
-          // renderer is in exactly the state a thrown load leaves it in, so
-          // it gets the same banner rather than a silent skip (#11818).
-          console.error("[MAIN] Worktree port not brokered:", attachResult.reason);
-          reportFailure(new Error(describeStartupPortFailure(attachResult.reason)));
-        }
-      } catch (error) {
-        console.error("[MAIN] Failed to load worktrees:", error);
-        reportFailure(error);
-      }
+    switch (outcome.status) {
+      case "loaded":
+        console.log("[MAIN] Worktrees loaded; worktree port brokered");
+        break;
+      case "no-client":
+        console.error(
+          "[MAIN] Workspace client unavailable - cannot load worktrees for:",
+          projectPathForWorktrees
+        );
+        break;
+      case "load-failed":
+        console.error("[MAIN] Failed to load worktrees:", outcome.error);
+        break;
+      case "port-failed":
+        console.error("[MAIN] Worktree port not brokered:", outcome.reason);
+        break;
     }
   }
 

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -32,6 +32,21 @@ import { actionService } from "@/services/ActionService";
 // genuinely stalls, per the CLAUDE.md runtime-signals promote-trigger.
 const TOPOLOGY_DARK_ESCALATION_MS = 30_000;
 
+// The first worktree fetch is triggered by the worktree port becoming ready,
+// and nothing bounds that wait: when main never brokers a port, `isLoading`
+// stays true and the sidebar renders its skeleton forever with no way to reach
+// the error banner (#11818). Main now reports every no-port outcome it can see,
+// but the report itself can still be lost (app view swapped mid-boot, renderer
+// listener not yet wired), so this is the renderer's own floor under the hang.
+// Longer than the 30s a single workspace-host command may take, so a slow but
+// healthy packaged-Windows cold start is never cut short.
+const INITIAL_PORT_READY_TIMEOUT_MS = 45_000;
+
+// Owned by this file so the ready-after-timeout path can tell its own message
+// apart from a newer one main pushed, and clear only the former.
+const INITIAL_PORT_TIMEOUT_MESSAGE =
+  "The workspace service didn't finish connecting, so worktrees couldn't load.";
+
 export const WorktreeStoreContext = createContext<WorktreeViewStoreApi | null>(null);
 
 interface WorktreeUpdateEvent {
@@ -746,10 +761,73 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     cleanups.push(clearTopologyEscalation);
 
     // Fetch on initial ready and on every port re-attach (host restart / re-broker)
-    if (worktreePort.isReady()) {
+    let initialPortReady = worktreePort.isReady();
+    let initialPortTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function clearInitialPortTimer() {
+      if (initialPortTimer !== null) {
+        clearTimeout(initialPortTimer);
+        initialPortTimer = null;
+      }
+    }
+
+    function armInitialPortTimer() {
+      if (initialPortTimer !== null || initialPortReady) return;
+      // Only a window bound to a project ever has a port brokered for it — an
+      // unbound picker view legitimately never sees one, so arming there would
+      // raise a banner for working software.
+      if (!useProjectStore.getState().currentProject) return;
+      initialPortTimer = setTimeout(() => {
+        initialPortTimer = null;
+        if (initialPortReady || worktreePort.isReady()) return;
+        // A report from main describes the failure better than we can.
+        if (useProjectStore.getState().worktreeLoadError !== null) return;
+        useProjectStore.getState().setWorktreeLoadError(INITIAL_PORT_TIMEOUT_MESSAGE);
+        // The banner renders *above* the skeleton, so the skeleton has to be
+        // settled too or Retry ends up stacked on a still-spinning sidebar.
+        store.getState().setLoading(false);
+      }, INITIAL_PORT_READY_TIMEOUT_MS);
+    }
+
+    function handleInitialPortReady() {
+      initialPortReady = true;
+      clearInitialPortTimer();
+      // Clear only the message this file owns: a newer error from main
+      // describes something the refetch below won't resolve.
+      if (useProjectStore.getState().worktreeLoadError === INITIAL_PORT_TIMEOUT_MESSAGE) {
+        useProjectStore.getState().setWorktreeLoadError(null);
+      }
       fetchInitialState();
     }
-    cleanups.push(worktreePort.onReady(fetchInitialState));
+
+    if (initialPortReady) {
+      fetchInitialState();
+    } else {
+      armInitialPortTimer();
+    }
+    cleanups.push(worktreePort.onReady(handleInitialPortReady));
+    cleanups.push(clearInitialPortTimer);
+
+    // `currentProject` can hydrate after this effect runs, so the arming
+    // decision is re-taken on change rather than only at mount. Scoped to the
+    // pre-ready window: once a port has arrived, the disconnect/fatal handlers
+    // below own the sidebar's state.
+    cleanups.push(
+      useProjectStore.subscribe((state, prev) => {
+        if (initialPortReady) return;
+        if (
+          state.worktreeLoadError !== prev.worktreeLoadError &&
+          state.worktreeLoadError !== null
+        ) {
+          // Main reported a failed load, so no port is coming for it — settle
+          // the skeleton rather than leaving the banner over a live spinner.
+          clearInitialPortTimer();
+          store.getState().setLoading(false);
+          return;
+        }
+        if (state.currentProject !== prev.currentProject) armInitialPortTimer();
+      })
+    );
 
     // Surface a "Reconnecting…" state the moment the workspace host dies, so
     // the UI doesn't appear frozen while we wait (up to 2–4s) for the
@@ -769,6 +847,10 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // fetch rather than a silent wake refresh.
     cleanups.push(
       worktreePort.onFatalDisconnect(() => {
+        // A confirmed fatal disconnect is a better description than the
+        // initial-connection watchdog's, so retire the watchdog rather than
+        // letting it overwrite this later.
+        clearInitialPortTimer();
         store
           .getState()
           .setFatalError(

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -771,17 +771,31 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
       }
     }
 
+    // A load status can land before this effect runs at all — the IPC listener
+    // that sets `worktreeLoadError` is installed at module scope, well before
+    // React mounts the provider — and the subscription below only sees
+    // *transitions*. Without settling it here, that pre-existing error would
+    // leave the banner stacked on a skeleton that never ends.
+    function settleForExistingLoadError(): boolean {
+      if (useProjectStore.getState().worktreeLoadError === null) return false;
+      clearInitialPortTimer();
+      store.getState().setLoading(false);
+      return true;
+    }
+
     function armInitialPortTimer() {
       if (initialPortTimer !== null || initialPortReady) return;
       // Only a window bound to a project ever has a port brokered for it — an
       // unbound picker view legitimately never sees one, so arming there would
       // raise a banner for working software.
       if (!useProjectStore.getState().currentProject) return;
+      if (settleForExistingLoadError()) return;
       initialPortTimer = setTimeout(() => {
         initialPortTimer = null;
         if (initialPortReady || worktreePort.isReady()) return;
-        // A report from main describes the failure better than we can.
-        if (useProjectStore.getState().worktreeLoadError !== null) return;
+        // A report from main describes the failure better than we can, but the
+        // skeleton still has to end.
+        if (settleForExistingLoadError()) return;
         useProjectStore.getState().setWorktreeLoadError(INITIAL_PORT_TIMEOUT_MESSAGE);
         // The banner renders *above* the skeleton, so the skeleton has to be
         // settled too or Retry ends up stacked on a still-spinning sidebar.

--- a/src/contexts/__tests__/WorktreeStoreContext.initialPortReady.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.initialPortReady.test.tsx
@@ -28,6 +28,7 @@ let fatalCallbacks: Array<() => void> = [];
 let requestCount = 0;
 
 function setCurrentProject(path: string | null): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- only the fields this suite reads
   const project = path ? ({ id: "p1", name: "p1", path } as unknown as Project) : null;
   useProjectStore.setState({ currentProject: project });
 }
@@ -47,6 +48,7 @@ beforeEach(() => {
   useProjectStore.setState({ worktreeLoadError: null });
   setCurrentProject("/repo/proj");
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- jsdom global, stubbed per test
   (globalThis as unknown as { window: Window }).window.electron = {
     worktreePort: {
       isReady: () => portReady,

--- a/src/contexts/__tests__/WorktreeStoreContext.initialPortReady.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.initialPortReady.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useContext } from "react";
+
+import { useProjectStore } from "@/store/projectStore";
+import type { WorktreeSnapshot } from "@shared/types";
+import type { Project } from "@shared/types/project";
+
+/**
+ * The initial-port watchdog (#11818).
+ *
+ * Nothing used to bound the wait for the worktree port to be brokered: when
+ * main never brokered one, `isLoading` stayed true and the sidebar rendered its
+ * skeleton forever with no route to the error banner. These cover the floor the
+ * renderer now puts under that hang, and the paths that must NOT trip it.
+ */
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn(() => "notif-id") }));
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
+
+const TIMEOUT_MESSAGE =
+  "The workspace service didn't finish connecting, so worktrees couldn't load.";
+
+let portReady = false;
+let readyCallbacks: Array<() => void> = [];
+
+function setCurrentProject(path: string | null): void {
+  const project = path ? ({ id: "p1", name: "p1", path } as unknown as Project) : null;
+  useProjectStore.setState({ currentProject: project });
+}
+
+// Warm the module cache under real timers: a dynamic import while fake timers
+// are installed never settles, so the import has to happen before any test
+// swaps them in.
+beforeAll(async () => {
+  await import("../WorktreeStoreContext");
+});
+
+beforeEach(() => {
+  portReady = false;
+  readyCallbacks = [];
+  useProjectStore.setState({ worktreeLoadError: null });
+  setCurrentProject("/repo/proj");
+
+  (globalThis as unknown as { window: Window }).window.electron = {
+    worktreePort: {
+      isReady: () => portReady,
+      request: (_name: string) =>
+        Promise.resolve({
+          states: [] as WorktreeSnapshot[],
+          watcherDegraded: false,
+          topologyWatcherDark: false,
+        }),
+      onEvent: (_name: string, _cb: (data: unknown) => void) => () => {},
+      onReady: (cb: () => void) => {
+        readyCallbacks.push(cb);
+        return () => {
+          readyCallbacks = readyCallbacks.filter((entry) => entry !== cb);
+        };
+      },
+      onDisconnected: (_cb: () => void) => () => {},
+      onFatalDisconnect: (_cb: () => void) => () => {},
+    },
+    worktree: {
+      getAllIssueAssociations: () => Promise.resolve({}),
+      getPRStatus: () => Promise.resolve(null),
+    },
+  } as unknown as typeof window.electron;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  useProjectStore.setState({ worktreeLoadError: null });
+  setCurrentProject(null);
+});
+
+async function renderProvider() {
+  const { WorktreeStoreProvider, WorktreeStoreContext } = await import("../WorktreeStoreContext");
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WorktreeStoreProvider>{children}</WorktreeStoreProvider>
+  );
+  const { result, unmount } = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  if (!result.current) throw new Error("WorktreeStoreContext is null");
+  return { store: result.current, unmount };
+}
+
+/** Fire the port-ready notification main would send once it brokers a port. */
+async function becomeReady(): Promise<void> {
+  portReady = true;
+  await act(async () => {
+    readyCallbacks.forEach((cb) => cb());
+    await Promise.resolve();
+  });
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("WorktreeStoreProvider — initial worktree-port watchdog (#11818)", () => {
+  it("keeps the sidebar loading while the port is still plausibly on its way", async () => {
+    vi.useFakeTimers();
+    const { store } = await renderProvider();
+
+    await advance(30_000);
+
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+    expect(store.getState().isLoading).toBe(true);
+  });
+
+  it("surfaces an error and settles the skeleton once the port never arrives", async () => {
+    vi.useFakeTimers();
+    const { store } = await renderProvider();
+
+    await advance(60_000);
+
+    expect(useProjectStore.getState().worktreeLoadError).toBe(TIMEOUT_MESSAGE);
+    // The banner renders above the skeleton, so the skeleton has to end too or
+    // Retry sits on top of a still-spinning sidebar.
+    expect(store.getState().isLoading).toBe(false);
+  });
+
+  it("does not escalate to the fatal-disconnect state", async () => {
+    vi.useFakeTimers();
+    const { store } = await renderProvider();
+
+    await advance(60_000);
+
+    // A port that never arrived is not proof the host crashed — `setFatalError`
+    // would offer "Restart service" instead of the load's own Retry.
+    expect(store.getState().error).toBeNull();
+  });
+
+  it("arms nothing for a window with no project bound", async () => {
+    setCurrentProject(null);
+    vi.useFakeTimers();
+    const { store } = await renderProvider();
+
+    await advance(60_000);
+
+    // An unbound picker view legitimately never has a port brokered for it.
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+    expect(store.getState().isLoading).toBe(true);
+  });
+
+  it("arms once a project binds after mount", async () => {
+    setCurrentProject(null);
+    vi.useFakeTimers();
+    await renderProvider();
+
+    await act(async () => {
+      setCurrentProject("/repo/late");
+      await Promise.resolve();
+    });
+    await advance(60_000);
+
+    expect(useProjectStore.getState().worktreeLoadError).toBe(TIMEOUT_MESSAGE);
+  });
+
+  it("cancels the watchdog when the port arrives in time", async () => {
+    vi.useFakeTimers();
+    const { store } = await renderProvider();
+
+    await becomeReady();
+    await advance(60_000);
+
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+    expect(store.getState().isLoading).toBe(false);
+  });
+
+  it("clears its own timeout message when the port arrives late", async () => {
+    vi.useFakeTimers();
+    await renderProvider();
+
+    await advance(60_000);
+    expect(useProjectStore.getState().worktreeLoadError).toBe(TIMEOUT_MESSAGE);
+
+    await becomeReady();
+
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+  });
+
+  it("leaves a main-process error in place when the port arrives late", async () => {
+    vi.useFakeTimers();
+    await renderProvider();
+
+    // Main described a real failure; a late port doesn't resolve it, so the
+    // banner must survive.
+    act(() => {
+      useProjectStore.getState().setWorktreeLoadError("Repository folder is gone");
+    });
+    await becomeReady();
+
+    expect(useProjectStore.getState().worktreeLoadError).toBe("Repository folder is gone");
+  });
+
+  it("settles the skeleton as soon as main reports a failure", async () => {
+    vi.useFakeTimers();
+    const { store } = await renderProvider();
+
+    act(() => {
+      useProjectStore.getState().setWorktreeLoadError("Repository folder is gone");
+    });
+
+    expect(store.getState().isLoading).toBe(false);
+
+    // And the watchdog no longer overwrites main's better description.
+    await advance(60_000);
+    expect(useProjectStore.getState().worktreeLoadError).toBe("Repository folder is gone");
+  });
+
+  it("clears the timer on unmount", async () => {
+    vi.useFakeTimers();
+    const { unmount } = await renderProvider();
+
+    unmount();
+    await advance(60_000);
+
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+  });
+});

--- a/src/contexts/__tests__/WorktreeStoreContext.initialPortReady.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.initialPortReady.test.tsx
@@ -24,6 +24,8 @@ const TIMEOUT_MESSAGE =
 
 let portReady = false;
 let readyCallbacks: Array<() => void> = [];
+let fatalCallbacks: Array<() => void> = [];
+let requestCount = 0;
 
 function setCurrentProject(path: string | null): void {
   const project = path ? ({ id: "p1", name: "p1", path } as unknown as Project) : null;
@@ -40,18 +42,25 @@ beforeAll(async () => {
 beforeEach(() => {
   portReady = false;
   readyCallbacks = [];
+  fatalCallbacks = [];
+  requestCount = 0;
   useProjectStore.setState({ worktreeLoadError: null });
   setCurrentProject("/repo/proj");
 
   (globalThis as unknown as { window: Window }).window.electron = {
     worktreePort: {
       isReady: () => portReady,
-      request: (_name: string) =>
-        Promise.resolve({
+      request: (_name: string) => {
+        requestCount += 1;
+        return Promise.resolve({
           states: [] as WorktreeSnapshot[],
           watcherDegraded: false,
           topologyWatcherDark: false,
-        }),
+          epoch: "epoch-1",
+          seq: 1,
+          lastAcknowledgedMutationIds: [] as string[],
+        });
+      },
       onEvent: (_name: string, _cb: (data: unknown) => void) => () => {},
       onReady: (cb: () => void) => {
         readyCallbacks.push(cb);
@@ -60,7 +69,12 @@ beforeEach(() => {
         };
       },
       onDisconnected: (_cb: () => void) => () => {},
-      onFatalDisconnect: (_cb: () => void) => () => {},
+      onFatalDisconnect: (cb: () => void) => {
+        fatalCallbacks.push(cb);
+        return () => {
+          fatalCallbacks = fatalCallbacks.filter((entry) => entry !== cb);
+        };
+      },
     },
     worktree: {
       getAllIssueAssociations: () => Promise.resolve({}),
@@ -214,6 +228,68 @@ describe("WorktreeStoreProvider — initial worktree-port watchdog (#11818)", ()
     // And the watchdog no longer overwrites main's better description.
     await advance(60_000);
     expect(useProjectStore.getState().worktreeLoadError).toBe("Repository folder is gone");
+  });
+
+  it("settles a skeleton when the error landed before the provider mounted", async () => {
+    // The IPC listener that sets `worktreeLoadError` is installed at module
+    // scope, so a boot failure can be recorded before React mounts anything.
+    // The subscription below only sees transitions, so this has to be caught
+    // when the watchdog is armed.
+    useProjectStore.setState({ worktreeLoadError: "Repository folder is gone" });
+    vi.useFakeTimers();
+    const { store } = await renderProvider();
+
+    expect(store.getState().isLoading).toBe(false);
+
+    await advance(60_000);
+    expect(useProjectStore.getState().worktreeLoadError).toBe("Repository folder is gone");
+  });
+
+  it("keeps a main-process error that replaced its own timeout message", async () => {
+    vi.useFakeTimers();
+    await renderProvider();
+
+    await advance(60_000);
+    expect(useProjectStore.getState().worktreeLoadError).toBe(TIMEOUT_MESSAGE);
+
+    // Main described the real failure after the watchdog guessed; a late port
+    // must not clear that better description.
+    act(() => {
+      useProjectStore.getState().setWorktreeLoadError("Repository folder is gone");
+    });
+    await becomeReady();
+
+    expect(useProjectStore.getState().worktreeLoadError).toBe("Repository folder is gone");
+  });
+
+  it("cancels the watchdog on a fatal disconnect", async () => {
+    vi.useFakeTimers();
+    const { store } = await renderProvider();
+
+    await act(async () => {
+      fatalCallbacks.forEach((cb) => cb());
+      await Promise.resolve();
+    });
+    await advance(60_000);
+
+    // The fatal error is the better description, and the watchdog must not
+    // stack its own banner on top of it.
+    expect(store.getState().error).not.toBeNull();
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+  });
+
+  it("refetches on every port re-attach, not just the first", async () => {
+    vi.useFakeTimers();
+    await renderProvider();
+
+    await becomeReady();
+    const afterFirst = requestCount;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    // Host restart → the port is re-brokered and fires ready again.
+    await becomeReady();
+
+    expect(requestCount).toBeGreaterThan(afterFirst);
   });
 
   it("clears the timer on unmount", async () => {


### PR DESCRIPTION
## Summary

On packaged Windows builds, the worktree sidebar gets stuck on its loading skeleton forever, and the file browser shows "No folder resolved for this workspace. Select a worktree and try again." No error, nothing logged.

I traced the mechanism end to end. The boot-time worktree-load gate in `windowServices.ts` requires a non-null workspace client, and when that gate fails there's no `else` branch at all. No `loadProject()`, no `attachDirectPort()`, no `brokerPort()`. So the renderer's worktree port never gets brokered, `worktreePort.onReady` never fires, `fetchInitialState()` never runs, the per-view worktree store's `isLoading` never leaves its initial `true`, and `SidebarContent` renders the skeleton forever. `worktreeLoadError` stays null too, so the existing `WorktreeLoadErrorBanner` never appears either.

I want to be plain about this: the root trigger isn't confirmed. The issue proposed a TOCTOU race on the module-global workspace-client ref, but `setWorkspaceClientRef(null)` has exactly one caller, `shutdown.ts` inside the `before-quit` handler, which doesn't explain a hang on an ordinary packaged-Windows launch. So this PR doesn't claim to have proven the cause. It closes every startup path that can leave the renderer without a port, and adds a bounded fallback so the symptom can't recur regardless of cause.

Resolves #11818.

## Changes

- Capture the workspace client once instead of re-reading the module ref across two `await` gaps. The construction path is first-window-only, so later windows previously had only the global read.
- Report the missing-client case instead of silently skipping the load.
- Treat a resolved `loadProject()` that still left no brokered port (dead renderer target, missing host, missing broker, `brokerPort()` returning false) as a failure, since the renderer can't distinguish it from a thrown load.
- Resolve the status `projectId` from the restored project when there is one, else from the path being loaded, so path-only windows (CLI open, Dock drop) can reach the banner too. Previously they resolved no id and the status was dropped.
- Defer the status send on `isLoadingMainFrame()` rather than `isLoading()`. A loading subframe made `isLoading()` true while `did-finish-load` never fired again, parking the send forever. This matches the existing `menu.ts` Dock-drop precedent.
- Add a 45s renderer-side watchdog on the initial port wait, longer than the 30s a single workspace-host command may take. It settles the skeleton into the existing Tier-3 `WorktreeLoadErrorBanner` with its Retry action. It also settles a load error that arrived before the provider mounted, since the IPC listener installs at module scope, so the store subscription only ever saw later transitions.
- Extract the boot flow into `runStartupWorktreeLoad()` (new file, `electron/window/startupWorktreeLoad.ts`), so the silent-skip regression is covered by tests directly instead of by a copy of the logic. The old suite replicated the implementation locally.
- Remove the `else if (!workspaceReady)` branch, unreachable since the feature landed (`workspaceReady` is a hardcoded `true`). The const itself stays, it's still used by smoke-test output.

## Known limitations (pre-existing, deliberately out of scope)

- A superseded startup load can still attach a stale host's port if the user switches projects mid-boot. Fixing that needs `loadProject()` to report ownership.
- For a path-only window whose folder isn't registered yet, the resolved id is a path hash that may differ from the id the project is finally registered under (git-root/realpath resolution). The renderer watchdog is the backstop for that case.

## Testing

- 346 tests across 16 files pass locally: the branch's own suites plus every suite covering the changed modules.
- `npm run typecheck` clean.
- Eslint and prettier clean on changed files; new files add zero eslint-ratchet warnings.
- No E2E spec covers a never-brokered port.
- Not manually reproduced on packaged Windows. The environment-specific report couldn't be verified locally.
