### PR TITLE
fix(pty): quit Codex with a gated Ctrl-C instead of injecting /quit

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
@@ -68,8 +68,12 @@ vi.mock("../../../../shared/config/agentRegistry.js", () => ({
   isRegisteredAgent: vi.fn(() => false),
   getAssistantWiredAgentIds: vi.fn(() => ["claude"]),
   getEffectiveAgentConfig: vi.fn((id: string) => {
-    if (id === "claude") return { resume: { kind: "session-id" } };
+    // The pattern is load-bearing: bookmarking gates on the id being
+    // OBSERVABLE, not merely on the resume kind (#11851).
+    if (id === "claude")
+      return { resume: { kind: "session-id", sessionIdPattern: "claude --resume ([\\w-]+)" } };
     if (id === "rolling") return { resume: { kind: "rolling-history" } };
+    if (id === "uncapturable") return { resume: { kind: "session-id" } };
     return undefined;
   }),
 }));
@@ -194,6 +198,18 @@ describe("prepareBookmark handler", () => {
 
   it("rejects NOT_BOOKMARKABLE for an agent without exact-session resume", async () => {
     ptyClient.getTerminalAsync.mockResolvedValue({ ...agentInfo, launchAgentId: "rolling" });
+    register();
+    await expect(
+      handlerFor(CHANNELS.AGENT_SESSION_PREPARE_BOOKMARK)({}, { terminalId: "term-1", label: "L" })
+    ).rejects.toMatchObject({ code: "NOT_BOOKMARKABLE" });
+    expect(ptyClient.gracefulKill).not.toHaveBeenCalled();
+  });
+
+  it("rejects NOT_BOOKMARKABLE before killing a pane whose id is unobservable", async () => {
+    // An agent can resume by exact id yet have no way to LEARN one (#11851 —
+    // Antigravity, 0 captures in 6). Gating on the resume kind alone would tear
+    // down the user's live agent and only then report that nothing was saved.
+    ptyClient.getTerminalAsync.mockResolvedValue({ ...agentInfo, launchAgentId: "uncapturable" });
     register();
     await expect(
       handlerFor(CHANNELS.AGENT_SESSION_PREPARE_BOOKMARK)({}, { terminalId: "term-1", label: "L" })

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -30,7 +30,10 @@ import type {
 } from "../../../../shared/types/ipc/agentSessionHistory.js";
 import { resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
 import { normalizeTerminalGridDimension } from "../../../../shared/types/terminal.js";
-import { DEFAULT_DANGEROUS_ARGS } from "../../../../shared/types/agentSettings.js";
+import {
+  DEFAULT_DANGEROUS_ARGS,
+  supportsExactSessionCapture,
+} from "../../../../shared/types/agentSettings.js";
 import {
   getAssistantWiredAgentIds,
   getEffectiveAgentConfig,
@@ -991,10 +994,13 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         message: `Terminal ${terminalId} is not a live agent pane`,
       });
     }
-    // Only agents with an exact-session resume can be bookmarked — a
-    // rolling-history / resume-latest agent has no specific conversation to pin.
-    const resume = getEffectiveAgentConfig(info.launchAgentId)?.resume;
-    if (resume?.kind !== "session-id") {
+    // Only agents whose session id can actually be OBSERVED can be bookmarked —
+    // a rolling-history / resume-latest agent has no specific conversation to
+    // pin. Gated on the capture path rather than on `resume.kind` alone: an
+    // agent can resume by exact id yet have no way to learn one (#11851), and
+    // the capture below is a KILL, so passing that pane through here would tear
+    // down the user's live agent and only then report that nothing was saved.
+    if (!supportsExactSessionCapture(info.launchAgentId)) {
       throw new AppError({
         code: "NOT_BOOKMARKABLE",
         message: `Agent ${info.launchAgentId} has no exact-session resume to bookmark`,

--- a/electron/services/pty/TerminalGracefulShutdown.ts
+++ b/electron/services/pty/TerminalGracefulShutdown.ts
@@ -210,6 +210,13 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
   let shutdownBuffer = "";
   let resolved = false;
 
+  // The overall budget as an instant, not just a timer. A timer callback only
+  // runs when the loop gets a turn, so an `onData` that began before the
+  // deadline can settle a gate and have its continuation write AFTER it if the
+  // pty-host stalls in between — on app quit, under load, which is exactly when
+  // that happens. The timer wakes the teardown; this is what bounds the writes.
+  const deadlineAt = startedAt + GRACEFUL_SHUTDOWN_TIMEOUT_MS;
+
   // Held for the whole teardown so nothing else can write between our bytes,
   // and released on every exit path by the `finally` below — including a
   // throwing `host.kill()`, which would otherwise strand the terminal's input.
@@ -322,6 +329,16 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
         const stripped = stripAnsiCodes(shutdownBuffer);
         const match = pattern.exec(stripped);
         if (match?.[1]) {
+          // A session id in this chunk means the agent is already on its way
+          // out, so this chunk must never also read as permission to press
+          // again — including when the capture below turns out to be
+          // provisional. A chunk ending exactly after the id (no trailing
+          // boundary yet) would otherwise fall through to the gate and fire the
+          // next press at the precise moment the hint is printing. Leaving the
+          // arm pending is safe: the next chunk completes the capture, `onExit`
+          // takes EOF as the boundary, or the per-press timer stops the
+          // escalation without ending the teardown.
+          if (gateArm) settleGateArm(false);
           // Guard against truncated captures when the PTY delivers the
           // session-ID line in chunks. Every `sessionIdPattern` ends with a
           // greedy `[\w-]+` capture group — if that group ends at the buffer
@@ -367,6 +384,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
       const runGatedEscalation = async (signal: AgentGatedKeyEscalation): Promise<void> => {
         while (pressesSent < signal.maxPresses) {
           if (resolved) return;
+          if (Date.now() >= deadlineAt) return;
 
           // Same demotion guard the quit path uses between its writes: if the
           // agent exited between presses, the next one lands in a plain shell.

--- a/electron/services/pty/TerminalGracefulShutdown.ts
+++ b/electron/services/pty/TerminalGracefulShutdown.ts
@@ -1,6 +1,8 @@
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
+import type { AgentGatedKeyEscalation } from "../../../shared/config/agentRegistry.js";
 import { supportsSessionIdAssignment } from "../../../shared/types/agentSettings.js";
 import { stripAnsiCodes } from "../../../shared/utils/artifactParser.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import {
   GRACEFUL_SHUTDOWN_TIMEOUT_MS,
   GRACEFUL_SHUTDOWN_BUFFER_SIZE,
@@ -16,6 +18,12 @@ const logger = createLogger("pty:TerminalGracefulShutdown");
 export interface TerminalGracefulShutdownHost {
   readonly terminalInfo: TerminalInfo;
   readonly isAgentLive: boolean;
+  /**
+   * Take exclusive ownership of the terminal's input for the teardown and
+   * return the release. Shutdown writes bypass the normal input path, so
+   * anything still draining there would interleave with them (#11851).
+   */
+  acquireInputLock(): () => void;
   kill(reason: string): void;
 }
 
@@ -30,6 +38,13 @@ export interface TerminalGracefulShutdownHost {
  * mid-stream or on the last-chance match at exit doesn't explain anything,
  * because nothing went wrong. Failure stays granular for the opposite reason:
  * each bucket points at a different suspect.
+ *
+ * A stalled gated escalation (#11851) deliberately gets no bucket of its own.
+ * Running out of gate matches or presses stops the ESCALATION, not the
+ * teardown: the remaining budget is still spent listening, so the terminal
+ * ends on whichever of `captured` / `exited-no-match` / `timeout` it earns.
+ * How far the escalation got rides the same log line as `pressesSent` instead,
+ * which keeps every outcome a distinct branch.
  *
  * `preassigned` is a third thing: not a capture that succeeded but a capture
  * that was never needed, because the id was chosen at launch (#11782). It stays
@@ -51,7 +66,9 @@ export type GracefulShutdownOutcome =
   | "prelude-write-failed"
   | "demoted-during-clear-delay"
   | "demoted-during-submit-delay"
-  | "quit-signal-write-failed";
+  | "demoted-during-gated-signal"
+  | "quit-signal-write-failed"
+  | "gated-signal-write-failed";
 
 /**
  * Issue the agent's `quitCommand` / `shutdownKeySequence`, optionally wait
@@ -84,6 +101,11 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
   // Never log the captured session id itself — it's a resume credential
   // (`--resume <id>`) and `logs.getAll` serves this buffer to agents verbatim.
   // `captured` carries everything the issue asked for.
+  // Presses the gated escalation actually got out (#11851). Zero for every
+  // agent on the `quitCommand` path, which is what makes the field readable:
+  // a Codex line reading `captured` with 1 press and one reading `timeout`
+  // with 3 are different stories, and neither needs its own outcome bucket.
+  let pressesSent = 0;
   const logOutcome = (outcome: GracefulShutdownOutcome, captured: boolean): void => {
     logger.info("Graceful shutdown capture outcome", {
       terminalId: terminal.id,
@@ -91,6 +113,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
       agentId: liveAgentId,
       outcome,
       captured,
+      pressesSent,
       elapsedMs: Date.now() - startedAt,
     });
   };
@@ -156,9 +179,15 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
     host.kill("graceful-shutdown");
     return preassignedId;
   }
+  // Structured escalation is `session-id`-only, so the union has to be narrowed
+  // before the field exists. It REPLACES the quit-command path rather than
+  // preceding it: the type makes them mutually exclusive, and falling back to
+  // `quitCommand` after a stalled escalation would write the very text into the
+  // transcript that the escalation exists to keep out (#11851).
+  const shutdownSignal = resume.kind === "session-id" ? resume.shutdownSignal : undefined;
   const quitCommand = resume.quitCommand;
   const shutdownKeySequence = resume.shutdownKeySequence;
-  if (!quitCommand && !shutdownKeySequence) {
+  if (!quitCommand && !shutdownKeySequence && !shutdownSignal) {
     logOutcome("no-quit-signal", false);
     return null;
   }
@@ -167,151 +196,292 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
   );
   const quitSubmitMode = agentConfig?.capabilities?.quitSubmitMode ?? "split-write";
 
-  // Only `session-id` triggers the post-quit pattern-match capture loop —
-  // other kinds (rolling-history, named-target, project-scoped) just send
-  // the quit signal and resolve null. Lesson from #4781: never run the
-  // capture loop for non-`session-id` agents — directory-scoped sessions
-  // (Kiro) don't emit IDs and the ghost regex would either time out or
-  // false-positive on unrelated output.
-  const pattern = resume.kind === "session-id" ? new RegExp(resume.sessionIdPattern) : null;
+  // Only a declared `sessionIdPattern` triggers the post-quit capture loop.
+  // Other kinds (rolling-history, named-target, project-scoped) just send the
+  // quit signal and resolve null. Lesson from #4781: never run the capture loop
+  // for non-`session-id` agents — directory-scoped sessions (Kiro) don't emit
+  // IDs and the ghost regex would either time out or false-positive on
+  // unrelated output. A `session-id` agent that omits the pattern is the same
+  // case (#11851): it resumes by an id this tree can hold but never observes
+  // one being printed, so a pattern would be a ghost regex too.
+  const sessionIdPattern = resume.kind === "session-id" ? resume.sessionIdPattern : undefined;
+  const pattern = sessionIdPattern ? new RegExp(sessionIdPattern) : null;
 
   let shutdownBuffer = "";
   let resolved = false;
 
-  return new Promise<string | null>((resolve) => {
-    // Pre-declared so finish() can dispose them centrally (forward reference).
-    // No-op sentinel keeps disposal safe even on synchronous early-exit paths
-    // before assignment. node-pty's IDisposable scan is idempotent, so the
-    // existing branch-local dispose calls remain harmless double-disposes.
-    let origOnData: { dispose(): void } = { dispose() {} };
-    let origOnExit: { dispose(): void } = { dispose() {} };
+  // Held for the whole teardown so nothing else can write between our bytes,
+  // and released on every exit path by the `finally` below — including a
+  // throwing `host.kill()`, which would otherwise strand the terminal's input.
+  const releaseInputLock = host.acquireInputLock();
+  try {
+    return await new Promise<string | null>((resolve) => {
+      // Pre-declared so finish() can dispose them centrally (forward reference).
+      // No-op sentinel keeps disposal safe even on synchronous early-exit paths
+      // before assignment. node-pty's IDisposable scan is idempotent, so the
+      // existing branch-local dispose calls remain harmless double-disposes.
+      let origOnData: { dispose(): void } = { dispose() {} };
+      let origOnExit: { dispose(): void } = { dispose() {} };
 
-    const finish = (sessionId: string | null, outcome: GracefulShutdownOutcome) => {
-      if (resolved) return;
-      resolved = true;
-      clearTimeout(timer);
+      // At most one gate arm is live at a time, created immediately before each
+      // press and settled by the first of: a fresh `gateText` match in
+      // `gateProbe`, its own per-press timer, or `finish()`. `settled` is the
+      // latch that makes Ratatui's full-frame redraws harmless — the footer is
+      // repainted on every tick, so without it one press would keep re-arming
+      // the escalation off a single stale frame.
+      let gateArm: {
+        settled: boolean;
+        timer: NodeJS.Timeout | null;
+        resolve: (matched: boolean) => void;
+      } | null = null;
+      // Output since the CURRENT press only. Reset per press rather than scanned
+      // by offset into `shutdownBuffer`, whose tail truncation would shift any
+      // stored index; accumulating also means a `gateText` split across two PTY
+      // chunks still matches.
+      let gateProbe = "";
 
-      // Dispose listeners before kill() so a synchronous onExit during teardown
-      // can't re-enter this path. Lesson from #4974: order matters in shutdown.
-      origOnData.dispose();
-      origOnExit.dispose();
+      const settleGateArm = (matched: boolean): void => {
+        const arm = gateArm;
+        if (!arm || arm.settled) return;
+        arm.settled = true;
+        if (arm.timer) clearTimeout(arm.timer);
+        gateArm = null;
+        arm.resolve(matched);
+      };
 
-      if (sessionId) {
-        terminal.agentSessionId = sessionId;
-      }
+      const finish = (sessionId: string | null, outcome: GracefulShutdownOutcome) => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timer);
+        // Unblocks an escalation parked on its gate and clears that press's
+        // timer; the loop re-checks `resolved` after every await, so it stops
+        // rather than sending a press into a process that is already going.
+        settleGateArm(false);
 
-      // Logged before kill() so a throwing kill can't erase the diagnostic, and
-      // after the `resolved` guard so a losing racer never double-logs.
-      logOutcome(outcome, sessionId !== null);
-
-      host.kill("graceful-shutdown");
-      resolve(sessionId);
-    };
-
-    const timer = setTimeout(() => finish(null, "timeout"), GRACEFUL_SHUTDOWN_TIMEOUT_MS);
-
-    origOnData = terminal.ptyProcess.onData((data: string) => {
-      if (resolved) return;
-      if (!pattern) return;
-
-      shutdownBuffer += data;
-      if (shutdownBuffer.length > GRACEFUL_SHUTDOWN_BUFFER_SIZE) {
-        shutdownBuffer = shutdownBuffer.slice(-GRACEFUL_SHUTDOWN_BUFFER_SIZE);
-      }
-
-      const stripped = stripAnsiCodes(shutdownBuffer);
-      const match = pattern.exec(stripped);
-      if (match?.[1]) {
-        // Guard against truncated captures when the PTY delivers the
-        // session-ID line in chunks. Every `sessionIdPattern` ends with a
-        // greedy `[\w-]+` capture group — if that group ends at the buffer
-        // tail, the regex's character class may still be consuming a token
-        // that is mid-arrival. Wait for at least one trailing character
-        // (newline, space, prompt glyph) that confirms the token boundary
-        // has been seen. Without this, Gemini's resume hint can be captured
-        // as "fc1c3a37-2294-4" instead of the full 36-char UUID, leaving
-        // restore-on-restart to hand the agent an invalid identifier.
-        const captureEnd = match.index + match[0].length;
-        if (captureEnd < stripped.length) {
-          finish(match[1], "captured");
-        }
-      }
-    });
-
-    origOnExit = terminal.ptyProcess.onExit(() => {
-      if (!pattern) {
-        finish(null, "exited-no-pattern");
-        return;
-      }
-      const stripped = stripAnsiCodes(shutdownBuffer);
-      const match = pattern.exec(stripped);
-      const sessionId = match?.[1] ?? null;
-      finish(sessionId, sessionId ? "captured" : "exited-no-match");
-    });
-
-    // Clear any partial user input at the agent prompt before issuing the quit command.
-    // Without this prelude, concatenated input (e.g. "half-typed/quit") is treated as a
-    // chat message by the agent and the session-ID line is never emitted. See #5785.
-    //   \x05 — Ctrl-E: move cursor to end of line
-    //   \x15 — Ctrl-U: erase from cursor to beginning of line
-    // ESC is avoided because it navigates/dismisses TUI state in bubbletea and ink CLIs.
-    (async () => {
-      try {
-        terminal.ptyProcess.write("\x05\x15");
-      } catch {
+        // Dispose listeners before kill() so a synchronous onExit during teardown
+        // can't re-enter this path. Lesson from #4974: order matters in shutdown.
         origOnData.dispose();
         origOnExit.dispose();
-        finish(null, "prelude-write-failed");
-        return;
-      }
 
-      await new Promise<void>((r) => setTimeout(r, GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS));
-
-      if (resolved) return;
-
-      // Re-check liveness: if the agent demoted during the clear-delay
-      // window (e.g. user typed /quit milliseconds before shutdown), the
-      // pending write would land in a plain shell.
-      if (!host.isAgentLive) {
-        origOnData.dispose();
-        origOnExit.dispose();
-        finish(null, "demoted-during-clear-delay");
-        return;
-      }
-
-      try {
-        if (shutdownKeySequence) {
-          terminal.ptyProcess.write(shutdownKeySequence);
+        if (sessionId) {
+          terminal.agentSessionId = sessionId;
         }
-        if (quitCommand) {
-          if (quitSubmitMode === "single-write") {
-            // Ink-based TUIs (e.g. Claude Code) require body + Enter in the
-            // same PTY write so the slash-command parser sees them in one
-            // event-loop tick. A non-zero gap is interpreted as deliberate
-            // slow typing, so the command never submits and the
-            // session-ID line is never echoed (issue #6981).
-            terminal.ptyProcess.write(quitCommand + "\r");
-          } else {
-            terminal.ptyProcess.write(quitCommand);
-            await new Promise<void>((r) => setTimeout(r, quitSubmitEnterDelayMs));
 
-            if (resolved) return;
+        // Logged before kill() so a throwing kill can't erase the diagnostic, and
+        // after the `resolved` guard so a losing racer never double-logs.
+        logOutcome(outcome, sessionId !== null);
 
-            if (!host.isAgentLive) {
-              origOnData.dispose();
-              origOnExit.dispose();
-              finish(null, "demoted-during-submit-delay");
-              return;
-            }
+        // A throwing kill must not escape. `finish()` is reached from the
+        // `onData`/`onExit` listeners, so an escaping throw unwinds into
+        // node-pty's emitter instead of this promise — which would then never
+        // settle, stranding the input lock the `finally` below releases and
+        // hanging the caller's own timeout. Swallow it and resolve: the
+        // terminal is still live, and `PtyManager.gracefulKill` already has a
+        // fallback kill for exactly that observation.
+        try {
+          host.kill("graceful-shutdown");
+        } catch (error) {
+          logger.warn("Graceful shutdown kill threw; falling through to the caller", {
+            terminalId: terminal.id,
+            error: formatErrorMessage(error, "kill threw a non-Error"),
+          });
+        }
+        resolve(sessionId);
+      };
 
-            terminal.ptyProcess.write("\r");
+      const timer = setTimeout(() => finish(null, "timeout"), GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+
+      origOnData = terminal.ptyProcess.onData((data: string) => {
+        if (resolved) return;
+
+        // Gate first so the escalation is never starved by an early `return`
+        // below, but settled only after the capture check — a frame that carries
+        // both the footer and the resume hint must resolve as a capture, not as
+        // permission to press again.
+        if (gateArm && shutdownSignal) {
+          gateProbe += data;
+          if (gateProbe.length > GRACEFUL_SHUTDOWN_BUFFER_SIZE) {
+            gateProbe = gateProbe.slice(-GRACEFUL_SHUTDOWN_BUFFER_SIZE);
           }
         }
-      } catch {
-        origOnData.dispose();
-        origOnExit.dispose();
-        finish(null, "quit-signal-write-failed");
-      }
-    })();
-  });
+        const gateMatched =
+          gateArm !== null &&
+          shutdownSignal !== undefined &&
+          stripAnsiCodes(gateProbe).includes(shutdownSignal.gateText);
+
+        if (!pattern) {
+          if (gateMatched) settleGateArm(true);
+          return;
+        }
+
+        shutdownBuffer += data;
+        if (shutdownBuffer.length > GRACEFUL_SHUTDOWN_BUFFER_SIZE) {
+          shutdownBuffer = shutdownBuffer.slice(-GRACEFUL_SHUTDOWN_BUFFER_SIZE);
+        }
+
+        const stripped = stripAnsiCodes(shutdownBuffer);
+        const match = pattern.exec(stripped);
+        if (match?.[1]) {
+          // Guard against truncated captures when the PTY delivers the
+          // session-ID line in chunks. Every `sessionIdPattern` ends with a
+          // greedy `[\w-]+` capture group — if that group ends at the buffer
+          // tail, the regex's character class may still be consuming a token
+          // that is mid-arrival. Wait for at least one trailing character
+          // (newline, space, prompt glyph) that confirms the token boundary
+          // has been seen. Without this, Gemini's resume hint can be captured
+          // as "fc1c3a37-2294-4" instead of the full 36-char UUID, leaving
+          // restore-on-restart to hand the agent an invalid identifier.
+          const captureEnd = match.index + match[0].length;
+          if (captureEnd < stripped.length) {
+            finish(match[1], "captured");
+            return;
+          }
+        }
+
+        if (gateMatched) settleGateArm(true);
+      });
+
+      origOnExit = terminal.ptyProcess.onExit(() => {
+        if (!pattern) {
+          finish(null, "exited-no-pattern");
+          return;
+        }
+        const stripped = stripAnsiCodes(shutdownBuffer);
+        const match = pattern.exec(stripped);
+        const sessionId = match?.[1] ?? null;
+        finish(sessionId, sessionId ? "captured" : "exited-no-match");
+      });
+
+      // Escalate one press at a time, gated on the agent's own confirm-to-quit
+      // footer (#11851). Nothing else is written: no input-clear prelude (its
+      // Ctrl-E/Ctrl-U readline assumption does not hold here, and Ctrl-C already
+      // clears leftover composer text on its own) and no quit command.
+      //
+      // Running out of gate matches or presses ends the ESCALATION, never the
+      // teardown. The measured resume hint lands 0.76-1.16s after the first
+      // press, so killing at the first unanswered gate would throw away captures
+      // the old code would have caught — a press that quit the agent outright,
+      // or one that dismissed a modal without redrawing the footer, prints its
+      // hint with no further footer ever appearing. Stop pressing, keep
+      // listening, and let the normal outcomes decide.
+      const runGatedEscalation = async (signal: AgentGatedKeyEscalation): Promise<void> => {
+        while (pressesSent < signal.maxPresses) {
+          if (resolved) return;
+
+          // Same demotion guard the quit path uses between its writes: if the
+          // agent exited between presses, the next one lands in a plain shell.
+          if (!host.isAgentLive) {
+            finish(null, "demoted-during-gated-signal");
+            return;
+          }
+
+          // Armed BEFORE the write so a footer arriving in the same tick as the
+          // press is still counted; `gateProbe` resets with it so only output
+          // produced by THIS press can satisfy it.
+          gateProbe = "";
+          const armed = new Promise<boolean>((resolveArm) => {
+            const arm = {
+              settled: false,
+              timer: null as NodeJS.Timeout | null,
+              resolve: resolveArm,
+            };
+            arm.timer = setTimeout(() => settleGateArm(false), signal.perPressTimeoutMs);
+            gateArm = arm;
+          });
+
+          try {
+            terminal.ptyProcess.write(signal.keySequence);
+          } catch {
+            settleGateArm(false);
+            finish(null, "gated-signal-write-failed");
+            return;
+          }
+          pressesSent++;
+
+          const matchedGate = await armed;
+          if (resolved) return;
+
+          // A press whose gate never matched is the end of the escalation: with
+          // no positive proof the TUI is still holding raw mode, the next press
+          // could be a real SIGINT that kills the process before it prints
+          // anything (three ungated presses produced nothing at all after 12s).
+          if (!matchedGate) return;
+        }
+      };
+
+      (async () => {
+        if (shutdownSignal) {
+          await runGatedEscalation(shutdownSignal);
+          return;
+        }
+
+        // Clear any partial user input at the agent prompt before issuing the quit command.
+        // Without this prelude, concatenated input (e.g. "half-typed/quit") is treated as a
+        // chat message by the agent and the session-ID line is never emitted. See #5785.
+        //   \x05 — Ctrl-E: move cursor to end of line
+        //   \x15 — Ctrl-U: erase from cursor to beginning of line
+        // ESC is avoided because it navigates/dismisses TUI state in bubbletea and ink CLIs.
+        // Not sent on the gated path above: Ctrl-E/Ctrl-U assume readline semantics that
+        // the agents taking that path don't have, and Ctrl-C clears the composer anyway.
+        try {
+          terminal.ptyProcess.write("\x05\x15");
+        } catch {
+          origOnData.dispose();
+          origOnExit.dispose();
+          finish(null, "prelude-write-failed");
+          return;
+        }
+
+        await new Promise<void>((r) => setTimeout(r, GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS));
+
+        if (resolved) return;
+
+        // Re-check liveness: if the agent demoted during the clear-delay
+        // window (e.g. user typed /quit milliseconds before shutdown), the
+        // pending write would land in a plain shell.
+        if (!host.isAgentLive) {
+          origOnData.dispose();
+          origOnExit.dispose();
+          finish(null, "demoted-during-clear-delay");
+          return;
+        }
+
+        try {
+          if (shutdownKeySequence) {
+            terminal.ptyProcess.write(shutdownKeySequence);
+          }
+          if (quitCommand) {
+            if (quitSubmitMode === "single-write") {
+              // Ink-based TUIs (e.g. Claude Code) require body + Enter in the
+              // same PTY write so the slash-command parser sees them in one
+              // event-loop tick. A non-zero gap is interpreted as deliberate
+              // slow typing, so the command never submits and the
+              // session-ID line is never echoed (issue #6981).
+              terminal.ptyProcess.write(quitCommand + "\r");
+            } else {
+              terminal.ptyProcess.write(quitCommand);
+              await new Promise<void>((r) => setTimeout(r, quitSubmitEnterDelayMs));
+
+              if (resolved) return;
+
+              if (!host.isAgentLive) {
+                origOnData.dispose();
+                origOnExit.dispose();
+                finish(null, "demoted-during-submit-delay");
+                return;
+              }
+
+              terminal.ptyProcess.write("\r");
+            }
+          }
+        } catch {
+          origOnData.dispose();
+          origOnExit.dispose();
+          finish(null, "quit-signal-write-failed");
+        }
+      })();
+    });
+  } finally {
+    releaseInputLock();
+  }
 }

--- a/electron/services/pty/TerminalInputController.ts
+++ b/electron/services/pty/TerminalInputController.ts
@@ -30,7 +30,49 @@ export interface TerminalInputControllerHost {
 }
 
 export class TerminalInputController {
+  private shutdownLockDepth = 0;
+  private inputGeneration = 0;
+
   constructor(private readonly host: TerminalInputControllerHost) {}
+
+  /** True while a graceful shutdown owns the PTY's input stream. */
+  get isInputLocked(): boolean {
+    return this.shutdownLockDepth > 0;
+  }
+
+  /**
+   * Take exclusive ownership of this terminal's input for the duration of a
+   * graceful shutdown, and return the release (#11851).
+   *
+   * Teardown writes bypass this controller entirely and go straight to
+   * `ptyProcess.write()`. A single quit write mostly got away with that, but a
+   * gated Ctrl-C escalation spans a second or more, and anything landing
+   * between two presses — a live keystroke on the ≤512-byte fast path, a
+   * chunked paste still pacing, the trailing Enter of an in-flight submit —
+   * either lands in the agent's composer or breaks the press economics the
+   * gate depends on.
+   *
+   * Blocked input is DROPPED, not buffered. Replaying it after teardown would
+   * deliver it to whatever occupies the pane next — a plain shell, or nothing
+   * at all — which is worse than losing a keystroke aimed at a process that is
+   * being killed.
+   *
+   * Bumping the generation is what stops work already past its entry guard:
+   * `performSubmit` re-reads it after every await, so a submit awaiting its
+   * pre-Enter delay when the lock engages abandons the Enter instead of
+   * submitting whatever the shutdown signal left in the composer.
+   */
+  acquireShutdownInputLock(): () => void {
+    this.shutdownLockDepth++;
+    this.inputGeneration++;
+    this.host.writeQueue.cancelPendingInput();
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.shutdownLockDepth--;
+    };
+  }
 
   /**
    * Throwing variant of `write` for the small-keystroke fast path. Used by the
@@ -45,6 +87,15 @@ export class TerminalInputController {
    */
   tryWrite(data: string, traceId?: string): { ok: boolean; error?: NodeJS.ErrnoException } {
     const terminal = this.host.terminalInfo;
+    if (this.isInputLocked) {
+      // EBUSY rather than EBADF: the PTY is fine, it is just not ours to write
+      // to right now. Broadcast surfaces this per target instead of silently
+      // dropping the keystroke into a terminal mid-teardown.
+      return {
+        ok: false,
+        error: Object.assign(new Error("terminal is shutting down"), { code: "EBUSY" }),
+      };
+    }
     if (terminal.isExited) {
       return {
         ok: false,
@@ -88,6 +139,9 @@ export class TerminalInputController {
 
   write(data: string, traceId?: string): void {
     const terminal = this.host.terminalInfo;
+    if (this.isInputLocked) {
+      return;
+    }
     terminal.lastInputTime = Date.now();
 
     if (terminal.isExited) {
@@ -175,7 +229,7 @@ export class TerminalInputController {
   }
 
   submit(text: string): void {
-    if (this.host.terminalInfo.isExited) {
+    if (this.isInputLocked || this.host.terminalInfo.isExited) {
       return;
     }
 
@@ -202,7 +256,7 @@ export class TerminalInputController {
    */
   stage(text: string): void {
     const terminal = this.host.terminalInfo;
-    if (terminal.isExited || !terminal.ptyProcess) {
+    if (this.isInputLocked || terminal.isExited || !terminal.ptyProcess) {
       return;
     }
     const normalized = normalizeSubmitText(text);
@@ -224,6 +278,13 @@ export class TerminalInputController {
 
   async performSubmit(text: string): Promise<void> {
     const terminal = this.host.terminalInfo;
+    // Re-checked after every await below: a shutdown lock taken mid-submit must
+    // abandon the trailing Enter, or it submits whatever the teardown signal
+    // left in the composer (#11851).
+    const generation = this.inputGeneration;
+    if (this.isInputLocked) {
+      return;
+    }
     terminal.lastInputTime = Date.now();
 
     if (terminal.isExited) {
@@ -271,6 +332,10 @@ export class TerminalInputController {
 
     await this.host.writeQueue.waitForInputWriteDrain();
 
+    if (this.isInputLocked || this.inputGeneration !== generation) {
+      return;
+    }
+
     if (useOutputSettle) {
       await this.host.writeQueue.waitForOutputSettle({
         debounceMs: OUTPUT_SETTLE_DEBOUNCE_MS,
@@ -282,6 +347,10 @@ export class TerminalInputController {
     }
 
     if (!this.host.terminalInfo.ptyProcess) {
+      return;
+    }
+
+    if (this.isInputLocked || this.inputGeneration !== generation) {
       return;
     }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1391,6 +1391,7 @@ export class TerminalProcess {
       get isAgentLive() {
         return self.isAgentLive;
       },
+      acquireInputLock: () => this.inputController.acquireShutdownInputLock(),
       kill: (reason) => this.kill(reason),
     });
   }

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -173,6 +173,7 @@ export class TerminalProcess {
   private semanticBufferManager!: SemanticBufferManager;
   private identityWatcher!: IdentityWatcher;
 
+  private gracefulShutdownInFlight: Promise<string | null> | null = null;
   private writeQueue!: WriteQueue;
   private inputController!: TerminalInputController;
   private ptyDataPipeline!: PtyDataPipeline;
@@ -1383,10 +1384,23 @@ export class TerminalProcess {
     };
   }
 
+  /**
+   * Single-flight: concurrent callers share one teardown rather than each
+   * running their own. The entry gates inside `runGracefulShutdown` (`isExited`
+   * / `wasKilled`) can't do this — neither is set until the teardown finishes,
+   * so two callers arriving together both pass. Overlapping teardowns used to
+   * be merely untidy (two `/quit` writes), but a gated key escalation makes
+   * them dangerous: each loop counts only its OWN presses, so two loops can
+   * write past the cap the agent's config exists to enforce (#11851). Hibernate
+   * racing app quit, or a bookmark capture racing a project close, is enough.
+   */
   gracefulShutdown(): Promise<string | null> {
+    if (this.gracefulShutdownInFlight) {
+      return this.gracefulShutdownInFlight;
+    }
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
-    return runGracefulShutdown({
+    const inFlight = runGracefulShutdown({
       terminalInfo: this.terminalInfo,
       get isAgentLive() {
         return self.isAgentLive;
@@ -1394,6 +1408,22 @@ export class TerminalProcess {
       acquireInputLock: () => this.inputController.acquireShutdownInputLock(),
       kill: (reason) => this.kill(reason),
     });
+    this.gracefulShutdownInFlight = inFlight;
+    // Latch cleared on a SEPARATE chain rather than by returning `inFlight
+    // .finally(...)`: chaining would add a microtask hop to every caller, and
+    // the preassigned path's whole promise is that it settles without spending
+    // anything. Cleared only if we are still the current attempt, so a late
+    // settle from a superseded promise can't unlatch a newer one. The cost is a
+    // one-tick window after settlement where a fresh call gets the finished
+    // promise back — which answers with the same captured id, and by then the
+    // terminal is killed anyway, so a real second teardown had nothing to do.
+    const clear = () => {
+      if (self.gracefulShutdownInFlight === inFlight) {
+        self.gracefulShutdownInFlight = null;
+      }
+    };
+    void inFlight.then(clear, clear);
+    return inFlight;
   }
 
   kill(

--- a/electron/services/pty/WriteQueue.ts
+++ b/electron/services/pty/WriteQueue.ts
@@ -108,6 +108,35 @@ export class WriteQueue {
   }
 
   /**
+   * Drop everything queued and wake every drain waiter, WITHOUT disposing:
+   * the queue stays usable afterwards. The reusable half of {@link dispose},
+   * added for the graceful-shutdown input lock (#11851) — teardown writes go
+   * straight to the PTY, so a chunked paste still pacing through this queue
+   * would interleave its bytes with the shutdown signal, and a gated
+   * escalation spanning a second or more is wide open to that.
+   *
+   * `submitInFlight` is deliberately left alone. It is owned by the running
+   * `drainSubmitQueue` loop, which clears it in its own `finally`; forcing it
+   * false here would let a second submit start while the first is still
+   * awaiting, which is the exact interleaving the flag exists to prevent.
+   * Draining the queues is enough — the in-flight submit finds nothing left to
+   * do, and `TerminalInputController`'s generation check stops it writing.
+   */
+  cancelPendingInput(): void {
+    if (this.disposed) return;
+    if (this.inputWriteTimeout) {
+      clearTimeout(this.inputWriteTimeout);
+      this.inputWriteTimeout = null;
+    }
+    this.inputWriteQueue = [];
+    this.submitQueue = [];
+    for (const resolve of this.inputWriteDrainResolvers) {
+      resolve();
+    }
+    this.inputWriteDrainResolvers = [];
+  }
+
+  /**
    * Cancel the pacing timer, drop pending chunks and submits, and mark the
    * queue disposed. Idempotent. Any in-flight `waitForInputWriteDrain` /
    * `waitForOutputSettle` resolves immediately on the next poll because the

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -3,8 +3,9 @@ import type { IPty } from "node-pty";
 import { TerminalProcess } from "../TerminalProcess.js";
 import type { SpawnContext } from "../terminalSpawn.js";
 import { GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS, GRACEFUL_SHUTDOWN_TIMEOUT_MS } from "../types.js";
-import { SUBMIT_ENTER_DELAY_MS } from "../terminalInput.js";
+import { SUBMIT_ENTER_DELAY_MS, OUTPUT_SETTLE_MAX_WAIT_MS } from "../terminalInput.js";
 import { getAgentConfig } from "../../../../shared/config/agentRegistry.js";
+import type { AgentGatedKeyEscalation } from "../../../../shared/config/agentRegistry.js";
 import { logBuffer } from "../../LogBuffer.js";
 import { getLogLevelOverrides, setLogLevelOverrides } from "../../../utils/logger.js";
 
@@ -19,13 +20,20 @@ vi.mock("node-pty", () => {
 const CTRL_C = String.fromCharCode(3);
 
 /**
- * Mirrors `shared/config/agents/codex.ts`'s `shutdownSignal`. Deliberately NOT
- * imported from the config: these tests drive the escalation's timing, and
- * reading the same numbers the implementation reads would make them agree by
- * construction. If Codex's tuning changes, these should fail and be re-derived.
+ * Codex's declared escalation, read from the config the implementation reads.
+ * Copying the numbers here instead would let an implementation that hardcoded
+ * them — rather than honouring `shutdownSignal` — pass every test below.
  */
-const CODEX_PER_PRESS_TIMEOUT_MS = 750;
-const CODEX_MAX_PRESSES = 3;
+function codexShutdownSignal(): AgentGatedKeyEscalation {
+  const resume = getAgentConfig("codex")?.resume;
+  if (resume?.kind !== "session-id" || !resume.shutdownSignal) {
+    throw new Error("codex must declare a gated shutdown signal");
+  }
+  return resume.shutdownSignal;
+}
+
+const CODEX_PER_PRESS_TIMEOUT_MS = codexShutdownSignal().perPressTimeoutMs;
+const CODEX_MAX_PRESSES = codexShutdownSignal().maxPresses;
 
 interface MockPtyHandles {
   pty: IPty;
@@ -58,7 +66,13 @@ function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
   });
 
   const pty: Partial<IPty> = {
-    pid: 123,
+    // 0, not a real-looking pid: TerminalProcess.kill() routes through
+    // ProcessTreeKiller, which for any pid > 0 calls process.kill(pid, ...) /
+    // taskkill for real and arms a 500ms SIGKILL sweep. Every test here ends in
+    // a kill, and several advance past that delay, so a plausible pid would
+    // signal whatever actually owns it on this machine. `pid <= 0` takes the
+    // early bail that only calls the mocked pty.kill().
+    pid: 0,
     cols: 80,
     rows: 24,
     write: (data: string) => {
@@ -395,6 +409,52 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     await expect(shutdownPromise).resolves.toBe("live-agent");
   });
 
+  it("captures a session ID after split-submitting the quit command", async () => {
+    // The split-write happy path: body, gap, Enter, then the resume hint. Claude
+    // covers capture on the single-write path and Kiro covers a split write with
+    // no capture, so without this nothing covers their composition. Used to be
+    // Codex's test; Codex now takes the gated Ctrl-C path (#11851).
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "gemini");
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit");
+
+    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
+    expect(handles.writeMock).toHaveBeenCalledTimes(3);
+    expect(handles.writeMock.mock.calls[2]?.[0]).toBe("\r");
+
+    handles.emitData("gemini --resume gemini-session-123\n");
+    await expect(shutdownPromise).resolves.toBe("gemini-session-123");
+    expect(terminal.getInfo().agentSessionId).toBe("gemini-session-123");
+  });
+
+  it("sends the quit command but scrapes nothing for a session-id agent with no pattern", async () => {
+    // Antigravity resumes by an id it holds but never prints one this tree can
+    // match, so it declares no `sessionIdPattern` (#11851). It must still be
+    // quit — just without a ghost regex burning the budget on unrelated output.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "antigravity");
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
+
+    expect(handles.writeMock.mock.calls.map((c) => c[0]).join("")).toContain("/quit");
+
+    // Output that the old fabricated pattern was shaped to match must not be
+    // captured, because nothing claims it can be.
+    handles.emitData("Run agy --conversation not-a-real-capture\n");
+    handles.emitExit(0);
+
+    await expect(shutdownPromise).resolves.toBeNull();
+    expect(terminal.getInfo().agentSessionId).toBeUndefined();
+  });
+
   it("skips Enter when the split-write agent demotes during the quit-submit delay", async () => {
     // Mid-flight liveness guard for the split-write path only — a readline/
     // Ratatui CLI writes the body and Enter as separate PTY writes with a delay
@@ -678,6 +738,109 @@ describe("TerminalProcess.gracefulShutdown — gated Ctrl-C escalation (#11851)"
     expect(handles.writeMock).toHaveBeenCalledTimes(1);
   });
 
+  it("stops at the cap when repaints keep arriving in separate frames", async () => {
+    // The repaint test above emits its frames back to back, so the loop never
+    // gets a turn between them. node-pty delivers real frames in separate
+    // callbacks with microtasks in between, which is the sequence that can walk
+    // the escalation forward one press per repaint. Ratatui redraws the whole
+    // frame, so a repaint emitted while a press is already tearing the TUI down
+    // is indistinguishable from a genuine re-arm — the cap is the only thing
+    // standing between that and the press count measured as unrecoverable.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    for (let frame = 0; frame < 6; frame++) {
+      handles.emitData(footerFrame());
+      // Yield fully between frames so each one meets a freshly armed press.
+      await vi.advanceTimersByTimeAsync(1);
+    }
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(CODEX_MAX_PRESSES);
+
+    handles.emitData("  codex resume capped-across-frames\n");
+    await expect(promise).resolves.toBe("capped-across-frames");
+    expect(handles.writeMock).toHaveBeenCalledTimes(CODEX_MAX_PRESSES);
+  });
+
+  it("never presses again off a frame that already carries a session id", async () => {
+    // PTY chunk boundaries are arbitrary. A chunk ending exactly after the id
+    // has no trailing boundary yet, so the capture is held as provisional — but
+    // the agent is plainly quitting, and letting that same chunk satisfy the
+    // gate would fire the next press at the exact moment the hint is printing.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    // Footer and an unterminated resume hint in one chunk.
+    handles.emitData(`${footerFrame()}\n  codex resume boundary-id`);
+    await vi.advanceTimersByTimeAsync(1);
+
+    // Provisional capture, so not resolved yet — but no press either.
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    handles.emitData("\n");
+    await expect(promise).resolves.toBe("boundary-id");
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one escalation between concurrent teardown callers", async () => {
+    // Neither `isExited` nor `wasKilled` is set until a teardown finishes, so
+    // two callers arriving together both clear the entry gates. Each loop
+    // counts only its own presses, so without single-flighting the aggregate
+    // sails past the cap the config exists to enforce.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const first = terminal.gracefulShutdown();
+    const second = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    handles.emitData(footerFrame());
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handles.writeMock).toHaveBeenCalledTimes(CODEX_MAX_PRESSES);
+
+    handles.emitData("  codex resume shared-teardown\n");
+    await expect(first).resolves.toBe("shared-teardown");
+    await expect(second).resolves.toBe("shared-teardown");
+    expect(handles.writeMock).toHaveBeenCalledTimes(CODEX_MAX_PRESSES);
+  });
+
+  it("writes no press once the wall-clock budget is spent, even if a gate answers late", async () => {
+    // The overall timer only fires when the loop gets a turn. An onData that
+    // began before the deadline can settle a gate and have its continuation run
+    // after it, which on a loaded machine mid-app-quit is a real ordering.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    // Freeze the loop's view of the clock past the deadline WITHOUT letting the
+    // overall timer run — the exact interleaving the write-site check exists for.
+    vi.setSystemTime(Date.now() + GRACEFUL_SHUTDOWN_TIMEOUT_MS + 1);
+    handles.emitData(footerFrame());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+    await expect(promise).resolves.toBeNull();
+  });
+
   it("leaves room to hear the resume hint even when a press stalls", async () => {
     // A press whose gate never answers costs a full `perPressTimeoutMs` and
     // then ends the escalation — but that press may well be the one that quit
@@ -686,16 +849,13 @@ describe("TerminalProcess.gracefulShutdown — gated Ctrl-C escalation (#11851)"
     // escalation must not be able to consume it outright. Read from the real
     // config so a retune has to face both numbers.
     const MEASURED_HINT_LATENCY_MS = 1160;
-    const resume = getAgentConfig("codex")?.resume;
-    expect(resume?.kind).toBe("session-id");
-    if (resume?.kind !== "session-id") return;
-    const signal = resume.shutdownSignal;
-    expect(signal).toBeDefined();
-    const perPress = signal?.perPressTimeoutMs ?? Infinity;
-    expect(perPress + MEASURED_HINT_LATENCY_MS).toBeLessThan(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
-    expect((signal?.maxPresses ?? Infinity) * perPress).toBeLessThanOrEqual(
-      GRACEFUL_SHUTDOWN_TIMEOUT_MS
-    );
+    const signal = codexShutdownSignal();
+    // Worst case is every gate but the last one answering at its deadline, then
+    // the final press printing its hint at the slowest measured latency. Both
+    // halves have to fit, so neither term may be checked on its own.
+    const worstCaseMs =
+      (signal.maxPresses - 1) * signal.perPressTimeoutMs + MEASURED_HINT_LATENCY_MS;
+    expect(worstCaseMs).toBeLessThan(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
   });
 
   it("gives up at the overall budget rather than pressing past it", async () => {
@@ -765,6 +925,34 @@ describe("TerminalProcess.gracefulShutdown — input lock (#11851)", () => {
 
     handles.emitData("  codex resume paste-dropped\n");
     await expect(promise).resolves.toBe("paste-dropped");
+  });
+
+  it("abandons the Enter of a submit that was already in flight", async () => {
+    // The entry guards catch input that STARTS after the lock. This is the other
+    // half: performSubmit writes the body, awaits its pre-Enter gap, then writes
+    // Enter. A teardown beginning inside that gap must leave the Enter unsent,
+    // or it submits whatever the shutdown signal left in the composer.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    terminal.submit("half-typed prompt");
+    await vi.advanceTimersByTimeAsync(1);
+    const afterBody = handles.writeMock.mock.calls.map((c) => c[0]).join("");
+    expect(afterBody).toContain("half-typed prompt");
+    expect(afterBody).not.toContain("\r");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Let the submit's pre-Enter wait elapse inside the teardown. The gated
+    // path writes only Ctrl-C, so any "\r" in the log can only be that Enter.
+    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS + OUTPUT_SETTLE_MAX_WAIT_MS);
+
+    expect(handles.writeMock.mock.calls.map((c) => c[0]).join("")).not.toContain("\r");
+
+    handles.emitData("  codex resume submit-abandoned\n");
+    await expect(promise).resolves.toBe("submit-abandoned");
   });
 
   it("releases the lock even when the kill on the way out throws", async () => {
@@ -1108,6 +1296,10 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
       terminal.getInfo().detectedAgentId = undefined;
       await vi.advanceTimersByTimeAsync(CODEX_PER_PRESS_TIMEOUT_MS);
       await expect(promise).resolves.toBeNull();
+      // Logging the right outcome is not enough: the point of the guard is that
+      // the press never went out, and an implementation that wrote first and
+      // logged after would satisfy the outcome check alone.
+      expect(handles.writeMock).toHaveBeenCalledTimes(1);
       return soleOutcome();
     },
 

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -4,12 +4,28 @@ import { TerminalProcess } from "../TerminalProcess.js";
 import type { SpawnContext } from "../terminalSpawn.js";
 import { GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS, GRACEFUL_SHUTDOWN_TIMEOUT_MS } from "../types.js";
 import { SUBMIT_ENTER_DELAY_MS } from "../terminalInput.js";
+import { getAgentConfig } from "../../../../shared/config/agentRegistry.js";
 import { logBuffer } from "../../LogBuffer.js";
 import { getLogLevelOverrides, setLogLevelOverrides } from "../../../utils/logger.js";
 
 vi.mock("node-pty", () => {
   return { spawn: vi.fn() };
 });
+
+// Built rather than written as an escape in a pattern: eslint's `no-control-regex`
+// is error-level in this repo, so a raw control char must never reach a regex
+// literal. Keeping the byte in one named constant also makes every assertion
+// below read as "the Ctrl-C press" rather than as an opaque escape.
+const CTRL_C = String.fromCharCode(3);
+
+/**
+ * Mirrors `shared/config/agents/codex.ts`'s `shutdownSignal`. Deliberately NOT
+ * imported from the config: these tests drive the escalation's timing, and
+ * reading the same numbers the implementation reads would make them agree by
+ * construction. If Codex's tuning changes, these should fail and be re-derived.
+ */
+const CODEX_PER_PRESS_TIMEOUT_MS = 750;
+const CODEX_MAX_PRESSES = 3;
 
 interface MockPtyHandles {
   pty: IPty;
@@ -379,35 +395,16 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     await expect(shutdownPromise).resolves.toBe("live-agent");
   });
 
-  it("captures Codex session ID after split-submitting /quit", async () => {
-    const handles = createMockPty();
-    const terminal = createAgentTerminal(handles, "codex");
-
-    const shutdownPromise = terminal.gracefulShutdown();
-    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-
-    expect(handles.writeMock).toHaveBeenCalledTimes(2);
-    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
-    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit");
-
-    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
-    expect(handles.writeMock).toHaveBeenCalledTimes(3);
-    expect(handles.writeMock.mock.calls[2]?.[0]).toBe("\r");
-
-    handles.emitData("codex resume codex-session-123\n");
-    await expect(shutdownPromise).resolves.toBe("codex-session-123");
-    expect(terminal.getInfo().agentSessionId).toBe("codex-session-123");
-  });
-
   it("skips Enter when the split-write agent demotes during the quit-submit delay", async () => {
-    // Mid-flight liveness guard for the split-write path only — Codex (and
-    // other Ratatui/readline CLIs) writes the body and Enter as separate
-    // PTY writes with a delay between them. If the agent demotes during
-    // that gap, the trailing Enter must be skipped so it doesn't land in a
-    // plain shell. Claude uses single-write so this guard isn't reachable
-    // for it; using `codex` keeps the split-write coverage explicit.
+    // Mid-flight liveness guard for the split-write path only — a readline/
+    // Ratatui CLI writes the body and Enter as separate PTY writes with a delay
+    // between them. If the agent demotes during that gap, the trailing Enter
+    // must be skipped so it doesn't land in a plain shell. Claude uses
+    // single-write so this guard isn't reachable for it, and Codex no longer
+    // writes a quit command at all (#11851) — Gemini is the split-write agent
+    // that still exercises it.
     const handles = createMockPty();
-    const terminal = createAgentTerminal(handles, "codex");
+    const terminal = createAgentTerminal(handles, "gemini");
 
     const shutdownPromise = terminal.gracefulShutdown();
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
@@ -472,6 +469,326 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
 
     await expect(shutdownPromise).resolves.toBeNull();
     expect(terminal.getInfo().agentSessionId).toBeUndefined();
+  });
+});
+
+describe("TerminalProcess.gracefulShutdown — gated Ctrl-C escalation (#11851)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Every resolved shutdown ends in TerminalProcess.kill(), which arms a
+    // ~500ms SIGKILL escalation in ProcessTreeKiller. Left queued, the next
+    // test's timer advance fires it and sweeps the mock's pid — a real number —
+    // against the real OS.
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  /** One Ratatui repaint of the confirm-to-quit footer, with its usual ANSI dressing. */
+  function footerFrame(): string {
+    return "\x1b[2K\x1b[0G  Ctrl+C again to quit  \x1b[0m";
+  }
+
+  it("writes Ctrl-C as its very first byte, never the prelude or a quit command", async () => {
+    // The whole point of the issue: `\x05\x15` assumes readline semantics
+    // Codex does not have, and `/quit` mid-turn is queued as a chat message
+    // that ends up in the user's transcript and in Codex's own resume picker.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe(CTRL_C);
+
+    handles.emitData("  codex resume gated-1\n");
+    await expect(promise).resolves.toBe("gated-1");
+
+    const written = handles.writeMock.mock.calls.map((c) => c[0]);
+    expect(written.every((chunk) => chunk === CTRL_C)).toBe(true);
+    expect(written.join("")).not.toContain("/quit");
+  });
+
+  it("stops at one press when that press was enough", async () => {
+    // An idle session with a clean composer quits on the first press and never
+    // prints the footer at all. Pressing again on a process already on its way
+    // out is the fatal case, so silence must mean stop.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    handles.emitData("  codex resume single-press\n");
+    await expect(promise).resolves.toBe("single-press");
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends the next press only after a fresh gate match", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    // Most of the per-press window passes with no footer: still one press.
+    await vi.advanceTimersByTimeAsync(CODEX_PER_PRESS_TIMEOUT_MS - 50);
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    handles.emitData(footerFrame());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe(CTRL_C);
+
+    handles.emitData("  codex resume two-press\n");
+    await expect(promise).resolves.toBe("two-press");
+  });
+
+  it("spends one press per gate arm no matter how often the footer repaints", async () => {
+    // Ratatui repaints the whole frame every tick, so one absorbed press
+    // produces the footer text over and over. Counting matches instead of
+    // latching per arm would burn the press budget on a single confirmation and
+    // walk straight into the third press that measured as fatal.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    // Five repaints of the same confirmation, all landing before the loop gets
+    // a chance to arm its next press.
+    for (let i = 0; i < 5; i++) {
+      handles.emitData(footerFrame());
+    }
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+
+    handles.emitData("  codex resume no-double-fire\n");
+    await expect(promise).resolves.toBe("no-double-fire");
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("matches a gate string split across two PTY chunks", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    handles.emitData("  Ctrl+C ag");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    handles.emitData("ain to quit  ");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+
+    handles.emitData("  codex resume split-gate\n");
+    await expect(promise).resolves.toBe("split-gate");
+  });
+
+  it("keeps listening for the whole budget after the gate goes quiet", async () => {
+    // The measured resume hint lands 0.76-1.16s after the first press. Treating
+    // an unanswered gate as a reason to finish would kill the terminal while its
+    // hint was still in flight — worse than the code this replaces.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Gate never matches: the escalation gives up after one press...
+    await vi.advanceTimersByTimeAsync(CODEX_PER_PRESS_TIMEOUT_MS + 10);
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    // ...but the terminal is still alive and still scraping.
+    handles.emitData("  codex resume late-hint\n");
+    await expect(promise).resolves.toBe("late-hint");
+    expect(terminal.getInfo().agentSessionId).toBe("late-hint");
+  });
+
+  it("never exceeds the configured press cap, and still waits out the budget", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Answer every gate, so only the cap can stop the escalation.
+    for (let i = 0; i < CODEX_MAX_PRESSES + 2; i++) {
+      handles.emitData(footerFrame());
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    expect(handles.writeMock).toHaveBeenCalledTimes(CODEX_MAX_PRESSES);
+
+    handles.emitData("  codex resume capped\n");
+    await expect(promise).resolves.toBe("capped");
+    expect(handles.writeMock).toHaveBeenCalledTimes(CODEX_MAX_PRESSES);
+  });
+
+  it("sends no further press once the process has exited", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    handles.emitData("  codex resume on-exit-capture");
+    handles.emitExit(0);
+
+    await expect(promise).resolves.toBe("on-exit-capture");
+
+    // A footer racing in behind the exit must not resurrect the escalation.
+    handles.emitData(footerFrame());
+    await vi.advanceTimersByTimeAsync(CODEX_PER_PRESS_TIMEOUT_MS * 2);
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops pressing when the capture wins between two presses", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // One frame carrying both the footer and the resume hint: the capture has
+    // to win, or the escalation presses again on an agent already quitting.
+    handles.emitData(`${footerFrame()}\n  codex resume same-frame\n`);
+    await expect(promise).resolves.toBe("same-frame");
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves room to hear the resume hint even when a press stalls", async () => {
+    // A press whose gate never answers costs a full `perPressTimeoutMs` and
+    // then ends the escalation — but that press may well be the one that quit
+    // the agent, whose hint was measured arriving up to 1160ms later. So the
+    // stall plus the hint has to fit the per-terminal budget, and the whole
+    // escalation must not be able to consume it outright. Read from the real
+    // config so a retune has to face both numbers.
+    const MEASURED_HINT_LATENCY_MS = 1160;
+    const resume = getAgentConfig("codex")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind !== "session-id") return;
+    const signal = resume.shutdownSignal;
+    expect(signal).toBeDefined();
+    const perPress = signal?.perPressTimeoutMs ?? Infinity;
+    expect(perPress + MEASURED_HINT_LATENCY_MS).toBeLessThan(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+    expect((signal?.maxPresses ?? Infinity) * perPress).toBeLessThanOrEqual(
+      GRACEFUL_SHUTDOWN_TIMEOUT_MS
+    );
+  });
+
+  it("gives up at the overall budget rather than pressing past it", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+
+    await expect(promise).resolves.toBeNull();
+    expect(handles.writeMock.mock.calls.length).toBeLessThanOrEqual(CODEX_MAX_PRESSES);
+  });
+});
+
+describe("TerminalProcess.gracefulShutdown — input lock (#11851)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("refuses user input for the duration and releases it when the teardown ends", async () => {
+    // Teardown writes bypass TerminalInputController entirely, so without the
+    // lock a keystroke on the <=512-byte fast path lands between two presses —
+    // in the agent's composer, and in the middle of the press economics the
+    // gate depends on.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const writesBefore = handles.writeMock.mock.calls.length;
+    terminal.write("hello");
+    terminal.submit("some prompt");
+    terminal.stage("staged text");
+    expect(handles.writeMock.mock.calls.length).toBe(writesBefore);
+    expect(terminal.tryWrite("x").ok).toBe(false);
+
+    handles.emitData("  codex resume locked\n");
+    await expect(promise).resolves.toBe("locked");
+  });
+
+  it("drops input still pacing through the write queue", async () => {
+    // A chunked paste mid-flight would otherwise keep emitting its chunks on
+    // the pacing timer, straight into the shutdown exchange.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+
+    terminal.write("x".repeat(4096));
+    const queuedBefore = handles.writeMock.mock.calls.length;
+    expect(queuedBefore).toBeGreaterThan(0);
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Only the Ctrl-C press was added; the rest of the paste is gone.
+    expect(handles.writeMock.mock.calls.length).toBe(queuedBefore + 1);
+    await vi.advanceTimersByTimeAsync(CODEX_PER_PRESS_TIMEOUT_MS);
+    const written = handles.writeMock.mock.calls.map((c) => c[0]);
+    expect(written.filter((chunk) => chunk.startsWith("x"))).toHaveLength(1);
+
+    handles.emitData("  codex resume paste-dropped\n");
+    await expect(promise).resolves.toBe("paste-dropped");
+  });
+
+  it("releases the lock even when the kill on the way out throws", async () => {
+    // finish() calls host.kill() from inside the onData listener, so a throw
+    // there unwinds into node-pty's emitter rather than this promise — leaving
+    // it forever pending and the input lock forever held. The captured id has
+    // to come back regardless of whether the kill succeeded.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles, "codex");
+    vi.spyOn(terminal, "kill").mockImplementation(() => {
+      throw new Error("kill exploded");
+    });
+
+    const promise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+    handles.emitData("  codex resume kill-throws\n");
+
+    await expect(promise).resolves.toBe("kill-throws");
+
+    // Input works again despite the throw.
+    const writesBefore = handles.writeMock.mock.calls.length;
+    terminal.write("after");
+    expect(handles.writeMock.mock.calls.length).toBe(writesBefore + 1);
   });
 });
 
@@ -761,16 +1078,48 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
     },
 
     // ...whereas here the split-write body landed and only Enter is missing.
-    // Codex splits body and Enter, so only it reaches this gate.
+    // Gemini splits body and Enter, so it reaches this gate; Codex takes the
+    // gated-escalation path below instead and never writes a quit command.
     async demotedDuringSubmitDelay() {
       const handles = createMockPty();
-      const terminal = createAgentTerminal(handles, "codex");
+      const terminal = createAgentTerminal(handles, "gemini");
       const promise = terminal.gracefulShutdown();
       await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
       terminal.getInfo().agentState = "exited";
       terminal.getInfo().detectedAgentId = undefined;
       await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
       await expect(promise).resolves.toBeNull();
+      return soleOutcome();
+    },
+
+    // The gated escalation's own demotion guard (#11851). Codex's presses are
+    // separated by a gate wait, so the agent can exit between them just as it
+    // can between a split-write body and its Enter — and the next press would
+    // land in whatever replaced it.
+    async demotedDuringGatedSignal() {
+      const handles = createMockPty();
+      const terminal = createAgentTerminal(handles, "codex");
+      const promise = terminal.gracefulShutdown();
+      await Promise.resolve();
+      await Promise.resolve();
+      // Satisfy the first press's gate so the loop comes back for a second one.
+      handles.emitData("  Ctrl+C again to quit\n");
+      terminal.getInfo().agentState = "exited";
+      terminal.getInfo().detectedAgentId = undefined;
+      await vi.advanceTimersByTimeAsync(CODEX_PER_PRESS_TIMEOUT_MS);
+      await expect(promise).resolves.toBeNull();
+      return soleOutcome();
+    },
+
+    // Distinct from `quit-signal-write-failed`: a dead PTY on the gated path
+    // has written no slash command to be half-submitted, so the two failures
+    // point at different suspects.
+    async gatedSignalWriteFailed() {
+      const handles = createMockPty((data: string) => {
+        if (data === CTRL_C) throw new Error("pty dead");
+      });
+      const terminal = createAgentTerminal(handles, "codex");
+      await expect(terminal.gracefulShutdown()).resolves.toBeNull();
       return soleOutcome();
     },
   };
@@ -857,6 +1206,7 @@ describe("TerminalProcess.gracefulShutdown — outcome logging", () => {
       "captured",
       "elapsedMs",
       "outcome",
+      "pressesSent",
       "projectId",
       "terminalId",
     ]);

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -309,6 +309,91 @@ describe("WriteQueue.waitForInputWriteDrain", () => {
   });
 });
 
+describe("WriteQueue.cancelPendingInput", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("drops queued chunks and stops the pacing timer", async () => {
+    const m = makeOptions();
+    const queue = new WriteQueue(m.options);
+
+    queue.enqueueChunked("y".repeat(WRITE_MAX_CHUNK_SIZE * 4));
+    const writesBeforeCancel = m.writeToPty.mock.calls.length;
+    expect(queue.hasPendingWrites()).toBe(true);
+
+    queue.cancelPendingInput();
+
+    expect(queue.hasPendingWrites()).toBe(false);
+    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS * 10);
+    expect(m.writeToPty.mock.calls.length).toBe(writesBeforeCancel);
+  });
+
+  it("wakes drain waiters instead of leaving them parked forever", async () => {
+    // performSubmit awaits waitForInputWriteDrain mid-sequence. Cancelling
+    // without resolving would deadlock that submit and leak submitInFlight.
+    const m = makeOptions();
+    const queue = new WriteQueue(m.options);
+
+    queue.enqueueChunked("z".repeat(WRITE_MAX_CHUNK_SIZE * 4));
+    let drained = false;
+    const waiting = queue.waitForInputWriteDrain().then(() => {
+      drained = true;
+    });
+
+    queue.cancelPendingInput();
+    await waiting;
+    expect(drained).toBe(true);
+  });
+
+  it("leaves the queue usable, unlike dispose", () => {
+    // The distinction the shutdown input lock depends on (#11851): the lock is
+    // released when teardown ends, and on a teardown that resolved without
+    // killing the pane the queue has to still accept input.
+    const m = makeOptions();
+    const queue = new WriteQueue(m.options);
+
+    queue.enqueueChunked("a".repeat(WRITE_MAX_CHUNK_SIZE * 3));
+    queue.cancelPendingInput();
+    m.writeToPty.mockClear();
+
+    queue.enqueueChunked("after-cancel");
+    expect(m.writeToPty).toHaveBeenCalledWith("after-cancel");
+  });
+
+  it("drops queued submits without stranding the in-flight slot", async () => {
+    const m = makeOptions();
+    let releaseFirst: (() => void) | undefined;
+    m.performSubmit.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        })
+    );
+    const queue = new WriteQueue(m.options);
+
+    queue.submit("first");
+    queue.submit("second");
+    await Promise.resolve();
+    expect(m.performSubmit).toHaveBeenCalledTimes(1);
+
+    queue.cancelPendingInput();
+    releaseFirst?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // "second" was dropped, and the freed in-flight slot still accepts work.
+    expect(m.performSubmit).toHaveBeenCalledTimes(1);
+    m.performSubmit.mockImplementation(async () => {});
+    queue.submit("third");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(m.performSubmit).toHaveBeenCalledWith("third");
+  });
+});
+
 describe("WriteQueue.dispose", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -310,7 +310,20 @@ export const PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS = 5 * 60 * 1000; // 5 min
 export { TRASH_TTL_MS } from "../../../shared/config/trash.js";
 
 // Graceful shutdown configuration
-export const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 2500;
+//
+// Total per-terminal budget for the quit signal plus the session-id scrape.
+// Raised from 2500ms for the gated Ctrl-C escalation (#11851), which spends
+// part of its budget waiting for the agent's confirm-to-quit footer between
+// presses before the resume hint can even arrive (measured at 0.76-1.16s).
+//
+// The real ceiling is the 4000ms per-project race in `electron/lifecycle/
+// shutdown.ts` — a terminal that outlives it has its captured id discarded.
+// 3000ms leaves 1000ms for the PtyClient RPC round-trip on either side of this
+// window. Both layers are `Promise.all` (terminals within a project, projects
+// within the quit), so this budget is parallel, not additive: ten terminals
+// cost one terminal's wall clock, not ten. Raise it only against that 4000ms
+// number, and only with the RPC round-trip still covered.
+export const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 3000;
 export const GRACEFUL_SHUTDOWN_BUFFER_SIZE = 8 * 1024;
 // Delay between writing the input-clear prelude and the quit command. Without this gap,
 // the target CLI's async event loop can drop or corrupt the quit command bytes under load.

--- a/scripts/pattern-discovery/runner.ts
+++ b/scripts/pattern-discovery/runner.ts
@@ -146,10 +146,18 @@ async function runSession(options: RunnerOptions): Promise<string> {
       }
 
       if (promptIndex >= options.prompts.length && silenceMs > 5000 && bootDetected) {
-        console.log("[runner] All prompts sent, sending quit command");
-        const quitCmd = agentConfig.resume?.quitCommand ?? "/quit";
-        ptyProcess.write(quitCmd + "\r");
         clearInterval(promptInterval);
+        // No blind `/quit` fallback: an agent without a `quitCommand` uses a
+        // structured shutdown signal instead (#11851), and typing a slash
+        // command into it lands in the conversation the corpus is capturing.
+        const quitCmd = agentConfig.resume?.quitCommand;
+        if (quitCmd) {
+          console.log("[runner] All prompts sent, sending quit command");
+          ptyProcess.write(quitCmd + "\r");
+        } else {
+          console.log("[runner] All prompts sent, no quit command — killing the harness");
+          ptyProcess.kill();
+        }
       }
     }, 1000);
 

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -533,7 +533,7 @@ describe("mistral configuration", () => {
 
   it("captures session IDs from 'vibe --resume {id}' output", () => {
     const resume = getAgentConfig("mistral")?.resume;
-    if (resume?.kind === "session-id") {
+    if (resume?.kind === "session-id" && resume.sessionIdPattern) {
       const re = new RegExp(resume.sessionIdPattern);
       const match = "Or: vibe --resume abc-123-def-456".match(re);
       expect(match?.[1]).toBe("abc-123-def-456");
@@ -1060,16 +1060,80 @@ describe("screen-mode flag capabilities (#11423)", () => {
 });
 
 describe("resume configuration", () => {
-  it("session-id agents have a quitCommand and a sessionIdPattern", () => {
-    const ids = getAgentIds();
-    for (const id of ids) {
+  it("every session-id agent declares exactly one shutdown protocol", () => {
+    // Weaker than "must have a quitCommand" on purpose: an agent may take a
+    // structured `shutdownSignal` instead (#11851). Stronger in the direction
+    // that matters — declaring BOTH is the bug the type exists to prevent, since
+    // a gated escalation exists precisely to avoid writing a slash command.
+    for (const id of getAgentIds()) {
       const resume = getAgentConfig(id)?.resume;
-      if (resume?.kind === "session-id") {
-        expect(typeof resume.args).toBe("function");
-        expect(resume.quitCommand).toBeTruthy();
-        expect(resume.sessionIdPattern).toBeTruthy();
-      }
+      if (resume?.kind !== "session-id") continue;
+      expect(typeof resume.args).toBe("function");
+      const declared = [resume.quitCommand, resume.shutdownSignal].filter(Boolean);
+      expect(
+        declared,
+        `${id} must declare a quitCommand or a shutdownSignal, not both`
+      ).toHaveLength(1);
     }
+  });
+
+  it("no session-id agent ships an empty or uncompilable sessionIdPattern", () => {
+    // The field is optional now — an agent whose id was never observable omits
+    // it rather than carrying a pattern that matches nothing (#11851). What is
+    // NOT allowed is a present-but-useless one: an empty string matches
+    // everywhere, and an uncompilable one throws inside the teardown listener.
+    for (const id of getAgentIds()) {
+      const resume = getAgentConfig(id)?.resume;
+      if (resume?.kind !== "session-id" || resume.sessionIdPattern === undefined) continue;
+      expect(resume.sessionIdPattern, `${id} declares an empty sessionIdPattern`).not.toBe("");
+      const compiled = new RegExp(resume.sessionIdPattern);
+      // One capture group is what the teardown reads back as the id.
+      expect(compiled.exec("")?.[1] ?? null).toBeNull();
+    }
+  });
+
+  it("an agent with no capture path still has a way to resume", () => {
+    // Dropping a fabricated pattern must not strand the agent: without either a
+    // capture path or a resume-latest fallback it could never come back at all.
+    for (const id of getAgentIds()) {
+      const resume = getAgentConfig(id)?.resume;
+      if (resume?.kind !== "session-id") continue;
+      const canCapture = Boolean(resume.sessionIdPattern) || Boolean(resume.assignSessionIdArgs);
+      if (canCapture) continue;
+      expect(
+        resume.resumeLatestArgs?.length,
+        `${id} can neither capture nor resume-latest`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("codex quits on a gated Ctrl-C and writes no slash command", () => {
+    const resume = getAgentConfig("codex")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind !== "session-id") return;
+    // The `/quit` write is what landed in the user's own transcript (#11851).
+    expect(resume.quitCommand).toBeUndefined();
+    const signal = resume.shutdownSignal;
+    expect(signal?.kind).toBe("gated-key-escalation");
+    expect(signal?.keySequence).toBe(String.fromCharCode(3));
+    // A gate the TUI never prints would silently degrade to a single press.
+    expect("  Ctrl+C again to quit  ").toContain(signal?.gateText);
+    // Budget fit lives in the pty suite, which owns GRACEFUL_SHUTDOWN_TIMEOUT_MS —
+    // importing it here would drag electron into a shared/ test.
+    expect(signal?.maxPresses).toBeGreaterThan(1);
+    expect(signal?.perPressTimeoutMs).toBeGreaterThan(0);
+  });
+
+  it("antigravity claims no session-id capture it cannot make", () => {
+    // 0 captures in 6 teardowns, and no public `agy` output to verify a
+    // corrected pattern against (#11851). Resuming by an id it already holds
+    // still works, and `-c` remains the path that actually restores.
+    const resume = getAgentConfig("antigravity")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind !== "session-id") return;
+    expect(resume.sessionIdPattern).toBeUndefined();
+    expect(resume.args("conv-42")).toEqual(["--conversation", "conv-42"]);
+    expect(resume.resumeLatestArgs).toEqual(["-c"]);
   });
 
   it("claude is session-id and produces --resume flag args", () => {
@@ -1163,7 +1227,7 @@ describe("resume configuration", () => {
   it("goose sessionIdPattern extracts the id from the session-closed line", () => {
     const resume = getAgentConfig("goose")?.resume;
     expect(resume?.kind).toBe("session-id");
-    if (resume?.kind === "session-id") {
+    if (resume?.kind === "session-id" && resume.sessionIdPattern) {
       const re = new RegExp(resume.sessionIdPattern);
       const match = re.exec("● session closed · 20260429_1");
       expect(match?.[1]).toBe("20260429_1");

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -534,12 +534,12 @@ describe("mistral configuration", () => {
 
   it("captures session IDs from 'vibe --resume {id}' output", () => {
     const resume = getAgentConfig("mistral")?.resume;
-    if (resume?.kind === "session-id" && resume.sessionIdPattern) {
-      const re = new RegExp(resume.sessionIdPattern);
-      const match = "Or: vibe --resume abc-123-def-456".match(re);
-      expect(match?.[1]).toBe("abc-123-def-456");
-      expect("vibe --continue".match(re)).toBeNull();
-    }
+    if (resume?.kind !== "session-id") throw new Error("mistral resume must be session-id");
+    expect(resume.sessionIdPattern).toBeDefined();
+    const re = new RegExp(resume.sessionIdPattern!);
+    const match = "Or: vibe --resume abc-123-def-456".match(re);
+    expect(match?.[1]).toBe("abc-123-def-456");
+    expect("vibe --continue".match(re)).toBeNull();
   });
 
   it("relies on prompt fast-path without a per-agent quiet override", () => {
@@ -1243,12 +1243,11 @@ describe("resume configuration", () => {
 
   it("goose sessionIdPattern extracts the id from the session-closed line", () => {
     const resume = getAgentConfig("goose")?.resume;
-    expect(resume?.kind).toBe("session-id");
-    if (resume?.kind === "session-id" && resume.sessionIdPattern) {
-      const re = new RegExp(resume.sessionIdPattern);
-      const match = re.exec("● session closed · 20260429_1");
-      expect(match?.[1]).toBe("20260429_1");
-    }
+    if (resume?.kind !== "session-id") throw new Error("goose resume must be session-id");
+    expect(resume.sessionIdPattern).toBeDefined();
+    const re = new RegExp(resume.sessionIdPattern!);
+    const match = re.exec("● session closed · 20260429_1");
+    expect(match?.[1]).toBe("20260429_1");
   });
 });
 

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -19,6 +19,7 @@ import {
   type AssistantSupports,
 } from "../agentRegistry.js";
 import { UserAgentConfigSchema } from "../../types/userAgentRegistry.js";
+import { buildResumeCommand, buildResumeLatestCommand } from "../../types/agentSettings.js";
 import {
   BUILT_IN_AGENT_IDS,
   LAUNCHABLE_AGENT_IDS,
@@ -1069,11 +1070,20 @@ describe("resume configuration", () => {
       const resume = getAgentConfig(id)?.resume;
       if (resume?.kind !== "session-id") continue;
       expect(typeof resume.args).toBe("function");
-      const declared = [resume.quitCommand, resume.shutdownSignal].filter(Boolean);
+      // `shutdownKeySequence` counts as part of the legacy protocol: pairing it
+      // with a structured signal is the same contradiction, and leaving it out
+      // of this check would let that pair through.
+      const legacy = Boolean(resume.quitCommand) || Boolean(resume.shutdownKeySequence);
+      const structured = Boolean(resume.shutdownSignal);
       expect(
-        declared,
-        `${id} must declare a quitCommand or a shutdownSignal, not both`
+        [legacy, structured].filter(Boolean),
+        `${id} must declare a legacy quit signal or a shutdownSignal, not both`
       ).toHaveLength(1);
+      if (legacy) {
+        // An empty string is falsy to the teardown's own `if (quitCommand)`
+        // guard, so it would silently send nothing at all.
+        expect(resume.quitCommand ?? resume.shutdownKeySequence).not.toBe("");
+      }
     }
   });
 
@@ -1086,9 +1096,12 @@ describe("resume configuration", () => {
       const resume = getAgentConfig(id)?.resume;
       if (resume?.kind !== "session-id" || resume.sessionIdPattern === undefined) continue;
       expect(resume.sessionIdPattern, `${id} declares an empty sessionIdPattern`).not.toBe("");
-      const compiled = new RegExp(resume.sessionIdPattern);
-      // One capture group is what the teardown reads back as the id.
-      expect(compiled.exec("")?.[1] ?? null).toBeNull();
+      // The teardown reads `match[1]`, so a pattern with no capture group can
+      // never yield an id no matter what the agent prints. Alternating with an
+      // empty branch forces a match on "" so the group count is readable even
+      // when the pattern itself matches nothing.
+      const groupCount = (new RegExp(`${resume.sessionIdPattern}|`).exec("")?.length ?? 1) - 1;
+      expect(groupCount, `${id}'s sessionIdPattern has no capture group`).toBeGreaterThanOrEqual(1);
     }
   });
 
@@ -1132,8 +1145,12 @@ describe("resume configuration", () => {
     expect(resume?.kind).toBe("session-id");
     if (resume?.kind !== "session-id") return;
     expect(resume.sessionIdPattern).toBeUndefined();
-    expect(resume.args("conv-42")).toEqual(["--conversation", "conv-42"]);
-    expect(resume.resumeLatestArgs).toEqual(["-c"]);
+    // Staying `session-id` is load-bearing, not incidental: the resume-latest
+    // builder is gated on that kind, so reclassifying would silently take away
+    // the `-c` restore that actually works. Pinned as built commands rather than
+    // raw arrays so a change to either builder has to face this.
+    expect(buildResumeCommand("antigravity", "conv-42")).toBe("agy --conversation conv-42");
+    expect(buildResumeLatestCommand("antigravity")).toBe("agy -c");
   });
 
   it("claude is session-id and produces --resume flag args", () => {

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -241,6 +241,137 @@ export interface AgentPackages {
 }
 
 /**
+ * A shutdown signal that escalates one key press at a time, gated on the
+ * agent's own output rather than on a fixed press count (#11851).
+ *
+ * `shutdownKeySequence` is written exactly once, which is safe only for agents
+ * where one press is either enough or harmless. Codex is neither: while its
+ * Ratatui TUI holds raw mode a Ctrl-C is just a keystroke, but the instant
+ * cooked mode returns the next one is a real SIGINT that kills the process
+ * before it can print its resume hint. Measured on `codex-cli 0.147.0`: two
+ * presses print the hint in 0.76-1.16s depending on state, three print nothing
+ * at all. The press count needed varies with state (leftover composer text
+ * costs one, being mid-turn costs another), so no constant is correct.
+ *
+ * `gateText` is the escape hatch: the TUI prints a confirm-to-quit footer after
+ * an absorbed press, so a fresh match is positive proof the TUI is still alive
+ * and in raw mode — i.e. that the next press is still a keystroke. Send one,
+ * wait for a fresh match, and only then send the next.
+ *
+ * Declaring this REPLACES the `quitCommand` path entirely: no input-clear
+ * prelude, no slash command, no fallback. Writing `quitCommand` after a stalled
+ * escalation would put the very text into the user's transcript that this
+ * exists to keep out.
+ *
+ * Per-agent evidence only. Do not copy this to another agent without measuring
+ * that agent's own TUI — the gate string, the press economics, and the raw-mode
+ * boundary are all specific to the CLI that was measured.
+ */
+export interface AgentGatedKeyEscalation {
+  kind: "gated-key-escalation";
+  /** Raw bytes written per press (e.g. Ctrl-C). */
+  keySequence: string;
+  /**
+   * Literal substring (NOT a regex) matched against ANSI-stripped output
+   * produced since the last press. A literal keeps an unescapable TUI glyph
+   * from silently compiling into a pattern that never matches.
+   */
+  gateText: string;
+  /**
+   * Hard cap on presses. A safety net, not the mechanism — the gate is what
+   * actually decides whether another press is safe. Reaching the cap stops the
+   * escalation but does NOT end the teardown.
+   */
+  maxPresses: number;
+  /**
+   * How long to wait for a fresh `gateText` match after a press. On expiry the
+   * escalation stops and the teardown keeps listening for the session pattern
+   * on its remaining budget — a press that quit the agent outright, or one that
+   * dismissed a modal without redrawing the footer, still gets its hint read.
+   */
+  perPressTimeoutMs: number;
+}
+
+interface AgentSessionIdResumeBase {
+  kind: "session-id";
+  /** Returns CLI args for resuming a captured session (e.g. ["--resume", id]). */
+  args: (sessionId: string) => string[];
+  /**
+   * Regex with a single capture group for the session ID emitted post-quit.
+   *
+   * OMIT when the agent prints no resume hint this tree can match against real
+   * output. An omitted pattern skips the teardown capture loop outright, which
+   * is the honest shape for an agent whose id can't be observed: a fabricated
+   * pattern spends the whole shutdown budget matching nothing and reports
+   * `exited-no-match`, which reads as a broken regex rather than as an agent
+   * that never had a hint to scrape (#11851 — Antigravity, 0 captures in 6).
+   * `resumeLatestArgs` stays available to such an agent as its resume path.
+   */
+  sessionIdPattern?: string;
+  /**
+   * CLI args for resuming the most recent session without a captured ID
+   * (e.g. ["--continue"] for Claude, ["-r", "latest"] for Gemini,
+   * ["resume", "--last"] for Codex). When present, the relaunch path uses
+   * these args as a fallback when `sessionIdPattern` capture missed
+   * (timeout, no match). Scoped to the launch CWD by the underlying CLI.
+   * Omit for agents that have no resume-latest flag.
+   */
+  resumeLatestArgs?: string[];
+  /**
+   * CLI args that ASSIGN a caller-supplied session id at launch, for CLIs
+   * that accept one (e.g. Claude's `--session-id <uuid>`). Declaring this
+   * inverts how the id is obtained (#11782): instead of scraping it out of
+   * the TUI during teardown, Daintree mints the id up front and hands it to
+   * the CLI, so the id is known before the session exists.
+   *
+   * That removes the scrape's whole failure surface for this agent. The
+   * teardown scrape only works when the agent is idle and unblocked at the
+   * exact moment we tear it down — a mid-turn agent swallows `quitCommand`
+   * as chat text, a modal (trust/approval prompt) eats the keystrokes, and
+   * an empty session exits without printing a hint at all. A pre-assigned
+   * id also survives the paths the scrape can never reach: force quit, a
+   * crash, a SIGKILL, or a pty-host death, none of which run a teardown.
+   *
+   * ONE-SHOT, NOT IDEMPOTENT. The id may only be assigned when creating a
+   * NEW conversation — re-sending an already-used id is an error, not a
+   * resume (`claude --session-id <used>` exits with "Session ID <id> is
+   * already in use"). Resuming that conversation later goes through
+   * {@link AgentResume.args} (`--resume <id>`), which reuses the original
+   * id rather than minting a new one. So: assign once at fresh launch,
+   * resume by id forever after, and mint a DISTINCT id for a duplicated
+   * pane (see `buildAssignedSessionIdArgs`).
+   *
+   * Omit for CLIs that only hand out their own ids — those keep the
+   * `sessionIdPattern` teardown scrape as their sole capture path.
+   */
+  assignSessionIdArgs?: (sessionId: string) => string[];
+}
+
+/**
+ * `session-id` resume, with its shutdown protocol as a closed choice: EITHER
+ * the structured gated escalation OR the one-shot `quitCommand` (plus optional
+ * `shutdownKeySequence`) that every other scrape agent uses. The two are
+ * mutually exclusive at the type level because combining them is always a bug —
+ * a gated Ctrl-C exists precisely to avoid writing a slash command, so a config
+ * carrying both would defeat itself on the fallback path.
+ */
+export type AgentSessionIdResume = AgentSessionIdResumeBase &
+  (
+    | {
+        shutdownSignal: AgentGatedKeyEscalation;
+        quitCommand?: never;
+        shutdownKeySequence?: never;
+      }
+    | {
+        shutdownSignal?: never;
+        /** Command sent to the running agent to trigger graceful exit (e.g. "/quit"). */
+        quitCommand: string;
+        /** Optional raw key sequence sent before `quitCommand` (e.g. Ctrl-C). */
+        shutdownKeySequence?: string;
+      }
+  );
+
+/**
  * Discriminated union describing how an agent's prior session can be resumed.
  * The `kind` field selects the shape:
  *
@@ -259,58 +390,12 @@ export interface AgentPackages {
  *
  * `quitCommand` and `shutdownKeySequence` apply to all kinds — the PTY host
  * sends the quit command (or the key sequence, if provided) on graceful
- * shutdown. `sessionIdPattern` applies only to `session-id` and is the only
- * field that triggers the PTY host's pattern-match capture loop.
+ * shutdown. `sessionIdPattern` and `shutdownSignal` apply only to `session-id`;
+ * `sessionIdPattern` is the only field that triggers the PTY host's
+ * pattern-match capture loop.
  */
 export type AgentResume =
-  | {
-      kind: "session-id";
-      /** Returns CLI args for resuming a captured session (e.g. ["--resume", id]). */
-      args: (sessionId: string) => string[];
-      /** Command sent to the running agent to trigger graceful exit (e.g. "/quit"). */
-      quitCommand: string;
-      /** Regex with a single capture group for the session ID emitted post-quit. */
-      sessionIdPattern: string;
-      /** Optional raw key sequence sent before `quitCommand` (e.g. Ctrl-C). */
-      shutdownKeySequence?: string;
-      /**
-       * CLI args for resuming the most recent session without a captured ID
-       * (e.g. ["--continue"] for Claude, ["-r", "latest"] for Gemini,
-       * ["resume", "--last"] for Codex). When present, the relaunch path uses
-       * these args as a fallback when `sessionIdPattern` capture missed
-       * (timeout, no match). Scoped to the launch CWD by the underlying CLI.
-       * Omit for agents that have no resume-latest flag.
-       */
-      resumeLatestArgs?: string[];
-      /**
-       * CLI args that ASSIGN a caller-supplied session id at launch, for CLIs
-       * that accept one (e.g. Claude's `--session-id <uuid>`). Declaring this
-       * inverts how the id is obtained (#11782): instead of scraping it out of
-       * the TUI during teardown, Daintree mints the id up front and hands it to
-       * the CLI, so the id is known before the session exists.
-       *
-       * That removes the scrape's whole failure surface for this agent. The
-       * teardown scrape only works when the agent is idle and unblocked at the
-       * exact moment we tear it down — a mid-turn agent swallows `quitCommand`
-       * as chat text, a modal (trust/approval prompt) eats the keystrokes, and
-       * an empty session exits without printing a hint at all. A pre-assigned
-       * id also survives the paths the scrape can never reach: force quit, a
-       * crash, a SIGKILL, or a pty-host death, none of which run a teardown.
-       *
-       * ONE-SHOT, NOT IDEMPOTENT. The id may only be assigned when creating a
-       * NEW conversation — re-sending an already-used id is an error, not a
-       * resume (`claude --session-id <used>` exits with "Session ID <id> is
-       * already in use"). Resuming that conversation later goes through
-       * {@link AgentResume.args} (`--resume <id>`), which reuses the original
-       * id rather than minting a new one. So: assign once at fresh launch,
-       * resume by id forever after, and mint a DISTINCT id for a duplicated
-       * pane (see `buildAssignedSessionIdArgs`).
-       *
-       * Omit for CLIs that only hand out their own ids — those keep the
-       * `sessionIdPattern` teardown scrape as their sole capture path.
-       */
-      assignSessionIdArgs?: (sessionId: string) => string[];
-    }
+  | AgentSessionIdResume
   | {
       kind: "rolling-history";
       args: () => string[];

--- a/shared/config/agents/antigravity.ts
+++ b/shared/config/agents/antigravity.ts
@@ -58,11 +58,19 @@ export const config: AgentConfig = {
     promptHintPatterns: [],
     completionPatterns: [],
   },
+  // No `sessionIdPattern`: the `agy --conversation <id>` hint this tree used to
+  // scrape for has never matched real output — 0 captures in 6 teardowns
+  // (#11851) — and there is no public `agy` output to verify a corrected one
+  // against. Claiming a pattern that cannot match is worse than claiming none:
+  // it spends the whole shutdown budget matching nothing and then reports
+  // `exited-no-match`, which reads as a broken regex rather than as an agent
+  // whose id was never observable. `--conversation <id>` stays as `args` so a
+  // stored id still resumes exactly, and `-c` remains the working restore path.
+  // Restore this pattern only alongside real captured `agy` output.
   resume: {
     kind: "session-id",
     args: (sessionId: string) => ["--conversation", sessionId],
     quitCommand: "/quit",
-    sessionIdPattern: "agy --conversation ([\\w-]+)",
     resumeLatestArgs: ["-c"],
   },
   help: {

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -131,15 +131,22 @@ export const config: AgentConfig = {
     // servers. Ctrl-C survives all three because it is not composer text.
     //
     // The footer substring is harvested from the real `codex-cli 0.147.0`
-    // binary — it is deliberately a short fragment rather than the full
-    // sentence so a wording tweak upstream doesn't silently stop matching.
-    // 750ms is generous for a footer that redraws within a frame; three presses
-    // is a backstop, not a target (two sufficed in every measured state).
+    // binary — deliberately a short fragment rather than the full sentence, so
+    // a wording tweak upstream doesn't silently stop matching. 750ms is
+    // generous for a footer that redraws within a frame.
+    //
+    // TWO presses, not three. Two sufficed in every measured state and three
+    // produced nothing at all after 12s, so a third can only ever lose. The cap
+    // has to carry that on its own because the gate cannot: Ratatui repaints
+    // the whole frame, so a repaint emitted while press two is already tearing
+    // the TUI down looks identical to a genuine re-arm, and the substring can
+    // in principle be satisfied by conversation text too. Raise this only with
+    // a measured state where two presses demonstrably fail.
     shutdownSignal: {
       kind: "gated-key-escalation",
       keySequence: "\x03",
       gateText: "again to quit",
-      maxPresses: 3,
+      maxPresses: 2,
       perPressTimeoutMs: 750,
     },
   },

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -120,9 +120,28 @@ export const config: AgentConfig = {
   resume: {
     kind: "session-id",
     args: (sessionId: string) => ["resume", sessionId],
-    quitCommand: "/quit",
     sessionIdPattern: "codex resume ([\\w-]+)",
     resumeLatestArgs: ["resume", "--last"],
+    // Codex takes a gated Ctrl-C instead of `/quit` (#11851). Writing the slash
+    // command left `/quit` sitting in the user's own transcript and in Codex's
+    // `/resume` picker: mid-turn the composer queues it as a chat message the
+    // model then answers, burning tokens and capturing no id at all (38% over
+    // 26 measured teardowns). A modal or the directory-trust prompt swallowed
+    // it outright, and every launch is busy for its first 10-30s booting MCP
+    // servers. Ctrl-C survives all three because it is not composer text.
+    //
+    // The footer substring is harvested from the real `codex-cli 0.147.0`
+    // binary — it is deliberately a short fragment rather than the full
+    // sentence so a wording tweak upstream doesn't silently stop matching.
+    // 750ms is generous for a footer that redraws within a frame; three presses
+    // is a backstop, not a target (two sufficed in every measured state).
+    shutdownSignal: {
+      kind: "gated-key-escalation",
+      keySequence: "\x03",
+      gateText: "again to quit",
+      maxPresses: 3,
+      perPressTimeoutMs: 750,
+    },
   },
   help: {
     args: [],

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1029,10 +1029,6 @@ export function buildAssignedSessionIdArgs(
 }
 
 /**
- * Whether `agentId` lets Daintree choose the session id at launch, making the
- * teardown scrape unnecessary for it (#11782).
- */
-/**
  * True when this agent's session id can actually be OBSERVED for a specific
  * pane — either scraped at teardown via `sessionIdPattern` or minted at launch
  * via `assignSessionIdArgs`.
@@ -1049,6 +1045,10 @@ export function supportsExactSessionCapture(agentId: string | undefined): boolea
   return Boolean(resume.sessionIdPattern) || typeof resume.assignSessionIdArgs === "function";
 }
 
+/**
+ * Whether `agentId` lets Daintree choose the session id at launch, making the
+ * teardown scrape unnecessary for it (#11782).
+ */
 export function supportsSessionIdAssignment(agentId: string | undefined): boolean {
   if (!agentId) return false;
   const resume = getEffectiveAgentConfig(agentId)?.resume;

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1032,6 +1032,23 @@ export function buildAssignedSessionIdArgs(
  * Whether `agentId` lets Daintree choose the session id at launch, making the
  * teardown scrape unnecessary for it (#11782).
  */
+/**
+ * True when this agent's session id can actually be OBSERVED for a specific
+ * pane — either scraped at teardown via `sessionIdPattern` or minted at launch
+ * via `assignSessionIdArgs`.
+ *
+ * `resume.kind === "session-id"` alone does not imply this. An agent can resume
+ * by exact id (so `args(id)` is meaningful for an id it already holds) while
+ * having no way to learn one in the first place (#11851). Callers that need a
+ * concrete id for THIS pane must gate on this, not on the kind.
+ */
+export function supportsExactSessionCapture(agentId: string | undefined): boolean {
+  if (!agentId) return false;
+  const resume = getEffectiveAgentConfig(agentId)?.resume;
+  if (resume?.kind !== "session-id") return false;
+  return Boolean(resume.sessionIdPattern) || typeof resume.assignSessionIdArgs === "function";
+}
+
 export function supportsSessionIdAssignment(agentId: string | undefined): boolean {
   if (!agentId) return false;
   const resume = getEffectiveAgentConfig(agentId)?.resume;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -341,6 +341,7 @@ export {
   buildResumeLatestCommand,
   buildAssignedSessionIdArgs,
   supportsSessionIdAssignment,
+  supportsExactSessionCapture,
   mintAssignedSessionId,
   stripAssignedSessionIdArgs,
   buildLaunchCommandFromFlags,


### PR DESCRIPTION
At graceful shutdown Daintree wrote `\x05\x15`, then the agent's `quitCommand`, then Enter into the PTY and scraped stdout for a session id. For Codex that text is visible to the user: mid-turn the composer queues `/quit` as a chat message the model answers, so it lands in the transcript and in Codex's own `/resume` picker, burns tokens, and still captures nothing. Measured capture rate was 38% over 26 teardowns.

Codex now quits on a gated Ctrl-C instead. Write one `\x03`, wait for a fresh match of the TUI's `again to quit` footer in output produced *since that press*, and only then write the next. No prelude, no slash command, no fallback — a fallback would put back exactly the text this removes.

The gate exists because the press count isn't constant: leftover composer text costs one press, being mid-turn costs another, and one press too many is fatal. While the Ratatui TUI holds raw mode `\x03` is a keystroke, but the moment cooked mode returns it's a real SIGINT that kills the process before the resume hint prints. Two presses printed the hint in 0.76–1.16s in every measured state; three printed nothing at all after 12s.

### What's in here

- `AgentGatedKeyEscalation` on `AgentResume`, as a mutually-exclusive alternative to `quitCommand`/`shutdownKeySequence` at the type level. Declaring both is always a bug, so the type refuses it.
- Codex configured for it: Ctrl-C, `again to quit`, **2** presses max, 750ms per gate.
- A stalled gate or the press cap stops the *escalation*, not the teardown. The terminal keeps listening on its remaining budget — killing at the first silent gate would discard a hint still in flight, which is worse than the code being replaced.
- An input lock held for the whole teardown (`WriteQueue.cancelPendingInput` + generation checks in `TerminalInputController`). Teardown writes bypass the normal input path, so a keystroke on the ≤512-byte fast path, a chunked paste still pacing, or the trailing Enter of an in-flight submit would otherwise land between two presses.
- `gracefulShutdown` is now single-flight per terminal. Neither `isExited` nor `wasKilled` is set until a teardown finishes, so concurrent callers (hibernate racing app quit) each ran their own loop and the aggregate press count sailed past the per-loop cap.
- `GRACEFUL_SHUTDOWN_TIMEOUT_MS` 2500 → 3000, still 1000ms under the 4000ms per-project race. Both layers are `Promise.all`, so the budget is parallel, not additive.
- `sessionIdPattern` is now optional, and Antigravity's is gone — it captured 0 of 6 and can't be verified against real `agy` output. A fabricated pattern is worse than none: it burns the budget matching nothing and reports `exited-no-match`, which reads as a broken regex.
- Pane bookmarks gate on the id being *observable*, not on `resume.kind`. Bookmarking does a capture-kill first, so Antigravity previously tore down a live pane and only then reported that nothing was saved.
- The pattern-discovery harness no longer falls back to a blind `/quit`.

### Deviations from the issue, and why

1. **Antigravity keeps `kind: "session-id"`.** The issue said it should either get a verified pattern or stop claiming `session-id` resume. Reclassifying to `rolling-history` would have silently broken its restore: `buildResumeLatestCommand` hard-returns `undefined` for any non-`session-id` kind, and `buildResumeCommand` is only reached with a captured id, which Antigravity never has. It would have traded a pattern that costs nothing for the `agy -c` path that actually works. Dropping just the pattern gets the honesty without the regression.
2. **2 presses, not 3.** Ratatui repaints the whole frame, so a repaint emitted while press two is already tearing the TUI down is indistinguishable from a genuine re-arm. The gate can't tell them apart, so the cap has to. Two sufficed in every measured state and three can only ever lose.
3. **A gate timeout stops escalating rather than finishing.** See above — the hint arrives up to 1160ms after the first press.
4. **The other scrape agents are unchanged.** The issue lists them in scope, but none has its own evidence, and copying Codex's Ctrl-C without measuring each TUI is explicitly what the issue forbids. Grok already self-flags its pattern as provisional, Mistral cites its source exit path, Goose has a pattern contract test, and Kiro/Aider don't scrape at all. Left alone deliberately.

### Testing

3654 tests pass locally across the pty, terminal-IPC, shared-config, shared-types, state-hydration and panel-registry suites; typecheck clean; prettier and eslint clean on every changed file.

New coverage pins the fatal cases specifically: that the first byte is Ctrl-C and neither the prelude nor `/quit` is ever written; that repaints in *separate* frames still stop at the cap; that a chunk carrying a session id never also authorizes a press; that concurrent callers share one escalation; and that no press escapes once the wall-clock budget is spent.

Two things found while testing, both fixed here: the mock PTY used `pid: 123`, so every test in that suite was calling `process.kill` against whatever really owns that pid and arming a real SIGKILL sweep (now `pid: 0`, which takes `ProcessTreeKiller`'s early bail); and a throwing `host.kill()` escaped through the `onData` listener, leaving the promise pending forever and the new input lock stranded.

### Known gaps

- `submit`/`stage` return no status, so an MCP `terminal.sendCommand` arriving inside the teardown window gets `{sent: true}` for input the host dropped. Pre-existing in shape — both already silent-drop on `isExited` — and an honest fix needs an acknowledged pty-host RPC. Worth its own issue.
- Verified on macOS only. Linux PTY and Windows ConPTY behaviour for the gated exchange is unverified.

Resolves #11851