### PR TITLE
fix(switcher): thread the row clock into ranked scratch results

### DIFF
--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -201,7 +201,8 @@ interface ProjectListItemProps {
    * unchanged — an ambient `Date.now()` inside it would simply freeze. Ages and
    * the recency deadline both derive from this prop instead, so the tick that
    * changes it is what invalidates the row. `ScratchListItem` threads its clock
-   * the same way; `rowStatusClock.contract.test.ts` holds every row to it.
+   * the same way, and `rowStatusClock.contract.test.ts` holds both ranked rows
+   * to it — source-level, because vitest cannot see the freeze.
    */
   nowMs: number;
   onSelect: (row: ProjectSwitcherProjectRow) => void;

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -200,8 +200,8 @@ interface ProjectListItemProps {
    * does not re-run this component's body while its props are referentially
    * unchanged — an ambient `Date.now()` inside it would simply freeze. Ages and
    * the recency deadline both derive from this prop instead, so the tick that
-   * changes it is what invalidates the row. `ScratchSection` already threads its
-   * `now` the same way.
+   * changes it is what invalidates the row. `ScratchListItem` threads its clock
+   * the same way; `rowStatusClock.contract.test.ts` holds every row to it.
    */
   nowMs: number;
   onSelect: (row: ProjectSwitcherProjectRow) => void;
@@ -595,13 +595,16 @@ function ProjectListItem({
 function ScratchListItem({
   scratch,
   isSelected,
+  nowMs,
   onSelect,
 }: {
   scratch: ProjectSwitcherScratchRow;
   isSelected: boolean;
+  /** The clock this row renders against, passed rather than read — see `ProjectListItemProps`. */
+  nowMs: number;
   onSelect: (row: ProjectSwitcherScratchRow) => void;
 }) {
-  const status = getScratchRowStatus(scratch);
+  const status = getScratchRowStatus(scratch, nowMs);
 
   return (
     <div
@@ -881,7 +884,12 @@ function ProjectListContent({
     return (
       <div key={`${row.kind}-${row.id}`} role="presentation">
         {row.kind === "scratch" ? (
-          <ScratchListItem scratch={row} isSelected={isSelected} onSelect={onSelect} />
+          <ScratchListItem
+            scratch={row}
+            isSelected={isSelected}
+            nowMs={nowMs}
+            onSelect={onSelect}
+          />
         ) : (
           <ProjectListItem
             project={row}

--- a/src/components/Project/__tests__/rowStatusClock.contract.test.ts
+++ b/src/components/Project/__tests__/rowStatusClock.contract.test.ts
@@ -16,12 +16,13 @@ import ts from "typescript";
 // the age advances the way it never does in a build — a render-then-advance-
 // timers test passes identically with and without the bug.
 //
-// The clock has to survive a whole chain to reach the screen, and the type
-// checker guards none of it: a reactive source, a prop carrying it down, and a
-// row that renders against that prop rather than a reading of its own. Breaking
-// any one link refreezes the age, so each link gets an assertion. Pinning only
-// the last one is what makes this contract look green while the parent quietly
-// swaps its `useGlobalMinuteClock()` for a `Date.now()`.
+// The clock has to survive a whole chain to reach the screen: a reactive
+// source, a prop carrying it down, and a row that renders against that prop
+// rather than a reading of its own. Types enforce that the prop and the
+// argument are *present*; nothing in them can speak to where the value came
+// from or whether it still moves. Breaking any one link refreezes the age, so
+// each link gets an assertion — pinning only the last one is what would leave
+// this green while the parent quietly swapped its hook for a `Date.now()`.
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SRC_ROOT = path.resolve(TEST_DIR, "../../..");
@@ -31,7 +32,7 @@ const HELPERS_REL = "lib/projectRowStatus.ts";
 /** The status-helper family: `getProjectRowStatus`, `getScratchRowStatus`, and any sibling. */
 const HELPER_PATTERN = /^get.+RowStatus$/;
 
-/** The module the family is declared in, however a consumer spells the path to it. */
+/** The module the family is declared in, by alias or relative path. Barrels and extension-bearing specifiers are not followed. */
 const HELPERS_MODULE = /(^|\/)projectRowStatus$/;
 
 /** The prop every row carries its clock on, so the chain can be followed by name. */
@@ -63,12 +64,15 @@ const REQUIRED_ROWS = ["ProjectListItem", "ScratchListItem"];
 const AMBIENT_CLOCK_ALLOWLIST = new Set(["ScratchSection"]);
 
 function parse(file: string): ts.SourceFile {
+  // By extension, not TSX for everything: `.ts` parsed as TSX turns generic
+  // arrows and type assertions into recovered garbage, and a call read out of a
+  // mis-parsed tree is not evidence of anything.
   return ts.createSourceFile(
     file,
     fs.readFileSync(file, "utf8"),
     ts.ScriptTarget.Latest,
     true,
-    ts.ScriptKind.TSX
+    file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
 }
 
@@ -83,7 +87,9 @@ function walk(dir: string, out: string[] = []): string[] {
     if (entry.isDirectory()) {
       if (entry.name === "__tests__" || entry.name === "node_modules") continue;
       walk(full, out);
-    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+    } else if (/\.tsx?$/.test(entry.name) && !/\.(test|spec)\.tsx?$/.test(entry.name)) {
+      // Colocated tests are excluded alongside `__tests__`: a row name only a
+      // fixture defines must not be what satisfies the coverage checks below.
       out.push(full);
     }
   }
@@ -207,10 +213,30 @@ interface HelperCall {
   clock: ts.Expression | undefined;
 }
 
-const sources = walk(SRC_ROOT).map((file) => ({ file, rel: relative(file), source: parse(file) }));
+/**
+ * Every source that could reach the helper family, parsed.
+ *
+ * Text-filtered before parsing: the renderer is ~1,500 files, and holding an
+ * AST for each one costs hundreds of megabytes for the handful that mention
+ * this module. The two contract targets are parsed unconditionally, since the
+ * module that declares the family need never name itself.
+ */
+function loadTarget(rel: string): { rel: string; source: ts.SourceFile } {
+  const full = path.join(SRC_ROOT, rel);
+  if (!fs.existsSync(full)) throw new Error(`Contract target no longer exists: src/${rel}`);
+  return { rel, source: parse(full) };
+}
+
+const palette = loadTarget(PALETTE_REL);
+const helpers = loadTarget(HELPERS_REL);
 
 const helperCalls: HelperCall[] = [];
-for (const { rel, source } of sources) {
+for (const file of walk(SRC_ROOT)) {
+  const rel = relative(file);
+  const preloaded = [palette, helpers].find((entry) => entry.rel === rel);
+  if (!preloaded && !fs.readFileSync(file, "utf8").includes("projectRowStatus")) continue;
+
+  const source = preloaded?.source ?? parse(file);
   const bindings = helperBindings(source);
   if (bindings.direct.size === 0 && bindings.namespaces.size === 0) continue;
 
@@ -229,9 +255,6 @@ for (const { rel, source } of sources) {
     });
   });
 }
-
-const palette = sources.find((entry) => entry.rel === PALETTE_REL);
-if (!palette) throw new Error(`Contract target no longer exists: src/${PALETTE_REL}`);
 
 /** Local names bound to a hook that re-renders on a new reading. */
 function reactiveClockBindings(source: ts.SourceFile): Set<string> {
@@ -282,22 +305,17 @@ describe("row status clocks (#11823)", () => {
       }
     });
 
-    // The rows have to be receiving a clock at all for the check above to mean
-    // anything — an attribute that vanished would otherwise pass by absence.
     expect(offenders).toEqual([]);
-    expect(offenders.length + countClockAttributes(palette.source)).toBeGreaterThan(0);
+
+    // Checked by name, not counted: an attribute deleted outright, or replaced
+    // by a `{...spread}` the walk above never sees, would otherwise pass this
+    // by absence — which is the shape the original bug had.
+    const clocked = new Set(rowsRenderedWithAReactiveClock(palette.source, reactive));
+    expect(REQUIRED_ROWS.filter((row) => !clocked.has(row))).toEqual([]);
   });
 
   it("leaves the row-status helpers no ambient clock to fall back to", () => {
-    const helpers = sources.find((entry) => entry.rel === HELPERS_REL);
-    if (!helpers) throw new Error(`Contract target no longer exists: src/${HELPERS_REL}`);
-
-    const exported = exportedHelpers(helpers.source);
-    expect(exported.map(({ name }) => name).sort()).toEqual(
-      ["getProjectRowStatus", "getScratchRowStatus"].sort()
-    );
-
-    const offenders = exported
+    const offenders = exportedHelpers(helpers.source)
       .filter(({ fn }) => !requiresClock(fn))
       .map(({ name }) => `${name} does not require an explicit clock as its second parameter`);
 
@@ -315,13 +333,24 @@ describe("row status clocks (#11823)", () => {
   });
 });
 
-/** `nowMs={…}` attributes in the file, however they are spelled. */
-function countClockAttributes(source: ts.SourceFile): number {
-  let count = 0;
+/** Row components rendered with a `nowMs` fed straight from a re-rendering hook. */
+function rowsRenderedWithAReactiveClock(source: ts.SourceFile, reactive: Set<string>): string[] {
+  const rows: string[] = [];
   eachNode(source, (node) => {
-    if (ts.isJsxAttribute(node) && node.name.getText() === CLOCK_PROP) count += 1;
+    if (!ts.isJsxSelfClosingElement(node) && !ts.isJsxOpeningElement(node)) return;
+    const clocked = node.attributes.properties.some(
+      (attribute) =>
+        ts.isJsxAttribute(attribute) &&
+        attribute.name.getText() === CLOCK_PROP &&
+        attribute.initializer !== undefined &&
+        ts.isJsxExpression(attribute.initializer) &&
+        attribute.initializer.expression !== undefined &&
+        ts.isIdentifier(attribute.initializer.expression) &&
+        reactive.has(attribute.initializer.expression.text)
+    );
+    if (clocked) rows.push(node.tagName.getText());
   });
-  return count;
+  return rows;
 }
 
 /**
@@ -376,6 +405,8 @@ function requiresClock(
   if (!clock) return false;
   if (clock.questionToken !== undefined) return false;
   if (clock.initializer !== undefined) return false;
+  // `...nowMs: number[]` is a required parameter the caller may still omit.
+  if (clock.dotDotDotToken !== undefined) return false;
 
   let defaulted = false;
   eachNode(clock, (node) => {

--- a/src/components/Project/__tests__/rowStatusClock.contract.test.ts
+++ b/src/components/Project/__tests__/rowStatusClock.contract.test.ts
@@ -16,18 +16,38 @@ import ts from "typescript";
 // the age advances the way it never does in a build — a render-then-advance-
 // timers test passes identically with and without the bug.
 //
-// Two invariants, because the type checker only covers half of it. A required
-// clock parameter turns an omitted argument into a compile error, but it cannot
-// stop a caller passing `Date.now()` inline, which type checks and freezes just
-// the same. The palette contract covers that half by pinning where the clock
-// comes from.
+// The clock has to survive a whole chain to reach the screen, and the type
+// checker guards none of it: a reactive source, a prop carrying it down, and a
+// row that renders against that prop rather than a reading of its own. Breaking
+// any one link refreezes the age, so each link gets an assertion. Pinning only
+// the last one is what makes this contract look green while the parent quietly
+// swaps its `useGlobalMinuteClock()` for a `Date.now()`.
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
-const PALETTE_PATH = path.resolve(TEST_DIR, "../ProjectSwitcherPalette.tsx");
-const HELPERS_PATH = path.resolve(TEST_DIR, "../../../lib/projectRowStatus.ts");
+const SRC_ROOT = path.resolve(TEST_DIR, "../../..");
+const PALETTE_REL = "components/Project/ProjectSwitcherPalette.tsx";
+const HELPERS_REL = "lib/projectRowStatus.ts";
 
 /** The status-helper family: `getProjectRowStatus`, `getScratchRowStatus`, and any sibling. */
 const HELPER_PATTERN = /^get.+RowStatus$/;
+
+/** The module the family is declared in, however a consumer spells the path to it. */
+const HELPERS_MODULE = /(^|\/)projectRowStatus$/;
+
+/** The prop every row carries its clock on, so the chain can be followed by name. */
+const CLOCK_PROP = "nowMs";
+
+/** Hooks that return a clock React re-renders on. An ambient read is not one. */
+const REACTIVE_CLOCKS = new Set(["useGlobalMinuteClock"]);
+
+/**
+ * Rows that must stay under this contract.
+ *
+ * Named rather than counted because the walk is only as good as what it finds:
+ * moving a row into its own file, or renaming the helper family out of the
+ * pattern, would otherwise shrink the checked set to nothing and pass.
+ */
+const REQUIRED_ROWS = ["ProjectListItem", "ScratchListItem"];
 
 /**
  * Components whose clock is knowingly still ambient.
@@ -35,10 +55,10 @@ const HELPER_PATTERN = /^get.+RowStatus$/;
  * `ScratchSection` reads `Date.now()` in its own body. The palette holds a
  * per-minute tick for it, but that tick is state on the palette root and never
  * reaches here: the compiler caches the `<ScratchSection>` element on its props
- * alone, so the root re-runs and the cached child is reused. Threading a clock
- * into it is a separate fix from the ranked row #11823 reports, and listing it
- * here keeps the gap visible instead of letting a suffix-matched predicate
- * quietly skip it.
+ * alone, so the root re-runs and the cached child is reused. Its pinned rows and
+ * cleanup countdown go stale the same way the ranked row did — a separate fix
+ * from the one #11823 reports, listed here so the gap stays visible instead of
+ * being quietly skipped by a predicate that never looked.
  */
 const AMBIENT_CLOCK_ALLOWLIST = new Set(["ScratchSection"]);
 
@@ -57,28 +77,82 @@ function eachNode(node: ts.Node, visit: (node: ts.Node) => void): void {
   node.forEachChild((child) => eachNode(child, visit));
 }
 
-/**
- * Local binding names the status helpers were imported under, following aliases
- * so `import { getScratchRowStatus as read }` is still tracked.
- */
-function importedHelperNames(source: ts.SourceFile): Set<string> {
-  const names = new Set<string>();
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      walk(full, out);
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function relative(file: string): string {
+  return path.relative(SRC_ROOT, file).split(path.sep).join("/");
+}
+
+interface HelperBindings {
+  /** Local names the helpers are callable under, following `as` aliases. */
+  direct: Set<string>;
+  /** Namespace bindings, so `rowStatus.getScratchRowStatus(…)` is still seen. */
+  namespaces: Set<string>;
+}
+
+/** How this file can reach the helper family, if it can reach it at all. */
+function helperBindings(source: ts.SourceFile): HelperBindings {
+  const direct = new Set<string>();
+  const namespaces = new Set<string>();
+
   eachNode(source, (node) => {
     if (!ts.isImportDeclaration(node)) return;
+    if (!ts.isStringLiteral(node.moduleSpecifier)) return;
+    if (!HELPERS_MODULE.test(node.moduleSpecifier.text)) return;
+
     const bindings = node.importClause?.namedBindings;
-    if (!bindings || !ts.isNamedImports(bindings)) return;
+    if (!bindings) return;
+    if (ts.isNamespaceImport(bindings)) {
+      namespaces.add(bindings.name.text);
+      return;
+    }
     for (const element of bindings.elements) {
       const imported = element.propertyName?.text ?? element.name.text;
-      if (HELPER_PATTERN.test(imported)) names.add(element.name.text);
+      if (HELPER_PATTERN.test(imported)) direct.add(element.name.text);
     }
   });
-  return names;
+
+  // `const read = getScratchRowStatus` — a rename that keeps the call reachable
+  // under a name the import never mentioned.
+  eachNode(source, (node) => {
+    if (!ts.isVariableDeclaration(node) || !node.initializer) return;
+    if (!ts.isIdentifier(node.name) || !ts.isIdentifier(node.initializer)) return;
+    if (direct.has(node.initializer.text)) direct.add(node.name.text);
+  });
+
+  return { direct, namespaces };
+}
+
+/** The status helper this call resolves to, or undefined if it is not one. */
+function calledHelper(node: ts.CallExpression, bindings: HelperBindings): string | undefined {
+  const callee = node.expression;
+  if (ts.isIdentifier(callee)) {
+    return bindings.direct.has(callee.text) ? callee.text : undefined;
+  }
+  if (ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.expression)) {
+    const viaNamespace =
+      bindings.namespaces.has(callee.expression.text) && HELPER_PATTERN.test(callee.name.text);
+    return viaNamespace ? callee.name.text : undefined;
+  }
+  return undefined;
 }
 
 /**
  * The component a call sits in. Nearest enclosing function *declaration*, so a
  * call made from a nested `renderItem`-style arrow still resolves to the
- * component whose props hold the clock.
+ * component whose props hold the clock. A row written as an arrow assigned to a
+ * const resolves to nothing and is reported, rather than skipped.
  */
 function owningComponent(node: ts.Node): ts.FunctionDeclaration | undefined {
   let current: ts.Node | undefined = node.parent;
@@ -90,12 +164,16 @@ function owningComponent(node: ts.Node): ts.FunctionDeclaration | undefined {
 }
 
 /**
- * Whether `argument` is that component's own prop — a destructured binding with
- * no default of its own, or a member of a whole-props parameter. Anything else
- * (an ambient `Date.now()`, a module constant, a local re-binding) is invisible
- * to the compiler's cache key and cannot invalidate the row.
+ * Whether `argument` is this component's own `nowMs` prop.
+ *
+ * Deliberately narrow: a destructured binding of `nowMs` with no default of its
+ * own, or `props.nowMs`. The compiler would also track a plain local alias, but
+ * every shape this accepts is one a reader can confirm at a glance, and the
+ * rows all already spell it this way. Requiring the *original* property name
+ * rather than any prop is what ties this link to the one above it — a row handed
+ * some other stable number would otherwise satisfy it.
  */
-function comesFromProps(owner: ts.FunctionDeclaration, argument: ts.Expression): boolean {
+function isClockProp(owner: ts.FunctionDeclaration, argument: ts.Expression): boolean {
   const props = owner.parameters[0];
   if (!props) return false;
 
@@ -103,9 +181,11 @@ function comesFromProps(owner: ts.FunctionDeclaration, argument: ts.Expression):
     if (!ts.isIdentifier(argument)) return false;
     return props.name.elements.some(
       (element) =>
+        element.dotDotDotToken === undefined &&
+        element.initializer === undefined &&
         ts.isIdentifier(element.name) &&
         element.name.text === argument.text &&
-        element.initializer === undefined
+        (element.propertyName?.getText(owner.getSourceFile()) ?? element.name.text) === CLOCK_PROP
     );
   }
 
@@ -113,68 +193,193 @@ function comesFromProps(owner: ts.FunctionDeclaration, argument: ts.Expression):
     ts.isIdentifier(props.name) &&
     ts.isPropertyAccessExpression(argument) &&
     ts.isIdentifier(argument.expression) &&
-    argument.expression.text === props.name.text
+    argument.expression.text === props.name.text &&
+    argument.name.text === CLOCK_PROP
   );
 }
 
-const palette = parse(PALETTE_PATH);
-const helperNames = importedHelperNames(palette);
-
 interface HelperCall {
+  file: string;
   helper: string;
   owner: string;
+  ownerNode: ts.FunctionDeclaration | undefined;
   line: number;
   clock: ts.Expression | undefined;
-  ownerNode: ts.FunctionDeclaration | undefined;
 }
 
-const paletteCalls: HelperCall[] = [];
-eachNode(palette, (node) => {
-  if (!ts.isCallExpression(node) || !ts.isIdentifier(node.expression)) return;
-  if (!helperNames.has(node.expression.text)) return;
-  const ownerNode = owningComponent(node);
-  paletteCalls.push({
-    helper: node.expression.text,
-    owner: ownerNode?.name?.text ?? "<module>",
-    line: palette.getLineAndCharacterOfPosition(node.getStart(palette)).line + 1,
-    clock: node.arguments[1],
-    ownerNode,
+const sources = walk(SRC_ROOT).map((file) => ({ file, rel: relative(file), source: parse(file) }));
+
+const helperCalls: HelperCall[] = [];
+for (const { rel, source } of sources) {
+  const bindings = helperBindings(source);
+  if (bindings.direct.size === 0 && bindings.namespaces.size === 0) continue;
+
+  eachNode(source, (node) => {
+    if (!ts.isCallExpression(node)) return;
+    const helper = calledHelper(node, bindings);
+    if (!helper) return;
+    const ownerNode = owningComponent(node);
+    helperCalls.push({
+      file: rel,
+      helper,
+      owner: ownerNode?.name?.text ?? "<not a function declaration>",
+      ownerNode,
+      line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+      clock: node.arguments[1],
+    });
   });
-});
+}
+
+const palette = sources.find((entry) => entry.rel === PALETTE_REL);
+if (!palette) throw new Error(`Contract target no longer exists: src/${PALETTE_REL}`);
+
+/** Local names bound to a hook that re-renders on a new reading. */
+function reactiveClockBindings(source: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  eachNode(source, (node) => {
+    if (!ts.isVariableDeclaration(node) || !node.initializer) return;
+    if (!ts.isCallExpression(node.initializer)) return;
+    const callee = node.initializer.expression;
+    if (!ts.isIdentifier(callee) || !REACTIVE_CLOCKS.has(callee.text)) return;
+    if (ts.isIdentifier(node.name)) names.add(node.name.text);
+  });
+  return names;
+}
 
 describe("row status clocks (#11823)", () => {
-  it("renders every palette row against a clock handed to it, never one it reads itself", () => {
-    // Guards the walk itself: a rename or a moved import that stopped matching
-    // would otherwise leave an empty list quietly passing every assertion.
-    expect(helperNames.size).toBeGreaterThan(0);
-    expect(paletteCalls.length).toBeGreaterThan(0);
-
-    const offenders = paletteCalls
+  it("renders every row against a clock handed to it, never one it reads itself", () => {
+    const offenders = helperCalls
       .filter(({ owner }) => !AMBIENT_CLOCK_ALLOWLIST.has(owner))
-      .filter(({ ownerNode, clock }) => !ownerNode || !clock || !comesFromProps(ownerNode, clock))
+      .filter(({ ownerNode, clock }) => !ownerNode || !clock || !isClockProp(ownerNode, clock))
       .map(
-        ({ owner, helper, line, clock }) =>
-          `${owner}:${line} ${helper}(…, ${clock?.getText(palette) ?? "<no clock>"}) — the clock is not one of ${owner}'s props`
+        ({ file, owner, helper, line, clock }) =>
+          `src/${file}:${line} ${owner} calls ${helper}(…, ${
+            clock?.getText() ?? "<no clock>"
+          }) — not its own \`${CLOCK_PROP}\` prop`
       );
 
     expect(offenders).toEqual([]);
   });
 
-  it("leaves the status helpers no ambient clock to fall back to", () => {
-    const helpers = parse(HELPERS_PATH);
+  it("feeds every row clock from a hook that re-renders, not a one-off reading", () => {
+    const reactive = reactiveClockBindings(palette.source);
 
-    const declarations = helpers.statements
-      .filter(ts.isFunctionDeclaration)
-      .filter((fn) => fn.name !== undefined && HELPER_PATTERN.test(fn.name.text));
+    const offenders: string[] = [];
+    eachNode(palette.source, (node) => {
+      if (!ts.isJsxAttribute(node) || node.name.getText() !== CLOCK_PROP) return;
+      const line = palette.source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+      const value = node.initializer;
+      const passed =
+        value && ts.isJsxExpression(value) && value.expression && ts.isIdentifier(value.expression)
+          ? value.expression
+          : undefined;
+      if (!passed || !reactive.has(passed.text)) {
+        offenders.push(
+          `src/${PALETTE_REL}:${line} ${CLOCK_PROP}=${value?.getText() ?? "?"} does not come from ${[
+            ...REACTIVE_CLOCKS,
+          ].join("/")}`
+        );
+      }
+    });
 
-    expect(declarations.length).toBeGreaterThan(0);
+    // The rows have to be receiving a clock at all for the check above to mean
+    // anything — an attribute that vanished would otherwise pass by absence.
+    expect(offenders).toEqual([]);
+    expect(offenders.length + countClockAttributes(palette.source)).toBeGreaterThan(0);
+  });
 
-    const offenders = declarations
-      .filter((fn) => fn.parameters.some((parameter) => parameter.initializer !== undefined))
-      .map(
-        (fn) => `${fn.name?.text ?? "<anonymous>"} defaults a parameter instead of requiring it`
-      );
+  it("leaves the row-status helpers no ambient clock to fall back to", () => {
+    const helpers = sources.find((entry) => entry.rel === HELPERS_REL);
+    if (!helpers) throw new Error(`Contract target no longer exists: src/${HELPERS_REL}`);
+
+    const exported = exportedHelpers(helpers.source);
+    expect(exported.map(({ name }) => name).sort()).toEqual(
+      ["getProjectRowStatus", "getScratchRowStatus"].sort()
+    );
+
+    const offenders = exported
+      .filter(({ fn }) => !requiresClock(fn))
+      .map(({ name }) => `${name} does not require an explicit clock as its second parameter`);
 
     expect(offenders).toEqual([]);
+  });
+
+  it("keeps every row it names, and every exemption it grants, real", () => {
+    const owners = new Set(helperCalls.map(({ owner }) => owner));
+
+    const missing = REQUIRED_ROWS.filter((row) => !owners.has(row));
+    expect(missing).toEqual([]);
+
+    const dead = [...AMBIENT_CLOCK_ALLOWLIST].filter((name) => !owners.has(name));
+    expect(dead).toEqual([]);
   });
 });
+
+/** `nowMs={…}` attributes in the file, however they are spelled. */
+function countClockAttributes(source: ts.SourceFile): number {
+  let count = 0;
+  eachNode(source, (node) => {
+    if (ts.isJsxAttribute(node) && node.name.getText() === CLOCK_PROP) count += 1;
+  });
+  return count;
+}
+
+/**
+ * Exported members of the helper family, counting both declaration forms — an
+ * `export const get… = (row, nowMs = Date.now()) => …` reintroduces the default
+ * just as effectively as a function declaration does.
+ */
+function exportedHelpers(
+  source: ts.SourceFile
+): { name: string; fn: ts.FunctionDeclaration | ts.ArrowFunction | ts.FunctionExpression }[] {
+  const found: {
+    name: string;
+    fn: ts.FunctionDeclaration | ts.ArrowFunction | ts.FunctionExpression;
+  }[] = [];
+
+  const isExported = (node: ts.Node): boolean =>
+    ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node) ?? []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+
+  for (const statement of source.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name && isExported(statement)) {
+      if (HELPER_PATTERN.test(statement.name.text)) {
+        found.push({ name: statement.name.text, fn: statement });
+      }
+      continue;
+    }
+    if (!ts.isVariableStatement(statement) || !isExported(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer) continue;
+      if (!HELPER_PATTERN.test(declaration.name.text)) continue;
+      if (
+        ts.isArrowFunction(declaration.initializer) ||
+        ts.isFunctionExpression(declaration.initializer)
+      ) {
+        found.push({ name: declaration.name.text, fn: declaration.initializer });
+      }
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Whether the clock is genuinely required: present, not optional, not defaulted,
+ * and — when it arrives in an options object — carrying no defaulted member to
+ * hide an ambient read behind.
+ */
+function requiresClock(
+  fn: ts.FunctionDeclaration | ts.ArrowFunction | ts.FunctionExpression
+): boolean {
+  const clock = fn.parameters[1];
+  if (!clock) return false;
+  if (clock.questionToken !== undefined) return false;
+  if (clock.initializer !== undefined) return false;
+
+  let defaulted = false;
+  eachNode(clock, (node) => {
+    if (ts.isBindingElement(node) && node.initializer !== undefined) defaulted = true;
+  });
+  return !defaulted;
+}

--- a/src/components/Project/__tests__/rowStatusClock.contract.test.ts
+++ b/src/components/Project/__tests__/rowStatusClock.contract.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+// Row status lines are clock-derived, and React Compiler — wired for both `vite
+// dev` and `vite build` in `compilationMode: "infer"` — auto-memoizes every row
+// the palette draws. A row that reads the clock ambiently instead of receiving
+// it caches its status against unchanged props, so the reading taken on first
+// render is the only one it ever gets: a scratch in the ranked list opened at
+// "just now" and stayed there for as long as the palette was up (#11823).
+//
+// Source enforcement rather than a rendering assertion is deliberate. Vitest
+// wires no compiler plugin, so under test these rows re-run every render and
+// the age advances the way it never does in a build — a render-then-advance-
+// timers test passes identically with and without the bug.
+//
+// Two invariants, because the type checker only covers half of it. A required
+// clock parameter turns an omitted argument into a compile error, but it cannot
+// stop a caller passing `Date.now()` inline, which type checks and freezes just
+// the same. The palette contract covers that half by pinning where the clock
+// comes from.
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PALETTE_PATH = path.resolve(TEST_DIR, "../ProjectSwitcherPalette.tsx");
+const HELPERS_PATH = path.resolve(TEST_DIR, "../../../lib/projectRowStatus.ts");
+
+/** The status-helper family: `getProjectRowStatus`, `getScratchRowStatus`, and any sibling. */
+const HELPER_PATTERN = /^get.+RowStatus$/;
+
+/**
+ * Components whose clock is knowingly still ambient.
+ *
+ * `ScratchSection` reads `Date.now()` in its own body. The palette holds a
+ * per-minute tick for it, but that tick is state on the palette root and never
+ * reaches here: the compiler caches the `<ScratchSection>` element on its props
+ * alone, so the root re-runs and the cached child is reused. Threading a clock
+ * into it is a separate fix from the ranked row #11823 reports, and listing it
+ * here keeps the gap visible instead of letting a suffix-matched predicate
+ * quietly skip it.
+ */
+const AMBIENT_CLOCK_ALLOWLIST = new Set(["ScratchSection"]);
+
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    fs.readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+}
+
+function eachNode(node: ts.Node, visit: (node: ts.Node) => void): void {
+  visit(node);
+  node.forEachChild((child) => eachNode(child, visit));
+}
+
+/**
+ * Local binding names the status helpers were imported under, following aliases
+ * so `import { getScratchRowStatus as read }` is still tracked.
+ */
+function importedHelperNames(source: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  eachNode(source, (node) => {
+    if (!ts.isImportDeclaration(node)) return;
+    const bindings = node.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) return;
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (HELPER_PATTERN.test(imported)) names.add(element.name.text);
+    }
+  });
+  return names;
+}
+
+/**
+ * The component a call sits in. Nearest enclosing function *declaration*, so a
+ * call made from a nested `renderItem`-style arrow still resolves to the
+ * component whose props hold the clock.
+ */
+function owningComponent(node: ts.Node): ts.FunctionDeclaration | undefined {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (ts.isFunctionDeclaration(current)) return current;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+/**
+ * Whether `argument` is that component's own prop — a destructured binding with
+ * no default of its own, or a member of a whole-props parameter. Anything else
+ * (an ambient `Date.now()`, a module constant, a local re-binding) is invisible
+ * to the compiler's cache key and cannot invalidate the row.
+ */
+function comesFromProps(owner: ts.FunctionDeclaration, argument: ts.Expression): boolean {
+  const props = owner.parameters[0];
+  if (!props) return false;
+
+  if (ts.isObjectBindingPattern(props.name)) {
+    if (!ts.isIdentifier(argument)) return false;
+    return props.name.elements.some(
+      (element) =>
+        ts.isIdentifier(element.name) &&
+        element.name.text === argument.text &&
+        element.initializer === undefined
+    );
+  }
+
+  return (
+    ts.isIdentifier(props.name) &&
+    ts.isPropertyAccessExpression(argument) &&
+    ts.isIdentifier(argument.expression) &&
+    argument.expression.text === props.name.text
+  );
+}
+
+const palette = parse(PALETTE_PATH);
+const helperNames = importedHelperNames(palette);
+
+interface HelperCall {
+  helper: string;
+  owner: string;
+  line: number;
+  clock: ts.Expression | undefined;
+  ownerNode: ts.FunctionDeclaration | undefined;
+}
+
+const paletteCalls: HelperCall[] = [];
+eachNode(palette, (node) => {
+  if (!ts.isCallExpression(node) || !ts.isIdentifier(node.expression)) return;
+  if (!helperNames.has(node.expression.text)) return;
+  const ownerNode = owningComponent(node);
+  paletteCalls.push({
+    helper: node.expression.text,
+    owner: ownerNode?.name?.text ?? "<module>",
+    line: palette.getLineAndCharacterOfPosition(node.getStart(palette)).line + 1,
+    clock: node.arguments[1],
+    ownerNode,
+  });
+});
+
+describe("row status clocks (#11823)", () => {
+  it("renders every palette row against a clock handed to it, never one it reads itself", () => {
+    // Guards the walk itself: a rename or a moved import that stopped matching
+    // would otherwise leave an empty list quietly passing every assertion.
+    expect(helperNames.size).toBeGreaterThan(0);
+    expect(paletteCalls.length).toBeGreaterThan(0);
+
+    const offenders = paletteCalls
+      .filter(({ owner }) => !AMBIENT_CLOCK_ALLOWLIST.has(owner))
+      .filter(({ ownerNode, clock }) => !ownerNode || !clock || !comesFromProps(ownerNode, clock))
+      .map(
+        ({ owner, helper, line, clock }) =>
+          `${owner}:${line} ${helper}(…, ${clock?.getText(palette) ?? "<no clock>"}) — the clock is not one of ${owner}'s props`
+      );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("leaves the status helpers no ambient clock to fall back to", () => {
+    const helpers = parse(HELPERS_PATH);
+
+    const declarations = helpers.statements
+      .filter(ts.isFunctionDeclaration)
+      .filter((fn) => fn.name !== undefined && HELPER_PATTERN.test(fn.name.text));
+
+    expect(declarations.length).toBeGreaterThan(0);
+
+    const offenders = declarations
+      .filter((fn) => fn.parameters.some((parameter) => parameter.initializer !== undefined))
+      .map(
+        (fn) => `${fn.name?.text ?? "<anonymous>"} defaults a parameter instead of requiring it`
+      );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -429,11 +429,15 @@ function getOpenedStatus(lastOpened: number): WorkspaceActivityStatus {
   };
 }
 
-/** The one status line a project row has to show, if it shows one at all. */
-export function getProjectRowStatus(
-  project: SearchableProject,
-  nowMs: number = Date.now()
-): ProjectRowStatus {
+/**
+ * The one status line a project row has to show, if it shows one at all.
+ *
+ * The clock is required rather than defaulted. Every caller renders inside a
+ * row React Compiler auto-memoizes, where a `Date.now()` fallback taken in here
+ * is invisible to the cache key the call is stored under — the row keeps the
+ * reading from its first render and the age never advances (#11823).
+ */
+export function getProjectRowStatus(project: SearchableProject, nowMs: number): ProjectRowStatus {
   // Only surface the fragment when it actually disambiguates — a plain basename
   // is already the folder name shown beside it, so repeating it is noise.
   const pathHint = project.displayPath.includes("/") ? project.displayPath : undefined;
@@ -467,10 +471,9 @@ export function getProjectRowStatus(
  * (the folder is app-managed), no auto-parking (scratches are never swept into
  * a closed status), and no `pathHint`: scratch paths are UUIDs under the app's
  * own directory, so a fragment of one disambiguates nothing.
+ *
+ * Requires its clock for the same reason `getProjectRowStatus` does.
  */
-export function getScratchRowStatus(
-  scratch: SearchableScratch,
-  nowMs: number = Date.now()
-): ProjectRowStatus {
+export function getScratchRowStatus(scratch: SearchableScratch, nowMs: number): ProjectRowStatus {
   return getWorkspaceActivityStatus(scratch, nowMs) ?? getOpenedStatus(scratch.lastOpened);
 }


### PR DESCRIPTION
A scratch row in the ranked search list opened at "just now" and stayed there. `ScratchListItem` called `getScratchRowStatus(scratch)` with no clock, falling back to the helper's ambient `Date.now()` default. React Compiler auto-memoizes that row on its props, so the reading taken at first render was the only one it ever got — the per-minute tick #11518 hoisted to the palette level had nothing to invalidate it with.

`ProjectListItem` already avoided this by taking `nowMs` as an explicit prop from `useGlobalMinuteClock()`. The ranked scratch row was the one row type never brought along.

What changed:
- `ScratchListItem` takes `nowMs` and passes it to `getScratchRowStatus`, fed from the clock `ProjectListContent` already computes for `ProjectListItem`.
- Both row-status helpers now require their clock instead of defaulting it to `Date.now()`. Every call site in the repo already passed one — the default's only effect was to let this bug compile silently. An omitted clock is now a type error.
- A new AST source contract (`rowStatusClock.contract.test.ts`) holds the whole chain: a reactive clock hook, feeding the `nowMs` prop, reaching the helper. Vitest wires no React Compiler plugin, so a render-and-advance-timers test passes identically with and without the bug — the guard has to read the source. It was verified to fail on the pre-fix code, and again on a re-injected regression after being rewritten.

Verified against the installed React 19.2 / compiler 1.0 transform: the compiled status cache for `ScratchListItem` now depends on both `scratch` and `nowMs`.

Known gap, deliberately out of scope: `ScratchSection` (the pinned scratch list, a different surface) reads `Date.now()` in its own body and is frozen the same way — the palette-root tick can't reach it because the compiler caches the `<ScratchSection>` element on its props alone. Fixing it means rethinking that tick, which is its own change; the contract test allowlists it with the reason written down so the gap stays visible rather than silently skipped. Worth its own issue.

Resolves #11823