### PR TITLE
test(projectview): Playwright-free harness for CDP renderer freeze

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -224,6 +224,8 @@ npm run build && npm run test:freeze-harness
 FREEZE_HARNESS_RUNS=5 npm run test:freeze-harness   # variance
 ```
 
+The whole measurement has to finish before the cached view's first memory purge (`CACHED_VIEW_PURGE_DELAY_MS`, armed the moment the view is cached), or the purge perturbs the throughput being measured. That is checked against the elapsed clock just before the control leg, so widening `DAINTREE_FREEZE_HARNESS_WINDOW_MS` past what fits fails the run with the shortfall rather than reporting a number measured across a purge.
+
 Reference numbers (macOS, Electron 42, 3s windows): control ~54,000 ticks, frozen **0**, recovered ~52,000. With `freezeWebContents` neutered the same run reads control 54,026 / frozen 53,875 — a ratio of 1.0x against 54,000x, so the harness is discriminating by a wide margin.
 
 **Measured on macOS only.** The mechanism is Chromium/CDP semantics and should be platform-independent, but that is an inference; Windows is unverified and is the platform most likely to differ. The harness is not wired into any workflow yet — run it on demand.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -209,6 +209,25 @@ Two distinct smoke checks run at different points in the pipeline:
 
 `npm run test:e2e:core` runs the 5 Playwright specs in `e2e/core/` against the Electron app. These are deterministic release-gate tests that gate every OS publish.
 
+## `test:freeze-harness` — why it can't be a Playwright spec
+
+`npm run test:freeze-harness` (`scripts/run-freeze-harness.mjs` + `electron/services/freezeHarness.ts`) measures whether a cached project view's renderer genuinely stops executing tasks when the efficiency-freeze path freezes it, and resumes when it is thawed.
+
+**Do not port this to Playwright.** Playwright sends `Emulation.setFocusEmulationEnabled` to every page target it attaches to. That handler takes out a `WebContents` capturer with `stay_hidden=false`, which permanently tells the renderer it is user-visible. `Page.setWebLifecycleState(frozen)` calls `WasHidden()` internally, so on a forced-visible page it no-ops — while still returning success. A freeze assertion written in Playwright passes whether or not freeze works, in every project view, always (#11846). A second CDP session can't undo it either: `capture_handle_` and `focus_emulation_enabled_` are per-session handler state.
+
+The harness therefore boots the real app with no Playwright and no debugger client of its own — attaching one would collide with the `ensureAttached` inside `freezeWebContents`, land in `EXPECTED_CDP_ERRORS`, and be swallowed. The renderer counts its own `MessageChannel` tasks into wall-clock buckets; `webContents.executeJavaScript` (Blink script execution, not CDP) reads the timeline out **after** the thaw, because a frozen renderer cannot answer while frozen. Three legs are measured at equal width — cached-unfrozen, frozen, thawed — and the assertions are **ratios**, not timing bounds, because a bound goes red on a loaded box.
+
+`MessageChannel` rather than a timer is deliberate: timers are subject to background throttling, which would confound "frozen" with "merely throttled".
+
+```bash
+npm run build && npm run test:freeze-harness
+FREEZE_HARNESS_RUNS=5 npm run test:freeze-harness   # variance
+```
+
+Reference numbers (macOS, Electron 42, 3s windows): control ~54,000 ticks, frozen **0**, recovered ~52,000. With `freezeWebContents` neutered the same run reads control 54,026 / frozen 53,875 — a ratio of 1.0x against 54,000x, so the harness is discriminating by a wide margin.
+
+**Measured on macOS only.** The mechanism is Chromium/CDP semantics and should be platform-independent, but that is an inference; Windows is unverified and is the platform most likely to differ. The harness is not wired into any workflow yet — run it on demand.
+
 ## Smoke Audit Cadence
 
 The `core` Playwright project is the release-gate smoke — 5 specs that gate every OS publish. To ensure these 5 specs stay calibrated against real regressions, run a quarterly "kill rate" audit:

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -224,7 +224,7 @@ npm run build && npm run test:freeze-harness
 FREEZE_HARNESS_RUNS=5 npm run test:freeze-harness   # variance
 ```
 
-The whole measurement has to finish before the cached view's first memory purge (`CACHED_VIEW_PURGE_DELAY_MS`, armed the moment the view is cached), or the purge perturbs the throughput being measured. That is checked against the elapsed clock just before the control leg, so widening `DAINTREE_FREEZE_HARNESS_WINDOW_MS` past what fits fails the run with the shortfall rather than reporting a number measured across a purge.
+All three measurement windows have to close before the cached view's first memory purge (`CACHED_VIEW_PURGE_DELAY_MS`, armed as the view is parked), or the purge perturbs the throughput being measured. The planned schedule is checked against the elapsed clock just before the control leg, and the actual finish is checked again after the last window — so widening `DAINTREE_FREEZE_HARNESS_WINDOW_MS` past what fits, or timers running long on a loaded box, fails the run with the shortfall rather than reporting a number measured across a purge.
 
 Reference numbers (macOS, Electron 42, 3s windows): control ~54,000 ticks, frozen **0**, recovered ~52,000. With `freezeWebContents` neutered the same run reads control 54,026 / frozen 53,875 — a ratio of 1.0x against 54,000x, so the harness is discriminating by a wide margin.
 

--- a/electron/services/__tests__/freezeHarness.test.ts
+++ b/electron/services/__tests__/freezeHarness.test.ts
@@ -7,8 +7,17 @@ vi.mock("../ProjectStore.js", () => ({
   },
 }));
 
+// The harness imports the purge delay from the lifecycle controller so the two
+// can't drift. The controller reaches `electron` at module scope, which a unit
+// test has no business booting — and every budget assertion below passes its own
+// delay explicitly, so the value here is never the thing under test.
+vi.mock("../../window/ProjectViewLifecycleController.js", () => ({
+  CACHED_VIEW_PURGE_DELAY_MS: 20_000,
+}));
+
 const {
   evaluateFreezeMeasurement,
+  evaluatePurgeBudget,
   longestStall,
   sumTicksInWindow,
   MIN_CONTROL_TICKS,
@@ -183,5 +192,66 @@ describe("evaluateFreezeMeasurement", () => {
     });
     expect(verdict.passed).toBe(false);
     expect(verdict.failures.join("\n")).toContain("positive control is not alive");
+  });
+});
+
+describe("evaluatePurgeBudget", () => {
+  const base = { elapsedSinceCachedMs: 2_000, measureWindowMs: 3_000, purgeDelayMs: 20_000 };
+
+  it("scales the remaining schedule by three windows, one per measurement leg", () => {
+    // The three legs are the only window-width terms; the settles and the guard
+    // are fixed. So a delta in window width must show up exactly three times.
+    const narrow = evaluatePurgeBudget({ ...base, measureWindowMs: 1_000 });
+    const wide = evaluatePurgeBudget({ ...base, measureWindowMs: 1_500 });
+    expect(wide.plannedRemainingMs - narrow.plannedRemainingMs).toBe(3 * 500);
+  });
+
+  it("charges setup time against the same deadline, one ms for one ms", () => {
+    const early = evaluatePurgeBudget(base);
+    const late = evaluatePurgeBudget({ ...base, elapsedSinceCachedMs: 2_000 + 750 });
+    expect(early.headroomMs - late.headroomMs).toBe(750);
+    // The schedule ahead is unchanged — only where it lands moved.
+    expect(late.plannedRemainingMs).toBe(early.plannedRemainingMs);
+  });
+
+  it("subtracts the guard from the purge delay rather than spending it", () => {
+    const guarded = evaluatePurgeBudget({ ...base, guardMs: 1_000 });
+    const unguarded = evaluatePurgeBudget({ ...base, guardMs: 0 });
+    expect(unguarded.deadlineMs - guarded.deadlineMs).toBe(1_000);
+    expect(guarded.headroomMs).toBe(unguarded.headroomMs - 1_000);
+  });
+
+  it("flips at the boundary its own headroom identifies", () => {
+    const fitting = evaluatePurgeBudget(base);
+    expect(fitting.fits).toBe(true);
+
+    // Consume exactly the reported headroom: still fits, with nothing to spare.
+    const exact = evaluatePurgeBudget({
+      ...base,
+      elapsedSinceCachedMs: base.elapsedSinceCachedMs + fitting.headroomMs,
+    });
+    expect(exact.headroomMs).toBe(0);
+    expect(exact.fits).toBe(true);
+
+    // One millisecond past it does not.
+    const over = evaluatePurgeBudget({
+      ...base,
+      elapsedSinceCachedMs: base.elapsedSinceCachedMs + fitting.headroomMs + 1,
+    });
+    expect(over.fits).toBe(false);
+  });
+
+  it("rejects a window override large enough to outlast the purge", () => {
+    // The failure this guard exists for: DAINTREE_FREEZE_HARNESS_WINDOW_MS is
+    // free-form, and a wide window pushes the recovery leg past the purge.
+    const wide = evaluatePurgeBudget({ ...base, measureWindowMs: 5_000 });
+    expect(wide.fits).toBe(false);
+    expect(wide.plannedFinishMs).toBeGreaterThan(wide.deadlineMs);
+  });
+
+  it("reports a finish that is the elapsed time plus everything still scheduled", () => {
+    const budget = evaluatePurgeBudget(base);
+    expect(budget.plannedFinishMs).toBe(base.elapsedSinceCachedMs + budget.plannedRemainingMs);
+    expect(budget.headroomMs).toBe(budget.deadlineMs - budget.plannedFinishMs);
   });
 });

