### PR TITLE
fix(palette): draw resume mark on auto-parked projects

### DIFF
--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -234,24 +234,29 @@ function StatusDot({
   status: ProjectRowStatus;
   showResumeDot?: boolean;
 }) {
+  // One slot, one decision. Written as a single choice rather than two
+  // conditions so the slot cannot hold two dots at once: the resume mark only
+  // reaches here on a status that already agreed to yield, and an auto-parked
+  // row is the case where both would otherwise have drawn (#11822).
+  const dot = showResumeDot ? (
+    // Hidden from assistive tech, which hears the row's own "N agents will
+    // resume" phrase instead — a live region per row would re-announce the
+    // whole list on every render, and colour must not be the only carrier.
+    <div
+      className="w-1.5 h-1.5 rounded-full bg-text-secondary"
+      data-testid="workspace-resume-dot"
+      aria-hidden="true"
+    />
+  ) : status.isDormantFallback ? null : (
+    <div
+      className={cn("w-1.5 h-1.5 rounded-full", ROW_DOT_CLASS[status.tone])}
+      data-testid="workspace-status-dot"
+    />
+  );
+
   return (
     <div className="w-1.5 shrink-0" data-testid="workspace-status-slot">
-      {!status.isDormantFallback && (
-        <div
-          className={cn("w-1.5 h-1.5 rounded-full", ROW_DOT_CLASS[status.tone])}
-          data-testid="workspace-status-dot"
-        />
-      )}
-      {showResumeDot && (
-        // Hidden from assistive tech, which hears the row's own "N agents will
-        // resume" phrase instead — a live region per row would re-announce the
-        // whole list on every render, and colour must not be the only carrier.
-        <div
-          className="w-1.5 h-1.5 rounded-full bg-text-secondary"
-          data-testid="workspace-resume-dot"
-          aria-hidden="true"
-        />
-      )}
+      {dot}
     </div>
   );
 }
