### PR TITLE
fix(terminal): deliver the worktree-move instruction instead of queueing it

### DIFF
--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -345,6 +345,12 @@ interface BasePanelData {
 export interface PanelWorktreeMoveNotice {
   /** Worktree the panel was filed under by the move that raised this notice. */
   destinationWorktreeId: string;
+  /**
+   * Set when a "Tell the agent" click could not put the instruction into the
+   * terminal (#11867). The bar stays up and says so rather than disappearing
+   * on a delivery that never happened.
+   */
+  deliveryFailed?: boolean;
 }
 
 export interface PtyPanelData extends BasePanelData {

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -685,12 +685,21 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           // either. Say no and let the caller keep its banner up.
           if (!view || !latest || latest.disabled) return false;
           const snapshot = view.state.doc.toString();
+          const readStoredDraft = () =>
+            useTerminalInputStore.getState().getDraftInput(terminalId, latest.projectId);
+          const storedAtSend = readStoredDraft();
           return sendText(snapshot, {
             compose: (draft) => composeDraftWithInstruction(draft, instruction),
             submit,
-            // What was sent is a snapshot; what is on screen when the submit
-            // finally lands may not be. Only the snapshot is ours to clear.
-            isDraftUnchanged: () => editorViewRef.current?.state.doc.toString() === snapshot,
+            // What was sent is a snapshot; what the user has by the time the
+            // submit lands may not be. Only the snapshot is ours to clear.
+            // The store is checked as well as the document because voice,
+            // prompt history, file references and type-anywhere all write the
+            // draft store first and reach CodeMirror an effect later — during
+            // that window the document alone still looks untouched.
+            isDraftUnchanged: () =>
+              editorViewRef.current?.state.doc.toString() === snapshot &&
+              readStoredDraft() === storedAtSend,
           });
         },
       }),

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -684,9 +684,13 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           // a bar that cannot take the user's own Enter cannot take this
           // either. Say no and let the caller keep its banner up.
           if (!view || !latest || latest.disabled) return false;
-          return sendText(view.state.doc.toString(), {
+          const snapshot = view.state.doc.toString();
+          return sendText(snapshot, {
             compose: (draft) => composeDraftWithInstruction(draft, instruction),
             submit,
+            // What was sent is a snapshot; what is on screen when the submit
+            // finally lands may not be. Only the snapshot is ours to clear.
+            isDraftUnchanged: () => editorViewRef.current?.state.doc.toString() === snapshot,
           });
         },
       }),

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -69,12 +69,31 @@ import { useHostReparent } from "./hooks/useHostReparent";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { SelectedFileMenuItems } from "./SelectedFileMenuItems";
 import { resolveSelectedFilePath } from "@/services/terminal/filePathDetection";
+import { composeDraftWithInstruction } from "@/services/terminal/worktreeMoveInstruction";
 
 export interface HybridInputBarHandle {
   focus: () => void;
   /** Returns whether an editor was mounted to take the focus. */
   focusWithCursorAtEnd: () => boolean;
   cancelPendingFocus: () => void;
+  /**
+   * Submit the live draft with `instruction` appended, through `submit` rather
+   * than the pane's fire-and-forget send, and report whether the terminal took
+   * it (#11867).
+   *
+   * The composed text comes from the mounted CodeMirror document, never from
+   * the draft store: an external write syncs into the editor in a later effect,
+   * so a caller that wrote the store and read it back in the same click stack
+   * would compose against the previous draft.
+   *
+   * Calls `sendText`, not `sendFromEditor`, which is what keeps this strictly
+   * panel-specific — the fleet-broadcast branch lives in `sendFromEditor` and
+   * is unreachable from here by construction rather than by a flag.
+   */
+  submitWithInstruction: (
+    instruction: string,
+    submit: (text: string) => Promise<boolean>
+  ) => Promise<boolean>;
 }
 
 export interface HybridInputBarProps {
@@ -658,8 +677,20 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         cancelPendingFocus: () => {
           focusGenerationRef.current += 1;
         },
+        submitWithInstruction: async (instruction, submit) => {
+          const view = editorViewRef.current;
+          const latest = latestRef.current;
+          // "Mounted and usable", not "rendered": the editor loads lazily, and
+          // a bar that cannot take the user's own Enter cannot take this
+          // either. Say no and let the caller keep its banner up.
+          if (!view || !latest || latest.disabled) return false;
+          return sendText(view.state.doc.toString(), {
+            compose: (draft) => composeDraftWithInstruction(draft, instruction),
+            submit,
+          });
+        },
       }),
-      [focusEditor]
+      [focusEditor, sendText]
     );
 
     // Claim the type-anywhere routing target (#11134) whenever the user really

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -100,7 +100,7 @@ import { registerPanelFocusHandler } from "@/components/Panel/panelFocusRegistry
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import { isPtyPanel } from "@shared/types/panel";
 import { useSessionLostBanner } from "./useSessionLostBanner";
-import { useWorktreeMoveBanner } from "./useWorktreeMoveBanner";
+import { useWorktreeMoveBanner, type WorktreeMoveDeliveryRoute } from "./useWorktreeMoveBanner";
 import { WorktreeMoveBanner } from "./WorktreeMoveBanner";
 import type { TerminalRuntimeIdentity } from "@shared/types/panel";
 
