### PR TITLE
docs(window): correct WebContents lifecycle guidance

### DIFF
--- a/electron/utils/webContentsLifecycle.ts
+++ b/electron/utils/webContentsLifecycle.ts
@@ -1,29 +1,33 @@
 /**
- * webContentsLifecycle — Shared CDP helpers for per-renderer freeze and CPU throttle.
+ * webContentsLifecycle: Shared CDP helpers for per-renderer freeze and CPU throttle.
  *
  * Wraps `Page.setWebLifecycleState` and `Emulation.setCPUThrottlingRate` so callers
- * don't need to know about `debugger.attach`, `Page.enable`, or the swallow-list of
- * expected CDP errors that surface during teardown/navigation races.
+ * do not need to know about `debugger.attach`, `Page.enable`, or expected CDP errors
+ * during teardown and navigation races.
  *
  * Why CDP instead of `WebContents.setBackgroundThrottling`: since Electron 28,
  * `setBackgroundThrottling(false)` on any view in a BrowserWindow disables timer
- * throttling for ALL sibling WebContents in that window. With one always-active
- * view per window, that silently un-throttled every cached sibling and made the
- * cached-view `setBackgroundThrottling(true)` ineffective (#8599).
- * `Emulation.setCPUThrottlingRate` is per-target — it slows the V8/Blink clock
- * for one renderer only while leaving the event loop, IPC, and MessagePort
- * dispatch running, so it is safe for cached views that still receive
- * worktree/workspace messages.
+ * throttling for all sibling WebContents in that window. With one always-active
+ * view per window, that makes cached-view `setBackgroundThrottling(true)` ineffective
+ * (#8599). `Emulation.setCPUThrottlingRate` is per-target and slows one renderer while
+ * leaving its event loop, IPC, and MessagePort dispatch live, which cached views need
+ * for worktree and workspace messages.
  *
- * Chromium 146 does NOT auto-resume a frozen renderer on focus or re-attach —
- * an explicit `"active"` call is required. Callers that activate a previously
- * deactivated view must call `unfreezeWebContents` before relying on the
- * renderer's event loop.
+ * Frozen renderers do not auto-resume on focus or reattach. Callers activating a
+ * frozen view must call `unfreezeWebContents` before relying on its event loop.
  *
- * Audit: electron/main.ts and electron/bootstrap.ts checked — no
- * `disable-renderer-backgrounding` or `disable-background-timer-throttling`
- * appendSwitch calls. If either is reintroduced, CDP freeze silently no-ops
- * (lesson #4683).
+ * Do not verify freeze with Playwright. It unconditionally enables focus emulation
+ * on every page target and forces the renderer visible, so a
+ * `Page.setWebLifecycleState` freeze reports success without freezing. A second CDP
+ * session cannot release Playwright's per-session capture. Use
+ * `npm run test:freeze-harness`. See the `test:freeze-harness` section in
+ * `docs/e2e-testing.md` (#11846).
+ *
+ * Audit: `electron/main.ts` and `electron/setup/environment.ts` have no `appendSwitch`
+ * calls for `disable-renderer-backgrounding` or `disable-background-timer-throttling`.
+ * Do not add either. The former removes cached-renderer OS priority demotion and the
+ * latter removes hidden-page timer throttling, raising idle CPU. Neither disables CDP
+ * freeze or CPU throttling.
  */
 
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";


### PR DESCRIPTION
## Summary

- Replaces the opening docblock in `electron/utils/webContentsLifecycle.ts` with the corrected guidance the maintainer supplied verbatim in #11846. No executable code changed, only the comment block.
- #11846 established that Playwright unconditionally enables focus emulation on every page target it attaches to, which forces a hidden `WebContents` to report itself as visible. `Page.setWebLifecycleState(frozen)` calls `WasHidden()` internally, so a forced-visible page can never actually be frozen. Freeze silently no-ops while still returning `ok`, which makes the #11790 / #11796 freeze guard structurally untestable from Playwright, in every project view, always. The new docblock warns future readers off attempting that and points them at `npm run test:freeze-harness` instead.
- Fixes three more inaccuracies the old comment carried: it blamed `electron/bootstrap.ts` for the Chromium `appendSwitch` calls, but that file has none of its own, it just imports `./setup/environment.js`, which holds nine of them against `main.ts`'s three. It also extrapolated from lesson #4683 that reintroducing `disable-renderer-backgrounding` or `disable-background-timer-throttling` would make freeze silently no-op; measurement shows freeze still zeroes the renderer with both switches applied; they gate OS process priority and Blink's hidden-page timer clamp, neither touches `PageVisibilityState` or the freeze state machine, so the comment now cites their real cost (higher idle CPU) as the reason to leave them out. And it anchored the no-auto-resume freeze behavior to Chromium 146, which the new text drops since that behavior lives in Blink's scheduler with no version or platform gating.

Resolves #11846

## Changes

- `electron/utils/webContentsLifecycle.ts`: docblock only, rewritten to match the maintainer's corrected text from the issue.

## Testing

- `npx prettier --check electron/utils/webContentsLifecycle.ts` passes.
- `npx eslint electron/utils/webContentsLifecycle.ts` passes.
- `npm run check` passes with no lint-ratchet regressions.
- `git diff --name-only origin/develop...HEAD` prints exactly one path.
- No tests added or run, deliberately. The maintainer already ruled that a test asserting on comment text would be tautological, and grepping confirms no test or `npm run check` guard asserts on this file's comment content. `npm run check`'s typecheck is what proves the file still parses.
