### PR TITLE
fix(switcher): rank search results by live agent activity

### DIFF
--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -1174,6 +1174,40 @@ describe("scratch activity in the search freeze — issue #11861", () => {
     projectStatsState.stats = {};
   });
 
+  it("still resolves when the palette opened before the scratches loaded", async () => {
+    // Loading the workspace lists is itself async and retried, so a palette
+    // opened during boot captures an EMPTY snapshot. Treating "nothing to ask
+    // about" as a settled answer would fold the scratches that arrive a moment
+    // later in as quiet, with no recapture ever due.
+    scratchState.scratches = [];
+    scratchState.currentScratch = null;
+    projectStatsState.stats = {};
+
+    const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
+    act(() => result.current.open("modal"));
+
+    // The lists land first...
+    act(() => {
+      seedScratches(2);
+      rerender();
+    });
+    // ...and their stats only after.
+    act(() => {
+      projectStatsState.stats = {
+        "scratch-1": { activeAgentCount: 0, waitingAgentCount: 2, processCount: 0 },
+        "scratch-2": { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 },
+      };
+      rerender();
+    });
+    act(() => result.current.setQuery("Spike"));
+
+    // Recency alone puts the newer scratch-2 first, so only a snapshot that was
+    // still open to a recapture can produce this.
+    await waitFor(() => {
+      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-1", "scratch-2"]);
+    });
+  });
+
   it("resolves a cold scratch-only session once its stats land", async () => {
     // With no projects there is nothing for a project-gated hydration check to
     // ask about, so it reads as hydrated immediately and freezes every scratch

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -1169,6 +1169,52 @@ describe("scratches in search results", () => {
  * actually happens, that it re-runs when the map moves, and that the open-time
  * pull (the only guaranteed hydration path) asks for scratch ids too.
  */
+describe("scratch activity in the search freeze — issue #11861", () => {
+  beforeEach(() => {
+    projectStatsState.stats = {};
+  });
+
+  it("ranks scratches on frozen activity, and holds it against a stats push", async () => {
+    // Scratches join the ranked list (#11466) but never a browse band, so
+    // search's freeze is the only one that covers them. A snapshot that
+    // captured projects alone would leave every scratch reading as quiet.
+    const seeded = seedScratches(2);
+    // Recency runs the other way, so the wait is the only thing that can put
+    // scratch-1 first.
+    expect(seeded[1]!.lastOpened).toBeGreaterThan(seeded[0]!.lastOpened);
+    projectStatsState.stats = {
+      "scratch-1": { activeAgentCount: 0, waitingAgentCount: 2, processCount: 0 },
+    };
+
+    const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
+    act(() => result.current.open("modal"));
+    act(() => result.current.setQuery("Spike"));
+
+    await waitFor(() => {
+      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-1", "scratch-2"]);
+    });
+
+    // The wait moves to the other scratch mid-read; the order does not.
+    act(() => {
+      projectStatsState.stats = {
+        "scratch-2": { activeAgentCount: 0, waitingAgentCount: 2, processCount: 0 },
+      };
+      rerender();
+    });
+    expect(result.current.results.map((row) => row.id)).toEqual(["scratch-1", "scratch-2"]);
+    // The counts on the rows are still live.
+    expect(result.current.results.find((row) => row.id === "scratch-2")?.waitingAgentCount).toBe(2);
+
+    // Reopening adopts what is true now.
+    act(() => result.current.close());
+    act(() => result.current.open("modal"));
+    act(() => result.current.setQuery("Spike"));
+    await waitFor(() => {
+      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2", "scratch-1"]);
+    });
+  });
+});
+
 describe("scratch agent-status join", () => {
   // The stats fixture is module-scoped and shared with the suites above, so it
   // has to be cleared per-spec or a seeded map leaks into the next assertion.

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -1174,10 +1174,57 @@ describe("scratch activity in the search freeze — issue #11861", () => {
     projectStatsState.stats = {};
   });
 
+  it("resolves a cold scratch-only session once its stats land", async () => {
+    // With no projects there is nothing for a project-gated hydration check to
+    // ask about, so it reads as hydrated immediately and freezes every scratch
+    // as quiet — for the whole session, since the one recapture never fires.
+    const seeded = seedScratches(2);
+    expect(seeded[1]!.lastOpened).toBeGreaterThan(seeded[0]!.lastOpened);
+    projectStatsState.stats = {};
+    vi.mocked(projectClient.getBulkStats).mockResolvedValue({
+      "scratch-1": {
+        processCount: 0,
+        terminalCount: 0,
+        estimatedMemoryMB: 0,
+        terminalTypes: {},
+        processIds: [],
+        activeAgentCount: 0,
+        waitingAgentCount: 2,
+        blockedAgentCount: 0,
+        completedAgentCount: 0,
+        unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
+      },
+      "scratch-2": {
+        processCount: 0,
+        terminalCount: 0,
+        estimatedMemoryMB: 0,
+        terminalTypes: {},
+        processIds: [],
+        activeAgentCount: 0,
+        waitingAgentCount: 0,
+        blockedAgentCount: 0,
+        completedAgentCount: 0,
+        unacknowledgedCompletedAgentCount: 0,
+        snoozedAgentCount: 0,
+      },
+    });
+
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+    act(() => result.current.open("modal"));
+    await waitFor(() => expect(projectClient.getBulkStats).toHaveBeenCalled());
+    act(() => result.current.setQuery("Spike"));
+
+    // Recency alone would put the newer scratch-2 first; only a snapshot that
+    // resolved after hydration can see the wait on scratch-1.
+    await waitFor(() => {
+      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-1", "scratch-2"]);
+    });
+  });
+
   it("ranks scratches on frozen activity, and holds it against a stats push", async () => {
     // Scratches join the ranked list (#11466) but never a browse band, so
-    // search's freeze is the only one that covers them. A snapshot that
-    // captured projects alone would leave every scratch reading as quiet.
+    // search's freeze is the only one that covers them at all.
     const seeded = seedScratches(2);
     // Recency runs the other way, so the wait is the only thing that can put
     // scratch-1 first.

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -1251,6 +1251,165 @@ describe("useProjectSwitcherPalette", () => {
     });
   });
 
+  describe("search activity freeze — issue #11861", () => {
+    const base = (id: string, name: string) => ({
+      id,
+      name,
+      path: `/repo/${id}`,
+      emoji: "🌲",
+      lastOpened: 100,
+      frecencyScore: 3.0,
+      status: "closed" as const,
+    });
+    const pair = () => [base("one", "alpha-one"), base("two", "alpha-two")];
+    const QUIET = { activeAgentCount: 0, waitingAgentCount: 0, processCount: 0 };
+    const WAITING = { activeAgentCount: 0, waitingAgentCount: 2, processCount: 0 };
+
+    it("holds the ranked order against a stats push while the counts keep updating", async () => {
+      // Search ranks equally-well-matched names by what they are asking for, and
+      // that answer arrives live over IPC. Re-ranking on every push would move a
+      // row out from under the pointer between deciding to click and clicking —
+      // and would change what Enter commits, since selection is the top row
+      // until the user arrows.
+      const projects = pair();
+      projectState.projects = projects;
+      projectState.currentProject = null;
+      projectStatsState.stats = { two: WAITING };
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(projects.map((p) => p.id)));
+
+      const { result, rerender, unmount } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(2);
+      });
+      act(() => {
+        result.current.setQuery("alpha");
+      });
+      await waitFor(() => {
+        expect(result.current.results.map((r) => r.id)).toEqual(["two", "one"]);
+      });
+
+      // The wait moves to the other project mid-read.
+      act(() => {
+        projectStatsState.stats = { one: WAITING, two: QUIET };
+        rerender();
+      });
+
+      // The order is the one the user is looking at...
+      expect(result.current.results.map((r) => r.id)).toEqual(["two", "one"]);
+      // ...while the rows themselves report what is true now, which is what
+      // keeps a held row's status line honest about why it is where it is.
+      expect(result.current.results.find((r) => r.id === "one")?.waitingAgentCount).toBe(2);
+      expect(result.current.results.find((r) => r.id === "two")?.waitingAgentCount).toBe(0);
+
+      // Reopening is what refreshes it — the freeze is per session, not forever.
+      act(() => {
+        result.current.close();
+      });
+      act(() => {
+        result.current.open("modal");
+      });
+      act(() => {
+        result.current.setQuery("alpha");
+      });
+      await waitFor(() => {
+        expect(result.current.results.map((r) => r.id)).toEqual(["one", "two"]);
+      });
+      unmount();
+    });
+
+    it("regroups a session that opened before any stats arrived, then holds", async () => {
+      // A snapshot taken cold reads every row as quiet, which is not an order —
+      // it is the absence of one. It has to resolve once, the way browse's band
+      // freeze does, rather than locking the session into the guess.
+      const projects = pair();
+      projectState.projects = projects;
+      projectState.currentProject = null;
+      projectStatsState.stats = {};
+      const bulk = emptyBulkStats(projects.map((p) => p.id));
+      bulk.two!.waitingAgentCount = 2;
+      getBulkStatsMock.mockResolvedValue(bulk);
+
+      const { result, rerender, unmount } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(setStatsMock).toHaveBeenCalled();
+      });
+      act(() => {
+        result.current.setQuery("alpha");
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.map((r) => r.id)).toEqual(["two", "one"]);
+      });
+
+      // Resolved once, and now as immovable as a session that opened warm.
+      act(() => {
+        projectStatsState.stats = { one: WAITING, two: QUIET };
+        rerender();
+      });
+      expect(result.current.results.map((r) => r.id)).toEqual(["two", "one"]);
+      unmount();
+    });
+
+    it("holds a project that registered after the freeze just as still", async () => {
+      // An arrival has no snapshot entry, so it ranks as quiet until it is
+      // folded in. What it must never do is track the live counts — that is the
+      // one row still moving on every push.
+      const projects = pair();
+      projectState.projects = projects;
+      projectState.currentProject = null;
+      projectStatsState.stats = { two: WAITING };
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(projects.map((p) => p.id)));
+
+      const { result, rerender, unmount } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(2);
+      });
+      act(() => {
+        result.current.setQuery("alpha");
+      });
+      await waitFor(() => {
+        expect(result.current.results.map((r) => r.id)).toEqual(["two", "one"]);
+      });
+
+      // A third project registers, already blocked — the loudest thing in the list.
+      act(() => {
+        projectState.projects = [...projects, base("three", "alpha-three")];
+        projectStatsState.stats = {
+          two: WAITING,
+          three: {
+            activeAgentCount: 0,
+            waitingAgentCount: 5,
+            blockedAgentCount: 5,
+            processCount: 0,
+          },
+        };
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+      expect(result.current.results.map((r) => r.id)).toEqual(["three", "two", "one"]);
+
+      // And having taken that one position it stops moving, like everything else.
+      act(() => {
+        projectStatsState.stats = { one: WAITING, two: QUIET, three: QUIET };
+        rerender();
+      });
+      expect(result.current.results.map((r) => r.id)).toEqual(["three", "two", "one"]);
+      unmount();
+    });
+  });
+
   describe("toggle for repeated Cmd+Alt+P", () => {
     const threeProjects = [
       {

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -1,5 +1,9 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useDeferredValue } from "react";
-import { rankSwitcherMatches } from "@/lib/projectSwitcherSearch";
+import {
+  computeSearchActivityKey,
+  rankSwitcherMatches,
+  type SearchActivityKey,
+} from "@/lib/projectSwitcherSearch";
 import { buildDisplayPaths } from "@/lib/projectDisplayPath";
 import { useProjectStore } from "@/store/projectStore";
 import { useProjectStatsStore } from "@/store/projectStatsStore";
@@ -416,6 +420,25 @@ export interface UseProjectSwitcherPaletteReturn {
   isDeletingOriginalScratch: boolean;
 }
 
+/**
+ * Whether this row's freeze is a guess until main reports stats for it.
+ *
+ * Shared by browse's layout freeze and search's activity freeze so the two
+ * cannot drift on when a session stops being provisional — they resolve on the
+ * same commit, and the user sees one regroup rather than two moments apart.
+ *
+ * The active row is banded `current` and a missing one `unavailable` without
+ * consulting stats, so neither says anything about hydration. They are excluded
+ * from the QUESTION, not from either freeze: both still capture a key for every
+ * row. Search has no `current` band and reads an active row's activity like any
+ * other, but gating on rows main may never report — a missing project, a scratch
+ * that has never hosted a terminal — would leave the regroup permanently
+ * pending, which is the failure this exclusion exists to avoid.
+ */
+function isStatsSensitive(project: SearchableProject): boolean {
+  return !project.isActive && !project.isMissing;
+}
+
 interface FrozenLayout {
   order: string[];
   sections: Map<string, ProjectSectionKey>;
@@ -424,6 +447,24 @@ interface FrozenLayout {
    * reached the view, so every band in it is a placeholder. Cleared by the one
    * regroup that resolves the session.
    */
+  isProvisional: boolean;
+}
+
+/**
+ * Search's own freeze: what every workspace was asking of the user when the
+ * palette opened, keyed by row id (#11861).
+ *
+ * Separate from {@link FrozenLayout} rather than folded into it, because that
+ * one answers a different question. It holds browse's ORDER and BAND membership
+ * — current/pinned/snoozed policy search has no use for — and it covers projects
+ * only, while search ranks scratches in the same list (#11466).
+ *
+ * What is frozen is the SORT KEY, never the row. The view-models stay live, so a
+ * promoted row's status line keeps counting up while the row itself holds still.
+ */
+interface FrozenSearchActivity {
+  keys: Map<string, SearchActivityKey>;
+  /** Same meaning as {@link FrozenLayout.isProvisional}, resolved on the same commit. */
   isProvisional: boolean;
 }
 
@@ -672,16 +713,21 @@ function compareWithinSection(
  * keys off the same signal ({@link UseProjectSwitcherPaletteReturn.isRankedSearch}),
  * so for that frame the scratches are simply still down there — never listed
  * twice, and never briefly absent from both places.
+ *
+ * `activityKeys` is the session's frozen activity snapshot, which search ranks
+ * by once the text scores tie. Browse ignores it: its own freeze already holds
+ * that order.
  */
 function buildResults(
   browseRows: ProjectSwitcherRow[],
   browseOrdered: SearchableProject[],
   scratches: SearchableScratch[],
   rankQuery: string,
-  isSearching: boolean
+  isSearching: boolean,
+  activityKeys: ReadonlyMap<string, SearchActivityKey> | null
 ): ProjectSwitcherRow[] {
   if (isSearching && rankQuery.trim()) {
-    return rankSwitcherMatches(rankQuery, browseOrdered, scratches);
+    return rankSwitcherMatches(rankQuery, browseOrdered, scratches, activityKeys);
   }
   return browseRows;
 }
@@ -993,6 +1039,29 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     []
   );
 
+  // Search's activity keys are frozen for the same reason and over the same
+  // session, but separately: browse's freeze is projects-and-bands, and search
+  // ranks scratches in the same list with no bands at all (#11861).
+  const [frozenSearchActivity, setFrozenSearchActivity] = useState<FrozenSearchActivity | null>(
+    null
+  );
+
+  const captureSearchActivity = useCallback(
+    (
+      projects: SearchableProject[],
+      scratches: SearchableScratch[],
+      isProvisional = false
+    ): FrozenSearchActivity => {
+      const keys = new Map<string, SearchActivityKey>();
+      // Every row, including the active and the missing ones: search has no band
+      // that spares a row from being ranked on what it is doing.
+      for (const project of projects) keys.set(project.id, computeSearchActivityKey(project));
+      for (const scratch of scratches) keys.set(scratch.id, computeSearchActivityKey(scratch));
+      return { keys, isProvisional };
+    },
+    []
+  );
+
   // Changing the sort order is the one input that must beat the freeze. The
   // freeze exists so rows don't move on their own; a mode the user just picked
   // is the opposite of that, and holding it until the next open would read as
@@ -1081,8 +1150,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     // session just behaves as it did before this fix.
     if (frozenLayout.isProvisional) {
       const stillGuessing = liveBrowseOrder.some(
-        (project) =>
-          !project.isActive && !project.isMissing && projectStats[project.id] === undefined
+        (project) => isStatsSensitive(project) && projectStats[project.id] === undefined
       );
       if (!stillGuessing) {
         setFrozenLayout((previous) =>
@@ -1190,6 +1258,60 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     return list;
   }, [scratches, currentScratch?.id, projectStats]);
 
+  // The search freeze's counterpart to the browse regroup above, gated on the
+  // same predicate so both resolve on one commit.
+  //
+  // A provisional snapshot read every row as quiet, which is not an ordering —
+  // it is the absence of one. Once no stats-sensitive row is still a guess it is
+  // recaptured whole, exactly once, and holds from there.
+  //
+  // Rows that appear afterwards are folded in at their key of the moment. Until
+  // that lands they rank as quiet rather than as their live counts
+  // (`rankSwitcherMatches`), so an arrival still never moves on a stats push —
+  // it takes its one position and then holds like everything else.
+  useEffect(() => {
+    if (!frozenSearchActivity) return;
+
+    if (frozenSearchActivity.isProvisional) {
+      const stillGuessing = liveBrowseOrder.some(
+        (project) => isStatsSensitive(project) && projectStats[project.id] === undefined
+      );
+      if (!stillGuessing) {
+        setFrozenSearchActivity((previous) =>
+          // Identity, not truthiness: an effect left over from a previous open
+          // session must not recapture this one against stale rows.
+          previous === frozenSearchActivity
+            ? captureSearchActivity(searchableProjects, scratchResults)
+            : previous
+        );
+        return;
+      }
+    }
+
+    const arrivals = [...searchableProjects, ...scratchResults].filter(
+      (row) => !frozenSearchActivity.keys.has(row.id)
+    );
+    if (arrivals.length === 0) return;
+    setFrozenSearchActivity((previous) => {
+      if (!previous) return previous;
+      const keys = new Map(previous.keys);
+      for (const row of arrivals) {
+        if (keys.has(row.id)) continue;
+        keys.set(row.id, computeSearchActivityKey(row));
+      }
+      // Spread, so a session still waiting on its first stats stays provisional
+      // and folds this arrival into its pending recapture.
+      return { ...previous, keys };
+    });
+  }, [
+    searchableProjects,
+    scratchResults,
+    liveBrowseOrder,
+    projectStats,
+    frozenSearchActivity,
+    captureSearchActivity,
+  ]);
+
   /**
    * What is executing across every workspace, for the palette header (#11832).
    *
@@ -1235,8 +1357,16 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const isRankedSearch = isSearching && resultsQuery.trim().length > 0;
 
   const results = useMemo<ProjectSwitcherRow[]>(
-    () => buildResults(browseRows, browseOrdered, scratchResults, resultsQuery, isSearching),
-    [browseRows, browseOrdered, scratchResults, resultsQuery, isSearching]
+    () =>
+      buildResults(
+        browseRows,
+        browseOrdered,
+        scratchResults,
+        resultsQuery,
+        isSearching,
+        frozenSearchActivity?.keys ?? null
+      ),
+    [browseRows, browseOrdered, scratchResults, resultsQuery, isSearching, frozenSearchActivity]
   );
 
   // The selected ROW is the state; its index is derived. Tracking an index
@@ -1301,13 +1431,16 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       // looking at. Active and unavailable rows are banded without stats, so
       // they say nothing about hydration; pinned rows do, since attention
       // outranks a pin.
-      const statsSensitive = liveBrowseOrder.filter(
-        (project) => !project.isActive && !project.isMissing
-      );
+      const statsSensitive = liveBrowseOrder.filter(isStatsSensitive);
       const isProvisional =
         statsSensitive.length > 0 &&
         statsSensitive.every((project) => projectStats[project.id] === undefined);
       setFrozenLayout(captureLayout(liveBrowseOrder, isProvisional));
+      // The same verdict, so search's ordering and browse's banding stop being
+      // guesses at the same moment rather than regrouping one after the other.
+      setFrozenSearchActivity(
+        captureSearchActivity(searchableProjects, scratchResults, isProvisional)
+      );
       // Preselect the first ENABLED row that isn't the project we're already
       // in, so open-then-Enter is a one-two return that never defaults onto an
       // Unavailable row (selecting one opens the relocation dialog — the right
@@ -1323,7 +1456,14 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         liveBrowseOrder[0];
       setSelectedRowId(initial?.id ?? null);
     },
-    [liveBrowseOrder, captureLayout, projectStats]
+    [
+      liveBrowseOrder,
+      captureLayout,
+      projectStats,
+      captureSearchActivity,
+      searchableProjects,
+      scratchResults,
+    ]
   );
 
   const close = useCallback(() => {
@@ -1335,6 +1475,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     setQuery("");
     setSelectedRowId(null);
     setFrozenLayout(null);
+    setFrozenSearchActivity(null);
   }, [mode]);
 
   // Steps the selection by `delta` rows, wrapping. Resolves the current row

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -421,22 +421,44 @@ export interface UseProjectSwitcherPaletteReturn {
 }
 
 /**
- * Whether this row's freeze is a guess until main reports stats for it.
- *
- * Shared by browse's layout freeze and search's activity freeze so the two
- * cannot drift on when a session stops being provisional — they resolve on the
- * same commit, and the user sees one regroup rather than two moments apart.
+ * Whether this project's BAND is a guess until main reports stats for it.
  *
  * The active row is banded `current` and a missing one `unavailable` without
- * consulting stats, so neither says anything about hydration. They are excluded
- * from the QUESTION, not from either freeze: both still capture a key for every
- * row. Search has no `current` band and reads an active row's activity like any
- * other, but gating on rows main may never report — a missing project, a scratch
- * that has never hosted a terminal — would leave the regroup permanently
- * pending, which is the failure this exclusion exists to avoid.
+ * consulting stats, so neither says anything about hydration — they are excluded
+ * from the question, never from the freeze itself.
+ *
+ * Browse only. Search bands nothing and reads an active row's activity like any
+ * other's, so it asks a wider question — see {@link countSearchRowsAwaitingStats}.
  */
 function isStatsSensitive(project: SearchableProject): boolean {
   return !project.isActive && !project.isMissing;
+}
+
+/**
+ * How many rows search ranks, and how many of those main has not reported on.
+ *
+ * Wider than {@link isStatsSensitive} on both axes, because search ranks every
+ * row on what it is doing: the active project and the unavailable one included,
+ * and scratches alongside projects (#11466). Gating search on browse's
+ * project-only question would strand a session that has scratches but no
+ * projects — with nothing to ask about it would read as hydrated at once, and
+ * freeze every scratch as quiet for the rest of the session.
+ *
+ * Safe to ask about every row because the bulk pull seeds an entry for each id
+ * it is handed, present or absent, and it is handed both kinds
+ * (`projectAgentCounts`). A row stays unkeyed only if the pull never lands, and
+ * a session that never hydrates simply behaves as it did before any of this —
+ * the same floor browse's regroup has.
+ */
+function countSearchRowsAwaitingStats(
+  projects: SearchableProject[],
+  scratches: SearchableScratch[],
+  stats: ProjectStatusMap
+): { total: number; unkeyed: number } {
+  let unkeyed = 0;
+  for (const project of projects) if (stats[project.id] === undefined) unkeyed += 1;
+  for (const scratch of scratches) if (stats[scratch.id] === undefined) unkeyed += 1;
+  return { total: projects.length + scratches.length, unkeyed };
 }
 
 interface FrozenLayout {
@@ -715,8 +737,8 @@ function compareWithinSection(
  * twice, and never briefly absent from both places.
  *
  * `activityKeys` is the session's frozen activity snapshot, which search ranks
- * by once the text scores tie. Browse ignores it: its own freeze already holds
- * that order.
+ * by within each tier of name-match quality. Browse ignores it: its own freeze
+ * already holds that order.
  */
 function buildResults(
   browseRows: ProjectSwitcherRow[],
@@ -1273,10 +1295,12 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     if (!frozenSearchActivity) return;
 
     if (frozenSearchActivity.isProvisional) {
-      const stillGuessing = liveBrowseOrder.some(
-        (project) => isStatsSensitive(project) && projectStats[project.id] === undefined
+      const { unkeyed } = countSearchRowsAwaitingStats(
+        searchableProjects,
+        scratchResults,
+        projectStats
       );
-      if (!stillGuessing) {
+      if (unkeyed === 0) {
         setFrozenSearchActivity((previous) =>
           // Identity, not truthiness: an effect left over from a previous open
           // session must not recapture this one against stale rows.
@@ -1293,12 +1317,19 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     );
     if (arrivals.length === 0) return;
     setFrozenSearchActivity((previous) => {
-      if (!previous) return previous;
+      // Identity, for the same reason the recapture above checks it: an updater
+      // queued against a previous open session must not seat its arrivals in
+      // this one. Bailing is free — the snapshot is a dependency, so the effect
+      // fires again against whichever one React actually applied.
+      if (previous !== frozenSearchActivity) return previous;
       const keys = new Map(previous.keys);
+      let added = false;
       for (const row of arrivals) {
         if (keys.has(row.id)) continue;
         keys.set(row.id, computeSearchActivityKey(row));
+        added = true;
       }
+      if (!added) return previous;
       // Spread, so a session still waiting on its first stats stays provisional
       // and folds this arrival into its pending recapture.
       return { ...previous, keys };
@@ -1306,7 +1337,6 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   }, [
     searchableProjects,
     scratchResults,
-    liveBrowseOrder,
     projectStats,
     frozenSearchActivity,
     captureSearchActivity,
@@ -1436,10 +1466,19 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         statsSensitive.length > 0 &&
         statsSensitive.every((project) => projectStats[project.id] === undefined);
       setFrozenLayout(captureLayout(liveBrowseOrder, isProvisional));
-      // The same verdict, so search's ordering and browse's banding stop being
-      // guesses at the same moment rather than regrouping one after the other.
+      // Its own verdict, over its own rows: search ranks scratches and the
+      // active row too, so browse's answer does not cover the set it froze.
+      const searchRows = countSearchRowsAwaitingStats(
+        searchableProjects,
+        scratchResults,
+        projectStats
+      );
       setFrozenSearchActivity(
-        captureSearchActivity(searchableProjects, scratchResults, isProvisional)
+        captureSearchActivity(
+          searchableProjects,
+          scratchResults,
+          searchRows.total > 0 && searchRows.unkeyed === searchRows.total
+        )
       );
       // Preselect the first ENABLED row that isn't the project we're already
       // in, so open-then-Enter is a one-two return that never defaults onto an

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -486,7 +486,11 @@ interface FrozenLayout {
  */
 interface FrozenSearchActivity {
   keys: Map<string, SearchActivityKey>;
-  /** Same meaning as {@link FrozenLayout.isProvisional}, resolved on the same commit. */
+  /**
+   * Same meaning as {@link FrozenLayout.isProvisional}, but reached on its own
+   * terms — search asks about a wider set of rows, so a session can be
+   * provisional for one freeze and settled for the other.
+   */
   isProvisional: boolean;
 }
 
@@ -1280,27 +1284,36 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     return list;
   }, [scratches, currentScratch?.id, projectStats]);
 
-  // The search freeze's counterpart to the browse regroup above, gated on the
-  // same predicate so both resolve on one commit.
+  // The search freeze's counterpart to the browse regroup above, over search's
+  // own set of rows rather than browse's.
   //
   // A provisional snapshot read every row as quiet, which is not an ordering —
-  // it is the absence of one. Once no stats-sensitive row is still a guess it is
-  // recaptured whole, exactly once, and holds from there.
+  // it is the absence of one. Once no row search ranks is still a guess it is
+  // recaptured whole, exactly once, and holds from there. A session that opened
+  // before the workspace lists themselves loaded stays provisional through the
+  // arrivals below, so the recapture is still ahead of it: `total === 0` is the
+  // emptiest guess there is, not a settled answer.
   //
   // Rows that appear afterwards are folded in at their key of the moment. Until
   // that lands they rank as quiet rather than as their live counts
-  // (`rankSwitcherMatches`), so an arrival still never moves on a stats push —
-  // it takes its one position and then holds like everything else.
+  // (`rankSwitcherMatches`) — so an arrival is seated once at the bottom of its
+  // text tier and once at its real place, and never again. Browse's arrivals
+  // avoid even that because their band-end slot is the same before and after;
+  // search has nowhere equivalent to park one. Reading live counts for the
+  // gap instead would leave that row tracking every push, which is the whole
+  // thing this freeze exists to stop.
   useEffect(() => {
     if (!frozenSearchActivity) return;
 
     if (frozenSearchActivity.isProvisional) {
-      const { unkeyed } = countSearchRowsAwaitingStats(
+      const { total, unkeyed } = countSearchRowsAwaitingStats(
         searchableProjects,
         scratchResults,
         projectStats
       );
-      if (unkeyed === 0) {
+      // `total > 0` so an empty session waits for its rows instead of resolving
+      // against nothing and locking whatever arrives next in as quiet.
+      if (total > 0 && unkeyed === 0) {
         setFrozenSearchActivity((previous) =>
           // Identity, not truthiness: an effect left over from a previous open
           // session must not recapture this one against stale rows.
@@ -1477,7 +1490,12 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         captureSearchActivity(
           searchableProjects,
           scratchResults,
-          searchRows.total > 0 && searchRows.unkeyed === searchRows.total
+          // No rows counts as provisional, unlike browse's check. Loading the
+          // workspace lists is itself async and retried, so a palette opened
+          // during boot can capture nothing at all — and calling that snapshot
+          // settled would let the scratches that arrive a moment later fold in
+          // as quiet with no recapture ever due.
+          searchRows.unkeyed === searchRows.total
         )
       );
       // Preselect the first ENABLED row that isn't the project we're already

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -4,6 +4,7 @@ import {
   scoreProjectQuery,
   scoreScratchQuery,
   rankSwitcherMatches,
+  QUIET_SEARCH_ACTIVITY,
 } from "../projectSwitcherSearch";
 import type { SearchableProject, SearchableScratch } from "@/hooks/useProjectSwitcherPalette";
 
@@ -200,17 +201,17 @@ describe("rankSwitcherMatches", () => {
   ];
 
   it("returns empty for empty query", () => {
-    expect(rankSwitcherMatches("", projects, [])).toEqual([]);
-    expect(rankSwitcherMatches("  ", projects, [])).toEqual([]);
+    expect(rankSwitcherMatches("", projects, [], null)).toEqual([]);
+    expect(rankSwitcherMatches("  ", projects, [], null)).toEqual([]);
   });
 
   it("filters out non-matching projects", () => {
-    const results = rankSwitcherMatches("xyz", projects, []);
+    const results = rankSwitcherMatches("xyz", projects, [], null);
     expect(results).toHaveLength(0);
   });
 
   it("ranks exact name substring matches first", () => {
-    const results = rankSwitcherMatches("daintree", projects, []);
+    const results = rankSwitcherMatches("daintree", projects, [], null);
     expect(results.length).toBeGreaterThanOrEqual(2);
     expect(results[0]!.name).toContain("daintree");
   });
@@ -230,13 +231,13 @@ describe("rankSwitcherMatches", () => {
         frecencyScore: 5.0,
       }),
     ];
-    const results = rankSwitcherMatches("alpha", tieProjects, []);
+    const results = rankSwitcherMatches("alpha", tieProjects, [], null);
     expect(results[0]!.id).toBe("b"); // higher frecencyScore wins
   });
 
   it("trims whitespace from query before matching", () => {
-    const results = rankSwitcherMatches("  daintree  ", projects, []);
-    const resultsClean = rankSwitcherMatches("daintree", projects, []);
+    const results = rankSwitcherMatches("  daintree  ", projects, [], null);
+    const resultsClean = rankSwitcherMatches("daintree", projects, [], null);
     expect(results).toHaveLength(resultsClean.length);
     expect(results.map((r) => r.id)).toEqual(resultsClean.map((r) => r.id));
   });
@@ -245,7 +246,7 @@ describe("rankSwitcherMatches", () => {
     const many = Array.from({ length: 20 }, (_, i) =>
       makeProject({ id: `p${i}`, name: `project-${i}`, path: `/repos/p${i}`, lastOpened: i })
     );
-    const results = rankSwitcherMatches("project", many, []);
+    const results = rankSwitcherMatches("project", many, [], null);
     expect(results).toHaveLength(20);
   });
 
@@ -257,12 +258,12 @@ describe("rankSwitcherMatches", () => {
     const weak = makeProject({ id: "weak", name: "a-l-p-h-a", path: "/zzz", frecencyScore: 99 });
     const scratch = makeScratch({ id: "mid", name: "alpha-spike" });
 
-    const mixed = rankSwitcherMatches("alpha", [weak, strong], [scratch]);
+    const mixed = rankSwitcherMatches("alpha", [weak, strong], [scratch], null);
 
     expect(mixed.map((r) => r.id)).toEqual(["strong", "mid", "weak"]);
     // And the projects keep the order they had with no scratch in the pool.
     expect(mixed.filter((r) => r.kind === "project").map((r) => r.id)).toEqual(
-      rankSwitcherMatches("alpha", [weak, strong], []).map((r) => r.id)
+      rankSwitcherMatches("alpha", [weak, strong], [], null).map((r) => r.id)
     );
   });
 
@@ -270,7 +271,8 @@ describe("rankSwitcherMatches", () => {
     const results = rankSwitcherMatches(
       "alpha",
       [makeProject({ id: "p", name: "alpha-app", path: "/repos/alpha" })],
-      [makeScratch({ id: "s", name: "alpha-notes" })]
+      [makeScratch({ id: "s", name: "alpha-notes" })],
+      null
     );
     expect(results.map((r) => r.kind).sort()).toEqual(["project", "scratch"]);
   });
@@ -280,7 +282,7 @@ describe("rankSwitcherMatches", () => {
       makeScratch({ id: "s1", name: "auth-notes" }),
       makeScratch({ id: "s2", name: "billing-spike" }),
     ];
-    const results = rankSwitcherMatches("auth", [], scratches);
+    const results = rankSwitcherMatches("auth", [], scratches, null);
     expect(results.map((r) => r.id)).toEqual(["s1"]);
   });
 
@@ -294,7 +296,7 @@ describe("rankSwitcherMatches", () => {
       scoreScratchQuery("release", scratch.name)
     );
 
-    expect(rankSwitcherMatches("release", [project], [scratch]).map((r) => r.id)).toEqual([
+    expect(rankSwitcherMatches("release", [project], [scratch], null).map((r) => r.id)).toEqual([
       "p",
       "s",
     ]);
@@ -306,7 +308,8 @@ describe("rankSwitcherMatches", () => {
     const results = rankSwitcherMatches(
       "auth",
       [makeProject({ id: "p", name: "a-u-t-h-elper", path: "/repos/auth-adjacent" })],
-      [makeScratch({ id: "s", name: "auth-notes" })]
+      [makeScratch({ id: "s", name: "auth-notes" })],
+      null
     );
     expect(results[0]!.id).toBe("s");
   });
@@ -318,8 +321,410 @@ describe("rankSwitcherMatches", () => {
       [
         makeScratch({ id: "old", name: "notes", lastOpened: 100 }),
         makeScratch({ id: "new", name: "notes", lastOpened: 900 }),
-      ]
+      ],
+      null
     );
     expect(results.map((r) => r.id)).toEqual(["new", "old"]);
+  });
+});
+
+describe("rankSwitcherMatches activity ordering", () => {
+  // The four real workspaces from #11861. Every name starts with "Daintree" and
+  // every path sits under the same parent, which is what made all four score
+  // identically at every prefix.
+  const DAINTREE_ROOT = "/Users/gpriday/Projects/Daintree";
+
+  function daintreeFixture(): SearchableProject[] {
+    return [
+      makeProject({
+        id: "daintree",
+        name: "Daintree",
+        path: `${DAINTREE_ROOT}/daintree`,
+        frecencyScore: 163.2,
+        activeAgentCount: 1,
+      }),
+      makeProject({
+        id: "backend",
+        name: "Daintree Assistant Backend",
+        path: `${DAINTREE_ROOT}/assistant-backend`,
+        frecencyScore: 102.3,
+        completedAgentCount: 1,
+        unacknowledgedCompletedAgentCount: 1,
+      }),
+      makeProject({
+        id: "assistant",
+        name: "Daintree Assistant",
+        path: `${DAINTREE_ROOT}/assistant`,
+        frecencyScore: 75.6,
+        waitingAgentCount: 2,
+      }),
+      makeProject({
+        id: "website",
+        name: "Daintree Website",
+        path: `${DAINTREE_ROOT}/website`,
+        frecencyScore: 12.7,
+        waitingAgentCount: 1,
+        blockedAgentCount: 1,
+      }),
+    ];
+  }
+
+  it("keeps every shared-prefix name in one cohort, whatever trails the match", () => {
+    // The suffixes differ in length and the paths differ in tail, but none of
+    // that may split the cohort — a cohort that splits has activity ordering
+    // rows that were never comparable in the first place.
+    const projects = daintreeFixture();
+    // Frecency runs the other way, so the comparator this replaces returns the
+    // exact reverse of the expectation below at every one of these queries.
+    expect(
+      [...projects].sort((a, b) => b.frecencyScore - a.frecencyScore).map((p) => p.id)
+    ).toEqual(["daintree", "backend", "assistant", "website"]);
+
+    for (const query of ["d", "dai", "daint"]) {
+      expect(rankSwitcherMatches(query, projects, [], null).map((r) => r.id)).toEqual([
+        "website", // blocked
+        "assistant", // waiting
+        "backend", // unreviewed completion
+        "daintree", // working
+      ]);
+    }
+  });
+
+  it("keeps a dormant exact name first against prefix matches that are on fire", () => {
+    const projects = daintreeFixture().map((project) =>
+      project.id === "daintree"
+        ? makeProject({ ...project, frecencyScore: 0, lastOpened: 0, activeAgentCount: 0 })
+        : makeProject({ ...project, waitingAgentCount: 40, blockedAgentCount: 40 })
+    );
+
+    expect(rankSwitcherMatches("daintree", projects, [], null)[0]!.id).toBe("daintree");
+    // One character short of the full name it is merely a prefix match again,
+    // so the tier is what is carrying it rather than anything about the row.
+    expect(rankSwitcherMatches("daintre", projects, [], null)[0]!.id).not.toBe("daintree");
+  });
+
+  it("orders an equal-quality cohort by what it is asking, loudest first", () => {
+    const projects = [
+      makeProject({ id: "quiet", name: "alpha-quiet", path: "/repos/alpha" }),
+      makeProject({
+        id: "work-1",
+        name: "alpha-work-1",
+        path: "/repos/alpha",
+        activeAgentCount: 1,
+      }),
+      makeProject({
+        id: "work-3",
+        name: "alpha-work-3",
+        path: "/repos/alpha",
+        activeAgentCount: 3,
+      }),
+      makeProject({
+        id: "review",
+        name: "alpha-review",
+        path: "/repos/alpha",
+        completedAgentCount: 2,
+        unacknowledgedCompletedAgentCount: 2,
+      }),
+      makeProject({
+        id: "wait-1",
+        name: "alpha-wait-1",
+        path: "/repos/alpha",
+        waitingAgentCount: 1,
+      }),
+      makeProject({
+        id: "wait-3",
+        name: "alpha-wait-3",
+        path: "/repos/alpha",
+        waitingAgentCount: 3,
+      }),
+    ];
+
+    expect(rankSwitcherMatches("alpha", projects, [], null).map((r) => r.id)).toEqual([
+      "wait-3",
+      "wait-1",
+      "review",
+      "work-3",
+      "work-1",
+      "quiet",
+    ]);
+  });
+
+  it("never lets activity lift a row out of a weaker text tier", () => {
+    // Forty blocked agents on a scattered subsequence and on a name that never
+    // matched at all, against a prefix match asking for nothing.
+    const projects = [
+      makeProject({
+        id: "loose",
+        name: "a-l-p-h-a-x",
+        path: "/repos/loose",
+        waitingAgentCount: 40,
+        blockedAgentCount: 40,
+      }),
+      makeProject({
+        id: "path-only",
+        name: "zeta",
+        path: "/repos/alpha/zeta",
+        waitingAgentCount: 40,
+        blockedAgentCount: 40,
+      }),
+      makeProject({ id: "prefix", name: "alpha-core", path: "/repos/prefix" }),
+    ];
+    // Both decoys really do match, so they are being ordered rather than filtered.
+    expect(scoreProjectQuery("alpha", "a-l-p-h-a-x", "/repos/loose")).toBeGreaterThan(0);
+    expect(scoreProjectQuery("alpha", "zeta", "/repos/alpha/zeta")).toBeGreaterThan(0);
+
+    expect(rankSwitcherMatches("alpha", projects, [], null).map((r) => r.id)).toEqual([
+      "prefix",
+      "loose",
+      "path-only",
+    ]);
+  });
+
+  it("does not let a shared path decide between two equally good names", () => {
+    const decoy = makeProject({
+      id: "decoy",
+      name: "Daintree Website",
+      path: `${DAINTREE_ROOT}/website`,
+    });
+    const busy = makeProject({
+      id: "busy",
+      name: "Daintree Assistant",
+      path: "/opt/checkouts/assistant",
+      waitingAgentCount: 1,
+    });
+    // The decoy's path really is worth more, so this proves the path term was
+    // outranked rather than merely absent.
+    expect(scoreProjectQuery("daint", decoy.name, decoy.path)).toBeGreaterThan(
+      scoreProjectQuery("daint", busy.name, busy.path)
+    );
+
+    expect(rankSwitcherMatches("daint", [decoy, busy], [], null).map((r) => r.id)).toEqual([
+      "busy",
+      "decoy",
+    ]);
+  });
+
+  it("ranks an active scratch on activity without giving it path relevance", () => {
+    const project = makeProject({
+      id: "p",
+      name: "alpha-app",
+      path: `${DAINTREE_ROOT}/alpha/alpha-app`,
+    });
+    const busyScratch = makeScratch({ id: "s", name: "alpha-notes", waitingAgentCount: 1 });
+    // A scratch whose only claim on the query is its machine-generated folder,
+    // and the busiest row in the pool.
+    const uuidScratch = makeScratch({
+      id: "alpha-9f8e7d6c",
+      name: "unrelated",
+      waitingAgentCount: 40,
+      blockedAgentCount: 40,
+    });
+    expect(uuidScratch.path).toContain("alpha");
+
+    expect(
+      rankSwitcherMatches("alpha", [project], [busyScratch, uuidScratch], null).map((r) => r.id)
+    ).toEqual(["s", "p"]);
+  });
+
+  it("orders the same rows the same way whatever order they arrive in", () => {
+    // Rows alike on every key but their id, plus one that has to sort below all
+    // of them. Any pair the comparator called equal would seat differently
+    // across these orderings; an intransitive one would too.
+    const projects = [
+      makeProject({ id: "p-a", name: "alpha", path: "/repos/alpha" }),
+      makeProject({ id: "p-b", name: "alpha", path: "/repos/alpha" }),
+      makeProject({ id: "p-c", name: "alpha", path: "/repos/alpha" }),
+      makeProject({
+        id: "loose",
+        name: "a-l-p-h-a-z",
+        path: "/repos/loose",
+        waitingAgentCount: 40,
+        blockedAgentCount: 40,
+        frecencyScore: 999,
+      }),
+    ];
+    const scratches = [
+      makeScratch({ id: "s-a", name: "alpha", lastOpened: 5 }),
+      makeScratch({ id: "s-b", name: "alpha", lastOpened: 5 }),
+      makeScratch({ id: "s-c", name: "alpha", lastOpened: 5 }),
+    ];
+
+    function permutations<T>(items: T[]): T[][] {
+      if (items.length <= 1) return [items];
+      return items.flatMap((item, index) =>
+        permutations([...items.slice(0, index), ...items.slice(index + 1)]).map((rest) => [
+          item,
+          ...rest,
+        ])
+      );
+    }
+
+    // The ranker takes the two kinds as separate arrays, so this IS every
+    // distinct input the palette can hand it for this fixture.
+    const projectOrders = permutations(projects);
+    const scratchOrders = permutations(scratches);
+    expect(projectOrders.length * scratchOrders.length).toBe(144);
+
+    const expected = ["p-a", "p-b", "p-c", "s-a", "s-b", "s-c", "loose"];
+    for (const projectOrder of projectOrders) {
+      for (const scratchOrder of scratchOrders) {
+        const ids = rankSwitcherMatches("alpha", projectOrder, scratchOrder, null).map((r) => r.id);
+        expect(ids).toEqual(expected);
+      }
+    }
+  });
+
+  it("leaves the filter's threshold to the filter, and the ranker without one", () => {
+    // Both surfaces read the same raw `scoreField` output against different
+    // bars. Rescaling it to a ratio would move both at once; each half of this
+    // pins one side.
+    const RESEARCH_TITLE = "Research file browser folder selection usability";
+    expect(isFilterMatch("fltsnp", "fleet snapshot service")).toBe(true);
+    expect(isFilterMatch("rust", RESEARCH_TITLE)).toBe(false);
+
+    // The ranker has no floor, so the query the filter rejects still ranks —
+    // it just sorts last, which is the backstop the filter does not have.
+    const scattered = makeProject({ id: "scattered", name: RESEARCH_TITLE, path: "/repos/notes" });
+    expect(rankSwitcherMatches("rust", [scattered], [], null).map((r) => r.id)).toEqual([
+      "scattered",
+    ]);
+  });
+});
+
+describe("rankSwitcherMatches activity classification", () => {
+  // One shared path so every row's text score is identical and only activity —
+  // then, on an activity tie, the name — can order them.
+  function row(id: string, overrides: Partial<SearchableProject> = {}): SearchableProject {
+    return makeProject({ id, name: `alpha-${id}`, path: "/repos/alpha", ...overrides });
+  }
+
+  function rank(projects: SearchableProject[]): string[] {
+    return rankSwitcherMatches("alpha", projects, [], null).map((r) => r.id);
+  }
+
+  it("puts a blocked agent above a larger pool of merely waiting ones", () => {
+    expect(
+      rank([
+        row("waiting", { waitingAgentCount: 5 }),
+        row("blocked", { waitingAgentCount: 1, blockedAgentCount: 1 }),
+      ])
+    ).toEqual(["blocked", "waiting"]);
+  });
+
+  it("sizes the blocked class by its own count, not by the waits it is a subset of", () => {
+    // "a-fewer-blocked" has the bigger waiting pool and the smaller blocked one.
+    // Summing the two would put it first; so would reading `waitingAgentCount`.
+    // Its name also sorts first, so a tie would too — only the subset count
+    // produces the expectation below.
+    const fewerBlocked = row("a-fewer-blocked", { waitingAgentCount: 5, blockedAgentCount: 2 });
+    const moreBlocked = row("z-more-blocked", { waitingAgentCount: 3, blockedAgentCount: 3 });
+    expect(rank([fewerBlocked, moreBlocked])).toEqual(["z-more-blocked", "a-fewer-blocked"]);
+  });
+
+  it("lets an assistant escalate a row nothing else is asking about", () => {
+    expect(
+      rank([
+        row("dormant"),
+        row("assistant-working", { assistantState: "working" }),
+        row("assistant-unseen", {
+          assistantState: "waiting",
+          assistantStateSince: 500,
+          lastOpened: 100,
+        }),
+        row("assistant-blocked", { assistantState: "waiting", assistantWaitingReason: "error" }),
+      ])
+    ).toEqual(["assistant-blocked", "assistant-unseen", "assistant-working", "dormant"]);
+  });
+
+  it("counts an escalated assistant as one presence, never as part of a worker tally", () => {
+    // Three workers waiting plus an unseen assistant, against four workers
+    // waiting. Folding the assistant into the tally makes the first row four as
+    // well, and its name wins the tie — so that bug produces the reverse of this.
+    const mixed = row("a-mixed", {
+      waitingAgentCount: 3,
+      assistantState: "waiting",
+      assistantStateSince: 500,
+      lastOpened: 100,
+    });
+    const workers = row("z-workers", { waitingAgentCount: 4 });
+    expect(rank([mixed, workers])).toEqual(["z-workers", "a-mixed"]);
+    expect(rank([workers, mixed])).toEqual(["z-workers", "a-mixed"]);
+  });
+
+  it("does not let an assistant re-tier a row a worker already spoke for", () => {
+    // A worker waiting alongside an assistant that has failed. The row is a
+    // wait — the tier its status line will also report — not a block. Letting
+    // the assistant speak would tie the two in the blocked class, where the
+    // name tie-break returns the reverse of this.
+    const workerWait = row("a-worker-wait", {
+      waitingAgentCount: 1,
+      assistantState: "waiting",
+      assistantWaitingReason: "error",
+    });
+    const workerBlocked = row("z-worker-blocked", { waitingAgentCount: 1, blockedAgentCount: 1 });
+    expect(rank([workerWait, workerBlocked])).toEqual(["z-worker-blocked", "a-worker-wait"]);
+  });
+
+  it("treats a seen assistant wait, snoozed runs, acknowledged work and processes as quiet", () => {
+    const ranked = rank([
+      row("seen-wait", { assistantState: "waiting", assistantStateSince: 100, lastOpened: 500 }),
+      row("snoozed", { snoozedAgentCount: 4, nextSnoozeWakeAt: 999 }),
+      row("acknowledged", { completedAgentCount: 4, unacknowledgedCompletedAgentCount: 0 }),
+      row("processes", { processCount: 9 }),
+      row("busy", { waitingAgentCount: 1 }),
+    ]);
+
+    // The one demanding row leads. The other four are indistinguishable on
+    // activity, so they fall through to the name tie-break — which is what
+    // proves none of those four signals promoted anything.
+    expect(ranked).toEqual(["busy", "acknowledged", "processes", "seen-wait", "snoozed"]);
+  });
+
+  it("still reads a snoozed working run as working, exactly as browse does", () => {
+    // Snooze withholds a run from the demanding tallies, not from the working
+    // one — `activeAgentCount` keeps counting it, in main and in browse's
+    // Running band alike. Search must not net it out on its own.
+    expect(
+      rank([row("dormant"), row("snoozed-worker", { activeAgentCount: 1, snoozedAgentCount: 1 })])
+    ).toEqual(["snoozed-worker", "dormant"]);
+  });
+});
+
+describe("rankSwitcherMatches frozen activity", () => {
+  const busy = makeProject({
+    id: "busy",
+    name: "alpha-busy",
+    path: "/repos/alpha",
+    waitingAgentCount: 3,
+  });
+  const calm = makeProject({ id: "calm", name: "alpha-calm", path: "/repos/alpha" });
+
+  it("ranks on the snapshot rather than on the rows' live counts", () => {
+    // The snapshot says the calm row was the busy one when the palette opened.
+    // The live counts say the opposite, and must not move anything.
+    const snapshot = new Map([
+      ["calm", { activityClass: 1, activityVolume: 3 }],
+      ["busy", QUIET_SEARCH_ACTIVITY],
+    ]);
+    expect(rankSwitcherMatches("alpha", [busy, calm], [], snapshot).map((r) => r.id)).toEqual([
+      "calm",
+      "busy",
+    ]);
+    // Without a snapshot the same rows rank the other way, so the fixture is
+    // not quietly agreeing with itself.
+    expect(rankSwitcherMatches("alpha", [busy, calm], [], null).map((r) => r.id)).toEqual([
+      "busy",
+      "calm",
+    ]);
+  });
+
+  it("reads a row the snapshot never saw as quiet, not as whatever it is doing now", () => {
+    // A row that registered mid-session. Falling back to its live counts would
+    // put it back on the stats push the freeze exists to insulate it from.
+    const snapshot = new Map([["calm", { activityClass: 1, activityVolume: 3 }]]);
+    expect(rankSwitcherMatches("alpha", [busy, calm], [], snapshot).map((r) => r.id)).toEqual([
+      "calm",
+      "busy",
+    ]);
   });
 });

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -670,19 +670,28 @@ describe("rankSwitcherMatches activity classification", () => {
   });
 
   it("treats a seen assistant wait, snoozed runs, acknowledged work and processes as quiet", () => {
-    // Named so every one of these four sits BELOW where a promotion would put
-    // it: the demanding row sorts last alphabetically and still leads, and
-    // "y-acknowledged" sorts last of the quiet run, so a completion wrongly
-    // read as unreviewed would jump it to second.
+    // "a-control" carries no signal at all and sorts first, so none of the four
+    // rows under test holds the top quiet slot by name. Any one of them wrongly
+    // promoted has to jump the control row to get there, which shows up here.
     const ranked = rank([
-      row("b-seen-wait", { assistantState: "waiting", assistantStateSince: 100, lastOpened: 500 }),
-      row("c-snoozed", { snoozedAgentCount: 4, nextSnoozeWakeAt: 999 }),
-      row("y-acknowledged", { completedAgentCount: 4, unacknowledgedCompletedAgentCount: 0 }),
-      row("a-processes", { processCount: 9 }),
-      row("z-busy", { waitingAgentCount: 1 }),
+      row("x-seen-wait", { assistantState: "waiting", assistantStateSince: 100, lastOpened: 500 }),
+      row("y-snoozed", { snoozedAgentCount: 4, nextSnoozeWakeAt: 999 }),
+      row("z-acknowledged", { completedAgentCount: 4, unacknowledgedCompletedAgentCount: 0 }),
+      row("w-processes", { processCount: 9 }),
+      row("a-control"),
+      row("m-busy", { waitingAgentCount: 1 }),
     ]);
 
-    expect(ranked).toEqual(["z-busy", "a-processes", "b-seen-wait", "c-snoozed", "y-acknowledged"]);
+    // The demanding row leads from the middle of the alphabet, so the waiting
+    // class is what put it there rather than its name.
+    expect(ranked).toEqual([
+      "m-busy",
+      "a-control",
+      "w-processes",
+      "x-seen-wait",
+      "y-snoozed",
+      "z-acknowledged",
+    ]);
   });
 
   it("still reads a snoozed working run as working, exactly as browse does", () => {

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -5,6 +5,7 @@ import {
   scoreScratchQuery,
   rankSwitcherMatches,
   QUIET_SEARCH_ACTIVITY,
+  computeSearchActivityKey,
 } from "../projectSwitcherSearch";
 import type { SearchableProject, SearchableScratch } from "@/hooks/useProjectSwitcherPalette";
 
@@ -504,7 +505,7 @@ describe("rankSwitcherMatches activity ordering", () => {
     ]);
   });
 
-  it("ranks an active scratch on activity without giving it path relevance", () => {
+  it("ranks a busy scratch on its activity without giving it path relevance", () => {
     const project = makeProject({
       id: "p",
       name: "alpha-app",
@@ -622,18 +623,21 @@ describe("rankSwitcherMatches activity classification", () => {
   });
 
   it("lets an assistant escalate a row nothing else is asking about", () => {
+    // Named so the name tie-break runs the OTHER way: with no assistant
+    // classification at all these four are equally quiet and come back
+    // alphabetically, which is the exact reverse of the expectation.
     expect(
       rank([
-        row("dormant"),
-        row("assistant-working", { assistantState: "working" }),
-        row("assistant-unseen", {
+        row("a-dormant"),
+        row("b-working", { assistantState: "working" }),
+        row("c-unseen", {
           assistantState: "waiting",
           assistantStateSince: 500,
           lastOpened: 100,
         }),
-        row("assistant-blocked", { assistantState: "waiting", assistantWaitingReason: "error" }),
+        row("d-blocked", { assistantState: "waiting", assistantWaitingReason: "error" }),
       ])
-    ).toEqual(["assistant-blocked", "assistant-unseen", "assistant-working", "dormant"]);
+    ).toEqual(["d-blocked", "c-unseen", "b-working", "a-dormant"]);
   });
 
   it("counts an escalated assistant as one presence, never as part of a worker tally", () => {
@@ -666,18 +670,19 @@ describe("rankSwitcherMatches activity classification", () => {
   });
 
   it("treats a seen assistant wait, snoozed runs, acknowledged work and processes as quiet", () => {
+    // Named so every one of these four sits BELOW where a promotion would put
+    // it: the demanding row sorts last alphabetically and still leads, and
+    // "y-acknowledged" sorts last of the quiet run, so a completion wrongly
+    // read as unreviewed would jump it to second.
     const ranked = rank([
-      row("seen-wait", { assistantState: "waiting", assistantStateSince: 100, lastOpened: 500 }),
-      row("snoozed", { snoozedAgentCount: 4, nextSnoozeWakeAt: 999 }),
-      row("acknowledged", { completedAgentCount: 4, unacknowledgedCompletedAgentCount: 0 }),
-      row("processes", { processCount: 9 }),
-      row("busy", { waitingAgentCount: 1 }),
+      row("b-seen-wait", { assistantState: "waiting", assistantStateSince: 100, lastOpened: 500 }),
+      row("c-snoozed", { snoozedAgentCount: 4, nextSnoozeWakeAt: 999 }),
+      row("y-acknowledged", { completedAgentCount: 4, unacknowledgedCompletedAgentCount: 0 }),
+      row("a-processes", { processCount: 9 }),
+      row("z-busy", { waitingAgentCount: 1 }),
     ]);
 
-    // The one demanding row leads. The other four are indistinguishable on
-    // activity, so they fall through to the name tie-break — which is what
-    // proves none of those four signals promoted anything.
-    expect(ranked).toEqual(["busy", "acknowledged", "processes", "seen-wait", "snoozed"]);
+    expect(ranked).toEqual(["z-busy", "a-processes", "b-seen-wait", "c-snoozed", "y-acknowledged"]);
   });
 
   it("still reads a snoozed working run as working, exactly as browse does", () => {
@@ -698,12 +703,15 @@ describe("rankSwitcherMatches frozen activity", () => {
     waitingAgentCount: 3,
   });
   const calm = makeProject({ id: "calm", name: "alpha-calm", path: "/repos/alpha" });
+  // Taken from the helper rather than written out, so the fixture cannot drift
+  // from — or quietly restate — how a key is encoded.
+  const WAS_WAITING = computeSearchActivityKey(busy);
 
   it("ranks on the snapshot rather than on the rows' live counts", () => {
     // The snapshot says the calm row was the busy one when the palette opened.
     // The live counts say the opposite, and must not move anything.
     const snapshot = new Map([
-      ["calm", { activityClass: 1, activityVolume: 3 }],
+      ["calm", WAS_WAITING],
       ["busy", QUIET_SEARCH_ACTIVITY],
     ]);
     expect(rankSwitcherMatches("alpha", [busy, calm], [], snapshot).map((r) => r.id)).toEqual([
@@ -721,7 +729,7 @@ describe("rankSwitcherMatches frozen activity", () => {
   it("reads a row the snapshot never saw as quiet, not as whatever it is doing now", () => {
     // A row that registered mid-session. Falling back to its live counts would
     // put it back on the stats push the freeze exists to insulate it from.
-    const snapshot = new Map([["calm", { activityClass: 1, activityVolume: 3 }]]);
+    const snapshot = new Map([["calm", WAS_WAITING]]);
     expect(rankSwitcherMatches("alpha", [busy, calm], [], snapshot).map((r) => r.id)).toEqual([
       "calm",
       "busy",

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -146,11 +146,16 @@ export function scoreProjectQuery(query: string, name: string, path: string): nu
  * directly comparable: an equal name match leaves the project ahead by exactly
  * its path term, which is never negative.
  *
- * A scratch containing the query outranking a loosely-matched project is now a
- * guarantee rather than a consequence of these totals. {@link rankSwitcherMatches}
- * compares a name-match tier before it consults either one, and that tier applies
- * to every pair, projects included — which is what keeps the comparator
- * transitive. The totals decide an order only once two rows have tied on it.
+ * A scratch whose name contains the query outranking a loosely-matched project
+ * no longer rests on these totals: {@link rankSwitcherMatches} compares a
+ * name-match tier before it consults either one, and that tier applies to every
+ * pair, projects included — which is what keeps the comparator transitive. The
+ * totals are consulted only after both the tier and the activity keys have tied.
+ *
+ * One caveat inherited from {@link scoreField}: a scratch scoring 0 is filtered
+ * out before any of that, and a long enough name drains the substring bonus to
+ * nothing. The guarantee covers a substring match that still scores, not every
+ * substring match.
  */
 export function scoreScratchQuery(query: string, name: string): number {
   if (!query) return 0;
@@ -313,9 +318,10 @@ interface RankedEntry {
  *
  * In order: how well the NAME answers the query, then what the workspace is
  * asking of the user, then how loud that ask is, then the raw text score, then
- * kind, then per-kind recency, then name, then id. Activity sits below the text
- * tier and can never climb out of it (#11861) — it separates rows the text
- * scores cannot tell apart, which is what four workspaces sharing a prefix are.
+ * kind, then per-kind recency, then name, then id. Activity sits below the name
+ * tier and can never climb out of it (#11861), but it orders EVERY pair inside
+ * one — including a pair the raw scores could have separated, which is the
+ * point: those scores are what a shared parent directory decides.
  *
  * `activityKeys` is the palette session's frozen snapshot, keyed by row id.
  * Activity arrives live over IPC and every push re-runs this ranking, so reading

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -1,7 +1,9 @@
+import { classifyAssistantActivity } from "@/lib/projectAssistantActivity";
 import type {
   ProjectSwitcherRow,
   SearchableProject,
   SearchableScratch,
+  WorkspaceRowStatusFields,
 } from "@/hooks/useProjectSwitcherPalette";
 
 const NAME_WEIGHT = 4;
@@ -144,13 +146,11 @@ export function scoreProjectQuery(query: string, name: string, path: string): nu
  * directly comparable: an equal name match leaves the project ahead by exactly
  * its path term, which is never negative.
  *
- * That a scratch containing the query outranks a loosely-matched project is a
- * consequence of the scores, not a guarantee. Long queries let a project's
- * per-character boundary bonuses plus a path hit overtake the substring bonus —
- * but only where the project's own name matches nearly as exactly, which is a
- * project that deserves the top slot anyway. Promoting substring quality into a
- * ranking tier would have to apply to every pair, projects included, or the
- * comparator stops being transitive.
+ * A scratch containing the query outranking a loosely-matched project is now a
+ * guarantee rather than a consequence of these totals. {@link rankSwitcherMatches}
+ * compares a name-match tier before it consults either one, and that tier applies
+ * to every pair, projects included — which is what keeps the comparator
+ * transitive. The totals decide an order only once two rows have tied on it.
  */
 export function scoreScratchQuery(query: string, name: string): number {
   if (!query) return 0;
@@ -161,49 +161,244 @@ export function scoreScratchQuery(query: string, name: string): number {
   return NAME_WEIGHT * nameScore;
 }
 
-/** Projects sort ahead of scratches on an exact score tie. */
+/** Projects sort ahead of scratches once every earlier key has tied. */
 const KIND_RANK: Record<ProjectSwitcherRow["kind"], number> = { project: 0, scratch: 1 };
+
+/**
+ * How well a row's NAME answers the query, as a discrete tier.
+ *
+ * Read off the name STRING rather than off {@link scoreField}'s output, for two
+ * reasons. Ranking by score alone is what #11861 was: four workspaces sharing a
+ * prefix score identically at every prefix, because the walk stops the moment
+ * the query is consumed and never looks at what trails it. And a class derived
+ * from a project's TOTAL would see the path, which would scatter rows whose
+ * names are equally good across several tiers on the strength of a directory
+ * they merely happen to share — the "grouped before the path is consulted"
+ * requirement, met structurally by never showing the path to this function.
+ *
+ * Discrete on purpose. Activity orders rows WITHIN a tier and can never lift one
+ * out of it, so a scattered subsequence with five agents waiting still sits
+ * below a clean prefix match with none. That is the contract every launcher
+ * that gets this right shares (fzf's `--tiebreak`, `prescient.el`'s match
+ * tiers): the secondary signal orders inside the class, it does not jump it.
+ *
+ * `exact` is not folded in with `prefix` even though every exact match is also a
+ * prefix one: typing a workspace's whole name has to land on that workspace,
+ * whatever the four projects it shares a prefix with are doing.
+ */
+const TEXT_CLASS_EXACT = 0;
+const TEXT_CLASS_NAME_PREFIX = 1;
+const TEXT_CLASS_NAME_SUBSTRING = 2;
+const TEXT_CLASS_FUZZY_NAME = 3;
+const TEXT_CLASS_PATH_ONLY = 4;
+
+/**
+ * `hasNameMatch` rather than a name score, because the only thing the last two
+ * tiers turn on is whether the name matched at all. A scratch always passes it:
+ * its total IS its name term ({@link scoreScratchQuery}), so a scratch that
+ * scored at all matched its name, and `path-only` is structurally unreachable
+ * for one — which is what keeps a scratch from ever picking up path relevance.
+ */
+function textQualityClass(lowerQuery: string, name: string, hasNameMatch: boolean): number {
+  const lowerName = name.toLowerCase();
+  if (lowerName === lowerQuery) return TEXT_CLASS_EXACT;
+  if (lowerName.startsWith(lowerQuery)) return TEXT_CLASS_NAME_PREFIX;
+  if (lowerName.includes(lowerQuery)) return TEXT_CLASS_NAME_SUBSTRING;
+  return hasNameMatch ? TEXT_CLASS_FUZZY_NAME : TEXT_CLASS_PATH_ONLY;
+}
+
+const ACTIVITY_BLOCKED = 0;
+const ACTIVITY_WAITING = 1;
+const ACTIVITY_REVIEW = 2;
+const ACTIVITY_WORKING = 3;
+const ACTIVITY_QUIET = 4;
+
+/**
+ * What a workspace is asking of the user, reduced to the pair of numbers the
+ * search comparator orders equally-well-matched rows by.
+ *
+ * `activityVolume` is only ever compared against another row in the SAME class,
+ * so the counts it carries never have to be commensurable across classes.
+ */
+export interface SearchActivityKey {
+  readonly activityClass: number;
+  readonly activityVolume: number;
+}
+
+/**
+ * Asking nothing. Also what a row absent from a frozen snapshot reads as — see
+ * {@link rankSwitcherMatches}.
+ */
+export const QUIET_SEARCH_ACTIVITY: SearchActivityKey = {
+  activityClass: ACTIVITY_QUIET,
+  activityVolume: 0,
+};
+
+/**
+ * The demand a row is making, on the same terms browse bands and tiers by
+ * (`sectionForProject`/`attentionClass`) so the two modes cannot disagree about
+ * what a workspace is doing while its status line says one thing either way.
+ *
+ * Workers are consulted before the assistant, exactly as `attentionClass` does
+ * it: an escalated assistant tiers a row that nothing else was asking about,
+ * and never re-tiers one a worker has already spoken for. The assistant is
+ * worth exactly one unit and is never added to a worker tally (#11806).
+ *
+ * `blockedAgentCount` is a SUBSET of `waitingAgentCount`, so it is the volume of
+ * its own class and is never summed alongside it.
+ *
+ * Deliberately blind to three signals, all of which are non-demanding in browse
+ * and stay non-demanding here: `snoozedAgentCount` (the user already said not
+ * yet), `completedAgentCount` (only the unacknowledged subset is an ask), and
+ * `processCount` (residency, not intent).
+ *
+ * Snoozing does NOT withdraw a run from `activeAgentCount` — a snoozed worker
+ * still counts as working, in main's tally and in browse's Running band alike
+ * (`WorkspaceRowStatusFields`, `projectAgentCounts`). That asymmetry is the data
+ * model's decision, not an oversight: snooze withholds a run from the tallies
+ * that make a workspace read as DEMANDING — waiting, its blocked subset, and
+ * unacknowledged completions, all three of which this function reads and all
+ * three of which are already snooze-free. Netting snooze out of the working
+ * class here would put search at odds with browse over the same row, and could
+ * not be done soundly anyway: a snoozed COMPLETION would cancel an unrelated
+ * live worker.
+ */
+export function computeSearchActivityKey(workspace: WorkspaceRowStatusFields): SearchActivityKey {
+  if (workspace.blockedAgentCount > 0) {
+    return { activityClass: ACTIVITY_BLOCKED, activityVolume: workspace.blockedAgentCount };
+  }
+  if (workspace.waitingAgentCount > 0) {
+    return { activityClass: ACTIVITY_WAITING, activityVolume: workspace.waitingAgentCount };
+  }
+
+  const assistant = classifyAssistantActivity(workspace);
+  if (assistant === "blocked") return { activityClass: ACTIVITY_BLOCKED, activityVolume: 1 };
+  if (assistant === "waiting-unseen") return { activityClass: ACTIVITY_WAITING, activityVolume: 1 };
+
+  if (workspace.unacknowledgedCompletedAgentCount > 0) {
+    return {
+      activityClass: ACTIVITY_REVIEW,
+      activityVolume: workspace.unacknowledgedCompletedAgentCount,
+    };
+  }
+  if (workspace.activeAgentCount > 0) {
+    return { activityClass: ACTIVITY_WORKING, activityVolume: workspace.activeAgentCount };
+  }
+  if (assistant === "working") return { activityClass: ACTIVITY_WORKING, activityVolume: 1 };
+
+  return QUIET_SEARCH_ACTIVITY;
+}
+
+interface RankedEntry {
+  row: ProjectSwitcherRow;
+  textClass: number;
+  activity: SearchActivityKey;
+  score: number;
+  /** `frecencyScore` for a project, `lastOpened` for a scratch. Only ever compared same-kind. */
+  recency: number;
+}
 
 /**
  * Ranks projects and scratches into the one array the palette renders, indexes
  * and walks with the arrow keys (#11071). Scratches are only ever ranked — in
  * browse they stay in their own pinned section, which is the caller's business.
  *
- * The comparator is a lexicographic tuple — score, then kind, then the per-kind
- * recency proxy — which makes it transitive and total. That matters: a rule that
- * reordered only CROSS-kind pairs (say, promoting a name substring over a loose
- * subsequence) while same-kind pairs stayed on raw score would admit cycles, and
- * `Array.prototype.sort` on an intransitive comparator is implementation-defined.
+ * The comparator is a lexicographic tuple, which is what makes it transitive and
+ * total — every key is a number or a string compared the same way for every
+ * pair, and the last of them is the row id, so it returns 0 only for a row
+ * against itself. A rule that reordered only SOME pairs (say, promoting a name
+ * substring cross-kind while same-kind pairs stayed on raw score) would admit
+ * cycles, and `Array.prototype.sort` on an intransitive comparator is
+ * implementation-defined.
  *
- * With an empty scratch list this reduces exactly to the old project-only
- * ranking, so search order for a user without scratches is unchanged.
+ * In order: how well the NAME answers the query, then what the workspace is
+ * asking of the user, then how loud that ask is, then the raw text score, then
+ * kind, then per-kind recency, then name, then id. Activity sits below the text
+ * tier and can never climb out of it (#11861) — it separates rows the text
+ * scores cannot tell apart, which is what four workspaces sharing a prefix are.
+ *
+ * `activityKeys` is the palette session's frozen snapshot, keyed by row id.
+ * Activity arrives live over IPC and every push re-runs this ranking, so reading
+ * the rows' own counts would move a row out from under the pointer between the
+ * moment the user decided to click and the moment they clicked — and would
+ * change what Enter commits, since selection is the top row until the user
+ * arrows. Passing `null` ranks against the rows' live counts instead, which is
+ * what a caller ranking a fixed list wants. A row MISSING from a supplied
+ * snapshot reads as {@link QUIET_SEARCH_ACTIVITY} rather than falling back to
+ * its live counts: it arrived mid-session, and the whole point of the freeze is
+ * that no row's position tracks a live push. It is folded into the snapshot on
+ * the next commit and takes its real key from there.
+ *
+ * The parameter is required rather than optional so that omitting the snapshot
+ * at the production call site is a compile error instead of a silent unfreeze.
+ *
+ * With an empty scratch list this still reduces to a project-only ranking, but
+ * NOT to the old one: search now leads on match quality and activity rather than
+ * on the blended score, which is the change (#11861).
  */
 export function rankSwitcherMatches(
   query: string,
   projects: SearchableProject[],
-  scratches: SearchableScratch[]
+  scratches: SearchableScratch[],
+  activityKeys: ReadonlyMap<string, SearchActivityKey> | null
 ): ProjectSwitcherRow[] {
   const trimmed = query.trim();
   if (!trimmed) return [];
+  const lowerQuery = trimmed.toLowerCase();
 
-  const scored: { row: ProjectSwitcherRow; score: number }[] = [];
+  const activityFor = (workspace: WorkspaceRowStatusFields & { id: string }): SearchActivityKey =>
+    activityKeys === null
+      ? computeSearchActivityKey(workspace)
+      : (activityKeys.get(workspace.id) ?? QUIET_SEARCH_ACTIVITY);
+
+  const scored: RankedEntry[] = [];
 
   for (const project of projects) {
     const score = scoreProjectQuery(trimmed, project.name, project.path);
-    if (score > 0) scored.push({ row: { kind: "project", ...project }, score });
+    if (score <= 0) continue;
+    scored.push({
+      row: { kind: "project", ...project },
+      // Walks the name a second time rather than taking the term apart out of
+      // `score`: how the two fields are weighted stays owned by
+      // `scoreProjectQuery`, and names are short.
+      textClass: textQualityClass(lowerQuery, project.name, scoreField(trimmed, project.name) > 0),
+      activity: activityFor(project),
+      score,
+      recency: project.frecencyScore,
+    });
   }
   for (const scratch of scratches) {
     const score = scoreScratchQuery(trimmed, scratch.name);
-    if (score > 0) scored.push({ row: { kind: "scratch", ...scratch }, score });
+    if (score <= 0) continue;
+    scored.push({
+      row: { kind: "scratch", ...scratch },
+      textClass: textQualityClass(lowerQuery, scratch.name, true),
+      activity: activityFor(scratch),
+      score,
+      recency: scratch.lastOpened,
+    });
   }
 
   scored.sort((a, b) => {
+    if (a.textClass !== b.textClass) return a.textClass - b.textClass;
+    if (a.activity.activityClass !== b.activity.activityClass) {
+      return a.activity.activityClass - b.activity.activityClass;
+    }
+    if (a.activity.activityVolume !== b.activity.activityVolume) {
+      return b.activity.activityVolume - a.activity.activityVolume;
+    }
     if (a.score !== b.score) return b.score - a.score;
     if (a.row.kind !== b.row.kind) return KIND_RANK[a.row.kind] - KIND_RANK[b.row.kind];
-    if (a.row.kind === "project" && b.row.kind === "project") {
-      return b.row.frecencyScore - a.row.frecencyScore;
-    }
-    return b.row.lastOpened - a.row.lastOpened;
+    // Kinds are equal by here, so this never compares a frecency against a
+    // timestamp — the two scales never have to be commensurable.
+    if (a.recency !== b.recency) return b.recency - a.recency;
+    const byName = a.row.name.localeCompare(b.row.name, undefined, { sensitivity: "base" });
+    if (byName !== 0) return byName;
+    // Ends on the id for the same reason `compareProjectsByMode` does: without
+    // it two rows alike on every key above compare equal, and a sort that
+    // reports a tie between distinct rows can seat them either way between
+    // renders. Activity ties are far more common than score ties were.
+    return a.row.id.localeCompare(b.row.id);
   });
 
   return scored.map((entry) => entry.row);


### PR DESCRIPTION
## Summary

- Search mode in the project switcher ranked by text score, then kind, then frecency, so live agent activity never entered the order at all.
- Four workspaces sharing the `Daintree` name prefix (and a parent directory) scored identically at every prefix, so frecency alone decided which one `Enter` landed on, whether or not any of them had agents blocked.
- Rewrote the comparator in `rankSwitcherMatches` into a full lexicographic key so activity breaks ties inside a text-match tier without ever being able to climb out of one.

Resolves #11861

## Changes

`rankSwitcherMatches` (`src/lib/projectSwitcherSearch.ts`) now sorts on: name-match tier (exact, prefix, substring, fuzzy-name, path-only) → activity class → activity volume → raw text score → kind rank → per-kind recency → name → id.

- The name-match tier is read off the name string itself, never a normalised score. That's what groups every shared-prefix name into one cohort before the path gets consulted. `scoreField` and `isFilterMatch` are untouched: Pilot's filter (`src/components/Pilot/pilotRows.ts`) reads their raw output against a calibrated threshold, and rescaling either would break it.
- Activity only orders pairs inside a tier, it can never lift a row out of one. A scattered match with five agents waiting still sits below a clean prefix match with none, same discrete-class model as fzf's `--tiebreak` and `prescient.el`.
- An exact name match is its own tier. Typing `Daintree` lands on the project called Daintree even if it's been dormant for a month while everything else is busy.
- Activity classes mirror browse's own model (blocked, waiting, unreviewed completion, working, quiet, with an unseen assistant wait folded into waiting), read from `WorkspaceRowStatusFields` so projects and scratches share one definition. `classifyAssistantActivity` stays the sole authority on the assistant's state, which counts as exactly one activity unit and never joins a worker tally (#11806). Snoozed runs, acknowledged completions, and a bare `processCount` stay non-demanding, same as browse. One thing worth flagging: a snoozed but WORKING run still reads as working, matching browse and main's own tallies, since snoozing withholds a run from the demanding tallies, not the working one.
- Activity counts arrive live over IPC and every push used to re-run the ranking. The sort keys are now frozen per palette session, snapshot on open and refreshed the next time it opens, the same way browse freezes its layout. Displayed counts stay live, so a promoted row's status line still explains itself. A cold session resolves its guess once, mirroring browse's #11452 regroup.
- The comparator now ends on `id.localeCompare`. Its doc comment claimed a total order it didn't have: it returned 0 for two distinct rows tying on score and frecency. Activity ties are far more common than score ties, so that stopped being theoretical.

This went through three rounds of adversarial review before landing.

## Testing

- `src/lib/__tests__/projectSwitcherSearch.test.ts`: the eight behavioural cases the issue names (shared-prefix cohort, dormant exact name, activity class and volume ordering, activity never crossing a text tier, path decoys, scratch activity without path relevance, determinism across all 144 orderings of a mixed fixture, and the `isFilterMatch` abbreviation guard), plus a full activity-cascade suite and frozen-snapshot semantics.
- Hook-level freeze tests in both palette suites (`useProjectSwitcherPalette.test.tsx`, `useProjectSwitcherPalette.scratch.test.tsx`): order holds against a stats push while counts keep updating, reopening refreshes it, a cold session regroups exactly once and then holds, a mid-session arrival is folded in and then holds, and scratch-only sessions resolve both cold and opened-before-load.
- Locally: 439 tests across 8 files, `npm run typecheck`, eslint (0 errors), and prettier all clean.
