### PR TITLE
feat(switcher): split liveness from demand in the project switcher

### DIFF
--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -468,6 +468,7 @@ export function ModalHostLayer({
               onSelect={projectSwitcherPalette.selectRow}
               onHoverProject={projectSwitcherPalette.onHoverProject}
               onHoverProjectEnd={projectSwitcherPalette.onHoverProjectEnd}
+              fleetLiveness={projectSwitcherPalette.fleetLiveness}
               onClose={projectSwitcherPalette.close}
               onStopProject={(projectId) => void projectSwitcherPalette.stopProject(projectId)}
               onCloseProject={(projectId) => void projectSwitcherPalette.removeProject(projectId)}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -2064,6 +2064,7 @@ export function Toolbar({
                     onSelect={projectSwitcher.selectRow}
                     onHoverProject={projectSwitcher.onHoverProject}
                     onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
+                    fleetLiveness={projectSwitcher.fleetLiveness}
                     onClose={handlePillDropdownClose}
                     onDropdownCloseAutoFocus={suppressPillTooltipForFocusRestore}
                     onAddProject={projectSwitcher.addProject}

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -413,8 +413,14 @@ export function ProjectSwitcher() {
                   className="absolute top-0.5 right-0.5 flex h-3 w-3 items-center justify-center"
                 >
                   {badgeStatus.isLive ? (
+                    // Sized inline rather than by class. `Button` sizes every
+                    // SVG under it with a descendant rule (`[&_svg]:size-4`),
+                    // which outranks a utility class on the glyph itself — so a
+                    // classed 10px arc would silently render at 16px and spill
+                    // out of the badge's box.
                     <SpinnerCircle
-                      className={cn("h-2.5 w-2.5", badgeStatus.arc)}
+                      className={badgeStatus.arc}
+                      style={{ width: "0.625rem", height: "0.625rem" }}
                       data-testid="project-switcher-badge-arc"
                     />
                   ) : (

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { ChevronsUpDown, FileText, Plus } from "lucide-react";
+import { SpinnerCircle } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { useProjectStore } from "@/store/projectStore";
@@ -144,29 +145,44 @@ export function ProjectSwitcher() {
 
   // Reads the totals across every non-active project rather than `results`,
   // which is ordered and filtered for presentation.
+  //
+  // Two axes on one mark, the same split the switcher's rows draw (#11832):
+  // hue says what is being asked of the user, shape says whether anything is
+  // still moving. Before that they contended for one carrier, so a fleet that
+  // was both waiting AND churning looked exactly like one that had stalled.
   const badgeStatus = useMemo(() => {
     const { activeAgentCount, waitingAgentCount, waitingProjectCount } =
       projectSwitcher.nonActiveAgentCounts;
 
+    if (waitingAgentCount === 0 && activeAgentCount === 0) return null;
+
+    const parts: string[] = [];
     // Waiting counts PROJECTS, not agents: the number answers "how many places
     // need me?", which stays legible when eight agents pile up in one repo. An
     // agent tally there would read as eight separate obligations.
     if (waitingAgentCount > 0) {
-      return {
-        color: "bg-state-waiting",
-        pulse: false,
-        label: `${waitingProjectCount} project${waitingProjectCount === 1 ? "" : "s"} waiting for input`,
-      };
+      parts.push(
+        `${waitingProjectCount} project${waitingProjectCount === 1 ? "" : "s"} waiting for input`
+      );
     }
     // Work in progress isn't an obligation, so it stays an agent count.
     if (activeAgentCount > 0) {
-      return {
-        color: "bg-activity-active",
-        pulse: true,
-        label: `${activeAgentCount} background agent${activeAgentCount === 1 ? "" : "s"} working`,
-      };
+      parts.push(
+        `${activeAgentCount} background agent${activeAgentCount === 1 ? "" : "s"} working`
+      );
     }
-    return null;
+
+    return {
+      // Demand still wins the hue outright — the badge's colour has always
+      // meant "this needs you", and liveness rides the shape instead of
+      // competing for it.
+      color: waitingAgentCount > 0 ? "bg-state-waiting" : "bg-activity-active",
+      arc: waitingAgentCount > 0 ? "text-state-waiting" : "text-activity-active",
+      isLive: activeAgentCount > 0,
+      // Both facts, always. The mark is a single glyph and the label is the
+      // only place a reader who cannot see it learns either one.
+      label: parts.join(", "),
+    };
   }, [projectSwitcher.nonActiveAgentCounts]);
 
   const stopDialog = (
@@ -224,6 +240,7 @@ export function ProjectSwitcher() {
             onSelectNewWindow={handleSelectNewWindow}
             onHoverProject={projectSwitcher.onHoverProject}
             onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
+            fleetLiveness={projectSwitcher.fleetLiveness}
             removeConfirmProject={projectSwitcher.removeConfirmProject}
             onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
             onConfirmRemove={projectSwitcher.confirmRemoveProject}
@@ -311,6 +328,7 @@ export function ProjectSwitcher() {
         onCopyPath={projectSwitcher.copyPath}
         onHoverProject={projectSwitcher.onHoverProject}
         onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
+        fleetLiveness={projectSwitcher.fleetLiveness}
         removeConfirmProject={projectSwitcher.removeConfirmProject}
         onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
         onConfirmRemove={projectSwitcher.confirmRemoveProject}
@@ -386,15 +404,28 @@ export function ProjectSwitcher() {
                 <ChevronsUpDown className="shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
               )}
               {badgeStatus && (
+                // A fixed box either mark centres in, so switching between them
+                // moves nothing around it. The 10px arc lands on the same
+                // footprint the 8px dot and its ring already occupied.
                 <span
                   role="status"
                   aria-label={badgeStatus.label}
-                  className={cn(
-                    "absolute top-1 right-1 h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
-                    badgeStatus.color,
-                    badgeStatus.pulse && "animate-activity-pulse"
+                  className="absolute top-0.5 right-0.5 flex h-3 w-3 items-center justify-center"
+                >
+                  {badgeStatus.isLive ? (
+                    <SpinnerCircle
+                      className={cn("h-2.5 w-2.5", badgeStatus.arc)}
+                      data-testid="project-switcher-badge-arc"
+                    />
+                  ) : (
+                    <span
+                      className={cn(
+                        "h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
+                        badgeStatus.color
+                      )}
+                    />
                   )}
-                />
+                </span>
               )}
             </Button>
           </TooltipTrigger>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -43,12 +43,13 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ArrowDownAZ, ChartNoAxesColumn, Clock } from "@/components/icons";
+import { ArrowDownAZ, ChartNoAxesColumn, Clock, SpinnerCircle } from "@/components/icons";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
+  formatFleetLiveness,
   getProjectRowStatus,
   getScratchRowStatus,
-  ROW_DOT_CLASS,
+  ROW_MARK_CLASS,
   ROW_TONE_CLASS,
   type ProjectRowStatus,
 } from "@/lib/projectRowStatus";
@@ -124,6 +125,16 @@ export interface ProjectSwitcherPaletteProps {
   /** Pointer-leave callback used to cancel a pending hover prefetch. */
   onHoverProjectEnd?: (pointerType: string) => void;
   onOpenProjectSettings?: () => void;
+  /**
+   * What is executing across every workspace, for the header's one-line answer
+   * to "is it safe to look away?" (#11832).
+   *
+   * Deliberately not derived from `results`, which is filtered and reordered for
+   * presentation — a search for one project would otherwise report the fleet as
+   * quiet. Optional because it is a summary: a caller without the totals shows
+   * no line, which is the same thing an idle fleet shows.
+   */
+  fleetLiveness?: { runningAgentCount: number; workingAssistantCount: number };
   dropdownAlign?: "start" | "center" | "end";
   /**
    * Fired when the dropdown's Popover restores focus to its trigger on close.
@@ -219,14 +230,21 @@ interface ProjectListItemProps {
 }
 
 /**
- * The dot repeats the status line's tone rather than encoding anything on its
- * own — status must never be colour-only, and the sentence beside it already
- * carries the meaning for anyone who can't separate these hues.
+ * The mark takes its hue from the status line's tone and its shape from whether
+ * the row is still executing (#11832) — two independent facts on one glyph.
+ * Neither is ever the only carrier: status must not be colour-only, and the
+ * sentence beside it says both in words.
  *
- * A row with nothing to report draws no dot, only the slot that reserves its
+ * A row with nothing to report draws no mark, only the slot that reserves its
  * width (#11692). The slot is what keeps the tiles and names in one column: an
- * omitted dot would pull every quiet row 14px left of the busy ones, and a list
- * that is mostly quiet would read as the ragged edge rather than the tidy one.
+ * omitted mark would pull every quiet row left of the busy ones, and a list that
+ * is mostly quiet would read as the ragged edge rather than the tidy one.
+ *
+ * The slot is sized for the arc rather than the dot. At the old 6px the arc's
+ * gap was about a pixel and a half of stroke, which anti-aliasing turns into a
+ * smudge — the shape has to be legible at 1x or it isn't a carrier at all. The
+ * closed marks keep their 6px so a quiet list is no louder than before; the slot
+ * centres whichever one draws, so the column stays put either way.
  */
 function StatusDot({
   status,
@@ -235,10 +253,11 @@ function StatusDot({
   status: ProjectRowStatus;
   showResumeDot?: boolean;
 }) {
-  // One slot, one decision. Written as a single choice rather than two
-  // conditions so the slot cannot hold two dots at once: the resume mark only
+  // One slot, one decision. Written as a single choice rather than separate
+  // conditions so the slot cannot hold two marks at once: the resume mark only
   // reaches here on a status that already agreed to yield, and an auto-parked
-  // row is the case where both would otherwise have drawn (#11822).
+  // row is the case where both would otherwise have drawn (#11822). Liveness
+  // never contends for the slot — every status that yields has stopped.
   const dot = showResumeDot ? (
     // Hidden from assistive tech, which hears the row's own "N agents will
     // resume" phrase instead — a live region per row would re-announce the
@@ -248,16 +267,70 @@ function StatusDot({
       data-testid="workspace-resume-dot"
       aria-hidden="true"
     />
-  ) : status.isDormantFallback ? null : (
+  ) : status.isDormantFallback ? null : status.isLive ? (
+    // Static: the open gap is the fact, and it survives reduced motion, a
+    // paused frame and a screenshot. Twenty rows spinning would also turn the
+    // list into a field of movement, which is the opposite of scannable.
+    <SpinnerCircle
+      className={cn("w-2.5 h-2.5", ROW_MARK_CLASS[status.tone].arc)}
+      data-testid="workspace-status-dot"
+    />
+  ) : (
     <div
-      className={cn("w-1.5 h-1.5 rounded-full", ROW_DOT_CLASS[status.tone])}
+      className={cn("w-1.5 h-1.5 rounded-full", ROW_MARK_CLASS[status.tone].dot)}
       data-testid="workspace-status-dot"
     />
   );
 
   return (
-    <div className="w-1.5 shrink-0" data-testid="workspace-status-slot">
+    <div
+      className="flex w-2.5 h-2.5 shrink-0 items-center justify-center"
+      data-testid="workspace-status-slot"
+    >
       {dot}
+    </div>
+  );
+}
+
+/**
+ * A row's second line: what it wants, then what is still moving, then which
+ * project it is.
+ *
+ * Shared by all three row renderers so the clause cannot appear on one kind of
+ * workspace and not another — the two scratch paths drew a single toned element
+ * before this, which left them structurally unable to carry a second fragment.
+ *
+ * Exactly one token is coloured. The demand tone is the row's loudest statement
+ * and stays that way; the running clause is muted because it reports something
+ * that needs nothing from the user, and a second hue here would make every busy
+ * row argue with itself. Both are ordinary text, so a reader hears the whole
+ * line whether or not they can resolve the mark's shape.
+ */
+function RowStatusLine({ status }: { status: ProjectRowStatus }) {
+  if (status.isDormantFallback && !status.pathHint) return null;
+
+  return (
+    <div className="flex items-center gap-1 min-w-0 mt-0.5">
+      {!status.isDormantFallback && (
+        <span className={cn("truncate text-[11px] leading-none", ROW_TONE_CLASS[status.tone])}>
+          {status.text}
+        </span>
+      )}
+      {/*
+       * `shrink-0` where the path hint takes `shrink`: the hint answers which
+       * project this is, which the name above already mostly does, while this
+       * is the only place the hidden run is stated at all.
+       */}
+      {status.livenessDetail && (
+        <span className="text-[11px] leading-none text-daintree-text/50 shrink-0">
+          · {status.livenessDetail}
+        </span>
+      )}
+      {status.pathHint && (
+        <span className="truncate text-[11px] leading-none text-daintree-text/50 shrink">
+          {status.isDormantFallback ? status.pathHint : `· ${status.pathHint}`}
+        </span>
+      )}
     </div>
   );
 }
@@ -482,22 +555,7 @@ function ProjectListItem({
          * same folder name, so it belongs to identity rather than status and
          * survives on its own.
          */}
-        {(!status.isDormantFallback || status.pathHint) && (
-          <div className="flex items-center gap-1 min-w-0 mt-0.5">
-            {!status.isDormantFallback && (
-              <span
-                className={cn("truncate text-[11px] leading-none", ROW_TONE_CLASS[status.tone])}
-              >
-                {status.text}
-              </span>
-            )}
-            {status.pathHint && (
-              <span className="truncate text-[11px] leading-none text-daintree-text/50 shrink">
-                {status.isDormantFallback ? status.pathHint : `· ${status.pathHint}`}
-              </span>
-            )}
-          </div>
-        )}
+        <RowStatusLine status={status} />
       </div>
     </div>
   );
@@ -659,13 +717,7 @@ function ScratchListItem({
           {scratch.isActive && <span className="sr-only">, current</span>}
           {showResumeDot && <ResumableAgentsLabel count={scratch.resumableAgentCount ?? 0} />}
         </div>
-        {!status.isDormantFallback && (
-          <div
-            className={cn("truncate text-[11px] leading-none mt-0.5", ROW_TONE_CLASS[status.tone])}
-          >
-            {status.text}
-          </div>
-        )}
+        <RowStatusLine status={status} />
       </div>
     </div>
   );
@@ -1319,16 +1371,7 @@ function ScratchSection({
                            * be deleted is exactly the row that has something to
                            * report even when nothing is running.
                            */}
-                          {!status.isDormantFallback && (
-                            <div
-                              className={cn(
-                                "text-[11px] leading-none truncate mt-0.5",
-                                ROW_TONE_CLASS[status.tone]
-                              )}
-                            >
-                              {status.text}
-                            </div>
-                          )}
+                          <RowStatusLine status={status} />
                           {countdown && (
                             <div
                               className="text-[11px] leading-none text-daintree-text/40 mt-0.5 truncate"
@@ -1538,6 +1581,7 @@ interface ProjectPaletteInnerProps {
   onRequestDeleteAllScratches?: () => void;
   onRenameScratch?: (scratchId: string, name: string) => void;
   onSaveAsProject?: (scratchId: string) => void;
+  fleetLiveness?: { runningAgentCount: number; workingAssistantCount: number };
 }
 
 function ProjectPaletteInner({
@@ -1574,8 +1618,10 @@ function ProjectPaletteInner({
   onRequestDeleteAllScratches,
   onRenameScratch,
   onSaveAsProject,
+  fleetLiveness,
 }: ProjectPaletteInnerProps) {
   const projectSwitcherShortcut = useEffectiveCombo("project.switcherPalette");
+  const fleetSummary = fleetLiveness ? formatFleetLiveness(fleetLiveness) : null;
 
   useEffect(() => {
     if (listRef.current && selectedIndex >= 0 && selectedIndex < results.length) {
@@ -1670,7 +1716,18 @@ function ProjectPaletteInner({
 
   return (
     <>
-      <AppPaletteDialog.Header label="Switch project" shortcut={projectSwitcherShortcut}>
+      <AppPaletteDialog.Header
+        label="Switch project"
+        shortcut={projectSwitcherShortcut}
+        // Absent, not zeroed, when the fleet is idle: "is anything running?" is
+        // answered by the line being there at all, and a standing "0 running"
+        // would make the reader parse a number to learn nothing.
+        trailing={
+          fleetSummary ? (
+            <span data-testid="fleet-liveness-summary">{fleetSummary}</span>
+          ) : undefined
+        }
+      >
         <AppPaletteDialog.Input
           inputRef={inputRef}
           value={query}
@@ -1864,6 +1921,7 @@ function ModalContent({
         onRequestDeleteAllScratches={innerProps.onRequestDeleteAllScratches}
         onRenameScratch={innerProps.onRenameScratch}
         onSaveAsProject={innerProps.onSaveAsProject}
+        fleetLiveness={innerProps.fleetLiveness}
       />
     </AppPaletteDialog>
   );
@@ -1983,6 +2041,7 @@ function DropdownContent({
           onRequestDeleteAllScratches={innerProps.onRequestDeleteAllScratches}
           onRenameScratch={innerProps.onRenameScratch}
           onSaveAsProject={innerProps.onSaveAsProject}
+          fleetLiveness={innerProps.fleetLiveness}
         />
       </AppPalettePopover.Content>
     </AppPalettePopover>
@@ -2130,6 +2189,7 @@ export function ProjectSwitcherPalette({
   onDismissSaveAsProjectConfirm,
   onConfirmDeleteOriginalScratch,
   isDeletingOriginalScratch = false,
+  fleetLiveness,
 }: ProjectSwitcherPaletteProps) {
   const paletteInputRef = useRef<HTMLInputElement>(null);
 
@@ -2177,6 +2237,7 @@ export function ProjectSwitcherPalette({
         onRequestDeleteAllScratches={onRequestDeleteAllScratches}
         onRenameScratch={onRenameScratch}
         onSaveAsProject={onSaveAsProject}
+        fleetLiveness={fleetLiveness}
       >
         {children}
       </DropdownContent>
@@ -2215,6 +2276,7 @@ export function ProjectSwitcherPalette({
         onRequestDeleteAllScratches={onRequestDeleteAllScratches}
         onRenameScratch={onRenameScratch}
         onSaveAsProject={onSaveAsProject}
+        fleetLiveness={fleetLiveness}
       />
     );
 

--- a/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
@@ -412,8 +412,12 @@ describe("ProjectSwitcher background-agent badge", () => {
       waitingProjectCount: 2,
     };
     const { getByRole, queryByTestId } = render(<ProjectSwitcher />);
-    expect(getByRole("status").getAttribute("aria-label")).toContain("2 projects waiting");
+    const badge = getByRole("status");
+    expect(badge.getAttribute("aria-label")).toContain("2 projects waiting");
     expect(queryByTestId("project-switcher-badge-arc")).toBeNull();
+    // A closed mark is actually drawn — "no arc" would also be satisfied by a
+    // badge that had quietly stopped rendering anything at all.
+    expect(badge.querySelector("span")).toBeTruthy();
   });
 
   it("falls back to working agents when none are waiting", () => {

--- a/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
@@ -386,16 +386,34 @@ describe("ProjectSwitcher background-agent badge", () => {
     expect(label).not.toContain("8");
   });
 
-  it("prefers waiting projects over working agents", () => {
+  it("reports the wait and the work still in flight together", () => {
+    // These used to contend for one carrier, so a fleet that was both asking
+    // for input AND still churning looked exactly like one that had stalled
+    // (#11832). Demand still leads — it is the half that needs the user.
     paletteState.nonActiveAgentCounts = {
       activeAgentCount: 5,
       waitingAgentCount: 1,
       waitingProjectCount: 1,
     };
-    const { getByRole } = render(<ProjectSwitcher />);
+    const { getByRole, getByTestId } = render(<ProjectSwitcher />);
     const label = getByRole("status").getAttribute("aria-label");
     expect(label).toContain("1 project waiting for input");
-    expect(label).not.toContain("working");
+    expect(label).toContain("5 background agents working");
+    expect(label?.indexOf("waiting")).toBeLessThan(label?.indexOf("working") ?? -1);
+    // Hue carries the demand, shape carries the liveness — so the mark is the
+    // open glyph even though the colour still says "waiting".
+    expect(getByTestId("project-switcher-badge-arc")).toBeTruthy();
+  });
+
+  it("closes the badge's shape when the fleet is only waiting", () => {
+    paletteState.nonActiveAgentCounts = {
+      activeAgentCount: 0,
+      waitingAgentCount: 2,
+      waitingProjectCount: 2,
+    };
+    const { getByRole, queryByTestId } = render(<ProjectSwitcher />);
+    expect(getByRole("status").getAttribute("aria-label")).toContain("2 projects waiting");
+    expect(queryByTestId("project-switcher-badge-arc")).toBeNull();
   });
 
   it("falls back to working agents when none are waiting", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -377,10 +377,11 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
 });
 
 /**
- * The leading dot marks rows that have something to say. It used to sit on
+ * The leading mark flags rows that have something to say. It used to sit on
  * every row as a hollow ring, which made the most common mark in the list the
  * one carrying no information — and left it competing with the filled dots that
- * do (#11692).
+ * do (#11692). Its shape is a second signal now (#11832); these cases cover
+ * only whether a mark is drawn at all.
  */
 describe("ProjectSwitcherPalette status dot", () => {
   it("marks a row with something to report and leaves a quiet one unmarked", () => {
@@ -400,7 +401,8 @@ describe("ProjectSwitcherPalette status dot", () => {
 
   /*
    * Structural only — jsdom does no layout, so this pins that the slot element
-   * survives on a quiet row, not that it still measures 6px. What it rules out
+   * survives on a quiet row, not that it still measures its nominal width. What
+   * it rules out
    * is the tempting simplification: dropping the whole slot instead of just its
    * dot, which would pull every quiet row's tile left of the busy ones.
    */
@@ -460,10 +462,14 @@ describe("ProjectSwitcherPalette liveness axis", () => {
   it("draws an open mark for a row still executing and a closed one for a row at rest", () => {
     const { stalled, churning } = renderPair(2);
 
-    // Topology, read off the element itself rather than a class name: the
-    // closed mark is a painted box, the open one is stroked geometry with a
-    // gap in it. Asserting the utility class would only restate the source.
-    expect(markIn(churning)?.querySelector("circle")).toBeTruthy();
+    // Topology, read off the geometry rather than a class name: the live mark
+    // is a stroked circle with a gap in it, which is what "open" means. A dash
+    // pattern is the only thing that puts the gap there — swapping in a plain
+    // ring would still be an SVG circle, and asserting merely "is an SVG"
+    // would call that a pass. The dash VALUES stay unasserted: those belong to
+    // the glyph, and pinning them here would just restate its source.
+    const liveCircle = markIn(churning)?.querySelector("circle");
+    expect(liveCircle?.getAttribute("stroke-dasharray")).toBeTruthy();
     expect(markIn(stalled)?.querySelector("circle")).toBeNull();
   });
 
@@ -495,13 +501,17 @@ describe("ProjectSwitcherPalette liveness axis", () => {
   });
 
   it("reaches assistive tech as words, not as a shape", () => {
-    const { churning } = renderPair(3);
+    renderPair(3);
 
-    // The mark is `aria-hidden`, so the clause is the only carrier left. It
+    // Queried by accessible NAME, not by text content: the mark is
+    // `aria-hidden`, so the clause is the only carrier left, and a clause that
+    // was itself hidden from the accessibility tree would still sit in the DOM
+    // for `textContent` to find while leaving shape as the sole encoding. It
     // rides the row's own name rather than a live region — one per row would
     // re-announce the whole list on every tick.
-    expect(churning.textContent).toContain("3 running");
-    expect(markIn(churning)?.getAttribute("aria-hidden")).toBe("true");
+    const spoken = screen.getByRole("option", { name: /Churning.*3 running/s });
+    expect(spoken).toBeTruthy();
+    expect(markIn(spoken)?.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("says nothing extra on a row whose sentence already names the run", () => {
@@ -541,6 +551,41 @@ describe("ProjectSwitcherPalette liveness axis", () => {
     expect(screen.getByText("Agent needs input")).toBeTruthy();
     expect(screen.getByText(/2 running/)).toBeTruthy();
   });
+
+  it("carries both axes on a scratch in the ranked list too", () => {
+    // A third renderer: a searched scratch is drawn by `ScratchListItem`, not by
+    // the pinned section above, and the two used to format their status lines
+    // independently of each other and of the project row.
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        query="spike"
+        results={[
+          {
+            kind: "scratch",
+            id: "s2",
+            name: "Spike",
+            path: "/userData/scratch/s2",
+            createdAt: 0,
+            lastOpened: 0,
+            isActive: false,
+            activeAgentCount: 2,
+            waitingAgentCount: 1,
+            blockedAgentCount: 0,
+            completedAgentCount: 0,
+            unacknowledgedCompletedAgentCount: 0,
+            snoozedAgentCount: 0,
+            processCount: 0,
+          },
+        ]}
+      />
+    );
+
+    const row = screen.getByRole("option", { name: /Spike/ });
+    expect(within(row).getByText("Agent needs input")).toBeTruthy();
+    expect(within(row).getByText(/2 running/)).toBeTruthy();
+    expect(markIn(row)?.querySelector("circle")?.getAttribute("stroke-dasharray")).toBeTruthy();
+  });
 });
 
 describe("ProjectSwitcherPalette fleet summary", () => {
@@ -575,12 +620,28 @@ describe("ProjectSwitcherPalette fleet summary", () => {
 
     expect(screen.queryByTestId("fleet-liveness-summary")).toBeNull();
   });
+
+  it("reaches the header through the modal path too", () => {
+    // The palette has two hosts and the outer component re-lists every prop by
+    // hand into each. Covering only the dropdown left the modal's chain free to
+    // drop the summary silently — which is exactly how it shipped broken the
+    // first time.
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        fleetLiveness={{ runningAgentCount: 4, workingAssistantCount: 0 }}
+        results={[makeProject()]}
+      />
+    );
+
+    expect(screen.getByTestId("fleet-liveness-summary").textContent).toContain("4");
+  });
 });
 
 describe("ProjectSwitcherPalette status conveyance", () => {
-  // The dot repeats the status line's tone and nothing else. It carries no
-  // accessible name of its own, so status is never announced twice and never
-  // depends on telling two hues apart.
+  // The mark carries no accessible name of its own, so status is never
+  // announced twice and never depends on telling two hues — or two shapes —
+  // apart. Everything it shows is also stated in the sentence beside it.
   it("conveys status as text rather than a labelled dot", () => {
     render(
       <ProjectSwitcherPalette {...baseProps} results={[makeProject({ waitingAgentCount: 2 })]} />

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -50,8 +50,20 @@ vi.mock("@/store/uiStore", () => ({
 }));
 
 vi.mock("@/components/ui/AppPaletteDialog", () => {
-  const Header = ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="palette-header">{children}</div>
+  // `trailing` is rendered, not dropped: it is a slot the palette puts real
+  // content in, and a mock that swallows it would let the header's summary
+  // regress to nothing while this suite stayed green.
+  const Header = ({
+    children,
+    trailing,
+  }: {
+    children: React.ReactNode;
+    trailing?: React.ReactNode;
+  }) => (
+    <div data-testid="palette-header">
+      {trailing}
+      {children}
+    </div>
   );
   const Input = ({
     inputRef,
@@ -411,6 +423,157 @@ describe("ProjectSwitcherPalette status dot", () => {
     expect(slotIn(quiet)).toBeTruthy();
     expect(slotIn(busy)!.querySelector("[data-testid='workspace-status-dot']")).toBeTruthy();
     expect(slotIn(quiet)!.querySelector("[data-testid='workspace-status-dot']")).toBeNull();
+  });
+});
+
+/**
+ * Two facts, two carriers (#11832). The row's hue and sentence say what it wants
+ * from the user; its shape and a muted clause say whether anything is still
+ * executing. The tests below always compare two rows that differ in exactly one
+ * of those, so a change that collapsed them back onto one carrier fails here
+ * rather than passing by matching a string.
+ */
+describe("ProjectSwitcherPalette liveness axis", () => {
+  const markIn = (row: HTMLElement) => row.querySelector("[data-testid='workspace-status-dot']");
+
+  function renderPair(runningCount: number) {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({ id: "stalled", name: "Stalled", waitingAgentCount: 1 }),
+          makeProject({
+            id: "churning",
+            name: "Churning",
+            waitingAgentCount: 1,
+            activeAgentCount: runningCount,
+          }),
+        ]}
+      />
+    );
+    return {
+      stalled: screen.getByRole("option", { name: /Stalled/ }),
+      churning: screen.getByRole("option", { name: /Churning/ }),
+    };
+  }
+
+  it("draws an open mark for a row still executing and a closed one for a row at rest", () => {
+    const { stalled, churning } = renderPair(2);
+
+    // Topology, read off the element itself rather than a class name: the
+    // closed mark is a painted box, the open one is stroked geometry with a
+    // gap in it. Asserting the utility class would only restate the source.
+    expect(markIn(churning)?.querySelector("circle")).toBeTruthy();
+    expect(markIn(stalled)?.querySelector("circle")).toBeNull();
+  });
+
+  it("leaves the demand sentence identical on both", () => {
+    const { stalled, churning } = renderPair(2);
+
+    // Purely additive: the tier that won the line is unchanged, so a row that
+    // gained the clause did not lose anything to it.
+    const demand = (row: HTMLElement) => within(row).getByText("Agent needs input");
+    expect(demand(churning).textContent).toBe(demand(stalled).textContent);
+    expect(demand(churning).className).toBe(demand(stalled).className);
+  });
+
+  it("trails the hidden count on the churning row only", () => {
+    const { stalled, churning } = renderPair(2);
+
+    expect(within(churning).getByText(/2 running/)).toBeTruthy();
+    expect(within(stalled).queryByText(/running/)).toBeNull();
+  });
+
+  it("keeps the clause out of the coloured token", () => {
+    const { churning } = renderPair(2);
+
+    // The demand tone is the row's one coloured word. A clause folded into that
+    // element would inherit the hue and read as part of the ask.
+    const demand = within(churning).getByText("Agent needs input");
+    expect(demand.textContent).not.toContain("running");
+    expect(within(churning).getByText(/2 running/)).not.toBe(demand);
+  });
+
+  it("reaches assistive tech as words, not as a shape", () => {
+    const { churning } = renderPair(3);
+
+    // The mark is `aria-hidden`, so the clause is the only carrier left. It
+    // rides the row's own name rather than a live region — one per row would
+    // re-announce the whole list on every tick.
+    expect(churning.textContent).toContain("3 running");
+    expect(markIn(churning)?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("says nothing extra on a row whose sentence already names the run", () => {
+    render(
+      <ProjectSwitcherPalette {...baseProps} results={[makeProject({ activeAgentCount: 2 })]} />
+    );
+
+    const row = screen.getByRole("option", { name: /Test Project/ });
+    expect(within(row).getByText("2 agents running")).toBeTruthy();
+    // Open mark, one sentence: "2 agents running · 2 running" says it twice.
+    expect(markIn(row)?.querySelector("circle")).toBeTruthy();
+    expect(row.textContent).not.toContain("· 2 running");
+  });
+
+  it("carries both axes on a scratch row too", () => {
+    // The pinned section is its own render path and used to draw the status
+    // line as a single toned element, which left it structurally unable to hold
+    // a second fragment at all.
+    const busyScratch: SearchableScratch = {
+      id: "s1",
+      name: "Spike",
+      path: "/userData/scratch/s1",
+      createdAt: 0,
+      lastOpened: 0,
+      isActive: false,
+      activeAgentCount: 2,
+      waitingAgentCount: 1,
+      blockedAgentCount: 0,
+      completedAgentCount: 0,
+      unacknowledgedCompletedAgentCount: 0,
+      snoozedAgentCount: 0,
+      processCount: 0,
+    };
+
+    render(<ProjectSwitcherPalette {...baseProps} results={[]} scratchResults={[busyScratch]} />);
+
+    expect(screen.getByText("Agent needs input")).toBeTruthy();
+    expect(screen.getByText(/2 running/)).toBeTruthy();
+  });
+});
+
+describe("ProjectSwitcherPalette fleet summary", () => {
+  it("reports what is running across every workspace", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        fleetLiveness={{ runningAgentCount: 4, workingAssistantCount: 0 }}
+        results={[makeProject()]}
+      />
+    );
+
+    expect(screen.getByTestId("fleet-liveness-summary").textContent).toContain("4");
+  });
+
+  it("disappears when nothing is executing anywhere", () => {
+    // Its absence is the answer to "is it safe to look away?" — a standing zero
+    // would make the reader parse a number to learn there is nothing to learn.
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        fleetLiveness={{ runningAgentCount: 0, workingAssistantCount: 0 }}
+        results={[makeProject()]}
+      />
+    );
+
+    expect(screen.queryByTestId("fleet-liveness-summary")).toBeNull();
+  });
+
+  it("stays silent for a caller that has no totals to give", () => {
+    render(<ProjectSwitcherPalette {...baseProps} results={[makeProject()]} />);
+
+    expect(screen.queryByTestId("fleet-liveness-summary")).toBeNull();
   });
 });
 

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -392,7 +392,7 @@ AppPaletteDialog.Header = function AppPaletteHeader({
          * asked for metadata — this way the shortcut-only row stays the row it
          * has always been.
          */}
-        {trailing ? (
+        {trailing != null ? (
           <span className="flex items-center gap-2 min-w-0">
             <span className="truncate">{trailing}</span>
             {shortcut ? <KbdChord shortcut={shortcut} /> : null}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -346,6 +346,13 @@ interface AppPaletteHeaderProps {
   label: string;
   /** Canonical shortcut string rendered via KbdChord (e.g. "Cmd+N"). */
   shortcut?: string;
+  /**
+   * Ambient metadata for the label row — a count or summary the palette wants
+   * standing beside its name rather than inside its list. Non-interactive: the
+   * header sits outside the arrow-key domain, so anything focusable here is
+   * unreachable by the keyboard the palette is driven with.
+   */
+  trailing?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
   /**
@@ -359,6 +366,7 @@ interface AppPaletteHeaderProps {
 AppPaletteDialog.Header = function AppPaletteHeader({
   label,
   shortcut,
+  trailing,
   children,
   className,
   isLoading = false,
@@ -377,7 +385,21 @@ AppPaletteDialog.Header = function AppPaletteHeader({
     >
       <div className="flex justify-between items-center mb-1.5 text-[11px] text-daintree-text/50">
         <span>{label}</span>
-        {shortcut ? <KbdChord shortcut={shortcut} /> : null}
+        {/*
+         * Grouped only when there is something to group. `justify-between`
+         * spaces its children across the row, so folding the chord into a
+         * wrapper unconditionally would move it on every palette that never
+         * asked for metadata — this way the shortcut-only row stays the row it
+         * has always been.
+         */}
+        {trailing ? (
+          <span className="flex items-center gap-2 min-w-0">
+            <span className="truncate">{trailing}</span>
+            {shortcut ? <KbdChord shortcut={shortcut} /> : null}
+          </span>
+        ) : shortcut ? (
+          <KbdChord shortcut={shortcut} />
+        ) : null}
       </div>
       {children}
       <div

--- a/src/components/ui/__tests__/AppPaletteDialogHeader.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialogHeader.test.tsx
@@ -40,6 +40,57 @@ function getLoadingBar(): HTMLElement | null {
   return document.querySelector<HTMLElement>(".palette-loading-bar");
 }
 
+describe("AppPaletteDialog.Header trailing metadata", () => {
+  it("shows the metadata alongside the label, the shortcut and the input", () => {
+    render(
+      <AppPaletteDialog.Header
+        label="Switch project"
+        shortcut="Cmd+P"
+        trailing={<span>3 running</span>}
+      >
+        <input aria-label="Search" />
+      </AppPaletteDialog.Header>
+    );
+
+    expect(screen.getByText("Switch project")).toBeTruthy();
+    expect(screen.getByText("3 running")).toBeTruthy();
+    expect(screen.getByTestId("kbd-chord")).toBeTruthy();
+    expect(screen.getByLabelText("Search")).toBeTruthy();
+  });
+
+  it("leaves a header without metadata exactly as it was", () => {
+    // The label row spaces its children apart, so grouping the chord into a
+    // wrapper unconditionally would shift it on every palette that never asked
+    // for a trailing slot. Without metadata the chord stays the label's own
+    // sibling.
+    const { container } = render(
+      <AppPaletteDialog.Header label="Quick switch" shortcut="Cmd+K">
+        <input aria-label="Search" />
+      </AppPaletteDialog.Header>
+    );
+    const chord = container.querySelector("[data-testid='kbd-chord']");
+
+    expect(chord?.previousElementSibling?.textContent).toBe("Quick switch");
+  });
+
+  it("groups the chord with the metadata when there is metadata to group", () => {
+    const { container } = render(
+      <AppPaletteDialog.Header
+        label="Switch project"
+        shortcut="Cmd+P"
+        trailing={<span>3 running</span>}
+      >
+        <input aria-label="Search" />
+      </AppPaletteDialog.Header>
+    );
+    const chord = container.querySelector("[data-testid='kbd-chord']");
+
+    // Now they travel together at the row's far end, so the metadata does not
+    // land marooned in the middle of a spaced-apart row.
+    expect(chord?.previousElementSibling?.textContent).toBe("3 running");
+  });
+});
+
 describe("AppPaletteDialog.Header loading bar", () => {
   it("renders the loading bar element so it can fade in/out", () => {
     render(

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -1438,3 +1438,43 @@ describe("resumable agent count passthrough", () => {
     expect(result.current.scratchResults[0]?.activeAgentCount).toBe(5);
   });
 });
+
+describe("fleetLiveness", () => {
+  it("counts the agents running inside scratches, not only those in projects", () => {
+    // The header answers "is it safe to look away?", and a scratch hosts real
+    // agents — a tally that walked projects alone would call the fleet quiet
+    // while a scratch was mid-run.
+    seedScratches(2);
+    projectStatsState.stats = {
+      "scratch-1": { activeAgentCount: 3, waitingAgentCount: 0, processCount: 3 },
+      "scratch-2": { activeAgentCount: 4, waitingAgentCount: 0, processCount: 4 },
+    };
+
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    // Includes `scratch-1`, which `seedScratches` makes the current workspace:
+    // the work in front of you counts toward "still going" as much as the work
+    // behind you does. That is the deliberate difference from the trigger
+    // badge, which asks the narrower "is somewhere ELSE asking for me?".
+    expect(result.current.fleetLiveness.runningAgentCount).toBe(7);
+  });
+
+  it("tallies a scratch's working assistant apart from its agents", () => {
+    seedScratches(1);
+    projectStatsState.stats = {
+      "scratch-1": {
+        activeAgentCount: 2,
+        waitingAgentCount: 0,
+        processCount: 2,
+        assistantState: "working",
+      },
+    };
+
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    // Never summed into the agent count: the assistant is not a run the user
+    // launched, and folding it in would make the worker tally a lie.
+    expect(result.current.fleetLiveness.runningAgentCount).toBe(2);
+    expect(result.current.fleetLiveness.workingAssistantCount).toBe(1);
+  });
+});

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -248,6 +248,117 @@ describe("useProjectSwitcherPalette", () => {
     usePaletteStore.setState({ activePaletteId: null });
   });
 
+  // The header's "is it safe to look away?" total, tested against raw projects
+  // plus pushed stats rather than through the palette — a component fixture
+  // that injected already-summed totals would go on passing while this
+  // aggregation drifted.
+  describe("fleetLiveness", () => {
+    const fixture = (id: string, extra: Partial<ProjectFixture> = {}): ProjectFixture => ({
+      id,
+      name: id,
+      path: `/repo/${id}`,
+      emoji: "🌲",
+      lastOpened: 100,
+      frecencyScore: 3.0,
+      status: "background",
+      ...extra,
+    });
+
+    const originalProjects = projectState.projects;
+    afterEach(() => {
+      projectState.projects = originalProjects;
+    });
+
+    it("sums the running agents across projects and leaves the rest out", async () => {
+      // Distinct sentinels rather than repeated values: a memo that read one
+      // project and multiplied, or that summed the wrong field, would still
+      // land on the right total with uniform fixtures.
+      projectState.projects = [fixture("project-1"), fixture("project-2")];
+      projectStatsState.stats = {
+        "project-1": { activeAgentCount: 3, waitingAgentCount: 7, processCount: 9 },
+        "project-2": { activeAgentCount: 4, waitingAgentCount: 0, processCount: 0 },
+      };
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      await waitFor(() => {
+        expect(result.current.fleetLiveness.runningAgentCount).toBe(7);
+      });
+      // Neither the waits nor the process counts are executing agents, so a
+      // total that picked either up would be answering a different question.
+      expect(result.current.fleetLiveness.runningAgentCount).not.toBe(14);
+      expect(result.current.fleetLiveness.workingAssistantCount).toBe(0);
+    });
+
+    it("counts working assistants as their own tally, never as agents", () => {
+      projectState.projects = [fixture("project-1"), fixture("project-2")];
+      projectStatsState.stats = {
+        "project-1": {
+          activeAgentCount: 2,
+          waitingAgentCount: 0,
+          processCount: 0,
+          assistantState: "working",
+        },
+        // `directing` is the assistant's other executing state — the classifier
+        // treats both as working, so the tally has to as well.
+        "project-2": {
+          activeAgentCount: 0,
+          waitingAgentCount: 0,
+          processCount: 0,
+          assistantState: "directing",
+        },
+      };
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      expect(result.current.fleetLiveness.runningAgentCount).toBe(2);
+      expect(result.current.fleetLiveness.workingAssistantCount).toBe(2);
+    });
+
+    it("ignores an assistant that is merely parked at its prompt", () => {
+      projectState.projects = [fixture("project-1")];
+      projectStatsState.stats = {
+        "project-1": {
+          activeAgentCount: 0,
+          waitingAgentCount: 0,
+          processCount: 0,
+          assistantState: "waiting",
+        },
+      };
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      // Resting, not executing — a fleet that is only waiting IS safe to look
+      // away from, which is the whole question the summary answers.
+      expect(result.current.fleetLiveness.workingAssistantCount).toBe(0);
+    });
+
+    it("does not shrink when a query filters the visible rows", async () => {
+      projectState.projects = [
+        fixture("project-1", { name: "Alpha" }),
+        fixture("project-2", { name: "Beta" }),
+      ];
+      projectStatsState.stats = {
+        "project-1": { activeAgentCount: 3, waitingAgentCount: 0, processCount: 0 },
+        "project-2": { activeAgentCount: 5, waitingAgentCount: 0, processCount: 0 },
+      };
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open();
+      });
+      act(() => {
+        result.current.setQuery("Alpha");
+      });
+
+      // Derived from the unfiltered rows on purpose: searching for one project
+      // must not report the fleet as quieter than it is.
+      await waitFor(() => {
+        expect(result.current.fleetLiveness.runningAgentCount).toBe(8);
+      });
+    });
+  });
+
   it("reads project stats from the push-based store", async () => {
     projectStatsState.stats = {
       "project-1": { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -355,6 +355,17 @@ export interface UseProjectSwitcherPaletteReturn {
      */
     waitingProjectCount: number;
   };
+  /**
+   * What is still executing across EVERY workspace — projects and scratches,
+   * the current one included — for the palette header's "is it safe to look
+   * away?" line (#11832). Unfiltered by the search query on purpose.
+   */
+  fleetLiveness: {
+    /** Agents the user launched, across all workspaces. Assistants never counted here. */
+    runningAgentCount: number;
+    /** Workspaces whose assistant is mid-task — a separate tally, not an agent. */
+    workingAssistantCount: number;
+  };
   /** Scratch (one-off agent workspace) view-models, sorted by lastOpened desc. */
   scratchResults: SearchableScratch[];
   /**
@@ -1178,6 +1189,29 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     list.sort((a, b) => b.lastOpened - a.lastOpened);
     return list;
   }, [scratches, currentScratch?.id, projectStats]);
+
+  /**
+   * What is executing across every workspace, for the palette header (#11832).
+   *
+   * Broader than `nonActiveAgentCounts` above in both directions, because the
+   * two answer different questions. That one is the trigger's badge — "is
+   * somewhere else asking for me?" — so it excludes the project on screen. This
+   * one is "is it safe to look away?", which the work in front of you counts
+   * toward as much as the work behind you, and scratches host agents too.
+   *
+   * Assistants are counted, separately. They are not runs the user launched, so
+   * folding them into the agent tally would misreport it — but an assistant
+   * mid-task is a reason the app is not finished with itself.
+   */
+  const fleetLiveness = useMemo(() => {
+    let runningAgentCount = 0;
+    let workingAssistantCount = 0;
+    for (const workspace of [...searchableProjects, ...scratchResults]) {
+      runningAgentCount += workspace.activeAgentCount;
+      if (classifyAssistantActivity(workspace) === "working") workingAssistantCount += 1;
+    }
+    return { runningAgentCount, workingAssistantCount };
+  }, [searchableProjects, scratchResults]);
 
   // Clearing the box reverts to browse immediately rather than holding the
   // deferred ranking for a commit — otherwise browse would flash the stale
@@ -2121,6 +2155,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     isSleepingProject,
     backgroundWaitingCount,
     nonActiveAgentCounts,
+    fleetLiveness,
     scratchResults,
     createScratch,
     selectScratch,

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { getProjectRowStatus, getScratchRowStatus, formatWaitAge } from "../projectRowStatus";
+import {
+  formatFleetLiveness,
+  formatWaitAge,
+  getProjectRowStatus,
+  getScratchRowStatus,
+} from "../projectRowStatus";
 import type { SearchableProject, SearchableScratch } from "@/hooks/useProjectSwitcherPalette";
 
 const NOW = 1_700_000_000_000;
@@ -891,5 +896,237 @@ describe("assistant presence status lines (#11806)", () => {
     // and an undatable wait must not render as an epoch-old one.
     expect(status.text).toBe("Assistant waiting");
     expect(status.text).not.toContain("·");
+  });
+});
+
+/**
+ * Liveness is the second axis (#11832): demand says what the row wants, this
+ * says whether it will change on its own. The cases below are written as
+ * comparisons between two computed statuses rather than assertions about
+ * particular strings, because the property under test is that one axis moves
+ * while the other does not.
+ */
+describe("row status liveness", () => {
+  const RUNNING = 2;
+
+  it("separates a waiting row that is still churning from one that has stalled", () => {
+    // The bug: the cascade picks the wait and drops everything under it, so
+    // these two rendered identically while only one of them was still moving.
+    const stalled = getProjectRowStatus(
+      project({ waitingAgentCount: 1, oldestWaitingSince: NOW - 17 * 60_000 }),
+      NOW
+    );
+    const churning = getProjectRowStatus(
+      project({
+        waitingAgentCount: 1,
+        oldestWaitingSince: NOW - 17 * 60_000,
+        activeAgentCount: RUNNING,
+      }),
+      NOW
+    );
+
+    // Demand is untouched — the whole point is that this is additive.
+    expect(churning.text).toBe(stalled.text);
+    expect(churning.tone).toBe(stalled.tone);
+
+    expect(stalled.isLive).toBe(false);
+    expect(churning.isLive).toBe(true);
+    expect(stalled.livenessDetail).toBeUndefined();
+    expect(churning.livenessDetail).toBe(`${RUNNING} running`);
+  });
+
+  it("says nothing extra on the line that already names the running agents", () => {
+    // "2 agents running · 2 running" would state one fact twice.
+    const status = getProjectRowStatus(project({ activeAgentCount: RUNNING }), NOW);
+
+    expect(status.isLive).toBe(true);
+    expect(status.livenessDetail).toBeUndefined();
+  });
+
+  it("singularises the clause the way the sentences above it do", () => {
+    const status = getProjectRowStatus(project({ waitingAgentCount: 1, activeAgentCount: 1 }), NOW);
+
+    expect(status.livenessDetail).toBe("1 running");
+  });
+
+  it("keeps the clause off a row where nothing is executing", () => {
+    // Every settled tone at once: a completion, a snooze and a bare process
+    // count are all reachable only after the cascade established that no agent
+    // is running, so none of them may claim otherwise.
+    const settled = [
+      project({ completedAgentCount: 1, latestCompletionAt: NOW - 60_000 }),
+      project({ snoozedAgentCount: 1 }),
+      project({ processCount: 4 }),
+      project({ lastOpened: NOW - 3600_000 }),
+      project({ status: "closed", autoParkedAt: NOW - 60_000 }),
+    ].map((row) => getProjectRowStatus(row, NOW));
+
+    for (const status of settled) {
+      expect(status.isLive).toBe(false);
+      expect(status.livenessDetail).toBeUndefined();
+    }
+  });
+
+  it("does not take a process count for a running agent", () => {
+    // `processCount` nets out the assistant's own PTY and trails the truth by a
+    // poll interval, so a row keyed off it would claim to be moving after its
+    // last agent stopped.
+    const byProcess = getProjectRowStatus(project({ waitingAgentCount: 1, processCount: 5 }), NOW);
+    const byAgent = getProjectRowStatus(
+      project({ waitingAgentCount: 1, activeAgentCount: 1 }),
+      NOW
+    );
+
+    expect(byProcess.isLive).toBe(false);
+    expect(byAgent.isLive).toBe(true);
+  });
+
+  it("counts a working assistant as live without inventing an agent for it", () => {
+    const hidden = getProjectRowStatus(
+      project({ waitingAgentCount: 1, assistantState: "working" }),
+      NOW
+    );
+
+    expect(hidden.isLive).toBe(true);
+    // Named, not numbered: the assistant is one thing the user never launched,
+    // and "1 running" would enrol it in a tally it is excluded from everywhere
+    // else.
+    expect(hidden.livenessDetail).toBe("Assistant working");
+    expect(hidden.livenessDetail).not.toMatch(/\d/);
+  });
+
+  it("reports the workers when both they and the assistant are going", () => {
+    const status = getProjectRowStatus(
+      project({ waitingAgentCount: 1, activeAgentCount: RUNNING, assistantState: "working" }),
+      NOW
+    );
+
+    expect(status.livenessDetail).toBe(`${RUNNING} running`);
+  });
+
+  it("leaves the assistant's own line without a clause about itself", () => {
+    const status = getProjectRowStatus(project({ assistantState: "working" }), NOW);
+
+    expect(status.isLive).toBe(true);
+    expect(status.livenessDetail).toBeUndefined();
+  });
+
+  it("treats a directing assistant as executing, the way the classifier does", () => {
+    const directing = getProjectRowStatus(project({ assistantState: "directing" }), NOW);
+    const idle = getProjectRowStatus(project({ assistantState: "idle" }), NOW);
+
+    expect(directing.isLive).toBe(true);
+    expect(idle.isLive).toBe(false);
+  });
+
+  it("needs no union with the snooze count to see a snoozed run still working", () => {
+    // Snoozing withholds a row from the demanding tallies; it does not stop the
+    // run, so a still-working snoozed agent is already inside `activeAgentCount`.
+    const status = getProjectRowStatus(
+      project({ snoozedAgentCount: 1, activeAgentCount: 1, waitingAgentCount: 1 }),
+      NOW
+    );
+
+    expect(status.isLive).toBe(true);
+    expect(status.livenessDetail).toBe("1 running");
+  });
+
+  it("keeps reporting the run when the folder underneath it has gone", () => {
+    // `isMissing` pre-empts the activity cascade outright, so without this the
+    // one row whose agents are most likely orphaned says the least about them.
+    const missing = getProjectRowStatus(
+      project({ isMissing: true, activeAgentCount: RUNNING }),
+      NOW
+    );
+    const found = getProjectRowStatus(project({ isMissing: true }), NOW);
+
+    expect(missing.text).toBe(found.text);
+    expect(missing.tone).toBe(found.tone);
+    expect(missing.livenessDetail).toBe(`${RUNNING} running`);
+    expect(found.livenessDetail).toBeUndefined();
+  });
+
+  it("carries the clause under every demand tier that can hide a run", () => {
+    // One matrix rather than a case each: the property is that no tier above
+    // `running` may swallow it, and enumerating them is what catches a tier
+    // added later that forgets.
+    const hiding = [
+      project({ waitingAgentCount: 1 }),
+      project({ waitingAgentCount: 2, blockedAgentCount: 1 }),
+      project({ blockedAgentCount: 1 }),
+      project({ unacknowledgedCompletedAgentCount: 1, completedAgentCount: 1 }),
+      project({ assistantState: "waiting", assistantWaitingReason: "error" }),
+    ];
+
+    for (const row of hiding) {
+      const stalled = getProjectRowStatus(row, NOW);
+      const churning = getProjectRowStatus({ ...row, activeAgentCount: RUNNING }, NOW);
+
+      expect(churning.text).toBe(stalled.text);
+      expect(churning.tone).toBe(stalled.tone);
+      expect(stalled.livenessDetail).toBeUndefined();
+      expect(churning.livenessDetail).toBe(`${RUNNING} running`);
+    }
+  });
+
+  it("gives a scratch the same two axes a project gets", () => {
+    const stalled = getScratchRowStatus(scratch({ waitingAgentCount: 1 }), NOW);
+    const churning = getScratchRowStatus(
+      scratch({ waitingAgentCount: 1, activeAgentCount: RUNNING }),
+      NOW
+    );
+
+    expect(churning.text).toBe(stalled.text);
+    expect(stalled.isLive).toBe(false);
+    expect(churning.isLive).toBe(true);
+    expect(churning.livenessDetail).toBe(`${RUNNING} running`);
+  });
+
+  it("never carries a detail without the liveness that justifies it", () => {
+    // The two fields answer different questions and a renderer trusts both, so
+    // a status claiming hidden work while reporting itself at rest would draw a
+    // closed mark beside a sentence about a running agent.
+    const rows = [
+      project({ waitingAgentCount: 1 }),
+      project({ waitingAgentCount: 1, activeAgentCount: 3 }),
+      project({ activeAgentCount: 1 }),
+      project({ assistantState: "working" }),
+      project({ processCount: 2 }),
+      project({ isMissing: true, activeAgentCount: 1 }),
+      project({ lastOpened: NOW - 3600_000 }),
+    ];
+
+    for (const row of rows) {
+      const status = getProjectRowStatus(row, NOW);
+      if (!status.isLive) expect(status.livenessDetail).toBeUndefined();
+    }
+  });
+});
+
+describe("formatFleetLiveness", () => {
+  it("says nothing at all when the fleet has gone quiet", () => {
+    // Absence is the signal. A standing "0 running" would make the reader parse
+    // a number to learn there is nothing to learn.
+    expect(formatFleetLiveness({ runningAgentCount: 0, workingAssistantCount: 0 })).toBeNull();
+  });
+
+  it("reports agents and assistants as separate tallies", () => {
+    const both = formatFleetLiveness({ runningAgentCount: 3, workingAssistantCount: 2 });
+
+    // Never summed: an assistant is not a run the user launched, so one number
+    // covering both would answer neither question it is asked.
+    expect(both).not.toContain("5");
+    expect(both).toContain("3");
+    expect(both).toContain("2");
+  });
+
+  it("drops the half that is idle rather than printing a zero", () => {
+    const agentsOnly = formatFleetLiveness({ runningAgentCount: 4, workingAssistantCount: 0 });
+    const assistantsOnly = formatFleetLiveness({ runningAgentCount: 0, workingAssistantCount: 1 });
+
+    expect(agentsOnly).not.toContain("assistant");
+    expect(agentsOnly).not.toContain("0");
+    expect(assistantsOnly).not.toContain("0");
+    expect(assistantsOnly).toContain("assistant");
   });
 });

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -992,7 +992,6 @@ describe("row status liveness", () => {
     // and "1 running" would enrol it in a tally it is excluded from everywhere
     // else.
     expect(hidden.livenessDetail).toBe("Assistant working");
-    expect(hidden.livenessDetail).not.toMatch(/\d/);
   });
 
   it("reports the workers when both they and the assistant are going", () => {
@@ -1048,8 +1047,9 @@ describe("row status liveness", () => {
 
   it("carries the clause under every demand tier that can hide a run", () => {
     // One matrix rather than a case each: the property is that no tier above
-    // `running` may swallow it, and enumerating them is what catches a tier
-    // added later that forgets.
+    // `running` may swallow it. A fixed list cannot catch a tier added later —
+    // `withLiveness` running on every exit is what does that — so this pins the
+    // tiers that exist today rather than claiming to police future ones.
     const hiding = [
       project({ waitingAgentCount: 1 }),
       project({ waitingAgentCount: 2, blockedAgentCount: 1 }),
@@ -1114,10 +1114,11 @@ describe("formatFleetLiveness", () => {
     const both = formatFleetLiveness({ runningAgentCount: 3, workingAssistantCount: 2 });
 
     // Never summed: an assistant is not a run the user launched, so one number
-    // covering both would answer neither question it is asked.
+    // covering both would answer neither question it is asked. Matched as whole
+    // phrases — a bare `toContain("3")` also passes on "32 running".
     expect(both).not.toContain("5");
-    expect(both).toContain("3");
-    expect(both).toContain("2");
+    expect(both).toMatch(/\b3 running\b/);
+    expect(both).toMatch(/\b2 assistants working\b/);
   });
 
   it("drops the half that is idle rather than printing a zero", () => {

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -50,32 +50,63 @@ export const ROW_TONE_CLASS: Record<ProjectRowTone, string> = {
   "assistant-blocked": "text-status-danger/80",
 };
 
-export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
-  blocked: "bg-status-danger",
-  waiting: "bg-status-warning",
-  review: "bg-activity-completed",
-  working: "bg-activity-active animate-activity-pulse",
-  running: "bg-status-success",
+/**
+ * The two shapes a row's leading mark can take, in one tone's hue.
+ *
+ * Co-located rather than kept as two parallel maps so a tone added later cannot
+ * compile until it has answered both questions. They are different class
+ * families on purpose: the closed mark is a `div` that needs a background or a
+ * border, and the open arc is an SVG stroking `currentColor`, so it needs a text
+ * colour.
+ */
+export interface RowMarkStyle {
+  /** Closed topology — the row is at rest. Filled for a run the user launched, a ring for the settled states. */
+  dot: string;
+  /** Open topology — something on the row is still executing. */
+  arc: string;
+}
+
+/**
+ * Hue says what the row wants from the user; shape says whether it is still
+ * moving (#11832). The two are independent, so every tone has to name both:
+ * "wants input, still churning" and "wants input, and everything else is done"
+ * are the two situations the old single-shape dot rendered identically.
+ *
+ * Three tones can never draw their arc today — `running`, `snoozed` and `muted`
+ * are all reached only after the cascade has established that nothing is
+ * executing. They still carry one, because the map's whole job is that a tone
+ * cannot ship without a shape for each axis.
+ */
+export const ROW_MARK_CLASS: Record<ProjectRowTone, RowMarkStyle> = {
+  blocked: { dot: "bg-status-danger", arc: "text-status-danger" },
+  waiting: { dot: "bg-status-warning", arc: "text-status-warning" },
+  review: { dot: "bg-activity-completed", arc: "text-activity-completed" },
+  // No pulse on either shape any more. A working row is live by definition, so
+  // it always draws the arc — and the open gap says "still moving" without
+  // asking a reader to notice a fade, which reduced motion switches off anyway.
+  working: { dot: "bg-activity-active", arc: "text-activity-active" },
+  running: { dot: "bg-status-success", arc: "text-status-success" },
   // Dashed rather than solid, because "snoozed" and "settled" are different
   // facts and the switcher's greys already carry the settled ones. Colour alone
   // could not separate them — a dashed ring reads as temporarily suspended at a
   // glance, and survives both high-contrast modes and a colour-blind reader.
-  snoozed: "border border-dashed border-daintree-text/40",
+  snoozed: { dot: "border border-dashed border-daintree-text/40", arc: "text-daintree-text/40" },
   // Hollow, because "finished" and "suspended" are settled states rather than
   // live ones. It used to sit on every dormant row too, which made a ring the
   // most common mark in the list and left it competing with the filled dots
   // that mean something — dormant rows draw no dot at all now (#11692), so the
   // ring is back to marking the two muted states that earned a line.
-  muted: "border border-daintree-text/20",
+  muted: { dot: "border border-daintree-text/20", arc: "text-daintree-text/20" },
   // Hollow, and that is the whole point: the filled dot means a run the user
   // launched, and the assistant is the machine acting on its own. It is the
   // convention for machine-initiated background work, and it leaves the worker
-  // dot meaning exactly what it meant before (#11806). Stronger than `muted`'s
-  // ring because this one marks something live rather than something finished.
-  assistant: "border border-daintree-text/40",
+  // dot meaning exactly what it meant before (#11806). The arc beside it is a
+  // different question — a closed ring for an assistant that is mid-task would
+  // say "at rest" about something that is demonstrably not.
+  assistant: { dot: "border border-daintree-text/40", arc: "text-daintree-text/40" },
   // Same hollow shape carrying the danger hue: still not a worker run, but a
   // failure the row should not have to be read closely to notice.
-  "assistant-blocked": "border border-status-danger",
+  "assistant-blocked": { dot: "border border-status-danger", arc: "text-status-danger" },
 };
 
 /**
@@ -90,6 +121,31 @@ export interface ProjectRowStatus {
   /** Status sentence, or the fallback "Opened …" line when nothing is running. */
   text: string;
   tone: ProjectRowTone;
+  /**
+   * Whether anything on this row is still executing — the second axis (#11832).
+   *
+   * Independent of `tone`, which answers what the row wants from the user. The
+   * cascade below picks one demand tier and drops the rest, so before this
+   * existed a project with a waiting agent and a running one rendered exactly
+   * like a project where everything had stopped. It drives the mark's shape:
+   * open means the row will change on its own, closed means it will not.
+   *
+   * Required rather than optional so a status constructed later cannot quietly
+   * default to "at rest" — every line has to answer, and the answer is derived
+   * in one place from the counts rather than read off the tone.
+   */
+  isLive: boolean;
+  /**
+   * The running work this row's sentence does not mention, phrased for a
+   * trailing clause: "2 running", or "Assistant working" when the assistant is
+   * the only thing executing.
+   *
+   * Absent when nothing is running, and absent when the sentence already names
+   * it — "2 agents running · 2 running" would say the same thing twice. It is
+   * the non-visual carrier for the shape: the mark is `aria-hidden`, so without
+   * a word for it liveness would exist in topology alone.
+   */
+  livenessDetail?: string;
   /**
    * Disambiguating path fragment, present only when this project's folder name
    * collides with another registered project's, so identical-looking monorepo
@@ -175,7 +231,58 @@ export function formatWakeTime(wakeAtMs: number): string {
   });
 }
 
-type WorkspaceActivityStatus = Omit<ProjectRowStatus, "pathHint">;
+/**
+ * A status line before the liveness axis is attached.
+ *
+ * The cascade below answers only "what does this row want?", and every one of
+ * its branches would otherwise have to remember to answer the second question
+ * too. Leaving liveness off the shape entirely, and deriving it once in
+ * `withLiveness`, is what makes a branch added later live-aware for free.
+ */
+type ActivityLine = Omit<ProjectRowStatus, "pathHint" | "isLive" | "livenessDetail"> & {
+  /**
+   * Set by the two branches whose own sentence already names the running work,
+   * so the trailing clause doesn't repeat it. A flag rather than a tone check:
+   * `working` happens to be one of them today, but the fact belongs to the
+   * sentence, and a tone is not a promise about wording.
+   */
+  namesLiveWork?: true;
+};
+
+/**
+ * Attaches the liveness axis to a finished status line.
+ *
+ * Worker runs come from `activeAgentCount`, which is already exactly the right
+ * set: it counts the agents actually executing, and a snoozed run that is still
+ * working is inside it — snoozing withholds a row from the demanding tallies, it
+ * does not stop the run. `processCount` is deliberately not consulted: it nets
+ * out the assistant's own PTY and lags the truth by a poll interval, so a row
+ * would claim to be moving after its last agent stopped.
+ *
+ * A working assistant counts. It is excluded from every worker tally on purpose
+ * (#11806) and stays excluded from the count in the clause — inventing an agent
+ * the user never launched is the thing that exclusion exists to prevent — but
+ * "is anything still executing" is a different question from "how many of my
+ * runs", and answering it "no" while the assistant works would make the open
+ * shape a lie.
+ */
+function withLiveness(
+  line: ActivityLine,
+  workspace: WorkspaceRowStatusFields
+): Omit<ProjectRowStatus, "pathHint"> {
+  const { namesLiveWork, ...status } = line;
+  const running = workspace.activeAgentCount;
+  const isLive = running > 0 || classifyAssistantActivity(workspace) === "working";
+
+  if (!isLive || namesLiveWork) return { ...status, isLive };
+
+  return {
+    ...status,
+    isLive,
+    livenessDetail:
+      running > 0 ? pluralAgents(running, "1 running", "running") : "Assistant working",
+  };
+}
 
 /**
  * The assistant's line: it says what the assistant is, never a count (#11806).
@@ -194,9 +301,10 @@ function assistantStatus(
   activity: Exclude<AssistantActivity, null>,
   since: number | undefined,
   nowMs: number
-): WorkspaceActivityStatus {
+): ActivityLine {
   if (activity === "working") {
-    return { text: "Assistant working", tone: "assistant" };
+    // Names the live work itself, so it never also trails "· Assistant working".
+    return { text: "Assistant working", tone: "assistant", namesLiveWork: true };
   }
 
   const lead = activity === "blocked" ? "Assistant blocked" : "Assistant waiting";
@@ -220,11 +328,15 @@ function assistantStatus(
  * Returns null when nothing is running, leaving the caller to supply the
  * dormant line its own kind understands (a project can be auto-parked; a
  * scratch only ever has an opened time).
+ *
+ * Answers the demand axis only. Liveness is attached afterwards by
+ * `withLiveness`, which is why a branch here can drop a running agent from its
+ * sentence without the row losing the fact (#11832).
  */
-function getWorkspaceActivityStatus(
+function classifyWorkspaceActivity(
   project: WorkspaceRowStatusFields,
   nowMs: number
-): WorkspaceActivityStatus | null {
+): ActivityLine | null {
   // Classified once, consumed at three different heights below. Sharing the
   // helper with `sectionForProject` is what keeps a row's band and its line
   // telling the same story about the assistant. Not an absolute guarantee: the
@@ -338,6 +450,8 @@ function getWorkspaceActivityStatus(
     return {
       text: pluralAgents(project.activeAgentCount, "Agent running", "agents running"),
       tone: "working",
+      // The count is the sentence here; a trailing clause would repeat it.
+      namesLiveWork: true,
     };
   }
 
@@ -412,7 +526,7 @@ function getWorkspaceActivityStatus(
  * takes the flag and shows nothing (#11692). The text stays here because a
  * surface with room for it should still say it the same way.
  */
-function getOpenedStatus(lastOpened: number): WorkspaceActivityStatus {
+function getOpenedStatus(lastOpened: number): ActivityLine {
   if (lastOpened > 0) {
     return {
       text: `Opened ${formatTimeAgo(lastOpened)}`,
@@ -441,25 +555,32 @@ export function getProjectRowStatus(project: SearchableProject, nowMs: number): 
   // Only surface the fragment when it actually disambiguates — a plain basename
   // is already the folder name shown beside it, so repeating it is noise.
   const pathHint = project.displayPath.includes("/") ? project.displayPath : undefined;
-  const withHint = (status: WorkspaceActivityStatus): ProjectRowStatus =>
-    pathHint ? { ...status, pathHint } : status;
+  // Every branch leaves through here, so none of them can return a line that
+  // never answered the liveness question.
+  const finish = (line: ActivityLine): ProjectRowStatus => {
+    const status = withLiveness(line, project);
+    return pathHint ? { ...status, pathHint } : status;
+  };
 
+  // A folder that has gone missing still gets the clause: its agents were
+  // spawned before it vanished and may well still be running, and this is the
+  // one branch that pre-empts the activity cascade outright.
   if (project.isMissing) {
-    return withHint({ text: "Directory not found", tone: "blocked" });
+    return finish({ text: "Directory not found", tone: "blocked" });
   }
 
-  const activity = getWorkspaceActivityStatus(project, nowMs);
-  if (activity) return withHint(activity);
+  const activity = classifyWorkspaceActivity(project, nowMs);
+  if (activity) return finish(activity);
 
   // Auto-closed by the background-idle sweep (#10830) — name the reason rather
   // than showing a bare time-ago that makes the project look merely stale. The
   // reason is the row's own line; the ring beside it is only settled state, so
   // it steps aside for a resume promise that has more to say (#11822).
   if (project.status === "closed" && project.autoParkedAt) {
-    return withHint({ text: "Suspended to free memory", tone: "muted", allowsResumeMark: true });
+    return finish({ text: "Suspended to free memory", tone: "muted", allowsResumeMark: true });
   }
 
-  return withHint(getOpenedStatus(project.lastOpened));
+  return finish(getOpenedStatus(project.lastOpened));
 }
 
 /**
@@ -475,5 +596,35 @@ export function getProjectRowStatus(project: SearchableProject, nowMs: number): 
  * Requires its clock for the same reason `getProjectRowStatus` does.
  */
 export function getScratchRowStatus(scratch: SearchableScratch, nowMs: number): ProjectRowStatus {
-  return getWorkspaceActivityStatus(scratch, nowMs) ?? getOpenedStatus(scratch.lastOpened);
+  return withLiveness(
+    classifyWorkspaceActivity(scratch, nowMs) ?? getOpenedStatus(scratch.lastOpened),
+    scratch
+  );
+}
+
+/**
+ * The palette header's one-line answer to "is it safe to look away?" (#11832).
+ *
+ * Null when nothing is executing anywhere, which is the whole point — the line
+ * appears while the fleet is busy and disappears when it goes quiet, so its
+ * absence is as readable as its content.
+ *
+ * Assistants are tallied separately rather than added in. They are not runs the
+ * user launched, and one number covering both would answer neither "how much of
+ * my work is still going" nor "is the machine doing something on its own".
+ */
+export function formatFleetLiveness(counts: {
+  runningAgentCount: number;
+  workingAssistantCount: number;
+}): string | null {
+  const parts: string[] = [];
+  if (counts.runningAgentCount > 0) {
+    parts.push(pluralAgents(counts.runningAgentCount, "1 running", "running"));
+  }
+  if (counts.workingAssistantCount > 0) {
+    parts.push(
+      pluralAgents(counts.workingAssistantCount, "1 assistant working", "assistants working")
+    );
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
 }


### PR DESCRIPTION
Resolves #11832

## What

The switcher's row status was a winner-take-all cascade — blocked > waiting > review > running — so a project with one agent waiting for input and one still running rendered identically to a project where everything had stopped. Running was being treated as a priority tier when it's really a second axis.

Demand (what does this row want from me) and liveness (is anything still executing) now have separate carriers:

- **Shape on the mark.** Hue still comes from the demand tone; topology now comes from liveness. A closed dot means at rest, an open arc means something is still executing. The arc is the app's existing `SpinnerCircle` — the same glyph the dock, Pilot and the worktree rows already use for a working agent — so the switcher adopts the shared vocabulary rather than inventing one. Static, no rotation: the gap is the fact, and it survives reduced motion, a paused frame and a screenshot. The slot grew 6px -> 10px because the gap isn't legible below that, with every mark centred in it so the tile column stays aligned.
- **A muted trailing clause.** `Agent needs input · waiting 17m · 2 running` whenever a higher tier hid the run. It's a separate span, so the demand tone stays the only coloured token on the line — and since the mark is `aria-hidden`, that clause is also the screen-reader carrier. Shape is never the sole encoding.
- **A fleet summary in the palette header.** What's running across every workspace, projects and scratches, the current one included. It disappears when nothing is executing anywhere — the absence is the answer to "is it safe to look away?".

Band membership, row ordering, and the demand cascade priority are untouched. `status.text` is byte-identical to before, which is why every existing waterfall assertion still passes unchanged.

## Design calls worth flagging

- **Liveness is `activeAgentCount > 0 || assistant === "working"`.** A snoozed-but-still-running agent is already inside `activeAgentCount` — snoozing withholds a row from the demanding tallies, it doesn't stop the run — so no union with `snoozedAgentCount` is needed. `processCount` is deliberately excluded: it nets out the assistant's own PTY and trails reality by a poll interval, so a row keyed off it would claim to be moving after its last agent stopped.
- **A working assistant counts as live, but is never numbered.** A closed ring beside an assistant that is demonstrably mid-task would make the topology a lie. But it stays out of the agent count — that clause reads `Assistant working`, not `1 running`, because inventing a run the user never launched is exactly what excluding it from the tallies exists to prevent. The header keeps the two as separate tallies for the same reason.
- **`isLive` is a required field**, derived once in `withLiveness` at every exit point rather than per-branch, so a demand tier added later is liveness-aware without having to remember. A `namesLiveWork` flag suppresses the clause on the two branches whose own sentence already names the run.

## Worth a look

**The title-bar badge I changed isn't mounted.** The issue asks for the badge to get the same treatment, and I gave it that — hue from demand, shape from liveness, and a label stating both facts instead of the old winner-take-all where waiting silently erased working. But `ProjectSwitcher.tsx` turns out to have no production consumer: it's exported from `components/Project/index.ts` and rendered only by its own tests. The real title-bar is `Toolbar.tsx`'s `toolbar-project-pill`, which has never had a status badge at all. So this fix is currently latent. Putting a badge on the toolbar pill is a genuinely new piece of design (placement against the existing overflow badge, among other things), so I've left it — happy to do it as a follow-up if that's the intent.

Two smaller notes:

- **Forced colors is still a gap for the closed marks.** Their `background-color` is stripped there, which is pre-existing and not something this issue asks about. The arc improves it for free — an SVG stroke on `currentColor` survives. Worth its own pass.
- **`rowStatusClock.contract.test.ts` doesn't enforce what its docstring claims.** It checks that the exported helpers take a clock parameter, not that nothing reads one ambiently — a literal `Date.now()` inside a helper would pass today. Pre-existing, flagging it rather than fixing it here.

## Testing

- `projectRowStatus.test.ts` — a `row status liveness` block that compares two computed statuses differing only in `activeAgentCount` and asserts the demand half is identical while the liveness half moves. Plus: no duplicated statement on the branch that already names the run, `processCount` never setting liveness, assistant `working`/`directing` handling, snoozed-with-active, `isMissing` with running agents, and an invariant that a detail never appears without the liveness justifying it.
- `ProjectSwitcherPalette.render.test.tsx` — the two axes across all three row renderers (project, ranked scratch, pinned scratch). The open mark is asserted by its dash geometry rather than "is an SVG", since a closed ring would satisfy the latter; the clause is asserted via the row's accessible name rather than `textContent`, since hiding it from the accessibility tree would satisfy that.
- `useProjectSwitcherPalette.test.tsx` / `.scratch.test.tsx` — the fleet total where it's actually computed: across projects and scratches, current workspace included, assistants tallied apart from agents, and unmoved by a search query.
- `ProjectSwitcher.loading.test.tsx` — the badge now states both facts. The old `expect(label).not.toContain("working")` assertion was encoding the exact collapse this issue removes, so it's been rewritten.

Local: 3438 tests green across `src/lib`, `src/components/Project`, `src/components/ui`, `src/hooks`, plus the whole `src/config/__tests__` contract-scanner directory (387) since those are repo-wide `readFileSync` scanners invisible to a targeted run. Typecheck clean. Prettier and ESLint clean on changed files (22 warnings remain, all pre-existing and outside the lines touched).