### PR TITLE
fix(package): stop shipping the other arch's better-sqlite3 prebuild

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -221,6 +221,15 @@ module.exports = async function () {
       // the foreign-platform binaries (~12MB). Both darwin arches stay — the
       // universal build merges x64 and arm64 app trees, and the identical
       // Mach-O prebuilds present in both are allowlisted via x64ArchFiles.
+      //
+      // The foreign *arch* cannot be dropped here (#11829). This pattern is
+      // compiled once per platform, and the two trees the universal merge
+      // consumes are packed with the same arch a standalone single-arch pack
+      // reports — so an arch-keyed pattern would strip a prebuild from both
+      // merge inputs and @electron/universal would abort on the resulting
+      // Mach-O file-set mismatch. afterPack.cjs prunes the foreign arch
+      // instead, where the -x64-temp/-arm64-temp output dir distinguishes a
+      // merge input from a package that ships.
       files: [...baseFiles(), "!node_modules/better-sqlite3/prebuilds/{linux,linuxmusl,win32}-*.node"],
       x64ArchFiles:
         "Contents/Resources/app.asar.unpacked/node_modules/{node-pty/build/Release/**,better-sqlite3/prebuilds/darwin-*.node,win-job-object/bin/**,posix-pty-reaper/build/Release/**,onnxruntime-node/bin/**,@parcel/watcher-darwin-*/watcher.node,@parcel/watcher/bin/darwin-*/watcher.node}",
@@ -307,6 +316,7 @@ module.exports = async function () {
     win: {
       icon: "build/icon.ico",
       // Foreign-platform better-sqlite3 prebuilds — see the mac.files note.
+      // The other Windows arch is pruned in afterPack.cjs (#11829).
       files: [...baseFiles(), "!node_modules/better-sqlite3/prebuilds/{darwin,linux,linuxmusl}-*.node"],
       artifactName: "${productName}-${version}-${arch}-setup.${ext}",
       target: [
@@ -354,6 +364,7 @@ module.exports = async function () {
       icon: "build/icon.png",
       // Foreign-platform better-sqlite3 prebuilds — see the mac.files note.
       // Electron only runs on glibc, so the linuxmusl variants go too.
+      // The other glibc arch is pruned in afterPack.cjs (#11829).
       files: [...baseFiles(), "!node_modules/better-sqlite3/prebuilds/{darwin,win32,linuxmusl}-*.node"],
       executableName: "daintree",
       target: ["AppImage", "deb"],

--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -45,15 +45,23 @@ function isMacUniversalIntermediate(appOutDir, electronPlatformName) {
  * `@electron/universal` aborts the merge when the trees hold different sets of
  * Mach-O files. Every other target carries exactly its own arch.
  *
- * `exact: false` means electron-builder reported an arch this file does not
- * recognise, so the set is a guess from the runner rather than the target.
- * Validation still runs against the guess (that is the long-standing
- * behaviour, and it is what lets tests omit an arch), but the prune and the
- * foreign-binary guard are skipped: deleting against a guessed arch could
- * remove the binary the package actually needs. Unlike isRunnerExecutableArch,
- * where skipping loses validation, skipping here only forgoes ~2MB of
- * shrinkage — the same bytes that shipped before #11829 — so degrading is
- * strictly better than failing a release build on an unknown enum value.
+ * How the arch is unknown decides what happens, because the two cases mean
+ * different things:
+ *
+ * A value this file does not recognise means electron-builder named the target
+ * and we failed to understand it — builder-util grew an enum entry. That fails
+ * the pack. Guessing would validate the runner's own prebuild instead of the
+ * target's and report a green build for a package whose database cannot work:
+ * better-sqlite3 ships x64 and arm64 only, so a genuinely new arch has no
+ * prebuild to find. Same reasoning as isRunnerExecutableArch — an unrecognised
+ * arch must never quietly reduce what gets validated.
+ *
+ * No arch at all is the long-standing fallback that lets callers omit it, and
+ * electron-builder always supplies one for a real pack. It keeps validating
+ * against the runner (`exact: false`), but the prune and the foreign-binary
+ * guard are skipped: deleting against a guessed target could remove the binary
+ * the package needs, and skipping only forgoes ~2MB of shrinkage — the bytes
+ * that shipped before #11829 anyway.
  */
 function resolveBetterSqlitePrebuildTarget(contextArch, electronPlatformName, appOutDir) {
   if (
@@ -63,8 +71,17 @@ function resolveBetterSqlitePrebuildTarget(contextArch, electronPlatformName, ap
     return { arches: ["x64", "arm64"], exact: true };
   }
   const name = ARCH_ENUM_NAMES[contextArch];
-  if (name === undefined) return { arches: [process.arch], exact: false };
-  return { arches: [name], exact: true };
+  if (name !== undefined) return { arches: [name], exact: true };
+  if (contextArch !== undefined) {
+    throw new Error(
+      `[afterPack] CRITICAL: electron-builder reported an arch this hook does not recognise ` +
+        `(${String(contextArch)}). The better-sqlite3 prebuild this package needs cannot be ` +
+        "identified, so validating it would only confirm the runner's own binary and the " +
+        "database would fail at runtime. Add the value to ARCH_ENUM_NAMES from builder-util's " +
+        "Arch enum."
+    );
+  }
+  return { arches: [process.arch], exact: false };
 }
 
 const prebuildFileName = (electronPlatformName, arch) => `${electronPlatformName}-${arch}.node`;
@@ -149,10 +166,13 @@ function pruneForeignBetterSqlitePrebuilds(prebuildsPath, electronPlatformName, 
  * stopped shedding another OS or the musl variants, a prebuild naming shape
  * the prune's prefix no longer matches, or a delete that silently did nothing.
  *
- * Filenames only. A binary carrying the wrong Mach-O/ELF/PE header under the
- * right name still passes, and this says nothing about any other dependency —
- * catching those needs a generic native-binary header scan, which is a
- * different change.
+ * Filenames only, and only the top level. A binary carrying the wrong
+ * Mach-O/ELF/PE header under the right name still passes, a nested
+ * `prebuilds/<dir>/*.node` is not seen, and this says nothing about any other
+ * dependency — catching those needs a generic native-binary header scan, which
+ * is a different change. The flat layout is better-sqlite3 v13's contract; if
+ * it ever nests, validateBetterSqlitePrebuilds fails first on the prebuild it
+ * can no longer find, which is the loud signal to revisit this.
  */
 function validateNoForeignBetterSqlitePrebuilds(
   prebuildsPath,
@@ -691,9 +711,9 @@ exports.default = async function afterPack(context) {
     );
   } else {
     console.warn(
-      `[afterPack] Skipping better-sqlite3 foreign-arch prune: electron-builder reported an ` +
-        `unrecognized arch (${String(context.arch)}), so the target arch is a guess from the ` +
-        `${process.arch} runner and is not safe to delete against.`
+      "[afterPack] Skipping better-sqlite3 foreign-arch prune and foreign-binary guard: " +
+        `electron-builder passed no arch, so the target is a guess from the ${process.arch} ` +
+        "runner and is not safe to delete against. The package keeps the other arch's prebuild."
     );
   }
 

--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -14,15 +14,166 @@ const ARCH_ENUM_NAMES = { 0: "ia32", 1: "x64", 2: "armv7l", 3: "arm64" };
 const UNIVERSAL_ARCH = 4;
 
 /**
- * The prebuild arches a package must carry. A macOS universal package merges
- * both slices, so both darwin prebuilds must be present; otherwise the single
- * target arch (falling back to the runner arch when electron-builder passes
- * no arch, e.g. in tests).
+ * Whether `appOutDir` is one of the two intermediate trees a macOS universal
+ * build merges, rather than a package that ships as-is.
+ *
+ * `doUniversalPack` (app-builder-lib macPackager.js) packs x64 and arm64 into
+ * `${appOutDir}-x64-temp` / `${appOutDir}-arm64-temp`, hands both to
+ * `@electron/universal`, then removes them — so afterPack fires three times on
+ * a universal build. Crucially, each intermediate reports the same
+ * `context.arch` a genuine standalone single-arch pack does (x64=1, arm64=3),
+ * so the arch alone cannot tell the two apart. The basename suffix is the only
+ * signal, which is why the prune below is keyed off it.
+ *
+ * The suffix must match exactly: an output directory that merely contains
+ * "-x64-temp" (say `mac-x64-temp-backup`) is a real package and must be pruned.
+ * The inverse mistake is the safe one — misreading a standalone pack as an
+ * intermediate keeps a prebuild that today ships anyway.
  */
-function getBetterSqlitePrebuildArches(contextArch) {
-  if (contextArch === UNIVERSAL_ARCH) return ["x64", "arm64"];
+function isMacUniversalIntermediate(appOutDir, electronPlatformName) {
+  if (electronPlatformName !== "darwin" || typeof appOutDir !== "string") return false;
+  const base = path.basename(appOutDir);
+  return base.endsWith("-x64-temp") || base.endsWith("-arm64-temp");
+}
+
+/**
+ * The prebuild arches a package must carry, and whether that set is certain
+ * enough to delete against.
+ *
+ * Both darwin prebuilds are required for a universal build — for the merged
+ * output because it runs on either arch, and for the two intermediates because
+ * `@electron/universal` aborts the merge when the trees hold different sets of
+ * Mach-O files. Every other target carries exactly its own arch.
+ *
+ * `exact: false` means electron-builder reported an arch this file does not
+ * recognise, so the set is a guess from the runner rather than the target.
+ * Validation still runs against the guess (that is the long-standing
+ * behaviour, and it is what lets tests omit an arch), but the prune and the
+ * foreign-binary guard are skipped: deleting against a guessed arch could
+ * remove the binary the package actually needs. Unlike isRunnerExecutableArch,
+ * where skipping loses validation, skipping here only forgoes ~2MB of
+ * shrinkage — the same bytes that shipped before #11829 — so degrading is
+ * strictly better than failing a release build on an unknown enum value.
+ */
+function resolveBetterSqlitePrebuildTarget(contextArch, electronPlatformName, appOutDir) {
+  if (
+    contextArch === UNIVERSAL_ARCH ||
+    isMacUniversalIntermediate(appOutDir, electronPlatformName)
+  ) {
+    return { arches: ["x64", "arm64"], exact: true };
+  }
   const name = ARCH_ENUM_NAMES[contextArch];
-  return [name || process.arch];
+  if (name === undefined) return { arches: [process.arch], exact: false };
+  return { arches: [name], exact: true };
+}
+
+const prebuildFileName = (electronPlatformName, arch) => `${electronPlatformName}-${arch}.node`;
+
+/**
+ * List `prebuilds/`, or null when the directory is absent.
+ *
+ * A missing directory is left to validateBetterSqlitePrebuilds, which names the
+ * exact prebuild it wanted; duplicating that error here would only bury it. Any
+ * other read failure is real and surfaces immediately — the prune cannot report
+ * what it did not read.
+ */
+function listBetterSqlitePrebuilds(prebuildsPath) {
+  try {
+    // Copied before sorting: readdirSync's result is the caller's to keep, and
+    // both the prune and the guard read this directory on the same package.
+    return [...fs.readdirSync(prebuildsPath)].sort();
+  } catch (err) {
+    if (err && err.code === "ENOENT") return null;
+    const msg = err && err.message ? err.message : String(err);
+    throw new Error(
+      `[afterPack] CRITICAL: better-sqlite3 prebuilds directory could not be read at ${prebuildsPath}: ${msg}. ` +
+        "Foreign-arch prebuilds can neither be removed nor verified. Check the packaged " +
+        "directory's permissions and the files/asarUnpack configuration."
+    );
+  }
+}
+
+/**
+ * Delete the prebuilds this target does not need (#11829).
+ *
+ * better-sqlite3 v13 ships every platform/arch pair in one package. The
+ * platform `files` overrides shed the foreign *platforms*, but no `files`
+ * pattern can shed the foreign *arch*: the pattern is compiled once per
+ * platform, and the two universal intermediates are indistinguishable from a
+ * standalone pack at that point (see isMacUniversalIntermediate). So a single
+ * arch package shipped the other arch's ~2MB binary — never loaded, just dead
+ * weight. Removing it here is safe: the prebuilds are asarUnpack'd loose files,
+ * so there is no archive to repack, and afterPack runs before fuses, signing
+ * and blockmap generation.
+ *
+ * Only this platform's own prebuilds are considered, matched on the
+ * `<platform>-` prefix rather than `<platform>` alone — `linuxmusl-x64.node`
+ * starts with "linux" but belongs to a different platform, and shedding it is
+ * the `files` override's job. A foreign-platform file that reaches here is a
+ * config regression, and validateNoForeignBetterSqlitePrebuilds reports it
+ * instead of quietly deleting the evidence.
+ *
+ * The arch is not parsed, so a prebuild for an arch this file has never heard
+ * of (a future `darwin-riscv64.node`) is still recognised as unwanted.
+ */
+function pruneForeignBetterSqlitePrebuilds(prebuildsPath, electronPlatformName, expectedArches) {
+  const entries = listBetterSqlitePrebuilds(prebuildsPath);
+  if (entries === null) return;
+
+  const keep = new Set(expectedArches.map((arch) => prebuildFileName(electronPlatformName, arch)));
+  for (const entry of entries) {
+    if (!entry.startsWith(`${electronPlatformName}-`) || !entry.endsWith(".node")) continue;
+    if (keep.has(entry)) continue;
+
+    const prebuildPath = path.join(prebuildsPath, entry);
+    try {
+      fs.unlinkSync(prebuildPath);
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      throw new Error(
+        `[afterPack] CRITICAL: foreign better-sqlite3 prebuild could not be removed at ${prebuildPath}: ${msg}. ` +
+          "The package would ship a native binary for an arch it never loads. Check the " +
+          "packaged file's permissions."
+      );
+    }
+    console.log(`[afterPack] Removed foreign better-sqlite3 prebuild: ${prebuildPath}`);
+  }
+}
+
+/**
+ * Fail the pack when a prebuild for another platform or arch survives.
+ *
+ * Not a restatement of the prune: the prune only touches this platform's own
+ * prebuilds, while this asserts the *complete* remaining set, so it catches
+ * what the prune deliberately does not — a platform `files` override that
+ * stopped shedding another OS or the musl variants, a prebuild naming shape
+ * the prune's prefix no longer matches, or a delete that silently did nothing.
+ *
+ * Filenames only. A binary carrying the wrong Mach-O/ELF/PE header under the
+ * right name still passes, and this says nothing about any other dependency —
+ * catching those needs a generic native-binary header scan, which is a
+ * different change.
+ */
+function validateNoForeignBetterSqlitePrebuilds(
+  prebuildsPath,
+  electronPlatformName,
+  expectedArches
+) {
+  const entries = listBetterSqlitePrebuilds(prebuildsPath);
+  if (entries === null) return;
+
+  const expected = new Set(
+    expectedArches.map((arch) => prebuildFileName(electronPlatformName, arch))
+  );
+  const foreign = entries.filter((entry) => entry.endsWith(".node") && !expected.has(entry));
+  if (foreign.length > 0) {
+    throw new Error(
+      `[afterPack] CRITICAL: better-sqlite3 prebuilds for another platform or arch survived packing ` +
+        `in ${prebuildsPath}: ${foreign.join(", ")}. Expected only ${[...expected].join(", ")}. ` +
+        "The package would ship native binaries it never loads. Check the platform `files` " +
+        "exclusions in electron-builder.config.cjs and the afterPack prune above."
+    );
+  }
 }
 
 /**
@@ -148,13 +299,17 @@ function validateAppAsar(asarPath) {
  * validateWinJobObjectAbi, and the OPPOSITE of the pre-v13 raw-V8 ABI probe
  * this replaces. The load probe only runs when the prebuild targets the
  * runner's own platform and arch; cross-target packages get a presence check.
+ *
+ * Takes the expected arches rather than deriving them, so this and the prune
+ * that runs before it cannot disagree about what the package is supposed to
+ * carry — a disagreement would fail the two legitimate universal intermediates.
  */
-function validateBetterSqlitePrebuilds(betterSqlitePath, electronPlatformName, contextArch) {
-  for (const arch of getBetterSqlitePrebuildArches(contextArch)) {
+function validateBetterSqlitePrebuilds(betterSqlitePath, electronPlatformName, expectedArches) {
+  for (const arch of expectedArches) {
     const prebuildPath = path.join(
       betterSqlitePath,
       "prebuilds",
-      `${electronPlatformName}-${arch}.node`
+      prebuildFileName(electronPlatformName, arch)
     );
     if (!fs.existsSync(prebuildPath)) {
       throw new Error(
@@ -518,7 +673,31 @@ exports.default = async function afterPack(context) {
     );
   }
 
-  validateBetterSqlitePrebuilds(betterSqlitePath, electronPlatformName, context.arch);
+  // One expected-arch set drives all three steps below. Deriving it twice is
+  // the trap here: a prune and a guard that disagree would fail the two
+  // universal intermediates, which legitimately carry both darwin prebuilds.
+  const prebuildsPath = path.join(betterSqlitePath, "prebuilds");
+  const prebuildTarget = resolveBetterSqlitePrebuildTarget(
+    context.arch,
+    electronPlatformName,
+    appOutDir
+  );
+  if (prebuildTarget.exact) {
+    pruneForeignBetterSqlitePrebuilds(prebuildsPath, electronPlatformName, prebuildTarget.arches);
+    validateNoForeignBetterSqlitePrebuilds(
+      prebuildsPath,
+      electronPlatformName,
+      prebuildTarget.arches
+    );
+  } else {
+    console.warn(
+      `[afterPack] Skipping better-sqlite3 foreign-arch prune: electron-builder reported an ` +
+        `unrecognized arch (${String(context.arch)}), so the target arch is a guess from the ` +
+        `${process.arch} runner and is not safe to delete against.`
+    );
+  }
+
+  validateBetterSqlitePrebuilds(betterSqlitePath, electronPlatformName, prebuildTarget.arches);
 
   console.log(`[afterPack] better-sqlite3 verified: ${betterSqlitePath}`);
 

--- a/scripts/afterPack.test.ts
+++ b/scripts/afterPack.test.ts
@@ -9,6 +9,7 @@ const mockReaddirSync = vi.fn();
 const mockMkdirSync = vi.fn();
 const mockCopyFileSync = vi.fn();
 const mockStatSync = vi.fn();
+const mockUnlinkSync = vi.fn();
 const mockSpawnSync = vi.fn();
 const mockGetRawHeader = vi.fn();
 const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -60,6 +61,12 @@ describe("afterPack", () => {
     mockStatSync.mockReturnValue({ size: 40 * 1024 * 1024 });
     mockGetRawHeader.mockReturnValue(asarHeader());
 
+    // Default: every directory reads as empty. The foreign-prebuild prune
+    // (#11829) enumerates better-sqlite3/prebuilds on every package, so without
+    // a default it would iterate undefined in every unrelated test. Empty is
+    // also the inert answer for the guard — it rejects only files it can see.
+    mockReaddirSync.mockReturnValue([]);
+
     // Both load probes (win-job-object and better-sqlite3's packaged prebuild)
     // are N-API addons — ABI-stable, so a successful dlopen under Node is the
     // passing case. Default: everything loads cleanly.
@@ -75,6 +82,7 @@ describe("afterPack", () => {
           mkdirSync: mockMkdirSync,
           copyFileSync: mockCopyFileSync,
           statSync: mockStatSync,
+          unlinkSync: mockUnlinkSync,
         };
       }
       if (id === "child_process" || id === "node:child_process") {
@@ -453,6 +461,223 @@ describe("afterPack", () => {
       await expect(
         afterPack(createContext("darwin", "/build/mac", "Daintree", Arch.universal))
       ).rejects.toThrow(/better-sqlite3 prebuild not found/);
+    });
+  });
+
+  describe("better-sqlite3 foreign-arch prune (#11829)", () => {
+    // better-sqlite3 v13 ships every platform/arch pair in one package. The
+    // platform `files` overrides shed the foreign platforms; the foreign arch
+    // can only be shed here, because no `files` pattern can tell a standalone
+    // single-arch pack apart from one of the two trees the macOS universal
+    // merge consumes — both report the same arch to the hook.
+    const unpackedBase = (platform: string, outDir: string) =>
+      platform === "darwin"
+        ? path.join(outDir, "Daintree.app/Contents/Resources/app.asar.unpacked")
+        : path.join(outDir, "resources/app.asar.unpacked");
+
+    const prebuildsDir = (platform: string, outDir: string) =>
+      path.join(unpackedBase(platform, outDir), "node_modules/better-sqlite3/prebuilds");
+
+    /**
+     * A minimal in-memory prebuilds/ directory: unlinkSync really removes the
+     * entry, so the guard's re-read after the prune sees what the prune left
+     * rather than the original fixture. Only better-sqlite3's listing is
+     * driven — every other readdirSync (the Windows conpty version-folder
+     * scan) keeps the empty default, so these fixtures cannot leak into it.
+     */
+    const seedPrebuilds = (entries: string[]) => {
+      const present = new Set(entries);
+      mockReaddirSync.mockImplementation((p: string) =>
+        String(p).includes("better-sqlite3") ? [...present] : []
+      );
+      mockUnlinkSync.mockImplementation((p: string) => {
+        present.delete(path.basename(String(p)));
+      });
+      return present;
+    };
+
+    const unlinked = () => mockUnlinkSync.mock.calls.map((c) => String(c[0]));
+
+    it.each([
+      ["darwin", "/build/mac", Arch.arm64, "darwin-arm64.node", "darwin-x64.node"],
+      ["win32", "/build/win", Arch.x64, "win32-x64.node", "win32-arm64.node"],
+      ["linux", "/build/linux", Arch.x64, "linux-x64.node", "linux-arm64.node"],
+    ] as const)(
+      "removes the other CPU arch's prebuild from a standalone %s package",
+      async (platform, outDir, arch, keep, drop) => {
+        mockExistsSync.mockReturnValue(true);
+        const present = seedPrebuilds([keep, drop]);
+
+        await afterPack(createContext(platform, outDir, "Daintree", arch));
+
+        expect(unlinked()).toEqual([path.join(prebuildsDir(platform, outDir), drop)]);
+        expect([...present]).toEqual([keep]);
+      }
+    );
+
+    it("removes a same-platform prebuild for an arch this hook has never heard of", async () => {
+      // The arch is never parsed, only compared against the expected filenames,
+      // so a prebuild directory that grows a new target sheds it without this
+      // file learning the name first.
+      mockExistsSync.mockReturnValue(true);
+      seedPrebuilds(["darwin-x64.node", "darwin-riscv64.node"]);
+
+      await afterPack(createContext("darwin", "/build/mac", "Daintree", Arch.x64));
+
+      expect(unlinked()).toEqual([
+        path.join(prebuildsDir("darwin", "/build/mac"), "darwin-riscv64.node"),
+      ]);
+    });
+
+    it.each([
+      ["linux", "/build/linux", Arch.x64, "linux-x64.node", "linuxmusl-x64.node"],
+      ["darwin", "/build/mac", Arch.arm64, "darwin-arm64.node", "linux-x64.node"],
+    ] as const)(
+      "reports rather than deletes a foreign-platform prebuild on %s",
+      async (platform, outDir, arch, keep, leak) => {
+        // The prune matches on the `<platform>-` prefix, not `<platform>` —
+        // "linuxmusl-x64.node" starts with "linux" but is another platform's
+        // binary, and shedding it belongs to the `files` override. Deleting it
+        // here would hide that the override stopped working, so the guard
+        // fails the pack instead.
+        mockExistsSync.mockReturnValue(true);
+        seedPrebuilds([keep, leak]);
+
+        await expect(afterPack(createContext(platform, outDir, "Daintree", arch))).rejects.toThrow(
+          /prebuilds for another platform or arch survived packing/
+        );
+
+        expect(unlinked()).toEqual([]);
+      }
+    );
+
+    it.each([
+      ["/build/mac-x64-temp", Arch.x64],
+      ["/build/mac-arm64-temp", Arch.arm64],
+    ] as const)(
+      "keeps both darwin prebuilds in the universal intermediate %s",
+      async (outDir, arch) => {
+        // @electron/universal aborts the merge when the two trees hold different
+        // sets of Mach-O files, and it does so before x64ArchFiles is consulted.
+        // Each intermediate reports the same arch a standalone pack does, so the
+        // -<arch>-temp suffix is the only thing keeping the prune off them.
+        mockExistsSync.mockReturnValue(true);
+        const present = seedPrebuilds(["darwin-arm64.node", "darwin-x64.node"]);
+
+        await afterPack(createContext("darwin", outDir, "Daintree", arch));
+
+        expect(unlinked()).toEqual([]);
+        expect([...present].sort()).toEqual(["darwin-arm64.node", "darwin-x64.node"]);
+      }
+    );
+
+    it("prunes an output directory that merely contains the intermediate suffix", async () => {
+      // Matched as a suffix, not a substring: this is a package that ships.
+      mockExistsSync.mockReturnValue(true);
+      seedPrebuilds(["darwin-arm64.node", "darwin-x64.node"]);
+
+      await afterPack(
+        createContext("darwin", "/build/mac-x64-temp-backup", "Daintree", Arch.arm64)
+      );
+
+      expect(unlinked()).toEqual([
+        path.join(prebuildsDir("darwin", "/build/mac-x64-temp-backup"), "darwin-x64.node"),
+      ]);
+    });
+
+    it("keeps both darwin prebuilds in the merged universal package", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const present = seedPrebuilds(["darwin-arm64.node", "darwin-x64.node"]);
+
+      await afterPack(createContext("darwin", "/build/mac", "Daintree", Arch.universal));
+
+      expect(unlinked()).toEqual([]);
+      expect([...present].sort()).toEqual(["darwin-arm64.node", "darwin-x64.node"]);
+    });
+
+    it("fails the pack when a prune silently does nothing", async () => {
+      // The guard re-reads the directory rather than trusting unlinkSync's
+      // return, so a delete that no-ops cannot ship a foreign binary.
+      mockExistsSync.mockReturnValue(true);
+      seedPrebuilds(["linux-x64.node", "linux-arm64.node"]);
+      mockUnlinkSync.mockImplementation(() => {});
+
+      await expect(
+        afterPack(createContext("linux", "/build/linux", "Daintree", Arch.x64))
+      ).rejects.toThrow(/prebuilds for another platform or arch survived packing/);
+
+      expect(unlinked()).toEqual([
+        path.join(prebuildsDir("linux", "/build/linux"), "linux-arm64.node"),
+      ]);
+    });
+
+    it("leaves entries that are not prebuild binaries alone", async () => {
+      mockExistsSync.mockReturnValue(true);
+      seedPrebuilds(["linux-x64.node", "README.md", "linux-x64.node.map"]);
+
+      await afterPack(createContext("linux", "/build/linux", "Daintree", Arch.x64));
+
+      expect(unlinked()).toEqual([]);
+    });
+
+    it("fails the pack when a foreign prebuild cannot be deleted", async () => {
+      mockExistsSync.mockReturnValue(true);
+      seedPrebuilds(["linux-x64.node", "linux-arm64.node"]);
+      mockUnlinkSync.mockImplementation(() => {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      });
+
+      await expect(
+        afterPack(createContext("linux", "/build/linux", "Daintree", Arch.x64))
+      ).rejects.toThrow(/foreign better-sqlite3 prebuild could not be removed/);
+    });
+
+    it("leaves a missing prebuilds directory to the presence check", async () => {
+      // Reporting it here too would only bury the existing error, which names
+      // the exact prebuild the package needed.
+      mockExistsSync.mockImplementation((p) => !String(p).includes("prebuilds"));
+      mockReaddirSync.mockImplementation((p: string) => {
+        if (String(p).includes("better-sqlite3")) {
+          throw Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+        }
+        return [];
+      });
+
+      await expect(
+        afterPack(createContext("linux", "/build/linux", "Daintree", Arch.x64))
+      ).rejects.toThrow(/better-sqlite3 prebuild not found/);
+
+      expect(unlinked()).toEqual([]);
+    });
+
+    it("fails the pack when the prebuilds directory cannot be read", async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockImplementation((p: string) => {
+        if (String(p).includes("better-sqlite3")) {
+          throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+        }
+        return [];
+      });
+
+      await expect(
+        afterPack(createContext("linux", "/build/linux", "Daintree", Arch.x64))
+      ).rejects.toThrow(/prebuilds directory could not be read/);
+    });
+
+    it("skips the prune when electron-builder reports an unrecognized arch", async () => {
+      // The expected arch would be a guess from the runner, and deleting
+      // against a guess could remove the binary the package actually needs.
+      // Shipping the extra prebuild is the pre-#11829 status quo, so this
+      // degrades rather than failing a release build.
+      mockExistsSync.mockReturnValue(true);
+      seedPrebuilds([`linux-${process.arch}.node`, "linux-riscv64.node"]);
+
+      await afterPack(createContext("linux", "/build/linux"));
+
+      expect(unlinked()).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping better-sqlite3 foreign-arch prune")
+      );
     });
   });
 

--- a/scripts/afterPack.test.ts
+++ b/scripts/afterPack.test.ts
@@ -61,6 +61,13 @@ describe("afterPack", () => {
     mockStatSync.mockReturnValue({ size: 40 * 1024 * 1024 });
     mockGetRawHeader.mockReturnValue(asarHeader());
 
+    // clearAllMocks only clears call history — implementations and queued
+    // `once` values survive it, so a test that makes unlinkSync throw would
+    // otherwise poison every later test that deletes anything. Reset the two
+    // mocks the prune drives before installing their defaults.
+    mockReaddirSync.mockReset();
+    mockUnlinkSync.mockReset();
+
     // Default: every directory reads as empty. The foreign-prebuild prune
     // (#11829) enumerates better-sqlite3/prebuilds on every package, so without
     // a default it would iterate undefined in every unrelated test. Empty is
@@ -498,12 +505,18 @@ describe("afterPack", () => {
 
     const unlinked = () => mockUnlinkSync.mock.calls.map((c) => String(c[0]));
 
+    // Every single-arch target the build actually ships (electron-builder.config.cjs:
+    // mac dmg/zip x64 + arm64, win nsis x64 + arm64, linux x64). appx x64 shares
+    // the nsis x64 pack — app-builder-lib packs once per arch, then builds both
+    // distributables from that tree — so it needs no row of its own.
     it.each([
-      ["darwin", "/build/mac", Arch.arm64, "darwin-arm64.node", "darwin-x64.node"],
+      ["darwin", "/build/mac-arm64", Arch.arm64, "darwin-arm64.node", "darwin-x64.node"],
+      ["darwin", "/build/mac", Arch.x64, "darwin-x64.node", "darwin-arm64.node"],
       ["win32", "/build/win", Arch.x64, "win32-x64.node", "win32-arm64.node"],
+      ["win32", "/build/win-arm64", Arch.arm64, "win32-arm64.node", "win32-x64.node"],
       ["linux", "/build/linux", Arch.x64, "linux-x64.node", "linux-arm64.node"],
     ] as const)(
-      "removes the other CPU arch's prebuild from a standalone %s package",
+      "removes the other CPU arch's prebuild from a standalone %s package at %s",
       async (platform, outDir, arch, keep, drop) => {
         mockExistsSync.mockReturnValue(true);
         const present = seedPrebuilds([keep, drop]);
@@ -554,20 +567,53 @@ describe("afterPack", () => {
     it.each([
       ["/build/mac-x64-temp", Arch.x64],
       ["/build/mac-arm64-temp", Arch.arm64],
+      ["/build/mac", Arch.universal],
     ] as const)(
-      "keeps both darwin prebuilds in the universal intermediate %s",
+      "keeps both darwin prebuilds while still pruning, for the universal target at %s",
       async (outDir, arch) => {
         // @electron/universal aborts the merge when the two trees hold different
         // sets of Mach-O files, and it does so before x64ArchFiles is consulted.
         // Each intermediate reports the same arch a standalone pack does, so the
         // -<arch>-temp suffix is the only thing keeping the prune off them.
+        //
+        // The riscv sentinel is what makes this more than "nothing happened":
+        // an implementation that simply switched the prune off for universal
+        // targets would keep both darwin files too and pass on that assertion
+        // alone. Removing exactly the sentinel proves the prune ran and spared
+        // the pair the merge depends on.
         mockExistsSync.mockReturnValue(true);
-        const present = seedPrebuilds(["darwin-arm64.node", "darwin-x64.node"]);
+        const present = seedPrebuilds([
+          "darwin-arm64.node",
+          "darwin-x64.node",
+          "darwin-riscv64.node",
+        ]);
 
         await afterPack(createContext("darwin", outDir, "Daintree", arch));
 
-        expect(unlinked()).toEqual([]);
+        expect(unlinked()).toEqual([
+          path.join(prebuildsDir("darwin", outDir), "darwin-riscv64.node"),
+        ]);
         expect([...present].sort()).toEqual(["darwin-arm64.node", "darwin-x64.node"]);
+      }
+    );
+
+    it.each([
+      ["/build/mac-x64-temp", Arch.x64],
+      ["/build/mac", Arch.universal],
+    ] as const)(
+      "still rejects a foreign-platform prebuild on the universal target at %s",
+      async (outDir, arch) => {
+        // The guard has to stay armed on the path that legitimately keeps both
+        // arches, or a broken `files` exclusion ships unnoticed in exactly the
+        // artifact that runs on every Mac.
+        mockExistsSync.mockReturnValue(true);
+        seedPrebuilds(["darwin-arm64.node", "darwin-x64.node", "linux-x64.node"]);
+
+        await expect(afterPack(createContext("darwin", outDir, "Daintree", arch))).rejects.toThrow(
+          /prebuilds for another platform or arch survived packing/
+        );
+
+        expect(unlinked()).toEqual([]);
       }
     );
 
@@ -583,16 +629,6 @@ describe("afterPack", () => {
       expect(unlinked()).toEqual([
         path.join(prebuildsDir("darwin", "/build/mac-x64-temp-backup"), "darwin-x64.node"),
       ]);
-    });
-
-    it("keeps both darwin prebuilds in the merged universal package", async () => {
-      mockExistsSync.mockReturnValue(true);
-      const present = seedPrebuilds(["darwin-arm64.node", "darwin-x64.node"]);
-
-      await afterPack(createContext("darwin", "/build/mac", "Daintree", Arch.universal));
-
-      expect(unlinked()).toEqual([]);
-      expect([...present].sort()).toEqual(["darwin-arm64.node", "darwin-x64.node"]);
     });
 
     it("fails the pack when a prune silently does nothing", async () => {
@@ -664,7 +700,7 @@ describe("afterPack", () => {
       ).rejects.toThrow(/prebuilds directory could not be read/);
     });
 
-    it("skips the prune when electron-builder reports an unrecognized arch", async () => {
+    it("skips the prune when electron-builder passes no arch at all", async () => {
       // The expected arch would be a guess from the runner, and deleting
       // against a guess could remove the binary the package actually needs.
       // Shipping the extra prebuild is the pre-#11829 status quo, so this
@@ -678,6 +714,25 @@ describe("afterPack", () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("Skipping better-sqlite3 foreign-arch prune")
       );
+    });
+
+    it("fails the pack on an arch value it does not recognise", async () => {
+      // The opposite polarity to the no-arch case above, and deliberately so:
+      // electron-builder named a target and this file failed to understand it,
+      // which means builder-util grew an enum entry. Falling back to the runner
+      // here would validate the runner's own prebuild and call a package green
+      // whose database cannot work — better-sqlite3 ships x64 and arm64 only,
+      // so a genuinely new arch has no prebuild to find.
+      mockExistsSync.mockReturnValue(true);
+      const unknownArch =
+        Math.max(...Object.values(Arch).filter((v): v is number => typeof v === "number")) + 1;
+      seedPrebuilds([`linux-${process.arch}.node`]);
+
+      await expect(
+        afterPack(createContext("linux", "/build/linux", "Daintree", unknownArch))
+      ).rejects.toThrow(/reported an arch this hook does not recognise/);
+
+      expect(unlinked()).toEqual([]);
     });
   });
 
@@ -857,11 +912,18 @@ describe("afterPack", () => {
       // Skipping reduces validation, so it has to be a decision about a
       // known-foreign slice. A future builder-util enum value must not silently
       // disable the probe.
+      //
+      // The hook now rejects that same unknown arch further down, when it can
+      // no longer name the better-sqlite3 prebuild the package needs (#11829).
+      // The probe still has to have run first — asserting only the rejection
+      // would pass even if the exec check had been skipped.
       mockExistsSync.mockReturnValue(true);
       const unknownArch =
         Math.max(...Object.values(Arch).filter((v): v is number => typeof v === "number")) + 1;
 
-      await afterPack(createContext("linux", "/build/linux", "Daintree", unknownArch));
+      await expect(
+        afterPack(createContext("linux", "/build/linux", "Daintree", unknownArch))
+      ).rejects.toThrow(/does not recognise/);
 
       expect(mockSpawnSync).toHaveBeenCalled();
     });

--- a/scripts/ci/electron-builder-config.test.mjs
+++ b/scripts/ci/electron-builder-config.test.mjs
@@ -98,6 +98,16 @@ describe("electron-builder config — platform files overrides (#11475)", () => 
         expect(pattern, `${platform}.files pattern "${pattern}"`).toMatch(
           /^!node_modules\/better-sqlite3\/prebuilds\//
         );
+        // Foreign *platforms* only — never a CPU arch (#11829). A pattern is
+        // compiled once per platform, and the two trees the macOS universal
+        // merge consumes are packed with the same arch a standalone pack
+        // reports, so an arch-keyed exclusion strips a prebuild from both merge
+        // inputs and @electron/universal aborts on the Mach-O file-set
+        // mismatch. Shedding the foreign arch is afterPack.cjs's job, where the
+        // -x64-temp/-arm64-temp output dir tells the two apart.
+        expect(pattern, `${platform}.files pattern "${pattern}" names a CPU arch`).not.toMatch(
+          /(x64|arm64|ia32|armv7l)/
+        );
       }
     }
   });


### PR DESCRIPTION
## Summary

- better-sqlite3 v13 ships prebuilds for every platform+arch pair in one flat directory. The electron-builder `files` overrides already stripped foreign platforms but kept both CPU arches, so every single-arch artifact carried about 2MB of dead weight: the arm64 macOS build shipped `darwin-x64.node`, the x64 Windows installer shipped `win32-arm64.node`, and the x64 Linux build shipped `linux-arm64.node`.
- This prunes the foreign arch inside `scripts/afterPack.cjs` instead of a `files` pattern, and adds a guard that fails the pack when a foreign prebuild survives.

Resolves #11829

## Why afterPack, not a files pattern

`doUniversalPack` (app-builder-lib) packs x64 and arm64 into `${appOutDir}-x64-temp` and `${appOutDir}-arm64-temp`, then hands both trees to `@electron/universal`, which hard-throws on any Mach-O file-set mismatch between them, before `x64ArchFiles` is ever consulted. So `x64ArchFiles` can't cover this case.

Both intermediates report the exact same `context.arch` value that a genuine standalone single-arch pack reports, so no `${arch}` macro in `mac.files` can tell them apart. An arch-keyed pattern would strip the prebuild from both merge inputs and break the universal build. The `-x64-temp` / `-arm64-temp` basename suffix is the only reliable discriminator, and it's only available inside the hook, not the files config.

## Design notes

- One shared expected-arch set drives the prune, the guard, and the existing presence check, so they can't disagree and falsely fail the two legitimate universal intermediates.
- The prune only touches this platform's own prebuilds, matched on a `<platform>-` prefix (with the hyphen: `linuxmusl-x64.node` starts with "linux" but belongs to a different platform).
- A foreign-*platform* file reaching the hook means the `files` config itself regressed, so the guard reports it instead of silently deleting the evidence.
- An arch value electron-builder reports that the hook doesn't recognize now fails the pack, rather than validating only the runner's own prebuild and reporting green on a package whose database can't work.
- No arch info at all keeps the long-standing runner fallback and skips the prune. Deleting on a guess could remove the binary the package actually needs.
- `scripts/ci/electron-builder-config.test.mjs` now forbids arch-keyed better-sqlite3 negations. It previously allowed the exact pattern that breaks the universal merge.

## Changes

- `scripts/afterPack.cjs`: adds `isMacUniversalIntermediate`, `resolveBetterSqlitePrebuildTarget`, `listBetterSqlitePrebuilds`, `pruneForeignBetterSqlitePrebuilds`, `validateNoForeignBetterSqlitePrebuilds`. `validateBetterSqlitePrebuilds` now takes the shared `expectedArches`.
- `scripts/afterPack.test.ts`: new "better-sqlite3 foreign-arch prune (#11829)" block, `unlinkSync` added to the fs mock, mock resets tightened.
- `scripts/ci/electron-builder-config.test.mjs`: forbids arch-keyed prebuild negations.
- `electron-builder.config.cjs`: comments only, no pattern changes.

## Known limits

This doesn't fully deliver what the issue asked for, a check that catches "the next dependency that ships fat prebuilds." The guard matches filenames at the top level only. It doesn't read Mach-O/ELF/PE headers, doesn't recurse into a nested `prebuilds/` subdirectory, and covers better-sqlite3 only. Catching an arbitrary future dependency needs a generic native-binary header scan, which is separate work. better-sqlite3 was empirically the only offender: the issue confirmed `darwin-x64.node` was the only non-arm64 Mach-O anywhere in a packaged arm64 bundle, and `node-pty` / `win-job-object` / `posix-pty-reaper` are source-compiled per target, so exactly one binary ever exists for those.

macOS packaging isn't built in PR CI (Ubuntu typecheck/lint/unit/build only), so the universal path is covered by unit tests here but hasn't been exercised by a real local `npm run package` in this session. Reviewer should run `npm run package:mac` across arm64, x64, and universal before release, per the issue's Verification section.

## Testing

- `npx vitest run scripts/afterPack.test.ts scripts/ci/electron-builder-config.test.mjs` → 102 tests pass
- `prettier --check` clean on all four changed files
- eslint skips `scripts/**` and the builder config by project config