--- a/electron/services/__tests__/freezeHarness.test.ts
+++ b/electron/services/__tests__/freezeHarness.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: {
+    addProject: vi.fn(),
+    removeProject: vi.fn(),
+  },
+}));
+
+const {
+  evaluateFreezeMeasurement,
+  longestStall,
+  sumTicksInWindow,
+  MIN_CONTROL_TICKS,
+  MIN_FREEZE_RATIO,
+} = await import("../freezeHarness.js");
+
+const BUCKET_MS = 10;
+
+/** Ticks laid down at a flat rate across [startMs, endMs). */
+function evenBuckets(startMs: number, endMs: number, perBucket: number): [number, number][] {
+  const buckets: [number, number][] = [];
+  for (let t = startMs; t < endMs; t += BUCKET_MS) {
+    buckets.push([Math.floor(t / BUCKET_MS), perBucket]);
+  }
+  return buckets;
+}
+
+describe("sumTicksInWindow", () => {
+  it("counts a window that lines up exactly with bucket edges", () => {
+    const buckets = evenBuckets(1000, 2000, 5);
+    expect(sumTicksInWindow(buckets, 1000, 2000, "contained", BUCKET_MS)).toBe(500);
+  });
+
+  it("excludes buckets outside the window", () => {
+    const buckets = evenBuckets(0, 3000, 5);
+    expect(sumTicksInWindow(buckets, 1000, 2000, "contained", BUCKET_MS)).toBe(500);
+  });
+
+  it("deflates in contained mode and inflates in overlapping mode at a straddled edge", () => {
+    // One bucket covering [1000,1010) with the window starting mid-bucket.
+    const buckets: [number, number][] = [[100, 7]];
+    expect(sumTicksInWindow(buckets, 1005, 2000, "contained", BUCKET_MS)).toBe(0);
+    expect(sumTicksInWindow(buckets, 1005, 2000, "overlapping", BUCKET_MS)).toBe(7);
+  });
+
+  it("keeps quantisation biased against passing", () => {
+    // The asymmetry is the point: a straddling bucket must never deflate the
+    // frozen leg (overlapping) nor inflate the control leg (contained), so
+    // rounding can only push the ratio down.
+    const straddling: [number, number][] = [[99, 9]];
+    const frozen = sumTicksInWindow(straddling, 995, 1995, "overlapping", BUCKET_MS);
+    const control = sumTicksInWindow(straddling, 995, 1995, "contained", BUCKET_MS);
+    expect(frozen).toBeGreaterThanOrEqual(control);
+  });
+
+  it("returns zero for an empty timeline", () => {
+    expect(sumTicksInWindow([], 0, 1000, "contained", BUCKET_MS)).toBe(0);
+  });
+});
+
+describe("longestStall", () => {
+  it("finds the gap and its bounds", () => {
+    // Live at bucket 10 and bucket 20 → gap covers [110, 200).
+    const buckets: [number, number][] = [
+      [10, 5],
+      [20, 5],
+    ];
+    expect(longestStall(buckets, BUCKET_MS)).toEqual({
+      startMs: 110,
+      endMs: 200,
+      durationMs: 90,
+    });
+  });
+
+  it("reports no stall for a contiguous timeline", () => {
+    expect(longestStall(evenBuckets(0, 500, 3), BUCKET_MS).durationMs).toBe(0);
+  });
+
+  it("reports no stall when fewer than two live buckets exist", () => {
+    expect(longestStall([[7, 1]], BUCKET_MS).durationMs).toBe(0);
+    expect(longestStall([], BUCKET_MS).durationMs).toBe(0);
+  });
+
+  it("ignores buckets recorded with a zero count", () => {
+    const buckets: [number, number][] = [
+      [10, 5],
+      [15, 0],
+      [20, 5],
+    ];
+    expect(longestStall(buckets, BUCKET_MS).durationMs).toBe(90);
+  });
+});
+
+describe("evaluateFreezeMeasurement", () => {
+  it("passes on a real working-freeze measurement", () => {
+    // Observed on macOS, Electron 42: freeze stops the renderer dead.
+    const verdict = evaluateFreezeMeasurement({
+      controlTicks: 54224,
+      frozenTicks: 0,
+      recoveredTicks: 52533,
+    });
+    expect(verdict.passed).toBe(true);
+    expect(verdict.failures).toEqual([]);
+    expect(verdict.freezeRatio).toBeGreaterThan(MIN_FREEZE_RATIO);
+  });
+
+  it("fails when freeze does not stop the renderer", () => {
+    // Observed with freezeWebContents neutered: the legs are indistinguishable.
+    const verdict = evaluateFreezeMeasurement({
+      controlTicks: 54026,
+      frozenTicks: 53875,
+      recoveredTicks: 53495,
+    });
+    expect(verdict.passed).toBe(false);
+    expect(verdict.freezeRatio).toBeCloseTo(1, 1);
+    expect(verdict.failures.join("\n")).toContain("freeze did not stop the renderer");
+  });
+
+  it("fails when the positive control is dead, rather than reporting a vacuous ratio", () => {
+    const verdict = evaluateFreezeMeasurement({
+      controlTicks: 0,
+      frozenTicks: 0,
+      recoveredTicks: 0,
+    });
+    expect(verdict.passed).toBe(false);
+    expect(verdict.failures.join("\n")).toContain("positive control is not alive");
+  });
+
+  it("fails when the view never resumes, so a dead view cannot masquerade as a frozen one", () => {
+    const verdict = evaluateFreezeMeasurement({
+      controlTicks: 54000,
+      frozenTicks: 0,
+      recoveredTicks: 0,
+    });
+    expect(verdict.passed).toBe(false);
+    const message = verdict.failures.join("\n");
+    expect(message).toContain("did not resume at a comparable rate");
+  });
+
+  it("fails when the view resumes at only a trickle", () => {
+    const verdict = evaluateFreezeMeasurement({
+      controlTicks: 54000,
+      frozenTicks: 0,
+      recoveredTicks: 100,
+    });
+    expect(verdict.passed).toBe(false);
+    expect(verdict.failures.join("\n")).toContain("did not resume at a comparable rate");
+  });
+
+  it("does not let a zero frozen count divide by zero", () => {
+    const verdict = evaluateFreezeMeasurement({
+      controlTicks: 5000,
+      frozenTicks: 0,
+      recoveredTicks: 5000,
+    });
+    expect(Number.isFinite(verdict.freezeRatio)).toBe(true);
+    expect(verdict.freezeRatio).toBe(5000);
+  });
+
+  it("holds the line exactly at the ratio threshold", () => {
+    const atThreshold = evaluateFreezeMeasurement({
+      controlTicks: MIN_FREEZE_RATIO * 10,
+      frozenTicks: 10,
+      recoveredTicks: MIN_FREEZE_RATIO * 10,
+    });
+    expect(atThreshold.freezeRatio).toBe(MIN_FREEZE_RATIO);
+    expect(atThreshold.passed).toBe(true);
+
+    const justUnder = evaluateFreezeMeasurement({
+      controlTicks: MIN_FREEZE_RATIO * 10 - 10,
+      frozenTicks: 10,
+      recoveredTicks: MIN_FREEZE_RATIO * 10,
+    });
+    expect(justUnder.passed).toBe(false);
+  });
+
+  it("treats a control just under the liveness floor as not alive", () => {
+    const verdict = evaluateFreezeMeasurement({
+      controlTicks: MIN_CONTROL_TICKS - 1,
+      frozenTicks: 0,
+      recoveredTicks: MIN_CONTROL_TICKS - 1,
+    });
+    expect(verdict.passed).toBe(false);
+    expect(verdict.failures.join("\n")).toContain("positive control is not alive");
+  });
+});

--- a/electron/services/freezeHarness.ts
+++ b/electron/services/freezeHarness.ts
@@ -354,11 +354,12 @@ async function createHarnessRepo(root: string, name: string): Promise<string> {
  * error; the caller maps that to the process exit code.
  */
 export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean> {
-  // Every failure has to come back as `false`, not a rejection: the caller maps
-  // the return value to the process exit code, and a throw would escape
-  // `setupWindowServices` with the harness window still up and no exit issued.
-  // `mkdtemp` is inside the guard for that reason — a full or unwritable tmpdir
-  // is a setup failure like any other.
+  // Every failure comes back as `false`, not a rejection: the caller maps the
+  // return value to the process exit code, and a boolean is a verdict where a
+  // throw is an accident. `mkdtemp` is inside the guard for that reason — a full
+  // or unwritable tmpdir is a setup failure like any other. The caller also
+  // catches, so this is defence in depth rather than the only thing standing
+  // between a failed run and a booted app that never exits.
   let tempRoot: string | null = null;
   const createdProjectIds: string[] = [];
 
@@ -468,8 +469,8 @@ export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean
     const actualFinishMs = recoveredEnd - cached.lastUsed;
     if (actualFinishMs > budget.deadlineMs) {
       log(
-        "FAILED — measurement overran the cached-view purge: last window closed %dms after caching, " +
-          "past the %dms deadline. Planned %dms; timers ran long.",
+        "FAILED — measurement overran its purge budget: last window closed %dms after caching, " +
+          "past the %dms guarded deadline. Planned %dms; timers ran long.",
         actualFinishMs,
         budget.deadlineMs,
         budget.plannedFinishMs

--- a/electron/services/freezeHarness.ts
+++ b/electron/services/freezeHarness.ts
@@ -46,6 +46,7 @@ import os from "os";
 import path from "path";
 import { promisify } from "util";
 import type { ProjectViewManager } from "../window/ProjectViewManager.js";
+import { CACHED_VIEW_PURGE_DELAY_MS } from "../window/ProjectViewLifecycleController.js";
 import { projectStore } from "./ProjectStore.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
@@ -64,8 +65,10 @@ const PROBE_WARMUP_MS = 750;
 /**
  * Each measurement leg runs for this long. All three legs use the same width.
  * Overridable for run-to-run variance work, but the whole run must stay inside
- * `CACHED_VIEW_PURGE_DELAY_MS` (20s from the moment the view is cached) so the
- * periodic CDP memory purge never lands mid-measurement.
+ * `CACHED_VIEW_PURGE_DELAY_MS` (from the moment the view is cached) so the
+ * periodic CDP memory purge never lands mid-measurement. `evaluatePurgeBudget`
+ * enforces that against the elapsed clock and fails the run rather than
+ * reporting a number measured across a purge.
  */
 const MEASURE_WINDOW_MS = readWindowMsOverride() ?? 3_000;
 
@@ -96,6 +99,12 @@ const THAW_SETTLE_MS = 1_000;
 /** A still-frozen or dead renderer never answers; fail loudly instead of hanging. */
 const PROBE_READ_TIMEOUT_MS = 15_000;
 const VIEW_SETTLE_MS = 1_500;
+/**
+ * Slack subtracted from the purge deadline before the budget is accepted, so a
+ * schedule that only fits if every `setTimeout` lands on time is rejected rather
+ * than run. Timer overshoot across eight sequential delays is cumulative.
+ */
+const PURGE_BUDGET_GUARD_MS = 1_000;
 
 /**
  * Liveness floor for the positive control only. Without it, a probe that never
@@ -185,6 +194,53 @@ export function longestStall(
     if (durationMs > best.durationMs) best = { startMs, endMs, durationMs };
   }
   return best;
+}
+
+export interface PurgeBudget {
+  /** Deterministic schedule still ahead of the check point, in ms. */
+  plannedRemainingMs: number;
+  /** When the last window closes, measured from the instant the view was cached. */
+  plannedFinishMs: number;
+  /** The purge instant the run has to beat, guard already subtracted. */
+  deadlineMs: number;
+  /** Signed slack against the deadline. Negative means the run would overrun it. */
+  headroomMs: number;
+  fits: boolean;
+}
+
+/**
+ * Does the rest of the run fit before the cached view's first memory purge?
+ *
+ * The purge timer is armed inside `deactivateEntry` the moment the view flips to
+ * `cached`, and fires `CACHED_VIEW_PURGE_DELAY_MS` later. A purge landing
+ * mid-measurement perturbs the very throughput being measured, so the docstring
+ * on `MEASURE_WINDOW_MS` has always said the run must finish first — this makes
+ * that a check rather than a promise, because `MEASURE_WINDOW_MS` is
+ * env-overridable and a large override silently produces a corrupted number.
+ *
+ * Takes elapsed time rather than assuming it: probe injection is an IPC
+ * round-trip of unbounded duration, so the setup cost is only knowable at the
+ * check point. Everything after that point is `setTimeout`s of known width.
+ */
+export function evaluatePurgeBudget({
+  elapsedSinceCachedMs,
+  measureWindowMs,
+  purgeDelayMs = CACHED_VIEW_PURGE_DELAY_MS,
+  guardMs = PURGE_BUDGET_GUARD_MS,
+}: {
+  elapsedSinceCachedMs: number;
+  measureWindowMs: number;
+  purgeDelayMs?: number;
+  guardMs?: number;
+}): PurgeBudget {
+  // Three measurement legs plus the two settles and the trailing guard that
+  // separate them. Mirrors the call order in `runFreezeHarness` below.
+  const plannedRemainingMs =
+    3 * measureWindowMs + FREEZE_SETTLE_MS + FREEZE_TRAILING_GUARD_MS + THAW_SETTLE_MS;
+  const plannedFinishMs = elapsedSinceCachedMs + plannedRemainingMs;
+  const deadlineMs = purgeDelayMs - guardMs;
+  const headroomMs = deadlineMs - plannedFinishMs;
+  return { plannedRemainingMs, plannedFinishMs, deadlineMs, headroomMs, fits: headroomMs >= 0 };
 }
 
 export function evaluateFreezeMeasurement(measurement: FreezeMeasurement): FreezeVerdict {
@@ -296,10 +352,16 @@ async function createHarnessRepo(root: string, name: string): Promise<string> {
  * error; the caller maps that to the process exit code.
  */
 export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean> {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "daintree-freeze-harness-"));
+  // Every failure has to come back as `false`, not a rejection: the caller maps
+  // the return value to the process exit code, and a throw would escape
+  // `setupWindowServices` with the harness window still up and no exit issued.
+  // `mkdtemp` is inside the guard for that reason — a full or unwritable tmpdir
+  // is a setup failure like any other.
+  let tempRoot: string | null = null;
   const createdProjectIds: string[] = [];
 
   try {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), "daintree-freeze-harness-"));
     const pathA = await createHarnessRepo(tempRoot, "project-a");
     const pathB = await createHarnessRepo(tempRoot, "project-b");
     const projectA = await projectStore.addProject(pathA);
@@ -335,6 +397,16 @@ export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean
       String(cached.view.getVisible())
     );
 
+    // Establish a known-thawed baseline before injecting. `deactivateEntry`
+    // freezes the outgoing view immediately — no debounce — when efficiency
+    // freeze is already on, and `ResourceProfileService` can turn it on at any
+    // point on its own 30s cadence. Without this, a run that started under the
+    // efficiency profile would inject into a frozen renderer (which never
+    // answers) or measure a control leg that was frozen the whole time. Calling
+    // it with `false` when already false and idle is a no-op; with a freeze
+    // timer pending it cancels the timer and thaws, which is what we want.
+    pvm.setEfficiencyFreeze(false);
+
     const started = await withTimeout(
       cachedWc.executeJavaScript(PROBE_START_JS, true) as Promise<string>,
       PROBE_READ_TIMEOUT_MS,
@@ -346,6 +418,26 @@ export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean
     }
     await delay(PROBE_WARMUP_MS);
     log("CHECK: probe running — OK");
+
+    // Last point before the clock matters. Setup is done, so the only unknown —
+    // how long injection took — is now measured rather than assumed.
+    const budget = evaluatePurgeBudget({
+      elapsedSinceCachedMs: Date.now() - cached.lastUsed,
+      measureWindowMs: MEASURE_WINDOW_MS,
+    });
+    if (!budget.fits) {
+      log(
+        "FAILED — measurement would outlast the cached-view purge: window=%dms needs %dms more, " +
+          "finishing at %dms after caching against a %dms deadline (%dms short). " +
+          "Lower DAINTREE_FREEZE_HARNESS_WINDOW_MS.",
+        MEASURE_WINDOW_MS,
+        budget.plannedRemainingMs,
+        budget.plannedFinishMs,
+        budget.deadlineMs,
+        -budget.headroomMs
+      );
+      return false;
+    }
 
     const controlStart = Date.now();
     await delay(MEASURE_WINDOW_MS);
@@ -440,6 +532,14 @@ export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean
     log("FAILED — %s", formatErrorMessage(error, "freeze harness threw"));
     return false;
   } finally {
+    // An early return or a throw can leave the view frozen; the process is about
+    // to exit either way, but a frozen view can't answer the CDP teardown the
+    // shutdown path issues.
+    try {
+      pvm.setEfficiencyFreeze(false);
+    } catch {
+      // best-effort
+    }
     for (const projectId of createdProjectIds) {
       try {
         await projectStore.removeProject(projectId);
@@ -447,6 +547,14 @@ export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean
         // best-effort cleanup
       }
     }
-    await rm(tempRoot, { recursive: true, force: true });
+    if (tempRoot) {
+      // Guarded: on Windows the app can still hold a handle under this root, and
+      // a rejected unlink here would replace a completed verdict with a throw.
+      try {
+        await rm(tempRoot, { recursive: true, force: true });
+      } catch (error) {
+        log("WARN — could not remove %s: %s", tempRoot, formatErrorMessage(error, "unknown"));
+      }
+    }
   }
 }

