### PR TITLE
fix(terminal): reject unviable background resize boxes

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -411,6 +411,12 @@ export class ProjectViewManager {
     win.on("unmaximize", this.resizeHandler);
     win.on("enter-full-screen", this.resizeHandler);
     win.on("leave-full-screen", this.resizeHandler);
+    // `restore` is what replays a notification `notifyBackgroundResize` declined
+    // to send while minimized. Deminiaturizing to the same frame emits no
+    // `resize` — the frame did not change — so without this a cached view keeps
+    // the geometry it had before the minimize until the next real resize or its
+    // own reveal (#11900).
+    win.on("restore", this.resizeHandler);
 
     // Per-instance random phase offset: every window has its own sampler, and
     // app.getAppMetrics() costs 5–50ms of synchronous main-thread work. A
@@ -1043,9 +1049,9 @@ export class ProjectViewManager {
     // A minimized window's content bounds are platform-dependent and not a
     // layout the renderer can scale against. Forwarding them shrinks every
     // cached pane's geometry proportionally, and a pane that lands on the column
-    // floor re-wraps committed scrollback into a strip no later reflow undoes
-    // (#11900). Skipping costs nothing: restoring fires `resize` again, and a
-    // switch back to the view resets the scaling basis from live layout anyway.
+    // floor re-wraps committed scrollback narrow enough to lose it (#11900).
+    // Nothing is dropped by skipping: `restore` is registered above and reruns
+    // this with usable bounds.
     if (this.win.isMinimized()) return;
     const { width, height } = this.win.getContentBounds();
     for (const [projectId, entry] of this.views) {
@@ -1099,6 +1105,7 @@ export class ProjectViewManager {
       this.win.removeListener("unmaximize", this.resizeHandler);
       this.win.removeListener("enter-full-screen", this.resizeHandler);
       this.win.removeListener("leave-full-screen", this.resizeHandler);
+      this.win.removeListener("restore", this.resizeHandler);
       this.resizeHandler = null;
     }
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1040,6 +1040,13 @@ export class ProjectViewManager {
   // derives terminal sizes from these bounds instead of from layout.
   private notifyBackgroundResize(): void {
     if (this.disposed || this.win.isDestroyed()) return;
+    // A minimized window's content bounds are platform-dependent and not a
+    // layout the renderer can scale against. Forwarding them shrinks every
+    // cached pane's geometry proportionally, and a pane that lands on the column
+    // floor re-wraps committed scrollback into a strip no later reflow undoes
+    // (#11900). Skipping costs nothing: restoring fires `resize` again, and a
+    // switch back to the view resets the scaling basis from live layout anyway.
+    if (this.win.isMinimized()) return;
     const { width, height } = this.win.getContentBounds();
     for (const [projectId, entry] of this.views) {
       if (projectId === this.activeProjectId) continue;

--- a/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
@@ -135,6 +135,7 @@ import { CHANNELS } from "../../ipc/channels.js";
 function createMockWindow() {
   return {
     isDestroyed: vi.fn(() => false),
+    isMinimized: vi.fn(() => false),
     on: vi.fn(),
     removeListener: vi.fn(),
     getContentBounds: vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 })),
@@ -192,6 +193,30 @@ describe("ProjectViewManager — background resize forwarding", () => {
     expect(backgroundResizeSends(initialWc)).toHaveLength(0);
 
     vi.advanceTimersByTime(300);
+    const sends = backgroundResizeSends(initialWc);
+    expect(sends).toHaveLength(1);
+    expect(sends[0][1]).toEqual({ width: 1440, height: 900 });
+  });
+
+  it("forwards nothing while the window is minimized", async () => {
+    // A minimized window's content bounds are not a layout to scale against.
+    // Forwarding them shrinks every cached pane proportionally, and a pane that
+    // bottoms out on the column floor re-wraps its committed scrollback into a
+    // strip no later reflow undoes (#11900).
+    await manager.switchTo("proj-b", "/path/b");
+    win.isMinimized.mockReturnValue(true);
+    win.getContentBounds.mockReturnValue({ x: 0, y: 0, width: 63, height: 59 });
+
+    fireResize();
+    vi.advanceTimersByTime(300);
+    expect(backgroundResizeSends(initialWc)).toHaveLength(0);
+
+    // Restoring re-arms the ordinary path, so nothing is permanently lost.
+    win.isMinimized.mockReturnValue(false);
+    win.getContentBounds.mockReturnValue({ x: 0, y: 0, width: 1440, height: 900 });
+    fireResize();
+    vi.advanceTimersByTime(300);
+
     const sends = backgroundResizeSends(initialWc);
     expect(sends).toHaveLength(1);
     expect(sends[0][1]).toEqual({ width: 1440, height: 900 });

--- a/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
@@ -222,6 +222,29 @@ describe("ProjectViewManager — background resize forwarding", () => {
     expect(sends[0][1]).toEqual({ width: 1440, height: 900 });
   });
 
+  it("replays the skipped notification on restore, which fires no resize of its own", async () => {
+    // Deminiaturizing to the same frame emits `restore` and nothing else, so the
+    // notification declined during the minimize has to be re-driven from that
+    // event or a cached view keeps its pre-minimize geometry indefinitely.
+    await manager.switchTo("proj-b", "/path/b");
+    const restoreCall = win.on.mock.calls.find(([event]) => event === "restore");
+    if (!restoreCall) throw new Error("restore handler not registered");
+
+    win.isMinimized.mockReturnValue(true);
+    fireResize();
+    vi.advanceTimersByTime(300);
+    expect(backgroundResizeSends(initialWc)).toHaveLength(0);
+
+    win.isMinimized.mockReturnValue(false);
+    win.getContentBounds.mockReturnValue({ x: 0, y: 0, width: 1440, height: 900 });
+    (restoreCall[1] as () => void)();
+    vi.advanceTimersByTime(300);
+
+    const sends = backgroundResizeSends(initialWc);
+    expect(sends).toHaveLength(1);
+    expect(sends[0][1]).toEqual({ width: 1440, height: 900 });
+  });
+
   it("never sends to the active view", async () => {
     await manager.switchTo("proj-b", "/path/b");
     const activeWc = manager.getActiveView()!.webContents as unknown as ReturnType<

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -13,6 +13,38 @@ const RESIZE_DEBOUNCE_MS = 100;
 const RESIZE_LOCK_TTL_MS = 5000;
 const SETTLED_RESIZE_DELAY_MS = 500;
 
+/**
+ * Smallest a container may report on either axis before its pixel box stops
+ * counting as layout at all.
+ *
+ * A box of a few pixels does not fail loudly — `colsForWidth` floors at 2 and
+ * `rowsForHeight` at 1, matching FitAddon, so it succeeds at 2x1 and both grids
+ * adopt it. A cached pane keeps parsing bytes through that, and xterm re-wraps
+ * committed scrollback to two columns on the way; reflow cannot undo it when
+ * real layout returns, so the history stays a vertical strip until it scrolls
+ * away (#11900). `applyBackgroundWindowResize` produces exactly such a box by
+ * scaling every pane's origin against a transient near-zero content bound
+ * during a minimize or a view detach.
+ *
+ * The value is the floor `fit`/`reconcileGeometryFresh` already applied to
+ * measured rects — this makes the pixel entry points agree rather than
+ * introducing a second policy.
+ */
+const MIN_VIABLE_RESIZE_PX = 50;
+
+/**
+ * Whether a pixel box is worth deriving a grid from. Finiteness is checked
+ * explicitly because `Infinity >= MIN_VIABLE_RESIZE_PX` is true.
+ */
+function isViableResizeBox(width: number, height: number): boolean {
+  return (
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width >= MIN_VIABLE_RESIZE_PX &&
+    height >= MIN_VIABLE_RESIZE_PX
+  );
+}
+
 import { exceedsResizeFlushSyncBudget, RESIZE_FLUSH_SYNC_BUDGET_BYTES } from "./resizeFlushBudget";
 
 export { RESIZE_FLUSH_SYNC_BUDGET_BYTES };
@@ -351,7 +383,7 @@ export class TerminalResizeController {
     }
 
     const rect = managed.hostElement.getBoundingClientRect();
-    if (rect.width < 50 || rect.height < 50) {
+    if (!isViableResizeBox(rect.width, rect.height)) {
       return null;
     }
 
@@ -414,9 +446,12 @@ export class TerminalResizeController {
       return null;
     }
 
-    // Mirrors applyBackgroundResize's guard: a non-finite box would otherwise poison the
-    // pixel cache and deliver a garbage grid to the PTY.
-    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    // Mirrors applyBackgroundResize's guard, ahead of tier routing, the dedup
+    // check and every cache write so both branches below inherit it: a box that
+    // is non-finite — or too small to be layout rather than a transient — would
+    // otherwise poison the pixel cache and deliver a garbage grid to the PTY
+    // (#11900).
+    if (!isViableResizeBox(width, height)) {
       return null;
     }
 
@@ -592,7 +627,12 @@ export class TerminalResizeController {
     width: number,
     height: number
   ): { cols: number; rows: number } | null {
-    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    // Above the instance lookup, the alt-buffer exclusion and the resize lock on
+    // purpose. Rejecting further down would cancel queued foreground work and
+    // overwrite a stashed viable box on the way to dropping this one, so a
+    // transient near-zero bound would cost geometry even once it stopped
+    // corrupting it (#11900).
+    if (!isViableResizeBox(width, height)) {
       return null;
     }
     const managed = this.deps.getInstance(id);
@@ -677,6 +717,13 @@ export class TerminalResizeController {
     height: number,
     wasAtBottom: boolean
   ): CachedMetricGrid | null {
+    // Both callers reject a sub-viable box earlier, where rejecting costs
+    // nothing. Repeated here because this is where a box becomes a grid and
+    // reaches the caches — the invariant belongs with the mutation, so a future
+    // caller inherits it instead of re-deriving it (#11900).
+    if (!isViableResizeBox(width, height)) {
+      return null;
+    }
     const cellDims = getXtermCellDimensions(managed.terminal);
     if (!cellDims) {
       return null;
@@ -862,7 +909,7 @@ export class TerminalResizeController {
     if (!managed.hostElement.checkVisibility()) return false;
 
     const rect = managed.hostElement.getBoundingClientRect();
-    if (rect.width < 50 || rect.height < 50) return false;
+    if (!isViableResizeBox(rect.width, rect.height)) return false;
 
     // Never reflow a live alt-screen TUI here. A full-screen app (OpenCode, and
     // any agent with blockAltScreen disabled) paints an absolutely-positioned

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -23,14 +23,22 @@ const SETTLED_RESIZE_DELAY_MS = 500;
  * committed scrollback to two columns on the way; reflow cannot undo it when
  * real layout returns, so the history stays a vertical strip until it scrolls
  * away (#11900). `applyBackgroundWindowResize` produces exactly such a box by
- * scaling every pane's origin against a transient near-zero content bound
- * during a minimize or a view detach.
+ * scaling every pane's origin against the window content bounds Main forwards
+ * on a resize, maximize or full-screen transition — one implausible bound
+ * shrinks every cached pane at once.
  *
  * The value is the floor `fit`/`reconcileGeometryFresh` already applied to
  * measured rects — this makes the pixel entry points agree rather than
- * introducing a second policy.
+ * introducing a second policy. It bounds the box, not the grid the box becomes;
+ * the column floor in `resizeGridFromCachedCellMetrics` covers that.
  */
-const MIN_VIABLE_RESIZE_PX = 50;
+export const MIN_VIABLE_RESIZE_PX = 50;
+
+/**
+ * FitAddon's own column floor, which `colsForWidth` reproduces. A width that
+ * divides to exactly this produced no measurement — the floor absorbed it.
+ */
+const FIT_MIN_COLS = 2;
 
 /**
  * Whether a pixel box is worth deriving a grid from. Finiteness is checked
@@ -238,7 +246,7 @@ function toFitPx(px: number): number {
  */
 function colsForWidth(terminal: Terminal, widthPx: number, cellWidth: number): number {
   const availableWidth = toFitPx(widthPx) - getEffectiveScrollbarWidth(terminal.options);
-  return Math.max(2, normalizeTerminalGridDimension(availableWidth / cellWidth));
+  return Math.max(FIT_MIN_COLS, normalizeTerminalGridDimension(availableWidth / cellWidth));
 }
 
 /**
@@ -730,6 +738,22 @@ export class TerminalResizeController {
     }
     const cols = colsForWidth(managed.terminal, width, cellDims.width);
     const rows = rowsForHeight(height, cellDims.height);
+    // The pixel floor is necessary but not sufficient. It is a fixed count of
+    // pixels, while the grid those pixels become also depends on the gutter and
+    // the cell: at the largest supported font a box sitting exactly on that
+    // floor still divides to FIT_MIN_COLS. Landing on the column floor means the
+    // arithmetic bottomed out rather than measured a pane, and re-wrapping
+    // committed scrollback that narrow is the damage #11900 is about — columns
+    // are what reflow rewraps, so this is checked on cols alone.
+    //
+    // Only these cached-metric paths take it. They have no live layout to sanity
+    // check against, and nothing is lost by declining: both grids stay where
+    // they are, and the reveal-time `reconcileGeometryFresh` sizes the pane from
+    // real bounds. A visible pane keeps its floor grid, which is the honest
+    // answer when the container really is that narrow.
+    if (cols <= FIT_MIN_COLS) {
+      return null;
+    }
     // Convergence is a claim about the grid xterm actually holds, never about
     // the target cache. `latestCols`/`latestRows` are written AHEAD of the
     // commit — by `applyResize`'s settled branch, by `sendPtyResize`, and by the

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -20,9 +20,11 @@ const SETTLED_RESIZE_DELAY_MS = 500;
  * A box of a few pixels does not fail loudly — `colsForWidth` floors at 2 and
  * `rowsForHeight` at 1, matching FitAddon, so it succeeds at 2x1 and both grids
  * adopt it. A cached pane keeps parsing bytes through that, and xterm re-wraps
- * committed scrollback to two columns on the way; reflow cannot undo it when
- * real layout returns, so the history stays a vertical strip until it scrolls
- * away (#11900). `applyBackgroundWindowResize` produces exactly such a box by
+ * committed scrollback to two columns on the way. Widening does unwrap ordinary
+ * soft-wrapped lines, so the strip is not always permanent — but a rewrap that
+ * narrow multiplies the line count, and whatever overflows the scrollback cap is
+ * evicted and gone, as is anything the app hard-wrapped at two columns while the
+ * PTY was that size (#11900). `applyBackgroundWindowResize` produces such a box by
  * scaling every pane's origin against the window content bounds Main forwards
  * on a resize, maximize or full-screen transition — one implausible bound
  * shrinks every cached pane at once.
@@ -645,6 +647,14 @@ export class TerminalResizeController {
     }
     const managed = this.deps.getInstance(id);
     if (!managed) return null;
+    // The box cleared the pixel floor, but the grid it derives is what actually
+    // reflows, and that also depends on the gutter and the cell. Ask before
+    // touching anything: the checks below discard the alt-buffer stash, replace
+    // the lock stash and cancel queued work, so learning at the helper that this
+    // box was never usable would cost real geometry to reject an unusable one.
+    if (this.derivesFloorGrid(managed, width)) {
+      return null;
+    }
     // Choke point for the alt-screen exclusion: a live full-screen TUI paints an
     // absolutely-positioned frame that xterm never reflows, and racing its own
     // SIGWINCH redraw is the #10805/#10632 corruption. Leaving BOTH grids at the
@@ -710,6 +720,21 @@ export class TerminalResizeController {
     return { cols: grid.cols, rows: grid.rows };
   }
 
+  /**
+   * Whether `width` divides down to the column floor for this pane's cached
+   * cell — the signal that a box passed the pixel floor and still describes no
+   * usable pane (#11900).
+   *
+   * Answers `false` when cell metrics are missing: that is a separate condition
+   * with its own handling further in, and reporting it as a floor grid here
+   * would reroute it.
+   */
+  private derivesFloorGrid(managed: ManagedTerminal, width: number): boolean {
+    const cellDims = getXtermCellDimensions(managed.terminal);
+    if (!cellDims) return false;
+    return colsForWidth(managed.terminal, width, cellDims.width) <= FIT_MIN_COLS;
+  }
+
   // Computes cols/rows from cached cell metrics with no DOM reads — a hidden or
   // detached view has no live layout to measure. Pure computation + state
   // update; the caller owns the commit policy, and the two callers differ in
@@ -741,16 +766,18 @@ export class TerminalResizeController {
     // The pixel floor is necessary but not sufficient. It is a fixed count of
     // pixels, while the grid those pixels become also depends on the gutter and
     // the cell: at the largest supported font a box sitting exactly on that
-    // floor still divides to FIT_MIN_COLS. Landing on the column floor means the
-    // arithmetic bottomed out rather than measured a pane, and re-wrapping
-    // committed scrollback that narrow is the damage #11900 is about — columns
-    // are what reflow rewraps, so this is checked on cols alone.
+    // floor still divides to FIT_MIN_COLS. Checked on columns alone because
+    // columns are what reflow rewraps.
     //
-    // Only these cached-metric paths take it. They have no live layout to sanity
-    // check against, and nothing is lost by declining: both grids stay where
-    // they are, and the reveal-time `reconcileGeometryFresh` sizes the pane from
-    // real bounds. A visible pane keeps its floor grid, which is the honest
-    // answer when the container really is that narrow.
+    // A conservative classification, not a proof — a genuine many-way split at
+    // maximum font size can measure this narrow. These paths are where that
+    // trade is worth taking: they extrapolate from a cached cell with no live
+    // layout to check against, and declining costs only staleness, since both
+    // grids stay put and the reveal-time `reconcileGeometryFresh` measures the
+    // pane for real. `applyBackgroundResize` asks the same question up front, so
+    // by here this is the backstop for anything that reaches the conversion
+    // another way; a visible pane keeps its floor grid, the honest answer when
+    // the container really is that narrow (#11900).
     if (cols <= FIT_MIN_COLS) {
       return null;
     }

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -464,9 +464,14 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
     }
   });
 
-  it("clamps to FitAddon's floor when the container is thinner than the gutter", () => {
-    const narrow = { width: 10, height: 360 };
-    const { managed, fitAddon } = buildPane(narrow);
+  // Both floors are reached with a container the resize entry points still
+  // accept as layout — a box below that floor is now refused outright rather
+  // than flooring to 2x1 and re-wrapping a cached pane's scrollback (#11900),
+  // so the degenerate geometry has to come from the gutter and the cell size
+  // instead of from the box.
+  it("clamps to FitAddon's floor when the gutter is wider than the container", () => {
+    const narrow = { width: 50, height: 360 };
+    const { managed, fitAddon } = buildPane(narrow, { scrollbar: { width: 60 } });
     const controller = makeController(managed);
 
     const proposal = fitAddon.proposeDimensions();
@@ -479,8 +484,8 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
   });
 
   it("clamps to FitAddon's floor when the container is shorter than one cell", () => {
-    const short = { width: 665, height: 9 };
-    const { managed, fitAddon } = buildPane(short);
+    const short = { width: 665, height: 50 };
+    const { managed, fitAddon } = buildPane(short, {}, { width: 9, height: 60 });
     const controller = makeController(managed);
 
     const proposal = fitAddon.proposeDimensions();
@@ -488,6 +493,17 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
 
     expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
     expect(applied!.rows).toBeGreaterThanOrEqual(1);
+  });
+
+  it("refuses a box too small to be layout instead of flooring it to a strip", () => {
+    // The #11900 ingress: a transient near-zero content bound scaled down every
+    // cached pane's origin, and 2x1 is a grid the controller used to accept.
+    const { managed } = buildPane();
+    const controller = makeController(managed);
+
+    expect(controller.resize("t1", 5, 5)).toBeNull();
+    expect(managed.latestCols).toBe(80); // untouched seed value
+    expect(resizeMock).not.toHaveBeenCalled();
   });
 
   it("rejects a non-finite box instead of caching a garbage grid", () => {

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -28,7 +28,7 @@ import {
   __resetSidebarLayoutTransitionLockForTests,
   unlockSidebarHydration,
 } from "@/lib/layoutTransitionLock";
-import { getXtermOptions } from "@/config/xtermConfig";
+import { getEffectiveScrollbarWidth, getXtermOptions } from "@/config/xtermConfig";
 import type { ManagedTerminal } from "../types";
 
 /**
@@ -474,36 +474,34 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
     const { managed, fitAddon } = buildPane(narrow, { scrollbar: { width: 60 } });
     const controller = makeController(managed);
 
+    // Witness that the fixture is genuinely in the flooring regime: the gutter
+    // alone exceeds the container, so available width is negative and only the
+    // floor can produce a column count. Without this the equality below would
+    // still hold on a fixture that quietly stopped reaching the floor.
+    expect(getEffectiveScrollbarWidth(managed.terminal.options)).toBeGreaterThan(narrow.width);
+
     const proposal = fitAddon.proposeDimensions();
     const applied = controller.resize("t1", narrow.width, narrow.height);
 
     // Negative available width must not produce a negative or zero column count
-    // on either side — both floor at 2.
+    // on either side.
     expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
-    expect(applied!.cols).toBeGreaterThanOrEqual(2);
   });
 
   it("clamps to FitAddon's floor when the container is shorter than one cell", () => {
     const short = { width: 665, height: 50 };
-    const { managed, fitAddon } = buildPane(short, {}, { width: 9, height: 60 });
+    const cell = { width: 9, height: 60 };
+    const { managed, fitAddon } = buildPane(short, {}, cell);
     const controller = makeController(managed);
+
+    // Same witness on the row axis: one cell is taller than the whole container,
+    // so the unclamped quotient is below one and the floor is what answers.
+    expect(cell.height).toBeGreaterThan(short.height);
 
     const proposal = fitAddon.proposeDimensions();
     const applied = controller.resize("t1", short.width, short.height);
 
     expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
-    expect(applied!.rows).toBeGreaterThanOrEqual(1);
-  });
-
-  it("refuses a box too small to be layout instead of flooring it to a strip", () => {
-    // The #11900 ingress: a transient near-zero content bound scaled down every
-    // cached pane's origin, and 2x1 is a grid the controller used to accept.
-    const { managed } = buildPane();
-    const controller = makeController(managed);
-
-    expect(controller.resize("t1", 5, 5)).toBeNull();
-    expect(managed.latestCols).toBe(80); // untouched seed value
-    expect(resizeMock).not.toHaveBeenCalled();
   });
 
   it("rejects a non-finite box instead of caching a garbage grid", () => {

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -2171,6 +2171,156 @@ describe("TerminalResizeController", () => {
     });
   });
 
+  /**
+   * A pixel box small enough to be a transient rather than layout used to
+   * succeed rather than fail: the column and row math floors at FitAddon's own
+   * 2x1, so a few-pixel box produced a valid-looking grid and both halves
+   * adopted it. A cached pane parses every byte through that, and xterm re-wraps
+   * committed scrollback to two columns on the way — damage no later reflow
+   * undoes, leaving the history a vertical strip until it scrolls away (#11900).
+   *
+   * `applyBackgroundWindowResize` generates exactly that box: it scales every
+   * pane's origin by the ratio of Main's forwarded content bounds, so one
+   * transient near-zero bound during a minimize or view detach shrinks every
+   * backgrounded terminal at once.
+   *
+   * The guards sit at the entry points rather than at the shared cached-metrics
+   * helper alone, which is what the last two cases here pin down: by the time
+   * that helper runs, `applyBackgroundResize` has already cancelled queued work,
+   * and `resize`'s measured branch never reaches it at all.
+   */
+  describe("minimum viable resize box (#11900)", () => {
+    function mockDataBuffer(): ResizeControllerDeps["dataBuffer"] {
+      return {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as unknown as ResizeControllerDeps["dataBuffer"];
+    }
+
+    function attachCellDims(managed: ReturnType<typeof createManagedTerminal>) {
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+      });
+    }
+
+    function makeController(managed: ReturnType<typeof createManagedTerminal>) {
+      return new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: mockDataBuffer(),
+      });
+    }
+
+    /**
+     * The four fields a rejected box must leave alone. Captured from the fixture
+     * and compared to itself rather than asserted against literals, so the seed
+     * values stay the fixture's business.
+     */
+    const geometryOf = (managed: ReturnType<typeof createManagedTerminal>) => ({
+      lastWidth: managed.lastWidth,
+      lastHeight: managed.lastHeight,
+      latestCols: managed.latestCols,
+      latestRows: managed.latestRows,
+    });
+
+    it("refuses a sub-viable box on the cached-metrics branch without moving either grid", () => {
+      const managed = createManagedTerminal();
+      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      managed.isFocused = false;
+      managed.isVisible = false;
+      attachCellDims(managed);
+      const controller = makeController(managed);
+      const before = geometryOf(managed);
+
+      expect(controller.resize("term-1", 5, 5)).toBeNull();
+      // Either axis alone is enough to disqualify the box.
+      expect(controller.resize("term-1", 1600, 5)).toBeNull();
+      expect(controller.resize("term-1", 5, 800)).toBeNull();
+
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(geometryOf(managed)).toEqual(before);
+    });
+
+    it("refuses a sub-viable box on the measured branch a cached view's stale isVisible routes it down", () => {
+      // A backgrounded project view leaves `isVisible` true from before the
+      // detach, so the tier is BACKGROUND but the branch taken is the measured
+      // one — which never touches the cached-metrics helper. Reverting only
+      // `resize`'s own guard fails this test while the helper backstop remains.
+      const managed = createManagedTerminal();
+      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      managed.isFocused = false;
+      managed.isVisible = true;
+      attachCellDims(managed);
+      const controller = makeController(managed);
+      const before = geometryOf(managed);
+
+      expect(controller.resize("term-1", 5, 5)).toBeNull();
+
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(managed.fitAddon.proposeDimensions).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(geometryOf(managed)).toEqual(before);
+    });
+
+    it("applies the next viable box after refusing a sub-viable one", () => {
+      // Refusal must not stamp the box into the pixel cache: the dedup gate
+      // compares against it, so a poisoned cache would swallow the recovery
+      // measurement that arrives when real layout returns.
+      const managed = createManagedTerminal();
+      attachCellDims(managed);
+      const controller = makeController(managed);
+
+      expect(controller.resize("term-1", 5, 5)).toBeNull();
+      expect(controller.resize("term-1", 1200, 700)).toEqual({ cols: colsFor(1200), rows: 35 });
+
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1200), 35);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1200), 35);
+    });
+
+    it("refuses a sub-viable background box without cancelling queued foreground work", () => {
+      // `applyBackgroundResize` cancels pending work before it derives a grid,
+      // so a guard placed in the shared helper instead of at the top would drop
+      // this debounced resize on the way to rejecting the box.
+      const managed = createManagedTerminal();
+      managed.isFocused = false;
+      managed.terminal.buffer.active.length = 300;
+      attachCellDims(managed);
+      const controller = makeController(managed);
+
+      controller.resize("term-1", 1200, 800);
+      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
+      vi.advanceTimersByTime(100);
+
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1200), 40);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1200), 40);
+    });
+
+    it("refuses a sub-viable background box without overwriting a stashed viable one", () => {
+      // Same ordering requirement one branch over: the lock stash is written
+      // before the grid is derived, so a late guard would replace real geometry
+      // with the transient and replay it on unlock.
+      const managed = createManagedTerminal();
+      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      managed.isFocused = false;
+      managed.isVisible = false;
+      attachCellDims(managed);
+      const controller = makeController(managed);
+
+      controller.lockResize("term-1", true);
+      controller.applyBackgroundResize("term-1", 1600, 800);
+      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
+      expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
+
+      controller.lockResize("term-1", false);
+
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+    });
+  });
+
   describe("applyBackgroundResize", () => {
     function makeController(managed: ReturnType<typeof createManagedTerminal> | undefined) {
       return new TerminalResizeController({
@@ -2400,6 +2550,10 @@ describe("TerminalResizeController", () => {
       expect(controller.applyBackgroundResize("term-1", 1600, Number.POSITIVE_INFINITY)).toBeNull();
       expect(controller.applyBackgroundResize("term-1", 0, 800)).toBeNull();
       expect(controller.applyBackgroundResize("term-1", -100, 800)).toBeNull();
+      // Positive but far too small to be layout: the column math floors at 2, so
+      // this used to resize both grids to a 2-column strip rather than fail
+      // (#11900).
+      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
       expect(resizeMock).not.toHaveBeenCalled();
       expect(managed.lastWidth).toBe(800);
       expect(managed.latestCols).toBe(80);

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -25,6 +25,7 @@ import {
   getXtermCellDimensions,
   REVEAL_REWRAP_QUIESCENT_MS,
   RESIZE_FLUSH_SYNC_BUDGET_BYTES,
+  MIN_VIABLE_RESIZE_PX,
   type ResizeControllerDeps,
 } from "../TerminalResizeController";
 import { TERMINAL_SCROLLBAR_WIDTH } from "@/config/xtermConfig";
@@ -2199,9 +2200,12 @@ describe("TerminalResizeController", () => {
       } as unknown as ResizeControllerDeps["dataBuffer"];
     }
 
-    function attachCellDims(managed: ReturnType<typeof createManagedTerminal>) {
+    function attachCellDims(
+      managed: ReturnType<typeof createManagedTerminal>,
+      cell: { width: number; height: number } = CELL
+    ) {
       Object.assign(managed.terminal, {
-        _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+        _core: { _renderService: { dimensions: { css: { cell } } } },
       });
     }
 
@@ -2213,16 +2217,26 @@ describe("TerminalResizeController", () => {
     }
 
     /**
-     * The four fields a rejected box must leave alone. Captured from the fixture
-     * and compared to itself rather than asserted against literals, so the seed
+     * Every field a rejected box must leave alone. Captured from the fixture and
+     * compared to itself rather than asserted against literals, so the seed
      * values stay the fixture's business.
+     *
+     * `latestWasAtBottom` has to be seeded against the grain to be worth
+     * snapshotting: the fixture's buffer computes as at-bottom, so a seed of
+     * `true` would survive an unwanted write unchanged. `seedDetectable` flips
+     * it, making any write visible.
      */
     const geometryOf = (managed: ReturnType<typeof createManagedTerminal>) => ({
       lastWidth: managed.lastWidth,
       lastHeight: managed.lastHeight,
       latestCols: managed.latestCols,
       latestRows: managed.latestRows,
+      latestWasAtBottom: managed.latestWasAtBottom,
     });
+
+    function seedDetectable(managed: ReturnType<typeof createManagedTerminal>) {
+      managed.latestWasAtBottom = false;
+    }
 
     it("refuses a sub-viable box on the cached-metrics branch without moving either grid", () => {
       const managed = createManagedTerminal();
@@ -2230,6 +2244,7 @@ describe("TerminalResizeController", () => {
       managed.isFocused = false;
       managed.isVisible = false;
       attachCellDims(managed);
+      seedDetectable(managed);
       const controller = makeController(managed);
       const before = geometryOf(managed);
 
@@ -2237,6 +2252,97 @@ describe("TerminalResizeController", () => {
       // Either axis alone is enough to disqualify the box.
       expect(controller.resize("term-1", 1600, 5)).toBeNull();
       expect(controller.resize("term-1", 5, 800)).toBeNull();
+
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(geometryOf(managed)).toEqual(before);
+    });
+
+    it("accepts the smallest viable box and refuses the pixel just below it", () => {
+      // Pins which side of the comparison the threshold itself falls on —
+      // rejected one pixel below, accepted exactly at it — so tightening the
+      // check to `>` fails here. Being relative to the constant, this cannot
+      // detect a change to its VALUE, and after the column floor below it no
+      // longer needs to: the pixel bound decides whether a box is worth
+      // measuring, while the grid it produces is what has to be safe.
+      const belowFloor = MIN_VIABLE_RESIZE_PX - 1;
+
+      for (const box of [
+        { width: belowFloor, height: MIN_VIABLE_RESIZE_PX },
+        { width: MIN_VIABLE_RESIZE_PX, height: belowFloor },
+      ]) {
+        const managed = createManagedTerminal();
+        attachCellDims(managed);
+        seedDetectable(managed);
+        const controller = makeController(managed);
+        const before = geometryOf(managed);
+
+        expect(controller.resize("term-1", box.width, box.height)).toBeNull();
+        expect(geometryOf(managed)).toEqual(before);
+      }
+
+      const managed = createManagedTerminal();
+      // A cell small enough that the smallest viable box still clears the column
+      // floor — the box is what is under test here, not the grid it becomes.
+      attachCellDims(managed, { width: 1, height: 1 });
+      const controller = makeController(managed);
+
+      expect(
+        controller.resize("term-1", MIN_VIABLE_RESIZE_PX, MIN_VIABLE_RESIZE_PX)
+      ).not.toBeNull();
+    });
+
+    it("treats a non-finite host rect as unmeasurable in fit and the fresh reconcile", () => {
+      // A comparison against the floor is false for NaN, so both methods used to
+      // fall past their size check on an unmeasurable rect and take a proposal
+      // from FitAddon's own DOM read instead — a different measurement channel,
+      // trusted for a box the first one could not measure. Sharing one predicate
+      // makes finiteness part of the question.
+      for (const rect of [
+        { left: 0, width: Number.NaN, height: 700 },
+        { left: 0, width: 1000, height: Number.POSITIVE_INFINITY },
+      ]) {
+        const managed = createManagedTerminal();
+        attachCellDims(managed);
+        seedDetectable(managed);
+        managed.hostElement.getBoundingClientRect.mockReturnValue(rect);
+        const controller = makeController(managed);
+        const before = geometryOf(managed);
+
+        expect(controller.fit("term-1")).toBeNull();
+        // Reported as "not measurable yet" so the reveal sweep retries rather
+        // than treating the pane as reconciled.
+        expect(controller.reconcileGeometryFresh("term-1")).toBe(false);
+
+        expect(managed.fitAddon.proposeDimensions).not.toHaveBeenCalled();
+        expect(managed.terminal.resize).not.toHaveBeenCalled();
+        expect(resizeMock).not.toHaveBeenCalled();
+        expect(geometryOf(managed)).toEqual(before);
+      }
+    });
+
+    it("refuses a background grid that bottomed out on the column floor", () => {
+      // The pixel floor bounds the box, not the grid: a box on that floor still
+      // divides to the column floor once the gutter and a large cell are
+      // applied. Re-wrapping committed scrollback that narrow is the damage, so
+      // the cached-metrics paths check the derived grid too.
+      const managed = createManagedTerminal();
+      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      managed.isFocused = false;
+      managed.isVisible = false;
+      attachCellDims(managed, { width: 30, height: 60 });
+      seedDetectable(managed);
+      const controller = makeController(managed);
+      const before = geometryOf(managed);
+
+      // Comfortably above the pixel floor, yet only the floor's worth of columns
+      // survives the gutter and the cell — the witness that this box is rejected
+      // for its grid and not for its size.
+      const box = MIN_VIABLE_RESIZE_PX * 2;
+      expect(Math.floor((box - SCROLLBAR_PX) / 30)).toBeLessThanOrEqual(2);
+
+      expect(controller.resize("term-1", box, box)).toBeNull();
+      expect(controller.applyBackgroundResize("term-1", box, box)).toBeNull();
 
       expect(managed.terminal.resize).not.toHaveBeenCalled();
       expect(resizeMock).not.toHaveBeenCalled();
@@ -2264,10 +2370,11 @@ describe("TerminalResizeController", () => {
       expect(geometryOf(managed)).toEqual(before);
     });
 
-    it("applies the next viable box after refusing a sub-viable one", () => {
-      // Refusal must not stamp the box into the pixel cache: the dedup gate
-      // compares against it, so a poisoned cache would swallow the recovery
-      // measurement that arrives when real layout returns.
+    it("lets a transient pass through without costing the resize that follows it", () => {
+      // The refusal must be inert, not merely safe: it commits nothing of its
+      // own, and the next real measurement still lands. (The caches it must
+      // leave alone are covered by the snapshots above; a 5px box and a 1200px
+      // box differ too plainly for the pixel dedup to be the thing under test.)
       const managed = createManagedTerminal();
       attachCellDims(managed);
       const controller = makeController(managed);
@@ -2292,10 +2399,18 @@ describe("TerminalResizeController", () => {
       const controller = makeController(managed);
 
       controller.resize("term-1", 1200, 800);
-      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
-      vi.advanceTimersByTime(100);
+      expect(controller.hasPendingResize("term-1")).toBe(true);
 
+      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
+      expect(controller.hasPendingResize("term-1")).toBe(true);
+
+      // Drain without naming the debounce interval — the survival of the job is
+      // the contract, its duration is not.
+      controller.flushResize("term-1");
+
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
       expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1200), 40);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1200), 40);
     });
 
@@ -2315,6 +2430,31 @@ describe("TerminalResizeController", () => {
       expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
       expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
 
+      controller.lockResize("term-1", false);
+
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+    });
+
+    it("refuses a sub-viable background box without clearing a stash through the alt-buffer branch", () => {
+      // The alt-buffer exclusion discards the stash on its way out, so a guard
+      // sitting below it would let a transient delivered while a TUI is up throw
+      // away geometry captured before the TUI started. Pins the guard above that
+      // branch, which the lock-stash case alone does not.
+      const managed = createManagedTerminal();
+      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      managed.isFocused = false;
+      managed.isVisible = false;
+      attachCellDims(managed);
+      const controller = makeController(managed);
+
+      controller.lockResize("term-1", true);
+      controller.applyBackgroundResize("term-1", 1600, 800);
+
+      managed.isAltBuffer = true;
+      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
+      expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
+
+      managed.isAltBuffer = false;
       controller.lockResize("term-1", false);
 
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -2177,18 +2177,21 @@ describe("TerminalResizeController", () => {
    * succeed rather than fail: the column and row math floors at FitAddon's own
    * 2x1, so a few-pixel box produced a valid-looking grid and both halves
    * adopted it. A cached pane parses every byte through that, and xterm re-wraps
-   * committed scrollback to two columns on the way — damage no later reflow
-   * undoes, leaving the history a vertical strip until it scrolls away (#11900).
+   * committed scrollback to two columns on the way — multiplying the line count
+   * until the scrollback cap evicts the top of the history for good (#11900).
    *
-   * `applyBackgroundWindowResize` generates exactly that box: it scales every
-   * pane's origin by the ratio of Main's forwarded content bounds, so one
-   * transient near-zero bound during a minimize or view detach shrinks every
+   * `applyBackgroundWindowResize` generates that box: it scales every pane's
+   * origin by the ratio of the content bounds Main forwards on a window resize,
+   * maximize or full-screen transition, so one implausible bound shrinks every
    * backgrounded terminal at once.
    *
-   * The guards sit at the entry points rather than at the shared cached-metrics
-   * helper alone, which is what the last two cases here pin down: by the time
-   * that helper runs, `applyBackgroundResize` has already cancelled queued work,
-   * and `resize`'s measured branch never reaches it at all.
+   * Two questions, asked separately. Is the BOX layout at all, and does the GRID
+   * it derives describe a pane — the second because the pixel floor is a fixed
+   * count of pixels while the grid also depends on the gutter and the cell.
+   * Both are asked at the entry points rather than at the shared cached-metrics
+   * helper alone, which is what the placement cases here pin down: by the time
+   * that helper runs, `applyBackgroundResize` has already discarded stashes and
+   * cancelled queued work, and `resize`'s measured branch never reaches it.
    */
   describe("minimum viable resize box (#11900)", () => {
     function mockDataBuffer(): ResizeControllerDeps["dataBuffer"] {
@@ -2388,77 +2391,107 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1200), 35);
     });
 
-    it("refuses a sub-viable background box without cancelling queued foreground work", () => {
-      // `applyBackgroundResize` cancels pending work before it derives a grid,
-      // so a guard placed in the shared helper instead of at the top would drop
-      // this debounced resize on the way to rejecting the box.
-      const managed = createManagedTerminal();
-      managed.isFocused = false;
-      managed.terminal.buffer.active.length = 300;
-      attachCellDims(managed);
-      const controller = makeController(managed);
+    /**
+     * Both rejection kinds, run through every placement case below. They are
+     * refused for different reasons at different checks, and each has to be
+     * refused before `applyBackgroundResize` starts discarding geometry — so
+     * neither can stand in for the other.
+     *
+     * The floor-grid box clears the pixel bound with room to spare; what
+     * disqualifies it is the wide cell, which leaves only the floor's worth of
+     * columns once the gutter is reserved.
+     */
+    const FLOOR_GRID_CELL = { width: 30, height: 60 };
+    const rejected = [
+      { kind: "a sub-viable box", box: { width: 5, height: 5 }, cell: CELL },
+      { kind: "a floor-grid box", box: { width: 100, height: 100 }, cell: FLOOR_GRID_CELL },
+    ];
 
-      controller.resize("term-1", 1200, 800);
-      expect(controller.hasPendingResize("term-1")).toBe(true);
+    for (const { kind, box, cell } of rejected) {
+      it(`refuses ${kind} without cancelling queued foreground work`, () => {
+        // `applyBackgroundResize` cancels pending work before it derives a grid,
+        // so a guard placed in the shared helper instead of at the top would
+        // drop this debounced resize on the way to rejecting the box.
+        const managed = createManagedTerminal();
+        managed.isFocused = false;
+        managed.terminal.buffer.active.length = 300;
+        attachCellDims(managed, cell);
+        const controller = makeController(managed);
 
-      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
-      expect(controller.hasPendingResize("term-1")).toBe(true);
+        controller.resize("term-1", 1200, 800);
+        expect(controller.hasPendingResize("term-1")).toBe(true);
 
-      // Drain without naming the debounce interval — the survival of the job is
-      // the contract, its duration is not.
-      controller.flushResize("term-1");
+        expect(controller.applyBackgroundResize("term-1", box.width, box.height)).toBeNull();
+        expect(controller.hasPendingResize("term-1")).toBe(true);
 
-      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
-      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1200), 40);
-      expect(resizeMock).toHaveBeenCalledTimes(1);
-      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1200), 40);
-    });
+        // Drain without naming the debounce interval — the survival of the job
+        // is the contract, its duration is not.
+        controller.flushResize("term-1");
 
-    it("refuses a sub-viable background box without overwriting a stashed viable one", () => {
-      // Same ordering requirement one branch over: the lock stash is written
-      // before the grid is derived, so a late guard would replace real geometry
-      // with the transient and replay it on unlock.
-      const managed = createManagedTerminal();
-      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
-      managed.isFocused = false;
-      managed.isVisible = false;
-      attachCellDims(managed);
-      const controller = makeController(managed);
+        const cols = Math.max(2, Math.floor((1200 - SCROLLBAR_PX) / cell.width));
+        const rows = Math.max(1, Math.floor(800 / cell.height));
+        expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+        expect(managed.terminal.resize).toHaveBeenCalledWith(cols, rows);
+        expect(resizeMock).toHaveBeenCalledTimes(1);
+        expect(resizeMock).toHaveBeenCalledWith("term-1", cols, rows);
+      });
 
-      controller.lockResize("term-1", true);
-      controller.applyBackgroundResize("term-1", 1600, 800);
-      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
-      expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
+      it(`refuses ${kind} without overwriting a stashed viable one`, () => {
+        // Same ordering requirement one branch over: the lock stash is written
+        // before the grid is derived, so a late guard would replace real
+        // geometry with the transient and replay it on unlock.
+        const managed = createManagedTerminal();
+        managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+        managed.isFocused = false;
+        managed.isVisible = false;
+        attachCellDims(managed, cell);
+        const controller = makeController(managed);
 
-      controller.lockResize("term-1", false);
+        controller.lockResize("term-1", true);
+        controller.applyBackgroundResize("term-1", 1600, 800);
+        expect(controller.applyBackgroundResize("term-1", box.width, box.height)).toBeNull();
+        expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
 
-      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
-    });
+        controller.lockResize("term-1", false);
 
-    it("refuses a sub-viable background box without clearing a stash through the alt-buffer branch", () => {
-      // The alt-buffer exclusion discards the stash on its way out, so a guard
-      // sitting below it would let a transient delivered while a TUI is up throw
-      // away geometry captured before the TUI started. Pins the guard above that
-      // branch, which the lock-stash case alone does not.
-      const managed = createManagedTerminal();
-      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
-      managed.isFocused = false;
-      managed.isVisible = false;
-      attachCellDims(managed);
-      const controller = makeController(managed);
+        const cols = Math.max(2, Math.floor((1600 - SCROLLBAR_PX) / cell.width));
+        expect(resizeMock).toHaveBeenCalledWith(
+          "term-1",
+          cols,
+          Math.max(1, Math.floor(800 / cell.height))
+        );
+      });
 
-      controller.lockResize("term-1", true);
-      controller.applyBackgroundResize("term-1", 1600, 800);
+      it(`refuses ${kind} without clearing a stash through the alt-buffer branch`, () => {
+        // The alt-buffer exclusion discards the stash on its way out, so a guard
+        // sitting below it would let a transient delivered while a TUI is up
+        // throw away geometry captured before the TUI started. Pins the guard
+        // above that branch, which the lock-stash case alone does not.
+        const managed = createManagedTerminal();
+        managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+        managed.isFocused = false;
+        managed.isVisible = false;
+        attachCellDims(managed, cell);
+        const controller = makeController(managed);
 
-      managed.isAltBuffer = true;
-      expect(controller.applyBackgroundResize("term-1", 5, 5)).toBeNull();
-      expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
+        controller.lockResize("term-1", true);
+        controller.applyBackgroundResize("term-1", 1600, 800);
 
-      managed.isAltBuffer = false;
-      controller.lockResize("term-1", false);
+        managed.isAltBuffer = true;
+        expect(controller.applyBackgroundResize("term-1", box.width, box.height)).toBeNull();
+        expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
 
-      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
-    });
+        managed.isAltBuffer = false;
+        controller.lockResize("term-1", false);
+
+        const cols = Math.max(2, Math.floor((1600 - SCROLLBAR_PX) / cell.width));
+        expect(resizeMock).toHaveBeenCalledWith(
+          "term-1",
+          cols,
+          Math.max(1, Math.floor(800 / cell.height))
+        );
+      });
+    }
   });
 
   describe("applyBackgroundResize", () => {


### PR DESCRIPTION
## Summary

- Switching back to a project after navigating away could leave an agent terminal's scrollback rewrapped into a roughly 2-column vertical strip for a large chunk of history, with only the newest output at the bottom rendering full width. It only healed as new output scrolled the damage away.
- The cause: `colsForWidth()` floors at 2 columns and `rowsForHeight()` floors at 1 row, matching `@xterm/addon-fit`'s own floors bug for bug. A near-zero-but-positive pixel box didn't fail, it succeeded at a 2x1 grid, and both xterm and the PTY adopted it. xterm re-wraps committed scrollback on resize, so the line count multiplied until the scrollback cap evicted the top of the history for good.
- `TerminalInstanceService.applyBackgroundWindowResize()` produces exactly that box: it scales every cached pane's origin by the ratio of the window content bounds Main forwards, so one implausible bound shrinks every backgrounded terminal at once. xterm 6.x has no API to suppress reflow on resize, so the only lever is refusing to call it.

Resolves #11900

## Changes

The fix asks two questions, both before any state changes happen, in `src/services/terminal/TerminalResizeController.ts`:

1. **Is the box a layout at all?** A new `MIN_VIABLE_RESIZE_PX` (50) and `isViableResizeBox()` fold in a finiteness check and replace the duplicated `< 50` rect literals in `fit()` and `reconcileGeometryFresh()`, extending the same floor to `resize()` and `applyBackgroundResize()`, which previously checked only finiteness (and on one path didn't even check for zero or negative).
2. **Does the grid it derives describe a pane?** The pixel bound is a fixed count of pixels, but the grid also depends on the gutter and the cell, so at the largest supported font size (24px) a box sitting exactly on the 50px floor still divides to 2 columns. A new `derivesFloorGrid()` refuses that on the cached-metrics paths, which extrapolate with no live layout to check against. A visible pane keeps its floor grid since that's the honest answer when the container really is that narrow; `reconcileGeometryFresh()` re-measures from real bounds at reveal time.

Both checks live at the entry points, above the branches that discard the alt-buffer stash, replace the lock stash, and cancel queued foreground work, because rejecting later would cost real geometry to refuse an unusable box.

Also in `electron/window/ProjectViewManager.ts`: it no longer forwards background bounds while the window is minimized (platform dependent, not a layout to scale against), and it now registers a `restore` handler, since deminiaturizing to the same frame emits no `resize` event, so a notification declined during the minimize was never replayed.

**Known follow-up, deliberately out of scope**: `ProjectViewManager`'s resize handler applies content bounds to child views via `setBounds` before the minimize check, and `ProjectViewFactory` does the same on activation, so a view can still be sized from collapsed bounds while minimized. That's a distinct mechanism, and fixing it means reworking bounds application across activation/reattachment, so it belongs in its own change.

## Testing

- 2,567 tests pass across 120 files, covering the full `src/services/terminal/__tests__/` and `electron/window/__tests__/` directories.
- Typecheck passes, eslint reports 0 errors, lint-ratchet warning counts unchanged.
- Ran 9 mutation tests against the new guards (reverting each guard, moving `applyBackgroundResize()`'s guard below the alt-buffer branch, flipping the boundary comparison, removing the `isMinimized` skip); each one fails a specific named test. Two are equivalent mutants, called out rather than hidden: the box backstop inside the private cached-metrics helper is unreachable from the public surface and is kept as documented defense in depth, and changing `MIN_VIABLE_RESIZE_PX` from 50 to 49 changes nothing for safety now that the column floor is what prevents the damage.