### PR TITLE
fix(completions): sync the Codex slash-command catalog with Codex 0.147.0

### DIFF
--- a/shared/types/__tests__/slashCommands.test.ts
+++ b/shared/types/__tests__/slashCommands.test.ts
@@ -1,17 +1,78 @@
 import { describe, expect, it } from "vitest";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "../../config/agentIds.js";
 import { AGENT_REGISTRY } from "../../config/agentRegistry.js";
+import type { CompletionSourceConfig } from "../completionSources.js";
 import { BUILTIN_SLASH_COMMANDS, getBuiltinSlashCommands } from "../slashCommands.js";
 
 const AGENT_IDS = new Set<string>(BUILT_IN_AGENT_IDS);
 
-/** Agents whose config declares the shared built-in catalog as a `/` source. */
-function agentsDeclaringBuiltinCatalog(): BuiltInAgentId[] {
-  return BUILT_IN_AGENT_IDS.filter((agentId) =>
-    AGENT_REGISTRY[agentId].completionSources?.some(
-      (source) => source.discovery.method === "static"
-    )
+/**
+ * The command set Codex 0.147.0's own `/` popup lists, captured from the
+ * installed CLI (#11843). This is an upstream contract, not a copy of the
+ * catalog: it fails whenever the two drift apart in either direction, which is
+ * the regression the catalog kept suffering. To refresh after a Codex upgrade,
+ * launch `codex`, type `/`, scroll the popup, and diff it against this list —
+ * then update the catalog and this fixture together, in that order.
+ */
+const CODEX_0_147_0_POPUP_COMMANDS = [
+  "agent",
+  "app",
+  "approve",
+  "archive",
+  "clear",
+  "compact",
+  "copy",
+  "delete",
+  "diff",
+  "exit",
+  "experimental",
+  "fast",
+  "feedback",
+  "fork",
+  "goal",
+  "hooks",
+  "ide",
+  "import",
+  "init",
+  "keymap",
+  "logout",
+  "mcp",
+  "memories",
+  "mention",
+  "model",
+  "new",
+  "permissions",
+  "personality",
+  "pets",
+  "plan",
+  "plugins",
+  "ps",
+  "raw",
+  "rename",
+  "resume",
+  "review",
+  "side",
+  "skills",
+  "status",
+  "statusline",
+  "stop",
+  "subagents",
+  "theme",
+  "title",
+  "usage",
+  "vim",
+] as const;
+
+/** The `/` sources whose commands come from the shared built-in catalog. */
+function builtinCatalogSources(agentId: BuiltInAgentId): CompletionSourceConfig[] {
+  return (AGENT_REGISTRY[agentId].completionSources ?? []).filter(
+    (source) =>
+      source.discovery.method === "static" && source.discovery.catalog === "builtin-slash-commands"
   );
+}
+
+function agentsReadingBuiltinCatalog(): BuiltInAgentId[] {
+  return BUILT_IN_AGENT_IDS.filter((agentId) => builtinCatalogSources(agentId).length > 0);
 }
 
 describe("BUILTIN_SLASH_COMMANDS registry", () => {
@@ -25,13 +86,14 @@ describe("BUILTIN_SLASH_COMMANDS registry", () => {
     expect(new Set(labels).size).toBe(labels.length);
   });
 
-  it("derives every label from its id", () => {
+  it("derives every label from its id as a single slash token", () => {
     for (const entry of BUILTIN_SLASH_COMMANDS) {
       expect(entry.label).toBe(`/${entry.id}`);
+      expect(entry.id).toMatch(/^[a-z0-9][a-z0-9-]*$/);
     }
   });
 
-  it("has non-empty, trimmed, period-free copy on every entry", () => {
+  it("has non-empty, trimmed, period-free text on every entry", () => {
     for (const entry of BUILTIN_SLASH_COMMANDS) {
       for (const value of [
         entry.id,
@@ -74,6 +136,31 @@ describe("BUILTIN_SLASH_COMMANDS registry", () => {
       }
     }
   });
+
+  // Array order is the order the menu renders on a bare `/` (rankSlashCommands
+  // returns the list untouched for an empty query), so the grouping the file
+  // documents has to hold in the data, not just in the comments.
+  it("keeps each support group contiguous and alphabetical", () => {
+    const groupOf = (agents: readonly BuiltInAgentId[]) => [...agents].sort().join("+");
+    const seen = new Set<string>();
+    let current: string | null = null;
+    let previousId = "";
+
+    for (const entry of BUILTIN_SLASH_COMMANDS) {
+      const group = groupOf(entry.supportedAgents);
+      if (group !== current) {
+        expect(seen.has(group), `${group} entries are split across the array`).toBe(false);
+        seen.add(group);
+        current = group;
+        previousId = "";
+      }
+      expect(
+        entry.id > previousId,
+        `/${entry.id} is out of alphabetical order within the ${group} group`
+      ).toBe(true);
+      previousId = entry.id;
+    }
+  });
 });
 
 describe("getBuiltinSlashCommands", () => {
@@ -90,10 +177,14 @@ describe("getBuiltinSlashCommands", () => {
     for (const agentId of BUILT_IN_AGENT_IDS) {
       for (const command of getBuiltinSlashCommands(agentId)) {
         const entry = BUILTIN_SLASH_COMMANDS.find((e) => e.id === command.id);
-        expect(command).toEqual({
-          id: entry?.id,
-          label: entry?.label,
-          description: entry?.descriptions?.[agentId] ?? entry?.description,
+        expect(entry, `${agentId} returned an unknown command id ${command.id}`).toBeDefined();
+        if (!entry) continue;
+        // toStrictEqual (not toEqual) so an explicitly-undefined `kind`,
+        // `sourcePath` or `trigger` still counts as a leaked key.
+        expect(command).toStrictEqual({
+          id: entry.id,
+          label: entry.label,
+          description: entry.descriptions?.[agentId] ?? entry.description,
           scope: "built-in",
           agentId,
         });
@@ -112,19 +203,19 @@ describe("getBuiltinSlashCommands", () => {
 
 describe("catalog / agent-registry consistency", () => {
   it("only declares support for agents that read the built-in catalog", () => {
-    const readers = new Set<string>(agentsDeclaringBuiltinCatalog());
+    const readers = new Set<string>(agentsReadingBuiltinCatalog());
     for (const entry of BUILTIN_SLASH_COMMANDS) {
       for (const agentId of entry.supportedAgents) {
         expect(
           readers.has(agentId),
-          `/${entry.id} lists ${agentId}, which declares no static built-in completion source`
+          `/${entry.id} lists ${agentId}, whose config never declares the built-in catalog`
         ).toBe(true);
       }
     }
   });
 
   it("gives every agent that reads the catalog a non-empty command list", () => {
-    const readers = agentsDeclaringBuiltinCatalog();
+    const readers = agentsReadingBuiltinCatalog();
     expect(readers.length).toBeGreaterThan(0);
     for (const agentId of readers) {
       expect(
@@ -132,5 +223,24 @@ describe("catalog / agent-registry consistency", () => {
         `${agentId} resolves to no commands`
       ).toBeGreaterThan(0);
     }
+  });
+
+  it("binds the built-in catalog to the slash trigger", () => {
+    // A `$`-triggered built-in source would leave every other test green while
+    // the slash menu silently dropped the agent's whole command list.
+    for (const agentId of agentsReadingBuiltinCatalog()) {
+      for (const source of builtinCatalogSources(agentId)) {
+        expect(source.trigger, `${agentId} reads the built-in catalog under a non-/ trigger`).toBe(
+          "/"
+        );
+      }
+    }
+  });
+});
+
+describe("Codex upstream conformance", () => {
+  it("matches the command set Codex 0.147.0 lists in its own popup", () => {
+    const actual = getBuiltinSlashCommands("codex").map((c) => c.id);
+    expect([...actual].sort()).toEqual([...CODEX_0_147_0_POPUP_COMMANDS].sort());
   });
 });

--- a/shared/types/__tests__/slashCommands.test.ts
+++ b/shared/types/__tests__/slashCommands.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
+import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "../../config/agentIds.js";
+import { AGENT_REGISTRY } from "../../config/agentRegistry.js";
 import { BUILTIN_SLASH_COMMANDS, getBuiltinSlashCommands } from "../slashCommands.js";
+
+const AGENT_IDS = new Set<string>(BUILT_IN_AGENT_IDS);
+
+/** Agents whose config declares the shared built-in catalog as a `/` source. */
+function agentsDeclaringBuiltinCatalog(): BuiltInAgentId[] {
+  return BUILT_IN_AGENT_IDS.filter((agentId) =>
+    AGENT_REGISTRY[agentId].completionSources?.some(
+      (source) => source.discovery.method === "static"
+    )
+  );
+}
 
 describe("BUILTIN_SLASH_COMMANDS registry", () => {
   it("has no duplicate ids", () => {
@@ -12,148 +25,112 @@ describe("BUILTIN_SLASH_COMMANDS registry", () => {
     expect(new Set(labels).size).toBe(labels.length);
   });
 
-  it("every entry has at least one supportedAgent", () => {
+  it("derives every label from its id", () => {
+    for (const entry of BUILTIN_SLASH_COMMANDS) {
+      expect(entry.label).toBe(`/${entry.id}`);
+    }
+  });
+
+  it("has non-empty, trimmed, period-free copy on every entry", () => {
+    for (const entry of BUILTIN_SLASH_COMMANDS) {
+      for (const value of [
+        entry.id,
+        entry.description,
+        ...Object.values(entry.descriptions ?? {}),
+      ]) {
+        expect(value).toBe(value.trim());
+        expect(value.length).toBeGreaterThan(0);
+        expect(value.endsWith(".")).toBe(false);
+      }
+    }
+  });
+
+  it("declares only real, non-duplicated agent ids in supportedAgents", () => {
     for (const entry of BUILTIN_SLASH_COMMANDS) {
       expect(entry.supportedAgents.length).toBeGreaterThan(0);
+      expect(new Set(entry.supportedAgents).size).toBe(entry.supportedAgents.length);
+      for (const agentId of entry.supportedAgents) {
+        expect(AGENT_IDS.has(agentId)).toBe(true);
+      }
+    }
+  });
+
+  it("only overrides descriptions for agents the entry actually supports", () => {
+    for (const entry of BUILTIN_SLASH_COMMANDS) {
+      for (const agentId of Object.keys(entry.descriptions ?? {})) {
+        expect(AGENT_IDS.has(agentId)).toBe(true);
+        expect(entry.supportedAgents).toContain(agentId);
+      }
+    }
+  });
+
+  it("never overrides a description with the base text", () => {
+    for (const entry of BUILTIN_SLASH_COMMANDS) {
+      for (const [agentId, override] of Object.entries(entry.descriptions ?? {})) {
+        expect(
+          override,
+          `/${entry.id} declares a ${agentId} override identical to its base description`
+        ).not.toBe(entry.description);
+      }
     }
   });
 });
 
 describe("getBuiltinSlashCommands", () => {
-  it("returns 34 commands for claude", () => {
-    expect(getBuiltinSlashCommands("claude")).toHaveLength(34);
+  it("returns exactly the entries declaring the agent, in registry order", () => {
+    for (const agentId of BUILT_IN_AGENT_IDS) {
+      const expected = BUILTIN_SLASH_COMMANDS.filter((e) =>
+        e.supportedAgents.includes(agentId)
+      ).map((e) => e.id);
+      expect(getBuiltinSlashCommands(agentId).map((c) => c.id)).toEqual(expected);
+    }
   });
 
-  it("returns 27 commands for gemini", () => {
-    expect(getBuiltinSlashCommands("gemini")).toHaveLength(27);
-  });
-
-  it("returns 35 commands for codex", () => {
-    expect(getBuiltinSlashCommands("codex")).toHaveLength(35);
-  });
-
-  it("returns empty array for unsupported agents", () => {
-    expect(getBuiltinSlashCommands("opencode")).toEqual([]);
-    expect(getBuiltinSlashCommands("cursor")).toEqual([]);
-  });
-
-  it("stamps agentId correctly on all returned commands", () => {
-    for (const agentId of ["claude", "gemini", "codex"] as const) {
-      const commands = getBuiltinSlashCommands(agentId);
-      for (const cmd of commands) {
-        expect(cmd.agentId).toBe(agentId);
+  it("projects each entry to the public SlashCommand shape and nothing else", () => {
+    for (const agentId of BUILT_IN_AGENT_IDS) {
+      for (const command of getBuiltinSlashCommands(agentId)) {
+        const entry = BUILTIN_SLASH_COMMANDS.find((e) => e.id === command.id);
+        expect(command).toEqual({
+          id: entry?.id,
+          label: entry?.label,
+          description: entry?.descriptions?.[agentId] ?? entry?.description,
+          scope: "built-in",
+          agentId,
+        });
       }
     }
   });
 
-  it("sets scope to built-in on all returned commands", () => {
-    const commands = getBuiltinSlashCommands("claude");
-    for (const cmd of commands) {
-      expect(cmd.scope).toBe("built-in");
+  it("returns unique ids and labels per agent", () => {
+    for (const agentId of BUILT_IN_AGENT_IDS) {
+      const commands = getBuiltinSlashCommands(agentId);
+      expect(new Set(commands.map((c) => c.id)).size).toBe(commands.length);
+      expect(new Set(commands.map((c) => c.label)).size).toBe(commands.length);
+    }
+  });
+});
+
+describe("catalog / agent-registry consistency", () => {
+  it("only declares support for agents that read the built-in catalog", () => {
+    const readers = new Set<string>(agentsDeclaringBuiltinCatalog());
+    for (const entry of BUILTIN_SLASH_COMMANDS) {
+      for (const agentId of entry.supportedAgents) {
+        expect(
+          readers.has(agentId),
+          `/${entry.id} lists ${agentId}, which declares no static built-in completion source`
+        ).toBe(true);
+      }
     }
   });
 
-  it("applies per-agent description overrides for /init", () => {
-    const claudeInit = getBuiltinSlashCommands("claude").find((c) => c.label === "/init");
-    const codexInit = getBuiltinSlashCommands("codex").find((c) => c.label === "/init");
-    const geminiInit = getBuiltinSlashCommands("gemini").find((c) => c.label === "/init");
-
-    expect(claudeInit?.description).toBe("Initialize project configuration");
-    expect(codexInit?.description).toBe("Scaffold AGENTS.md instructions");
-    expect(geminiInit?.description).toBe("Initialize project configuration");
-  });
-
-  it("applies per-agent description overrides for /model", () => {
-    const claudeModel = getBuiltinSlashCommands("claude").find((c) => c.label === "/model");
-    const codexModel = getBuiltinSlashCommands("codex").find((c) => c.label === "/model");
-
-    expect(claudeModel?.description).toBe("Switch active AI model");
-    expect(codexModel?.description).toBe("Switch model or reasoning settings");
-  });
-
-  it("applies per-agent description overrides for /clear", () => {
-    const claudeClear = getBuiltinSlashCommands("claude").find((c) => c.label === "/clear");
-    const geminiClear = getBuiltinSlashCommands("gemini").find((c) => c.label === "/clear");
-
-    expect(claudeClear?.description).toBe("Reset display and attention buffer");
-    expect(geminiClear?.description).toBe("Clear the terminal display");
-  });
-
-  it("applies per-agent description overrides for /goal", () => {
-    const entry = BUILTIN_SLASH_COMMANDS.find((e) => e.id === "goal");
-    const claudeGoal = getBuiltinSlashCommands("claude").find((c) => c.label === "/goal");
-    const codexGoal = getBuiltinSlashCommands("codex").find((c) => c.label === "/goal");
-
-    expect(entry?.descriptions?.codex).toBeTruthy();
-    expect(claudeGoal?.description).toBe(entry?.description);
-    expect(codexGoal?.description).toBe(entry?.descriptions?.codex);
-    expect(claudeGoal?.description).not.toBe(codexGoal?.description);
-  });
-
-  it("/compact appears for claude and codex but not gemini", () => {
-    expect(getBuiltinSlashCommands("claude").some((c) => c.label === "/compact")).toBe(true);
-    expect(getBuiltinSlashCommands("codex").some((c) => c.label === "/compact")).toBe(true);
-    expect(getBuiltinSlashCommands("gemini").some((c) => c.label === "/compact")).toBe(false);
-  });
-
-  it("/goal appears for claude and codex but not gemini", () => {
-    expect(getBuiltinSlashCommands("claude").some((c) => c.label === "/goal")).toBe(true);
-    expect(getBuiltinSlashCommands("codex").some((c) => c.label === "/goal")).toBe(true);
-    expect(getBuiltinSlashCommands("gemini").some((c) => c.label === "/goal")).toBe(false);
-  });
-
-  it("/compress appears for gemini only", () => {
-    expect(getBuiltinSlashCommands("gemini").some((c) => c.label === "/compress")).toBe(true);
-    expect(getBuiltinSlashCommands("claude").some((c) => c.label === "/compress")).toBe(false);
-    expect(getBuiltinSlashCommands("codex").some((c) => c.label === "/compress")).toBe(false);
-  });
-
-  it("/add-dir appears for claude only", () => {
-    expect(getBuiltinSlashCommands("claude").some((c) => c.label === "/add-dir")).toBe(true);
-    expect(getBuiltinSlashCommands("gemini").some((c) => c.label === "/add-dir")).toBe(false);
-    expect(getBuiltinSlashCommands("codex").some((c) => c.label === "/add-dir")).toBe(false);
-  });
-
-  it("codex catalog is refreshed: /approvals dropped, /permissions kept, 14 additions present", () => {
-    const codex = new Set(getBuiltinSlashCommands("codex").map((c) => c.label));
-    // /approvals is a deprecated alias of the already-shared /permissions.
-    expect(codex.has("/approvals")).toBe(false);
-    expect(codex.has("/permissions")).toBe(true);
-    // /mention and /logout are retained (present in installed Codex 0.144.1).
-    expect(codex.has("/mention")).toBe(true);
-    expect(codex.has("/logout")).toBe(true);
-    // The 14 additions researched against the installed CLI.
-    const additions = [
-      "/apps",
-      "/plugins",
-      "/skills",
-      "/fast",
-      "/plan",
-      "/goal",
-      "/personality",
-      "/memories",
-      "/agent",
-      "/feedback",
-      "/raw",
-      "/stop",
-      "/approve",
-      "/sandbox-add-read-dir",
-    ];
-    for (const label of additions) expect(codex.has(label)).toBe(true);
-  });
-
-  it("does not include kind or sourcePath on returned commands", () => {
-    const commands = getBuiltinSlashCommands("claude");
-    for (const cmd of commands) {
-      expect(cmd).not.toHaveProperty("kind");
-      expect(cmd).not.toHaveProperty("sourcePath");
-    }
-  });
-
-  it("no duplicate labels within any agent's results", () => {
-    for (const agentId of ["claude", "gemini", "codex"] as const) {
-      const labels = getBuiltinSlashCommands(agentId).map((c) => c.label);
-      expect(new Set(labels).size).toBe(labels.length);
+  it("gives every agent that reads the catalog a non-empty command list", () => {
+    const readers = agentsDeclaringBuiltinCatalog();
+    expect(readers.length).toBeGreaterThan(0);
+    for (const agentId of readers) {
+      expect(
+        getBuiltinSlashCommands(agentId).length,
+        `${agentId} resolves to no commands`
+      ).toBeGreaterThan(0);
     }
   });
 });

--- a/shared/types/slashCommands.ts
+++ b/shared/types/slashCommands.ts
@@ -45,24 +45,25 @@ export interface BuiltinSlashCommandEntry {
   supportedAgents: readonly BuiltInAgentId[];
 }
 
+// Entries are grouped by the agents that support them and kept alphabetical
+// within each group: `rankSlashCommands` returns the list untouched for an
+// empty query, so array order is the order the menu shows on a bare `/`.
 const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
   // Shared by all three agents (claude, gemini, codex)
   {
-    id: "bug",
-    label: "/bug",
-    description: "File an issue report",
+    id: "clear",
+    label: "/clear",
+    description: "Clear the terminal display",
+    descriptions: {
+      claude: "Reset display and attention buffer",
+      codex: "Clear the terminal and start a new chat",
+    },
     supportedAgents: ["claude", "gemini", "codex"],
   },
   {
     id: "copy",
     label: "/copy",
     description: "Copy last response to clipboard",
-    supportedAgents: ["claude", "gemini", "codex"],
-  },
-  {
-    id: "cost",
-    label: "/cost",
-    description: "Show estimated costs (alias for /stats)",
     supportedAgents: ["claude", "gemini", "codex"],
   },
   {
@@ -77,13 +78,6 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     label: "/exit",
     description: "Exit the session",
     descriptions: { claude: "Terminate session & cleanup" },
-    supportedAgents: ["claude", "gemini", "codex"],
-  },
-  {
-    id: "help",
-    label: "/help",
-    description: "Show available commands",
-    descriptions: { gemini: "Show help for available commands" },
     supportedAgents: ["claude", "gemini", "codex"],
   },
   {
@@ -125,46 +119,60 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     descriptions: { codex: "Run a code review pass" },
     supportedAgents: ["claude", "gemini", "codex"],
   },
+
+  // Shared by claude + gemini.
+  // None of these exist in Codex 0.147.0 (verified against the installed
+  // binary's command table), so codex is deliberately absent here.
+  {
+    id: "bug",
+    label: "/bug",
+    description: "File an issue report",
+    supportedAgents: ["claude", "gemini"],
+  },
+  {
+    id: "cost",
+    label: "/cost",
+    description: "Show estimated costs (alias for /stats)",
+    supportedAgents: ["claude", "gemini"],
+  },
+  {
+    id: "help",
+    label: "/help",
+    description: "Show available commands",
+    descriptions: { gemini: "Show help for available commands" },
+    supportedAgents: ["claude", "gemini"],
+  },
   {
     id: "security-review",
     label: "/security-review",
     description: "Security-focused code review",
-    supportedAgents: ["claude", "gemini", "codex"],
+    supportedAgents: ["claude", "gemini"],
   },
   {
     id: "settings",
     label: "/settings",
     description: "Open settings configuration",
     descriptions: { gemini: "Edit settings configuration" },
-    supportedAgents: ["claude", "gemini", "codex"],
+    supportedAgents: ["claude", "gemini"],
   },
   {
     id: "stats",
     label: "/stats",
     description: "Show token usage and session statistics",
     descriptions: { gemini: "Show session statistics (tokens, latency)" },
-    supportedAgents: ["claude", "gemini", "codex"],
+    supportedAgents: ["claude", "gemini"],
   },
   {
     id: "tools",
     label: "/tools",
     description: "List available tools and capabilities",
     descriptions: { gemini: "List enabled tools/capabilities" },
-    supportedAgents: ["claude", "gemini", "codex"],
+    supportedAgents: ["claude", "gemini"],
   },
   {
     id: "undo",
     label: "/undo",
     description: "Revert the last conversation turn",
-    supportedAgents: ["claude", "gemini", "codex"],
-  },
-
-  // Shared by claude + gemini
-  {
-    id: "clear",
-    label: "/clear",
-    description: "Clear the terminal display",
-    descriptions: { claude: "Reset display and attention buffer" },
     supportedAgents: ["claude", "gemini"],
   },
 
@@ -181,6 +189,50 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     description: "Set a goal that must be met before stopping",
     descriptions: { codex: "Manage the session goal (edit, pause, resume, clear)" },
     supportedAgents: ["claude", "codex"],
+  },
+  {
+    id: "hooks",
+    label: "/hooks",
+    description: "Manage execution event hooks",
+    descriptions: { codex: "View and manage lifecycle hooks" },
+    supportedAgents: ["claude", "codex"],
+  },
+  {
+    id: "resume",
+    label: "/resume",
+    description: "Rehydrate previous session context",
+    descriptions: { codex: "Resume a saved chat" },
+    supportedAgents: ["claude", "codex"],
+  },
+  {
+    id: "statusline",
+    label: "/statusline",
+    description: "Customize UI status bar",
+    descriptions: { codex: "Configure which items appear in the status line" },
+    supportedAgents: ["claude", "codex"],
+  },
+  {
+    id: "usage",
+    label: "/usage",
+    description: "Show plan usage limits",
+    descriptions: { codex: "View account usage or use a usage limit reset" },
+    supportedAgents: ["claude", "codex"],
+  },
+
+  // Shared by gemini + codex
+  {
+    id: "theme",
+    label: "/theme",
+    description: "Customize CLI visual theme",
+    descriptions: { codex: "Choose a syntax highlighting theme" },
+    supportedAgents: ["gemini", "codex"],
+  },
+  {
+    id: "vim",
+    label: "/vim",
+    description: "Toggle Vim input mode",
+    descriptions: { codex: "Toggle Vim mode for the composer" },
+    supportedAgents: ["gemini", "codex"],
   },
 
   // Claude-only
@@ -221,18 +273,6 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     supportedAgents: ["claude"],
   },
   {
-    id: "hooks",
-    label: "/hooks",
-    description: "Manage execution event hooks",
-    supportedAgents: ["claude"],
-  },
-  {
-    id: "resume",
-    label: "/resume",
-    description: "Rehydrate previous session context",
-    supportedAgents: ["claude"],
-  },
-  {
     id: "rewind",
     label: "/rewind",
     description: "Undo last turn(s) to fix hallucinations",
@@ -245,12 +285,6 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     supportedAgents: ["claude"],
   },
   {
-    id: "statusline",
-    label: "/statusline",
-    description: "Customize UI status bar",
-    supportedAgents: ["claude"],
-  },
-  {
     id: "terminal-setup",
     label: "/terminal-setup",
     description: "Configure keybindings",
@@ -260,12 +294,6 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     id: "todos",
     label: "/todos",
     description: "Inspect agent task queue",
-    supportedAgents: ["claude"],
-  },
-  {
-    id: "usage",
-    label: "/usage",
-    description: "Show plan usage limits",
     supportedAgents: ["claude"],
   },
 
@@ -312,24 +340,88 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     description: "Undo recent file changes",
     supportedAgents: ["gemini"],
   },
-  {
-    id: "theme",
-    label: "/theme",
-    description: "Customize CLI visual theme",
-    supportedAgents: ["gemini"],
-  },
-  {
-    id: "vim",
-    label: "/vim",
-    description: "Toggle Vim input mode",
-    supportedAgents: ["gemini"],
-  },
 
   // Codex-only.
-  // Refreshed against installed Codex v0.144.1: `/approvals` is a deprecated
-  // alias of the already-shared `/permissions`, so it is dropped here; `/mention`
-  // and `/logout` remain (both present in the installed binary). Skills/apps/
-  // plugins and the newer session controls were added below.
+  // Refreshed against installed Codex v0.147.0 (#11843). The catalog mirrors
+  // the command set Codex's own `/` popup lists: to re-verify after a Codex
+  // upgrade, open the CLI, type `/`, and diff the popup against these entries.
+  // Deliberately excluded: `/apps`, `/sandbox-add-read-dir` and
+  // `/setup-default-sandbox` exist in the binary but are context-gated and
+  // unreachable in a normal session; `/btw` and `/quit` are aliases Codex
+  // hides from its own list; `/debug-config`, `/rollout`, `/test-approval`,
+  // `/debug-m-drop` and `/debug-m-update` are internal debug commands.
+  {
+    id: "agent",
+    label: "/agent",
+    description: "Switch the active agent thread",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "app",
+    label: "/app",
+    description: "Continue this session in the desktop app",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "approve",
+    label: "/approve",
+    description: "Approve one retry of a recent auto-review denial",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "archive",
+    label: "/archive",
+    description: "Archive this session and exit",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "delete",
+    label: "/delete",
+    description: "Permanently delete this session and exit",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "experimental",
+    label: "/experimental",
+    description: "Toggle experimental features",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "fast",
+    label: "/fast",
+    description: "1.5x speed, increased usage",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "feedback",
+    label: "/feedback",
+    description: "Send logs to maintainers",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "fork",
+    label: "/fork",
+    description: "Fork the current chat",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "ide",
+    label: "/ide",
+    description: "Include selection, open files, and context from your IDE",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "import",
+    label: "/import",
+    description: "Import setup, this project, and recent chats from Claude Code",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "keymap",
+    label: "/keymap",
+    description: "Remap TUI shortcuts",
+    supportedAgents: ["codex"],
+  },
   {
     id: "logout",
     label: "/logout",
@@ -337,45 +429,15 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     supportedAgents: ["codex"],
   },
   {
+    id: "memories",
+    label: "/memories",
+    description: "Configure memory use and generation",
+    supportedAgents: ["codex"],
+  },
+  {
     id: "mention",
     label: "/mention",
-    description: "Add file/symbol to context window",
-    supportedAgents: ["codex"],
-  },
-  {
-    id: "status",
-    label: "/status",
-    description: "Show active config and usage",
-    supportedAgents: ["codex"],
-  },
-  {
-    id: "apps",
-    label: "/apps",
-    description: "Manage connectors and integrations",
-    supportedAgents: ["codex"],
-  },
-  {
-    id: "plugins",
-    label: "/plugins",
-    description: "Manage installed plugins",
-    supportedAgents: ["codex"],
-  },
-  {
-    id: "skills",
-    label: "/skills",
-    description: "Browse and manage skills",
-    supportedAgents: ["codex"],
-  },
-  {
-    id: "fast",
-    label: "/fast",
-    description: "Toggle fast response mode",
-    supportedAgents: ["codex"],
-  },
-  {
-    id: "plan",
-    label: "/plan",
-    description: "Draft a plan before acting",
+    description: "Mention a file",
     supportedAgents: ["codex"],
   },
   {
@@ -385,45 +447,75 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     supportedAgents: ["codex"],
   },
   {
-    id: "memories",
-    label: "/memories",
-    description: "Manage saved memories",
+    id: "pets",
+    label: "/pets",
+    description: "Choose or hide the terminal pet",
     supportedAgents: ["codex"],
   },
   {
-    id: "agent",
-    label: "/agent",
-    description: "Configure agent behavior",
+    id: "plan",
+    label: "/plan",
+    description: "Switch to Plan mode",
     supportedAgents: ["codex"],
   },
   {
-    id: "feedback",
-    label: "/feedback",
-    description: "Send feedback to OpenAI",
+    id: "plugins",
+    label: "/plugins",
+    description: "Manage installed plugins",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "ps",
+    label: "/ps",
+    description: "List background terminals",
     supportedAgents: ["codex"],
   },
   {
     id: "raw",
     label: "/raw",
-    description: "Toggle raw output mode",
+    description: "Toggle raw scrollback mode for copy-friendly selection",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "rename",
+    label: "/rename",
+    description: "Rename the current thread",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "side",
+    label: "/side",
+    description: "Start a side conversation in an ephemeral fork",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "skills",
+    label: "/skills",
+    description: "Browse and manage skills",
+    supportedAgents: ["codex"],
+  },
+  {
+    id: "status",
+    label: "/status",
+    description: "Show active config and usage",
     supportedAgents: ["codex"],
   },
   {
     id: "stop",
     label: "/stop",
-    description: "Stop the current task",
+    description: "Stop all background terminals",
     supportedAgents: ["codex"],
   },
   {
-    id: "approve",
-    label: "/approve",
-    description: "Approve the pending action",
+    id: "subagents",
+    label: "/subagents",
+    description: "Switch the active agent thread",
     supportedAgents: ["codex"],
   },
   {
-    id: "sandbox-add-read-dir",
-    label: "/sandbox-add-read-dir",
-    description: "Grant read access to a directory",
+    id: "title",
+    label: "/title",
+    description: "Configure which items appear in the terminal title",
     supportedAgents: ["codex"],
   },
 ];

--- a/shared/types/slashCommands.ts
+++ b/shared/types/slashCommands.ts
@@ -91,6 +91,7 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
     id: "mcp",
     label: "/mcp",
     description: "Manage Model Context Protocol servers",
+    descriptions: { codex: "List configured MCP tools; use /mcp verbose for details" },
     supportedAgents: ["claude", "gemini", "codex"],
   },
   {


### PR DESCRIPTION
## Summary

- The Codex slash-command catalog had drifted from the real CLI in both directions: it omitted commands Codex supports and advertised eight that don't exist in Codex at all.
- Rather than guess, I established ground truth by scraping the live Codex 0.147.0 TUI popup (driving the CLI through a pty and rendering the frames with a VT emulator) and cross-checked it against the command table in the Rust binary's string pool.
- `getBuiltinSlashCommands("codex")` now resolves to exactly the 46 commands Codex's own `/` popup lists. No more, no fewer.

Resolves #11843

## Changes

- Added 14 entries that were missing: `/app`, `/archive`, `/delete`, `/experimental`, `/fork`, `/ide`, `/import`, `/keymap`, `/pets`, `/ps`, `/rename`, `/side`, `/subagents`, `/title`.
- Re-gated 7 existing entries onto `codex`: `/clear`, `/hooks`, `/resume`, `/statusline`, `/usage`, `/theme`, `/vim`.
- Dropped `codex` from 8 commands it never supported: `/bug`, `/cost`, `/help`, `/security-review`, `/settings`, `/stats`, `/tools`, `/undo`.
- Removed `/apps` and `/sandbox-add-read-dir`, real Codex enum variants that are context-gated and unreachable in a normal session (verified they don't appear even under `--sandbox workspace-write`), so listing them unconditionally would recreate the false-positive half of the original bug.
- Corrected 9 descriptions that misstated what a command does. The worst was `/stop`, which said "Stop the current task" when it actually stops all background terminals. Also fixed `/agent`, `/approve`, `/plan`, `/fast`, `/raw`, `/feedback`, `/memories`, `/mention`, plus a codex-specific `/mcp` override since Codex's `/mcp` lists tools rather than managing servers.
- Regrouped the array so the group comments match the data. This matters beyond tidiness: `rankSlashCommands` returns the list untouched for an empty query, so array order is the order the menu renders on a bare `/`. Each group is now kept alphabetical, and a test enforces both properties.

Two open questions from the issue, resolved with evidence rather than guesses:

- `/quit` is real and reachable in Codex (typing it filters and matches, description "exit Codex"), but Codex deliberately hides it from its own popup as an alias of `/exit`. `/btw` is the same, an alias of `/side`. Both are deliberately left out, so the catalog mirrors what Codex itself advertises. `/quit` stays a gemini-only entry, unchanged.
- `/delete` gets no Daintree confirm dialog, and that's deliberate. Selecting a slash command only types literal text into the agent's PTY, the same thing a user can do by typing it by hand, so it isn't a Daintree destructive action in the sense that governs ActionService/IPC dispatches. Codex already halts with its own native confirm ("Delete this session? Cannot be undone... / Yes, delete and exit"), so intercepting it here would just be a double prompt. The row states the consequence instead: "Permanently delete this session and exit".

## Testing

The old tests asserted hardcoded per-agent counts (34/27/35) and an itemized list of the 14 additions, both tautological under the repo's no-tautological-assertions rule, since editing the catalog forced the same edit in the test while proving nothing. Those are deleted, not incremented.

In their place: structural invariants (labels derive from ids, `supportedAgents` contain only real agent ids, description overrides only target supported agents and never restate the base text, groups stay contiguous and alphabetical), a bidirectional cross-check against `AGENT_REGISTRY` (every agent named in `supportedAgents` declares the built-in catalog as a `/` source, and every agent declaring it resolves to a non-empty list), and one upstream conformance fixture pinned to Codex 0.147.0. That last one is a literal list, deliberately: its oracle is the external CLI at a named version, not the catalog file, so it goes red on drift in either direction, and it carries the re-verification recipe in a comment for the next refresh.

Locally, 232 targeted tests pass (catalog, ranking, autocomplete item mapping, completion discovery engine, completion parsers, agent settings), and prettier/eslint are clean on both changed files. No renderer, Electron service, or agent-config change was needed. The catalog is passive data and every consumer reads it generically.
