### PR TITLE
fix(assistant): close the sidebar when the user stops the assistant

### DIFF
--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -1064,8 +1064,7 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
       expect.anything(),
       expect.anything()
     );
-    // Confirmed stop closes the panel too — the confirm gates the teardown, not
-    // the slide-out (#11833).
+    // The same confirmation gates both the teardown and the slide-out (#11833).
     expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
   });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -1006,8 +1006,8 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
       expect.anything()
     );
     expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
-    // Stop ends the session but keeps the panel open (it is not "hide").
-    expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
+    // …and the panel slides out rather than lingering on the empty state (#11833).
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
   });
 
   it("shows the Stop assistant confirm when the agent is working (no teardown yet)", () => {
@@ -1064,8 +1064,9 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
       expect.anything(),
       expect.anything()
     );
-    // Confirmed stop keeps the panel open — restart is one click away.
-    expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
+    // Confirmed stop closes the panel too — the confirm gates the teardown, not
+    // the slide-out (#11833).
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
   });
 
   it("aborts a relaunch in flight so a late-settling dispatch never binds a fresh session", async () => {

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -600,12 +600,16 @@ export class HelpSessionController {
    * User-facing "Stop assistant" — actually end the running assistant terminal
    * rather than merely hiding the panel (`handleClose` only flips `isOpen`,
    * leaving the agent running). Unlike `newSession()` this does NOT relaunch:
-   * it tears the bound session down and leaves the panel open on its empty /
-   * start state so restarting is one click away (D0 inverse). Idempotent — a
-   * no-op when nothing is running and no launch is in flight.
+   * it tears the bound session down and slides the sidebar out (#11833), so
+   * every way a session ends — Stop, agent self-exit, PTY exit — leaves the
+   * panel closed rather than lingering on the empty state. Stop discards the
+   * conversation instead of pausing it, which is why the UI gates it behind a
+   * confirm whenever there is live work or an engaged conversation to lose;
+   * reopening starts fresh through the normal launch / auto-launch flow.
+   * Idempotent — a no-op when nothing is running and no launch is in flight.
    */
   endSession(): void {
-    this._stopBoundSession({ close: false });
+    this._stopBoundSession();
   }
 
   /**
@@ -613,10 +617,9 @@ export class HelpSessionController {
    * user typed `/exit`, or the agent quit — surfaced as `agentState: "exited"`.
    * Most assistant agents run inside a shell, so the agent exiting does NOT
    * exit the PTY (`handleTerminalPanelMissing` never fires and the sidebar
-   * would otherwise linger on a dead shell). Treat it like the Stop button but
-   * also slide the sidebar out: the user ended the session from the terminal,
-   * so hide the panel rather than leave it open on the empty state. No
-   * confirmation — the exit already happened.
+   * would otherwise linger on a dead shell). Treat it exactly like the Stop
+   * button — same teardown, same slide-out. No confirmation — the exit already
+   * happened.
    *
    * Guards keep a stale or racing signal from tearing down the wrong session:
    * skip while a hibernate owns the teardown, and only act when `terminalId`
@@ -632,13 +635,15 @@ export class HelpSessionController {
   }
 
   /**
-   * Shared stop core for the Stop button (`endSession`, keeps the panel open)
-   * and the terminal self-exit (`handleAgentExited`, slides the sidebar out).
-   * Aborts any in-flight launch first (mirrors `cancelLaunch`) so a
-   * late-settling provision can't bind a fresh terminal after the stop, tears
-   * the bound session down (revoke-before-kill), then makes the stop stick.
+   * Shared stop core for the Stop button (`endSession`) and the terminal
+   * self-exit (`handleAgentExited`). Aborts any in-flight launch first (mirrors
+   * `cancelLaunch`) so a late-settling provision can't bind a fresh terminal
+   * after the stop, tears the bound session down (revoke-before-kill), makes
+   * the stop stick, then slides the sidebar out. The close is unconditional:
+   * both callers end the session outright, so neither leaves the panel behind
+   * on its empty state.
    */
-  private _stopBoundSession(opts: { close: boolean }): void {
+  private _stopBoundSession(): void {
     this._launchGen++;
     this._isLaunching = false;
     this._clearLaunchWatchdog();
@@ -658,9 +663,7 @@ export class HelpSessionController {
 
     this._applyStopSuppression();
 
-    if (opts.close) {
-      useHelpPanelStore.getState().setOpen(false);
-    }
+    useHelpPanelStore.getState().setOpen(false);
   }
 
   /**
@@ -670,11 +673,15 @@ export class HelpSessionController {
    * can't resume on next open, disarm any pending hibernate timer, consume this
    * open cycle's auto-launch budget so a consented auto-launch
    * (`_maybeAutoLaunch`) can't immediately respawn the assistant that was just
-   * stopped (reopening the panel resets this in `_syncInputs`, so the next open
-   * still auto-launches as before), then clear session-scoped banners and drop
-   * the phase to idle so the panel lands on a clean empty / start state. Shared
-   * by `_stopBoundSession` (Stop button + agent self-exit) and the PTY-exit
-   * path (`handleTerminalPanelMissing`).
+   * stopped, then clear session-scoped banners and drop the phase to idle so
+   * the panel lands on a clean empty / start state. Shared by
+   * `_stopBoundSession` (Stop button + agent self-exit) and the PTY-exit path
+   * (`handleTerminalPanelMissing`).
+   *
+   * Every caller also closes the panel, and `_maybeAutoLaunch` hard-gates on
+   * `isOpen`, so the budget consumption is the belt against a sync still
+   * carrying the pre-close `isOpen` landing after the stop. `syncInputs` clears
+   * it once the close is observed, leaving the next open free to auto-launch.
    */
   private _applyStopSuppression(): void {
     // Read the workspace from the synced inputs, not the project store: in a

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -600,13 +600,16 @@ export class HelpSessionController {
    * User-facing "Stop assistant" — actually end the running assistant terminal
    * rather than merely hiding the panel (`handleClose` only flips `isOpen`,
    * leaving the agent running). Unlike `newSession()` this does NOT relaunch:
-   * it tears the bound session down and slides the sidebar out (#11833), so
-   * every way a session ends — Stop, agent self-exit, PTY exit — leaves the
-   * panel closed rather than lingering on the empty state. Stop discards the
-   * conversation instead of pausing it, which is why the UI gates it behind a
-   * confirm whenever there is live work or an engaged conversation to lose;
-   * reopening starts fresh through the normal launch / auto-launch flow.
-   * Idempotent — a no-op when nothing is running and no launch is in flight.
+   * it tears the bound session down and slides the sidebar out (#11833) rather
+   * than lingering on the empty state, matching the agent self-exit and PTY-exit
+   * paths once their identity/hibernation guards pass. (The replacing flows —
+   * `newSession`, `runAnyway`, agent switch — also tear down, but keep the panel
+   * open because they immediately launch again.) Stop discards the conversation
+   * instead of pausing it, which is why the UI gates it behind a confirm
+   * whenever there is live work or an engaged conversation to lose; reopening
+   * starts fresh through the normal launch / auto-launch flow. Safe to call
+   * repeatedly: with nothing bound it skips the teardown but still invalidates
+   * any in-flight launch and closes, converging on the same stopped state.
    */
   endSession(): void {
     this._stopBoundSession();
@@ -617,9 +620,9 @@ export class HelpSessionController {
    * user typed `/exit`, or the agent quit — surfaced as `agentState: "exited"`.
    * Most assistant agents run inside a shell, so the agent exiting does NOT
    * exit the PTY (`handleTerminalPanelMissing` never fires and the sidebar
-   * would otherwise linger on a dead shell). Treat it exactly like the Stop
-   * button — same teardown, same slide-out. No confirmation — the exit already
-   * happened.
+   * would otherwise linger on a dead shell). Once the hibernation and
+   * current-terminal guards below pass, reuse the Stop button's teardown and
+   * slide-out. No confirmation — the exit already happened.
    *
    * Guards keep a stale or racing signal from tearing down the wrong session:
    * skip while a hibernate owns the teardown, and only act when `terminalId`
@@ -631,7 +634,7 @@ export class HelpSessionController {
   handleAgentExited(terminalId: string): void {
     if (this._snapshot.phase === "hibernating") return;
     if (useHelpPanelStore.getState().terminalId !== terminalId) return;
-    this._stopBoundSession({ close: true });
+    this._stopBoundSession();
   }
 
   /**
@@ -678,10 +681,13 @@ export class HelpSessionController {
    * `_stopBoundSession` (Stop button + agent self-exit) and the PTY-exit path
    * (`handleTerminalPanelMissing`).
    *
-   * Every caller also closes the panel, and `_maybeAutoLaunch` hard-gates on
-   * `isOpen`, so the budget consumption is the belt against a sync still
-   * carrying the pre-close `isOpen` landing after the stop. `syncInputs` clears
-   * it once the close is observed, leaving the next open free to auto-launch.
+   * Closing the panel is what actually prevents the relaunch — every caller
+   * closes, and `_maybeAutoLaunch` hard-gates on `isOpen`. The budget write is
+   * a cheap belt on this shared tail, not the load-bearing guard: a pre-close
+   * render snapshot can reach `syncInputs` late, but it carries that render's
+   * still-bound `terminalId`, so the terminal gate already turns it away.
+   * `syncInputs` clears the flag once the close is observed, leaving the next
+   * open free to auto-launch.
    */
   private _applyStopSuppression(): void {
     // Read the workspace from the synced inputs, not the project store: in a

--- a/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
@@ -663,9 +663,10 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
 
     // clearTerminal ran — the store now reports no bound terminal.
     helpPanelState.terminalId = null;
-    // Stop closes the panel, but a sync still carrying the pre-close `isOpen`
-    // can land after it. Without the budget guard that stale-open sync would
-    // immediately respawn the assistant the user just stopped.
+    // A synthetic still-open sync with the terminal already cleared. The real
+    // Stop path can't commit this pair — `isOpen` and `terminalId` clear in the
+    // same batch — but splitting them isolates the auto-launch budget from the
+    // `isOpen` gate, so a regression in the budget guard alone stays visible.
     ctrl.syncInputs({
       isOpen: true,
       isReadyToLaunch: true,
@@ -758,7 +759,8 @@ describe("HelpSessionController — terminal PTY exit slides the sidebar out (#1
 
     ctrl.handleTerminalPanelMissing({ terminalId: "term-1", terminalExists: false });
 
-    // Minimal cleanup still runs, but the hibernate flow owns the slot + close.
+    // Minimal cleanup still runs; the hibernate flow owns the slot and phase,
+    // and this path must not touch panel visibility.
     expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(helpPanelState.clearHibernateSession).not.toHaveBeenCalled();

--- a/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
@@ -565,7 +565,7 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
     syncWorkspaceInputs(ctrl, workspace);
   }
 
-  it("tears the bound session down without relaunching", () => {
+  it("tears the bound session down without relaunching, then closes the panel", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "live" });
     bindLiveSession(ctrl);
@@ -581,9 +581,9 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
     // No fresh terminal is reserved — unlike newSession(), stop does not relaunch.
     expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
-    // The Stop button leaves the panel open on its empty state (D0 inverse) —
-    // only the terminal self-exit path slides the sidebar out.
-    expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
+    // #11833: Stop slides the sidebar out rather than lingering on the empty
+    // state — the same close the self-exit paths already perform.
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
     expect(ctrl.getSnapshot().phase).toBe("idle");
   });
 
@@ -663,8 +663,9 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
 
     // clearTerminal ran — the store now reports no bound terminal.
     helpPanelState.terminalId = null;
-    // The panel is still open with auto-launch consented; without the guard this
-    // would immediately respawn the assistant the user just stopped.
+    // Stop closes the panel, but a sync still carrying the pre-close `isOpen`
+    // can land after it. Without the budget guard that stale-open sync would
+    // immediately respawn the assistant the user just stopped.
     ctrl.syncInputs({
       isOpen: true,
       isReadyToLaunch: true,
@@ -816,7 +817,7 @@ describe("HelpSessionController — handleAgentExited (agent /exit inside a live
     expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
     expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
-    // Full stop, and the sidebar slides out (unlike the Stop button).
+    // Full stop, and the sidebar slides out — same as the Stop button (#11833).
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
     expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
     expect(ctrl["_hasAutoLaunched"]).toBe(true);


### PR DESCRIPTION
## Summary

- Picking "Stop assistant" from the Assistant panel's overflow menu used to tear the session down but leave the panel open on its empty first-run state. Now it closes the sidebar too, matching what already happened when the agent exited on its own from inside its terminal.
- `HelpSessionController._stopBoundSession()` lost its `close` option entirely and now always calls `setOpen(false)`. Both callers, `endSession()` (menu Stop, previously `close: false`) and `handleAgentExited()` (self-exit, previously `close: true`), converge on the same behavior. Keeping a boolean every caller passed the same way would just leave room for the two paths to drift apart again.
- Also refreshed the stale doc comments that justified staying open as a cheap "D0 inverse". That framing was wrong even before this change: starting a new assistant doesn't restore the conversation Stop discarded, so it was never really an inverse. The comments now describe Stop as irreversible teardown whose confirm is conditional on there being live work or an engaged conversation to lose.

Resolves #11833

## Changes

- Teardown ordering is unchanged: invalidate the in-flight launch, tear down the bound session (revoke before kill), apply stop suppression, then close.
- Reopening still works as before: the hibernate slot is dropped on stop, so reopening lands on the normal launch / auto-launch flow. The restart affordance is one navigation step further out, not gone.
- Flipped the three assertions that pinned the panel-stays-open behavior to assert the close instead: one at the controller level, two at the UI level covering the no-confirm idle path and the confirmed path.

## Testing

- Considered and rejected a new test pinning teardown-before-close ordering: `HibernationManager.maybeArm` only runs from the React-effect-driven `syncInputs`, which observes the final closed/no-terminal state, so intra-function call order isn't observable and the assertion couldn't fail. No e2e covers this flow.
- `npm run typecheck` clean.
- 480 tests across 27 files pass: all 5 `HelpSessionController` suites, all 20 `HelpPanel` suites, both `AppLayout` assistant specs, `focusStore.adversarial`.
- `prettier` and `eslint` clean on the changed files.

## Follow-ups (not in this PR)

1. **Keyboard focus lands on `<body>` after a menu-triggered stop.** The overflow menu item is portaled, so it's neither `document.body` nor inside `panelRef` when the close effect runs. `HelpPanel.tsx` clears `previousFocusRef` and declines the restore, and Radix's default `onCloseAutoFocus` then targets a trigger that's gone inert. There's no focus trap (Chromium's inert fixup blurs cleanly), but logical focus is lost. A correct fix needs a conditional `onCloseAutoFocus` on the shared `DropdownMenuContent` and can only be verified in real Chromium, since the header suite uses a pass-through dropdown mock, so it belongs in its own change with an e2e test.
2. **The focus-mode gesture snapshot can reopen the panel after a stop** (`AppLayout.tsx` restores the captured `assistantWasOpen`). Pre-existing #9641 behavior with a pinned test in `focusStore.adversarial.test.ts`; a destructive stop arguably should relinquish the assistant half of that snapshot.
3. **`help.launchAgent` isn't governed by the controller's `_launchGen`** (`src/services/actions/definitions/helpActions.ts`), so a launch already in flight can bind and reopen after a stop. Pre-dates this change.