--- a/electron/services/freezeHarness.ts
+++ b/electron/services/freezeHarness.ts
@@ -211,8 +211,10 @@ export interface PurgeBudget {
 /**
  * Does the rest of the run fit before the cached view's first memory purge?
  *
- * The purge timer is armed inside `deactivateEntry` the moment the view flips to
- * `cached`, and fires `CACHED_VIEW_PURGE_DELAY_MS` later. A purge landing
+ * `deactivateEntry` stamps `lastUsed` when the view flips to `cached` and arms
+ * the purge timer a little later in the same pass, so measuring from `lastUsed`
+ * puts the deadline slightly early — conservative, which is the safe direction.
+ * The timer fires `CACHED_VIEW_PURGE_DELAY_MS` after it is armed. A purge landing
  * mid-measurement perturbs the very throughput being measured, so the docstring
  * on `MEASURE_WINDOW_MS` has always said the run must finish first — this makes
  * that a check rather than a promise, because `MEASURE_WINDOW_MS` is
@@ -456,6 +458,25 @@ export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean
     await delay(MEASURE_WINDOW_MS);
     const recoveredEnd = Date.now();
 
+    // The budget above checks the plan; this checks what actually happened.
+    // `setTimeout` widths are minimums, so eight sequential delays on a loaded
+    // box can finish materially later than planned — and a purge landing inside
+    // a measured window is exactly what the budget exists to keep out of the
+    // numbers. Only the windows have to beat it: the read that follows can take
+    // as long as it likes, because a purge cannot retroactively change bucket
+    // counts already recorded.
+    const actualFinishMs = recoveredEnd - cached.lastUsed;
+    if (actualFinishMs > budget.deadlineMs) {
+      log(
+        "FAILED — measurement overran the cached-view purge: last window closed %dms after caching, " +
+          "past the %dms deadline. Planned %dms; timers ran long.",
+        actualFinishMs,
+        budget.deadlineMs,
+        budget.plannedFinishMs
+      );
+      return false;
+    }
+
     // First read of the run. Anything earlier would have to survive the frozen
     // window, and a frozen renderer does not answer.
     const reading = await withTimeout(
@@ -532,14 +553,6 @@ export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean
     log("FAILED — %s", formatErrorMessage(error, "freeze harness threw"));
     return false;
   } finally {
-    // An early return or a throw can leave the view frozen; the process is about
-    // to exit either way, but a frozen view can't answer the CDP teardown the
-    // shutdown path issues.
-    try {
-      pvm.setEfficiencyFreeze(false);
-    } catch {
-      // best-effort
-    }
     for (const projectId of createdProjectIds) {
       try {
         await projectStore.removeProject(projectId);
@@ -555,6 +568,15 @@ export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean
       } catch (error) {
         log("WARN — could not remove %s: %s", tempRoot, formatErrorMessage(error, "unknown"));
       }
+    }
+    // Last, not first: `ResourceProfileService` runs on its own cadence and can
+    // re-enable efficiency freeze during the awaits above. Desired-state only —
+    // the thaw it triggers is fire-and-forget, so this records the intent rather
+    // than guaranteeing the renderer is running again by the time we return.
+    try {
+      pvm.setEfficiencyFreeze(false);
+    } catch {
+      // best-effort
     }
   }
 }

--- a/electron/services/freezeHarness.ts
+++ b/electron/services/freezeHarness.ts
@@ -1,0 +1,452 @@
+/**
+ * Freeze harness (#11846) — Playwright-free, real-app measurement of whether a
+ * cached project view's renderer actually stops executing tasks when the
+ * production efficiency-freeze path freezes it.
+ *
+ * Why this exists rather than an E2E spec: Playwright sends
+ * `Emulation.setFocusEmulationEnabled` to every page target it attaches to,
+ * which takes out a `WebContents` capturer with `stay_hidden=false`. The
+ * renderer is then permanently told it is user-visible, `WasHidden()` has
+ * nothing to do, and `Page.setWebLifecycleState(frozen)` no-ops while still
+ * returning success. Freeze is therefore unobservable from Playwright in every
+ * project view, always. This harness boots the real `main.ts`/`bootstrap.ts`
+ * with no debugger client of its own, so the freeze it measures is the freeze
+ * users get.
+ *
+ * Three constraints shape the design:
+ *
+ * 1. No debugger client on the measured view. `freezeWebContents` calls
+ *    `ensureAttached`; a second attach collides, lands in `EXPECTED_CDP_ERRORS`
+ *    and is swallowed — the harness would suppress the freeze it came to
+ *    observe. The renderer counts its own tasks instead, and
+ *    `webContents.executeJavaScript` (Blink script execution, not CDP) moves
+ *    the numbers out. The CPU throttle and memory purge the app itself attaches
+ *    for are part of the production path and are deliberately left alone.
+ *
+ * 2. A frozen renderer cannot answer. `executeJavaScript` will not return while
+ *    the page is frozen, so nothing can be read *during* the frozen window. The
+ *    probe accumulates per-bucket tick counts keyed by wall-clock epoch time;
+ *    the harness thaws first, then reads the whole timeline and slices out the
+ *    interval that elapsed while frozen. Main and renderer share one system
+ *    clock, so the slice boundaries need no clock alignment.
+ *
+ * 3. Ratios, not bounds. Reference numbers are ~113,000 tasks unfrozen against
+ *    0 frozen. A timing threshold goes red on a loaded box; a hundredfold ratio
+ *    does not.
+ *
+ * `MessageChannel` self-posting is the tick source on purpose. Timers are
+ * subject to background throttling, which would confound "frozen" with "merely
+ * throttled"; `MessageChannel` tasks are not throttled, so a collapse to zero
+ * isolates freeze specifically.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { execFile } from "child_process";
+import os from "os";
+import path from "path";
+import { promisify } from "util";
+import type { ProjectViewManager } from "../window/ProjectViewManager.js";
+import { projectStore } from "./ProjectStore.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+const execFileAsync = promisify(execFile);
+
+export const FREEZE_HARNESS_LOG_PREFIX = "[FREEZE-HARNESS]";
+
+/**
+ * Renderer-side tick bucket width. Bounds probe memory at one entry per bucket
+ * (~1,600 entries for a default run). Kept small so bucket quantisation at a
+ * window edge stays a rounding error rather than a measurable contribution.
+ */
+const BUCKET_MS = 10;
+/** Let the tick loop reach steady state before the control window opens. */
+const PROBE_WARMUP_MS = 750;
+/**
+ * Each measurement leg runs for this long. All three legs use the same width.
+ * Overridable for run-to-run variance work, but the whole run must stay inside
+ * `CACHED_VIEW_PURGE_DELAY_MS` (20s from the moment the view is cached) so the
+ * periodic CDP memory purge never lands mid-measurement.
+ */
+const MEASURE_WINDOW_MS = readWindowMsOverride() ?? 3_000;
+
+function readWindowMsOverride(): number | null {
+  const raw = process.env.DAINTREE_FREEZE_HARNESS_WINDOW_MS;
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+/**
+ * `setEfficiencyFreeze(true)` debounces its freeze pass by 500ms internally,
+ * then the CDP command has to land. Excluded from the frozen window so the
+ * measurement covers only time the view was actually frozen.
+ */
+const FREEZE_SETTLE_MS = 1_500;
+/**
+ * Guard between the close of the frozen window and the thaw. Without it the
+ * window's trailing edge coincides with `setEfficiencyFreeze(false)`, so the
+ * boundary bucket straddling that instant is filled with post-thaw ticks and
+ * attributed to the frozen leg — a false negative that scales with how fast the
+ * renderer runs. Symmetric with FREEZE_SETTLE_MS: both keep the measured window
+ * strictly inside the interval the view was actually frozen, so the harness
+ * measures the freeze rather than its transitions.
+ */
+const FREEZE_TRAILING_GUARD_MS = 750;
+/** Symmetric allowance for the renderer to resume after `setEfficiencyFreeze(false)`. */
+const THAW_SETTLE_MS = 1_000;
+/** A still-frozen or dead renderer never answers; fail loudly instead of hanging. */
+const PROBE_READ_TIMEOUT_MS = 15_000;
+const VIEW_SETTLE_MS = 1_500;
+
+/**
+ * Liveness floor for the positive control only. Without it, a probe that never
+ * started reads 0/0/0 and every ratio is vacuous. This is not a threshold on
+ * the behavior under test — that assertion is the ratio below.
+ */
+export const MIN_CONTROL_TICKS = 1_000;
+/** Reference gap is ~113,000 against 0. A hundredfold is the conservative floor. */
+export const MIN_FREEZE_RATIO = 100;
+export const MIN_RECOVERY_RATIO = 100;
+/** Recovery must resume at a comparable rate, not merely be non-zero. */
+export const MIN_RECOVERY_FRACTION_OF_CONTROL = 0.1;
+
+export type TickBucket = readonly [bucket: number, count: number];
+
+export interface ProbeReading {
+  total: number;
+  buckets: TickBucket[];
+  visibilityState: string;
+  hasFocus: boolean;
+}
+
+export interface FreezeMeasurement {
+  controlTicks: number;
+  frozenTicks: number;
+  recoveredTicks: number;
+}
+
+export interface FreezeVerdict {
+  passed: boolean;
+  failures: string[];
+  freezeRatio: number;
+  recoveryRatio: number;
+  recoveryFraction: number;
+}
+
+/**
+ * Bucket-to-window overlap policy. `"contained"` counts only buckets wholly
+ * inside the window; `"overlapping"` counts any bucket that touches it.
+ *
+ * The two modes are not symmetric by accident. The frozen leg is summed with
+ * `"overlapping"` so a bucket straddling a boundary inflates the frozen count,
+ * and the control and recovery legs with `"contained"` so a straddling bucket
+ * deflates them. Both choices push the ratio down, so bucket quantisation can
+ * only make the harness harder to pass, never easier.
+ */
+export function sumTicksInWindow(
+  buckets: readonly TickBucket[],
+  startMs: number,
+  endMs: number,
+  mode: "contained" | "overlapping",
+  bucketMs: number = BUCKET_MS
+): number {
+  let total = 0;
+  for (const [bucket, count] of buckets) {
+    const bucketStart = bucket * bucketMs;
+    const bucketEnd = bucketStart + bucketMs;
+    const matches =
+      mode === "contained"
+        ? bucketStart >= startMs && bucketEnd <= endMs
+        : bucketEnd > startMs && bucketStart < endMs;
+    if (matches) total += count;
+  }
+  return total;
+}
+
+/**
+ * Longest zero-tick stretch in the timeline, with its wall-clock bounds.
+ * Diagnostic only — never asserted, because a duration is exactly the kind of
+ * timing bound that goes red on a loaded box. Its value is in explaining a red
+ * run: comparing the stall's bounds against the frozen window's bounds
+ * separates "freeze leaked" from "the measurement window was misaligned".
+ */
+export function longestStall(
+  buckets: readonly TickBucket[],
+  bucketMs: number = BUCKET_MS
+): { startMs: number; endMs: number; durationMs: number } {
+  const live = buckets
+    .filter(([, count]) => count > 0)
+    .map(([bucket]) => bucket)
+    .sort((a, b) => a - b);
+  let best = { startMs: 0, endMs: 0, durationMs: 0 };
+  for (let i = 1; i < live.length; i++) {
+    const startMs = (live[i - 1]! + 1) * bucketMs;
+    const endMs = live[i]! * bucketMs;
+    const durationMs = endMs - startMs;
+    if (durationMs > best.durationMs) best = { startMs, endMs, durationMs };
+  }
+  return best;
+}
+
+export function evaluateFreezeMeasurement(measurement: FreezeMeasurement): FreezeVerdict {
+  const { controlTicks, frozenTicks, recoveredTicks } = measurement;
+  // Guard the divisor, not the numerator: a genuine freeze reads exactly 0 and
+  // must not divide by zero, but it also must not be rounded up into a pass.
+  const divisor = Math.max(frozenTicks, 1);
+  const freezeRatio = controlTicks / divisor;
+  const recoveryRatio = recoveredTicks / divisor;
+  const recoveryFraction = controlTicks > 0 ? recoveredTicks / controlTicks : 0;
+
+  const failures: string[] = [];
+
+  if (controlTicks < MIN_CONTROL_TICKS) {
+    failures.push(
+      `positive control is not alive: ${controlTicks} ticks in the unfrozen window (need >= ${MIN_CONTROL_TICKS}). ` +
+        `Every ratio below is vacuous without it.`
+    );
+  }
+
+  if (freezeRatio < MIN_FREEZE_RATIO) {
+    failures.push(
+      `freeze did not stop the renderer: ${controlTicks} ticks unfrozen vs ${frozenTicks} frozen ` +
+        `(ratio ${freezeRatio.toFixed(1)}x, need >= ${MIN_FREEZE_RATIO}x).`
+    );
+  }
+
+  if (recoveryRatio < MIN_RECOVERY_RATIO) {
+    failures.push(
+      `recovery leg did not clear the frozen leg: ${recoveredTicks} ticks recovered vs ${frozenTicks} frozen ` +
+        `(ratio ${recoveryRatio.toFixed(1)}x, need >= ${MIN_RECOVERY_RATIO}x).`
+    );
+  }
+
+  if (recoveryFraction < MIN_RECOVERY_FRACTION_OF_CONTROL) {
+    failures.push(
+      `view did not resume at a comparable rate after thaw: ${recoveredTicks} ticks vs ${controlTicks} control ` +
+        `(${(recoveryFraction * 100).toFixed(1)}%, need >= ${MIN_RECOVERY_FRACTION_OF_CONTROL * 100}%). ` +
+        `A view measuring zero because it died looks identical to one that froze properly.`
+    );
+  }
+
+  return { passed: failures.length === 0, failures, freezeRatio, recoveryRatio, recoveryFraction };
+}
+
+const PROBE_START_JS = `(() => {
+  if (window.__daintreeFreezeProbe) return "already-running";
+  const probe = { total: 0, buckets: new Map() };
+  window.__daintreeFreezeProbe = probe;
+  const channel = new MessageChannel();
+  channel.port1.onmessage = () => {
+    probe.total++;
+    const bucket = Math.floor(Date.now() / ${BUCKET_MS});
+    probe.buckets.set(bucket, (probe.buckets.get(bucket) || 0) + 1);
+    channel.port2.postMessage(0);
+  };
+  channel.port2.postMessage(0);
+  return "started";
+})()`;
+
+const PROBE_READ_JS = `(() => {
+  const probe = window.__daintreeFreezeProbe;
+  if (!probe) return null;
+  return {
+    total: probe.total,
+    buckets: Array.from(probe.buckets.entries()),
+    visibilityState: document.visibilityState,
+    hasFocus: document.hasFocus(),
+  };
+})()`;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+  });
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+        timer.unref();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function log(message: string, ...args: unknown[]): void {
+  console.error(`${FREEZE_HARNESS_LOG_PREFIX} ${message}`, ...args);
+}
+
+async function createHarnessRepo(root: string, name: string): Promise<string> {
+  const repoPath = path.join(root, name);
+  await mkdir(repoPath, { recursive: true });
+  await writeFile(path.join(repoPath, "README.md"), `# ${name}\n`, "utf8");
+  await execFileAsync("git", ["init"], { cwd: repoPath });
+  return repoPath;
+}
+
+/**
+ * Drives the real freeze path on one cached view and reports whether the
+ * renderer genuinely stopped. Returns false on any failed assertion or setup
+ * error; the caller maps that to the process exit code.
+ */
+export async function runFreezeHarness(pvm: ProjectViewManager): Promise<boolean> {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "daintree-freeze-harness-"));
+  const createdProjectIds: string[] = [];
+
+  try {
+    const pathA = await createHarnessRepo(tempRoot, "project-a");
+    const pathB = await createHarnessRepo(tempRoot, "project-b");
+    const projectA = await projectStore.addProject(pathA);
+    createdProjectIds.push(projectA.id);
+    const projectB = await projectStore.addProject(pathB);
+    createdProjectIds.push(projectB.id);
+
+    // Real activation path: A becomes active, then B displaces it. `switchTo`
+    // runs `deactivateEntry` on A — detach, setVisible(false), CPU throttle,
+    // cached state — which is exactly the state a freeze acts on in production.
+    await pvm.switchTo(projectA.id, pathA);
+    await delay(VIEW_SETTLE_MS);
+    await pvm.switchTo(projectB.id, pathB);
+    await delay(VIEW_SETTLE_MS);
+
+    const cached = pvm.getAllViews().find((entry) => entry.projectId === projectA.id);
+    if (!cached) {
+      log("FAILED — project A has no view after switching away from it");
+      return false;
+    }
+    if (cached.state !== "cached") {
+      log("FAILED — project A's view is %s, expected cached", cached.state);
+      return false;
+    }
+    const cachedWc = cached.view.webContents;
+    if (cachedWc.isDestroyed()) {
+      log("FAILED — project A's cached webContents was destroyed before measurement");
+      return false;
+    }
+    log(
+      "CHECK: cached view ready — projectId=%s visible=%s",
+      projectA.id.slice(0, 8),
+      String(cached.view.getVisible())
+    );
+
+    const started = await withTimeout(
+      cachedWc.executeJavaScript(PROBE_START_JS, true) as Promise<string>,
+      PROBE_READ_TIMEOUT_MS,
+      "probe injection timed out"
+    );
+    if (started !== "started") {
+      log("FAILED — probe did not start (%s)", String(started));
+      return false;
+    }
+    await delay(PROBE_WARMUP_MS);
+    log("CHECK: probe running — OK");
+
+    const controlStart = Date.now();
+    await delay(MEASURE_WINDOW_MS);
+    const controlEnd = Date.now();
+
+    pvm.setEfficiencyFreeze(true);
+    await delay(FREEZE_SETTLE_MS);
+    const frozenStart = Date.now();
+    await delay(MEASURE_WINDOW_MS);
+    const frozenEnd = Date.now();
+
+    await delay(FREEZE_TRAILING_GUARD_MS);
+    pvm.setEfficiencyFreeze(false);
+    await delay(THAW_SETTLE_MS);
+    const recoveredStart = Date.now();
+    await delay(MEASURE_WINDOW_MS);
+    const recoveredEnd = Date.now();
+
+    // First read of the run. Anything earlier would have to survive the frozen
+    // window, and a frozen renderer does not answer.
+    const reading = await withTimeout(
+      cachedWc.executeJavaScript(PROBE_READ_JS, true) as Promise<ProbeReading | null>,
+      PROBE_READ_TIMEOUT_MS,
+      "probe read timed out after thaw — the view never resumed executing JavaScript"
+    );
+    if (!reading) {
+      log("FAILED — probe state was missing after thaw (renderer navigated or was replaced)");
+      return false;
+    }
+
+    const measurement: FreezeMeasurement = {
+      controlTicks: sumTicksInWindow(reading.buckets, controlStart, controlEnd, "contained"),
+      frozenTicks: sumTicksInWindow(reading.buckets, frozenStart, frozenEnd, "overlapping"),
+      recoveredTicks: sumTicksInWindow(reading.buckets, recoveredStart, recoveredEnd, "contained"),
+    };
+    const verdict = evaluateFreezeMeasurement(measurement);
+
+    const stall = longestStall(reading.buckets);
+    log(
+      "visibilityState=%s hasFocus=%s totalTicks=%d",
+      reading.visibilityState,
+      String(reading.hasFocus),
+      reading.total
+    );
+    // Offsets are relative to the frozen window's start, so a red run shows at
+    // a glance whether the stall covered the window or fell beside it.
+    log(
+      "frozenWindow=[0,%d] longestStall=[%d,%d] durationMs=%d frozenInterior=%d",
+      frozenEnd - frozenStart,
+      stall.startMs - frozenStart,
+      stall.endMs - frozenStart,
+      stall.durationMs,
+      sumTicksInWindow(reading.buckets, frozenStart, frozenEnd, "contained")
+    );
+    log(
+      "window=%dms control=%d frozen=%d recovered=%d",
+      MEASURE_WINDOW_MS,
+      measurement.controlTicks,
+      measurement.frozenTicks,
+      measurement.recoveredTicks
+    );
+    log(
+      "freezeRatio=%sx recoveryRatio=%sx recoveryFraction=%s%%",
+      verdict.freezeRatio.toFixed(1),
+      verdict.recoveryRatio.toFixed(1),
+      (verdict.recoveryFraction * 100).toFixed(1)
+    );
+    log(
+      "RESULT %s",
+      JSON.stringify({
+        control: measurement.controlTicks,
+        frozen: measurement.frozenTicks,
+        recovered: measurement.recoveredTicks,
+        freezeRatio: Number(verdict.freezeRatio.toFixed(2)),
+        recoveryRatio: Number(verdict.recoveryRatio.toFixed(2)),
+        visibilityState: reading.visibilityState,
+      })
+    );
+
+    if (!verdict.passed) {
+      for (const failure of verdict.failures) {
+        log("FAILED — %s", failure);
+      }
+      return false;
+    }
+
+    log("CHECK: freeze ratio — OK");
+    log("CHECK: recovery — OK");
+    log("PASS");
+    return true;
+  } catch (error) {
+    log("FAILED — %s", formatErrorMessage(error, "freeze harness threw"));
+    return false;
+  } finally {
+    for (const projectId of createdProjectIds) {
+      try {
+        await projectStore.removeProject(projectId);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}

--- a/electron/setup/runtimeFlags.ts
+++ b/electron/setup/runtimeFlags.ts
@@ -18,6 +18,7 @@ export const E2E_DISABLE_CACHED_VIEW_CPU_THROTTLE_ARG =
   "--daintree-e2e-disable-cached-view-cpu-throttle";
 export const E2E_CRASH_DUMPS_DIR_ARG = "--daintree-e2e-crash-dumps-dir=";
 export const E2E_SIDELOAD_PLUGIN_DIR_ARG = "--daintree-e2e-sideload-plugin-dir=";
+export const FREEZE_HARNESS_ARG = "--daintree-freeze-harness";
 
 function hasArg(flag: string): boolean {
   return process.argv.includes(flag);
@@ -76,6 +77,16 @@ export function getE2ESideloadPluginDir(): string | undefined {
       : undefined;
 }
 
+/**
+ * Freeze harness mode (#11846). Boots the real app, drives one cached project
+ * view through the production freeze/thaw path and measures whether its
+ * renderer actually stopped executing tasks. Never packaged: this is a
+ * developer/CI measurement mode, not a product surface.
+ */
+export function getIsFreezeHarness(): boolean {
+  return !isPackaged && hasArg(FREEZE_HARNESS_ARG);
+}
+
 export const isE2EMode = getIsE2EMode();
 export const isE2ESkipFirstRunDialogs = getIsE2ESkipFirstRunDialogs();
 export const isE2EFaultMode = getIsE2EFaultMode();
@@ -83,4 +94,5 @@ export const isE2EDeferRendererLoad = getIsE2EDeferRendererLoad();
 export const isE2EDisableCachedViewCpuThrottle = getIsE2EDisableCachedViewCpuThrottle();
 export const e2eCrashDumpsDir = getE2ECrashDumpsDir();
 export const e2eSideloadPluginDir = getE2ESideloadPluginDir();
+export const isFreezeHarness = getIsFreezeHarness();
 export const smokeTestStart = isSmokeTest ? Date.now() : 0;

--- a/electron/window/ProjectViewLifecycleController.ts
+++ b/electron/window/ProjectViewLifecycleController.ts
@@ -34,7 +34,12 @@ import type { ViewEntry } from "./ProjectViewManagerTypes.js";
 // the interval re-purges long-cached views whose background work (agent
 // output, worktree events) keeps re-accumulating garbage. Purge is per-target
 // CDP — the active view is never touched.
-const CACHED_VIEW_PURGE_DELAY_MS = 20_000;
+/**
+ * Delay from a view becoming cached to its first memory purge. Exported so
+ * the freeze harness can budget its measurement against the same number
+ * rather than duplicating it (`electron/services/freezeHarness.ts`).
+ */
+export const CACHED_VIEW_PURGE_DELAY_MS = 20_000;
 const CACHED_VIEW_PURGE_INTERVAL_MS = 60_000;
 
 export function deactivateEntry(host: ProjectViewManager, current: ViewEntry): void {

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -805,19 +805,33 @@ export async function setupWindowServices(
       app.exit(1);
       return "exit-requested";
     }
-    const passed = await runFreezeHarness(opts.projectViewManager);
-    if (win && !win.isDestroyed()) win.destroy();
+    // `app.exit` lives in the finally so that nothing between here and it can
+    // strand the process: the harness contracts to return a boolean, but a
+    // throw from it or from `win.destroy()` would otherwise leave a booted app
+    // with no exit issued and the runner waiting out its whole timeout.
+    let passed = false;
     try {
-      getWorkspaceClientRef()?.dispose();
-    } catch {
-      /* ignore */
+      passed = await runFreezeHarness(opts.projectViewManager);
+    } catch (error) {
+      console.error("[FREEZE-HARNESS] FAILED — harness threw:", error);
+    } finally {
+      try {
+        if (win && !win.isDestroyed()) win.destroy();
+      } catch {
+        /* ignore */
+      }
+      try {
+        getWorkspaceClientRef()?.dispose();
+      } catch {
+        /* ignore */
+      }
+      try {
+        getPtyClient()?.dispose();
+      } catch {
+        /* ignore */
+      }
+      app.exit(passed ? 0 : 1);
     }
-    try {
-      getPtyClient()?.dispose();
-    } catch {
-      /* ignore */
-    }
-    app.exit(passed ? 0 : 1);
     return "exit-requested";
   }
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -16,6 +16,7 @@ import { scratchStore } from "../services/ScratchStore.js";
 import { initializeAgentAvailabilityStore } from "../services/AgentAvailabilityStore.js";
 import { initializePowerSaveBlockerService } from "../services/PowerSaveBlockerService.js";
 import { runSmokeFunctionalChecks } from "../services/smokeTest.js";
+import { runFreezeHarness } from "../services/freezeHarness.js";
 import { markPerformance } from "../utils/performance.js";
 import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
@@ -37,7 +38,7 @@ import {
   queuePendingOpenDirPath,
 } from "../setup/environment.js";
 import { shouldDeferRendererLoadForE2E } from "./earlyRenderer.js";
-import { isE2EFaultMode } from "../setup/runtimeFlags.js";
+import { isE2EFaultMode, isFreezeHarness } from "../setup/runtimeFlags.js";
 import {
   extractCliPath,
   hasCliPathFlag,
@@ -792,6 +793,31 @@ export async function setupWindowServices(
       /* ignore */
     }
     app.exit(allPassed ? 0 : 1);
+    return "exit-requested";
+  }
+
+  // Freeze harness (#11846). Runs after the normal boot — unlike the smoke
+  // path it does not defer the renderer load, because the point is to measure
+  // the freeze a real user's cached view gets.
+  if (isFreezeHarness) {
+    if (!opts.projectViewManager) {
+      console.error("[FREEZE-HARNESS] FAILED — window has no ProjectViewManager");
+      app.exit(1);
+      return "exit-requested";
+    }
+    const passed = await runFreezeHarness(opts.projectViewManager);
+    if (win && !win.isDestroyed()) win.destroy();
+    try {
+      getWorkspaceClientRef()?.dispose();
+    } catch {
+      /* ignore */
+    }
+    try {
+      getPtyClient()?.dispose();
+    } catch {
+      /* ignore */
+    }
+    app.exit(passed ? 0 : 1);
     return "exit-requested";
   }
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "check": "npm run typecheck && npm run check:channels && npm run check:crash-loop-constants && npm run check:node-version && npm run check:ipc && npm run check:ipc-renderer && npm run check:ipc-handwritten && npm run check:help && npm run check:confirm-wiring && npm run check:keybindings && npm run check:plugin-manifests && npm run check:process-tools && npm run check:api-surface && npm run lint:ratchet && npm run format:check",
     "fix": "npm run format && npm run lint:fix",
     "test:smoke": "node scripts/run-smoke.mjs",
+    "test:freeze-harness": "node scripts/run-freeze-harness.mjs",
     "test:smoke:packaged": "node scripts/run-packaged-smoke.mjs",
     "test:e2e": "npx playwright test",
     "test:e2e:core": "npx playwright test --project=core",

--- a/scripts/run-freeze-harness.mjs
+++ b/scripts/run-freeze-harness.mjs
@@ -50,9 +50,97 @@ export const REQUIRED_MARKERS = [
 
 const FAILURE_MARKER = "[FREEZE-HARNESS] FAILED";
 
+/** Grace between the graceful kill and the hard one, and again before we stop waiting. */
+const CHILD_KILL_GRACE_MS = 5_000;
+/** Backstop for a pipe whose write callback never fires. See `exitAfterFlush`. */
+const FLUSH_TIMEOUT_MS = 5_000;
+
 export function parsePositiveInt(value, fallback) {
   const parsed = Number.parseInt(value ?? "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * How to kill the child's whole tree on a given platform, as data.
+ *
+ * Electron's descendants (GPU, utility, pty-host, workspace-host) inherit this
+ * script's stdout/stderr, so a survivor holds those pipes open and this process
+ * never exits — the v0.32.0 Windows hang, which took a release step from 43s to
+ * a 12-minute timeout. Killing the root alone is not enough.
+ *
+ * Deliberately PID-scoped on both platforms. `run-packaged-smoke.mjs` can fall
+ * back to `taskkill /im Daintree.exe` because it is single-tenant against a
+ * packaged build; this runner launches the *unpackaged* `electron.exe`, so an
+ * image-name kill would take out VS Code and every other Electron app on the
+ * developer's machine. There is no last resort here, by design.
+ *
+ * Returned as a descriptor rather than executed so the platform branch is
+ * testable without spawning anything.
+ */
+export function describeTreeKill(platform, pid, { force = false } = {}) {
+  if (!Number.isInteger(pid) || pid <= 0) return { kind: "none" };
+  if (platform === "win32") {
+    // `/t` walks the tree as it stands right now, so anything already orphaned
+    // by the root's own exit is out of reach — which is why the caller escalates
+    // rather than trusting one call.
+    return {
+      kind: "taskkill",
+      command: "taskkill",
+      args: ["/pid", String(pid), "/t", "/f"],
+    };
+  }
+  // Valid only because the child is spawned `detached` on POSIX, which makes it
+  // a process-group leader with pgid === pid. Never negate a pid that was not.
+  return { kind: "group-signal", pid: -pid, signal: force ? "SIGKILL" : "SIGTERM" };
+}
+
+/** Whether the child should lead its own process group. Windows has no groups. */
+export function shouldDetach(platform) {
+  return platform !== "win32";
+}
+
+function runTreeKill(child, { force }) {
+  const action = describeTreeKill(process.platform, child.pid, { force });
+  if (action.kind === "none") return;
+  if (action.kind === "taskkill") {
+    spawn(action.command, action.args, { stdio: "ignore", windowsHide: true }).on("error", () => {});
+    return;
+  }
+  try {
+    process.kill(action.pid, action.signal);
+  } catch {
+    // The group is already gone, or we raced its exit. Fall back to the root.
+    try {
+      child.kill(action.signal);
+    } catch {
+      // Ignore races with process exit.
+    }
+  }
+}
+
+/**
+ * Exit without waiting for the event loop to drain.
+ *
+ * Mirrors `run-packaged-smoke.mjs`. Flush first: under CI stdout/stderr are
+ * pipes, which are async, and this script forwards the app's output through
+ * them — a bare exit truncates the tail of the log, which is exactly the part
+ * that explains a failure. The timer is the backstop for a blocked pipe whose
+ * write callback never fires, and is unref'd so it cannot itself hold us open.
+ */
+function exitAfterFlush(code) {
+  let exited = false;
+  const done = () => {
+    if (exited) return;
+    exited = true;
+    process.exit(code);
+  };
+
+  const bail = setTimeout(done, FLUSH_TIMEOUT_MS);
+  bail.unref();
+
+  process.stdout.write("", () => {
+    process.stderr.write("", done);
+  });
 }
 
 /**
@@ -128,17 +216,39 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
         const child = spawn(electronPath, args, {
           cwd: ROOT,
           env,
+          detached: shouldDetach(process.platform),
           stdio: ["ignore", "pipe", "pipe"],
         });
 
         let timedOut = false;
         let output = "";
         let hardKillTimer;
+        let giveUpTimer;
+        let settled = false;
 
-        const cleanup = async () => {
+        // One settlement path. `error` and `close` can both fire (a spawn
+        // failure emits `error`, and a failed spawn may never emit `close` at
+        // all), and cleanup must never be what decides whether this promise
+        // settles — see `finish` below.
+        const finish = (error, result) => {
+          if (settled) return;
+          settled = true;
           clearTimeout(timeoutTimer);
           if (hardKillTimer) clearTimeout(hardKillTimer);
-          await rm(userDataDir, { recursive: true, force: true });
+          if (giveUpTimer) clearTimeout(giveUpTimer);
+          // Fire-and-forget, and non-throwing: on Windows the app can still hold
+          // a handle under the user-data dir, and an rm rejection inside an async
+          // listener would leave this promise pending forever — the runner would
+          // hang on a run that had already produced its verdict.
+          rm(userDataDir, { recursive: true, force: true }).catch((removeError) => {
+            console.error(
+              `[FREEZE-RUNNER] Could not remove ${userDataDir}: ${
+                removeError instanceof Error ? removeError.message : String(removeError)
+              }`
+            );
+          });
+          if (error) reject(error);
+          else resolve(result);
         };
 
         const timeoutTimer = setTimeout(() => {
@@ -146,8 +256,15 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
           console.error(
             `[FREEZE-RUNNER] Run ${runIndex}/${runCount}: timed out after ${timeoutMs}ms`
           );
-          child.kill();
-          hardKillTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+          runTreeKill(child, { force: false });
+          hardKillTimer = setTimeout(() => runTreeKill(child, { force: true }), CHILD_KILL_GRACE_MS);
+          // A tree we could not fully reach may keep the stdio pipes open, so
+          // `close` never arrives. Settle anyway — the timeout is already the
+          // verdict, and waiting past it is the hang we are defending against.
+          giveUpTimer = setTimeout(
+            () => finish(null, { code: null, signal: "SIGKILL", output, timedOut: true }),
+            CHILD_KILL_GRACE_MS * 2
+          );
         }, timeoutMs);
         timeoutTimer.unref();
 
@@ -159,15 +276,8 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
         child.stdout?.on("data", (chunk) => capture(chunk, process.stdout));
         child.stderr?.on("data", (chunk) => capture(chunk, process.stderr));
 
-        child.on("error", async (error) => {
-          await cleanup();
-          reject(error);
-        });
-
-        child.on("close", async (code, signal) => {
-          await cleanup();
-          resolve({ code, signal, output, timedOut });
-        });
+        child.on("error", (error) => finish(error, null));
+        child.on("close", (code, signal) => finish(null, { code, signal, output, timedOut }));
       })
       .catch(reject);
   });
@@ -184,7 +294,16 @@ async function main() {
     const result = await runHarnessOnce({ runIndex: i, runCount, timeoutMs });
     const parsed = extractResultLine(result.output);
     if (parsed) results.push(parsed);
-    validateHarnessOutput(i, runCount, result);
+    try {
+      validateHarnessOutput(i, runCount, result);
+    } catch (error) {
+      // Only `[FREEZE-HARNESS]` lines are echoed live, so a child that died
+      // before its first marker has said nothing at all on the console — the
+      // reason is sitting unread in `output`. Dump it, once, on the way out.
+      console.error(`[FREEZE-RUNNER] Captured output from run ${i}/${runCount}:`);
+      console.error(result.output.trimEnd() || "(child produced no output)");
+      throw error;
+    }
     console.log(`[FREEZE-RUNNER] Run ${i}/${runCount}: PASS`);
   }
 
@@ -203,11 +322,13 @@ const invokedDirectly =
   process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
 if (invokedDirectly) {
-  main().catch((error) => {
-    console.error(
-      "[FREEZE-RUNNER] FAILED:",
-      error instanceof Error ? error.message : String(error)
-    );
-    process.exit(1);
-  });
+  main()
+    .then(() => exitAfterFlush(0))
+    .catch((error) => {
+      console.error(
+        "[FREEZE-RUNNER] FAILED:",
+        error instanceof Error ? error.message : String(error)
+      );
+      exitAfterFlush(1);
+    });
 }

--- a/scripts/run-freeze-harness.mjs
+++ b/scripts/run-freeze-harness.mjs
@@ -21,7 +21,7 @@
  * is the platform most likely to differ and is unverified.
  */
 
-import { spawn } from "child_process";
+import { spawn, spawnSync } from "child_process";
 import { constants as fsConstants } from "fs";
 import { access, mkdtemp, rm } from "fs/promises";
 import { createRequire } from "module";
@@ -67,6 +67,8 @@ const FLUSH_TIMEOUT_MS = 5_000;
  * falls back rather than silently inverting what the caller asked for.
  */
 const MAX_TIMER_MS = 2_147_483_647;
+/** Runs are ~15s each; a ceiling here is a typo guard, not a capability limit. */
+const MAX_RUNS = 1_000;
 
 export function parsePositiveInt(value, fallback, max = MAX_TIMER_MS) {
   const raw = String(value ?? "").trim();
@@ -111,9 +113,9 @@ export function boundedTail(text, maxChars) {
 export function describeTreeKill(platform, pid, { force = false } = {}) {
   if (!Number.isInteger(pid) || pid <= 0) return { kind: "none" };
   if (platform === "win32") {
-    // `/t` walks the tree as it stands right now, so anything already orphaned
-    // by the root's own exit is out of reach — which is why the caller escalates
-    // rather than trusting one call.
+    // `/t` walks the tree as it stands right now, so a descendant already
+    // reparented away is out of reach; the caller escalates rather than
+    // trusting one call, and stops entirely once the root pid is stale.
     // `/f` only on escalation. Without it taskkill asks the tree to close, which
     // is the graceful half of the same escalation the POSIX branch expresses as
     // SIGTERM-then-SIGKILL; forcing on the first call would make the second one
@@ -124,6 +126,8 @@ export function describeTreeKill(platform, pid, { force = false } = {}) {
   }
   // Valid only because the child is spawned `detached` on POSIX, which makes it
   // a process-group leader with pgid === pid. Never negate a pid that was not.
+  // The group outlives the leader, so this stays deliverable after the root has
+  // exited — which is precisely when the survivors matter.
   return { kind: "group-signal", pid: -pid, signal: force ? "SIGKILL" : "SIGTERM" };
 }
 
@@ -132,14 +136,36 @@ export function shouldDetach(platform) {
   return platform !== "win32";
 }
 
-function runTreeKill(child, { force, rootExited }) {
-  // Once the root has exited its pid is meaningless — the descendants that are
-  // still holding the pipes are no longer under it, and on Windows the pid may
-  // already have been recycled onto an unrelated process tree.
-  if (rootExited) return;
+/**
+ * Is the pid still a safe thing to aim at once the root has exited?
+ *
+ * Platform-specific, because the two branches address different things. Windows
+ * `taskkill /pid /t` walks a tree rooted at that pid, which no longer exists —
+ * and the pid may already have been recycled onto an unrelated process. POSIX
+ * aims at `-pid`, the process GROUP, which outlives its leader and still
+ * contains exactly the survivors holding our pipes. Suppressing there would
+ * disable the escalation at the moment it becomes the only thing that can work.
+ */
+export function shouldSuppressTreeKill(platform, rootExited) {
+  return rootExited && platform === "win32";
+}
+
+function runTreeKill(child, { force, rootExited, sync = false }) {
+  if (shouldSuppressTreeKill(process.platform, rootExited)) return;
   const action = describeTreeKill(process.platform, child.pid, { force });
   if (action.kind === "none") return;
   if (action.kind === "taskkill") {
+    // Synchronously when we are about to exit: `spawn` only *starts* taskkill,
+    // and a runner that exits in the same tick gives it no ordering guarantee.
+    // POSIX needs no equivalent — `process.kill` is the syscall itself.
+    if (sync) {
+      try {
+        spawnSync(action.command, action.args, { stdio: "ignore", windowsHide: true });
+      } catch {
+        // Nothing left to escalate to.
+      }
+      return;
+    }
     spawn(action.command, action.args, { stdio: "ignore", windowsHide: true }).on(
       "error",
       () => {}
@@ -273,10 +299,12 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
         let exitSignal = null;
 
         const onSignal = (signal) => {
-          // `detached` put Electron in its own process group, so a Ctrl+C in the
-          // terminal reaches this script and nothing else. Pass it on, or we
-          // trade the Windows hang this file exists to fix for a POSIX orphan.
-          runTreeKill(child, { force: false, rootExited });
+          // On POSIX `detached` put Electron in its own process group, so a
+          // Ctrl+C in the terminal reaches this script and nothing else. Pass it
+          // on, or we trade the Windows hang this file exists to fix for a POSIX
+          // orphan. Windows spawns attached, but forwarding is still correct
+          // there — the runner is the only thing that will do it.
+          runTreeKill(child, { force: false, rootExited, sync: true });
           process.exit(128 + (os.constants.signals[signal] ?? 0));
         };
         const SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
@@ -371,8 +399,15 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
           rootExited = true;
           exitCode = code;
           exitSignal = signal;
+          if (settled) return;
+          // Disarm the timeout: the root has reported, so the run is decided.
+          // Without this a root that exits 0 with every PASS marker moments
+          // before the deadline still settles `timedOut: true` and is reported
+          // as a failure — the drain below outlives the timer that flips it.
+          clearTimeout(timeoutTimer);
+          const timedOutAtExit = timedOut;
           drainTimer = setTimeout(
-            () => void finish(null, { code, signal, output, timedOut }),
+            () => void finish(null, { code, signal, output, timedOut: timedOutAtExit }),
             OUTPUT_DRAIN_MS
           );
         });
@@ -393,7 +428,7 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
 async function main() {
   await assertBuildArtifacts();
 
-  const runCount = parsePositiveInt(process.env.FREEZE_HARNESS_RUNS, 1);
+  const runCount = parsePositiveInt(process.env.FREEZE_HARNESS_RUNS, 1, MAX_RUNS);
   const timeoutMs = parsePositiveInt(process.env.FREEZE_HARNESS_TIMEOUT_MS, 180_000);
   const results = [];
 

--- a/scripts/run-freeze-harness.mjs
+++ b/scripts/run-freeze-harness.mjs
@@ -52,12 +52,43 @@ const FAILURE_MARKER = "[FREEZE-HARNESS] FAILED";
 
 /** Grace between the graceful kill and the hard one, and again before we stop waiting. */
 const CHILD_KILL_GRACE_MS = 5_000;
+/** How long the stdio pipes get to drain after the root exits before we settle anyway. */
+const OUTPUT_DRAIN_MS = 2_000;
+/** Cap on how long settlement waits for the user-data dir to be removed. */
+const CLEANUP_DEADLINE_MS = 5_000;
+/** Cap on the failure dump, so one write cannot outrun the flush before exit. */
+const MAX_DUMP_CHARS = 64_000;
 /** Backstop for a pipe whose write callback never fires. See `exitAfterFlush`. */
 const FLUSH_TIMEOUT_MS = 5_000;
 
-export function parsePositiveInt(value, fallback) {
-  const parsed = Number.parseInt(value ?? "", 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+/**
+ * Node clamps an out-of-range `setTimeout` delay to 1ms, so an oversized
+ * timeout is not a long timeout — it is an instant one. Anything above this
+ * falls back rather than silently inverting what the caller asked for.
+ */
+const MAX_TIMER_MS = 2_147_483_647;
+
+export function parsePositiveInt(value, fallback, max = MAX_TIMER_MS) {
+  const raw = String(value ?? "").trim();
+  // Number.parseInt("5junk") is 5 and parseInt("1.5") is 1; neither is what the
+  // caller wrote, and silently reinterpreting an env var is how you debug the
+  // wrong run for an hour.
+  if (!/^\d+$/.test(raw)) return fallback;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= max ? parsed : fallback;
+}
+
+/**
+ * Last `maxChars` of the child's output, prefixed with how much was dropped.
+ * The dump is a single write racing `exitAfterFlush`'s bail timer, so it has to
+ * be a predictable size — a chatty 180s child can otherwise produce a string
+ * large enough that the flush is cut off and the diagnostic is lost entirely.
+ */
+export function boundedTail(text, maxChars) {
+  const value = String(text ?? "");
+  if (value.length <= maxChars) return value;
+  const dropped = value.length - maxChars;
+  return `[... ${dropped} earlier characters omitted ...]\n${value.slice(-maxChars)}`;
 }
 
 /**
@@ -83,11 +114,13 @@ export function describeTreeKill(platform, pid, { force = false } = {}) {
     // `/t` walks the tree as it stands right now, so anything already orphaned
     // by the root's own exit is out of reach — which is why the caller escalates
     // rather than trusting one call.
-    return {
-      kind: "taskkill",
-      command: "taskkill",
-      args: ["/pid", String(pid), "/t", "/f"],
-    };
+    // `/f` only on escalation. Without it taskkill asks the tree to close, which
+    // is the graceful half of the same escalation the POSIX branch expresses as
+    // SIGTERM-then-SIGKILL; forcing on the first call would make the second one
+    // a duplicate rather than a step up.
+    const args = ["/pid", String(pid), "/t"];
+    if (force) args.push("/f");
+    return { kind: "taskkill", command: "taskkill", args };
   }
   // Valid only because the child is spawned `detached` on POSIX, which makes it
   // a process-group leader with pgid === pid. Never negate a pid that was not.
@@ -99,11 +132,18 @@ export function shouldDetach(platform) {
   return platform !== "win32";
 }
 
-function runTreeKill(child, { force }) {
+function runTreeKill(child, { force, rootExited }) {
+  // Once the root has exited its pid is meaningless — the descendants that are
+  // still holding the pipes are no longer under it, and on Windows the pid may
+  // already have been recycled onto an unrelated process tree.
+  if (rootExited) return;
   const action = describeTreeKill(process.platform, child.pid, { force });
   if (action.kind === "none") return;
   if (action.kind === "taskkill") {
-    spawn(action.command, action.args, { stdio: "ignore", windowsHide: true }).on("error", () => {});
+    spawn(action.command, action.args, { stdio: "ignore", windowsHide: true }).on(
+      "error",
+      () => {}
+    );
     return;
   }
   try {
@@ -224,29 +264,55 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
         let output = "";
         let hardKillTimer;
         let giveUpTimer;
+        let drainTimer;
         let settled = false;
+        // Set from `exit`, which fires when the root process goes away. `close`
+        // fires only once every inherited stdio pipe has drained — see below.
+        let rootExited = false;
+        let exitCode = null;
+        let exitSignal = null;
 
-        // One settlement path. `error` and `close` can both fire (a spawn
-        // failure emits `error`, and a failed spawn may never emit `close` at
-        // all), and cleanup must never be what decides whether this promise
-        // settles — see `finish` below.
-        const finish = (error, result) => {
+        const onSignal = (signal) => {
+          // `detached` put Electron in its own process group, so a Ctrl+C in the
+          // terminal reaches this script and nothing else. Pass it on, or we
+          // trade the Windows hang this file exists to fix for a POSIX orphan.
+          runTreeKill(child, { force: false, rootExited });
+          process.exit(128 + (os.constants.signals[signal] ?? 0));
+        };
+        const SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
+        for (const signal of SIGNALS) process.on(signal, onSignal);
+
+        // One settlement path. `error` and `close` can both fire, `close` may
+        // never fire at all, and cleanup must never be what decides whether this
+        // promise settles.
+        const finish = async (error, result) => {
           if (settled) return;
           settled = true;
           clearTimeout(timeoutTimer);
           if (hardKillTimer) clearTimeout(hardKillTimer);
           if (giveUpTimer) clearTimeout(giveUpTimer);
-          // Fire-and-forget, and non-throwing: on Windows the app can still hold
-          // a handle under the user-data dir, and an rm rejection inside an async
-          // listener would leave this promise pending forever — the runner would
-          // hang on a run that had already produced its verdict.
-          rm(userDataDir, { recursive: true, force: true }).catch((removeError) => {
-            console.error(
-              `[FREEZE-RUNNER] Could not remove ${userDataDir}: ${
-                removeError instanceof Error ? removeError.message : String(removeError)
-              }`
-            );
-          });
+          if (drainTimer) clearTimeout(drainTimer);
+          for (const signal of SIGNALS) process.off(signal, onSignal);
+          // Awaited, but only up to a deadline. Awaiting unconditionally is the
+          // hang this file exists to prevent; not awaiting at all means the
+          // explicit exit routinely kills the removal mid-flight and leaks an
+          // Electron profile per run. On Windows a held handle also needs a
+          // moment to be released after the tree dies.
+          await Promise.race([
+            rm(userDataDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 200 }).catch(
+              (removeError) => {
+                console.error(
+                  `[FREEZE-RUNNER] Could not remove ${userDataDir}: ${
+                    removeError instanceof Error ? removeError.message : String(removeError)
+                  }`
+                );
+              }
+            ),
+            new Promise((r) => {
+              const t = setTimeout(r, CLEANUP_DEADLINE_MS);
+              t.unref();
+            }),
+          ]);
           if (error) reject(error);
           else resolve(result);
         };
@@ -256,13 +322,16 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
           console.error(
             `[FREEZE-RUNNER] Run ${runIndex}/${runCount}: timed out after ${timeoutMs}ms`
           );
-          runTreeKill(child, { force: false });
-          hardKillTimer = setTimeout(() => runTreeKill(child, { force: true }), CHILD_KILL_GRACE_MS);
+          runTreeKill(child, { force: false, rootExited });
+          hardKillTimer = setTimeout(
+            () => runTreeKill(child, { force: true, rootExited }),
+            CHILD_KILL_GRACE_MS
+          );
           // A tree we could not fully reach may keep the stdio pipes open, so
           // `close` never arrives. Settle anyway — the timeout is already the
           // verdict, and waiting past it is the hang we are defending against.
           giveUpTimer = setTimeout(
-            () => finish(null, { code: null, signal: "SIGKILL", output, timedOut: true }),
+            () => void finish(null, { code: exitCode, signal: exitSignal, output, timedOut: true }),
             CHILD_KILL_GRACE_MS * 2
           );
         }, timeoutMs);
@@ -276,8 +345,46 @@ function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
         child.stdout?.on("data", (chunk) => capture(chunk, process.stdout));
         child.stderr?.on("data", (chunk) => capture(chunk, process.stderr));
 
-        child.on("error", (error) => finish(error, null));
-        child.on("close", (code, signal) => finish(null, { code, signal, output, timedOut }));
+        child.on("error", (error) => {
+          if (rootExited || timedOut) {
+            // Not a spawn failure — `error` also reports a kill we failed to
+            // deliver. Settling on it here would report the wrong cause and
+            // disarm the escalation that is still mid-flight.
+            console.error(
+              `[FREEZE-RUNNER] Teardown error: ${
+                error instanceof Error ? error.message : String(error)
+              }`
+            );
+            return;
+          }
+          void finish(error, null);
+        });
+
+        // `exit` is the root's verdict; `close` additionally waits for every
+        // inherited stdio pipe to drain. Electron's descendants inherit those
+        // pipes, so a single survivor means `close` never arrives — and a run
+        // that PASSED and exited 0 would otherwise sit here until the timeout
+        // and be reported as a failure. Take the verdict from `exit`, give the
+        // pipes a bounded moment to drain for the sake of the log tail, then
+        // settle regardless.
+        child.on("exit", (code, signal) => {
+          rootExited = true;
+          exitCode = code;
+          exitSignal = signal;
+          drainTimer = setTimeout(
+            () => void finish(null, { code, signal, output, timedOut }),
+            OUTPUT_DRAIN_MS
+          );
+        });
+
+        child.on("close", (code, signal) => {
+          void finish(null, {
+            code: code ?? exitCode,
+            signal: signal ?? exitSignal,
+            output,
+            timedOut,
+          });
+        });
       })
       .catch(reject);
   });
@@ -301,7 +408,9 @@ async function main() {
       // before its first marker has said nothing at all on the console — the
       // reason is sitting unread in `output`. Dump it, once, on the way out.
       console.error(`[FREEZE-RUNNER] Captured output from run ${i}/${runCount}:`);
-      console.error(result.output.trimEnd() || "(child produced no output)");
+      console.error(
+        boundedTail(result.output.trimEnd(), MAX_DUMP_CHARS) || "(child produced no output)"
+      );
       throw error;
     }
     console.log(`[FREEZE-RUNNER] Run ${i}/${runCount}: PASS`);

--- a/scripts/run-freeze-harness.mjs
+++ b/scripts/run-freeze-harness.mjs
@@ -1,0 +1,213 @@
+/**
+ * CDP freeze harness runner (#11846) — launches the built Electron app in
+ * `--daintree-freeze-harness` mode and validates that a cached project view's
+ * renderer genuinely stops executing tasks when the production efficiency-freeze
+ * path freezes it, and resumes when it is thawed.
+ *
+ * Deliberately not a Playwright spec. Playwright sends
+ * `Emulation.setFocusEmulationEnabled` to every page target it attaches to,
+ * which pins the renderer to "user-visible" and makes
+ * `Page.setWebLifecycleState(frozen)` a silent no-op that still returns ok. A
+ * freeze assertion written in Playwright passes whether or not freeze works, so
+ * it can never fail. This runner keeps Playwright out of the process entirely.
+ *
+ * Mirrors `run-smoke.mjs`: spawn the real app, scrape markers, exit non-zero on
+ * a missing marker or a non-zero child exit. The measurement and every
+ * assertion live in `electron/services/freezeHarness.ts` — this file only
+ * launches and adjudicates.
+ *
+ * Platform coverage: measured on macOS only. The finding is Chromium/CDP
+ * semantics so it should hold cross-platform, but that is an inference. Windows
+ * is the platform most likely to differ and is unverified.
+ */
+
+import { spawn } from "child_process";
+import { constants as fsConstants } from "fs";
+import { access, mkdtemp, rm } from "fs/promises";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const require = createRequire(import.meta.url);
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..");
+
+const BUILD_ARTIFACTS = [
+  "dist/index.html",
+  "dist-electron/electron/bootstrap.js",
+  "dist-electron/electron/main.js",
+];
+
+export const REQUIRED_MARKERS = [
+  "[FREEZE-HARNESS] CHECK: cached view ready",
+  "[FREEZE-HARNESS] CHECK: probe running — OK",
+  "[FREEZE-HARNESS] CHECK: freeze ratio — OK",
+  "[FREEZE-HARNESS] CHECK: recovery — OK",
+  "[FREEZE-HARNESS] PASS",
+];
+
+const FAILURE_MARKER = "[FREEZE-HARNESS] FAILED";
+
+export function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Pull the machine-readable RESULT line out of the child's output, so a run can
+ * report its numbers even when it fails. Returns null when absent.
+ */
+export function extractResultLine(output) {
+  const match = /\[FREEZE-HARNESS\] RESULT (\{.*\})/.exec(output ?? "");
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+export function validateHarnessOutput(runIndex, runCount, result) {
+  const { code, signal, output, timedOut } = result;
+  if (timedOut) {
+    throw new Error(`Freeze harness run ${runIndex}/${runCount} timed out`);
+  }
+  if (output.includes(FAILURE_MARKER)) {
+    throw new Error(`Freeze harness run ${runIndex}/${runCount} reported a failure`);
+  }
+  if (code !== 0) {
+    throw new Error(
+      `Freeze harness run ${runIndex}/${runCount} failed with code ${code} (signal ${signal})`
+    );
+  }
+  for (const marker of REQUIRED_MARKERS) {
+    if (!output.includes(marker)) {
+      throw new Error(
+        `Freeze harness run ${runIndex}/${runCount} missing expected marker: ${marker}`
+      );
+    }
+  }
+}
+
+async function assertBuildArtifacts() {
+  for (const relativePath of BUILD_ARTIFACTS) {
+    const fullPath = path.join(ROOT, relativePath);
+    try {
+      await access(fullPath, fsConstants.R_OK);
+    } catch {
+      throw new Error(`Missing build artifact: ${relativePath}. Run "npm run build" first.`);
+    }
+  }
+}
+
+function runHarnessOnce({ runIndex, runCount, timeoutMs }) {
+  const electronPath = require("electron");
+  return new Promise((resolve, reject) => {
+    mkdtemp(path.join(os.tmpdir(), "daintree-freeze-harness-run-"))
+      .then((userDataDir) => {
+        const args = [
+          ".",
+          "--daintree-freeze-harness",
+          "--disable-gpu",
+          "--disable-software-rasterizer",
+          "--noerrdialogs",
+          `--user-data-dir=${userDataDir}`,
+        ];
+        if (process.platform === "linux") {
+          args.push("--no-sandbox");
+        }
+
+        console.log(`[FREEZE-RUNNER] Run ${runIndex}/${runCount}: launching Electron`);
+
+        const env = { ...process.env, NODE_ENV: "production" };
+        delete env.ELECTRON_RUN_AS_NODE;
+        delete env.ATOM_SHELL_INTERNAL_RUN_AS_NODE;
+
+        const child = spawn(electronPath, args, {
+          cwd: ROOT,
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        let timedOut = false;
+        let output = "";
+        let hardKillTimer;
+
+        const cleanup = async () => {
+          clearTimeout(timeoutTimer);
+          if (hardKillTimer) clearTimeout(hardKillTimer);
+          await rm(userDataDir, { recursive: true, force: true });
+        };
+
+        const timeoutTimer = setTimeout(() => {
+          timedOut = true;
+          console.error(
+            `[FREEZE-RUNNER] Run ${runIndex}/${runCount}: timed out after ${timeoutMs}ms`
+          );
+          child.kill();
+          hardKillTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+        }, timeoutMs);
+        timeoutTimer.unref();
+
+        const capture = (chunk, stream) => {
+          const text = chunk.toString();
+          output += text;
+          if (text.includes("[FREEZE-HARNESS]")) stream.write(text);
+        };
+        child.stdout?.on("data", (chunk) => capture(chunk, process.stdout));
+        child.stderr?.on("data", (chunk) => capture(chunk, process.stderr));
+
+        child.on("error", async (error) => {
+          await cleanup();
+          reject(error);
+        });
+
+        child.on("close", async (code, signal) => {
+          await cleanup();
+          resolve({ code, signal, output, timedOut });
+        });
+      })
+      .catch(reject);
+  });
+}
+
+async function main() {
+  await assertBuildArtifacts();
+
+  const runCount = parsePositiveInt(process.env.FREEZE_HARNESS_RUNS, 1);
+  const timeoutMs = parsePositiveInt(process.env.FREEZE_HARNESS_TIMEOUT_MS, 180_000);
+  const results = [];
+
+  for (let i = 1; i <= runCount; i++) {
+    const result = await runHarnessOnce({ runIndex: i, runCount, timeoutMs });
+    const parsed = extractResultLine(result.output);
+    if (parsed) results.push(parsed);
+    validateHarnessOutput(i, runCount, result);
+    console.log(`[FREEZE-RUNNER] Run ${i}/${runCount}: PASS`);
+  }
+
+  if (results.length > 1) {
+    const ratios = results.map((r) => r.freezeRatio);
+    console.log(
+      `[FREEZE-RUNNER] freezeRatio across ${results.length} runs: min=${Math.min(
+        ...ratios
+      )} max=${Math.max(...ratios)}`
+    );
+  }
+  console.log(`[FREEZE-RUNNER] All ${runCount} run(s) passed`);
+}
+
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(
+      "[FREEZE-RUNNER] FAILED:",
+      error instanceof Error ? error.message : String(error)
+    );
+    process.exit(1);
+  });
+}

--- a/scripts/run-freeze-harness.test.mjs
+++ b/scripts/run-freeze-harness.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   REQUIRED_MARKERS,
+  boundedTail,
   describeTreeKill,
   extractResultLine,
   parsePositiveInt,
@@ -8,14 +9,15 @@ import {
   validateHarnessOutput,
 } from "./run-freeze-harness.mjs";
 
+// Built from the exported markers rather than restating them: a renamed marker
+// should break the runner's contract test, not force a matching edit to a
+// fixture that never exercised the producer in the first place. The first
+// marker keeps a trailing suffix so the `startsWith` filter below stays honest.
 const PASSING_OUTPUT = [
-  "[FREEZE-HARNESS] CHECK: cached view ready — projectId=7f39de12 visible=false",
-  "[FREEZE-HARNESS] CHECK: probe running — OK",
+  `${REQUIRED_MARKERS[0]} — projectId=7f39de12 visible=false`,
+  ...REQUIRED_MARKERS.slice(1),
   "[FREEZE-HARNESS] window=3000ms control=54224 frozen=0 recovered=52533",
   '[FREEZE-HARNESS] RESULT {"control":54224,"frozen":0,"recovered":52533,"freezeRatio":54224,"recoveryRatio":52533,"visibilityState":"hidden"}',
-  "[FREEZE-HARNESS] CHECK: freeze ratio — OK",
-  "[FREEZE-HARNESS] CHECK: recovery — OK",
-  "[FREEZE-HARNESS] PASS",
 ].join("\n");
 
 function okResult(overrides = {}) {
@@ -113,16 +115,67 @@ describe("describeTreeKill", () => {
     expect(action.args).toContain("/t");
   });
 
-  it("never falls back to an image-name kill", () => {
+  it("escalates on Windows by forcing, not by changing the target", () => {
+    const graceful = describeTreeKill("win32", 4321);
+    const forced = describeTreeKill("win32", 4321, { force: true });
+    // Graceful asks the tree to close; only the escalation forces it. Both
+    // forcing would make the second call a duplicate rather than a step up.
+    expect(graceful.args).not.toContain("/f");
+    expect(forced.args).toContain("/f");
+    expect(forced.args.filter((a) => a !== "/f")).toEqual(graceful.args);
+  });
+
+  it("addresses the tree only by pid, never by image name", () => {
     // This runner launches the unpackaged electron binary, so `taskkill /im`
     // would take out every other Electron app on the developer's machine.
     const action = describeTreeKill("win32", 4321, { force: true });
-    expect(action.args).not.toContain("/im");
-    expect(action.args.join(" ")).not.toMatch(/\.exe/i);
+    expect(action.args).toEqual(["/pid", "4321", "/t", "/f"]);
   });
 
   it.each([undefined, null, 0, -1, 1.5, NaN])("issues no kill for the pid %s", (pid) => {
     expect(describeTreeKill("darwin", pid).kind).toBe("none");
     expect(describeTreeKill("win32", pid).kind).toBe("none");
+  });
+});
+
+describe("parsePositiveInt ceiling", () => {
+  it("rejects a delay Node would clamp to a near-instant timer", () => {
+    // Node clamps an out-of-range setTimeout to ~1ms, so accepting this would
+    // turn "wait a very long time" into "time out immediately".
+    const tooLarge = 2_147_483_648;
+    expect(parsePositiveInt(String(tooLarge), 180_000)).toBe(180_000);
+    expect(parsePositiveInt(String(tooLarge - 1), 180_000)).toBe(tooLarge - 1);
+  });
+
+  it("refuses to reinterpret a value the caller did not write", () => {
+    // parseInt would read these as 5 and 1 respectively.
+    expect(parsePositiveInt("5junk", 7)).toBe(7);
+    expect(parsePositiveInt("1.5", 7)).toBe(7);
+    expect(parsePositiveInt(" 5 ", 7)).toBe(5);
+  });
+
+  it("honours a caller-supplied ceiling independently of the timer ceiling", () => {
+    expect(parsePositiveInt("11", 1, 10)).toBe(1);
+    expect(parsePositiveInt("10", 1, 10)).toBe(10);
+  });
+});
+
+describe("boundedTail", () => {
+  it("passes short text through untouched", () => {
+    expect(boundedTail("all of it", 100)).toBe("all of it");
+  });
+
+  it("keeps the end, which is where the failure is, and says what it dropped", () => {
+    const text = "abcdefghij";
+    const tail = boundedTail(text, 4);
+    expect(tail.endsWith("ghij")).toBe(true);
+    expect(tail).toContain(String(text.length - 4));
+  });
+
+  it("bounds the payload so one write cannot outrun the flush", () => {
+    const huge = "x".repeat(500_000);
+    // The prefix adds a little, but the result must stay the same order of
+    // magnitude as the cap rather than the input.
+    expect(boundedTail(huge, 1_000).length).toBeLessThan(1_100);
   });
 });

--- a/scripts/run-freeze-harness.test.mjs
+++ b/scripts/run-freeze-harness.test.mjs
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  REQUIRED_MARKERS,
+  extractResultLine,
+  parsePositiveInt,
+  validateHarnessOutput,
+} from "./run-freeze-harness.mjs";
+
+const PASSING_OUTPUT = [
+  "[FREEZE-HARNESS] CHECK: cached view ready — projectId=7f39de12 visible=false",
+  "[FREEZE-HARNESS] CHECK: probe running — OK",
+  "[FREEZE-HARNESS] window=3000ms control=54224 frozen=0 recovered=52533",
+  '[FREEZE-HARNESS] RESULT {"control":54224,"frozen":0,"recovered":52533,"freezeRatio":54224,"recoveryRatio":52533,"visibilityState":"hidden"}',
+  "[FREEZE-HARNESS] CHECK: freeze ratio — OK",
+  "[FREEZE-HARNESS] CHECK: recovery — OK",
+  "[FREEZE-HARNESS] PASS",
+].join("\n");
+
+function okResult(overrides = {}) {
+  return { code: 0, signal: null, output: PASSING_OUTPUT, timedOut: false, ...overrides };
+}
+
+describe("parsePositiveInt", () => {
+  it("parses a positive integer", () => {
+    expect(parsePositiveInt("5", 1)).toBe(5);
+  });
+
+  it.each([undefined, "", "0", "-3", "abc"])("falls back for %s", (value) => {
+    expect(parsePositiveInt(value, 7)).toBe(7);
+  });
+});
+
+describe("extractResultLine", () => {
+  it("pulls the machine-readable numbers out of a run", () => {
+    expect(extractResultLine(PASSING_OUTPUT)).toMatchObject({
+      control: 54224,
+      frozen: 0,
+      recovered: 52533,
+      visibilityState: "hidden",
+    });
+  });
+
+  it("still reports numbers from a failing run", () => {
+    const failing =
+      '[FREEZE-HARNESS] RESULT {"control":54026,"frozen":53875,"freezeRatio":1}\n' +
+      "[FREEZE-HARNESS] FAILED — freeze did not stop the renderer";
+    expect(extractResultLine(failing)).toMatchObject({ frozen: 53875, freezeRatio: 1 });
+  });
+
+  it("returns null when absent or unparseable", () => {
+    expect(extractResultLine("nothing here")).toBeNull();
+    expect(extractResultLine("[FREEZE-HARNESS] RESULT {broken")).toBeNull();
+    expect(extractResultLine(undefined)).toBeNull();
+  });
+});
+
+describe("validateHarnessOutput", () => {
+  it("accepts a clean passing run", () => {
+    expect(() => validateHarnessOutput(1, 1, okResult())).not.toThrow();
+  });
+
+  it("rejects a run that reported a failure even if it somehow exited zero", () => {
+    const output = `${PASSING_OUTPUT}\n[FREEZE-HARNESS] FAILED — freeze did not stop the renderer`;
+    expect(() => validateHarnessOutput(1, 1, okResult({ output }))).toThrow(/reported a failure/);
+  });
+
+  it("rejects a non-zero exit", () => {
+    expect(() => validateHarnessOutput(1, 1, okResult({ code: 1 }))).toThrow(/failed with code 1/);
+  });
+
+  it("rejects a timeout", () => {
+    expect(() => validateHarnessOutput(1, 1, okResult({ timedOut: true }))).toThrow(/timed out/);
+  });
+
+  it.each(REQUIRED_MARKERS)("rejects output missing the %s marker", (marker) => {
+    const output = PASSING_OUTPUT.split("\n")
+      .filter((line) => !line.startsWith(marker))
+      .join("\n");
+    expect(() => validateHarnessOutput(1, 1, okResult({ output }))).toThrow(/missing expected/);
+  });
+
+  it("rejects a silent run that produced no output at all", () => {
+    expect(() => validateHarnessOutput(1, 1, okResult({ output: "" }))).toThrow(/missing expected/);
+  });
+});

--- a/scripts/run-freeze-harness.test.mjs
+++ b/scripts/run-freeze-harness.test.mjs
@@ -6,6 +6,7 @@ import {
   extractResultLine,
   parsePositiveInt,
   shouldDetach,
+  shouldSuppressTreeKill,
   validateHarnessOutput,
 } from "./run-freeze-harness.mjs";
 
@@ -177,5 +178,33 @@ describe("boundedTail", () => {
     // The prefix adds a little, but the result must stay the same order of
     // magnitude as the cap rather than the input.
     expect(boundedTail(huge, 1_000).length).toBeLessThan(1_100);
+  });
+});
+
+describe("shouldSuppressTreeKill", () => {
+  it("keeps killing while the root is alive on every platform", () => {
+    for (const platform of ["darwin", "linux", "win32"]) {
+      expect(shouldSuppressTreeKill(platform, false)).toBe(false);
+    }
+  });
+
+  it("stops aiming at a dead root's pid on Windows, where /t walks a tree that is gone", () => {
+    // The pid may also have been recycled onto an unrelated process by now.
+    expect(shouldSuppressTreeKill("win32", true)).toBe(true);
+  });
+
+  it("keeps signalling the POSIX group after its leader exits", () => {
+    // The group outlives the leader and still holds the survivors pinning our
+    // stdio pipes open — suppressing here would disable escalation exactly when
+    // it becomes the only thing that can reach them.
+    expect(shouldSuppressTreeKill("darwin", true)).toBe(false);
+    expect(shouldSuppressTreeKill("linux", true)).toBe(false);
+  });
+
+  it("diverges by platform only once the root is gone", () => {
+    const alive = ["darwin", "win32"].map((p) => shouldSuppressTreeKill(p, false));
+    const dead = ["darwin", "win32"].map((p) => shouldSuppressTreeKill(p, true));
+    expect(new Set(alive).size).toBe(1);
+    expect(new Set(dead).size).toBe(2);
   });
 });

--- a/scripts/run-freeze-harness.test.mjs
+++ b/scripts/run-freeze-harness.test.mjs
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
   REQUIRED_MARKERS,
+  describeTreeKill,
   extractResultLine,
   parsePositiveInt,
+  shouldDetach,
   validateHarnessOutput,
 } from "./run-freeze-harness.mjs";
 
@@ -81,5 +83,46 @@ describe("validateHarnessOutput", () => {
 
   it("rejects a silent run that produced no output at all", () => {
     expect(() => validateHarnessOutput(1, 1, okResult({ output: "" }))).toThrow(/missing expected/);
+  });
+});
+
+describe("describeTreeKill", () => {
+  it("targets the process group on POSIX, which only detached spawning creates", () => {
+    // The negative pid is a process-group id. It is valid only because the child
+    // leads its own group — so the two decisions have to agree.
+    const action = describeTreeKill("darwin", 4321);
+    expect(shouldDetach("darwin")).toBe(true);
+    expect(action).toMatchObject({ kind: "group-signal", pid: -4321 });
+  });
+
+  it("escalates the signal without changing the target", () => {
+    const graceful = describeTreeKill("linux", 4321);
+    const forced = describeTreeKill("linux", 4321, { force: true });
+    expect(forced.pid).toBe(graceful.pid);
+    expect(forced.signal).not.toBe(graceful.signal);
+    expect([graceful.signal, forced.signal]).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("uses a pid-scoped tree kill on Windows, which has no process groups", () => {
+    const action = describeTreeKill("win32", 4321);
+    expect(shouldDetach("win32")).toBe(false);
+    expect(action.kind).toBe("taskkill");
+    expect(action.args).toContain("4321");
+    // /t is the whole point — killing the root alone leaves Electron's children
+    // holding the inherited stdio pipes open.
+    expect(action.args).toContain("/t");
+  });
+
+  it("never falls back to an image-name kill", () => {
+    // This runner launches the unpackaged electron binary, so `taskkill /im`
+    // would take out every other Electron app on the developer's machine.
+    const action = describeTreeKill("win32", 4321, { force: true });
+    expect(action.args).not.toContain("/im");
+    expect(action.args.join(" ")).not.toMatch(/\.exe/i);
+  });
+
+  it.each([undefined, null, 0, -1, 1.5, NaN])("issues no kill for the pid %s", (pid) => {
+    expect(describeTreeKill("darwin", pid).kind).toBe("none");
+    expect(describeTreeKill("win32", pid).kind).toBe("none");
   });
 });


### PR DESCRIPTION
Refs #11846. Does not close it — that issue stays open for the `webContentsLifecycle.ts` comment.

The Playwright-free freeze harness you invited. It boots the real app and measures whether CDP freeze actually stops the renderer, which #11846 established Playwright structurally cannot do.

## Your four requirements

1. **Real app, not a mirror.** A `--daintree-freeze-harness` flag boots through the real `main.ts` / `bootstrap.ts` / `setupWindowServices`, then drives the production path: `ProjectViewManager.switchTo` → `deactivateEntry` → `setEfficiencyFreeze` → `freezeAllCached`. Nothing stubbed.
2. **No debugger client on the measured view** — satisfied, but by a different means than you suggested, and I'd like your call on it. You proposed an IPC channel; this uses `webContents.executeJavaScript`, which is Blink script execution rather than CDP, so it never calls `debugger.attach` and cannot collide with `ensureAttached`. Same shape as your suggestion — counter ticks in the renderer, main reads it — but it adds zero entries to `channels.ts`, zero `IpcEventMap` entries and zero preload surface, which seemed worth preserving given `check:preload-backdoors` and the recent tool-surface shrink. Say the word and I'll swap it for a real channel.
3. **Ratio, not a bound.** `MIN_FREEZE_RATIO=100`, `MIN_RECOVERY_RATIO=100`, `MIN_RECOVERY_FRACTION_OF_CONTROL=0.1`. Stall duration is logged, never asserted. The single absolute is `MIN_CONTROL_TICKS=1000`, a liveness floor on the positive control only — without it a dead probe reads 0/0/0 and every ratio passes vacuously.
4. **Recovery leg.** Two assertions: recovered-vs-frozen ratio, and recovered ≥ 10% of control so a trickle doesn't pass. A hung renderer fails separately via a 15s read timeout with its own message.

## Verified in both directions

```
freeze intact      control =  51,340   frozen = 0   recovered = 50,283   ratio 51,340x   PASS
freeze neutered    control =  54,334   frozen = 58,495                   ratio     0.9x  FAIL (exit 1)
```

Against a 100x floor that is three orders of magnitude of headroom on either side. `frozen=0` and `frozenInterior=0` on every green run; control rate varies 41k–59k between runs, which is exactly why the assertions are ratios rather than thresholds.

## One correction to my own issue text

I claimed in #11846 that this would catch the `disable-renderer-backgrounding` regression from lesson #4683. **It does not, because that regression no longer breaks freeze.** Appending both switches in `main.ts`:

```
without switches   control =  51,340   frozen = 0   PASS
with both          control = 446,953   frozen = 0   PASS
```

The switches took effect — control rate up 8.7x — and freeze still zeroed the renderer. Details and the implication for the audit comment at `webContentsLifecycle.ts:20-27` are in a comment on #11846. Flagging it here because it changes what this harness is worth: it verifies freeze semantics, it does not guard that particular regression.

## Placement

`scripts/run-freeze-harness.mjs` + `electron/services/freezeHarness.ts` + a flag in `runtimeFlags.ts` + `npm run test:freeze-harness`. This mirrors `--smoke-test`, the repo's only other Playwright-free real-app-boot harness, including `run-packaged-smoke.mjs`'s convention of exported pure functions behind an `invokedDirectly` guard so the adjudication logic is unit-testable.

**Deliberately not wired into CI.** `docs/e2e-testing.md:183` records the test-nightly as retired, and only `nightly-publish.yml` still runs on a cron, so there was no obvious home. Left as run-on-demand rather than guessed at — tell me where you want it and I'll wire it.

## Limits and known risks

- **macOS only.** Windows unverified, and as you predicted it is the likeliest to differ. Stated as a limit in the runner header and the docs rather than implied as coverage.
- `ResourceProfileService` can call `setEfficiencyFreeze` underneath the harness on a profile transition. Both directions fail *safe* — red, never a false green — but it is a genuine flake source on a memory-pressured box. Not observed across 13 runs.
- Cached views get a periodic CDP memory purge 20s after caching; a run completes in ~14s. Raising `DAINTREE_FREEZE_HARNESS_WINDOW_MS` past ~4,500 would cross that.
- `MIN_CONTROL_TICKS=1000` sits 40x below the slowest observed control, but is untested on a slow CI box.

## Checks

`npm run check` clean — typecheck, lint ratchet at the 1091 baseline, format. Full unit suite 49,754 passing. Mutation check: forcing the verdict to always-pass kills 6 tests.
