### PR TITLE
fix(switcher): show the resume dot on scratch rows

### DIFF
--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -24,11 +24,13 @@ import { store } from "../store.js";
 import { getSharedDb } from "./persistence/db.js";
 import {
   projects as projectsTable,
+  scratches as scratchesTable,
   appState as appStateTable,
   type ProjectRow,
 } from "./persistence/schema.js";
 import { eq, desc, and, isNull, ne, or, sql } from "drizzle-orm";
 import { countResumableAgentPanels } from "./projectStateRestore.js";
+import { isProjectWorkspaceId, isScratchWorkspaceId } from "../../shared/utils/workspaceIds.js";
 import {
   generateProjectId,
   mintProjectId,
@@ -203,23 +205,36 @@ export class ProjectStore {
     // Every write of the terminals array recomputes the switcher's resume count
     // (#11801), so the number a dormant row carries is whatever its last save
     // actually persisted rather than whatever was true when it was last opened.
-    this.stateManager.setStatePersistedObserver((projectId, state) =>
-      this.persistResumableAgentCount(projectId, state)
+    // The slot holds one observer, and scratch state comes through this same
+    // manager — so this one routes both kinds by id shape (#11821) rather than
+    // a second observer replacing this one.
+    this.stateManager.setStatePersistedObserver((workspaceId, state) =>
+      this.persistResumableAgentCount(workspaceId, state)
     );
   }
 
   /**
-   * Write the derived resume count for a project whose state just landed.
+   * Write the derived resume count for a workspace whose state just landed.
+   *
+   * One observer serves both kinds because one state manager does: scratches
+   * persist their panel grid under the same `projects/<id>/` layout (#11484), so
+   * every scratch save arrives here too. The id's shape says which table owns
+   * the row (#11821) — `workspaceIds` is the authority, and asking a store
+   * "is this id a scratch?" would instead answer whether that store had
+   * finished hydrating. An id of neither shape belongs to no table and writes
+   * nothing.
    *
    * Derived metadata, so it never throws into the write path: the state file is
-   * already committed, and a project id with no row — scratch state shares this
-   * manager — simply updates nothing. A miss here self-heals on the next save
-   * or on the deferred maintenance pass.
+   * already committed, and a miss here self-heals on the next save or on the
+   * deferred maintenance pass.
    */
-  private persistResumableAgentCount(projectId: string, state: ProjectState | null): void {
+  private persistResumableAgentCount(workspaceId: string, state: ProjectState | null): void {
     try {
+      const isScratch = isScratchWorkspaceId(workspaceId);
+      if (!isScratch && !isProjectWorkspaceId(workspaceId)) return;
+      const kind = isScratch ? "scratch" : "project";
       const count = state
-        ? countResumableAgentPanels(state.terminals, `resume-count(project:${projectId})`)
+        ? countResumableAgentPanels(state.terminals, `resume-count(${kind}:${workspaceId})`)
         : // Cleared state restores nothing. That is an answer, not an absence
           // of one, so it is written rather than left unknown.
           0;
@@ -228,11 +243,30 @@ export class ProjectStore {
       // size and draft edits all save state without touching the panel set, and
       // an unconditional UPDATE would put every one of them through SQLite and
       // the WAL on the main process for a number that did not move.
+      if (isScratch) {
+        db.update(scratchesTable)
+          .set({ resumableAgentCount: count })
+          .where(
+            and(
+              eq(scratchesTable.id, workspaceId),
+              // A tombstoned scratch is already gone from every renderer-facing
+              // query, so maintenance writes stop at the tombstone the way every
+              // other write in `ScratchStore` does.
+              isNull(scratchesTable.deletedAt),
+              or(
+                isNull(scratchesTable.resumableAgentCount),
+                ne(scratchesTable.resumableAgentCount, count)
+              )
+            )
+          )
+          .run();
+        return;
+      }
       db.update(projectsTable)
         .set({ resumableAgentCount: count })
         .where(
           and(
-            eq(projectsTable.id, projectId),
+            eq(projectsTable.id, workspaceId),
             or(
               isNull(projectsTable.resumableAgentCount),
               ne(projectsTable.resumableAgentCount, count)
@@ -241,7 +275,7 @@ export class ProjectStore {
         )
         .run();
     } catch (error) {
-      logError(`[ProjectStore] Failed to persist resume count for ${projectId}`, error);
+      logError(`[ProjectStore] Failed to persist resume count for ${workspaceId}`, error);
     }
   }
 

--- a/electron/services/ScratchStore.ts
+++ b/electron/services/ScratchStore.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import { randomUUID } from "crypto";
-import { eq, desc, and, isNull, isNotNull, lt, or } from "drizzle-orm";
+import { eq, desc, and, isNull, isNotNull, lt, or, sql } from "drizzle-orm";
 import type { Scratch } from "../../shared/types/scratch.js";
 import { getSharedDb } from "./persistence/db.js";
 import {
@@ -29,7 +29,19 @@ export async function removeScratchStateDir(scratchId: string): Promise<void> {
   }
 }
 
+/**
+ * A count only counts when it could have come from counting panels. A negative
+ * or fractional cell is corruption, not a claim, so it reads back as unknown —
+ * the same rule `ProjectStore` applies to its own persisted counts. Duplicated
+ * rather than imported: `ProjectStore` is a heavyweight singleton that builds
+ * itself at module eval, and this file keeps that import lazy on purpose.
+ */
+function readPersistedCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
 function rowToScratch(row: ScratchRow): Scratch {
+  const resumableAgentCount = readPersistedCount(row.resumableAgentCount);
   return {
     id: row.id,
     path: row.path,
@@ -39,6 +51,7 @@ function rowToScratch(row: ScratchRow): Scratch {
     ...(typeof row.lastCompletionSeenAt === "number"
       ? { lastCompletionSeenAt: row.lastCompletionSeenAt }
       : {}),
+    ...(resumableAgentCount !== null ? { resumableAgentCount } : {}),
   };
 }
 
@@ -226,6 +239,56 @@ export class ScratchStore {
     if (result.changes === 0) {
       throw new Error(`Scratch not found: ${scratchId}`);
     }
+  }
+
+  /**
+   * Bring a scratch row's resume count in line with a state read taken outside
+   * the write path — the deferred maintenance pass, which is how scratches that
+   * predate the field ever get one (#11821). Mirrors
+   * `ProjectStore.reconcileResumableAgentCount` against the other table.
+   *
+   * Compare-and-swap against the value read before that state load, because the
+   * two race: a save landing mid-scan is newer than anything the scan holds, and
+   * an unconditional write would replace a fresh count with a stale one.
+   *
+   * Passing `count: null` retracts the row's claim rather than replacing it —
+   * for a scratch whose state could not be read, where the honest answer is
+   * "unknown" and holding the old number would keep promising panels nothing
+   * can enumerate any more.
+   *
+   * Returns the updated scratch when the row actually changed, so the caller can
+   * broadcast exactly the rows a palette would need to redraw, and `null`
+   * otherwise. Tombstoned rows are excluded like every other write here: a
+   * scratch mid-deletion is already gone from every renderer-facing query.
+   */
+  reconcileResumableAgentCount(
+    scratchId: string,
+    previousCount: number | null,
+    count: number | null
+  ): Scratch | null {
+    if (previousCount === count) return null;
+    if (!isValidScratchId(scratchId)) return null;
+    const db = getSharedDb();
+    const result = db
+      .update(scratchesTable)
+      .set({ resumableAgentCount: count })
+      .where(
+        and(
+          eq(scratchesTable.id, scratchId),
+          isNull(scratchesTable.deletedAt),
+          previousCount === null
+            ? // "Unknown" is wider than SQL NULL. `readPersistedCount` also
+              // reports a negative or fractional cell as unknown, so matching
+              // NULL alone would leave a corrupt row permanently unrepairable:
+              // the reader keeps answering unknown, and the swap keeps missing
+              // the very value that made it answer that way.
+              sql`(${scratchesTable.resumableAgentCount} IS NULL OR ${scratchesTable.resumableAgentCount} < 0 OR ${scratchesTable.resumableAgentCount} <> CAST(${scratchesTable.resumableAgentCount} AS INTEGER))`
+            : eq(scratchesTable.resumableAgentCount, previousCount)
+        )
+      )
+      .run();
+    if (result.changes === 0) return null;
+    return this.getScratchById(scratchId);
   }
 
   /** Acknowledgement watermarks for live scratches, keyed by id. */

--- a/electron/services/__tests__/ProjectStore.resumableAgentCount.test.ts
+++ b/electron/services/__tests__/ProjectStore.resumableAgentCount.test.ts
@@ -257,12 +257,33 @@ describe("ProjectStore resumable agent count", () => {
       expect(storedCount()).toBe(1);
     });
 
-    it("survives state for an id belonging to neither table", () => {
-      // Not a 64-hex project id and not a scratch UUID, so it addresses no row
-      // in either table and the observer has nothing to write.
+    it("writes nothing at all for an id belonging to neither table", () => {
+      // Not a 64-hex project id and not a scratch UUID. SQLite will happily
+      // hold such an id, so the rows below exist to prove the observer STOPS
+      // rather than merely missing: without the shape check it would run an
+      // UPDATE against `projects` for whatever id it was handed.
+      const malformed = "no-such-workspace";
+      db.insert(schema.projects)
+        .values({
+          id: malformed,
+          path: "/tmp/malformed",
+          name: "Malformed",
+          emoji: "🌲",
+          lastOpened: Date.now(),
+          resumableAgentCount: 42,
+        })
+        .run();
+      insertScratch({ id: malformed });
+      db.update(schema.scratches)
+        .set({ resumableAgentCount: 42 })
+        .where(eq(schema.scratches.id, malformed))
+        .run();
+
       expect(() =>
-        observerSlot.current?.("no-such-workspace", { terminals: [agentPanel("a")] })
+        observerSlot.current?.(malformed, { terminals: [agentPanel("a")] })
       ).not.toThrow();
+      expect(storedCount(malformed)).toBe(42);
+      expect(storedScratchCount(malformed)).toBe(42);
     });
   });
 
@@ -309,9 +330,10 @@ describe("ProjectStore resumable agent count", () => {
     it("stops at the tombstone for a scratch being deleted", () => {
       const doomed = "8c6b1f22-1f3e-4a76-b1b0-2f9a7c4e51aa";
       insertScratch({ id: doomed, deletedAt: Date.now() });
-      // Removal tombstones the row, then tears the state directory down — which
-      // saves through this observer. A row already gone from every
-      // renderer-facing query takes no maintenance writes.
+      // Removal tombstones the row first and only reaps it once the directory
+      // is gone, so a debounced save already in flight can still land in that
+      // window. A row gone from every renderer-facing query takes no
+      // maintenance writes.
       observerSlot.current?.(doomed, { terminals: [agentPanel("a")] });
       expect(storedScratchCount(doomed)).toBeNull();
     });
@@ -322,6 +344,26 @@ describe("ProjectStore resumable agent count", () => {
           terminals: [agentPanel("a")],
         })
       ).not.toThrow();
+    });
+
+    it("does not re-write a row whose count has not moved", () => {
+      // Layout, focus, size and draft edits all save state without touching the
+      // panel set. The value guard is what keeps those off SQLite and the WAL,
+      // so an unconditional UPDATE would be a real regression rather than a
+      // cosmetic one — count the writes, not the resulting value.
+      sqlite.exec(`
+        CREATE TABLE scratch_writes (n INTEGER);
+        CREATE TRIGGER count_scratch_writes AFTER UPDATE ON scratches
+        BEGIN INSERT INTO scratch_writes VALUES (1); END;
+      `);
+      const writes = () =>
+        (sqlite.prepare("SELECT COUNT(*) AS n FROM scratch_writes").get() as { n: number }).n;
+
+      observerSlot.current?.(SCRATCH_ID, { terminals: [agentPanel("a")] });
+      expect(writes()).toBe(1);
+
+      observerSlot.current?.(SCRATCH_ID, { terminals: [agentPanel("a")] });
+      expect(writes()).toBe(1);
     });
   });
 

--- a/electron/services/__tests__/ProjectStore.resumableAgentCount.test.ts
+++ b/electron/services/__tests__/ProjectStore.resumableAgentCount.test.ts
@@ -33,11 +33,24 @@ const CREATE_TABLES_SQL = `
     stats_last_updated INTEGER,
     git_backed INTEGER
   );
+  CREATE TABLE IF NOT EXISTS scratches (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    last_opened INTEGER NOT NULL,
+    deleted_at INTEGER,
+    last_completion_seen_at INTEGER,
+    resumable_agent_count INTEGER
+  );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
   );
 `;
+
+/** A well-formed scratch id — the observer routes on the id's shape. */
+const SCRATCH_ID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
 
 let sqlite: Database.Database;
 let db: ReturnType<typeof drizzle<typeof schema>>;
@@ -122,6 +135,24 @@ describe("ProjectStore resumable agent count", () => {
   const storedCount = (id = projectId): number | null => {
     const row = db.select().from(schema.projects).where(eq(schema.projects.id, id)).get();
     return row?.resumableAgentCount ?? null;
+  };
+
+  const storedScratchCount = (id = SCRATCH_ID): number | null => {
+    const row = db.select().from(schema.scratches).where(eq(schema.scratches.id, id)).get();
+    return row?.resumableAgentCount ?? null;
+  };
+
+  const insertScratch = (overrides: { id?: string; deletedAt?: number } = {}) => {
+    db.insert(schema.scratches)
+      .values({
+        id: overrides.id ?? SCRATCH_ID,
+        path: `/tmp/scratches/${overrides.id ?? SCRATCH_ID}`,
+        name: "Scratch",
+        createdAt: Date.now(),
+        lastOpened: Date.now(),
+        ...(overrides.deletedAt !== undefined ? { deletedAt: overrides.deletedAt } : {}),
+      })
+      .run();
   };
 
   beforeEach(async () => {
@@ -226,10 +257,70 @@ describe("ProjectStore resumable agent count", () => {
       expect(storedCount()).toBe(1);
     });
 
-    it("survives state for an id that has no project row", () => {
-      // Scratch workspaces share the state manager but own no `projects` row.
+    it("survives state for an id belonging to neither table", () => {
+      // Not a 64-hex project id and not a scratch UUID, so it addresses no row
+      // in either table and the observer has nothing to write.
       expect(() =>
-        observerSlot.current?.("no-such-project", { terminals: [agentPanel("a")] })
+        observerSlot.current?.("no-such-workspace", { terminals: [agentPanel("a")] })
+      ).not.toThrow();
+    });
+  });
+
+  // Scratches persist their panel grid through the SAME state manager (#11484),
+  // so the one observer sees both kinds and the id's shape decides which table
+  // it writes (#11821).
+  describe("routing a scratch's state to the scratch row", () => {
+    beforeEach(() => insertScratch());
+
+    it("recounts a scratch's saved agents onto its own row", () => {
+      observerSlot.current?.(SCRATCH_ID, {
+        terminals: [
+          agentPanel("a"),
+          agentPanel("b"),
+          agentPanel("c", { launchAgentId: undefined }),
+        ],
+      });
+      expect(storedScratchCount()).toBe(2);
+    });
+
+    it("writes a known zero when a scratch's state is cleared away", () => {
+      observerSlot.current?.(SCRATCH_ID, { terminals: [agentPanel("a")] });
+      expect(storedScratchCount()).toBe(1);
+
+      observerSlot.current?.(SCRATCH_ID, null);
+      expect(storedScratchCount()).toBe(0);
+    });
+
+    it("leaves the project table untouched when a scratch saves", () => {
+      // The bug this replaces: the write targeted `projects` unconditionally,
+      // so a scratch save matched nothing. It must now match its own row and
+      // still not reach across into anyone else's.
+      observerSlot.current?.(SCRATCH_ID, { terminals: [agentPanel("a")] });
+      expect(storedScratchCount()).toBe(1);
+      expect(storedCount()).toBeNull();
+    });
+
+    it("leaves the scratch table untouched when a project saves", () => {
+      observerSlot.current?.(projectId, { terminals: [agentPanel("a"), agentPanel("b")] });
+      expect(storedCount()).toBe(2);
+      expect(storedScratchCount()).toBeNull();
+    });
+
+    it("stops at the tombstone for a scratch being deleted", () => {
+      const doomed = "8c6b1f22-1f3e-4a76-b1b0-2f9a7c4e51aa";
+      insertScratch({ id: doomed, deletedAt: Date.now() });
+      // Removal tombstones the row, then tears the state directory down — which
+      // saves through this observer. A row already gone from every
+      // renderer-facing query takes no maintenance writes.
+      observerSlot.current?.(doomed, { terminals: [agentPanel("a")] });
+      expect(storedScratchCount(doomed)).toBeNull();
+    });
+
+    it("survives a scratch id with no row of its own", () => {
+      expect(() =>
+        observerSlot.current?.("11111111-2222-4333-8444-555555555555", {
+          terminals: [agentPanel("a")],
+        })
       ).not.toThrow();
     });
   });

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -119,6 +119,7 @@ function row(overrides: Partial<ScratchRow> & Pick<ScratchRow, "id" | "path">): 
     lastOpened: overrides.lastOpened ?? 0,
     deletedAt: overrides.deletedAt ?? null,
     lastCompletionSeenAt: overrides.lastCompletionSeenAt ?? null,
+    resumableAgentCount: overrides.resumableAgentCount ?? null,
   };
 }
 

--- a/electron/services/__tests__/ScratchStore.test.ts
+++ b/electron/services/__tests__/ScratchStore.test.ts
@@ -331,10 +331,25 @@ describe("ScratchStore resumable agent count (#11821)", () => {
     });
 
     it("treats a corrupt count as never counted rather than as a claim", () => {
+      // Both read paths, because the palette's browse list comes from
+      // `getAllScratches` while a single row lookup comes from `getScratchById`
+      // — a guard applied to one only would leave the other making the claim.
       for (const corrupt of [-1, 1.5]) {
         setStoredCount(corrupt);
         expect(store.getScratchById(scratchId)?.resumableAgentCount).toBeUndefined();
+        expect(store.getAllScratches()[0]?.resumableAgentCount).toBeUndefined();
       }
+    });
+
+    it("treats a non-numeric cell as never counted", () => {
+      // SQLite's INTEGER affinity keeps a non-coercible TEXT as TEXT, so the
+      // reader has to reject by type rather than assume the column's declared
+      // one. Written through raw SQL: the typed builder would refuse it.
+      sqlite
+        .prepare("UPDATE scratches SET resumable_agent_count = 'lots' WHERE id = ?")
+        .run(scratchId);
+      expect(store.getScratchById(scratchId)?.resumableAgentCount).toBeUndefined();
+      expect(store.getAllScratches()[0]?.resumableAgentCount).toBeUndefined();
     });
   });
 
@@ -376,11 +391,15 @@ describe("ScratchStore resumable agent count (#11821)", () => {
       expect(storedCount()).toBeNull();
     });
 
-    it("repairs a corrupt cell that reads back as unknown", () => {
-      // `readPersistedCount` reports -1 as unknown, so the sweep arrives with
-      // previousCount null. Matching SQL NULL alone would never match this row
-      // and it would stay corrupt forever.
-      setStoredCount(-1);
+    it.each([
+      ["negative", -1],
+      ["fractional", 1.5],
+    ])("repairs a %s cell that reads back as unknown", (_label, corrupt) => {
+      // `readPersistedCount` reports both as unknown, so the sweep arrives with
+      // previousCount null. Matching SQL NULL alone would never match these rows
+      // and they would stay corrupt forever — the fractional case is the one the
+      // `<> CAST(... AS INTEGER)` arm exists for.
+      setStoredCount(corrupt);
       expect(store.reconcileResumableAgentCount(scratchId, null, 2)?.resumableAgentCount).toBe(2);
       expect(storedCount()).toBe(2);
     });
@@ -394,10 +413,24 @@ describe("ScratchStore resumable agent count (#11821)", () => {
       expect(storedCount()).toBeNull();
     });
 
-    it("rejects a malformed id instead of addressing the whole table", () => {
-      setStoredCount(1);
-      expect(store.reconcileResumableAgentCount("not-a-uuid", null, 6)).toBeNull();
-      expect(storedCount()).toBe(1);
+    it("rejects a malformed id instead of addressing the row it names", () => {
+      // The row genuinely exists under that id — SQLite holds any TEXT primary
+      // key — so this fails if the guard stops running. Pointed at a row with
+      // some other id the UPDATE would miss anyway and prove nothing.
+      const malformed = "not-a-uuid";
+      db.insert(schema.scratches)
+        .values({
+          id: malformed,
+          path: "/tmp/daintree-scratch-test/malformed",
+          name: "Malformed",
+          createdAt: 1_000,
+          lastOpened: 2_000,
+          resumableAgentCount: 1,
+        })
+        .run();
+
+      expect(store.reconcileResumableAgentCount(malformed, 1, 6)).toBeNull();
+      expect(storedCount(malformed)).toBe(1);
     });
   });
 

--- a/electron/services/__tests__/ScratchStore.test.ts
+++ b/electron/services/__tests__/ScratchStore.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import fs from "fs/promises";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
+import { eq } from "drizzle-orm";
 import * as schema from "../persistence/schema.js";
 
 const CREATE_TABLES_SQL = `
@@ -13,7 +14,8 @@ const CREATE_TABLES_SQL = `
     created_at INTEGER NOT NULL,
     last_opened INTEGER NOT NULL,
     deleted_at INTEGER,
-    last_completion_seen_at INTEGER
+    last_completion_seen_at INTEGER,
+    resumable_agent_count INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,
@@ -268,5 +270,153 @@ describe("ScratchStore.markCompletionSeen", () => {
     store.markCompletionSeen(scratchId, 5_000);
 
     expect([...store.getLastCompletionSeenMap().keys()]).toEqual([scratchId]);
+  });
+});
+
+describe("ScratchStore resumable agent count (#11821)", () => {
+  let store: ScratchStore;
+  let scratchId: string;
+
+  const storedCount = (id = scratchId): number | null => {
+    const row = db.select().from(schema.scratches).where(eq(schema.scratches.id, id)).get();
+    return row?.resumableAgentCount ?? null;
+  };
+
+  const setStoredCount = (value: number | null, id = scratchId) => {
+    db.update(schema.scratches)
+      .set({ resumableAgentCount: value })
+      .where(eq(schema.scratches.id, id))
+      .run();
+  };
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+
+    scratchId = randomUUID();
+    db.insert(schema.scratches)
+      .values({
+        id: scratchId,
+        path: "/tmp/daintree-scratch-test/" + scratchId,
+        name: "Test Scratch",
+        createdAt: 1_000,
+        lastOpened: 2_000,
+      })
+      .run();
+
+    store = new ScratchStore();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  describe("what a row reports", () => {
+    it("says nothing at all for a row that has never been counted", () => {
+      // The column is NULL for every scratch that predates the field. Reporting
+      // 0 there would claim it restores nothing, which nobody checked.
+      expect(store.getScratchById(scratchId)?.resumableAgentCount).toBeUndefined();
+    });
+
+    it("carries a counted zero as an answer, distinct from never having counted", () => {
+      setStoredCount(0);
+      expect(store.getScratchById(scratchId)?.resumableAgentCount).toBe(0);
+    });
+
+    it("carries a positive count through both read paths", () => {
+      setStoredCount(4);
+      expect(store.getScratchById(scratchId)?.resumableAgentCount).toBe(4);
+      expect(store.getAllScratches()[0]?.resumableAgentCount).toBe(4);
+    });
+
+    it("treats a corrupt count as never counted rather than as a claim", () => {
+      for (const corrupt of [-1, 1.5]) {
+        setStoredCount(corrupt);
+        expect(store.getScratchById(scratchId)?.resumableAgentCount).toBeUndefined();
+      }
+    });
+  });
+
+  describe("reconciling a row the write path never reached", () => {
+    it("fills in a row that had no count", () => {
+      expect(store.reconcileResumableAgentCount(scratchId, null, 3)?.resumableAgentCount).toBe(3);
+      expect(storedCount()).toBe(3);
+    });
+
+    it("reports no change when the row already agrees", () => {
+      setStoredCount(2);
+      expect(store.reconcileResumableAgentCount(scratchId, 2, 2)).toBeNull();
+    });
+
+    it("repairs a row whose stored count has gone stale", () => {
+      setStoredCount(5);
+      expect(store.reconcileResumableAgentCount(scratchId, 5, 1)?.resumableAgentCount).toBe(1);
+      expect(storedCount()).toBe(1);
+    });
+
+    it("leaves a row alone when a newer write landed since it was read", () => {
+      // The sweep read NULL, then a real save wrote 7 while it was still
+      // loading state off disk. Its answer is older than the row's.
+      setStoredCount(7);
+      expect(store.reconcileResumableAgentCount(scratchId, null, 2)).toBeNull();
+      expect(storedCount()).toBe(7);
+    });
+
+    it("leaves a row alone when its known count moved to a different one", () => {
+      setStoredCount(3);
+      expect(store.reconcileResumableAgentCount(scratchId, 1, 9)).toBeNull();
+      expect(storedCount()).toBe(3);
+    });
+
+    it("retracts the claim when the scratch's state can no longer be read", () => {
+      setStoredCount(3);
+      const updated = store.reconcileResumableAgentCount(scratchId, 3, null);
+      expect(updated?.resumableAgentCount).toBeUndefined();
+      expect(storedCount()).toBeNull();
+    });
+
+    it("repairs a corrupt cell that reads back as unknown", () => {
+      // `readPersistedCount` reports -1 as unknown, so the sweep arrives with
+      // previousCount null. Matching SQL NULL alone would never match this row
+      // and it would stay corrupt forever.
+      setStoredCount(-1);
+      expect(store.reconcileResumableAgentCount(scratchId, null, 2)?.resumableAgentCount).toBe(2);
+      expect(storedCount()).toBe(2);
+    });
+
+    it("does not touch a tombstoned row", () => {
+      db.update(schema.scratches)
+        .set({ deletedAt: 9_000 })
+        .where(eq(schema.scratches.id, scratchId))
+        .run();
+      expect(store.reconcileResumableAgentCount(scratchId, null, 4)).toBeNull();
+      expect(storedCount()).toBeNull();
+    });
+
+    it("rejects a malformed id instead of addressing the whole table", () => {
+      setStoredCount(1);
+      expect(store.reconcileResumableAgentCount("not-a-uuid", null, 6)).toBeNull();
+      expect(storedCount()).toBe(1);
+    });
+  });
+
+  describe("surviving the other writers", () => {
+    it("keeps the count across a rename", () => {
+      setStoredCount(3);
+      expect(store.updateScratch(scratchId, { name: "Renamed" }).resumableAgentCount).toBe(3);
+    });
+
+    it("keeps the count across a switch that restamps lastOpened", () => {
+      setStoredCount(3);
+      store.setCurrentScratch(scratchId);
+      expect(storedCount()).toBe(3);
+    });
+
+    it("keeps the count across a completion watermark stamp", () => {
+      setStoredCount(3);
+      store.markCompletionSeen(scratchId, 5_000);
+      expect(storedCount()).toBe(3);
+    });
   });
 });

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -13,6 +13,8 @@ vi.mock("electron", () => ({
 }));
 
 import { openDb } from "../db.js";
+import { eq } from "drizzle-orm";
+import * as schema from "../schema.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const migrationsFolder = path.resolve(__dirname, "../migrations");
@@ -603,6 +605,88 @@ describe("openDb (integration)", () => {
       // The neighbouring key is what proves the DELETE was scoped rather than
       // a table-wide wipe that happened to satisfy the first assertion.
       expect(keys).toContain("currentProjectId");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("gives an existing scratch a column the Drizzle schema can address (migration 0013)", async () => {
+    // Names the column on purpose, for the same reason the 0012 test does: the
+    // generic journal test derives its expectations from the migration's own
+    // SQL, so a column misspelled in BOTH would satisfy it, and every store
+    // suite hand-creates the table rather than migrating into it. This is the
+    // only place the shipped SQL and `schema.ts` have to agree — which matters
+    // because 0013 was hand-trimmed from a generated draft (#11821).
+    const dbPath = path.join(tmpDir, "scratch-resume-count.db");
+
+    const journal = JSON.parse(
+      fs.readFileSync(path.join(migrationsFolder, "meta", "_journal.json"), "utf8")
+    ).entries as Array<{ when: number; tag: string }>;
+
+    const Database = (await import("better-sqlite3")).default;
+    const seed = new Database(dbPath);
+    // Everything up to 0013 already applied, so only the migration under test
+    // runs against a `scratches` table at its pre-0013 shape — holding a scratch
+    // that predates the field, which is the population it exists to backfill.
+    seed.exec(`
+      CREATE TABLE __drizzle_migrations (
+        id SERIAL PRIMARY KEY,
+        hash text NOT NULL,
+        created_at numeric
+      );
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        name TEXT NOT NULL,
+        emoji TEXT NOT NULL,
+        last_opened INTEGER NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        frecency_score REAL NOT NULL DEFAULT 3.0,
+        last_accessed_at INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE scratches (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        name TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_opened INTEGER NOT NULL,
+        deleted_at INTEGER,
+        last_completion_seen_at INTEGER
+      );
+      CREATE TABLE app_state (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+    const applied = seed.prepare(
+      "INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)"
+    );
+    for (const entry of journal.slice(0, -1)) applied.run(entry.tag, entry.when);
+    seed
+      .prepare(
+        "INSERT INTO scratches (id, path, name, created_at, last_opened) VALUES (?, ?, ?, ?, ?)"
+      )
+      .run("11111111-2222-4333-8444-555555555555", "/tmp/s", "Spike", 1, 2);
+    seed.close();
+
+    const { sqlite, db } = openDb(dbPath, migrationsFolder);
+    try {
+      // Round-tripped through the ORM rather than raw SQL: that is what binds
+      // the migration's column name to the one `ScratchStore` actually reads.
+      db.update(schema.scratches)
+        .set({ resumableAgentCount: 3 })
+        .where(eq(schema.scratches.id, "11111111-2222-4333-8444-555555555555"))
+        .run();
+      const row = db
+        .select()
+        .from(schema.scratches)
+        .where(eq(schema.scratches.id, "11111111-2222-4333-8444-555555555555"))
+        .get();
+
+      expect(row?.resumableAgentCount).toBe(3);
+      // Pre-existing rows come out of the migration making no claim, not
+      // claiming zero.
+      expect(row?.name).toBe("Spike");
     } finally {
       sqlite.close();
     }

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -671,6 +671,18 @@ describe("openDb (integration)", () => {
 
     const { sqlite, db } = openDb(dbPath, migrationsFolder);
     try {
+      // Read before anything writes: pre-existing rows come out of the
+      // migration making no claim, not claiming zero. Asserted rather than
+      // assumed because a `NOT NULL DEFAULT 0` column would satisfy every
+      // other assertion here while handing the sweep a count nobody measured.
+      const backfilled = db
+        .select()
+        .from(schema.scratches)
+        .where(eq(schema.scratches.id, "11111111-2222-4333-8444-555555555555"))
+        .get();
+
+      expect(backfilled?.resumableAgentCount).toBeNull();
+
       // Round-tripped through the ORM rather than raw SQL: that is what binds
       // the migration's column name to the one `ScratchStore` actually reads.
       db.update(schema.scratches)
@@ -684,8 +696,8 @@ describe("openDb (integration)", () => {
         .get();
 
       expect(row?.resumableAgentCount).toBe(3);
-      // Pre-existing rows come out of the migration making no claim, not
-      // claiming zero.
+      // The row that predates the column is still the row the write landed on —
+      // the migration added a field to it rather than replacing it.
       expect(row?.name).toBe("Spike");
     } finally {
       sqlite.close();

--- a/electron/services/persistence/migrations/0013_add_scratch_resumable_agent_count.sql
+++ b/electron/services/persistence/migrations/0013_add_scratch_resumable_agent_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scratches` ADD `resumable_agent_count` integer;

--- a/electron/services/persistence/migrations/meta/_journal.json
+++ b/electron/services/persistence/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1786861242046,
       "tag": "0012_replace_project_recency_with_resumable_agents",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1786880380226,
+      "tag": "0013_add_scratch_resumable_agent_count",
+      "breakpoints": true
     }
   ]
 }

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -80,6 +80,12 @@ export const scratches = sqliteTable("scratches", {
   // all renderer-facing queries.
   deletedAt: integer("deleted_at"),
   lastCompletionSeenAt: integer("last_completion_seen_at"),
+  // How many saved agent panels this scratch would restore if opened (#11821)
+  // — the same switcher resume dot projects carry. Scratches persist their
+  // panel grid under the shared `projects/<id>/` layout, so the count is
+  // derived by the same write-through observer and reconciled by the same
+  // deferred sweep. Null means "not computed yet", distinct from a computed 0.
+  resumableAgentCount: integer("resumable_agent_count"),
 });
 
 export type ProjectRow = typeof projects.$inferSelect;

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -596,21 +596,27 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
     });
 
     it("broadcasts moved scratches on the scratch channel, not the project one", async () => {
+      // The reconciler's OWN return value is what must go out — it is the
+      // freshly-read row. Broadcasting the input scratch instead would push the
+      // pre-backfill count and leave the palette drawing the old dot.
+      const reconciled = { id: "moved", resumableAgentCount: 1 };
       scratchStoreMock.getAllScratches.mockReturnValue([{ id: "moved" }, { id: "unchanged" }]);
       projectStoreMock.getProjectState.mockResolvedValue({ terminals: [agentPanel("t1")] });
       scratchStoreMock.reconcileResumableAgentCount.mockImplementation((id: string) =>
-        id === "moved" ? { id: "moved", resumableAgentCount: 1 } : null
+        id === "moved" ? reconciled : null
       );
 
       await __test__.evictStaleSessionFiles();
 
       const scratchUpdates = broadcastToRendererMock.mock.calls.filter(
-        ([channel]) => channel === "scratch:updated"
+        ([channel]) => channel === CHANNELS.SCRATCH_UPDATED
       );
       expect(scratchUpdates).toHaveLength(1);
-      expect(scratchUpdates[0][1]).toMatchObject({ id: "moved" });
+      expect(scratchUpdates[0][1]).toBe(reconciled);
       expect(
-        broadcastToRendererMock.mock.calls.filter(([channel]) => channel === "project:updated")
+        broadcastToRendererMock.mock.calls.filter(
+          ([channel]) => channel === CHANNELS.PROJECT_UPDATED
+        )
       ).toHaveLength(0);
     });
 
@@ -644,6 +650,43 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
 
       const arg = evictSessionFilesMock.mock.calls[0][0];
       expect([...(arg.knownIds ?? [])].sort()).toEqual(["term-p1", "term-s1"]);
+    });
+
+    it("reads workspace states with a bounded fan-out", async () => {
+      // Not a style preference: `ProjectStateManager` cannot tell an EMFILE from
+      // a corrupt file, so a descriptor exhaustion here marks a workspace
+      // unreadable AND renames its healthy state.json to `.corrupted.*`. An
+      // unbounded read over every project and scratch would make the sweep the
+      // thing that destroys the state it exists to preserve.
+      projectStoreMock.getAllProjects.mockReturnValue(
+        Array.from({ length: 40 }, (_, i) => ({ id: `proj-${i}` }))
+      );
+      scratchStoreMock.getAllScratches.mockReturnValue(
+        Array.from({ length: 40 }, (_, i) => ({ id: `scratch-${i}` }))
+      );
+
+      let inFlight = 0;
+      let peak = 0;
+      const release: (() => void)[] = [];
+      projectStoreMock.getProjectState.mockImplementation(async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise<void>((resolve) => release.push(resolve));
+        inFlight -= 1;
+        return null;
+      });
+
+      const sweep = __test__.evictStaleSessionFiles();
+      // Drain in waves: each release lets the next queued read start, so `peak`
+      // records the real ceiling rather than the first batch's size.
+      while (release.length > 0) {
+        release.shift()!();
+        await Promise.resolve();
+      }
+      await sweep;
+
+      expect(peak).toBeGreaterThan(0);
+      expect(peak).toBeLessThan(80);
     });
 
     it("disables the orphan pass when a scratch's state was unreadable", async () => {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -685,8 +685,14 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
       }
       await sweep;
 
-      expect(peak).toBeGreaterThan(0);
-      expect(peak).toBeLessThan(80);
+      // Against the ceiling itself, not the item count. The queue above is
+      // deliberately far longer than the limit, so a bounded fan-out saturates
+      // and never exceeds: the observed peak IS the declared limit. Compared to
+      // the constant rather than restating its value, so retuning the ceiling
+      // retunes the test — and a fan-out that quietly went unbounded, or
+      // collapsed to serial, fails here instead of passing a range check that
+      // the item count would have satisfied at any limit.
+      expect(peak).toBe(__test__.STATE_READ_CONCURRENCY);
     });
 
     it("disables the orphan pass when a scratch's state was unreadable", async () => {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -276,6 +276,17 @@ vi.mock("../../services/ProjectStore.js", () => ({
   projectStore: projectStoreMock,
 }));
 
+const scratchStoreMock = vi.hoisted(() => ({
+  getAllScratches: vi.fn<() => { id: string; resumableAgentCount?: number }[]>(() => []),
+  reconcileResumableAgentCount: vi.fn<
+    (id: string, previous: number | null, count: number | null) => unknown
+  >(() => null),
+}));
+
+vi.mock("../../services/ScratchStore.js", () => ({
+  scratchStore: scratchStoreMock,
+}));
+
 vi.mock("../../setup/environment.js", () => ({
   exposeGc: vi.fn(),
   isSmokeTest: false,
@@ -351,6 +362,10 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
     projectStoreMock.wasStateUnreadableThisSession.mockReturnValue(false);
     projectStoreMock.reconcileResumableAgentCount.mockReset();
     projectStoreMock.reconcileResumableAgentCount.mockReturnValue(null);
+    scratchStoreMock.getAllScratches.mockReset();
+    scratchStoreMock.getAllScratches.mockReturnValue([]);
+    scratchStoreMock.reconcileResumableAgentCount.mockReset();
+    scratchStoreMock.reconcileResumableAgentCount.mockReturnValue(null);
     broadcastToRendererMock.mockReset();
   }
 
@@ -358,6 +373,17 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
   // Restore defaults so a custom implementation set here can't leak into the
   // sibling "task ordering" describe — these hoisted mocks are shared.
   afterEach(resetSweepMocks);
+
+  /** A saved panel the resume count is allowed to count. */
+  const agentPanel = (id: string, overrides: Record<string, unknown> = {}) => ({
+    id,
+    title: "Agent",
+    kind: "terminal",
+    cwd: "/repo",
+    location: "grid",
+    launchAgentId: "claude",
+    ...overrides,
+  });
 
   it("passes a populated knownIds set when every project-state read is reliable", async () => {
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-a" }, { id: "proj-b" }]);
@@ -425,16 +451,6 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
    * in ProjectStore.resumableAgentCount.test.ts.
    */
   describe("resume-count backfill", () => {
-    const agentPanel = (id: string, overrides: Record<string, unknown> = {}) => ({
-      id,
-      title: "Agent",
-      kind: "terminal",
-      cwd: "/repo",
-      location: "grid",
-      launchAgentId: "claude",
-      ...overrides,
-    });
-
     it("counts the agent panels a readable state would restore", async () => {
       projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-a" }]);
       projectStoreMock.getProjectState.mockResolvedValue({
@@ -513,6 +529,136 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
       await __test__.evictStaleSessionFiles();
 
       expect(evictSessionFilesMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /**
+   * The same backfill for scratches (#11821). Without it the write-path fix
+   * alone leaves every scratch that existed before the field dark forever —
+   * which is the bug again, one population over.
+   */
+  describe("scratch resume-count backfill", () => {
+    it("counts a dormant scratch's saved agents and fills its row", async () => {
+      scratchStoreMock.getAllScratches.mockReturnValue([{ id: "scratch-a" }]);
+      projectStoreMock.getProjectState.mockResolvedValue({
+        terminals: [agentPanel("t1"), agentPanel("t2")],
+      });
+
+      await __test__.evictStaleSessionFiles();
+
+      expect(scratchStoreMock.reconcileResumableAgentCount).toHaveBeenCalledWith(
+        "scratch-a",
+        null,
+        2
+      );
+    });
+
+    it("reads an absent scratch state as an authoritative zero", async () => {
+      scratchStoreMock.getAllScratches.mockReturnValue([{ id: "scratch-a" }]);
+      projectStoreMock.getProjectState.mockResolvedValue(null);
+
+      await __test__.evictStaleSessionFiles();
+
+      expect(scratchStoreMock.reconcileResumableAgentCount).toHaveBeenCalledWith(
+        "scratch-a",
+        null,
+        0
+      );
+    });
+
+    it("retracts the claim when a scratch's state was unreadable", async () => {
+      scratchStoreMock.getAllScratches.mockReturnValue([
+        { id: "scratch-a", resumableAgentCount: 2 },
+      ]);
+      projectStoreMock.getProjectState.mockResolvedValue(null);
+      projectStoreMock.wasStateUnreadableThisSession.mockImplementation(
+        (id: string) => id === "scratch-a"
+      );
+
+      await __test__.evictStaleSessionFiles();
+
+      expect(scratchStoreMock.reconcileResumableAgentCount).toHaveBeenCalledWith(
+        "scratch-a",
+        2,
+        null
+      );
+    });
+
+    it("carries the previously known count into the compare-and-swap", async () => {
+      scratchStoreMock.getAllScratches.mockReturnValue([
+        { id: "scratch-a", resumableAgentCount: 0 },
+      ]);
+      projectStoreMock.getProjectState.mockResolvedValue({ terminals: [agentPanel("t1")] });
+
+      await __test__.evictStaleSessionFiles();
+
+      expect(scratchStoreMock.reconcileResumableAgentCount).toHaveBeenCalledWith("scratch-a", 0, 1);
+    });
+
+    it("broadcasts moved scratches on the scratch channel, not the project one", async () => {
+      scratchStoreMock.getAllScratches.mockReturnValue([{ id: "moved" }, { id: "unchanged" }]);
+      projectStoreMock.getProjectState.mockResolvedValue({ terminals: [agentPanel("t1")] });
+      scratchStoreMock.reconcileResumableAgentCount.mockImplementation((id: string) =>
+        id === "moved" ? { id: "moved", resumableAgentCount: 1 } : null
+      );
+
+      await __test__.evictStaleSessionFiles();
+
+      const scratchUpdates = broadcastToRendererMock.mock.calls.filter(
+        ([channel]) => channel === "scratch:updated"
+      );
+      expect(scratchUpdates).toHaveLength(1);
+      expect(scratchUpdates[0][1]).toMatchObject({ id: "moved" });
+      expect(
+        broadcastToRendererMock.mock.calls.filter(([channel]) => channel === "project:updated")
+      ).toHaveLength(0);
+    });
+
+    it("still runs the orphan pass when a scratch's count cannot be written", async () => {
+      scratchStoreMock.getAllScratches.mockReturnValue([{ id: "scratch-a" }]);
+      projectStoreMock.getProjectState.mockResolvedValue({ terminals: [agentPanel("t1")] });
+      scratchStoreMock.reconcileResumableAgentCount.mockImplementation(() => {
+        throw new Error("database is locked");
+      });
+
+      await __test__.evictStaleSessionFiles();
+
+      expect(evictSessionFilesMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /**
+   * Scratch `.restore` files sit in the same pool as project ones and carry no
+   * workspace reference, so the orphan pass has to be told about them too or it
+   * reads a live scratch's scrollback as unattributed.
+   */
+  describe("scratch terminals in the orphan pass", () => {
+    it("declares a scratch's terminals known", async () => {
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-a" }]);
+      scratchStoreMock.getAllScratches.mockReturnValue([{ id: "scratch-a" }]);
+      projectStoreMock.getProjectState.mockImplementation(async (id: string) =>
+        id === "proj-a" ? { terminals: [{ id: "term-p1" }] } : { terminals: [{ id: "term-s1" }] }
+      );
+
+      await __test__.evictStaleSessionFiles();
+
+      const arg = evictSessionFilesMock.mock.calls[0][0];
+      expect([...(arg.knownIds ?? [])].sort()).toEqual(["term-p1", "term-s1"]);
+    });
+
+    it("disables the orphan pass when a scratch's state was unreadable", async () => {
+      // Fail closed for the same reason a project does: the missing ids can't be
+      // attributed back, so deleting on that basis would eat live scrollback.
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-a" }]);
+      scratchStoreMock.getAllScratches.mockReturnValue([{ id: "scratch-quarantined" }]);
+      projectStoreMock.getProjectState.mockResolvedValue({ terminals: [{ id: "term-p1" }] });
+      projectStoreMock.wasStateUnreadableThisSession.mockImplementation(
+        (id: string) => id === "scratch-quarantined"
+      );
+
+      await __test__.evictStaleSessionFiles();
+
+      expect(evictSessionFilesMock.mock.calls[0][0].knownIds).toBeUndefined();
     });
   });
 });

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -1305,4 +1305,7 @@ export async function initGlobalServices(
  * Exported only for unit tests so they can verify session eviction logic
  * without driving the full deferred queue. Not part of the public surface.
  */
-export const __test__ = { evictStaleSessionFiles };
+// `STATE_READ_CONCURRENCY` rides the test seam rather than becoming a module
+// export: nothing in production reads it, and the sweep's ceiling test has to
+// compare against the real value instead of restating a literal.
+export const __test__ = { evictStaleSessionFiles, STATE_READ_CONCURRENCY };

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -62,6 +62,7 @@ import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { countResumableAgentPanels } from "../services/projectStateRestore.js";
 import type { Project, ProjectState } from "../../shared/types/project.js";
+import type { Scratch } from "../../shared/types/scratch.js";
 import { sendToRenderer } from "../ipc/handlers.js";
 import { wireUpdateMenuState } from "../menu.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
@@ -77,6 +78,7 @@ import { setPluginDirResolver } from "../setup/protocols.js";
 import { isE2EFaultMode } from "../setup/runtimeFlags.js";
 import { activateOpenFileInstaller } from "../setup/openFileInstall.js";
 import { projectStore } from "../services/ProjectStore.js";
+import { scratchStore } from "../services/ScratchStore.js";
 import { registerCommands } from "../services/commands/index.js";
 import { store, wasStoreFreshAtBoot } from "../store.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -154,13 +156,59 @@ function reconcileResumableAgentCounts(projects: Project[], states: (ProjectStat
   }
 }
 
+/**
+ * The scratch half of the same backfill (#11821). Scratches persist their panel
+ * grid under the shared `projects/<id>/` layout, so their states load through
+ * the same call and the sweep costs no extra reads for them either.
+ *
+ * Kept beside the project pass rather than folded into it: the two write
+ * different tables, return different entities and broadcast on different
+ * channels, and the compare-and-swap each needs is the one its own store owns.
+ */
+function reconcileScratchResumableAgentCounts(
+  scratches: Scratch[],
+  states: (ProjectState | null)[]
+): void {
+  for (const [i, scratch] of scratches.entries()) {
+    const state = states[i];
+    // Same three-way reading as projects: unreadable retracts the claim,
+    // genuinely absent state is authoritative emptiness, present state counts.
+    const count = projectStore.wasStateUnreadableThisSession(scratch.id)
+      ? null
+      : state
+        ? countResumableAgentPanels(state.terminals, `resume-count-backfill(scratch:${scratch.id})`)
+        : 0;
+
+    try {
+      const updated = scratchStore.reconcileResumableAgentCount(
+        scratch.id,
+        scratch.resumableAgentCount ?? null,
+        count
+      );
+      if (updated) broadcastToRenderer(CHANNELS.SCRATCH_UPDATED, updated);
+    } catch (error) {
+      console.warn(
+        `[MAIN] Session eviction: failed to reconcile resume count for scratch ${scratch.id}:`,
+        error
+      );
+    }
+  }
+}
+
 async function evictStaleSessionFiles(): Promise<void> {
   try {
     const allProjects = projectStore.getAllProjects();
+    const allScratches = scratchStore.getAllScratches();
     const knownIds = new Set<string>();
 
-    const states = await Promise.all(allProjects.map((p) => projectStore.getProjectState(p.id)));
-    for (const state of states) {
+    const [states, scratchStates] = await Promise.all([
+      Promise.all(allProjects.map((p) => projectStore.getProjectState(p.id))),
+      Promise.all(allScratches.map((s) => projectStore.getProjectState(s.id))),
+    ]);
+    // Scratch terminals belong to the same `.restore` pool as project ones, so
+    // they have to be declared known here or the orphan pass below would read a
+    // live scratch's scrollback as unattributed and delete it.
+    for (const state of [...states, ...scratchStates]) {
       if (state?.terminals) {
         for (const t of state.terminals) {
           knownIds.add(t.id);
@@ -169,6 +217,7 @@ async function evictStaleSessionFiles(): Promise<void> {
     }
 
     reconcileResumableAgentCounts(allProjects, states);
+    reconcileScratchResumableAgentCounts(allScratches, scratchStates);
 
     const appTerminals = store.get("appState")?.terminals;
     if (Array.isArray(appTerminals)) {
@@ -177,21 +226,24 @@ async function evictStaleSessionFiles(): Promise<void> {
       }
     }
 
-    // If any project's state was unreadable this session, `knownIds` is
-    // incomplete — it's missing every terminal id belonging to that project.
-    // A .restore file carries only a bare terminal id (no project reference),
-    // so the missing ids can't be attributed back to the affected project;
-    // the orphan pass can't tell "this project's scrollback" from a genuine
+    // If any workspace's state was unreadable this session, `knownIds` is
+    // incomplete — it's missing every terminal id belonging to that workspace.
+    // A .restore file carries only a bare terminal id (no workspace reference),
+    // so the missing ids can't be attributed back to the affected workspace;
+    // the orphan pass can't tell "this workspace's scrollback" from a genuine
     // orphan. Fail closed: skip the orphan-eviction pass entirely this cycle
     // (pass knownIds: undefined) rather than delete recoverable scrollback.
-    // TTL and max-size passes don't depend on cross-project attribution, so
+    // TTL and max-size passes don't depend on cross-workspace attribution, so
     // they keep running as backstops.
-    const orphanSweepUnsafe = allProjects.some((p) =>
-      projectStore.wasStateUnreadableThisSession(p.id)
+    //
+    // Scratches count here for exactly the reason projects do: their .restore
+    // files are in the same pool and are just as unattributable (#11821).
+    const orphanSweepUnsafe = [...allProjects, ...allScratches].some((w) =>
+      projectStore.wasStateUnreadableThisSession(w.id)
     );
     if (orphanSweepUnsafe) {
       console.warn(
-        "[MAIN] Session eviction: skipping orphan pass — at least one project's state was unreadable or quarantined this session; retaining all .restore files to avoid deleting recoverable scrollback (TTL and size-cap passes still active)"
+        "[MAIN] Session eviction: skipping orphan pass — at least one workspace's state was unreadable or quarantined this session; retaining all .restore files to avoid deleting recoverable scrollback (TTL and size-cap passes still active)"
       );
     }
 

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -195,16 +195,60 @@ function reconcileScratchResumableAgentCounts(
   }
 }
 
+/**
+ * How many workspace states the sweep reads at once.
+ *
+ * Bounded rather than a bare `Promise.all` over every workspace, because the
+ * failure mode is not a slow sweep — it is lost state. `ProjectStateManager`
+ * cannot tell a descriptor exhaustion from a corrupt file: an `EMFILE` lands in
+ * the same catch as a parse error, which marks the workspace unreadable AND
+ * renames its perfectly healthy `state.json` to `.corrupted.<ts>`. A sweep that
+ * exists to reclaim disk must not be the thing that destroys restorable panels,
+ * and adding scratches to it (#11821) roughly doubled the fan-out that gets
+ * there.
+ */
+const STATE_READ_CONCURRENCY = 8;
+
+/**
+ * `Promise.all`-shaped map with a concurrency ceiling, preserving input order so
+ * callers can keep reading results index-aligned with what they passed in.
+ *
+ * Still a barrier: it settles only once every read has finished, which is what
+ * makes consulting `wasStateUnreadableThisSession` afterwards meaningful — that
+ * flag is set as a side effect of the reads themselves.
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let index = cursor++; index < items.length; index = cursor++) {
+      results[index] = await fn(items[index]!);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
 async function evictStaleSessionFiles(): Promise<void> {
   try {
     const allProjects = projectStore.getAllProjects();
     const allScratches = scratchStore.getAllScratches();
     const knownIds = new Set<string>();
 
-    const [states, scratchStates] = await Promise.all([
-      Promise.all(allProjects.map((p) => projectStore.getProjectState(p.id))),
-      Promise.all(allScratches.map((s) => projectStore.getProjectState(s.id))),
-    ]);
+    // One queue over both kinds, so the ceiling bounds the sweep as a whole
+    // rather than each half separately. Split back apart by the boundary the
+    // ids were concatenated at — both halves stay index-aligned with their
+    // own list, which is what the compare-and-swap below depends on.
+    const workspaceIds = [...allProjects.map((p) => p.id), ...allScratches.map((s) => s.id)];
+    const allStates = await mapWithConcurrency(workspaceIds, STATE_READ_CONCURRENCY, (id) =>
+      projectStore.getProjectState(id)
+    );
+    const states = allStates.slice(0, allProjects.length);
+    const scratchStates = allStates.slice(allProjects.length);
     // Scratch terminals belong to the same `.restore` pool as project ones, so
     // they have to be declared known here or the orphan pass below would read a
     // live scratch's scrollback as unattributed and delete it.

--- a/shared/types/scratch.ts
+++ b/shared/types/scratch.ts
@@ -22,4 +22,14 @@ export interface Scratch {
    * with a completion on screen.
    */
   lastCompletionSeenAt?: number;
+  /**
+   * How many saved agent panels this scratch would restore if opened (#11821),
+   * mirroring the project field. Main derives it from the persisted state, so
+   * the switcher row draws its resume dot without reading anything.
+   *
+   * Absent means main has not resolved this scratch yet, which is not the same
+   * as resolving it to 0: an unresolved row makes no claim rather than a wrong
+   * one. Main's to set — never something a renderer may assert.
+   */
+  resumableAgentCount?: number;
 }

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -263,30 +263,57 @@ function StatusDot({
 }
 
 /**
- * Whether the row should mark that opening this project brings agents back
- * (#11801).
+ * Whether the row should mark that opening this workspace brings agents back
+ * (#11801, extended to scratches in #11821).
  *
  * Gated on the status classifier's own answer because a live status always
- * outranks the promise: the coloured dot says what the project is doing now,
+ * outranks the promise: the coloured dot says what the workspace is doing now,
  * the grey one only says what it would come back with. So the mark lands on the
  * rows that have stopped — the dormant ones #11692 cleared, and the auto-parked
  * ones whose settled ring has less to say than the promise (#11822) — and never
  * displaces a mark that means more. Keyed off the count rather than which band
  * the row sorts into, so a pinned project keeps it too.
  *
- * An absent count means main has not resolved this project yet, which is not
+ * An absent count means main has not resolved this workspace yet, which is not
  * the same as resolving it to zero — an unresolved row makes no claim rather
  * than a wrong one. Zero is an answer and also draws nothing: there is nothing
  * to come back to.
  *
- * The current project is excluded outright. Its count is real, but you are
+ * The current workspace is excluded outright. Its count is real, but you are
  * already standing in it — those agents are on screen, not waiting to return.
  * Without this the row would read ", current, 3 agents will resume".
+ *
+ * Takes the two fields it reads rather than either view-model: projects and
+ * scratches deliberately do not share a shape, and a union parameter would make
+ * every project-only field type-reachable from the two scratch render paths.
  */
-function showResumableAgentMark(status: ProjectRowStatus, project: SearchableProject): boolean {
-  if (project.isActive) return false;
+function showResumableAgentMark(
+  status: ProjectRowStatus,
+  workspace: { isActive: boolean; resumableAgentCount?: number }
+): boolean {
+  if (workspace.isActive) return false;
   if (status.allowsResumeMark !== true) return false;
-  return project.resumableAgentCount !== undefined && project.resumableAgentCount > 0;
+  return workspace.resumableAgentCount !== undefined && workspace.resumableAgentCount > 0;
+}
+
+/**
+ * The grey dot's meaning, said rather than shown (#11801). The dot itself is
+ * `aria-hidden`, so without this the row would carry the fact in colour alone.
+ * Part of the accessible name, not a live region, so a list render doesn't
+ * announce every markable row.
+ *
+ * The count rather than the bare fact: the number is already here, and
+ * "3 agents will resume" answers the question the dot only raises.
+ *
+ * Shared by all three row renderers — the two scratch paths draw the same
+ * sentence the project rows do, so the phrasing cannot drift between them.
+ */
+function ResumableAgentsLabel({ count }: { count: number }) {
+  return (
+    <span className="sr-only">
+      , {count} {count === 1 ? "agent" : "agents"} will resume
+    </span>
+  );
 }
 
 /** Matches the resolution of the wait ages on screen — they change by the minute. */
@@ -429,22 +456,8 @@ function ProjectListItem({
            * attach itself to the wrong noun.
            */}
           {project.isActive && <span className="sr-only">, current</span>}
-          {/*
-           * The grey dot's meaning, said rather than shown (#11801). The dot
-           * itself is `aria-hidden`, so without this the row would carry the
-           * fact in colour alone. Same shape as `, current` above — part of the
-           * accessible name, not a live region, so a list render doesn't
-           * announce every markable row.
-           *
-           * The count rather than the bare fact: the number is already here,
-           * and "3 agents will resume" answers the question the dot only raises.
-           */}
-          {showResumeDot && (
-            <span className="sr-only">
-              , {project.resumableAgentCount}{" "}
-              {project.resumableAgentCount === 1 ? "agent" : "agents"} will resume
-            </span>
-          )}
+          {/* Same shape as `, current` above — see `ResumableAgentsLabel`. */}
+          {showResumeDot && <ResumableAgentsLabel count={project.resumableAgentCount ?? 0} />}
           {isProjectNotificationsMuted && (
             <>
               {/*
@@ -606,6 +619,7 @@ function ScratchListItem({
   onSelect: (row: ProjectSwitcherScratchRow) => void;
 }) {
   const status = getScratchRowStatus(scratch, nowMs);
+  const showResumeDot = showResumableAgentMark(status, scratch);
 
   return (
     <div
@@ -625,7 +639,7 @@ function ScratchListItem({
       )}
       onClick={() => onSelect(scratch)}
     >
-      <StatusDot status={status} />
+      <StatusDot status={status} showResumeDot={showResumeDot} />
 
       <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
         <FileText className="h-4 w-4" aria-hidden="true" />
@@ -643,6 +657,7 @@ function ScratchListItem({
           <span className="truncate text-sm font-semibold leading-tight">{scratch.name}</span>
           <span className="text-[11px] leading-none text-daintree-text/50 shrink-0">· Scratch</span>
           {scratch.isActive && <span className="sr-only">, current</span>}
+          {showResumeDot && <ResumableAgentsLabel count={scratch.resumableAgentCount ?? 0} />}
         </div>
         {!status.isDormantFallback && (
           <div
@@ -1255,6 +1270,7 @@ function ScratchSection({
 
                 const countdown = formatScratchCleanupCountdown(scratch.lastOpened, now);
                 const status = getScratchRowStatus(scratch, now);
+                const showResumeDot = showResumableAgentMark(status, scratch);
                 const hasContextActions = Boolean(onRequestDelete || onSaveAsProject || onRename);
                 return (
                   <ContextMenu key={scratch.id}>
@@ -1274,13 +1290,23 @@ function ScratchSection({
                         // would have a reader announce one state as two.
                         aria-selected={scratch.isActive}
                       >
-                        <StatusDot status={status} />
+                        <StatusDot status={status} showResumeDot={showResumeDot} />
                         <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
                           <FileText className="h-4 w-4" aria-hidden="true" />
                         </div>
                         <div className="flex-1 min-w-0">
                           <div className="text-sm font-medium truncate leading-tight">
                             {scratch.name}
+                            {/*
+                             * Inside the name element, not after it: this row
+                             * has no `, current` span to follow (the section's
+                             * `aria-selected` carries that), so the phrase
+                             * attaches to the name the way it does on a
+                             * project row.
+                             */}
+                            {showResumeDot && (
+                              <ResumableAgentsLabel count={scratch.resumableAgentCount ?? 0} />
+                            )}
                           </div>
                           {/*
                            * No origin hint here — the section header already

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -1625,6 +1625,9 @@ describe("ProjectSwitcherPalette scratch resumable-agent dot", () => {
       );
       expect(screen.getByTestId("workspace-status-dot")).toBeTruthy();
       expect(screen.queryByTestId("workspace-resume-dot")).toBeNull();
+      // The phrase has to go with the dot. Suppressing only the dot would leave
+      // a reader hearing a promise the row no longer shows.
+      expect(screen.queryByRole("option", { name: /will resume/i })).toBeNull();
     });
 
     it("says nothing on the scratch you are already standing in", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -1512,3 +1512,149 @@ describe("ProjectSwitcherPalette resumable-agent dot", () => {
     }
   });
 });
+
+/**
+ * The same mark on scratch rows (#11821). Scratches are dormant far more often
+ * than projects are — they exist to be abandoned and come back to — so the row
+ * that most needs "opening this brings your agents back" was the one that never
+ * said it.
+ *
+ * Both surfaces are covered because they are genuinely separate renderers: the
+ * ranked row in the search listbox, and the pinned browse section's own button.
+ * A fix applied to one and not the other is the shape this bug already took.
+ */
+describe("ProjectSwitcherPalette scratch resumable-agent dot", () => {
+  function scratchRow(
+    overrides: Partial<ProjectSwitcherScratchRow> & { id: string; name: string }
+  ): ProjectSwitcherScratchRow {
+    return {
+      kind: "scratch",
+      path: `/userData/scratch/${overrides.id}`,
+      createdAt: 0,
+      // Long enough ago that the row falls back to dormant with nothing to say,
+      // which is the only state the mark is allowed to occupy.
+      lastOpened: 0,
+      isActive: false,
+      activeAgentCount: 0,
+      waitingAgentCount: 0,
+      blockedAgentCount: 0,
+      completedAgentCount: 0,
+      unacknowledgedCompletedAgentCount: 0,
+      snoozedAgentCount: 0,
+      processCount: 0,
+      ...overrides,
+    };
+  }
+
+  /** The ranked list — a scratch among projects while searching. */
+  function renderRanked(scratch: ProjectSwitcherScratchRow) {
+    return render(
+      <ProjectSwitcherPalette
+        {...dropdownProps}
+        query="spike"
+        results={[scratch]}
+        onCreateScratch={vi.fn()}
+        onSelectScratch={vi.fn()}
+      />
+    );
+  }
+
+  /** The pinned browse section — its own button, its own markup. */
+  function renderBrowse(scratch: ProjectSwitcherScratchRow) {
+    return render(
+      <ProjectSwitcherPalette
+        {...dropdownProps}
+        query=""
+        results={[]}
+        scratchResults={[scratch]}
+        onCreateScratch={vi.fn()}
+        onSelectScratch={vi.fn()}
+      />
+    );
+  }
+
+  describe.each([
+    ["ranked search row", renderRanked],
+    ["pinned browse row", renderBrowse],
+  ])("%s", (_label, renderScratch) => {
+    it("marks a quiet scratch that would bring agents back", () => {
+      renderScratch(scratchRow({ id: "s1", name: "Spike notes", resumableAgentCount: 3 }));
+      expect(screen.getByTestId("workspace-resume-dot")).toBeTruthy();
+    });
+
+    it("says the count rather than leaving it to the colour", () => {
+      // Part of the row's own name — the ranked row's "· Scratch" origin hint
+      // sits between the two, which is why this matches across it rather than
+      // pinning the phrase directly to the name.
+      renderScratch(scratchRow({ id: "s1", name: "Spike notes", resumableAgentCount: 3 }));
+      expect(
+        screen.getByRole("option", { name: /Spike notes.*3 agents will resume/i })
+      ).toBeTruthy();
+      expect(screen.getByTestId("workspace-resume-dot").getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("counts one agent in the singular", () => {
+      renderScratch(scratchRow({ id: "s1", name: "Solo", resumableAgentCount: 1 }));
+      expect(screen.getByRole("option", { name: /Solo.*1 agent will resume/i })).toBeTruthy();
+      expect(screen.queryByRole("option", { name: /1 agents will resume/i })).toBeNull();
+    });
+
+    it("leaves a scratch that restores no agents unmarked and unannounced", () => {
+      renderScratch(scratchRow({ id: "s1", name: "Spike notes", resumableAgentCount: 0 }));
+      expect(screen.queryByTestId("workspace-resume-dot")).toBeNull();
+      expect(screen.queryByRole("option", { name: /will resume/i })).toBeNull();
+    });
+
+    it("makes no claim for a scratch main has not counted yet", () => {
+      // Absent is not zero, but it is equally not a promise.
+      renderScratch(scratchRow({ id: "s1", name: "Spike notes" }));
+      expect(screen.queryByTestId("workspace-resume-dot")).toBeNull();
+      expect(screen.queryByRole("option", { name: /will resume/i })).toBeNull();
+    });
+
+    it("yields to a scratch that has a real status to report", () => {
+      // One dot in the one-dot slot: what it is doing now outranks what it
+      // would come back with.
+      renderScratch(
+        scratchRow({
+          id: "s1",
+          name: "Spike notes",
+          waitingAgentCount: 1,
+          resumableAgentCount: 2,
+        })
+      );
+      expect(screen.getByTestId("workspace-status-dot")).toBeTruthy();
+      expect(screen.queryByTestId("workspace-resume-dot")).toBeNull();
+    });
+
+    it("says nothing on the scratch you are already standing in", () => {
+      // Its agents are on screen, not waiting to return — the row would
+      // otherwise read ", current, 4 agents will resume".
+      renderScratch(
+        scratchRow({ id: "s1", name: "Spike notes", isActive: true, resumableAgentCount: 4 })
+      );
+      expect(screen.queryByTestId("workspace-resume-dot")).toBeNull();
+      expect(screen.queryByRole("option", { name: /will resume/i })).toBeNull();
+    });
+  });
+
+  it("marks only the scratches that carry a count", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...dropdownProps}
+        query=""
+        results={[]}
+        scratchResults={[
+          scratchRow({ id: "s1", name: "Marked", resumableAgentCount: 2 }),
+          scratchRow({ id: "s2", name: "Unmarked", resumableAgentCount: 0 }),
+        ]}
+        onCreateScratch={vi.fn()}
+      />
+    );
+
+    const marked = screen.getByRole("option", { name: /Marked/ });
+    const unmarked = screen.getByRole("option", { name: /Unmarked/ });
+    expect(marked.querySelector("[data-testid='workspace-resume-dot']")).toBeTruthy();
+    expect(unmarked.querySelector("[data-testid='workspace-resume-dot']")).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -1388,3 +1388,48 @@ describe("scratch agent-status join", () => {
     expect(projectClient.getBulkStats).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * The resume count is main's answer about what a dormant scratch would restore
+ * (#11821). The view-model's only job is to carry it without editing it —
+ * absent, zero and positive are three distinct states downstream, and the
+ * common regression is collapsing the first two with a `?? 0`.
+ */
+describe("resumable agent count passthrough", () => {
+  function seedScratchesWithCounts(counts: (number | undefined)[]): void {
+    scratchState.scratches = counts.map((resumableAgentCount, i) => ({
+      id: `scratch-${i + 1}`,
+      name: `Spike ${i + 1}`,
+      path: `/tmp/scratches/scratch-${i + 1}`,
+      createdAt: 1_000 + i,
+      lastOpened: 1_000 + i,
+      ...(resumableAgentCount !== undefined ? { resumableAgentCount } : {}),
+    }));
+    scratchState.currentScratch = null;
+  }
+
+  it("keeps absent, zero and positive counts distinct", () => {
+    // Sorted by lastOpened desc, so the seeded order comes back reversed.
+    seedScratchesWithCounts([undefined, 0, 3]);
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    const byId = new Map(result.current.scratchResults.map((s) => [s.id, s.resumableAgentCount]));
+    expect(byId.get("scratch-1")).toBeUndefined();
+    expect(byId.get("scratch-2")).toBe(0);
+    expect(byId.get("scratch-3")).toBe(3);
+  });
+
+  it("reads the count off the scratch, not off its live agent stats", () => {
+    // The two answer different questions: the stats say what is running now,
+    // the count says what a closed workspace would bring back. A row with no
+    // live agents at all still carries whatever main last persisted.
+    seedScratchesWithCounts([2]);
+    projectStatsState.stats = {
+      "scratch-1": { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+    };
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    expect(result.current.scratchResults[0]?.resumableAgentCount).toBe(2);
+    expect(result.current.scratchResults[0]?.activeAgentCount).toBe(0);
+  });
+});

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -171,6 +171,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   scratchState.scratches = [];
   scratchState.currentScratch = null;
+  // Shared across the whole file, so a spec that seeds stats would otherwise
+  // hand them to every spec that runs after it.
+  projectStatsState.stats = {};
   scratchState.createScratch.mockResolvedValue({ id: "scratch-1" });
   scratchState.switchScratch.mockResolvedValue(undefined);
   scratchState.renameScratch.mockResolvedValue(undefined);
@@ -1424,12 +1427,14 @@ describe("resumable agent count passthrough", () => {
     // the count says what a closed workspace would bring back. A row with no
     // live agents at all still carries whatever main last persisted.
     seedScratchesWithCounts([2]);
+    // A live count deliberately different from the saved one, so a view-model
+    // that sourced the mark from stats would read 5 rather than 2.
     projectStatsState.stats = {
-      "scratch-1": { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+      "scratch-1": { activeAgentCount: 5, waitingAgentCount: 0, processCount: 5 },
     };
     const { result } = renderHook(() => useProjectSwitcherPalette());
 
     expect(result.current.scratchResults[0]?.resumableAgentCount).toBe(2);
-    expect(result.current.scratchResults[0]?.activeAgentCount).toBe(0);
+    expect(result.current.scratchResults[0]?.activeAgentCount).toBe(5);
   });
 });

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -90,6 +90,13 @@ export interface SearchableScratch extends WorkspaceRowStatusFields {
   name: string;
   path: string;
   createdAt: number;
+  /**
+   * How many saved agent panels this scratch would restore if opened (#11821).
+   * Main derives it from the persisted state, so the row draws its dot without
+   * reading anything. Absent means not yet computed — distinct from a known 0,
+   * which is an answer.
+   */
+  resumableAgentCount?: number;
 }
 
 /**
@@ -1144,6 +1151,9 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         path: s.path,
         createdAt: s.createdAt,
         lastOpened: s.lastOpened,
+        // Passed through as-is, never `?? 0`: coercing an absent count to 0
+        // here would turn "not computed yet" into "restores nothing".
+        resumableAgentCount: s.resumableAgentCount,
         isActive: currentScratch?.id === s.id,
         activeAgentCount: stats?.activeAgentCount ?? 0,
         waitingAgentCount: stats?.waitingAgentCount ?? 0,


### PR DESCRIPTION
## Summary

- Since #11801, the project switcher has shown a grey resume dot plus an accessible "N agents will resume" label on dormant project rows, ones whose saved agent panels will come back when reopened. Scratch rows never got it, which is backwards: scratches are the workspaces users abandon and return to most often.
- The bug existed at every layer. `ProjectStore.persistResumableAgentCount` ran its `UPDATE` against the `projects` table unconditionally. Scratches share the same state manager and persist their panel grid under the same `projects/<id>/` layout (#11484), so every scratch save reached this write and silently matched zero rows, the `scratches` table had no column to write to in the first place. The deferred startup backfill only walked `projectStore.getAllProjects()`, so every scratch that existed beforehand would have stayed dark even after the write path was fixed. `Scratch` / `SearchableScratch` had no count field, and both scratch render paths called `StatusDot` with no `showResumeDot`.
- This mirrors the #11801 fix across all of it: migration `0013` adds a nullable `resumable_agent_count` to `scratches` (null means not computed, distinct from a computed zero), the state-persist observer routes by workspace-id shape via `shared/utils/workspaceIds.ts`, `ScratchStore` gets its own compare-and-swap reconciler, the session-eviction sweep backfills scratches and broadcasts `SCRATCH_UPDATED` for exactly the rows that moved, and both `ScratchListItem` (ranked search) and `ScratchSection` (pinned browse) wire the dot plus a shared `ResumableAgentsLabel` so the three renderers can't drift in phrasing.

Resolves #11821

## Changes

- `electron/services/persistence/schema.ts` + migration `0013_add_scratch_resumable_agent_count.sql`: nullable `resumable_agent_count` column on `scratches`.
- `electron/services/ProjectStore.ts`: route the persist-observer write by workspace-id shape instead of assuming `projects`.
- `electron/services/ScratchStore.ts`: compare-and-swap reconciler for scratch counts, mirroring `ProjectStore`'s.
- `electron/window/globalServicesInit.ts`: backfill sweep now covers scratches alongside projects, and the state-read fan-out is bounded at a concurrency of 8 (scratches roughly doubled the read volume, and `ProjectStateManager` can't distinguish an `EMFILE` from a corrupt file when it fails open).
- Scratch terminals are now declared in the `.restore` orphan sweep's `knownIds`, and an unreadable scratch state fails that pass closed the way a project's already did, closing a scrollback-deletion gap that predates this fix.
- `shared/types/scratch.ts`, `src/hooks/useProjectSwitcherPalette.ts`, `src/components/Project/ProjectSwitcherPalette.tsx`: count field on `Scratch` / `SearchableScratch`, and both render surfaces wired to `showResumeDot` plus the shared `ResumableAgentsLabel`.

## Testing

- 329 tests pass across the 8 affected suites, typecheck clean, `drizzle-kit check` clean.
- New coverage: observer routing by workspace-id shape (including ids belonging to neither table), the scratch CAS reconciler's corrupt-cell repair arms, the tombstone filter, the value guard keeping unchanged counts off the WAL, both halves of the scratch backfill/orphan sweep, the read-concurrency ceiling, view-model passthrough keeping absent/zero/positive counts distinct, and both scratch render surfaces via `describe.each`.
- Migration `0013` is bound to the Drizzle schema column by a real test that upgrades a database through migration `0012` first.

Migration `0013` follows the repo's existing convention: schema snapshots are frozen at `0003`, and migrations `0004` through `0012` all ship with a journal entry and no `meta/NNNN_snapshot.json`, since `drizzle-kit generate` diffs against the stale `0003` snapshot. The generated draft here was trimmed to the single intended `ALTER TABLE` and its snapshot dropped, matching that convention.
