### PR TITLE
fix(dock): fix dock reordering for non-PTY panes and stale chip order

### DIFF
--- a/e2e/full/panels/core-drag-drop.spec.ts
+++ b/e2e/full/panels/core-drag-drop.spec.ts
@@ -5,6 +5,7 @@ import { openAndOnboardProject } from "../../helpers/project";
 import {
   getGridPanelIds,
   getDockPanelIds,
+  getDockChipIds,
   getGridPanelCount,
   getDockPanelCount,
   getPanelById,
@@ -162,6 +163,10 @@ test.describe.serial("Core: Panel Drag & Drop", () => {
     await test.step("Keyboard-drag the first chip and verify the dock order changes", async () => {
       const dockIdsBefore = await getDockPanelIds(window);
       expect(dockIdsBefore).toHaveLength(2);
+      const chipIdsBefore = await getDockChipIds(window);
+      // The rail paints the same order as the offscreen containers to begin
+      // with — the bug only shows up after a reorder (#11873).
+      expect(chipIdsBefore).toEqual(dockIdsBefore);
 
       const chips = window.locator(`${SEL.dock.rail} ${SEL.dock.chip}`);
       await expect.poll(() => chips.count(), { timeout: T_MEDIUM }).toBeGreaterThanOrEqual(2);
@@ -180,6 +185,12 @@ test.describe.serial("Core: Panel Drag & Drop", () => {
       // Same panels, different order — the chip moved past its neighbour.
       expect([...dockIdsAfter].sort()).toEqual([...dockIdsBefore].sort());
       expect(dockIdsAfter[0]).not.toBe(dockIdsBefore[0]);
+
+      // The rail must repaint, not just the store. Reordering writes only
+      // `panelIds`, which the offscreen containers above mirror directly — they
+      // stayed green while every chip snapped back to its pre-drag slot
+      // (#11873), so the visible order is the assertion that matters.
+      await expect.poll(() => getDockChipIds(window), { timeout: T_MEDIUM }).toEqual(dockIdsAfter);
     });
   });
 

--- a/e2e/full/panels/core-drag-drop.spec.ts
+++ b/e2e/full/panels/core-drag-drop.spec.ts
@@ -163,13 +163,16 @@ test.describe.serial("Core: Panel Drag & Drop", () => {
     await test.step("Keyboard-drag the first chip and verify the dock order changes", async () => {
       const dockIdsBefore = await getDockPanelIds(window);
       expect(dockIdsBefore).toHaveLength(2);
-      const chipIdsBefore = await getDockChipIds(window);
-      // The rail paints the same order as the offscreen containers to begin
-      // with — the bug only shows up after a reorder (#11873).
-      expect(chipIdsBefore).toEqual(dockIdsBefore);
 
       const chips = window.locator(`${SEL.dock.rail} ${SEL.dock.chip}`);
       await expect.poll(() => chips.count(), { timeout: T_MEDIUM }).toBeGreaterThanOrEqual(2);
+
+      // Both panels were docked individually, so no tab group formed and each
+      // one owns a chip. Poll rather than read once — the rail can be a render
+      // behind the offscreen containers the setup above waited on. This also
+      // pins the ungrouped precondition the final assertion depends on: a
+      // multi-panel group would collapse N panels into one chip.
+      await expect.poll(() => getDockChipIds(window), { timeout: T_MEDIUM }).toEqual(dockIdsBefore);
 
       let dockIdsAfter = dockIdsBefore;
       // Try moving right, then fall back to left, mirroring the grid-reorder

--- a/e2e/helpers/panels.ts
+++ b/e2e/helpers/panels.ts
@@ -563,6 +563,21 @@ export async function getDockPanelIds(page: Page): Promise<string[]> {
     .evaluateAll((els) => els.map((el) => el.getAttribute("data-panel-id") ?? "").filter(Boolean));
 }
 
+/**
+ * Ids of the chips as painted in the dock rail, left to right.
+ *
+ * `getDockPanelIds` reads the offscreen panel containers, which mirror
+ * `panelIds` directly — they reordered correctly while the visible rail kept
+ * painting the pre-drag order, so they cannot catch #11873. Assert both.
+ */
+export async function getDockChipIds(page: Page): Promise<string[]> {
+  return page
+    .locator(`${SEL.dock.rail} ${SEL.dock.chipId}`)
+    .evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-dock-item-id") ?? "").filter(Boolean)
+    );
+}
+
 export function getPanelById(page: Page, id: string): Locator {
   return page.locator(`[data-panel-id="${id}"]`);
 }

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -144,6 +144,8 @@ export const SEL = {
     container: "#dock-container",
     rail: '[role="toolbar"][aria-label="Docked panels"]',
     chip: "[data-dock-item]",
+    /** Sortable wrapper around each chip — carries the panel id the rail sorts on. */
+    chipId: "[data-dock-item-id]",
     chipByTitle: (title: string) => `[data-dock-item][aria-label^="${title}"]`,
     tablist: '[role="tablist"][aria-label="Dock panel tabs"]',
     tabByPanelId: (id: string) => `[data-tab-id="${id}"]`,

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -129,7 +129,21 @@ export function SortableDockItem({
       {...remainingAttributes}
       aria-roledescription="sortable item"
     >
-      <div ref={setNodeRef} style={style} role="listitem" className={cn("relative flex-shrink-0")}>
+      {/*
+        `data-dock-item-id` carries the sortable id — the same id dnd-kit sorts
+        on — so the rendered rail order is readable from the DOM. The offscreen
+        panel containers already expose `data-panel-id`, but those mirror
+        `panelIds` directly and stayed correct while the rail painted a stale
+        order, which is how #11873 went unnoticed. A distinct attribute name
+        keeps `[data-panel-id="…"]` locators matching exactly one element.
+      */}
+      <div
+        ref={setNodeRef}
+        style={style}
+        role="listitem"
+        data-dock-item-id={terminal.id}
+        className={cn("relative flex-shrink-0")}
+      >
         {dropDirection !== null && (
           <div
             aria-hidden="true"

--- a/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
@@ -68,6 +68,21 @@ describe("SortableDockItem", () => {
     expect(getByTestId("child")).toBeTruthy();
   });
 
+  it("tags the listitem with the panel id it sorts on", () => {
+    // The rail's rendered order is only observable through this attribute. The
+    // offscreen `[data-panel-id]` containers mirror `panelIds` directly, so they
+    // stayed correct while the rail painted a stale order — which is how #11873
+    // went unnoticed by the dock-reorder E2E.
+    mockState = { isDragging: false };
+    const { container } = render(
+      <SortableDockItem terminal={terminal} sourceIndex={0}>
+        <div />
+      </SortableDockItem>
+    );
+    const item = container.querySelector('[role="listitem"]');
+    expect(item?.getAttribute("data-dock-item-id")).toBe(terminal.id);
+  });
+
   it("does not render role=button on the outer m.div (stripped from dnd-kit attributes)", () => {
     mockState = { isDragging: false };
     const { container } = render(

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -19,7 +19,10 @@ import {
 } from "@shared/types/panel";
 import { extractHostPort } from "@/components/Browser/browserUtils";
 import { getRenderablePanel } from "@/store/slices/panelRegistry/selectors";
-import { panelMatchesWorktreeScope } from "@/store/slices/panelRegistry/worktreeIndex";
+import {
+  collectUngroupedCandidateIds,
+  panelMatchesWorktreeScope,
+} from "@/store/slices/panelRegistry/worktreeIndex";
 import type { TrashedTerminal } from "@/store/slices";
 import { DockedTerminalItem } from "./DockedTerminalItem";
 import { DockedNonPtyPanelItem } from "./DockedNonPtyPanelItem";
@@ -79,7 +82,6 @@ export type { DockDensity } from "@/store/preferencesStore";
 
 // Stable empty refs so the narrowed dock subscriptions below can bail under
 // `useShallow` when the dock is empty instead of yielding a fresh `[]`.
-const EMPTY_DOCK_SIGNATURE: readonly string[] = [];
 const EMPTY_DOCK_TERMINALS: readonly DockPanelData[] = [];
 
 interface ContentDockProps {
@@ -133,14 +135,12 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
   const trashedTerminals = usePanelStore((state) => state.trashedTerminals);
   const storeTabGroups = usePanelStore((state) => state.tabGroups);
-  const getTabGroups = usePanelStore((state) => state.getTabGroups);
-  const getTabGroupPanels = usePanelStore((state) => state.getTabGroupPanels);
   const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
   const setDockDensity = usePreferencesStore((s) => s.setDockDensity);
 
-  // Narrow dock subscriptions (#10908). Subscribing to the whole `panelsById`
+  // Narrow dock subscription (#10908). Subscribing to the whole `panelsById`
   // re-rendered the dock on every panel's rAF status-buffer flush — including
-  // grid agents that never appear here. Both selectors below react only to dock
+  // grid agents that never appear here. This selector reacts only to dock
   // panels. Membership is `isDockPanel` — every registered kind that hasn't
   // opted out with `dockable: false`, PTY and non-PTY alike, including plugin
   // kinds (#11332). Panels are read through `getRenderablePanel` (not
@@ -149,38 +149,27 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   // #10512 grid render-eligibility predicate, which deliberately does not
   // apply to the dock.
   //
-  // `dockPanelSignature` is a structural `${id}:${worktreeId}` list that stays
-  // referentially stable across status-buffer flushes, so the (activity-agnostic)
-  // `tabGroups` derivation recomputes only on real dock membership/scope changes.
-  // It iterates `panelsById` (not `panelIds`) so a batched dock panel — committed
-  // to `panelsById` before `panelIds` is revealed at flush — still invalidates
-  // `tabGroups`, matching the old whole-map subscription's recompute and letting
-  // `getTabGroups` surface the index-only panel (#9649).
-  const dockPanelSignature = usePanelStore(
-    useShallow((state) => {
-      const result: string[] = [];
-      for (const id of Object.keys(state.panelsById)) {
-        const terminal = getRenderablePanel(state.panelsById, id);
-        if (
-          terminal &&
-          isDockPanel(terminal) &&
-          terminal.location === "dock" &&
-          !state.trashedTerminals.has(terminal.id)
-        ) {
-          result.push(`${terminal.id}:${terminal.worktreeId ?? ""}`);
-        }
-      }
-      return result.length === 0 ? EMPTY_DOCK_SIGNATURE : result;
-    })
-  );
-
-  // Live dock panel objects. The dock renders live activity/agent state from
-  // these, so unlike the grid this stays object-valued — but `useShallow` only
-  // fires when a *dock* panel's reference changes, not on grid-agent churn.
+  // The list is object-valued (the dock renders live activity/agent state from
+  // it) and ordered, and it is the sole authority for chip order — so a pure
+  // `reorderTerminals`, which rewrites only `panelIds`/`panelIdsByWorktreeId`,
+  // repaints the rail. Order used to come from the `getTabGroups` action behind
+  // a `useMemo` whose deps were read for invalidation only; React Compiler
+  // drops deps a callback never consumes, so that memo held the pre-drag order
+  // and every dock reorder snapped back (#11873). Everything downstream now
+  // consumes its inputs for real, so the compiler keeps them in the cache key.
+  //
+  // Candidate ids come from `collectUngroupedCandidateIds`, the same helper
+  // `getTabGroups` uses, so a panel committed mid-spawn-batch — eagerly in the
+  // worktree index while `panelIds` only appends at flush — still paints on
+  // first mount (#9649).
   const dockTerminalsRaw = usePanelStore(
     useShallow((state) => {
       const result: DockPanelData[] = [];
-      for (const id of state.panelIds) {
+      for (const id of collectUngroupedCandidateIds(
+        state.panelIds,
+        state.panelIdsByWorktreeId,
+        undefined
+      )) {
         const terminal = getRenderablePanel(state.panelsById, id);
         if (
           terminal &&
@@ -194,23 +183,6 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
       return result.length === 0 ? EMPTY_DOCK_TERMINALS : result;
     })
   );
-
-  // Get tab groups for the dock, excluding the help panel terminal
-  const tabGroups = useMemo(() => {
-    void dockPanelSignature;
-    void storeTabGroups;
-    void trashedTerminals;
-    const groups = getTabGroups("dock", activeWorktreeId ?? undefined);
-    if (!helpTerminalId) return groups;
-    return groups.filter((g) => !(g.panelIds.length === 1 && g.panelIds[0] === helpTerminalId));
-  }, [
-    getTabGroups,
-    activeWorktreeId,
-    dockPanelSignature,
-    storeTabGroups,
-    trashedTerminals,
-    helpTerminalId,
-  ]);
 
   const dockTerminals = useMemo<DockPanelData[]>(() => {
     // `dockTerminalsRaw` already narrows to dock/dockable/non-trashed panels;
@@ -439,14 +411,11 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
         item.terminal !== undefined
     );
 
+  // Every input is genuinely consumed, so React Compiler keeps all three in the
+  // cache key — the reason chip order now tracks `panelIds` (#11873).
   const dockItems = useMemo<DockRenderItem[]>(() => {
-    return buildDockRenderItems(
-      tabGroups,
-      (groupId) => getTabGroupPanels(groupId, "dock").filter(isPtyPanel),
-      helpTerminalId,
-      dockTerminals
-    );
-  }, [tabGroups, getTabGroupPanels, helpTerminalId, dockTerminals]);
+    return buildDockRenderItems(dockTerminals, storeTabGroups, activeWorktreeId);
+  }, [dockTerminals, storeTabGroups, activeWorktreeId]);
 
   // Tab group IDs for SortableContext
   const panelIds = useMemo(() => {
@@ -560,8 +529,8 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                       }
 
                       // Multi-panel group: pass group context for group-aware DnD.
-                      // Groups resolve through the isPtyPanel filter above, so
-                      // the runtime narrow below never drops a panel.
+                      // `buildDockRenderItems` resolves group members PTY-only,
+                      // so the runtime narrow below never drops a panel.
                       const firstPanel = panels[0]!;
                       return (
                         <SortableDockItem

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -161,14 +161,19 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   // Candidate ids come from `collectUngroupedCandidateIds`, the same helper
   // `getTabGroups` uses, so a panel committed mid-spawn-batch — eagerly in the
   // worktree index while `panelIds` only appends at flush — still paints on
-  // first mount (#9649).
+  // first mount (#9649). Pass the active worktree, not `undefined`: the scoped
+  // call orders pending ids active-bucket-then-global, while the unscoped one
+  // follows `panelIdsByWorktreeId`'s insertion order. Only the pending tail
+  // differs, and only while a batch is open, but the downstream worktree filter
+  // can't restore the order — so scope it here and stay identical to
+  // `getTabGroups`. Committed `panelIds` order is unaffected either way.
   const dockTerminalsRaw = usePanelStore(
     useShallow((state) => {
       const result: DockPanelData[] = [];
       for (const id of collectUngroupedCandidateIds(
         state.panelIds,
         state.panelIdsByWorktreeId,
-        undefined
+        activeWorktreeId ?? undefined
       )) {
         const terminal = getRenderablePanel(state.panelsById, id);
         if (

--- a/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
@@ -45,10 +45,12 @@ const fixture = vi.hoisted(() => {
     panelState: {
       panelsById: Object.fromEntries(dockPanels.map((panel) => [panel.id, panel])),
       panelIds: dockPanels.map((panel) => panel.id),
+      // The rail reads the worktree index alongside `panelIds` so a panel
+      // committed mid-spawn-batch still paints (#9649). These fixtures are all
+      // worktree-less, so they live in the `__none__` bucket.
+      panelIdsByWorktreeId: { __none__: dockPanels.map((panel) => panel.id) },
       trashedTerminals: new Map<string, never>(),
       tabGroups: new Map<string, never>(),
-      getTabGroups: () => [],
-      getTabGroupPanels: () => [],
     },
     // Returning children needs no JSX, which keeps this usable from vi.hoisted.
     passthrough: ({ children }: { children?: React.ReactNode }) => children,

--- a/src/components/Layout/__tests__/dockRenderItems.test.ts
+++ b/src/components/Layout/__tests__/dockRenderItems.test.ts
@@ -3,7 +3,7 @@ import type { BrowserPanelData, FilePanelData, PtyPanelData } from "@shared/type
 import type { TabGroup } from "@/types";
 import { buildDockRenderItems } from "../dockRenderItems";
 
-function terminal(id: string): PtyPanelData {
+function terminal(id: string, worktreeId?: string): PtyPanelData {
   return {
     id,
     title: id,
@@ -13,17 +13,25 @@ function terminal(id: string): PtyPanelData {
     rows: 24,
     location: "dock",
     isVisible: false,
+    worktreeId,
   } as PtyPanelData;
 }
 
-function group(panelIds: string[], activeTabId = panelIds[0] ?? ""): TabGroup {
+function group(panelIds: string[], activeTabId = panelIds[0] ?? "", overrides?: Partial<TabGroup>) {
   return {
     id: "group-1",
     panelIds,
     activeTabId,
     location: "dock",
-  };
+    ...overrides,
+  } satisfies TabGroup;
 }
+
+function groupMap(...groups: TabGroup[]): ReadonlyMap<string, TabGroup> {
+  return new Map(groups.map((g) => [g.id, g]));
+}
+
+const NO_GROUPS: ReadonlyMap<string, TabGroup> = new Map();
 
 function filePanel(id: string): FilePanelData {
   return {
@@ -47,9 +55,13 @@ function browserPanel(id: string): BrowserPanelData {
   } as BrowserPanelData;
 }
 
+function idsOf(items: ReturnType<typeof buildDockRenderItems>): string[] {
+  return items.map((item) => item.group.id);
+}
+
 describe("buildDockRenderItems", () => {
   it("renders a docked file panel as a standalone chip", () => {
-    const items = buildDockRenderItems([], () => [], null, [filePanel("spec")]);
+    const items = buildDockRenderItems([filePanel("spec")], NO_GROUPS, null);
 
     expect(items).toHaveLength(1);
     expect(items[0]?.panels[0]?.kind).toBe("file");
@@ -59,22 +71,21 @@ describe("buildDockRenderItems", () => {
   it("renders a docked browser panel as a standalone chip", () => {
     // #11053: browser panels were committable to the dock but had no render
     // membership, so they vanished. They must surface as standalone chips.
-    const items = buildDockRenderItems([], () => [], null, [browserPanel("docs")]);
+    const items = buildDockRenderItems([browserPanel("docs")], NO_GROUPS, null);
 
     expect(items).toHaveLength(1);
     expect(items[0]?.panels[0]?.kind).toBe("browser");
     expect(items[0]?.group.panelIds).toEqual(["docs"]);
   });
 
-  it("renders a browser panel standalone even when its stored group only resolves PTY panels", () => {
+  it("renders a browser panel standalone even when its stored group lists it", () => {
     // A grid tab group containing a terminal and a browser panel moved to the
-    // dock: groups resolve PTY-only, so the browser panel falls through to the
-    // flat membership list and must not vanish (#11053).
+    // dock: dock groups stay PTY-only, so the browser panel must not join the
+    // group and must not vanish (#11053).
     const items = buildDockRenderItems(
-      [group(["term-1", "docs"], "term-1")],
-      () => [terminal("term-1")],
-      null,
-      [terminal("term-1"), browserPanel("docs")]
+      [terminal("term-1"), browserPanel("docs")],
+      groupMap(group(["term-1", "docs"], "term-1")),
+      null
     );
 
     expect(items).toHaveLength(2);
@@ -82,15 +93,11 @@ describe("buildDockRenderItems", () => {
     expect(items[1]?.panels[0]?.id).toBe("docs");
   });
 
-  it("renders a file panel standalone even when its stored group only resolves PTY panels", () => {
-    // A grid tab group containing a terminal and a file panel moved to the
-    // dock: groups resolve PTY-only, so the file panel falls through to the
-    // flat membership list and must not vanish.
+  it("renders a file panel standalone even when its stored group lists it", () => {
     const items = buildDockRenderItems(
-      [group(["term-1", "spec"], "term-1")],
-      () => [terminal("term-1")],
-      null,
-      [terminal("term-1"), filePanel("spec")]
+      [terminal("term-1"), filePanel("spec")],
+      groupMap(group(["term-1", "spec"], "term-1")),
+      null
     );
 
     expect(items).toHaveLength(2);
@@ -98,16 +105,17 @@ describe("buildDockRenderItems", () => {
     expect(items[1]?.panels[0]?.id).toBe("spec");
   });
 
-  it("drops stale groups whose panels no longer resolve to dock terminals", () => {
-    const items = buildDockRenderItems([group(["closed-panel"])], () => []);
+  it("drops stale groups whose panels no longer resolve to dock panels", () => {
+    const items = buildDockRenderItems([], groupMap(group(["closed-panel"])), null);
 
     expect(items).toEqual([]);
   });
 
   it("repairs panelIds and activeTabId to match resolved panels", () => {
     const items = buildDockRenderItems(
-      [group(["closed-panel", "live-panel"], "closed-panel")],
-      (groupId) => (groupId === "group-1" ? [terminal("live-panel")] : [])
+      [terminal("live-panel")],
+      groupMap(group(["closed-panel", "live-panel"], "closed-panel")),
+      null
     );
 
     expect(items).toHaveLength(1);
@@ -116,11 +124,13 @@ describe("buildDockRenderItems", () => {
     expect(items[0]?.panels.map((panel) => panel.id)).toEqual(["live-panel"]);
   });
 
-  it("excludes the help terminal from normal dock rendering", () => {
+  it("drops a group member that is absent from the ordered panel list", () => {
+    // The help panel is filtered out of the ordered list upstream, so it must
+    // not resurface through its stored group.
     const items = buildDockRenderItems(
-      [group(["help", "live-panel"], "help")],
-      () => [terminal("help"), terminal("live-panel")],
-      "help"
+      [terminal("live-panel")],
+      groupMap(group(["help", "live-panel"], "help")),
+      null
     );
 
     expect(items).toHaveLength(1);
@@ -128,8 +138,8 @@ describe("buildDockRenderItems", () => {
     expect(items[0]?.panels.map((panel) => panel.id)).toEqual(["live-panel"]);
   });
 
-  it("renders ungrouped dock terminals even when group derivation is empty", () => {
-    const items = buildDockRenderItems([], () => [], null, [terminal("ungrouped-dock")]);
+  it("renders ungrouped dock panels when there are no groups at all", () => {
+    const items = buildDockRenderItems([terminal("ungrouped-dock")], NO_GROUPS, null);
 
     expect(items).toHaveLength(1);
     expect(items[0]?.group).toMatchObject({
@@ -141,15 +151,116 @@ describe("buildDockRenderItems", () => {
     expect(items[0]?.panels.map((panel) => panel.id)).toEqual(["ungrouped-dock"]);
   });
 
-  it("does not duplicate dock terminals already rendered through a group", () => {
+  it("does not duplicate a panel rendered through a group", () => {
     const items = buildDockRenderItems(
-      [group(["live-panel"])],
-      () => [terminal("live-panel")],
-      null,
-      [terminal("live-panel")]
+      [terminal("live-panel")],
+      groupMap(group(["live-panel"])),
+      null
     );
 
     expect(items).toHaveLength(1);
     expect(items[0]?.group.panelIds).toEqual(["live-panel"]);
+  });
+
+  // ── #11873: order is driven by the ordered panel list ──────────────────
+
+  it("emits chips in the ordered panel list's order", () => {
+    // The regression: a dock reorder rewrites only `panelIds`, so the ordered
+    // list is the sole signal that anything moved. Order must come from it,
+    // never from the tab-group map's iteration order.
+    const items = buildDockRenderItems(
+      [terminal("c"), terminal("a"), terminal("b")],
+      NO_GROUPS,
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["c", "a", "b"]);
+  });
+
+  it("reorders the rail when only the ordered panel list changes", () => {
+    const groups = groupMap(group(["a", "b"], "a", { id: "pair" }));
+    const before = buildDockRenderItems(
+      [terminal("a"), terminal("b"), terminal("solo")],
+      groups,
+      null
+    );
+    const after = buildDockRenderItems(
+      [terminal("solo"), terminal("a"), terminal("b")],
+      groups,
+      null
+    );
+
+    expect(idsOf(before)).toEqual(["pair", "solo"]);
+    expect(idsOf(after)).toEqual(["solo", "pair"]);
+  });
+
+  it("keeps a non-PTY panel at its canonical position instead of appending it", () => {
+    // Resolving every group through a PTY-only filter dropped a non-PTY panel's
+    // group and re-appended it after every terminal, so `[a1, browser, a2]`
+    // rendered as `a1, a2, browser` (#11873).
+    const items = buildDockRenderItems(
+      [terminal("a1"), browserPanel("docs"), terminal("a2"), filePanel("spec")],
+      NO_GROUPS,
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["a1", "docs", "a2", "spec"]);
+  });
+
+  it("keeps several non-PTY panels each at their own position", () => {
+    const items = buildDockRenderItems(
+      [browserPanel("docs"), terminal("a1"), filePanel("spec"), terminal("a2")],
+      NO_GROUPS,
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["docs", "a1", "spec", "a2"]);
+  });
+
+  it("emits an explicit group at its earliest surviving member's position", () => {
+    // #10435: forcing explicit groups ahead of virtual ones made a panel jump
+    // to position 0 the moment it gained a second tab.
+    const items = buildDockRenderItems(
+      [terminal("solo"), terminal("a"), terminal("tail"), terminal("b")],
+      groupMap(group(["a", "b"], "a", { id: "pair" })),
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["solo", "pair", "tail"]);
+  });
+
+  it("keeps a group's internal tab order even when the rail order differs", () => {
+    const items = buildDockRenderItems(
+      [terminal("b"), terminal("a")],
+      groupMap(group(["a", "b"], "b", { id: "pair" })),
+      null
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.group.panelIds).toEqual(["a", "b"]);
+    expect(items[0]?.group.activeTabId).toBe("b");
+  });
+
+  // ── Worktree scope ─────────────────────────────────────────────────────
+
+  it("ignores a group scoped to another worktree, rendering its members standalone", () => {
+    const items = buildDockRenderItems(
+      [terminal("a"), terminal("b")],
+      groupMap(group(["a", "b"], "a", { id: "pair", worktreeId: "wt-b" })),
+      "wt-a"
+    );
+
+    expect(idsOf(items)).toEqual(["a", "b"]);
+  });
+
+  it("keeps a global group visible inside a worktree-scoped dock", () => {
+    // Dock-global panels are visible in every worktree-scoped dock (#11289).
+    const items = buildDockRenderItems(
+      [terminal("a"), terminal("b")],
+      groupMap(group(["a", "b"], "a", { id: "pair" })),
+      "wt-a"
+    );
+
+    expect(idsOf(items)).toEqual(["pair"]);
   });
 });

--- a/src/components/Layout/__tests__/dockRenderItems.test.ts
+++ b/src/components/Layout/__tests__/dockRenderItems.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type {
-  BrowserPanelData,
-  DockPanelData,
-  FilePanelData,
-  PtyPanelData,
-} from "@shared/types/panel";
+import type { BrowserPanelData, FilePanelData, PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 import { buildDockRenderItems } from "../dockRenderItems";
 
@@ -167,8 +162,6 @@ describe("buildDockRenderItems", () => {
     expect(items[0]?.group.panelIds).toEqual(["live-panel"]);
   });
 
-  // ── #11873: order is driven by the ordered panel list ──────────────────
-
   it("emits chips in the ordered panel list's order", () => {
     // The regression: a dock reorder rewrites only `panelIds`, so the ordered
     // list is the sole signal that anything moved. Order must come from it,
@@ -245,8 +238,6 @@ describe("buildDockRenderItems", () => {
     expect(items[0]?.group.panelIds).toEqual(["a", "b"]);
     expect(items[0]?.group.activeTabId).toBe("b");
   });
-
-  // ── Worktree scope ─────────────────────────────────────────────────────
 
   it("ignores a group scoped to another worktree, rendering its members standalone", () => {
     const items = buildDockRenderItems(
@@ -343,8 +334,6 @@ describe("buildDockRenderItems", () => {
     expect(idsOf(items)).toEqual(["a", "b"]);
   });
 
-  // ── Malformed input ────────────────────────────────────────────────────
-
   it("renders a panel once when two groups both claim it", () => {
     // Overlapping membership is invalid state, but it must not put the same
     // panel under two chips — two sortables would share one dnd-kit id.
@@ -367,11 +356,14 @@ describe("buildDockRenderItems", () => {
   });
 
   it("does not mutate the groups or panels it is given", () => {
-    const stored = Object.freeze(
-      group(["a", "closed"], "closed", { id: "pair" })
-    ) as unknown as TabGroup;
+    // Freeze as statements so the bindings keep their mutable types — the
+    // builder's parameters are already readonly, and casting back would just
+    // trade a real assertion for a type assertion.
+    const stored = group(["a", "closed"], "closed", { id: "pair" });
+    Object.freeze(stored);
     Object.freeze(stored.panelIds);
-    const panels = Object.freeze([terminal("a")]) as unknown as DockPanelData[];
+    const panels = [terminal("a")];
+    Object.freeze(panels);
 
     const items = buildDockRenderItems(panels, groupMap(stored), null);
 

--- a/src/components/Layout/__tests__/dockRenderItems.test.ts
+++ b/src/components/Layout/__tests__/dockRenderItems.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { BrowserPanelData, FilePanelData, PtyPanelData } from "@shared/types/panel";
+import type {
+  BrowserPanelData,
+  DockPanelData,
+  FilePanelData,
+  PtyPanelData,
+} from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 import { buildDockRenderItems } from "../dockRenderItems";
 
@@ -262,5 +267,148 @@ describe("buildDockRenderItems", () => {
     );
 
     expect(idsOf(items)).toEqual(["pair"]);
+  });
+
+  it("orders two explicit groups by their earliest rail member, not map order", () => {
+    // Positioning a group at `orderedPanels.indexOf(group.panelIds[0])`, or
+    // simply preserving the map's insertion order, passes every single-group
+    // test above but gets this one wrong.
+    const groups = groupMap(
+      group(["a", "b"], "a", { id: "g1" }),
+      group(["c", "d"], "c", { id: "g2" })
+    );
+
+    expect(
+      idsOf(
+        buildDockRenderItems(
+          [terminal("c"), terminal("d"), terminal("solo"), terminal("a"), terminal("b")],
+          groups,
+          null
+        )
+      )
+    ).toEqual(["g2", "solo", "g1"]);
+
+    expect(
+      idsOf(
+        buildDockRenderItems(
+          [terminal("a"), terminal("b"), terminal("solo"), terminal("c"), terminal("d")],
+          groups,
+          null
+        )
+      )
+    ).toEqual(["g1", "solo", "g2"]);
+  });
+
+  it("emits a group at its earliest rail member even when that is not its first tab", () => {
+    const items = buildDockRenderItems(
+      [terminal("b"), terminal("solo"), terminal("a")],
+      groupMap(group(["a", "b"], "a", { id: "pair" })),
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["pair", "solo"]);
+    expect(items[0]?.group.panelIds).toEqual(["a", "b"]);
+  });
+
+  it("repairs activeTabId when the active tab is a non-PTY member", () => {
+    const items = buildDockRenderItems(
+      [browserPanel("docs"), terminal("t2"), filePanel("spec"), terminal("t1")],
+      groupMap(group(["t1", "docs", "t2", "spec"], "docs", { id: "mixed" })),
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["docs", "mixed", "spec"]);
+    const mixed = items[1];
+    expect(mixed?.panels.map((panel) => panel.id)).toEqual(["t1", "t2"]);
+    expect(mixed?.group.activeTabId).toBe("t1");
+  });
+
+  it("renders every member standalone when a group has no PTY members at all", () => {
+    const items = buildDockRenderItems(
+      [filePanel("spec"), browserPanel("docs")],
+      groupMap(group(["docs", "spec"], "docs")),
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["spec", "docs"]);
+  });
+
+  it("ignores a group stored against the grid", () => {
+    const items = buildDockRenderItems(
+      [terminal("a"), terminal("b")],
+      groupMap(group(["a", "b"], "a", { id: "pair", location: "grid" })),
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["a", "b"]);
+  });
+
+  // ── Malformed input ────────────────────────────────────────────────────
+
+  it("renders a panel once when two groups both claim it", () => {
+    // Overlapping membership is invalid state, but it must not put the same
+    // panel under two chips — two sortables would share one dnd-kit id.
+    const items = buildDockRenderItems(
+      [terminal("a"), terminal("b"), terminal("c")],
+      groupMap(group(["a", "b"], "a", { id: "g1" }), group(["a", "c"], "a", { id: "g2" })),
+      null
+    );
+
+    const rendered = items.flatMap((item) => item.panels.map((panel) => panel.id));
+    expect(rendered).toEqual([...new Set(rendered)]);
+    expect([...rendered].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("renders a duplicated ordered panel once", () => {
+    const dupe = terminal("a");
+    const items = buildDockRenderItems([dupe, dupe], NO_GROUPS, null);
+
+    expect(idsOf(items)).toEqual(["a"]);
+  });
+
+  it("does not mutate the groups or panels it is given", () => {
+    const stored = Object.freeze(
+      group(["a", "closed"], "closed", { id: "pair" })
+    ) as unknown as TabGroup;
+    Object.freeze(stored.panelIds);
+    const panels = Object.freeze([terminal("a")]) as unknown as DockPanelData[];
+
+    const items = buildDockRenderItems(panels, groupMap(stored), null);
+
+    expect(items[0]?.group.panelIds).toEqual(["a"]);
+    expect(items[0]?.group.activeTabId).toBe("a");
+    // The stored group is the live Zustand object — it must come back untouched.
+    expect(stored.panelIds).toEqual(["a", "closed"]);
+    expect(stored.activeTabId).toBe("closed");
+  });
+
+  it("groups a global group under a global scope", () => {
+    const items = buildDockRenderItems(
+      [terminal("a"), terminal("b")],
+      groupMap(group(["a", "b"], "a", { id: "pair" })),
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["pair"]);
+  });
+
+  it("groups a worktree-scoped group under its own worktree", () => {
+    const items = buildDockRenderItems(
+      [terminal("a", "wt-a"), terminal("b", "wt-a")],
+      groupMap(group(["a", "b"], "a", { id: "pair", worktreeId: "wt-a" })),
+      "wt-a"
+    );
+
+    expect(idsOf(items)).toEqual(["pair"]);
+  });
+
+  it("ignores a worktree-scoped group under the global scope", () => {
+    const items = buildDockRenderItems(
+      [terminal("a", "wt-a"), terminal("b", "wt-a")],
+      groupMap(group(["a", "b"], "a", { id: "pair", worktreeId: "wt-a" })),
+      null
+    );
+
+    expect(idsOf(items)).toEqual(["a", "b"]);
   });
 });

--- a/src/components/Layout/dockRenderItems.ts
+++ b/src/components/Layout/dockRenderItems.ts
@@ -44,6 +44,12 @@ export function buildDockRenderItems(
   // group — and falls through to a standalone chip below. Groups are scoped by
   // their own worktree as well as their members' so a group pinned to another
   // worktree can't surface through a global member.
+  //
+  // A panel belongs to at most one chip: claiming ids as they resolve means the
+  // first group wins and a later group can't re-list an id already taken. The
+  // store guards against overlapping membership, but a corrupt or hand-edited
+  // group would otherwise render the same panel under two chips — with two
+  // sortables sharing one dnd-kit id.
   const resolvedGroups = new Map<string, { group: TabGroup; panels: PtyPanelData[] }>();
   const groupIdByPanelId = new Map<string, string>();
   for (const group of tabGroups.values()) {
@@ -52,18 +58,24 @@ export function buildDockRenderItems(
 
     const panels: PtyPanelData[] = [];
     for (const id of group.panelIds) {
+      if (groupIdByPanelId.has(id)) continue;
       const panel = panelsById.get(id);
-      if (panel && isPtyPanel(panel)) panels.push(panel);
+      if (!panel || !isPtyPanel(panel)) continue;
+      panels.push(panel);
+      groupIdByPanelId.set(id, group.id);
     }
     if (panels.length === 0) continue;
 
     resolvedGroups.set(group.id, { group, panels });
-    for (const panel of panels) groupIdByPanelId.set(panel.id, group.id);
   }
 
   const items: DockRenderItem[] = [];
   const emittedGroupIds = new Set<string>();
+  const emittedPanelIds = new Set<string>();
   for (const panel of orderedPanels) {
+    if (emittedPanelIds.has(panel.id)) continue;
+    emittedPanelIds.add(panel.id);
+
     const groupId = groupIdByPanelId.get(panel.id);
 
     if (groupId === undefined) {

--- a/src/components/Layout/dockRenderItems.ts
+++ b/src/components/Layout/dockRenderItems.ts
@@ -1,4 +1,5 @@
-import type { DockPanelData, PtyPanelData } from "@shared/types/panel";
+import { isPtyPanel, type DockPanelData, type PtyPanelData } from "@shared/types/panel";
+import { panelMatchesWorktreeScope } from "@/store/slices/panelRegistry/worktreeIndex";
 import type { TabGroup } from "@/types";
 
 export interface DockRenderItem {
@@ -6,50 +7,93 @@ export interface DockRenderItem {
   panels: DockPanelData[];
 }
 
+/**
+ * Project the dock rail from two reactive snapshots: the ordered dock panels
+ * and the tab-group map.
+ *
+ * `orderedPanels` is the sole authority for chip order. It arrives in canonical
+ * `panelIds` order, so a pure `reorderTerminals` — which rewrites only
+ * `panelIds`/`panelIdsByWorktreeId` — repaints the rail. Order used to come
+ * from the `getTabGroups` store action behind a `useMemo` whose deps were read
+ * for invalidation only; React Compiler drops deps a callback never consumes,
+ * so that memo held the pre-drag order and every reorder snapped back (#11873).
+ *
+ * Explicit dock tab groups stay PTY-only by design — every dockable non-PTY
+ * kind (file, browser and plugin view panels — #11332) docks as a standalone
+ * chip. Those chips are emitted in place, at their canonical position, rather
+ * than appended after every terminal: resolving each group through a PTY-only
+ * filter used to leave a non-PTY panel's group empty, dropping it out of the
+ * rail and re-appending it at the end, so `[a1, browser, a2]` rendered as
+ * `a1, a2, browser` (#11873).
+ *
+ * A group is emitted once, at its earliest surviving member's position, so
+ * explicit and virtual groups interleave exactly as `getTabGroups` orders them
+ * — a panel must not jump to position 0 the moment it gains a second tab
+ * (#10435).
+ */
 export function buildDockRenderItems(
-  tabGroups: TabGroup[],
-  // Tab groups stay PTY-only — every dockable non-PTY kind (file, browser and
-  // plugin view panels — #11332) docks as a standalone chip.
-  resolvePanels: (groupId: string) => PtyPanelData[],
-  excludedPanelId?: string | null,
-  dockTerminals: DockPanelData[] = []
+  orderedPanels: readonly DockPanelData[],
+  tabGroups: ReadonlyMap<string, TabGroup>,
+  activeWorktreeId: string | null | undefined
 ): DockRenderItem[] {
-  const renderedPanelIds = new Set<string>();
-  const items: DockRenderItem[] = tabGroups.flatMap((group) => {
-    const panels = resolvePanels(group.id).filter((panel) => panel.id !== excludedPanelId);
-    if (panels.length === 0) return [];
+  const panelsById = new Map<string, DockPanelData>();
+  for (const panel of orderedPanels) panelsById.set(panel.id, panel);
 
-    const panelIdSet = new Set(panels.map((panel) => panel.id));
-    const panelIds = group.panelIds.filter((id) => panelIdSet.has(id));
-    if (panelIds.length === 0) return [];
-    panelIds.forEach((id) => renderedPanelIds.add(id));
+  // Resolve each in-scope dock group to its surviving PTY members, in the
+  // group's own tab order. A non-PTY member is dropped here — it never joins a
+  // group — and falls through to a standalone chip below. Groups are scoped by
+  // their own worktree as well as their members' so a group pinned to another
+  // worktree can't surface through a global member.
+  const resolvedGroups = new Map<string, { group: TabGroup; panels: PtyPanelData[] }>();
+  const groupIdByPanelId = new Map<string, string>();
+  for (const group of tabGroups.values()) {
+    if (group.location !== "dock") continue;
+    if (!panelMatchesWorktreeScope(group.worktreeId, activeWorktreeId, "dock")) continue;
 
-    return [
-      {
+    const panels: PtyPanelData[] = [];
+    for (const id of group.panelIds) {
+      const panel = panelsById.get(id);
+      if (panel && isPtyPanel(panel)) panels.push(panel);
+    }
+    if (panels.length === 0) continue;
+
+    resolvedGroups.set(group.id, { group, panels });
+    for (const panel of panels) groupIdByPanelId.set(panel.id, group.id);
+  }
+
+  const items: DockRenderItem[] = [];
+  const emittedGroupIds = new Set<string>();
+  for (const panel of orderedPanels) {
+    const groupId = groupIdByPanelId.get(panel.id);
+
+    if (groupId === undefined) {
+      items.push({
         group: {
-          ...group,
-          panelIds,
-          activeTabId: panelIds.includes(group.activeTabId)
-            ? group.activeTabId
-            : (panelIds[0] ?? ""),
+          id: panel.id,
+          location: "dock",
+          worktreeId: panel.worktreeId,
+          activeTabId: panel.id,
+          panelIds: [panel.id],
         },
-        panels,
-      },
-    ];
-  });
+        panels: [panel],
+      });
+      continue;
+    }
 
-  for (const panel of dockTerminals) {
-    if (panel.id === excludedPanelId) continue;
-    if (renderedPanelIds.has(panel.id)) continue;
+    if (emittedGroupIds.has(groupId)) continue;
+    emittedGroupIds.add(groupId);
+
+    const resolved = resolvedGroups.get(groupId)!;
+    const panelIds = resolved.panels.map((member) => member.id);
     items.push({
       group: {
-        id: panel.id,
-        location: "dock",
-        worktreeId: panel.worktreeId,
-        activeTabId: panel.id,
-        panelIds: [panel.id],
+        ...resolved.group,
+        panelIds,
+        activeTabId: panelIds.includes(resolved.group.activeTabId)
+          ? resolved.group.activeTabId
+          : (panelIds[0] ?? ""),
       },
-      panels: [panel],
+      panels: resolved.panels,
     });
   }
 

--- a/src/components/Terminal/__tests__/contentGridTrashDep.test.ts
+++ b/src/components/Terminal/__tests__/contentGridTrashDep.test.ts
@@ -57,9 +57,15 @@ describe("ContentGrid tabGroups memo includes trashedTerminals dep (trash-visibi
 describe("ContentDock excludes trashed panels through a compiler-safe dataflow", () => {
   it("filters trashed panels out of the ordered dock selector", async () => {
     const content = await readFile(DOCK_PATH, "utf-8");
-    const selector = content.slice(content.indexOf("const dockTerminalsRaw = usePanelStore("));
-    expect(selector).not.toBe("");
-    expect(selector.slice(0, selector.indexOf("\n  );"))).toContain("trashedTerminals");
+    // Assert both slice markers resolve. An unfound marker yields -1, which
+    // silently widens the slice to most of the file and lets an unrelated
+    // `trashedTerminals` read elsewhere in ContentDock satisfy the check.
+    const start = content.indexOf("const dockTerminalsRaw = usePanelStore(");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = content.indexOf("\n  );", start);
+    expect(end).toBeGreaterThan(start);
+
+    expect(content.slice(start, end)).toContain("state.trashedTerminals.has(");
   });
 
   it("does not call the tab-group store getters during render", async () => {

--- a/src/components/Terminal/__tests__/contentGridTrashDep.test.ts
+++ b/src/components/Terminal/__tests__/contentGridTrashDep.test.ts
@@ -57,17 +57,18 @@ describe("ContentGrid tabGroups memo includes trashedTerminals dep (trash-visibi
 describe("ContentDock excludes trashed panels through a compiler-safe dataflow", () => {
   it("filters trashed panels out of the ordered dock selector", async () => {
     const content = await readFile(DOCK_PATH, "utf-8");
-    expect(content).toContain("!state.trashedTerminals.has(terminal.id)");
+    const selector = content.slice(content.indexOf("const dockTerminalsRaw = usePanelStore("));
+    expect(selector).not.toBe("");
+    expect(selector.slice(0, selector.indexOf("\n  );"))).toContain("trashedTerminals");
   });
 
-  it("derives dock render items from the ordered selector, not a store getter", async () => {
+  it("does not call the tab-group store getters during render", async () => {
     const content = await readFile(DOCK_PATH, "utf-8");
-    expect(content).toContain(
-      "buildDockRenderItems(dockTerminals, storeTabGroups, activeWorktreeId)"
-    );
     // `getTabGroups`/`getTabGroupPanels` are store actions: stable references
     // the compiler happily caches against while their hidden state moves under
-    // it. Calling one during render is how the rail went stale (#11873).
+    // them. Calling one during render is how the rail went stale (#11873) — the
+    // dock reads reactive snapshots instead. This is the invariant, so it holds
+    // across renames of the values those snapshots are bound to.
     expect(content).not.toMatch(/\bgetTabGroups\(/);
     expect(content).not.toMatch(/\bgetTabGroupPanels\(/);
   });

--- a/src/components/Terminal/__tests__/contentGridTrashDep.test.ts
+++ b/src/components/Terminal/__tests__/contentGridTrashDep.test.ts
@@ -1,12 +1,14 @@
 /**
  * Regression test for issue where trashing a terminal left it visible in the grid.
  *
- * Root cause: the `tabGroups` useMemo in ContentGrid (and ContentDock) only depended on
- * `storeTerminalIds`, which does NOT change when a terminal is trashed — only `panelsById`
- * and `trashedTerminals` change. This meant the memo stayed stale and the trashed terminal
+ * Root cause: the `tabGroups` useMemo in ContentGrid only depended on `storeTerminalIds`,
+ * which does NOT change when a terminal is trashed — only `panelsById` and
+ * `trashedTerminals` change. This meant the memo stayed stale and the trashed terminal
  * remained rendered.
  *
  * Fix: add `trashedTerminals` to both the useShallow selector and the tabGroups memo deps.
+ *
+ * ContentDock took a different route — see the second describe block below.
  */
 
 import { describe, it, expect } from "vitest";
@@ -38,13 +40,40 @@ describe("ContentGrid tabGroups memo includes trashedTerminals dep (trash-visibi
   });
 });
 
-describe("ContentDock tabGroups memo includes trashedTerminals dep (trash-visibility regression)", () => {
-  it("includes trashedTerminals in the tabGroups memo dependency array", async () => {
+/**
+ * ContentDock no longer has a `tabGroups` memo to carry a `trashedTerminals`
+ * dep — and that dep never worked there anyway. The renderer compiles with
+ * React Compiler in `compilationMode: "infer"` (vite.config.ts), which drops
+ * deps the callback never consumes, so the dock memo's `void trashedTerminals`
+ * read was eliminated from the compiled cache key along with every other
+ * invalidation-only dep. The same elimination is what froze dock chip order
+ * after a reorder (#11873).
+ *
+ * The dock now excludes trashed panels in the narrow store selector that feeds
+ * the rail, and derives render items from that selector's output — a value the
+ * compiler cannot drop, because the builder genuinely consumes it. These
+ * assertions pin that dataflow rather than a dep-array shape.
+ */
+describe("ContentDock excludes trashed panels through a compiler-safe dataflow", () => {
+  it("filters trashed panels out of the ordered dock selector", async () => {
     const content = await readFile(DOCK_PATH, "utf-8");
-    const tabGroupsBlock = content.slice(content.indexOf("const tabGroups = useMemo("));
-    // Match the dependency array: }, [deps]) — the bracket after "}, "
-    const depsArrayMatch = tabGroupsBlock.match(/\},\s*\[([^\]]+)\]/s);
-    expect(depsArrayMatch).not.toBeNull();
-    expect(depsArrayMatch![1]).toContain("trashedTerminals");
+    expect(content).toContain("!state.trashedTerminals.has(terminal.id)");
+  });
+
+  it("derives dock render items from the ordered selector, not a store getter", async () => {
+    const content = await readFile(DOCK_PATH, "utf-8");
+    expect(content).toContain(
+      "buildDockRenderItems(dockTerminals, storeTabGroups, activeWorktreeId)"
+    );
+    // `getTabGroups`/`getTabGroupPanels` are store actions: stable references
+    // the compiler happily caches against while their hidden state moves under
+    // it. Calling one during render is how the rail went stale (#11873).
+    expect(content).not.toMatch(/\bgetTabGroups\(/);
+    expect(content).not.toMatch(/\bgetTabGroupPanels\(/);
+  });
+
+  it("keeps no invalidation-only reads, which the compiler eliminates", async () => {
+    const content = await readFile(DOCK_PATH, "utf-8");
+    expect(content).not.toMatch(/^\s*void \w+;\s*$/m);
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
@@ -4,7 +4,9 @@ import {
   removeFromWorktreeIndex,
   transferBetweenWorktreeIndex,
   buildWorktreeIndex,
+  collectUngroupedCandidateIds,
   panelMatchesWorktreeScope,
+  NO_WORKTREE,
   type PanelIdsByWorktreeId,
 } from "../worktreeIndex";
 
@@ -188,6 +190,70 @@ describe("worktreeIndex", () => {
         p3: { worktreeId: "wt-A" },
       });
       expect(index["wt-A"]).toEqual(["p3", "p1", "p2"]);
+    });
+  });
+
+  describe("collectUngroupedCandidateIds", () => {
+    it("returns the committed list untouched when no id is pending", () => {
+      const panelIds = ["a", "b"];
+      const result = collectUngroupedCandidateIds(panelIds, { "wt-a": ["a", "b"] }, "wt-a");
+
+      // Same array reference — the common path must not allocate.
+      expect(result).toBe(panelIds);
+    });
+
+    it("appends ids the worktree index knows about but panelIds has not revealed", () => {
+      // #9649: during a spawn batch the index is written eagerly while panelIds
+      // only appends at flush, so the pending panel must still surface.
+      const result = collectUngroupedCandidateIds(["a"], { "wt-a": ["a", "pending"] }, "wt-a");
+
+      expect(result).toEqual(["a", "pending"]);
+    });
+
+    it("orders pending ids active-worktree-first, then global", () => {
+      // The dock renders global panels alongside the active worktree's, so the
+      // two buckets both contribute pending ids. Insertion order of the index
+      // object must not decide their relative position (#11873).
+      const index: PanelIdsByWorktreeId = {
+        [NO_WORKTREE]: ["global-committed", "global-pending"],
+        "wt-a": ["local-committed", "local-pending"],
+      };
+
+      expect(
+        collectUngroupedCandidateIds(["global-committed", "local-committed"], index, "wt-a")
+      ).toEqual(["global-committed", "local-committed", "local-pending", "global-pending"]);
+    });
+
+    it("ignores buckets for other worktrees when scoped", () => {
+      const index: PanelIdsByWorktreeId = {
+        "wt-a": ["a", "a-pending"],
+        "wt-b": ["b-pending"],
+      };
+
+      expect(collectUngroupedCandidateIds(["a"], index, "wt-a")).toEqual(["a", "a-pending"]);
+    });
+
+    it("scans every bucket when unscoped", () => {
+      const index: PanelIdsByWorktreeId = {
+        "wt-a": ["a", "a-pending"],
+        "wt-b": ["b-pending"],
+      };
+
+      expect(collectUngroupedCandidateIds(["a"], index, undefined)).toEqual([
+        "a",
+        "a-pending",
+        "b-pending",
+      ]);
+    });
+
+    it("never repeats an id already committed to panelIds", () => {
+      const result = collectUngroupedCandidateIds(
+        ["a", "b"],
+        { "wt-a": ["a", "b"], [NO_WORKTREE]: ["b"] },
+        "wt-a"
+      );
+
+      expect(result).toEqual(["a", "b"]);
     });
   });
 });

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -16,7 +16,7 @@ import {
 } from "./helpers";
 import {
   buildWorktreeIndex,
-  NO_WORKTREE,
+  collectUngroupedCandidateIds,
   panelMatchesWorktreeScope,
   transferBetweenWorktreeIndex,
 } from "./worktreeIndex";
@@ -24,51 +24,6 @@ import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
-
-/**
- * Candidate panel ids for the ungrouped-panel scan in `getTabGroups`.
- *
- * Iterates `panelIds` first (preserving committed order so explicit/virtual
- * group ordering and drag-reorder via `reorderTabGroups` stay correct), then
- * appends any ids present in `panelIdsByWorktreeId` but not yet in `panelIds`.
- *
- * That tail is the fix for #9649: during a `beginSpawnBatch`/`flushSpawnBatch`
- * window, the worktree index is updated eagerly at panel creation while
- * `panelIds` only appends at flush. Reading `panelIds` alone left freshly-
- * batched recipe panels out of every virtual group until a worktree switch
- * forced a re-derive. `gridPanelIds` in `useContentGridContext` already reads
- * the index, so including its pending ids keeps the ungrouped source consistent
- * with the grid's structural dep — the panel paints on first mount.
- *
- * For a concrete `worktreeId`, the tail scans that worktree's bucket plus the
- * `NO_WORKTREE` bucket (dock-global panels are visible in every worktree-scoped
- * dock — the per-panel `panelMatchesWorktreeScope` filter inside the loop keeps
- * them out of grid queries). For `worktreeId === undefined`, it scans every
- * bucket.
- */
-function collectUngroupedCandidateIds(
-  panelIds: string[],
-  panelIdsByWorktreeId: Record<string, string[]>,
-  worktreeId: string | undefined
-): string[] {
-  const seen = new Set(panelIds);
-  const buckets =
-    worktreeId === undefined
-      ? Object.values(panelIdsByWorktreeId)
-      : [panelIdsByWorktreeId[worktreeId], panelIdsByWorktreeId[NO_WORKTREE]];
-
-  let pending: string[] | undefined;
-  for (const bucket of buckets) {
-    if (!bucket) continue;
-    for (const id of bucket) {
-      if (seen.has(id)) continue;
-      seen.add(id);
-      (pending ??= []).push(id);
-    }
-  }
-
-  return pending ? [...panelIds, ...pending] : panelIds;
-}
 
 function getPanelTabGroupLocation(
   panel: PanelInstance | CarrierPanel | undefined

--- a/src/store/slices/panelRegistry/worktreeIndex.ts
+++ b/src/store/slices/panelRegistry/worktreeIndex.ts
@@ -36,6 +36,58 @@ export function panelMatchesWorktreeScope(
   return location === "dock" && panelWt === undefined && scopeWt !== undefined;
 }
 
+/**
+ * Candidate panel ids, in canonical order, for a scan over every registered
+ * panel — the ungrouped-panel pass in `getTabGroups` and the dock rail's own
+ * ordered membership selector (`ContentDock`).
+ *
+ * Iterates `panelIds` first (preserving committed order so explicit/virtual
+ * group ordering and drag-reorder via `reorderTabGroups` stay correct), then
+ * appends any ids present in `panelIdsByWorktreeId` but not yet in `panelIds`.
+ *
+ * That tail is the fix for #9649: during a `beginSpawnBatch`/`flushSpawnBatch`
+ * window, the worktree index is updated eagerly at panel creation while
+ * `panelIds` only appends at flush. Reading `panelIds` alone left freshly-
+ * batched recipe panels out of every virtual group until a worktree switch
+ * forced a re-derive. `gridPanelIds` in `useContentGridContext` already reads
+ * the index, so including its pending ids keeps the ungrouped source consistent
+ * with the grid's structural dep — the panel paints on first mount.
+ *
+ * For a concrete `worktreeId`, the tail scans that worktree's bucket plus the
+ * `NO_WORKTREE` bucket (dock-global panels are visible in every worktree-scoped
+ * dock — the per-panel `panelMatchesWorktreeScope` filter inside the loop keeps
+ * them out of grid queries). For `worktreeId === undefined`, it scans every
+ * bucket.
+ *
+ * Lives here rather than beside `getTabGroups` because both callers need it and
+ * this module is a leaf — importing it from `tabGroups.ts` into a component
+ * pulls the whole panel-registry action graph into module init and deadlocks
+ * the store's own barrel on a cycle.
+ */
+export function collectUngroupedCandidateIds(
+  panelIds: string[],
+  panelIdsByWorktreeId: Record<string, string[]>,
+  worktreeId: string | undefined
+): string[] {
+  const seen = new Set(panelIds);
+  const buckets =
+    worktreeId === undefined
+      ? Object.values(panelIdsByWorktreeId)
+      : [panelIdsByWorktreeId[worktreeId], panelIdsByWorktreeId[NO_WORKTREE]];
+
+  let pending: string[] | undefined;
+  for (const bucket of buckets) {
+    if (!bucket) continue;
+    for (const id of bucket) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      (pending ??= []).push(id);
+    }
+  }
+
+  return pending ? [...panelIds, ...pending] : panelIds;
+}
+
 function bucketKey(worktreeId: string | undefined | null): string {
   return worktreeId ?? NO_WORKTREE;
 }


### PR DESCRIPTION
## Summary

- `ContentDock` derived chip order from a `getTabGroups` store action inside a `useMemo` whose real dependencies were only referenced through `void x` statements. React Compiler (in `infer` mode) reads the compiled output, not the source, and dropped all three of them as unused, so a drag never invalidated the cache and the rail kept painting the pre-drag order.
- `buildDockRenderItems` resolved every tab group through a PTY-only filter, so a docked browser or file panel's virtual single-panel group came back empty, got dropped, and was re-appended from a fallback loop at the end. `[a1, browser, a2]` rendered as `a1, a2, browser`.
- Both bugs are fixed together: `buildDockRenderItems` is now a pure projection over two reactive snapshots (the ordered dock-panel list and the tab-group map), with the ordered list as the sole authority for chip order.

Resolves #11873

## The two bugs

**Stale chip order.** The `useMemo` deps (`dockPanelSignature`, `storeTabGroups`, `trashedTerminals`) were only touched via `void dockPanelSignature;` etc. I ran the actual compiler transform over the file to confirm what was happening: the compiled cache guard came out as `if (cachedActiveWorktreeId !== activeWorktreeId || cachedGetter !== getTabGroups || cachedHelpId !== helpTerminalId)`, all three invalidation-only deps eliminated. Since `reorderTerminals` only writes `panelIds`/`panelIdsByWorktreeId`, nothing in the surviving key changed after a drag, so the rail never repainted. This also means the `trashedTerminals` dep, added for an earlier and unrelated trash-visibility fix, never did anything on the dock side.

**Non-PTY chips pushed to the end.** Any docked browser or file panel resolves to a virtual single-panel group. Running that through a PTY-only filter dropped it, then a fallback loop re-appended it at the tail, out of position.

**The fix.** `buildDockRenderItems` is now a pure projection over the ordered dock-panel list and the tab-group map. The ordered list is the sole authority for chip order, so a plain reorder repaints correctly. Groups still emit at their earliest surviving member's position (preserving the behavior from #10435), stay PTY-only by design, and non-PTY panes render in place instead of at the end. `ContentDock` no longer calls `getTabGroups` or `getTabGroupPanels` at all. Recompiling confirms the new cache guard checks `activeWorktreeId`, `dockTerminals`, and `storeTabGroups`: every real input is now in the key.

**On the left/right asymmetry from the report:** there's no code path that treats left and right differently, `dockPanelSignature` was order-blind in both directions. What made it look asymmetric was bug two: the rail rendered a stale PTY prefix followed by a fresh non-PTY suffix, so chips in the non-PTY tail could genuinely reorder among themselves while the PTY chips ahead of them stayed frozen. Fixing only one of these would not have resolved the reported behavior.

## Changes

- `dockRenderItems.ts`: rewrote `buildDockRenderItems` as a pure projection over the ordered panel list and tab-group map; each panel claimed by at most one chip.
- `ContentDock.tsx`: dropped the `getTabGroups`/`getTabGroupPanels` calls and the dead `useMemo` deps entirely.
- `collectUngroupedCandidateIds` moved from `tabGroups.ts` to the leaf `worktreeIndex.ts`. Importing it from `tabGroups.ts` into a component drags the whole panel-registry action graph into module init and deadlocks the store barrel (`createTabGroupActions is not a function`). It's worktree-index logic anyway, and both call sites now share it; the dock passes the active worktree so pending ids order active-bucket-then-global, matching `getTabGroups`.
- `SortableDockItem.tsx` now emits `data-dock-item-id`. The rail had no id in the DOM at all, which is why the existing E2E test couldn't catch this: it reads `[data-panel-location="dock"]` against the offscreen containers, which mirror `panelIds` directly and stayed green the whole time.

## Testing

8763 tests across 116 files pass locally, covering every touched module plus everything importing them. New coverage: chip order follows the ordered list, non-PTY panes stay interleaved in position, two-group ordering by earliest rail member, `activeTabId` repair when the active tab is non-PTY, all-non-PTY and grid-located groups, duplicate membership and duplicate ordered ids, input immutability, direct `collectUngroupedCandidateIds` coverage including bucket-priority behavior, and the dock-reorder E2E test now asserts visible chip order rather than just the offscreen containers.

One known gap worth stating plainly: reverting `ContentDock`'s candidate-scan scope argument back to `undefined` would leave every test green. Pinning that down would need a `ContentDock` spawn-batch render harness, which is more machinery than a transient pre-flush ordering nuance justifies. The helper's bucket-priority semantics are unit-tested and the call site documents why `undefined` is wrong there.