@@ -427,7 +427,6 @@ function TerminalPaneComponent({
   const clearReconnectError = usePanelStore((state) => state.clearReconnectError);
   const clearScrollbackRestoreError = usePanelStore((state) => state.clearScrollbackRestoreError);
   const sessionLostBanner = useSessionLostBanner(id);
-  const worktreeMoveBanner = useWorktreeMoveBanner(id);
 
   const cliDetails = useCliAvailabilityStore((state) => state.details);
   const getPanelCliDetail = (): AgentCliDetail | undefined => {
@@ -579,6 +578,19 @@ function TerminalPaneComponent({
     hybridInputEnabled,
     isFleetArmed: isArmed,
     fleetSize: armedIds.size,
+  });
+
+  // Below `showHybridInputBar`/`isHybridInputDisabled` because it needs both:
+  // "the bar is rendered" and "the bar can take input" are different questions,
+  // and delivering the move instruction has to respect the second one (#11867).
+  const worktreeMoveRoute: WorktreeMoveDeliveryRoute = isHybridInputDisabled
+    ? "blocked"
+    : showHybridInputBar
+      ? "hybrid"
+      : "direct";
+  const worktreeMoveBanner = useWorktreeMoveBanner(id, {
+    route: worktreeMoveRoute,
+    inputBarRef,
   });
 
   const pingedIdSelector = (state: ReturnType<typeof usePanelStore.getState>) =>
@@ -1425,6 +1437,7 @@ function TerminalPaneComponent({
       <BannerSlot visible={worktreeMoveBanner.visible}>
         <WorktreeMoveBanner
           destinationPath={worktreeMoveBanner.destinationPath}
+          deliveryFailed={worktreeMoveBanner.deliveryFailed}
           onTell={worktreeMoveBanner.tell}
           onDismiss={worktreeMoveBanner.dismiss}
         />

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -100,7 +100,7 @@ import { registerPanelFocusHandler } from "@/components/Panel/panelFocusRegistry
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import { isPtyPanel } from "@shared/types/panel";
 import { useSessionLostBanner } from "./useSessionLostBanner";
-import { useWorktreeMoveBanner, type WorktreeMoveDeliveryRoute } from "./useWorktreeMoveBanner";
+import { useWorktreeMoveBanner, resolveWorktreeMoveRoute } from "./useWorktreeMoveBanner";
 import { WorktreeMoveBanner } from "./WorktreeMoveBanner";
 import type { TerminalRuntimeIdentity } from "@shared/types/panel";
 
@@ -583,13 +583,12 @@ function TerminalPaneComponent({
   // Below `showHybridInputBar`/`isHybridInputDisabled` because it needs both:
   // "the bar is rendered" and "the bar can take input" are different questions,
   // and delivering the move instruction has to respect the second one (#11867).
-  const worktreeMoveRoute: WorktreeMoveDeliveryRoute = isHybridInputDisabled
-    ? "blocked"
-    : showHybridInputBar
-      ? "hybrid"
-      : "direct";
   const worktreeMoveBanner = useWorktreeMoveBanner(id, {
-    route: worktreeMoveRoute,
+    route: resolveWorktreeMoveRoute({
+      isHybridInputDisabled,
+      hasHybridInputBar: showHybridInputBar,
+      isFleetComposing: isArmed && armedIds.size >= 2,
+    }),
     inputBarRef,
   });
 

--- a/src/components/Terminal/WorktreeMoveBanner.tsx
+++ b/src/components/Terminal/WorktreeMoveBanner.tsx
@@ -4,6 +4,8 @@ import { InlineStatusBanner } from "./InlineStatusBanner";
 export interface WorktreeMoveBannerProps {
   /** Destination path, or `undefined` when the worktree has since gone. */
   destinationPath: string | undefined;
+  /** A tell was tried and the terminal did not take it (#11867). */
+  deliveryFailed?: boolean;
   onTell: () => void;
   onDismiss: () => void;
 }
@@ -30,18 +32,36 @@ export interface WorktreeMoveBannerProps {
  *
  * With no destination there is nothing to tell, so the control is absent rather
  * than present-but-disabled: the sentence explains why, and the X still works.
+ *
+ * A failed delivery turns the same bar red rather than raising a toast: the
+ * signal and its recovery both live here, and the bar is already on screen.
+ * It also stops being a polite status — the user asked for something and it
+ * did not happen, which is worth interrupting for. The recovery keeps the
+ * sentence shape; the red wash renders a boxed fill no better than the amber
+ * one did, and `InlineStatusBanner` types an error banner as taking at most one
+ * boxed `action` anyway.
  */
 export function WorktreeMoveBanner({
   destinationPath,
+  deliveryFailed = false,
   onTell,
   onDismiss,
 }: WorktreeMoveBannerProps) {
+  const description =
+    destinationPath === undefined
+      ? "The destination worktree is no longer available"
+      : deliveryFailed
+        ? "The instruction didn't reach the terminal. Check that it's connected and unlocked, then retry."
+        : undefined;
+
   return (
     <InlineStatusBanner
       icon={FolderGit2}
-      severity="warning"
-      title="Agent may still be in the original worktree"
-      description={destinationPath ? undefined : "The destination worktree is no longer available"}
+      severity={deliveryFailed ? "error" : "warning"}
+      title={
+        deliveryFailed ? "Couldn't tell the agent" : "Agent may still be in the original worktree"
+      }
+      description={description}
       descriptionExtras={
         destinationPath ? (
           <button
@@ -55,12 +75,13 @@ export function WorktreeMoveBanner({
             }}
             className="-ml-1 mt-0.5 inline-block max-w-full cursor-pointer rounded-sm px-1 py-0.5 text-left text-xs font-medium whitespace-normal break-words text-daintree-text underline underline-offset-4 outline-hidden transition-[background-color] duration-150 ease-out hover:bg-overlay-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
           >
-            Tell it to continue in {destinationPath}
+            {deliveryFailed ? "Retry telling it to continue in" : "Tell it to continue in"}{" "}
+            {destinationPath}
           </button>
         ) : undefined
       }
-      role="status"
-      ariaLive="polite"
+      role={deliveryFailed ? "alert" : "status"}
+      ariaLive={deliveryFailed ? undefined : "polite"}
       onClose={onDismiss}
       closeAriaLabel="Dismiss worktree move notice"
     />

--- a/src/components/Terminal/WorktreeMoveBanner.tsx
+++ b/src/components/Terminal/WorktreeMoveBanner.tsx
@@ -51,7 +51,7 @@ export function WorktreeMoveBanner({
     destinationPath === undefined
       ? "The destination worktree is no longer available"
       : deliveryFailed
-        ? "The instruction didn't reach the terminal. Check that it's connected and unlocked, then retry."
+        ? "The instruction didn't reach the terminal. Wait until it's connected, unlocked and not restarting, then retry."
         : undefined;
 
   return (

--- a/src/components/Terminal/__tests__/WorktreeMoveBanner.test.tsx
+++ b/src/components/Terminal/__tests__/WorktreeMoveBanner.test.tsx
@@ -31,7 +31,7 @@ beforeAll(() => {
   });
 });
 
-function renderBanner(destinationPath: string | undefined) {
+function renderBanner(destinationPath: string | undefined, deliveryFailed = false) {
   const onTell = vi.fn();
   const onDismiss = vi.fn();
   // Stands in for TerminalPane, which focuses the pane from a React `onClick`
@@ -43,6 +43,7 @@ function renderBanner(destinationPath: string | undefined) {
       <div onClick={onPaneClick}>
         <WorktreeMoveBanner
           destinationPath={destinationPath}
+          deliveryFailed={deliveryFailed}
           onTell={onTell}
           onDismiss={onDismiss}
         />
@@ -54,6 +55,7 @@ function renderBanner(destinationPath: string | undefined) {
 
 const PATH = "/repo/wt-b";
 const TELL = `Tell it to continue in ${PATH}`;
+const RETRY = `Retry telling it to continue in ${PATH}`;
 const DISMISS = "Dismiss worktree move notice";
 
 describe("WorktreeMoveBanner", () => {
@@ -74,32 +76,54 @@ describe("WorktreeMoveBanner", () => {
     expect(screen.getByRole("button", { name: DISMISS })).not.toBeNull();
   });
 
-  it("carries the whole sentence as the control, in the text column", () => {
-    // #11868: the action *is* the sentence, not a boxed button beside it. A
-    // banner action lives in the controls row, a sibling of the text column, so
-    // it would only meet the title at the banner root — restoring the
-    // indistinct fill this fix removed while still passing every other test
-    // here. Walking up rather than indexing fixed levels keeps this honest
-    // without pinning InlineStatusBanner's exact nesting.
-    const { container } = renderBanner(PATH);
+  const SENTENCE_CASES = [
+    {
+      state: "first attempt",
+      bannerRole: "status",
+      deliveryFailed: false,
+      controlName: TELL,
+      titleText: "Agent may still be in the original worktree",
+    },
+    {
+      state: "after a failed send",
+      bannerRole: "alert",
+      deliveryFailed: true,
+      controlName: RETRY,
+      titleText: "Couldn't tell the agent",
+    },
+  ];
 
-    const banner = container.querySelector('[role="status"]');
-    const title = screen.getByText("Agent may still be in the original worktree");
-    const tell = screen.getByRole("button", { name: TELL });
+  it.each(SENTENCE_CASES)(
+    "carries the whole sentence as the control, in the text column ($state)",
+    ({ bannerRole, deliveryFailed, controlName, titleText }) => {
+      // #11868: the action *is* the sentence, not a boxed button beside it. A
+      // banner action lives in the controls row, a sibling of the text column,
+      // so it would only meet the title at the banner root — restoring the
+      // indistinct fill this fix removed while still passing every other test
+      // here. Walking up rather than indexing fixed levels keeps this honest
+      // without pinning InlineStatusBanner's exact nesting. The recovery on a
+      // failed send (#11867) is the same sentence in the same slot: the red
+      // wash hides a boxed fill exactly as the amber one did.
+      const { container } = renderBanner(PATH, deliveryFailed);
 
-    let shared = title.parentElement;
-    while (shared && !shared.contains(tell)) shared = shared.parentElement;
+      const banner = container.querySelector(`[role="${bannerRole}"]`);
+      const title = screen.getByText(titleText);
+      const tell = screen.getByRole("button", { name: controlName });
 
-    expect(shared).not.toBeNull();
-    expect(shared).not.toBe(banner);
-    // Nesting it in the description would be invalid `<p>` markup and would
-    // flatten the control away in the live region's announcement.
-    expect(tell.closest("p")).toBeNull();
-    // A native button, not a `role="button"` stand-in: Enter/Space activation
-    // comes free, and TerminalPane's keydown handler passes over events whose
-    // target is a BUTTON — a span would leak them to the pane.
-    expect(tell).toBeInstanceOf(HTMLButtonElement);
-  });
+      let shared = title.parentElement;
+      while (shared && !shared.contains(tell)) shared = shared.parentElement;
+
+      expect(shared).not.toBeNull();
+      expect(shared).not.toBe(banner);
+      // Nesting it in the description would be invalid `<p>` markup and would
+      // flatten the control away in the live region's announcement.
+      expect(tell.closest("p")).toBeNull();
+      // A native button, not a `role="button"` stand-in: Enter/Space activation
+      // comes free, and TerminalPane's keydown handler passes over events whose
+      // target is a BUTTON — a span would leak them to the pane.
+      expect(tell).toBeInstanceOf(HTMLButtonElement);
+    }
+  );
 
   it("is a polite status, not an alert", () => {
     // It reports a condition the user created; it must not interrupt them.
@@ -137,7 +161,48 @@ describe("WorktreeMoveBanner", () => {
     renderBanner(undefined);
 
     expect(screen.getByText("The destination worktree is no longer available")).not.toBeNull();
-    expect(screen.queryByRole("button", { name: /^Tell it to continue in / })).toBeNull();
+    expect(screen.queryByRole("button", { name: /continue in / })).toBeNull();
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+
+  it("interrupts once a delivery has failed, instead of staying polite", () => {
+    // The user asked for something and it did not happen (#11867) — that is
+    // worth taking the screen reader off its queue for.
+    const { container } = renderBanner(PATH, true);
+
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it("offers one recovery action and the close, and no more, on failure", () => {
+    const { onTell, onPaneClick } = renderBanner(PATH, true);
+
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+    // The first-attempt wording is gone: the sentence now says it is a retry.
+    expect(screen.queryByRole("button", { name: TELL })).toBeNull();
+    expect(screen.getByRole("button", { name: DISMISS })).not.toBeNull();
+    const retry = screen.getByRole("button", { name: RETRY });
+
+    fireEvent.click(retry);
+    expect(onTell).toHaveBeenCalledTimes(1);
+    expect(onPaneClick).not.toHaveBeenCalled();
+  });
+
+  it("says the send failed before offering the retry", () => {
+    // The description carries the why; the sentence-control carries the what.
+    renderBanner(PATH, true);
+
+    expect(screen.getByRole("alert").textContent).toContain("didn't reach the terminal");
+    expect(screen.getByRole("button", { name: RETRY })).not.toBeNull();
+  });
+
+  it("offers no recovery at all when the destination is gone", () => {
+    // A failed send does not conjure a destination back into existence, and a
+    // dead disabled Retry would only look like the app had stopped responding.
+    renderBanner(undefined, true);
+
+    expect(screen.getByText("The destination worktree is no longer available")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /continue in / })).toBeNull();
     expect(screen.getAllByRole("button")).toHaveLength(1);
   });
 

--- a/src/components/Terminal/__tests__/useWorktreeMoveBanner.test.tsx
+++ b/src/components/Terminal/__tests__/useWorktreeMoveBanner.test.tsx
@@ -509,6 +509,38 @@ describe("useWorktreeMoveBanner", () => {
       expect(noticeOf("t-1")).toBe("wt-b");
     });
 
+    it("refuses once the pane has joined a fleet mid-send", async () => {
+      // Committing now would clear a draft that has become the fleet's, and
+      // `useFleetMirror` would push the empty value into every armed pane.
+      seed(panel("t-1", NOTICE));
+      let release!: () => void;
+      const parked = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const { ref } = stubBar(async (submit) => {
+        await parked;
+        return submit("INSTRUCTION");
+      });
+      let route: WorktreeMoveDeliveryRoute = "hybrid";
+      const hook = renderHook(() => useWorktreeMoveBanner("t-1", { route, inputBarRef: ref }));
+
+      let pending!: Promise<void>;
+      act(() => {
+        pending = hook.result.current.tell();
+      });
+
+      route = "direct";
+      hook.rerender();
+
+      await act(async () => {
+        release();
+        await pending;
+      });
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(noticeOf("t-1")).toBe("wt-b");
+    });
+
     it("sends nothing when the destination vanished between render and click", async () => {
       seed(panel("t-1", NOTICE));
       const { result } = render("t-1", "direct");

--- a/src/components/Terminal/__tests__/useWorktreeMoveBanner.test.tsx
+++ b/src/components/Terminal/__tests__/useWorktreeMoveBanner.test.tsx
@@ -4,13 +4,24 @@
  * the pane — that is why it lives in the panel store rather than in
  * `TerminalPane` (#11853, same reasoning as #11589). These tests drive both
  * outcomes through a real store-connected render and then remount.
+ *
+ * They also pin #11867's contract: the bar is cleared when the terminal *took*
+ * the text, not when a scheduler accepted a job, and every other outcome leaves
+ * the bar up saying so.
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
+import { createRef, type RefObject } from "react";
 import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import type { HybridInputBarHandle } from "../HybridInputBar";
+import type { WorktreeMoveDeliveryRoute } from "../useWorktreeMoveBanner";
 
-const mockQueue = vi.fn().mockReturnValue(true);
+const mockDispatch = vi.fn();
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => mockDispatch(...args) },
+}));
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -44,14 +55,13 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   },
 }));
 
-vi.mock("@/services/terminal/worktreeMoveInstruction", () => ({
-  queueWorktreeMoveInstruction: (...args: unknown[]) => mockQueue(...args),
-}));
-
 const worktrees = new Map<string, { id: string; path: string }>();
 vi.mock("@/hooks/useWorktreeStore", () => ({
   useWorktreeStore: (selector: (state: { worktrees: typeof worktrees }) => unknown) =>
     selector({ worktrees }),
+}));
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStoreOrNull: () => ({ getState: () => ({ worktrees }) }),
 }));
 
 vi.mock("../../../store/slices/panelRegistry/persistence", async () => {
@@ -84,16 +94,56 @@ function seed(...panels: PanelInstance[]) {
   });
 }
 
-function noticeOf(id: string): string | undefined {
+function ptyOf(id: string): PtyPanelData | undefined {
   const p = usePanelStore.getState().panelsById[id];
-  return p && isPtyPanel(p) ? p.worktreeMoveNotice?.destinationWorktreeId : undefined;
+  return p && isPtyPanel(p) ? p : undefined;
+}
+
+function noticeOf(id: string): string | undefined {
+  return ptyOf(id)?.worktreeMoveNotice?.destinationWorktreeId;
 }
 
 const NOTICE = { worktreeMoveNotice: { destinationWorktreeId: "wt-b" } };
 
+/** A stand-in for the mounted bar. `submit` is the hook's own guarded callback. */
+function stubBar(behaviour: (submit: (text: string) => Promise<boolean>) => Promise<boolean>) {
+  const submitWithInstruction = vi.fn(
+    async (_instruction: string, submit: (text: string) => Promise<boolean>) => behaviour(submit)
+  );
+  const ref = createRef<HybridInputBarHandle>() as RefObject<HybridInputBarHandle | null>;
+  ref.current = {
+    focus: vi.fn(),
+    focusWithCursorAtEnd: vi.fn().mockReturnValue(true),
+    cancelPendingFocus: vi.fn(),
+    submitWithInstruction,
+  };
+  return { ref, submitWithInstruction };
+}
+
+/** A bar that just forwards the composed text, the way the real one does. */
+const forwardingBar = (draft = "") =>
+  stubBar(async (submit) => submit(draft ? `${draft}\n\nINSTRUCTION` : "INSTRUCTION"));
+
+const nullBarRef = { current: null } as RefObject<HybridInputBarHandle | null>;
+
+function render(
+  panelId: string,
+  route: WorktreeMoveDeliveryRoute,
+  inputBarRef: RefObject<HybridInputBarHandle | null> = nullBarRef
+) {
+  return renderHook(() => useWorktreeMoveBanner(panelId, { route, inputBarRef }));
+}
+
+/** Every `tell` is async now; settle it inside `act` so store writes are seen. */
+async function tell(result: { current: { tell: () => Promise<void> } }) {
+  await act(async () => {
+    await result.current.tell();
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockQueue.mockReturnValue(true);
+  mockDispatch.mockResolvedValue({ ok: true, result: { sent: true } });
   worktrees.clear();
   worktrees.set("wt-b", { id: "wt-b", path: "/repo/wt-b" });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
@@ -102,21 +152,19 @@ beforeEach(() => {
 describe("useWorktreeMoveBanner", () => {
   it("is hidden for a pane with no pending move", () => {
     seed(panel("t-1"));
-    const { result } = renderHook(() => useWorktreeMoveBanner("t-1"));
-    expect(result.current.visible).toBe(false);
+    expect(render("t-1", "direct").result.current.visible).toBe(false);
   });
 
   it("is hidden for an unknown or non-PTY pane", () => {
     seed({ id: "b-1", kind: "browser", title: "b-1", location: "grid" } as PanelInstance);
-    const { result: missing } = renderHook(() => useWorktreeMoveBanner("nope"));
-    const { result: browser } = renderHook(() => useWorktreeMoveBanner("b-1"));
-    expect(missing.current.visible).toBe(false);
-    expect(browser.current.visible).toBe(false);
+    expect(render("nope", "direct").result.current.visible).toBe(false);
+    expect(render("b-1", "direct").result.current.visible).toBe(false);
   });
 
   it("shows the destination's current path", () => {
     seed(panel("t-1", NOTICE));
-    const { result } = renderHook(() => useWorktreeMoveBanner("t-1"));
+    const { result } = render("t-1", "direct");
+
     expect(result.current.visible).toBe(true);
     expect(result.current.destinationPath).toBe("/repo/wt-b");
   });
@@ -125,85 +173,288 @@ describe("useWorktreeMoveBanner", () => {
     // No fallback path: guessing one is how a destructive default ships (#7880).
     seed(panel("t-1", NOTICE));
     worktrees.clear();
-    const { result } = renderHook(() => useWorktreeMoveBanner("t-1"));
+    const { result } = render("t-1", "direct");
+
     expect(result.current.visible).toBe(true);
     expect(result.current.destinationPath).toBeUndefined();
   });
 
-  it("queues the instruction and hides the bar on tell", () => {
-    seed(panel("t-1", NOTICE));
-    const { result } = renderHook(() => useWorktreeMoveBanner("t-1"));
+  describe("direct route", () => {
+    it("submits through the action layer with no agent-state gate", async () => {
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
 
-    act(() => result.current.tell());
+      await tell(result);
 
-    expect(mockQueue).toHaveBeenCalledWith("t-1", "wt-b");
-    expect(noticeOf("t-1")).toBeUndefined();
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      const [actionId, args] = mockDispatch.mock.calls[0]!;
+      expect(actionId).toBe("terminal.sendCommand");
+      expect(args).toMatchObject({ terminalId: "t-1" });
+      expect((args as { command: string }).command).toContain("/repo/wt-b");
+      expect(noticeOf("t-1")).toBeUndefined();
+    });
+
+    it("sends only the instruction, never a draft it cannot see", async () => {
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
+
+      await tell(result);
+
+      const { command } = mockDispatch.mock.calls[0]![1] as { command: string };
+      expect(command.includes("\n")).toBe(false);
+    });
   });
 
-  it("leaves the bar up when the instruction cannot be queued", () => {
-    // Swallowing the user's one click would be worse than showing it again.
-    mockQueue.mockReturnValue(false);
-    seed(panel("t-1", NOTICE));
-    const { result } = renderHook(() => useWorktreeMoveBanner("t-1"));
+  describe("hybrid route", () => {
+    it("delegates to the mounted bar and dispatches what the bar composed", async () => {
+      seed(panel("t-1", NOTICE));
+      const { ref, submitWithInstruction } = forwardingBar("look at this");
+      const { result } = render("t-1", "hybrid", ref);
 
-    act(() => result.current.tell());
+      await tell(result);
 
-    expect(noticeOf("t-1")).toBe("wt-b");
+      expect(submitWithInstruction).toHaveBeenCalledTimes(1);
+      expect(submitWithInstruction.mock.calls[0]![0]).toContain("/repo/wt-b");
+      const { command } = mockDispatch.mock.calls[0]![1] as { command: string };
+      expect(command).toContain("look at this");
+      expect(noticeOf("t-1")).toBeUndefined();
+    });
+
+    it("keeps the bar up and does not fall through when the editor is not mounted", async () => {
+      // A second send could duplicate the sentence; one more click cannot.
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "hybrid", nullBarRef);
+
+      await tell(result);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(noticeOf("t-1")).toBe("wt-b");
+      expect(ptyOf("t-1")?.worktreeMoveNotice?.deliveryFailed).toBe(true);
+    });
+
+    it("does not fall through when the bar refuses the send", async () => {
+      seed(panel("t-1", NOTICE));
+      const { ref } = stubBar(async () => false);
+      const { result } = render("t-1", "hybrid", ref);
+
+      await tell(result);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(ptyOf("t-1")?.worktreeMoveNotice?.deliveryFailed).toBe(true);
+    });
+  });
+
+  describe("blocked route", () => {
+    it("submits nothing while the pane cannot take input, and says so", async () => {
+      // Backend recovery, a restart or an input lock: submitting behind any of
+      // them is exactly the silent loss #11867 exists to end.
+      seed(panel("t-1", NOTICE));
+      const { ref } = forwardingBar();
+      const { result } = render("t-1", "blocked", ref);
+
+      await tell(result);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(noticeOf("t-1")).toBe("wt-b");
+      expect(result.current.deliveryFailed).toBe(true);
+    });
+  });
+
+  describe("delivery failure", () => {
+    it("keeps the bar up and marks it when the terminal rejects the text", async () => {
+      mockDispatch.mockResolvedValue({ ok: false, error: { code: "NOT_FOUND", message: "gone" } });
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
+
+      await tell(result);
+
+      expect(noticeOf("t-1")).toBe("wt-b");
+      expect(result.current.deliveryFailed).toBe(true);
+    });
+
+    it("clears the bar when a retry finally lands", async () => {
+      mockDispatch.mockResolvedValueOnce({ ok: false, error: { code: "X", message: "no" } });
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
+
+      await tell(result);
+      expect(result.current.deliveryFailed).toBe(true);
+
+      await tell(result);
+
+      expect(noticeOf("t-1")).toBeUndefined();
+      expect(mockDispatch).toHaveBeenCalledTimes(2);
+    });
+
+    it("survives an unmount and remount, and stays on its own pane", async () => {
+      mockDispatch.mockResolvedValue({ ok: false, error: { code: "X", message: "no" } });
+      seed(panel("t-1", NOTICE), panel("t-2", NOTICE));
+      const first = render("t-1", "direct");
+
+      await tell(first.result);
+      first.unmount();
+
+      expect(render("t-1", "direct").result.current.deliveryFailed).toBe(true);
+      expect(render("t-2", "direct").result.current.deliveryFailed).toBe(false);
+    });
+  });
+
+  describe("staleness", () => {
+    it("resolves the destination path at click time, not at render time", async () => {
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
+      worktrees.set("wt-b", { id: "wt-b", path: "/repo/moved-since" });
+
+      await tell(result);
+
+      const { command } = mockDispatch.mock.calls[0]![1] as { command: string };
+      expect(command).toContain("/repo/moved-since");
+      expect(command).not.toContain("/repo/wt-b");
+    });
+
+    it("aborts before dispatching when the destination moves mid-send", async () => {
+      // The bar's own token resolution is a round trip; the world can change.
+      seed(panel("t-1", NOTICE));
+      const { ref } = stubBar(async (submit) => {
+        worktrees.set("wt-b", { id: "wt-b", path: "/repo/somewhere-else" });
+        return submit("INSTRUCTION");
+      });
+      const { result } = render("t-1", "hybrid", ref);
+
+      await tell(result);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(noticeOf("t-1")).toBe("wt-b");
+    });
+
+    it("aborts before dispatching when the notice is answered mid-send", async () => {
+      seed(panel("t-1", NOTICE));
+      const { ref } = stubBar(async (submit) => {
+        usePanelStore.getState().setWorktreeMoveNotice("t-1", undefined);
+        return submit("INSTRUCTION");
+      });
+      const { result } = render("t-1", "hybrid", ref);
+
+      await tell(result);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(noticeOf("t-1")).toBeUndefined();
+    });
+
+    it("does not answer a newer notice raised for the same destination", async () => {
+      // Identity, not destination id: a move away and back leaves the same id
+      // on a notice this attempt was never allowed to speak for.
+      let resolveDispatch!: (v: unknown) => void;
+      mockDispatch.mockReturnValue(
+        new Promise((resolve) => {
+          resolveDispatch = resolve;
+        })
+      );
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
+
+      let pending!: Promise<void>;
+      act(() => {
+        pending = result.current.tell();
+      });
+      act(() => {
+        const store = usePanelStore.getState();
+        store.setWorktreeMoveNotice("t-1", undefined);
+        store.setWorktreeMoveNotice("t-1", { destinationWorktreeId: "wt-b" });
+      });
+      await act(async () => {
+        resolveDispatch({ ok: true, result: { sent: true } });
+        await pending;
+      });
+
+      expect(noticeOf("t-1")).toBe("wt-b");
+    });
+
+    it("dispatches once when the button is clicked twice", async () => {
+      let resolveDispatch!: (v: unknown) => void;
+      mockDispatch.mockReturnValue(
+        new Promise((resolve) => {
+          resolveDispatch = resolve;
+        })
+      );
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
+
+      let first!: Promise<void>;
+      let second!: Promise<void>;
+      act(() => {
+        first = result.current.tell();
+        second = result.current.tell();
+      });
+      await act(async () => {
+        resolveDispatch({ ok: true, result: { sent: true } });
+        await Promise.all([first, second]);
+      });
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("sends nothing when the destination vanished between render and click", async () => {
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
+      worktrees.clear();
+
+      await tell(result);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(noticeOf("t-1")).toBe("wt-b");
+    });
   });
 
   it("hides the bar on dismiss without sending anything", () => {
     seed(panel("t-1", NOTICE));
-    const { result } = renderHook(() => useWorktreeMoveBanner("t-1"));
+    const { result } = render("t-1", "direct");
 
     act(() => result.current.dismiss());
 
-    expect(mockQueue).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
     expect(noticeOf("t-1")).toBeUndefined();
   });
 
-  it("leaves nothing on the panel after a tell", () => {
+  it("leaves nothing on the panel after a delivered tell", async () => {
     // Compliance is undetectable, so any surviving marker would sit lit forever
     // on total success. Both outcomes consume the same field.
     seed(panel("t-1", NOTICE));
-    const { result } = renderHook(() => useWorktreeMoveBanner("t-1"));
+    const { result } = render("t-1", "direct");
 
-    act(() => result.current.tell());
+    await tell(result);
 
-    const p = usePanelStore.getState().panelsById["t-1"];
-    expect(p && isPtyPanel(p) ? p.worktreeMoveNotice : "unset").toBeUndefined();
+    expect(ptyOf("t-1")?.worktreeMoveNotice).toBeUndefined();
   });
 
   // The bug this shape exists to prevent: a worktree switch does exactly this.
   it("keeps the answer across an unmount and remount", () => {
     seed(panel("t-1", NOTICE));
 
-    const first = renderHook(() => useWorktreeMoveBanner("t-1"));
+    const first = render("t-1", "direct");
     expect(first.result.current.visible).toBe(true);
     act(() => first.result.current.dismiss());
     first.unmount();
 
-    const second = renderHook(() => useWorktreeMoveBanner("t-1"));
-    expect(second.result.current.visible).toBe(false);
+    expect(render("t-1", "direct").result.current.visible).toBe(false);
   });
 
   it("keeps an unanswered bar across an unmount and remount", () => {
     seed(panel("t-1", NOTICE));
+    render("t-1", "direct").unmount();
 
-    const first = renderHook(() => useWorktreeMoveBanner("t-1"));
-    first.unmount();
-
-    const second = renderHook(() => useWorktreeMoveBanner("t-1"));
+    const second = render("t-1", "direct");
     expect(second.result.current.visible).toBe(true);
     expect(second.result.current.destinationPath).toBe("/repo/wt-b");
   });
 
-  it("answers each pane of a moved group independently", () => {
+  it("answers each pane of a moved group independently", async () => {
     seed(panel("t-1", NOTICE), panel("t-2", NOTICE));
+    const first = render("t-1", "direct");
 
-    const first = renderHook(() => useWorktreeMoveBanner("t-1"));
-    act(() => first.result.current.tell());
+    await tell(first.result);
 
-    expect(mockQueue).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(noticeOf("t-1")).toBeUndefined();
     expect(noticeOf("t-2")).toBe("wt-b");
   });

--- a/src/components/Terminal/__tests__/useWorktreeMoveBanner.test.tsx
+++ b/src/components/Terminal/__tests__/useWorktreeMoveBanner.test.tsx
@@ -72,7 +72,8 @@ vi.mock("../../../store/slices/panelRegistry/persistence", async () => {
 });
 
 const { usePanelStore } = await import("@/store/panelStore");
-const { useWorktreeMoveBanner } = await import("../useWorktreeMoveBanner");
+const { useWorktreeMoveBanner, resolveWorktreeMoveRoute } =
+  await import("../useWorktreeMoveBanner");
 
 function panel(id: string, overrides: Partial<PtyPanelData> = {}): PanelInstance {
   return {
@@ -149,6 +150,36 @@ beforeEach(() => {
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
 });
 
+describe("resolveWorktreeMoveRoute", () => {
+  const route = (over: Partial<Parameters<typeof resolveWorktreeMoveRoute>[0]> = {}) =>
+    resolveWorktreeMoveRoute({
+      isHybridInputDisabled: false,
+      hasHybridInputBar: true,
+      isFleetComposing: false,
+      ...over,
+    });
+
+  it("refuses to pick a delivery route while the pane cannot take input", () => {
+    // Whatever else is true, a locked / recovering / restarting pane is blocked.
+    for (const over of [{ hasHybridInputBar: true }, { hasHybridInputBar: false }]) {
+      expect(route({ ...over, isHybridInputDisabled: true })).toBe("blocked");
+      expect(route({ ...over, isHybridInputDisabled: true, isFleetComposing: true })).toBe(
+        "blocked"
+      );
+    }
+  });
+
+  it("uses the bar only when one is actually rendered", () => {
+    expect(route({ hasHybridInputBar: true })).toBe("hybrid");
+    expect(route({ hasHybridInputBar: false })).toBe("direct");
+  });
+
+  it("leaves a fleet's shared draft alone", () => {
+    // Submitting it would mirror the cleared value into every armed pane.
+    expect(route({ hasHybridInputBar: true, isFleetComposing: true })).toBe("direct");
+  });
+});
+
 describe("useWorktreeMoveBanner", () => {
   it("is hidden for a pane with no pending move", () => {
     seed(panel("t-1"));
@@ -215,6 +246,9 @@ describe("useWorktreeMoveBanner", () => {
 
       expect(submitWithInstruction).toHaveBeenCalledTimes(1);
       expect(submitWithInstruction.mock.calls[0]![0]).toContain("/repo/wt-b");
+      // Exactly one: delegating to the bar and *then* dispatching directly
+      // would put the sentence in front of the agent twice.
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
       const { command } = mockDispatch.mock.calls[0]![1] as { command: string };
       expect(command).toContain("look at this");
       expect(noticeOf("t-1")).toBeUndefined();
@@ -394,6 +428,87 @@ describe("useWorktreeMoveBanner", () => {
       expect(mockDispatch).toHaveBeenCalledTimes(1);
     });
 
+    it("answers the notice that is current at click time, not at render time", async () => {
+      seed(panel("t-1", NOTICE));
+      const { result } = render("t-1", "direct");
+      worktrees.set("wt-c", { id: "wt-c", path: "/repo/wt-c" });
+      act(() => {
+        usePanelStore.getState().setWorktreeMoveNotice("t-1", { destinationWorktreeId: "wt-c" });
+      });
+
+      await tell(result);
+
+      const { command } = mockDispatch.mock.calls[0]![1] as { command: string };
+      expect(command).toContain("/repo/wt-c");
+      expect(noticeOf("t-1")).toBeUndefined();
+    });
+
+    it("does not dispatch for a notice replaced before the send begins", async () => {
+      // Identity, not destination id: a same-destination replacement is still a
+      // different question from the one this click answered.
+      seed(panel("t-1", NOTICE));
+      const { ref } = stubBar(async (submit) => {
+        const store = usePanelStore.getState();
+        store.setWorktreeMoveNotice("t-1", undefined);
+        store.setWorktreeMoveNotice("t-1", { destinationWorktreeId: "wt-b" });
+        return submit("INSTRUCTION");
+      });
+      const { result } = render("t-1", "hybrid", ref);
+
+      await tell(result);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(noticeOf("t-1")).toBe("wt-b");
+    });
+
+    it("says so rather than sending to a path that moved mid-send", async () => {
+      seed(panel("t-1", NOTICE));
+      const { ref } = stubBar(async (submit) => {
+        worktrees.set("wt-b", { id: "wt-b", path: "/repo/elsewhere" });
+        return submit("INSTRUCTION");
+      });
+      const { result } = render("t-1", "hybrid", ref);
+
+      await tell(result);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(ptyOf("t-1")?.worktreeMoveNotice?.deliveryFailed).toBe(true);
+    });
+
+    it("refuses to submit once the pane has been blocked mid-send", async () => {
+      // Resolving `@diff` is a round trip; a lock or a restart can land inside
+      // it, and the route decided at click time must not outlive that. The bar
+      // is parked mid-resolution here, the pane re-renders blocked, and only
+      // then does the submit get its chance.
+      seed(panel("t-1", NOTICE));
+      let release!: () => void;
+      const parked = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const { ref } = stubBar(async (submit) => {
+        await parked;
+        return submit("INSTRUCTION");
+      });
+      let route: WorktreeMoveDeliveryRoute = "hybrid";
+      const hook = renderHook(() => useWorktreeMoveBanner("t-1", { route, inputBarRef: ref }));
+
+      let pending!: Promise<void>;
+      act(() => {
+        pending = hook.result.current.tell();
+      });
+
+      route = "blocked";
+      hook.rerender();
+
+      await act(async () => {
+        release();
+        await pending;
+      });
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(noticeOf("t-1")).toBe("wt-b");
+    });
+
     it("sends nothing when the destination vanished between render and click", async () => {
       seed(panel("t-1", NOTICE));
       const { result } = render("t-1", "direct");
@@ -404,6 +519,35 @@ describe("useWorktreeMoveBanner", () => {
       expect(mockDispatch).not.toHaveBeenCalled();
       expect(noticeOf("t-1")).toBe("wt-b");
     });
+  });
+
+  // The bug itself (#11867): the bar used to go the moment a job was accepted,
+  // long before anything reached the terminal.
+  it("keeps the bar up for the whole send, and drops it only once it lands", async () => {
+    let resolveDispatch!: (v: unknown) => void;
+    mockDispatch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDispatch = resolve;
+      })
+    );
+    seed(panel("t-1", NOTICE));
+    const { result } = render("t-1", "direct");
+    const before = ptyOf("t-1")?.worktreeMoveNotice;
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.tell();
+    });
+
+    expect(result.current.visible).toBe(true);
+    expect(ptyOf("t-1")?.worktreeMoveNotice).toBe(before);
+
+    await act(async () => {
+      resolveDispatch({ ok: true, result: { sent: true } });
+      await pending;
+    });
+
+    expect(noticeOf("t-1")).toBeUndefined();
   });
 
   it("hides the bar on dismiss without sending anything", () => {

--- a/src/components/Terminal/hooks/__tests__/useTokenResolution.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useTokenResolution.test.ts
@@ -153,7 +153,7 @@ describe("useTokenResolution.sendText — targeted submit", () => {
   });
 
   it("clears the draft exactly once when the submit is accepted", async () => {
-    const { sendText, applyEditorValue, clearDraftInput } = setup();
+    const { sendText, applyEditorValue, clearDraftInput, onSend } = setup();
 
     await act(async () => {
       await sendText("send me", { submit: async () => true });
@@ -162,6 +162,22 @@ describe("useTokenResolution.sendText — targeted submit", () => {
     expect(applyEditorValue).toHaveBeenCalledTimes(1);
     expect(applyEditorValue.mock.calls[0]![0]).toBe("");
     expect(clearDraftInput).toHaveBeenCalledTimes(1);
+    // Exactly one delivery: the targeted submit replaces the pane's own send
+    // rather than joining it, or the agent would get the text twice.
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("keeps a draft the user changed while the submit was in flight", async () => {
+    // The snapshot went out; whatever is on screen now is newer than it and is
+    // not ours to delete.
+    const { sendText, applyEditorValue, clearDraftInput } = setup();
+
+    await act(async () => {
+      await sendText("snapshot", { submit: async () => true, isDraftUnchanged: () => false });
+    });
+
+    expect(applyEditorValue).not.toHaveBeenCalled();
+    expect(clearDraftInput).not.toHaveBeenCalled();
   });
 
   it("resolves tokens in the draft but never in the composed suffix", async () => {

--- a/src/components/Terminal/hooks/__tests__/useTokenResolution.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useTokenResolution.test.ts
@@ -56,6 +56,8 @@ function setup(overrides: Partial<Latest> = {}) {
     addToHistory,
     applyEditorValue: params.applyEditorValue as ReturnType<typeof vi.fn>,
     clearDraftInput: latest.clearDraftInput as ReturnType<typeof vi.fn>,
+    setIsExpanded: params.setIsExpanded as ReturnType<typeof vi.fn>,
+    setActiveCompletionContext: params.setActiveCompletionContext as ReturnType<typeof vi.fn>,
   };
 }
 
@@ -169,8 +171,14 @@ describe("useTokenResolution.sendText — targeted submit", () => {
 
   it("keeps a draft the user changed while the submit was in flight", async () => {
     // The snapshot went out; whatever is on screen now is newer than it and is
-    // not ours to delete.
-    const { sendText, applyEditorValue, clearDraftInput } = setup();
+    // not ours to delete — and neither is the composer state around it.
+    const {
+      sendText,
+      applyEditorValue,
+      clearDraftInput,
+      setIsExpanded,
+      setActiveCompletionContext,
+    } = setup();
 
     await act(async () => {
       await sendText("snapshot", { submit: async () => true, isDraftUnchanged: () => false });
@@ -178,6 +186,8 @@ describe("useTokenResolution.sendText — targeted submit", () => {
 
     expect(applyEditorValue).not.toHaveBeenCalled();
     expect(clearDraftInput).not.toHaveBeenCalled();
+    expect(setIsExpanded).not.toHaveBeenCalled();
+    expect(setActiveCompletionContext).not.toHaveBeenCalled();
   });
 
   it("resolves tokens in the draft but never in the composed suffix", async () => {

--- a/src/components/Terminal/hooks/__tests__/useTokenResolution.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useTokenResolution.test.ts
@@ -50,7 +50,13 @@ function setup(overrides: Partial<Latest> = {}) {
     agentId: undefined,
   };
   const { result } = renderHook(() => useTokenResolution(params));
-  return { sendText: result.current.sendText, onSend, addToHistory };
+  return {
+    sendText: result.current.sendText,
+    onSend,
+    addToHistory,
+    applyEditorValue: params.applyEditorValue as ReturnType<typeof vi.fn>,
+    clearDraftInput: latest.clearDraftInput as ReturnType<typeof vi.fn>,
+  };
 }
 
 describe("useTokenResolution.sendText", () => {
@@ -103,5 +109,135 @@ describe("useTokenResolution.sendText", () => {
 
     expect(getWorkingDiff).not.toHaveBeenCalled();
     expect(onSend.mock.calls[0]![0].text).toBe("just $neo and @file.ts");
+  });
+});
+
+/**
+ * #11867's contract for a targeted submit: the editor, the draft store and the
+ * history are a single transaction that commits only once the terminal has
+ * actually taken the text.
+ */
+describe("useTokenResolution.sendText — targeted submit", () => {
+  beforeEach(() => {
+    (window as unknown as { electron: unknown }).electron = {
+      git: { getWorkingDiff: vi.fn().mockResolvedValue("BODY") },
+    };
+  });
+
+  it("reports acceptance instead of returning silently", async () => {
+    const { sendText } = setup();
+    let accepted: boolean | undefined;
+    let refused: boolean | undefined;
+
+    await act(async () => {
+      accepted = await sendText("hi", { submit: async () => true });
+      refused = await sendText("hi", { submit: async () => false });
+    });
+
+    expect(accepted).toBe(true);
+    expect(refused).toBe(false);
+  });
+
+  it("leaves the draft alone when the submit is refused", async () => {
+    const { sendText, applyEditorValue, clearDraftInput, addToHistory, onSend } = setup();
+
+    await act(async () => {
+      await sendText("keep me", { submit: async () => false });
+    });
+
+    expect(applyEditorValue).not.toHaveBeenCalled();
+    expect(clearDraftInput).not.toHaveBeenCalled();
+    expect(addToHistory).not.toHaveBeenCalled();
+    // The pane's fire-and-forget path must not run alongside the targeted one.
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("clears the draft exactly once when the submit is accepted", async () => {
+    const { sendText, applyEditorValue, clearDraftInput } = setup();
+
+    await act(async () => {
+      await sendText("send me", { submit: async () => true });
+    });
+
+    expect(applyEditorValue).toHaveBeenCalledTimes(1);
+    expect(applyEditorValue.mock.calls[0]![0]).toBe("");
+    expect(clearDraftInput).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves tokens in the draft but never in the composed suffix", async () => {
+    // The appended sentence carries a directory path verbatim; a path that
+    // happens to look like an @-token must not be rewritten into a diff.
+    const submit = vi.fn().mockResolvedValue(true);
+    const { sendText } = setup();
+
+    await act(async () => {
+      await sendText("check @diff", {
+        compose: (draft) => `${draft}\n\ncontinue in /repo/@diff`,
+        submit,
+      });
+    });
+
+    const sent = submit.mock.calls[0]![0] as string;
+    expect(sent).toContain("```diff\nBODY\n```");
+    expect(sent).toContain("continue in /repo/@diff");
+  });
+
+  it("records the authored composition in history, not the expansion", async () => {
+    const { sendText, addToHistory } = setup();
+
+    await act(async () => {
+      await sendText("check @diff", {
+        compose: (draft) => `${draft}\n\nAND THIS`,
+        submit: async () => true,
+      });
+    });
+
+    expect(addToHistory).toHaveBeenCalledWith("t1", "check @diff\n\nAND THIS", undefined);
+  });
+
+  it("sends a composed instruction even when the draft is empty", async () => {
+    const submit = vi.fn().mockResolvedValue(true);
+    const { sendText } = setup();
+
+    await act(async () => {
+      await sendText("", { compose: () => "INSTRUCTION", submit });
+    });
+
+    expect(submit).toHaveBeenCalledWith("INSTRUCTION");
+  });
+
+  it("refuses a second send while the first is still awaiting its submit", async () => {
+    let release!: (v: boolean) => void;
+    const submit = vi.fn().mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        release = resolve;
+      })
+    );
+    const { sendText } = setup();
+
+    let first!: Promise<boolean>;
+    let second!: boolean;
+    await act(async () => {
+      first = sendText("one", { submit });
+      second = await sendText("two", { submit });
+      release(true);
+      await first;
+    });
+
+    expect(second).toBe(false);
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses while disabled without consulting the submit", async () => {
+    const submit = vi.fn().mockResolvedValue(true);
+    const { sendText } = setup({ disabled: true });
+    let sent: boolean | undefined;
+
+    await act(async () => {
+      sent = await sendText("hi", { submit });
+    });
+
+    expect(sent).toBe(false);
+    expect(submit).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/hooks/useTokenResolution.ts
+++ b/src/components/Terminal/hooks/useTokenResolution.ts
@@ -135,6 +135,14 @@ export interface SendTextOptions {
    * (#11867).
    */
   submit?: (text: string) => Promise<boolean>;
+  /**
+   * Consulted just before the editor and the draft store are cleared, on a send
+   * that has already succeeded. `false` leaves the draft alone: an awaited
+   * `submit` is a window the user can keep typing in, and eating what they
+   * wrote in it to tidy up after text that has already gone out is the worse
+   * of the two outcomes.
+   */
+  isDraftUnchanged?: () => boolean;
 }
 
 interface UseTokenResolutionParams {
@@ -272,8 +280,10 @@ export function useTokenResolution({
         }
 
         setIsExpanded(false);
-        applyEditorValue("", { selection: EditorSelection.create([EditorSelection.cursor(0)]) });
-        latest.clearDraftInput(latest.terminalId, latest.projectId);
+        if (options?.isDraftUnchanged?.() ?? true) {
+          applyEditorValue("", { selection: EditorSelection.create([EditorSelection.cursor(0)]) });
+          latest.clearDraftInput(latest.terminalId, latest.projectId);
+        }
         setActiveCompletionContext(null);
         return true;
       } finally {

--- a/src/components/Terminal/hooks/useTokenResolution.ts
+++ b/src/components/Terminal/hooks/useTokenResolution.ts
@@ -119,6 +119,24 @@ interface LatestRefShape {
   clearDraftInput: (terminalId: string, projectId?: string) => void;
 }
 
+export interface SendTextOptions {
+  /**
+   * Turn the resolved draft into the exact text to submit. Applied *after*
+   * token resolution so anything appended here reaches the terminal verbatim —
+   * a directory path that happens to contain something shaped like an @-token
+   * must not be rewritten into a diff.
+   */
+  compose?: (resolvedDraft: string) => string;
+  /**
+   * Replaces the pane's fire-and-forget `onSend` handoff with a submission that
+   * reports whether the terminal accepted the text. The editor, the draft store
+   * and the history are committed only when it resolves `true`, so a caller
+   * that surfaces failure can retry without the draft having been eaten
+   * (#11867).
+   */
+  submit?: (text: string) => Promise<boolean>;
+}
+
 interface UseTokenResolutionParams {
   latestRef: React.RefObject<LatestRefShape | null>;
   applyEditorValue: (
@@ -143,98 +161,124 @@ export function useTokenResolution({
 }: UseTokenResolutionParams) {
   const isSendingRef = useRef(false);
 
+  /**
+   * Returns whether the text actually reached the terminal. Every bail-out is
+   * `false`: callers that only mirror the user's Enter can keep ignoring it,
+   * but a caller that has to tell the user whether their click landed cannot
+   * work with a silent void (#11867).
+   */
   const sendText = useCallback(
-    async (text: string) => {
+    async (text: string, options?: SendTextOptions): Promise<boolean> => {
       const latest = latestRef.current;
-      if (!latest || latest.disabled) return;
-      if (text.trim().length === 0) return;
-      if (isSendingRef.current) return;
+      if (!latest || latest.disabled) return false;
+      if (isSendingRef.current) return false;
 
-      let resolvedText = text;
+      // Held across the whole transaction, not just the diff fetch it used to
+      // guard: an awaited `submit` is another window in which a second send
+      // could otherwise interleave and double-post.
+      isSendingRef.current = true;
+      try {
+        let resolvedText = text;
 
-      const terminalTokens = getAllAtTerminalTokens(text);
-      const selectionTokens = getAllAtSelectionTokens(text);
-      const diffTokens = getAllAtDiffTokens(text);
+        const terminalTokens = getAllAtTerminalTokens(text);
+        const selectionTokens = getAllAtSelectionTokens(text);
+        const diffTokens = getAllAtDiffTokens(text);
 
-      const replacements: Array<{ start: number; end: number; replacement: string }> = [];
+        const replacements: Array<{ start: number; end: number; replacement: string }> = [];
 
-      for (const token of terminalTokens) {
-        const managed = terminalInstanceService.get(terminalId);
-        let replacement: string;
-        if (managed) {
-          const buffer = managed.terminal.buffer.active;
-          const start = Math.max(0, buffer.length - 100);
-          const lines: string[] = [];
-          for (let i = start; i < buffer.length; i++) {
-            const line = buffer.getLine(i);
-            if (line) lines.push(line.translateToString(true));
-          }
-          const content = lines.join("\n").trimEnd();
-          replacement = content ? "```\n" + content + "\n```" : "[No terminal output]";
-        } else {
-          replacement = "[Terminal not available]";
-        }
-        replacements.push({ start: token.start, end: token.end, replacement });
-      }
-
-      for (const token of selectionTokens) {
-        const selection = terminalInstanceService.getCachedSelection(terminalId);
-        const replacement = selection ? "```\n" + selection + "\n```" : "[No terminal selection]";
-        replacements.push({ start: token.start, end: token.end, replacement });
-      }
-
-      if (diffTokens.length > 0) {
-        isSendingRef.current = true;
-        try {
-          for (const token of diffTokens) {
-            let replacement: string;
-            try {
-              const raw = await window.electron.git.getWorkingDiff(cwd, token.diffType);
-              if (raw) {
-                replacement = "```diff\n" + raw + "\n```";
-              } else {
-                const labels: Record<DiffContextType, string> = {
-                  unstaged: "working tree",
-                  staged: "staged",
-                  head: "HEAD",
-                };
-                replacement = `No ${labels[token.diffType]} changes.`;
-              }
-            } catch (err) {
-              const msg = formatErrorMessage(err, "Failed to fetch diff");
-              replacement = `[Error fetching diff: ${msg}]`;
+        for (const token of terminalTokens) {
+          const managed = terminalInstanceService.get(terminalId);
+          let replacement: string;
+          if (managed) {
+            const buffer = managed.terminal.buffer.active;
+            const start = Math.max(0, buffer.length - 100);
+            const lines: string[] = [];
+            for (let i = start; i < buffer.length; i++) {
+              const line = buffer.getLine(i);
+              if (line) lines.push(line.translateToString(true));
             }
-            replacements.push({ start: token.start, end: token.end, replacement });
+            const content = lines.join("\n").trimEnd();
+            replacement = content ? "```\n" + content + "\n```" : "[No terminal output]";
+          } else {
+            replacement = "[Terminal not available]";
           }
-        } finally {
-          isSendingRef.current = false;
+          replacements.push({ start: token.start, end: token.end, replacement });
         }
-      }
 
-      if (replacements.length > 0) {
-        replacements.sort((a, b) => b.start - a.start);
-        for (const r of replacements) {
-          resolvedText = resolvedText.slice(0, r.start) + r.replacement + resolvedText.slice(r.end);
+        for (const token of selectionTokens) {
+          const selection = terminalInstanceService.getCachedSelection(terminalId);
+          const replacement = selection ? "```\n" + selection + "\n```" : "[No terminal selection]";
+          replacements.push({ start: token.start, end: token.end, replacement });
         }
+
+        for (const token of diffTokens) {
+          let replacement: string;
+          try {
+            const raw = await window.electron.git.getWorkingDiff(cwd, token.diffType);
+            if (raw) {
+              replacement = "```diff\n" + raw + "\n```";
+            } else {
+              const labels: Record<DiffContextType, string> = {
+                unstaged: "working tree",
+                staged: "staged",
+                head: "HEAD",
+              };
+              replacement = `No ${labels[token.diffType]} changes.`;
+            }
+          } catch (err) {
+            const msg = formatErrorMessage(err, "Failed to fetch diff");
+            replacement = `[Error fetching diff: ${msg}]`;
+          }
+          replacements.push({ start: token.start, end: token.end, replacement });
+        }
+
+        if (replacements.length > 0) {
+          replacements.sort((a, b) => b.start - a.start);
+          for (const r of replacements) {
+            resolvedText =
+              resolvedText.slice(0, r.start) + r.replacement + resolvedText.slice(r.end);
+          }
+        }
+
+        const outgoing = options?.compose ? options.compose(resolvedText) : resolvedText;
+        // Checked on the composed result rather than the raw draft: an empty
+        // draft is a perfectly good send once an instruction has been appended.
+        if (outgoing.trim().length === 0) return false;
+
+        if (options?.submit) {
+          // Nothing below this line runs on a refused submission — the draft the
+          // user can still see is the draft they still have.
+          if (!(await options.submit(outgoing))) return false;
+        } else {
+          const payload = buildTerminalSendPayload(outgoing);
+          latest.onSend({ data: payload.data, trackerData: payload.trackerData, text: outgoing });
+        }
+
+        // Learn dictionary words from manual corrections to dictated text. Uses
+        // the original `text` (the human-authored content), not `resolvedText`
+        // (which has @-token expansions spliced in).
+        detectDictionaryCorrections(terminalId, text);
+
+        // History keeps what the human authored, so recalling it re-runs the
+        // tokens rather than a frozen expansion — composed the same way, because
+        // the instruction was part of what was sent.
+        const authored = options?.compose ? options.compose(text) : text;
+        latest.addToHistory(latest.terminalId, authored, latest.projectId);
+        latest.resetHistoryIndex(latest.terminalId, latest.projectId);
+        if (latest.projectId) {
+          useCommandHistoryStore
+            .getState()
+            .recordPrompt(latest.projectId, authored, agentId ?? null);
+        }
+
+        setIsExpanded(false);
+        applyEditorValue("", { selection: EditorSelection.create([EditorSelection.cursor(0)]) });
+        latest.clearDraftInput(latest.terminalId, latest.projectId);
+        setActiveCompletionContext(null);
+        return true;
+      } finally {
+        isSendingRef.current = false;
       }
-
-      // Learn dictionary words from manual corrections to dictated text. Uses
-      // the original `text` (the human-authored content), not `resolvedText`
-      // (which has @-token expansions spliced in).
-      detectDictionaryCorrections(terminalId, text);
-
-      const payload = buildTerminalSendPayload(resolvedText);
-      latest.onSend({ data: payload.data, trackerData: payload.trackerData, text: resolvedText });
-      latest.addToHistory(latest.terminalId, text, latest.projectId);
-      latest.resetHistoryIndex(latest.terminalId, latest.projectId);
-      if (latest.projectId) {
-        useCommandHistoryStore.getState().recordPrompt(latest.projectId, text, agentId ?? null);
-      }
-
-      setIsExpanded(false);
-      applyEditorValue("", { selection: EditorSelection.create([EditorSelection.cursor(0)]) });
-      latest.clearDraftInput(latest.terminalId, latest.projectId);
-      setActiveCompletionContext(null);
     },
     [
       applyEditorValue,

--- a/src/components/Terminal/hooks/useTokenResolution.ts
+++ b/src/components/Terminal/hooks/useTokenResolution.ts
@@ -279,12 +279,15 @@ export function useTokenResolution({
             .recordPrompt(latest.projectId, authored, agentId ?? null);
         }
 
-        setIsExpanded(false);
+        // The whole composer reset is one decision: if the draft is newer than
+        // what went out, collapsing it and closing the completion the user has
+        // since opened would be the same overreach as deleting their text.
         if (options?.isDraftUnchanged?.() ?? true) {
+          setIsExpanded(false);
           applyEditorValue("", { selection: EditorSelection.create([EditorSelection.cursor(0)]) });
           latest.clearDraftInput(latest.terminalId, latest.projectId);
+          setActiveCompletionContext(null);
         }
-        setActiveCompletionContext(null);
         return true;
       } finally {
         isSendingRef.current = false;

--- a/src/components/Terminal/useWorktreeMoveBanner.ts
+++ b/src/components/Terminal/useWorktreeMoveBanner.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, type RefObject } from "react";
+import { useCallback, useEffect, useRef, type RefObject } from "react";
 import { isPtyPanel, type PanelWorktreeMoveNotice } from "@shared/types/panel";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -114,11 +114,15 @@ export function useWorktreeMoveBanner(
   );
 
   const setWorktreeMoveNotice = usePanelStore((state) => state.setWorktreeMoveNotice);
-  // Read at dispatch time, not captured: a lock or a restart can land while the
-  // bar is still resolving `@diff`, and the route decided at click time would
-  // then submit behind it.
+  // Read at dispatch time, not captured: a lock, a restart or a fleet arming
+  // can land while the bar is still resolving `@diff`, and the route decided at
+  // click time would then act on a pane that has since changed underneath it.
+  // Written in an effect rather than during render so a render React discards
+  // cannot leave a route here that the user never got.
   const routeRef = useRef(route);
-  routeRef.current = route;
+  useEffect(() => {
+    routeRef.current = route;
+  }, [route]);
 
   const dismiss = useCallback(
     () => setWorktreeMoveNotice(panelId, undefined),
@@ -146,7 +150,10 @@ export function useWorktreeMoveBanner(
      * the moment there is actually something to send.
      */
     const submit = async (command: string): Promise<boolean> => {
-      if (routeRef.current === "blocked") return false;
+      // Any change, not just a block. Arming a fleet turns this pane's draft
+      // into the fleet's, and committing the send would clear it out from
+      // under every other armed pane.
+      if (routeRef.current !== route) return false;
       if (readNotice(panelId) !== attempt) return false;
       if (readWorktreePath(attempt.destinationWorktreeId) !== path) return false;
       const result = await actionService.dispatch(

--- a/src/components/Terminal/useWorktreeMoveBanner.ts
+++ b/src/components/Terminal/useWorktreeMoveBanner.ts
@@ -17,6 +17,25 @@ import type { HybridInputBarHandle } from "./HybridInputBar";
  */
 export type WorktreeMoveDeliveryRoute = "hybrid" | "direct" | "blocked";
 
+/**
+ * Pick the route from the pane's live input state.
+ *
+ * Fleet composition goes direct even though a usable bar is right there. That
+ * draft belongs to the fleet, not to this pane: submitting it mirrors the
+ * cleared value into every other armed pane (`useFleetMirror`), which would
+ * delete drafts the user never sent from panes they were not looking at. The
+ * instruction alone is what this pane's agent needs anyway.
+ */
+export function resolveWorktreeMoveRoute(options: {
+  isHybridInputDisabled: boolean;
+  hasHybridInputBar: boolean;
+  isFleetComposing: boolean;
+}): WorktreeMoveDeliveryRoute {
+  if (options.isHybridInputDisabled) return "blocked";
+  if (options.isFleetComposing) return "direct";
+  return options.hasHybridInputBar ? "hybrid" : "direct";
+}
+
 export interface WorktreeMoveBanner {
   /** True while this pane has an unanswered cross-worktree move prompt. */
   visible: boolean;
@@ -40,6 +59,16 @@ function readWorktreePath(worktreeId: string): string | undefined {
   const path = getCurrentViewStoreOrNull()?.getState().worktrees.get(worktreeId)?.path;
   return path?.trim() ? path : undefined;
 }
+
+/**
+ * Panels with a tell in flight.
+ *
+ * Module-scoped, not a component ref: a worktree switch unmounts this pane
+ * mid-dispatch, and a per-mount lock would let the remount fire a second
+ * instruction at the same notice — delivering the sentence twice, and letting
+ * the loser's failure overwrite the winner's success.
+ */
+const inFlight = new Set<string>();
 
 function readNotice(panelId: string): PanelWorktreeMoveNotice | undefined {
   const panel = usePanelStore.getState().panelsById[panelId];
@@ -85,7 +114,11 @@ export function useWorktreeMoveBanner(
   );
 
   const setWorktreeMoveNotice = usePanelStore((state) => state.setWorktreeMoveNotice);
-  const inFlightRef = useRef(false);
+  // Read at dispatch time, not captured: a lock or a restart can land while the
+  // bar is still resolving `@diff`, and the route decided at click time would
+  // then submit behind it.
+  const routeRef = useRef(route);
+  routeRef.current = route;
 
   const dismiss = useCallback(
     () => setWorktreeMoveNotice(panelId, undefined),
@@ -93,7 +126,7 @@ export function useWorktreeMoveBanner(
   );
 
   const tell = useCallback(async () => {
-    if (inFlightRef.current) return;
+    if (inFlight.has(panelId)) return;
 
     // Read through, not off the render: a second move can land between the
     // paint and the click, and the notice captured here is the one this
@@ -113,6 +146,7 @@ export function useWorktreeMoveBanner(
      * the moment there is actually something to send.
      */
     const submit = async (command: string): Promise<boolean> => {
+      if (routeRef.current === "blocked") return false;
       if (readNotice(panelId) !== attempt) return false;
       if (readWorktreePath(attempt.destinationWorktreeId) !== path) return false;
       const result = await actionService.dispatch(
@@ -123,7 +157,7 @@ export function useWorktreeMoveBanner(
       return result.ok;
     };
 
-    inFlightRef.current = true;
+    inFlight.add(panelId);
     let delivered = false;
     try {
       if (route === "hybrid") {
@@ -138,7 +172,7 @@ export function useWorktreeMoveBanner(
         delivered = await submit(buildWorktreeMoveInstruction(path));
       }
     } finally {
-      inFlightRef.current = false;
+      inFlight.delete(panelId);
     }
 
     // A move, a dismiss, or another pane's answer while this was in flight owns

--- a/src/components/Terminal/useWorktreeMoveBanner.ts
+++ b/src/components/Terminal/useWorktreeMoveBanner.ts
@@ -1,8 +1,21 @@
-import { useCallback } from "react";
-import { isPtyPanel } from "@shared/types/panel";
+import { useCallback, useRef, type RefObject } from "react";
+import { isPtyPanel, type PanelWorktreeMoveNotice } from "@shared/types/panel";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
-import { queueWorktreeMoveInstruction } from "@/services/terminal/worktreeMoveInstruction";
+import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
+import { actionService } from "@/services/ActionService";
+import { buildWorktreeMoveInstruction } from "@/services/terminal/worktreeMoveInstruction";
+import type { HybridInputBarHandle } from "./HybridInputBar";
+
+/**
+ * How this pane can put the instruction in front of its agent right now.
+ *
+ * `blocked` is not the same as `direct`. The bar being absent is a setting; the
+ * bar being unusable is a backend that is disconnected, recovering, restarting,
+ * or an input lock — and submitting behind any of those is the silent loss this
+ * exists to end. Collapsing the two would route around every one of them.
+ */
+export type WorktreeMoveDeliveryRoute = "hybrid" | "direct" | "blocked";
 
 export interface WorktreeMoveBanner {
   /** True while this pane has an unanswered cross-worktree move prompt. */
@@ -14,10 +27,23 @@ export interface WorktreeMoveBanner {
    * default gets shipped (#7880).
    */
   destinationPath: string | undefined;
-  /** Send the instruction (now, or once the agent is free) and hide the bar. */
-  tell: () => void;
+  /** True once a tell has been tried and the terminal did not take it. */
+  deliveryFailed: boolean;
+  /** Send the instruction, and hide the bar only if the terminal took it. */
+  tell: () => Promise<void>;
   /** Hide the bar. Nothing is sent and nothing is recorded. */
   dismiss: () => void;
+}
+
+/** The destination's path as it is *now* — never as it was when rendered. */
+function readWorktreePath(worktreeId: string): string | undefined {
+  const path = getCurrentViewStoreOrNull()?.getState().worktrees.get(worktreeId)?.path;
+  return path?.trim() ? path : undefined;
+}
+
+function readNotice(panelId: string): PanelWorktreeMoveNotice | undefined {
+  const panel = usePanelStore.getState().panelsById[panelId];
+  return panel && isPtyPanel(panel) ? panel.worktreeMoveNotice : undefined;
 }
 
 /**
@@ -33,38 +59,98 @@ export interface WorktreeMoveBanner {
  * Both outcomes clear the same field. There is deliberately no "was it told"
  * flag: compliance is undetectable, `panel.cwd` still names the source worktree
  * even after the agent moves over completely, and any marker that outlives the
- * click would sit lit forever on total success.
+ * click would sit lit forever on total success. `deliveryFailed` is a different
+ * claim — not "did the agent comply" but "did the terminal accept the text",
+ * which is the one thing the submit layer can actually answer (#11867).
  */
-export function useWorktreeMoveBanner(panelId: string): WorktreeMoveBanner {
-  const destinationWorktreeId = usePanelStore((state) => {
+export function useWorktreeMoveBanner(
+  panelId: string,
+  options: {
+    route: WorktreeMoveDeliveryRoute;
+    inputBarRef: RefObject<HybridInputBarHandle | null>;
+  }
+): WorktreeMoveBanner {
+  const { route, inputBarRef } = options;
+
+  // The whole notice, not just its id: its object identity is the attempt
+  // generation. `setWorktreeMoveNotice` only replaces it when something
+  // actually changed, so the reference is stable enough to select directly.
+  const notice = usePanelStore((state) => {
     const panel = state.panelsById[panelId];
-    const pty = panel && isPtyPanel(panel) ? panel : undefined;
-    return pty?.worktreeMoveNotice?.destinationWorktreeId;
+    return panel && isPtyPanel(panel) ? panel.worktreeMoveNotice : undefined;
   });
 
   const destinationPath = useWorktreeStore((state) =>
-    destinationWorktreeId ? state.worktrees.get(destinationWorktreeId)?.path : undefined
+    notice ? state.worktrees.get(notice.destinationWorktreeId)?.path : undefined
   );
 
   const setWorktreeMoveNotice = usePanelStore((state) => state.setWorktreeMoveNotice);
+  const inFlightRef = useRef(false);
 
   const dismiss = useCallback(
     () => setWorktreeMoveNotice(panelId, undefined),
     [setWorktreeMoveNotice, panelId]
   );
 
-  const tell = useCallback(() => {
-    if (!destinationWorktreeId) return;
-    // Only clear once the instruction is actually owned by the scheduler.
-    // A destination that vanished between render and click leaves the bar up
-    // rather than silently swallowing the user's one click.
-    if (!queueWorktreeMoveInstruction(panelId, destinationWorktreeId)) return;
-    setWorktreeMoveNotice(panelId, undefined);
-  }, [panelId, destinationWorktreeId, setWorktreeMoveNotice]);
+  const tell = useCallback(async () => {
+    if (inFlightRef.current) return;
+
+    // Read through, not off the render: a second move can land between the
+    // paint and the click, and the notice captured here is the one this
+    // attempt is allowed to answer.
+    const attempt = readNotice(panelId);
+    if (!attempt) return;
+    const path = readWorktreePath(attempt.destinationWorktreeId);
+    if (!path) return;
+
+    /**
+     * The one delivery path, shared by both routes (#11867) — the same action
+     * the MCP surface uses, with no agent-state gate in front of it.
+     *
+     * Re-checks identity immediately before dispatching as well as after.
+     * Resolving `@diff` in the user's draft is a round trip to git, so the
+     * destination can move, or the notice be answered, between the click and
+     * the moment there is actually something to send.
+     */
+    const submit = async (command: string): Promise<boolean> => {
+      if (readNotice(panelId) !== attempt) return false;
+      if (readWorktreePath(attempt.destinationWorktreeId) !== path) return false;
+      const result = await actionService.dispatch(
+        "terminal.sendCommand",
+        { terminalId: panelId, command },
+        { source: "user" }
+      );
+      return result.ok;
+    };
+
+    inFlightRef.current = true;
+    let delivered = false;
+    try {
+      if (route === "hybrid") {
+        const instruction = buildWorktreeMoveInstruction(path);
+        // No fall-through to the direct route on a `false`. A bar that refused
+        // may still have got as far as the terminal, and a second send would
+        // put the sentence in twice; leaving the bar up costs one more click
+        // and cannot duplicate anything.
+        delivered =
+          (await inputBarRef.current?.submitWithInstruction(instruction, submit)) ?? false;
+      } else if (route === "direct") {
+        delivered = await submit(buildWorktreeMoveInstruction(path));
+      }
+    } finally {
+      inFlightRef.current = false;
+    }
+
+    // A move, a dismiss, or another pane's answer while this was in flight owns
+    // the field now. Late results do not get to overwrite them.
+    if (readNotice(panelId) !== attempt) return;
+    setWorktreeMoveNotice(panelId, delivered ? undefined : { ...attempt, deliveryFailed: true });
+  }, [panelId, route, inputBarRef, setWorktreeMoveNotice]);
 
   return {
-    visible: destinationWorktreeId !== undefined,
+    visible: notice !== undefined,
     destinationPath: destinationPath?.trim() ? destinationPath : undefined,
+    deliveryFailed: notice?.deliveryFailed === true,
     tell,
     dismiss,
   };

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -496,6 +496,10 @@ export function registerTerminalQueryActions(
     category: "terminal",
     kind: "command",
     danger: "safe",
+    // Never captured into `lastAction`: replaying `action.repeatLast` would
+    // re-inject the exact same text into the agent pane, which for a composed
+    // submission (instruction plus the user's draft) is a silent duplicate send.
+    nonRepeatable: true,
     // Reachable by user and agent (MCP) dispatch, but NOT by plugin
     // host.dispatch — sending text into an agent terminal is exactly the
     // injection the capability model gates. Plugins must declare `agent:input`

--- a/src/services/terminal/__tests__/crossWorktreeMove.test.ts
+++ b/src/services/terminal/__tests__/crossWorktreeMove.test.ts
@@ -444,6 +444,23 @@ describe("moveTerminalToWorktreeAndFollowRescue — move notice (#11853)", () =>
     expect(noticeOf("t1")).toBe("wt-b");
   });
 
+  it("clears a stale delivery failure when the same move is raised again", () => {
+    // The bar's error state belongs to one attempt (#11867). A fresh move has
+    // not failed yet, even when it names the destination the last one did.
+    seedPanels([agentPanel("t1", "wt-a", "/repo/wt-a")]);
+    usePanelStore
+      .getState()
+      .setWorktreeMoveNotice("t1", { destinationWorktreeId: "wt-b", deliveryFailed: true });
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-b");
+
+    expect(noticeOf("t1")).toBe("wt-b");
+    const panel = usePanelStore.getState().panelsById["t1"];
+    expect(panel && isPtyPanel(panel) ? panel.worktreeMoveNotice?.deliveryFailed : "unset").toBe(
+      undefined
+    );
+  });
+
   it("raises the notice when the launch root cannot be classified at all", () => {
     // `unknown` is not proof of alignment — treating "can't prove it" as "it's
     // fine" is the silence this feature exists to end.

--- a/src/services/terminal/__tests__/worktreeMoveInstruction.test.ts
+++ b/src/services/terminal/__tests__/worktreeMoveInstruction.test.ts
@@ -50,9 +50,13 @@ describe("composeDraftWithInstruction", () => {
   it("adds only newlines, and only the ones the draft is missing", () => {
     for (const draft of ["fix it", "fix it\n", "fix it\n\n", "fix it\n\n\n\n", "fix it  "]) {
       const composed = composeDraftWithInstruction(draft, INSTRUCTION);
+
+      // Anchored first: without this the rows that already end in a blank line
+      // would pass even if the instruction were dropped entirely.
+      expect(composed.startsWith(draft)).toBe(true);
+      expect(composed.endsWith(INSTRUCTION)).toBe(true);
       const separator = composed.slice(draft.length, composed.length - INSTRUCTION.length);
 
-      expect(composed.startsWith(draft)).toBe(true);
       // Nothing but newlines is ever inserted...
       expect(separator).toMatch(/^\n*$/);
       // ...enough of them to leave a blank line...

--- a/src/services/terminal/__tests__/worktreeMoveInstruction.test.ts
+++ b/src/services/terminal/__tests__/worktreeMoveInstruction.test.ts
@@ -1,373 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type { AgentState } from "@/types";
-
-const mockSubmit = vi.fn().mockResolvedValue(undefined);
-const mockGetAgentState = vi.fn<(id: string) => AgentState | undefined>();
-// A SET per panel, mirroring `managed.agentStateSubscribers` in the real
-// service. Keying by panel id alone would let a re-registration silently
-// replace the previous listener, which is exactly how a leaked job stayed
-// invisible: the real service keeps both, and both fire.
-const stateListeners = new Map<string, Set<(state: AgentState) => void>>();
-const exitListeners = new Map<string, Set<(code: number) => void>>();
-const disposedState: string[] = [];
-const disposedExit: string[] = [];
-
-/**
- * Mirrors the real `addAgentStateListener`, which invokes its callback
- * *synchronously* when the state is already known — before it has returned the
- * disposer. That reentrancy is the trap the scheduler has to survive.
- */
-let fireImmediatelyWith: AgentState | undefined;
-
-let destroyedListener: ((id: string) => void) | null = null;
-/** Panels the service has an instance for. Liveness is now part of the contract. */
-const liveInstances = new Set<string>();
-
-vi.mock("@/services/TerminalInstanceService", () => ({
-  terminalInstanceService: {
-    get: (id: string) => (liveInstances.has(id) ? { id } : null),
-    addInstanceDestroyedListener: (cb: (id: string) => void) => {
-      destroyedListener = cb;
-      return () => {
-        destroyedListener = null;
-      };
-    },
-    getAgentState: (id: string) => mockGetAgentState(id),
-    addAgentStateListener: (id: string, cb: (state: AgentState) => void) => {
-      const set = stateListeners.get(id) ?? new Set();
-      set.add(cb);
-      stateListeners.set(id, set);
-      if (fireImmediatelyWith !== undefined) cb(fireImmediatelyWith);
-      return () => {
-        disposedState.push(id);
-        set.delete(cb);
-      };
-    },
-    addExitListener: (id: string, cb: (code: number) => void) => {
-      const set = exitListeners.get(id) ?? new Set();
-      set.add(cb);
-      exitListeners.set(id, set);
-      return () => {
-        disposedExit.push(id);
-        set.delete(cb);
-      };
-    },
-  },
-}));
-
-vi.mock("@/clients", () => ({
-  terminalClient: { submit: (...args: unknown[]) => mockSubmit(...args) },
-}));
-
-const worktrees = new Map<string, { id: string; path: string }>();
-vi.mock("@/store/createWorktreeStore", () => ({
-  getCurrentViewStoreOrNull: () => ({ getState: () => ({ worktrees }) }),
-}));
-
-/** Notify every live subscriber, the way the real service's Set does. */
-function fireState(id: string, state: AgentState): void {
-  for (const cb of [...(stateListeners.get(id) ?? [])]) cb(state);
-}
-
-function fireExit(id: string, code = 0): void {
-  for (const cb of [...(exitListeners.get(id) ?? [])]) cb(code);
-}
-
-/** How many state listeners are still registered for a panel. */
-function liveStateListeners(id: string): number {
-  return stateListeners.get(id)?.size ?? 0;
-}
-
-/** How many exit listeners are still registered for a panel. */
-function liveExitListeners(id: string): number {
-  return exitListeners.get(id)?.size ?? 0;
-}
-
-const {
-  queueWorktreeMoveInstruction,
-  cancelWorktreeMoveInstruction,
-  hasPendingWorktreeMoveInstruction,
+import { describe, it, expect } from "vitest";
+import {
   buildWorktreeMoveInstruction,
-  __resetWorktreeMoveInstructions,
-} = await import("../worktreeMoveInstruction");
+  composeDraftWithInstruction,
+} from "../worktreeMoveInstruction";
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  stateListeners.clear();
-  exitListeners.clear();
-  disposedState.length = 0;
-  disposedExit.length = 0;
-  fireImmediatelyWith = undefined;
-  worktrees.clear();
-  worktrees.set("wt-b", { id: "wt-b", path: "/repo/wt-b" });
-  liveInstances.clear();
-  liveInstances.add("p1");
-  liveInstances.add("p2");
-  destroyedListener = null;
-  mockGetAgentState.mockReturnValue("working");
-});
-
-afterEach(() => {
-  __resetWorktreeMoveInstructions();
-});
-
-describe("queueWorktreeMoveInstruction", () => {
-  it("submits immediately when the agent is already idle", () => {
-    mockGetAgentState.mockReturnValue("idle");
-
-    expect(queueWorktreeMoveInstruction("p1", "wt-b")).toBe(true);
-
-    expect(mockSubmit).toHaveBeenCalledWith("p1", "Please continue in the directory /repo/wt-b");
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-  });
-
-  it("submits immediately when the agent is waiting", () => {
-    mockGetAgentState.mockReturnValue("waiting");
-
-    queueWorktreeMoveInstruction("p1", "wt-b");
-
-    expect(mockSubmit).toHaveBeenCalledTimes(1);
-  });
-
-  it("queues instead of interrupting a working agent", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-
-    expect(mockSubmit).not.toHaveBeenCalled();
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(true);
-  });
-
-  it("delivers once the agent reports idle", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-
-    fireState("p1", "idle");
-
-    expect(mockSubmit).toHaveBeenCalledWith("p1", "Please continue in the directory /repo/wt-b");
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-  });
-
-  it("stays queued through states that are not idle or waiting", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-
-    fireState("p1", "working");
-    fireState("p1", "directing");
-    fireState("p1", "completed");
-
-    expect(mockSubmit).not.toHaveBeenCalled();
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(true);
-  });
-
-  it("delivers exactly once even if idle is reported repeatedly", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-
-    fireState("p1", "idle");
-    fireState("p1", "waiting");
-    fireState("p1", "idle");
-
-    expect(mockSubmit).toHaveBeenCalledTimes(1);
-  });
-
-  it("never submits on a timer, however long the agent works", () => {
-    // #11840's helper injected blindly after 30s. Landing the sentence
-    // mid-turn is the one failure mode this feature is not allowed to have.
-    vi.useFakeTimers();
-    try {
-      queueWorktreeMoveInstruction("p1", "wt-b");
-      // Stronger than advancing a fixed span: no timer exists to fire, so no
-      // fallback delay however long, rather than "longer than the one we tried".
-      expect(vi.getTimerCount()).toBe(0);
-      vi.advanceTimersByTime(30_000);
-      expect(mockSubmit).not.toHaveBeenCalled();
-      expect(hasPendingWorktreeMoveInstruction("p1")).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("unsubscribes when the listener fires before it returns its disposer", () => {
-    // The synchronous-callback path: `deliver()` runs while the disposer is
-    // still the no-op placeholder, so the unsubscribe has to happen after.
-    fireImmediatelyWith = "idle";
-
-    expect(queueWorktreeMoveInstruction("p1", "wt-b")).toBe(true);
-
-    expect(mockSubmit).toHaveBeenCalledTimes(1);
-    expect(disposedState).toContain("p1");
-    expect(liveStateListeners("p1")).toBe(0);
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-  });
-
-  it("refuses to queue against a panel with no renderer instance", () => {
-    // Returning `true` here would hide the banner while nothing was listening.
-    liveInstances.delete("p1");
-
-    expect(queueWorktreeMoveInstruction("p1", "wt-b")).toBe(false);
-
-    expect(mockSubmit).not.toHaveBeenCalled();
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-    expect(liveStateListeners("p1")).toBe(0);
-  });
-
-  it("refuses to queue against a destination that cannot be resolved", () => {
-    expect(queueWorktreeMoveInstruction("p1", "wt-gone")).toBe(false);
-
-    expect(mockSubmit).not.toHaveBeenCalled();
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-  });
-
-  it("resolves the destination path at delivery, not at queue time", () => {
-    // The path can be corrected under a stable id (a rename the host re-reports).
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    worktrees.set("wt-b", { id: "wt-b", path: "/moved/wt-b" });
-
-    fireState("p1", "idle");
-
-    expect(mockSubmit).toHaveBeenCalledWith("p1", "Please continue in the directory /moved/wt-b");
-  });
-
-  it("sends nothing when a physical worktree move replaces the destination id", () => {
-    // Worktree ids are normalized absolute paths, so `git worktree move` retires
-    // the old id and introduces a new one rather than editing a path in place.
-    // Failing closed is the point: no fallback, no guessed path, no message.
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    worktrees.delete("wt-b");
-    worktrees.set("/repo/wt-b-renamed", { id: "/repo/wt-b-renamed", path: "/repo/wt-b-renamed" });
-
-    fireState("p1", "idle");
-
-    expect(mockSubmit).not.toHaveBeenCalled();
-  });
-
-  it("sends nothing when the destination vanishes before the agent frees up", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    worktrees.delete("wt-b");
-
-    fireState("p1", "idle");
-
-    expect(mockSubmit).not.toHaveBeenCalled();
-  });
-
-  it("drops the instruction when the process exits first", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-
-    fireExit("p1");
-
-    expect(mockSubmit).not.toHaveBeenCalled();
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-    expect(disposedState).toContain("p1");
-  });
-
-  it("replaces an earlier instruction for the same panel", () => {
-    // Regression: the replacement used to overwrite the map entry while the
-    // first job's listeners stayed live on the service, so a single idle
-    // delivered BOTH sentences — the second naming a directory the user had
-    // already moved on from.
-    worktrees.set("wt-c", { id: "wt-c", path: "/repo/wt-c" });
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    queueWorktreeMoveInstruction("p1", "wt-c");
-
-    // The superseded job must be gone from the service, not merely unreachable.
-    expect(liveStateListeners("p1")).toBe(1);
-
-    fireState("p1", "idle");
-
-    expect(mockSubmit).toHaveBeenCalledTimes(1);
-    expect(mockSubmit).toHaveBeenCalledWith("p1", "Please continue in the directory /repo/wt-c");
-  });
-
-  it("leaves no listener behind once an instruction has been delivered", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    expect(liveStateListeners("p1")).toBe(1);
-
-    fireState("p1", "idle");
-
-    expect(liveStateListeners("p1")).toBe(0);
-  });
-
-  it("deregisters the superseded job's exit listener too", () => {
-    // Counting is what makes this real: firing every listener would pass
-    // whether or not the stale one survived, because the replacement's own
-    // listener clears `pending` anyway.
-    worktrees.set("wt-c", { id: "wt-c", path: "/repo/wt-c" });
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    expect(liveExitListeners("p1")).toBe(1);
-
-    queueWorktreeMoveInstruction("p1", "wt-c");
-
-    expect(liveExitListeners("p1")).toBe(1);
-  });
-
-  it("keeps instructions for different panels independent", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    queueWorktreeMoveInstruction("p2", "wt-b");
-
-    cancelWorktreeMoveInstruction("p1");
-
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-    expect(hasPendingWorktreeMoveInstruction("p2")).toBe(true);
-  });
-
-  it("survives a submit rejection without retrying", async () => {
-    mockSubmit.mockRejectedValueOnce(new Error("pty gone"));
-    mockGetAgentState.mockReturnValue("idle");
-
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    await Promise.resolve();
-
-    expect(mockSubmit).toHaveBeenCalledTimes(1);
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-  });
-});
-
-describe("instance teardown", () => {
-  it("drops the instruction when the renderer instance is destroyed", () => {
-    // `destroy()` clears the exit subscribers instead of firing them, so a
-    // restart or a close gives the scheduler no signal from the exit path.
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(true);
-
-    destroyedListener?.("p1");
-
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-    expect(liveStateListeners("p1")).toBe(0);
-    expect(liveExitListeners("p1")).toBe(0);
-    expect(mockSubmit).not.toHaveBeenCalled();
-  });
-
-  it("leaves other panels' instructions alone on teardown", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    queueWorktreeMoveInstruction("p2", "wt-b");
-
-    destroyedListener?.("p1");
-
-    expect(hasPendingWorktreeMoveInstruction("p2")).toBe(true);
-  });
-});
-
-describe("cancelWorktreeMoveInstruction", () => {
-  it("disposes both listeners", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-
-    cancelWorktreeMoveInstruction("p1");
-
-    expect(disposedState).toContain("p1");
-    expect(disposedExit).toContain("p1");
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(false);
-  });
-
-  it("is a no-op for a panel with nothing pending", () => {
-    expect(() => cancelWorktreeMoveInstruction("p-none")).not.toThrow();
-  });
-
-  it("does not let a stale token cancel a replacement instruction", () => {
-    queueWorktreeMoveInstruction("p1", "wt-b");
-    queueWorktreeMoveInstruction("p1", "wt-b");
-
-    // Token 1 belonged to the job the second queue already replaced.
-    cancelWorktreeMoveInstruction("p1", 1);
-
-    expect(hasPendingWorktreeMoveInstruction("p1")).toBe(true);
-  });
-});
+const INSTRUCTION = buildWorktreeMoveInstruction("/repo/wt-b");
 
 describe("buildWorktreeMoveInstruction", () => {
   it("names the directory exactly once, on one line", () => {
@@ -384,5 +21,52 @@ describe("buildWorktreeMoveInstruction", () => {
 
   it("does not leak a different destination's path", () => {
     expect(buildWorktreeMoveInstruction("/repo/wt-c")).not.toContain("/repo/wt-b");
+  });
+});
+
+describe("composeDraftWithInstruction", () => {
+  it("sends the instruction alone when the draft is blank", () => {
+    for (const blank of ["", "   ", "\n\n", " \t\n "]) {
+      expect(composeDraftWithInstruction(blank, INSTRUCTION)).toBe(INSTRUCTION);
+    }
+  });
+
+  it("reproduces a non-blank draft byte for byte", () => {
+    // Trailing spaces can be a deliberate Markdown hard break, and the point of
+    // #11867's bar path is that the user's draft goes along untouched.
+    const draft = "look at @diff  ";
+    const composed = composeDraftWithInstruction(draft, INSTRUCTION);
+
+    expect(composed.startsWith(draft)).toBe(true);
+    expect(composed.endsWith(INSTRUCTION)).toBe(true);
+  });
+
+  it("separates the draft from the instruction with a blank line", () => {
+    const composed = composeDraftWithInstruction("fix the bug", INSTRUCTION);
+
+    expect(composed.slice("fix the bug".length, -INSTRUCTION.length)).toBe("\n\n");
+  });
+
+  it("adds only newlines, and only the ones the draft is missing", () => {
+    for (const draft of ["fix it", "fix it\n", "fix it\n\n", "fix it\n\n\n\n", "fix it  "]) {
+      const composed = composeDraftWithInstruction(draft, INSTRUCTION);
+      const separator = composed.slice(draft.length, composed.length - INSTRUCTION.length);
+
+      expect(composed.startsWith(draft)).toBe(true);
+      // Nothing but newlines is ever inserted...
+      expect(separator).toMatch(/^\n*$/);
+      // ...enough of them to leave a blank line...
+      expect(draft + separator).toMatch(/\n\n$/);
+      // ...and never one more than that.
+      if (separator.length > 0) {
+        expect(`${draft}${separator.slice(0, -1)}`).not.toMatch(/\n\n$/);
+      }
+    }
+  });
+
+  it("appends once, so the instruction cannot be doubled", () => {
+    const composed = composeDraftWithInstruction("already said it", INSTRUCTION);
+
+    expect(composed.split(INSTRUCTION)).toHaveLength(2);
   });
 });

--- a/src/services/terminal/crossWorktreeMove.ts
+++ b/src/services/terminal/crossWorktreeMove.ts
@@ -2,7 +2,6 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
 import { classifyLaunchRootAlignment } from "@/utils/worktreeAlignment";
-import { cancelWorktreeMoveInstruction } from "@/services/terminal/worktreeMoveInstruction";
 import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 
@@ -92,11 +91,6 @@ export function reconcileMovedPanel(panelId: string, destinationWorktreeId: stri
   const store = usePanelStore.getState();
   const panel = store.panelsById[panelId];
   if (!panel || !isPtyPanel(panel)) return;
-
-  // Any move invalidates a queued instruction: it names the *previous*
-  // destination's path, and delivering that after a second move would send the
-  // agent somewhere the user has already moved on from.
-  cancelWorktreeMoveInstruction(panelId);
 
   if (!isPanelProcessLive(panel)) {
     alignDeadPanelCwd(panelId, destinationWorktreeId);

--- a/src/services/terminal/worktreeMoveInstruction.ts
+++ b/src/services/terminal/worktreeMoveInstruction.ts
@@ -1,9 +1,3 @@
-import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { terminalClient } from "@/clients";
-import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
-import { logWarn } from "@/utils/logger";
-import type { AgentState } from "@/types";
-
 /**
  * The one sentence a cross-worktree move is allowed to put into a live agent
  * session (#11853), and only when the user asks for it.
@@ -12,183 +6,16 @@ export function buildWorktreeMoveInstruction(worktreePath: string): string {
   return `Please continue in the directory ${worktreePath}`;
 }
 
-interface PendingInstruction {
-  /**
-   * Identity for this job. Cleanup is token-checked so a callback from a job
-   * that has already been replaced cannot delete its replacement.
-   */
-  token: number;
-  destinationWorktreeId: string;
-  dispose: () => void;
-}
-
 /**
- * Instructions waiting for their agent to finish what it is doing.
+ * Join whatever the user already had in the input bar with the instruction.
  *
- * Module-owned rather than component state, for the same reason the notice
- * itself lives in the panel store: switching worktrees unmounts the pane, and a
- * job parked in a component would be torn down by a gesture that has nothing to
- * do with the agent's turn.
+ * Sending the draft along is the point, not a side effect to avoid (#11867), so
+ * the draft is reproduced byte for byte — trailing spaces can be a deliberate
+ * Markdown hard break, and rewriting the user's own text to make room for ours
+ * is not this function's call. Only the newlines that are missing get added.
  */
-const pending = new Map<string, PendingInstruction>();
-let nextToken = 1;
-let teardownWatch: (() => void) | null = null;
-
-/**
- * Drop a panel's job when its renderer instance is torn down.
- *
- * `destroy()` clears the exit subscribers instead of firing them, so a restart,
- * a close, or a store reset would otherwise leave the entry in `pending`
- * forever — holding disposer closures over the dead instance. Subscribed lazily
- * so importing this module costs nothing until something is actually queued.
- */
-function ensureTeardownWatch(): void {
-  teardownWatch ??= terminalInstanceService.addInstanceDestroyedListener((id) => {
-    cancelWorktreeMoveInstruction(id);
-  });
-}
-
-/** The destination's path as it is *now* — never as it was when clicked. */
-function readWorktreePath(worktreeId: string): string | undefined {
-  const path = getCurrentViewStoreOrNull()?.getState().worktrees.get(worktreeId)?.path;
-  return path?.trim() ? path : undefined;
-}
-
-/**
- * Drop a panel's pending instruction.
- *
- * `token` scopes the cancellation to one job: an exit or state callback that
- * fires late must not remove the instruction a newer gesture has since queued.
- * Passing no token cancels whatever is currently pending, which is what the
- * external lifecycle hooks (move, restart, close) want.
- */
-export function cancelWorktreeMoveInstruction(panelId: string, token?: number): void {
-  const job = pending.get(panelId);
-  if (!job) return;
-  if (token !== undefined && job.token !== token) return;
-  pending.delete(panelId);
-  job.dispose();
-}
-
-/** Test seam — module state outlives any single component by design. */
-export function __resetWorktreeMoveInstructions(): void {
-  for (const job of pending.values()) job.dispose();
-  pending.clear();
-  teardownWatch?.();
-  teardownWatch = null;
-}
-
-function submit(panelId: string, destinationWorktreeId: string): void {
-  // Resolved at delivery, not at click time: a worktree can be physically moved
-  // while the agent finishes its turn, and sending a path that no longer exists
-  // is worse than sending nothing.
-  const path = readWorktreePath(destinationWorktreeId);
-  if (!path) {
-    logWarn("[WorktreeMove] destination vanished before the instruction could be sent", {
-      panelId,
-      destinationWorktreeId,
-    });
-    return;
-  }
-  terminalClient.submit(panelId, buildWorktreeMoveInstruction(path)).catch((error: unknown) => {
-    // Logged, not surfaced: the banner is already gone, and re-raising it would
-    // be the persistent marker #11853 exists to remove. The transcript is where
-    // the user sees whether the agent got the message.
-    logWarn("[WorktreeMove] failed to send the continue-in-directory instruction", {
-      panelId,
-      error,
-    });
-  });
-}
-
-/**
- * Send "continue in {path}" now, or the moment the agent is next free.
- *
- * There is no timeout. #11840's injection helper had a 30s blind fallback that
- * fired mid-turn if the agent never reported idle, which is exactly the
- * annoyance this feature is not allowed to have: an agent that never goes idle
- * simply never gets told. A job that waits out a long turn is pending work, not
- * a leak — it is disposed on exit, on close, on restart, and on any later move
- * (see `cancelWorktreeMoveInstruction`).
- *
- * Returns `false` when there is nothing to queue against — an unresolvable
- * destination or a panel with no live instance — so the caller can leave the
- * banner up instead of pretending the message is on its way.
- */
-export function queueWorktreeMoveInstruction(
-  panelId: string,
-  destinationWorktreeId: string
-): boolean {
-  if (!readWorktreePath(destinationWorktreeId)) return false;
-  // Without an instance there is nothing to listen to: `addAgentStateListener`
-  // hands back a no-op disposer for an unknown id, so the job would sit in
-  // `pending` forever while the banner disappeared — swallowing the user's one
-  // click. Say so instead, and let the bar stay up.
-  if (!terminalInstanceService.get(panelId)) return false;
-
-  ensureTeardownWatch();
-
-  // Before anything new registers. Overwriting the map entry alone would orphan
-  // the previous job with its listeners still live on the service, and both
-  // would fire on the next idle — delivering a second sentence naming the
-  // destination the user has already moved on from.
-  cancelWorktreeMoveInstruction(panelId);
-
-  const state = terminalInstanceService.getAgentState(panelId);
-  if (state === "idle" || state === "waiting") {
-    submit(panelId, destinationWorktreeId);
-    return true;
-  }
-
-  const token = nextToken++;
-  // `addAgentStateListener` invokes its callback synchronously when the state is
-  // already known, i.e. before it has returned the disposer this closure wants
-  // to call. `settled` is what keeps that path from leaking the listener: the
-  // callback records that it fired, and the registration below disposes
-  // immediately rather than storing a job that has already delivered.
-  let settled = false;
-  let unsubState: () => void = () => {};
-  let unsubExit: () => void = () => {};
-  const dispose = () => {
-    unsubState();
-    unsubExit();
-  };
-
-  const deliver = () => {
-    if (settled) return;
-    settled = true;
-    cancelWorktreeMoveInstruction(panelId, token);
-    dispose();
-    submit(panelId, destinationWorktreeId);
-  };
-
-  unsubState = terminalInstanceService.addAgentStateListener(panelId, (next: AgentState) => {
-    if (next === "idle" || next === "waiting") deliver();
-  });
-
-  // Delivered synchronously, before `unsubState` held anything but the no-op
-  // placeholder — so `deliver`'s own `dispose()` could not have unsubscribed.
-  // Undo the registration here, where the real disposer finally exists.
-  if (settled) {
-    unsubState();
-    return true;
-  }
-
-  // A process that dies mid-turn can never be told anything. Dropping the job
-  // here also stops it outliving a restart, whose fresh session was never the
-  // one the user was looking at when they clicked.
-  unsubExit = terminalInstanceService.addExitListener(panelId, () => {
-    if (settled) return;
-    settled = true;
-    cancelWorktreeMoveInstruction(panelId, token);
-    dispose();
-  });
-
-  pending.set(panelId, { token, destinationWorktreeId, dispose });
-  return true;
-}
-
-/** Whether this panel has an instruction waiting on its agent. Test/diagnostic. */
-export function hasPendingWorktreeMoveInstruction(panelId: string): boolean {
-  return pending.has(panelId);
+export function composeDraftWithInstruction(draft: string, instruction: string): string {
+  if (draft.trim() === "") return instruction;
+  const trailingNewlines = /\n*$/.exec(draft)?.[0].length ?? 0;
+  return `${draft}${"\n".repeat(Math.max(0, 2 - trailingNewlines))}${instruction}`;
 }

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -1077,9 +1077,17 @@ export const createRestartActions = (
     set((state) => {
       const terminal = state.panelsById[id];
       if (!terminal || !isPtyPanel(terminal)) return state;
-      // Clearing an already-clear notice, or re-raising the same destination,
-      // keeps the same state object so repeat writes don't wake subscribers.
-      if (terminal.worktreeMoveNotice?.destinationWorktreeId === notice?.destinationWorktreeId) {
+      // Clearing an already-clear notice, or re-raising the same destination in
+      // the same delivery state, keeps the same state object so repeat writes
+      // don't wake subscribers. `deliveryFailed` has to be part of that
+      // comparison: marking an existing notice as failed changes nothing else
+      // about it, so a destination-only check would silently drop the write
+      // (#11867). Normalized because absent and `false` mean the same thing.
+      const current = terminal.worktreeMoveNotice;
+      if (
+        current?.destinationWorktreeId === notice?.destinationWorktreeId &&
+        (current?.deliveryFailed ?? false) === (notice?.deliveryFailed ?? false)
+      ) {
         return state;
       }
       return {


### PR DESCRIPTION
## Summary

- The worktree move "tell the agent" banner was clearing as soon as the instruction was queued, not once it was actually sent. `queueWorktreeMoveInstruction` only submitted immediately when the agent state was `idle` or `waiting`; any other state parked the job on an agent-state listener with no timeout. Agent state is a passive-output heuristic, and a freshly created xterm starts at `agentState: undefined`, a value `addAgentStateListener` never fires an initial callback for. So a click shortly after a move could park the instruction forever while the banner had already disappeared. Deferred `terminalClient.submit` rejections were logged and dropped.
- The banner now clears only when `terminal.sendCommand` reports the terminal took the text. Every other outcome leaves it up and switches it to an error state ("Couldn't tell the agent") with a Retry action. Both delivery paths go through `ActionService` / `terminal.sendCommand`, the same path the MCP surface uses, with no agent-state gate.

Resolves #11867

## Changes

- When the hybrid input bar is mounted and usable, delivery goes through a new `HybridInputBarHandle.submitWithInstruction`, which composes the live CodeMirror document with the instruction and calls `sendText` directly. It never calls `sendFromEditor`, so fleet broadcast is unreachable by construction rather than by a flag, and it never round-trips the draft store.
- Pane availability is now three states instead of two: `hybrid | direct | blocked`. A pane that's input-locked, restarting, or on a disconnected/recovering backend refuses rather than submitting behind it. A fleet-composing pane goes `direct`, since clearing a shared draft mirrors the empty value into every other armed pane.
- `sendText` returns `Promise<boolean>`, and with a targeted `submit` it commits the editor/draft/history only once the terminal has accepted the text. A draft the user changed while the send was in flight is preserved rather than cleared.
- `worktreeMoveInstruction.ts` drops from 194 lines to two pure functions. The pending map, token counter, teardown watch, and agent-state/exit listeners are gone, along with `crossWorktreeMove.ts`'s cancellation call.
- `PanelWorktreeMoveNotice` gains a `deliveryFailed` flag, and `setWorktreeMoveNotice`'s dedupe now compares it too. A destination-only check would have silently dropped the failure write.

## Testing

- 174 targeted tests passing: `worktreeMoveInstruction`, `crossWorktreeMove`, `useTokenResolution`, `useWorktreeMoveBanner`, `WorktreeMoveBanner`, terminal serializer, panel field coverage, `layoutUndoStore`.
- `npm run typecheck` clean.
- `eslint` clean on all 14 changed files.

## Known limitation

`terminal.sendCommand` confirms that a submission was queued and that the PTY was live at submit time (`handleTerminalSubmit` probes liveness and throws `EBADF`/`EPIPE` for a missing or exited PTY), not that the agent actually consumed the text end to end. Closing that residual window needs a new acknowledged main-process IPC contract, which is out of scope here.
