### PR TITLE
fix(terminal): link soft-wrapped bare file paths as one path

### DIFF
--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -157,9 +157,9 @@ interface LogicalLine {
   startRow: number;
   /** Where each row's text begins in `text`, indexed from `startRow`. */
   rowOffsets: number[];
-  /** The budget, not a real line start, ended the window — `^` is a lie here. */
+  /** No real line start ended the window — `^` is a lie at `text`'s start. */
   clippedStart: boolean;
-  /** The budget, not a real line end, ended the window — `$` is a lie here. */
+  /** No real line end ended the window — `$` is a lie at `text`'s end. */
   clippedEnd: boolean;
 }
 
@@ -216,19 +216,36 @@ function projectToRow(
   return [Math.max(0, localStart), Math.min(rowLength, localEnd)];
 }
 
+/** Whether any cell between `from` and `to` is a space. */
+function hasSpaceIn(text: string, from: number, to: number): boolean {
+  for (let index = from; index < to; index++) {
+    if (text.charCodeAt(index) === 32) return true;
+  }
+  return false;
+}
+
 /**
- * Whether a match sits against an edge the rejoin budget invented rather than
- * a real line boundary. The regexes' `^`/`$` read that cutoff as a token
- * boundary — the same lie a row edge tells — so a token touching one can't be
- * trusted to be whole. Callers claim it anyway (claiming only ever suppresses
- * links) and simply never link it. A token lying entirely outside the window
- * stays invisible; bounding the rejoin is what makes hover affordable, and
- * that needs a logical line past 2048 columns to reach.
+ * Whether a match sits inside a token the window's edge may have cut in half.
+ *
+ * A clipped edge is not a line boundary — the rejoin budget or a scrollback
+ * eviction put it there — so the regexes' `^`/`$` lie about it. So does a
+ * boundary CHARACTER that can appear mid-token: `(` is legal inside a file
+ * URL, which is exactly how `file:///tmp/(src/foo.ts` offers `src/foo.ts` as a
+ * bare path. Once the scheme has been cut away there is nothing left to claim
+ * that span, so matching on `startIndex === 0` alone would let the fragment
+ * through. Only a real space between the cut and the match proves the match's
+ * own token began after it — and a space is the only whitespace a row can
+ * translate to, since xterm stores tabs as cells and pads empty ones with it.
+ *
+ * Callers claim a rejected match anyway; claiming only ever suppresses links.
+ * A token lying entirely outside the window stays invisible: bounding the
+ * rejoin is what makes hover affordable, and reaching that bound needs a
+ * logical line past 2048 columns.
  */
 function touchesClippedEdge(logical: LogicalLine, startIndex: number, endIndex: number): boolean {
   return (
-    (logical.clippedStart && startIndex === 0) ||
-    (logical.clippedEnd && endIndex === logical.text.length)
+    (logical.clippedStart && !hasSpaceIn(logical.text, 0, startIndex)) ||
+    (logical.clippedEnd && !hasSpaceIn(logical.text, endIndex, logical.text.length))
   );
 }
 
