### PR TITLE
feat(switcher): weigh running agents against waiting ones on every row

### DIFF
--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { ChevronsUpDown, FileText, Plus } from "lucide-react";
-import { SpinnerCircle } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { useProjectStore } from "@/store/projectStore";
@@ -146,10 +145,12 @@ export function ProjectSwitcher() {
   // Reads the totals across every non-active project rather than `results`,
   // which is ordered and filtered for presentation.
   //
-  // Two axes on one mark, the same split the switcher's rows draw (#11832):
-  // hue says what is being asked of the user, shape says whether anything is
-  // still moving. Before that they contended for one carrier, so a fleet that
-  // was both waiting AND churning looked exactly like one that had stalled.
+  // One mark, one axis: the dot's hue says what is being asked of the user. The
+  // fleet's running work is in the label rather than the glyph — a second shape
+  // on this mark could say that something was moving but never how much, which
+  // is the half worth knowing. The switcher's rows split the same way, and get
+  // to draw the proportion because they have one project's counts to weigh; a
+  // fleet-wide badge would be averaging every project into one dot.
   const badgeStatus = useMemo(() => {
     const { activeAgentCount, waitingAgentCount, waitingProjectCount } =
       projectSwitcher.nonActiveAgentCounts;
@@ -173,14 +174,13 @@ export function ProjectSwitcher() {
     }
 
     return {
-      // Demand still wins the hue outright — the badge's colour has always
-      // meant "this needs you", and liveness rides the shape instead of
-      // competing for it.
-      color: waitingAgentCount > 0 ? "bg-state-waiting" : "bg-activity-active",
-      arc: waitingAgentCount > 0 ? "text-state-waiting" : "text-activity-active",
-      isLive: activeAgentCount > 0,
-      // Both facts, always. The mark is a single glyph and the label is the
-      // only place a reader who cannot see it learns either one.
+      // Demand wins the hue outright — the badge's colour has always meant
+      // "this needs you" — and liveness stays in the label rather than
+      // competing for the one mark a fleet-wide badge has.
+      color: waitingAgentCount > 0 ? "bg-state-waiting" : "bg-activity-working",
+      // Both facts, always. The mark carries demand alone, so the label is the
+      // only place either a reader who cannot see it or one who can learns how
+      // much is still running.
       label: parts.join(", "),
     };
   }, [projectSwitcher.nonActiveAgentCounts]);
@@ -404,33 +404,20 @@ export function ProjectSwitcher() {
                 <ChevronsUpDown className="shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
               )}
               {badgeStatus && (
-                // A fixed box either mark centres in, so switching between them
-                // moves nothing around it. The 10px arc lands on the same
-                // footprint the 8px dot and its ring already occupied.
+                // A fixed box the mark centres in, so a change of hue moves
+                // nothing around it.
                 <span
                   role="status"
                   aria-label={badgeStatus.label}
                   className="absolute top-0.5 right-0.5 flex h-3 w-3 items-center justify-center"
                 >
-                  {badgeStatus.isLive ? (
-                    // Sized inline rather than by class. `Button` sizes every
-                    // SVG under it with a descendant rule (`[&_svg]:size-4`),
-                    // which outranks a utility class on the glyph itself — so a
-                    // classed 10px arc would silently render at 16px and spill
-                    // out of the badge's box.
-                    <SpinnerCircle
-                      className={badgeStatus.arc}
-                      style={{ width: "0.625rem", height: "0.625rem" }}
-                      data-testid="project-switcher-badge-arc"
-                    />
-                  ) : (
-                    <span
-                      className={cn(
-                        "h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
-                        badgeStatus.color
-                      )}
-                    />
-                  )}
+                  <span
+                    className={cn(
+                      "h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
+                      badgeStatus.color
+                    )}
+                    data-testid="project-switcher-badge-dot"
+                  />
                 </span>
               )}
             </Button>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -293,22 +293,34 @@ function StatusDot({
 }
 
 /**
- * The wedge covering `share` of the mark, swept clockwise from 12 o'clock.
- *
- * Drawn against a full-bleed circle rather than as a stroked arc: the mark is a
- * filled disc that happens to be two colours, so the wedge is a pie slice with
- * no outline of its own and the two fills meet on a single shared edge.
- *
- * `share` only ever arrives snapped to a quarter, so every endpoint here lands
- * exactly on an axis and the boundary is a clean vertical or horizontal cut
- * rather than something the rasteriser has to feather.
+ * Half the width of the notch cut at each boundary of a two-tone mark, in
+ * turns. At 8px it lands a little under a pixel at the rim — enough to read as
+ * a division rather than as a seam, and small enough that the wedge it eats
+ * cannot move the mark across one of the quarters `runningShare` snaps to.
  */
-function wedgePath(share: number): string {
-  const angle = share * 2 * Math.PI;
-  const x = 8 + 8 * Math.sin(angle);
-  const y = 8 - 8 * Math.cos(angle);
-  const largeArc = share > 0.5 ? 1 : 0;
-  return `M 8 8 L 8 0 A 8 8 0 ${largeArc} 1 ${x} ${y} Z`;
+const MARK_GAP_TURNS = 0.025;
+
+/**
+ * One slice of the mark, from `startTurn` to `endTurn` clockwise from 12
+ * o'clock.
+ *
+ * Both halves are drawn this way rather than laying a wedge over a full-bleed
+ * circle. Inset by `MARK_GAP_TURNS` at each end, the two slices leave a
+ * transparent notch at both boundaries and the row shows through — which is
+ * what makes the split survive two hues that sit close together, as `review`
+ * and `working` do in most palettes (both are greens, `activity-completed`
+ * falling back to `status-success`). Meeting on a shared edge those two read as
+ * one solid disc, which is exactly the single-hue mark the split exists to
+ * replace. Transparent rather than a drawn separator, so it is right in every
+ * theme without anything here having to know which one is active.
+ */
+function wedgePath(startTurn: number, endTurn: number): string {
+  const point = (turn: number) => {
+    const angle = turn * 2 * Math.PI;
+    return `${(8 + 8 * Math.sin(angle)).toFixed(3)} ${(8 - 8 * Math.cos(angle)).toFixed(3)}`;
+  };
+  const largeArc = endTurn - startTurn > 0.5 ? 1 : 0;
+  return `M 8 8 L ${point(startTurn)} A 8 8 0 ${largeArc} 1 ${point(endTurn)} Z`;
 }
 
 /**
@@ -350,10 +362,10 @@ function AgentMixDot({ tone, mix }: { tone: ProjectRowTone; mix: ProjectRowStatu
       data-running-share={share}
       aria-hidden="true"
     >
-      {/* The demand hue fills the disc; the running share is laid over it, so
-          the two meet on the wedge's edge with nothing between them. */}
-      <circle cx="8" cy="8" r="8" fill={ROW_MARK_COLOR[tone]} />
-      <path d={wedgePath(share)} fill={ROW_MARK_COLOR.working} />
+      {/* Running leads from 12 o'clock and demand takes the rest. Neither
+          reaches the other: the notch between them is the separator. */}
+      <path d={wedgePath(MARK_GAP_TURNS, share - MARK_GAP_TURNS)} fill={ROW_MARK_COLOR.working} />
+      <path d={wedgePath(share + MARK_GAP_TURNS, 1 - MARK_GAP_TURNS)} fill={ROW_MARK_COLOR[tone]} />
     </svg>
   );
 }
