### PR TITLE
fix(actions): let the assistant move a terminal between worktrees

### DIFF
--- a/electron/services/__tests__/McpServerService.tierAuthorization.test.ts
+++ b/electron/services/__tests__/McpServerService.tierAuthorization.test.ts
@@ -1102,6 +1102,12 @@ describe("McpServerService", () => {
           "Move the target terminal from the dock back into the grid. Accepts an optional terminalId; defaults to the currently focused terminal.",
       }),
       createManifestEntry({
+        id: "terminal.moveToWorktree" as ActionId,
+        title: "Move to Worktree",
+        description:
+          "Move the target terminal to another worktree. Accepts an optional terminalId; defaults to the currently focused terminal.",
+      }),
+      createManifestEntry({
         id: "terminal.toggleDock" as ActionId,
         title: "Toggle Dock",
         description:

--- a/electron/services/__tests__/McpServerService.tierAuthorization.test.ts
+++ b/electron/services/__tests__/McpServerService.tierAuthorization.test.ts
@@ -1105,7 +1105,22 @@ describe("McpServerService", () => {
         id: "terminal.moveToWorktree" as ActionId,
         title: "Move to Worktree",
         description:
-          "Move the target terminal to another worktree. Accepts an optional terminalId; defaults to the currently focused terminal.",
+          "Move the named terminal to another worktree. An agent caller must name the terminal and a live destination worktree.",
+        requiresArgs: true,
+        inputSchema: {
+          type: "object",
+          properties: { terminalId: { type: "string" }, worktreeId: { type: "string" } },
+          required: ["worktreeId"],
+        },
+      }),
+      // Present in the manifest but in no tier allowlist (#11877), so the
+      // absence assertions below are answered by the tier gate rather than by
+      // a fixture that simply never offered it.
+      createManifestEntry({
+        id: "terminal.moveToNewWorktree" as ActionId,
+        title: "Move to New Worktree…",
+        description:
+          "Open the new-worktree dialog and move a terminal into the worktree it creates",
       }),
       createManifestEntry({
         id: "terminal.toggleDock" as ActionId,
@@ -1540,6 +1555,74 @@ describe("McpServerService", () => {
       })) as TextToolResult;
       expect(denied.isError).toBe(true);
       expect(denied.content[0]?.text).toContain("TIER_NOT_PERMITTED");
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
+
+    // Fixed ids, not a loop over ACTION_TIER_ADDONS: the derived loops above
+    // shrink with the allowlist, so dropping the entry again would leave them
+    // green. These two pin the #11877 decision itself — the cross-worktree move
+    // is reachable, and its dialog-bound sibling is deliberately not.
+    it("lets the action tier move a terminal across worktrees (#11877)", async () => {
+      paneTokenTiers.set("token-action", "action");
+      const dispatchMock = vi.fn((): ActionDispatchResult => ({ ok: true, result: undefined }));
+      const { window } = createMockWindow({
+        getManifest: tierManifest,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-action",
+      });
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((tool) => tool.name);
+      expect(ids).toContain("terminal.moveToWorktree");
+
+      const moved = (await client.callTool({
+        name: "terminal.moveToWorktree",
+        arguments: { terminalId: "panel-1", worktreeId: "wt-2" },
+      })) as TextToolResult;
+
+      expect(moved.isError).toBeFalsy();
+      expect(dispatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: "terminal.moveToWorktree",
+          args: { terminalId: "panel-1", worktreeId: "wt-2" },
+        })
+      );
+    });
+
+    it("keeps the dialog-bound move-to-new-worktree off every tier (#11877)", async () => {
+      paneTokenTiers.set("token-sys", "system");
+      const dispatchMock = vi.fn((): ActionDispatchResult => ({
+        ok: true,
+        result: "should-not-run",
+      }));
+      const { window } = createMockWindow({
+        getManifest: tierManifest,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-sys",
+      });
+      transports.push(transport);
+
+      // System is the widest tier, so absence here covers the narrower ones.
+      const ids = (await client.listTools()).tools.map((tool) => tool.name);
+      expect(ids).not.toContain("terminal.moveToNewWorktree");
+
+      const denied = (await client.callTool({
+        name: "terminal.moveToNewWorktree",
+        arguments: { terminalId: "panel-1" },
+      })) as TextToolResult;
+
+      expect(denied.isError).toBe(true);
+      expect(denied.content[0]?.text).toContain("TIER_NOT_PERMITTED");
+      // Never reaches the renderer, so its own defense-in-depth throw is a
+      // second line rather than the one doing the work.
       expect(dispatchMock).not.toHaveBeenCalled();
     });
 

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -114,6 +114,7 @@ export const ACTION_TIER_ADDONS = [
   "terminal.restart",
   "terminal.moveToDock",
   "terminal.moveToGrid",
+  "terminal.moveToWorktree",
   "terminal.toggleDock",
   "terminal.rename",
   TERMINAL_WAIT_UNTIL_IDLE_TOOL,

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -4764,7 +4764,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Move a terminal panel to a different worktree. The process is never restarted: a live agent keeps running in the directory it launched from, and its pane offers to tell it to continue in the destination. The panel move is reversible. Name the target explicitly — an automated caller cannot see what the user has focused.",
+    "description": "Move a terminal panel to a different worktree. The process is never restarted: a live agent keeps running in the directory it launched from, and its pane offers to tell it to continue in the destination. A panel that shares a tab group travels with the rest of that group, so this can relocate more than the one panel named. The move is reversible. Name the target explicitly — an automated caller cannot see what the user has focused.",
     "examples": undefined,
     "id": "terminal.moveToWorktree",
     "keywords": undefined,

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -4764,7 +4764,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Move a terminal panel to a different worktree. The process is never restarted: a live agent keeps running in the directory it launched from, and its pane offers to tell it to continue in the destination.",
+    "description": "Move a terminal panel to a different worktree. The process is never restarted: a live agent keeps running in the directory it launched from, and its pane offers to tell it to continue in the destination. The panel move is reversible. Name the target explicitly — an automated caller cannot see what the user has focused.",
     "examples": undefined,
     "id": "terminal.moveToWorktree",
     "keywords": undefined,

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -518,6 +518,68 @@ describe("terminal action hardening", () => {
       }
     );
 
+    // moveToWorktree is reachable from the assistant's action tier (#11877), and
+    // its side effect is a worktreeId change rather than a location change, so
+    // the table above could not prove it stayed put — these assert the mutation
+    // each action actually performs.
+    it("moveToWorktree rejects agent dispatch that names no terminal, leaving the focused panel in its worktree", async () => {
+      const actions = buildRegistry(registerTerminalActions);
+      const moveToWorktree = actions.get("terminal.moveToWorktree")!();
+
+      usePanelStore.setState({
+        panelsById: { focused: createTerminal({ id: "focused", worktreeId: "wt-1" }) },
+        panelIds: ["focused"],
+        focusedId: "focused",
+      });
+
+      await expect(
+        moveToWorktree.run({ worktreeId: "wt-2" } as never, { dispatchSource: "agent" } as never)
+      ).rejects.toThrow(
+        /requires an explicit `terminalId` when dispatched by an agent or MCP client/
+      );
+
+      // The move mutates worktreeId, not location, so this is the only
+      // assertion that would fail if the guard let the action through.
+      expect(usePanelStore.getState().panelsById.focused?.worktreeId).toBe("wt-1");
+    });
+
+    it("moveToNewWorktree refuses agent dispatch outright rather than hanging its dialog at a headless caller", async () => {
+      const actions = buildRegistry(registerTerminalActions);
+      const moveToNewWorktree = actions.get("terminal.moveToNewWorktree")!();
+
+      const openCreateFlow = vi.fn();
+      // Swapped back in `finally`: the suite's beforeEach resets store DATA but
+      // not store METHODS, so leaving the stub in place would silently poison
+      // every later test that reaches the real one.
+      const realMoveToNewWorktree = usePanelStore.getState().moveToNewWorktree;
+      usePanelStore.setState({
+        panelsById: { focused: createTerminal({ id: "focused", worktreeId: "wt-1" }) },
+        panelIds: ["focused"],
+        focusedId: "focused",
+        moveToNewWorktree: openCreateFlow,
+      } as never);
+
+      try {
+        // Named target too: the objection is the interactive dialog, so naming
+        // a terminal must not buy a way past it the way it does for siblings
+        // whose only worry is which panel an unbound call would land on.
+        await expect(
+          moveToNewWorktree.run(
+            { terminalId: "focused" } as never,
+            {
+              dispatchSource: "agent",
+            } as never
+          )
+        ).rejects.toThrow(
+          /opens the new-worktree dialog, which a headless caller can never answer/
+        );
+
+        expect(openCreateFlow).not.toHaveBeenCalled();
+      } finally {
+        usePanelStore.setState({ moveToNewWorktree: realMoveToNewWorktree } as never);
+      }
+    });
+
     it("toggleDock moves the terminal the agent named, not the focused one", async () => {
       const actions = buildRegistry(registerTerminalActions);
       const toggleDock = actions.get("terminal.toggleDock")!();

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -638,10 +638,16 @@ describe("terminal action hardening", () => {
       focusedId: "term-a",
     });
 
-    await moveToWorktree.run({ terminalId: "missing", worktreeId: "wt-2" }, {} as never);
+    // A foreground source keeps both of these quiet no-ops; a headless caller
+    // is told instead (#11877), which its own tests cover.
+    await moveToWorktree.run({ terminalId: "missing", worktreeId: "wt-2" }, {
+      dispatchSource: "user",
+    } as never);
     expect(usePanelStore.getState().focusedId).toBe("term-a");
 
-    await moveToWorktree.run({ terminalId: "term-a", worktreeId: "wt-1" }, {} as never);
+    await moveToWorktree.run({ terminalId: "term-a", worktreeId: "wt-1" }, {
+      dispatchSource: "user",
+    } as never);
     expect(usePanelStore.getState().focusedId).toBe("term-a");
   });
 

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -823,7 +823,15 @@ describe("terminal.moveToWorktree", () => {
     setPanelState({ panels: [] });
     const run = setupActions();
 
-    await run("terminal.moveToWorktree", { terminalId: "ghost", worktreeId: "wt-2" });
+    // A foreground source stays a quiet no-op: the person can see that nothing
+    // moved. `ActionService` always stamps a source, defaulting to "user", so
+    // the bare-context shape used elsewhere in this file never reaches
+    // production for this branch.
+    await run(
+      "terminal.moveToWorktree",
+      { terminalId: "ghost", worktreeId: "wt-2" },
+      { dispatchSource: "user" }
+    );
 
     expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
     expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
@@ -889,19 +897,59 @@ describe("terminal.moveToWorktree", () => {
     expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith("p1", "wt-2");
   });
 
-  it("leaves the destination unchecked for a drag or menu caller, which can only name a real row", async () => {
+  it("refuses a dead destination for a menu caller too, quietly — the row can go stale mid-click", async () => {
     setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }] });
     getCurrentViewStoreOrNullMock.mockReturnValue({
       getState: () => ({ worktrees: new Map([["wt-live", {}]]) }),
     });
     const run = setupActions();
 
-    await run("terminal.moveToWorktree", { terminalId: "p1", worktreeId: "wt-unlisted" });
-
-    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith(
-      "p1",
-      "wt-unlisted"
+    // No throw: the person can see the result. But the move must not happen —
+    // the integrity rule is uniform, only the reporting is not.
+    await run(
+      "terminal.moveToWorktree",
+      { terminalId: "p1", worktreeId: "wt-unlisted" },
+      { dispatchSource: "context-menu" }
     );
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
+    expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a plugin's dead destination — headless callers are told, not silently no-oped", async () => {
+    setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }] });
+    getCurrentViewStoreOrNullMock.mockReturnValue({
+      getState: () => ({ worktrees: new Map([["wt-live", {}]]) }),
+    });
+    const run = setupActions();
+
+    await expect(
+      run(
+        "terminal.moveToWorktree",
+        { terminalId: "p1", worktreeId: "wt-unlisted" },
+        { dispatchSource: "plugin" }
+      )
+    ).rejects.toThrow(/no open worktree with that `worktreeId`/);
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
+  });
+
+  // `panelsById` is a plain object, so a prototype-backed id is truthy without
+  // being a panel.
+  it("does not treat a prototype-backed id as a panel", async () => {
+    setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }] });
+    const run = setupActions();
+
+    await expect(
+      run(
+        "terminal.moveToWorktree",
+        { terminalId: "constructor", worktreeId: "wt-2" },
+        { dispatchSource: "agent" }
+      )
+    ).rejects.toThrow(/found no panel with that `terminalId`/);
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
+    expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
   });
 
   it("tells an agent its named panel is gone rather than reporting a move that did not happen", async () => {

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -8,6 +8,10 @@ const layoutUndoMock = vi.hoisted(() => ({
   getState: vi.fn(() => ({ pushLayoutSnapshot: pushLayoutSnapshotMock })),
 }));
 const moveTerminalToWorktreeAndFollowRescueMock = vi.hoisted(() => vi.fn());
+// Defaults to "no view store mounted", which is how every pre-existing test in
+// this file ran before the destination check existed — the check degrades to a
+// pass when nothing can answer, so those cases stay untouched.
+const getCurrentViewStoreOrNullMock = vi.hoisted(() => vi.fn(() => null as unknown));
 const buildPanelDuplicateOptionsMock = vi.hoisted(() => vi.fn());
 const resolveInheritedPanelCwdMock = vi.hoisted(() => vi.fn());
 const flushOptimisticClosesMock = vi.hoisted(() => vi.fn());
@@ -27,6 +31,9 @@ vi.mock("@/services/terminal/optimisticPanelClose", () => ({
 }));
 vi.mock("@/services/terminal/crossWorktreeMove", () => ({
   moveTerminalToWorktreeAndFollowRescue: moveTerminalToWorktreeAndFollowRescueMock,
+}));
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStoreOrNull: getCurrentViewStoreOrNullMock,
 }));
 vi.mock("@/services/agentResume", () => ({
   buildResumePanelOptions: buildResumePanelOptionsMock,
@@ -115,6 +122,9 @@ function setPanelState(options: {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // clearAllMocks resets calls but not implementations, so a destination-map
+  // stub set by one test would otherwise answer for every test after it.
+  getCurrentViewStoreOrNullMock.mockReturnValue(null);
   listAgentSessionsMock.mockResolvedValue([]);
   (globalThis as unknown as { window: { electron: unknown } }).window = {
     ...(globalThis as unknown as { window?: object }).window,
@@ -840,6 +850,73 @@ describe("terminal.moveToWorktree", () => {
     // The snapshot is pushed just before the move, so an unpushed stack proves
     // the guard fired before any layout mutation, not merely before the helper.
     expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent's unknown destination worktree instead of filing the panel under it", async () => {
+    setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }] });
+    getCurrentViewStoreOrNullMock.mockReturnValue({
+      getState: () => ({ worktrees: new Map([["wt-live", {}]]) }),
+    });
+    const run = setupActions();
+
+    await expect(
+      run(
+        "terminal.moveToWorktree",
+        { terminalId: "p1", worktreeId: "wt-hallucinated" },
+        { dispatchSource: "agent" }
+      )
+    ).rejects.toThrow(/no open worktree with that `worktreeId`/);
+
+    // Filing it anyway would hide a live process under a worktree no view can
+    // select, which is the whole reason the check exists.
+    expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
+    expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("moves to a destination the view store confirms is live", async () => {
+    setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }] });
+    getCurrentViewStoreOrNullMock.mockReturnValue({
+      getState: () => ({ worktrees: new Map([["wt-2", {}]]) }),
+    });
+    const run = setupActions();
+
+    await run(
+      "terminal.moveToWorktree",
+      { terminalId: "p1", worktreeId: "wt-2" },
+      { dispatchSource: "agent" }
+    );
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith("p1", "wt-2");
+  });
+
+  it("leaves the destination unchecked for a drag or menu caller, which can only name a real row", async () => {
+    setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }] });
+    getCurrentViewStoreOrNullMock.mockReturnValue({
+      getState: () => ({ worktrees: new Map([["wt-live", {}]]) }),
+    });
+    const run = setupActions();
+
+    await run("terminal.moveToWorktree", { terminalId: "p1", worktreeId: "wt-unlisted" });
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith(
+      "p1",
+      "wt-unlisted"
+    );
+  });
+
+  it("tells an agent its named panel is gone rather than reporting a move that did not happen", async () => {
+    setPanelState({ panels: [] });
+    const run = setupActions();
+
+    await expect(
+      run(
+        "terminal.moveToWorktree",
+        { terminalId: "ghost", worktreeId: "wt-2" },
+        { dispatchSource: "agent" }
+      )
+    ).rejects.toThrow(/found no panel with that `terminalId`/);
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
   });
 
   it("still moves the terminal an agent names explicitly", async () => {

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -70,11 +70,11 @@ function setupActions(overrides?: { activeWorktreeId?: string | undefined }) {
       "activeWorktreeId" in (overrides ?? {}) ? overrides!.activeWorktreeId : "wt-1",
   } as unknown as ActionCallbacks;
   registerTerminalSpawnActions(actions, callbacks);
-  return async (id: string, args?: unknown): Promise<unknown> => {
+  return async (id: string, args?: unknown, ctx?: unknown): Promise<unknown> => {
     const factory = actions.get(id);
     if (!factory) throw new Error(`missing ${id}`);
     const def = factory() as AnyActionDefinition;
-    return def.run(args, {} as never);
+    return def.run(args, (ctx ?? {}) as never);
   };
 }
 
@@ -737,6 +737,28 @@ describe("terminal.moveToNewWorktree", () => {
 
     expect(moveToNewWorktree).not.toHaveBeenCalled();
   });
+
+  // The gesture IS the interactive create-worktree dialog, so there is no
+  // argument that makes this answerable headlessly — naming the terminal must
+  // not help (#11877).
+  it.each([undefined, {}, { terminalId: "p1" }])(
+    "refuses agent dispatch (%j) instead of opening the dialog",
+    async (args) => {
+      const moveToNewWorktree = vi.fn();
+      setPanelState({
+        focusedId: "p1",
+        panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }],
+        moveToNewWorktree,
+      });
+      const run = setupActions();
+
+      await expect(
+        run("terminal.moveToNewWorktree", args, { dispatchSource: "agent" })
+      ).rejects.toThrow(/opens the new-worktree dialog, which a headless caller can never answer/);
+
+      expect(moveToNewWorktree).not.toHaveBeenCalled();
+    }
+  );
 });
 
 describe("terminal.moveToWorktree", () => {
@@ -795,5 +817,51 @@ describe("terminal.moveToWorktree", () => {
 
     expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
     expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  // Reachable from the assistant's action tier since #11877, so the focused
+  // fallback above must not be reachable by an unbound agent call: focus drifts
+  // across the MCP round trip, and this relocates a panel across worktrees
+  // rather than merely rearranging it (#11532).
+  it("rejects agent dispatch that names no terminal, without moving the focused panel", async () => {
+    setPanelState({
+      focusedId: "p-focused",
+      panels: [{ id: "p-focused", location: "grid", worktreeId: "wt-1" }],
+    });
+    const run = setupActions();
+
+    await expect(
+      run("terminal.moveToWorktree", { worktreeId: "wt-2" }, { dispatchSource: "agent" })
+    ).rejects.toThrow(
+      /requires an explicit `terminalId` when dispatched by an agent or MCP client/
+    );
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
+    // The snapshot is pushed just before the move, so an unpushed stack proves
+    // the guard fired before any layout mutation, not merely before the helper.
+    expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("still moves the terminal an agent names explicitly", async () => {
+    setPanelState({
+      focusedId: "p-focused",
+      panels: [
+        { id: "p-focused", location: "grid", worktreeId: "wt-1" },
+        { id: "p-named", location: "grid", worktreeId: "wt-1" },
+      ],
+    });
+    const run = setupActions();
+
+    await run(
+      "terminal.moveToWorktree",
+      { terminalId: "p-named", worktreeId: "wt-2" },
+      { dispatchSource: "agent" }
+    );
+
+    // The named panel, never the focused one — the whole point of the guard.
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith(
+      "p-named",
+      "wt-2"
+    );
   });
 });

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -13,6 +13,7 @@ import { buildResumePanelOptions } from "@/services/agentResume";
 import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
+import { requireExplicitTerminalIdForAgentDispatch } from "./terminalTargetBinding";
 import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
 import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
 import { isPtyPanel } from "@shared/types/panel";
@@ -259,7 +260,8 @@ export function registerTerminalSpawnActions(
     description:
       "Move a terminal panel to a different worktree. The process is never restarted: a live " +
       "agent keeps running in the directory it launched from, and its pane offers to tell it " +
-      "to continue in the destination.",
+      "to continue in the destination. The panel move is reversible. Name the target " +
+      "explicitly — an automated caller cannot see what the user has focused.",
     category: "terminal",
     kind: "command",
     // Relabelling a panel is reversible — drag it back — and nothing here
@@ -272,8 +274,9 @@ export function registerTerminalSpawnActions(
       terminalId: z.string().optional(),
       worktreeId: z.string(),
     }),
-    run: async (args: unknown) => {
+    run: async (args: unknown, ctx) => {
       const { terminalId, worktreeId } = args as { terminalId?: string; worktreeId: string };
+      requireExplicitTerminalIdForAgentDispatch("terminal.moveToWorktree", terminalId, ctx);
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
@@ -297,8 +300,23 @@ export function registerTerminalSpawnActions(
     danger: "safe",
     scope: "renderer",
     argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
-    run: async (args: unknown) => {
+    run: async (args: unknown, ctx) => {
       const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
+      // Deliberately not in any tier allowlist, and guarded here anyway as
+      // defense in depth — the same treatment `terminal.toggleMaximize` gets.
+      // This action's whole gesture is the interactive create-worktree dialog
+      // (#11853): the move happens in the dialog's `onCreated` callback, which
+      // a headless caller can never answer, and `run()` has already returned by
+      // then. Allowlisting it would hang a modal in front of the user and
+      // report a move that never happened (#11532, #11877). An agent that wants
+      // a panel in a fresh worktree creates the worktree with the headless
+      // worktree-creation capability, then moves the panel to the id it
+      // returns.
+      if (ctx.dispatchSource === "agent") {
+        throw new Error(
+          "terminal.moveToNewWorktree can't be dispatched by an agent or MCP client — it opens the new-worktree dialog, which a headless caller can never answer. Create the worktree first, then move the panel into it by id."
+        );
+      }
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (!targetId) return;

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -15,6 +15,7 @@ import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import { requireExplicitTerminalIdForAgentDispatch } from "./terminalTargetBinding";
 import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
+import { isForegroundDispatch } from "./dispatchSource";
 import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
 import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
 import { isPtyPanel } from "@shared/types/panel";
@@ -283,35 +284,41 @@ export function registerTerminalSpawnActions(
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
-        const terminal = state.panelsById[targetId];
-        // A named-but-missing panel is a normal race for an agent: it can be
-        // closed between the listing and this call. The drag paths can only
-        // name a panel they are holding, so they keep the quiet return, but an
-        // agent told "OK" for a move that never happened would go on to reason
-        // about a panel that is no longer there (#11877).
-        if (!terminal && ctx.dispatchSource === "agent") {
-          throw new Error(
-            "terminal.moveToWorktree found no panel with that `terminalId` — it may have been closed. Re-read the terminal listing and pass a current panel id."
-          );
+        // Only a person who can see the panel gets a silent no-op; anything
+        // headless — agent, plugin, or a source we don't recognise — is told,
+        // because it cannot observe the difference between "moved" and
+        // "nothing there" and would reason on from a false success.
+        const reportsFailures = !isForegroundDispatch(ctx.dispatchSource);
+        // `Object.hasOwn`, not a truthiness check: `panelsById` is a plain
+        // object, so an id like "constructor" resolves off the prototype and
+        // would be moved as if it were a real panel (same reason
+        // `terminal.close` does this).
+        if (!Object.hasOwn(state.panelsById, targetId)) {
+          if (reportsFailures) {
+            throw new Error(
+              "terminal.moveToWorktree found no panel with that `terminalId` — it may have been closed. Re-read the terminal listing and pass a current panel id."
+            );
+          }
+          return;
         }
+        const terminal = state.panelsById[targetId];
         if (!terminal || terminal.worktreeId === worktreeId) {
           return;
         }
-        // The destination is a bare string, and until this action was reachable
-        // by an agent it could only ever come from a real worktree row. A
-        // hallucinated or stale id would file the panel — and every panel in its
-        // tab group — under a worktree no view can select, hiding a live process
-        // while the caller is told the move succeeded. Verified only when a view
-        // store can answer: a null registry means no project view is mounted
-        // (unit tests, teardown), which is a wiring gap rather than a bad
-        // argument, so it degrades the way the project-location resolver does.
-        if (ctx.dispatchSource === "agent") {
-          const worktrees = getCurrentViewStoreOrNull()?.getState().worktrees;
-          if (worktrees && !worktrees.has(worktreeId)) {
+        // Checked for EVERY caller, not just headless ones: filing a panel
+        // under an id no view can select hides a live process whoever asked for
+        // it, and a menu row can go stale between opening and clicking. Only
+        // the reporting differs. Verified when a view store can answer — the
+        // accessor is null only before the provider mounts, which cannot
+        // coexist with a panel to move, so there is nothing to fail closed on.
+        const worktrees = getCurrentViewStoreOrNull()?.getState().worktrees;
+        if (worktrees && !worktrees.has(worktreeId)) {
+          if (reportsFailures) {
             throw new Error(
               "terminal.moveToWorktree found no open worktree with that `worktreeId`. Pass an id from the worktree listing, or create the worktree first and use the id it returns."
             );
           }
+          return;
         }
 
         useLayoutUndoStore.getState().pushLayoutSnapshot();

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -14,6 +14,7 @@ import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import { requireExplicitTerminalIdForAgentDispatch } from "./terminalTargetBinding";
+import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
 import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
 import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
 import { isPtyPanel } from "@shared/types/panel";
@@ -260,8 +261,10 @@ export function registerTerminalSpawnActions(
     description:
       "Move a terminal panel to a different worktree. The process is never restarted: a live " +
       "agent keeps running in the directory it launched from, and its pane offers to tell it " +
-      "to continue in the destination. The panel move is reversible. Name the target " +
-      "explicitly — an automated caller cannot see what the user has focused.",
+      "to continue in the destination. A panel that shares a tab group travels with the " +
+      "rest of that group, so this can relocate more than the one panel named. The move is " +
+      "reversible. Name the target explicitly — an automated caller cannot see what the " +
+      "user has focused.",
     category: "terminal",
     kind: "command",
     // Relabelling a panel is reversible — drag it back — and nothing here
@@ -272,7 +275,7 @@ export function registerTerminalSpawnActions(
     scope: "renderer",
     argsSchema: z.object({
       terminalId: z.string().optional(),
-      worktreeId: z.string(),
+      worktreeId: z.string().min(1),
     }),
     run: async (args: unknown, ctx) => {
       const { terminalId, worktreeId } = args as { terminalId?: string; worktreeId: string };
@@ -281,8 +284,34 @@ export function registerTerminalSpawnActions(
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
         const terminal = state.panelsById[targetId];
+        // A named-but-missing panel is a normal race for an agent: it can be
+        // closed between the listing and this call. The drag paths can only
+        // name a panel they are holding, so they keep the quiet return, but an
+        // agent told "OK" for a move that never happened would go on to reason
+        // about a panel that is no longer there (#11877).
+        if (!terminal && ctx.dispatchSource === "agent") {
+          throw new Error(
+            "terminal.moveToWorktree found no panel with that `terminalId` — it may have been closed. Re-read the terminal listing and pass a current panel id."
+          );
+        }
         if (!terminal || terminal.worktreeId === worktreeId) {
           return;
+        }
+        // The destination is a bare string, and until this action was reachable
+        // by an agent it could only ever come from a real worktree row. A
+        // hallucinated or stale id would file the panel — and every panel in its
+        // tab group — under a worktree no view can select, hiding a live process
+        // while the caller is told the move succeeded. Verified only when a view
+        // store can answer: a null registry means no project view is mounted
+        // (unit tests, teardown), which is a wiring gap rather than a bad
+        // argument, so it degrades the way the project-location resolver does.
+        if (ctx.dispatchSource === "agent") {
+          const worktrees = getCurrentViewStoreOrNull()?.getState().worktrees;
+          if (worktrees && !worktrees.has(worktreeId)) {
+            throw new Error(
+              "terminal.moveToWorktree found no open worktree with that `worktreeId`. Pass an id from the worktree listing, or create the worktree first and use the id it returns."
+            );
+          }
         }
 
         useLayoutUndoStore.getState().pushLayoutSnapshot();
@@ -314,7 +343,7 @@ export function registerTerminalSpawnActions(
       // returns.
       if (ctx.dispatchSource === "agent") {
         throw new Error(
-          "terminal.moveToNewWorktree can't be dispatched by an agent or MCP client — it opens the new-worktree dialog, which a headless caller can never answer. Create the worktree first, then move the panel into it by id."
+          "terminal.moveToNewWorktree can't be dispatched by an agent or MCP client — it opens the new-worktree dialog, which a headless caller can never answer. Don't retry it. Create the worktree headlessly with `worktree.createWithRecipe` (pass `branchName`, and omit `recipeId` when no recipe is wanted), then call `terminal.moveToWorktree` with the original `terminalId` and the `worktreeId` it returns."
         );
       }
       const state = usePanelStore.getState();


### PR DESCRIPTION
## Summary

The issue asked to add `terminal.moveToWorktree` and `terminal.moveToNewWorktree` to `ACTION_TIER_ADDONS` so the in-app assistant stops getting `TIER_NOT_PERMITTED` on both. I did something a bit different, and it's worth reading why before the diff.

Resolves #11877

## What's allowlisted, and what isn't

`terminal.moveToWorktree` is allowlisted at the `action` tier, as asked. It's `danger: "safe"` (D0) on record in `docs/architecture/destructive-action-safeguards.md`, the same class as its siblings `moveToDock` and `moveToGrid`, which are already allowlisted.

`terminal.moveToNewWorktree` is deliberately not allowlisted. Its whole gesture is the interactive create-worktree dialog: `usePanelStore.moveToNewWorktree` (`src/store/slices/panelRegistry/restart.ts:994`) opens `openCreateDialog(...)` and only performs the move inside the dialog's `onCreated` callback, kicked off with a fire-and-forget `void Promise.all(...)`. `run()` returns before anything has actually moved, so allowlisting it would hand an agent a tool that pops a modal it can't answer, then reports success for a move that may never happen.

`terminal.rename` already set this precedent (`terminalLifecycleActions.ts:347`): throw on agent dispatch rather than hang a prompt in front of the user (#11532). `moveToNewWorktree` now throws on agent dispatch too, as defense in depth, the same treatment the dormant `toggleMaximize` gets.

The capability isn't lost. `worktree.createWithRecipe` is already allowlisted and is explicitly a headless MCP tool that returns `{ worktreeId, ... }`, so the assistant composes create-then-move as two calls. The rejection message names that exact pair.

## The bug this exposure would have shipped

Worth calling out specifically, since it's the reason this PR is bigger than an allowlist entry.

Making `moveToWorktree` LLM-reachable meant an arbitrary `worktreeId` string could reach the panel store, which files the panel, and for a grouped panel its entire tab group, under a worktree no view can select. That hides a live process while telling the caller "OK". The codebase already knew this value was untrusted (`crossWorktreeMove.ts:179` checks liveness), but only *after* the move, and only on the rare rescue-follow path.

So this PR also:

- Checks the destination is a live worktree before any mutation, for **every** caller. Filing a panel under a dead id is corruption no matter who asked; only the reporting varies (headless callers get an error, foreground callers keep the quiet no-op they can already see for themselves).
- Binds the action to an explicit `terminalId` on agent dispatch, matching every sibling panel-move action. Focus drifts across the MCP round trip (#11532), and this relocates a panel across worktrees rather than merely rearranging it.
- Tells a headless caller its named panel is gone instead of returning a bare "OK" for a move that never happened.
- Uses `Object.hasOwn` for the panel lookup, matching `terminal.close`. `panelsById` is a plain object, so an id like `"constructor"` resolved off the prototype and would have been moved as if it were a real panel.
- Rejects an empty `worktreeId` at the schema.
- Discloses the tab-group blast radius in the LLM-facing description.

## Changes

- `shared/config/helpAssistantTierAllowlists.ts`: add `terminal.moveToWorktree` to `ACTION_TIER_ADDONS`.
- `src/services/actions/definitions/terminalSpawnActions.ts`: live-destination check for all callers, explicit `terminalId` binding + stale-panel/gone-panel reporting on agent dispatch, `Object.hasOwn` lookup, empty-`worktreeId` schema rejection, updated tool description, `moveToNewWorktree` throws on agent dispatch.
- Test updates across `terminalSpawnActions`, `actionDefinitions.adversarial`, `McpServerService.tierAuthorization`, and the `actionDefinitions.quality` snapshot.

## Testing

542 tests green across the affected suites: `terminalSpawnActions`, `actionDefinitions.adversarial`, `actionDefinitions.quality`, `McpServerService.tierAuthorization`, `mcp-server/tierAuth`, `mcp-server/sessionServer`.

The two tier decisions are pinned by fixed-id tests rather than loops over `ACTION_TIER_ADDONS`, because a derived loop shrinks with the allowlist and stays green even if the entry gets dropped again. New coverage for the plugin, menu, prototype-backed-id, and stale-panel paths.

## Deliberately deferred

`nonRepeatable: true` is missing on `terminal.moveToNewWorktree`. That's a pre-existing, unrelated gap, flagged in review and left alone to keep this PR focused.
