### PR TITLE
fix(pty): keep a slow submit's exclusive hold on the composer

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -61,6 +61,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   // out to every window. Classified "external" to drop it from the relay
   // loop — it has no EVENTS_PUSH producer, so no renderer delivery at all.
   "terminal:status": "external",
+  "terminal:submit-status": "external",
 
   // Agent session journaled (relayed from TypedEventBus; emitted by the main
   // close paths and bridged from the pty-host's trash-expiry capture)

--- a/electron/ipc/handlers/terminal/__tests__/events.submitStatus.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/events.submitStatus.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import type { TerminalSubmitStatusPayload } from "../../../../../shared/types/pty-host.js";
+
+const { broadcastToRenderer, broadcastToProjectRenderers } = vi.hoisted(() => ({
+  broadcastToRenderer: vi.fn(),
+  broadcastToProjectRenderers: vi.fn(),
+}));
+
+vi.mock("../../../utils.js", () => ({ broadcastToRenderer, broadcastToProjectRenderers }));
+vi.mock("../../../../services/McpPaneConfigService.js", () => ({
+  mcpPaneConfigService: { revokePaneConfig: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock("../../../../services/pty/agentSessionJournal.js", () => ({
+  journalAgentSession: vi.fn(),
+}));
+// The real bus's `on()` returns an unsubscribe function, which the handler
+// pushes straight onto its cleanup list — a bare EventEmitter returns itself
+// and the teardown then throws.
+vi.mock("../../../../services/events.js", () => ({
+  events: { on: vi.fn(() => vi.fn()), emit: vi.fn() },
+}));
+
+import { CHANNELS } from "../../../channels.js";
+import { registerTerminalEventHandlers } from "../events.js";
+import type { HandlerDependencies } from "../../../types.js";
+
+describe("terminal event handlers — submit-status forwarding (#11875)", () => {
+  let ptyClient: EventEmitter & { getTerminalProjectId: ReturnType<typeof vi.fn> };
+  let dispose: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ptyClient = Object.assign(new EventEmitter(), {
+      getTerminalProjectId: vi.fn((id: string) => `project-for-${id}`),
+    });
+    dispose = registerTerminalEventHandlers({
+      ptyClient,
+    } as unknown as HandlerDependencies);
+  });
+
+  afterEach(() => {
+    dispose();
+  });
+
+  function submitEnvelopes() {
+    return broadcastToProjectRenderers.mock.calls.filter(
+      (call) => call[1] === CHANNELS.EVENTS_PUSH && call[2]?.name === "terminal:submit-status"
+    );
+  }
+
+  it("forwards the payload as a single object, not positional args", () => {
+    // The router emits one `{ id, state }` object. Both ends of this
+    // EventEmitter hop are untyped, so a positional/object mismatch would
+    // compile cleanly and deliver `undefined` to the renderer.
+    const payload: TerminalSubmitStatusPayload = { id: "t1", state: "slow" };
+
+    ptyClient.emit("submit-status", payload);
+
+    const envelopes = submitEnvelopes();
+    expect(envelopes).toHaveLength(1);
+    expect(envelopes[0]?.[2]).toEqual({
+      name: "terminal:submit-status",
+      payload: { id: "t1", state: "slow" },
+    });
+  });
+
+  it("carries every state through unchanged", () => {
+    for (const state of ["slow", "stalled", "settled", "failed"] as const) {
+      ptyClient.emit("submit-status", { id: "t1", state });
+    }
+
+    expect(submitEnvelopes().map((call) => call[2].payload.state)).toEqual([
+      "slow",
+      "stalled",
+      "settled",
+      "failed",
+    ]);
+  });
+
+  it("scopes to the owning project rather than fanning out to every view", () => {
+    ptyClient.emit("submit-status", { id: "t1", state: "slow" });
+
+    expect(ptyClient.getTerminalProjectId).toHaveBeenCalledWith("t1");
+    expect(submitEnvelopes()[0]?.[0]).toBe("project-for-t1");
+    expect(
+      broadcastToRenderer.mock.calls.some((call) => call[1]?.name === "terminal:submit-status")
+    ).toBe(false);
+  });
+
+  it("passes an unknown project through so the util can fall back to a full broadcast", () => {
+    // A killed terminal drops its pendingSpawns entry, so the project can be
+    // null exactly when a late `settled` arrives — the fallback is what stops
+    // that clearing event being swallowed.
+    ptyClient.getTerminalProjectId.mockReturnValue(null);
+
+    ptyClient.emit("submit-status", { id: "t1", state: "settled" });
+
+    expect(submitEnvelopes()[0]?.[0]).toBeNull();
+  });
+
+  it("stops forwarding once the handlers are disposed", () => {
+    dispose();
+
+    ptyClient.emit("submit-status", { id: "t1", state: "slow" });
+
+    expect(submitEnvelopes()).toHaveLength(0);
+    expect(ptyClient.listenerCount("submit-status")).toBe(0);
+  });
+});

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -12,6 +12,7 @@ import type {
   TerminalResizeResult,
   BroadcastWriteResultPayload,
   FdLeakWarningPayload,
+  TerminalSubmitStatusPayload,
 } from "../../../../shared/types/pty-host.js";
 import type { HandlerDependencies } from "../../types.js";
 
@@ -50,6 +51,18 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   };
   ptyClient.on("error", handlePtyError);
   handlers.push(() => ptyClient.off("error", handlePtyError));
+
+  // Submit-lane status (#11875). Project-scoped for the same reason as
+  // `terminal:status` below: only views of the owning project host a panel for
+  // this terminal, so don't pay a clone + IPC task per unrelated view.
+  const handleSubmitStatus = (payload: TerminalSubmitStatusPayload) => {
+    broadcastToProjectRenderers(ptyClient.getTerminalProjectId(payload.id), CHANNELS.EVENTS_PUSH, {
+      name: "terminal:submit-status",
+      payload,
+    });
+  };
+  ptyClient.on("submit-status", handleSubmitStatus);
+  handlers.push(() => ptyClient.off("submit-status", handleSubmitStatus));
 
   // Spawn result events (success or failure)
   const handleSpawnResult = (id: string, result: SpawnResult) => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -148,6 +148,7 @@ import type {
 import type { TerminalActivityPayload } from "../shared/types/terminal.js";
 import type {
   TerminalStatusPayload,
+  TerminalSubmitStatusPayload,
   SpawnResult,
   TerminalResourceBatchPayload,
   BroadcastWriteResultPayload,
@@ -1290,6 +1291,9 @@ function buildElectronApi(): ElectronAPI {
 
       onStatus: (callback: (data: TerminalStatusPayload) => void) =>
         _typedOn(CHANNELS.TERMINAL_STATUS, callback),
+
+      onSubmitStatus: (callback: (data: TerminalSubmitStatusPayload) => void): (() => void) =>
+        _eventBusOn("terminal:submit-status", callback),
 
       onReliabilityMetric: (
         callback: (data: TerminalReliabilityMetricPayload) => void

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1294,6 +1294,15 @@ ptyManager.on("error", (id: string, error: string) => {
   sendEvent({ type: "error", id, error });
 });
 
+// Submit-lane status (#11875). Only fires for submits that cross a threshold
+// or fail, so this is a rare event, not a per-submit pulse.
+ptyManager.on(
+  "submit-status",
+  (id: string, state: import("../shared/types/pty-host.js").TerminalSubmitStatusState) => {
+    sendEvent({ type: "submit-status", id, state });
+  }
+);
+
 ptyManager.on(
   "resize-result",
   (id: string, result: import("../shared/types/pty-host.js").TerminalResizeResult) => {

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -473,6 +473,9 @@ export class PtyManager extends EventEmitter {
               this.registry.delete(termId);
             }
           },
+          onSubmitStatus: (termId, state) => {
+            this.emit("submit-status", termId, state);
+          },
           onPreserved: (termId) => {
             // Preserved terminals retain their full scrollback snapshot in
             // memory and aren't otherwise removed until trash/kill or project

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -474,6 +474,12 @@ export class PtyManager extends EventEmitter {
             }
           },
           onSubmitStatus: (termId, state) => {
+            // Same staleness guard as onExit: a submit unwinding after the
+            // terminal was replaced must not report onto its successor, or a
+            // late "settled" would clear a pill the new process owns.
+            if (this.registry.get(termId) !== terminalProcess) {
+              return;
+            }
             this.emit("submit-status", termId, state);
           },
           onPreserved: (termId) => {

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -182,6 +182,10 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
       emitter.emit("error", event.id, event.error);
       return true;
 
+    case "submit-status":
+      emitter.emit("submit-status", { id: event.id, state: event.state });
+      return true;
+
     case "snapshot":
       broker.resolve<TerminalSnapshot | null>(event.requestId, event.snapshot ?? null);
       return true;

--- a/electron/services/pty/TerminalInputController.ts
+++ b/electron/services/pty/TerminalInputController.ts
@@ -47,10 +47,9 @@ export class TerminalInputController {
    * Teardown writes bypass this controller entirely and go straight to
    * `ptyProcess.write()`. A single quit write mostly got away with that, but a
    * gated Ctrl-C escalation spans a second or more, and anything landing
-   * between two presses — a live keystroke on the ≤512-byte fast path, a
-   * chunked paste still pacing, the trailing Enter of an in-flight submit —
-   * either lands in the agent's composer or breaks the press economics the
-   * gate depends on.
+   * between two presses — a live keystroke, the trailing Enter of an in-flight
+   * submit — either lands in the agent's composer or breaks the press
+   * economics the gate depends on.
    *
    * Blocked input is DROPPED, not buffered. Replaying it after teardown would
    * deliver it to whatever occupies the pane next — a plain shell, or nothing
@@ -81,9 +80,9 @@ export class TerminalInputController {
    * swallowed by `logWriteError`. Returns `{ ok: true }` on success and
    * `{ ok: false, error: NodeJS.ErrnoException }` when `pty.write()` throws.
    *
-   * Falls back to `write()` (queued chunking) for payloads >512 bytes; the
-   * caller cannot meaningfully observe failures in the chunked async path,
-   * but broadcast keystrokes are always single chunks so this is fine.
+   * Falls back to `write()` for payloads >512 bytes, which reports failures
+   * through `logWriteError` rather than returning them; broadcast keystrokes
+   * are always well under that, so the distinction never bites in practice.
    */
   tryWrite(data: string, traceId?: string): { ok: boolean; error?: NodeJS.ErrnoException } {
     const terminal = this.host.terminalInfo;
@@ -110,8 +109,8 @@ export class TerminalInputController {
     }
 
     if (data.length > 512) {
-      // Long payloads queue through chunkInput in write(); we lose precise
-      // per-call failure visibility but that path isn't used by broadcast.
+      // write() swallows the throw into logWriteError, so we lose precise
+      // per-call failure visibility — but that path isn't used by broadcast.
       this.write(data, traceId);
       return { ok: true };
     }
@@ -216,16 +215,16 @@ export class TerminalInputController {
       return;
     }
 
-    if (data.length <= 512) {
-      try {
-        terminal.ptyProcess.write(data);
-      } catch (error) {
-        this.host.logWriteError(error, { operation: "write(fast-path)", traceId });
-      }
-      return;
+    // Everything goes straight to the PTY, large payloads included. Daintree
+    // used to re-split anything over 512 bytes into 50-byte chunks on a 5ms
+    // interval; node-pty owns that queueing now (microsoft/node-pty#831), so
+    // the extra lane only added latency — roughly 10KB/s, which is what made
+    // large context injections take tens of seconds (#11875).
+    try {
+      terminal.ptyProcess.write(data);
+    } catch (error) {
+      this.host.logWriteError(error, { operation: "write(direct)", traceId });
     }
-
-    this.host.writeQueue.enqueueChunked(data);
   }
 
   submit(text: string): void {
@@ -329,8 +328,6 @@ export class TerminalInputController {
         this.write(body);
       }
     }
-
-    await this.host.writeQueue.waitForInputWriteDrain();
 
     if (this.isInputLocked || this.inputGeneration !== generation) {
       return;

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -8,7 +8,10 @@ import serialize, { type SerializeAddon as SerializeAddonType } from "@xterm/add
 const { SerializeAddon } = serialize;
 import unicode11 from "@xterm/addon-unicode11";
 const { Unicode11Addon } = unicode11;
-import type { TerminalResizeResult } from "../../../shared/types/pty-host.js";
+import type {
+  TerminalResizeResult,
+  TerminalSubmitStatusState,
+} from "../../../shared/types/pty-host.js";
 import type { PanelTitleMode } from "../../../shared/types/panel.js";
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
 import { applyXtermReflowFastpath } from "../../../shared/utils/xtermReflowFastpath.js";
@@ -116,6 +119,12 @@ export interface TerminalProcessCallbacks {
    * counted, so a burst of exits can't slip past the cap.
    */
   onPreserved?: (id: string) => void;
+  /**
+   * Fired when a submit crosses the slow/stalled threshold, settles after
+   * having done so, or fails (#11875). Absent for the overwhelming majority of
+   * submits, which complete well inside the threshold and report nothing.
+   */
+  onSubmitStatus?: (id: string, state: TerminalSubmitStatusState) => void;
 }
 
 export interface TerminalProcessDependencies {
@@ -455,13 +464,11 @@ export class TerminalProcess {
       },
     });
     this.writeQueue = new WriteQueue({
-      writeToPty: (data) => {
-        this.terminalInfo.ptyProcess.write(data);
-      },
       isExited: () => !this.lifecycle.isAlive,
       lastOutputTime: () => this.terminalInfo.lastOutputTime,
       performSubmit: (text) => this.performSubmit(text),
       onWriteError: (error, context) => this.logWriteError(error, context),
+      onSubmitStatus: (state) => this.callbacks.onSubmitStatus?.(this.id, state),
     });
     this.sessionSnapshotter = this.createSessionSnapshotter();
     this.identityWatcher = new IdentityWatcher(this.createIdentityWatcherDelegate());

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1222,9 +1222,9 @@ export class TerminalProcess {
    * swallowed by `logWriteError`. Returns `{ ok: true }` on success and
    * `{ ok: false, error: NodeJS.ErrnoException }` when `pty.write()` throws.
    *
-   * Falls back to `write()` (queued chunking) for payloads >512 bytes; the
-   * caller cannot meaningfully observe failures in the chunked async path,
-   * but broadcast keystrokes are always single chunks so this is fine.
+   * Falls back to `write()` for payloads >512 bytes, which reports failures
+   * through `logWriteError` rather than returning them; broadcast keystrokes
+   * are always well under that, so the distinction never bites in practice.
    */
   tryWrite(data: string, traceId?: string): { ok: boolean; error?: NodeJS.ErrnoException } {
     return this.inputController.tryWrite(data, traceId);

--- a/electron/services/pty/WriteQueue.ts
+++ b/electron/services/pty/WriteQueue.ts
@@ -128,7 +128,10 @@ export class WriteQueue {
    *
    * The status timer is cleared because the caller is tearing this terminal's
    * input down: escalating a submit to "stalled" mid-shutdown would report a
-   * problem the user can do nothing about.
+   * problem the user can do nothing about. If a status was already reported,
+   * it is retracted in the same breath — dropping the timer without a closing
+   * event would strand the pill or banner on a submit nothing is tracking any
+   * more.
    *
    * Note this cannot recall bytes already handed to node-pty — its own write
    * queue owns them. What it stops is everything Daintree has not yet written.
@@ -137,14 +140,25 @@ export class WriteQueue {
     if (this.disposed) return;
     this.submitQueue = [];
     this.clearSubmitStatusTimer();
+    if (this.submitStatusReported) {
+      this.submitStatusReported = false;
+      this.emitSubmitStatus("settled");
+    }
   }
 
   /**
-   * Drop pending submits, stop status reporting, and mark the queue disposed.
-   * Idempotent. Any in-flight `waitForOutputSettle` resolves on its next poll
-   * because the `disposed` flag short-circuits the loop — without this, an
-   * in-flight `performSubmit` mid-settle would deadlock and leak
+   * Drop pending submits, stop threshold reporting, and mark the queue
+   * disposed. Idempotent. Any in-flight `waitForOutputSettle` resolves on its
+   * next poll because the `disposed` flag short-circuits the loop — without
+   * this, an in-flight `performSubmit` mid-settle would deadlock and leak
    * `submitInFlight`.
+   *
+   * This stops the slow/stalled TIMERS, not the terminal event: a submit still
+   * running at dispose will emit its `settled`/`failed` when it unwinds. That
+   * is deliberate — the closing event is what clears the renderer, so
+   * suppressing it would be the one way to strand a pill. `PtyManager` drops
+   * events from a superseded incarnation, so a late one cannot land on a
+   * restarted terminal.
    */
   dispose(): void {
     if (this.disposed) return;
@@ -185,13 +199,19 @@ export class WriteQueue {
     this.submitStatusTimer = timer;
   }
 
-  private armSlowSubmitReporting(): void {
+  /**
+   * `startedAt` is captured by the caller before `performSubmit` runs, so the
+   * escalation lands at SUBMIT_STALLED_THRESHOLD_MS measured from the submit's
+   * actual start. Re-arming for a fixed remainder instead would drift: if a
+   * blocked event loop delayed the slow callback, "stalled" would fire that
+   * much late on top.
+   */
+  private armSlowSubmitReporting(startedAt: number): void {
     this.armSubmitStatusTimer(SUBMIT_SLOW_THRESHOLD_MS, () => {
       this.submitStatusReported = true;
       this.emitSubmitStatus("slow");
-      // Remainder of the window, not another full one: escalation belongs at
-      // SUBMIT_STALLED_THRESHOLD_MS total.
-      this.armSubmitStatusTimer(SUBMIT_STALLED_THRESHOLD_MS - SUBMIT_SLOW_THRESHOLD_MS, () => {
+      const remaining = Math.max(0, startedAt + SUBMIT_STALLED_THRESHOLD_MS - Date.now());
+      this.armSubmitStatusTimer(remaining, () => {
         this.emitSubmitStatus("stalled");
       });
     });
@@ -206,8 +226,9 @@ export class WriteQueue {
         try {
           // Await the submit itself — never a race against the timer. The timer
           // reports; it does not release the lane (#11875).
+          const startedAt = Date.now();
           const work = this.options.performSubmit(next);
-          this.armSlowSubmitReporting();
+          this.armSlowSubmitReporting(startedAt);
           await work;
           if (this.submitStatusReported) {
             this.emitSubmitStatus("settled");

--- a/electron/services/pty/WriteQueue.ts
+++ b/electron/services/pty/WriteQueue.ts
@@ -1,12 +1,20 @@
-import { WRITE_INTERVAL_MS } from "./types.js";
-import { chunkInput } from "./terminalInput.js";
+import type { TerminalSubmitStatusState } from "../../../shared/types/pty-host.js";
 
-const SUBMIT_TIMEOUT_MS = 3000;
+/**
+ * How long one submit may hold the composer before we say so. Reporting only —
+ * the submit keeps the lane (see {@link WriteQueue}).
+ */
+const SUBMIT_SLOW_THRESHOLD_MS = 3000;
+
+/**
+ * Total in-flight time after which a submit is treated as stuck rather than
+ * merely slow, and the renderer escalates from an ambient pill to a banner
+ * with a recovery action.
+ */
+const SUBMIT_STALLED_THRESHOLD_MS = 30000;
 
 export interface WriteQueueOptions {
-  /** Raw byte sink for paced chunks. May throw on PTY errors. */
-  writeToPty: (data: string) => void;
-  /** True once the underlying PTY has exited; aborts pacing and drain waits. */
+  /** True once the underlying PTY has exited; aborts the output-settle wait. */
   isExited: () => boolean;
   /** Current `lastOutputTime` accessor used by `waitForOutputSettle`. */
   lastOutputTime: () => number;
@@ -14,6 +22,12 @@ export interface WriteQueueOptions {
   performSubmit: (text: string) => Promise<void>;
   /** Optional sink for synchronous PTY write errors. */
   onWriteError?: (error: unknown, context: { operation: string }) => void;
+  /**
+   * Optional sink for submit-lane status transitions (#11875). Only called for
+   * submits that cross a threshold or fail; a normal fast submit reports
+   * nothing. Must not throw — it is invoked from a timer callback.
+   */
+  onSubmitStatus?: (state: TerminalSubmitStatusState) => void;
 }
 
 export interface OutputSettleOptions {
@@ -23,45 +37,51 @@ export interface OutputSettleOptions {
 }
 
 /**
- * Owns the two write-pacing state machines that used to live inline on
- * `TerminalProcess`:
+ * Serialises async submit jobs against one terminal so a second submission
+ * cannot interleave its body/Enter writes with an earlier one's output-settle
+ * wait.
  *
- * 1. The chunked input queue + interval timer (paces large payloads through
- *    the PTY at `WRITE_INTERVAL_MS` to avoid overwhelming TUI parsers).
- * 2. The submit queue + in-flight guard (serialises async submit jobs so a
- *    second submission cannot interleave its body/Enter writes with an
- *    earlier one's output-settle wait).
+ * The invariant is composer ownership, not byte pacing: `performSubmit` writes
+ * its body before its first await, so from that moment the agent's composer
+ * holds text that cannot be withdrawn. Whatever happens next, the next submit
+ * must not write until the current one is done — otherwise the second body
+ * appends to the first and a single Enter submits both as one merged prompt.
+ *
+ * This is why the slow-submit timer is report-only. It used to be a
+ * `Promise.race`, which released the in-flight slot when it fired but did
+ * nothing to stop the writer, so the abandoned submit's trailing Enter landed
+ * after the next submit's body (#11875). A submit that never settles now
+ * blocks that terminal's submit lane, and that is the correct trade: starting
+ * the next submit is the unsafe action, and there is no rollback for bytes
+ * already in a composer.
+ *
+ * Byte-level pacing used to live here too — a 50-byte chunk queue on a 5ms
+ * interval, copied from VS Code as a workaround for microsoft/vscode#38137, a
+ * race writing to the FD. node-pty fixed that upstream in microsoft/node-pty#831
+ * and VS Code deleted its throttle two days later (microsoft/vscode#283065);
+ * node-pty now runs its own FIFO write queue against the raw fd and reschedules
+ * on EAGAIN. We pin 1.2.0-beta.14, which carries the fix, so the pacing was
+ * deleted rather than retuned. Writes go straight to `ptyProcess.write()`.
  *
  * Shell-capture side effects (`suppressNextShellSubmitSignal`,
  * `markShellCommandSubmitted`, activity-monitor notification) stay in
- * `TerminalProcess`; the queue's job is purely serialisation and pacing.
+ * `TerminalProcess`; the queue's job is purely serialisation.
  */
 export class WriteQueue {
-  private inputWriteQueue: string[] = [];
-  private inputWriteTimeout: NodeJS.Timeout | null = null;
-  private inputWriteDrainResolvers: Array<() => void> = [];
   private submitQueue: string[] = [];
   private submitInFlight = false;
   private disposed = false;
+  /**
+   * At most one submit is ever in flight, so a single handle is enough. It is
+   * re-armed rather than paired with a second timer so escalation lands at
+   * SUBMIT_STALLED_THRESHOLD_MS total, not slow+stalled.
+   */
+  private submitStatusTimer: NodeJS.Timeout | undefined;
+  /** Whether the current submit has already reported slow/stalled — decides
+   *  whether its completion is worth a `settled` event. */
+  private submitStatusReported = false;
 
   constructor(private readonly options: WriteQueueOptions) {}
-
-  /**
-   * Split `data` into PTY-sized chunks and enqueue for paced delivery. Does
-   * nothing after `dispose()`; an empty payload is a no-op.
-   */
-  enqueueChunked(data: string): void {
-    if (this.disposed) return;
-    const chunks = chunkInput(data);
-    if (chunks.length === 0) return;
-    this.inputWriteQueue.push(...chunks);
-    this.startWrite();
-  }
-
-  /** True while pacing is in flight (queued chunks or pending timer). */
-  hasPendingWrites(): boolean {
-    return this.inputWriteQueue.length > 0 || this.inputWriteTimeout !== null;
-  }
 
   /**
    * Serialise an async submit. The first caller wins the in-flight slot and
@@ -75,19 +95,6 @@ export class WriteQueue {
     if (this.submitInFlight) return;
     this.submitInFlight = true;
     void this.drainSubmitQueue();
-  }
-
-  /**
-   * Resolves once the chunked input queue is fully drained, the PTY has
-   * exited, or the queue has been disposed. Uses a stored Promise resolver
-   * triggered from `startWrite` end-of-flight, `dispose()`, and the
-   * `isExited()` sync gate so no polling is needed.
-   */
-  async waitForInputWriteDrain(): Promise<void> {
-    if (this.disposed || this.options.isExited() || !this.hasPendingWrites()) return;
-    await new Promise<void>((resolve) => {
-      this.inputWriteDrainResolvers.push(resolve);
-    });
   }
 
   /**
@@ -108,97 +115,86 @@ export class WriteQueue {
   }
 
   /**
-   * Drop everything queued and wake every drain waiter, WITHOUT disposing:
-   * the queue stays usable afterwards. The reusable half of {@link dispose},
-   * added for the graceful-shutdown input lock (#11851) — teardown writes go
-   * straight to the PTY, so a chunked paste still pacing through this queue
-   * would interleave its bytes with the shutdown signal, and a gated
-   * escalation spanning a second or more is wide open to that.
+   * Drop everything queued and stop reporting on the in-flight submit, WITHOUT
+   * disposing: the queue stays usable afterwards. The reusable half of
+   * {@link dispose}, added for the graceful-shutdown input lock (#11851).
    *
    * `submitInFlight` is deliberately left alone. It is owned by the running
    * `drainSubmitQueue` loop, which clears it in its own `finally`; forcing it
    * false here would let a second submit start while the first is still
    * awaiting, which is the exact interleaving the flag exists to prevent.
-   * Draining the queues is enough — the in-flight submit finds nothing left to
+   * Draining the queue is enough — the in-flight submit finds nothing left to
    * do, and `TerminalInputController`'s generation check stops it writing.
+   *
+   * The status timer is cleared because the caller is tearing this terminal's
+   * input down: escalating a submit to "stalled" mid-shutdown would report a
+   * problem the user can do nothing about.
+   *
+   * Note this cannot recall bytes already handed to node-pty — its own write
+   * queue owns them. What it stops is everything Daintree has not yet written.
    */
   cancelPendingInput(): void {
     if (this.disposed) return;
-    if (this.inputWriteTimeout) {
-      clearTimeout(this.inputWriteTimeout);
-      this.inputWriteTimeout = null;
-    }
-    this.inputWriteQueue = [];
     this.submitQueue = [];
-    for (const resolve of this.inputWriteDrainResolvers) {
-      resolve();
-    }
-    this.inputWriteDrainResolvers = [];
+    this.clearSubmitStatusTimer();
   }
 
   /**
-   * Cancel the pacing timer, drop pending chunks and submits, and mark the
-   * queue disposed. Idempotent. Any in-flight `waitForInputWriteDrain` /
-   * `waitForOutputSettle` resolves immediately on the next poll because the
-   * `disposed` flag short-circuits both loops — without this, an in-flight
-   * `performSubmit` mid-`await waitForInputWriteDrain()` would deadlock and
-   * leak `submitInFlight`.
+   * Drop pending submits, stop status reporting, and mark the queue disposed.
+   * Idempotent. Any in-flight `waitForOutputSettle` resolves on its next poll
+   * because the `disposed` flag short-circuits the loop — without this, an
+   * in-flight `performSubmit` mid-settle would deadlock and leak
+   * `submitInFlight`.
    */
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    if (this.inputWriteTimeout) {
-      clearTimeout(this.inputWriteTimeout);
-      this.inputWriteTimeout = null;
-    }
-    this.inputWriteQueue = [];
     this.submitQueue = [];
-    for (const resolve of this.inputWriteDrainResolvers) {
-      resolve();
-    }
-    this.inputWriteDrainResolvers = [];
+    this.clearSubmitStatusTimer();
   }
 
-  private startWrite(): void {
-    if (this.disposed) return;
-    if (this.inputWriteTimeout !== null || this.inputWriteQueue.length === 0) {
-      if (this.inputWriteQueue.length === 0 && this.inputWriteTimeout === null) {
-        for (const resolve of this.inputWriteDrainResolvers) {
-          resolve();
-        }
-        this.inputWriteDrainResolvers = [];
-      }
-      return;
-    }
-
-    this.doWrite();
-
-    if (this.inputWriteQueue.length > 0) {
-      this.inputWriteTimeout = setTimeout(() => {
-        if (this.disposed) return;
-        this.inputWriteTimeout = null;
-        this.startWrite();
-      }, WRITE_INTERVAL_MS);
-    } else {
-      for (const resolve of this.inputWriteDrainResolvers) {
-        resolve();
-      }
-      this.inputWriteDrainResolvers = [];
-    }
-  }
-
-  private doWrite(): void {
-    if (this.disposed) return;
-    if (this.inputWriteQueue.length === 0) return;
-
-    const chunk = this.inputWriteQueue.shift()!;
-    if (this.options.isExited()) return;
-
+  /** Deliver a status transition without letting a throwing sink escape into a
+   *  timer callback and take down the pty-host. */
+  private emitSubmitStatus(state: TerminalSubmitStatusState): void {
     try {
-      this.options.writeToPty(chunk);
-    } catch (error) {
-      this.options.onWriteError?.(error, { operation: "write(chunk)" });
+      this.options.onSubmitStatus?.(state);
+    } catch {
+      // Reporting is best-effort; the submit itself is unaffected.
     }
+  }
+
+  private clearSubmitStatusTimer(): void {
+    if (this.submitStatusTimer !== undefined) {
+      clearTimeout(this.submitStatusTimer);
+      this.submitStatusTimer = undefined;
+    }
+  }
+
+  /**
+   * Arm the single status handle. `unref()` keeps a slow submit from holding
+   * the pty-host UtilityProcess open on its own, and the identity check makes a
+   * timer that fires after being superseded (or after dispose) a no-op.
+   */
+  private armSubmitStatusTimer(delayMs: number, onFire: () => void): void {
+    const timer = setTimeout(() => {
+      if (this.disposed || this.submitStatusTimer !== timer) return;
+      this.submitStatusTimer = undefined;
+      onFire();
+    }, delayMs);
+    timer.unref?.();
+    this.submitStatusTimer = timer;
+  }
+
+  private armSlowSubmitReporting(): void {
+    this.armSubmitStatusTimer(SUBMIT_SLOW_THRESHOLD_MS, () => {
+      this.submitStatusReported = true;
+      this.emitSubmitStatus("slow");
+      // Remainder of the window, not another full one: escalation belongs at
+      // SUBMIT_STALLED_THRESHOLD_MS total.
+      this.armSubmitStatusTimer(SUBMIT_STALLED_THRESHOLD_MS - SUBMIT_SLOW_THRESHOLD_MS, () => {
+        this.emitSubmitStatus("stalled");
+      });
+    });
   }
 
   private async drainSubmitQueue(): Promise<void> {
@@ -206,28 +202,25 @@ export class WriteQueue {
       while (!this.disposed && this.submitQueue.length > 0) {
         const next = this.submitQueue.shift();
         if (next === undefined) continue;
+        this.submitStatusReported = false;
         try {
+          // Await the submit itself — never a race against the timer. The timer
+          // reports; it does not release the lane (#11875).
           const work = this.options.performSubmit(next);
-          let timedOut = false;
-          let timeoutId: NodeJS.Timeout | undefined;
-          const timeoutPromise = new Promise<void>((_, reject) => {
-            timeoutId = setTimeout(() => {
-              timedOut = true;
-              reject(new Error(`performSubmit timed out after ${SUBMIT_TIMEOUT_MS}ms`));
-            }, SUBMIT_TIMEOUT_MS);
-          });
-          try {
-            await Promise.race([work, timeoutPromise]);
-          } finally {
-            if (timedOut) {
-              work.catch(() => {
-                // Absorb post-timeout rejection — already routed to onWriteError.
-              });
-            }
-            clearTimeout(timeoutId);
+          this.armSlowSubmitReporting();
+          await work;
+          if (this.submitStatusReported) {
+            this.emitSubmitStatus("settled");
           }
         } catch (error) {
+          // A rejected submit is over — it will never write again — so the lane
+          // drains normally and the exclusive-ownership invariant still holds.
+          // It still surfaces, because the body may already be sitting in the
+          // composer with no Enter behind it.
+          this.emitSubmitStatus("failed");
           this.options.onWriteError?.(error, { operation: "performSubmit" });
+        } finally {
+          this.clearSubmitStatusTimer();
         }
       }
     } finally {

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -162,6 +162,24 @@ describe("routeHostEvent", () => {
     expect(errorListener).toHaveBeenCalledWith("t1", "boom");
   });
 
+  it("emits submit-status as a single typed payload, not an error string", () => {
+    // #11875. The state has to survive the host->Main hop as a closed union the
+    // renderer can switch on; folding it into the `error` string carrier is
+    // exactly what this event exists to avoid.
+    const { deps, emitter } = makeDeps();
+    const listener = vi.fn();
+    const errorListener = vi.fn();
+    emitter.on("submit-status", listener);
+    emitter.on("error", errorListener);
+
+    routeHostEvent({ type: "submit-status", id: "t1", state: "slow" }, deps);
+    routeHostEvent({ type: "submit-status", id: "t1", state: "settled" }, deps);
+
+    expect(listener).toHaveBeenNthCalledWith(1, { id: "t1", state: "slow" });
+    expect(listener).toHaveBeenNthCalledWith(2, { id: "t1", state: "settled" });
+    expect(errorListener).not.toHaveBeenCalled();
+  });
+
   it("calls onReady when the host emits ready", () => {
     const { deps, callbacks } = makeDeps();
     routeHostEvent({ type: "ready" }, deps);

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -903,23 +903,32 @@ describe("TerminalProcess.gracefulShutdown — input lock (#11851)", () => {
     await expect(promise).resolves.toBe("locked");
   });
 
-  it("drops input still pacing through the write queue", async () => {
-    // A chunked paste mid-flight would otherwise keep emitting its chunks on
-    // the pacing timer, straight into the shutdown exchange.
+  it("leaves no application-paced remainder to leak into the shutdown exchange", async () => {
+    // This used to assert that a chunked paste stopped dripping once the lock
+    // engaged. There is no chunk queue any more (#11875) — a large write goes
+    // to node-pty in one call — so the guarantee is now stronger and simpler:
+    // nothing of ours is left pending to interleave with the Ctrl-C exchange.
+    // Written as a timer-advance rather than a one-shot count so a
+    // reintroduced pacing lane would fail here.
     const handles = createMockPty();
     const terminal = createAgentTerminal(handles, "codex");
 
-    terminal.write("x".repeat(4096));
-    const queuedBefore = handles.writeMock.mock.calls.length;
-    expect(queuedBefore).toBeGreaterThan(0);
+    const paste = "x".repeat(4096);
+    terminal.write(paste);
+
+    const pasteWrites = handles.writeMock.mock.calls.filter((c) => c[0] === paste);
+    expect(pasteWrites).toHaveLength(1);
+    const writesBefore = handles.writeMock.mock.calls.length;
 
     const promise = terminal.gracefulShutdown();
     await Promise.resolve();
     await Promise.resolve();
 
-    // Only the Ctrl-C press was added; the rest of the paste is gone.
-    expect(handles.writeMock.mock.calls.length).toBe(queuedBefore + 1);
+    // Only the Ctrl-C press was added.
+    expect(handles.writeMock.mock.calls.length).toBe(writesBefore + 1);
     await vi.advanceTimersByTimeAsync(CODEX_PER_PRESS_TIMEOUT_MS);
+
+    // No further fragment of the payload arrived on any timer.
     const written = handles.writeMock.mock.calls.map((c) => c[0]);
     expect(written.filter((chunk) => chunk.startsWith("x"))).toHaveLength(1);
 

--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -438,4 +438,83 @@ describe("TerminalProcess.submit", () => {
     expect(ptyWriteMock).toHaveBeenLastCalledWith("\r");
     vi.useRealTimers();
   });
+
+  // #11875. A slow submit must keep exclusive ownership of the agent's composer
+  // until it finishes. The old `Promise.race` in `drainSubmitQueue` released the
+  // serialiser when the 3000ms timer fired but left `performSubmit` running, so
+  // the next submit wrote its body into the same composer and the abandoned
+  // submit's trailing Enter arrived afterwards — submitting `<FIRST><SECOND>`
+  // as one merged prompt.
+  //
+  // The delay here is an explicitly deferred output-settle gate, NOT a large
+  // paced payload. The byte pacing that used to create this window was deleted
+  // in this same change, so a size-based trigger would quietly stop exercising
+  // the bug. The 4096-char sentinel stays as a stream-integrity payload: it
+  // proves a >512-byte write still arrives whole and in order now that it goes
+  // straight to node-pty instead of through a 50-byte chunk queue.
+  it("keeps the composer exclusive while a slow submit is still in flight", async () => {
+    vi.useFakeTimers();
+    const terminal = createTerminal({ kind: "terminal", launchAgentId: "gemini" });
+    // Gemini has supportsBracketedPaste: false, which is what routes performSubmit
+    // through the waitForOutputSettle branch this test gates on.
+    (
+      terminal as unknown as { terminalInfo: { detectedAgentId: string } }
+    ).terminalInfo.detectedAgentId = "gemini";
+
+    // CR/LF-free on purpose: the assertions below locate composer frames by
+    // counting "\r", and a newline would also trip the shell-submit detection
+    // in write().
+    const sentinel = "S".repeat(4096);
+    terminal.write(sentinel);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const writeQueue = (
+      terminal as unknown as {
+        writeQueue: { waitForOutputSettle: (opts: unknown) => Promise<void> };
+      }
+    ).writeQueue;
+
+    // Hold the first submit past the slow threshold, let the second settle
+    // immediately. This is the whole clock of the test.
+    let releaseFirstSettle: (() => void) | undefined;
+    const firstSettle = new Promise<void>((resolve) => {
+      releaseFirstSettle = resolve;
+    });
+    let settleCalls = 0;
+    vi.spyOn(writeQueue, "waitForOutputSettle").mockImplementation(() => {
+      settleCalls++;
+      return settleCalls === 1 ? firstSettle : Promise.resolve();
+    });
+
+    terminal.submit("<FIRST>");
+    terminal.submit("<SECOND>");
+
+    // The first body is written before performSubmit's first await.
+    expect(ptyWriteMock.mock.calls.map((c) => c[0]).join("")).toContain("<FIRST>");
+
+    // Past the 3000ms slow threshold: the first submit is still holding the
+    // composer, so the second must not have written anything yet.
+    await vi.advanceTimersByTimeAsync(3100);
+    {
+      const midStream = ptyWriteMock.mock.calls.map((c) => c[0]).join("");
+      expect(midStream).not.toContain("<SECOND>");
+      expect(midStream).not.toContain("\r");
+    }
+
+    releaseFirstSettle?.();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const stream = ptyWriteMock.mock.calls.map((c) => c[0]).join("");
+    const firstEnter = stream.indexOf("\r");
+    const secondEnter = stream.indexOf("\r", firstEnter + 1);
+    expect(stream.indexOf("<FIRST>")).toBeLessThan(firstEnter);
+    expect(stream.indexOf("<SECOND>")).toBeGreaterThan(firstEnter);
+    expect(stream.indexOf("<SECOND>")).toBeLessThan(secondEnter);
+    expect(stream.match(/\r/g)).toHaveLength(2);
+
+    // The oversized write arrived whole and ahead of both composer frames.
+    expect(stream.indexOf(sentinel)).toBe(0);
+
+    vi.useRealTimers();
+  });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.writeErrorThrottle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.writeErrorThrottle.test.ts
@@ -106,7 +106,9 @@ describe("TerminalProcess write-error throttle", () => {
 
     const logs = errorLogs();
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toContain("PTY write(fast-path) failed for t1");
+    // Was "write(fast-path)" while a separate chunked lane existed for >512-byte
+    // payloads. Both lanes are now one direct write, so there is one label (#11875).
+    expect(logs[0]).toContain("PTY write(direct) failed for t1");
     // The error object is forwarded as the second arg.
     expect(errSpy.mock.calls[0]?.[1]).toBeInstanceOf(Error);
   });
@@ -182,5 +184,31 @@ describe("TerminalProcess write-error throttle", () => {
     terminal.write("a", "trace-42");
 
     expect(errorLogs()[0]).toContain("traceId=trace-42");
+  });
+
+  // #11875. Payloads over 512 bytes used to be re-split into 50-byte chunks and
+  // dripped through a 5ms interval timer. node-pty owns write queueing now, so
+  // they go straight through — one call, whole payload, no timers involved.
+  it("passes an oversized write to the PTY once, whole and unchunked", () => {
+    const handles = createMockPty();
+    const terminal = createTerminal(handles);
+    const big = "x".repeat(4096);
+
+    terminal.write(big);
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+    expect(handles.writeMock).toHaveBeenCalledWith(big);
+    expect(errorLogs()).toHaveLength(0);
+  });
+
+  it("reports a throwing oversized write instead of dropping it silently", () => {
+    const handles = createMockPty(() => {
+      throw new Error("EPIPE");
+    });
+    const terminal = createTerminal(handles);
+
+    terminal.write("y".repeat(4096));
+
+    expect(errorLogs()[0]).toContain("write(direct)");
   });
 });

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -1,133 +1,48 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WriteQueue, type WriteQueueOptions } from "../WriteQueue.js";
-import { WRITE_INTERVAL_MS, WRITE_MAX_CHUNK_SIZE } from "../types.js";
+import type { TerminalSubmitStatusState } from "../../../../shared/types/pty-host.js";
+
+/** Mirrors the production constants in WriteQueue.ts. Kept as local literals
+ *  rather than imported so a change to the real thresholds shows up as a test
+ *  failure to think about, not a silently-tracking pair of numbers. */
+const SLOW_MS = 3000;
+const STALLED_MS = 30000;
 
 type MutableOptions = {
-  writeToPty: ReturnType<typeof vi.fn<(data: string) => void>>;
   isExited: { value: boolean };
   lastOutputTime: { value: number };
   performSubmit: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
   onWriteError: ReturnType<typeof vi.fn>;
+  statuses: TerminalSubmitStatusState[];
   options: WriteQueueOptions;
 };
 
 function makeOptions(): MutableOptions {
   const isExited = { value: false };
   const lastOutputTime = { value: Date.now() };
-  const writeToPty = vi.fn<(data: string) => void>();
   const performSubmit = vi.fn<(text: string) => Promise<void>>(async () => {});
   const onWriteError = vi.fn();
+  const statuses: TerminalSubmitStatusState[] = [];
   return {
-    writeToPty,
     isExited,
     lastOutputTime,
     performSubmit,
     onWriteError,
+    statuses,
     options: {
-      writeToPty: (data) => writeToPty(data),
       isExited: () => isExited.value,
       lastOutputTime: () => lastOutputTime.value,
       performSubmit: (text) => performSubmit(text),
       onWriteError: (e, ctx) => onWriteError(e, ctx),
+      onSubmitStatus: (state) => statuses.push(state),
     },
   };
 }
 
-describe("WriteQueue.enqueueChunked", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("writes a single small payload synchronously", () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-
-    wq.enqueueChunked("hello");
-
-    expect(m.writeToPty).toHaveBeenCalledTimes(1);
-    expect(m.writeToPty).toHaveBeenCalledWith("hello");
-  });
-
-  it("paces large payloads at WRITE_INTERVAL_MS between chunks", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    // Force at least three chunks.
-    const big = "x".repeat(WRITE_MAX_CHUNK_SIZE * 3);
-
-    wq.enqueueChunked(big);
-
-    // First chunk fires synchronously.
-    expect(m.writeToPty).toHaveBeenCalledTimes(1);
-
-    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS);
-    expect(m.writeToPty).toHaveBeenCalledTimes(2);
-
-    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS);
-    expect(m.writeToPty).toHaveBeenCalledTimes(3);
-
-    // Reassembled order matches input.
-    const written = m.writeToPty.mock.calls.map((c) => c[0]).join("");
-    expect(written).toBe(big);
-  });
-
-  it("preserves order when a second enqueueChunked arrives while the first is still pacing", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    const first = "a".repeat(WRITE_MAX_CHUNK_SIZE * 3);
-    const second = "b".repeat(WRITE_MAX_CHUNK_SIZE * 2);
-
-    wq.enqueueChunked(first);
-    // After one interval, the second chunk of `first` has fired but the
-    // queue is still draining. Append `second` mid-flight.
-    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS);
-    wq.enqueueChunked(second);
-
-    await vi.runAllTimersAsync();
-
-    const written = m.writeToPty.mock.calls.map((c) => c[0]).join("");
-    expect(written).toBe(first + second);
-  });
-
-  it("ignores empty payloads", () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-
-    wq.enqueueChunked("");
-
-    expect(m.writeToPty).not.toHaveBeenCalled();
-  });
-
-  it("stops writing once isExited turns true mid-drain", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    const big = "x".repeat(WRITE_MAX_CHUNK_SIZE * 3);
-
-    wq.enqueueChunked(big);
-    expect(m.writeToPty).toHaveBeenCalledTimes(1);
-
-    m.isExited.value = true;
-    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS * 5);
-
-    // No further writes after exit.
-    expect(m.writeToPty).toHaveBeenCalledTimes(1);
-  });
-
-  it("routes writeToPty exceptions to onWriteError without throwing", () => {
-    const m = makeOptions();
-    m.writeToPty.mockImplementation(() => {
-      throw new Error("EBADF");
-    });
-    const wq = new WriteQueue(m.options);
-
-    expect(() => wq.enqueueChunked("oops")).not.toThrow();
-    expect(m.onWriteError).toHaveBeenCalledOnce();
-    expect(m.onWriteError.mock.calls[0]?.[1]).toEqual({ operation: "write(chunk)" });
-  });
-});
+/** A submit that never settles, for exercising the slow/stalled thresholds. */
+function neverSettles(): Promise<void> {
+  return new Promise<void>(() => {});
+}
 
 describe("WriteQueue.submit", () => {
   beforeEach(() => {
@@ -155,6 +70,9 @@ describe("WriteQueue.submit", () => {
   });
 
   it("absorbs a performSubmit rejection without abandoning the queue", async () => {
+    // A rejected submit is finished — it will never write again — so the lane
+    // is safe to drain. This is the one case that differs from a slow submit,
+    // which is still holding the composer and must NOT be followed.
     const m = makeOptions();
     const seen: string[] = [];
     m.performSubmit.mockImplementation(async (text) => {
@@ -204,111 +122,6 @@ describe("WriteQueue.submit", () => {
   });
 });
 
-describe("WriteQueue.waitForInputWriteDrain", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("resolves immediately when nothing is queued", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-
-    await expect(wq.waitForInputWriteDrain()).resolves.toBeUndefined();
-  });
-
-  it("resolves after the chunked queue empties", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 2));
-
-    let resolved = false;
-    void wq.waitForInputWriteDrain().then(() => {
-      resolved = true;
-    });
-
-    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS * 5);
-    expect(resolved).toBe(true);
-  });
-
-  it("resolves promptly when dispose() fires mid-drain", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 5));
-
-    let resolved = false;
-    void wq.waitForInputWriteDrain().then(() => {
-      resolved = true;
-    });
-
-    wq.dispose();
-    await vi.advanceTimersByTimeAsync(0);
-    expect(resolved).toBe(true);
-  });
-
-  it("resolves immediately when isExited turns true with queued chunks", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 3));
-
-    m.isExited.value = true;
-
-    // Should resolve immediately despite queued chunks.
-    await expect(wq.waitForInputWriteDrain()).resolves.toBeUndefined();
-  });
-
-  it("supports a second drain cycle after the first resolves", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-
-    // First drain: enqueue and wait for it to empty.
-    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 2));
-    await vi.runAllTimersAsync();
-    await expect(wq.waitForInputWriteDrain()).resolves.toBeUndefined();
-
-    // Second drain: enqueue again and verify a fresh resolver lifecycle.
-    wq.enqueueChunked("y".repeat(WRITE_MAX_CHUNK_SIZE * 2));
-    await vi.runAllTimersAsync();
-    await expect(wq.waitForInputWriteDrain()).resolves.toBeUndefined();
-  });
-
-  it("does not schedule polling timers during drain", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 5));
-
-    const timerCountBefore = vi.getTimerCount();
-    await vi.runAllTimersAsync();
-
-    // After draining all chunks, the only remaining timer should be the
-    // pacing timer (cleared on last chunk). No polling timers added.
-    // With the Promise-based approach, drain() produces no extra timers.
-    expect(vi.getTimerCount()).toBeLessThanOrEqual(timerCountBefore);
-  });
-
-  it("resolves all concurrent drain waiters", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 3));
-
-    let firstResolved = false;
-    let secondResolved = false;
-    void wq.waitForInputWriteDrain().then(() => {
-      firstResolved = true;
-    });
-    void wq.waitForInputWriteDrain().then(() => {
-      secondResolved = true;
-    });
-
-    await vi.runAllTimersAsync();
-    expect(firstResolved).toBe(true);
-    expect(secondResolved).toBe(true);
-  });
-});
-
 describe("WriteQueue.cancelPendingInput", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -316,53 +129,6 @@ describe("WriteQueue.cancelPendingInput", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-  });
-
-  it("drops queued chunks and stops the pacing timer", async () => {
-    const m = makeOptions();
-    const queue = new WriteQueue(m.options);
-
-    queue.enqueueChunked("y".repeat(WRITE_MAX_CHUNK_SIZE * 4));
-    const writesBeforeCancel = m.writeToPty.mock.calls.length;
-    expect(queue.hasPendingWrites()).toBe(true);
-
-    queue.cancelPendingInput();
-
-    expect(queue.hasPendingWrites()).toBe(false);
-    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS * 10);
-    expect(m.writeToPty.mock.calls.length).toBe(writesBeforeCancel);
-  });
-
-  it("wakes drain waiters instead of leaving them parked forever", async () => {
-    // performSubmit awaits waitForInputWriteDrain mid-sequence. Cancelling
-    // without resolving would deadlock that submit and leak submitInFlight.
-    const m = makeOptions();
-    const queue = new WriteQueue(m.options);
-
-    queue.enqueueChunked("z".repeat(WRITE_MAX_CHUNK_SIZE * 4));
-    let drained = false;
-    const waiting = queue.waitForInputWriteDrain().then(() => {
-      drained = true;
-    });
-
-    queue.cancelPendingInput();
-    await waiting;
-    expect(drained).toBe(true);
-  });
-
-  it("leaves the queue usable, unlike dispose", () => {
-    // The distinction the shutdown input lock depends on (#11851): the lock is
-    // released when teardown ends, and on a teardown that resolved without
-    // killing the pane the queue has to still accept input.
-    const m = makeOptions();
-    const queue = new WriteQueue(m.options);
-
-    queue.enqueueChunked("a".repeat(WRITE_MAX_CHUNK_SIZE * 3));
-    queue.cancelPendingInput();
-    m.writeToPty.mockClear();
-
-    queue.enqueueChunked("after-cancel");
-    expect(m.writeToPty).toHaveBeenCalledWith("after-cancel");
   });
 
   it("drops queued submits without stranding the in-flight slot", async () => {
@@ -392,6 +158,39 @@ describe("WriteQueue.cancelPendingInput", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(m.performSubmit).toHaveBeenCalledWith("third");
   });
+
+  it("leaves the queue usable, unlike dispose", async () => {
+    // The distinction the shutdown input lock depends on (#11851): the lock is
+    // released when teardown ends, and on a teardown that resolved without
+    // killing the pane the queue has to still accept input.
+    const m = makeOptions();
+    const queue = new WriteQueue(m.options);
+
+    queue.submit("before-cancel");
+    queue.cancelPendingInput();
+    m.performSubmit.mockClear();
+
+    queue.submit("after-cancel");
+    await vi.runAllTimersAsync();
+    expect(m.performSubmit).toHaveBeenCalledWith("after-cancel");
+  });
+
+  it("stops the slow submit from escalating once input is being torn down", async () => {
+    // Escalating to "stalled" mid-shutdown would report a problem the user can
+    // do nothing about.
+    const m = makeOptions();
+    m.performSubmit.mockImplementation(neverSettles);
+    const queue = new WriteQueue(m.options);
+
+    queue.submit("stuck");
+    await vi.advanceTimersByTimeAsync(SLOW_MS);
+    expect(m.statuses).toEqual(["slow"]);
+
+    queue.cancelPendingInput();
+    await vi.advanceTimersByTimeAsync(STALLED_MS);
+
+    expect(m.statuses).toEqual(["slow"]);
+  });
 });
 
 describe("WriteQueue.dispose", () => {
@@ -413,35 +212,34 @@ describe("WriteQueue.dispose", () => {
     }).not.toThrow();
   });
 
-  it("drops further enqueueChunked and submit calls", async () => {
+  it("drops further submit calls", async () => {
     const m = makeOptions();
     const wq = new WriteQueue(m.options);
     wq.dispose();
 
-    wq.enqueueChunked("nope");
     wq.submit("nope");
 
     await vi.runAllTimersAsync();
-    expect(m.writeToPty).not.toHaveBeenCalled();
     expect(m.performSubmit).not.toHaveBeenCalled();
   });
 
-  it("cancels the pacing timer so no further writes fire after dispose", async () => {
-    const m = makeOptions();
-    const wq = new WriteQueue(m.options);
-    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 4));
-    expect(m.writeToPty).toHaveBeenCalledTimes(1);
-
-    wq.dispose();
-    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS * 10);
-    expect(m.writeToPty).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not start a write timer in the constructor (no enqueue, no work)", () => {
+  it("schedules no timers in the constructor (no submit, no work)", () => {
     const m = makeOptions();
     new WriteQueue(m.options);
-    // No timers should have been scheduled yet.
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("silences a pending slow-submit report", async () => {
+    const m = makeOptions();
+    m.performSubmit.mockImplementation(neverSettles);
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("stuck");
+    // Disposed before the slow threshold is ever reached.
+    wq.dispose();
+    await vi.advanceTimersByTimeAsync(STALLED_MS);
+
+    expect(m.statuses).toEqual([]);
   });
 });
 
@@ -488,7 +286,12 @@ describe("WriteQueue.waitForOutputSettle", () => {
   });
 });
 
-describe("WriteQueue.submit timeout", () => {
+// #11875. The slow-submit timer reports; it does not release the submit lane.
+// These replace the old "submit timeout" suite, which asserted the opposite —
+// that the queue kept draining and cleared `submitInFlight` once the 3000ms
+// timer fired. That behaviour was the bug: it let the next submit write its
+// body into a composer the abandoned submit still owned.
+describe("WriteQueue slow-submit reporting", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -497,85 +300,164 @@ describe("WriteQueue.submit timeout", () => {
     vi.useRealTimers();
   });
 
-  it("routes a stuck performSubmit to onWriteError after SUBMIT_TIMEOUT_MS", async () => {
-    const m = makeOptions();
-    // A performSubmit that never settles.
-    m.performSubmit.mockImplementation(() => new Promise(() => {}));
-    const wq = new WriteQueue(m.options);
-
-    wq.submit("stuck");
-
-    await vi.advanceTimersByTimeAsync(3000);
-
-    expect(m.onWriteError).toHaveBeenCalled();
-    const err = m.onWriteError.mock.calls[0]?.[0] as Error;
-    expect(err.message).toContain("timed out");
-  });
-
-  it("continues processing remaining submits after a timeout", async () => {
+  it("does NOT start the next submit when the slow threshold passes", async () => {
     const m = makeOptions();
     const seen: string[] = [];
-    m.performSubmit.mockImplementation(async (text) => {
+    m.performSubmit.mockImplementation((text) => {
       seen.push(text);
-      if (text === "stuck") {
-        // Never resolve.
-        return new Promise(() => {});
-      }
+      return text === "stuck" ? neverSettles() : Promise.resolve();
     });
     const wq = new WriteQueue(m.options);
 
     wq.submit("stuck");
     wq.submit("after");
 
-    // Advance past the timeout for the first stuck submit.
-    await vi.advanceTimersByTimeAsync(3000);
-    // Let the second submit drain.
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(SLOW_MS * 2);
 
-    expect(seen).toEqual(["stuck", "after"]);
-    expect(m.onWriteError).toHaveBeenCalled();
+    // The lane stays owned by the stuck submit. This is the whole fix.
+    expect(seen).toEqual(["stuck"]);
+    expect(m.onWriteError).not.toHaveBeenCalled();
   });
 
-  it("clears submitInFlight after timeout so later submits work", async () => {
+  it("reports slow without manufacturing an error", async () => {
     const m = makeOptions();
-    m.performSubmit.mockImplementation(() => new Promise(() => {}));
+    m.performSubmit.mockImplementation(neverSettles);
     const wq = new WriteQueue(m.options);
 
     wq.submit("stuck");
-    await vi.advanceTimersByTimeAsync(3000);
 
-    // After the timeout, the queue should accept new submits.
-    m.performSubmit.mockImplementation(async () => {});
-    wq.submit("fresh");
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(SLOW_MS - 1);
+    expect(m.statuses).toEqual([]);
 
-    expect(m.performSubmit).toHaveBeenCalledWith("fresh");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(m.statuses).toEqual(["slow"]);
+    expect(m.onWriteError).not.toHaveBeenCalled();
   });
 
-  it("does not cause unhandled rejection when work rejects after timeout", async () => {
+  it("escalates to stalled at the total threshold, not slow + stalled", async () => {
     const m = makeOptions();
-    let lateReject!: (reason?: unknown) => void;
+    m.performSubmit.mockImplementation(neverSettles);
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("stuck");
+
+    await vi.advanceTimersByTimeAsync(SLOW_MS);
+    expect(m.statuses).toEqual(["slow"]);
+
+    // One tick short of STALLED_MS total.
+    await vi.advanceTimersByTimeAsync(STALLED_MS - SLOW_MS - 1);
+    expect(m.statuses).toEqual(["slow"]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(m.statuses).toEqual(["slow", "stalled"]);
+  });
+
+  it("reports settled when a slow submit finally completes, then drains the queue", async () => {
+    const m = makeOptions();
+    let release!: () => void;
+    const seen: string[] = [];
+    m.performSubmit.mockImplementation((text) => {
+      seen.push(text);
+      if (text === "slowly") {
+        return new Promise<void>((r) => {
+          release = r;
+        });
+      }
+      return Promise.resolve();
+    });
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("slowly");
+    wq.submit("after");
+
+    await vi.advanceTimersByTimeAsync(SLOW_MS);
+    expect(m.statuses).toEqual(["slow"]);
+    expect(seen).toEqual(["slowly"]);
+
+    release();
+    await vi.runAllTimersAsync();
+
+    expect(m.statuses).toEqual(["slow", "settled"]);
+    expect(seen).toEqual(["slowly", "after"]);
+  });
+
+  it("stays silent for a submit that completes inside the threshold", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("quick");
+    await vi.runAllTimersAsync();
+
+    expect(m.statuses).toEqual([]);
+  });
+
+  it("leaves no timer armed once a submit settles", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("quick");
+    await vi.runAllTimersAsync();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("reports failed when performSubmit rejects, and reports the original error once", async () => {
+    const m = makeOptions();
+    m.performSubmit.mockImplementation(async () => {
+      throw new Error("PTY write failed");
+    });
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("boom");
+    await vi.runAllTimersAsync();
+
+    expect(m.statuses).toEqual(["failed"]);
+    expect(m.onWriteError).toHaveBeenCalledTimes(1);
+    const err = m.onWriteError.mock.calls[0]?.[0] as Error;
+    expect(err.message).toBe("PTY write failed");
+  });
+
+  it("reports slow then failed when a slow submit eventually rejects", async () => {
+    const m = makeOptions();
+    let fail!: (reason?: unknown) => void;
     m.performSubmit.mockImplementation(
       () =>
         new Promise<void>((_, reject) => {
-          lateReject = reject;
+          fail = reject;
         })
     );
     const wq = new WriteQueue(m.options);
 
     wq.submit("late-reject");
+    await vi.advanceTimersByTimeAsync(SLOW_MS);
+    expect(m.statuses).toEqual(["slow"]);
 
-    // Fire the timeout.
-    await vi.advanceTimersByTimeAsync(3000);
-
-    // Now reject the original performSubmit after the timeout.
-    lateReject(new Error("PTY write failed"));
+    fail(new Error("PTY write failed"));
     await vi.runAllTimersAsync();
 
-    // onWriteError should be called exactly once (the timeout error,
-    // not the late rejection).
+    expect(m.statuses).toEqual(["slow", "failed"]);
     expect(m.onWriteError).toHaveBeenCalledTimes(1);
-    const err = m.onWriteError.mock.calls[0]?.[0] as Error;
-    expect(err.message).toContain("timed out");
+  });
+
+  it("survives a status sink that throws", async () => {
+    // The sink runs inside a timer callback in the pty-host; letting it throw
+    // would take the whole utility process down.
+    const m = makeOptions();
+    m.performSubmit.mockImplementation(neverSettles);
+    const wq = new WriteQueue({
+      ...m.options,
+      onSubmitStatus: () => {
+        throw new Error("sink exploded");
+      },
+    });
+
+    wq.submit("stuck");
+    await vi.advanceTimersByTimeAsync(SLOW_MS);
+
+    // Reaching here at all is the assertion: a throwing sink neither escaped
+    // the timer callback nor stopped the queue accepting further work.
+    m.performSubmit.mockImplementation(async () => {});
+    wq.cancelPendingInput();
+    expect(() => wq.submit("still-usable")).not.toThrow();
   });
 });

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -175,9 +175,11 @@ describe("WriteQueue.cancelPendingInput", () => {
     expect(m.performSubmit).toHaveBeenCalledWith("after-cancel");
   });
 
-  it("stops the slow submit from escalating once input is being torn down", async () => {
+  it("retracts a reported status instead of stranding it, and stops escalating", async () => {
     // Escalating to "stalled" mid-shutdown would report a problem the user can
-    // do nothing about.
+    // do nothing about. But dropping the timer WITHOUT a closing event would
+    // leave the pill up on a submit nothing is tracking any more, so the
+    // retraction is what keeps the renderer from getting stuck.
     const m = makeOptions();
     m.performSubmit.mockImplementation(neverSettles);
     const queue = new WriteQueue(m.options);
@@ -187,9 +189,21 @@ describe("WriteQueue.cancelPendingInput", () => {
     expect(m.statuses).toEqual(["slow"]);
 
     queue.cancelPendingInput();
-    await vi.advanceTimersByTimeAsync(STALLED_MS);
+    expect(m.statuses).toEqual(["slow", "settled"]);
 
-    expect(m.statuses).toEqual(["slow"]);
+    await vi.advanceTimersByTimeAsync(STALLED_MS);
+    expect(m.statuses).toEqual(["slow", "settled"]);
+  });
+
+  it("stays silent on cancel when nothing was ever reported", async () => {
+    const m = makeOptions();
+    m.performSubmit.mockImplementation(neverSettles);
+    const queue = new WriteQueue(m.options);
+
+    queue.submit("stuck");
+    queue.cancelPendingInput();
+
+    expect(m.statuses).toEqual([]);
   });
 });
 
@@ -348,6 +362,29 @@ describe("WriteQueue slow-submit reporting", () => {
     await vi.advanceTimersByTimeAsync(STALLED_MS - SLOW_MS - 1);
     expect(m.statuses).toEqual(["slow"]);
 
+    await vi.advanceTimersByTimeAsync(1);
+    expect(m.statuses).toEqual(["slow", "stalled"]);
+  });
+
+  it("anchors the stalled deadline to the submit's start, not to when slow fired", async () => {
+    // Re-arming for a fixed remainder would drift: a blocked event loop that
+    // delays the slow callback would push stalled out by the same amount. The
+    // contract is STALLED_MS measured from the submit, so once the clock is
+    // already past that point stalled is due immediately.
+    const m = makeOptions();
+    m.performSubmit.mockImplementation(neverSettles);
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("stuck");
+
+    // Jump the wall clock past the stalled deadline while the slow timer is
+    // still pending, then let it fire.
+    vi.setSystemTime(Date.now() + STALLED_MS);
+    await vi.advanceTimersByTimeAsync(SLOW_MS);
+    expect(m.statuses).toEqual(["slow"]);
+
+    // Deadline already passed, so escalation is due immediately rather than
+    // another full window away — 1ms is enough, 27_000ms would not be.
     await vi.advanceTimersByTimeAsync(1);
     expect(m.statuses).toEqual(["slow", "stalled"]);
   });

--- a/electron/services/pty/terminalInput.ts
+++ b/electron/services/pty/terminalInput.ts
@@ -7,7 +7,6 @@ import {
   containsFullBracketedPaste,
 } from "../../../shared/utils/terminalInputProtocol.js";
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
-import { WRITE_MAX_CHUNK_SIZE } from "./types.js";
 
 export { BRACKETED_PASTE_START, BRACKETED_PASTE_END, PASTE_THRESHOLD_CHARS };
 
@@ -80,29 +79,4 @@ export function isBracketedPaste(data: string): boolean {
 // occasional sequence whose payload happens to contain CSI I/O (#8865).
 export function isFocusReport(data: string): boolean {
   return data === "\x1b[I" || data === "\x1b[O";
-}
-
-export function chunkInput(data: string): string[] {
-  if (data.length === 0) {
-    return [];
-  }
-  if (data.length <= WRITE_MAX_CHUNK_SIZE) {
-    return [data];
-  }
-
-  const chunks: string[] = [];
-  let start = 0;
-
-  for (let i = 0; i < data.length - 1; i++) {
-    if (i - start + 1 >= WRITE_MAX_CHUNK_SIZE || data[i + 1] === "\x1b") {
-      chunks.push(data.substring(start, i + 1));
-      start = i + 1;
-    }
-  }
-
-  if (start < data.length) {
-    chunks.push(data.substring(start));
-  }
-
-  return chunks;
 }

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -277,10 +277,6 @@ export const SEMANTIC_BUFFER_MAX_LINES = 50;
 export const SEMANTIC_BUFFER_MAX_LINE_LENGTH = 1000;
 export const SEMANTIC_FLUSH_INTERVAL_MS = 100;
 
-// Input chunking constants
-export const WRITE_MAX_CHUNK_SIZE = 50;
-export const WRITE_INTERVAL_MS = 5;
-
 // Scrollback configuration
 // All PTY panels get the same headless-mirror scrollback; there is no "agent
 // tier" scrollback decision any more. This is the pty-host analysis mirror, NOT

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -479,6 +479,8 @@ export type {
   AgentKilledPayload,
   TerminalFlowStatus,
   TerminalStatusPayload,
+  TerminalSubmitStatusState,
+  TerminalSubmitStatusPayload,
   BroadcastWriteTargetResult,
   BroadcastWriteResultPayload,
   SpawnResult,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -156,6 +156,7 @@ export interface KeybindingImportResult {
 }
 import type {
   TerminalStatusPayload,
+  TerminalSubmitStatusPayload,
   PtyHostActivityTier,
   SpawnResult,
   TerminalResourceBatchPayload,
@@ -311,6 +312,9 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     requestWorkerIngestPort(id: string): Promise<{ token: string } | null>;
     releaseWorkerIngestPort(id: string): Promise<void>;
     onStatus(callback: (data: TerminalStatusPayload) => void): () => void;
+    /** Submit-lane status for one terminal (#11875). Fires only for submits that
+     *  cross the slow/stalled threshold or fail. */
+    onSubmitStatus(callback: (data: TerminalSubmitStatusPayload) => void): () => void;
     onReliabilityMetric(callback: (data: TerminalReliabilityMetricPayload) => void): () => void;
     /**
      * Geometry the PTY actually holds after each resize it processed. Compare

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -102,6 +102,7 @@ import type {
   SpawnResult,
   TerminalReliabilityMetricPayload,
   TerminalResizeResult,
+  TerminalSubmitStatusPayload,
   TerminalStatusPayload,
   TerminalResourceBatchPayload,
   BroadcastWriteResultPayload,
@@ -1400,6 +1401,7 @@ export interface IpcEventMap {
     timestamp: number;
   };
   "terminal:status": TerminalStatusPayload;
+  "terminal:submit-status": TerminalSubmitStatusPayload;
   "terminal:reliability-metric": TerminalReliabilityMetricPayload;
   "terminal:fd-leak-warning": FdLeakWarningPayload;
   "terminal:resource-metrics": { metrics: TerminalResourceBatchPayload; timestamp: number };
@@ -2129,6 +2131,7 @@ export type IpcEventBusMap = Pick<
   | "terminal:resize-result"
   | "terminal:reliability-metric"
   | "terminal:status"
+  | "terminal:submit-status"
   // Agent session journaled — resume surfaces refetch (global broadcast)
   | "agent-session:recorded"
   // A gated park auto-released — the ready-again hand-back (global broadcast)

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -513,6 +513,11 @@ export type PtyHostEvent =
   // stale exit arriving after a same-id respawn can't close the successor.
   | { type: "exit"; id: string; exitCode: number; signal?: number; launchGeneration?: number }
   | { type: "error"; id: string; error: string }
+  // Typed submit-lane status (#11875). Deliberately NOT folded into the `error`
+  // carrier above: "this prompt is taking a while" is not an error, and the
+  // renderer needs a closed state union it can drive a pill/banner from rather
+  // than a free-form string it would have to pattern-match.
+  | { type: "submit-status"; id: string; state: TerminalSubmitStatusState }
   | { type: "spawn-result"; id: string; result: SpawnResult }
   | { type: "resize-result"; id: string; result: TerminalResizeResult }
   | { type: "kill-by-project-result"; requestId: string; killed: number }
@@ -958,6 +963,36 @@ export interface TerminalStatusPayload {
   /** Byte count discarded — only set when status is "data-loss". */
   droppedBytes?: number;
   timestamp: number;
+}
+
+/**
+ * Lifecycle of one submit operation's ownership of an agent's composer (#11875).
+ *
+ * A submit owns the composer from its first body byte until it writes its
+ * trailing Enter; the submit queue serialises that ownership so two prompts
+ * can never merge into one. These states report on a submit that is taking
+ * too long WITHOUT breaking that serialisation — the slow submit keeps the
+ * lane, because the alternative (starting the next one) is what corrupted the
+ * composer in the first place, and bytes already handed to the PTY cannot be
+ * withdrawn.
+ *
+ * Only reported for submits that cross a threshold: a normal fast submit emits
+ * nothing at all.
+ *
+ * - `slow`     — still in flight at SUBMIT_SLOW_THRESHOLD_MS. Ambient signal only.
+ * - `stalled`  — still in flight at SUBMIT_STALLED_THRESHOLD_MS. Needs recovery.
+ * - `settled`  — finished after having been reported slow or stalled. Clears the UI.
+ * - `failed`   — `performSubmit` rejected. The submit is over, so the lane drains
+ *                normally; the composer may hold a partial body, which is why this
+ *                surfaces rather than being logged silently.
+ */
+export type TerminalSubmitStatusState = "slow" | "stalled" | "settled" | "failed";
+
+/** Payload for submit-status events. One in-flight submit per terminal, so the
+ *  terminal id is a sufficient correlator — no submission id is needed. */
+export interface TerminalSubmitStatusPayload {
+  id: string;
+  state: TerminalSubmitStatusState;
 }
 
 /**

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -8,6 +8,7 @@ import type {
   BackendTerminalInfo,
   TerminalReconnectResult,
   TerminalStatusPayload,
+  TerminalSubmitStatusPayload,
   BroadcastWriteResultPayload,
   SpawnResult,
   SerializedTerminalSnapshot,
@@ -836,6 +837,15 @@ export const terminalClient = {
       ipcCleanup();
     };
   },
+
+  /**
+   * Listen for submit-lane status on any terminal (#11875). Unlike `onStatus`
+   * this is a plain event-bus passthrough — there is no MessagePort path,
+   * because a slow submit is a rare per-terminal transition rather than a
+   * throughput pulse. Callers filter by `payload.id` themselves.
+   */
+  onSubmitStatus: (callback: (data: TerminalSubmitStatusPayload) => void): (() => void) =>
+    window.electron.terminal.onSubmitStatus(callback),
 
   /**
    * Listen for terminal reliability metrics (pause-start/end, suspend,

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -464,6 +464,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     exitCode,
     queueCount,
     flowStatus,
+    submitStatus,
     completedWithNoChanges,
     isHibernated,
   ]);

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -98,6 +98,8 @@ export interface ContentPanelProps extends BasePanelProps {
   lastCommand?: string;
   queueCount?: number;
   flowStatus?: PersistableFlowStatus;
+  /** Submit-lane state, forwarded to the auto-constructed TerminalHeaderContent (#11875). */
+  submitStatus?: "slow" | "stalled" | "failed";
   /**
    * True when the agent transitioned to `completed` and the worktree's
    * changed-file count is zero. Drives the "Finished, no changes" pill
@@ -234,6 +236,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     lastCommand,
     queueCount = 0,
     flowStatus,
+    submitStatus,
     completedWithNoChanges = false,
     onRestart,
     isPinged,
@@ -442,6 +445,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           exitCode={exitCode}
           queueCount={queueCount}
           flowStatus={flowStatus}
+          submitStatus={submitStatus}
           completedWithNoChanges={completedWithNoChanges}
           isHibernated={isHibernated}
         />

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -59,6 +59,12 @@ export interface TerminalHeaderContentProps {
   queueCount?: number;
   flowStatus?: TerminalFlowStatus;
   /**
+   * Submit-lane state for this terminal (#11875). Only `"slow"` renders here —
+   * it is the Tier-1 ambient half of the signal. `"stalled"`/`"failed"` escalate
+   * to `TerminalSubmitStatusBanner` in the pane, which owns the recovery action.
+   */
+  submitStatus?: "slow" | "stalled" | "failed";
+  /**
    * True when the agent transitioned to `completed` and the worktree's
    * changed-file count is zero. Drives the "Finished, no changes" pill
    * so users get a quiet confirmation instead of the chip silently disappearing.
@@ -107,6 +113,7 @@ export function TerminalHeaderContent({
   exitCode = null,
   queueCount = 0,
   flowStatus,
+  submitStatus,
   completedWithNoChanges = false,
   isHibernated = false,
 }: TerminalHeaderContentProps) {
@@ -365,6 +372,32 @@ export function TerminalHeaderContent({
         <span className="text-xs font-mono text-status-error" role="status" aria-live="off">
           [exit {exitCode}]
         </span>
+      )}
+
+      {/* Prompt-still-sending badge — Tier-1 ambient (#11875). Self-clearing:
+          the submit reports `settled` when it finally lands. Deliberately no
+          action here — the original Enter is still armed, so any "send again"
+          affordance would double-submit. If it stops progressing entirely the
+          pane escalates to a banner and this pill gives way to it. */}
+      {submitStatus === "slow" && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className="inline-flex items-center gap-1 text-xs font-sans bg-overlay-soft text-daintree-text/60 px-1.5 py-0.5 rounded border border-divider"
+              role="status"
+              aria-live="off"
+            >
+              <Hourglass className="w-3 h-3" aria-hidden="true" />
+              Prompt still sending
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="max-w-xs">
+            <div className="flex flex-col gap-0.5">
+              <span className="font-medium">Still sending</span>
+              <span>Later prompts stay queued so they can&apos;t merge into this one.</span>
+            </div>
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {/* Paused-backpressure badge — Tier-1 ambient (auto-recovering).

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -40,6 +40,8 @@ import { TerminalErrorBanner } from "./TerminalErrorBanner";
 import { SpawnErrorBanner } from "./SpawnErrorBanner";
 import { ReconnectErrorBanner } from "./ReconnectErrorBanner";
 import { ScrollbackRestoreErrorBanner } from "./ScrollbackRestoreErrorBanner";
+import { TerminalSubmitStatusBanner } from "./TerminalSubmitStatusBanner";
+import { useTerminalSubmitStatus } from "./useTerminalSubmitStatus";
 import { TerminalAttachErrorBanner } from "./TerminalAttachErrorBanner";
 import { useShouldSuppressLocalError } from "@/components/Recovery/useShouldSuppressLocalError";
 import { UpdateCwdDialog } from "./UpdateCwdDialog";
@@ -1248,6 +1250,16 @@ function TerminalPaneComponent({
     !suppressParseError && Boolean(scrollbackRestoreError) && !restartError;
   const showRestartStatus = restartBannerVariant.type !== "none";
 
+  // Submit-lane status (#11875). `slow` stays ambient in the header pill; only
+  // the escalated states get a banner, and only when the backend is healthy
+  // enough for the message to mean anything.
+  const submitStatus = useTerminalSubmitStatus(id, { isRestarting, isExited });
+  const showSubmitStatusBanner =
+    !suppressBackendDependent &&
+    (submitStatus === "stalled" || submitStatus === "failed") &&
+    !restartError &&
+    !spawnError;
+
   return (
     <ContentPanel
       ref={containerRef}
@@ -1283,6 +1295,7 @@ function TerminalPaneComponent({
       detectedProcessId={detectedProcessId}
       queueCount={queueCount}
       flowStatus={flowStatus}
+      submitStatus={submitStatus ?? undefined}
       isPinged={isPinged}
       wasJustSelected={wasJustSelected}
       ambientAgentState={ambientAgentState}
@@ -1361,6 +1374,17 @@ function TerminalPaneComponent({
             onUpdateCwd={handleUpdateCwd}
             onRetry={handleRestart}
             onTrash={handleTrash}
+            isRestarting={isRestarting}
+          />
+        )}
+      </BannerSlot>
+
+      <BannerSlot visible={showSubmitStatusBanner}>
+        {(submitStatus === "stalled" || submitStatus === "failed") && (
+          <TerminalSubmitStatusBanner
+            terminalId={id}
+            status={submitStatus}
+            onRestart={handleRestart}
             isRestarting={isRestarting}
           />
         )}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1384,7 +1384,6 @@ function TerminalPaneComponent({
           <TerminalSubmitStatusBanner
             terminalId={id}
             status={submitStatus}
-            onRestart={handleRestart}
             isRestarting={isRestarting}
           />
         )}

--- a/src/components/Terminal/TerminalSubmitStatusBanner.tsx
+++ b/src/components/Terminal/TerminalSubmitStatusBanner.tsx
@@ -1,0 +1,65 @@
+import { RotateCcw, SendHorizonal } from "lucide-react";
+import { InlineStatusBanner } from "./InlineStatusBanner";
+
+export interface TerminalSubmitStatusBannerProps {
+  terminalId: string;
+  /** Only the two escalated states reach this banner; `slow` stays an ambient
+   *  header pill and never renders here. */
+  status: "stalled" | "failed";
+  onRestart: (id: string) => void;
+  isRestarting?: boolean;
+  className?: string;
+}
+
+const BANNER_COPY = {
+  stalled: {
+    title: "Prompt send stalled",
+    description:
+      "Daintree is still waiting for this prompt to finish sending. Later prompts stay queued so they can't merge into it.",
+    icon: SendHorizonal,
+  },
+  failed: {
+    title: "Prompt send failed",
+    description:
+      "The terminal couldn't finish sending this prompt. Restart it before trying again so a partial prompt doesn't merge with the next one.",
+    icon: SendHorizonal,
+  },
+} as const;
+
+/**
+ * Tier-3 surface for a submit that stopped making progress (#11875).
+ *
+ * There is deliberately no "send again" or "press Enter" affordance. The
+ * original submit still owns the composer and its Enter is still armed, so a
+ * second send would submit the prompt twice. Restarting the terminal is the
+ * only recovery that actually resolves the ambiguity, so it is the only action
+ * offered.
+ */
+export function TerminalSubmitStatusBanner({
+  terminalId,
+  status,
+  onRestart,
+  isRestarting = false,
+  className,
+}: TerminalSubmitStatusBannerProps) {
+  const copy = BANNER_COPY[status];
+
+  return (
+    <InlineStatusBanner
+      icon={copy.icon}
+      title={copy.title}
+      description={copy.description}
+      severity={status === "failed" ? "error" : "warning"}
+      action={{
+        id: "restart",
+        label: "Restart terminal",
+        icon: RotateCcw,
+        variant: "primary",
+        onClick: () => onRestart(terminalId),
+        ariaLabel: "Restart terminal",
+        loading: isRestarting,
+      }}
+      className={className}
+    />
+  );
+}

--- a/src/components/Terminal/TerminalSubmitStatusBanner.tsx
+++ b/src/components/Terminal/TerminalSubmitStatusBanner.tsx
@@ -1,12 +1,12 @@
-import { RotateCcw, SendHorizonal } from "lucide-react";
+import { RotateCcw, SendHorizontal } from "lucide-react";
 import { InlineStatusBanner } from "./InlineStatusBanner";
+import { actionService } from "@/services/ActionService";
 
 export interface TerminalSubmitStatusBannerProps {
   terminalId: string;
   /** Only the two escalated states reach this banner; `slow` stays an ambient
    *  header pill and never renders here. */
   status: "stalled" | "failed";
-  onRestart: (id: string) => void;
   isRestarting?: boolean;
   className?: string;
 }
@@ -16,13 +16,11 @@ const BANNER_COPY = {
     title: "Prompt send stalled",
     description:
       "Daintree is still waiting for this prompt to finish sending. Later prompts stay queued so they can't merge into it.",
-    icon: SendHorizonal,
   },
   failed: {
     title: "Prompt send failed",
     description:
       "The terminal couldn't finish sending this prompt. Restart it before trying again so a partial prompt doesn't merge with the next one.",
-    icon: SendHorizonal,
   },
 } as const;
 
@@ -34,11 +32,17 @@ const BANNER_COPY = {
  * second send would submit the prompt twice. Restarting the terminal is the
  * only recovery that actually resolves the ambiguity, so it is the only action
  * offered.
+ *
+ * Restart goes through `ActionService` rather than the store primitive the
+ * sibling error banners call. Those fire on a dead or failed terminal, where
+ * there is nothing running to lose; this one fires while a submit is in
+ * flight, which is exactly the running-agent case `terminal.restart`'s
+ * `danger: "confirm"` gate exists to catch (D1, docs/architecture/
+ * destructive-action-safeguards.md).
  */
 export function TerminalSubmitStatusBanner({
   terminalId,
   status,
-  onRestart,
   isRestarting = false,
   className,
 }: TerminalSubmitStatusBannerProps) {
@@ -46,16 +50,18 @@ export function TerminalSubmitStatusBanner({
 
   return (
     <InlineStatusBanner
-      icon={copy.icon}
+      icon={SendHorizontal}
       title={copy.title}
       description={copy.description}
-      severity={status === "failed" ? "error" : "warning"}
+      severity="error"
       action={{
         id: "restart",
         label: "Restart terminal",
         icon: RotateCcw,
         variant: "primary",
-        onClick: () => onRestart(terminalId),
+        onClick: () => {
+          void actionService.dispatch("terminal.restart", { terminalId }, { source: "user" });
+        },
         ariaLabel: "Restart terminal",
         loading: isRestarting,
       }}

--- a/src/components/Terminal/useTerminalSubmitStatus.ts
+++ b/src/components/Terminal/useTerminalSubmitStatus.ts
@@ -6,6 +6,16 @@ import type { TerminalSubmitStatusState } from "@shared/types";
  *  overwhelming majority case — submits that complete normally report nothing. */
 export type TerminalSubmitStatus = Exclude<TerminalSubmitStatusState, "settled"> | null;
 
+/** State is tagged with the terminal it describes. A tab group renders one
+ *  unkeyed pane fiber for whichever tab is active, so on a tab switch this
+ *  hook's state survives into a commit that already carries the new id —
+ *  untagged, that paints terminal A's banner under terminal B's name for a
+ *  frame, with a restart button pointed at the wrong process. */
+interface TaggedStatus {
+  terminalId: string;
+  status: TerminalSubmitStatus;
+}
+
 /**
  * Pane-local view of one terminal's submit lane (#11875).
  *
@@ -14,30 +24,33 @@ export type TerminalSubmitStatus = Exclude<TerminalSubmitStatusState, "settled">
  * worth persisting or restoring. It mirrors how the other pane banners are fed.
  *
  * `reset` is keyed on the things that mean "the process this status described
- * is gone" — a restart, an exit, or the pane being pointed at a different
- * terminal. Without that, a status from a killed process would sit on the
- * restarted pane forever, since the new process has no reason to emit
- * `settled`.
+ * is gone" — a restart or an exit. Without that, a status from a killed
+ * process would sit on the restarted pane, since the new process has no reason
+ * to emit `settled`.
  */
 export function useTerminalSubmitStatus(
   terminalId: string,
   reset: { isRestarting?: boolean; isExited?: boolean } = {}
 ): TerminalSubmitStatus {
-  const [status, setStatus] = useState<TerminalSubmitStatus>(null);
+  const [tagged, setTagged] = useState<TaggedStatus | null>(null);
   const { isRestarting, isExited } = reset;
 
   useEffect(() => {
     return terminalClient.onSubmitStatus((payload) => {
       if (payload.id !== terminalId) return;
-      setStatus(payload.state === "settled" ? null : payload.state);
+      setTagged(
+        payload.state === "settled"
+          ? null
+          : { terminalId, status: payload.state as TerminalSubmitStatus }
+      );
     });
   }, [terminalId]);
 
-  // Clearing on id change is handled by this effect too — the state is per-pane
-  // and a new id means the previous terminal's status is meaningless here.
   useEffect(() => {
-    setStatus(null);
+    setTagged(null);
   }, [terminalId, isRestarting, isExited]);
 
-  return status;
+  // Read through the tag rather than trusting the stored value: on the commit
+  // where `terminalId` changes, this runs before the reset effect above.
+  return tagged?.terminalId === terminalId ? tagged.status : null;
 }

--- a/src/components/Terminal/useTerminalSubmitStatus.ts
+++ b/src/components/Terminal/useTerminalSubmitStatus.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { terminalClient } from "@/clients";
+import type { TerminalSubmitStatusState } from "@shared/types";
+
+/** What the pane is currently showing about its submit lane. `null` is the
+ *  overwhelming majority case — submits that complete normally report nothing. */
+export type TerminalSubmitStatus = Exclude<TerminalSubmitStatusState, "settled"> | null;
+
+/**
+ * Pane-local view of one terminal's submit lane (#11875).
+ *
+ * Deliberately not a store: this is transient per-pane runtime state with no
+ * consumer outside the pane that owns the terminal, and nothing about it is
+ * worth persisting or restoring. It mirrors how the other pane banners are fed.
+ *
+ * `reset` is keyed on the things that mean "the process this status described
+ * is gone" — a restart, an exit, or the pane being pointed at a different
+ * terminal. Without that, a status from a killed process would sit on the
+ * restarted pane forever, since the new process has no reason to emit
+ * `settled`.
+ */
+export function useTerminalSubmitStatus(
+  terminalId: string,
+  reset: { isRestarting?: boolean; isExited?: boolean } = {}
+): TerminalSubmitStatus {
+  const [status, setStatus] = useState<TerminalSubmitStatus>(null);
+  const { isRestarting, isExited } = reset;
+
+  useEffect(() => {
+    return terminalClient.onSubmitStatus((payload) => {
+      if (payload.id !== terminalId) return;
+      setStatus(payload.state === "settled" ? null : payload.state);
+    });
+  }, [terminalId]);
+
+  // Clearing on id change is handled by this effect too — the state is per-pane
+  // and a new id means the previous terminal's status is meaningless here.
+  useEffect(() => {
+    setStatus(null);
+  }, [terminalId, isRestarting, isExited]);
+
+  return status;
+}


### PR DESCRIPTION
**The bug.** `WriteQueue.drainSubmitQueue` raced `performSubmit` against a 3000ms timer with `Promise.race`. When the timer fired it released the `submitInFlight` serialiser but did nothing to stop the writer. The abandoned submit kept running and eventually wrote its trailing Enter — after the next submit had already written its body into the same agent composer. Two prompts merged into one, and the agent received neither.

Bumping a generation counter or passing an `AbortSignal` only changes *which* Enter fires the merged prompt: `performSubmit` writes its body before its first await, so by the time the timer fires those bytes are already in the composer and cannot be withdrawn. The invariant that actually has to hold is that the next submit does not start writing while the previous one still owns the composer.

**What ships.**

1. **The 3000ms timer is report-only.** `performSubmit` is awaited directly; a side timer reports `slow` without rejecting, without clearing `submitInFlight`, and without starting the next submit. Renamed `SUBMIT_TIMEOUT_MS` → `SUBMIT_SLOW_THRESHOLD_MS`, because it is no longer a timeout. One re-arming, unref'd handle escalates to `stalled` at 30s measured from the submit's start. A submit that never settles now blocks that terminal's submit lane — the right trade, since starting the next submit is the unsafe action and there is no rollback for bytes already in a composer.

2. **The byte pacing is deleted.** `WRITE_MAX_CHUNK_SIZE = 50` / `WRITE_INTERVAL_MS = 5`, `chunkInput`, the chunk queue, `hasPendingWrites`, and `waitForInputWriteDrain` are gone. They were copied from VS Code as a workaround for microsoft/vscode#38137, a race writing to the FD — fixed upstream by microsoft/node-pty#831 and removed from VS Code two days later in microsoft/vscode#283065. We pin node-pty 1.2.0-beta.14, which carries the fix: `CustomWriteStream` runs its own FIFO queue against the raw fd and reschedules on `EAGAIN` (`unixTerminal.js:286-350`). We were carrying a workaround upstream had deleted, at upstream's original constants, for a bug our own dependency already fixes. It capped PTY input at ~10,000 chars/sec, which is the real cause of the long context injections in #57, #10034 and #372 — CopyTree's 4096-char slices were being re-split into 50-byte chunks at 5ms each. Kept: the submit-operation queue, `waitForOutputSettle`, the agent Enter delays (`submitEnterDelayMs`; the Ink constraint behind #5830 is still load-bearing), CopyTree's `setImmediate` yielding and cancellation checks, and both shutdown generation guards.

3. **A slow or failed submit is now visible.** A typed `terminal:submit-status` event carries `slow`/`stalled`/`settled`/`failed` from the pty-host to the renderer on the existing multiplexed event bus — a closed union rather than an overloaded error string. Tier 1 is an ambient "Prompt still sending" pill in the terminal header, self-clearing. It escalates at 30s to a Tier 3 `InlineStatusBanner` in the owning pane whose only action is "Restart terminal", dispatched through `ActionService` so `terminal.restart`'s `danger: "confirm"` running-agent gate still applies. There is deliberately no "press Enter" or "send again" affordance: the original Enter is still armed, so a second send would submit twice.

**Not in this PR.** Submit bodies still jump ahead of an in-flight CopyTree injection — that needs a per-terminal input-operation fence living in the pty-host, and gets its own issue. Removing the pacing shrinks that window from tens of seconds to sub-millisecond but does not close it.

**Testing.** The regression test asserts two clean composer frames: exactly two CRs, with the second body strictly between them. Suppressing only the stale Enter fails the CR count; letting the second body start early fails the boundary assertion. It gates on a deferred output-settle promise rather than payload size, because the pacing the original repro used as its clock is deleted in this same change — a size-based trigger would have quietly stopped exercising the bug. Verified failing on the parent commit and passing after. Local: typecheck clean, 5786 tests passing, prettier + eslint clean on changed files.

**Risks worth native validation before merge.** node-pty#831 is Unix-only; `windowsTerminal.js` writes to a named-pipe socket and ignores its backpressure return, so ConPTY loses pacing with no upstream replacement (VS Code removed it on Windows too). node-pty deliberately accepts macOS Bash 3.2 readline corruption on fast writes (microsoft/node-pty#833) — agent CLIs are not bash, but anyone on system bash is exposed. Fleet broadcast writes to every target in a loop, so large unbracketed payloads across many terminals are no longer rate-limited. Worth running `e2e/full/terminal/core-context-injection.spec.ts` and a large paste on macOS, Linux and Windows.

Resolves #11875