@@ -260,10 +265,11 @@ function StatusDot({
  * Whether the row should mark that opening this project brings agents back
  * (#11801).
  *
- * Gated on the dormant fallback because a live status always outranks the
- * promise: the coloured dot says what the project is doing now, the grey one
- * only says what it would come back with. So the mark lands exactly where the
- * slot was already empty — the dormant rows #11692 cleared — and never
+ * Gated on the status classifier's own answer because a live status always
+ * outranks the promise: the coloured dot says what the project is doing now,
+ * the grey one only says what it would come back with. So the mark lands on the
+ * rows that have stopped — the dormant ones #11692 cleared, and the auto-parked
+ * ones whose settled ring has less to say than the promise (#11822) — and never
  * displaces a mark that means more. Keyed off the count rather than which band
  * the row sorts into, so a pinned project keeps it too.
  *
@@ -278,7 +284,7 @@ function StatusDot({
  */
 function showResumableAgentMark(status: ProjectRowStatus, project: SearchableProject): boolean {
   if (project.isActive) return false;
-  if (status.isDormantFallback !== true) return false;
+  if (status.allowsResumeMark !== true) return false;
   return project.resumableAgentCount !== undefined && project.resumableAgentCount > 0;
 }
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -322,6 +322,33 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
     expect(screen.getByTestId("workspace-status-dot")).toBeTruthy();
   });
 
+  it("keeps the auto-park reason while its ring gives way to the resume mark", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({
+            name: "Parked",
+            status: "closed",
+            autoParkedAt: Date.now(),
+            lastOpened: Date.now() - 2 * 3600000,
+            resumableAgentCount: 2,
+          }),
+        ]}
+      />
+    );
+
+    // Why it is parked and how much comes back are both facts about this row,
+    // and it only has one dot to spend — so the reason stays in the line while
+    // the dot goes to the promise (#11822).
+    const row = screen.getByRole("option", { name: /Parked, 2 agents will resume/i });
+    expect(within(row).getByText("Suspended to free memory")).toBeTruthy();
+    expect(within(row).getByTestId("workspace-resume-dot")).toBeTruthy();
+    // The slot holds one dot: a fix that left both conditions independent would
+    // stack them here rather than swapping.
+    expect(within(row).queryByTestId("workspace-status-dot")).toBeNull();
+  });
+
   it("says nothing at all for a closed project without the parked marker", () => {
     const twoHoursAgo = Date.now() - 2 * 3600000;
     render(
@@ -1324,6 +1351,32 @@ describe("ProjectSwitcherPalette resumable-agent dot", () => {
     // the regression.
     expect(screen.getByTestId("workspace-status-dot")).toBeTruthy();
     expect(screen.queryByTestId("workspace-resume-dot")).toBeNull();
+  });
+
+  it("does not read an open project's finished agents as a resume promise", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({
+            name: "Open elsewhere",
+            status: "background",
+            isBackground: true,
+            completedAgentCount: 1,
+            resumableAgentCount: 2,
+          }),
+        ]}
+      />
+    );
+
+    // "Agent finished" is muted like the parked line, so gating the mark on
+    // tone would light this row up — and its agents finished in a window that
+    // is still open, not on disk waiting to be brought back.
+    const row = screen.getByRole("option", { name: /Open elsewhere/i });
+    expect(within(row).getByText(/Agent finished/)).toBeTruthy();
+    expect(within(row).getByTestId("workspace-status-dot")).toBeTruthy();
+    expect(within(row).queryByTestId("workspace-resume-dot")).toBeNull();
+    expect(screen.queryByRole("option", { name: /will resume/i })).toBeNull();
   });
 
   it("keys off the count rather than the band, so a pinned row keeps the mark", () => {

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -412,6 +412,45 @@ describe("getProjectRowStatus", () => {
     expect(getProjectRowStatus(reportable[1]!, NOW).tone).toBe("muted");
   });
 
+  // Cuts across the flag above rather than with it: an auto-parked row keeps
+  // its line and still yields its dot, which is the pairing #11822 fixed. The
+  // rows that say what a project is doing keep their own mark.
+  it("lets a stopped row yield its dot without giving up its line", () => {
+    const yields = [
+      project({ lastOpened: NOW - 2 * 3600_000 }),
+      project({ lastOpened: 0 }),
+      project({ status: "closed", autoParkedAt: NOW - 1000, lastOpened: NOW - 5000 }),
+    ];
+    for (const row of yields) {
+      expect(getProjectRowStatus(row, NOW).allowsResumeMark).toBe(true);
+    }
+
+    // The auto-parked row is the one that has to hold both answers at once —
+    // yielding the dot while keeping the reason it was parked.
+    const parked = getProjectRowStatus(yields[2]!, NOW);
+    expect(parked.isDormantFallback).toBeUndefined();
+    expect(parked.text.length).toBeGreaterThan(0);
+
+    // Stated as open projects, because that is the only way these arise: a
+    // closed project has no live PTYs, so its counts are always zero. A row
+    // whose agents finished elsewhere is not waiting on disk for anyone.
+    const keepsItsMark = [
+      project({ status: "background", isBackground: true, completedAgentCount: 1 }),
+      project({ status: "background", isBackground: true, waitingAgentCount: 1 }),
+      project({ status: "background", isBackground: true, activeAgentCount: 1 }),
+      project({ status: "background", isBackground: true, snoozedAgentCount: 1 }),
+      project({ status: "background", isBackground: true, processCount: 1 }),
+      project({ isMissing: true }),
+    ];
+    for (const row of keepsItsMark) {
+      expect(getProjectRowStatus(row, NOW).allowsResumeMark).toBeUndefined();
+    }
+
+    // The finished row is muted like the parked one, so the two are only ever
+    // told apart by this flag — a tone check here would light up both.
+    expect(getProjectRowStatus(keepsItsMark[0]!, NOW).tone).toBe("muted");
+  });
+
   // The hint disambiguates two projects sharing a folder name, so it is part of
   // the row's identity rather than its status — it has to survive the flag that
   // takes the status line away.

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -431,24 +431,63 @@ describe("getProjectRowStatus", () => {
     expect(parked.isDormantFallback).toBeUndefined();
     expect(parked.text.length).toBeGreaterThan(0);
 
-    // Stated as open projects, because that is the only way these arise: a
-    // closed project has no live PTYs, so its counts are always zero. A row
-    // whose agents finished elsewhere is not waiting on disk for anyone.
+    // The hint is decorated onto the status afterwards, so it is the one path
+    // that could drop the flag while every other row kept it — and it would
+    // only show up on parked projects whose folder name collides.
+    expect(
+      getProjectRowStatus(
+        project({
+          status: "closed",
+          autoParkedAt: NOW - 1000,
+          displayPath: "payments/api",
+        }),
+        NOW
+      )
+    ).toMatchObject({ allowsResumeMark: true, pathHint: "payments/api" });
+
+    // Stated as open projects, which is where these settle: the counts are
+    // computed from live terminals, so a project that stays closed reports
+    // zero. A row whose agents finished in a window that is still open is not
+    // waiting on disk for anyone.
     const keepsItsMark = [
       project({ status: "background", isBackground: true, completedAgentCount: 1 }),
       project({ status: "background", isBackground: true, waitingAgentCount: 1 }),
       project({ status: "background", isBackground: true, activeAgentCount: 1 }),
       project({ status: "background", isBackground: true, snoozedAgentCount: 1 }),
       project({ status: "background", isBackground: true, processCount: 1 }),
-      project({ isMissing: true }),
+      project({ status: "missing", isMissing: true }),
     ];
     for (const row of keepsItsMark) {
       expect(getProjectRowStatus(row, NOW).allowsResumeMark).toBeUndefined();
     }
 
-    // The finished row is muted like the parked one, so the two are only ever
-    // told apart by this flag — a tone check here would light up both.
-    expect(getProjectRowStatus(keepsItsMark[0]!, NOW).tone).toBe("muted");
+    // The finished row is muted exactly like the parked one, so tone cannot be
+    // what separates them — asserted as the pair, since checking either alone
+    // would stay green while the premise stopped being true.
+    expect(getProjectRowStatus(keepsItsMark[0]!, NOW).tone).toBe(parked.tone);
+  });
+
+  // The sweep marks a project closed at once, while its counts arrive on a
+  // 200ms debounce — so a parked row briefly carries the activity it had a
+  // moment ago. It has to keep saying what it was doing until the counts
+  // settle: promising a resume while agents still read as running would be the
+  // wrong half of the story.
+  it("waits for the counts to settle before a parked row promises a resume", () => {
+    const midSweep = project({
+      status: "closed",
+      autoParkedAt: NOW - 50,
+      activeAgentCount: 1,
+      lastOpened: NOW - 5000,
+    });
+
+    const status = getProjectRowStatus(midSweep, NOW);
+    expect(status.allowsResumeMark).toBeUndefined();
+    expect(status.text).toContain("running");
+
+    // Once the counts catch up, the same row parks and offers its dot.
+    const settled = getProjectRowStatus({ ...midSweep, activeAgentCount: 0 }, NOW);
+    expect(settled.allowsResumeMark).toBe(true);
+    expect(settled.text).toBe("Suspended to free memory");
   });
 
   // The hint disambiguates two projects sharing a folder name, so it is part of

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -109,6 +109,22 @@ export interface ProjectRowStatus {
    * keeps — a tone check would silently delete them along with the timestamps.
    */
   isDormantFallback?: true;
+  /**
+   * Set when this status will yield its leading dot to the resumable-agent mark
+   * (#11801, #11822). Both of the rows that reach it have stopped: the
+   * opened-time fallback draws no dot at all, and an auto-parked project keeps
+   * its explanatory line but has only a settled ring to give up.
+   *
+   * Separate from `isDormantFallback` because the two answer different
+   * questions. That flag decides whether a row has a second line; this one
+   * decides which mark wins the slot, and auto-park needs to say yes to the
+   * second while still saying no to the first.
+   *
+   * Unset is the conservative answer: a status that says what a project is
+   * doing keeps its own dot, so a state added later cannot start promising a
+   * resume it was never classified for.
+   */
+  allowsResumeMark?: true;
 }
 
 /** Compact duration for a wait that is already minutes old. Sub-minute reads as "just now". */
@@ -398,9 +414,19 @@ function getWorkspaceActivityStatus(
  */
 function getOpenedStatus(lastOpened: number): WorkspaceActivityStatus {
   if (lastOpened > 0) {
-    return { text: `Opened ${formatTimeAgo(lastOpened)}`, tone: "muted", isDormantFallback: true };
+    return {
+      text: `Opened ${formatTimeAgo(lastOpened)}`,
+      tone: "muted",
+      isDormantFallback: true,
+      allowsResumeMark: true,
+    };
   }
-  return { text: "Not opened yet", tone: "muted", isDormantFallback: true };
+  return {
+    text: "Not opened yet",
+    tone: "muted",
+    isDormantFallback: true,
+    allowsResumeMark: true,
+  };
 }
 
 /** The one status line a project row has to show, if it shows one at all. */
@@ -422,9 +448,11 @@ export function getProjectRowStatus(
   if (activity) return withHint(activity);
 
   // Auto-closed by the background-idle sweep (#10830) — name the reason rather
-  // than showing a bare time-ago that makes the project look merely stale.
+  // than showing a bare time-ago that makes the project look merely stale. The
+  // reason is the row's own line; the ring beside it is only settled state, so
+  // it steps aside for a resume promise that has more to say (#11822).
   if (project.status === "closed" && project.autoParkedAt) {
-    return withHint({ text: "Suspended to free memory", tone: "muted" });
+    return withHint({ text: "Suspended to free memory", tone: "muted", allowsResumeMark: true });
   }
 
   return withHint(getOpenedStatus(project.lastOpened));


### PR DESCRIPTION
## Summary
When a project gets auto-closed by the idle background sweep (`status === "closed"` plus an `autoParkedAt` marker), the project switcher shows "Suspended to free memory" but never draws the grey resumable-agents dot or its screen-reader suffix announcing how many agents will resume, even when the project has agents waiting to come back.
`#11801` introduced that mark and explicitly said it should land on closed projects that kept their layout: Free memory, the idle sweep, and eventually a slept project. The idle-sweep row was always meant to carry it, the implementation just missed that case.

Resolves #11822

## Why it wasn't a one-line fix
`showResumableAgentMark` gates the mark on `status.isDormantFallback === true`, and the auto-park branch never sets that flag. But `isDormantFallback` also gates the row's second text line, so flipping it on for the auto-park branch would have deleted "Suspended to free memory" entirely, trading a missing dot for a missing explanation.

## Changes
- Added `allowsResumeMark` to `ProjectRowStatus`, a second flag orthogonal to `isDormantFallback` that answers a different question: `isDormantFallback` decides whether a row has a second line, `allowsResumeMark` decides which mark wins the dot slot. An auto-parked row needs to say yes to the second and no to the first.
- Set the new flag on the opened-time fallback and the auto-park branch. Every status describing what a project is currently doing leaves it unset and keeps its own dot, so a state added later can't start promising a resume it was never classified for.
- Rewrote `StatusDot` from two independently-conditioned sibling divs into a single choice that yields exactly one node. The two dots were only ever mutually exclusive by accident, and decoupling the gate would have let a settled ring and a resume mark stack in the same 6px slot. Now the slot can't hold two dots by construction.
- `src/lib/projectRowStatus.ts`, `src/components/Project/ProjectSwitcherPalette.tsx`, plus their test files.

## Testing
Checked the following invariants hold with adversarial review:
- A row with nothing to say draws no dot and no second line (`#11692`'s rule).
- The resume promise never displaces a live status dot and never appears on the current project (`#11801`'s rule).
- `resumableAgentCount === undefined` ("not counted yet") stays distinct from a real `0`.
- The dot stays `aria-hidden`, with the fact carried in the row's accessible name, so colour is never the only carrier.

Also worth calling out: the idle sweep marks a project closed synchronously while its agent counts arrive on a 200ms debounce, so a parked row briefly carries the activity it had a moment ago. The row correctly keeps reporting live work until the counts settle rather than promising a resume mid-transition, and that transition is now pinned by a test in both directions.

Ran `npx vitest run src/lib/__tests__/projectRowStatus.test.ts src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx` (154 passed), eslint on all 4 changed files (clean), `npm run typecheck` (clean), and prettier check (clean). No e2e specs touch this surface.
