### PR TITLE
fix(mcp): make native automation grants reachable for confirm actions

### DIFF
--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -331,9 +331,8 @@ tools/call(actionId, args)
 
 Gate order is load-bearing: a native grant's use is charged **after** admission and after the workspace-bound confirm ceiling — an unauthorized or refused call must never burn one — but **before** dedup, so a replayed duplicate spends a use without dispatching. The per-call rate limiter that used to sit between admission and dedup was removed in #10764.
 
-### Rate limits and dedup
+### Dedup
 
-- **Rate limits** (`RATE_LIMIT_TIERS`, `RATE_LIMIT_TOOL_MAP`): per-`(session, toolId)` token bucket. `highFreqRead` (60/min) for cheap polling, `standard` (30/min) default, `mutation` (10/min) for side-effecting tools (commit, push, issue/PR, worktree.delete).
 - **Dedup** (`MCP_DEDUP_ALLOWLIST`): creation tools only, admitted on one of two distinct grounds — either an LLM retry leaves a duplicate artifact (an orphan terminal, a second agent, a duplicate issue/comment/review), or the retry creates nothing and the cached success is preferable to the error a redundant redispatch would raise (`worktree.delete`, `forge.createPR`, `forge.mergePR`, which 422s a duplicate PR and PUTs a merge). Keyed by a caller-supplied `requestKey` (prefixed with `actionId`, capped at `MAX_REQUEST_KEY_LENGTH`) or an auto canonical args hash, with an args-hash collision guard (#8429). TTL `MCP_DEDUP_TTL_MS` (120s), FIFO-capped at `MCP_DEDUP_MAX_ENTRIES_PER_SESSION` (256). Deliberately **out** (#11534): navigation (`forge.open*`) and idempotent state-sets (assign/unassign, close/reopen/edit, labels), which create no duplicate to suppress and whose cached 120s no-op breaks the legitimate repeat — reopening a URL the user closed, or re-assigning after an unassign — plus `git.commit`/`git.push`, whose arguments a legitimate repeat reuses unchanged, so deduping them would report success for a commit or push that never happened.
 
 ## Tool argument and result conventions (#11543)

--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -278,30 +278,28 @@ tools/call(actionId, args)
   │      └─ yes → return SESSION_GONE (business, do not retry) before any audit,
   │               denial counter, grant lookup, dedup entry or dispatch
   │
-  ├─1 Tier floor: isTierPermitted(tier, actionId)?
-  │      ├─ no → grantCache.check(sessionId, actionId)
-  │      │      ├─ granted → proceed (capture issuedAt for post-dispatch refresh;
-  │      │      │            widens the floor only — never bypasses confirm)
-  │      │      └─ denied  → peekNativeGrant(sessionId, actionId)
-  │      │             ├─ granted → proceed (capture grantId: widens the floor
-  │      │             │            AND pre-authorizes confirm)
-  │      │             └─ denied  → incrementDenial → maybe notifyTierMismatch (banner,
-  │      │                          suppressed after MCP_DENIAL_SILENCE_THRESHOLD) →
-  │      │                          recordDenial(abusePolicy); if tripped → revokeSession →
-  │      │                          return TIER_NOT_PERMITTED
-  │      └─ yes → peekNativeGrant(sessionId, actionId)  (#11878)
-  │             └─ granted → capture grantId for confirm pre-authorization
+  ├─1 Admission — did anything OTHER than a native grant let this call in?
+  │      ├─ isTierPermitted(tier, actionId) → yes: admitted by the floor
+  │      └─ no → grantCache.check(sessionId, actionId)
+  │             └─ granted → admitted (capture issuedAt for post-dispatch
+  │                          refresh; widens the floor only, never bypasses
+  │                          confirm)
   │
-  │      The native peek runs on BOTH legs because a native grant does two
-  │      jobs and only the first is a tier concern: it widens past the floor,
-  │      and it pre-authorizes the confirm modal. Nesting it under denial made
-  │      it unreachable for a tool the tier already permitted — worktree.delete
-  │      is danger:"confirm" but system-tier permitted, so pre-authorizing it
-  │      in Settings did nothing. The per-tool grant is denial-only: it widens
-  │      the floor and nothing else, so it has no say once the floor admits.
-  │
-  ├─2 Rate limit: consumeRateLimitToken(sessionId, actionId)
-  │      └─ empty bucket → return MCP_RATE_LIMITED (retryAfter; retriable)
+  ├─2 Native grant: peekNativeGrant(sessionId, actionId)  (#11878)
+  │      │  Runs independently of gate 1, because a native grant answers a
+  │      │  different question: it both widens the floor AND pre-authorizes
+  │      │  the confirm modal. Nesting it under either admission source left
+  │      │  it unreachable — worktree.delete is danger:"confirm" but
+  │      │  system-tier permitted, so pre-authorizing it in Settings did
+  │      │  nothing; the same held when a per-tool grant had just admitted it.
+  │      │  Skipped only for an already-admitted introspection carrier, which
+  │      │  can never raise a modal, so a peek would just drain the budget.
+  │      ├─ granted → capture grantId (widens the floor AND pre-authorizes
+  │      │            confirm; the use is charged later, at commit-to-dispatch)
+  │      └─ neither gate 1 nor a grant admitted it → incrementDenial → maybe
+  │                   notifyTierMismatch (banner, suppressed after
+  │                   MCP_DENIAL_SILENCE_THRESHOLD) → recordDenial(abusePolicy);
+  │                   if tripped → revokeSession → return TIER_NOT_PERMITTED
   │
   ├─3 Dedup (creation-tool allowlist only):
   │      ├─ cached result within TTL & same args → return cached (audit: dedup)
@@ -331,7 +329,7 @@ tools/call(actionId, args)
   └─7 Audit: appendAuditRecord({ toolId, tier, args, durationMs, outcome })
 ```
 
-Gate order is load-bearing: rate-limit is charged **after** the tier/grant check (an unauthorized call shouldn't consume tokens) but **before** dedup (dedup is an idempotency guard, not a rate-limit bypass — a tight loop replaying one dedup key must still be bounded).
+Gate order is load-bearing: a native grant's use is charged **after** admission and after the workspace-bound confirm ceiling — an unauthorized or refused call must never burn one — but **before** dedup, so a replayed duplicate spends a use without dispatching. The per-call rate limiter that used to sit between admission and dedup was removed in #10764.
 
 ### Rate limits and dedup
 

--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -196,7 +196,7 @@ The introspection tools (`actions.list`, `actions.search`, `actions.getSchema`) 
 How `danger` interacts with tier gating:
 
 - `danger: "restricted"` — never exposed (hard floor in `shouldExposeTool`) and never dispatchable, the latter enforced by `ActionService.dispatch` rather than by the tier gate.
-- `danger: "confirm"` — _exposed and dispatchable_ if the tier permits, but the `CallTool` handler dispatches it **unconfirmed** so the human approves it host-side in the renderer's native `McpConfirmDialog` (via the renderer bridge) before the mutation fires. This is the MCP-side wiring of the same confirm gate documented in [`destructive-action-safeguards.md`](./destructive-action-safeguards.md): `danger:"confirm"` classifies the action; the host `ConfirmDialog` is the user-facing confirm. A client's self-declared `elicitation.form` capability is **never** treated as authorization — a headless/agentic client could otherwise answer its own in-band elicitation `accept` and self-approve a destructive call with no human in the loop (#11342). When no Daintree window is open to surface the dialog the call is refused with `CONFIRMATION_REQUIRED` (`confirmationChannel: "unavailable"`); only a host-issued native automation grant pre-authorizes a dispatch.
+- `danger: "confirm"` — _exposed and dispatchable_ if the tier permits, but the `CallTool` handler dispatches it **unconfirmed** so the human approves it host-side in the renderer's native `McpConfirmDialog` (via the renderer bridge) before the mutation fires. This is the MCP-side wiring of the same confirm gate documented in [`destructive-action-safeguards.md`](./destructive-action-safeguards.md): `danger:"confirm"` classifies the action; the host `ConfirmDialog` is the user-facing confirm. A client's self-declared `elicitation.form` capability is **never** treated as authorization — a headless/agentic client could otherwise answer its own in-band elicitation `accept` and self-approve a destructive call with no human in the loop (#11342). When no Daintree window is open to surface the dialog the call is refused with `CONFIRMATION_REQUIRED` (`confirmationChannel: "unavailable"`); only a host-issued native automation grant pre-authorizes a dispatch — and it does so whether or not the static tier already permitted the action, since pre-authorizing the modal is orthogonal to clearing the floor (#11878).
 
 ## Session lifecycle (`sessionStore.ts`, `httpLifecycle.ts`)
 
@@ -279,12 +279,26 @@ tools/call(actionId, args)
   │               denial counter, grant lookup, dedup entry or dispatch
   │
   ├─1 Tier floor: isTierPermitted(tier, actionId)?
-  │      └─ no → grantCache.check(sessionId, actionId)
-  │             ├─ granted → proceed (capture issuedAt for post-dispatch refresh)
-  │             └─ denied  → incrementDenial → maybe notifyTierMismatch (banner,
-  │                          suppressed after MCP_DENIAL_SILENCE_THRESHOLD) →
-  │                          recordDenial(abusePolicy); if tripped → revokeSession →
-  │                          return TIER_NOT_PERMITTED
+  │      ├─ no → grantCache.check(sessionId, actionId)
+  │      │      ├─ granted → proceed (capture issuedAt for post-dispatch refresh;
+  │      │      │            widens the floor only — never bypasses confirm)
+  │      │      └─ denied  → peekNativeGrant(sessionId, actionId)
+  │      │             ├─ granted → proceed (capture grantId: widens the floor
+  │      │             │            AND pre-authorizes confirm)
+  │      │             └─ denied  → incrementDenial → maybe notifyTierMismatch (banner,
+  │      │                          suppressed after MCP_DENIAL_SILENCE_THRESHOLD) →
+  │      │                          recordDenial(abusePolicy); if tripped → revokeSession →
+  │      │                          return TIER_NOT_PERMITTED
+  │      └─ yes → peekNativeGrant(sessionId, actionId)  (#11878)
+  │             └─ granted → capture grantId for confirm pre-authorization
+  │
+  │      The native peek runs on BOTH legs because a native grant does two
+  │      jobs and only the first is a tier concern: it widens past the floor,
+  │      and it pre-authorizes the confirm modal. Nesting it under denial made
+  │      it unreachable for a tool the tier already permitted — worktree.delete
+  │      is danger:"confirm" but system-tier permitted, so pre-authorizing it
+  │      in Settings did nothing. The per-tool grant is denial-only: it widens
+  │      the floor and nothing else, so it has no say once the floor admits.
   │
   ├─2 Rate limit: consumeRateLimitToken(sessionId, actionId)
   │      └─ empty bucket → return MCP_RATE_LIMITED (retryAfter; retriable)

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2288,10 +2288,14 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     // Before #11878 that made the grant unreachable and the modal fired on
     // every call despite an explicit Settings pre-authorization.
     const sessionStore = fakeSessionStore("system");
+    // Unref'd for the reason `seedLiveSession` documents: a referenced
+    // 1,000,000 ms timer holds the Vitest worker open past the suite.
+    const idleTimer = setTimeout(() => {}, 1_000_000);
+    idleTimer.unref?.();
     sessionStore.sessions.set("s", {
       transport: {} as never,
       server: {} as never,
-      idleTimer: setTimeout(() => {}, 1_000_000),
+      idleTimer,
     });
     const resetIdle = sessionStore.resetIdleTimer as ReturnType<typeof vi.fn>;
     resetIdle.mockClear();
@@ -2303,6 +2307,7 @@ describe("sessionServer grant cache fallback (#8442)", () => {
       maxUses: 2,
     });
     const refreshSpy = vi.spyOn(sessionStore.grantCache, "refreshNativeGrant");
+    const checkSpy = vi.spyOn(sessionStore.grantCache, "check");
     const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
     const deps = fakeDeps({ sessionStore, dispatchAction });
     const server = createSessionServer("s", deps);
@@ -2314,23 +2319,66 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     })) as { isError?: boolean };
 
     expect(result.isError).not.toBe(true);
-    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), true);
+    // Pins the leg: an untouched per-tool cache proves the floor admitted this
+    // call, so the bypass below can only have come from the native grant.
+    expect(checkSpy).not.toHaveBeenCalled();
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(
+      "worktree.delete",
+      expect.objectContaining({ worktreeId: "wt-1" }),
+      true
+    );
     expect(refreshSpy).toHaveBeenCalledWith(grant.id);
     expect(resetIdle).toHaveBeenCalledWith("s");
     expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(1);
     sessionStore.grantCache.dispose();
   });
 
-  it("per-tool grant keeps precedence over a native grant when the tier denies (#11878)", async () => {
-    // Guards against a refactor that hoists the native peek above the tier
-    // check: the per-tool grant already authorizes this call, so the native
-    // grant must stay untouched rather than burning a use it never needed.
-    const sessionStore = fakeSessionStore("workbench");
-    sessionStore.sessions.set("s", {
-      transport: {} as never,
-      server: {} as never,
-      idleTimer: setTimeout(() => {}, 1_000_000),
+  it("a spent grant leaves a tier-permitted confirm tool dispatching unconfirmed (#11878)", async () => {
+    // The non-mocked proof that the grant only ever bought the modal bypass:
+    // once its single use is gone the call must still run — just with the
+    // modal back. The tier-denied equivalent fails closed instead, because
+    // there the grant was the authorization itself.
+    const sessionStore = fakeSessionStore("system");
+    sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 1,
     });
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    // Distinct args on the second call: worktree.delete is on the dedup
+    // allowlist, so a replay would return the cached result and never reach
+    // the gate this test is about.
+    const first = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: { worktreeId: "wt-1" },
+    })) as { isError?: boolean };
+    const second = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: { worktreeId: "wt-2" },
+    })) as { isError?: boolean };
+
+    expect(first.isError).not.toBe(true);
+    expect(second.isError).not.toBe(true);
+    expect(dispatchAction).toHaveBeenNthCalledWith(1, "worktree.delete", expect.any(Object), true);
+    expect(dispatchAction).toHaveBeenNthCalledWith(2, "worktree.delete", expect.any(Object), false);
+    sessionStore.grantCache.dispose();
+  });
+
+  it("a per-tool grant does not suppress native confirm pre-authorization (#11878)", async () => {
+    // Both grant kinds can be live at once. The per-tool grant is what admits
+    // the call past the denying floor, but only the native grant can waive the
+    // modal — so holding both must still waive it. The native peek used to sit
+    // behind the per-tool check, which made an explicit Settings
+    // pre-authorization silently do nothing here, exactly as it did for a
+    // tier-permitted tool.
+    const sessionStore = fakeSessionStore("workbench");
     sessionStore.grantCache.issueGrant("s", "worktree.delete");
     const grant = sessionStore.grantCache.issueNativeGrant({
       sessionId: "s",
@@ -2339,8 +2387,6 @@ describe("sessionServer grant cache fallback (#8442)", () => {
       allowedTools: ["worktree.delete"],
       maxUses: 2,
     });
-    const peekSpy = vi.spyOn(sessionStore.grantCache, "peekNativeGrant");
-    const consumeSpy = vi.spyOn(sessionStore.grantCache, "consumeNativeGrantUse");
     const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
     const deps = fakeDeps({ sessionStore, dispatchAction });
     const server = createSessionServer("s", deps);
@@ -2348,11 +2394,8 @@ describe("sessionServer grant cache fallback (#8442)", () => {
 
     await callTool(server, { name: "worktree.delete", arguments: {} });
 
-    // A per-tool grant widens the floor but never bypasses the modal.
-    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), false);
-    expect(peekSpy).not.toHaveBeenCalled();
-    expect(consumeSpy).not.toHaveBeenCalled();
-    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(2);
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), true);
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(1);
     sessionStore.grantCache.dispose();
   });
 
@@ -2361,14 +2404,16 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     // bypass. Refusing here would report "not permitted for the 'system'
     // tier" for an action that tier plainly permits.
     const sessionStore = fakeSessionStore("system");
-    sessionStore.grantCache.issueNativeGrant({
+    const grant = sessionStore.grantCache.issueNativeGrant({
       sessionId: "s",
       actorId: "help-1",
       actorType: "help-session",
       allowedTools: ["worktree.delete"],
       maxUses: 2,
     });
-    vi.spyOn(sessionStore.grantCache, "consumeNativeGrantUse").mockReturnValue(false);
+    const consumeSpy = vi
+      .spyOn(sessionStore.grantCache, "consumeNativeGrantUse")
+      .mockReturnValue(false);
     const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
     const deps = fakeDeps({ sessionStore, dispatchAction });
     const server = createSessionServer("s", deps);
@@ -2379,6 +2424,9 @@ describe("sessionServer grant cache fallback (#8442)", () => {
       arguments: {},
     })) as { isError?: boolean };
 
+    // Without this the test would pass for the wrong reason: never peeking at
+    // all also yields an unconfirmed dispatch.
+    expect(consumeSpy).toHaveBeenCalledWith(grant.id, "worktree.delete");
     expect(result.isError).not.toBe(true);
     expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), false);
     sessionStore.grantCache.dispose();
@@ -2387,14 +2435,16 @@ describe("sessionServer grant cache fallback (#8442)", () => {
   it("a tier-denied call still fails closed when the grant dies between peek and consume (#11878)", async () => {
     // Here the grant WAS the authorization, so losing it must fail closed.
     const sessionStore = fakeSessionStore("workbench");
-    sessionStore.grantCache.issueNativeGrant({
+    const grant = sessionStore.grantCache.issueNativeGrant({
       sessionId: "s",
       actorId: "help-1",
       actorType: "help-session",
       allowedTools: ["worktree.delete"],
       maxUses: 2,
     });
-    vi.spyOn(sessionStore.grantCache, "consumeNativeGrantUse").mockReturnValue(false);
+    const consumeSpy = vi
+      .spyOn(sessionStore.grantCache, "consumeNativeGrantUse")
+      .mockReturnValue(false);
     const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
     const deps = fakeDeps({ sessionStore, dispatchAction });
     const server = createSessionServer("s", deps);
@@ -2405,8 +2455,12 @@ describe("sessionServer grant cache fallback (#8442)", () => {
       arguments: {},
     })) as { isError?: boolean; content?: Array<{ text?: string }> };
 
+    // Proves the refusal came from the consume-failure guard rather than the
+    // ordinary tier denial, which would produce the same error for a
+    // different reason.
+    expect(consumeSpy).toHaveBeenCalledWith(grant.id, "worktree.delete");
     expect(result.isError).toBe(true);
-    expect(result.content?.[0]?.text ?? "").toContain("TIER_NOT_PERMITTED");
+    expect(result.content?.[0]?.text ?? "").toContain(TIER_NOT_PERMITTED_CODE);
     expect(dispatchAction).not.toHaveBeenCalled();
     sessionStore.grantCache.dispose();
   });
@@ -2425,6 +2479,7 @@ describe("sessionServer grant cache fallback (#8442)", () => {
       allowedTools: ["worktree.list"],
       maxUses: 2,
     });
+    const checkSpy = vi.spyOn(sessionStore.grantCache, "check");
     const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
     const deps = fakeDeps({ sessionStore, dispatchAction });
     const server = createSessionServer("s", deps);
@@ -2432,8 +2487,37 @@ describe("sessionServer grant cache fallback (#8442)", () => {
 
     await callTool(server, { name: "worktree.list", arguments: {} });
 
+    // Pins the leg — an untouched per-tool cache means the floor admitted it.
+    expect(checkSpy).not.toHaveBeenCalled();
     expect(dispatchAction).toHaveBeenCalledWith("worktree.list", expect.any(Object), true);
     expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(1);
+    sessionStore.grantCache.dispose();
+  });
+
+  it("an already-admitted introspection carrier does not spend a native use (#11878)", async () => {
+    // actions.search can never raise a confirm modal, so once the floor has
+    // admitted it a grant buys it nothing — peeking would only drain the
+    // automation budget on a discovery call and evict entries mid-enumeration.
+    // The peek still runs when the carrier is NOT otherwise admitted, because
+    // there the grant is what authorizes it.
+    const sessionStore = fakeSessionStore("workbench");
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["actions.search"],
+      maxUses: 2,
+    });
+    const peekSpy = vi.spyOn(sessionStore.grantCache, "peekNativeGrant");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "actions.search", arguments: { query: "worktree" } });
+
+    expect(peekSpy).not.toHaveBeenCalled();
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(2);
     sessionStore.grantCache.dispose();
   });
 

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2258,9 +2258,10 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     );
   }
 
-  it("floor-permitted tool never consults the grant cache", async () => {
+  it("floor-permitted tool skips the per-tool grant but still peeks native pre-authorization", async () => {
     const sessionStore = fakeSessionStore("workbench");
     const checkSpy = vi.spyOn(sessionStore.grantCache, "check");
+    const peekSpy = vi.spyOn(sessionStore.grantCache, "peekNativeGrant");
     const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
     const deps = fakeDeps({ sessionStore, dispatchAction });
     const server = createSessionServer("s", deps);
@@ -2270,7 +2271,169 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     await callTool(server, { name: "worktree.list", arguments: {} });
 
     expect(dispatchAction).toHaveBeenCalled();
+    // A per-tool grant only widens the floor, so it has nothing to say once
+    // the floor already admits the call.
     expect(checkSpy).not.toHaveBeenCalled();
+    // A native grant ALSO pre-authorizes the confirm modal, which is
+    // orthogonal to the floor — so it is consulted on this leg too (#11878).
+    expect(peekSpy).toHaveBeenCalledWith("s", "worktree.list");
+    // No grant exists here, so the dispatch stays unconfirmed.
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.list", expect.any(Object), false);
+    sessionStore.grantCache.dispose();
+  });
+
+  it("native grant pre-authorizes a tier-permitted confirm tool and consumes a use (#11878)", async () => {
+    // worktree.delete is `danger: "confirm"` but IS on the system-tier
+    // allowlist, so the floor admits it and the tier-denied leg never runs.
+    // Before #11878 that made the grant unreachable and the modal fired on
+    // every call despite an explicit Settings pre-authorization.
+    const sessionStore = fakeSessionStore("system");
+    sessionStore.sessions.set("s", {
+      transport: {} as never,
+      server: {} as never,
+      idleTimer: setTimeout(() => {}, 1_000_000),
+    });
+    const resetIdle = sessionStore.resetIdleTimer as ReturnType<typeof vi.fn>;
+    resetIdle.mockClear();
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 2,
+    });
+    const refreshSpy = vi.spyOn(sessionStore.grantCache, "refreshNativeGrant");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: { worktreeId: "wt-1" },
+    })) as { isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), true);
+    expect(refreshSpy).toHaveBeenCalledWith(grant.id);
+    expect(resetIdle).toHaveBeenCalledWith("s");
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(1);
+    sessionStore.grantCache.dispose();
+  });
+
+  it("per-tool grant keeps precedence over a native grant when the tier denies (#11878)", async () => {
+    // Guards against a refactor that hoists the native peek above the tier
+    // check: the per-tool grant already authorizes this call, so the native
+    // grant must stay untouched rather than burning a use it never needed.
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.sessions.set("s", {
+      transport: {} as never,
+      server: {} as never,
+      idleTimer: setTimeout(() => {}, 1_000_000),
+    });
+    sessionStore.grantCache.issueGrant("s", "worktree.delete");
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 2,
+    });
+    const peekSpy = vi.spyOn(sessionStore.grantCache, "peekNativeGrant");
+    const consumeSpy = vi.spyOn(sessionStore.grantCache, "consumeNativeGrantUse");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+
+    // A per-tool grant widens the floor but never bypasses the modal.
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), false);
+    expect(peekSpy).not.toHaveBeenCalled();
+    expect(consumeSpy).not.toHaveBeenCalled();
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(2);
+    sessionStore.grantCache.dispose();
+  });
+
+  it("a tier-permitted call falls back to the modal when the grant dies between peek and consume (#11878)", async () => {
+    // The tier still admits the call, so losing the grant costs only the
+    // bypass. Refusing here would report "not permitted for the 'system'
+    // tier" for an action that tier plainly permits.
+    const sessionStore = fakeSessionStore("system");
+    sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 2,
+    });
+    vi.spyOn(sessionStore.grantCache, "consumeNativeGrantUse").mockReturnValue(false);
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), false);
+    sessionStore.grantCache.dispose();
+  });
+
+  it("a tier-denied call still fails closed when the grant dies between peek and consume (#11878)", async () => {
+    // Here the grant WAS the authorization, so losing it must fail closed.
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 2,
+    });
+    vi.spyOn(sessionStore.grantCache, "consumeNativeGrantUse").mockReturnValue(false);
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean; content?: Array<{ text?: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text ?? "").toContain("TIER_NOT_PERMITTED");
+    expect(dispatchAction).not.toHaveBeenCalled();
+    sessionStore.grantCache.dispose();
+  });
+
+  it("a tier-permitted non-confirm tool in the grant's allowlist still spends a use (#11878)", async () => {
+    // Decision lock, not an endorsement: `maxUses` is a budget of matching
+    // dispatches, and spending one only where the bypass is actually needed
+    // would mean resolving effective danger — async manifest plus
+    // args-conditional elevation — before the consume site. Over-charging
+    // fails toward more confirmation, so it is the safe direction to accept.
+    const sessionStore = fakeSessionStore("workbench");
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.list"],
+      maxUses: 2,
+    });
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "worktree.list", arguments: {} });
+
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.list", expect.any(Object), true);
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(1);
     sessionStore.grantCache.dispose();
   });
 
@@ -4419,11 +4582,17 @@ describe("workspace-bound external sessions (#11789)", () => {
         allowedTools: ["recipe.run"],
         maxUses: 3,
       });
+      const peekSpy = vi.spyOn(deps.sessionStore.grantCache, "peekNativeGrant");
       const server = createSessionServer(SESSION, deps);
       await server.connect(makeMockTransport());
 
       await callTool(server, { name: "recipe.run", arguments: {} });
 
+      // recipe.run is ON the external allowlist, so this is the tier-PERMITTED
+      // leg — which #11878 newly routes through the native peek. The
+      // workspace-bound refusal is a hard ceiling that still returns before
+      // the consume site, so the peek must not cost the grant anything.
+      expect(peekSpy).toHaveBeenCalledWith(SESSION, "recipe.run");
       expect(deps.sessionStore.grantCache.getNativeGrant(grant.id)?.remainingUses).toBe(3);
     });
 

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2465,6 +2465,40 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     sessionStore.grantCache.dispose();
   });
 
+  it("a per-tool grant keeps a lost native grant from failing the call closed (#11878)", async () => {
+    // The floor denies, so only the per-tool grant admits this — which is why
+    // the consume-failure guard has to ask "did anything else admit this?"
+    // rather than "did the tier permit this?". Under the narrower question
+    // this call would be refused as tier-denied even though a live grant
+    // admitted it.
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.grantCache.issueGrant("s", "worktree.delete");
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 2,
+    });
+    const consumeSpy = vi
+      .spyOn(sessionStore.grantCache, "consumeNativeGrantUse")
+      .mockReturnValue(false);
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean };
+
+    expect(consumeSpy).toHaveBeenCalledWith(grant.id, "worktree.delete");
+    expect(result.isError).not.toBe(true);
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), false);
+    sessionStore.grantCache.dispose();
+  });
+
   it("a tier-permitted non-confirm tool in the grant's allowlist still spends a use (#11878)", async () => {
     // Decision lock, not an endorsement: `maxUses` is a budget of matching
     // dispatches, and spending one only where the bypass is actually needed
@@ -2516,6 +2550,9 @@ describe("sessionServer grant cache fallback (#8442)", () => {
 
     await callTool(server, { name: "actions.search", arguments: { query: "worktree" } });
 
+    // The dispatch assertion keeps this honest: skipping the peek must be the
+    // guard doing its job, not the call bailing out before it gets there.
+    expect(dispatchAction).toHaveBeenCalled();
     expect(peekSpy).not.toHaveBeenCalled();
     expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(2);
     sessionStore.grantCache.dispose();

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -620,16 +620,28 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     //      live grant exists, the dispatch proceeds and the grant's TTL
     //      is refreshed on success.
     //
-    // The order means that a session whose static tier already permits the
-    // action never consults the grant cache — grants are an additive layer,
-    // never required when the floor already grants access.
+    //   3. Native session-scoped automation grants (#10648) — these do two
+    //      jobs, and only the first is a tier concern: they widen past the
+    //      static floor, AND they pre-authorise the `danger: "confirm"` modal.
+    //      The second job is orthogonal to the floor, so the lookup runs on
+    //      BOTH legs of the tier check (#11878). Nesting it under denial (as
+    //      it originally was) made every grant unreachable for a tool the tier
+    //      already permitted — `worktree.delete` is `danger: "confirm"` but
+    //      system-tier permitted, so pre-authorising it in Settings did
+    //      nothing and the modal still fired on every call.
+    //
+    // The order means a session whose static tier already permits the action
+    // never consults the per-tool grant cache — those grants only widen the
+    // floor and never bypass confirmation, so they have nothing to add once
+    // the floor allows the call.
+    const tierPermitted = isTierPermitted(tier, actionId);
     let grantIssuedAt: number | undefined;
     // Set when a native session-scoped automation grant (#10648) authorized
     // this call. Captured here so the post-dispatch path can refresh the
     // grant's TTL window, and so the `danger: "confirm"` modal is bypassed —
     // a native grant is an explicit user approval of the tool's scope.
     let nativeGrantId: string | undefined;
-    if (!isTierPermitted(tier, actionId)) {
+    if (!tierPermitted) {
       const grant = sessionStore.grantCache.check(sessionId, actionId);
       const native = grant.granted
         ? null
@@ -706,6 +718,27 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           code: TIER_NOT_PERMITTED_CODE,
           message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
         });
+      }
+    } else {
+      // The floor already admits this call, so nothing here can widen it —
+      // the peek exists purely to learn whether a live native grant should
+      // pre-authorise the `danger: "confirm"` modal below (#11878). Only
+      // native grants are consulted: a per-tool "Approve once" grant widens
+      // the floor and nothing else, so it has no say once the floor allows
+      // the call.
+      //
+      // A match charges a use at the single consume site below, exactly as on
+      // the denied leg. That also charges tools in the grant's `allowedTools`
+      // that are NOT confirm-gated, where the grant buys the call nothing.
+      // Accepted deliberately: `maxUses` is a budget of matching dispatches,
+      // and over-charging fails toward MORE confirmation, never less. Spending
+      // a use only on calls that truly need one would mean resolving the
+      // action's effective danger — the async manifest plus args-conditional
+      // elevation — before this point, which is a far larger change than the
+      // bug warrants.
+      const native = sessionStore.grantCache.peekNativeGrant(sessionId, actionId);
+      if (native.granted) {
+        nativeGrantId = native.grantId;
       }
     }
 
@@ -829,16 +862,25 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     // Charge the native automation grant's use now that the call has cleared
     // the tier/grant check and is committed to proceeding (#10648). Doing it
     // here — not at the peek above — means an unauthorized call never burns a
-    // use. The peek→consume path is synchronous (no `await`), so the grant
-    // can't be revoked between peek and consume; a `false` return is purely
-    // defensive and fails closed.
+    // use. A `false` return is purely defensive: the grant was live at the
+    // peek, so it can only have aged out or been revoked in between.
+    //
+    // How that failure lands depends on which leg peeked (#11878). On the
+    // denied leg the grant WAS the authorization, so losing it fails closed.
+    // On the permitted leg it only bought a confirmation bypass, and the tier
+    // still admits the call — so drop the bypass and let the normal modal
+    // decide. Refusing there would answer a `system`-tier `worktree.delete`
+    // with "not permitted for the 'system' tier", which is simply untrue.
     if (nativeGrantId !== undefined) {
       const consumed = sessionStore.grantCache.consumeNativeGrantUse(nativeGrantId, actionId);
       if (!consumed) {
-        return buildToolError({
-          code: TIER_NOT_PERMITTED_CODE,
-          message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
-        });
+        if (!tierPermitted) {
+          return buildToolError({
+            code: TIER_NOT_PERMITTED_CODE,
+            message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
+          });
+        }
+        nativeGrantId = undefined;
       }
     }
 

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -620,20 +620,18 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     //      live grant exists, the dispatch proceeds and the grant's TTL
     //      is refreshed on success.
     //
-    //   3. Native session-scoped automation grants (#10648) — these do two
-    //      jobs, and only the first is a tier concern: they widen past the
-    //      static floor, AND they pre-authorise the `danger: "confirm"` modal.
-    //      The second job is orthogonal to the floor, so the lookup runs on
-    //      BOTH legs of the tier check (#11878). Nesting it under denial (as
-    //      it originally was) made every grant unreachable for a tool the tier
-    //      already permitted — `worktree.delete` is `danger: "confirm"` but
-    //      system-tier permitted, so pre-authorising it in Settings did
-    //      nothing and the modal still fired on every call.
+    //   3. Native session-scoped automation grants (#10648) — the only layer
+    //      that both widens past the floor AND pre-authorises the
+    //      `danger: "confirm"` modal. Because that second job answers a
+    //      different question from "may this call run at all", the lookup is
+    //      independent of whichever layer admitted the call (#11878).
     //
     // The order means a session whose static tier already permits the action
     // never consults the per-tool grant cache — those grants only widen the
     // floor and never bypass confirmation, so they have nothing to add once
-    // the floor allows the call.
+    // the floor allows the call. Native grants are not ordered that way: see
+    // the peek below for why nesting them under any one admission source is
+    // what made them unreachable in the first place.
     const tierPermitted = isTierPermitted(tier, actionId);
     let grantIssuedAt: number | undefined;
     // Set when a native session-scoped automation grant (#10648) authorized
@@ -641,105 +639,105 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     // grant's TTL window, and so the `danger: "confirm"` modal is bypassed —
     // a native grant is an explicit user approval of the tool's scope.
     let nativeGrantId: string | undefined;
+    // True once something OTHER than a native grant has admitted this call —
+    // the static floor, or a per-tool "Approve once" grant. It decides two
+    // things below: whether a missing native grant is fatal, and how a lost
+    // one is handled at the consume site.
+    let authorizedWithoutNativeGrant = tierPermitted;
     if (!tierPermitted) {
       const grant = sessionStore.grantCache.check(sessionId, actionId);
-      const native = grant.granted
-        ? null
-        : sessionStore.grantCache.peekNativeGrant(sessionId, actionId);
       if (grant.granted) {
         // Grant authorised the call. Capture the `issuedAt` token so the
         // post-dispatch refresh can verify the entry wasn't revoked and
         // re-issued under us (race guard, lesson #2243).
         grantIssuedAt = grant.issuedAt;
-      } else if (native?.granted) {
-        // A native automation grant covers this tool and has a use left. It
-        // overrides the static tier floor only because the user explicitly
-        // approved this tool's scope — the grant's allowlist gates which tools
-        // `peekNativeGrant` authorizes. The use is NOT charged here: it is
-        // consumed only once the call is committed to dispatching (below), so
-        // an unauthorized call can't burn a use.
-        nativeGrantId = native.grantId;
-      } else {
-        // Increment first, then ask the cache whether to suppress. The
-        // post-increment count reflects "this denial counted"; the cache's
-        // threshold compares against that. With threshold=2 the 1st and
-        // 2nd denials fire the banner and the 3rd+ are suppressed.
-        sessionStore.grantCache.incrementDenial(sessionId, actionId);
-        const suppressBanner = sessionStore.grantCache.shouldSuppressBanner(sessionId, actionId);
-        try {
-          appendAuditRecord({
-            toolId: actionId,
-            sessionId,
-            tier,
-            args,
-            durationMs: Date.now() - startedAt,
-            outcome: { kind: "unauthorized" },
-            bannerSuppressed: suppressBanner ? true : undefined,
-            capturedTurnId,
-          });
-        } catch (err) {
-          console.error("[MCP] Failed to append audit record:", err);
-        }
-        if (notifyTierMismatch && !suppressBanner) {
-          try {
-            notifyTierMismatch({
-              sessionId,
-              toolId: actionId,
-              tier,
-              targetTier: minimumPermittingTier(actionId),
-            });
-          } catch (err) {
-            console.error("[MCP] Failed to notify tier-mismatch:", err);
-          }
-        }
-        if (recordDenial) {
-          const result = recordDenial(sessionId, "tierMismatch");
-          if (result.tripped) {
-            const pinnedId = sessionStore.sessionWebContentsMap.get(sessionId);
-            // Snapshot ownership with the pin, before revocation clears both.
-            const rendererOwned = sessionStore.isRendererOwnedOrigin(sessionId);
-            sessionStore.revokeSession(sessionId);
-            clearDenialState?.(sessionId);
-            if (notifySessionRevoked) {
-              try {
-                notifySessionRevoked({
-                  sessionId,
-                  denialKind: "tierMismatch",
-                  pinnedWebContentsId: pinnedId,
-                  rendererOwned,
-                });
-              } catch (err) {
-                console.error("[MCP] Failed to notify session-revoked:", err);
-              }
-            }
-          }
-        }
-        return buildToolError({
-          code: TIER_NOT_PERMITTED_CODE,
-          message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
-        });
+        authorizedWithoutNativeGrant = true;
       }
-    } else {
-      // The floor already admits this call, so nothing here can widen it —
-      // the peek exists purely to learn whether a live native grant should
-      // pre-authorise the `danger: "confirm"` modal below (#11878). Only
-      // native grants are consulted: a per-tool "Approve once" grant widens
-      // the floor and nothing else, so it has no say once the floor allows
-      // the call.
-      //
-      // A match charges a use at the single consume site below, exactly as on
-      // the denied leg. That also charges tools in the grant's `allowedTools`
-      // that are NOT confirm-gated, where the grant buys the call nothing.
-      // Accepted deliberately: `maxUses` is a budget of matching dispatches,
-      // and over-charging fails toward MORE confirmation, never less. Spending
-      // a use only on calls that truly need one would mean resolving the
-      // action's effective danger — the async manifest plus args-conditional
-      // elevation — before this point, which is a far larger change than the
-      // bug warrants.
+    }
+    // A native automation grant does two jobs, and only the first is a floor
+    // concern: it widens past the floor, AND it pre-authorises the
+    // `danger: "confirm"` modal. The second is orthogonal to whatever admitted
+    // the call, so the peek cannot be nested under any one admission source
+    // (#11878). It used to sit inside the tier-denied branch, behind the
+    // per-tool check — which left the grant unreachable both for a tool the
+    // tier already permitted (`worktree.delete` is `danger: "confirm"` but
+    // system-tier permitted) and for one a per-tool grant had just admitted.
+    // Either way the modal still fired on every call despite an explicit
+    // Settings pre-authorisation.
+    //
+    // The one exception: an introspection carrier is never confirm-gated, so
+    // once the call is already admitted a grant buys it nothing — peeking
+    // would only spend a use and evict entries on a discovery call. When the
+    // call is NOT otherwise admitted the peek still runs, because there the
+    // grant is doing its first job and is load-bearing for authorization.
+    if (!authorizedWithoutNativeGrant || !INTROSPECTION_TOOL_IDS.has(actionId)) {
+      // The use is NOT charged here: it is consumed only once the call is
+      // committed to dispatching (below), so an unauthorized call can't burn
+      // a use. The grant's allowlist gates which tools this authorizes.
       const native = sessionStore.grantCache.peekNativeGrant(sessionId, actionId);
       if (native.granted) {
         nativeGrantId = native.grantId;
       }
+    }
+    if (!authorizedWithoutNativeGrant && nativeGrantId === undefined) {
+      // Increment first, then ask the cache whether to suppress. The
+      // post-increment count reflects "this denial counted"; the cache's
+      // threshold compares against that. With threshold=2 the 1st and
+      // 2nd denials fire the banner and the 3rd+ are suppressed.
+      sessionStore.grantCache.incrementDenial(sessionId, actionId);
+      const suppressBanner = sessionStore.grantCache.shouldSuppressBanner(sessionId, actionId);
+      try {
+        appendAuditRecord({
+          toolId: actionId,
+          sessionId,
+          tier,
+          args,
+          durationMs: Date.now() - startedAt,
+          outcome: { kind: "unauthorized" },
+          bannerSuppressed: suppressBanner ? true : undefined,
+          capturedTurnId,
+        });
+      } catch (err) {
+        console.error("[MCP] Failed to append audit record:", err);
+      }
+      if (notifyTierMismatch && !suppressBanner) {
+        try {
+          notifyTierMismatch({
+            sessionId,
+            toolId: actionId,
+            tier,
+            targetTier: minimumPermittingTier(actionId),
+          });
+        } catch (err) {
+          console.error("[MCP] Failed to notify tier-mismatch:", err);
+        }
+      }
+      if (recordDenial) {
+        const result = recordDenial(sessionId, "tierMismatch");
+        if (result.tripped) {
+          const pinnedId = sessionStore.sessionWebContentsMap.get(sessionId);
+          // Snapshot ownership with the pin, before revocation clears both.
+          const rendererOwned = sessionStore.isRendererOwnedOrigin(sessionId);
+          sessionStore.revokeSession(sessionId);
+          clearDenialState?.(sessionId);
+          if (notifySessionRevoked) {
+            try {
+              notifySessionRevoked({
+                sessionId,
+                denialKind: "tierMismatch",
+                pinnedWebContentsId: pinnedId,
+                rendererOwned,
+              });
+            } catch (err) {
+              console.error("[MCP] Failed to notify session-revoked:", err);
+            }
+          }
+        }
+      }
+      return buildToolError({
+        code: TIER_NOT_PERMITTED_CODE,
+        message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
+      });
     }
 
     // Confirm-gated tools are unreachable for a workspace-bound external
@@ -865,16 +863,27 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     // use. A `false` return is purely defensive: the grant was live at the
     // peek, so it can only have aged out or been revoked in between.
     //
-    // How that failure lands depends on which leg peeked (#11878). On the
-    // denied leg the grant WAS the authorization, so losing it fails closed.
-    // On the permitted leg it only bought a confirmation bypass, and the tier
-    // still admits the call — so drop the bypass and let the normal modal
+    // How that failure lands depends on what else admitted the call (#11878).
+    // When the grant WAS the authorization, losing it fails closed. When the
+    // floor or a per-tool grant already admitted it, the grant only bought a
+    // confirmation bypass — so drop the bypass and let the normal modal
     // decide. Refusing there would answer a `system`-tier `worktree.delete`
     // with "not permitted for the 'system' tier", which is simply untrue.
+    //
+    // Accounting note: a matching call spends a use even when the tool is not
+    // confirm-gated, so the grant buys it nothing. Charging only where the
+    // bypass is actually needed would mean resolving effective danger — the
+    // async manifest plus args-conditional elevation — before this point,
+    // which is a far larger change than the bug warrants. Two consequences
+    // are worth knowing rather than assuming away: a matching call also
+    // slides the whole grant's TTL, so a harmless tool in a mixed grant can
+    // extend a confirm-gated sibling's bypass window (bounded by the hard
+    // lifetime ceiling), and because this site precedes dedup, a replayed
+    // duplicate spends a use without dispatching.
     if (nativeGrantId !== undefined) {
       const consumed = sessionStore.grantCache.consumeNativeGrantUse(nativeGrantId, actionId);
       if (!consumed) {
-        if (!tierPermitted) {
+        if (!authorizedWithoutNativeGrant) {
           return buildToolError({
             code: TIER_NOT_PERMITTED_CODE,
             message: `action '${actionId}' is not permitted for the '${tier}' tier.`,


### PR DESCRIPTION
## Summary

A native automation grant does two separate jobs: it widens past the static tier floor, and it pre-authorizes the `danger: "confirm"` modal. Only the first is a tier concern, but the grant lookup lived inside the tier-denied branch, behind the per-tool grant check. So for any action the tier already permitted, the grant was simply unreachable. `worktree.delete` is `danger: "confirm"` but sits on the system-tier allowlist, which meant typing it into Settings → Automation grants did nothing at all: the modal still fired on every call. It's CWE-863, a complete-mediation failure: the bypass exemption wasn't evaluated uniformly across paths.

Review turned up a second instance of the same bug one layer over: a per-tool "Approve once" grant suppressed native confirm pre-authorization exactly the way the tier floor did, so a session holding both grants still got the modal. Fixed both by making the peek independent of whatever admitted the call, rather than special-casing the tier leg.

Resolves #11878

## Changes

In `sessionServer.ts`:

- Admission is now computed once (`authorizedWithoutNativeGrant` = static floor OR per-tool grant), then the native grant is peeked independently of it.
- The consume-failure guard keys on admission rather than tier. A lost grant still fails closed when the grant *was* the authorization, but when the floor or a per-tool grant already admitted the call it now drops the bypass and falls back to the modal. Previously it would have answered a `system`-tier `worktree.delete` call with "not permitted for the 'system' tier," which is untrue.
- The peek is skipped for an already-admitted introspection carrier (`actions.list`/`actions.search`): those can never raise a modal, so peeking would only drain the grant budget and evict entries on a discovery call. When a carrier is *not* otherwise admitted, the peek still runs, since there the grant is load-bearing for authorization.

Deliberate trade-off, documented in the code and pinned by a test: a matching call spends a use even when the tool isn't confirm-gated. Charging only where the bypass is actually needed would mean resolving effective danger (the async manifest plus args-conditional elevation) before the consume site, which is a much larger change than this bug warrants. Two consequences worth knowing rather than assuming away: a matching call also slides the whole grant's TTL, so a harmless tool in a mixed grant can extend a confirm-gated sibling's bypass window (bounded by the hard lifetime ceiling); and because the consume site precedes dedup, a replayed duplicate spends a use without dispatching. Both are pre-existing behaviors that this change extends to the tier-permitted path. Worth a separate look, not worth widening this PR.

Unchanged on purpose: the workspace-bound confirm refusal stays a hard ceiling above all of this, still returning before any use is charged.

Docs: corrected the `tools/call` gate-chain diagram in `docs/architecture/mcp-server.md`, which encoded the buggy ordering verbatim, and dropped the rate-limit gate that was actually removed in #10764.

## Testing

8 new/reworked cases covering the permitted leg, per-tool-plus-native, both consume-failure legs, grant exhaustion, the introspection guard, and the use-accounting decision. The whole `mcp-server` suite passes locally: 1011 tests across 18 files. ESLint and Prettier clean on all three changed files.
