### PR TITLE
fix(assistant): offer only models and toggles the selected agent can use

### DIFF
--- a/electron/services/AgentModelCatalogService.ts
+++ b/electron/services/AgentModelCatalogService.ts
@@ -17,11 +17,13 @@ const execFileAsync = promisify(execFile);
 const ModelEntrySchema = z
   .object({
     name: z.string().optional(),
-    // `limit.context` is read lazily as `unknown` at the catalog level so a
-    // single non-numeric value (e.g. `null`, `"unlimited"`, or any future
-    // type) never rejects the entire catalog. `extractRemote` guards with
-    // `typeof ctx === "number"` before reading the value.
+    // `limit.context`, `tool_call` and `modalities` are read lazily as
+    // `unknown` at the catalog level so a single unexpected value (e.g.
+    // `null`, `"unlimited"`, or any future type) never rejects the entire
+    // catalog. `extractRemote` narrows each one before reading it.
     limit: z.object({ context: z.unknown() }).passthrough().optional(),
+    tool_call: z.unknown().optional(),
+    modalities: z.object({ output: z.unknown() }).passthrough().optional(),
   })
   .passthrough();
 
@@ -82,8 +84,13 @@ const MAX_CODEX_BUFFER = 256 * 1024;
  * `shared/config/agents/*.ts` remain the offline-safe fallback.
  *
  * Codex receives an additional offline enrichment pass from `codex debug
- * models --bundled` when the Codex CLI is on PATH; remote and CLI sources
- * are merged into the resolved list, with bundled IDs always present.
+ * models --bundled` when the Codex CLI is on PATH.
+ *
+ * Sources contribute metadata freely, but membership is decided by whichever
+ * source actually speaks for the CLI — see {@link authoritativeIds}. models.dev
+ * groups by *provider*, so left unchecked it offers image, embedding and
+ * legacy models that no coding CLI accepts; entries that reach the union at
+ * all must first clear {@link canDriveAgentCli}.
  *
  * Unknown model IDs (and remote/CLI failures) degrade silently per the
  * issue constraint — `console.warn` only, never `notify()`.
@@ -127,7 +134,12 @@ export class AgentModelCatalogService {
       codex = await this.getCodexCatalog();
     }
 
-    const merged = this.merge(bundled, remote, codex);
+    const merged = this.merge(
+      bundled,
+      remote,
+      codex,
+      this.authoritativeIds(agentId, bundled, codex)
+    );
 
     let source: ResolvedModelCatalog["source"];
     if (!remote && !codex) {
@@ -178,6 +190,9 @@ export class AgentModelCatalogService {
     for (const [modelId, entry] of Object.entries(provider.models)) {
       const parsed = ModelEntrySchema.safeParse(entry);
       if (!parsed.success) continue;
+      // Runs before the context aggregate so an excluded image or embedding
+      // entry can't inflate the resolved window either.
+      if (!canDriveAgentCli(parsed.data)) continue;
       const name = parsed.data.name ?? modelId;
       const ctx = parsed.data.limit?.context;
       if (typeof ctx === "number" && ctx > maxContext) {
@@ -194,10 +209,32 @@ export class AgentModelCatalogService {
     return { models, contextWindow: maxContext > 0 ? maxContext : null };
   }
 
+  /**
+   * The IDs this agent's picker is allowed to offer, in display order, or
+   * `null` to keep the plain union of every source.
+   *
+   * A live CLI catalog is the strongest signal there is — it's the binary
+   * that will receive the `--model` flag answering for itself — so it wins
+   * outright. Failing that, an agent whose bundled list is marked
+   * {@link AgentConfig.curatedModels} answers for itself. Everyone else keeps
+   * discovering new models from the remote catalog.
+   */
+  private authoritativeIds(
+    agentId: string,
+    bundled: AgentResolved,
+    codex: AgentResolved | null
+  ): string[] | null {
+    if (codex && codex.models.length > 0) return codex.models.map((m) => m.id);
+    const curated = getEffectiveAgentConfig(agentId)?.curatedModels === true;
+    if (curated && bundled.models.length > 0) return bundled.models.map((m) => m.id);
+    return null;
+  }
+
   private merge(
     bundled: AgentResolved,
     remote: AgentResolved | null,
-    codex: AgentResolved | null
+    codex: AgentResolved | null,
+    authoritativeIds: string[] | null
   ): AgentResolved {
     if (!remote && !codex) return bundled;
 
@@ -235,10 +272,18 @@ export class AgentModelCatalogService {
     const contextWindow =
       codex?.contextWindow ?? remote?.contextWindow ?? bundled.contextWindow ?? null;
 
-    return {
-      models: Array.from(byId.values()),
-      contextWindow,
-    };
+    // Every source contributed metadata; only the authoritative one decides
+    // membership and order. Projecting last means a curated entry still picks
+    // up a better display name from models.dev without letting models.dev
+    // smuggle in IDs the CLI would reject.
+    const models = authoritativeIds
+      ? authoritativeIds.flatMap((id) => {
+          const model = byId.get(id);
+          return model ? [model] : [];
+        })
+      : Array.from(byId.values());
+
+    return { models, contextWindow };
   }
 
   /** Returns parsed catalog or null when all sources fail. */
@@ -439,32 +484,65 @@ export class AgentModelCatalogService {
         name: z.string().optional(),
         context_window: z.number().optional(),
         max_context_window: z.number().optional(),
+        // The CLI's own answer to "should a picker offer this?". Read as
+        // `unknown` for the same reason as the models.dev fields — an
+        // unexpected type must not reject the whole catalog.
+        visibility: z.unknown().optional(),
+        priority: z.unknown().optional(),
       })
       .passthrough();
 
-    const models: AgentModelConfig[] = [];
+    const listed: { model: AgentModelConfig; priority: number }[] = [];
     let maxContext = 0;
     for (const entry of entries) {
       const safe = CodexEntrySchema.safeParse(entry);
       if (!safe.success) continue;
       const id = safe.data.slug ?? safe.data.id;
       if (!id) continue;
+      // Codex marks internal and retired slugs `"hide"` (`codex-auto-review`,
+      // superseded releases). Only `"list"` entries belong in a picker, and an
+      // absent or unrecognised value is treated as hidden so a format change
+      // can't quietly reopen the gate.
+      if (safe.data.visibility !== "list") continue;
       const name = safe.data.display_name ?? safe.data.name ?? id;
       const ctx = safe.data.max_context_window ?? safe.data.context_window;
       if (typeof ctx === "number" && ctx > maxContext) maxContext = ctx;
-      models.push({
-        id,
-        name,
-        shortLabel: deriveShortLabel(name, id),
+      listed.push({
+        model: { id, name, shortLabel: deriveShortLabel(name, id) },
+        priority:
+          typeof safe.data.priority === "number" ? safe.data.priority : Number.MAX_SAFE_INTEGER,
       });
     }
-    if (models.length === 0) return null;
-    return { models, contextWindow: maxContext > 0 ? maxContext : null };
+    if (listed.length === 0) return null;
+    // Ascending `priority` is the CLI's own recommended order; entries without
+    // one sort last, ties keeping input order (Array.prototype.sort is stable).
+    listed.sort((a, b) => a.priority - b.priority);
+    return {
+      models: listed.map((l) => l.model),
+      contextWindow: maxContext > 0 ? maxContext : null,
+    };
   }
 }
 
 function isNodeError(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
+}
+
+/**
+ * Whether a models.dev entry describes a model an agent CLI could actually be
+ * pointed at. models.dev lists everything a provider publishes — image,
+ * embedding and realtime-audio models included — and a coding CLI rejects all
+ * of those. Tool calling plus text output is the minimum a CLI needs.
+ *
+ * Deliberately fail-closed: an entry whose capability fields are missing or
+ * the wrong type is dropped rather than offered. Losing a model from the
+ * picker is recoverable (the bundled list is still there); offering one the
+ * CLI rejects is the bug this guards.
+ */
+function canDriveAgentCli(entry: z.infer<typeof ModelEntrySchema>): boolean {
+  if (entry.tool_call !== true) return false;
+  const output = entry.modalities?.output;
+  return Array.isArray(output) && output.includes("text");
 }
 
 /**

--- a/electron/services/__tests__/AgentModelCatalogService.test.ts
+++ b/electron/services/__tests__/AgentModelCatalogService.test.ts
@@ -4,46 +4,42 @@ import * as os from "node:os";
 import * as fs from "node:fs/promises";
 
 import { AgentModelCatalogService } from "../AgentModelCatalogService.js";
+import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
+
+/**
+ * A models.dev entry the capability filter accepts: tool calling plus text
+ * output. Entries missing either are what the filter exists to drop.
+ */
+function chatModel(name: string, context: number): Record<string, unknown> {
+  return {
+    name,
+    limit: { context },
+    tool_call: true,
+    modalities: { input: ["text"], output: ["text"] },
+  };
+}
 
 function makeCatalog(): Record<string, unknown> {
   return {
     anthropic: {
       name: "Anthropic",
       models: {
-        "claude-sonnet-4-6": {
-          name: "Claude Sonnet 4.6",
-          limit: { context: 1_000_000 },
-        },
-        "claude-opus-4-6": {
-          name: "Claude Opus 4.6",
-          limit: { context: 200_000 },
-        },
-        "claude-haiku-4-5-20251001": {
-          name: "Claude Haiku 4.5",
-          limit: { context: 200_000 },
-        },
+        "claude-sonnet-4-6": chatModel("Claude Sonnet 4.6", 1_000_000),
+        "claude-opus-4-6": chatModel("Claude Opus 4.6", 200_000),
+        "claude-haiku-4-5-20251001": chatModel("Claude Haiku 4.5", 200_000),
       },
     },
     openai: {
       name: "OpenAI",
       models: {
-        "gpt-5.4": {
-          name: "GPT-5.4",
-          limit: { context: 128_000 },
-        },
-        o3: {
-          name: "o3",
-          limit: { context: 200_000 },
-        },
+        "gpt-5.4": chatModel("GPT-5.4", 128_000),
+        o3: chatModel("o3", 200_000),
       },
     },
     google: {
       name: "Google",
       models: {
-        "gemini-2.5-pro": {
-          name: "Gemini 2.5 Pro",
-          limit: { context: 1_048_576 },
-        },
+        "gemini-2.5-pro": chatModel("Gemini 2.5 Pro", 1_048_576),
       },
     },
   };
@@ -60,6 +56,16 @@ function mockFetch(payload: unknown, opts: { ok?: boolean; status?: number } = {
     status: opts.status ?? 200,
     json: async () => payload,
   }));
+}
+
+/** `visibility`/`priority` as the real `codex debug models --bundled` emits them. */
+const LISTED = (priority: number) => ({ visibility: "list", priority });
+
+function mockCodexCli(models: Record<string, unknown>[]): ExecFn {
+  return vi.fn(async () => ({
+    stdout: JSON.stringify({ models }),
+    stderr: "",
+  })) as unknown as ExecFn;
 }
 
 function mockFailingFetch(error: unknown): FetchFn {
@@ -118,28 +124,50 @@ describe("AgentModelCatalogService", () => {
     await cleanup(cachePath);
   });
 
-  it("returns remote-derived models merged with bundled IDs for claude", async () => {
+  it("keeps a curated agent's list authoritative — remote IDs never join it", async () => {
     const fetchImpl = mockFetch(makeCatalog());
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const bundledIds = getEffectiveAgentConfig("claude")!.models!.map((m) => m.id);
+    const result = await service.getResolvedModels("claude");
+
+    expect(result.agentId).toBe("claude");
+    // Every dated Anthropic ID in the fixture clears the capability filter, so
+    // only the curated-list projection keeps them out of the picker (#11879).
+    expect(result.models.map((m) => m.id)).toEqual(bundledIds);
+    expect(result.contextWindow).toBe(1_000_000);
+    expect(result.source).toBe("merged");
+  });
+
+  it("lets remote metadata enrich a curated entry without changing membership", async () => {
+    const fetchImpl = mockFetch({
+      anthropic: {
+        models: {
+          // Same ID as a curated alias: remote may improve its display name.
+          opus: chatModel("Claude Opus (latest)", 400_000),
+          "claude-opus-4-7": chatModel("Claude Opus 4.7", 200_000),
+        },
+      },
+    });
     const service = new AgentModelCatalogService({ cachePath, fetchImpl });
 
     const result = await service.getResolvedModels("claude");
 
-    expect(result.agentId).toBe("claude");
-    expect(result.models.map((m) => m.id)).toEqual(
-      expect.arrayContaining(["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5-20251001"])
-    );
-    expect(result.contextWindow).toBe(1_000_000);
-    expect(result.source).toBe("merged");
+    const opus = result.models.find((m) => m.id === "opus");
+    expect(opus?.name).toBe("Claude Opus (latest)");
+    // Curated shortLabel survives the remote name.
+    expect(opus?.shortLabel).toBe("Opus");
+    expect(result.models.map((m) => m.id)).not.toContain("claude-opus-4-7");
   });
 
   it("preserves bundled shortLabel for known models", async () => {
     const fetchImpl = mockFetch(makeCatalog());
     const service = new AgentModelCatalogService({ cachePath, fetchImpl });
 
-    const result = await service.getResolvedModels("claude");
+    const result = await service.getResolvedModels("gemini");
 
-    const sonnet = result.models.find((m) => m.id === "claude-sonnet-4-6");
-    expect(sonnet?.shortLabel).toBe("Sonnet");
+    const pro = result.models.find((m) => m.id === "gemini-2.5-pro");
+    expect(pro?.shortLabel).toBe("2.5 Pro");
   });
 
   it("falls back to bundled when fetch fails", async () => {
@@ -179,25 +207,115 @@ describe("AgentModelCatalogService", () => {
     expect(result.models.length).toBeGreaterThan(0);
   });
 
-  it("tolerates malformed entries — non-object entries skipped, valid ones surface", async () => {
+  // A non-object entry fails `models` at the record level, so the whole catalog
+  // is rejected rather than the one entry — the resolver must still degrade to
+  // bundled silently instead of throwing into IPC. (`extractRemote`'s per-entry
+  // safeParse is a second line of defence that this path never reaches.)
+  it("degrades to bundled when a malformed entry rejects the remote catalog", async () => {
     const fetchImpl = mockFetch({
-      anthropic: {
+      google: {
         models: {
-          "claude-sonnet-4-6": { name: "Claude Sonnet 4.6", limit: { context: 1_000_000 } },
+          "gemini-3-pro": chatModel("Gemini 3 Pro", 1_000_000),
           "string-entry": "not-an-object",
           "null-entry": null,
-          "claude-opus-4-6": { name: "Claude Opus 4.6", limit: { context: 200_000 } },
         },
       },
     });
     const service = new AgentModelCatalogService({ cachePath, fetchImpl });
 
-    const result = await service.getResolvedModels("claude");
+    const result = await service.getResolvedModels("gemini");
 
-    expect(result.models.map((m) => m.id)).toContain("claude-sonnet-4-6");
-    expect(result.models.map((m) => m.id)).toContain("claude-opus-4-6");
+    expect(result.source).toBe("bundled");
+    expect(result.models.map((m) => m.id)).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
     expect(result.models.find((m) => m.id === "string-entry")).toBeUndefined();
-    expect(result.models.find((m) => m.id === "null-entry")).toBeUndefined();
+  });
+
+  it("drops models.dev entries no coding CLI could drive", async () => {
+    const fetchImpl = mockFetch({
+      google: {
+        models: {
+          "gemini-3-pro": chatModel("Gemini 3 Pro", 1_000_000),
+          // Image + embedding models: published by the provider, rejected by
+          // the CLI. These are the entries #11879 reported in the picker.
+          "gemini-image-1": {
+            name: "Gemini Image 1",
+            limit: { context: 4_000_000 },
+            tool_call: false,
+            modalities: { input: ["text"], output: ["image"] },
+          },
+          "gemini-embedding-1": {
+            name: "Gemini Embedding",
+            limit: { context: 8_000_000 },
+            tool_call: false,
+            modalities: { input: ["text"], output: ["text"] },
+          },
+          // Tool-capable but audio-out: still not something --model takes.
+          "gemini-realtime": {
+            name: "Gemini Realtime",
+            limit: { context: 2_000_000 },
+            tool_call: true,
+            modalities: { input: ["audio"], output: ["audio"] },
+          },
+          // Capability fields absent entirely — fail closed.
+          "gemini-unknown": { name: "Gemini Unknown", limit: { context: 3_000_000 } },
+        },
+      },
+    });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("gemini");
+
+    expect(result.models.map((m) => m.id)).toContain("gemini-3-pro");
+    for (const excluded of [
+      "gemini-image-1",
+      "gemini-embedding-1",
+      "gemini-realtime",
+      "gemini-unknown",
+    ]) {
+      expect(result.models.map((m) => m.id)).not.toContain(excluded);
+    }
+    // Excluded entries advertise far larger windows; none may reach the
+    // resolved value, which is why the filter runs before the aggregate.
+    expect(result.contextWindow).toBe(1_000_000);
+  });
+
+  it("keeps discovery alive for agents whose list is not curated", async () => {
+    const fetchImpl = mockFetch({
+      google: {
+        models: {
+          "gemini-4-pro": chatModel("Gemini 4 Pro", 2_000_000),
+        },
+      },
+    });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("gemini");
+
+    // A brand-new remote model reaches the picker for a discovery agent — the
+    // capability filter is generic, not a curated-agent allowlist in disguise.
+    expect(result.models.map((m) => m.id)).toContain("gemini-4-pro");
+    expect(result.models.map((m) => m.id)).toContain("gemini-2.5-pro");
+  });
+
+  it("falls back to bundled when every remote entry fails the capability filter", async () => {
+    const fetchImpl = mockFetch({
+      google: {
+        models: {
+          "gemini-image-1": {
+            name: "Gemini Image 1",
+            limit: { context: 4_000_000 },
+            tool_call: false,
+            modalities: { input: ["text"], output: ["image"] },
+          },
+        },
+      },
+    });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("gemini");
+
+    expect(result.source).toBe("bundled");
+    expect(result.models.map((m) => m.id)).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
   });
 
   it("dedupes concurrent calls via singleflight", async () => {
@@ -253,17 +371,14 @@ describe("AgentModelCatalogService", () => {
     const result = await offline.getResolvedModels("claude");
 
     expect(result.source).toBe("merged");
-    expect(result.models.map((m) => m.id)).toContain("claude-sonnet-4-6");
+    expect(result.models.map((m) => m.id)).toContain("opus");
   });
 
-  it("enriches codex models from the bundled CLI catalog", async () => {
-    const execFileImpl: ExecFn = vi.fn(async () => ({
-      stdout: JSON.stringify([
-        { slug: "gpt-5.4", display_name: "GPT-5.4", context_window: 200_000 },
-        { slug: "o3-mini", display_name: "o3-mini", context_window: 128_000 },
-      ]),
-      stderr: "",
-    })) as unknown as ExecFn;
+  it("takes the codex CLI catalog as authoritative, dropping remote-only IDs", async () => {
+    const execFileImpl = mockCodexCli([
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", context_window: 200_000, ...LISTED(1) },
+      { slug: "gpt-5.2", display_name: "GPT-5.2", context_window: 128_000, ...LISTED(29) },
+    ]);
 
     const service = new AgentModelCatalogService({
       cachePath,
@@ -274,14 +389,83 @@ describe("AgentModelCatalogService", () => {
 
     const result = await service.getResolvedModels("codex");
 
-    expect(result.models.map((m) => m.id)).toEqual(
-      expect.arrayContaining(["gpt-5.4", "o3", "o3-mini"])
-    );
+    // `gpt-5.4` and `o3` are in the models.dev fixture and pass the capability
+    // filter, but the CLI is the thing that will receive `--model`.
+    expect(result.models.map((m) => m.id)).toEqual(["gpt-5.6-sol", "gpt-5.2"]);
     // Codex CLI's context window is preferred when present.
     expect(result.contextWindow).toBe(200_000);
   });
 
-  it("silently ignores codex CLI failure", async () => {
+  it("offers only models the codex CLI marks visible", async () => {
+    const execFileImpl = mockCodexCli([
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", context_window: 400_000, ...LISTED(1) },
+      {
+        slug: "gpt-5.4",
+        display_name: "GPT-5.4",
+        context_window: 900_000,
+        visibility: "hide",
+        priority: 16,
+      },
+      { slug: "codex-auto-review", display_name: "Auto review", visibility: "hide", priority: 43 },
+      // No visibility field at all — treated as hidden, not as opt-in.
+      { slug: "gpt-mystery", display_name: "Mystery", context_window: 999_000 },
+    ]);
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch({}),
+      execFileImpl,
+    });
+
+    const result = await service.getResolvedModels("codex");
+
+    expect(result.models.map((m) => m.id)).toEqual(["gpt-5.6-sol"]);
+    // A hidden entry's context window must not leak into the resolved value.
+    expect(result.contextWindow).toBe(400_000);
+  });
+
+  it("orders codex models by the CLI's priority, unranked entries last", async () => {
+    const execFileImpl = mockCodexCli([
+      { slug: "gpt-5.5", display_name: "GPT-5.5", ...LISTED(7) },
+      { slug: "gpt-unranked", display_name: "Unranked", visibility: "list" },
+      { slug: "gpt-5.6-terra", display_name: "GPT-5.6 Terra", ...LISTED(2) },
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", ...LISTED(1) },
+    ]);
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch({}),
+      execFileImpl,
+    });
+
+    const result = await service.getResolvedModels("codex");
+
+    expect(result.models.map((m) => m.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.5",
+      "gpt-unranked",
+    ]);
+  });
+
+  it("falls back to the curated codex list when every CLI entry is hidden", async () => {
+    const execFileImpl = mockCodexCli([
+      { slug: "codex-auto-review", display_name: "Auto review", visibility: "hide", priority: 43 },
+    ]);
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch(makeCatalog()),
+      execFileImpl,
+    });
+
+    const bundledIds = getEffectiveAgentConfig("codex")!.models!.map((m) => m.id);
+    const result = await service.getResolvedModels("codex");
+
+    expect(result.models.map((m) => m.id)).toEqual(bundledIds);
+  });
+
+  it("silently ignores codex CLI failure and keeps the curated list", async () => {
     const execFileImpl: ExecFn = vi.fn(async () => {
       const err: NodeJS.ErrnoException = new Error("not found");
       err.code = "ENOENT";
@@ -294,10 +478,27 @@ describe("AgentModelCatalogService", () => {
       execFileImpl,
     });
 
+    const bundledIds = getEffectiveAgentConfig("codex")!.models!.map((m) => m.id);
     const result = await service.getResolvedModels("codex");
 
-    expect(result.models.map((m) => m.id)).toContain("gpt-5.4");
+    expect(result.models.map((m) => m.id)).toEqual(bundledIds);
     expect(result.source).toBe("merged");
+  });
+
+  it("uses the CLI catalog when the network is down", async () => {
+    const execFileImpl = mockCodexCli([
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", context_window: 400_000, ...LISTED(1) },
+    ]);
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFailingFetch(new Error("offline")),
+      execFileImpl,
+    });
+
+    const result = await service.getResolvedModels("codex");
+
+    expect(result.models.map((m) => m.id)).toEqual(["gpt-5.6-sol"]);
   });
 
   it("returns null for unknown agent IDs", async () => {
@@ -315,8 +516,8 @@ describe("AgentModelCatalogService", () => {
     const execFileImpl: ExecFn = vi.fn(async () => ({
       stdout: JSON.stringify({
         models: [
-          { slug: "gpt-5.5", display_name: "GPT-5.5", context_window: 256_000 },
-          { slug: "gpt-5.4", display_name: "GPT-5.4", context_window: 128_000 },
+          { slug: "gpt-5.5", display_name: "GPT-5.5", context_window: 256_000, ...LISTED(7) },
+          { slug: "gpt-5.4", display_name: "GPT-5.4", context_window: 128_000, ...LISTED(16) },
         ],
       }),
       stderr: "",
@@ -337,27 +538,30 @@ describe("AgentModelCatalogService", () => {
 
   it("tolerates non-numeric limit.context anywhere in the remote catalog", async () => {
     const fetchImpl = mockFetch({
-      anthropic: {
+      google: {
         models: {
-          "claude-sonnet-4-6": { name: "Claude Sonnet 4.6", limit: { context: 200_000 } },
-          "claude-experimental": { name: "Claude Experimental", limit: { context: "unlimited" } },
+          "gemini-3-pro": chatModel("Gemini 3 Pro", 200_000),
+          "gemini-experimental": {
+            ...chatModel("Gemini Experimental", 0),
+            limit: { context: "unlimited" },
+          },
         },
       },
       // A whole separate provider with a malformed entry must not poison
-      // the catalog for the well-formed anthropic provider.
+      // the catalog for the well-formed google provider.
       openai: {
         models: {
-          "gpt-5.4": { name: "GPT-5.4", limit: { context: null } },
+          "gpt-5.4": { ...chatModel("GPT-5.4", 0), limit: { context: null } },
         },
       },
     });
     const service = new AgentModelCatalogService({ cachePath, fetchImpl });
 
-    const result = await service.getResolvedModels("claude");
+    const result = await service.getResolvedModels("gemini");
 
     expect(result.source).toBe("merged");
-    expect(result.models.map((m) => m.id)).toContain("claude-sonnet-4-6");
-    expect(result.models.map((m) => m.id)).toContain("claude-experimental");
+    expect(result.models.map((m) => m.id)).toContain("gemini-3-pro");
+    expect(result.models.map((m) => m.id)).toContain("gemini-experimental");
     expect(result.contextWindow).toBe(200_000);
   });
 
@@ -366,7 +570,9 @@ describe("AgentModelCatalogService", () => {
       await new Promise((r) => setTimeout(r, 5));
       return {
         stdout: JSON.stringify({
-          models: [{ slug: "gpt-5.5", display_name: "GPT-5.5", context_window: 256_000 }],
+          models: [
+            { slug: "gpt-5.5", display_name: "GPT-5.5", context_window: 256_000, ...LISTED(7) },
+          ],
         }),
         stderr: "",
       };
@@ -389,22 +595,19 @@ describe("AgentModelCatalogService", () => {
 
   it("derives shortLabel from name for remote-only models", async () => {
     const fetchImpl = mockFetch({
-      anthropic: {
+      google: {
         models: {
-          "claude-new-model": {
-            name: "Claude New (preview)",
-            limit: { context: 200_000 },
-          },
+          "gemini-new-model": chatModel("Gemini New (preview)", 200_000),
         },
       },
     });
     const service = new AgentModelCatalogService({ cachePath, fetchImpl });
 
-    const result = await service.getResolvedModels("claude");
+    const result = await service.getResolvedModels("gemini");
 
-    const newModel = result.models.find((m) => m.id === "claude-new-model");
+    const newModel = result.models.find((m) => m.id === "gemini-new-model");
     expect(newModel).toBeDefined();
     // Trailing parenthetical is stripped to keep the label short.
-    expect(newModel?.shortLabel).toBe("Claude New");
+    expect(newModel?.shortLabel).toBe("Gemini New");
   });
 });

--- a/electron/services/__tests__/AgentModelCatalogService.test.ts
+++ b/electron/services/__tests__/AgentModelCatalogService.test.ts
@@ -68,6 +68,11 @@ function mockCodexCli(models: Record<string, unknown>[]): ExecFn {
   })) as unknown as ExecFn;
 }
 
+/** The IDs an agent ships as its offline fallback, in declared order. */
+function bundledIdsFor(agentId: string): string[] {
+  return getEffectiveAgentConfig(agentId)!.models!.map((m) => m.id);
+}
+
 function mockFailingFetch(error: unknown): FetchFn {
   return vi.fn(async () => {
     throw error;
@@ -128,7 +133,7 @@ describe("AgentModelCatalogService", () => {
     const fetchImpl = mockFetch(makeCatalog());
     const service = new AgentModelCatalogService({ cachePath, fetchImpl });
 
-    const bundledIds = getEffectiveAgentConfig("claude")!.models!.map((m) => m.id);
+    const bundledIds = bundledIdsFor("claude");
     const result = await service.getResolvedModels("claude");
 
     expect(result.agentId).toBe("claude");
@@ -166,8 +171,9 @@ describe("AgentModelCatalogService", () => {
 
     const result = await service.getResolvedModels("gemini");
 
-    const pro = result.models.find((m) => m.id === "gemini-2.5-pro");
-    expect(pro?.shortLabel).toBe("2.5 Pro");
+    const bundledPro = getEffectiveAgentConfig("gemini")!.models![0]!;
+    const pro = result.models.find((m) => m.id === bundledPro.id);
+    expect(pro?.shortLabel).toBe(bundledPro.shortLabel);
   });
 
   it("falls back to bundled when fetch fails", async () => {
@@ -226,8 +232,7 @@ describe("AgentModelCatalogService", () => {
     const result = await service.getResolvedModels("gemini");
 
     expect(result.source).toBe("bundled");
-    expect(result.models.map((m) => m.id)).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
-    expect(result.models.find((m) => m.id === "string-entry")).toBeUndefined();
+    expect(result.models.map((m) => m.id)).toEqual(bundledIdsFor("gemini"));
   });
 
   it("drops models.dev entries no coding CLI could drive", async () => {
@@ -279,6 +284,42 @@ describe("AgentModelCatalogService", () => {
     expect(result.contextWindow).toBe(1_000_000);
   });
 
+  it("reads the capability fields by type, not by truthiness", async () => {
+    const fetchImpl = mockFetch({
+      google: {
+        models: {
+          // Text alongside another output modality is still text-capable.
+          "gemini-multi": {
+            name: "Gemini Multi",
+            limit: { context: 500_000 },
+            tool_call: true,
+            modalities: { input: ["text"], output: ["image", "text"] },
+          },
+          // Truthy strings must not stand in for the real types.
+          "gemini-stringy-tool": {
+            name: "Gemini Stringy",
+            limit: { context: 900_000 },
+            tool_call: "true",
+            modalities: { input: ["text"], output: ["text"] },
+          },
+          "gemini-stringy-output": {
+            name: "Gemini Stringy Output",
+            limit: { context: 900_000 },
+            tool_call: true,
+            modalities: { input: ["text"], output: "text" },
+          },
+        },
+      },
+    });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("gemini");
+
+    expect(result.models.map((m) => m.id)).toContain("gemini-multi");
+    expect(result.models.map((m) => m.id)).not.toContain("gemini-stringy-tool");
+    expect(result.models.map((m) => m.id)).not.toContain("gemini-stringy-output");
+  });
+
   it("keeps discovery alive for agents whose list is not curated", async () => {
     const fetchImpl = mockFetch({
       google: {
@@ -294,7 +335,7 @@ describe("AgentModelCatalogService", () => {
     // A brand-new remote model reaches the picker for a discovery agent — the
     // capability filter is generic, not a curated-agent allowlist in disguise.
     expect(result.models.map((m) => m.id)).toContain("gemini-4-pro");
-    expect(result.models.map((m) => m.id)).toContain("gemini-2.5-pro");
+    expect(result.models.map((m) => m.id)).toEqual(expect.arrayContaining(bundledIdsFor("gemini")));
   });
 
   it("falls back to bundled when every remote entry fails the capability filter", async () => {
@@ -315,7 +356,7 @@ describe("AgentModelCatalogService", () => {
     const result = await service.getResolvedModels("gemini");
 
     expect(result.source).toBe("bundled");
-    expect(result.models.map((m) => m.id)).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
+    expect(result.models.map((m) => m.id)).toEqual(bundledIdsFor("gemini"));
   });
 
   it("dedupes concurrent calls via singleflight", async () => {
@@ -374,9 +415,40 @@ describe("AgentModelCatalogService", () => {
     expect(result.models.map((m) => m.id)).toContain("opus");
   });
 
+  it("filters a disk cache written before the capability fields existed", async () => {
+    // Pre-change caches hold bare `{name, limit}` entries. They stay within TTL
+    // after an app update, so the filter has to run on every read — not only on
+    // freshly fetched payloads — or the old unfiltered list survives the fix.
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(
+      cachePath,
+      JSON.stringify({
+        fetchedAt: Date.now(),
+        raw: {
+          google: {
+            models: {
+              "gemini-legacy": { name: "Gemini Legacy", limit: { context: 900_000 } },
+            },
+          },
+        },
+      }),
+      "utf-8"
+    );
+
+    const fetchImpl = mockFailingFetch(new Error("offline"));
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("gemini");
+
+    expect(result.models.map((m) => m.id)).not.toContain("gemini-legacy");
+    expect(result.models.map((m) => m.id)).toEqual(bundledIdsFor("gemini"));
+  });
+
   it("takes the codex CLI catalog as authoritative, dropping remote-only IDs", async () => {
+    // Deliberately unequal to the remote catalog's 200_000 max, so reversing
+    // the CLI-before-remote precedence would change the assertion below.
     const execFileImpl = mockCodexCli([
-      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", context_window: 200_000, ...LISTED(1) },
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", context_window: 512_000, ...LISTED(1) },
       { slug: "gpt-5.2", display_name: "GPT-5.2", context_window: 128_000, ...LISTED(29) },
     ]);
 
@@ -392,8 +464,8 @@ describe("AgentModelCatalogService", () => {
     // `gpt-5.4` and `o3` are in the models.dev fixture and pass the capability
     // filter, but the CLI is the thing that will receive `--model`.
     expect(result.models.map((m) => m.id)).toEqual(["gpt-5.6-sol", "gpt-5.2"]);
-    // Codex CLI's context window is preferred when present.
-    expect(result.contextWindow).toBe(200_000);
+    // Codex CLI's context window is preferred over the remote catalog's.
+    expect(result.contextWindow).toBe(512_000);
   });
 
   it("offers only models the codex CLI marks visible", async () => {
@@ -448,6 +520,32 @@ describe("AgentModelCatalogService", () => {
     ]);
   });
 
+  it("treats a non-numeric priority as unranked and keeps ties in CLI order", async () => {
+    const execFileImpl = mockCodexCli([
+      // Same priority: input order decides, so a non-stable sort would flip these.
+      { slug: "gpt-tie-first", display_name: "Tie first", visibility: "list", priority: 5 },
+      { slug: "gpt-tie-second", display_name: "Tie second", visibility: "list", priority: 5 },
+      // A string priority must not be coerced into rank 1.
+      { slug: "gpt-stringy", display_name: "Stringy", visibility: "list", priority: "1" },
+      { slug: "gpt-ranked", display_name: "Ranked", ...LISTED(2) },
+    ]);
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch({}),
+      execFileImpl,
+    });
+
+    const result = await service.getResolvedModels("codex");
+
+    expect(result.models.map((m) => m.id)).toEqual([
+      "gpt-ranked",
+      "gpt-tie-first",
+      "gpt-tie-second",
+      "gpt-stringy",
+    ]);
+  });
+
   it("falls back to the curated codex list when every CLI entry is hidden", async () => {
     const execFileImpl = mockCodexCli([
       { slug: "codex-auto-review", display_name: "Auto review", visibility: "hide", priority: 43 },
@@ -459,10 +557,9 @@ describe("AgentModelCatalogService", () => {
       execFileImpl,
     });
 
-    const bundledIds = getEffectiveAgentConfig("codex")!.models!.map((m) => m.id);
     const result = await service.getResolvedModels("codex");
 
-    expect(result.models.map((m) => m.id)).toEqual(bundledIds);
+    expect(result.models.map((m) => m.id)).toEqual(bundledIdsFor("codex"));
   });
 
   it("silently ignores codex CLI failure and keeps the curated list", async () => {
@@ -478,17 +575,21 @@ describe("AgentModelCatalogService", () => {
       execFileImpl,
     });
 
-    const bundledIds = getEffectiveAgentConfig("codex")!.models!.map((m) => m.id);
     const result = await service.getResolvedModels("codex");
 
-    expect(result.models.map((m) => m.id)).toEqual(bundledIds);
+    expect(result.models.map((m) => m.id)).toEqual(bundledIdsFor("codex"));
     expect(result.source).toBe("merged");
   });
 
   it("uses the CLI catalog when the network is down", async () => {
-    const execFileImpl = mockCodexCli([
-      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", context_window: 400_000, ...LISTED(1) },
-    ]);
+    // Bare-array output (no `{models:[...]}` wrapper) is still a supported shape.
+    const execFileImpl: ExecFn = vi.fn(async () => ({
+      stdout: JSON.stringify([
+        { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", context_window: 400_000, ...LISTED(1) },
+        { slug: "gpt-5.4", display_name: "GPT-5.4", visibility: "hide", priority: 16 },
+      ]),
+      stderr: "",
+    })) as unknown as ExecFn;
 
     const service = new AgentModelCatalogService({
       cachePath,

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -856,14 +856,15 @@ describe("opencode TUI environment", () => {
 });
 
 describe("model configuration", () => {
-  it("claude has models with expected IDs", () => {
+  // `claude --model` accepts either a full name or a family alias resolving to
+  // the latest release. Pinned IDs go stale on every release (#11879), so the
+  // invariant is the *shape* of the list, not which families are in it today.
+  it("claude offers bare family aliases, never pinned release IDs", () => {
     const config = getAgentConfig("claude");
     expect(config?.models).toBeDefined();
     expect(config!.models!.length).toBeGreaterThanOrEqual(3);
-    const modelIds = config!.models!.map((m) => m.id);
-    expect(modelIds).toContain("claude-sonnet-4-6");
-    expect(modelIds).toContain("claude-opus-4-6");
-    expect(modelIds).toContain("claude-haiku-4-5-20251001");
+    const pinned = config!.models!.map((m) => m.id).filter((id) => /\d/.test(id));
+    expect(pinned).toEqual([]);
   });
 
   it("gemini has models", () => {
@@ -875,13 +876,19 @@ describe("model configuration", () => {
     expect(modelIds).toContain("gemini-2.5-flash");
   });
 
-  it("codex has models", () => {
+  // Codex doesn't validate `--model` against an allowlist — an unrecognised
+  // slug silently falls back to generic metadata rather than erroring — so the
+  // fallback list must name explicit tier slugs, never the ambiguous family
+  // alias that prefixes them (#11879).
+  it("codex offers explicit tier slugs, never a bare family alias", () => {
     const config = getAgentConfig("codex");
     expect(config?.models).toBeDefined();
     expect(config!.models!.length).toBeGreaterThanOrEqual(1);
     const modelIds = config!.models!.map((m) => m.id);
-    expect(modelIds).toContain("gpt-5.4");
-    expect(modelIds).toContain("gpt-5.3-codex-spark");
+    const ambiguous = modelIds.filter((id) =>
+      modelIds.some((other) => other !== id && other.startsWith(`${id}-`))
+    );
+    expect(ambiguous).toEqual([]);
   });
 
   it("each model has id, name, and shortLabel", () => {
@@ -905,9 +912,9 @@ describe("model configuration", () => {
 
 describe("getAgentModelConfig", () => {
   it("returns model config for valid agent and model ID", () => {
-    const model = getAgentModelConfig("claude", "claude-opus-4-6");
+    const model = getAgentModelConfig("claude", "opus");
     expect(model).toBeDefined();
-    expect(model!.name).toBe("Opus 4.6");
+    expect(model!.name).toBe("Opus");
     expect(model!.shortLabel).toBe("Opus");
   });
 
@@ -922,7 +929,7 @@ describe("getAgentModelConfig", () => {
 
 describe("getAgentDisplayTitle", () => {
   it("returns agent name with model shortLabel when modelId matches", () => {
-    expect(getAgentDisplayTitle("claude", "claude-opus-4-6")).toBe("Claude (Opus)");
+    expect(getAgentDisplayTitle("claude", "opus")).toBe("Claude (Opus)");
   });
 
   it("returns plain agent name when no modelId provided", () => {

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -912,10 +912,12 @@ describe("model configuration", () => {
 
 describe("getAgentModelConfig", () => {
   it("returns model config for valid agent and model ID", () => {
-    const model = getAgentModelConfig("claude", "opus");
-    expect(model).toBeDefined();
-    expect(model!.name).toBe("Opus");
-    expect(model!.shortLabel).toBe("Opus");
+    // A non-first entry whose name and shortLabel differ, so "returns the
+    // first model" and "returns name instead of shortLabel" both fail here.
+    const expected = getAgentConfig("codex")!.models![1]!;
+    const model = getAgentModelConfig("codex", expected.id);
+    expect(model).toEqual(expected);
+    expect(model!.name).not.toBe(model!.shortLabel);
   });
 
   it("returns undefined for invalid model ID", () => {
@@ -929,7 +931,9 @@ describe("getAgentModelConfig", () => {
 
 describe("getAgentDisplayTitle", () => {
   it("returns agent name with model shortLabel when modelId matches", () => {
-    expect(getAgentDisplayTitle("claude", "opus")).toBe("Claude (Opus)");
+    const model = getAgentConfig("codex")!.models![1]!;
+    expect(getAgentDisplayTitle("codex", model.id)).toBe(`Codex (${model.shortLabel})`);
+    expect(getAgentDisplayTitle("codex", model.id)).not.toContain(model.name);
   });
 
   it("returns plain agent name when no modelId provided", () => {

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -531,6 +531,17 @@ export interface AgentConfig {
   iconId: string;
   /** Available models for per-panel model selection at launch time */
   models?: AgentModelConfig[];
+  /**
+   * Marks {@link models} as the authoritative set this CLI accepts, not just an
+   * offline fallback. `AgentModelCatalogService` then lets the remote
+   * models.dev catalog enrich these entries (names, context windows) but never
+   * contribute IDs of its own, because models.dev groups by *provider* — every
+   * model OpenAI or Anthropic publishes — not by what the CLI's `--model` flag
+   * takes. Leave unset for agents whose list is a partial seed and should keep
+   * growing from remote discovery. A live CLI-derived catalog (Codex's
+   * `debug models --bundled`) still outranks a curated list.
+   */
+  curatedModels?: boolean;
   supportsContextInjection: boolean;
   /**
    * Per-concern wiring shape for the Daintree assistant overlay. Replaces the

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -74,11 +74,16 @@ export const config: AgentConfig = {
       "Run 'claude auth login' to authenticate after installing",
     ],
   },
+  // `claude --model` takes either a full name (`claude-fable-5`) or an alias
+  // for the latest model in a family. Aliases are the right shape here: a
+  // pinned ID goes stale on every release, an alias never does.
   models: [
-    { id: "claude-sonnet-4-6", name: "Sonnet 4.6", shortLabel: "Sonnet" },
-    { id: "claude-opus-4-6", name: "Opus 4.6", shortLabel: "Opus" },
-    { id: "claude-haiku-4-5-20251001", name: "Haiku 4.5", shortLabel: "Haiku" },
+    { id: "opus", name: "Opus", shortLabel: "Opus" },
+    { id: "fable", name: "Fable", shortLabel: "Fable" },
+    { id: "haiku", name: "Haiku", shortLabel: "Haiku" },
+    { id: "sonnet", name: "Sonnet", shortLabel: "Sonnet" },
   ],
+  curatedModels: true,
   contextWindow: 200_000,
   capabilities: {
     scrollback: 10000,

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -67,11 +67,18 @@ export const config: AgentConfig = {
       "Run 'codex auth login' after installing to authenticate",
     ],
   },
+  // Offline fallback for when `codex debug models --bundled` can't be probed.
+  // Ordered to match the CLI's own `priority`. Explicit tier slugs, not the
+  // bare `gpt-5.6` family alias: the CLI doesn't validate `--model` against an
+  // allowlist, so an unlisted slug silently falls back to generic metadata
+  // instead of failing loudly.
   models: [
-    { id: "gpt-5.4", name: "GPT-5.4", shortLabel: "GPT-5.4" },
-    { id: "o3", name: "o3", shortLabel: "o3" },
-    { id: "gpt-5.3-codex-spark", name: "Codex Spark", shortLabel: "Spark" },
+    { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", shortLabel: "Sol" },
+    { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", shortLabel: "Terra" },
+    { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", shortLabel: "Luna" },
+    { id: "gpt-5.5", name: "GPT-5.5", shortLabel: "GPT-5.5" },
   ],
+  curatedModels: true,
   contextWindow: 128_000,
   capabilities: {
     scrollback: 10000,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -2341,9 +2341,16 @@ export interface HelpAssistantSettings {
    */
   tier: HelpAssistantTier;
   /**
-   * Pass `--dangerously-skip-permissions` (Claude) and write
-   * `defaultMode: "bypassPermissions"` into the session's `.claude/settings.json`.
-   * Bypasses Claude Code's per-tool confirmation gate. Defaults to false.
+   * Run the assistant without its per-tool confirmation gate. One flag, but
+   * each backend honours it differently — Claude gets
+   * `--dangerously-skip-permissions` plus `defaultMode: "bypassPermissions"` in
+   * the session's `.claude/settings.json`, Codex gets
+   * `--dangerously-bypass-approvals-and-sandbox`, and the Daintree Assistant
+   * (which has no such flag) gets `DAINTREE_ASSISTANT_AUTO_APPROVE=1` in its
+   * spawn env. The canonical per-agent flag lives in `DEFAULT_DANGEROUS_ARGS`
+   * and is only appended for agents declaring `supports.permissionBypass`; see
+   * the help-launch branch in `electron/ipc/handlers/terminal/lifecycle.ts`.
+   * Defaults to false.
    */
   bypassPermissions: boolean;
   /** How long to retain help-session audit logs. 7 = 7 days, 30 = 30 days, 0 = off. Defaults to 7. */
@@ -2360,7 +2367,7 @@ export interface HelpAssistantSettings {
   customArgs: string;
   /**
    * Minutes the assistant panel must be continuously hidden before its PTY is
-   * gracefully shut down to capture the Claude resume session ID. 0 disables
+   * gracefully shut down to capture the agent's resume session ID. 0 disables
    * idle hibernation. Defaults to 5 — hiding is a layout gesture, so an idle
    * hidden assistant releases its memory quickly and reopening resumes the
    * same conversation transparently (return-to-panel rates fall off within a

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -41,6 +41,7 @@ import { useDebounce } from "@/hooks/useDebounce";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
+import { DEFAULT_DANGEROUS_ARGS } from "@shared/types/agentSettings";
 import { agentCapabilitiesClient } from "@/clients/agentCapabilitiesClient";
 import type { AgentModelConfig } from "@shared/config/agentRegistry";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
@@ -154,6 +155,81 @@ const HIBERNATE_OPTIONS = [
   { value: "120", label: "2 hours" },
 ];
 
+interface BypassCopy {
+  title: string;
+  subtitle: string;
+  ariaLabel: string;
+  warning: string;
+}
+
+const TIER_IS_LAST_SAFEGUARD =
+  "The capability tier above is the only remaining safeguard for Daintree actions.";
+
+/**
+ * Per-agent wording for the one stored `bypassPermissions` preference. The
+ * generic template below is accurate for a plain confirmation gate, but
+ * understates any agent whose flag gives up more than that — Codex drops its
+ * sandbox alongside its approvals — and understating the blast radius is the
+ * same failure as labelling every agent with Claude's flag.
+ */
+const BYPASS_COPY: Record<string, Omit<BypassCopy, "subtitle"> & { effect: string }> = {
+  claude: {
+    title: "Bypass Claude permission prompts",
+    effect: "Skip Claude's per-tool confirmation gate",
+    ariaLabel: "Bypass Claude permission prompts during help sessions",
+    warning: `With this on, Claude's permission gate is bypassed for all tools — built-in (Bash, Write) and MCP. ${TIER_IS_LAST_SAFEGUARD}`,
+  },
+  codex: {
+    title: "Bypass Codex approvals and sandbox",
+    effect: "Skip Codex's approval prompts and run tools unsandboxed",
+    ariaLabel: "Bypass Codex approvals and sandbox during help sessions",
+    warning: `With this on, Codex runs every tool without approval and outside its sandbox, so it reaches anywhere the process can. ${TIER_IS_LAST_SAFEGUARD}`,
+  },
+};
+
+/**
+ * What "bypass permissions" means for the selected agent, or `null` when the
+ * agent has no bypass mechanism and the control should stay hidden.
+ *
+ * The flag always comes from `DEFAULT_DANGEROUS_ARGS` — the same map the launch
+ * path appends from (`electron/ipc/handlers/terminal/lifecycle.ts`) — so the
+ * subtitle can't drift from what actually reaches the command line.
+ */
+function getBypassCopy(agentId: string | null): BypassCopy | null {
+  if (!agentId) return null;
+
+  // The assistant has no CLI flag: bypass skips its own confirm sheet via
+  // DAINTREE_ASSISTANT_AUTO_APPROVE, which is why it carries no
+  // DEFAULT_DANGEROUS_ARGS entry and declares `permissionBypass: false`.
+  if (agentId === "daintree-assistant") {
+    return {
+      title: "Auto-approve assistant actions",
+      subtitle: "Skip the assistant's own per-action confirmation sheet",
+      ariaLabel: "Auto-approve Daintree Assistant actions during help sessions",
+      warning: `With this on, the assistant acts without asking — no confirmation sheet for anything it does. ${TIER_IS_LAST_SAFEGUARD}`,
+    };
+  }
+
+  const flag = DEFAULT_DANGEROUS_ARGS[agentId];
+  const config = getAgentConfig(agentId);
+  if (!flag || config?.supports === false || config?.supports?.permissionBypass !== true) {
+    return null;
+  }
+
+  const agentName = config?.name ?? agentId;
+  const known = BYPASS_COPY[agentId];
+  if (known) {
+    const { effect, ...rest } = known;
+    return { ...rest, subtitle: `${effect} (passes ${flag})` };
+  }
+  return {
+    title: `Bypass ${agentName} permission prompts`,
+    subtitle: `Skip ${agentName}'s confirmation gate (passes ${flag})`,
+    ariaLabel: `Bypass ${agentName} permission prompts during help sessions`,
+    warning: `With this on, ${agentName} runs every tool without asking. ${TIER_IS_LAST_SAFEGUARD}`,
+  };
+}
+
 export function DaintreeAssistantSettingsTab() {
   const [settings, setSettings] = useState<HelpAssistantSettings>(DEFAULT_SETTINGS);
   const [mcpStatus, setMcpStatus] = useState<McpStatusSnapshot | null>(null);
@@ -230,6 +306,8 @@ export function DaintreeAssistantSettingsTab() {
   // suggest a value is set when it isn't, leaving onChange unfired and the help
   // panel still in its empty state. The placeholder makes "no selection" explicit.
   const agentSelectValue = preferredAgentId ?? "";
+
+  const bypassCopy = useMemo(() => getBypassCopy(preferredAgentId), [preferredAgentId]);
 
   // Resolved model catalog for the currently-preferred agent. `null` means "not
   // loaded / unavailable" (we render nothing); an empty array means "agent has
@@ -909,7 +987,7 @@ export function DaintreeAssistantSettingsTab() {
       <SettingsSection
         icon={Moon}
         title="Hibernation"
-        description="Idle assistants release memory and capture a resume token, so reopening reconnects to the same Claude conversation."
+        description="Idle assistants release memory and capture a resume token, so reopening reconnects to the same conversation."
       >
         <SettingsSelect
           label="Hibernate after"
@@ -925,7 +1003,7 @@ export function DaintreeAssistantSettingsTab() {
       <SettingsSection
         icon={ShieldAlert}
         title="Security"
-        description="Pick how much the assistant can do without prompting, and whether to bypass Claude Code's per-tool confirmation gate."
+        description="Pick how much the assistant can do without prompting, and whether to bypass the agent's own confirmation gate."
       >
         <SettingsSelect
           label="Capability tier"
@@ -944,18 +1022,23 @@ export function DaintreeAssistantSettingsTab() {
 
         <SessionLiveStatusCard configuredTier={settings.tier} />
 
-        <SettingsSwitchCard
-          variant="compact"
-          icon={ShieldAlert}
-          title="Bypass Claude permission prompts"
-          subtitle="Skip Claude Code's per-tool confirmation gate (passes --dangerously-skip-permissions)"
-          isEnabled={settings.bypassPermissions}
-          onChange={toggleBypassPermissions}
-          ariaLabel="Bypass Claude Code permission prompts during help sessions"
-          colorScheme="amber"
-          disabled={loading}
-        />
-        {settings.bypassPermissions && (
+        {/* The stored preference is agent-agnostic but its effect is not, so the
+            card only renders once an agent with a real bypass mechanism is
+            selected — mirroring the agent-gated Debug logging switch above. */}
+        {bypassCopy && (
+          <SettingsSwitchCard
+            variant="compact"
+            icon={ShieldAlert}
+            title={bypassCopy.title}
+            subtitle={bypassCopy.subtitle}
+            isEnabled={settings.bypassPermissions}
+            onChange={toggleBypassPermissions}
+            ariaLabel={bypassCopy.ariaLabel}
+            colorScheme="amber"
+            disabled={loading}
+          />
+        )}
+        {bypassCopy && settings.bypassPermissions && (
           <div
             className={cn(
               "flex items-start gap-2 p-3 rounded-[var(--radius-md)]",
@@ -964,9 +1047,7 @@ export function DaintreeAssistantSettingsTab() {
           >
             <AlertTriangle className="w-4 h-4 text-status-warning shrink-0 mt-0.5" />
             <div className="text-xs text-daintree-text/70 leading-relaxed select-text">
-              With this on, Claude Code's permission gate is bypassed for all tools — built-in
-              (Bash, Write) and MCP. The capability tier above is the only remaining safeguard for
-              Daintree actions.
+              {bypassCopy.warning}
             </div>
           </div>
         )}

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -145,9 +145,19 @@ const { mockGetAssistantSupportedAgentIds } = vi.hoisted(() => ({
 vi.mock("@/config/agents", () => ({
   getAgentIds: () => ["claude", "codex"],
   getAssistantSupportedAgentIds: () => mockGetAssistantSupportedAgentIds(),
+  // `supports` must be present: the bypass card reads permissionBypass to
+  // decide whether the selected agent has a bypass mechanism at all.
   getAgentConfig: (id: string) => {
-    if (id === "claude") return { name: "Claude Code", assistantMinVersion: "2.0.0" };
-    if (id === "codex") return { name: "Codex" };
+    if (id === "claude")
+      return {
+        name: "Claude Code",
+        assistantMinVersion: "2.0.0",
+        supports: { permissionBypass: true, tier: "stable" },
+      };
+    if (id === "codex")
+      return { name: "Codex", supports: { permissionBypass: true, tier: "stable" } };
+    if (id === "daintree-assistant")
+      return { name: "Daintree Assistant", supports: { permissionBypass: false, tier: "stable" } };
     return undefined;
   },
 }));
@@ -351,6 +361,7 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("turning on bypass permissions reveals the inline warning copy", async () => {
+    helpPanelState.preferredAgentId = "claude";
     const { container } = render(
       <SettingsValidationProvider>
         <DaintreeAssistantSettingsTab />
@@ -360,15 +371,90 @@ describe("DaintreeAssistantSettingsTab", () => {
 
     expect(container.textContent).not.toContain("only remaining safeguard");
 
-    const toggle = screen.getByLabelText(
-      "Bypass Claude Code permission prompts during help sessions"
-    );
+    const toggle = screen.getByLabelText("Bypass Claude permission prompts during help sessions");
     fireEvent.click(toggle);
 
     await waitForContent(container, "only remaining safeguard");
     expect(window.electron.helpAssistant.setSettings).toHaveBeenCalledWith({
       bypassPermissions: true,
     });
+  });
+
+  // One stored boolean, three different mechanisms behind it. Labelling them
+  // all as Claude's flag reads as a no-op while silently enabling
+  // auto-approval, so the copy has to follow the selected agent (#11879).
+  it("labels the bypass toggle with the selected agent's own mechanism", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex", "daintree-assistant"]);
+    helpPanelState.preferredAgentId = "codex";
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Bypass Codex approvals and sandbox");
+
+    expect(container.textContent).toContain("--dangerously-bypass-approvals-and-sandbox");
+    expect(container.textContent).not.toContain("--dangerously-skip-permissions");
+    expect(container.textContent).not.toContain("Bypass Claude permission prompts");
+    expect(
+      screen.getByLabelText("Bypass Codex approvals and sandbox during help sessions")
+    ).toBeTruthy();
+  });
+
+  it("describes the Daintree Assistant's env-var bypass, not a CLI flag", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex", "daintree-assistant"]);
+    helpPanelState.preferredAgentId = "daintree-assistant";
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Auto-approve assistant actions");
+
+    // The assistant has no dangerous-args entry — no flag may be claimed.
+    expect(container.textContent).not.toContain("--dangerously");
+    expect(
+      screen.getByLabelText("Auto-approve Daintree Assistant actions during help sessions")
+    ).toBeTruthy();
+  });
+
+  it("hides the bypass toggle and its warning while no agent is selected", async () => {
+    helpPanelState.preferredAgentId = null;
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Capability tier");
+
+    expect(container.textContent).not.toContain("Bypass");
+    expect(container.textContent).not.toContain("only remaining safeguard");
+  });
+
+  it("renders exactly the model catalog the resolver returns", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    window.electron.agentCapabilities.getResolvedModelList = vi.fn().mockResolvedValue({
+      agentId: "claude",
+      models: [
+        { id: "opus", name: "Opus", shortLabel: "Opus" },
+        { id: "sonnet", name: "Sonnet", shortLabel: "Sonnet" },
+      ],
+      contextWindow: 200_000,
+      source: "merged",
+    });
+
+    render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+
+    const select = await screen.findByLabelText("Model");
+    const options = Array.from(select.querySelectorAll("option")).map((o) => o.textContent);
+    expect(options).toEqual(["Default (CLI default)", "Opus", "Sonnet"]);
   });
 
   it("changing the capability tier persists tier=system", async () => {

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -158,6 +158,14 @@ vi.mock("@/config/agents", () => ({
       return { name: "Codex", supports: { permissionBypass: true, tier: "stable" } };
     if (id === "daintree-assistant")
       return { name: "Daintree Assistant", supports: { permissionBypass: false, tier: "stable" } };
+    // Assistant-wired but with no bypass mechanism of any kind — the shape a
+    // user-defined agent takes.
+    if (id === "byoa")
+      return { name: "BYOA", supports: { permissionBypass: false, tier: "stable" } };
+    // Has a DEFAULT_DANGEROUS_ARGS entry (--yolo) but opts out of bypass, so it
+    // isolates the permissionBypass clause from the missing-flag clause.
+    if (id === "gemini")
+      return { name: "Gemini", supports: { permissionBypass: false, tier: "stable" } };
     return undefined;
   },
 }));
@@ -397,9 +405,14 @@ describe("DaintreeAssistantSettingsTab", () => {
     expect(container.textContent).toContain("--dangerously-bypass-approvals-and-sandbox");
     expect(container.textContent).not.toContain("--dangerously-skip-permissions");
     expect(container.textContent).not.toContain("Bypass Claude permission prompts");
-    expect(
-      screen.getByLabelText("Bypass Codex approvals and sandbox during help sessions")
-    ).toBeTruthy();
+
+    const toggle = screen.getByLabelText("Bypass Codex approvals and sandbox during help sessions");
+    fireEvent.click(toggle);
+
+    // The warning has to name the sandbox: Codex's flag gives up more than a
+    // confirmation gate, and understating that is the bug being fixed.
+    await waitForContent(container, "outside its sandbox");
+    expect(container.textContent).not.toContain("built-in (Bash, Write)");
   });
 
   it("describes the Daintree Assistant's env-var bypass, not a CLI flag", async () => {
@@ -413,15 +426,25 @@ describe("DaintreeAssistantSettingsTab", () => {
     );
     await waitForContent(container, "Auto-approve assistant actions");
 
-    // The assistant has no dangerous-args entry — no flag may be claimed.
+    expect(container.textContent).toContain("own per-action confirmation sheet");
+    // The assistant has no dangerous-args entry, so no flag may be claimed.
     expect(container.textContent).not.toContain("--dangerously");
-    expect(
-      screen.getByLabelText("Auto-approve Daintree Assistant actions during help sessions")
-    ).toBeTruthy();
+
+    const toggle = screen.getByLabelText(
+      "Auto-approve Daintree Assistant actions during help sessions"
+    );
+    fireEvent.click(toggle);
+
+    await waitForContent(container, "acts without asking");
+    expect(window.electron.helpAssistant.setSettings).toHaveBeenCalledWith({
+      bypassPermissions: true,
+    });
   });
 
-  it("hides the bypass toggle and its warning while no agent is selected", async () => {
-    helpPanelState.preferredAgentId = null;
+  // The gate is what keeps a switch off agents where flipping it does nothing.
+  it("hides the bypass toggle for an agent with no bypass mechanism", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "byoa"]);
+    helpPanelState.preferredAgentId = "byoa";
 
     const { container } = render(
       <SettingsValidationProvider>
@@ -430,7 +453,71 @@ describe("DaintreeAssistantSettingsTab", () => {
     );
     await waitForContent(container, "Capability tier");
 
-    expect(container.textContent).not.toContain("Bypass");
+    expect(screen.queryByRole("switch", { name: /bypass|auto-approve/i })).toBeNull();
+  });
+
+  it("hides the bypass toggle for an agent that opts out of permission bypass", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "gemini"]);
+    helpPanelState.preferredAgentId = "gemini";
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Capability tier");
+
+    // A dangerous flag exists for this agent, so only the supports declaration
+    // keeps the switch away — and the launch path honours the same declaration.
+    expect(screen.queryByRole("switch", { name: /bypass|auto-approve/i })).toBeNull();
+    expect(container.textContent).not.toContain("--yolo");
+  });
+
+  it("follows the selection when the preferred agent changes", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    helpPanelState.preferredAgentId = "claude";
+
+    const { container, rerender } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Bypass Claude permission prompts");
+
+    helpPanelState.preferredAgentId = "codex";
+    rerender(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+
+    await waitForContent(container, "Bypass Codex approvals and sandbox");
+    expect(container.textContent).not.toContain("Bypass Claude permission prompts");
+  });
+
+  it("hides the bypass toggle and its warning while no agent is selected", async () => {
+    helpPanelState.preferredAgentId = null;
+    // Persisted ON: the warning banner must be gated on the agent too, not just
+    // on the stored boolean, or it renders with no switch to turn it back off.
+    installApi({
+      getSettings: vi.fn().mockResolvedValue({
+        docSearch: true,
+        daintreeControl: true,
+        tier: "action" as const,
+        bypassPermissions: true,
+        auditRetention: 7,
+        customArgs: "",
+      }),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Capability tier");
+
+    expect(screen.queryByRole("switch", { name: /bypass|auto-approve/i })).toBeNull();
     expect(container.textContent).not.toContain("only remaining safeguard");
   });
 

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -922,7 +922,7 @@ export const SETTINGS_REGISTRY = [
         id: "assistant-skip-permissions",
         section: "Security",
         title: "Skip permission prompts",
-        description: "Bypass Claude Code's confirmation gate for help sessions",
+        description: "Bypass the selected agent's confirmation gate for help sessions",
         keywords: [
           "assistant",
           "permissions",


### PR DESCRIPTION
The issue reported two symptoms with one root cause — the assistant settings tab treats the model list and the permission toggle as agent-agnostic when both are agent-specific.

**Model dropdown**
- `extractRemote()` now drops models.dev entries that no coding CLI can drive (`tool_call === true` plus a text output modality, fail-closed). That removes the `gpt-image-*`, `chatgpt-image-latest`, `text-embedding-*` and realtime-audio entries the issue listed. The filter runs before the context-window aggregate so an excluded entry can't inflate it, and it's generic across all five `PROVIDER_TO_AGENT_ID` providers.
- `fetchCodexCatalog()` now reads the `visibility`/`priority` fields it was discarding, keeps only `visibility === "list"`, and orders by the CLI's own priority. Absent or unrecognised visibility counts as hidden, so a format change can't quietly reopen the gate.
- New `AgentConfig.curatedModels` marks a bundled list as the set the CLI actually accepts. Every source still contributes metadata, but membership and order come from whichever source speaks for the CLI: a live CLI catalog first, then a curated list, else the old union. models.dev can improve a curated entry's display name without smuggling in IDs the CLI would reject. Discovery stays on for gemini/qwen/mistral, whose lists aren't curated.
- Claude's bundled models are now the `opus`/`fable`/`haiku`/`sonnet` aliases (`claude --model` takes "an alias for the latest model"), and Codex's are the explicit tier slugs `gpt-5.6-sol`/`-terra`/`-luna` plus `gpt-5.5`.

**On the bare `gpt-5.6` alias** — the issue asked to confirm this before shipping. Checked against `openai/codex` source: the CLI does not validate `--model` against an allowlist, it logs `warn!("Unknown model {slug} is used. This will use fallback model metadata.")` and continues. So `gpt-5.6` does route to Sol, but only the three suffixed slugs appear in the CLI's own `visibility: "list"` output and get real rather than fallback metadata. The fallback list uses the explicit slugs.

**Bypass toggle**
Pure copy and gating — no behaviour change; the launch path in `terminal/lifecycle.ts` already branched correctly per agent. The title, subtitle, aria label and warning now come from the selected agent, with the flag text interpolated from `DEFAULT_DANGEROUS_ARGS` (the same map the launch path appends from) so the copy can't drift from what reaches the command line. Codex gets its own wording because its flag gives up the sandbox as well as approvals, and understating that is the same failure as labelling everything with Claude's flag. The switch and its warning are hidden together when the selected agent has no bypass mechanism, mirroring the agent-gated Debug logging switch above it. Claude-only wording is also gone from the hibernation and security descriptions, the settings-search entry and the `bypassPermissions` doc comment.

**Not in this PR**: the `contextWindow` side note. It is genuinely unconsumed — confirmed by grep, nothing reads `ResolvedModelCatalog.contextWindow` — but removing it touches the registry type, six agent configs, the service cache shape, the IPC type and handler, which is a wider blast radius than the two reported symptoms.

**Testing**
1010 tests pass across the catalog service, agent registry, assistant settings tab, settings registry/search/nav, agentCapabilities serialization, agent settings, and the spawn lifecycle. Own-file lint and format clean (4 remaining warnings are pre-existing on develop); `npm run typecheck` clean.

Rather than trust a green run, the new gating tests were mutation-checked: removing the `permissionBypass` clause from the bypass gate and removing the Codex `visibility` filter each caused the expected tests to fail. Review also caught that the pre-existing "tolerates malformed entries" test was passing vacuously — a non-object entry rejects the whole catalog at the provider level, and the old assertion only passed because the bundled Claude IDs matched the remote ones; it now states the invariant that actually holds.

Resolves #11879