### PR TITLE
fix(notifications): give grid-bar notifications a dismiss control

### DIFF
--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Info, X, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   BANNER_ENTER_DURATION,
@@ -297,7 +297,12 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
           )}
         </div>
 
-        {displayedNotification && actions.length > 0 && (
+        {/* Controls: action buttons first, dismiss trailing. Dismiss is always
+         *  present — the grid bar carries signals from outside the visible UI,
+         *  so the user must be able to clear one that is already handled or
+         *  irrelevant without waiting for a duration persistent notifications
+         *  do not have. Ordering matches Toast (actions, then close). */}
+        {displayedNotification && (
           <div className="flex shrink-0 items-center gap-1.5">
             {actions.map((action, index) => (
               <button
@@ -319,21 +324,19 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
                 {action.label}
               </button>
             ))}
+            <button
+              type="button"
+              onClick={() => removeNotification(displayedNotification.id)}
+              aria-label="Dismiss"
+              className={cn(
+                "flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-xs)] text-daintree-text/60 transition-colors hover:bg-tint/10 hover:text-daintree-text/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent/60",
+                buttonPointerClass
+              )}
+              {...interactionGuard}
+            >
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
           </div>
-        )}
-
-        {displayedNotification && actions.length === 0 && (
-          <button
-            type="button"
-            onClick={() => removeNotification(displayedNotification.id)}
-            className={cn(
-              "h-7 shrink-0 rounded-[var(--radius-xs)] border border-tint/10 bg-tint/5 px-2 text-xs text-daintree-text/60 transition-colors hover:bg-tint/10 hover:text-daintree-text/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent/60",
-              buttonPointerClass
-            )}
-            {...interactionGuard}
-          >
-            Dismiss
-          </button>
         )}
       </div>
     </div>

--- a/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
+++ b/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
@@ -244,10 +244,14 @@ describe("GridNotificationBar animation", () => {
   });
 
   it("renders action and dismiss controls as siblings of the live region, not inside it", () => {
-    const onClick = vi.fn();
+    // Two actions, matching the shape real producers use, so the ordering
+    // assertion would catch dismiss being inserted between them.
     addGridBar({
       message: "Pick one",
-      action: { label: "Confirm", onClick },
+      actions: [
+        { label: "Confirm", onClick: vi.fn() },
+        { label: "Not now", onClick: vi.fn(), variant: "secondary" },
+      ],
     });
     const { container, getByRole } = render(<GridNotificationBar />);
     act(() => {
@@ -262,15 +266,21 @@ describe("GridNotificationBar animation", () => {
     // A notification carrying actions still gets a dismiss control alongside
     // them, so the bar is clearable without committing to an action.
     const confirmBtn = getByRole("button", { name: "Confirm" });
+    const notNowBtn = getByRole("button", { name: "Not now" });
     const dismissBtn = getByRole("button", { name: "Dismiss" });
-    expect(live!.contains(confirmBtn)).toBe(false);
-    expect(live!.contains(dismissBtn)).toBe(false);
-    // Both still live in the bar row that owns the live region.
-    expect(live!.parentElement?.contains(confirmBtn)).toBe(true);
-    expect(live!.parentElement?.contains(dismissBtn)).toBe(true);
+    for (const btn of [confirmBtn, notNowBtn, dismissBtn]) {
+      expect(live!.contains(btn)).toBe(false);
+      // Still inside the bar row that owns the live region.
+      expect(live!.parentElement?.contains(btn)).toBe(true);
+    }
 
-    // Actions lead, dismiss trails: the escape control is last in tab order.
-    expect(Array.from(container.querySelectorAll("button"))).toEqual([confirmBtn, dismissBtn]);
+    // Every action leads, dismiss trails: the escape control is last in tab
+    // order. Identity per index, since toEqual on DOM nodes compares structure.
+    const buttons = Array.from(container.querySelectorAll("button"));
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]).toBe(confirmBtn);
+    expect(buttons[1]).toBe(notNowBtn);
+    expect(buttons[2]).toBe(dismissBtn);
   });
 
   it("renders the dismiss control as the only button when the notification has no actions", () => {
@@ -292,7 +302,7 @@ describe("GridNotificationBar animation", () => {
       message: "Already handled",
       action: { label: "Confirm", onClick: vi.fn() },
     });
-    const { container, getByRole } = render(<GridNotificationBar />);
+    const { container, getByRole, queryByRole } = render(<GridNotificationBar />);
     act(() => {
       vi.advanceTimersByTime(16);
     });
@@ -304,8 +314,11 @@ describe("GridNotificationBar animation", () => {
     // Hard removal: no soft `dismissed: true` row is left behind to accumulate,
     // since nothing downstream ever reads a dismissed grid-bar entry.
     expect(useNotificationStore.getState().notifications.some((n) => n.id === id)).toBe(false);
-    // Collapse starts immediately rather than waiting on a duration.
-    expect(getWrapper(container)?.className).toContain("h-0");
+
+    // Exit begins immediately rather than waiting on a duration: the controls
+    // stay mounted for the collapse but are already out of the a11y tree.
+    expect(container.querySelectorAll("button")).toHaveLength(2);
+    expect(queryByRole("button", { name: "Dismiss" })).toBeNull();
 
     act(() => {
       vi.advanceTimersByTime(BANNER_EXIT_DURATION);
@@ -315,6 +328,33 @@ describe("GridNotificationBar animation", () => {
     // every control is gone.
     expect(getLiveRegion(container)?.textContent).toBe("");
     expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("keeps the action and dismiss handlers separate", () => {
+    const onClick = vi.fn();
+    const id = addGridBar({
+      message: "Pick one",
+      action: { label: "Confirm", onClick },
+    });
+    const { getByRole } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    // The action fires its own callback and leaves the row in place for the
+    // producer to clear; the bar never auto-dismisses on an action click.
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Confirm" }));
+    });
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(useNotificationStore.getState().notifications.some((n) => n.id === id)).toBe(true);
+
+    // Dismiss clears the row without invoking the action.
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Dismiss" }));
+    });
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(useNotificationStore.getState().notifications.some((n) => n.id === id)).toBe(false);
   });
 
   it("blocks focus and screen readers on action and dismiss controls while collapsed", () => {

--- a/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
+++ b/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, act, within } from "@testing-library/react";
+import { render, act, fireEvent, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GRID_BAR_DWELL_FLOOR_MS, useNotificationStore } from "@/store/notificationStore";
 import {
@@ -243,13 +243,13 @@ describe("GridNotificationBar animation", () => {
     expect(live?.textContent).toContain("Announce me");
   });
 
-  it("renders action buttons as siblings of the live region, not inside it", () => {
+  it("renders action and dismiss controls as siblings of the live region, not inside it", () => {
     const onClick = vi.fn();
     addGridBar({
       message: "Pick one",
       action: { label: "Confirm", onClick },
     });
-    const { container } = render(<GridNotificationBar />);
+    const { container, getByRole } = render(<GridNotificationBar />);
     act(() => {
       vi.advanceTimersByTime(16);
     });
@@ -258,28 +258,66 @@ describe("GridNotificationBar animation", () => {
     expect(live).not.toBeNull();
     // The live region announces flat text; buttons must not be its descendants.
     expect(within(live!).queryAllByRole("button")).toHaveLength(0);
-    // But the button still exists in the bar as a sibling.
-    const allButtons = container.querySelectorAll("button");
-    expect(allButtons).toHaveLength(1);
-    expect(allButtons[0]?.textContent).toBe("Confirm");
-    expect(live!.contains(allButtons[0]!)).toBe(false);
+
+    // A notification carrying actions still gets a dismiss control alongside
+    // them, so the bar is clearable without committing to an action.
+    const confirmBtn = getByRole("button", { name: "Confirm" });
+    const dismissBtn = getByRole("button", { name: "Dismiss" });
+    expect(live!.contains(confirmBtn)).toBe(false);
+    expect(live!.contains(dismissBtn)).toBe(false);
+    // Both still live in the bar row that owns the live region.
+    expect(live!.parentElement?.contains(confirmBtn)).toBe(true);
+    expect(live!.parentElement?.contains(dismissBtn)).toBe(true);
+
+    // Actions lead, dismiss trails: the escape control is last in tab order.
+    expect(Array.from(container.querySelectorAll("button"))).toEqual([confirmBtn, dismissBtn]);
   });
 
-  it("renders the dismiss button as a sibling of the live region", () => {
+  it("renders the dismiss control as the only button when the notification has no actions", () => {
     addGridBar({ message: "Dismiss me" });
-    const { container } = render(<GridNotificationBar />);
+    const { container, getByRole } = render(<GridNotificationBar />);
     act(() => {
       vi.advanceTimersByTime(16);
     });
 
     const live = getLiveRegion(container);
     expect(live).not.toBeNull();
-    const dismissBtn = container.querySelector("button");
-    expect(dismissBtn?.textContent).toBe("Dismiss");
-    expect(live!.contains(dismissBtn!)).toBe(false);
+    const dismissBtn = getByRole("button", { name: "Dismiss" });
+    expect(container.querySelectorAll("button")).toHaveLength(1);
+    expect(live!.contains(dismissBtn)).toBe(false);
   });
 
-  it("blocks focus and screen readers on action buttons while collapsed", () => {
+  it("removes the notification from the store and empties the bar when dismiss is clicked", () => {
+    const id = addGridBar({
+      message: "Already handled",
+      action: { label: "Confirm", onClick: vi.fn() },
+    });
+    const { container, getByRole } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Dismiss" }));
+    });
+
+    // Hard removal: no soft `dismissed: true` row is left behind to accumulate,
+    // since nothing downstream ever reads a dismissed grid-bar entry.
+    expect(useNotificationStore.getState().notifications.some((n) => n.id === id)).toBe(false);
+    // Collapse starts immediately rather than waiting on a duration.
+    expect(getWrapper(container)?.className).toContain("h-0");
+
+    act(() => {
+      vi.advanceTimersByTime(BANNER_EXIT_DURATION);
+    });
+
+    // The live region stays mounted for AT registration, but is emptied and
+    // every control is gone.
+    expect(getLiveRegion(container)?.textContent).toBe("");
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("blocks focus and screen readers on action and dismiss controls while collapsed", () => {
     const onClick = vi.fn();
     addGridBar({
       message: "Pick one",
@@ -287,20 +325,25 @@ describe("GridNotificationBar animation", () => {
     });
     const { container } = render(<GridNotificationBar />);
 
-    // Pre-rAF (collapsed): button is non-tabbable and aria-hidden.
-    const earlyBtn = container.querySelector("button");
-    expect(earlyBtn).not.toBeNull();
-    expect(earlyBtn?.getAttribute("tabindex")).toBe("-1");
-    expect(earlyBtn?.getAttribute("aria-hidden")).toBe("true");
+    // Pre-rAF (collapsed): every control is non-tabbable and aria-hidden.
+    const earlyButtons = Array.from(container.querySelectorAll("button"));
+    expect(earlyButtons).toHaveLength(2);
+    for (const btn of earlyButtons) {
+      expect(btn.getAttribute("tabindex")).toBe("-1");
+      expect(btn.getAttribute("aria-hidden")).toBe("true");
+    }
 
     act(() => {
       vi.advanceTimersByTime(16);
     });
 
     // Visible: focusable and exposed to AT.
-    const liveBtn = container.querySelector("button");
-    expect(liveBtn?.hasAttribute("tabindex")).toBe(false);
-    expect(liveBtn?.hasAttribute("aria-hidden")).toBe(false);
+    const liveButtons = Array.from(container.querySelectorAll("button"));
+    expect(liveButtons).toHaveLength(2);
+    for (const btn of liveButtons) {
+      expect(btn.hasAttribute("tabindex")).toBe(false);
+      expect(btn.hasAttribute("aria-hidden")).toBe(false);
+    }
   });
 
   it("animates in when a notification is added after mount", () => {
@@ -666,8 +709,8 @@ describe("GridNotificationBar selection contract", () => {
   });
 
   it("releases promptly when the locked notification is dismissed mid-dwell", () => {
-    const lowId = addGridBar({ message: "Low priority", priority: "low" });
-    const { getByText, queryByText } = render(<GridNotificationBar />);
+    addGridBar({ message: "Low priority", priority: "low" });
+    const { getByRole, getByText, queryByText } = render(<GridNotificationBar />);
     act(() => {
       vi.advanceTimersByTime(16);
     });
@@ -682,9 +725,11 @@ describe("GridNotificationBar selection contract", () => {
     });
     expect(queryByText("High priority")).toBeNull();
 
-    // User dismisses the locked low one before its dwell expires.
+    // User dismisses the locked low one through the rendered control, ~1s into
+    // a 5s floor. Removing it drops it from the candidate set, so the lock
+    // releases without waiting out GRID_BAR_DWELL_FLOOR_MS.
     act(() => {
-      useNotificationStore.getState().removeNotification(lowId);
+      fireEvent.click(getByRole("button", { name: "Dismiss" }));
     });
     act(() => {
       vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY + 16);


### PR DESCRIPTION
## Summary
A notification routed with `placement: "grid-bar"` had no close control whenever it carried action buttons. `GridNotificationBar` rendered a text "Dismiss" button only in the `actions.length === 0` branch, so the three sticky producers (all of which ship actions) left the user with no way out except clicking an action, waiting for a higher-priority notification to supersede it, or waiting out a duration persistent notifications do not have.

Resolves #11855

## Changes
- One always-present icon-only lucide `X` (aria-label "Dismiss") now renders as the trailing control in a single shared controls group, replacing the conditional text-button fallback. One affordance in both states instead of two different ones depending on whether a producer supplied an action.
- Order is actions-first, dismiss-trailing, matching the Toast surface (`toaster.tsx` renders `actions.map` before its close `X`). Visual and tab order stay aligned, and the escape control is last.
- Wired to `removeNotification(id)` (hard splice) rather than `dismissNotification(id)` (soft `dismissed: true`). Nothing downstream ever reads a dismissed grid-bar row and nothing purges them, so the soft path would orphan entries forever. This also matches the fallback button it replaces and both producer hooks' own self-dismiss handlers.
- The new control honours the existing `interactionGuard` / `buttonPointerClass` contract, so it's non-tabbable, aria-hidden and pointer-blocked during the entry and exit windows exactly like the action buttons.

Decisions worth recording (the issue raised both as open questions):
- Dismissal is per-notification only. No `supersedeKey` suppression was added: `supersedeKey` lives in the notify payload and only archives history/inbox entries, never touching the live notifications array. All four grid-bar producers already self-guard re-firing with their own one-shot refs or sets, so there's no poll-driven bar to come straight back.
- `onDismiss` stays unwired. Its store contract is documented as toast-path-specific and no grid-bar producer sets it.
- No store, selector, dwell-timing, producer, history or docs changes. Dismissing a dwell-locked notification releases the lock for free, because removing it drops it from the selector's candidate set.

## Testing
28 tests in `GridNotificationBar.test.tsx` (4 existing updated, 2 added). New coverage: dismiss renders alongside actions and never lands between them; clicking it hard-removes the row and empties the bar; action and dismiss handlers stay separate; the collapsed-state guard applies to both controls; and the dwell-release test now goes through a real button click instead of a direct store call. Also ran the notification store suites, all five notify routing suites, the four producer-hook suites and the accent/colour contract suites: 501 tests green. Own-file lint and prettier clean.
