### PR TITLE
fix(panels): reroot a duplicated panel when its launch root is the wrong worktree

### DIFF
--- a/e2e/full/panels/core-panel-tab-groups.spec.ts
+++ b/e2e/full/panels/core-panel-tab-groups.spec.ts
@@ -88,7 +88,7 @@ test.describe.serial("Core: Panel Tab Groups", () => {
       expect(await getGridPanelCount(window)).toBe(1);
     });
 
-    test("duplicated tab inherits cwd and has functional PTY", async () => {
+    test("duplicated tab launches in its worktree directory and has functional PTY", async () => {
       const { window } = ctx;
       const panel = getFirstGridPanel(window);
 
@@ -96,7 +96,7 @@ test.describe.serial("Core: Panel Tab Groups", () => {
       await runTerminalCommand(window, panel, "node -e \"console.log('TAB_DUPLICATE_ALIVE')\"");
       await waitForTerminalText(panel, "TAB_DUPLICATE_ALIVE", T_LONG);
 
-      // Verify working directory is inherited
+      // A duplicate is a new process rooted in the worktree it is filed under (#11854)
       await runTerminalCommand(window, panel, 'node -p "process.cwd()"');
       const dirBasename = path.basename(fixtureDir);
       await waitForTerminalTextIgnoringLineBreaks(panel, dirBasename, T_LONG);

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -318,11 +318,21 @@ describe("terminal.duplicate (copy) suffix", () => {
   });
 
   it("re-derives a reopened panel's cwd from the worktree it ends up filed under", async () => {
-    const addPanel = vi.fn().mockResolvedValue(undefined);
+    // Snapshot the cwd as `addPanel` saw it: production hands the same object to
+    // the resolver and to `addPanel`, so inspecting the retained reference would
+    // still show a corrected value even if the two statements were swapped.
+    let cwdAtAddPanel: string | undefined;
+    const addPanel = vi.fn((options: AddPanelOptions) => {
+      cwdAtAddPanel = options.cwd;
+      return Promise.resolve(undefined);
+    });
     const pathsByWorktree: Record<string, string> = { "wt-1": "/worktrees/active" };
+    let worktreeIdAtResolve: string | undefined;
     resolveInheritedPanelCwdMock.mockImplementation(
-      (panel: { cwd?: string; worktreeId?: string }) =>
-        (panel.worktreeId && pathsByWorktree[panel.worktreeId]) || panel.cwd || ""
+      (panel: { cwd?: string; worktreeId?: string }) => {
+        worktreeIdAtResolve = panel.worktreeId;
+        return (panel.worktreeId && pathsByWorktree[panel.worktreeId]) || panel.cwd || "";
+      }
     );
     setPanelState({
       panels: [],
@@ -336,29 +346,54 @@ describe("terminal.duplicate (copy) suffix", () => {
     await run("terminal.duplicate");
 
     // The resolver must see the id that actually won, not the snapshot's.
-    expect(resolveInheritedPanelCwdMock).toHaveBeenCalledWith(
-      expect.objectContaining({ worktreeId: "wt-1" })
-    );
-    const opts = addPanel.mock.calls[0]![0] as AddPanelOptions;
-    expect(opts.worktreeId).toBe("wt-1");
-    expect(opts.cwd).toBe(pathsByWorktree["wt-1"]);
+    expect(worktreeIdAtResolve).toBe("wt-1");
+    expect(cwdAtAddPanel).toBe(pathsByWorktree["wt-1"]);
   });
 
-  it("keeps a reopened panel's cwd when its worktree no longer resolves", async () => {
+  it("resolves a reopened panel against its own worktree when the snapshot kept one", async () => {
     const addPanel = vi.fn().mockResolvedValue(undefined);
-    resolveInheritedPanelCwdMock.mockImplementation(
-      (panel: { cwd?: string; worktreeId?: string }) => panel.cwd || ""
-    );
+    let worktreeIdAtResolve: string | undefined;
+    resolveInheritedPanelCwdMock.mockImplementation((panel: { worktreeId?: string }) => {
+      worktreeIdAtResolve = panel.worktreeId;
+      return "/worktrees/saved";
+    });
     setPanelState({
       panels: [],
       addPanel,
-      lastClosedConfig: { kind: "terminal", command: "bash", cwd: "/worktrees/stale" },
+      lastClosedConfig: {
+        kind: "terminal",
+        command: "bash",
+        cwd: "/worktrees/stale",
+        worktreeId: "wt-saved",
+      },
     });
 
     const run = setupActions();
     await run("terminal.duplicate");
 
-    expect((addPanel.mock.calls[0]![0] as AddPanelOptions).cwd).toBe("/worktrees/stale");
+    // A saved id outranks the active worktree, so resolution must key off it.
+    expect(worktreeIdAtResolve).toBe("wt-saved");
+    expect((addPanel.mock.calls[0]![0] as AddPanelOptions).cwd).toBe("/worktrees/saved");
+  });
+
+  it("re-derives a reopened dev-preview's cwd too, since it spawns a dev server", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    resolveInheritedPanelCwdMock.mockReturnValue("/worktrees/active");
+    setPanelState({
+      panels: [],
+      addPanel,
+      lastClosedConfig: {
+        kind: "dev-preview",
+        devCommand: "npm run dev",
+        cwd: "/worktrees/stale",
+      },
+    });
+
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(resolveInheritedPanelCwdMock).toHaveBeenCalled();
+    expect((addPanel.mock.calls[0]![0] as AddPanelOptions).cwd).toBe("/worktrees/active");
   });
 
   it("leaves a reopened browser panel out of cwd resolution", async () => {
@@ -373,7 +408,6 @@ describe("terminal.duplicate (copy) suffix", () => {
     await run("terminal.duplicate");
 
     expect(resolveInheritedPanelCwdMock).not.toHaveBeenCalled();
-    expect((addPanel.mock.calls[0]![0] as AddPanelOptions).cwd).toBe("");
   });
 
   it("browser panel duplication never carries a (copy)-suffixed title (service omits title)", async () => {

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -19,6 +19,8 @@ vi.mock("@/store/layoutUndoStore", () => ({ useLayoutUndoStore: layoutUndoMock }
 vi.mock("@/services/terminal/panelDuplicationService", () => ({
   buildPanelDuplicateOptions: buildPanelDuplicateOptionsMock,
   resolveInheritedPanelCwd: resolveInheritedPanelCwdMock,
+  panelKindHasLaunchRoot: (kind: string | undefined) =>
+    kind === "terminal" || kind === "dev-preview",
 }));
 vi.mock("@/services/terminal/optimisticPanelClose", () => ({
   flushOptimisticCloses: flushOptimisticClosesMock,

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -9,6 +9,7 @@ const layoutUndoMock = vi.hoisted(() => ({
 }));
 const moveTerminalToWorktreeAndFollowRescueMock = vi.hoisted(() => vi.fn());
 const buildPanelDuplicateOptionsMock = vi.hoisted(() => vi.fn());
+const resolveInheritedPanelCwdMock = vi.hoisted(() => vi.fn());
 const flushOptimisticClosesMock = vi.hoisted(() => vi.fn());
 const buildResumePanelOptionsMock = vi.hoisted(() => vi.fn());
 const listAgentSessionsMock = vi.hoisted(() => vi.fn());
@@ -17,6 +18,7 @@ vi.mock("@/store/panelStore", () => ({ usePanelStore: panelStoreMock }));
 vi.mock("@/store/layoutUndoStore", () => ({ useLayoutUndoStore: layoutUndoMock }));
 vi.mock("@/services/terminal/panelDuplicationService", () => ({
   buildPanelDuplicateOptions: buildPanelDuplicateOptionsMock,
+  resolveInheritedPanelCwd: resolveInheritedPanelCwdMock,
 }));
 vi.mock("@/services/terminal/optimisticPanelClose", () => ({
   flushOptimisticCloses: flushOptimisticClosesMock,
@@ -129,6 +131,9 @@ beforeEach(() => {
       if (kind === "browser" || kind === "dev-preview") return base;
       return { ...base, title: panel.title };
     }
+  );
+  resolveInheritedPanelCwdMock.mockImplementation(
+    (panel: { cwd?: string; worktreeId?: string }) => panel.cwd ?? ""
   );
 });
 
@@ -310,6 +315,65 @@ describe("terminal.duplicate (copy) suffix", () => {
         worktreeId: "wt-1",
       })
     );
+  });
+
+  it("re-derives a reopened panel's cwd from the worktree it ends up filed under", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    const pathsByWorktree: Record<string, string> = { "wt-1": "/worktrees/active" };
+    resolveInheritedPanelCwdMock.mockImplementation(
+      (panel: { cwd?: string; worktreeId?: string }) =>
+        (panel.worktreeId && pathsByWorktree[panel.worktreeId]) || panel.cwd || ""
+    );
+    setPanelState({
+      panels: [],
+      addPanel,
+      // No worktreeId, so the action adopts the active worktree while `cwd`
+      // still points at the closed panel's directory.
+      lastClosedConfig: { kind: "terminal", command: "bash", cwd: "/worktrees/stale" },
+    });
+
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    // The resolver must see the id that actually won, not the snapshot's.
+    expect(resolveInheritedPanelCwdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: "wt-1" })
+    );
+    const opts = addPanel.mock.calls[0]![0] as AddPanelOptions;
+    expect(opts.worktreeId).toBe("wt-1");
+    expect(opts.cwd).toBe(pathsByWorktree["wt-1"]);
+  });
+
+  it("keeps a reopened panel's cwd when its worktree no longer resolves", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    resolveInheritedPanelCwdMock.mockImplementation(
+      (panel: { cwd?: string; worktreeId?: string }) => panel.cwd || ""
+    );
+    setPanelState({
+      panels: [],
+      addPanel,
+      lastClosedConfig: { kind: "terminal", command: "bash", cwd: "/worktrees/stale" },
+    });
+
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect((addPanel.mock.calls[0]![0] as AddPanelOptions).cwd).toBe("/worktrees/stale");
+  });
+
+  it("leaves a reopened browser panel out of cwd resolution", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      panels: [],
+      addPanel,
+      lastClosedConfig: { kind: "browser", cwd: "", browserUrl: "https://example.com" },
+    });
+
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(resolveInheritedPanelCwdMock).not.toHaveBeenCalled();
+    expect((addPanel.mock.calls[0]![0] as AddPanelOptions).cwd).toBe("");
   });
 
   it("browser panel duplication never carries a (copy)-suffixed title (service omits title)", async () => {

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -4,6 +4,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import {
   buildPanelDuplicateOptions,
+  panelKindHasLaunchRoot,
   resolveInheritedPanelCwd,
 } from "@/services/terminal/panelDuplicationService";
 import { flushOptimisticCloses } from "@/services/terminal/optimisticPanelClose";
@@ -165,9 +166,8 @@ export function registerTerminalSpawnActions(
           };
           // The worktree id above can fall back to the active worktree while
           // `cwd` still carries the closed panel's directory, so re-derive the
-          // directory from whichever id actually won (#11854). Browser panels
-          // keep their deliberate empty `cwd` and review panels have none.
-          if (reopenOptions.kind === "terminal" || reopenOptions.kind === "dev-preview") {
+          // directory from whichever id actually won (#11854).
+          if (panelKindHasLaunchRoot(reopenOptions.kind)) {
             reopenOptions.cwd = resolveInheritedPanelCwd(reopenOptions);
           }
           await state.addPanel(reopenOptions);

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -2,13 +2,17 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import { usePanelStore } from "@/store/panelStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
-import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
+import {
+  buildPanelDuplicateOptions,
+  resolveInheritedPanelCwd,
+} from "@/services/terminal/panelDuplicationService";
 import { flushOptimisticCloses } from "@/services/terminal/optimisticPanelClose";
 import { moveTerminalToWorktreeAndFollowRescue } from "@/services/terminal/crossWorktreeMove";
 import { buildResumePanelOptions } from "@/services/agentResume";
 import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
+import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
 import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
 import { isPtyPanel } from "@shared/types/panel";
 
@@ -153,12 +157,20 @@ export function registerTerminalSpawnActions(
                 "grid"
               )
             : lastClosed;
-          await state.addPanel({
+          const reopenOptions: AddPanelOptions = {
             ...baseOptions,
             location: "grid",
             worktreeId: lastClosed.worktreeId ?? callbacks.getActiveWorktreeId(),
             ...(spawnedBy ? { spawnedBy } : {}),
-          });
+          };
+          // The worktree id above can fall back to the active worktree while
+          // `cwd` still carries the closed panel's directory, so re-derive the
+          // directory from whichever id actually won (#11854). Browser panels
+          // keep their deliberate empty `cwd` and review panels have none.
+          if (reopenOptions.kind === "terminal" || reopenOptions.kind === "dev-preview") {
+            reopenOptions.cwd = resolveInheritedPanelCwd(reopenOptions);
+          }
+          await state.addPanel(reopenOptions);
         } else {
           await state.addPanel({
             kind: "terminal",

--- a/src/services/terminal/__tests__/panelDuplicationService.test.ts
+++ b/src/services/terminal/__tests__/panelDuplicationService.test.ts
@@ -865,7 +865,7 @@ describe("inherited worktree cwd resolution (#11854)", () => {
       const options = await buildPanelDuplicateOptions(panel, "grid");
 
       expect(options.cwd).toBe(filedPath);
-      expect(options.cwd).not.toBe(panel.cwd);
+      expect(options.cwd).not.toBe(stalePath);
       // The filing id is the input to the fix, never an output of it.
       expect(options.worktreeId).toBe(panel.worktreeId);
     });

--- a/src/services/terminal/__tests__/panelDuplicationService.test.ts
+++ b/src/services/terminal/__tests__/panelDuplicationService.test.ts
@@ -800,10 +800,21 @@ describe("inherited worktree cwd resolution (#11854)", () => {
     });
 
     it("does not treat a sibling worktree whose path merely extends the filed one as inside it", () => {
-      useIndex([[filedId, filedPath]]);
+      useIndex([
+        [filedId, filedPath],
+        ["wt-sibling", `${filedPath}-other`],
+      ]);
 
       expect(resolveInheritedPanelCwd({ cwd: `${filedPath}-other/src`, worktreeId: filedId })).toBe(
         filedPath
+      );
+    });
+
+    it("keeps a launch root that belongs to no known worktree, which no drag could produce", () => {
+      useIndex([[filedId, filedPath]]);
+
+      expect(resolveInheritedPanelCwd({ cwd: "/tmp/scratch", worktreeId: filedId })).toBe(
+        "/tmp/scratch"
       );
     });
 
@@ -868,17 +879,19 @@ describe("inherited worktree cwd resolution (#11854)", () => {
     });
   });
 
-  it("leaves the trash-time snapshot's launch root untouched for the reopen consumer to resolve", () => {
-    useIndex([
-      [filedId, filedPath],
-      ["wt-source", stalePath],
-    ]);
-    const panel = makePanel({ command: "bash", cwd: stalePath, worktreeId: filedId });
+  describe.each(spawningPanels)("buildPanelSnapshotOptions: %s", (_label, overrides) => {
+    it("leaves the trash-time launch root untouched for the reopen consumer to resolve", () => {
+      useIndex([
+        [filedId, filedPath],
+        ["wt-source", stalePath],
+      ]);
+      const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: filedId });
 
-    // Resolving here would freeze one answer into stored state; `terminal.duplicate`
-    // re-resolves at reopen against a fresher index.
-    expect(buildPanelSnapshotOptions(panel)?.cwd).toBe(stalePath);
-    expect(indexReads).toBe(0);
+      // Resolving here would freeze one answer into stored state; `terminal.duplicate`
+      // re-resolves at reopen against a fresher index.
+      expect(buildPanelSnapshotOptions(panel)?.cwd).toBe(stalePath);
+      expect(indexReads).toBe(0);
+    });
   });
 
   it("never resolves a directory for browser panels, which own none", async () => {

--- a/src/services/terminal/__tests__/panelDuplicationService.test.ts
+++ b/src/services/terminal/__tests__/panelDuplicationService.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  setWorktreePathIndexAccessor,
+  resetStoreAccessorsForTesting,
+} from "@/store/storeAccessors";
 import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
 import type { BrowserPanelOptions, DevPreviewPanelOptions } from "@shared/types/addPanelOptions";
@@ -62,6 +66,10 @@ vi.mock("@/store/projectPresetsStore", () => ({
     getState: vi.fn(() => ({ presetsByAgent: {} })),
   },
 }));
+
+afterEach(() => {
+  resetStoreAccessorsForTesting();
+});
 
 function makePanel(overrides: Partial<PtyPanelData> | Partial<PanelInstance> = {}): PanelInstance {
   return {
@@ -727,5 +735,121 @@ describe("adversarial: behavioral overrides flow to generateAgentCommand in dupl
 
     const opts = spy.mock.calls[0]![3] as Record<string, unknown>;
     expect(opts.presetArgs).toBeUndefined();
+  });
+});
+
+describe("inherited worktree cwd resolution (#11854)", () => {
+  const stalePath = "/worktrees/source";
+  const filedPath = "/worktrees/destination";
+  const filedId = "wt-destination";
+
+  let buildPanelSnapshotOptions: (panel: PanelInstance) => AddPanelOptions | null;
+  let buildPanelDuplicateOptions: (
+    panel: PanelInstance,
+    location: "grid" | "dock"
+  ) => Promise<AddPanelOptions>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { systemClient } = await import("@/clients");
+    (systemClient.getTmpDir as ReturnType<typeof vi.fn>).mockResolvedValue("/tmp");
+    const { useCcrPresetsStore } = await import("@/store/ccrPresetsStore");
+    (useCcrPresetsStore.getState as ReturnType<typeof vi.fn>).mockReturnValue({
+      ccrPresetsByAgent: {},
+    });
+    const { useProjectPresetsStore } = await import("@/store/projectPresetsStore");
+    (useProjectPresetsStore.getState as ReturnType<typeof vi.fn>).mockReturnValue({
+      presetsByAgent: {},
+    });
+    const mod = await import("../panelDuplicationService");
+    buildPanelSnapshotOptions = mod.buildPanelSnapshotOptions;
+    buildPanelDuplicateOptions = mod.buildPanelDuplicateOptions;
+  });
+
+  // Every kind whose cwd is a real spawn directory. Browser hardcodes "" and
+  // review has no cwd, so both are covered separately below.
+  const spawningPanels: Array<[string, Partial<PanelInstance>]> = [
+    ["agent terminal", { kind: "terminal", launchAgentId: "claude", command: "claude --flag" }],
+    ["plain terminal", { kind: "terminal", command: "bash" }],
+    ["dev-preview", { kind: "dev-preview", devCommand: "npm run dev" }],
+  ];
+
+  async function bothBuilders(panel: PanelInstance): Promise<Array<AddPanelOptions>> {
+    const snapshot = buildPanelSnapshotOptions(panel);
+    expect(snapshot).not.toBeNull();
+    return [snapshot!, await buildPanelDuplicateOptions(panel, "grid")];
+  }
+
+  describe.each(spawningPanels)("%s", (_label, overrides) => {
+    it("launches in the path of the worktree it is filed under, not the source cwd", async () => {
+      setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
+      const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: filedId });
+
+      for (const options of await bothBuilders(panel)) {
+        expect(options.cwd).toBe(filedPath);
+        expect(options.cwd).not.toBe(panel.cwd);
+        // The filing id is the input to the fix, never an output of it.
+        expect(options.worktreeId).toBe(panel.worktreeId);
+      }
+    });
+
+    it("keeps the source cwd when no view store is mounted", async () => {
+      setWorktreePathIndexAccessor(() => null);
+      const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: filedId });
+
+      for (const options of await bothBuilders(panel)) {
+        expect(options.cwd).toBe(panel.cwd);
+      }
+    });
+
+    it("keeps the source cwd when the filed worktree is no longer in the index", async () => {
+      setWorktreePathIndexAccessor(() => new Map([["wt-unrelated", "/worktrees/unrelated"]]));
+      const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: filedId });
+
+      for (const options of await bothBuilders(panel)) {
+        expect(options.cwd).toBe(panel.cwd);
+      }
+    });
+
+    it("keeps the source cwd for a worktree-less panel", async () => {
+      setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
+      const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: undefined });
+
+      for (const options of await bothBuilders(panel)) {
+        expect(options.cwd).toBe(panel.cwd);
+      }
+    });
+
+    it("falls back to an empty cwd when the panel has neither a cwd nor a resolvable worktree", async () => {
+      setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
+      const panel = makePanel({ ...overrides, cwd: undefined, worktreeId: undefined });
+
+      for (const options of await bothBuilders(panel)) {
+        expect(options.cwd).toBe("");
+      }
+    });
+  });
+
+  it("never resolves a cwd for browser panels, which own no directory", async () => {
+    setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
+    const panel = makePanel({
+      kind: "browser",
+      browserUrl: "https://example.com",
+      cwd: stalePath,
+      worktreeId: filedId,
+    } as Partial<PanelInstance>);
+
+    for (const options of await bothBuilders(panel)) {
+      expect(options.cwd).toBe("");
+    }
+  });
+
+  it("does not resolve a worktree path when the panel has no cwd to correct", async () => {
+    setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
+    const panel = makePanel({ kind: "review", worktreeId: filedId } as Partial<PanelInstance>);
+
+    for (const options of await bothBuilders(panel)) {
+      expect(options.cwd).toBeUndefined();
+    }
   });
 });

--- a/src/services/terminal/__tests__/panelDuplicationService.test.ts
+++ b/src/services/terminal/__tests__/panelDuplicationService.test.ts
@@ -743,15 +743,19 @@ describe("inherited worktree cwd resolution (#11854)", () => {
   const filedPath = "/worktrees/destination";
   const filedId = "wt-destination";
 
+  let resolveInheritedPanelCwd: (panel: { cwd?: string; worktreeId?: string }) => string;
   let buildPanelSnapshotOptions: (panel: PanelInstance) => AddPanelOptions | null;
   let buildPanelDuplicateOptions: (
     panel: PanelInstance,
     location: "grid" | "dock"
   ) => Promise<AddPanelOptions>;
+  let indexReads: number;
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    const { systemClient } = await import("@/clients");
+    indexReads = 0;
+    const { agentSettingsClient, systemClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({ agents: {} });
     (systemClient.getTmpDir as ReturnType<typeof vi.fn>).mockResolvedValue("/tmp");
     const { useCcrPresetsStore } = await import("@/store/ccrPresetsStore");
     (useCcrPresetsStore.getState as ReturnType<typeof vi.fn>).mockReturnValue({
@@ -762,76 +766,123 @@ describe("inherited worktree cwd resolution (#11854)", () => {
       presetsByAgent: {},
     });
     const mod = await import("../panelDuplicationService");
+    resolveInheritedPanelCwd = mod.resolveInheritedPanelCwd;
     buildPanelSnapshotOptions = mod.buildPanelSnapshotOptions;
     buildPanelDuplicateOptions = mod.buildPanelDuplicateOptions;
   });
 
-  // Every kind whose cwd is a real spawn directory. Browser hardcodes "" and
-  // review has no cwd, so both are covered separately below.
+  // Counting reads is what separates "returned the inherited cwd because the
+  // index said so" from "never consulted the index at all".
+  function useIndex(entries: Array<[string, string]> | null): void {
+    setWorktreePathIndexAccessor(() => {
+      indexReads += 1;
+      return entries === null ? null : new Map(entries);
+    });
+  }
+
+  describe("resolveInheritedPanelCwd", () => {
+    it("reroots a launch root that belongs to a different worktree", () => {
+      useIndex([
+        [filedId, filedPath],
+        ["wt-source", stalePath],
+      ]);
+
+      expect(resolveInheritedPanelCwd({ cwd: stalePath, worktreeId: filedId })).toBe(filedPath);
+    });
+
+    it("keeps a subdirectory of the filed worktree, which the user chose deliberately", () => {
+      useIndex([[filedId, filedPath]]);
+      const subdirectory = `${filedPath}/packages/api`;
+
+      expect(resolveInheritedPanelCwd({ cwd: subdirectory, worktreeId: filedId })).toBe(
+        subdirectory
+      );
+    });
+
+    it("does not treat a sibling worktree whose path merely extends the filed one as inside it", () => {
+      useIndex([[filedId, filedPath]]);
+
+      expect(resolveInheritedPanelCwd({ cwd: `${filedPath}-other/src`, worktreeId: filedId })).toBe(
+        filedPath
+      );
+    });
+
+    it("adopts the filed worktree when the panel carries no launch root at all", () => {
+      useIndex([[filedId, filedPath]]);
+
+      expect(resolveInheritedPanelCwd({ cwd: undefined, worktreeId: filedId })).toBe(filedPath);
+    });
+
+    it("keeps the launch root when no view store is mounted", () => {
+      useIndex(null);
+
+      expect(resolveInheritedPanelCwd({ cwd: stalePath, worktreeId: filedId })).toBe(stalePath);
+      expect(indexReads).toBeGreaterThan(0);
+    });
+
+    it("keeps the launch root when the filed worktree is no longer indexed", () => {
+      useIndex([["wt-unrelated", "/worktrees/unrelated"]]);
+
+      expect(resolveInheritedPanelCwd({ cwd: stalePath, worktreeId: filedId })).toBe(stalePath);
+      expect(indexReads).toBeGreaterThan(0);
+    });
+
+    it("never consults the index for a worktree-less panel", () => {
+      useIndex([[filedId, filedPath]]);
+
+      expect(resolveInheritedPanelCwd({ cwd: stalePath, worktreeId: undefined })).toBe(stalePath);
+      expect(indexReads).toBe(0);
+    });
+  });
+
+  // Every kind whose cwd is a real spawn directory, so each of the changed
+  // `cwd:` sites in the duplicate builder is distinguished.
   const spawningPanels: Array<[string, Partial<PanelInstance>]> = [
     ["agent terminal", { kind: "terminal", launchAgentId: "claude", command: "claude --flag" }],
     ["plain terminal", { kind: "terminal", command: "bash" }],
     ["dev-preview", { kind: "dev-preview", devCommand: "npm run dev" }],
   ];
 
-  async function bothBuilders(panel: PanelInstance): Promise<Array<AddPanelOptions>> {
-    const snapshot = buildPanelSnapshotOptions(panel);
-    expect(snapshot).not.toBeNull();
-    return [snapshot!, await buildPanelDuplicateOptions(panel, "grid")];
-  }
-
-  describe.each(spawningPanels)("%s", (_label, overrides) => {
-    it("launches in the path of the worktree it is filed under, not the source cwd", async () => {
-      setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
+  describe.each(spawningPanels)("buildPanelDuplicateOptions: %s", (_label, overrides) => {
+    it("launches in the worktree it is filed under, not the source worktree", async () => {
+      useIndex([
+        [filedId, filedPath],
+        ["wt-source", stalePath],
+      ]);
       const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: filedId });
 
-      for (const options of await bothBuilders(panel)) {
-        expect(options.cwd).toBe(filedPath);
-        expect(options.cwd).not.toBe(panel.cwd);
-        // The filing id is the input to the fix, never an output of it.
-        expect(options.worktreeId).toBe(panel.worktreeId);
-      }
+      const options = await buildPanelDuplicateOptions(panel, "grid");
+
+      expect(options.cwd).toBe(filedPath);
+      expect(options.cwd).not.toBe(panel.cwd);
+      // The filing id is the input to the fix, never an output of it.
+      expect(options.worktreeId).toBe(panel.worktreeId);
     });
 
-    it("keeps the source cwd when no view store is mounted", async () => {
-      setWorktreePathIndexAccessor(() => null);
-      const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: filedId });
+    it("keeps a launch root already inside the filed worktree", async () => {
+      useIndex([[filedId, filedPath]]);
+      const subdirectory = `${filedPath}/packages/api`;
+      const panel = makePanel({ ...overrides, cwd: subdirectory, worktreeId: filedId });
 
-      for (const options of await bothBuilders(panel)) {
-        expect(options.cwd).toBe(panel.cwd);
-      }
-    });
-
-    it("keeps the source cwd when the filed worktree is no longer in the index", async () => {
-      setWorktreePathIndexAccessor(() => new Map([["wt-unrelated", "/worktrees/unrelated"]]));
-      const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: filedId });
-
-      for (const options of await bothBuilders(panel)) {
-        expect(options.cwd).toBe(panel.cwd);
-      }
-    });
-
-    it("keeps the source cwd for a worktree-less panel", async () => {
-      setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
-      const panel = makePanel({ ...overrides, cwd: stalePath, worktreeId: undefined });
-
-      for (const options of await bothBuilders(panel)) {
-        expect(options.cwd).toBe(panel.cwd);
-      }
-    });
-
-    it("falls back to an empty cwd when the panel has neither a cwd nor a resolvable worktree", async () => {
-      setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
-      const panel = makePanel({ ...overrides, cwd: undefined, worktreeId: undefined });
-
-      for (const options of await bothBuilders(panel)) {
-        expect(options.cwd).toBe("");
-      }
+      expect((await buildPanelDuplicateOptions(panel, "grid")).cwd).toBe(subdirectory);
     });
   });
 
-  it("never resolves a cwd for browser panels, which own no directory", async () => {
-    setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
+  it("leaves the trash-time snapshot's launch root untouched for the reopen consumer to resolve", () => {
+    useIndex([
+      [filedId, filedPath],
+      ["wt-source", stalePath],
+    ]);
+    const panel = makePanel({ command: "bash", cwd: stalePath, worktreeId: filedId });
+
+    // Resolving here would freeze one answer into stored state; `terminal.duplicate`
+    // re-resolves at reopen against a fresher index.
+    expect(buildPanelSnapshotOptions(panel)?.cwd).toBe(stalePath);
+    expect(indexReads).toBe(0);
+  });
+
+  it("never resolves a directory for browser panels, which own none", async () => {
+    useIndex([[filedId, filedPath]]);
     const panel = makePanel({
       kind: "browser",
       browserUrl: "https://example.com",
@@ -839,17 +890,9 @@ describe("inherited worktree cwd resolution (#11854)", () => {
       worktreeId: filedId,
     } as Partial<PanelInstance>);
 
-    for (const options of await bothBuilders(panel)) {
-      expect(options.cwd).toBe("");
-    }
-  });
+    const options = await buildPanelDuplicateOptions(panel, "grid");
 
-  it("does not resolve a worktree path when the panel has no cwd to correct", async () => {
-    setWorktreePathIndexAccessor(() => new Map([[filedId, filedPath]]));
-    const panel = makePanel({ kind: "review", worktreeId: filedId } as Partial<PanelInstance>);
-
-    for (const options of await bothBuilders(panel)) {
-      expect(options.cwd).toBeUndefined();
-    }
+    expect(options.cwd).not.toBe(filedPath);
+    expect(indexReads).toBe(0);
   });
 });

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -163,6 +163,19 @@ function buildDevPreviewOptions(panel: import("@shared/types/panel").DevPreviewP
 }
 
 /**
+ * Kinds whose `cwd` is a real process launch directory. Browser panels carry a
+ * placeholder empty string and review panels carry no `cwd` at all, so neither
+ * has a launch root to resolve. Not `panelKindHasPty`: a dev preview spawns its
+ * server through `DevPreviewSessionService` rather than the panel's own PTY, so
+ * that flag is false for it while its `cwd` is still a real spawn directory.
+ */
+const LAUNCH_ROOT_KINDS: ReadonlySet<PanelKind> = new Set(["terminal", "dev-preview"]);
+
+export function panelKindHasLaunchRoot(kind: PanelKind | undefined): boolean {
+  return kind !== undefined && LAUNCH_ROOT_KINDS.has(kind);
+}
+
+/**
  * Working directory for a panel that inherits its worktree rather than choosing
  * one. A duplicate is a brand new process, so it belongs in the worktree it is
  * filed under — not the directory the source process kept after a cross-worktree

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -17,6 +17,7 @@ import { agentSettingsClient, systemClient } from "@/clients";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { getWorktreePathIndex } from "@/store/storeAccessors";
+import { classifyLaunchRootAlignment } from "@/utils/worktreeAlignment";
 import {
   buildAgentLaunchFlagsForRuntimeSettings,
   resolveAgentRuntimeSettings,
@@ -163,21 +164,35 @@ function buildDevPreviewOptions(panel: import("@shared/types/panel").DevPreviewP
 
 /**
  * Working directory for a panel that inherits its worktree rather than choosing
- * one. A duplicate or reopened panel is a brand new process, so it belongs in
- * the worktree it is filed under — not whatever directory the source process
- * happened to still be running in after a cross-worktree drag (#11854).
+ * one. A duplicate is a brand new process, so it belongs in the worktree it is
+ * filed under — not the directory the source process kept after a cross-worktree
+ * drag left `cwd` and `worktreeId` pointing at different worktrees (#11854).
+ *
+ * Only a genuine mismatch is rerooted. A launch root already inside the filed
+ * worktree is left alone, because a subdirectory is a deliberate choice there —
+ * `UpdateCwdDialog` and an explicit `terminal.spawn` cwd both produce one, and
+ * collapsing them to the worktree root would discard what the user picked.
+ * `classifyLaunchRootAlignment` makes that call segment-aware, so it survives
+ * nested worktrees and Windows separators where `startsWith` would not.
  *
  * Takes the filing id and the inherited fallback together so no branch can
  * resolve one without the other. Soft-degrades to the inherited `cwd` when the
  * panel has no worktree, no view store is mounted, or the id no longer resolves:
  * the id is inherited rather than asserted by a caller, so a stale one must not
- * fail the launch (#11655). Never throws — `buildPanelSnapshotOptions` runs
- * inside `trashPanel`.
+ * fail the launch (#11655).
  */
 export function resolveInheritedPanelCwd(panel: { cwd?: string; worktreeId?: string }): string {
   const fallback = panel.cwd || "";
   if (!panel.worktreeId) return fallback;
-  return getWorktreePathIndex()?.get(panel.worktreeId) ?? fallback;
+
+  const index = getWorktreePathIndex();
+  const filedPath = index?.get(panel.worktreeId);
+  if (!index || !filedPath) return fallback;
+
+  const worktrees = Array.from(index, ([id, path]) => ({ id, path }));
+  return classifyLaunchRootAlignment(fallback, worktrees, panel.worktreeId) === "aligned"
+    ? fallback
+    : filedPath;
 }
 
 /**
@@ -185,6 +200,13 @@ export function resolveInheritedPanelCwd(panel: { cwd?: string; worktreeId?: str
  * Copies the same fields as buildPanelDuplicateOptions but preserves the
  * existing command verbatim (no async agent command regeneration).
  * Does not include location — callers inject it at use time.
+ *
+ * Keeps `cwd` verbatim rather than resolving it against `worktreeId` the way
+ * `buildPanelDuplicateOptions` does. This snapshot is stored and reopened much
+ * later, so resolving here would freeze one answer and destroy the fallback the
+ * late resolve needs: if the filed worktree is deleted between trash and reopen,
+ * a baked-in path points at the deleted worktree while the untouched `cwd` still
+ * points somewhere real. `terminal.duplicate` resolves at reopen instead (#11854).
  *
  * Called synchronously from `trashPanel` / `trashPanelGroup` — must not throw.
  * Returns `null` for broken agent-running terminals (missing `command` or
@@ -210,7 +232,7 @@ export function buildPanelSnapshotOptions(panel: PanelInstance): AddPanelOptions
       // Reopen-last restores the same terminal — the ownership rung carries
       // verbatim so a renamed title stays pinned across close/reopen.
       titleMode: panel.titleMode,
-      cwd: resolveInheritedPanelCwd(panel),
+      cwd: panel.cwd || "",
       worktreeId: panel.worktreeId,
       exitBehavior: panel.exitBehavior,
       isInputLocked: panel.isInputLocked,
@@ -236,7 +258,7 @@ export function buildPanelSnapshotOptions(panel: PanelInstance): AddPanelOptions
   if (isDevPreviewPanel(panel)) {
     return {
       kind: "dev-preview",
-      cwd: resolveInheritedPanelCwd(panel),
+      cwd: panel.cwd || "",
       worktreeId: panel.worktreeId,
       exitBehavior: panel.exitBehavior,
       ...buildDevPreviewOptions(panel),
@@ -256,7 +278,7 @@ export function buildPanelSnapshotOptions(panel: PanelInstance): AddPanelOptions
       launchAgentId: panel.launchAgentId,
       title: panel.title,
       titleMode: panel.titleMode,
-      cwd: resolveInheritedPanelCwd(panel),
+      cwd: panel.cwd || "",
       worktreeId: panel.worktreeId,
       exitBehavior: panel.exitBehavior,
       isInputLocked: panel.isInputLocked,

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -168,12 +168,18 @@ function buildDevPreviewOptions(panel: import("@shared/types/panel").DevPreviewP
  * filed under — not the directory the source process kept after a cross-worktree
  * drag left `cwd` and `worktreeId` pointing at different worktrees (#11854).
  *
- * Only a genuine mismatch is rerooted. A launch root already inside the filed
- * worktree is left alone, because a subdirectory is a deliberate choice there —
- * `UpdateCwdDialog` and an explicit `terminal.spawn` cwd both produce one, and
- * collapsing them to the worktree root would discard what the user picked.
- * `classifyLaunchRootAlignment` makes that call segment-aware, so it survives
- * nested worktrees and Windows separators where `startsWith` would not.
+ * Only a launch root that provably belongs to a DIFFERENT worktree is rerooted,
+ * because that is the one state a drag can produce. Everything else is kept:
+ * a subdirectory of the filed worktree is a deliberate choice, and so is a path
+ * under no worktree at all (a scratch directory from `UpdateCwdDialog`, another
+ * drive on Windows) — a drag moves between worktrees, so it cannot have produced
+ * that path. Only an empty launch root adopts the filed worktree by default,
+ * having nothing to preserve. `classifyLaunchRootAlignment` decides this
+ * segment-aware, surviving nested worktrees and separator differences that
+ * `startsWith` would get wrong.
+ *
+ * The bias is deliberate: failing to reroot leaves today's behavior, while
+ * rerooting a directory the user chose silently discards it.
  *
  * Takes the filing id and the inherited fallback together so no branch can
  * resolve one without the other. Soft-degrades to the inherited `cwd` when the
@@ -190,9 +196,9 @@ export function resolveInheritedPanelCwd(panel: { cwd?: string; worktreeId?: str
   if (!index || !filedPath) return fallback;
 
   const worktrees = Array.from(index, ([id, path]) => ({ id, path }));
-  return classifyLaunchRootAlignment(fallback, worktrees, panel.worktreeId) === "aligned"
-    ? fallback
-    : filedPath;
+  const alignment = classifyLaunchRootAlignment(fallback, worktrees, panel.worktreeId);
+  if (alignment === "launch-root-mismatch") return filedPath;
+  return fallback || filedPath;
 }
 
 /**

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -16,6 +16,7 @@ import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 import { agentSettingsClient, systemClient } from "@/clients";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
+import { getWorktreePathIndex } from "@/store/storeAccessors";
 import {
   buildAgentLaunchFlagsForRuntimeSettings,
   resolveAgentRuntimeSettings,
@@ -161,6 +162,25 @@ function buildDevPreviewOptions(panel: import("@shared/types/panel").DevPreviewP
 }
 
 /**
+ * Working directory for a panel that inherits its worktree rather than choosing
+ * one. A duplicate or reopened panel is a brand new process, so it belongs in
+ * the worktree it is filed under — not whatever directory the source process
+ * happened to still be running in after a cross-worktree drag (#11854).
+ *
+ * Takes the filing id and the inherited fallback together so no branch can
+ * resolve one without the other. Soft-degrades to the inherited `cwd` when the
+ * panel has no worktree, no view store is mounted, or the id no longer resolves:
+ * the id is inherited rather than asserted by a caller, so a stale one must not
+ * fail the launch (#11655). Never throws — `buildPanelSnapshotOptions` runs
+ * inside `trashPanel`.
+ */
+export function resolveInheritedPanelCwd(panel: { cwd?: string; worktreeId?: string }): string {
+  const fallback = panel.cwd || "";
+  if (!panel.worktreeId) return fallback;
+  return getWorktreePathIndex()?.get(panel.worktreeId) ?? fallback;
+}
+
+/**
  * Build a synchronous snapshot of a panel's config for last-closed fallback.
  * Copies the same fields as buildPanelDuplicateOptions but preserves the
  * existing command verbatim (no async agent command regeneration).
@@ -190,7 +210,7 @@ export function buildPanelSnapshotOptions(panel: PanelInstance): AddPanelOptions
       // Reopen-last restores the same terminal — the ownership rung carries
       // verbatim so a renamed title stays pinned across close/reopen.
       titleMode: panel.titleMode,
-      cwd: panel.cwd || "",
+      cwd: resolveInheritedPanelCwd(panel),
       worktreeId: panel.worktreeId,
       exitBehavior: panel.exitBehavior,
       isInputLocked: panel.isInputLocked,
@@ -216,7 +236,7 @@ export function buildPanelSnapshotOptions(panel: PanelInstance): AddPanelOptions
   if (isDevPreviewPanel(panel)) {
     return {
       kind: "dev-preview",
-      cwd: panel.cwd || "",
+      cwd: resolveInheritedPanelCwd(panel),
       worktreeId: panel.worktreeId,
       exitBehavior: panel.exitBehavior,
       ...buildDevPreviewOptions(panel),
@@ -236,7 +256,7 @@ export function buildPanelSnapshotOptions(panel: PanelInstance): AddPanelOptions
       launchAgentId: panel.launchAgentId,
       title: panel.title,
       titleMode: panel.titleMode,
-      cwd: panel.cwd || "",
+      cwd: resolveInheritedPanelCwd(panel),
       worktreeId: panel.worktreeId,
       exitBehavior: panel.exitBehavior,
       isInputLocked: panel.isInputLocked,
@@ -310,7 +330,7 @@ export async function buildPanelDuplicateOptions(
       // Keep explicit names pinned on the copy — without this, detection
       // rewrites "X (copy)" back to the registry name moments after spawn.
       titleMode: presetWasStale ? undefined : duplicateTitleMode(sourcePanel),
-      cwd: sourcePanel.cwd || "",
+      cwd: resolveInheritedPanelCwd(sourcePanel),
       worktreeId: sourcePanel.worktreeId,
       location: targetLocation,
       exitBehavior: sourcePanel.exitBehavior,
@@ -337,7 +357,7 @@ export async function buildPanelDuplicateOptions(
   if (isDevPreviewPanel(sourcePanel)) {
     return {
       kind: "dev-preview",
-      cwd: sourcePanel.cwd || "",
+      cwd: resolveInheritedPanelCwd(sourcePanel),
       worktreeId: sourcePanel.worktreeId,
       location: targetLocation,
       exitBehavior: sourcePanel.exitBehavior,
@@ -357,7 +377,7 @@ export async function buildPanelDuplicateOptions(
     return {
       kind: "terminal",
       launchAgentId: sourcePanel.launchAgentId,
-      cwd: sourcePanel.cwd || "",
+      cwd: resolveInheritedPanelCwd(sourcePanel),
       title: sourcePanel.title,
       titleMode: duplicateTitleMode(sourcePanel),
       worktreeId: sourcePanel.worktreeId,


### PR DESCRIPTION
## Summary

- A panel carries two loosely coupled fields: `worktreeId` (which worktree it's filed under, set by a drag) and `cwd` (the directory its process actually launched in). A cross worktree drag changes `worktreeId` but deliberately leaves a live process's `cwd` alone, since you can't relocate a running process.
- `buildPanelDuplicateOptions` was copying both fields verbatim onto a brand new panel. Duplicate a panel that had been dragged to a different worktree, and the copy spawned a fresh process in the old worktree while filing it under the new one, no drag required.
- Fixed by rerooting the inherited `cwd` only when it provably belongs to a different worktree than the one the panel is filed under.

Resolves #11854

## The bug

`buildPanelDuplicateOptions` copies `cwd` and `worktreeId` off the source panel verbatim when building a duplicate. Those two fields disagree whenever a panel has been filed under a different worktree while its process kept the directory it originally launched in, which is exactly the state a cross worktree drag leaves behind. Duplicating that panel spawns a new process in the stale directory but files it under the new worktree, so the divergence propagates without anything being dragged.

## The fix

New helper `resolveInheritedPanelCwd` in `src/services/terminal/panelDuplicationService.ts`, applied at the three process launching branches of `buildPanelDuplicateOptions`: agent terminal, plain terminal, and dev preview. Browser panels hardcode an empty `cwd` and review panels have no `cwd`, so both are untouched.

## Reroot only on a proven mismatch

This is the part worth reviewing closely. The helper does not unconditionally reroot to the worktree root, it only reroots when the launch root provably belongs to a *different* worktree, because that's the one state a drag can actually produce:

- A launch root inside the filed worktree is kept. A subdirectory is a deliberate user choice, `UpdateCwdDialog` stores any validated directory and `terminal.spawn` accepts an explicit `cwd`, so overwriting it would be discarding a real choice, not fixing a bug.
- A launch root under no known worktree is also kept. A drag only moves a panel between worktrees, so it can't have produced that path.
- Only a genuinely empty launch root adopts the filed worktree's root, since there's nothing there to preserve.

The bias is deliberate: failing to reroot just leaves today's behavior, but rerooting a directory the user chose on purpose would silently discard it. Classification runs through the existing segment aware `classifyLaunchRootAlignment`, which survives nested worktrees and separator differences that a plain `startsWith` check gets wrong.

## Soft degrade, never throw

An unresolvable or absent `worktreeId` keeps the inherited `cwd` rather than failing the launch. The id is inherited data rather than something asserted by a caller, so a stale one must not fail the launch (precedent #11655). Contrast this with `transferPanelToWorktree`, which does fail closed, because it guards an explicit user triggered move rather than inherited data.

## The second divergence site

`terminal.duplicate`'s reopen-last-closed path (`terminalSpawnActions.ts`) could override `worktreeId` to the active worktree while `cwd` rode in unchanged from the stored snapshot. It now re-derives `cwd` after the worktree id settles.

## Why `buildPanelSnapshotOptions` stays untouched

The issue asked to look at this one too. Leaving it raw is the right call. The snapshot is stored at trash time and reopened much later, so resolving at trash time freezes one answer and destroys the fallback the late resolve needs: if the filed worktree is deleted between trash and reopen, a baked in path points at a deleted worktree while the untouched `cwd` still points somewhere real. Its sole consumer resolves at reopen time against a fresher worktree index instead, which also keeps `trashPanel`'s code path synchronous and non-throwing.

## Testing

255 tests pass across the 10 suites covering this code. The new coverage is mutation verified: reverting the fix kills 6 tests, and separately removing the narrowing logic (the part that avoids rerooting subdirectories and unknown paths) kills 4 different tests, so the tests discriminate correctly in both directions.

The e2e spec `core-panel-tab-groups.spec.ts` had its test name updated only, its assertion was already valid and unchanged. Not run locally since it needs a full app build.

## Out of scope

Found the same bug class in a few other places during review, each worth its own issue and related to #11853, which reworks the drag itself:

- Dragging a dev preview panel respawns its dev server in the old directory, because `isPtyPanel` in `worktreeMoveDecision.ts` only accepts terminal panels and doesn't treat a dev preview as a live process.
- Restart and cold hydration paths (`restart.ts`, `statePatcher.ts`) can replay already persisted stale `worktreeId`/`cwd` pairs.
- Agent session resume can reproduce the divergence from journaled records in `resumeLaunch.ts`.
- Delete rollback and the missing CLI gate can relaunch a panel without the divergence marker set.
