### PR TITLE
fix(assistant): give empty-state CTAs the configured agent's icon

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1128,6 +1128,19 @@ export function HelpPanel({
     preferredAgentId ??
     (supportedInstalledAgentIds.length === 1 ? (supportedInstalledAgentIds[0] ?? null) : null);
 
+  // Each empty-state CTA wears the mark of the agent it would actually launch,
+  // so the button says what's about to start. Rendered bare: the Button variant
+  // sizes descendant svgs and no brandColor is passed, so the glyph inherits the
+  // accent fill's foreground rather than painting itself the brand hue. Falls
+  // back to the generic mark when an id outlives its config (agent uninstalled
+  // mid-session), mirroring the droppedPreferredAgentId name lookup below.
+  const StartAssistantIcon = launchableAgentId
+    ? (getAgentConfig(launchableAgentId)?.icon ?? Sparkles)
+    : Sparkles;
+  const ResumeAssistantIcon = resumableAgentId
+    ? (getAgentConfig(resumableAgentId)?.icon ?? Sparkles)
+    : Sparkles;
+
   // Explicit, billed start (#10699). Records consent so future opens may
   // auto-launch, then launches directly — relying on syncInputs re-evaluation
   // would leave a render-cycle gap. An optional starter prompt seeds the first
@@ -1439,7 +1452,7 @@ export function HelpPanel({
                     onClick={handleResumeAssistant}
                     data-testid="help-resume-assistant"
                   >
-                    <Sparkles />
+                    <ResumeAssistantIcon />
                     Resume assistant
                   </Button>
                 </div>
@@ -1453,7 +1466,7 @@ export function HelpPanel({
                     onClick={() => handleStartAssistant()}
                     data-testid="help-start-assistant"
                   >
-                    <Sparkles />
+                    <StartAssistantIcon />
                     Start assistant
                   </Button>
                   {!hasEverLaunchedAgent && (

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1132,8 +1132,10 @@ export function HelpPanel({
   // so the button says what's about to start. Rendered bare: the Button variant
   // sizes descendant svgs and no brandColor is passed, so the glyph inherits the
   // accent fill's foreground rather than painting itself the brand hue. Falls
-  // back to the generic mark when an id outlives its config (agent uninstalled
-  // mid-session), mirroring the droppedPreferredAgentId name lookup below.
+  // back to the generic mark when an id outlives its registry entry — stored
+  // preferences are only revalidated on hydration, and uninstalling a CLI flips
+  // availability without dropping its config, so the live gap is an entry that
+  // disappears after selection. Mirrors the droppedPreferredAgentId lookup below.
   const StartAssistantIcon = launchableAgentId
     ? (getAgentConfig(launchableAgentId)?.icon ?? Sparkles)
     : Sparkles;

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -18,6 +18,7 @@ const {
   mockBuildResumeCommand,
   mockBuildResumeLatestCommand,
   mockGetAssistantSupportedAgentIds,
+  mockGetAgentConfig,
   mockGetHelpAssistantSettings,
   mockSystemSleepGetMetrics,
   mockSystemSleepOnSuspend,
@@ -50,6 +51,8 @@ const {
   mockBuildResumeCommand: vi.fn(),
   mockBuildResumeLatestCommand: vi.fn(),
   mockGetAssistantSupportedAgentIds: vi.fn(() => ["claude"]),
+  // Implementation is installed in resetState() so per-test overrides can't leak.
+  mockGetAgentConfig: vi.fn(),
   mockGetHelpAssistantSettings: vi.fn().mockResolvedValue({
     docSearch: true,
     daintreeControl: true,
@@ -215,7 +218,7 @@ vi.mock("@/config/agents", () => ({
   AGENT_REGISTRY: {
     claude: { name: "Claude", iconId: "claude", color: "#000", icon: () => null },
   },
-  getAgentConfig: () => ({ name: "Claude", icon: () => null, models: [] }),
+  getAgentConfig: (id: string) => mockGetAgentConfig(id),
   getAssistantSupportedAgentIds: () => mockGetAssistantSupportedAgentIds(),
   getAgentIds: () => ["claude"],
 }));
@@ -386,6 +389,25 @@ async function flushAsyncWork() {
   });
 }
 
+// Per-agent icon stand-ins for the empty-state CTA coverage. `getAgentConfig`
+// hands back a fresh config object on every call, so the icon *component*
+// reference is what has to stay stable — minting one per lookup would remount
+// the glyph each render. `data-agent-icon` is a test-only handle rather than a
+// copy of any production name, and `data-brand-color` records whether the CTA
+// passed a brandColor (it must not: the glyph inherits the button foreground).
+function makeAgentIconStub(agentId: string) {
+  return function AgentIconStub({ brandColor }: { brandColor?: string }) {
+    return <svg data-agent-icon={agentId} data-brand-color={brandColor ?? "inherit"} />;
+  };
+}
+const CLAUDE_ICON_STUB = makeAgentIconStub("claude");
+const CODEX_ICON_STUB = makeAgentIconStub("codex");
+const NULL_ICON_STUB = () => null;
+
+function agentIconMarkerIn(container: Element | null): string | null {
+  return container?.querySelector("[data-agent-icon]")?.getAttribute("data-agent-icon") ?? null;
+}
+
 function resetState() {
   helpPanelState.isOpen = true;
   helpPanelState.width = 380;
@@ -452,6 +474,14 @@ function resetState() {
   mockBuildResumeLatestCommand.mockReset();
   mockGetAssistantSupportedAgentIds.mockReset();
   mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
+  // Any-id-resolves-to-Claude with a glyph that renders nothing: the pre-#11834
+  // default, so the suite's other cases see exactly what they always did.
+  mockGetAgentConfig.mockReset();
+  mockGetAgentConfig.mockImplementation(() => ({
+    name: "Claude",
+    icon: NULL_ICON_STUB,
+    models: [],
+  }));
   mockGetHelpAssistantSettings.mockReset();
   mockGetHelpAssistantSettings.mockResolvedValue({
     docSearch: true,
@@ -896,6 +926,71 @@ describe("HelpPanel — Resume affordance for eviction-captured sessions", () =>
 
     expect(await findByTestId("help-start-assistant")).toBeTruthy();
     expect(queryByTestId("help-resume-assistant")).toBeNull();
+  });
+});
+
+describe("HelpPanel — empty-state CTA wears the launching agent's mark (#11834)", () => {
+  // A generic glyph on both CTAs said nothing about what was about to start.
+  // Each button now carries the mark of the agent it would actually launch,
+  // and the two buttons read different ids — Start follows the launch
+  // preference, Resume follows whichever agent's conversation was captured.
+  it("Start assistant wears the mark of the agent it would launch", async () => {
+    helpPanelState.autoLaunchEnabled = false; // default user — empty state stays visible
+    helpPanelState.preferredAgentId = "codex";
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetAgentConfig.mockImplementation((id: string) =>
+      id === "codex" ? { name: "Codex", icon: CODEX_ICON_STUB, models: [] } : undefined
+    );
+
+    const { findByTestId } = await act(async () => render(<HelpPanel width={380} />));
+    const startButton = await findByTestId("help-start-assistant");
+
+    expect(agentIconMarkerIn(startButton)).toBe("codex");
+    // No brandColor reaches the glyph, so it inherits the button's own
+    // foreground instead of painting itself the agent's brand hue.
+    expect(startButton.querySelector("[data-agent-icon]")?.getAttribute("data-brand-color")).toBe(
+      "inherit"
+    );
+  });
+
+  it("Resume assistant wears the captured agent's mark, not the launch preference's", async () => {
+    helpPanelState.autoLaunchEnabled = false;
+    // The preference points at codex while the stranded conversation belongs to
+    // claude. Resume relaunches the captured agent, so it must promise claude —
+    // this is what proves the two CTAs read different ids rather than sharing one.
+    helpPanelState.preferredAgentId = "codex";
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockBuildResumeLatestCommand.mockReturnValue("claude resume --last");
+    mockPeekPendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/tmp/help/proj-1",
+    });
+    mockGetAgentConfig.mockImplementation((id: string) => {
+      if (id === "claude") return { name: "Claude", icon: CLAUDE_ICON_STUB, models: [] };
+      if (id === "codex") return { name: "Codex", icon: CODEX_ICON_STUB, models: [] };
+      return undefined;
+    });
+
+    const { findByTestId } = await act(async () => render(<HelpPanel width={380} />));
+    const resumeButton = await findByTestId("help-resume-assistant");
+
+    expect(agentIconMarkerIn(resumeButton)).toBe("claude");
+  });
+
+  it("falls back to a generic mark when the launchable agent's config is gone", async () => {
+    helpPanelState.autoLaunchEnabled = false;
+    // A preferred id outlives the agent that was uninstalled under it. The CTA
+    // still needs a glyph rather than an empty slot beside its label.
+    helpPanelState.preferredAgentId = "ghost-agent";
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetAgentConfig.mockImplementation(() => undefined);
+
+    const { findByTestId } = await act(async () => render(<HelpPanel width={380} />));
+    const startButton = await findByTestId("help-start-assistant");
+
+    expect(agentIconMarkerIn(startButton)).toBeNull();
+    expect(startButton.querySelector("svg")).toBeTruthy();
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -978,15 +978,45 @@ describe("HelpPanel — empty-state CTA wears the launching agent's mark (#11834
     expect(agentIconMarkerIn(resumeButton)).toBe("claude");
   });
 
-  it("falls back to a generic mark when the launchable agent's config is gone", async () => {
+  it("infers the mark from the sole supported agent when no preference is set", async () => {
     helpPanelState.autoLaunchEnabled = false;
-    // A preferred id outlives the agent that was uninstalled under it. The CTA
-    // still needs a glyph rather than an empty slot beside its label.
-    helpPanelState.preferredAgentId = "ghost-agent";
+    // No stored preference, so the launch target is inferred from the single
+    // installed supported backend. The mark has to follow that inference rather
+    // than reading the (absent) preference straight off the store.
+    helpPanelState.preferredAgentId = null;
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
-    mockGetAgentConfig.mockImplementation(() => undefined);
+    mockGetAgentConfig.mockImplementation((id: string) =>
+      id === "claude" ? { name: "Claude", icon: CLAUDE_ICON_STUB, models: [] } : undefined
+    );
 
     const { findByTestId } = await act(async () => render(<HelpPanel width={380} />));
+
+    expect(agentIconMarkerIn(await findByTestId("help-start-assistant"))).toBe("claude");
+  });
+
+  it("swaps back to a generic mark when the launchable agent's config disappears", async () => {
+    helpPanelState.autoLaunchEnabled = false;
+    helpPanelState.preferredAgentId = "codex";
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    // Flipped between renders rather than via mockImplementationOnce: the config
+    // is resolved more than once per render, so a one-shot override would fall
+    // through mid-render and prove nothing.
+    let codexConfigResolves = true;
+    mockGetAgentConfig.mockImplementation((id: string) =>
+      id === "codex" && codexConfigResolves
+        ? { name: "Codex", icon: CODEX_ICON_STUB, models: [] }
+        : undefined
+    );
+
+    const { findByTestId, rerender } = await act(async () => render(<HelpPanel width={380} />));
+    expect(agentIconMarkerIn(await findByTestId("help-start-assistant"))).toBe("codex");
+
+    // The id now outlives its registry entry. The CTA has to keep a glyph rather
+    // than leave an empty slot beside its label.
+    codexConfigResolves = false;
+    await act(async () => {
+      rerender(<HelpPanel width={380} />);
+    });
     const startButton = await findByTestId("help-start-assistant");
 
     expect(agentIconMarkerIn(startButton)).toBeNull();


### PR DESCRIPTION
## Summary

- The assistant sidebar's empty state showed a generic `Sparkles` icon on both `Start assistant` and `Resume assistant`, regardless of which agent (Claude, Codex, or the Daintree Assistant) was actually configured to back the assistant.
- `HelpPanel.tsx` now resolves each CTA's icon from the agent config instead: `StartAssistantIcon` derived from `launchableAgentId`, `ResumeAssistantIcon` derived from `resumableAgentId`, each falling back to `Sparkles` if the lookup comes back empty.
- The icons render bare, no `brandColor`, no `className`, so they inherit the accent button's text color through `currentColor` rather than painting the brand's own hue. Sizing is unaffected since `Button` already constrains `svg` children to a fixed size.

Resolves #11834

## Changes

- No special case needed for the built-in Daintree Assistant agent: its icon id already resolves to the same bespoke brand icon component used elsewhere in this panel's footer, so the CTA and the footer end up showing the same mark for free.
- The `Sparkles` fallback isn't dead code: stored agent preferences are only revalidated when the panel hydrates, so a previously selected agent id can outlive its entry in the registry and the lookup can come back empty mid-session.
- Added four tests to `HelpPanel.hibernate.test.tsx`: the start icon follows `launchableAgentId`, the resume icon follows a different id than the launch preference (proving the two buttons read independent state), the icon is inferred correctly when only one agent is supported and no explicit preference is stored, and the icon falls back to the generic glyph when an agent's config disappears mid-session.

## Testing

- All 19 spec files under `HelpPanel`'s test directory pass, 302 tests total.
- All `src/config` contract suites pass, 387 tests.
- Lint and formatting clean on the changed files, project typechecks cleanly.