@@ -384,11 +396,22 @@ function RowStatusLine({ status }: { status: ProjectRowStatus }) {
   // #11692 takes it at its word. Everything else earned its line.
   const sentence = status.isDormantFallback ? null : status.text;
 
+  // The hue follows what this slot is actually reporting, because two different
+  // facts arrive in it. A count of runs the user launched is green, the way a
+  // run is green everywhere else in this app. "Assistant working" is
+  // machine-initiated presence, and reads at settled weight (#11806) — green
+  // there would both claim a run nobody started and paint the same fact a
+  // different colour from the assistant-only row, where it lands in the demand
+  // sentence instead. `withLiveness` only ever reaches the assistant phrase
+  // with no agents running, so the count is the fact itself, not a proxy.
+  const livenessTone =
+    (status.agentMix?.running ?? 0) > 0 ? ROW_TONE_CLASS.working : ROW_TONE_CLASS.assistant;
+
   const parts = [
     status.livenessDetail !== undefined && (
       <span
         key="running"
-        className={cn("shrink-0", ROW_TONE_CLASS.working)}
+        className={cn("shrink-0", livenessTone)}
         data-testid="workspace-running-count"
       >
         {status.livenessDetail}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useEffect, useRef, useState, useCallback } from "react";
+import { Fragment, useMemo, useEffect, useRef, useState, useCallback } from "react";
+import type { JSX } from "react";
 import {
   BellOff,
   ChevronDown,
@@ -43,13 +44,16 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ArrowDownAZ, ChartNoAxesColumn, Clock, SpinnerCircle } from "@/components/icons";
+import { ArrowDownAZ, ChartNoAxesColumn, Clock } from "@/components/icons";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
   formatFleetLiveness,
   getProjectRowStatus,
   getScratchRowStatus,
-  ROW_MARK_CLASS,
+  ROW_DOT_CLASS,
+  ROW_MARK_COLOR,
+  runningShare,
+  type ProjectRowTone,
   ROW_TONE_CLASS,
   type ProjectRowStatus,
 } from "@/lib/projectRowStatus";
@@ -230,21 +234,32 @@ interface ProjectListItemProps {
 }
 
 /**
- * The mark takes its hue from the status line's tone and its shape from whether
- * the row is still executing (#11832) — two independent facts on one glyph.
- * Neither is ever the only carrier: status must not be colour-only, and the
- * sentence beside it says both in words.
+ * The row's leading mark: one 8px shape that weighs the row's running agents
+ * against the ones asking for something (#11832).
+ *
+ * Two colours in one mark, as a quarter-snapped pie: green for the runs still
+ * going, the demand hue for the agents stopped on the user. A project that is
+ * half waiting and half working is the state the switcher exists to surface,
+ * and a single-hue dot could only ever report one half of it — which is the
+ * original bug, one carrier for two facts.
+ *
+ * A pie rather than the open arc #11836 tried. That arc failed for a reason
+ * worth recording: it is the app's `working` glyph everywhere else
+ * (`terminalStateConfig`), it was the one place that glyph did not spin, and
+ * hollowing the mark out spread the demand hue over a sub-pixel stroke that
+ * reads grey. This keeps the solid disc — the hue has its full area back — and
+ * puts the second fact in the one channel a disc has left.
+ *
+ * Angle is a weak channel at 8px, so the share is snapped to quarters and
+ * floored (see `runningShare`): the mark makes one of five statements — all
+ * green, mostly green, even, mostly demand, all demand — rather than a
+ * proportion nobody can measure at this size. The exact figures lead the line
+ * beside it, which is where anyone who needs them reads them anyway.
  *
  * A row with nothing to report draws no mark, only the slot that reserves its
  * width (#11692). The slot is what keeps the tiles and names in one column: an
  * omitted mark would pull every quiet row left of the busy ones, and a list that
  * is mostly quiet would read as the ragged edge rather than the tidy one.
- *
- * The slot is sized for the arc rather than the dot. At the old 6px the arc's
- * gap was about a pixel and a half of stroke, which anti-aliasing turns into a
- * smudge — the shape has to be legible at 1x or it isn't a carrier at all. The
- * closed marks keep their 6px so a quiet list is no louder than before; the slot
- * centres whichever one draws, so the column stays put either way.
  */
 function StatusDot({
   status,
@@ -256,35 +271,20 @@ function StatusDot({
   // One slot, one decision. Written as a single choice rather than separate
   // conditions so the slot cannot hold two marks at once: the resume mark only
   // reaches here on a status that already agreed to yield, and an auto-parked
-  // row is the case where both would otherwise have drawn (#11822). Liveness
-  // never contends for the slot — every status that yields has stopped.
+  // row is the case where both would otherwise have drawn (#11822).
   const dot = showResumeDot ? (
-    // Hidden from assistive tech, which hears the row's own "N agents will
-    // resume" phrase instead — a live region per row would re-announce the
-    // whole list on every render, and colour must not be the only carrier.
     <div
-      className="w-1.5 h-1.5 rounded-full bg-text-secondary"
+      className="workspace-mark w-2 h-2 rounded-full bg-text-secondary"
       data-testid="workspace-resume-dot"
       aria-hidden="true"
     />
-  ) : status.isDormantFallback ? null : status.isLive ? (
-    // Static: the open gap is the fact, and it survives reduced motion, a
-    // paused frame and a screenshot. Twenty rows spinning would also turn the
-    // list into a field of movement, which is the opposite of scannable.
-    <SpinnerCircle
-      className={cn("w-2.5 h-2.5", ROW_MARK_CLASS[status.tone].arc)}
-      data-testid="workspace-status-dot"
-    />
-  ) : (
-    <div
-      className={cn("w-1.5 h-1.5 rounded-full", ROW_MARK_CLASS[status.tone].dot)}
-      data-testid="workspace-status-dot"
-    />
+  ) : status.markTone === null ? null : (
+    <AgentMixDot tone={status.markTone} mix={status.agentMix} />
   );
 
   return (
     <div
-      className="flex w-2.5 h-2.5 shrink-0 items-center justify-center"
+      className="flex w-2 h-2 shrink-0 items-center justify-center"
       data-testid="workspace-status-slot"
     >
       {dot}
@@ -293,44 +293,159 @@ function StatusDot({
 }
 
 /**
- * A row's second line: what it wants, then what is still moving, then which
- * project it is.
+ * The mark itself: a solid disc when the row leans entirely one way, a two-tone
+ * pie when it has both kinds of agent at once.
  *
- * Shared by all three row renderers so the clause cannot appear on one kind of
- * workspace and not another — the two scratch paths drew a single toned element
- * before this, which left them structurally unable to carry a second fragment.
+ * Solid is the common case and stays a plain background class, so a row with
+ * only waits or only runs draws exactly what it drew before this existed and
+ * the ring tones keep their borders. The gradient is reached only by a row that
+ * genuinely has something to divide.
  *
- * Exactly one token is coloured. The demand tone is the row's loudest statement
- * and stays that way; the running clause is muted because it reports something
- * that needs nothing from the user, and a second hue here would make every busy
- * row argue with itself. Both are ordinary text, so a reader hears the whole
- * line whether or not they can resolve the mark's shape.
+ * `aria-hidden`, like every mark in this list: the row's own line states both
+ * counts in words, and a mark that also announced itself would have a reader
+ * hear the same fact twice.
  */
-function RowStatusLine({ status }: { status: ProjectRowStatus }) {
-  if (status.isDormantFallback && !status.pathHint) return null;
+/**
+ * Half the width of the notch cut at each boundary of a two-tone mark, in
+ * turns. At 8px it lands a little under a pixel at the rim — enough to read as
+ * a division rather than as a seam, and small enough that the wedge it eats
+ * cannot move the mark across one of its snapped quarters.
+ */
+const MARK_GAP_TURNS = 0.025;
+
+function AgentMixDot({ tone, mix }: { tone: ProjectRowTone; mix: ProjectRowStatus["agentMix"] }) {
+  const share = mix ? runningShare(mix) : 0;
+
+  if (share === 0 || share === 1) {
+    return (
+      <div
+        className={cn("workspace-mark w-2 h-2 rounded-full", ROW_DOT_CLASS[tone])}
+        data-testid="workspace-status-dot"
+        aria-hidden="true"
+      />
+    );
+  }
 
   return (
-    <div className="flex items-center gap-1 min-w-0 mt-0.5">
-      {!status.isDormantFallback && (
-        <span className={cn("truncate text-[11px] leading-none", ROW_TONE_CLASS[status.tone])}>
-          {status.text}
-        </span>
-      )}
-      {/*
-       * `shrink-0` where the path hint takes `shrink`: the hint answers which
-       * project this is, which the name above already mostly does, while this
-       * is the only place the hidden run is stated at all.
-       */}
-      {status.livenessDetail && (
-        <span className="text-[11px] leading-none text-daintree-text/50 shrink-0">
-          · {status.livenessDetail}
-        </span>
-      )}
-      {status.pathHint && (
-        <span className="truncate text-[11px] leading-none text-daintree-text/50 shrink">
-          {status.isDormantFallback ? status.pathHint : `· ${status.pathHint}`}
-        </span>
-      )}
+    <div
+      className="workspace-mark w-2 h-2 rounded-full"
+      style={{
+        // Hard stops, not a blend: the boundary between the two counts is the
+        // whole signal, and an interpolated one at 8px would smear into a single
+        // muddy hue. Green leads from 12 o'clock so the running share reads
+        // clockwise from the top on every row.
+        //
+        // Both boundaries are cut by a transparent notch rather than drawn in a
+        // colour. Transparent shows the row through, so the separator is right
+        // in every theme without anything having to know which one is active —
+        // and it is what makes the split survive two hues that sit close
+        // together, which `review` and `working` do in most palettes (both are
+        // greens). It costs `MARK_GAP_TURNS` of each wedge, well inside the
+        // quarter the share was already snapped to.
+        background: [
+          "conic-gradient(",
+          `transparent 0turn ${MARK_GAP_TURNS}turn,`,
+          `${ROW_MARK_COLOR.working} ${MARK_GAP_TURNS}turn ${share - MARK_GAP_TURNS}turn,`,
+          `transparent ${share - MARK_GAP_TURNS}turn ${share + MARK_GAP_TURNS}turn,`,
+          `${ROW_MARK_COLOR[tone]} ${share + MARK_GAP_TURNS}turn ${1 - MARK_GAP_TURNS}turn,`,
+          `transparent ${1 - MARK_GAP_TURNS}turn 1turn`,
+          ")",
+        ].join(" "),
+      }}
+      data-testid="workspace-status-dot"
+      data-running-share={share}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * A row's second line: what is still running, then what it wants, then which
+ * project it is.
+ *
+ * Running leads. It is the figure this surface gets opened for — "are my agents
+ * still going, and how many" — and it used to be the one fact the row could not
+ * state at all, because the sentence after it is chosen by a cascade that only
+ * ever prints its loudest tier. Trailing it instead put it at a different
+ * x-position on every row, behind a sentence whose length changes with the
+ * state, which is the opposite of scannable.
+ *
+ * Two coloured tokens now, and deliberately: a run is green everywhere else in
+ * this app, and greying it here to hold the row to one hue made the number read
+ * as an afterthought rather than as the answer. The two never compete for a
+ * meaning — green is always the work still moving, the demand tone is always
+ * the work stopped on the user.
+ *
+ * Shared by all three row renderers so a fragment cannot appear on one kind of
+ * workspace and not another — the two scratch paths drew a single toned element
+ * before this, which left them structurally unable to carry a second one.
+ */
+function RowStatusLine({ status }: { status: ProjectRowStatus }) {
+  // The dormant fallback is the row saying it has nothing to report, and
+  // #11692 takes it at its word. Everything else earned its line.
+  const sentence = status.isDormantFallback ? null : status.text;
+
+  const parts = [
+    status.livenessDetail !== undefined && (
+      <span
+        key="running"
+        className={cn("shrink-0", ROW_TONE_CLASS.working)}
+        data-testid="workspace-running-count"
+      >
+        {status.livenessDetail}
+      </span>
+    ),
+    sentence !== null && (
+      <span key="demand" className={cn("shrink-0", ROW_TONE_CLASS[status.tone])}>
+        {sentence}
+      </span>
+    ),
+    status.ageDetail !== undefined && (
+      // Muted, and never in the demand tone. The age is the one fragment here
+      // that asks for nothing, and colouring it made the coloured run long
+      // enough to outweigh the count leading the line.
+      <span key="age" className="truncate text-daintree-text/50">
+        {status.ageDetail}
+      </span>
+    ),
+    status.pathHint !== undefined && (
+      // `shrink` where the count takes `shrink-0`: the hint answers which
+      // project this is, which the name above already mostly does, while the
+      // count is the row's headline figure.
+      <span key="path" className="truncate shrink text-daintree-text/50">
+        {status.pathHint}
+      </span>
+    ),
+  ].filter((part): part is JSX.Element => part !== false);
+
+  if (parts.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1 min-w-0 mt-0.5 text-[11px] leading-none">
+      {parts.map((part, index) => (
+        <Fragment key={part.key}>
+          {/*
+           * The separator is its own element rather than a prefix on the token
+           * after it. Folded into a token it would inherit that token's hue,
+           * and it would land inside the text a reader — or a test — matches
+           * the token by.
+           *
+           * The visible dot is hidden from assistive tech and a comma stands in
+           * for it, because the tokens are adjacent inline elements with no
+           * whitespace between them: without this the row's accessible name
+           * runs together as "2 agents running1 needs inputwaiting 10m".
+           */}
+          {index > 0 && (
+            <>
+              <span className="sr-only">, </span>
+              <span className="shrink-0 text-daintree-text/40" aria-hidden="true">
+                ·
+              </span>
+            </>
+          )}
+          {part}
+        </Fragment>
+      ))}
     </div>
   );
 }

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -293,26 +293,37 @@ function StatusDot({
 }
 
 /**
+ * The wedge covering `share` of the mark, swept clockwise from 12 o'clock.
+ *
+ * Drawn against a full-bleed circle rather than as a stroked arc: the mark is a
+ * filled disc that happens to be two colours, so the wedge is a pie slice with
+ * no outline of its own and the two fills meet on a single shared edge.
+ *
+ * `share` only ever arrives snapped to a quarter, so every endpoint here lands
+ * exactly on an axis and the boundary is a clean vertical or horizontal cut
+ * rather than something the rasteriser has to feather.
+ */
+function wedgePath(share: number): string {
+  const angle = share * 2 * Math.PI;
+  const x = 8 + 8 * Math.sin(angle);
+  const y = 8 - 8 * Math.cos(angle);
+  const largeArc = share > 0.5 ? 1 : 0;
+  return `M 8 8 L 8 0 A 8 8 0 ${largeArc} 1 ${x} ${y} Z`;
+}
+
+/**
  * The mark itself: a solid disc when the row leans entirely one way, a two-tone
  * pie when it has both kinds of agent at once.
  *
  * Solid is the common case and stays a plain background class, so a row with
  * only waits or only runs draws exactly what it drew before this existed and
- * the ring tones keep their borders. The gradient is reached only by a row that
+ * the ring tones keep their borders. The pie is reached only by a row that
  * genuinely has something to divide.
  *
  * `aria-hidden`, like every mark in this list: the row's own line states both
  * counts in words, and a mark that also announced itself would have a reader
  * hear the same fact twice.
  */
-/**
- * Half the width of the notch cut at each boundary of a two-tone mark, in
- * turns. At 8px it lands a little under a pixel at the rim — enough to read as
- * a division rather than as a seam, and small enough that the wedge it eats
- * cannot move the mark across one of its snapped quarters.
- */
-const MARK_GAP_TURNS = 0.025;
-
 function AgentMixDot({ tone, mix }: { tone: ProjectRowTone; mix: ProjectRowStatus["agentMix"] }) {
   const share = mix ? runningShare(mix) : 0;
 
@@ -326,36 +337,24 @@ function AgentMixDot({ tone, mix }: { tone: ProjectRowTone; mix: ProjectRowStatu
     );
   }
 
+  // SVG rather than a `conic-gradient` on a rounded div. The gradient version
+  // needed the div's `border-radius` to clip it into a circle, and at 8px that
+  // clip's own antialiasing read as a thin dark rim around the whole mark. Two
+  // filled shapes in one viewBox have no clip and no stroke, so the disc's edge
+  // and the boundary between the counts are both drawn once.
   return (
-    <div
-      className="workspace-mark w-2 h-2 rounded-full"
-      style={{
-        // Hard stops, not a blend: the boundary between the two counts is the
-        // whole signal, and an interpolated one at 8px would smear into a single
-        // muddy hue. Green leads from 12 o'clock so the running share reads
-        // clockwise from the top on every row.
-        //
-        // Both boundaries are cut by a transparent notch rather than drawn in a
-        // colour. Transparent shows the row through, so the separator is right
-        // in every theme without anything having to know which one is active —
-        // and it is what makes the split survive two hues that sit close
-        // together, which `review` and `working` do in most palettes (both are
-        // greens). It costs `MARK_GAP_TURNS` of each wedge, well inside the
-        // quarter the share was already snapped to.
-        background: [
-          "conic-gradient(",
-          `transparent 0turn ${MARK_GAP_TURNS}turn,`,
-          `${ROW_MARK_COLOR.working} ${MARK_GAP_TURNS}turn ${share - MARK_GAP_TURNS}turn,`,
-          `transparent ${share - MARK_GAP_TURNS}turn ${share + MARK_GAP_TURNS}turn,`,
-          `${ROW_MARK_COLOR[tone]} ${share + MARK_GAP_TURNS}turn ${1 - MARK_GAP_TURNS}turn,`,
-          `transparent ${1 - MARK_GAP_TURNS}turn 1turn`,
-          ")",
-        ].join(" "),
-      }}
+    <svg
+      viewBox="0 0 16 16"
+      className="workspace-mark w-2 h-2"
       data-testid="workspace-status-dot"
       data-running-share={share}
       aria-hidden="true"
-    />
+    >
+      {/* The demand hue fills the disc; the running share is laid over it, so
+          the two meet on the wedge's edge with nothing between them. */}
+      <circle cx="8" cy="8" r="8" fill={ROW_MARK_COLOR[tone]} />
+      <path d={wedgePath(share)} fill={ROW_MARK_COLOR.working} />
+    </svg>
   );
 }
 

--- a/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
@@ -389,35 +389,51 @@ describe("ProjectSwitcher background-agent badge", () => {
   it("reports the wait and the work still in flight together", () => {
     // These used to contend for one carrier, so a fleet that was both asking
     // for input AND still churning looked exactly like one that had stalled
-    // (#11832). Demand still leads — it is the half that needs the user.
+    // (#11832). Both are in the label now; demand leads, because it is the half
+    // that needs the user.
     paletteState.nonActiveAgentCounts = {
       activeAgentCount: 5,
       waitingAgentCount: 1,
       waitingProjectCount: 1,
     };
-    const { getByRole, getByTestId } = render(<ProjectSwitcher />);
+    const { getByRole } = render(<ProjectSwitcher />);
     const label = getByRole("status").getAttribute("aria-label");
     expect(label).toContain("1 project waiting for input");
     expect(label).toContain("5 background agents working");
     expect(label?.indexOf("waiting")).toBeLessThan(label?.indexOf("working") ?? -1);
-    // Hue carries the demand, shape carries the liveness — so the mark is the
-    // open glyph even though the colour still says "waiting".
-    expect(getByTestId("project-switcher-badge-arc")).toBeTruthy();
   });
 
-  it("closes the badge's shape when the fleet is only waiting", () => {
-    paletteState.nonActiveAgentCounts = {
+  it("keeps the badge's hue on demand even while the fleet is working", () => {
+    // Compared across the three fleets rather than against a token name: what
+    // has to hold is that a fleet doing both marks itself the way a waiting one
+    // does and not the way a working one does. Naming the class would make
+    // renaming it a test edit while proving nothing about the choice.
+    const markFor = (counts: {
+      activeAgentCount: number;
+      waitingAgentCount: number;
+      waitingProjectCount: number;
+    }) => {
+      paletteState.nonActiveAgentCounts = counts;
+      const view = render(<ProjectSwitcher />);
+      const className = view.getByTestId("project-switcher-badge-dot").className;
+      view.unmount();
+      return className;
+    };
+
+    const waitingOnly = markFor({
       activeAgentCount: 0,
       waitingAgentCount: 2,
       waitingProjectCount: 2,
-    };
-    const { getByRole, queryByTestId } = render(<ProjectSwitcher />);
-    const badge = getByRole("status");
-    expect(badge.getAttribute("aria-label")).toContain("2 projects waiting");
-    expect(queryByTestId("project-switcher-badge-arc")).toBeNull();
-    // A closed mark is actually drawn — "no arc" would also be satisfied by a
-    // badge that had quietly stopped rendering anything at all.
-    expect(badge.querySelector("span")).toBeTruthy();
+    });
+    const workingOnly = markFor({
+      activeAgentCount: 3,
+      waitingAgentCount: 0,
+      waitingProjectCount: 0,
+    });
+    const both = markFor({ activeAgentCount: 5, waitingAgentCount: 1, waitingProjectCount: 1 });
+
+    expect(both).toBe(waitingOnly);
+    expect(both).not.toBe(workingOnly);
   });
 
   it("falls back to working agents when none are waiting", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
-import { render, screen, within, fireEvent, act } from "@testing-library/react";
+import { render, screen, within, fireEvent, act, cleanup } from "@testing-library/react";
 
 const originalScrollIntoView = Element.prototype.scrollIntoView;
 beforeAll(() => {
@@ -228,14 +228,14 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
       />
     );
     // A project that needs the user outranks one that is merely busy.
-    expect(screen.getByText("3 agents need input")).toBeTruthy();
+    expect(screen.getByText("3 need input")).toBeTruthy();
   });
 
   it("singularises a lone waiting agent", () => {
     render(
       <ProjectSwitcherPalette {...baseProps} results={[makeProject({ waitingAgentCount: 1 })]} />
     );
-    expect(screen.getByText("Agent needs input")).toBeTruthy();
+    expect(screen.getByText("1 needs input")).toBeTruthy();
   });
 
   it("ages the oldest wait", () => {
@@ -250,7 +250,7 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
         ]}
       />
     );
-    expect(screen.getByText("2 agents need input · oldest waiting 42m")).toBeTruthy();
+    expect(screen.getByText("2 need input")).toBeTruthy();
   });
 
   it("reports blocked agents alongside the plain waits, not instead of them", () => {
@@ -262,14 +262,16 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
     );
     // An agent stopped on an error is a different ask than one at a prompt, but
     // the two still waiting must not vanish behind it.
-    expect(screen.getByText("2 agents need input · 1 blocked")).toBeTruthy();
+    expect(screen.getByText("2 need input · 1 blocked")).toBeTruthy();
   });
 
-  it("reports running agents when nothing is waiting", () => {
+  it("reports running agents as a count rather than a sentence", () => {
     render(
       <ProjectSwitcherPalette {...baseProps} results={[makeProject({ activeAgentCount: 2 })]} />
     );
-    expect(screen.getByText("2 agents running")).toBeTruthy();
+    // Running is the second axis, not a tier of this waterfall — it draws in
+    // the row's own column so it survives a wait or a snooze winning the line.
+    expect(screen.getByTestId("workspace-running-count").textContent).toBe("2 agents running");
   });
 
   // A row with nothing running has nothing to report, and twenty of those in a
@@ -429,14 +431,15 @@ describe("ProjectSwitcherPalette status dot", () => {
 });
 
 /**
- * Two facts, two carriers (#11832). The row's hue and sentence say what it wants
- * from the user; its shape and a muted clause say whether anything is still
- * executing. The tests below always compare two rows that differ in exactly one
- * of those, so a change that collapsed them back onto one carrier fails here
+ * Two facts, two carriers (#11832). The row's mark weighs its running agents
+ * against the ones asking for something; its line states both counts, running
+ * first. The tests below always compare two rows that differ in exactly one of
+ * those, so a change that collapsed them back onto one carrier fails here
  * rather than passing by matching a string.
  */
 describe("ProjectSwitcherPalette liveness axis", () => {
   const markIn = (row: HTMLElement) => row.querySelector("[data-testid='workspace-status-dot']");
+  const shareOf = (row: HTMLElement) => markIn(row)?.getAttribute("data-running-share") ?? null;
 
   function renderPair(runningCount: number) {
     render(
@@ -459,71 +462,119 @@ describe("ProjectSwitcherPalette liveness axis", () => {
     };
   }
 
-  it("draws an open mark for a row still executing and a closed one for a row at rest", () => {
-    const { stalled, churning } = renderPair(2);
+  it("splits the mark on the row that has both, and leaves the stalled one solid", () => {
+    const { stalled, churning } = renderPair(3);
 
-    // Topology, read off the geometry rather than a class name: the live mark
-    // is a stroked circle with a gap in it, which is what "open" means. A dash
-    // pattern is the only thing that puts the gap there — swapping in a plain
-    // ring would still be an SVG circle, and asserting merely "is an SVG"
-    // would call that a pass. The dash VALUES stay unasserted: those belong to
-    // the glyph, and pinning them here would just restate its source.
-    const liveCircle = markIn(churning)?.querySelector("circle");
-    expect(liveCircle?.getAttribute("stroke-dasharray")).toBeTruthy();
-    expect(markIn(stalled)?.querySelector("circle")).toBeNull();
+    // The original bug in one assertion: these two rows want the same thing and
+    // used to draw the same mark, while only one of them was still moving.
+    expect(shareOf(stalled)).toBeNull();
+    expect(shareOf(churning)).not.toBeNull();
+    expect(markIn(stalled)?.className).not.toBe(markIn(churning)?.className);
+  });
+
+  it("leans the mark toward whichever side has more agents", () => {
+    // Relational rather than a literal fraction: what has to hold is that more
+    // running agents move the mark further toward the running side, whatever
+    // the snapping happens to round them to.
+    const mostlyRunning = renderPair(6).churning;
+    cleanup();
+    const evenlySplit = renderPair(1).churning;
+
+    expect(Number(shareOf(mostlyRunning))).toBeGreaterThan(Number(shareOf(evenlySplit)));
   });
 
   it("leaves the demand sentence identical on both", () => {
     const { stalled, churning } = renderPair(2);
 
     // Purely additive: the tier that won the line is unchanged, so a row that
-    // gained the clause did not lose anything to it.
-    const demand = (row: HTMLElement) => within(row).getByText("Agent needs input");
+    // gained the count did not lose anything to it.
+    const demand = (row: HTMLElement) => within(row).getByText("1 needs input");
     expect(demand(churning).textContent).toBe(demand(stalled).textContent);
     expect(demand(churning).className).toBe(demand(stalled).className);
   });
 
-  it("trails the hidden count on the churning row only", () => {
+  it("draws the count on the churning row only", () => {
     const { stalled, churning } = renderPair(2);
 
-    expect(within(churning).getByText(/2 running/)).toBeTruthy();
-    expect(within(stalled).queryByText(/running/)).toBeNull();
+    expect(within(churning).getByTestId("workspace-running-count").textContent).toBe(
+      "2 agents running"
+    );
+    expect(within(stalled).queryByTestId("workspace-running-count")).toBeNull();
   });
 
-  it("keeps the clause out of the coloured token", () => {
+  it("leads the line with the count and colours it apart from the demand", () => {
     const { churning } = renderPair(2);
 
-    // The demand tone is the row's one coloured word. A clause folded into that
-    // element would inherit the hue and read as part of the ask.
-    const demand = within(churning).getByText("Agent needs input");
-    expect(demand.textContent).not.toContain("running");
-    expect(within(churning).getByText(/2 running/)).not.toBe(demand);
+    // Running is the figure the switcher gets opened for, so it comes first —
+    // and it carries its own hue, because greying it made it read as an
+    // afterthought rather than as the answer.
+    const count = within(churning).getByTestId("workspace-running-count");
+    const demand = within(churning).getByText("1 needs input");
+    expect(count.compareDocumentPosition(demand) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(count.className).not.toBe(demand.className);
+    expect(count.textContent).not.toContain("need input");
   });
 
-  it("reaches assistive tech as words, not as a shape", () => {
+  it("reaches assistive tech as words, not as a mark", () => {
     renderPair(3);
 
     // Queried by accessible NAME, not by text content: the mark is
-    // `aria-hidden`, so the clause is the only carrier left, and a clause that
-    // was itself hidden from the accessibility tree would still sit in the DOM
-    // for `textContent` to find while leaving shape as the sole encoding. It
-    // rides the row's own name rather than a live region — one per row would
-    // re-announce the whole list on every tick.
-    const spoken = screen.getByRole("option", { name: /Churning.*3 running/s });
-    expect(spoken).toBeTruthy();
+    // `aria-hidden`, so the line is the only carrier left, and a count that was
+    // itself hidden from the accessibility tree would still sit in the DOM for
+    // `textContent` to find while leaving the mark as the sole encoding.
+    const spoken = screen.getByRole("option", { name: /Churning.*3 agents running/s });
     expect(markIn(spoken)?.getAttribute("aria-hidden")).toBe("true");
+    expect(
+      within(spoken).getByTestId("workspace-running-count").getAttribute("aria-hidden")
+    ).toBeNull();
   });
 
-  it("says nothing extra on a row whose sentence already names the run", () => {
+  it("states a row's run exactly once", () => {
     render(
       <ProjectSwitcherPalette {...baseProps} results={[makeProject({ activeAgentCount: 2 })]} />
     );
 
     const row = screen.getByRole("option", { name: /Test Project/ });
-    expect(within(row).getByText("2 agents running")).toBeTruthy();
-    // Open mark, one sentence: "2 agents running · 2 running" says it twice.
-    expect(markIn(row)?.querySelector("circle")).toBeTruthy();
-    expect(row.textContent).not.toContain("· 2 running");
+    // A row whose only fact is the run has no demand to state, so the count is
+    // the whole line — "2 agents running · 2 agents running" would say it twice.
+    expect(within(row).getByTestId("workspace-running-count").textContent).toBe("2 agents running");
+    expect(row.textContent?.match(/agents running/g)).toHaveLength(1);
+    // It is still marked, and solid: with nothing waiting there is nothing to
+    // weigh the run against.
+    expect(markIn(row)).toBeTruthy();
+    expect(shareOf(row)).toBeNull();
+  });
+
+  it("marks a running row differently from a waiting one", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({ id: "run", name: "Runs", activeAgentCount: 2 }),
+          makeProject({ id: "wait", name: "Waits", waitingAgentCount: 2 }),
+        ]}
+      />
+    );
+
+    // Both are solid discs, so hue is the only thing separating them — compared
+    // rather than named, so renaming a token is not a test edit.
+    const running = markIn(screen.getByRole("option", { name: /Runs/ }));
+    const waiting = markIn(screen.getByRole("option", { name: /Waits/ }));
+    expect(running?.className).not.toBe(waiting?.className);
+  });
+
+  it("keeps the resume promise off a row whose agents never stopped", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[makeProject({ activeAgentCount: 2, resumableAgentCount: 3 })]}
+      />
+    );
+
+    const row = screen.getByRole("option", { name: /Test Project/ });
+    expect(within(row).queryByTestId("workspace-resume-dot")).toBeNull();
+    expect(row.textContent).not.toContain("will resume");
+    expect(within(row).getByTestId("workspace-running-count")).toBeTruthy();
   });
 
   it("carries both axes on a scratch row too", () => {
@@ -548,8 +599,9 @@ describe("ProjectSwitcherPalette liveness axis", () => {
 
     render(<ProjectSwitcherPalette {...baseProps} results={[]} scratchResults={[busyScratch]} />);
 
-    expect(screen.getByText("Agent needs input")).toBeTruthy();
-    expect(screen.getByText(/2 running/)).toBeTruthy();
+    const row = screen.getByRole("option", { name: /Spike.*2 agents running/s });
+    expect(within(row).getByText("1 needs input")).toBeTruthy();
+    expect(shareOf(row)).not.toBeNull();
   });
 
   it("carries both axes on a scratch in the ranked list too", () => {
@@ -581,10 +633,9 @@ describe("ProjectSwitcherPalette liveness axis", () => {
       />
     );
 
-    const row = screen.getByRole("option", { name: /Spike/ });
-    expect(within(row).getByText("Agent needs input")).toBeTruthy();
-    expect(within(row).getByText(/2 running/)).toBeTruthy();
-    expect(markIn(row)?.querySelector("circle")?.getAttribute("stroke-dasharray")).toBeTruthy();
+    const row = screen.getByRole("option", { name: /Spike.*2 agents running/s });
+    expect(within(row).getByText("1 needs input")).toBeTruthy();
+    expect(shareOf(row)).not.toBeNull();
   });
 });
 
@@ -647,7 +698,7 @@ describe("ProjectSwitcherPalette status conveyance", () => {
       <ProjectSwitcherPalette {...baseProps} results={[makeProject({ waitingAgentCount: 2 })]} />
     );
 
-    expect(screen.getByText("2 agents need input")).toBeTruthy();
+    expect(screen.getByText("2 need input")).toBeTruthy();
     expect(screen.queryByLabelText("Agents waiting")).toBeNull();
     expect(screen.queryByLabelText("Idle")).toBeNull();
   });
@@ -1382,13 +1433,13 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
   it("states agent activity on a ranked scratch row", () => {
     render(<ProjectSwitcherPalette {...rankedProps({ waitingAgentCount: 2 })} />);
 
-    expect(screen.getByText("2 agents need input")).toBeTruthy();
+    expect(screen.getByText("2 need input")).toBeTruthy();
   });
 
   it("states agent activity on a pinned scratch row", () => {
     render(<ProjectSwitcherPalette {...browseProps({ waitingAgentCount: 2 })} />);
 
-    expect(screen.getByText("2 agents need input")).toBeTruthy();
+    expect(screen.getByText("2 need input")).toBeTruthy();
   });
 
   // In the ranked list a scratch sits among projects with no section header to
@@ -1404,9 +1455,10 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
       "Spike notes",
       "· Scratch",
     ]);
-    // The status keeps its own line rather than sharing the name's.
-    expect(nameLine.textContent).not.toContain("Agent running");
-    expect(screen.getByText("Agent running")).toBeTruthy();
+    // The running count keeps the row's trailing edge rather than sharing the
+    // name's line.
+    expect(nameLine.textContent).not.toContain("running");
+    expect(screen.getByTestId("workspace-running-count").textContent).toBe("1 agent running");
   });
 
   it("gives a quiet scratch one line without losing what it is", () => {
@@ -1436,7 +1488,7 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
     const lastOpened = Date.now() - (SCRATCH_CLEANUP_TTL_MS - 2 * 24 * 3600_000);
     render(<ProjectSwitcherPalette {...browseProps({ lastOpened, activeAgentCount: 1 })} />);
 
-    expect(screen.getByText("Agent running")).toBeTruthy();
+    expect(screen.getByTestId("workspace-running-count").textContent).toBe("1 agent running");
     expect(screen.getByTestId("scratch-cleanup-countdown")).toBeTruthy();
   });
 
@@ -1445,7 +1497,7 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
   it("conveys scratch status as text rather than a labelled dot", () => {
     render(<ProjectSwitcherPalette {...browseProps({ blockedAgentCount: 1 })} />);
 
-    expect(screen.getByText("Agent blocked")).toBeTruthy();
+    expect(screen.getByText("1 blocked")).toBeTruthy();
     expect(screen.queryByLabelText("Agents waiting")).toBeNull();
     expect(screen.queryByLabelText("Idle")).toBeNull();
   });
@@ -1494,13 +1546,13 @@ describe("ProjectSwitcherPalette scratch status treatment", () => {
         />
       );
 
-      expect(screen.getByText("Agent needs input · waiting 1m")).toBeTruthy();
+      expect(screen.getByText("waiting 1m")).toBeTruthy();
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(60_000);
       });
 
-      expect(screen.getByText("Agent needs input · waiting 2m")).toBeTruthy();
+      expect(screen.getByText("waiting 2m")).toBeTruthy();
     } finally {
       vi.useRealTimers();
     }
@@ -1597,7 +1649,7 @@ describe("ProjectSwitcherPalette resumable-agent dot", () => {
     // tone would light this row up — and its agents finished in a window that
     // is still open, not on disk waiting to be brought back.
     const row = screen.getByRole("option", { name: /Open elsewhere/i });
-    expect(within(row).getByText(/Agent finished/)).toBeTruthy();
+    expect(within(row).getByText(/1 finished/)).toBeTruthy();
     expect(within(row).getByTestId("workspace-status-dot")).toBeTruthy();
     expect(within(row).queryByTestId("workspace-resume-dot")).toBeNull();
     expect(screen.queryByRole("option", { name: /will resume/i })).toBeNull();

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -520,6 +520,40 @@ describe("ProjectSwitcherPalette liveness axis", () => {
     expect(count.textContent).not.toContain("need input");
   });
 
+  it("keeps the assistant's phrase out of the hue a launched run wears", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...baseProps}
+        results={[
+          makeProject({ id: "solo", name: "Solo", assistantState: "working" }),
+          makeProject({
+            id: "helped",
+            name: "Helped",
+            waitingAgentCount: 1,
+            assistantState: "working",
+          }),
+          makeProject({ id: "worked", name: "Worked", waitingAgentCount: 1, activeAgentCount: 2 }),
+        ]}
+      />
+    );
+
+    const rowOf = (name: RegExp) => screen.getByRole("option", { name });
+    const countIn = (row: HTMLElement) => within(row).getByTestId("workspace-running-count");
+    // The assistant says the same thing on both rows and only its carrier
+    // moves: alone it is the row's sentence, and with a wait beside it the
+    // sentence is taken and it lands in the slot the count uses. Compared to
+    // itself rather than to a named token, so the invariant is "one fact, one
+    // hue" and not whichever class happens to draw it.
+    const spokenAlone = within(rowOf(/Solo/)).getByText("Assistant working");
+    const spokenBeside = countIn(rowOf(/Helped/));
+
+    expect(spokenBeside.textContent).toBe(spokenAlone.textContent);
+    expect(spokenBeside.className).toBe(spokenAlone.className);
+    // And never the weight a run the user launched carries (#11806) — the slot
+    // used to paint everything that reached it in the worker hue.
+    expect(spokenBeside.className).not.toBe(countIn(rowOf(/Worked/)).className);
+  });
+
   it("reaches assistive tech as words, not as a mark", () => {
     renderPair(3);
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -469,7 +469,12 @@ describe("ProjectSwitcherPalette liveness axis", () => {
     // used to draw the same mark, while only one of them was still moving.
     expect(shareOf(stalled)).toBeNull();
     expect(shareOf(churning)).not.toBeNull();
-    expect(markIn(stalled)?.className).not.toBe(markIn(churning)?.className);
+    // Structurally different marks, not just differently classed ones: the
+    // split one is drawn as two filled shapes so its two colours meet on a
+    // shared edge, while a row leaning entirely one way stays a plain disc.
+    expect(markIn(stalled)?.tagName).toBe("DIV");
+    expect(markIn(churning)?.tagName).toBe("svg");
+    expect(markIn(churning)?.querySelector("path")).toBeTruthy();
   });
 
   it("leans the mark toward whichever side has more agents", () => {

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -156,7 +156,7 @@ export type ProjectSectionKey = (typeof PROJECT_SECTION_ORDER)[number];
  * completions alike — so any label naming a sort order would be a lie the row
  * contents immediately expose. "Running" requires live agents; projects with
  * only bare processes fall through to Pinned/Other, where their status line
- * still says "Process running".
+ * still reports the processes.
  */
 export const PROJECT_SECTION_LABELS: Record<ProjectSectionKey, string> = {
   current: "Current project",
@@ -485,7 +485,7 @@ function resortOtherBand(
  *   to the user, which outranks agents that are merely running.
  * - `pinned` sits above `running`: an explicit pin is a stronger signal than
  *   the operational fact that something is executing. A pinned running project
- *   stays in Pinned; its status line still says "Agent running".
+ *   stays in Pinned; its row still prints its running count.
  * - `running` requires live agents. Bare leftover processes are residency, not
  *   intent — those projects fall through to Pinned/Other.
  *

--- a/src/index.css
+++ b/src/index.css
@@ -2706,6 +2706,20 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     background-color: CanvasText !important;
   }
 
+  /* Project-switcher row marks. Every one of them is a background — a fill for
+     the solid states, a conic-gradient for a row that is part running and part
+     waiting — and forced colors drops background images entirely while forcing
+     ordinary backgrounds toward Canvas, so the whole 8px slot would read as
+     empty. Repaint them as a single CanvasText disc: the hue and the split are
+     gone either way here, and the row's own line states both counts in words,
+     so what this has to preserve is only that the row is marked at all.
+     !important beats the inline gradient the mixed mark sets. */
+  .workspace-mark {
+    background-color: CanvasText !important;
+    background-image: none !important;
+    border-color: CanvasText;
+  }
+
   /* SettingsSwitch (Radix Switch). The track's unchecked border is already
      covered by the global button/[role="button"] rule above. Add the checked
      fill plus thumb contrast so on/off is distinguishable beyond thumb position.

--- a/src/index.css
+++ b/src/index.css
@@ -2706,18 +2706,22 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     background-color: CanvasText !important;
   }
 
-  /* Project-switcher row marks. Every one of them is a background — a fill for
-     the solid states, a conic-gradient for a row that is part running and part
-     waiting — and forced colors drops background images entirely while forcing
-     ordinary backgrounds toward Canvas, so the whole 8px slot would read as
-     empty. Repaint them as a single CanvasText disc: the hue and the split are
-     gone either way here, and the row's own line states both counts in words,
-     so what this has to preserve is only that the row is marked at all.
-     !important beats the inline gradient the mixed mark sets. */
-  .workspace-mark {
+  /* Project-switcher row marks. The solid states are a CSS background, which
+     forced colors pushes toward Canvas, so the whole 8px slot would read as
+     empty. Repaint them as a CanvasText disc: hue is gone here either way, and
+     the row's own line states both counts in words, so all this has to preserve
+     is that the row is marked at all. */
+  div.workspace-mark {
     background-color: CanvasText !important;
-    background-image: none !important;
     border-color: CanvasText;
+  }
+
+  /* The two-tone mark is an SVG, so it needs its fills forced rather than its
+     background. Both shapes collapse to one CanvasText disc: the split cannot
+     survive a palette with no second colour to carry it. */
+  svg.workspace-mark circle,
+  svg.workspace-mark path {
+    fill: CanvasText;
   }
 
   /* SettingsSwitch (Radix Switch). The track's unchecked border is already

--- a/src/index.css
+++ b/src/index.css
@@ -2717,9 +2717,9 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   }
 
   /* The two-tone mark is an SVG, so it needs its fills forced rather than its
-     background. Both shapes collapse to one CanvasText disc: the split cannot
-     survive a palette with no second colour to carry it. */
-  svg.workspace-mark circle,
+     background. Both slices collapse to CanvasText: the split cannot survive a
+     palette with no second colour to carry it, and only the notch between them
+     is left to say the mark had two halves. */
   svg.workspace-mark path {
     fill: CanvasText;
   }

--- a/src/lib/__tests__/projectRowStatus.test.ts
+++ b/src/lib/__tests__/projectRowStatus.test.ts
@@ -4,6 +4,7 @@ import {
   formatWaitAge,
   getProjectRowStatus,
   getScratchRowStatus,
+  runningShare,
 } from "../projectRowStatus";
 import type { SearchableProject, SearchableScratch } from "@/hooks/useProjectSwitcherPalette";
 
@@ -71,6 +72,19 @@ describe("formatWaitAge", () => {
   });
 });
 
+/**
+ * The demand half of a row's line, as a reader sees it: the state phrase and
+ * the age that dates it, joined the way the row joins them.
+ *
+ * The two are separate fields because they draw in different ink — the state
+ * carries the demand tone, the age is muted — but almost every assertion below
+ * is about the sentence they make together, and splitting each one in two would
+ * say less about the copy while checking it twice.
+ */
+function demandLine(status: { text: string; ageDetail?: string }): string {
+  return status.ageDetail === undefined ? status.text : `${status.text} · ${status.ageDetail}`;
+}
+
 describe("getProjectRowStatus", () => {
   it("reports blocked and plain waits together, never one instead of the other", () => {
     // Blocked is a SUBSET of waiting. Reporting only the blocked agent would
@@ -80,7 +94,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("2 agents need input · 1 blocked");
+    expect(demandLine(status)).toBe("2 need input · 1 blocked");
     expect(status.tone).toBe("blocked");
   });
 
@@ -96,7 +110,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("Agent needs input · 1 blocked · oldest waiting 42m");
+    expect(demandLine(status)).toBe("1 needs input · 1 blocked · oldest 42m");
   });
 
   it("clamps a blocked count that exceeds the waits it is drawn from", () => {
@@ -105,14 +119,14 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("Agent blocked");
+    expect(demandLine(status)).toBe("1 blocked");
     expect(status.tone).toBe("blocked");
   });
 
   it("ranks a wait above work in progress", () => {
     const status = getProjectRowStatus(project({ waitingAgentCount: 1, activeAgentCount: 4 }), NOW);
 
-    expect(status.text).toBe("Agent needs input");
+    expect(demandLine(status)).toBe("1 needs input");
     expect(status.tone).toBe("waiting");
   });
 
@@ -122,7 +136,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("3 agents need input · oldest waiting 42m");
+    expect(demandLine(status)).toBe("3 need input · oldest 42m");
   });
 
   it("drops the 'oldest' qualifier when only one agent waits", () => {
@@ -131,13 +145,13 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("Agent needs input · waiting 7m");
+    expect(demandLine(status)).toBe("1 needs input · waiting 7m");
   });
 
   it("omits the age when no wait timestamp arrived", () => {
     const status = getProjectRowStatus(project({ waitingAgentCount: 2 }), NOW);
 
-    expect(status.text).toBe("2 agents need input");
+    expect(demandLine(status)).toBe("2 need input");
   });
 
   it("reads a fresh unseen completion as just finished", () => {
@@ -151,7 +165,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("Ready for review · just finished 3m ago");
+    expect(demandLine(status)).toBe("1 ready for review · just finished 3m ago");
     expect(status.tone).toBe("review");
   });
 
@@ -168,7 +182,7 @@ describe("getProjectRowStatus", () => {
       }),
       NOW
     );
-    expect(fresh.text).toBe("Ready for review · just finished 14m ago");
+    expect(demandLine(fresh)).toBe("1 ready for review · just finished 14m ago");
 
     const boundary = getProjectRowStatus(
       project({
@@ -179,7 +193,7 @@ describe("getProjectRowStatus", () => {
       }),
       NOW
     );
-    expect(boundary.text).toBe("Ready for review · finished 15m ago");
+    expect(demandLine(boundary)).toBe("1 ready for review · finished 15m ago");
 
     const stale = getProjectRowStatus(
       project({
@@ -190,7 +204,7 @@ describe("getProjectRowStatus", () => {
       }),
       NOW
     );
-    expect(stale.text).toBe("Ready for review · finished 16m ago");
+    expect(demandLine(stale)).toBe("1 ready for review · finished 16m ago");
   });
 
   it("elides the redundant timestamp on a seconds-old completion", () => {
@@ -205,7 +219,7 @@ describe("getProjectRowStatus", () => {
     );
 
     // "just finished just now ago" is not a sentence.
-    expect(status.text).toBe("Ready for review · just finished");
+    expect(demandLine(status)).toBe("1 ready for review · just finished");
   });
 
   it("ranges multiple unseen completions newest to oldest", () => {
@@ -219,7 +233,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("3 agents ready for review · 3m–2h ago");
+    expect(demandLine(status)).toBe("3 ready for review · 3m–2h ago");
     expect(status.tone).toBe("review");
   });
 
@@ -235,7 +249,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("2 agents ready for review · 3m–2h ago");
+    expect(demandLine(status)).toBe("2 ready for review · 3m–2h ago");
   });
 
   it("collapses the range when completions round to the same age", () => {
@@ -249,7 +263,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("2 agents ready for review · 8m ago");
+    expect(demandLine(status)).toBe("2 ready for review · 8m ago");
   });
 
   it("ranks a wait above a completion, and a completion above running work", () => {
@@ -275,7 +289,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
     expect(review.tone).toBe("review");
-    expect(review.text).toContain("Ready for review");
+    expect(review.text).toContain("ready for review");
   });
 
   it("mutes an acknowledged completion and drops the action phrase", () => {
@@ -289,7 +303,7 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("Agent finished · 2h ago");
+    expect(demandLine(status)).toBe("1 finished · 2h ago");
     expect(status.tone).toBe("muted");
   });
 
@@ -304,10 +318,10 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("3 agents finished · latest 2h ago");
+    expect(demandLine(status)).toBe("3 finished · latest 2h ago");
   });
 
-  it("ranks running work above acknowledged completions", () => {
+  it("reports running work beside an acknowledged completion rather than instead of it", () => {
     const status = getProjectRowStatus(
       project({
         activeAgentCount: 1,
@@ -319,15 +333,39 @@ describe("getProjectRowStatus", () => {
       NOW
     );
 
-    expect(status.text).toBe("Agent running");
-    expect(status.tone).toBe("working");
+    // Running is not a tier: the completion keeps the sentence it earned, and
+    // the run rides the count. Before, the run took the line and the two
+    // finished agents went unmentioned.
+    expect(demandLine(status)).toBe("2 finished · latest 1h ago");
+    expect(status.livenessDetail).toBe("1 agent running");
   });
 
   it("distinguishes agents from bare processes", () => {
-    expect(getProjectRowStatus(project({ activeAgentCount: 2 }), NOW).text).toBe(
-      "2 agents running"
+    // Agents report as a count with no sentence of their own to claim.
+    const agents = getProjectRowStatus(project({ activeAgentCount: 2 }), NOW);
+    expect(agents.livenessDetail).toBe("2 agents running");
+    expect(agents.isDormantFallback).toBe(true);
+
+    // A bare process is not an agent, so it stays a sentence and no count.
+    const bare = getProjectRowStatus(project({ processCount: 1 }), NOW);
+    expect(bare.text).toBe("1 process running");
+    expect(bare.livenessDetail).toBeUndefined();
+  });
+
+  it("keeps the process line from double-counting the PTYs its agents run in", () => {
+    // `processCount` includes each running agent's own terminal, so a row with
+    // two agents in three PTYs must not print a process count beside a count of
+    // 2 and leave the reader to reconcile them. Asserted as an equality with
+    // the same row carrying no processes at all: a reworded process line would
+    // slip past a "does not contain" check.
+    const withProcesses = getProjectRowStatus(
+      project({ activeAgentCount: 2, processCount: 3 }),
+      NOW
     );
-    expect(getProjectRowStatus(project({ processCount: 1 }), NOW).text).toBe("Process running");
+    const without = getProjectRowStatus(project({ activeAgentCount: 2, processCount: 0 }), NOW);
+
+    expect(withProcesses).toEqual(without);
+    expect(withProcesses.livenessDetail).toBe("2 agents running");
   });
 
   it("puts a missing directory above everything else", () => {
@@ -400,7 +438,6 @@ describe("getProjectRowStatus", () => {
       project({ completedAgentCount: 1, latestCompletionAt: NOW - 2 * 3600_000 }),
       project({ isMissing: true }),
       project({ waitingAgentCount: 1 }),
-      project({ activeAgentCount: 1 }),
       project({ processCount: 1 }),
     ];
     for (const row of reportable) {
@@ -410,6 +447,14 @@ describe("getProjectRowStatus", () => {
       // a sentence to print, so hiding the flagged ones can't blank a row.
       expect(status.text.length).toBeGreaterThan(0);
     }
+
+    // A row whose only fact is a running agent belongs on the dormant side now:
+    // it has nothing to ask of anyone, so it prints no sentence — but it is not
+    // silent, because the count and the mark both still speak for it.
+    const running = getProjectRowStatus(project({ activeAgentCount: 1 }), NOW);
+    expect(running.isDormantFallback).toBe(true);
+    expect(running.livenessDetail).toBe("1 agent running");
+    expect(running.markTone).toBe("working");
 
     // Two of the reportable rows are muted. If that stopped being true the test
     // above would pass while proving nothing.
@@ -470,29 +515,6 @@ describe("getProjectRowStatus", () => {
     // what separates them — asserted as the pair, since checking either alone
     // would stay green while the premise stopped being true.
     expect(getProjectRowStatus(keepsItsMark[0]!, NOW).tone).toBe(parked.tone);
-  });
-
-  // The sweep marks a project closed at once, while its counts arrive on a
-  // 200ms debounce — so a parked row briefly carries the activity it had a
-  // moment ago. It has to keep saying what it was doing until the counts
-  // settle: promising a resume while agents still read as running would be the
-  // wrong half of the story.
-  it("waits for the counts to settle before a parked row promises a resume", () => {
-    const midSweep = project({
-      status: "closed",
-      autoParkedAt: NOW - 50,
-      activeAgentCount: 1,
-      lastOpened: NOW - 5000,
-    });
-
-    const status = getProjectRowStatus(midSweep, NOW);
-    expect(status.allowsResumeMark).toBeUndefined();
-    expect(status.text).toContain("running");
-
-    // Once the counts catch up, the same row parks and offers its dot.
-    const settled = getProjectRowStatus({ ...midSweep, activeAgentCount: 0 }, NOW);
-    expect(settled.allowsResumeMark).toBe(true);
-    expect(settled.text).toBe("Suspended to free memory");
   });
 
   // The hint disambiguates two projects sharing a folder name, so it is part of
@@ -594,7 +616,7 @@ describe("snoozed rows", () => {
 
     expect(status.tone).toBe("snoozed");
     expect(status.text).toContain("snoozed");
-    expect(status.text).toContain("until");
+    expect(status.ageDetail).toContain("until");
   });
 
   it("pluralises the count", () => {
@@ -609,15 +631,15 @@ describe("snoozed rows", () => {
     const status = getProjectRowStatus(project({ snoozedAgentCount: 2 }), NOW);
 
     expect(status.tone).toBe("snoozed");
-    expect(status.text).not.toContain("until");
+    expect(status.ageDetail).toBeUndefined();
   });
 
   it("renders the same wake time regardless of how much later it is read", () => {
     // The anti-countdown contract: a static clock time stays true without being
     // redrawn, so no timer is needed to keep the row honest.
     const row = project({ snoozedAgentCount: 1, nextSnoozeWakeAt: WAKE_AT });
-    const early = getProjectRowStatus(row, NOW).text;
-    const later = getProjectRowStatus(row, NOW + 10 * 60_000).text;
+    const early = getProjectRowStatus(row, NOW).ageDetail;
+    const later = getProjectRowStatus(row, NOW + 10 * 60_000).ageDetail;
 
     expect(later).toBe(early);
   });
@@ -628,11 +650,11 @@ describe("snoozed rows", () => {
     const early = getProjectRowStatus(
       project({ snoozedAgentCount: 1, nextSnoozeWakeAt: WAKE_AT }),
       NOW
-    ).text;
+    ).ageDetail;
     const late = getProjectRowStatus(
       project({ snoozedAgentCount: 1, nextSnoozeWakeAt: WAKE_AT + 3 * 60 * 60_000 }),
       NOW
-    ).text;
+    ).ageDetail;
 
     expect(late).not.toBe(early);
   });
@@ -641,11 +663,13 @@ describe("snoozed rows", () => {
     const timed = getProjectRowStatus(
       project({ snoozedAgentCount: 2, nextSnoozeWakeAt: WAKE_AT }),
       NOW
-    ).text;
-    const unlimited = getProjectRowStatus(project({ snoozedAgentCount: 2 }), NOW).text;
+    );
+    const unlimited = getProjectRowStatus(project({ snoozedAgentCount: 2 }), NOW);
 
-    expect(timed.startsWith(unlimited)).toBe(true);
-    expect(timed.length).toBeGreaterThan(unlimited.length);
+    // The count is the same fact either way; only the wake time is conditional.
+    expect(timed.text).toBe(unlimited.text);
+    expect(timed.ageDetail).toBeTruthy();
+    expect(unlimited.ageDetail).toBeUndefined();
   });
 
   it("yields to a genuinely waiting agent", () => {
@@ -658,10 +682,13 @@ describe("snoozed rows", () => {
     expect(status.tone).toBe("waiting");
   });
 
-  it("yields to a running agent, so a project with work in flight reads as Running", () => {
+  it("keeps its line while a running agent reports beside it", () => {
+    // The snooze and the run are both true, and the row now says both: before,
+    // running took the line outright and the snoozed agent vanished from it.
     const status = getProjectRowStatus(project({ snoozedAgentCount: 1, activeAgentCount: 1 }), NOW);
 
-    expect(status.tone).toBe("working");
+    expect(status.tone).toBe("snoozed");
+    expect(status.livenessDetail).toBe("1 agent running");
   });
 
   it("yields to work awaiting review", () => {
@@ -750,8 +777,8 @@ describe("assistant presence status lines (#11806)", () => {
       NOW
     );
 
-    expect(fresh.text).toBe("Assistant waiting · just now");
-    expect(old.text).toBe("Assistant waiting · 42m");
+    expect(demandLine(fresh)).toBe("Assistant waiting · just now");
+    expect(demandLine(old)).toBe("Assistant waiting · 42m");
   });
 
   it("says blocked, in the danger tone, when the assistant failed", () => {
@@ -764,7 +791,7 @@ describe("assistant presence status lines (#11806)", () => {
       NOW
     );
 
-    expect(status.text).toBe("Assistant blocked · 5m");
+    expect(demandLine(status)).toBe("Assistant blocked · 5m");
     expect(status.tone).toBe("assistant-blocked");
   });
 
@@ -819,7 +846,7 @@ describe("assistant presence status lines (#11806)", () => {
       NOW
     );
 
-    expect(status.text).toContain("agents need input");
+    expect(status.text).toContain("need input");
   });
 
   it("reports a working assistant rather than the snooze beneath it", () => {
@@ -833,14 +860,17 @@ describe("assistant presence status lines (#11806)", () => {
     expect(status.text).toBe("Assistant working");
   });
 
-  it("leaves a running worker's line alone", () => {
+  it("counts the workers rather than announcing the assistant beside them", () => {
+    // Both are executing, but only the runs the user launched are countable
+    // (#11806) — and "Assistant working" must not stand in for a number when
+    // there is a real one to give.
     const status = getProjectRowStatus(
       project({ activeAgentCount: 2, assistantState: "working" }),
       NOW
     );
 
-    expect(status.text).toBe("2 agents running");
-    expect(status.tone).toBe("working");
+    expect(status.livenessDetail).toBe("2 agents running");
+    expect(status.markTone).toBe("working");
   });
 
   it("puts a seen wait below the snooze but above the settled lines", () => {
@@ -929,24 +959,131 @@ describe("row status liveness", () => {
     expect(churning.text).toBe(stalled.text);
     expect(churning.tone).toBe(stalled.tone);
 
-    expect(stalled.isLive).toBe(false);
-    expect(churning.isLive).toBe(true);
     expect(stalled.livenessDetail).toBeUndefined();
-    expect(churning.livenessDetail).toBe(`${RUNNING} running`);
+    expect(churning.livenessDetail).toBe(`${RUNNING} agents running`);
+    // And the mark follows: only one of them has anything to weigh.
+    expect(stalled.agentMix).toEqual({ demand: 1, running: 0 });
+    expect(churning.agentMix).toEqual({ demand: 1, running: RUNNING });
   });
 
-  it("says nothing extra on the line that already names the running agents", () => {
-    // "2 agents running · 2 running" would state one fact twice.
-    const status = getProjectRowStatus(project({ activeAgentCount: RUNNING }), NOW);
+  it("carries the count through whichever demand tier won the line", () => {
+    // The reason running cannot be a tier. Each of these rows has a louder fact
+    // than "3 agents running", and each of them used to swallow it whole — the
+    // count has to survive every one of them, because "how many of mine are
+    // still going" is the question this surface gets opened for.
+    //
+    // Asserted as a pair rather than against literal copy: the same row is
+    // computed with and without the run, and the demand half has to come back
+    // byte-identical. A tier that quietly started reporting the run itself
+    // would pass a "says something" check and fail this one.
+    const tiers: Array<[string, Partial<SearchableProject>]> = [
+      ["a wait", { waitingAgentCount: 1, oldestWaitingSince: NOW - 60_000 }],
+      ["a block", { waitingAgentCount: 1, blockedAgentCount: 1 }],
+      ["work awaiting review", { unacknowledgedCompletedAgentCount: 2 }],
+      ["a snooze", { snoozedAgentCount: 1, nextSnoozeWakeAt: NOW + 600_000 }],
+      ["a seen completion", { completedAgentCount: 1, latestCompletionAt: NOW - 60_000 }],
+      ["a missing directory", { isMissing: true }],
+      ["an already-seen assistant wait", { assistantState: "waiting", isActive: true }],
+    ];
 
-    expect(status.isLive).toBe(true);
+    for (const [label, overrides] of tiers) {
+      const settled = getProjectRowStatus(project({ ...overrides }), NOW);
+      const live = getProjectRowStatus(project({ ...overrides, activeAgentCount: 3 }), NOW);
+
+      expect(live.text, label).toBe(settled.text);
+      expect(live.tone, label).toBe(settled.tone);
+
+      expect(settled.livenessDetail, label).toBeUndefined();
+      expect(live.livenessDetail, label).toBe("3 agents running");
+
+      // The mark follows the demand only while the demand is asking for
+      // something. A snooze and a seen completion are not, so on those rows the
+      // run takes the mark instead of leaving it settled beside three agents
+      // that are visibly still going.
+      const asking = settled.tone !== "snoozed" && settled.tone !== "muted";
+      expect(live.markTone, label).toBe(asking ? settled.markTone : "working");
+    }
+  });
+
+  it("leaves a row with nothing happening unmarked", () => {
+    // The null case the required field exists for: no demand, no run, so the
+    // slot stays empty rather than defaulting to a tone that means something.
+    const quiet = getProjectRowStatus(project({ lastOpened: NOW - 3 * 3600_000 }), NOW);
+
+    expect(quiet.markTone).toBeNull();
+    expect(quiet.agentMix).toBeNull();
+    expect(quiet.isDormantFallback).toBe(true);
+  });
+
+  it("lets a working assistant keep its line without taking a running row's", () => {
+    // The one case where the mark and the sentence come apart: the assistant is
+    // presence rather than demand (#11806), so it says what it is while the
+    // mark goes to the runs the user actually launched.
+    const assistantOnly = getProjectRowStatus(project({ assistantState: "working" }), NOW);
+    expect(assistantOnly.text).toBe("Assistant working");
+    expect(assistantOnly.markTone).toBe("assistant");
+
+    const alsoRunning = getProjectRowStatus(
+      project({ assistantState: "working", activeAgentCount: 2 }),
+      NOW
+    );
+    expect(alsoRunning.markTone).toBe("working");
+    expect(alsoRunning.livenessDetail).toBe("2 agents running");
+  });
+
+  it("keeps a running row's own settled line instead of the assistant's", () => {
+    // The assistant branch sits above snooze so an assistant-only project does
+    // not announce "Agent snoozed" from the Running band. On a row that is
+    // itself running, the count already explains the band — so the snooze the
+    // user set has to survive rather than being evicted by the machine's own
+    // session.
+    const status = getProjectRowStatus(
+      project({
+        assistantState: "working",
+        activeAgentCount: 1,
+        snoozedAgentCount: 1,
+        nextSnoozeWakeAt: NOW + 600_000,
+      }),
+      NOW
+    );
+
+    expect(status.text).toContain("snoozed");
+    expect(status.livenessDetail).toBe("1 agent running");
+  });
+
+  it("withholds the parked line from a row whose agents are still running", () => {
+    // The sweep marks a project closed at once while its counts arrive on a
+    // 200ms debounce, so "Suspended to free memory" can reach a row that is
+    // demonstrably still working. Contradicting the count is worse than saying
+    // nothing, so the row drops to the silent fallback for that beat.
+    const parked = { status: "closed" as const, autoParkedAt: NOW - 50, lastOpened: NOW - 5000 };
+
+    const settled = getProjectRowStatus(project(parked), NOW);
+    expect(settled.text).toBe("Suspended to free memory");
+    expect(settled.allowsResumeMark).toBe(true);
+
+    const midSweep = getProjectRowStatus(project({ ...parked, activeAgentCount: 1 }), NOW);
+    expect(midSweep.text).not.toContain("Suspended");
+    expect(midSweep.isDormantFallback).toBe(true);
+    expect(midSweep.allowsResumeMark).toBeUndefined();
+    expect(midSweep.livenessDetail).toBe("1 agent running");
+    expect(midSweep.markTone).toBe("working");
+  });
+
+  it("says nothing extra on the line that already names the assistant's work", () => {
+    // "Assistant working · Assistant working" would state one fact twice. The
+    // suppression is scoped to that phrase: an assistant working alongside real
+    // runs still lets the count through, which the worker test above covers.
+    const status = getProjectRowStatus(project({ assistantState: "working" }), NOW);
+
+    expect(status.text).toBe("Assistant working");
     expect(status.livenessDetail).toBeUndefined();
   });
 
   it("singularises the clause the way the sentences above it do", () => {
     const status = getProjectRowStatus(project({ waitingAgentCount: 1, activeAgentCount: 1 }), NOW);
 
-    expect(status.livenessDetail).toBe("1 running");
+    expect(status.livenessDetail).toBe("1 agent running");
   });
 
   it("keeps the clause off a row where nothing is executing", () => {
@@ -962,8 +1099,9 @@ describe("row status liveness", () => {
     ].map((row) => getProjectRowStatus(row, NOW));
 
     for (const status of settled) {
-      expect(status.isLive).toBe(false);
       expect(status.livenessDetail).toBeUndefined();
+      // Nothing to weigh either, so these rows keep a plain settled mark.
+      expect(status.agentMix?.running ?? 0).toBe(0);
     }
   });
 
@@ -977,8 +1115,9 @@ describe("row status liveness", () => {
       NOW
     );
 
-    expect(byProcess.isLive).toBe(false);
-    expect(byAgent.isLive).toBe(true);
+    expect(byProcess.livenessDetail).toBeUndefined();
+    expect(byProcess.agentMix).toEqual({ demand: 1, running: 0 });
+    expect(byAgent.livenessDetail).toBe("1 agent running");
   });
 
   it("counts a working assistant as live without inventing an agent for it", () => {
@@ -987,9 +1126,8 @@ describe("row status liveness", () => {
       NOW
     );
 
-    expect(hidden.isLive).toBe(true);
     // Named, not numbered: the assistant is one thing the user never launched,
-    // and "1 running" would enrol it in a tally it is excluded from everywhere
+    // and "1 agent running" would enrol it in a tally it is excluded from everywhere
     // else.
     expect(hidden.livenessDetail).toBe("Assistant working");
   });
@@ -1000,22 +1138,24 @@ describe("row status liveness", () => {
       NOW
     );
 
-    expect(status.livenessDetail).toBe(`${RUNNING} running`);
+    expect(status.livenessDetail).toBe(`${RUNNING} agents running`);
   });
 
   it("leaves the assistant's own line without a clause about itself", () => {
     const status = getProjectRowStatus(project({ assistantState: "working" }), NOW);
 
-    expect(status.isLive).toBe(true);
+    expect(status.text).toBe("Assistant working");
     expect(status.livenessDetail).toBeUndefined();
   });
 
   it("treats a directing assistant as executing, the way the classifier does", () => {
+    // A directing assistant is mid-task, so it speaks; an idle one has nothing
+    // to say and lets the row fall through to whatever is underneath it.
     const directing = getProjectRowStatus(project({ assistantState: "directing" }), NOW);
     const idle = getProjectRowStatus(project({ assistantState: "idle" }), NOW);
 
-    expect(directing.isLive).toBe(true);
-    expect(idle.isLive).toBe(false);
+    expect(directing.text).toBe("Assistant working");
+    expect(idle.isDormantFallback).toBe(true);
   });
 
   it("needs no union with the snooze count to see a snoozed run still working", () => {
@@ -1026,8 +1166,7 @@ describe("row status liveness", () => {
       NOW
     );
 
-    expect(status.isLive).toBe(true);
-    expect(status.livenessDetail).toBe("1 running");
+    expect(status.livenessDetail).toBe("1 agent running");
   });
 
   it("keeps reporting the run when the folder underneath it has gone", () => {
@@ -1041,7 +1180,7 @@ describe("row status liveness", () => {
 
     expect(missing.text).toBe(found.text);
     expect(missing.tone).toBe(found.tone);
-    expect(missing.livenessDetail).toBe(`${RUNNING} running`);
+    expect(missing.livenessDetail).toBe(`${RUNNING} agents running`);
     expect(found.livenessDetail).toBeUndefined();
   });
 
@@ -1065,7 +1204,7 @@ describe("row status liveness", () => {
       expect(churning.text).toBe(stalled.text);
       expect(churning.tone).toBe(stalled.tone);
       expect(stalled.livenessDetail).toBeUndefined();
-      expect(churning.livenessDetail).toBe(`${RUNNING} running`);
+      expect(churning.livenessDetail).toBe(`${RUNNING} agents running`);
     }
   });
 
@@ -1077,15 +1216,15 @@ describe("row status liveness", () => {
     );
 
     expect(churning.text).toBe(stalled.text);
-    expect(stalled.isLive).toBe(false);
-    expect(churning.isLive).toBe(true);
-    expect(churning.livenessDetail).toBe(`${RUNNING} running`);
+    expect(stalled.livenessDetail).toBeUndefined();
+    expect(churning.livenessDetail).toBe(`${RUNNING} agents running`);
+    expect(churning.agentMix).toEqual({ demand: 1, running: RUNNING });
   });
 
-  it("never carries a detail without the liveness that justifies it", () => {
-    // The two fields answer different questions and a renderer trusts both, so
-    // a status claiming hidden work while reporting itself at rest would draw a
-    // closed mark beside a sentence about a running agent.
+  it("never counts in the line what the mark is not weighing", () => {
+    // The renderer trusts both fields, so a status that printed "2 agents
+    // running" while handing the mark a mix with nothing running would draw a
+    // settled dot beside a sentence about work in flight.
     const rows = [
       project({ waitingAgentCount: 1 }),
       project({ waitingAgentCount: 1, activeAgentCount: 3 }),
@@ -1093,19 +1232,22 @@ describe("row status liveness", () => {
       project({ assistantState: "working" }),
       project({ processCount: 2 }),
       project({ isMissing: true, activeAgentCount: 1 }),
+      project({ snoozedAgentCount: 1, activeAgentCount: 2 }),
       project({ lastOpened: NOW - 3600_000 }),
     ];
 
     for (const row of rows) {
       const status = getProjectRowStatus(row, NOW);
-      if (!status.isLive) expect(status.livenessDetail).toBeUndefined();
+      const running = status.agentMix?.running ?? 0;
+      const claimsAgents = status.livenessDetail?.includes("running") ?? false;
+      expect(claimsAgents).toBe(running > 0);
     }
   });
 });
 
 describe("formatFleetLiveness", () => {
   it("says nothing at all when the fleet has gone quiet", () => {
-    // Absence is the signal. A standing "0 running" would make the reader parse
+    // Absence is the signal. A standing "0 agents running" would make the reader parse
     // a number to learn there is nothing to learn.
     expect(formatFleetLiveness({ runningAgentCount: 0, workingAssistantCount: 0 })).toBeNull();
   });
@@ -1115,7 +1257,7 @@ describe("formatFleetLiveness", () => {
 
     // Never summed: an assistant is not a run the user launched, so one number
     // covering both would answer neither question it is asked. Matched as whole
-    // phrases — a bare `toContain("3")` also passes on "32 running".
+    // phrases — a bare `toContain("3")` also passes on "32 agents running".
     expect(both).not.toContain("5");
     expect(both).toMatch(/\b3 running\b/);
     expect(both).toMatch(/\b2 assistants working\b/);
@@ -1129,5 +1271,57 @@ describe("formatFleetLiveness", () => {
     expect(agentsOnly).not.toContain("0");
     expect(assistantsOnly).not.toContain("0");
     expect(assistantsOnly).toContain("assistant");
+  });
+});
+
+/**
+ * The mark's proportion, which has one job the exact counts cannot do: say
+ * which way a row leans without being read. Everything here is about staying
+ * honest at 8px, where the alternative to snapping is a wedge nobody can
+ * measure and a count that rounds away to nothing.
+ */
+describe("running share", () => {
+  it("gives the whole mark to whichever side is alone", () => {
+    expect(runningShare({ demand: 0, running: 4 })).toBe(1);
+    expect(runningShare({ demand: 4, running: 0 })).toBe(0);
+  });
+
+  it("never rounds a live agent out of the mark", () => {
+    // The failure this exists to prevent: 1-of-13 is 7.7%, which any honest
+    // rounding sends to zero — and a mark that says "nothing is running" about
+    // a project with a running agent is worse than one that says nothing.
+    const lopsided = runningShare({ demand: 12, running: 1 });
+    expect(lopsided).toBeGreaterThan(0);
+    expect(lopsided).toBeLessThan(0.5);
+
+    // Symmetrically, one straggler waiting must not be rounded away either.
+    const inverted = runningShare({ demand: 1, running: 12 });
+    expect(inverted).toBeLessThan(1);
+    expect(inverted).toBeGreaterThan(0.5);
+  });
+
+  it("lands on quarters, so the mark makes a finite set of statements", () => {
+    // Snapping is what makes an 8px angle readable at all: the reader
+    // recognises a shape rather than estimating a proportion. Sampled across
+    // the range rather than asserted case by case — the property is what
+    // matters, and a case list would just restate the arithmetic.
+    for (let demand = 0; demand <= 12; demand++) {
+      for (let running = 0; running <= 12; running++) {
+        if (demand === 0 && running === 0) continue;
+        const share = runningShare({ demand, running });
+        expect((share * 4) % 1).toBe(0);
+        expect(share).toBeGreaterThanOrEqual(0);
+        expect(share).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it("leans the way the counts do", () => {
+    // Monotonic in the direction that matters: adding runs never moves the mark
+    // toward the demand side.
+    expect(runningShare({ demand: 3, running: 1 })).toBeLessThan(
+      runningShare({ demand: 1, running: 3 })
+    );
+    expect(runningShare({ demand: 2, running: 2 })).toBe(0.5);
   });
 });

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -104,13 +104,13 @@ export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
  * The colour each tone paints with, as a CSS value rather than a utility class.
  *
  * Parallel to `ROW_DOT_CLASS` because the mark draws two ways: a solid mark is
- * a class on a div, and a two-tone mark is a `conic-gradient`, which needs
+ * a class on a div, and a two-tone mark is a pair of SVG fills, which need
  * actual colour values and cannot be assembled out of Tailwind backgrounds. The
  * two maps are kept adjacent and both total over the union, so a tone added
  * later has to answer for both or fail to compile.
  *
  * The ring tones resolve to the same greys their borders use. They cannot reach
- * the gradient today — a settled tone hands the mark to the run rather than
+ * the split mark today — a settled tone hands the mark to the run rather than
  * splitting it — but the map is total over the union, so a tone added later
  * cannot ship without a colour and silently paint transparent.
  */

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -34,80 +34,123 @@ export const ROW_TONE_CLASS: Record<ProjectRowTone, string> = {
   // warning of a wait and the success-green of a healthy process. Never danger
   // — completion is the desired outcome, not a fault.
   review: "text-activity-completed",
+  // Mark-only today: `working` is what a row draws when liveness has claimed a
+  // mark demand had no use for, and such a row has no sentence to colour. The
+  // entry stays because the map is total over the union — a tone must not be
+  // able to ship without an answer here — and because a surface with room for a
+  // "running" sentence should draw it in this hue rather than inventing one.
   working: "text-activity-working",
-  running: "text-daintree-text/50",
+  running: "text-daintree-text/65",
   // Muted like the other settled states, and deliberately NOT the accent: a
   // snooze is the user telling this row to stop asking for them, so it must not
   // be the loudest thing in the list on the way out.
-  snoozed: "text-daintree-text/50",
-  muted: "text-daintree-text/50",
+  //
+  // One step above the age beside it, though. These states are the quietest
+  // text on the row and the age is quieter still — at the same weight, "until
+  // 3:45 PM" read as the headline and "1 snoozed" as its footnote, which is the
+  // hierarchy upside down.
+  snoozed: "text-daintree-text/65",
+  muted: "text-daintree-text/65",
   // Machine-initiated work the user didn't launch, so it reads at the same
   // weight as the settled states rather than competing with the runs they
   // started (#11806).
-  assistant: "text-daintree-text/50",
+  assistant: "text-daintree-text/65",
   // An assistant that failed says so in the danger hue — the severity is real
   // — while its dot stays hollow, so it never reads as a worker run.
   "assistant-blocked": "text-status-danger/80",
 };
 
 /**
- * The two shapes a row's leading mark can take, in one tone's hue.
+ * The mark for one tone, as the utility classes that draw it.
  *
- * Co-located rather than kept as two parallel maps so a tone added later cannot
- * compile until it has answered both questions. They are different class
- * families on purpose: the closed mark is a `div` that needs a background or a
- * border, and the open arc is an SVG stroking `currentColor`, so it needs a text
- * colour.
+ * The solid states draw a filled 8px disc; the settled ones draw a ring. A row
+ * that is part running and part waiting draws neither: `AgentMixDot` takes
+ * these two tones' colours from `ROW_MARK_COLOR` and splits the disc between
+ * them (#11832 first shipped liveness as a second SHAPE on this mark — a
+ * hairline arc in a demand hue — which read as neither axis).
  */
-export interface RowMarkStyle {
-  /** Closed topology — the row is at rest. Filled for a run the user launched, a ring for the settled states. */
-  dot: string;
-  /** Open topology — something on the row is still executing. */
-  arc: string;
-}
-
-/**
- * Hue says what the row wants from the user; shape says whether it is still
- * moving (#11832). The two are independent, so every tone has to name both:
- * "wants input, still churning" and "wants input, and everything else is done"
- * are the two situations the old single-shape dot rendered identically.
- *
- * Three tones can never draw their arc today — `running`, `snoozed` and `muted`
- * are all reached only after the cascade has established that nothing is
- * executing. They still carry one, because the map's whole job is that a tone
- * cannot ship without a shape for each axis.
- */
-export const ROW_MARK_CLASS: Record<ProjectRowTone, RowMarkStyle> = {
-  blocked: { dot: "bg-status-danger", arc: "text-status-danger" },
-  waiting: { dot: "bg-status-warning", arc: "text-status-warning" },
-  review: { dot: "bg-activity-completed", arc: "text-activity-completed" },
-  // No pulse on either shape any more. A working row is live by definition, so
-  // it always draws the arc — and the open gap says "still moving" without
-  // asking a reader to notice a fade, which reduced motion switches off anyway.
-  working: { dot: "bg-activity-active", arc: "text-activity-active" },
-  running: { dot: "bg-status-success", arc: "text-status-success" },
+export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
+  blocked: "bg-status-danger",
+  waiting: "bg-status-warning",
+  review: "bg-activity-completed",
+  // Filled and pulsing, the way every other surface draws a run in flight. This
+  // tone is only ever reached as the liveness fallback now — a row with real
+  // demand keeps its demand hue — so the pulse lands on the rows whose only
+  // fact is that they are moving, and nowhere near twenty at once.
+  working: "bg-activity-working animate-activity-pulse",
+  running: "bg-status-success",
   // Dashed rather than solid, because "snoozed" and "settled" are different
   // facts and the switcher's greys already carry the settled ones. Colour alone
   // could not separate them — a dashed ring reads as temporarily suspended at a
   // glance, and survives both high-contrast modes and a colour-blind reader.
-  snoozed: { dot: "border border-dashed border-daintree-text/40", arc: "text-daintree-text/40" },
+  snoozed: "border border-dashed border-daintree-text/40",
   // Hollow, because "finished" and "suspended" are settled states rather than
   // live ones. It used to sit on every dormant row too, which made a ring the
   // most common mark in the list and left it competing with the filled dots
   // that mean something — dormant rows draw no dot at all now (#11692), so the
   // ring is back to marking the two muted states that earned a line.
-  muted: { dot: "border border-daintree-text/20", arc: "text-daintree-text/20" },
+  muted: "border border-daintree-text/20",
   // Hollow, and that is the whole point: the filled dot means a run the user
   // launched, and the assistant is the machine acting on its own. It is the
   // convention for machine-initiated background work, and it leaves the worker
-  // dot meaning exactly what it meant before (#11806). The arc beside it is a
-  // different question — a closed ring for an assistant that is mid-task would
-  // say "at rest" about something that is demonstrably not.
-  assistant: { dot: "border border-daintree-text/40", arc: "text-daintree-text/40" },
+  // dot meaning exactly what it meant before (#11806).
+  assistant: "border border-daintree-text/40",
   // Same hollow shape carrying the danger hue: still not a worker run, but a
   // failure the row should not have to be read closely to notice.
-  "assistant-blocked": { dot: "border border-status-danger", arc: "text-status-danger" },
+  "assistant-blocked": "border border-status-danger",
 };
+
+/**
+ * The colour each tone paints with, as a CSS value rather than a utility class.
+ *
+ * Parallel to `ROW_DOT_CLASS` because the mark draws two ways: a solid mark is
+ * a class on a div, and a two-tone mark is a `conic-gradient`, which needs
+ * actual colour values and cannot be assembled out of Tailwind backgrounds. The
+ * two maps are kept adjacent and both total over the union, so a tone added
+ * later has to answer for both or fail to compile.
+ *
+ * The ring tones resolve to the same greys their borders use. They cannot reach
+ * the gradient today — a settled tone hands the mark to the run rather than
+ * splitting it — but the map is total over the union, so a tone added later
+ * cannot ship without a colour and silently paint transparent.
+ */
+export const ROW_MARK_COLOR: Record<ProjectRowTone, string> = {
+  blocked: "var(--color-status-danger)",
+  waiting: "var(--color-status-warning)",
+  review: "var(--color-activity-completed)",
+  working: "var(--color-activity-working)",
+  running: "var(--color-status-success)",
+  snoozed: "rgb(from var(--color-daintree-text) r g b / 0.4)",
+  muted: "rgb(from var(--color-daintree-text) r g b / 0.2)",
+  assistant: "rgb(from var(--color-daintree-text) r g b / 0.4)",
+  "assistant-blocked": "var(--color-status-danger)",
+};
+
+/**
+ * Share of the mark the running agents take, snapped so it stays readable at
+ * 8px (#11832).
+ *
+ * Angle is a weak channel — Cleveland & McGill rank it below position and
+ * length — and below roughly 14px a continuous pie stops being a proportion at
+ * all and becomes "there are two colours here". Quantising to quarters is what
+ * rescues it: three mixed states (a quarter, half, three quarters) are shape
+ * recognition rather than angle estimation, and a reader can name which side is
+ * winning without measuring anything.
+ *
+ * The clamp is the other half. A naive round sends 1-of-13 to zero and deletes
+ * a running agent from the row, so any non-zero count keeps at least a quarter
+ * of the mark — the figures beside it carry the exact split, and the mark's job
+ * is only to say which way the row leans.
+ */
+export function runningShare(mix: { demand: number; running: number }): number {
+  const total = mix.demand + mix.running;
+  if (total === 0) return 0;
+  if (mix.demand === 0) return 1;
+  if (mix.running === 0) return 0;
+
+  const snapped = Math.round((mix.running / total) * 4) / 4;
+  return Math.min(0.75, Math.max(0.25, snapped));
+}
 
 /**
  * Wording boundary between "just finished" and plain "finished" on a
@@ -118,34 +161,70 @@ export const ROW_MARK_CLASS: Record<ProjectRowTone, RowMarkStyle> = {
 export const JUST_FINISHED_MS = 15 * 60_000;
 
 export interface ProjectRowStatus {
-  /** Status sentence, or the fallback "Opened …" line when nothing is running. */
+  /** Status sentence, or the fallback "Opened …" line when the row has nothing to report. */
   text: string;
   tone: ProjectRowTone;
   /**
-   * Whether anything on this row is still executing — the second axis (#11832).
+   * The row's running work, as the count itself: "2 agents running", or
+   * "Assistant working" when the machine's own session is the only thing
+   * executing.
    *
-   * Independent of `tone`, which answers what the row wants from the user. The
-   * cascade below picks one demand tier and drops the rest, so before this
-   * existed a project with a waiting agent and a running one rendered exactly
-   * like a project where everything had stopped. It drives the mark's shape:
-   * open means the row will change on its own, closed means it will not.
+   * A count rather than a flag, because "how many of my agents are still
+   * going" is the question this surface gets asked — a boolean can say that
+   * something is moving but never that four things are, and four is the answer
+   * someone came here for. Absent when nothing is running, so its absence is
+   * the other half of the signal: a row with a wait and no count is a row that
+   * has fully stopped on you.
    *
-   * Required rather than optional so a status constructed later cannot quietly
-   * default to "at rest" — every line has to answer, and the answer is derived
-   * in one place from the counts rather than read off the tone.
-   */
-  isLive: boolean;
-  /**
-   * The running work this row's sentence does not mention, phrased for a
-   * trailing clause: "2 running", or "Assistant working" when the assistant is
-   * the only thing executing.
-   *
-   * Absent when nothing is running, and absent when the sentence already names
-   * it — "2 agents running · 2 running" would say the same thing twice. It is
-   * the non-visual carrier for the shape: the mark is `aria-hidden`, so without
-   * a word for it liveness would exist in topology alone.
+   * Rendered in its own trailing column rather than trailing the sentence, so
+   * the number sits at the same place on every row and a fleet reads down it in
+   * one pass.
    */
   livenessDetail?: string;
+  /**
+   * The tone the leading mark draws in, or null when the row has earned no mark
+   * at all.
+   *
+   * Demand first: a row that wants something marks itself with what it wants.
+   * Liveness only claims the mark when demand has nothing to say — a project
+   * quietly running four agents is not asking for anything, so it takes the
+   * working hue rather than leaving the slot empty. Dormant rows keep the empty
+   * slot #11692 gave them.
+   *
+   * Derived here rather than read off `tone` by the renderer, because the two
+   * genuinely differ: the liveness fallback carries the dormant line's `muted`
+   * tone for its (absent) text while marking itself as working.
+   */
+  markTone: ProjectRowTone | null;
+  /**
+   * When the row's state started, phrased for the end of the line: "oldest 10m",
+   * "just finished 3m ago", "until 3:45 PM".
+   *
+   * Split out of the sentence rather than appended to it, because it is the one
+   * fragment on the line that is never a demand. Inside the sentence it wore
+   * the demand hue, which made the coloured run long enough to outweigh the
+   * running count that leads the line — the age is the slowest-moving fact
+   * here, so it draws in the quietest ink.
+   */
+  ageDetail?: string;
+  /**
+   * How the row's agents split between running and asking, as the two counts
+   * the mark weighs against each other — or null when the row has no agents in
+   * either bucket and its mark is a plain settled one.
+   *
+   * `demand` counts the agents the row's own sentence is about, so the mark and
+   * the line can never disagree about how many there are: waits (blocked
+   * included, since a block is a wait that needs more) for the waiting tiers,
+   * unreviewed hand-backs for the review tier, and zero for the settled tones,
+   * where nothing is being asked of anyone. `running` is the same figure the
+   * count column prints.
+   *
+   * Both are raw counts rather than a ready-made fraction: the snapping the
+   * mark does to stay legible at 8px is a rendering decision, and a classifier
+   * that had already rounded would leave the renderer unable to tell a genuine
+   * half from a rounded one.
+   */
+  agentMix: { demand: number; running: number } | null;
   /**
    * Disambiguating path fragment, present only when this project's folder name
    * collides with another registered project's, so identical-looking monorepo
@@ -236,17 +315,33 @@ export function formatWakeTime(wakeAtMs: number): string {
  *
  * The cascade below answers only "what does this row want?", and every one of
  * its branches would otherwise have to remember to answer the second question
- * too. Leaving liveness off the shape entirely, and deriving it once in
+ * too. Leaving liveness out of it entirely, and deriving it once in
  * `withLiveness`, is what makes a branch added later live-aware for free.
  */
-type ActivityLine = Omit<ProjectRowStatus, "pathHint" | "isLive" | "livenessDetail"> & {
+type ActivityLine = Omit<
+  ProjectRowStatus,
+  "pathHint" | "livenessDetail" | "markTone" | "agentMix"
+> & {
   /**
-   * Set by the two branches whose own sentence already names the running work,
-   * so the trailing clause doesn't repeat it. A flag rather than a tone check:
-   * `working` happens to be one of them today, but the fact belongs to the
-   * sentence, and a tone is not a promise about wording.
+   * How many agents this line is about, for the mark to weigh against the
+   * running count. Left unset by the tones that ask for nothing — a settled or
+   * suppressed line has no demand to give the mark, which is different from
+   * having a demand of zero agents only in that nobody has to remember to say
+   * so.
    */
-  namesLiveWork?: true;
+  demandCount?: number;
+  /**
+   * Set by the one line that reports the assistant working — presence, not
+   * demand (#11806) — which changes two things.
+   *
+   * It suppresses the assistant half of the count, since the sentence has
+   * already said it; a row whose agents are also running still gets its number,
+   * because "Assistant working" was never an answer to how many of them there
+   * are. And it yields the mark to a real run: the assistant's hollow ring
+   * outranks nothing, so a project with two agents in flight marks itself with
+   * them rather than with the machine keeping itself busy alongside.
+   */
+  assistantPresenceLine?: true;
 };
 
 /**
@@ -259,28 +354,72 @@ type ActivityLine = Omit<ProjectRowStatus, "pathHint" | "isLive" | "livenessDeta
  * out the assistant's own PTY and lags the truth by a poll interval, so a row
  * would claim to be moving after its last agent stopped.
  *
- * A working assistant counts. It is excluded from every worker tally on purpose
- * (#11806) and stays excluded from the count in the clause — inventing an agent
- * the user never launched is the thing that exclusion exists to prevent — but
- * "is anything still executing" is a different question from "how many of my
- * runs", and answering it "no" while the assistant works would make the open
- * shape a lie.
+ * A working assistant counts as live. It is excluded from every worker tally on
+ * purpose (#11806) and stays excluded from the number — inventing an agent the
+ * user never launched is the thing that exclusion exists to prevent — but "is
+ * anything still executing" is a different question from "how many of my runs",
+ * and answering it "no" while the assistant works would make the row a lie.
+ *
+ * Also the one place the mark is decided, because that decision needs both
+ * axes: which hue it takes, and how its two counts weigh against each other.
  */
 function withLiveness(
   line: ActivityLine,
   workspace: WorkspaceRowStatusFields
 ): Omit<ProjectRowStatus, "pathHint"> {
-  const { namesLiveWork, ...status } = line;
+  const { assistantPresenceLine, demandCount = 0, ...status } = line;
   const running = workspace.activeAgentCount;
   const isLive = running > 0 || classifyAssistantActivity(workspace) === "working";
 
-  if (!isLive || namesLiveWork) return { ...status, isLive };
+  // Demand owns the mark wherever it is asking for something. The lines that
+  // are not — a dormant fallback, the assistant's presence line, and the two
+  // settled tones — hand it to a live run instead, so a project quietly working
+  // through four agents marks itself as working rather than as empty, as the
+  // assistant's, or as the snooze it happens to also carry.
+  //
+  // Deliberately NOT every tone with a zero demand count. "Directory not found"
+  // and a blocked assistant both report zero agents and both still need saying:
+  // a row that turned green because its actionable state involved no agents
+  // would be hiding the one fact it exists to raise.
+  const yieldsMark =
+    status.isDormantFallback === true ||
+    assistantPresenceLine === true ||
+    status.tone === "snoozed" ||
+    status.tone === "muted";
+  const markTone: ProjectRowTone | null =
+    yieldsMark && running > 0 ? "working" : status.isDormantFallback ? null : status.tone;
+
+  // The weighting the mark draws (#11832). Null on a row with no agents in
+  // either bucket, which is what leaves the settled tones their plain ring:
+  // a mark that weighed 0 against 0 would have nothing to divide.
+  const agentMix = demandCount > 0 || running > 0 ? { demand: demandCount, running } : null;
+
+  // Nothing running and no working assistant: the row has no second fact.
+  if (!isLive) return { ...status, markTone, agentMix };
+
+  // A live row never promises a resume, whichever branch above offered one. The
+  // auto-park sweep flips a project to closed while its counts arrive on a
+  // debounce, so a settled line can land on a row whose agents are still going
+  // — and a resume is the wrong tense for an agent that never stopped.
+  // Stripped here rather than in the renderer so the status object itself
+  // cannot carry the contradiction.
+  delete status.allowsResumeMark;
+
+  // Agents first. The assistant only reaches the count when it is the sole
+  // thing executing, and then only if the sentence has not already said so.
+  if (running === 0) {
+    if (assistantPresenceLine) return { ...status, markTone, agentMix };
+    return { ...status, markTone, agentMix, livenessDetail: "Assistant working" };
+  }
 
   return {
     ...status,
-    isLive,
-    livenessDetail:
-      running > 0 ? pluralAgents(running, "1 running", "running") : "Assistant working",
+    markTone,
+    agentMix,
+    // Named, not just numbered. The noun grounds the row's most important
+    // figure and keeps it apart from the process and assistant counts that use
+    // the same shape of phrase.
+    livenessDetail: pluralAgents(running, "1 agent running", "agents running"),
   };
 }
 
@@ -304,13 +443,13 @@ function assistantStatus(
 ): ActivityLine {
   if (activity === "working") {
     // Names the live work itself, so it never also trails "· Assistant working".
-    return { text: "Assistant working", tone: "assistant", namesLiveWork: true };
+    return { text: "Assistant working", tone: "assistant", assistantPresenceLine: true };
   }
 
   const lead = activity === "blocked" ? "Assistant blocked" : "Assistant waiting";
   const tone: ProjectRowTone = activity === "blocked" ? "assistant-blocked" : "assistant";
   const age = since !== undefined ? formatWaitAge(since, nowMs) : null;
-  return { text: age ? `${lead} · ${age}` : lead, tone };
+  return age ? { text: lead, tone, ageDetail: age } : { text: lead, tone };
 }
 
 /**
@@ -319,15 +458,16 @@ function assistantStatus(
  *
  * Ordered by what would make someone act: a blocked agent first (it has stopped
  * and input may not restart it), then agents waiting on the user, then finished
- * work awaiting review, then work in progress, then dormant states. Counts and
+ * work awaiting review, then the settled states. Counts and
  * ages are carried through rather than collapsed to "Agent waiting…" — one
  * waiting agent and eight are different situations, and a wait that started
  * forty minutes ago is a different situation from one that started forty
  * seconds ago.
  *
- * Returns null when nothing is running, leaving the caller to supply the
- * dormant line its own kind understands (a project can be auto-parked; a
- * scratch only ever has an opened time).
+ * Returns null when the row has nothing to say, leaving the caller to supply
+ * the dormant line its own kind understands (a project can be auto-parked; a
+ * scratch only ever has an opened time). A row whose agents are running is one
+ * of those cases: running is not a tier here, so it has no sentence to win.
  *
  * Answers the demand axis only. Liveness is attached afterwards by
  * `withLiveness`, which is why a branch here can drop a running agent from its
@@ -360,31 +500,36 @@ function classifyWorkspaceActivity(
 
     const parts: string[] = [];
     if (needingInput > 0) {
-      // The subject rides the sentence ("Agent needs input", "3 agents need
-      // input") — a bare "1 needs input" made the reader supply the noun.
-      parts.push(needingInput === 1 ? "Agent needs input" : `${needingInput} agents need input`);
+      // Every state phrase on this line leads with its number, so the reader
+      // can compare it against the running count in front of it without
+      // re-parsing a sentence. "1 needs input" rather than "Agent needs input"
+      // for exactly that reason: a row where one figure is a numeral and the
+      // other is a noun is a row you have to read rather than scan.
+      parts.push(needingInput === 1 ? "1 needs input" : `${needingInput} need input`);
       if (blocked > 0) parts.push(`${blocked} blocked`);
-      // `oldestWaitingSince` is the earliest transition across ALL waits,
-      // blocked or not, so it can only ever be labelled as the oldest wait.
-      // Attaching it to a blocked count would date a fresh block by an older
-      // prompt's clock.
-      if (age) {
-        parts.push(
-          project.waitingAgentCount > 1
-            ? `oldest waiting ${age}`
-            : age === "just now"
-              ? age
-              : `waiting ${age}`
-        );
-      }
     } else {
-      parts.push(blocked === 1 ? "Agent blocked" : `${blocked} agents blocked`);
-      if (age) parts.push(blocked > 1 ? `oldest ${age}` : age);
+      parts.push(`${blocked} blocked`);
     }
+
+    // `oldestWaitingSince` is the earliest transition across ALL waits, blocked
+    // or not, so it can only ever be labelled as the oldest. Attaching it to a
+    // blocked count alone would date a fresh block by an older prompt's clock.
+    const ageDetail =
+      age === null
+        ? undefined
+        : project.waitingAgentCount > 1
+          ? `oldest ${age}`
+          : age === "just now"
+            ? age
+            : `waiting ${age}`;
 
     return {
       text: parts.join(" · "),
       tone: blocked > 0 ? "blocked" : "waiting",
+      // Blocked agents are inside `waitingAgentCount`, so this is every agent
+      // the sentence just accounted for and never a double count.
+      demandCount: project.waitingAgentCount,
+      ...(ageDetail !== undefined ? { ageDetail } : {}),
     };
   }
 
@@ -392,8 +537,9 @@ function classifyWorkspaceActivity(
   // waiting, but a malformed payload must not silently render as idle.
   if (project.blockedAgentCount > 0) {
     return {
-      text: pluralAgents(project.blockedAgentCount, "Agent blocked", "agents blocked"),
+      text: `${project.blockedAgentCount} blocked`,
       tone: "blocked",
+      demandCount: project.blockedAgentCount,
     };
   }
 
@@ -407,77 +553,79 @@ function classifyWorkspaceActivity(
   }
 
   // Finished work the user hasn't seen — the hand-back the attention band
-  // exists for. States the action ("ready for review") and how fresh the
-  // hand-back is, so a 3-minute-old completion and a 2-hour-old one stop
-  // rendering identically.
+  // exists for. States the action ("ready for review") and, in the age beside
+  // it, how fresh the hand-back is, so a 3-minute-old completion and a
+  // 2-hour-old one stop rendering identically.
   if (project.unacknowledgedCompletedAgentCount > 0) {
     const count = project.unacknowledgedCompletedAgentCount;
     const latest = project.latestUnacknowledgedCompletionAt;
     const oldest = project.oldestUnacknowledgedCompletionAt;
+    const line: ActivityLine = {
+      text: `${count} ready for review`,
+      tone: "review",
+      demandCount: count,
+    };
 
     if (count === 1) {
       const at = latest ?? oldest;
-      if (at === undefined) {
-        return { text: "Ready for review", tone: "review" };
-      }
+      if (at === undefined) return line;
       const finishedAge = formatWaitAge(at, nowMs);
-      const text =
-        nowMs - at < JUST_FINISHED_MS
-          ? finishedAge === "just now"
-            ? "Ready for review · just finished"
-            : `Ready for review · just finished ${agoPhrase(finishedAge)}`
-          : `Ready for review · finished ${agoPhrase(finishedAge)}`;
-      return { text, tone: "review" };
+      return {
+        ...line,
+        ageDetail:
+          nowMs - at < JUST_FINISHED_MS
+            ? finishedAge === "just now"
+              ? "just finished"
+              : `just finished ${agoPhrase(finishedAge)}`
+            : `finished ${agoPhrase(finishedAge)}`,
+      };
     }
 
-    const lead = `${count} agents ready for review`;
-    if (latest === undefined || oldest === undefined) {
-      return { text: lead, tone: "review" };
-    }
+    if (latest === undefined || oldest === undefined) return line;
     // Newest-to-oldest range; collapses when both round to the same value.
     // The producer keeps latest >= oldest, but this formatter is defensive
     // everywhere else — a swapped pair must not render as "2h–3m ago".
     const newestAge = formatRangeAge(Math.max(latest, oldest), nowMs);
     const oldestAge = formatRangeAge(Math.min(latest, oldest), nowMs);
-    const text =
-      newestAge === oldestAge
-        ? `${lead} · ${oldestAge} ago`
-        : `${lead} · ${newestAge}–${oldestAge} ago`;
-    return { text, tone: "review" };
-  }
-
-  if (project.activeAgentCount > 0) {
     return {
-      text: pluralAgents(project.activeAgentCount, "Agent running", "agents running"),
-      tone: "working",
-      // The count is the sentence here; a trailing clause would repeat it.
-      namesLiveWork: true,
+      ...line,
+      ageDetail: newestAge === oldestAge ? `${oldestAge} ago` : `${newestAge}–${oldestAge} ago`,
     };
   }
 
-  // A working assistant, above the snooze line because it is the reason the
-  // row is in Running at all when no worker is: a project whose assistant is
-  // working would otherwise announce "Agent snoozed" from the Running band.
-  if (assistant === "working") {
+  // Running is deliberately NOT a tier here. It is the second axis (#11832), and
+  // a tier is the one thing it cannot be: a tier only speaks when every louder
+  // fact is absent, which is exactly when "3 running" is least worth knowing.
+  // The count reaches the row through `withLiveness` instead, so it survives a
+  // wait, a snooze and a completion winning this cascade.
+
+  // A working assistant, but only on a row with no run of its own. It sits here
+  // — above snooze — because on such a row it is the entire reason the project
+  // is in the Running band, and "Agent snoozed" announced from that band would
+  // be a puzzle. On a row that IS running, the count already explains the band,
+  // so the assistant must not take the line: it would evict the snooze or the
+  // completion underneath it to report something the user did not start. It
+  // gets its turn further down instead.
+  if (assistant === "working" && project.activeAgentCount === 0) {
     return assistantStatus(assistant, project.assistantStateSince, nowMs);
   }
 
-  // Everything here is snoozed and nothing is running. Below `active` on
-  // purpose — a project with one snoozed agent and one working one is Running,
-  // because something genuinely is. Above the completed/dormant lines because a
-  // snoozed agent is live and coming back, which "Agent finished" would deny.
+  // Reached whether or not something is running — the count says that now, so
+  // this line is free to report the snooze underneath it. Above the
+  // completed/dormant lines because a snoozed agent is live and coming back,
+  // which "Agent finished" would deny.
   //
   // The wake time is stated once, statically. A counting-down "in 12m" would
   // pull the eye back to the row every minute, which is the precise thing the
   // user snoozed it to stop.
   if (project.snoozedAgentCount > 0) {
-    const lead = pluralAgents(project.snoozedAgentCount, "Agent snoozed", "agents snoozed");
+    const lead = `${project.snoozedAgentCount} snoozed`;
     const wakeAt = project.nextSnoozeWakeAt;
     // Absent when every snooze is the unlimited option — there is no wake time
     // to name, and inventing one would promise a return that no clock will
     // deliver.
     if (wakeAt === undefined) return { text: lead, tone: "snoozed" };
-    return { text: `${lead} · until ${formatWakeTime(wakeAt)}`, tone: "snoozed" };
+    return { text: lead, tone: "snoozed", ageDetail: `until ${formatWakeTime(wakeAt)}` };
   }
 
   // An assistant parked at its prompt, already seen. Its resting state, so it
@@ -491,24 +639,34 @@ function classifyWorkspaceActivity(
   // Everything completed has been seen: drop the action phrase and mute. The
   // fact is still worth a line — it explains why the shell is open.
   if (project.completedAgentCount > 0) {
-    const age =
-      project.latestCompletionAt !== undefined
-        ? agoPhrase(formatWaitAge(project.latestCompletionAt, nowMs))
-        : null;
-    const text =
-      project.completedAgentCount === 1
-        ? age
-          ? `Agent finished · ${age}`
-          : "Agent finished"
-        : age
-          ? `${project.completedAgentCount} agents finished · latest ${age}`
-          : `${project.completedAgentCount} agents finished`;
-    return { text, tone: "muted" };
+    const text = `${project.completedAgentCount} finished`;
+    if (project.latestCompletionAt === undefined) return { text, tone: "muted" };
+    const age = agoPhrase(formatWaitAge(project.latestCompletionAt, nowMs));
+    return {
+      text,
+      tone: "muted",
+      ageDetail: project.completedAgentCount === 1 ? age : `latest ${age}`,
+    };
   }
 
-  if (project.processCount > 0) {
+  // The working assistant's second chance, on a running row whose own agents had
+  // nothing settled to report. Below the worker lines rather than above them,
+  // for the reason it was skipped up top: the user's runs outrank the machine's
+  // own, and this line only exists to keep a row from reading as empty.
+  if (assistant === "working") {
+    return assistantStatus(assistant, project.assistantStateSince, nowMs);
+  }
+
+  // Bare processes, and only when no agent is running: `processCount` includes
+  // the PTYs those agents are sitting in, so a project with two working agents
+  // would otherwise say "3 processes running" beside a count of 2 and leave the
+  // reader to work out which number was about their work.
+  if (project.processCount > 0 && project.activeAgentCount === 0) {
     return {
-      text: pluralAgents(project.processCount, "Process running", "processes running"),
+      // "running" explicitly: a bare "1 process" leaves the reader guessing
+      // whether it is executing, idle or residue, and this row exists to say
+      // that something is still alive in a project with no agents left in it.
+      text: pluralAgents(project.processCount, "1 process running", "processes running"),
       tone: "running",
     };
   }
@@ -576,7 +734,14 @@ export function getProjectRowStatus(project: SearchableProject, nowMs: number): 
   // than showing a bare time-ago that makes the project look merely stale. The
   // reason is the row's own line; the ring beside it is only settled state, so
   // it steps aside for a resume promise that has more to say (#11822).
-  if (project.status === "closed" && project.autoParkedAt) {
+  //
+  // Withheld while agents are still running. The sweep marks a project closed
+  // at once and its counts arrive on a 200ms debounce, so this line can reach a
+  // row that is demonstrably still working — and "Suspended to free memory"
+  // beside "2 agents running" is a flat contradiction, not a stale timestamp.
+  // The row falls through to the dormant fallback for that beat, which prints
+  // no sentence at all and lets the count speak alone.
+  if (project.status === "closed" && project.autoParkedAt && project.activeAgentCount === 0) {
     return finish({ text: "Suspended to free memory", tone: "muted", allowsResumeMark: true });
   }
 


### PR DESCRIPTION
Resolves #11832.

## The problem, again

Each switcher row picks one status sentence out of a priority order: blocked, then waiting, then ready for review, then running. The first tier that matches wins the line and everything under it is dropped. So a project with one agent waiting on me and one still working reads exactly like a project where everything has stopped.

PR #11836 was meant to fix that and didn't. It gave the row's dot a second job: hue for demand, shape for liveness, drawn as a static `SpinnerCircle` arc whenever anything was executing. Three things went wrong with that:

- `SpinnerCircle` is the app's `working` glyph. `terminalStateConfig.tsx` maps it one to one, and the dock and the assistant header both spin it. The switcher was the only place it sat still, so it read as a spinner that had died.
- Hollowing the 6px disc out into a 10px ring at `1.333/16` stroke left about 0.83 CSS pixels of colour. Roughly half the ink of the old dot, spread as a hairline, so amber, green and red all trend toward grey at a glance.
- It answered "is anything moving" with a boolean. The thing I actually open the switcher for is "how many of my agents are still going", and a shape can't say four.

## What this does instead

**Running comes out of the priority order.** It was never a tier. A tier only speaks when every louder fact is absent, which is exactly when a running count is least worth knowing. The count now reaches the row through `withLiveness`, so it survives a wait, a snooze, a completion or an auto-park winning the sentence.

**The line leads with the count.** Three tokens, in the order I read them:

```
2 agents running · 2 need input · oldest 10m
```

Running in the working green, the demand phrase in its own tone, the age muted. `ageDetail` is split out of `text` so the age is never painted in the demand hue. Demand phrases are numeral-led and short now (`2 need input`, `2 blocked`, `3 ready for review`, `1 snoozed`, `1 finished`), because the long amber sentence was outweighing the green figure in front of it.

**The 8px mark is a two-colour pie.** Green for the share running, the demand hue for the rest, with a transparent notch cut at each boundary. `runningShare()` snaps to quarters and clamps to `[0.25, 0.75]`, so the mark makes one of five statements (all green, mostly green, even, mostly demand, all demand) and one running agent among twelve waiting can never round away to nothing.

The snapping isn't arbitrary. Angle is a weak channel (Cleveland and McGill rank it below position and length), and below roughly 14px a continuous pie stops being a proportion and becomes "there are two colours here". Quantising turns it into shape recognition, which does survive at this size. The notch is what keeps the split visible when the two hues are close, which `review` and `working` are in most of our palettes, since both are greens.

## Rows that contradicted their own count

Fixed along the way, all found by walking the cascade with a running count attached:

- An auto-parked project no longer says "Suspended to free memory" while its agents are still going. The sweep flips `status` to closed while the counts arrive on a 200ms debounce, so that line could land on a row that was demonstrably still working.
- A working assistant no longer takes the line from a running project's own snooze or completion. It still pre-empts them on an assistant-only row, where it's the whole reason the project is in the Running band.
- `processCount` is skipped when agents are running. It counts the PTYs those agents sit in, so the row was printing "3 processes running" next to a count of 2.
- `allowsResumeMark` is stripped on any live row. A resume is the wrong tense for an agent that never stopped.

## Notes

- `markTone` is new and deliberately differs from `tone` in two places: the dormant fallback and the assistant's presence line both hand the mark to a live run. The settled tones (`snoozed`, `muted`) do the same. Tones that are actually asking for something keep the mark, so a missing directory with two agents running still marks itself red rather than turning green.
- `isLive` is gone from `ProjectRowStatus`. It had no production reader once the arc came out, and the facts it stood for are on `agentMix` and `livenessDetail`, both of which are drawn.
- Forced colors: a solid mark is a CSS background, which forced colors pushes toward `Canvas`, and a split mark is a pair of SVG fills, which it leaves in author colours — so the 8px slot would either have gone blank or kept a hue nothing else on screen still had. There's a `.workspace-mark` repair in the forced-colors block that repaints both as `CanvasText`. Hue is gone there either way, and the line states both counts in words.
- The title-bar badge in `ProjectSwitcher.tsx` goes back to a plain dot. It's still not mounted anywhere (`Toolbar.tsx`'s pill is the real one), but leaving a static spinner in it would have been the same mistake in a second place.

## Still open

The `activity-completed` token used for "ready for review" is a muted green in most built-in themes, close enough to `activity-working` that the pie leans on its notch to read. Re-hueing it touches all 14 themes and is a separate call, so I've left it.

## Testing

`npm run check` clean. 5,245 tests green across `src/lib`, `src/components/Project`, `src/hooks` and `src/components/ui`.

New coverage worth naming: `runningShare` is asserted as properties rather than cases (always lands on a quarter, never rounds a live agent to nothing, leans the way the counts do); the cascade is pinned by computing each tier with and without a run and asserting the demand half comes back byte-identical; the two-tone mark is asserted via `data-running-share` rather than class names; and the count is checked through the row's accessible name on all three renderers, since the mark is `aria-hidden` and the line is the only carrier left.

