### PR TITLE
fix(fleet): carry a manual panel rename to the pty-host record

### DIFF
--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -133,6 +133,14 @@ const DEAD_CHANNEL_ALLOWLIST = new Set<string>([
   "terminal:set-focused",
   "terminal:update-observed-title",
 
+  // fire-and-forget — renderer→main panel rename, mirrored onto the pty-host
+  // terminal record so the fleet overview and the session journal name a run
+  // the way the user does (#11830). Not high-frequency like the group above,
+  // but send-only for the same reason as its `update-observed-title` sibling:
+  // the renderer store is already authoritative for display, so there is no
+  // result worth awaiting.
+  "terminal:update-title",
+
   // fire-and-forget — high-frequency renderer→main streaming audio chunks
   // for voice input. Same rationale as the terminal input channels.
   "voice-input:audio-chunk",

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -61,6 +61,7 @@ export const CHANNELS = {
   TERMINAL_BROADCAST_WRITE_RESULT: "terminal:broadcast-write-result",
   TERMINAL_AGENT_TITLE_STATE: "terminal:agent-title-state",
   TERMINAL_UPDATE_OBSERVED_TITLE: "terminal:update-observed-title",
+  TERMINAL_UPDATE_TITLE: "terminal:update-title",
   TERMINAL_REDUCE_SCROLLBACK: "terminal:reduce-scrollback",
   TERMINAL_RESTORE_SCROLLBACK: "terminal:restore-scrollback",
   TERMINAL_RESTART_SERVICE: "terminal:restart-service",

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -16,7 +16,7 @@ import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
 import { normalizeTerminalGridDimension } from "../../../../shared/types/terminal.js";
 import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
 import { isPanelTitleMode, type PanelTitleMode } from "../../../../shared/types/panel.js";
-import { getFleetSnapshotService } from "../projectCrud/stats.js";
+import { events } from "../../../services/events.js";
 import { defineIpcNamespace, op } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
@@ -306,9 +306,9 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       if (typeof title !== "string") return;
       if (!isPanelTitleMode(titleMode)) return;
       ptyClient.updateTitle(id, title, titleMode);
-      // The snapshot poll is 5s-aligned and no fleet event fires for a rename,
-      // so without this the overview lags a hand rename by up to a full cycle.
-      getFleetSnapshotService()?.refresh();
+      // The snapshot poll is 5s-aligned and nothing else reports a rename, so
+      // without this the overview lags a hand rename by up to a full cycle.
+      events.emit("terminal:title-changed", { id, timestamp: Date.now() });
     } catch (error) {
       console.error("[IPC] Error handling title update:", error);
     }

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -15,6 +15,8 @@ import { TerminalResizePayloadSchema } from "../../../schemas/ipc.js";
 import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
 import { normalizeTerminalGridDimension } from "../../../../shared/types/terminal.js";
 import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
+import { isPanelTitleMode, type PanelTitleMode } from "../../../../shared/types/panel.js";
+import { getFleetSnapshotService } from "../projectCrud/stats.js";
 import { defineIpcNamespace, op } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
@@ -287,6 +289,33 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       CHANNELS.TERMINAL_UPDATE_OBSERVED_TITLE,
       handleTerminalUpdateObservedTitle
     )
+  );
+
+  // A rename lives in the renderer panel store, but the record the fleet
+  // overview, session journal and shutdown records read is the pty-host's.
+  // Without this hop those surfaces keep naming the run by its launch title
+  // and every `titleMode === "user"` branch in main stays unreachable (#11830).
+  const handleTerminalUpdateTitle = (
+    _event: Electron.IpcMainEvent,
+    payload: { id: string; title: string; titleMode: PanelTitleMode }
+  ) => {
+    try {
+      if (!payload || typeof payload !== "object") return;
+      const { id, title, titleMode } = payload;
+      if (typeof id !== "string" || !id) return;
+      if (typeof title !== "string") return;
+      if (!isPanelTitleMode(titleMode)) return;
+      ptyClient.updateTitle(id, title, titleMode);
+      // The snapshot poll is 5s-aligned and no fleet event fires for a rename,
+      // so without this the overview lags a hand rename by up to a full cycle.
+      getFleetSnapshotService()?.refresh();
+    } catch (error) {
+      console.error("[IPC] Error handling title update:", error);
+    }
+  };
+  ipcMain.on(CHANNELS.TERMINAL_UPDATE_TITLE, handleTerminalUpdateTitle);
+  handlers.push(() =>
+    ipcMain.removeListener(CHANNELS.TERMINAL_UPDATE_TITLE, handleTerminalUpdateTitle)
   );
 
   const handleTerminalForceResume = async (id: string): Promise<void> => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -14,6 +14,7 @@ import { isTrustedRendererUrl, isRecoveryPageUrl } from "../shared/utils/trusted
 import { isIpcEnvelope } from "../shared/types/ipc/errors.js";
 import { deserializeError } from "../shared/utils/ipcErrorSerialization.js";
 import type { AppErrorCode } from "../shared/types/appError.js";
