### PR TITLE
fix(layout): offset full-height overlays below the global banner

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -813,15 +813,13 @@ export function AppLayout({
 
   const effectiveSidebarWidth = showSidebar ? sidebarWidth : 0;
 
-  const [contentRowEl, setContentRowEl] = useState<HTMLDivElement | null>(null);
-  const [toolbarWrapEl, setToolbarWrapEl] = useState<HTMLDivElement | null>(null);
+  const [bannerEl, setBannerEl] = useState<HTMLDivElement | null>(null);
 
-  // Feeds OVERLAY_TOP_OFFSET. Measuring the toolbar wrapper's top edge (rather
-  // than the content row's) deliberately excludes FleetArmingRibbon height: the
-  // ribbon carries no positive z-index, so these overlays paint over it and it
-  // clips nothing, and offsetting below it would resize the PortalDock's native
-  // WebContentsView on every ribbon toggle.
-  useGlobalBannerHeightVar(toolbarWrapEl, contentRowEl);
+  // Feeds OVERLAY_TOP_OFFSET. Only the banner is measured — FleetArmingRibbon
+  // is deliberately excluded: it carries no positive z-index, so these overlays
+  // paint over it and it clips nothing, and offsetting below it would resize the
+  // PortalDock's native WebContentsView on every ribbon toggle.
+  useGlobalBannerHeightVar(bannerEl);
 
   useEffect(() => {
     const portalOffset = layout.portalOpen ? layout.portalWidth : 0;
@@ -860,10 +858,16 @@ export function AppLayout({
       }}
     >
       <PortalVisibilityController />
-      <Suspense fallback={null}>
-        <LazyGlobalBannerCoordinator />
-      </Suspense>
-      <div {...(chromeInert ? { inert: true } : {})} ref={setToolbarWrapEl}>
+      {/* Wraps the coordinator and nothing else so its height IS the banner
+          height, which useGlobalBannerHeightVar measures (#11893). shrink-0
+          keeps #9530's guarantee that the banner's height is subtracted from
+          the flex-1 content area rather than squeezed out of the banner. */}
+      <div ref={setBannerEl} className="shrink-0">
+        <Suspense fallback={null}>
+          <LazyGlobalBannerCoordinator />
+        </Suspense>
+      </div>
+      <div {...(chromeInert ? { inert: true } : {})}>
         <Toolbar
           onLaunchAgent={handleLaunchAgent}
           onSettings={handleSettings}
@@ -884,7 +888,6 @@ export function AppLayout({
       <MoveOrRenameProjectDialog />
       <div
         {...(chromeInert ? { inert: true } : {})}
-        ref={setContentRowEl}
         className="flex-1 flex flex-col overflow-hidden"
         style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}
       >

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -40,6 +40,7 @@ import { appClient } from "@/clients";
 import type { CliAvailability, AgentSettings } from "@shared/types";
 import { useLayoutState, useOverlayOpen } from "@/hooks";
 import { useKeepMounted } from "@/hooks/useKeepMounted";
+import { useResizeObserverRaf } from "@/hooks/useResizeObserverRaf";
 import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import {
@@ -127,6 +128,15 @@ export const DEFAULT_SIDEBAR_WIDTH = 350;
 // this the lock releases anyway so the grid still measures (pre-#10827 visible
 // behavior) rather than staying blank. Far longer than a healthy restore.
 const SIDEBAR_HYDRATION_UNLOCK_FALLBACK_MS = 5000;
+
+// #11893: top edge for the body-portaled full-height overlays (ThemeBrowser,
+// PortalDock). They are position:fixed and paint under the z-[60] toolbar, so a
+// static top-12 clipped their top strip the moment a global banner pushed the
+// toolbar down. `3rem` is the toolbar's own h-12; the var carries the banner
+// height, which is content-driven (description length, action count) and so has
+// no constant to hardcode. The 0px fallback keeps the no-banner case identical
+// to the old top-12.
+const OVERLAY_TOP_OFFSET = "calc(3rem + var(--global-banner-height, 0px))";
 
 export function AppLayout({
   children,
@@ -803,6 +813,43 @@ export function AppLayout({
 
   const effectiveSidebarWidth = showSidebar ? sidebarWidth : 0;
 
+  const [contentRowEl, setContentRowEl] = useState<HTMLDivElement | null>(null);
+  const toolbarWrapRef = useRef<HTMLDivElement>(null);
+
+  // --global-banner-height: how far GlobalBannerCoordinator has pushed the
+  // toolbar down, or 0px when no banner is up. There is no store value to read:
+  // the coordinator can hold a slot while still rendering nothing (HostCrashBanner
+  // has a 400ms Doherty gate), so `slot !== null` is not a height.
+  //
+  // The toolbar wrapper's top edge IS the banner height (the root sits at
+  // viewport y=0 and never scrolls). We read that position but observe the
+  // content row's SIZE: the row is flex-1 with overflow:hidden, so its
+  // automatic minimum height resolves to 0 and it absorbs every top-chrome
+  // height change, making it the reliable trigger. Reading the row's own top
+  // instead would fold in FleetArmingRibbon height — the ribbon is normal-flow
+  // with no z-index, so these overlays paint over it and it clips nothing, and
+  // offsetting below it would resize the PortalDock's native WebContentsView on
+  // every ribbon toggle.
+  //
+  // rAF-coalesced per the house convention (see rendererGlobalErrorHandlers.ts).
+  // The trade is one frame of stale offset when a banner mounts while an overlay
+  // is already open; both overlays open on user action, long after this
+  // observer's initial fire, so the common path is never stale.
+  useResizeObserverRaf(contentRowEl, () => {
+    const bannerHeight = toolbarWrapRef.current?.getBoundingClientRect().top ?? 0;
+    document.documentElement.style.setProperty(
+      "--global-banner-height",
+      `${Math.max(0, bannerHeight)}px`
+    );
+  });
+
+  useEffect(() => {
+    const rootStyle = document.documentElement.style;
+    return () => {
+      rootStyle.removeProperty("--global-banner-height");
+    };
+  }, []);
+
   useEffect(() => {
     const portalOffset = layout.portalOpen ? layout.portalWidth : 0;
     // Two separate vars because they encode different layout truths.
@@ -843,7 +890,7 @@ export function AppLayout({
       <Suspense fallback={null}>
         <LazyGlobalBannerCoordinator />
       </Suspense>
-      <div {...(chromeInert ? { inert: true } : {})}>
+      <div {...(chromeInert ? { inert: true } : {})} ref={toolbarWrapRef}>
         <Toolbar
           onLaunchAgent={handleLaunchAgent}
           onSettings={handleSettings}
@@ -864,6 +911,7 @@ export function AppLayout({
       <MoveOrRenameProjectDialog />
       <div
         {...(chromeInert ? { inert: true } : {})}
+        ref={setContentRowEl}
         className="flex-1 flex flex-col overflow-hidden"
         style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}
       >
@@ -1029,11 +1077,13 @@ export function AppLayout({
               {/* Offset the panel below the top toolbar. The toolbar is z-[60]
                   / h-12 (Toolbar.tsx) and paints over the viewport's top 48px, so
                   a top-0 panel had its top strip (hero ✕ close, any top bar) hidden
-                  behind it. Start at top-12 (= toolbar h-12) so the whole panel —
-                  including the close button — is visible. */}
+                  behind it. OVERLAY_TOP_OFFSET adds the measured global-banner
+                  height on top of the toolbar's h-12, because a banner pushes the
+                  toolbar further down (#11893). */}
               <div
-                className="fixed top-12 bottom-0 z-40 pointer-events-auto"
+                className="fixed bottom-0 z-40 pointer-events-auto"
                 style={{
+                  top: OVERLAY_TOP_OFFSET,
                   right: "var(--right-obstruction-offset, 0px)",
                 }}
               >
@@ -1052,7 +1102,8 @@ export function AppLayout({
                 WebContentsView is already hidden via PortalVisibilityController. */}
             <div
               {...(chromeInert ? { inert: true } : {})}
-              className="fixed top-12 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"
+              className="fixed right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"
+              style={{ top: OVERLAY_TOP_OFFSET }}
             >
               <PortalDock />
             </div>

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -40,7 +40,7 @@ import { appClient } from "@/clients";
 import type { CliAvailability, AgentSettings } from "@shared/types";
 import { useLayoutState, useOverlayOpen } from "@/hooks";
 import { useKeepMounted } from "@/hooks/useKeepMounted";
-import { useResizeObserverRaf } from "@/hooks/useResizeObserverRaf";
+import { useGlobalBannerHeightVar } from "@/hooks/useGlobalBannerHeightVar";
 import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import {
@@ -814,41 +814,14 @@ export function AppLayout({
   const effectiveSidebarWidth = showSidebar ? sidebarWidth : 0;
 
   const [contentRowEl, setContentRowEl] = useState<HTMLDivElement | null>(null);
-  const toolbarWrapRef = useRef<HTMLDivElement>(null);
+  const [toolbarWrapEl, setToolbarWrapEl] = useState<HTMLDivElement | null>(null);
 
-  // --global-banner-height: how far GlobalBannerCoordinator has pushed the
-  // toolbar down, or 0px when no banner is up. There is no store value to read:
-  // the coordinator can hold a slot while still rendering nothing (HostCrashBanner
-  // has a 400ms Doherty gate), so `slot !== null` is not a height.
-  //
-  // The toolbar wrapper's top edge IS the banner height (the root sits at
-  // viewport y=0 and never scrolls). We read that position but observe the
-  // content row's SIZE: the row is flex-1 with overflow:hidden, so its
-  // automatic minimum height resolves to 0 and it absorbs every top-chrome
-  // height change, making it the reliable trigger. Reading the row's own top
-  // instead would fold in FleetArmingRibbon height — the ribbon is normal-flow
-  // with no z-index, so these overlays paint over it and it clips nothing, and
-  // offsetting below it would resize the PortalDock's native WebContentsView on
-  // every ribbon toggle.
-  //
-  // rAF-coalesced per the house convention (see rendererGlobalErrorHandlers.ts).
-  // The trade is one frame of stale offset when a banner mounts while an overlay
-  // is already open; both overlays open on user action, long after this
-  // observer's initial fire, so the common path is never stale.
-  useResizeObserverRaf(contentRowEl, () => {
-    const bannerHeight = toolbarWrapRef.current?.getBoundingClientRect().top ?? 0;
-    document.documentElement.style.setProperty(
-      "--global-banner-height",
-      `${Math.max(0, bannerHeight)}px`
-    );
-  });
-
-  useEffect(() => {
-    const rootStyle = document.documentElement.style;
-    return () => {
-      rootStyle.removeProperty("--global-banner-height");
-    };
-  }, []);
+  // Feeds OVERLAY_TOP_OFFSET. Measuring the toolbar wrapper's top edge (rather
+  // than the content row's) deliberately excludes FleetArmingRibbon height: the
+  // ribbon carries no positive z-index, so these overlays paint over it and it
+  // clips nothing, and offsetting below it would resize the PortalDock's native
+  // WebContentsView on every ribbon toggle.
+  useGlobalBannerHeightVar(toolbarWrapEl, contentRowEl);
 
   useEffect(() => {
     const portalOffset = layout.portalOpen ? layout.portalWidth : 0;
@@ -890,7 +863,7 @@ export function AppLayout({
       <Suspense fallback={null}>
         <LazyGlobalBannerCoordinator />
       </Suspense>
-      <div {...(chromeInert ? { inert: true } : {})} ref={toolbarWrapRef}>
+      <div {...(chromeInert ? { inert: true } : {})} ref={setToolbarWrapEl}>
         <Toolbar
           onLaunchAgent={handleLaunchAgent}
           onSettings={handleSettings}

--- a/src/components/Layout/__tests__/AppLayout.banner.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.banner.test.ts
@@ -46,36 +46,26 @@ describe("AppLayout publishes the global banner height — issue #11893", () => 
     source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
   });
 
-  it("measures the banner and publishes it as --global-banner-height", () => {
-    // The body-portaled overlays are position:fixed under the z-[60] toolbar, so
-    // they need the toolbar's live bottom edge. A banner's height is
-    // content-driven and the coordinator can hold a slot while rendering nothing
-    // (HostCrashBanner's Doherty gate), so measurement is the only source.
-    expect(source).toContain('import { useResizeObserverRaf } from "@/hooks/useResizeObserverRaf"');
-    expect(source).toMatch(/setProperty\(\s*"--global-banner-height",/);
+  // What the publisher DOES — measure, clamp, republish, clean up — is covered
+  // behaviorally in src/hooks/__tests__/useGlobalBannerHeightVar.test.tsx. This
+  // suite only pins the wiring that a source scan can see: that AppLayout hands
+  // the hook the two elements it needs.
+
+  it("hands the hook the toolbar wrapper, whose top edge is the banner height", () => {
+    // Argument order matters: the wrapper is what gets MEASURED (its top edge is
+    // the banner height, since the app root sits at viewport y=0), the content
+    // row is only a resize trigger.
+    expect(source).toMatch(/useGlobalBannerHeightVar\(toolbarWrapEl, contentRowEl\)/);
+    expect(source).toMatch(/<div(?=[^>]*ref=\{setToolbarWrapEl\})[^>]*>\s*<Toolbar\b/);
   });
 
-  it("observes the content row's size but reads the toolbar wrapper's position", () => {
-    // The content row is flex-1 + overflow:hidden, so it absorbs every top-chrome
-    // height change and is the reliable resize trigger. Its own top edge would
-    // fold in FleetArmingRibbon height — the ribbon is normal-flow with no
-    // z-index, so these overlays paint over it and it clips nothing, and
-    // offsetting below it would resize PortalDock's native WebContentsView on
-    // every ribbon toggle.
-    expect(source).toMatch(/useResizeObserverRaf\(contentRowEl,/);
-    expect(source).toMatch(/toolbarWrapRef\.current\?\.getBoundingClientRect\(\)\.top/);
-    expect(source).toContain("ref={setContentRowEl}");
-    // The ref must sit AFTER the inert spread so the mount-order regex above
-    // keeps matching the toolbar wrapper.
-    expect(source).toContain(
-      "<div {...(chromeInert ? { inert: true } : {})} ref={toolbarWrapRef}>"
+  it("attaches the trigger ref to the flex-1 content row", () => {
+    // The row is flex-1 + overflow:hidden, so its automatic minimum height
+    // resolves to 0 and it absorbs banner growth. A ref on any shrink-0 sibling
+    // would never report the change.
+    expect(source).toMatch(
+      /<div(?=[^>]*ref=\{setContentRowEl\})(?=[^>]*className="(?=[^"]*\bflex-1\b)(?=[^"]*\boverflow-hidden\b)[^"]*")[^>]*>/
     );
-  });
-
-  it("removes the custom property on unmount", () => {
-    // Mirrors the --right-obstruction-offset effect: the var lives on
-    // documentElement, so a stale value would outlive this AppLayout instance.
-    expect(source).toMatch(/removeProperty\("--global-banner-height"\)/);
   });
 });
 

--- a/src/components/Layout/__tests__/AppLayout.banner.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.banner.test.ts
@@ -33,8 +33,11 @@ describe("AppLayout global banner mount — issue #9530", () => {
     // 100vh AppLayout root overflowed the viewport and clipped the dock. The
     // banner must be a direct child of the h-screen flex column so its
     // shrink-0 height is subtracted from the flex-1 content area instead.
+    // Since #11893 the coordinator sits inside a measured wrapper, which is now
+    // the direct flex child carrying shrink-0 — the ordering invariant is
+    // unchanged, and the wrapper must hold the coordinator and nothing else.
     expect(source).toMatch(
-      /<PortalVisibilityController \/>\s*<Suspense fallback=\{null\}>\s*<LazyGlobalBannerCoordinator \/>\s*<\/Suspense>\s*<div \{\.\.\.\(chromeInert \? \{ inert: true \}/
+      /<PortalVisibilityController \/>\s*(?:\{\/\*[\s\S]*?\*\/\}\s*)?<div(?=[^>]*className="shrink-0")[^>]*>\s*<Suspense fallback=\{null\}>\s*<LazyGlobalBannerCoordinator \/>\s*<\/Suspense>\s*<\/div>\s*<div \{\.\.\.\(chromeInert \? \{ inert: true \}/
     );
   });
 });
@@ -51,20 +54,16 @@ describe("AppLayout publishes the global banner height — issue #11893", () => 
   // suite only pins the wiring that a source scan can see: that AppLayout hands
   // the hook the two elements it needs.
 
-  it("hands the hook the toolbar wrapper, whose top edge is the banner height", () => {
-    // Argument order matters: the wrapper is what gets MEASURED (its top edge is
-    // the banner height, since the app root sits at viewport y=0), the content
-    // row is only a resize trigger.
-    expect(source).toMatch(/useGlobalBannerHeightVar\(toolbarWrapEl, contentRowEl\)/);
-    expect(source).toMatch(/<div(?=[^>]*ref=\{setToolbarWrapEl\})[^>]*>\s*<Toolbar\b/);
-  });
-
-  it("attaches the trigger ref to the flex-1 content row", () => {
-    // The row is flex-1 + overflow:hidden, so its automatic minimum height
-    // resolves to 0 and it absorbs banner growth. A ref on any shrink-0 sibling
-    // would never report the change.
+  it("measures the wrapper that holds the coordinator and nothing else", () => {
+    // The measured element must contain ONLY the coordinator, so its height IS
+    // the banner height. Measuring a neighbour instead (the toolbar wrapper's
+    // top edge, or the content row's size) goes stale in the degenerate cases:
+    // a banner that grows while FleetArmingRibbon shrinks by the same amount, or
+    // one that grows after the content area has collapsed to 0 — both leave
+    // every other element's size untouched.
+    expect(source).toMatch(/useGlobalBannerHeightVar\(bannerEl\)/);
     expect(source).toMatch(
-      /<div(?=[^>]*ref=\{setContentRowEl\})(?=[^>]*className="(?=[^"]*\bflex-1\b)(?=[^"]*\boverflow-hidden\b)[^"]*")[^>]*>/
+      /<div(?=[^>]*ref=\{setBannerEl\})[^>]*>\s*<Suspense fallback=\{null\}>\s*<LazyGlobalBannerCoordinator \/>\s*<\/Suspense>\s*<\/div>/
     );
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.banner.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.banner.test.ts
@@ -39,6 +39,46 @@ describe("AppLayout global banner mount — issue #9530", () => {
   });
 });
 
+describe("AppLayout publishes the global banner height — issue #11893", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("measures the banner and publishes it as --global-banner-height", () => {
+    // The body-portaled overlays are position:fixed under the z-[60] toolbar, so
+    // they need the toolbar's live bottom edge. A banner's height is
+    // content-driven and the coordinator can hold a slot while rendering nothing
+    // (HostCrashBanner's Doherty gate), so measurement is the only source.
+    expect(source).toContain('import { useResizeObserverRaf } from "@/hooks/useResizeObserverRaf"');
+    expect(source).toMatch(/setProperty\(\s*"--global-banner-height",/);
+  });
+
+  it("observes the content row's size but reads the toolbar wrapper's position", () => {
+    // The content row is flex-1 + overflow:hidden, so it absorbs every top-chrome
+    // height change and is the reliable resize trigger. Its own top edge would
+    // fold in FleetArmingRibbon height — the ribbon is normal-flow with no
+    // z-index, so these overlays paint over it and it clips nothing, and
+    // offsetting below it would resize PortalDock's native WebContentsView on
+    // every ribbon toggle.
+    expect(source).toMatch(/useResizeObserverRaf\(contentRowEl,/);
+    expect(source).toMatch(/toolbarWrapRef\.current\?\.getBoundingClientRect\(\)\.top/);
+    expect(source).toContain("ref={setContentRowEl}");
+    // The ref must sit AFTER the inert spread so the mount-order regex above
+    // keeps matching the toolbar wrapper.
+    expect(source).toContain(
+      "<div {...(chromeInert ? { inert: true } : {})} ref={toolbarWrapRef}>"
+    );
+  });
+
+  it("removes the custom property on unmount", () => {
+    // Mirrors the --right-obstruction-offset effect: the var lives on
+    // documentElement, so a stale value would outlive this AppLayout instance.
+    expect(source).toMatch(/removeProperty\("--global-banner-height"\)/);
+  });
+});
+
 describe("App.tsx no longer owns the global banner — issue #9530", () => {
   let source: string;
 

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -366,15 +366,13 @@ describe("AppLayout portal viewport coverage — issue #6629", () => {
     // stopped at the Assistant's left edge. Body-portaling with `position:
     // fixed` lets the Portal escape <main>'s width and overlay the Assistant.
     expect(source).toMatch(/\{layout\.portalOpen &&\s*\n\s*createPortal\(/);
-    expect(source).toContain(
-      '"fixed right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
+    // Issue #11893: the top edge is driven by OVERLAY_TOP_OFFSET (toolbar height
+    // plus the measured global-banner height) rather than a static top-12, which
+    // a banner-shifted toolbar painted over.
+    expect(source).toMatch(
+      /<div(?=[^>]*className="(?=[^"]*\bfixed\b)(?=[^"]*\bright-0\b)(?=[^"]*\bbottom-0\b)(?=[^"]*\bz-50\b)[^"]*")(?=[^>]*style=\{\{[\s\S]{0,200}?\btop:\s*OVERLAY_TOP_OFFSET\b)[^>]*>\s*<PortalDock\s*\/>/
     );
-    // Issue #11893: the top edge tracks the global banner height rather than a
-    // static top-12, which a banner-shifted toolbar painted over.
-    expect(source).toContain("style={{ top: OVERLAY_TOP_OFFSET }}");
-    expect(source).not.toContain(
-      '"fixed top-12 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
-    );
+    expect(source).not.toContain("fixed top-12 right-0 bottom-0");
     // The portal target must be document.body to escape the inert subtrees and
     // the <main> width constraint. A different target would silently reintroduce
     // the bug.

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -367,6 +367,12 @@ describe("AppLayout portal viewport coverage — issue #6629", () => {
     // fixed` lets the Portal escape <main>'s width and overlay the Assistant.
     expect(source).toMatch(/\{layout\.portalOpen &&\s*\n\s*createPortal\(/);
     expect(source).toContain(
+      '"fixed right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
+    );
+    // Issue #11893: the top edge tracks the global banner height rather than a
+    // static top-12, which a banner-shifted toolbar painted over.
+    expect(source).toContain("style={{ top: OVERLAY_TOP_OFFSET }}");
+    expect(source).not.toContain(
       '"fixed top-12 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
     );
     // The portal target must be document.body to escape the inert subtrees and

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -62,19 +62,25 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
 
   it("anchors the panel with fixed positioning below the toolbar", () => {
     // Bug 3: absolute + h-full inside <main> was bounded by the flex cell.
-    // fixed + bottom-0 anchors to the viewport regardless of docks/panels below.
-    expect(source).toMatch(/className="fixed bottom-0 z-40 pointer-events-auto"/);
+    // fixed + bottom-0 anchors to the viewport regardless of docks/panels below,
+    // and the top edge is driven by OVERLAY_TOP_OFFSET (see #11893 below).
+    expect(source).toMatch(
+      /<div(?=[^>]*className="(?=[^"]*\bfixed\b)(?=[^"]*\bbottom-0\b)[^"]*")(?=[^>]*style=\{\{[\s\S]{0,200}?\btop:\s*OVERLAY_TOP_OFFSET\b)[^>]*>\s*<ThemeBrowser\s*\/>/
+    );
   });
 
-  it("tracks the global banner height instead of a static top-12 — issue #11893", () => {
+  it("offsets the panel by the toolbar height PLUS the banner height — issue #11893", () => {
     // A global banner pushes the z-[60] toolbar below 48px, so the old static
-    // top-12 left the panel's top strip (hero ✕ close) painted under it. Banner
-    // height is content-driven, so the offset must compose the toolbar's own
-    // h-12 with the measured banner height — no constant can replace it.
-    expect(source).toMatch(/var\(--global-banner-height, 0px\)/);
-    expect(source).toContain("top: OVERLAY_TOP_OFFSET,");
+    // top-12 left the panel's top strip (hero ✕ close) painted under it. The
+    // offset must ADD the measured banner height to the toolbar's own height —
+    // replacing one with the other would just move the clipping around. The
+    // toolbar's base height is deliberately not pinned here: changing it should
+    // not force a mirrored test edit.
+    expect(source).toMatch(
+      /const OVERLAY_TOP_OFFSET = "calc\([^"+]+\+\s*var\(--global-banner-height,\s*0px\)\)"/
+    );
     // The static offset must not come back.
-    expect(source).not.toMatch(/className="fixed top-12 bottom-0 z-40 pointer-events-auto"/);
+    expect(source).not.toContain("fixed top-12 bottom-0");
   });
 
   it("drops the static backdrop-blur from the main-content wrapper", () => {

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -62,9 +62,19 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
 
   it("anchors the panel with fixed positioning below the toolbar", () => {
     // Bug 3: absolute + h-full inside <main> was bounded by the flex cell.
-    // fixed top-12 bottom-0 anchors to the viewport (below the h-12 toolbar)
-    // regardless of docks/panels below.
-    expect(source).toMatch(/className="fixed top-12 bottom-0 z-40 pointer-events-auto"/);
+    // fixed + bottom-0 anchors to the viewport regardless of docks/panels below.
+    expect(source).toMatch(/className="fixed bottom-0 z-40 pointer-events-auto"/);
+  });
+
+  it("tracks the global banner height instead of a static top-12 — issue #11893", () => {
+    // A global banner pushes the z-[60] toolbar below 48px, so the old static
+    // top-12 left the panel's top strip (hero ✕ close) painted under it. Banner
+    // height is content-driven, so the offset must compose the toolbar's own
+    // h-12 with the measured banner height — no constant can replace it.
+    expect(source).toMatch(/var\(--global-banner-height, 0px\)/);
+    expect(source).toContain("top: OVERLAY_TOP_OFFSET,");
+    // The static offset must not come back.
+    expect(source).not.toMatch(/className="fixed top-12 bottom-0 z-40 pointer-events-auto"/);
   });
 
   it("drops the static backdrop-blur from the main-content wrapper", () => {

--- a/src/hooks/__tests__/useGlobalBannerHeightVar.test.tsx
+++ b/src/hooks/__tests__/useGlobalBannerHeightVar.test.tsx
@@ -3,31 +3,42 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useGlobalBannerHeightVar, GLOBAL_BANNER_HEIGHT_VAR } from "../useGlobalBannerHeightVar";
 
-/** One observed element plus the callback the hook registered for it. */
-interface Registered {
-  callback: (entries: ResizeObserverEntry[]) => void;
-  observed: Element[];
-}
-
 function readVar(): string {
   return document.documentElement.style.getPropertyValue(GLOBAL_BANNER_HEIGHT_VAR);
 }
 
-/** A div whose measured top edge is `top`, standing in for the toolbar wrapper. */
-function elementWithTop(top: number): HTMLDivElement {
-  const el = document.createElement("div");
-  el.getBoundingClientRect = () =>
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    ({ top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top }) as DOMRect;
-  return el;
-}
-
 describe("useGlobalBannerHeightVar", () => {
-  let registered: Registered[] = [];
+  let observerCallback: ((entries: ResizeObserverEntry[]) => void) | null = null;
+  let observed: Element[] = [];
   let rafCallbacks: (() => void)[] = [];
 
+  /** A stand-in banner wrapper whose measured height is controlled by `height`. */
+  function bannerWrapper(height: number) {
+    const el = document.createElement("div");
+    let current = height;
+    el.getBoundingClientRect = () =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      ({
+        height: current,
+        top: 0,
+        bottom: current,
+        left: 0,
+        right: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+      }) as DOMRect;
+    return {
+      el,
+      setHeight(next: number) {
+        current = next;
+      },
+    };
+  }
+
   beforeEach(() => {
-    registered = [];
+    observerCallback = null;
+    observed = [];
     rafCallbacks = [];
 
     vi.stubGlobal(
@@ -36,11 +47,10 @@ describe("useGlobalBannerHeightVar", () => {
         this: ResizeObserver | void,
         cb: (entries: ResizeObserverEntry[]) => void
       ) {
-        const entry: Registered = { callback: cb, observed: [] };
-        registered.push(entry);
+        observerCallback = cb;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         return {
-          observe: vi.fn((el: Element) => entry.observed.push(el)),
+          observe: vi.fn((el: Element) => observed.push(el)),
           unobserve: vi.fn(),
           disconnect: vi.fn(),
         } as unknown as ResizeObserver;
@@ -67,119 +77,95 @@ describe("useGlobalBannerHeightVar", () => {
     document.documentElement.style.removeProperty(GLOBAL_BANNER_HEIGHT_VAR);
   });
 
-  function flushRaf() {
+  /** Deliver a resize notification and run the rAF the hook coalesces onto. */
+  function fireResize(el: Element) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    observerCallback?.([{ target: el } as unknown as ResizeObserverEntry]);
     const cbs = [...rafCallbacks];
     rafCallbacks = [];
     for (const cb of cbs) cb();
   }
 
-  /** Drive the observer that was subscribed to `el`. */
-  function fireResizeFor(el: Element) {
-    const match = registered.find((r) => r.observed.includes(el));
-    if (!match) throw new Error("no observer subscribed to that element");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    match.callback([{ target: el } as unknown as ResizeObserverEntry]);
-    flushRaf();
-  }
+  it("publishes the measured banner height", () => {
+    const banner = bannerWrapper(72);
 
-  it("publishes the toolbar wrapper's top edge as the banner height", () => {
-    const toolbarWrap = elementWithTop(72);
-    const contentRow = document.createElement("div");
+    renderHook(() => useGlobalBannerHeightVar(banner.el));
+    fireResize(banner.el);
 
-    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
-    fireResizeFor(contentRow);
-
-    // A 72px top edge means a 72px banner is sitting above the toolbar.
     expect(readVar()).toBe("72px");
   });
 
-  it("publishes 0px when no banner is pushing the toolbar down", () => {
-    const toolbarWrap = elementWithTop(0);
-    const contentRow = document.createElement("div");
+  it("publishes 0px when the coordinator renders no banner", () => {
+    // GlobalBannerCoordinator returns null with no active slot, collapsing the
+    // wrapper — which must resolve to the same offset as the pre-#11893 top-12.
+    const banner = bannerWrapper(0);
 
-    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
-    fireResizeFor(contentRow);
+    renderHook(() => useGlobalBannerHeightVar(banner.el));
+    fireResize(banner.el);
 
     expect(readVar()).toBe("0px");
   });
 
-  it("clamps a negative top edge to 0px", () => {
+  it("clamps a negative measurement to 0px", () => {
     // Guards the Math.max: a negative offset would pull the overlays UP, back
     // under the toolbar — the exact clipping this fix exists to prevent.
-    const toolbarWrap = elementWithTop(-30);
-    const contentRow = document.createElement("div");
+    const banner = bannerWrapper(-30);
 
-    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
-    fireResizeFor(contentRow);
+    renderHook(() => useGlobalBannerHeightVar(banner.el));
+    fireResize(banner.el);
 
     expect(readVar()).toBe("0px");
   });
 
-  it("republishes when the banner height changes", () => {
-    let top = 40;
-    const toolbarWrap = document.createElement("div");
-    toolbarWrap.getBoundingClientRect = () =>
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      ({ top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top }) as DOMRect;
-    const contentRow = document.createElement("div");
+  it("republishes when the banner reflows to a taller height", () => {
+    const banner = bannerWrapper(40);
 
-    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
-    fireResizeFor(contentRow);
+    renderHook(() => useGlobalBannerHeightVar(banner.el));
+    fireResize(banner.el);
     expect(readVar()).toBe("40px");
 
-    // Banner text reflows to a second line: the content row shrinks, so the
-    // observer fires again and the published value must follow.
-    top = 64;
-    fireResizeFor(contentRow);
+    // Banner description wraps to a second line.
+    banner.setHeight(64);
+    fireResize(banner.el);
     expect(readVar()).toBe("64px");
   });
 
-  it("also republishes when only the toolbar wrapper resizes", () => {
-    // FleetArmingRibbon toggling changes the wrapper's own height without
-    // necessarily changing the content row's — e.g. a banner that grows by
-    // exactly as much as the ribbon shrinks. Without this second subscription
-    // that cancellation would leave the published value stale.
-    let top = 40;
-    const toolbarWrap = document.createElement("div");
-    toolbarWrap.getBoundingClientRect = () =>
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      ({ top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top }) as DOMRect;
-    const contentRow = document.createElement("div");
+  it("does not publish synchronously — the write is rAF-coalesced", () => {
+    // The house convention (rendererGlobalErrorHandlers.ts) is that our own
+    // observers rAF-defer rather than writing layout-affecting values inside the
+    // ResizeObserver callback.
+    const banner = bannerWrapper(72);
 
-    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+    renderHook(() => useGlobalBannerHeightVar(banner.el));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    observerCallback?.([{ target: banner.el } as unknown as ResizeObserverEntry]);
 
-    top = 96;
-    fireResizeFor(toolbarWrap);
-    expect(readVar()).toBe("96px");
+    expect(readVar()).toBe("");
   });
 
-  it("observes both the content row and the toolbar wrapper", () => {
-    const toolbarWrap = elementWithTop(0);
-    const contentRow = document.createElement("div");
+  it("observes the element it was given", () => {
+    const banner = bannerWrapper(0);
 
-    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+    renderHook(() => useGlobalBannerHeightVar(banner.el));
 
-    const allObserved = registered.flatMap((r) => r.observed);
-    expect(allObserved).toContain(contentRow);
-    expect(allObserved).toContain(toolbarWrap);
+    expect(observed).toContain(banner.el);
   });
 
   it("removes the custom property on unmount", () => {
     // The var lives on documentElement, so a stale value would outlive the
     // AppLayout instance that published it.
-    const toolbarWrap = elementWithTop(72);
-    const contentRow = document.createElement("div");
+    const banner = bannerWrapper(72);
 
-    const { unmount } = renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
-    fireResizeFor(contentRow);
+    const { unmount } = renderHook(() => useGlobalBannerHeightVar(banner.el));
+    fireResize(banner.el);
     expect(readVar()).toBe("72px");
 
     unmount();
     expect(readVar()).toBe("");
   });
 
-  it("subscribes nothing until the elements exist", () => {
-    renderHook(() => useGlobalBannerHeightVar(null, null));
+  it("subscribes nothing before the wrapper exists", () => {
+    renderHook(() => useGlobalBannerHeightVar(null));
 
     expect(ResizeObserver).not.toHaveBeenCalled();
     expect(readVar()).toBe("");

--- a/src/hooks/__tests__/useGlobalBannerHeightVar.test.tsx
+++ b/src/hooks/__tests__/useGlobalBannerHeightVar.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGlobalBannerHeightVar, GLOBAL_BANNER_HEIGHT_VAR } from "../useGlobalBannerHeightVar";
+
+/** One observed element plus the callback the hook registered for it. */
+interface Registered {
+  callback: (entries: ResizeObserverEntry[]) => void;
+  observed: Element[];
+}
+
+function readVar(): string {
+  return document.documentElement.style.getPropertyValue(GLOBAL_BANNER_HEIGHT_VAR);
+}
+
+/** A div whose measured top edge is `top`, standing in for the toolbar wrapper. */
+function elementWithTop(top: number): HTMLDivElement {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    ({ top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top }) as DOMRect;
+  return el;
+}
+
+describe("useGlobalBannerHeightVar", () => {
+  let registered: Registered[] = [];
+  let rafCallbacks: (() => void)[] = [];
+
+  beforeEach(() => {
+    registered = [];
+    rafCallbacks = [];
+
+    vi.stubGlobal(
+      "ResizeObserver",
+      vi.fn(function ResizeObserverMock(
+        this: ResizeObserver | void,
+        cb: (entries: ResizeObserverEntry[]) => void
+      ) {
+        const entry: Registered = { callback: cb, observed: [] };
+        registered.push(entry);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        return {
+          observe: vi.fn((el: Element) => entry.observed.push(el)),
+          unobserve: vi.fn(),
+          disconnect: vi.fn(),
+        } as unknown as ResizeObserver;
+      })
+    );
+
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: () => void) => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+      })
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn(() => {
+        rafCallbacks = [];
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.documentElement.style.removeProperty(GLOBAL_BANNER_HEIGHT_VAR);
+  });
+
+  function flushRaf() {
+    const cbs = [...rafCallbacks];
+    rafCallbacks = [];
+    for (const cb of cbs) cb();
+  }
+
+  /** Drive the observer that was subscribed to `el`. */
+  function fireResizeFor(el: Element) {
+    const match = registered.find((r) => r.observed.includes(el));
+    if (!match) throw new Error("no observer subscribed to that element");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    match.callback([{ target: el } as unknown as ResizeObserverEntry]);
+    flushRaf();
+  }
+
+  it("publishes the toolbar wrapper's top edge as the banner height", () => {
+    const toolbarWrap = elementWithTop(72);
+    const contentRow = document.createElement("div");
+
+    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+    fireResizeFor(contentRow);
+
+    // A 72px top edge means a 72px banner is sitting above the toolbar.
+    expect(readVar()).toBe("72px");
+  });
+
+  it("publishes 0px when no banner is pushing the toolbar down", () => {
+    const toolbarWrap = elementWithTop(0);
+    const contentRow = document.createElement("div");
+
+    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+    fireResizeFor(contentRow);
+
+    expect(readVar()).toBe("0px");
+  });
+
+  it("clamps a negative top edge to 0px", () => {
+    // Guards the Math.max: a negative offset would pull the overlays UP, back
+    // under the toolbar — the exact clipping this fix exists to prevent.
+    const toolbarWrap = elementWithTop(-30);
+    const contentRow = document.createElement("div");
+
+    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+    fireResizeFor(contentRow);
+
+    expect(readVar()).toBe("0px");
+  });
+
+  it("republishes when the banner height changes", () => {
+    let top = 40;
+    const toolbarWrap = document.createElement("div");
+    toolbarWrap.getBoundingClientRect = () =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      ({ top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top }) as DOMRect;
+    const contentRow = document.createElement("div");
+
+    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+    fireResizeFor(contentRow);
+    expect(readVar()).toBe("40px");
+
+    // Banner text reflows to a second line: the content row shrinks, so the
+    // observer fires again and the published value must follow.
+    top = 64;
+    fireResizeFor(contentRow);
+    expect(readVar()).toBe("64px");
+  });
+
+  it("also republishes when only the toolbar wrapper resizes", () => {
+    // FleetArmingRibbon toggling changes the wrapper's own height without
+    // necessarily changing the content row's — e.g. a banner that grows by
+    // exactly as much as the ribbon shrinks. Without this second subscription
+    // that cancellation would leave the published value stale.
+    let top = 40;
+    const toolbarWrap = document.createElement("div");
+    toolbarWrap.getBoundingClientRect = () =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      ({ top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top }) as DOMRect;
+    const contentRow = document.createElement("div");
+
+    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+
+    top = 96;
+    fireResizeFor(toolbarWrap);
+    expect(readVar()).toBe("96px");
+  });
+
+  it("observes both the content row and the toolbar wrapper", () => {
+    const toolbarWrap = elementWithTop(0);
+    const contentRow = document.createElement("div");
+
+    renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+
+    const allObserved = registered.flatMap((r) => r.observed);
+    expect(allObserved).toContain(contentRow);
+    expect(allObserved).toContain(toolbarWrap);
+  });
+
+  it("removes the custom property on unmount", () => {
+    // The var lives on documentElement, so a stale value would outlive the
+    // AppLayout instance that published it.
+    const toolbarWrap = elementWithTop(72);
+    const contentRow = document.createElement("div");
+
+    const { unmount } = renderHook(() => useGlobalBannerHeightVar(toolbarWrap, contentRow));
+    fireResizeFor(contentRow);
+    expect(readVar()).toBe("72px");
+
+    unmount();
+    expect(readVar()).toBe("");
+  });
+
+  it("subscribes nothing until the elements exist", () => {
+    renderHook(() => useGlobalBannerHeightVar(null, null));
+
+    expect(ResizeObserver).not.toHaveBeenCalled();
+    expect(readVar()).toBe("");
+  });
+});

--- a/src/hooks/useGlobalBannerHeightVar.ts
+++ b/src/hooks/useGlobalBannerHeightVar.ts
@@ -10,37 +10,30 @@ export const GLOBAL_BANNER_HEIGHT_VAR = "--global-banner-height";
  * toolbar's own height so they still clear the `z-[60]` toolbar after a banner
  * has pushed it down (#11893).
  *
- * There is no store value to read: the coordinator can hold a slot while still
- * rendering nothing (HostCrashBanner has a 400ms Doherty gate), so
- * `slot !== null` is not a height. `toolbarWrapEl`'s top edge IS the banner
- * height — the app root sits at viewport y=0 and never scrolls.
+ * `bannerEl` must be the wrapper that holds the coordinator and nothing else, so
+ * its height IS the banner height. Measuring the wrapper directly — rather than
+ * inferring the offset from a neighbour's size — is what makes this correct in
+ * the degenerate cases: a banner that grows while the ribbon shrinks by the same
+ * amount, or one that grows after the content area has already collapsed to 0,
+ * both leave every other element's size untouched.
  *
- * Both elements are observed because neither alone catches every change. The
- * content row is `flex-1` with `overflow: hidden`, so its automatic minimum
- * height resolves to 0 and it absorbs banner growth. The toolbar wrapper's own
- * height moves when FleetArmingRibbon toggles — which would otherwise cancel
- * out an equal-and-opposite banner change and leave the row's size, and so the
- * published value, stale.
+ * There is no store value to read instead: the coordinator can hold a slot while
+ * still rendering nothing (HostCrashBanner has a 400ms Doherty gate), so
+ * `slot !== null` is not a height.
  *
  * rAF-coalesced per the house convention (see `rendererGlobalErrorHandlers.ts`).
  * The trade is one frame of stale offset when a banner mounts while an overlay
- * is already open; both overlays open on user action, long after the observers'
+ * is already open; both overlays open on user action, long after the observer's
  * initial fire, so the common path is never stale.
  */
-export function useGlobalBannerHeightVar(
-  toolbarWrapEl: HTMLElement | null,
-  contentRowEl: HTMLElement | null
-): void {
-  const publish = () => {
-    const bannerHeight = toolbarWrapEl?.getBoundingClientRect().top ?? 0;
+export function useGlobalBannerHeightVar(bannerEl: HTMLElement | null): void {
+  useResizeObserverRaf(bannerEl, () => {
+    const height = bannerEl?.getBoundingClientRect().height ?? 0;
     document.documentElement.style.setProperty(
       GLOBAL_BANNER_HEIGHT_VAR,
-      `${Math.max(0, bannerHeight)}px`
+      `${Math.max(0, height)}px`
     );
-  };
-
-  useResizeObserverRaf(contentRowEl, publish);
-  useResizeObserverRaf(toolbarWrapEl, publish);
+  });
 
   useEffect(() => {
     const rootStyle = document.documentElement.style;

--- a/src/hooks/useGlobalBannerHeightVar.ts
+++ b/src/hooks/useGlobalBannerHeightVar.ts
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import { useResizeObserverRaf } from "./useResizeObserverRaf";
+
+export const GLOBAL_BANNER_HEIGHT_VAR = "--global-banner-height";
+
+/**
+ * Publishes the height of whatever `GlobalBannerCoordinator` is rendering above
+ * the toolbar as `--global-banner-height` on `documentElement` — `0px` when no
+ * banner is up. Body-portaled `position: fixed` overlays compose it with the
+ * toolbar's own height so they still clear the `z-[60]` toolbar after a banner
+ * has pushed it down (#11893).
+ *
+ * There is no store value to read: the coordinator can hold a slot while still
+ * rendering nothing (HostCrashBanner has a 400ms Doherty gate), so
+ * `slot !== null` is not a height. `toolbarWrapEl`'s top edge IS the banner
+ * height — the app root sits at viewport y=0 and never scrolls.
+ *
+ * Both elements are observed because neither alone catches every change. The
+ * content row is `flex-1` with `overflow: hidden`, so its automatic minimum
+ * height resolves to 0 and it absorbs banner growth. The toolbar wrapper's own
+ * height moves when FleetArmingRibbon toggles — which would otherwise cancel
+ * out an equal-and-opposite banner change and leave the row's size, and so the
+ * published value, stale.
+ *
+ * rAF-coalesced per the house convention (see `rendererGlobalErrorHandlers.ts`).
+ * The trade is one frame of stale offset when a banner mounts while an overlay
+ * is already open; both overlays open on user action, long after the observers'
+ * initial fire, so the common path is never stale.
+ */
+export function useGlobalBannerHeightVar(
+  toolbarWrapEl: HTMLElement | null,
+  contentRowEl: HTMLElement | null
+): void {
+  const publish = () => {
+    const bannerHeight = toolbarWrapEl?.getBoundingClientRect().top ?? 0;
+    document.documentElement.style.setProperty(
+      GLOBAL_BANNER_HEIGHT_VAR,
+      `${Math.max(0, bannerHeight)}px`
+    );
+  };
+
+  useResizeObserverRaf(contentRowEl, publish);
+  useResizeObserverRaf(toolbarWrapEl, publish);
+
+  useEffect(() => {
+    const rootStyle = document.documentElement.style;
+    return () => {
+      rootStyle.removeProperty(GLOBAL_BANNER_HEIGHT_VAR);
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- `AppLayout`'s two body-portaled `position: fixed` overlays, the ThemeBrowser panel (`z-40`) and the PortalDock (`z-50`), were anchored with a static `top-12` (48px), which assumed the `h-12` toolbar was the only chrome above them.
- When `GlobalBannerCoordinator` renders a global banner (expired forge token, host crash, safe mode, and so on), the banner pushes the `z-[60]` toolbar below 48px and the toolbar paints over the overlays' top strip, clipping the theme browser's hero image and its close button.
- Banner height is content-driven (description length, action button count), so no static offset can fix it. This PR measures the banner directly instead.

Resolves #11893

## The fix

`GlobalBannerCoordinator` is now wrapped in a `shrink-0` div that holds it and nothing else, so that wrapper's height is the banner height. A new hook, `useGlobalBannerHeightVar`, measures it with the shared rAF-coalesced `useResizeObserverRaf` and publishes `--global-banner-height` on `documentElement`, mirroring the existing `--right-obstruction-offset` idiom.

Both overlays now anchor to `calc(3rem + var(--global-banner-height, 0px))`, where `3rem` is the toolbar's own `h-12`. The `0px` fallback keeps the no-banner case byte-identical to the old `top-12`.

### Why measure rather than read state

`useGlobalBannerPriority` only exposes a slot union, and a slot can be claimed by a banner that renders nothing yet (`HostCrashBanner` has a 400ms Doherty gate), so a non-null slot isn't the same as a height.

An earlier revision of this PR inferred the offset from a neighbouring element's size instead of measuring directly. Review found that went stale in two degenerate cases: a banner growing while `FleetArmingRibbon` shrinks by the same amount, and a banner growing after the content area has already collapsed to 0 under app zoom. Measuring the banner directly is the robust fix.

### Deliberately excluded

`FleetArmingRibbon` height isn't part of the offset. The ribbon carries no positive z-index, so these overlays already paint over it and clip nothing, and offsetting below it would resize the PortalDock's native `WebContentsView` on every ribbon toggle.

## Testing

New behavioral suite `src/hooks/__tests__/useGlobalBannerHeightVar.test.tsx` (8 tests, local `ResizeObserver` and rAF stubs) covers measuring, the `Math.max` clamp, republishing on reflow, rAF deferral, teardown, and the null-element case.

The three AppLayout source-contract suites are updated: they had pinned the buggy `top-12` literal, and their assertions are now attribute-order-insensitive regexes that pin the invariant (toolbar height plus banner height) without pinning `3rem`. #9530's banner mount-order contract is extended to cover the new measured wrapper.

Locally: 579 tests across 30 files pass, covering all AppLayout suites, both hook suites, and the repo-scanning `src/config/__tests__` contract suites. eslint and prettier are clean on all changed files.

## Follow-up, not fixed here (worth its own issue)

Review surfaced a pre-existing accessibility gap that this PR doesn't touch: global banner controls stay keyboard-reachable while the ThemeBrowser overlay is open. The banner sits outside the `chromeInert` boundary, and `ThemeBrowser` declares `aria-modal="true"` but only implements autofocus rather than a real focus trap, so tabbing past its last control can reach a banner action behind the `z-30` scrim. Making a host-crash recovery banner inert is a real behavior decision, so it's left out of a layout bugfix.

## Files changed

- `src/components/Layout/AppLayout.tsx`
- `src/hooks/useGlobalBannerHeightVar.ts` (new)
- `src/hooks/__tests__/useGlobalBannerHeightVar.test.tsx` (new)
- `src/components/Layout/__tests__/AppLayout.banner.test.ts`
- `src/components/Layout/__tests__/AppLayout.sidebar.test.ts`
- `src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts`
