### PR TITLE
fix(recipes): pin recipe-set pane titles so agent detection can't overwrite them

### DIFF
--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -265,6 +265,39 @@ describe("recipeStore", () => {
       expect(devEntry?.agentLaunchFlags).toBeUndefined();
     });
 
+    it("captures owned titles and drops derived ones so the clone can't pin them (#11872)", () => {
+      panelStoreState.panelIds = ["panel-derived", "panel-custom", "panel-user"];
+      panelStoreState.panelsById = {
+        // Detection wrote this one — it must stay free to promote in the clone.
+        "panel-derived": {
+          id: "panel-derived",
+          kind: "terminal",
+          title: "Claude",
+          worktreeId: "wt-1",
+          location: "grid",
+        },
+        "panel-custom": {
+          id: "panel-custom",
+          kind: "terminal",
+          title: "TEAMLEAD",
+          titleMode: "custom",
+          worktreeId: "wt-1",
+          location: "grid",
+        },
+        "panel-user": {
+          id: "panel-user",
+          kind: "terminal",
+          title: "DEV1",
+          titleMode: "user",
+          worktreeId: "wt-1",
+          location: "grid",
+        },
+      };
+
+      const terminals = useRecipeStore.getState().generateRecipeFromActiveTerminals("wt-1");
+      expect(terminals.map((t) => t.title)).toEqual([undefined, "TEAMLEAD", "DEV1"]);
+    });
+
     it("captures dock placement and omits location for grid-equivalent panels (#9764)", () => {
       panelStoreState.panelIds = ["panel-dock", "panel-grid", "panel-overlay"];
       panelStoreState.panelsById = {
@@ -272,6 +305,7 @@ describe("recipeStore", () => {
           id: "panel-dock",
           kind: "terminal",
           title: "Docked",
+          titleMode: "user",
           worktreeId: "wt-1",
           location: "dock",
           command: "npm test",
@@ -280,6 +314,7 @@ describe("recipeStore", () => {
           id: "panel-grid",
           kind: "terminal",
           title: "Grid",
+          titleMode: "user",
           worktreeId: "wt-1",
           location: "grid",
         },
@@ -287,6 +322,7 @@ describe("recipeStore", () => {
           id: "panel-overlay",
           kind: "terminal",
           title: "Overlay",
+          titleMode: "user",
           worktreeId: "wt-1",
           location: "overlay",
         },

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -149,6 +149,7 @@ const runHistoryAppendMock = vi.fn().mockResolvedValue(undefined);
 
 import { useRecipeStore } from "../recipeStore";
 import { usePanelLimitStore } from "../panelLimitStore";
+import type { RecipeTerminal } from "@shared/types/project";
 
 describe("recipeStore", () => {
   beforeEach(() => {
@@ -647,6 +648,119 @@ describe("recipeStore", () => {
         spawnedBy: "mcp",
       })
     );
+  });
+
+  describe("recipe title pinning (#11872)", () => {
+    // `clearAllMocks` keeps whatever implementation a prior test installed, so
+    // give every case its own resolved id rather than inheriting one.
+    beforeEach(() => {
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+    });
+
+    const runWithTerminals = async (terminals: RecipeTerminal[]) => {
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-titles",
+            name: "Fleet",
+            projectId: "project-1",
+            terminals,
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+      await useRecipeStore.getState().runRecipe("recipe-titles", "/tmp/worktree", "worktree-1");
+      return addTerminalMock.mock.calls.map((call) => call[0]);
+    };
+
+    it("pins a named agent pane so detection cannot rename it", async () => {
+      const spawned = await runWithTerminals([{ type: "claude", title: "TEAMLEAD", env: {} }]);
+
+      expect(spawned).toHaveLength(1);
+      expect(addTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "terminal",
+          launchAgentId: "claude",
+          title: "TEAMLEAD",
+          titleMode: "custom",
+        })
+      );
+    });
+
+    it("pins a named plain terminal, which can still be handed an agent later", async () => {
+      const spawned = await runWithTerminals([
+        { type: "terminal", title: "DEVOPS", command: "zsh", env: {} },
+      ]);
+
+      expect(spawned).toHaveLength(1);
+      expect(addTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "terminal",
+          title: "DEVOPS",
+          titleMode: "custom",
+        })
+      );
+    });
+
+    it("pins every pane of a fleet independently rather than from one shared title", async () => {
+      const spawned = await runWithTerminals([
+        { type: "claude", title: "ARCHITECT", env: {} },
+        { type: "claude", title: "", env: {} },
+        { type: "claude", title: "DEV1", env: {} },
+      ]);
+
+      expect(spawned).toHaveLength(3);
+      const named = spawned.filter((options) => options.title);
+      const unnamed = spawned.filter((options) => !options.title);
+      expect(named.map((options) => options.title).sort()).toEqual(["ARCHITECT", "DEV1"]);
+      for (const options of named) {
+        expect(options).toHaveProperty("titleMode", "custom");
+      }
+      // The untitled pane sits between two pinned ones: a hoisted pin would
+      // have leaked a neighbour's decision onto it.
+      expect(unnamed).toHaveLength(1);
+      expect(unnamed[0]).not.toHaveProperty("titleMode");
+    });
+
+    it("leaves a blank title unpinned so the derived title still applies", async () => {
+      // Omitted, empty, whitespace-only, and control-only all mean "no name".
+      // The key must be absent, not `undefined`: `addPanel` reads a present
+      // key as an explicit "default", which is a different contract.
+      const spawned = await runWithTerminals([
+        { type: "terminal", command: "a", env: {} },
+        { type: "terminal", title: "", command: "b", env: {} },
+        { type: "terminal", title: "   ", command: "c", env: {} },
+        { type: "terminal", title: "", command: "d", env: {} },
+      ]);
+
+      expect(spawned).toHaveLength(4);
+      for (const options of spawned) {
+        expect(options).not.toHaveProperty("titleMode");
+      }
+    });
+
+    it("passes the recipe title through verbatim, sanitizing only to decide the pin", async () => {
+      // Padding is preserved so the pane matches what the recipe editor shows;
+      // sanitizing is a predicate here, not a rewrite.
+      const spawned = await runWithTerminals([
+        { type: "terminal", title: "  DEV1  ", command: "a", env: {} },
+      ]);
+
+      expect(spawned[0]).toMatchObject({ title: "  DEV1  ", titleMode: "custom" });
+    });
+
+    it("does not pin the dev-preview pane, which has no agent detection to fend off", async () => {
+      const spawned = await runWithTerminals([
+        { type: "dev-preview", title: "Web", devCommand: "npm run dev", env: {} },
+      ]);
+
+      expect(spawned).toHaveLength(1);
+      expect(spawned[0]).toMatchObject({ kind: "dev-preview", title: "Web" });
+      expect(spawned[0]).not.toHaveProperty("titleMode");
+    });
   });
 
   describe("runRecipeWithResults", () => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -165,6 +165,10 @@ describe("recipeStore", () => {
     // hoisted default so each test starts from an empty agent-settings shape
     // instead of inheriting a prior test's mockResolvedValue.
     getAgentSettingsMock.mockResolvedValue({ agents: {} });
+    // Same reason: without this, a test that never sets up addPanel inherits
+    // whichever spawn ids the previous test installed, so it passes in the
+    // suite and fails in isolation.
+    addTerminalMock.mockReset().mockResolvedValue(undefined);
     pluginRecordUseMock.mockResolvedValue(undefined);
     pluginUpdateMetadataMock.mockImplementation(async (id: string) => ({
       id,
@@ -651,14 +655,12 @@ describe("recipeStore", () => {
   });
 
   describe("recipe title pinning (#11872)", () => {
-    // `clearAllMocks` keeps whatever implementation a prior test installed, so
-    // give every case its own resolved id rather than inheriting one.
     beforeEach(() => {
       let callIndex = 0;
       addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
     });
 
-    const runWithTerminals = async (terminals: RecipeTerminal[]) => {
+    const runWithTerminals = async (terminals: RecipeTerminal[], terminalIndices?: number[]) => {
       useRecipeStore.setState({
         recipes: [
           {
@@ -672,9 +674,22 @@ describe("recipeStore", () => {
         isLoading: false,
         currentProjectId: "project-1",
       });
-      await useRecipeStore.getState().runRecipe("recipe-titles", "/tmp/worktree", "worktree-1");
+      await useRecipeStore
+        .getState()
+        .runRecipe(
+          "recipe-titles",
+          "/tmp/worktree",
+          "worktree-1",
+          undefined,
+          terminalIndices ? { terminalIndices } : undefined
+        );
       return addTerminalMock.mock.calls.map((call) => call[0]);
     };
+
+    const spawnedTitled = (
+      spawned: { title?: string }[],
+      title: string
+    ): { titleMode?: string } | undefined => spawned.find((options) => options.title === title);
 
     it("pins a named agent pane so detection cannot rename it", async () => {
       const spawned = await runWithTerminals([{ type: "claude", title: "TEAMLEAD", env: {} }]);
@@ -705,61 +720,101 @@ describe("recipeStore", () => {
       );
     });
 
-    it("pins every pane of a fleet independently rather than from one shared title", async () => {
+    it("pins by title content, not by agent type or pane shape", async () => {
+      // Every pane kind the spawn loop reaches, mixed in one run. Titles are
+      // the assertion key rather than call order: the agent branch awaits CLI
+      // resolution, so it can finish after a plain terminal queued later.
+      const spawned = await runWithTerminals([
+        { type: "codex", title: "ARCHITECT", env: {} },
+        { type: "terminal", title: "runner", command: "zsh", env: {} },
+        { type: "claude", title: "DEV1", env: {} },
+        { type: "terminal", title: "0", command: "zsh", env: {} },
+        { type: "dev-preview", title: "Web", devCommand: "npm run dev", env: {} },
+      ]);
+
+      expect(spawned).toHaveLength(5);
+      // A non-Claude agent, a lowercase name, and "0" all pin. Keying off the
+      // agent id, off casing, or off a length floor would still satisfy the
+      // role-name cases above, so those are the mutants these catch.
+      for (const title of ["ARCHITECT", "runner", "DEV1", "0"]) {
+        expect(spawnedTitled(spawned, title)?.titleMode).toBe("custom");
+      }
+      // A dev preview has no PTY and so no detection to fend off; pinning one
+      // would be inert, and reaching it at all means the branch order moved.
+      expect(spawnedTitled(spawned, "Web")).toMatchObject({ kind: "dev-preview" });
+      expect(spawnedTitled(spawned, "Web")?.titleMode).toBeUndefined();
+    });
+
+    it("decides each pane's pin from its own title", async () => {
       const spawned = await runWithTerminals([
         { type: "claude", title: "ARCHITECT", env: {} },
         { type: "claude", title: "", env: {} },
-        { type: "claude", title: "DEV1", env: {} },
+        { type: "terminal", title: "", command: "zsh", env: {} },
+        { type: "terminal", title: "DEV1", command: "zsh", env: {} },
       ]);
 
-      expect(spawned).toHaveLength(3);
+      expect(spawned).toHaveLength(4);
       const named = spawned.filter((options) => options.title);
       const unnamed = spawned.filter((options) => !options.title);
       expect(named.map((options) => options.title).sort()).toEqual(["ARCHITECT", "DEV1"]);
       for (const options of named) {
-        expect(options).toHaveProperty("titleMode", "custom");
+        expect(options.titleMode).toBe("custom");
       }
-      // The untitled pane sits between two pinned ones: a hoisted pin would
-      // have leaked a neighbour's decision onto it.
-      expect(unnamed).toHaveLength(1);
-      expect(unnamed[0]).not.toHaveProperty("titleMode");
+      // Unnamed panes are interleaved with named ones in both branches, so a
+      // pin hoisted above the loop or cached per branch would leak onto them.
+      expect(unnamed).toHaveLength(2);
+      for (const options of unnamed) {
+        expect(options.titleMode).toBeUndefined();
+      }
+    });
+
+    it("pins a retried terminal from its own index, not its place in the retry", async () => {
+      // `terminalIndices` carries original recipe indices; reading the title
+      // off the filtered spawn list would pin from the wrong pane.
+      const spawned = await runWithTerminals(
+        [
+          { type: "terminal", title: "SKIPPED", command: "a", env: {} },
+          { type: "terminal", title: "", command: "b", env: {} },
+          { type: "terminal", title: "DEV5", command: "c", env: {} },
+        ],
+        [2]
+      );
+
+      expect(spawned).toHaveLength(1);
+      expect(spawned[0]).toMatchObject({ title: "DEV5", titleMode: "custom" });
     });
 
     it("leaves a blank title unpinned so the derived title still applies", async () => {
-      // Omitted, empty, whitespace-only, and control-only all mean "no name".
-      // The key must be absent, not `undefined`: `addPanel` reads a present
-      // key as an explicit "default", which is a different contract.
+      // Omitted, empty, whitespace-only, and control-only all mean "no name":
+      // the pane keeps today's behaviour of taking a derived title and letting
+      // detection update it.
       const spawned = await runWithTerminals([
         { type: "terminal", command: "a", env: {} },
         { type: "terminal", title: "", command: "b", env: {} },
         { type: "terminal", title: "   ", command: "c", env: {} },
-        { type: "terminal", title: "", command: "d", env: {} },
+        // The recipe sanitizer keeps titles verbatim (unlike command/args), so
+        // control-only text arrives truthy; plain truthiness would pin it.
+        { type: "terminal", title: "\u0001\u007f", command: "d", env: {} },
       ]);
 
       expect(spawned).toHaveLength(4);
       for (const options of spawned) {
-        expect(options).not.toHaveProperty("titleMode");
+        expect(options.titleMode).toBeUndefined();
       }
     });
 
     it("passes the recipe title through verbatim, sanitizing only to decide the pin", async () => {
-      // Padding is preserved so the pane matches what the recipe editor shows;
-      // sanitizing is a predicate here, not a rewrite.
+      // The pane has to show what the recipe editor shows, so padding and
+      // embedded controls survive into `title`; sanitizing is the predicate
+      // here, not a rewrite of the string being handed over.
       const spawned = await runWithTerminals([
         { type: "terminal", title: "  DEV1  ", command: "a", env: {} },
+        { type: "terminal", title: "DEV\u00012", command: "b", env: {} },
       ]);
 
-      expect(spawned[0]).toMatchObject({ title: "  DEV1  ", titleMode: "custom" });
-    });
-
-    it("does not pin the dev-preview pane, which has no agent detection to fend off", async () => {
-      const spawned = await runWithTerminals([
-        { type: "dev-preview", title: "Web", devCommand: "npm run dev", env: {} },
-      ]);
-
-      expect(spawned).toHaveLength(1);
-      expect(spawned[0]).toMatchObject({ kind: "dev-preview", title: "Web" });
-      expect(spawned[0]).not.toHaveProperty("titleMode");
+      expect(spawned).toHaveLength(2);
+      expect(spawnedTitled(spawned, "  DEV1  ")?.titleMode).toBe("custom");
+      expect(spawnedTitled(spawned, "DEV\u00012")?.titleMode).toBe("custom");
     });
   });
 

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -769,12 +769,13 @@ describe("recipeStore", () => {
     });
 
     it("pins a retried terminal from its own index, not its place in the retry", async () => {
-      // `terminalIndices` carries original recipe indices; reading the title
-      // off the filtered spawn list would pin from the wrong pane.
+      // `terminalIndices` carries original recipe indices, and the retry list
+      // holds one entry at offset 0. Index 0 is blank so an offset read leaves
+      // the retried pane unpinned rather than coincidentally pinning it.
       const spawned = await runWithTerminals(
         [
-          { type: "terminal", title: "SKIPPED", command: "a", env: {} },
-          { type: "terminal", title: "", command: "b", env: {} },
+          { type: "terminal", title: "", command: "a", env: {} },
+          { type: "terminal", title: "SKIPPED", command: "b", env: {} },
           { type: "terminal", title: "DEV5", command: "c", env: {} },
         ],
         [2]
@@ -782,6 +783,23 @@ describe("recipeStore", () => {
 
       expect(spawned).toHaveLength(1);
       expect(spawned[0]).toMatchObject({ title: "DEV5", titleMode: "custom" });
+    });
+
+    it("leaves a retried blank terminal unpinned even when index 0 is named", async () => {
+      // The same mix-up in the other direction: an offset read would pin this
+      // pane from "TEAMLEAD" and freeze a name the recipe never gave it.
+      const spawned = await runWithTerminals(
+        [
+          { type: "terminal", title: "TEAMLEAD", command: "a", env: {} },
+          { type: "terminal", title: "SKIPPED", command: "b", env: {} },
+          { type: "terminal", title: "", command: "c", env: {} },
+        ],
+        [2]
+      );
+
+      expect(spawned).toHaveLength(1);
+      expect(spawned[0]).toMatchObject({ title: "" });
+      expect(spawned[0].titleMode).toBeUndefined();
     });
 
     it("leaves a blank title unpinned so the derived title still applies", async () => {
@@ -3266,12 +3284,15 @@ describe("recipeStore", () => {
 
     it("a failed frecency write does not fail the spawn", async () => {
       useRecipeStore.getState().setPluginRecipes([pluginRecipe()]);
+      addTerminalMock.mockResolvedValue("terminal-1");
       pluginRecordUseMock.mockRejectedValueOnce(new Error("disk full"));
-      await expect(
-        useRecipeStore
-          .getState()
-          .runRecipeWithResults("acme.tools.deploy", "/tmp/wt", "wt-1", undefined)
-      ).resolves.toBeDefined();
+      // Resolving is not the claim: the spawn has to have actually landed, or
+      // this passes just as well when nothing spawned at all.
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("acme.tools.deploy", "/tmp/wt", "wt-1", undefined);
+      expect(results.spawned).toHaveLength(1);
+      expect(results.failed).toHaveLength(0);
     });
 
     it("routes an empty-state pin to the plugin sidecar, not the global store", async () => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -655,6 +655,12 @@ describe("recipeStore", () => {
   });
 
   describe("recipe title pinning (#11872)", () => {
+    interface SpawnedOptions {
+      kind?: string;
+      title?: string;
+      titleMode?: string;
+    }
+
     beforeEach(() => {
       let callIndex = 0;
       addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
@@ -686,10 +692,8 @@ describe("recipeStore", () => {
       return addTerminalMock.mock.calls.map((call) => call[0]);
     };
 
-    const spawnedTitled = (
-      spawned: { title?: string }[],
-      title: string
-    ): { titleMode?: string } | undefined => spawned.find((options) => options.title === title);
+    const spawnedTitled = (spawned: SpawnedOptions[], title: string): SpawnedOptions | undefined =>
+      spawned.find((options) => options.title === title);
 
     it("pins a named agent pane so detection cannot rename it", async () => {
       const spawned = await runWithTerminals([{ type: "claude", title: "TEAMLEAD", env: {} }]);

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -34,6 +34,7 @@ import {
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
+import { sanitizeTerminalName } from "@/utils/agentLaunchValidation";
 import { sanitizeRecipeTerminals, MAX_TERMINALS_PER_RECIPE } from "@shared/utils/recipeSanitizer";
 import type { ActionSource } from "@shared/types/actions";
 import type { AgentCliDetail } from "@shared/types/ipc";
@@ -1029,6 +1030,27 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             });
           }
 
+          // A recipe that names its panes owns those names: pin them as
+          // "custom" so agent detection can't rewrite them on promotion or
+          // demote them on exit. Recipes are how a fleet gets launched and
+          // role titles (TEAMLEAD, DEV1...) are how its panes are told apart,
+          // so losing them defeats the point of naming (#11872). Mirrors the
+          // caller-name pin `agent.launch` has had since #10439.
+          //
+          // Sanitizing drives the predicate only — `title:` still passes the
+          // raw string so the pane matches what the recipe editor shows. The
+          // recipe sanitizer keeps titles verbatim (unlike command/args), so
+          // a whitespace- or control-only title would pass plain truthiness;
+          // `sanitizeTerminalName` returns "" for those, leaving them
+          // unpinned and eligible for the derived title as before. Derived
+          // per terminal, never hoisted above the map: one pane's title must
+          // not decide another's pin (#10794). Conditional spread, never
+          // `titleMode: undefined`, which `addPanel` reads as an explicit
+          // "default".
+          const titlePin = sanitizeTerminalName(terminal.title ?? "")
+            ? { titleMode: "custom" as const }
+            : {};
+
           if (isAgentRecipeType(terminal.type)) {
             const agentId = terminal.type as string;
             const agentConfig = getAgentConfig(agentId);
@@ -1133,6 +1155,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
               launchAgentId: agentId,
               command,
               title: terminal.title,
+              ...titlePin,
               cwd: worktreePath,
               worktreeId: worktreeId,
               agentLaunchFlags,
@@ -1151,6 +1174,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           return terminalStore.addPanel({
             kind: "terminal",
             title: terminal.title,
+            ...titlePin,
             cwd: worktreePath,
             command: terminal.command?.trim() || "",
             worktreeId: worktreeId,

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -162,7 +162,10 @@ function terminalToRecipeTerminal(terminal: PtyPanelData | DevPreviewPanelData):
 
   return {
     type,
-    title: terminal.title || undefined,
+    // Derived titles are runtime identity, not a name the author chose — capturing
+    // one would pin it on spawn and freeze the pane out of promotion (#11872).
+    title:
+      (terminal.titleMode ?? "default") === "default" ? undefined : terminal.title || undefined,
     command: terminal.command || undefined,
     devCommand: undefined,
     env: {},
@@ -1045,14 +1048,6 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           // unpinned and eligible for the derived title as before. Derived
           // per terminal, never hoisted above the map: one pane's title must
           // not decide another's pin (#10794).
-          //
-          // Only a title the recipe author wrote should pin. A recipe built by
-          // `generateRecipeFromActiveTerminals` captures whatever title a pane
-          // happened to carry, derived ones included, and `RecipeTerminal` has
-          // no field marking which is which — so a captured "Terminal" pins
-          // here and can no longer promote to "Claude". That is the capture-
-          // time provenance gap #11872 leaves open, not something the spawn
-          // site can tell apart.
           const titlePin = sanitizeTerminalName(terminal.title ?? "")
             ? { titleMode: "custom" as const }
             : {};

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -1044,9 +1044,15 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           // `sanitizeTerminalName` returns "" for those, leaving them
           // unpinned and eligible for the derived title as before. Derived
           // per terminal, never hoisted above the map: one pane's title must
-          // not decide another's pin (#10794). Conditional spread, never
-          // `titleMode: undefined`, which `addPanel` reads as an explicit
-          // "default".
+          // not decide another's pin (#10794).
+          //
+          // Only a title the recipe author wrote should pin. A recipe built by
+          // `generateRecipeFromActiveTerminals` captures whatever title a pane
+          // happened to carry, derived ones included, and `RecipeTerminal` has
+          // no field marking which is which — so a captured "Terminal" pins
+          // here and can no longer promote to "Claude". That is the capture-
+          // time provenance gap #11872 leaves open, not something the spawn
+          // site can tell apart.
           const titlePin = sanitizeTerminalName(terminal.title ?? "")
             ? { titleMode: "custom" as const }
             : {};

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -1040,7 +1040,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           // Sanitizing drives the predicate only — `title:` still passes the
           // raw string so the pane matches what the recipe editor shows. The
           // recipe sanitizer keeps titles verbatim (unlike command/args), so
-          // a whitespace- or control-only title would pass plain truthiness;
+          // a whitespace- or C0/DEL-only title would pass plain truthiness;
           // `sanitizeTerminalName` returns "" for those, leaving them
           // unpinned and eligible for the derived title as before. Derived
           // per terminal, never hoisted above the map: one pane's title must


### PR DESCRIPTION
Recipes name their panes and then lose the names. `addPanel` was called with `title: terminal.title` and no `titleMode`, so every recipe pane launched in `default` mode — the one mode the identity reducer treats as safe to overwrite — and agent detection renamed it a few seconds later. Launch a ten-pane fleet with role names and you get nine identical `Claude` panes, which is the exact thing naming them was for.

`agent.launch` has pinned its caller-supplied name since #10439. This does the same for recipes.

## What changed

`src/store/recipeStore.ts`, inside the per-terminal spawn map:

```ts
const titlePin = sanitizeTerminalName(terminal.title ?? "")
  ? { titleMode: "custom" as const }
  : {};
```

spread next to `title:` in both PTY `addPanel` calls (agent terminals and plain terminals). That's the whole production change — `addPanel` already threads `titleMode` onto the panel record and into the spawn IPC off the live panel (#11830), so the pty-host's own gates in `TerminalAgentDetection`/`TerminalExitHandler` get the pin for free. No reducer, schema, or IPC changes.

Three details worth stating:

- **The pin is derived per terminal, never hoisted above the map.** #10794 was exactly this bug: a pin computed once and applied where it didn't belong.
- **`sanitizeTerminalName` decides the pin; `title:` still passes the raw string.** `recipeSanitizer` keeps titles verbatim (unlike `command`/`args`), so a whitespace- or control-only title arrives truthy and plain truthiness would pin garbage. Sanitizing the *passed* title instead would desync the pane from what the recipe editor shows, which is beyond what this needs to do.
- **Conditional spread, never `titleMode: undefined`.** Same idiom as `useAgentLauncher`.

`custom` rather than `user` is deliberate: it stops detection and exit demotion from rewriting the base title, but still allows task composition, so a pane reads `DEV1: fix the parser` rather than being frozen at `DEV1`.

## Deliberately not in scope

Two things this leaves alone, both flagged on the issue:

- **`spawnPanelsFromRecipe`** (clone-layout) has the same omission. Its titles come from `terminalToRecipeTerminal`, which copies `terminal.title` with no regard for the source pane's mode, so pinning there would freeze whatever detection last wrote and stop panes demoting on exit. That needs a provenance rule at capture time, not a pin at spawn time.
- **`statePatcher.ts:699`** drops a `custom` mode when a panel's preset has gone stale, exempting only `user`. Recipe spawns attach `agentPresetId`, so a cold restore after a preset is deleted still loses the name. Pre-existing and not recipe-specific.

## One thing to look at before merging

The same capture-provenance gap has a second mouth I hadn't traced when I scoped this. A recipe built by `generateRecipeFromActiveTerminals` records derived titles — `Terminal`, `Claude` — with nothing marking them as derived. Run that recipe now and those titles pin. A plain pane captured as `Terminal` can no longer promote to `Claude` when you start an agent in it.

Before this change that title stayed default-owned and promotion worked, so it's a real narrowing, not just a pre-existing wart. I left it because the fix is the same capture-time provenance rule the clone-layout path needs, and doing it properly means deciding whether `terminalToRecipeTerminal` should skip titles whose source panel is in `default` mode — a change to the capture path, which is its own piece of work. Happy to fold it in here instead if you'd rather.

A related boundary: a title made only of characters `sanitizeTerminalName` doesn't strip (U+200B, U+2060, U+202E, U+0085) sanitizes non-empty and therefore pins, leaving a visually blank title detection can never recover. `agent.launch` behaves identically today — same helper, same predicate — so I kept them in sync rather than narrowing one surface.

## Verification

- `recipeStore`, `addPanelTitleMode`, `identityReducer` — 153 tests
- RecipeRunner, recipe actions, plugin recipes, RecipesTab — 93 tests
- dock launch, NewWorktreeDialog, worktreeStore, useWorktreeActions — 249 tests
- `npm run typecheck` clean; eslint/prettier clean on both files, warning count unchanged from baseline

Seven new cases in `recipeStore.test.ts`. Negative control: stripping the two spreads fails exactly the pin-asserting tests and leaves the absence-asserting ones green. The cases also cover a non-Claude agent, a lowercase name, `"0"`, a `terminalIndices` retry in both index directions, and a mixed agent/plain/dev-preview run, so a pin keyed off the agent id, off casing, off a length floor, cached per branch, or read at the wrong index doesn't survive.

One drive-by in the test file: the outer `beforeEach` cleared call counts but never reset `addTerminalMock`'s implementation, so it leaked between tests. Resetting it exposed a frecency test that passed with zero panes spawned; that now asserts the spawn actually landed.

Resolves #11872