@@ -559,8 +576,10 @@ export class FileLinksAddon implements ILinkProvider {
    * rather than starting at the logical line's first row: a run longer than
    * the budget would otherwise stop before reaching the hovered row, leaving
    * it unclaimed and its characters free for the bare-path pass to mis-link.
-   * Whichever end the budget cuts is reported as clipped, because a match
-   * touching an artificial edge can't be trusted to be whole.
+   * An end the budget cuts is reported as clipped, and so is a start that ran
+   * out of buffer while the topmost row still claimed to continue something:
+   * either way the edge is artificial, and a match against one can't be
+   * trusted to be whole.
    */
   private _readLogicalLine(rowIndex: number): LogicalLine | null {
     const buffer = this._terminal.buffer.active;

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -191,6 +191,78 @@ function mapToRow(logical: LogicalLine, index: number): { row: number; column: n
 }
 
 /**
+ * Project a logical-line span onto the hovered row, clamped to that row's
+ * text, or null when the span never touches it.
+ *
+ * Every claim in `claimed` — and every overlap test against it — speaks this
+ * coordinate space: the ledger is row-local, and the directory pass reading it
+ * never leaves the row. Handing it a logical-line index typechecks fine and
+ * silently stops shielding anything, so both scanning passes come through here
+ * instead of doing the arithmetic themselves.
+ */
+function projectToRow(
+  rowOffset: number,
+  rowLength: number,
+  startIndex: number,
+  endIndex: number
+): [number, number] | null {
+  const localStart = startIndex - rowOffset;
+  const localEnd = endIndex - rowOffset;
+  // Only tokens touching THIS row are ours to report. xterm projects a
+  // returned range onto the requested row and evicts lower-priority links that
+  // intersect it, so handing back a sibling row's link would blank a web link
+  // the user can actually see.
+  if (localEnd <= 0 || localStart >= rowLength) return null;
+  return [Math.max(0, localStart), Math.min(rowLength, localEnd)];
+}
+
+/**
+ * Whether a match sits against an edge the rejoin budget invented rather than
+ * a real line boundary. The regexes' `^`/`$` read that cutoff as a token
+ * boundary — the same lie a row edge tells — so a token touching one can't be
+ * trusted to be whole. Callers claim it anyway (claiming only ever suppresses
+ * links) and simply never link it. A token lying entirely outside the window
+ * stays invisible; bounding the rejoin is what makes hover affordable, and
+ * that needs a logical line past 2048 columns to reach.
+ */
+function touchesClippedEdge(logical: LogicalLine, startIndex: number, endIndex: number): boolean {
+  return (
+    (logical.clippedStart && startIndex === 0) ||
+    (logical.clippedEnd && endIndex === logical.text.length)
+  );
+}
+
+/** Buffer range for a logical-line span, which may cover several rows. */
+function rangeFor(logical: LogicalLine, startIndex: number, endIndex: number): IBufferRange {
+  const start = mapToRow(logical, startIndex);
+  const end = mapToRow(logical, endIndex - 1);
+  return {
+    // xterm rows are 1-based and the end column is inclusive, so `end`
+    // addresses the token's last character rather than the one past it.
+    start: { x: start.column + 1, y: start.row + 1 },
+    end: { x: end.column + 1, y: end.row + 1 },
+  };
+}
+
+/**
+ * Whether two reads of the same row's rejoin window describe the same
+ * geometry. Text alone isn't enough: a link spanning rows carries coordinates
+ * derived from `startRow` and `rowOffsets`, so a re-wrap that moves a row
+ * boundary without changing a character still invalidates the range it was
+ * given.
+ */
+function sameLogicalLine(a: LogicalLine, b: LogicalLine): boolean {
+  return (
+    a.text === b.text &&
+    a.startRow === b.startRow &&
+    a.clippedStart === b.clippedStart &&
+    a.clippedEnd === b.clippedEnd &&
+    a.rowOffsets.length === b.rowOffsets.length &&
+    a.rowOffsets.every((offset, index) => offset === b.rowOffsets[index])
+  );
+}
+
+/**
  * Cheap validation memo for directory candidates, keyed
  * `worktreeId\nrelativePath`. Hover re-fires for the same line constantly, so
  * without this every pointer crossing would re-stat the same tokens. Entries
@@ -259,60 +331,34 @@ export class FileLinksAddon implements ILinkProvider {
     // dropped instead of stacking a second link on the same characters.
     const claimed: Array<[number, number]> = [];
 
-    // `file://` URLs are scanned first so their spans are claimed before the
-    // bare-path and directory passes. Two gates, both O(1)-ish: a line with no
-    // scheme can't start a URL, and a line that neither continues nor is
-    // continued can't be hiding the rest of one. provideLinks is pointer-driven
-    // across every visible terminal, so the common line still does no work.
-    // `://` (not `file://`) keeps the guard case-insensitive without a copy.
-    const urlScanText =
-      lineText.includes("://") || partOfWrappedLine
-        ? this._collectUrlLinks(bufferLineNumber, lineText, links, claimed)
-        : null;
-
-    // matchAll on the module-scope global regex clones it internally (per spec)
-    // and never mutates lastIndex, so the regex is reused across hover calls
-    // without the per-call `new RegExp(FILE_PATH_REGEX)` allocation.
-    for (const match of lineText.matchAll(FILE_PATH_REGEX)) {
-      const fullMatch = match[1];
-      if (fullMatch === undefined) continue;
-      if (isPathExcluded(fullMatch)) {
-        continue;
-      }
-
-      const resolved = resolveFilePathCandidate(fullMatch, this._getCwd());
-      if (!resolved) {
-        continue;
-      }
-
-      const startIndex = match.index + match[0]!.indexOf(fullMatch);
-      // A `(` is legal inside a file URL and is also this regex's boundary
-      // character, so `file:///tmp/(src/foo.ts` offers `src/foo.ts` as a bare
-      // path — which would resolve against the cwd and link a different file
-      // than the URL names. Every URL span is claimed whether or not it
-      // resolved, so a rejected remote URL can't leak a local link either.
-      if (overlapsClaimed(claimed, startIndex, startIndex + fullMatch.length)) {
-        continue;
-      }
-      claimed.push([startIndex, startIndex + fullMatch.length]);
-
-      const range: IBufferRange = {
-        start: { x: startIndex + 1, y: bufferLineNumber },
-        end: { x: startIndex + fullMatch.length, y: bufferLineNumber },
-      };
-
-      links.push(
-        new FileLink(
-          range,
-          fullMatch,
-          resolved.absolutePath,
-          resolved.line,
-          resolved.col,
-          this._getCwd(),
-          this._onHover
-        )
-      );
+    // One rejoin, shared by both scanning passes and by the deferred reply's
+    // staleness check. xterm soft-wraps mid-token, so neither `file://` URLs
+    // nor bare paths can be decided from a single row: whichever fragment the
+    // margin leaves behind still parses, and linking it opens a real-but-wrong
+    // file. The no-separator fast path above already turned away the rows that
+    // would make this cost anything, and the window itself is budgeted.
+    const logical = this._readLogicalLine(bufferLineNumber - 1);
+    if (!logical) {
+      callback(undefined);
+      return;
     }
+    // The hovered row's offset into the joined text, for translating a match
+    // back into `lineText` coordinates — the space `claimed` and the row-local
+    // directory pass both speak. The window is anchored on this row, so the
+    // lookup always lands.
+    const rowOffset = logical.rowOffsets[bufferLineNumber - 1 - logical.startRow]!;
+
+    // `file://` URLs are scanned first so their spans are claimed before the
+    // bare-path and directory passes. The gate stays: a line with no scheme
+    // can't start a URL, and a line that neither continues nor is continued
+    // can't be hiding the rest of one. provideLinks is pointer-driven across
+    // every visible terminal, so the common line still runs no URL regex.
+    // `://` (not `file://`) keeps the guard case-insensitive without a copy.
+    if (lineText.includes("://") || partOfWrappedLine) {
+      this._collectUrlLinks(logical, rowOffset, lineText, links, claimed);
+    }
+
+    this._collectBarePathLinks(logical, rowOffset, lineText, links, claimed);
 
     const candidates = this._collectDirCandidates(lineText, claimed);
     if (candidates.length === 0) {
@@ -333,60 +379,63 @@ export class FileLinksAddon implements ILinkProvider {
     const timeout = new Promise<ScopedDirCandidate[]>((resolve) =>
       setTimeout(() => resolve([]), DIR_VALIDATION_TIMEOUT_MS)
     );
-    void Promise.race([this._validateDirCandidates(candidates), timeout]).then(
-      (confirmed) => {
-        // Disposed while validating (terminal closed): the registration is
-        // gone, so a late reply has no linkifier to serve.
-        if (this._disposed) return;
-        // The line may have been rewritten under the pointer while validation
-        // was in flight (streaming agent output). xterm caches replies by the
-        // pointer's current line, so links computed for the OLD text would
-        // paint on the new one — drop the whole reply instead.
-        const current = this._terminal.buffer.active.getLine(bufferLineNumber - 1);
-        if (!current || current.translateToString(true) !== lineText) {
-          callback(undefined);
-          return;
-        }
-        // A URL link can span rows this check never looks at, so re-read the
-        // whole window it was computed from: rewriting only the continuation
-        // row would otherwise leave a link to the path the URL used to name.
-        if (
-          urlScanText !== null &&
-          this._readLogicalLine(bufferLineNumber - 1)?.text !== urlScanText
-        ) {
-          callback(undefined);
-          return;
-        }
-        for (const candidate of confirmed) {
-          const range: IBufferRange = {
-            start: { x: candidate.startIndex + 1, y: bufferLineNumber },
-            end: { x: candidate.startIndex + candidate.text.length, y: bufferLineNumber },
-          };
-          links.push(
-            new DirectoryLink(
-              range,
-              candidate.text,
-              candidate.absolutePath,
-              candidate.worktreeId,
-              candidate.relativePath,
-              this._onHover
-            )
-          );
-        }
-        callback(links.length > 0 ? links : undefined);
-      },
-      () => {
-        if (this._disposed) return;
-        callback(links.length > 0 ? links : undefined);
+
+    // Both outcomes land in one finalization. The staleness checks are not a
+    // success-path nicety: a file link can now span rows, so a reply arriving
+    // after the buffer moved would paint coordinates that no longer describe
+    // what the user is looking at — whether or not validation succeeded.
+    const finalize = (confirmed: ScopedDirCandidate[]): void => {
+      // Disposed while validating (terminal closed): the registration is
+      // gone, so a late reply has no linkifier to serve.
+      if (this._disposed) return;
+      // The line may have been rewritten under the pointer while validation
+      // was in flight (streaming agent output). xterm caches replies by the
+      // pointer's current line, so links computed for the OLD text would
+      // paint on the new one — drop the whole reply instead.
+      const current = this._terminal.buffer.active.getLine(bufferLineNumber - 1);
+      if (!current || current.translateToString(true) !== lineText) {
+        callback(undefined);
+        return;
       }
+      // A file or URL link can span rows that check never looks at, so re-read
+      // the whole window it was computed from: rewriting only a continuation
+      // row would otherwise leave a link to the path the line used to name,
+      // and a re-wrap that merely moves a row boundary would leave a range
+      // underlining the wrong cells.
+      const currentLogical = this._readLogicalLine(bufferLineNumber - 1);
+      if (!currentLogical || !sameLogicalLine(currentLogical, logical)) {
+        callback(undefined);
+        return;
+      }
+      for (const candidate of confirmed) {
+        const range: IBufferRange = {
+          start: { x: candidate.startIndex + 1, y: bufferLineNumber },
+          end: { x: candidate.startIndex + candidate.text.length, y: bufferLineNumber },
+        };
+        links.push(
+          new DirectoryLink(
+            range,
+            candidate.text,
+            candidate.absolutePath,
+            candidate.worktreeId,
+            candidate.relativePath,
+            this._onHover
+          )
+        );
+      }
+      callback(links.length > 0 ? links : undefined);
+    };
+
+    void Promise.race([this._validateDirCandidates(candidates), timeout]).then(finalize, () =>
+      finalize([])
     );
   }
 
   /**
    * Scan the logical line for `file://` URLs, appending links and claiming the
-   * spans they occupy on `bufferLineNumber`'s own row.
+   * spans they occupy on the hovered row.
    *
-   * Rows are rejoined first because xterm soft-wraps mid-token and the
+   * Rows are rejoined by the caller because xterm soft-wraps mid-token and the
    * motivating URL — an agent's generated-image path — is long enough to wrap
    * in any tiled terminal. Scanning one row would capture the prefix that
    * happens to end at the margin, and a truncated `file://` URL still parses,
@@ -394,24 +443,14 @@ export class FileLinksAddon implements ILinkProvider {
    *
    * Spans are claimed for every syntactic match, resolved or not: a rejected
    * remote URL must still shield its own characters from the bare-path pass.
-   *
-   * Returns the rejoined text it scanned, so a deferred reply can tell whether
-   * any contributing row changed underneath it, or null if there was no line.
    */
   private _collectUrlLinks(
-    bufferLineNumber: number,
+    logical: LogicalLine,
+    rowOffset: number,
     lineText: string,
     links: ILink[],
     claimed: Array<[number, number]>
-  ): string | null {
-    const logical = this._readLogicalLine(bufferLineNumber - 1);
-    if (!logical) return null;
-    // The current row's offset into the joined text, for translating a match
-    // back into `lineText` coordinates — that's the space `claimed` and the
-    // single-row bare-path and directory passes all speak. The window is
-    // anchored on this row, so the lookup always lands.
-    const rowOffset = logical.rowOffsets[bufferLineNumber - 1 - logical.startRow]!;
-
+  ): void {
     for (const match of logical.text.matchAll(FILE_URL_REGEX)) {
       const url = match[1];
       if (url === undefined) continue;
@@ -422,45 +461,20 @@ export class FileLinksAddon implements ILinkProvider {
       const startIndex = match.index + match[0]!.indexOf(url);
       const endIndex = startIndex + url.length;
 
-      // Only URLs touching THIS row are ours to report. xterm projects a
-      // returned range onto the requested row and evicts lower-priority links
-      // that intersect it, so handing back a sibling row's link would blank a
-      // web link the user can actually see.
-      const localStart = startIndex - rowOffset;
-      const localEnd = endIndex - rowOffset;
-      if (localEnd <= 0 || localStart >= lineText.length) continue;
-      claimed.push([Math.max(0, localStart), Math.min(lineText.length, localEnd)]);
+      const local = projectToRow(rowOffset, lineText.length, startIndex, endIndex);
+      if (!local) continue;
+      claimed.push(local);
 
-      // A token touching a clipped edge may continue past it, and the regex's
-      // `^`/`$` would read the budget cutoff as a boundary — the same lie a row
-      // edge tells. Claim it anyway (claiming only ever suppresses links) but
-      // never link it. A token starting entirely outside the window stays
-      // invisible; bounding the rejoin is what makes hover affordable, and that
-      // needs a logical line past 2048 columns to reach.
-      if (
-        (logical.clippedStart && startIndex === 0) ||
-        (logical.clippedEnd && endIndex === logical.text.length)
-      ) {
-        continue;
-      }
+      if (touchesClippedEdge(logical, startIndex, endIndex)) continue;
 
       const resolved = resolveFileUrlCandidate(url);
       if (!resolved) continue;
-
-      const start = mapToRow(logical, startIndex);
-      const end = mapToRow(logical, endIndex - 1);
-      const range: IBufferRange = {
-        // xterm rows are 1-based and the end column is inclusive, so `end`
-        // addresses the URL's last character rather than the one past it.
-        start: { x: start.column + 1, y: start.row + 1 },
-        end: { x: end.column + 1, y: end.row + 1 },
-      };
 
       // No line/col: `resolveFileUrlCandidate` deliberately doesn't peel a
       // `:line` suffix off a URL, so there is none to forward.
       links.push(
         new FileLink(
-          range,
+          rangeFor(logical, startIndex, endIndex),
           url,
           resolved.absolutePath,
           undefined,
@@ -470,7 +484,71 @@ export class FileLinksAddon implements ILinkProvider {
         )
       );
     }
-    return logical.text;
+  }
+
+  /**
+   * Scan the logical line for bare (non-URL) path tokens, appending links and
+   * claiming the spans they occupy on the hovered row.
+   *
+   * Rejoined for the same reason URLs are, and for one more: `FILE_PATH_REGEX`
+   * opens with `(?:^|[\s(])`, and on a continuation row that `^` asserts a
+   * token boundary at a column where the token is still mid-flight. Scanning a
+   * single row captured whichever fragment the margin left behind — and a
+   * fragment resolves against the cwd just as happily as the whole path, so
+   * the link, the hover callback, and right-click "Reveal" all agreed on a
+   * real-but-wrong file with nothing to signal it (#11865).
+   *
+   * Spans are claimed for every syntactic match touching the row, resolved or
+   * not. The directory pass is looser than this one by design (`and/or`
+   * matches it), so a token this pass owns but can't resolve must not come
+   * back as a lower-confidence directory link on the same characters.
+   */
+  private _collectBarePathLinks(
+    logical: LogicalLine,
+    rowOffset: number,
+    lineText: string,
+    links: ILink[],
+    claimed: Array<[number, number]>
+  ): void {
+    // matchAll on the module-scope global regex clones it internally (per spec)
+    // and never mutates lastIndex, so the regex is reused across hover calls
+    // without the per-call `new RegExp(FILE_PATH_REGEX)` allocation.
+    for (const match of logical.text.matchAll(FILE_PATH_REGEX)) {
+      const fullMatch = match[1];
+      if (fullMatch === undefined) continue;
+
+      const startIndex = match.index + match[0]!.indexOf(fullMatch);
+      const endIndex = startIndex + fullMatch.length;
+
+      const local = projectToRow(rowOffset, lineText.length, startIndex, endIndex);
+      if (!local) continue;
+
+      // A `(` is legal inside a file URL and is also this regex's boundary
+      // character, so `file:///tmp/(src/foo.ts` offers `src/foo.ts` as a bare
+      // path — which would resolve against the cwd and link a different file
+      // than the URL names. Every URL span is claimed whether or not it
+      // resolved, so a rejected remote URL can't leak a local link either.
+      if (overlapsClaimed(claimed, local[0], local[1])) continue;
+      claimed.push(local);
+
+      if (touchesClippedEdge(logical, startIndex, endIndex)) continue;
+      if (isPathExcluded(fullMatch)) continue;
+
+      const resolved = resolveFilePathCandidate(fullMatch, this._getCwd());
+      if (!resolved) continue;
+
+      links.push(
+        new FileLink(
+          rangeFor(logical, startIndex, endIndex),
+          fullMatch,
+          resolved.absolutePath,
+          resolved.line,
+          resolved.col,
+          this._getCwd(),
+          this._onHover
+        )
+      );
+    }
   }
 
   /**

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -388,20 +388,19 @@ export class FileLinksAddon implements ILinkProvider {
       // Disposed while validating (terminal closed): the registration is
       // gone, so a late reply has no linkifier to serve.
       if (this._disposed) return;
-      // The line may have been rewritten under the pointer while validation
+      // The buffer may have been rewritten under the pointer while validation
       // was in flight (streaming agent output). xterm caches replies by the
-      // pointer's current line, so links computed for the OLD text would
+      // pointer's current line, so links computed for the OLD content would
       // paint on the new one — drop the whole reply instead.
-      const current = this._terminal.buffer.active.getLine(bufferLineNumber - 1);
-      if (!current || current.translateToString(true) !== lineText) {
-        callback(undefined);
-        return;
-      }
-      // A file or URL link can span rows that check never looks at, so re-read
-      // the whole window it was computed from: rewriting only a continuation
-      // row would otherwise leave a link to the path the line used to name,
-      // and a re-wrap that merely moves a row boundary would leave a range
-      // underlining the wrong cells.
+      //
+      // The whole rejoin window is re-read rather than the hovered row alone:
+      // a link can span rows the row itself never sees, and a re-wrap that
+      // merely moves a boundary leaves a range underlining the wrong cells.
+      // Comparing windows also keeps the check off `translateToString(true)`,
+      // which is not stable across an intervening untrimmed read — xterm
+      // caches one string per line, and a trailing space the app actually
+      // printed survives `getTrimmedLength()` but not the cached value's
+      // `trimEnd()`, so the same unchanged row can compare unequal to itself.
       const currentLogical = this._readLogicalLine(bufferLineNumber - 1);
       if (!currentLogical || !sameLogicalLine(currentLogical, logical)) {
         callback(undefined);
@@ -582,7 +581,16 @@ export class FileLinksAddon implements ILinkProvider {
     let clippedEnd = false;
 
     // `isWrapped` marks a row as the CONTINUATION of the one above it.
-    while (startRow > 0 && buffer.getLine(startRow)?.isWrapped === true) {
+    while (buffer.getLine(startRow)?.isWrapped === true) {
+      // Row 0 still claiming to continue something means the rows carrying the
+      // token's head were trimmed out of scrollback — xterm keeps the flag
+      // when its circular buffer evicts the row above. The window then opens
+      // mid-token exactly the way the budget cutoff does, and a headless
+      // fragment resolves against the cwd just as happily as a whole path.
+      if (startRow === 0) {
+        clippedStart = true;
+        break;
+      }
       const above = buffer.getLine(startRow - 1);
       if (!above) break;
       const text = above.translateToString(false);

--- a/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
@@ -210,10 +210,12 @@ describe("FileLinksAddon directory links", () => {
     const addon = new FileLinksAddon(makeTerminal(rows), () => root);
     const callback = vi.fn();
     addon.provideLinks(1, callback);
+    await vi.waitFor(() => expect(fileBrowserClient.statPaths).toHaveBeenCalled());
+    expect(callback).not.toHaveBeenCalled();
     rows[0] = "completely different text";
     stat.resolve(["directory"]);
     await vi.waitFor(() => expect(callback).toHaveBeenCalled());
-    expect(callback).toHaveBeenCalledWith(undefined);
+    expect(callback.mock.calls).toEqual([[undefined]]);
   });
 
   it("drops the reply when only a wrapped URL's continuation row was rewritten", async () => {
@@ -227,10 +229,12 @@ describe("FileLinksAddon directory links", () => {
     const addon = new FileLinksAddon(makeTerminal(rows), () => root);
     const callback = vi.fn();
     addon.provideLinks(1, callback);
+    await vi.waitFor(() => expect(fileBrowserClient.statPaths).toHaveBeenCalled());
+    expect(callback).not.toHaveBeenCalled();
     rows[1] = "b.png";
     stat.resolve(["directory"]);
     await vi.waitFor(() => expect(callback).toHaveBeenCalled());
-    expect(callback).toHaveBeenCalledWith(undefined);
+    expect(callback.mock.calls).toEqual([[undefined]]);
   });
 
   it.each(["resolve", "reject"] as const)(
@@ -251,11 +255,13 @@ describe("FileLinksAddon directory links", () => {
       const addon = new FileLinksAddon(makeTerminal(rows), () => root);
       const callback = vi.fn();
       addon.provideLinks(1, callback);
+      await vi.waitFor(() => expect(fileBrowserClient.statPaths).toHaveBeenCalled());
+      expect(callback).not.toHaveBeenCalled();
       rows[1] = "y";
       if (outcome === "resolve") stat.resolve(["directory"]);
       else stat.reject(new Error("view evicted"));
       await vi.waitFor(() => expect(callback).toHaveBeenCalled());
-      expect(callback).toHaveBeenCalledWith(undefined);
+      expect(callback.mock.calls).toEqual([[undefined]]);
     }
   );
 
@@ -271,11 +277,13 @@ describe("FileLinksAddon directory links", () => {
     const addon = new FileLinksAddon(makeTerminal(rows), () => root);
     const callback = vi.fn();
     addon.provideLinks(1, callback);
+    await vi.waitFor(() => expect(fileBrowserClient.statPaths).toHaveBeenCalled());
+    expect(callback).not.toHaveBeenCalled();
     rows[1] = "render";
     rows[2] = "s/a.png";
     stat.resolve(["directory"]);
     await vi.waitFor(() => expect(callback).toHaveBeenCalled());
-    expect(callback).toHaveBeenCalledWith(undefined);
+    expect(callback.mock.calls).toEqual([[undefined]]);
   });
 
   it("shields a continuation fragment the file pass owns but cannot resolve", async () => {

--- a/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
@@ -244,11 +244,14 @@ describe("FileLinksAddon directory links", () => {
       // the same staleness checks the success branch does — a reply that only
       // drops its directory links would still paint a file link naming the
       // path the line used to carry.
-      const rows = ["src/generated holds src/renders/", "a.png"];
+      // The hovered row carries a token that reads as a whole path on its own,
+      // so a reply that skipped the checks would ship a link to `.../a.ts`
+      // while the buffer now says something else entirely.
+      const rows = ["src/generated holds src/renders/a.ts", "x"];
       const addon = new FileLinksAddon(makeTerminal(rows), () => root);
       const callback = vi.fn();
       addon.provideLinks(1, callback);
-      rows[1] = "b.png";
+      rows[1] = "y";
       if (outcome === "resolve") stat.resolve(["directory"]);
       else stat.reject(new Error("view evicted"));
       await vi.waitFor(() => expect(callback).toHaveBeenCalled());

--- a/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.directories.test.ts
@@ -28,25 +28,51 @@ function bindWorktrees(worktrees: Map<string, { id: string; path: string }>): vo
   } as unknown as ReturnType<typeof getCurrentViewStoreOrNull>);
 }
 
-function makeTerminal(lines: string[]): Terminal {
-  let call = 0;
+/**
+ * Rows keyed by buffer index, not by call order: the addon reads a row more
+ * than once per hover (the row itself, the wrap probe, the rejoin, the
+ * post-validation re-read), so a call-counting mock would silently change what
+ * a test means the moment that count moved. `rows` is read live, so a test can
+ * model a mid-validation rewrite by mutating it. `wrapped[i]` marks row i as
+ * the CONTINUATION of row i-1.
+ */
+function makeTerminal(rows: string[], wrapped?: boolean[]): Terminal {
   return {
     buffer: {
       active: {
-        getLine: vi.fn((): IBufferLine => {
-          const text = lines[Math.min(call, lines.length - 1)]!;
-          call += 1;
-          return { translateToString: () => text } as IBufferLine;
+        getLine: vi.fn((index: number): IBufferLine | undefined => {
+          const text = rows[index];
+          if (text === undefined) return undefined;
+          return {
+            translateToString: (trimRight?: boolean) => (trimRight ? text.trimEnd() : text),
+            isWrapped: wrapped ? wrapped[index] === true : index > 0,
+          } as IBufferLine;
         }),
       },
     },
   } as unknown as Terminal;
 }
 
-function provide(addon: FileLinksAddon): Promise<ILink[] | undefined> {
+function provide(addon: FileLinksAddon, bufferLineNumber = 1): Promise<ILink[] | undefined> {
   return new Promise((resolve) => {
-    addon.provideLinks(1, resolve);
+    addon.provideLinks(bufferLineNumber, resolve);
   });
+}
+
+/** A `statPaths` call held open so a test can rewrite the buffer under it. */
+function pendingStat(): {
+  resolve: (kinds: Array<"directory" | "file" | null>) => void;
+  reject: (error: Error) => void;
+} {
+  let resolve: (kinds: Array<"directory" | "file" | null>) => void = () => {};
+  let reject: (error: Error) => void = () => {};
+  vi.mocked(fileBrowserClient.statPaths).mockReturnValue(
+    new Promise((onResolve, onReject) => {
+      resolve = onResolve;
+      reject = onReject;
+    })
+  );
+  return { resolve, reject };
 }
 
 describe("FileLinksAddon directory links", () => {
@@ -176,52 +202,95 @@ describe("FileLinksAddon directory links", () => {
   it("drops the whole reply when the line was rewritten mid-validation", async () => {
     const root = nextRoot();
     bindWorktrees(new Map([[root, { id: root, path: root }]]));
-    vi.mocked(fileBrowserClient.statPaths).mockResolvedValue(["directory"]);
+    const stat = pendingStat();
 
-    // First read (provideLinks) sees the token; the post-validation re-read
-    // sees different text, so the stale reply must be discarded.
-    const addon = new FileLinksAddon(
-      makeTerminal(["output in src/generated now", "completely different text"]),
-      () => root
-    );
-    expect(await provide(addon)).toBeUndefined();
+    // The row is rewritten while validation is in flight, so links computed
+    // for the old text must not paint on the new.
+    const rows = ["output in src/generated now"];
+    const addon = new FileLinksAddon(makeTerminal(rows), () => root);
+    const callback = vi.fn();
+    addon.provideLinks(1, callback);
+    rows[0] = "completely different text";
+    stat.resolve(["directory"]);
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+    expect(callback).toHaveBeenCalledWith(undefined);
   });
 
   it("drops the reply when only a wrapped URL's continuation row was rewritten", async () => {
     const root = nextRoot();
     bindWorktrees(new Map([[root, { id: root, path: root }]]));
-    let release: (value: Array<"directory" | "file" | null>) => void = () => {};
-    vi.mocked(fileBrowserClient.statPaths).mockReturnValue(
-      new Promise((resolve) => {
-        release = resolve;
-      })
-    );
+    const stat = pendingStat();
 
     // The hovered row never changes, so the single-row guard sees nothing —
     // only the rejoined window reveals that the URL now names another file.
     const rows = ["src/generated file:///tmp/renders/", "a.png"];
-    const terminal = {
-      buffer: {
-        active: {
-          getLine: vi.fn((index: number): IBufferLine | undefined => {
-            const text = rows[index];
-            if (text === undefined) return undefined;
-            return {
-              translateToString: (trimRight?: boolean) => (trimRight ? text.trimEnd() : text),
-              isWrapped: index > 0,
-            } as IBufferLine;
-          }),
-        },
-      },
-    } as unknown as Terminal;
-
-    const addon = new FileLinksAddon(terminal, () => root);
+    const addon = new FileLinksAddon(makeTerminal(rows), () => root);
     const callback = vi.fn();
     addon.provideLinks(1, callback);
     rows[1] = "b.png";
-    release(["directory"]);
+    stat.resolve(["directory"]);
     await vi.waitFor(() => expect(callback).toHaveBeenCalled());
     expect(callback).toHaveBeenCalledWith(undefined);
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "drops the reply on %s when a wrapped bare path's continuation row was rewritten",
+    async (outcome) => {
+      const root = nextRoot();
+      bindWorktrees(new Map([[root, { id: root, path: root }]]));
+      const stat = pendingStat();
+
+      // A bare file link can span rows now, so the rejection branch has to run
+      // the same staleness checks the success branch does — a reply that only
+      // drops its directory links would still paint a file link naming the
+      // path the line used to carry.
+      const rows = ["src/generated holds src/renders/", "a.png"];
+      const addon = new FileLinksAddon(makeTerminal(rows), () => root);
+      const callback = vi.fn();
+      addon.provideLinks(1, callback);
+      rows[1] = "b.png";
+      if (outcome === "resolve") stat.resolve(["directory"]);
+      else stat.reject(new Error("view evicted"));
+      await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+      expect(callback).toHaveBeenCalledWith(undefined);
+    }
+  );
+
+  it("drops the reply when a re-wrap moves a row boundary without changing text", async () => {
+    const root = nextRoot();
+    bindWorktrees(new Map([[root, { id: root, path: root }]]));
+    const stat = pendingStat();
+
+    // Same hovered row, same rejoined string, different split. Every buffer
+    // coordinate a multi-row link carries comes from the row offsets, so
+    // comparing text alone would ship a range underlining the wrong cells.
+    const rows = ["src/generated holds src/", "renders", "/a.png"];
+    const addon = new FileLinksAddon(makeTerminal(rows), () => root);
+    const callback = vi.fn();
+    addon.provideLinks(1, callback);
+    rows[1] = "render";
+    rows[2] = "s/a.png";
+    stat.resolve(["directory"]);
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+    expect(callback).toHaveBeenCalledWith(undefined);
+  });
+
+  it("shields a continuation fragment the file pass owns but cannot resolve", async () => {
+    const root = nextRoot();
+    bindWorktrees(new Map([[root, { id: root, path: root }]]));
+
+    // With no cwd the rejoined relative token resolves to nothing, but its
+    // continuation row still reads as an absolute directory on its own. The
+    // file pass claims every span it matches, resolved or not, so the looser
+    // directory pass can't come back with a link to a path the line never
+    // named.
+    const addon = new FileLinksAddon(
+      makeTerminal(["open relative", `${root}/existing.ts`]),
+      () => ""
+    );
+
+    expect(await provide(addon, 2)).toBeUndefined();
+    expect(fileBrowserClient.statPaths).not.toHaveBeenCalled();
   });
 
   it("stays silent after disposal", async () => {

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -700,8 +700,8 @@ describe("FileLinksAddon", () => {
       };
 
       // Clipped at the end: the window stops at 2000 columns, exactly where
-      // this token's only extension sits, so the match ends on the cut.
-      const endClipped = `src/${"a".repeat(1994)}.ts${"/b".repeat(400)}`;
+      // this token's only extension ends, so the match runs onto the cut.
+      const endClipped = `src/${"a".repeat(1993)}.ts${"/b".repeat(400)}`;
       expect(await linksForRows(toRows(endClipped), 0)).toBeUndefined();
 
       // Clipped at the start: hovering the last row walks upward instead, and
@@ -723,6 +723,66 @@ describe("FileLinksAddon", () => {
         expect(links).toHaveLength(1);
         expect(readLink(links![0]!).absolutePath).toBe("/tmp/(src/foo.ts");
       }
+    });
+
+    it("refuses to link a path whose head was trimmed out of scrollback", async () => {
+      // xterm keeps `isWrapped` on the topmost row when the circular buffer
+      // evicts the rows above it, so the buffer still says "this continues
+      // something" with nothing left to continue. The visible fragment
+      // resolves against the cwd — the same silent wrong-file failure the
+      // rejoin exists to prevent, arriving by a different route.
+      expect(
+        await linksForRows(["rvices/foo.ts and more"], 0, { wrapped: [true] })
+      ).toBeUndefined();
+    });
+
+    it("spans a path that wrapped across three rows", async () => {
+      const rows = ["built src/components/Term", "inal/inputEditorExtensions/f", "ileChip.ts ok"];
+      for (const hoveredRow of [0, 1, 2]) {
+        const links = await linksForRows(rows, hoveredRow);
+        expect(links).toHaveLength(1);
+        const link = links![0]!;
+        expect(readLink(link).absolutePath).toBe(
+          "/home/user/project/src/components/Terminal/inputEditorExtensions/fileChip.ts"
+        );
+        expect(link.range.start).toEqual({ x: "built ".length + 1, y: 1 });
+        expect(link.range.end).toEqual({ x: "ileChip.ts".length, y: 3 });
+      }
+    });
+
+    it("ends the range on the right row when a match stops at a row boundary", async () => {
+      // The end column comes from the match's LAST character, not the one past
+      // it; mapping the exclusive end would push the range onto the next row's
+      // first cell and underline a character the token never covered.
+      const links = await linksForRows(["at src/App.tsx:42", " and elsewhere"], 0);
+      expect(links).toHaveLength(1);
+      const link = links![0]!;
+      expect(readLink(link).text).toBe("src/App.tsx:42");
+      expect(link.range.end).toEqual({ x: "at src/App.tsx:42".length, y: 1 });
+    });
+
+    it("still links a whole token inside a window the budget clipped", async () => {
+      // Clipping distrusts the window's EDGES, not everything inside it. An
+      // implementation that dropped every match whenever a flag was set would
+      // blind the pointer to paths it can see perfectly well.
+      const rows = Array.from({ length: 40 }, () => "z".repeat(80));
+      rows[20] = ` src/mid.ts ${"z".repeat(68)}`;
+      const links = await linksForRows(rows, 20);
+      expect(links).toHaveLength(1);
+      expect(readLink(links![0]!).absolutePath).toBe("/home/user/project/src/mid.ts");
+    });
+
+    it("rejoins a WSL UNC path that wrapped mid-token", async () => {
+      const links = await linksForRows(
+        ["see \\\\wsl$\\Ubuntu\\home\\user\\pro", "ject\\src\\App.tsx:45:12 failed"],
+        1
+      );
+      expect(links).toHaveLength(1);
+      const link = readLink(links![0]!);
+      expect(link.text).toBe("\\\\wsl$\\Ubuntu\\home\\user\\project\\src\\App.tsx:45:12");
+      expect(link.absolutePath).toBe("\\\\wsl$\\Ubuntu\\home\\user\\project\\src\\App.tsx");
+      expect(link._line).toBe(45);
+      expect(link._col).toBe(12);
     });
 
     it("hands the hover callback the full path, not the fragment", async () => {

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -556,6 +556,194 @@ describe("FileLinksAddon", () => {
     });
   });
 
+  describe("soft-wrapped bare paths (#11865)", () => {
+    const CWD = "/home/user/project";
+
+    /**
+     * Rows as xterm stores them, with `translateToString` honouring `trimRight`
+     * the way xterm does. `wrapped[i]` marks row i as the CONTINUATION of row
+     * i-1 — the flag the rejoin walks — so a hard newline is modelled by
+     * clearing that flag, never by anything about the text.
+     */
+    const makeWrappedTerminal = (rows: string[], wrapped?: boolean[]): Terminal => {
+      const terminal = createMockTerminal();
+      vi.mocked(terminal.buffer.active.getLine).mockImplementation((index: number) => {
+        const text = rows[index];
+        if (text === undefined) return undefined;
+        return {
+          translateToString: (trimRight?: boolean) => (trimRight ? text.trimEnd() : text),
+          isWrapped: wrapped ? wrapped[index] === true : index > 0,
+        } as IBufferLine;
+      });
+      return terminal;
+    };
+
+    const linksForRows = (
+      rows: string[],
+      hoveredRow: number,
+      options: { wrapped?: boolean[]; cwd?: string } = {}
+    ): Promise<ILink[] | undefined> =>
+      new Promise((resolve) => {
+        new FileLinksAddon(
+          makeWrappedTerminal(rows, options.wrapped),
+          () => options.cwd ?? CWD
+        ).provideLinks(hoveredRow + 1, resolve);
+      });
+
+    const readLink = (link: ILink) =>
+      link as unknown as {
+        kind: string;
+        text: string;
+        absolutePath: string;
+        _line?: number;
+        _col?: number;
+      };
+
+    it("rejoins a soft-wrapped bare path instead of linking the truncated tail", async () => {
+      // The fragment left on the continuation row resolves against the cwd
+      // just as happily as the whole path, so the old row-local scan produced
+      // a link to a real-but-wrong file with nothing to signal it.
+      const rows = ["compiled src/services/terminal/FileLinks", "Addon.ts in 2s"];
+      for (const hoveredRow of [0, 1]) {
+        const links = await linksForRows(rows, hoveredRow);
+        expect(links).toHaveLength(1);
+        const link = links![0]!;
+        expect(readLink(link).text).toBe("src/services/terminal/FileLinksAddon.ts");
+        expect(readLink(link).absolutePath).toBe(
+          "/home/user/project/src/services/terminal/FileLinksAddon.ts"
+        );
+        // One link spanning both rows — 1-based rows, inclusive end column.
+        expect(link.range.start).toEqual({ x: "compiled ".length + 1, y: 1 });
+        expect(link.range.end).toEqual({ x: "Addon.ts".length, y: 2 });
+      }
+    });
+
+    it("links a path split immediately before its extension", async () => {
+      const links = await linksForRows(["see src/components/Terminal", ".tsx now"], 1);
+      expect(links).toHaveLength(1);
+      expect(readLink(links![0]!).absolutePath).toBe(
+        "/home/user/project/src/components/Terminal.tsx"
+      );
+    });
+
+    it("keeps a :line:column suffix that wrapped onto the next row", async () => {
+      const links = await linksForRows(["error at src/App.tsx:4", "2:13 in build"], 0);
+      expect(links).toHaveLength(1);
+      const link = readLink(links![0]!);
+      expect(link.text).toBe("src/App.tsx:42:13");
+      expect(link.absolutePath).toBe("/home/user/project/src/App.tsx");
+      expect(link._line).toBe(42);
+      expect(link._col).toBe(13);
+    });
+
+    it("links from a continuation row that carries no separator of its own", async () => {
+      // `sprite.png` alone would hit the '/'-or-'\' fast path and never be
+      // scanned, leaving the tail of a wrapped path dead to the pointer.
+      const links = await linksForRows(["writing src/generated/", "sprite.png done"], 1);
+      expect(links).toHaveLength(1);
+      expect(readLink(links![0]!).absolutePath).toBe("/home/user/project/src/generated/sprite.png");
+    });
+
+    it("never fuses two paths separated by a hard newline", async () => {
+      // Structural: the rejoin only walks rows flagged as continuations, so a
+      // real line break leaves each path alone on its own row.
+      const rows = ["first src/alpha.ts", "second src/beta.ts"];
+      for (const hoveredRow of [0, 1]) {
+        const links = await linksForRows(rows, hoveredRow, { wrapped: [false, false] });
+        expect(links).toHaveLength(1);
+        const link = links![0]!;
+        expect(readLink(link).absolutePath).toBe(
+          hoveredRow === 0 ? "/home/user/project/src/alpha.ts" : "/home/user/project/src/beta.ts"
+        );
+        expect(link.range.start.y).toBe(hoveredRow + 1);
+        expect(link.range.end.y).toBe(hoveredRow + 1);
+      }
+    });
+
+    it("treats a wrap with no delimiter as the single token the user sees", async () => {
+      // Row one ran to the margin, so the terminal really did print one
+      // unbroken token — the rejoin has to read it the way an unwrapped line
+      // would, rather than inventing a boundary at the row edge.
+      const links = await linksForRows(["see src/foo.ts", "x/bar.md"], 0);
+      expect(links).toHaveLength(1);
+      const link = readLink(links![0]!);
+      expect(link.text).toBe("src/foo.tsx/bar.md");
+      expect(link.absolutePath).toBe("/home/user/project/src/foo.tsx/bar.md");
+    });
+
+    it("keeps the spaces that separate a wrapped path from the next token", async () => {
+      // Row one is full to the margin with real spaces. Trimming them on
+      // rejoin would fuse the two tokens into `src/a.tsdocs/b.md`.
+      const links = await linksForRows(["see src/a.ts   ", "docs/b.md"], 0);
+      expect(links).toHaveLength(1);
+      expect(readLink(links![0]!).absolutePath).toBe("/home/user/project/src/a.ts");
+    });
+
+    it("ignores a bare path that lies entirely on a sibling row", async () => {
+      // xterm evicts lower-priority links intersecting a returned range, so a
+      // link the pointer can't reach on this row must not be reported at all.
+      expect(
+        await linksForRows(["plain prose with no token", "see src/foo.ts"], 0)
+      ).toBeUndefined();
+    });
+
+    it("refuses to link a bare path clipped by the rejoin budget", async () => {
+      // The window is anchored on the hovered row and grows outward on a fixed
+      // budget, so a token longer than that gets an edge the regex reads as a
+      // real token boundary — the same lie a row edge tells.
+      const toRows = (token: string): string[] => {
+        const rows: string[] = [];
+        for (let index = 0; index < token.length; index += 80) {
+          rows.push(token.slice(index, index + 80));
+        }
+        return rows;
+      };
+
+      // Clipped at the end: the window stops at 2000 columns, exactly where
+      // this token's only extension sits, so the match ends on the cut.
+      const endClipped = `src/${"a".repeat(1994)}.ts${"/b".repeat(400)}`;
+      expect(await linksForRows(toRows(endClipped), 0)).toBeUndefined();
+
+      // Clipped at the start: hovering the last row walks upward instead, and
+      // the window opens mid-token where `^` is a lie.
+      const startClipped = `${"s".repeat(880)}/dir/${"c".repeat(1992)}.ts`;
+      const startRows = toRows(startClipped);
+      expect(await linksForRows(startRows, startRows.length - 1)).toBeUndefined();
+    });
+
+    it("keeps a wrapped file:// URL from leaking a bare-path link on either row", async () => {
+      // `(` is legal in a file URL and is also FILE_PATH_REGEX's boundary
+      // character. The URL's claim is recorded in ROW-LOCAL coordinates, so a
+      // logical-line match has to be projected back before it is tested
+      // against the ledger — skip that and the shielding silently stops firing
+      // while everything still typechecks.
+      const rows = ["open file:///tmp/(src/", "foo.ts"];
+      for (const hoveredRow of [0, 1]) {
+        const links = await linksForRows(rows, hoveredRow);
+        expect(links).toHaveLength(1);
+        expect(readLink(links![0]!).absolutePath).toBe("/tmp/(src/foo.ts");
+      }
+    });
+
+    it("hands the hover callback the full path, not the fragment", async () => {
+      // `hoveredLink` is what right-click "Reveal in File Manager" reads, so a
+      // fragment here opens a real-but-wrong file and reports no failure.
+      const seen: Array<{ absolutePath?: string } | null> = [];
+      const addon = new FileLinksAddon(
+        makeWrappedTerminal(["wrote src/generated/", "sprite.png"]),
+        () => CWD,
+        (link) => seen.push(link)
+      );
+
+      const link = await new Promise<ILink>((resolve) =>
+        addon.provideLinks(2, (links) => resolve(links![0]!))
+      );
+      link.hover?.(new Event("mousemove") as unknown as MouseEvent, link.text);
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.absolutePath).toBe("/home/user/project/src/generated/sprite.png");
+    });
+  });
+
   describe("path resolution", () => {
     it("should resolve relative paths against cwd", () => {
       return new Promise<void>((resolve) => {

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -736,6 +736,14 @@ describe("FileLinksAddon", () => {
       ).toBeUndefined();
     });
 
+    it("distrusts a match a mid-token boundary alone separates from a clipped edge", async () => {
+      // What survived of `file:///tmp/(src/foo.ts` after eviction. `(` is legal
+      // inside a file URL and is also FILE_PATH_REGEX's boundary character, so
+      // it is no proof that `src/foo.ts` is a whole token — and with the scheme
+      // gone there is no URL left to claim the span and shield it.
+      expect(await linksForRows(["tmp/(src/foo.ts done"], 0, { wrapped: [true] })).toBeUndefined();
+    });
+
     it("spans a path that wrapped across three rows", async () => {
       const rows = ["built src/components/Term", "inal/inputEditorExtensions/f", "ileChip.ts ok"];
       for (const hoveredRow of [0, 1, 2]) {


### PR DESCRIPTION
## Summary
- `provideLinks()` in `FileLinksAddon.ts` linked only the continuation fragment of a soft-wrapped bare file path, opening the wrong file (or nothing) on click, and feeding that same wrong path into hover state so "Reveal in File Manager" pointed at it too.
- The bare-path pass now scans the same rejoined logical line the `file://` URL pass already used, and maps matches back onto multi-row buffer ranges.
- Review turned up two related xterm quirks worth fixing alongside it: a clipped scrollback edge that can mask itself as a valid wrap, and a staleness check that could self-invalidate on an unchanged row.

Resolves #11865

## What was wrong
`provideLinks()` runs three passes over the hovered terminal buffer row. The `file://` URL pass already rejoins soft-wrapped rows into one logical line via `_readLogicalLine()`, fixed back in #11419 and #11421. The bare-path pass never got that treatment and still scanned a single physical row. So when xterm soft-wrapped a bare relative path mid-token, only the continuation fragment matched, and that fragment resolves against the working directory just as validly as the whole path would. Clicking it opened a real file, just the wrong one. The same wrong `absolutePath` rode the hover callback into `hoveredLink`, so right-click "Reveal in File Manager" pointed at the same wrong file, and nothing in the UI showed anything had gone wrong.

## What changed
Four commits:

1. The bare-path pass now scans the rejoined logical line and maps matches back to multi-row buffer ranges, mirroring the URL pass.
2. The row-local projection math, the clipped-edge check, and the range-mapping arithmetic moved into three shared helpers, `projectToRow`, `touchesClippedEdge`, and `rangeFor`, used by both passes. `claimed` is a row-local ledger: feeding it a logical-line index instead of a row-local one typechecks fine while silently disabling the shielding that stops a URL match and a bare-path match from claiming the same characters. Pulling this into shared helpers makes that mistake impossible to make by accident.
3. Every syntactically valid bare-path match touching the row now claims its span, resolved or not. The directory pass is deliberately looser (`and`/`or` can match it), so a token the file pass owns but can't resolve must not fall through as a lower-confidence directory link.
4. The deferred directory-validation reply now runs its staleness checks on both the success and rejection branches. The rejection branch previously ran neither, which was harmless only while a file link couldn't outlive its own row. It now compares the whole rejoin geometry rather than just the text, since a re-wrap that moves a row boundary without changing a character still invalidates a multi-row range.

## Notes from review
Two things worth calling out:

- xterm keeps `isWrapped` set on the topmost row even after its circular buffer evicts the rows above it, so a row 0 that still claims to continue something has just lost its head. That's now reported as a clipped start. A clipped edge invalidates more than a match sitting at index 0, too: `(` is legal inside a file URL and also the path regex's boundary character, so a scrollback-trimmed `file:///tmp/(src/foo.ts` still offered `src/foo.ts` as a bare-path link with no URL left to claim and shield it. The guard now requires a real space between the cut and the match, at both ends.
- The deferred reply used to compare the hovered row against `translateToString(true)` to detect staleness. That's not stable across the untrimmed read the rejoin performs: xterm caches one string per line with an `isTrimmed` flag, and a trailing space the app actually printed survives `getTrimmedLength()` but not the cached value's `trimEnd()`, so an unchanged row could compare unequal to itself and silently drop every deferred link. That comparison is gone; the geometry check now covers what it was trying to catch.

## Testing
160 targeted tests pass across `FileLinksAddon`, `FileLinksAddon.directories`, `filePathDetection`, `TerminalInstanceService.hoveredLink`, and `TerminalContextMenu.fileBrowser`, including a new `soft-wrapped bare paths (#11865)` block. Verified with a negative control: reverting the implementation while keeping the new tests in place fails 12 of them, so they're catching the actual defect rather than passing vacuously. Coverage includes hovering and clicking from either row, a path wrapping right before its extension, a `:line:col` suffix split across the wrap, a three-row span, a continuation row with no separator of its own, hard-newline non-fusion, sibling-row-only paths, budget-clipped windows from both ends, a whole token inside a clipped window, a scrollback-trimmed head, a wrapped WSL UNC path, trailing-space preservation, and the wrapped-URL claim-projection regression.

No full suite or build run locally; CI covers both.

## Follow-ups (out of scope)
- `_collectDirCandidates` is still row-local, the directory analogue of this bug. Pre-existing, deferred per the issue discussion: the file pass's widened claims already shield directory fragments of any path it owns, leaving only an extensionless directory that itself wraps.
- The addon treats UTF-16 string indices as xterm cell columns, so a wide char or combining mark shifts the underline by a cell. Pre-existing and identical for the URL pass and the old single-row bare path pass; fixing it means a `getCell` walk across the whole addon.
