### PR TITLE
fix(assistant): stop the close handoff popping a hover-less tooltip

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -57,6 +57,7 @@ import { isAgentInstalled } from "../../../shared/utils/agentAvailability";
 import { actionService } from "@/services/ActionService";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
+import { dismissAllTooltips } from "@/lib/tooltipDismissRegistry";
 import { TerminalRefreshTier } from "@/types";
 import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
 import { isPtyPanel } from "@shared/types/panel";
@@ -866,6 +867,15 @@ export function HelpPanel({
       document.contains(el) &&
       !panelRef.current?.contains(el)
     ) {
+      // Radix opens tooltips on focus as well as hover, so handing focus back
+      // to a tooltip trigger — the toolbar assistant button is the usual opener
+      // — pops a tooltip nothing is hovering. Same failure the dialog
+      // primitives already arm against (#11030); the suppression window is
+      // honored by both the tooltip open path and useShortcutHintHover's focus
+      // branch, and any real pointerenter clears it, so genuine hovers still
+      // teach. Inside the guard on purpose: a restore we decline must not
+      // suppress a tooltip the user did ask for.
+      dismissAllTooltips();
       el.focus();
     }
     return undefined;

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
@@ -278,6 +278,11 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import {
+  _resetForTests as resetTooltipDismissRegistry,
+  isTooltipFocusOpenSuppressed,
+  registerTooltipDismiss,
+} from "@/lib/tooltipDismissRegistry";
 
 // rAF mock so every deferred focus frame is driven explicitly. A flush runs only
 // the callbacks already queued, so HybridInputBar's nested frame needs a second
@@ -324,6 +329,7 @@ function anyFocusWriterCalled(): boolean {
 }
 
 beforeEach(() => {
+  resetTooltipDismissRegistry();
   rafQueue.clear();
   rafIdCounter = 0;
   hybridBarVisible = true;
@@ -733,6 +739,64 @@ describe("HelpPanel — reveal focus ownership (#11472)", () => {
       rerender(<HelpPanel width={380} />);
 
       expect(document.activeElement).toBe(foreignEditor);
+      opener.remove();
+    });
+
+    it("dismisses tooltips before handing focus back, not after", () => {
+      // Radix opens tooltips on focus, and the usual opener IS a tooltip
+      // trigger (the toolbar assistant button). Suppressing after the focus
+      // lands is inert, so the order is the whole fix.
+      const order: string[] = [];
+      const unregister = registerTooltipDismiss(() => order.push("dismiss"));
+      const opener = document.createElement("button");
+      opener.addEventListener("focus", () => order.push("focus"));
+      document.body.appendChild(opener);
+      opener.focus();
+      order.length = 0;
+
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      expect(isTooltipFocusOpenSuppressed()).toBe(false);
+
+      helpPanelState.isOpen = false;
+      rerender(<HelpPanel width={380} />);
+
+      // Arming is dismissAllTooltips()'s own contract, pinned in the registry
+      // suite — asserting it here too would only add a wall-clock race against
+      // the 250ms window.
+      expect(order).toEqual(["dismiss", "focus"]);
+      unregister();
+      opener.remove();
+    });
+
+    it("leaves tooltips alone when it declines to restore focus", () => {
+      // Guards against hoisting the call out of the restore predicate: no focus
+      // moves here, so there is nothing to suppress but plenty to swallow.
+      const dismissed = vi.fn();
+      const unregister = registerTooltipDismiss(dismissed);
+      const opener = document.createElement("button");
+      document.body.appendChild(opener);
+      opener.focus();
+
+      helpPanelState.isOpen = false;
+      const { rerender } = render(<HelpPanel width={380} />);
+      helpPanelState.isOpen = true;
+      rerender(<HelpPanel width={380} />);
+      act(() => flushFrame());
+      act(() => flushFrame());
+
+      focusForeignEditor();
+      helpPanelState.isOpen = false;
+      rerender(<HelpPanel width={380} />);
+
+      expect(dismissed).not.toHaveBeenCalled();
+      expect(isTooltipFocusOpenSuppressed()).toBe(false);
+      unregister();
       opener.remove();
     });
   });

--- a/src/lib/tooltipDismissRegistry.ts
+++ b/src/lib/tooltipDismissRegistry.ts
@@ -6,7 +6,11 @@
 // every dialog transition. Radix ships no provider-level "close all" API,
 // so each mounted Tooltip registers a dismiss callback here and the dialog
 // primitives (AppDialog / AppPaletteDialog) invoke `dismissAllTooltips()`
-// on every open and close.
+// on every open and close. Any other surface that restores focus
+// programmatically owes this call or an equivalent local suppression —
+// HelpPanel calls it when the assistant closes and hands focus back to
+// whatever opened it, while AppPalettePopover's consumers suppress their own
+// controlled tooltip instead (#11034 rejected blanket popover wiring).
 //
 // Dismissing alone isn't enough: the focus move the dialog performs AFTER
 // the dismiss re-opens a tooltip through Radix's focus path. Each dismiss


### PR DESCRIPTION
Closing the Daintree Assistant with the header chevron popped a tooltip nobody hovered — "Open Daintree Assistant — MCP anomaly signals detected", sitting there for 2.5s until the auto-dismiss backstop cleared it.

## Cause

`HelpPanel` restores focus on close to whatever owned it when the panel opened. The usual opener is the toolbar assistant button, which is a Radix Tooltip trigger — and Radix opens tooltips on focus as well as hover. So the restore's `el.focus()` opened a tooltip through a path the user never asked for.

This is the same failure #11030 fixed for dialogs. `tooltipDismissRegistry`'s own header names "focus restoration to the trigger on close" as its motivating bug, but `dismissAllTooltips()` was only ever wired into `AppDialog` and `AppPaletteDialog`. `HelpPanel` does the identical restore and never armed the window.

The anomaly suffix itself is working as designed (#10022) — it's the Tier 1 ambient surface for MCP audit signals. Only the hover-less tooltip is the bug.

## Fix

`dismissAllTooltips()` immediately before `el.focus()`, inside the restore guard. That closes any open tooltip and arms the 250ms suppression window, which both the tooltip open path and `useShortcutHintHover`'s focus branch already honour — so the stray shortcut hint on the same path is covered too. A real `pointerenter` clears the window, so genuine hovers still teach.

Inside the guard on purpose: when the guard declines to restore (the user already moved to another pane), no focus moves, so there is nothing to suppress but plenty to swallow.

## Tests

Two additions to `HelpPanel.revealFocusOwnership.test.tsx`:
- ordering — the dismissal must land *before* the focus; arming afterwards is inert. Verified to fail without the fix (`expected [ 'focus' ] to deeply equal [ 'dismiss', 'focus' ]`).
- the declined-restore path must not dismiss or suppress anything — guards against hoisting the call out of the predicate.

The "does it arm suppression" contract stays in the registry's own suite rather than being re-asserted here, where it would race the 250ms window on a loaded box.

## Not in scope

Four other paths restore focus to a Tooltip trigger with the same gap, all pre-existing: `copyTreeFocus.ts:38`, `ChordIndicator.tsx:54`, `useWebviewDialog.ts:27` (via `accessibility.ts:55`), and `toaster.tsx:229`. Worth one issue covering the set.

`AppPalettePopover` is deliberately excluded — #11034 rejected blanket popover wiring, and its consumers suppress their own controlled tooltip instead. The registry comment now records that as the sanctioned alternative.