+import type { PanelTitleMode } from "../shared/types/panel.js";
 import type {
   McpRuntimeSnapshot,
   McpGrantLifecyclePayload,
@@ -1343,6 +1344,9 @@ function buildElectronApi(): ElectronAPI {
 
       updateObservedTitle: (id: string, title: string) =>
         ipcRenderer.send(CHANNELS.TERMINAL_UPDATE_OBSERVED_TITLE, { id, title }),
+
+      updateTitle: (id: string, title: string, titleMode: PanelTitleMode) =>
+        ipcRenderer.send(CHANNELS.TERMINAL_UPDATE_TITLE, { id, title, titleMode }),
 
       onSpawnResult: (callback: (id: string, result: SpawnResultPayload) => void): (() => void) =>
         _eventBusOn("terminal:spawn-result", (payload) => {

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -40,6 +40,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     })),
     markChecked: vi.fn(),
     updateObservedTitle: vi.fn(),
+    updateTitle: vi.fn(),
     transitionState: vi.fn(() => true),
     trimScrollback: vi.fn(),
     setActivityMonitorTier: vi.fn(),
@@ -113,6 +114,29 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
 function termInfo(pid?: number) {
   return { ptyProcess: { pid } };
 }
+
+describe("lifecycle update-title handler", () => {
+  it("forwards the mode alongside the title so the lock survives the hop", () => {
+    // A rename that arrived without its mode would land as `"default"` and the
+    // next agent-detection sweep would overwrite it (#10794/#11830).
+    const ctx = makeCtx();
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "update-title", id: "t1", title: "Add valuation tool", titleMode: "user" });
+
+    expect(ctx.ptyManager.updateTitle).toHaveBeenCalledWith("t1", "Add valuation tool", "user");
+  });
+
+  it("routes a rename separately from an observed OSC title", () => {
+    const ctx = makeCtx();
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "update-observed-title", id: "t1", title: "agent task" });
+
+    expect(ctx.ptyManager.updateObservedTitle).toHaveBeenCalledWith("t1", "agent task");
+    expect(ctx.ptyManager.updateTitle).not.toHaveBeenCalled();
+  });
+});
 
 describe("lifecycle kill handlers — trackKilledPid", () => {
   beforeEach(() => {

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -227,6 +227,10 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
       ptyManager.updateObservedTitle(msg.id, msg.title);
     },
 
+    "update-title": (msg) => {
+      ptyManager.updateTitle(msg.id, msg.title, msg.titleMode);
+    },
+
     "transition-state": (msg) => {
       const success = ptyManager.transitionState(
         msg.id,

--- a/electron/services/FleetSnapshotService.ts
+++ b/electron/services/FleetSnapshotService.ts
@@ -92,6 +92,9 @@ export class FleetSnapshotService {
     // even though no agent state moved.
     subscribe("terminal:park-changed");
     subscribe("terminal:snooze-changed");
+    // A rename moves no agent state, so without this the row would carry the
+    // old title until the next aligned poll (#11830).
+    subscribe("terminal:title-changed");
   }
 
   updatePollInterval(ms: number): void {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -2380,6 +2380,10 @@ export class PtyClient extends EventEmitter {
     this.shardForTerminal(id).send({ type: "update-observed-title", id, title });
   }
 
+  updateTitle(id: string, title: string, titleMode: PanelTitleMode): void {
+    this.shardForTerminal(id).send({ type: "update-title", id, title, titleMode });
+  }
+
   async transitionState(
     id: string,
     event: { type: string; [key: string]: unknown },

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -2381,6 +2381,12 @@ export class PtyClient extends EventEmitter {
   }
 
   updateTitle(id: string, title: string, titleMode: PanelTitleMode): void {
+    // Keep the cached spawn options in step. `respawnPendingForShard` replays
+    // them verbatim after a pty-host crash and `TerminalProcess` re-stamps the
+    // title from them, so a stale entry would quietly restore the launch title
+    // over the rename the user just made.
+    const pending = this.pendingSpawns.get(id);
+    if (pending) this.pendingSpawns.set(id, { ...pending, title, titleMode });
     this.shardForTerminal(id).send({ type: "update-title", id, title, titleMode });
   }
 

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -8,6 +8,7 @@ import type { ProcessTreeCache } from "./ProcessTreeCache.js";
 import type { DetectionResult } from "./ProcessDetector.js";
 import type { ImagePathProbe } from "./pty/ImagePathProbe.js";
 import type { AnalysisWorkerPool } from "./pty/analysis/AnalysisWorkerPool.js";
+import type { PanelTitleMode } from "../../shared/types/panel.js";
 import { createLogger } from "../utils/logger.js";
 
 const logger = createLogger("pty-host:PtyManager");
@@ -935,6 +936,18 @@ export class PtyManager extends EventEmitter {
     const terminal = this.registry.get(id);
     if (!terminal) return;
     terminal.setObservedTitle(title);
+  }
+
+  /**
+   * Apply a renderer-side rename to the authoritative record so the fleet
+   * snapshot, session journal and shutdown records all name the run the way
+   * the user does. A rename for a terminal that has already gone is a no-op —
+   * the renderer store keeps the title either way.
+   */
+  updateTitle(id: string, title: string, titleMode: PanelTitleMode): void {
+    const terminal = this.registry.get(id);
+    if (!terminal) return;
+    terminal.setTitle(title, titleMode);
   }
 
   /**

--- a/electron/services/__tests__/FleetSnapshotService.test.ts
+++ b/electron/services/__tests__/FleetSnapshotService.test.ts
@@ -479,7 +479,11 @@ describe("FleetSnapshotService", () => {
     // Suppression compares projected rows, so if it ignored the title fields a
     // renamed run would keep broadcasting its launch title until some unrelated
     // state moved.
-    const client = makePtyClient([terminal({ title: "Document GSC access method" })]);
+    // Only the title moves — the mode is held constant so a passing run cannot
+    // be explained by the mode comparison alone.
+    const client = makePtyClient([
+      terminal({ title: "Document GSC access method", titleMode: "user" }),
+    ]);
     const service = new FleetSnapshotService(client as never);
 
     service.refresh();
@@ -564,6 +568,25 @@ describe("FleetSnapshotService", () => {
 
     expect(broadcastMock).toHaveBeenCalledTimes(2);
     expect(lastSnapshot().runs[0].agentState).toBe("waiting");
+    service.stop();
+  });
+
+  it("recomputes on a rename, which moves no agent state of its own", async () => {
+    // Nothing else in the fleet feed reports a rename, so if this event were
+    // not subscribed the overview would hold the old title for a full poll.
+    const client = makePtyClient([terminal({ title: "Document GSC access method" })]);
+    const service = new FleetSnapshotService(client as never);
+    service.start();
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    broadcastMock.mockClear();
+
+    client.setFleet([terminal({ title: "Add Website Valuation tool", titleMode: "user" })]);
+    eventEmitter.emit("terminal:title-changed", { id: "t1", timestamp: NOW });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+    expect(lastSnapshot().runs[0]?.title).toBe("Add Website Valuation tool");
     service.stop();
   });
 

--- a/electron/services/__tests__/FleetSnapshotService.test.ts
+++ b/electron/services/__tests__/FleetSnapshotService.test.ts
@@ -474,6 +474,52 @@ describe("FleetSnapshotService", () => {
     service.stop();
   });
 
+  it("re-broadcasts a rename rather than suppressing the run into its old title", async () => {
+    // The pty-host record is what carries a rename to this service (#11830).
+    // Suppression compares projected rows, so if it ignored the title fields a
+    // renamed run would keep broadcasting its launch title until some unrelated
+    // state moved.
+    const client = makePtyClient([terminal({ title: "Document GSC access method" })]);
+    const service = new FleetSnapshotService(client as never);
+
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+
+    client.setFleet([terminal({ title: "Add Website Valuation tool", titleMode: "user" })]);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(broadcastMock).toHaveBeenCalledTimes(2);
+    expect(lastSnapshot().runs[0]).toMatchObject({
+      title: "Add Website Valuation tool",
+      titleMode: "user",
+    });
+
+    service.stop();
+  });
+
+  it("carries a mode-only unlock, so clearing a rename is not mistaken for no change", async () => {
+    // An empty rename resets the title to the identity default and drops the
+    // lock. Title and mode move together (#10794): a projection that carried
+    // only the title would leave the row claiming a user lock it no longer has.
+    const client = makePtyClient([terminal({ title: "Claude", titleMode: "user" })]);
+    const service = new FleetSnapshotService(client as never);
+
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+
+    client.setFleet([terminal({ title: "Claude", titleMode: "default" })]);
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(broadcastMock).toHaveBeenCalledTimes(2);
+    expect(lastSnapshot().runs[0].titleMode).toBe("default");
+
+    service.stop();
+  });
+
   it("stays suppressed while a working agent floods output", async () => {
     // `lastOutputTime` is rewritten on every PTY data chunk, so a working agent
     // changes the host's terminal record many times a second. If the projection

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -282,6 +282,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "A run was parked or unparked (user intent, not agent state)",
   },
+  "terminal:title-changed": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "A panel was renamed and the authoritative record now agrees",
+  },
   "terminal:park-released": {
     category: "agent",
     requiresContext: false,
@@ -799,6 +805,17 @@ export type DaintreeEventMap = {
   };
 
   /**
+   * A rename reached the authoritative terminal record. The fleet projection
+   * subscribes because the row's title changed; nothing else about the run
+   * moved, so no other feed would report it and the 5s poll would otherwise
+   * own the latency of a hand rename (#11830).
+   */
+  "terminal:title-changed": {
+    id: string;
+    timestamp: number;
+  };
+
+  /**
    * Emitted whenever a run's snooze record is created, replaced or removed —
    * by the user, or automatically when they typed at the run. Both attention
    * projections subscribe: `ProjectStatsService` because a snooze changes the
@@ -994,6 +1011,7 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "terminal:restored",
   "terminal:park-changed",
   "terminal:park-released",
+  "terminal:title-changed",
   "terminal:snooze-changed",
   "agent-session:captured",
   "agent-session:recorded",

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -9,6 +9,7 @@ const { SerializeAddon } = serialize;
 import unicode11 from "@xterm/addon-unicode11";
 const { Unicode11Addon } = unicode11;
 import type { TerminalResizeResult } from "../../../shared/types/pty-host.js";
+import type { PanelTitleMode } from "../../../shared/types/panel.js";
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
 import { applyXtermReflowFastpath } from "../../../shared/utils/xtermReflowFastpath.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
@@ -1190,6 +1191,16 @@ export class TerminalProcess {
 
   setObservedTitle(title: string): void {
     this.terminalInfo.lastObservedTitle = title;
+  }
+
+  /**
+   * Mirror a renderer-side rename onto the authoritative record. `title` and
+   * `titleMode` move together: a title without its mode would still read as
+   * `"default"` and be overwritten by the next agent-detection sweep (#10794).
+   */
+  setTitle(title: string, titleMode: PanelTitleMode): void {
+    this.terminalInfo.title = title;
+    this.terminalInfo.titleMode = titleMode;
   }
 
   acknowledgeData(_byteCount: number): void {

--- a/electron/services/pty/__tests__/TerminalProcess.setTitle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.setTitle.test.ts
@@ -1,0 +1,47 @@
+/**
+ * `setTitle` is the only writer of a renamed title on the authoritative record.
+ * Its whole contract is that `title` and `titleMode` move together: a title
+ * landing without its mode still reads as `"default"`, and the next agent
+ * detection sweep overwrites the user's rename (#10794, #11830).
+ *
+ * Exercised through the prototype so the real mutator is under test without
+ * standing up a PTY — `setTitle` touches nothing but `terminalInfo`.
+ */
+import { describe, it, expect } from "vitest";
+import { TerminalProcess } from "../TerminalProcess.js";
+import type { PanelTitleMode } from "../../../../shared/types/panel.js";
+
+function applySetTitle(
+  info: { title?: string; titleMode?: PanelTitleMode; lastObservedTitle?: string },
+  title: string,
+  titleMode: PanelTitleMode
+) {
+  TerminalProcess.prototype.setTitle.call({ terminalInfo: info } as never, title, titleMode);
+  return info;
+}
+
+describe("TerminalProcess.setTitle", () => {
+  it("writes the mode in the same call as the title", () => {
+    const info = applySetTitle({ title: "claude", titleMode: "default" }, "Ship the fix", "user");
+
+    expect(info).toMatchObject({ title: "Ship the fix", titleMode: "user" });
+  });
+
+  it("lowers the mode as readily as it raises it, so an unlock is not one-way", () => {
+    const locked = applySetTitle({ title: "Mine", titleMode: "user" }, "Claude", "default");
+
+    // An empty rename resets the panel to its identity default and drops the
+    // lock; a mutator that only ever escalated would strand the terminal.
+    expect(locked.titleMode).toBe("default");
+  });
+
+  it("leaves the observed OSC title alone — it is a separate ingredient", () => {
+    const info = applySetTitle(
+      { title: "old", titleMode: "default", lastObservedTitle: "agent task" },
+      "Renamed",
+      "user"
+    );
+
+    expect(info.lastObservedTitle).toBe("agent task");
+  });
+});

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -2,7 +2,7 @@ import type { PushProgressEvent } from "./gitPush.js";
 import type { IdArrayFieldEdit } from "../../utils/layoutMerge.js";
 import type { GitStatus, StagingStatus } from "../git.js";
 import type { AgentId } from "../agent.js";
-import type { TabGroup } from "../panel.js";
+import type { TabGroup, PanelTitleMode } from "../panel.js";
 import type { WorktreeState } from "../worktree.js";
 import type {
   Project,
@@ -344,6 +344,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onBroadcastWriteResult(callback: (data: BroadcastWriteResultPayload) => void): () => void;
     reportTitleState(id: string, state: "working" | "waiting"): void;
     updateObservedTitle(id: string, title: string): void;
+    updateTitle(id: string, title: string, titleMode: PanelTitleMode): void;
     onSpawnResult(callback: (id: string, result: SpawnResult) => void): () => void;
     onReduceScrollback(
       callback: (data: { terminalIds: string[]; targetLines: number }) => void

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -221,7 +221,13 @@ export interface TerminalRuntimeIdentity {
  *
  * Absent defaults to `"default"` for hydration compatibility.
  */
-export type PanelTitleMode = "default" | "custom" | "user";
+export const PANEL_TITLE_MODES = ["default", "custom", "user"] as const;
+
+export type PanelTitleMode = (typeof PANEL_TITLE_MODES)[number];
+
+export function isPanelTitleMode(value: unknown): value is PanelTitleMode {
+  return PANEL_TITLE_MODES.includes(value as PanelTitleMode);
+}
 
 /** Structured error state for terminal restart failures */
 export interface TerminalRestartError {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -272,6 +272,7 @@ export type PtyHostRequest =
   | { type: "get-all-snapshots"; requestId: string }
   | { type: "mark-checked"; id: string }
   | { type: "update-observed-title"; id: string; title: string }
+  | { type: "update-title"; id: string; title: string; titleMode: PanelTitleMode }
   | {
       type: "transition-state";
       id: string;

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -17,6 +17,7 @@ import type {
   TerminalReliabilityMetricPayload,
   TerminalResizeResult,
 } from "@shared/types/pty-host";
+import type { PanelTitleMode } from "@shared/types/panel";
 import { normalizeTerminalGridDimension } from "@shared/types/terminal";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { logDebug, logWarn } from "@/utils/logger";
@@ -368,6 +369,16 @@ export const terminalClient = {
    */
   sendKey: (id: string, key: string): void => {
     window.electron.terminal.sendKey(id, key);
+  },
+
+  /**
+   * Mirror a panel rename onto the pty-host's terminal record. The renderer
+   * store is the display source, but the fleet overview, session journal and
+   * shutdown records all read the pty-host copy — without this they keep
+   * naming the run by its launch title (#11830).
+   */
+  updateTitle: (id: string, title: string, titleMode: PanelTitleMode): void => {
+    window.electron.terminal.updateTitle(id, title, titleMode);
   },
 
   /**

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     onData: vi.fn(),
     onExit: vi.fn(),
     onAgentStateChanged: vi.fn(),
+    updateTitle: vi.fn(),
     gracefulKill: mockGracefulKill,
     submit: vi.fn().mockResolvedValue(undefined),
     acknowledgeData: vi.fn(),
@@ -1122,5 +1123,81 @@ describe("restartTerminal input lock + parallel IPC (#9164)", () => {
     await restartPromise;
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * A restart captures the panel, then awaits settings, presets and a kill before
+ * it respawns. Renaming stays enabled throughout, and the kill drops the cached
+ * spawn options, so the respawn payload is the only thing that can carry a
+ * rename made in that window (#11830).
+ */
+describe("restartTerminal carries a rename that lands mid-restart", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    getMergedPresetMock.mockReturnValue(undefined);
+    buildAgentLaunchFlagsMock.mockReturnValue([]);
+    const { agentSettingsClient, projectClient } = await import("@/clients");
+    // Restored explicitly: `clearAllMocks` drops recorded calls but keeps an
+    // implementation, so a rename hook set by one case would otherwise fire in
+    // the next and quietly make the control case assert the wrong thing.
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockReset();
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (projectClient.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { reset } = usePanelStore.getState();
+    await reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  /** Rename at an await point the restart passes after capturing the panel. */
+  async function renameDuringRestart(title: string, source?: "user" | "automation") {
+    const { agentSettingsClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      usePanelStore.getState().updateTitle("test-1", title, source);
+      return {};
+    });
+  }
+
+  it("respawns under the new name, not the one captured before the awaits", async () => {
+    const active = { ...agentPanelBase, agentState: "working" as const };
+    usePanelStore.setState({ panelsById: { [active.id]: active }, panelIds: [active.id] });
+    await renameDuringRestart("Renamed mid-restart");
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.title).toBe("Renamed mid-restart");
+    expect(payload.titleMode).toBe("user");
+  });
+
+  it("keeps the captured title when nothing renamed the panel", async () => {
+    const active = { ...agentPanelBase, agentState: "working" as const };
+    usePanelStore.setState({ panelsById: { [active.id]: active }, panelIds: [active.id] });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.title).toBe(agentPanelBase.title);
+  });
+
+  it("carries the automation rung across the restart too", async () => {
+    const active = { ...agentPanelBase, agentState: "working" as const };
+    usePanelStore.setState({ panelsById: { [active.id]: active }, panelIds: [active.id] });
+    await renameDuringRestart("Renamed by MCP", "automation");
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.title).toBe("Renamed by MCP");
+    expect(payload.titleMode).toBe("custom");
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/updateTitleOwnership.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateTitleOwnership.test.ts
@@ -61,6 +61,11 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   },
 }));
 
+vi.mock("@/utils/logger", async () => {
+  const actual = await vi.importActual<typeof import("@/utils/logger")>("@/utils/logger");
+  return { ...actual, logWarn: vi.fn(), logError: vi.fn() };
+});
+
 vi.mock("../persistence", async () => {
   const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
   return {
@@ -192,19 +197,23 @@ describe("updateTitle pty-host sync", () => {
     vi.mocked(terminalClient.updateTitle).mockClear();
   });
 
-  it("sends the committed title and its mode together", async () => {
-    usePanelStore.getState().updateTitle("t1", "Add valuation tool");
+  it("sends the committed title and its mode together, once", async () => {
+    // Padded input: what rides the wire is the committed value, not the raw
+    // argument, so this cannot pass by echoing the input back.
+    usePanelStore.getState().updateTitle("t1", "  Add valuation tool  ");
 
     const panel = getPtyPanel("t1");
-    expect(await client()).toHaveBeenCalledWith("t1", panel?.title, panel?.titleMode);
+    expect(await client()).toHaveBeenCalledExactlyOnceWith("t1", panel?.title, panel?.titleMode);
+    expect(panel?.title).toBe("Add valuation tool");
   });
 
   it("sends the automation rung's own mode, not the user rung's", async () => {
     usePanelStore.getState().updateTitle("t1", "Auth worker", "automation");
 
     const mode = getPtyPanel("t1")?.titleMode;
-    expect(mode).not.toBe("user");
-    expect(await client()).toHaveBeenCalledWith("t1", "Auth worker", mode);
+    // The rung actually moved — "default" would mean the ladder never ran.
+    expect(mode).toBe("custom");
+    expect(await client()).toHaveBeenCalledExactlyOnceWith("t1", "Auth worker", mode);
   });
 
   it("sends the unlock when an empty rename resets to the default", async () => {
@@ -214,31 +223,71 @@ describe("updateTitle pty-host sync", () => {
     usePanelStore.getState().updateTitle("t1", "", "user");
 
     const panel = getPtyPanel("t1");
-    expect(await client()).toHaveBeenCalledWith("t1", panel?.title, "default");
+    expect(panel?.title).not.toBe("");
+    expect(await client()).toHaveBeenCalledExactlyOnceWith("t1", panel?.title, "default");
+  });
+
+  it("sends again when only the mode moves and the title stands still", async () => {
+    usePanelStore.getState().updateTitle("t1", "Deploy runner", "automation");
+    (await client()).mockClear();
+
+    usePanelStore.getState().updateTitle("t1", "Deploy runner", "user");
+
+    // Same string, higher rung: the lock is the whole point of the message, so
+    // a title-only change check would wrongly swallow this.
+    expect(getPtyPanel("t1")?.titleMode).toBe("user");
+    expect(await client()).toHaveBeenCalledExactlyOnceWith("t1", "Deploy runner", "user");
   });
 
   it("sends nothing when the rename bounces off a user lock", async () => {
     usePanelStore.getState().updateTitle("t1", "Mine", "user");
+    const locked = getPtyPanel("t1");
+    expect(locked?.titleMode).toBe("user");
     (await client()).mockClear();
 
     usePanelStore.getState().updateTitle("t1", "Overwritten by MCP", "automation");
 
+    // The panel object is untouched, which is what the sync guard keys off.
+    expect(getPtyPanel("t1")).toBe(locked);
     expect(await client()).not.toHaveBeenCalled();
   });
 
   it("sends nothing when the rename changes neither title nor mode", async () => {
     usePanelStore.getState().updateTitle("t1", "Mine", "user");
+    const committed = getPtyPanel("t1");
+    expect(committed).toBeDefined();
     (await client()).mockClear();
 
     usePanelStore.getState().updateTitle("t1", "Mine", "user");
 
+    expect(getPtyPanel("t1")).toBe(committed);
     expect(await client()).not.toHaveBeenCalled();
   });
 
-  it("sends nothing for an unknown panel", async () => {
+  it("treats an unknown panel as a clean no-op, not a swallowed throw", async () => {
+    const { logWarn } = await import("@/utils/logger");
+    vi.mocked(logWarn).mockClear();
+
     usePanelStore.getState().updateTitle("nope", "Ghost");
 
     expect(await client()).not.toHaveBeenCalled();
+    // Without the missing-panel guard this path throws into the catch below,
+    // which would leave the mock uncalled for entirely the wrong reason.
+    expect(vi.mocked(logWarn)).not.toHaveBeenCalled();
+  });
+
+  it("keeps the local rename when the bridge call throws", async () => {
+    const { logWarn } = await import("@/utils/logger");
+    vi.mocked(logWarn).mockClear();
+    (await client()).mockImplementationOnce(() => {
+      throw new Error("no bridge");
+    });
+
+    usePanelStore.getState().updateTitle("t1", "Offline rename");
+
+    expect(getPtyPanel("t1")?.title).toBe("Offline rename");
+    expect(getPtyPanel("t1")?.titleMode).toBe("user");
+    expect(vi.mocked(logWarn)).toHaveBeenCalledTimes(1);
   });
 
   it("sends nothing for a panel with no pty behind it", async () => {

--- a/src/store/slices/panelRegistry/__tests__/updateTitleOwnership.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateTitleOwnership.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -21,6 +21,7 @@ vi.mock("@/clients", () => ({
     onData: vi.fn(),
     onExit: vi.fn(),
     onAgentStateChanged: vi.fn(),
+    updateTitle: vi.fn(),
   },
   appClient: {
     setState: vi.fn().mockResolvedValue(undefined),
@@ -105,6 +106,9 @@ describe("updateTitle ownership ladder", () => {
       cwd: "/",
       bypassLimits: true,
     });
+
+    // Cleared after the spawn so each test counts only its own renames.
+    vi.mocked(terminalClient.updateTitle).mockClear();
   });
 
   it("defaults to the user rung and locks the title", () => {
@@ -151,5 +155,104 @@ describe("updateTitle ownership ladder", () => {
     const panel = getPtyPanel("t1");
     expect(panel?.title).toBe("Mine");
     expect(panel?.titleMode).toBe("user");
+  });
+});
+
+/**
+ * The renderer store drives the panel header, but the fleet overview, session
+ * journal and shutdown records read the pty-host's own terminal record. Without
+ * this sync that record keeps its launch title and every `titleMode === "user"`
+ * branch in main is unreachable for a hand rename (#11830).
+ */
+describe("updateTitle pty-host sync", () => {
+  async function client() {
+    const { terminalClient } = await import("@/clients");
+    return vi.mocked(terminalClient.updateTitle);
+  }
+
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+
+    const { terminalClient } = await import("@/clients");
+    vi.mocked(terminalClient.spawn).mockReset();
+    vi.mocked(terminalClient.spawn).mockImplementation(
+      async ({ id }: { id?: string }) => id ?? "spawn-id"
+    );
+
+    await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "t1",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    vi.mocked(terminalClient.updateTitle).mockClear();
+  });
+
+  it("sends the committed title and its mode together", async () => {
+    usePanelStore.getState().updateTitle("t1", "Add valuation tool");
+
+    const panel = getPtyPanel("t1");
+    expect(await client()).toHaveBeenCalledWith("t1", panel?.title, panel?.titleMode);
+  });
+
+  it("sends the automation rung's own mode, not the user rung's", async () => {
+    usePanelStore.getState().updateTitle("t1", "Auth worker", "automation");
+
+    const mode = getPtyPanel("t1")?.titleMode;
+    expect(mode).not.toBe("user");
+    expect(await client()).toHaveBeenCalledWith("t1", "Auth worker", mode);
+  });
+
+  it("sends the unlock when an empty rename resets to the default", async () => {
+    usePanelStore.getState().updateTitle("t1", "Mine", "user");
+    (await client()).mockClear();
+
+    usePanelStore.getState().updateTitle("t1", "", "user");
+
+    const panel = getPtyPanel("t1");
+    expect(await client()).toHaveBeenCalledWith("t1", panel?.title, "default");
+  });
+
+  it("sends nothing when the rename bounces off a user lock", async () => {
+    usePanelStore.getState().updateTitle("t1", "Mine", "user");
+    (await client()).mockClear();
+
+    usePanelStore.getState().updateTitle("t1", "Overwritten by MCP", "automation");
+
+    expect(await client()).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when the rename changes neither title nor mode", async () => {
+    usePanelStore.getState().updateTitle("t1", "Mine", "user");
+    (await client()).mockClear();
+
+    usePanelStore.getState().updateTitle("t1", "Mine", "user");
+
+    expect(await client()).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing for an unknown panel", async () => {
+    usePanelStore.getState().updateTitle("nope", "Ghost");
+
+    expect(await client()).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing for a panel with no pty behind it", async () => {
+    usePanelStore.setState({
+      panelsById: {
+        b1: { id: "b1", kind: "browser", title: "Docs", location: "grid" } as PanelInstance,
+      },
+      panelIds: ["b1"],
+    });
+    (await client()).mockClear();
+
+    usePanelStore.getState().updateTitle("b1", "Renamed tab");
+
+    expect(usePanelStore.getState().panelsById.b1?.title).toBe("Renamed tab");
+    expect(await client()).not.toHaveBeenCalled();
   });
 });

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -957,8 +957,12 @@ export const createAddPanelActions = (
             command: commandToExecute,
             kind,
             launchAgentId,
-            title,
-            titleMode: options.titleMode,
+            // Read off the live panel, not the values captured before the
+            // queue wait: a rename landing while the spawn was queued reaches
+            // a pty-host that has no record yet and is dropped, so the spawn
+            // itself has to carry it or it is lost (#11830).
+            title: _p1.title,
+            titleMode: _p1.titleMode,
             env: mergedEnv,
             restore: options.restore,
             spawnBatchId: options.spawnBatchId,

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -277,6 +277,8 @@ export const createCorePanelActions = (
   },
 
   updateTitle: (id, newTitle, source = "user") => {
+    const before = get().panelsById[id];
+
     set((state) => {
       const terminal = state.panelsById[id];
       if (!terminal) return state;
@@ -303,6 +305,21 @@ export const createCorePanelActions = (
       saveNormalized(newById, state.panelIds);
       return { panelsById: newById };
     });
+
+    // Mirror the rename onto the pty-host record. The renderer store drives the
+    // panel header, but the fleet overview, session journal and shutdown records
+    // read the pty-host copy — leave it stale and every `titleMode === "user"`
+    // branch in main stays unreachable for a hand rename (#11830). Sent from
+    // outside the updater so the reducer stays free of side effects, and only
+    // on a real write: the identity check skips every early-return above, so a
+    // bounced or no-op rename costs no IPC and no fleet recompute.
+    const after = get().panelsById[id];
+    if (!after || after === before || !panelKindHasPty(after.kind)) return;
+    try {
+      terminalClient.updateTitle(id, after.title, after.titleMode ?? "default");
+    } catch (error) {
+      logWarn("[PanelRegistry] Failed to sync renamed title to the pty host", { error });
+    }
   },
 
   updateLastObservedTitle: (id, title) => {

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -29,7 +29,7 @@ import { getAgentConfig } from "@/config/agents";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance, type PanelTitleMode } from "@shared/types/panel";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 import { computeEnvProvenance } from "@shared/utils/agentLifecycleLedger";
 import { markTerminalRestarting, unmarkTerminalRestarting } from "@/store/restartExitSuppression";
@@ -66,6 +66,23 @@ type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
 
 const INJECTION_TIMEOUT_MS = 30_000;
+
+/**
+ * The panel's title as of the spawn call rather than as of the capture several
+ * awaits earlier. Renaming stays enabled while a terminal restarts, so a rename
+ * landing mid-restart would otherwise be overwritten by the respawn, and the
+ * pty-host cache rewrite cannot save it — the kill already dropped that entry
+ * (#11830). Falls back to the captured panel if this one has since gone.
+ */
+function titleAtSpawn(
+  get: Get,
+  id: string,
+  captured: { title: string; titleMode?: PanelTitleMode }
+): { title: string; titleMode?: PanelTitleMode } {
+  const panel = get().panelsById[id];
+  const source = panel && isPtyPanel(panel) ? panel : captured;
+  return { title: source.title, titleMode: source.titleMode };
+}
 
 interface LoadedAgentRuntimeSettings {
   entry: AgentSettingsEntry;
@@ -811,10 +828,9 @@ export const createRestartActions = (
         // IPC handler does not treat them as agent spawns (issue #5764).
         kind: "terminal",
         launchAgentId: isAgent ? currentTerminal.launchAgentId : undefined,
-        title: currentTerminal.title,
         // Keep the ownership rung across restart so the backend's own
         // default-title rewrites stay gated for pinned/user titles.
-        titleMode: currentTerminal.titleMode,
+        ...titleAtSpawn(get, id, currentTerminal),
         command: isAgent ? spawnCommand : undefined,
         restore: false,
         env: restartEnv,
@@ -1341,11 +1357,10 @@ export const createRestartActions = (
         rows: spawnRows,
         kind: "terminal",
         launchAgentId: terminal.launchAgentId,
-        title: terminal.title,
         // Carried with the title, never without it: a title that arrives
         // unaccompanied re-stamps as "default" and the next detection sweep
         // overwrites the user's rename (#10794).
-        titleMode: terminal.titleMode,
+        ...titleAtSpawn(get, id, terminal),
         command: commandToRun,
         restore: false,
         env: restartEnv,

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -1342,6 +1342,10 @@ export const createRestartActions = (
         kind: "terminal",
         launchAgentId: terminal.launchAgentId,
         title: terminal.title,
+        // Carried with the title, never without it: a title that arrives
+        // unaccompanied re-stamps as "default" and the next detection sweep
+        // overwrites the user's rename (#10794).
+        titleMode: terminal.titleMode,
         command: commandToRun,
         restore: false,
         env: restartEnv,


### PR DESCRIPTION
## Summary

- The fleet overview (`Alt+Cmd+O`) kept showing an agent's self-reported terminal title for a run even after the user renamed that panel by hand, while the panel header showed the rename correctly. Two screens, same run, two different names.
- The composition logic was never the problem: `composeTitledPanel` already yields to a `"user"` title lock as soon as it sees one. The inputs feeding it were stale, because nothing carried a renderer rename back to the authoritative terminal record.
- This PR wires that record up properly, closes four respawn paths that would have quietly resurrected the old title, and adds a fleet event so the overview doesn't lag a rename by a full poll cycle.

Resolves #11830

## The bug

The terminal record that everything downstream treats as authoritative lives in the pty-host utility subprocess. It's stamped once at spawn and never touched again. A manual rename only ever updated the renderer's view of the panel, so every `titleMode === "user"` branch in main was unreachable after a hand rename. That's why the session journal, shutdown records, and run history all kept naming a renamed run by its old title too, not just the fleet overview.

## The fix

A new fire-and-forget `terminal:update-title` channel, modeled on the existing `terminal:update-observed-title` chain: renderer `terminalClient` → preload → `ipcMain.on` handler → `PtyClient.shardForTerminal().send()` → pty-host dispatcher → `PtyManager` → a new `TerminalProcess.setTitle`.

It fires from `updateTitle` in the panel registry, which is the single choke point behind the header rename, both tab strips, and the `terminal.rename` action, and only on an actual write to a pty-backed panel. `title` and `titleMode` are written together everywhere in this path. A title that arrives without its mode reads back as `"default"`, and the next agent-detection sweep overwrites it (#10794 territory).

## Respawn paths closed

Four places would have respawned a terminal under its old title even with the record fixed:

1. `PtyClient` caches spawn options and replays them verbatim after a pty-host crash. `updateTitle` now rewrites that cache too.
2. The fallback-preset restart path passed `title` without `titleMode`.
3. `addPanel` spawned using values captured before the await on the startup queue, so a rename made while a panel was queued got clobbered on admission.
4. Both restart paths capture the panel several awaits before the respawn while renaming is still enabled in the UI, and killing the terminal drops the cache that could have carried the new title through. Closed alongside the others.

## Fleet overview timeliness

`FleetSnapshotService` polls on a 5 second aligned interval, and nothing previously reported a rename, so the overview could lag a hand rename by up to a full cycle. Added a typed `terminal:title-changed` event that `FleetSnapshotService` subscribes to.

This is deliberately an event rather than a direct service call. Importing the stats module straight into the terminal IPC handler drags `ProjectStore` into that module's graph and breaks `io.projectIsolation`.

## Not changed, verified instead

`FleetSnapshotService`'s projection and `runsEqual` already carry and diff all three title fields, and `snapshots.ts` / `pty-host/handlers/terminalInfo.ts` already forward `title` and `titleMode` correctly. Project-view reconnect and restart were already correct once the underlying record was fixed, so none of that needed touching.

## Testing

719 tests pass across 46 targeted files. New coverage: the pty-host sync guards (fires on a real write, silent on a bounced/no-op/non-pty rename, carries the unlock forward, survives a throwing bridge), `TerminalProcess.setTitle` atomicity, rename-during-restart on both the user and automation rungs, and fleet re-broadcast on a title-only and a mode-only change.

`npm run typecheck`, `lint:ratchet` (held at 1091), `check:ipc-handwritten` (held at 237, a fire-and-forget send channel isn't an `IpcInvokeMap` entry), `check:channels`, and `format:check` all pass.

## Known, out of scope

- `TerminalRegistryController.spawn` passes `title` without `titleMode`, but it has no callers, so it's dead code.
- `ALL_EVENT_TYPES` has no exhaustiveness check against `EVENT_META`. Pre-existing gap; the new event is correctly registered in all three places regardless.
