### PR TITLE
Add everyday-interaction perf benchmarks (PERF-190..196)

### DIFF
--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -37,6 +37,16 @@ Artifacts are written to `.tmp/perf-results/`:
 
 The cold recipe fanout benchmark writes its versioned, atomically updated result to `.tmp/perf-results/recipe-fanout.json` by default.
 
+## Everyday-interaction scenarios (PERF-190..196)
+
+Three families in the in-process matrix measure interactions a user hits many times a day, driving real production code rather than a simulation. Read each scenario's scope limits below before trusting a delta — PERF-196 in particular measures a parser floor, not wall-clock restore.
+
+- **File picker (PERF-190/191/192)** — the `@`-mention completion and file palette, driven through the real `FileSearchService` against synthetic git repos (~3,200 and ~12,000 files). PERF-192 is the one to watch: it drops the cached path list and times `git ls-files` plus the directory-set build — the wait between pressing `@` and the picker showing anything. That list is rebuilt whenever its 10s TTL lapses and dropped outright when a worktree is created or deleted, so a session pays this repeatedly. Because `FileSearchService` silently falls back to a filesystem walk when git fails, PERF-192 asserts a git subprocess spawned and that the results contain a file only `git ls-files` can return. PERF-190/191 measure the warm per-keystroke re-scan.
+- **Terminal search (PERF-193/194)** — find-in-scrollback via the real `@xterm/addon-search` and the app's own `buildSearchOptions`. The search bar debounces at 150ms, so the gated number is a single post-debounce search over a full scrollback, not a per-keystroke cost. The addon memoizes its buffer-to-string translation for 15s and drops it on any line feed, so a terminal still streaming output re-translates on every search where a quiet one does not — worth ~1.3x across the mixed-term sweep, reported per run as `coldToWarmRatio`. PERF-193 gates that cold path, because it is what a live agent terminal actually pays, and reports the warm one alongside. Sizes come from `shared/config/scrollback.ts`, so the benchmark tracks the real configurable range. Fidelity gap (documented in `lib/terminalSearchFixture.ts`): headless has no render service, so decorations are shimmed — the buffer walk, the capped match collection and marker lifecycle are real, the highlight painting is not.
+- **Session snapshot/reparse (PERF-195/196)** — `SerializeAddon.serialize()` across a 12-terminal fleet at maximum scrollback (the real teardown cost on every quit), and feeding those payloads back through the xterm parser. PERF-196 is a PARSER FLOOR, not wall-clock restore: production sends payloads this size (~600 KiB) through `TerminalRestoreController`, which chunks at 32 KiB with UI yields and schedules fleet restores independently, and that controller cannot run in-process. A regression in chunking, yielding or scheduling is invisible to PERF-196 and needs a Playwright benchmark. The corpus is SGR-dense because real agent output is, and colour dominates payload size.
+
+These seven budgets carry `calibrating: true`. Every scenario inherits `maxRegressionPct` from `defaultBudget`, and `checkBaselineCoverage` fails a run when a scenario has a regression gate but no baseline entry — while baselines must be generated on the CI runner and never committed from a local machine. `calibrating` suppresses only the regression gate; the absolute `p95Ms` ceiling and every `maxMetricValues` entry still apply. Once `perf-update-baselines` publishes Linux baselines containing these scenarios, **remove the `calibrating` flag** to arm the inherited regression gate — do not add a new one. `npm run perf verify-baselines` fails on any scenario still flagged after its baseline lands, so the flag cannot rot unnoticed.
+
 ## Baselines
 
 Baselines are read from `scripts/perf/config/baseline.<mode>.json`.
@@ -76,6 +86,19 @@ npm run perf launch-ab -- --warm --json ...               # steady-state, machin
 ```
 
 Prefer this over `perf cold-start` for before/after comparisons across branches: build each branch with `npm run package:local`, move each `release/mac-<arch>` bundle aside, and point `--a`/`--b` at the two executables. (`electron-builder` wipes `release/` on every package run — never leave the only copy of a comparison build there.)
+
+## Keystroke-to-paint and TUI scroll (`perf interactivity`, `perf scroll`)
+
+Two opt-in Playwright benchmarks for the interactions that historically regressed silently — a focused terminal going dead under fleet load, and full-screen TUI scrolling stalling.
+
+`npm run perf interactivity` measures keydown → paint (PERF-120/121/122) across a `cat` floor, a hermetic composer-sim, and the sim under 12 background terminals plus a saturation tier. `npm run perf scroll` measures wheel-notch → paint for mouse-reporting TUIs (PERF-125/126/127), ending in the concurrent cell where six TUIs scroll at once with a bystander keystroke-echo probe.
+
+Both rebuild the e2e bundle, run multi-minute, and gate nothing in CI — they report invariants and ratios, with absolute budgets left until a calibration soak has run. They are opt-in commands, not part of any matrix mode.
+
+```bash
+npm run perf interactivity
+npm run perf scroll
+```
 
 ## Cold recipe fanout (`perf recipe-fanout`)
 

--- a/scripts/perf/__tests__/baselineCoverage.test.ts
+++ b/scripts/perf/__tests__/baselineCoverage.test.ts
@@ -94,6 +94,19 @@ describe("checkBaselineCoverage", () => {
     expect(gaps).toEqual([{ scenarioId: "PERF-070" }]);
   });
 
+  it("does not flag a calibrating scenario absent from the baseline", () => {
+    // A calibrating scenario inherits maxRegressionPct from defaultBudget but
+    // has deliberately not been baselined yet, so its absence is expected.
+    const calibratingConfig: PerfBudgetConfig = {
+      ...budgetConfig,
+      scenarios: { ...budgetConfig.scenarios, "PERF-070": { calibrating: true } },
+    };
+    const gaps = checkBaselineCoverage(baseline({ "PERF-001": 1 }), calibratingConfig, [
+      scenario("PERF-070"),
+    ]);
+    expect(gaps).toEqual([]);
+  });
+
   it("does not flag a scenario present in the baseline", () => {
     const gaps = checkBaselineCoverage(baseline({ "PERF-070": 900 }), budgetConfig, [
       scenario("PERF-070"),

--- a/scripts/perf/__tests__/gate.test.ts
+++ b/scripts/perf/__tests__/gate.test.ts
@@ -89,7 +89,11 @@ describe("evaluateScenarioBudget — metric ceilings", () => {
     expect(pass.failedBudget).toBe(false);
   });
 
-  it("ignores metrics that have no recorded average", () => {
+  it("fails closed when a configured metric has no recorded average", () => {
+    // Reversed from the original ignore-and-pass behaviour. `averageMetrics`
+    // includes any metric reported by at least ONE sample, so an absent entry
+    // means no sample emitted it at all — a renamed or dropped metric whose
+    // ceiling has silently stopped gating, not a sparse measurement.
     const result = evaluateScenarioBudget(
       makeParams({
         budget: { p95Ms: 1000, maxMetricValues: { eventLoopLagMs: 1 } },
@@ -97,7 +101,7 @@ describe("evaluateScenarioBudget — metric ceilings", () => {
         metricAverages: {},
       })
     );
-    expect(result.failedBudget).toBe(false);
+    expect(result.failedBudget).toBe(true);
   });
 });
 
@@ -245,5 +249,105 @@ describe("evaluateScenarioBudget — thresholds are exported, not magic numbers"
     );
     expect(justOver.failedBudget).toBe(true);
     expect(exactly.failedBudget).toBe(false);
+  });
+});
+
+describe("evaluateScenarioBudget — calibrating scenarios", () => {
+  it("skips the regression gate without a baseline and says why", () => {
+    const result = evaluateScenarioBudget(
+      makeParams({
+        budget: { p95Ms: 1000, maxRegressionPct: 15, calibrating: true },
+        baselineP95: undefined,
+      })
+    );
+    expect(result.failedBudget).toBe(false);
+    expect(result.reasons).toContain("calibrating - regression gate not yet enabled");
+    // The misleading missing-baseline reason must not also be reported.
+    expect(result.reasons).not.toContain("baseline missing - regression gate skipped");
+  });
+
+  it("rejects the contradictory critical + calibrating combination", () => {
+    const result = evaluateScenarioBudget(
+      makeParams({
+        budget: { p95Ms: 1000, maxRegressionPct: 15, calibrating: true },
+        baselineP95: undefined,
+        isCritical: true,
+      })
+    );
+    expect(result.failedBudget).toBe(true);
+    expect(result.reasons.join(" ")).toContain("contradictory");
+  });
+
+  it("reports that calibration is complete once a baseline exists", () => {
+    const result = evaluateScenarioBudget(
+      makeParams({
+        budget: { p95Ms: 1000, maxRegressionPct: 15, calibrating: true },
+        baselineP95: 40,
+      })
+    );
+    expect(result.failedBudget).toBe(false);
+    expect(result.reasons.join(" ")).toContain("remove `calibrating`");
+  });
+
+  it("still enforces the absolute p95 budget and metric ceilings", () => {
+    const result = evaluateScenarioBudget(
+      makeParams({
+        budget: { p95Ms: 100, maxMetricValues: { p99KeystrokeMs: 4 }, calibrating: true },
+        p95Ms: 250,
+        metricAverages: { p99KeystrokeMs: 9 },
+      })
+    );
+    expect(result.failedBudget).toBe(true);
+    expect(result.reasons).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("p95"),
+        expect.stringContaining("p99Keystroke"),
+      ])
+    );
+  });
+
+  it("suppresses a real regression that would otherwise fail", () => {
+    const budget = { p95Ms: 1000, maxRegressionPct: 15 };
+    const regressed = makeParams({ budget, p95Ms: 100, baselineP95: 50 });
+    expect(evaluateScenarioBudget(regressed).failedBudget).toBe(true);
+    expect(
+      evaluateScenarioBudget({ ...regressed, budget: { ...budget, calibrating: true } })
+        .failedBudget
+    ).toBe(false);
+  });
+});
+
+describe("evaluateScenarioBudget — metric ceilings", () => {
+  it("fails closed when a configured metric is not emitted", () => {
+    // A renamed or dropped metric silently removes its gate otherwise, which is
+    // the same silent-rot class as a missing baseline.
+    const result = evaluateScenarioBudget(
+      makeParams({
+        budget: { maxMetricValues: { p99KeystrokeMs: 4 } },
+        metricAverages: {},
+      })
+    );
+    expect(result.failedBudget).toBe(true);
+    expect(result.reasons.join(" ")).toContain("not emitted");
+  });
+
+  it("passes when every configured metric is emitted and under its ceiling", () => {
+    const result = evaluateScenarioBudget(
+      makeParams({
+        budget: { maxMetricValues: { a: 10, b: 20 } },
+        metricAverages: { a: 9, b: 19 },
+      })
+    );
+    expect(result.failedBudget).toBe(false);
+  });
+
+  it("still fails closed for a missing metric while calibrating", () => {
+    const result = evaluateScenarioBudget(
+      makeParams({
+        budget: { maxMetricValues: { onlyMetric: 1 }, calibrating: true },
+        metricAverages: {},
+      })
+    );
+    expect(result.failedBudget).toBe(true);
   });
 });

--- a/scripts/perf/__tests__/gate.test.ts
+++ b/scripts/perf/__tests__/gate.test.ts
@@ -317,7 +317,7 @@ describe("evaluateScenarioBudget — calibrating scenarios", () => {
   });
 });
 
-describe("evaluateScenarioBudget — metric ceilings", () => {
+describe("evaluateScenarioBudget — metric-only budgets (no p95Ms)", () => {
   it("fails closed when a configured metric is not emitted", () => {
     // A renamed or dropped metric silently removes its gate otherwise, which is
     // the same silent-rot class as a missing baseline.

--- a/scripts/perf/__tests__/scenarioMatrix.test.ts
+++ b/scripts/perf/__tests__/scenarioMatrix.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { allScenarios, assertMatrixCoverage, getScenariosForMode } from "../scenarios";
+import {
+  allScenarios,
+  assertMatrixCoverage,
+  EXPECTED_SCENARIO_IDS,
+  getScenariosForMode,
+} from "../scenarios";
 import { getConstructedReflowTerminalCount } from "../lib/reflowFixture";
 
 describe("perf scenario matrix", () => {
-  it("covers full PERF matrix", () => {
+  it("covers full PERF matrix in both directions", () => {
     expect(() => assertMatrixCoverage()).not.toThrow();
-    expect(allScenarios).toHaveLength(63);
+    // Set equality against the one declaration, rather than a copied count.
+    expect(new Set(allScenarios.map((scenario) => scenario.id))).toEqual(EXPECTED_SCENARIO_IDS);
+  });
+
+  it("assertMatrixCoverage rejects an undeclared scenario", () => {
+    const undeclared = { ...allScenarios[0]!, id: "PERF-999" };
+    allScenarios.push(undeclared);
+    try {
+      expect(() => assertMatrixCoverage()).toThrow(/PERF-999/);
+    } finally {
+      allScenarios.pop();
+    }
   });
 
   it("importing the resize/reflow scenario module constructs no terminals", () => {

--- a/scripts/perf/config/budgets.json
+++ b/scripts/perf/config/budgets.json
@@ -241,6 +241,44 @@
       "p95Ms": 55,
       "maxRegressionPct": 75,
       "maxMetricValues": { "msPerKAction": 6 }
+    },
+
+    "PERF-190": {
+      "calibrating": true,
+      "p95Ms": 60,
+      "maxMetricValues": { "p99KeystrokeMs": 4 }
+    },
+    "PERF-191": {
+      "calibrating": true,
+      "p95Ms": 220,
+      "maxMetricValues": { "msPerKFile": 0.5, "largeP99KeystrokeMs": 8 }
+    },
+    "PERF-192": {
+      "calibrating": true,
+      "p95Ms": 450,
+      "maxMetricValues": { "coldMsPerKFile": 22, "largeColdMs": 260 }
+    },
+
+    "PERF-193": {
+      "calibrating": true,
+      "p95Ms": 150,
+      "maxMetricValues": { "p99SearchMs": 22 }
+    },
+    "PERF-194": {
+      "calibrating": true,
+      "p95Ms": 220,
+      "maxMetricValues": { "msPerKLine": 2.5, "stepForwardMs": 2, "stepBackwardMs": 2 }
+    },
+
+    "PERF-195": {
+      "calibrating": true,
+      "p95Ms": 1600,
+      "maxMetricValues": { "p95TerminalMs": 160, "snapshotKB": 800 }
+    },
+    "PERF-196": {
+      "calibrating": true,
+      "p95Ms": 800,
+      "maxMetricValues": { "msPerKLine": 6 }
     }
   }
 }

--- a/scripts/perf/index.ts
+++ b/scripts/perf/index.ts
@@ -85,45 +85,6 @@ function viteAnalyze(): Runner {
     });
 }
 
-function playwrightMemory(): Runner {
-  return (rest) =>
-    spawnNode(
-      [
-        resolveBin(
-          ["node_modules/@playwright/test/cli.js", "node_modules/playwright/cli.js"],
-          "playwright"
-        ),
-        "test",
-        "--project=full-resilience",
-        "--workers=1",
-        "e2e/full/resilience/memory-kitchen-sink.spec.ts",
-        ...rest,
-      ],
-      { RUN_PERF_MEMORY: "1" }
-    );
-}
-
-function playwrightMemoryGrowth(): Runner {
-  return async (rest) => {
-    const buildExitCode = await npmScript("build:e2e");
-    if (buildExitCode !== 0) return buildExitCode;
-    return spawnNode(
-      [
-        resolveBin(
-          ["node_modules/@playwright/test/cli.js", "node_modules/playwright/cli.js"],
-          "playwright"
-        ),
-        "test",
-        "--project=full-resilience",
-        "--workers=1",
-        "e2e/full/resilience/memory-growth-perf.spec.ts",
-        ...rest,
-      ],
-      { RUN_PERF_MEMORY_GROWTH: "1" }
-    );
-  };
-}
-
 function npmScript(name: string): Promise<number> {
   const npmCli = process.env.npm_execpath;
   if (!npmCli) {
@@ -133,31 +94,27 @@ function npmScript(name: string): Promise<number> {
   return spawnNode([npmCli, "run", name]);
 }
 
-function playwrightRecipeFanout(): Runner {
-  return async (rest) => {
-    const buildExitCode = await npmScript("build:e2e:bench");
-    if (buildExitCode !== 0) return buildExitCode;
-    return spawnNode(
-      [
-        resolveBin(
-          ["node_modules/@playwright/test/cli.js", "node_modules/playwright/cli.js"],
-          "playwright"
-        ),
-        "test",
-        "--project=full-worktree",
-        "--workers=1",
-        "e2e/full/worktree/recipe-fanout-perf.spec.ts",
-        ...rest,
-      ],
-      { RUN_PERF_RECIPE_FANOUT: "1" }
-    );
-  };
+interface PlaywrightBench {
+  /** Playwright project the spec belongs to. */
+  project: string;
+  /** Spec path, repo-relative. */
+  spec: string;
+  /** Env var the spec's opt-in gate reads; always set to "1". */
+  gate: string;
+  /** npm build script to run first, when the spec needs a fresh bundle. */
+  build?: "build:e2e" | "build:e2e:bench";
 }
 
-function playwrightBulkIssueWorktrees(): Runner {
+/**
+ * Every Playwright-hosted benchmark is the same shape: optionally rebuild the
+ * e2e bundle, then run one spec in one worker with its opt-in env gate set.
+ */
+function playwrightBench({ project, spec, gate, build }: PlaywrightBench): Runner {
   return async (rest) => {
-    const buildExitCode = await npmScript("build:e2e:bench");
-    if (buildExitCode !== 0) return buildExitCode;
+    if (build) {
+      const buildExitCode = await npmScript(build);
+      if (buildExitCode !== 0) return buildExitCode;
+    }
     return spawnNode(
       [
         resolveBin(
@@ -165,33 +122,12 @@ function playwrightBulkIssueWorktrees(): Runner {
           "playwright"
         ),
         "test",
-        "--project=full-panels",
+        `--project=${project}`,
         "--workers=1",
-        "e2e/full/panels/bulk-issue-worktree-recipe-perf.spec.ts",
+        spec,
         ...rest,
       ],
-      { RUN_PERF_BULK_ISSUE_WORKTREES: "1" }
-    );
-  };
-}
-
-function playwrightMemoryPressureResponsiveness(): Runner {
-  return async (rest) => {
-    const buildExitCode = await npmScript("build:e2e:bench");
-    if (buildExitCode !== 0) return buildExitCode;
-    return spawnNode(
-      [
-        resolveBin(
-          ["node_modules/@playwright/test/cli.js", "node_modules/playwright/cli.js"],
-          "playwright"
-        ),
-        "test",
-        "--project=full-resilience",
-        "--workers=1",
-        "e2e/full/resilience/memory-pressure-responsiveness-perf.spec.ts",
-        ...rest,
-      ],
-      { RUN_PERF_MEMORY_PRESSURE: "1" }
+      { [gate]: "1" }
     );
   };
 }
@@ -215,19 +151,56 @@ const REGISTRY: Record<string, Command> = {
   },
   "recipe-fanout": {
     summary: "Cold recipe fanout through worktree, PTY host, and xterm",
-    runner: playwrightRecipeFanout(),
+    runner: playwrightBench({
+      project: "full-worktree",
+      spec: "e2e/full/worktree/recipe-fanout-perf.spec.ts",
+      gate: "RUN_PERF_RECIPE_FANOUT",
+      build: "build:e2e:bench",
+    }),
   },
   "bulk-issue-worktrees": {
     summary: "Fake issue selection through bulk worktree recipes and real PTYs",
-    runner: playwrightBulkIssueWorktrees(),
+    runner: playwrightBench({
+      project: "full-panels",
+      spec: "e2e/full/panels/bulk-issue-worktree-recipe-perf.spec.ts",
+      gate: "RUN_PERF_BULK_ISSUE_WORKTREES",
+      build: "build:e2e:bench",
+    }),
+  },
+  interactivity: {
+    summary: "Keystroke-to-paint latency under fleet load (PERF-120..122, opt-in)",
+    runner: playwrightBench({
+      project: "full-terminal",
+      spec: "e2e/full/terminal/interactivity-perf.spec.ts",
+      gate: "RUN_PERF_INTERACTIVITY",
+      build: "build:e2e",
+    }),
+  },
+  scroll: {
+    summary: "Wheel-to-paint latency for mouse-reporting TUIs (PERF-125..127, opt-in)",
+    runner: playwrightBench({
+      project: "full-terminal",
+      spec: "e2e/full/terminal/scroll-perf.spec.ts",
+      gate: "RUN_PERF_SCROLL",
+      build: "build:e2e",
+    }),
   },
   memory: {
     summary: "Memory kitchen-sink soak spec via Playwright",
-    runner: playwrightMemory(),
+    runner: playwrightBench({
+      project: "full-resilience",
+      spec: "e2e/full/resilience/memory-kitchen-sink.spec.ts",
+      gate: "RUN_PERF_MEMORY",
+    }),
   },
   "memory-growth": {
     summary: "Single-session retained-memory growth benchmark via Playwright",
-    runner: playwrightMemoryGrowth(),
+    runner: playwrightBench({
+      project: "full-resilience",
+      spec: "e2e/full/resilience/memory-growth-perf.spec.ts",
+      gate: "RUN_PERF_MEMORY_GROWTH",
+      build: "build:e2e",
+    }),
   },
   "memory-growth-compare": {
     summary: "Compare two long-session memory-growth results",
@@ -239,7 +212,12 @@ const REGISTRY: Record<string, Command> = {
   },
   "memory-pressure": {
     summary: "Renderer responsiveness during sustained synthetic memory pressure",
-    runner: playwrightMemoryPressureResponsiveness(),
+    runner: playwrightBench({
+      project: "full-resilience",
+      spec: "e2e/full/resilience/memory-pressure-responsiveness-perf.spec.ts",
+      gate: "RUN_PERF_MEMORY_PRESSURE",
+      build: "build:e2e:bench",
+    }),
   },
   analyze: {
     summary: "Bundle-size visualizer build (ANALYZE=true vite build)",

--- a/scripts/perf/lib/baselineCoverage.ts
+++ b/scripts/perf/lib/baselineCoverage.ts
@@ -46,6 +46,9 @@ export function checkBaselineFreshness(
  * would otherwise silently skip its regression gate. Returns those gaps so the
  * caller can fail the run before wasting measurement time.
  *
+ * Scenarios marked `calibrating` are excluded: they have deliberately not been
+ * baselined yet, so a missing entry is the expected state, not a gap.
+ *
  * Critical scenarios are excluded — `gate.ts` already fails closed for them.
  * A null baseline returns no gaps: that's the pre-existing "no file" path, not
  * the partial-coverage gap this check targets.
@@ -62,6 +65,7 @@ export function checkBaselineCoverage(
     if (budgetConfig.criticalScenarios.includes(scenario.id)) continue;
 
     const budget = getScenarioBudget(budgetConfig, scenario.id);
+    if (budget.calibrating) continue;
     if (budget.maxRegressionPct === undefined) continue;
 
     const baselineP95 = baseline.p95ByScenario?.[scenario.id];

--- a/scripts/perf/lib/fileSearchFixture.ts
+++ b/scripts/perf/lib/fileSearchFixture.ts
@@ -1,0 +1,278 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRng } from "./workloads";
+
+/**
+ * Fixture for the file-picker scenarios (PERF-190..192).
+ *
+ * Drives the real `FileSearchService` (electron/services/FileSearchService.ts)
+ * — the single implementation behind the `@`-mention picker and the file
+ * palette — against synthetic git repos. Nothing is mocked: the service shells
+ * out to `git ls-files` exactly as it does in the app, so the cold path
+ * measures real subprocess + parse cost and the warm path measures the real
+ * per-keystroke scan over the cached path list.
+ *
+ * Fixture git calls use execFileSync (spawnSync), which does not route through
+ * ChildProcess.prototype.spawn, so setup never pollutes any spawn counters a
+ * sibling scenario installs.
+ */
+
+/**
+ * A tracked file the fallback filesystem walker can never return: `dist` is in
+ * FileSearchService's FALLBACK_SKIP_NAMES, so only `git ls-files` surfaces it.
+ * Searching for it proves which listing path actually ran — without it, a
+ * totally broken `git ls-files` degrades silently to the walker and the
+ * benchmark reports walker time while claiming to measure git.
+ */
+export const GIT_ONLY_SENTINEL = "dist/git-listing-sentinel.ts";
+
+/** Representative single-app repo — Daintree itself sits at ~3,100 files. */
+export const REPRESENTATIVE_FILE_COUNT = 3200;
+
+/** Large monorepo, still under the service's 20k fallback cap. */
+export const MONOREPO_FILE_COUNT = 12000;
+
+const TOP_LEVEL = [
+  "src",
+  "electron",
+  "shared",
+  "packages",
+  "plugins",
+  "scripts",
+  "docs",
+  "e2e",
+] as const;
+
+const MID_LEVEL = [
+  "components",
+  "services",
+  "hooks",
+  "store",
+  "lib",
+  "utils",
+  "handlers",
+  "panels",
+  "config",
+  "types",
+] as const;
+
+const LEAF_WORDS = [
+  "Terminal",
+  "Worktree",
+  "Panel",
+  "Agent",
+  "Project",
+  "Session",
+  "Search",
+  "Recipe",
+  "Forge",
+  "Theme",
+  "Plugin",
+  "Notification",
+  "Palette",
+  "Diff",
+  "Browser",
+  "Layout",
+  "Window",
+  "Pty",
+] as const;
+
+const SUFFIXES = [
+  "Service",
+  "Controller",
+  "Manager",
+  "Store",
+  "View",
+  "Bar",
+  "Dialog",
+  "Registry",
+  "Client",
+  "Handler",
+] as const;
+
+const EXTENSIONS = [".ts", ".tsx", ".test.ts", ".css", ".md", ".json"] as const;
+
+function pick<T>(rng: () => number, items: readonly T[]): T {
+  return items[Math.floor(rng() * items.length)]!;
+}
+
+/**
+ * Deterministic, realistically-shaped repo paths: three-to-four segments deep,
+ * CamelCase leaf names with the extension mix of a TypeScript app. Shape
+ * matters — the service scores basename-prefix, path-prefix and substring hits
+ * separately, so a flat directory of `file-N.txt` would exercise one branch of
+ * `scorePath` and flatter it.
+ */
+function buildRelativePaths(count: number, seed: number): string[] {
+  const rng = createRng(seed);
+  const paths = new Set<string>();
+  let guard = 0;
+
+  while (paths.size < count && guard < count * 12) {
+    guard += 1;
+    const top = pick(rng, TOP_LEVEL);
+    const mid = pick(rng, MID_LEVEL);
+    const leaf = `${pick(rng, LEAF_WORDS)}${pick(rng, SUFFIXES)}`;
+    const ext = pick(rng, EXTENSIONS);
+    // ~40% get a fourth segment, so the tree has both shallow and deep files.
+    const deep = rng() < 0.4 ? `/${pick(rng, LEAF_WORDS).toLowerCase()}` : "";
+    // A numeric discriminator keeps names unique without making them unrealistic;
+    // only ~30% carry one, so plenty of clean basenames survive for prefix hits.
+    const disc = rng() < 0.3 ? `${Math.floor(rng() * 900)}` : "";
+    paths.add(`${top}/${mid}${deep}/${leaf}${disc}${ext}`);
+  }
+
+  return [...paths];
+}
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, {
+    cwd,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+      GIT_AUTHOR_NAME: "perf",
+      GIT_AUTHOR_EMAIL: "perf@example.invalid",
+      GIT_COMMITTER_NAME: "perf",
+      GIT_COMMITTER_EMAIL: "perf@example.invalid",
+    },
+  });
+}
+
+export interface FileSearchRepo {
+  path: string;
+  /** Number of files actually written (directories are added by the service). */
+  fileCount: number;
+}
+
+export interface FileSearchFixture {
+  root: string;
+  representative: FileSearchRepo;
+  monorepo: FileSearchRepo;
+}
+
+let fixture: FileSearchFixture | null = null;
+
+function buildRepo(root: string, name: string, fileCount: number, seed: number): FileSearchRepo {
+  const repoPath = join(root, name);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+  git(repoPath, ["config", "commit.gpgsign", "false"]);
+  git(repoPath, ["config", "core.fsmonitor", "false"]);
+
+  const relativePaths = buildRelativePaths(fileCount, seed);
+  const madeDirs = new Set<string>();
+  for (const relative of relativePaths) {
+    const dir = relative.slice(0, relative.lastIndexOf("/"));
+    if (!madeDirs.has(dir)) {
+      mkdirSync(join(repoPath, dir), { recursive: true });
+      madeDirs.add(dir);
+    }
+    // Contents are irrelevant to path search; keep them tiny so fixture build
+    // stays I/O-cheap and the repo fits comfortably in the page cache.
+    writeFileSync(join(repoPath, relative), "//\n");
+  }
+
+  mkdirSync(join(repoPath, "dist"), { recursive: true });
+  writeFileSync(join(repoPath, GIT_ONLY_SENTINEL), "//\n");
+
+  git(repoPath, ["add", "-A"]);
+  git(repoPath, ["commit", "-m", "fixture tree"]);
+
+  return { path: repoPath, fileCount: relativePaths.length };
+}
+
+/**
+ * Build both repos once per process. ~15k files of two bytes each; the git
+ * index work dominates and runs a few seconds, which is why the scenarios that
+ * use it are `heavy` tier.
+ */
+export function getFileSearchFixture(): FileSearchFixture {
+  if (fixture) return fixture;
+
+  // realpath matters: on macOS `mkdtemp` hands back a /var/... path while git
+  // reports /private/var/... from `rev-parse --show-toplevel`. FileSearchService
+  // derives its pathspec from `path.relative(gitRoot, cwd)`, so the mismatch
+  // yields a bogus `../../..` pathspec, `git ls-files` returns nothing, and the
+  // service silently falls back to its filesystem walk — the benchmark would
+  // then time the walker while claiming to measure git.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "daintree-perf-filesearch-")));
+  // Registered before the repos are built: a fixture that throws half-way
+  // through would otherwise leave ~15k files behind on the runner.
+  process.on("exit", () => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // Best-effort: a leaked temp dir must never fail a benchmark run.
+    }
+  });
+
+  fixture = {
+    root,
+    representative: buildRepo(root, "app-repo", REPRESENTATIVE_FILE_COUNT, 190),
+    monorepo: buildRepo(root, "monorepo", MONOREPO_FILE_COUNT, 191),
+  };
+
+  return fixture;
+}
+
+export interface FileSearchModule {
+  fileSearchService: import("../../../electron/services/FileSearchService").FileSearchService;
+}
+
+let modulePromise: Promise<FileSearchModule> | null = null;
+
+/**
+ * Loaded lazily: FileSearchService pulls in the logger, which resolves its file
+ * destination from DAINTREE_USER_DATA at module eval.
+ */
+export function loadFileSearchModule(): Promise<FileSearchModule> {
+  if (!modulePromise) {
+    if (!process.env.DAINTREE_USER_DATA) {
+      const userData = mkdtempSync(join(tmpdir(), "daintree-perf-userdata-"));
+      process.env.DAINTREE_USER_DATA = userData;
+      process.on("exit", () => {
+        try {
+          rmSync(userData, { recursive: true, force: true });
+        } catch {
+          // Best-effort.
+        }
+      });
+    }
+    modulePromise = import("../../../electron/services/FileSearchService").then((mod) => ({
+      fileSearchService: mod.fileSearchService,
+    }));
+  }
+  return modulePromise;
+}
+
+/**
+ * Queries a user actually types into the `@` picker, expanded one keystroke at
+ * a time by the scenarios. Every prefix is a full re-scan of the path list, so
+ * the short prefixes cost the most (nearly everything still matches and
+ * survives into the top-N heap).
+ *
+ * Each must actually match this fixture's generated vocabulary — the scenarios
+ * assert that per query, because a query silently matching nothing measures the
+ * reject path while reporting itself as typing latency. Leaf names are
+ * `{Word}{Suffix}{digits?}{ext}`, so a literal like `theme.css` never matches;
+ * use a word, a path prefix, a Word+Suffix pair, or an extension.
+ */
+export const TYPED_FILE_QUERIES = [
+  "terminal",
+  "src/comp",
+  "WorktreeService",
+  ".css",
+  "notif",
+] as const;
+
+/**
+ * A query with no match anywhere. This is the true worst case: `scorePath`
+ * returns null for every path, so the scan can never terminate early and the
+ * full list is walked.
+ */
+export const NO_MATCH_QUERY = "zzqqxvnomatch";

--- a/scripts/perf/lib/gate.ts
+++ b/scripts/perf/lib/gate.ts
@@ -75,9 +75,18 @@ export function evaluateScenarioBudget(params: GateParams): GateResult {
   if (budget.maxMetricValues) {
     for (const [metricName, maxValue] of Object.entries(budget.maxMetricValues)) {
       const actual = metricAverages[metricName];
+      // A configured ceiling whose metric is no longer emitted is a gate that
+      // has silently disappeared — the exact failure this file exists to
+      // prevent — so an absent metric fails rather than passes. Renaming a
+      // metric must therefore rename it in budgets.json too.
+      if (actual === undefined) {
+        failedBudget = true;
+        reasons.push(`${metricName} has a configured ceiling but was not emitted - failing closed`);
+        continue;
+      }
       // Treat a non-finite metric as a breach: NaN > maxValue is false, which
       // would otherwise let a broken metric slip past its ceiling.
-      if (actual !== undefined && (!Number.isFinite(actual) || actual > maxValue)) {
+      if (!Number.isFinite(actual) || actual > maxValue) {
         failedBudget = true;
         reasons.push(`${metricName} ${round(actual)} > max ${maxValue}`);
       }
@@ -86,7 +95,23 @@ export function evaluateScenarioBudget(params: GateParams): GateResult {
 
   const hasUsableBaseline = baselineP95 !== undefined && Number.isFinite(baselineP95);
 
-  if (!hasUsableBaseline) {
+  // Checked before the baseline branches: a calibrating scenario has no
+  // baseline BY DESIGN, so reporting it as a missing-baseline gap would be
+  // misleading — and for a critical one it would fail closed on the expected
+  // state rather than on a real problem.
+  if (budget.calibrating && isCritical) {
+    // A critical scenario is one whose regression gate must never be skipped,
+    // so the two settings are contradictory. Fail on the contradiction rather
+    // than silently letting `calibrating` win and disarm a critical gate.
+    failedBudget = true;
+    reasons.push("critical scenario marked calibrating - contradictory budget config");
+  } else if (budget.calibrating) {
+    reasons.push(
+      hasUsableBaseline
+        ? "calibrating but a baseline now exists - remove `calibrating` to arm the regression gate"
+        : "calibrating - regression gate not yet enabled"
+    );
+  } else if (!hasUsableBaseline) {
     if (isCritical) {
       failedBudget = true;
       reasons.push(

--- a/scripts/perf/lib/scrollbackSnapshotFixture.ts
+++ b/scripts/perf/lib/scrollbackSnapshotFixture.ts
@@ -1,0 +1,145 @@
+import type { SerializeAddon } from "@xterm/addon-serialize";
+import type { Terminal } from "@xterm/headless";
+import { createHeadlessTerminal } from "./workloads";
+import { buildSearchCorpus } from "./terminalSearchFixture";
+
+/**
+ * Fixture for the session snapshot/restore scenarios (PERF-195/196).
+ *
+ * Every preserved terminal is captured with `SerializeAddon.serialize()` — see
+ * PreservedSnapshotCapture.snapshotAndDispose and AnalysisSession — and every
+ * restored terminal replays that payload back through the xterm parser. Both
+ * legs run once per terminal per app lifecycle, so the cost multiplies by fleet
+ * size on quit and again on launch.
+ *
+ * The corpus is SGR-dense on purpose: real agent and build output is heavily
+ * coloured, and colour is what dominates a serialized payload. A plain-text
+ * corpus would understate both the byte count and the reparse cost by a wide
+ * margin.
+ */
+
+/** Matches PERF-121's background fleet, so the two benchmarks stay comparable. */
+export const REPRESENTATIVE_FLEET = 12;
+
+/**
+ * Wrap two of every three lines in SGR sequences (green, then bold red). The
+ * pattern is fixed rather than random so payload size is deterministic across
+ * runs — a snapshot that changed size run to run would make the byte metrics
+ * unreadable.
+ */
+function colourize(corpus: string): string {
+  return corpus
+    .split("\r\n")
+    .map((line, index) => {
+      if (line.length === 0) return line;
+      if (index % 3 === 0) return `\x1b[32m${line}\x1b[0m`;
+      if (index % 3 === 1) return `\x1b[1;31m${line}\x1b[0m`;
+      return line;
+    })
+    .join("\r\n");
+}
+
+export interface SnapshotSource {
+  terminal: Terminal;
+  addon: SerializeAddon;
+}
+
+async function createSeededTerminal(
+  scrollbackLines: number,
+  seed: number
+): Promise<SnapshotSource> {
+  const terminal = await createHeadlessTerminal({
+    cols: 120,
+    rows: 40,
+    scrollback: scrollbackLines,
+  });
+  const { SerializeAddon: SerializeAddonCtor } = await import("@xterm/addon-serialize");
+  const addon = new SerializeAddonCtor();
+  terminal.loadAddon(addon);
+
+  // Overfill so the scrollback is trimmed to its steady-state size, which is
+  // the state a long-running agent terminal is actually snapshotted in.
+  const corpus = colourize(buildSearchCorpus(Math.floor(scrollbackLines * 1.2), seed));
+  await new Promise<void>((resolve) => {
+    terminal.write(corpus, () => resolve());
+  });
+
+  return { terminal, addon };
+}
+
+export interface SnapshotFleet {
+  sources: SnapshotSource[];
+  scrollbackLines: number;
+}
+
+const fleetCache = new Map<string, Promise<SnapshotFleet>>();
+
+/**
+ * Build a fleet of seeded terminals once per process. `serialize()` does not
+ * mutate the buffer, so the same fleet is safe to re-snapshot every iteration.
+ */
+export function getSnapshotFleet(scrollbackLines: number, size: number): Promise<SnapshotFleet> {
+  const key = `${scrollbackLines}:${size}`;
+  let existing = fleetCache.get(key);
+  if (!existing) {
+    existing = (async () => {
+      const sources: SnapshotSource[] = [];
+      for (let i = 0; i < size; i += 1) {
+        // Distinct seeds so terminals do not share a buffer shape and give the
+        // allocator an unrealistically friendly access pattern.
+        sources.push(await createSeededTerminal(scrollbackLines, 1950 + i));
+      }
+      return { sources, scrollbackLines };
+    })();
+    fleetCache.set(key, existing);
+  }
+  return existing;
+}
+
+/**
+ * Fresh, empty terminals to replay snapshots into. Created OUTSIDE the timed
+ * bracket by callers: in production the xterm instance already exists when a
+ * snapshot is replayed into it, so construction is not part of restore latency.
+ */
+export async function createRestoreTargets(
+  scrollbackLines: number,
+  count: number
+): Promise<Terminal[]> {
+  const targets: Terminal[] = [];
+  for (let i = 0; i < count; i += 1) {
+    targets.push(
+      await createHeadlessTerminal({ cols: 120, rows: 40, scrollback: scrollbackLines })
+    );
+  }
+  return targets;
+}
+
+/**
+ * Replay one payload and resolve only once the parser has drained it.
+ *
+ * This is a single raw `write` — deliberately NOT the production restore path.
+ * `TerminalRestoreController` splits payloads over 256 KiB into 32 KiB chunks
+ * with UI yields between them, so the number this produces is the parser floor,
+ * not wall-clock restore. See the note on PERF-196.
+ *
+ * The timeout exists because a write whose callback never fires would otherwise
+ * hang the whole benchmark run until the workflow timeout.
+ */
+export function replaySnapshot(terminal: Terminal, payload: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("snapshot replay did not drain within 30s — parser callback never fired"));
+    }, 30_000);
+    terminal.write(payload, () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+/** Free a terminal's buffers once a scenario is done with it. */
+export function disposeTerminals(terminals: Terminal[]): void {
+  for (const terminal of terminals) {
+    terminal.dispose();
+  }
+}

--- a/scripts/perf/lib/terminalSearchFixture.ts
+++ b/scripts/perf/lib/terminalSearchFixture.ts
@@ -1,0 +1,184 @@
+import type { SearchAddon } from "@xterm/addon-search";
+import type { Terminal } from "@xterm/headless";
+import { createHeadlessTerminal, createRng } from "./workloads";
+
+/**
+ * Fixture for the terminal find-in-scrollback scenarios (PERF-193/194).
+ *
+ * Loads the real `@xterm/addon-search` onto a real `@xterm/headless` terminal
+ * and drives it through the app's own `buildSearchOptions`, so the measured
+ * work is production's: the buffer walk, the regex/whole-word matching, and
+ * `_highlightAllMatches`, which walks the buffer on every search to collect
+ * matches up to the addon's 1,000-match highlight limit — not just the one
+ * being jumped to. That collection pass is what makes search cost scale with
+ * scrollback rather than with distance to the next hit.
+ *
+ * TWO CACHE STATES, MEASURED SEPARATELY. `SearchLineCache` memoizes the
+ * buffer-cell-to-string translation for 15s, refreshing that window on every
+ * search and dropping it on `onLineFeed` / `onCursorMove` / `onResize`. So a
+ * terminal that is still streaming output pays the translation on essentially
+ * every search, while a quiet one pays it once. Benchmarking only the quiet
+ * case would hide any regression in translation, which is the expensive half.
+ * `invalidateLineCache()` writes one line feed — exactly what live output does
+ * — to force the cold state deterministically.
+ *
+ * FIDELITY GAP — read before trusting a delta: headless has no render service,
+ * so `registerDecoration` is shimmed. The shim is faithful about LIFECYCLE (it
+ * fires `onDispose` listeners exactly once, which is how the addon releases the
+ * real markers it registers), but it never paints, and `onRender` listeners
+ * therefore never fire. The scan, the match collection, and marker
+ * registration/disposal are real; painting the highlight overlays is not. The
+ * absolute numbers are a floor, not the whole cost the user sees.
+ */
+
+/** Words a developer actually greps for, mixed into the synthetic corpus. */
+const CORPUS_TOKENS = [
+  "error",
+  "warning",
+  "info",
+  "compiled",
+  "module",
+  "src/components/Terminal/index.tsx",
+  "electron/services/PtyManager.ts",
+  "node_modules",
+  "passed",
+  "failed",
+  "TypeError",
+  "undefined",
+  "await",
+  "resolved",
+  "chunk",
+  "bundle",
+  "vite",
+  "tsc",
+] as const;
+
+/**
+ * A deterministic build/agent-output corpus. Shape matters: real matches are
+ * scattered across the whole buffer at a realistic density, so the enumeration
+ * pass has genuine work rather than one lucky early hit.
+ */
+export function buildSearchCorpus(lines: number, seed: number): string {
+  const rng = createRng(seed);
+  const parts: string[] = [];
+  for (let i = 0; i < lines; i += 1) {
+    const token = (): string => CORPUS_TOKENS[Math.floor(rng() * CORPUS_TOKENS.length)]!;
+    parts.push(
+      `[${i}] ${token()} ${token()} ${token()} ${Math.floor(rng() * 1_000_000)} ${token()}`
+    );
+  }
+  return `${parts.join("\r\n")}\r\n`;
+}
+
+export interface SearchableTerminal {
+  terminal: Terminal;
+  addon: SearchAddon;
+  /** Decorations created by the most recent search; reset by resetDecorationCount(). */
+  decorationCount: () => number;
+  resetDecorationCount: () => void;
+  /** Live count of markers registered on the terminal — must stay bounded. */
+  markerCount: () => number;
+  /**
+   * Drop the addon's translated-line cache by feeding one line, the way live
+   * terminal output does. Call before a search that should measure the cold
+   * path. Resolves once the write has been parsed.
+   */
+  invalidateLineCache: () => Promise<void>;
+  bufferLines: number;
+}
+
+/**
+ * Minimal shims for the terminal APIs SearchAddon reaches for that headless
+ * does not implement. Selection is real state (the addon reads it back to
+ * decide where the next match starts from), so a stubbed selection would make
+ * `findNext` restart from the top every call and understate stepping cost.
+ *
+ * The decoration shim MUST honour disposal. The addon registers a real marker
+ * per match and releases it from the decoration's `onDispose` callback; a
+ * no-op `dispose` leaks every marker onto a terminal this fixture caches for
+ * the whole process, which both grows without bound and slows later scrolling
+ * work — a benchmark that corrupts its own later samples.
+ */
+function installSearchShims(terminal: Terminal, onDecoration: () => void): void {
+  const host = terminal as unknown as Record<string, unknown>;
+  let selection: unknown;
+
+  host.getSelectionPosition = (): unknown => selection;
+  host.select = (column: number, row: number, length: number): void => {
+    selection = { start: { x: column, y: row }, end: { x: column + length, y: row } };
+  };
+  host.clearSelection = (): void => {
+    selection = undefined;
+  };
+  host.hasSelection = (): boolean => selection !== undefined;
+  host.getSelection = (): string => "";
+  host.registerDecoration = (options: { marker?: unknown }): unknown => {
+    onDecoration();
+    const disposeListeners = new Set<() => void>();
+    let disposed = false;
+    const listen = (set: Set<() => void>, cb: () => void): { dispose: () => void } => {
+      set.add(cb);
+      return { dispose: () => set.delete(cb) };
+    };
+    return {
+      marker: options?.marker,
+      element: undefined,
+      // Never fires: headless does not render. Registering it keeps the addon's
+      // disposable bookkeeping identical to production.
+      onRender: (cb: () => void) => listen(new Set<() => void>(), cb),
+      onDispose: (cb: () => void) => listen(disposeListeners, cb),
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        for (const cb of [...disposeListeners]) cb();
+      },
+    };
+  };
+}
+
+/**
+ * Build a terminal whose scrollback is FULL at `scrollbackLines` — the state a
+ * long-running agent terminal is in. Writing more than the scrollback holds is
+ * deliberate: it forces the trim path so the buffer is at its steady-state size
+ * rather than partially filled.
+ */
+export async function createSearchableTerminal(
+  scrollbackLines: number,
+  seed: number
+): Promise<SearchableTerminal> {
+  const terminal = await createHeadlessTerminal({
+    cols: 120,
+    rows: 40,
+    scrollback: scrollbackLines,
+  });
+
+  let decorations = 0;
+  installSearchShims(terminal, () => {
+    decorations += 1;
+  });
+
+  const { SearchAddon: SearchAddonCtor } = await import("@xterm/addon-search");
+  const addon = new SearchAddonCtor();
+  terminal.loadAddon(addon);
+
+  const corpus = buildSearchCorpus(Math.floor(scrollbackLines * 1.2), seed);
+  await new Promise<void>((resolve) => {
+    terminal.write(corpus, () => resolve());
+  });
+
+  return {
+    terminal,
+    addon,
+    decorationCount: () => decorations,
+    resetDecorationCount: () => {
+      decorations = 0;
+    },
+    markerCount: () =>
+      (terminal as unknown as { _core?: { _markers?: unknown[] } })._core?._markers?.length ?? 0,
+    invalidateLineCache: () =>
+      new Promise<void>((resolve) => {
+        terminal.write("\r\n", () => resolve());
+      }),
+    bufferLines: terminal.buffer.active.length,
+  };
+}

--- a/scripts/perf/lib/terminalSearchFixture.ts
+++ b/scripts/perf/lib/terminalSearchFixture.ts
@@ -173,8 +173,7 @@ export async function createSearchableTerminal(
     resetDecorationCount: () => {
       decorations = 0;
     },
-    markerCount: () =>
-      (terminal as unknown as { _core?: { _markers?: unknown[] } })._core?._markers?.length ?? 0,
+    markerCount: () => terminal.markers.length,
     invalidateLineCache: () =>
       new Promise<void>((resolve) => {
         terminal.write("\r\n", () => resolve());

--- a/scripts/perf/scenarios/fileSearch.ts
+++ b/scripts/perf/scenarios/fileSearch.ts
@@ -1,0 +1,264 @@
+import { performance } from "node:perf_hooks";
+import type { PerfScenario } from "../types";
+import { percentile } from "../lib/stats";
+import { gitSpawnMark, gitSpawnsSince, installGitSpawnCounter } from "../lib/gitPipelineFixture";
+import {
+  getFileSearchFixture,
+  GIT_ONLY_SENTINEL,
+  loadFileSearchModule,
+  NO_MATCH_QUERY,
+  TYPED_FILE_QUERIES,
+  type FileSearchRepo,
+} from "../lib/fileSearchFixture";
+
+// File picker — the `@`-mention completion and the file palette, both served by
+// the real FileSearchService. Two costs the user feels, measured separately
+// because they have different fixes:
+//
+//   * COLD (PERF-192): with no cached path list, the first keystroke pays for
+//     `git ls-files` plus the directory-set build and sort. Nothing renders
+//     until it resolves, so this IS the picker's open latency. The list is
+//     rebuilt whenever its 10s TTL lapses, and dropped outright when a worktree
+//     is created or deleted, so a working session pays it repeatedly.
+//   * WARM (PERF-190/191): every subsequent keystroke re-scans the whole cached
+//     list through `scorePath` and re-heaps the top 50. This is the typing
+//     latency, and it scales linearly with repo size.
+//
+// `FileSearchService.search` swallows every error and returns `[]`, and
+// `loadFileList` silently falls back to a filesystem walk when git fails — both
+// of which are FASTER than the path being claimed. So the guards here assert
+// which path ran, not merely that something came back: every query family
+// asserts its own expected outcome, and PERF-192 proves both that git actually
+// spawned and that the result could only have come from the git listing.
+
+interface KeystrokeStreamResult {
+  sessionMs: number;
+  keystrokes: number;
+  p99KeystrokeMs: number;
+  totalMatches: number;
+}
+
+type SearchFn = (payload: { cwd: string; query: string; limit?: number }) => Promise<string[]>;
+
+/**
+ * Type every query one character at a time, timing each individual re-scan.
+ * Each full query must end with at least one match: an aggregate count lets a
+ * single surviving query mask several broken scoring branches.
+ */
+async function runKeystrokeStream(search: SearchFn, cwd: string): Promise<KeystrokeStreamResult> {
+  const perKeystroke: number[] = [];
+  let totalMatches = 0;
+
+  const sessionStart = performance.now();
+  for (const query of TYPED_FILE_QUERIES) {
+    let finalMatches = 0;
+    for (let end = 1; end <= query.length; end += 1) {
+      const start = performance.now();
+      const matches = await search({ cwd, query: query.slice(0, end), limit: 50 });
+      perKeystroke.push(performance.now() - start);
+      totalMatches += matches.length;
+      finalMatches = matches.length;
+    }
+    if (finalMatches === 0) {
+      throw new Error(`file search query '${query}' matched nothing in ${cwd} — scoring is broken`);
+    }
+  }
+  const sessionMs = performance.now() - sessionStart;
+
+  return {
+    sessionMs,
+    keystrokes: perKeystroke.length,
+    p99KeystrokeMs: percentile(perKeystroke, 99),
+    totalMatches,
+  };
+}
+
+/**
+ * Guarantee a full-TTL cache entry before a warm timing bracket. Priming with a
+ * plain search is not enough: `Cache.get` refreshes `lastAccessed` but never
+ * extends `expiresAt`, so a hit taken near expiry can lapse mid-stream and
+ * silently fold a cold `git ls-files` rebuild into a "warm" sample. Invalidating
+ * first forces a freshly-stamped entry.
+ */
+async function primeCache(
+  search: SearchFn,
+  invalidate: (cwd: string) => void,
+  repo: FileSearchRepo
+): Promise<void> {
+  invalidate(repo.path);
+  const primed = await search({ cwd: repo.path, query: "terminal", limit: 50 });
+  if (primed.length === 0) {
+    throw new Error(`file search returned no results for ${repo.path} — fixture or service broken`);
+  }
+}
+
+export const fileSearchScenarios: PerfScenario[] = [
+  {
+    id: "PERF-190",
+    name: "File Picker Typing - Warm List (representative repo)",
+    description:
+      "Real FileSearchService.search over a warm ~3,200-file git repo while typing 5 representative " +
+      "queries one keystroke at a time — every prefix is a full re-scan of the path list, as in the " +
+      "live `@` picker. durationMs is the whole typing session; p99KeystrokeMs is the single " +
+      "re-scan the user feels and must stay well inside a frame.",
+    tier: "heavy",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 6, ci: 10, nightly: 14 },
+    warmups: 2,
+    async run() {
+      const fixture = getFileSearchFixture();
+      const { fileSearchService } = await loadFileSearchModule();
+      const search: SearchFn = (payload) => fileSearchService.search(payload);
+      const invalidate = (cwd: string): void => fileSearchService.invalidate(cwd);
+
+      await primeCache(search, invalidate, fixture.representative);
+
+      const start = performance.now();
+      const stream = await runKeystrokeStream(search, fixture.representative.path);
+      const durationMs = performance.now() - start;
+
+      return {
+        durationMs,
+        metrics: {
+          keystrokes: stream.keystrokes,
+          p99KeystrokeMs: stream.p99KeystrokeMs,
+          avgKeystrokeMs: stream.sessionMs / Math.max(1, stream.keystrokes),
+          totalMatches: stream.totalMatches,
+          fileCount: fixture.representative.fileCount,
+        },
+      };
+    },
+  },
+  {
+    id: "PERF-191",
+    name: "File Picker Typing - Repo Scaling",
+    description:
+      "The same warm typing session run against a ~3,200-file repo and a ~12,000-file monorepo, plus " +
+      "a query matching nothing (which skips top-N heap maintenance and the final sort, so it is the " +
+      "cheap end, not the worst case). msPerKFile is the large repo's per-keystroke cost normalised " +
+      "by file count — a fixed-scale regression signal for scorePath/pickTopMatches.",
+    tier: "heavy",
+    modes: ["ci", "nightly"],
+    iterations: { ci: 8, nightly: 12 },
+    warmups: 1,
+    async run() {
+      const fixture = getFileSearchFixture();
+      const { fileSearchService } = await loadFileSearchModule();
+      const search: SearchFn = (payload) => fileSearchService.search(payload);
+      const invalidate = (cwd: string): void => fileSearchService.invalidate(cwd);
+
+      await primeCache(search, invalidate, fixture.representative);
+      await primeCache(search, invalidate, fixture.monorepo);
+
+      const start = performance.now();
+      const small = await runKeystrokeStream(search, fixture.representative.path);
+      const large = await runKeystrokeStream(search, fixture.monorepo.path);
+
+      const missStart = performance.now();
+      const missResults = await search({
+        cwd: fixture.monorepo.path,
+        query: NO_MATCH_QUERY,
+        limit: 50,
+      });
+      const missMs = performance.now() - missStart;
+      const durationMs = performance.now() - start;
+
+      // A query that matches nothing must return nothing. If it returns rows,
+      // scoring has stopped filtering and every timing here is meaningless.
+      if (missResults.length !== 0) {
+        throw new Error(
+          `no-match query returned ${missResults.length} results — scoring no longer filters`
+        );
+      }
+
+      const largeAvg = large.sessionMs / Math.max(1, large.keystrokes);
+      const msPerKFile = largeAvg / (fixture.monorepo.fileCount / 1000);
+
+      return {
+        durationMs,
+        metrics: {
+          smallP99KeystrokeMs: small.p99KeystrokeMs,
+          largeP99KeystrokeMs: large.p99KeystrokeMs,
+          msPerKFile,
+          noMatchScanMs: missMs,
+          monorepoFileCount: fixture.monorepo.fileCount,
+        },
+      };
+    },
+  },
+  {
+    id: "PERF-192",
+    name: "File Picker Cold Open - Git Path List Build",
+    description:
+      "Drops the cached path list and times the first search: real `git ls-files --cached --others " +
+      "--exclude-standard`, NUL parse, ancestor-directory set build and length sort, at both repo " +
+      "scales. This is the wait between pressing `@` and the picker showing anything. Asserts a git " +
+      "subprocess actually spawned and that the results contain a file only the git listing can " +
+      "return — without both, a broken git path degrades to the filesystem walker and this would " +
+      "report walker time under a git label.",
+    tier: "heavy",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 4, ci: 8, nightly: 12 },
+    warmups: 1,
+    async run() {
+      const fixture = getFileSearchFixture();
+      const { fileSearchService } = await loadFileSearchModule();
+      // Counts async git spawns from the product path. Fixture setup uses
+      // spawnSync, which does not route through ChildProcess.prototype.spawn.
+      installGitSpawnCounter();
+
+      fileSearchService.invalidate(fixture.representative.path);
+      fileSearchService.invalidate(fixture.monorepo.path);
+
+      const spawnMark = gitSpawnMark();
+      const start = performance.now();
+
+      const smallStart = performance.now();
+      const smallResults = await fileSearchService.search({
+        cwd: fixture.representative.path,
+        query: GIT_ONLY_SENTINEL,
+        limit: 50,
+      });
+      const smallColdMs = performance.now() - smallStart;
+
+      const largeStart = performance.now();
+      const largeResults = await fileSearchService.search({
+        cwd: fixture.monorepo.path,
+        query: GIT_ONLY_SENTINEL,
+        limit: 50,
+      });
+      const largeColdMs = performance.now() - largeStart;
+
+      const durationMs = performance.now() - start;
+      const spawns = gitSpawnsSince(spawnMark);
+
+      // Both halves must be genuinely cold AND genuinely git-backed.
+      if (spawns.count === 0) {
+        throw new Error(
+          "no git subprocess spawned during the cold open — the path list was served warm or the git listing was bypassed"
+        );
+      }
+      for (const [label, results] of [
+        ["representative", smallResults],
+        ["monorepo", largeResults],
+      ] as const) {
+        if (!results.includes(GIT_ONLY_SENTINEL)) {
+          throw new Error(
+            `${label} cold search did not return ${GIT_ONLY_SENTINEL} — the filesystem-walk fallback ran instead of git ls-files`
+          );
+        }
+      }
+
+      return {
+        durationMs,
+        metrics: {
+          smallColdMs,
+          largeColdMs,
+          coldMsPerKFile: largeColdMs / (fixture.monorepo.fileCount / 1000),
+          gitSpawns: spawns.count,
+          lsFilesSpawns: spawns.bySubcommand["ls-files"] ?? 0,
+        },
+      };
+    },
+  },
+];

--- a/scripts/perf/scenarios/index.ts
+++ b/scripts/perf/scenarios/index.ts
@@ -16,6 +16,9 @@ import { worktreeSidebarScenarios } from "./worktreeSidebar";
 import { fleetBroadcastScenarios } from "./fleetBroadcast";
 import { diffTokenizeScenarios } from "./diffTokenize";
 import { paletteFilterScenarios } from "./paletteFilter";
+import { fileSearchScenarios } from "./fileSearch";
+import { terminalSearchScenarios } from "./terminalSearch";
+import { scrollbackSnapshotScenarios } from "./scrollbackSnapshot";
 
 export const allScenarios: PerfScenario[] = [
   ...startupScenarios,
@@ -35,83 +38,110 @@ export const allScenarios: PerfScenario[] = [
   ...fleetBroadcastScenarios,
   ...diffTokenizeScenarios,
   ...paletteFilterScenarios,
+  ...fileSearchScenarios,
+  ...terminalSearchScenarios,
+  ...scrollbackSnapshotScenarios,
 ];
 
 export function getScenariosForMode(mode: PerfMode): PerfScenario[] {
   return allScenarios.filter((scenario) => scenario.modes.includes(mode));
 }
 
-export function assertMatrixCoverage(): void {
-  const expectedIds = new Set([
-    "PERF-001",
-    "PERF-002",
-    "PERF-003",
-    "PERF-004",
-    "PERF-010",
-    "PERF-011",
-    "PERF-012",
-    "PERF-013",
-    "PERF-020",
-    "PERF-021",
-    "PERF-022",
-    "PERF-023",
-    "PERF-024",
-    "PERF-030",
-    "PERF-031",
-    "PERF-032",
-    "PERF-033",
-    "PERF-034",
-    "PERF-035",
-    "PERF-040",
-    "PERF-041",
-    "PERF-042",
-    "PERF-050",
-    "PERF-051",
-    "PERF-052",
-    "PERF-060",
-    "PERF-061",
-    "PERF-062",
-    "PERF-063",
-    "PERF-070",
-    "PERF-071",
-    "PERF-072",
-    "PERF-073",
-    "PERF-080",
-    "PERF-090",
-    "PERF-091",
-    "PERF-100",
-    "PERF-101",
-    "PERF-102",
-    "PERF-103",
-    "PERF-104",
-    "PERF-110",
-    "PERF-111",
-    "PERF-112",
-    "PERF-130",
-    "PERF-131",
-    "PERF-132",
-    "PERF-133",
-    "PERF-134",
-    "PERF-135",
-    "PERF-136",
-    "PERF-137",
-    "PERF-138",
-    "PERF-139",
-    "PERF-140",
-    "PERF-141",
-    "PERF-150",
-    "PERF-151",
-    "PERF-160",
-    "PERF-161",
-    "PERF-162",
-    "PERF-170",
-    "PERF-171",
-  ]);
+/**
+ * The declared PERF matrix. This list is the contract: every id here must be
+ * implemented, and nothing may be implemented that is not listed. Exported so
+ * the matrix test can assert both directions against one declaration rather
+ * than keeping a second copy of the count.
+ */
+export const EXPECTED_SCENARIO_IDS: ReadonlySet<string> = new Set([
+  "PERF-001",
+  "PERF-002",
+  "PERF-003",
+  "PERF-004",
+  "PERF-010",
+  "PERF-011",
+  "PERF-012",
+  "PERF-013",
+  "PERF-020",
+  "PERF-021",
+  "PERF-022",
+  "PERF-023",
+  "PERF-024",
+  "PERF-030",
+  "PERF-031",
+  "PERF-032",
+  "PERF-033",
+  "PERF-034",
+  "PERF-035",
+  "PERF-040",
+  "PERF-041",
+  "PERF-042",
+  "PERF-050",
+  "PERF-051",
+  "PERF-052",
+  "PERF-060",
+  "PERF-061",
+  "PERF-062",
+  "PERF-063",
+  "PERF-070",
+  "PERF-071",
+  "PERF-072",
+  "PERF-073",
+  "PERF-080",
+  "PERF-090",
+  "PERF-091",
+  "PERF-100",
+  "PERF-101",
+  "PERF-102",
+  "PERF-103",
+  "PERF-104",
+  "PERF-110",
+  "PERF-111",
+  "PERF-112",
+  "PERF-130",
+  "PERF-131",
+  "PERF-132",
+  "PERF-133",
+  "PERF-134",
+  "PERF-135",
+  "PERF-136",
+  "PERF-137",
+  "PERF-138",
+  "PERF-139",
+  "PERF-140",
+  "PERF-141",
+  "PERF-150",
+  "PERF-151",
+  "PERF-160",
+  "PERF-161",
+  "PERF-162",
+  "PERF-170",
+  "PERF-171",
+  "PERF-190",
+  "PERF-191",
+  "PERF-192",
+  "PERF-193",
+  "PERF-194",
+  "PERF-195",
+  "PERF-196",
+]);
 
+/**
+ * Enforce the matrix contract in BOTH directions at runtime, so a scenario
+ * added without being declared fails the run rather than only the unit test.
+ */
+export function assertMatrixCoverage(): void {
   const actualIds = new Set(allScenarios.map((scenario) => scenario.id));
 
-  const missing = [...expectedIds].filter((id) => !actualIds.has(id));
+  const missing = [...EXPECTED_SCENARIO_IDS].filter((id) => !actualIds.has(id));
   if (missing.length > 0) {
     throw new Error(`Performance scenario coverage gap. Missing: ${missing.join(", ")}`);
+  }
+
+  const undeclared = [...actualIds].filter((id) => !EXPECTED_SCENARIO_IDS.has(id));
+  if (undeclared.length > 0) {
+    throw new Error(
+      `Performance scenario not declared in EXPECTED_SCENARIO_IDS: ${undeclared.join(", ")}`
+    );
   }
 }

--- a/scripts/perf/scenarios/scrollbackSnapshot.ts
+++ b/scripts/perf/scenarios/scrollbackSnapshot.ts
@@ -1,0 +1,175 @@
+import { performance } from "node:perf_hooks";
+import { SCROLLBACK_DEFAULT, SCROLLBACK_MAX } from "../../../shared/config/scrollback";
+import {
+  createRestoreTargets,
+  disposeTerminals,
+  getSnapshotFleet,
+  replaySnapshot,
+  REPRESENTATIVE_FLEET,
+} from "../lib/scrollbackSnapshotFixture";
+import { percentile } from "../lib/stats";
+import type { PerfScenario } from "../types";
+
+// Session snapshot and replay — the scrollback half of quitting and relaunching
+// the app. On teardown every preserved terminal is serialized
+// (PreservedSnapshotCapture / AnalysisSession); on launch every restored panel
+// feeds its payload back through the xterm parser.
+//
+// Both legs are per-terminal and multiply by fleet size, which is the point:
+// Daintree's normal state is a dozen-plus terminals, so a per-terminal cost that
+// looks trivial in isolation becomes a visible chunk of quit-and-relaunch. The
+// payload byte count is gated alongside the timings because it is what actually
+// lands on disk and gets read back, and it drives both legs.
+//
+// SCOPE LIMIT on PERF-196 — it measures the PARSER, not production restore.
+// `TerminalRestoreController` routes payloads over 256 KiB (these are ~600 KiB)
+// through reset, geometry alignment, 32 KiB chunking and UI yields, and
+// schedules fleet restores as independent tasks rather than the sequential loop
+// here. That controller lives in the renderer behind `@/clients`, so it cannot
+// be driven in-process. PERF-196 is therefore a lower bound on the parse work,
+// and a regression in chunking, yielding or scheduling is INVISIBLE to it.
+// Wall-clock restore belongs in a Playwright benchmark.
+//
+// PERF-033 already covers writing raw agent output into a terminal. This is a
+// different workload: a serialized snapshot is escape-dense reconstruction data,
+// not a log stream.
+
+/** A serialized 10k-line coloured buffer is ~600 KiB; well under this is empty or broken. */
+const MIN_LARGE_SNAPSHOT_BYTES = 250_000;
+
+export const scrollbackSnapshotScenarios: PerfScenario[] = [
+  {
+    id: "PERF-195",
+    name: "Session Snapshot Capture - Fleet Serialize",
+    description:
+      "Real SerializeAddon.serialize() across a 12-terminal fleet filled to the 10,000-line " +
+      "scrollback maximum with SGR-dense agent output — the teardown cost paid on every quit. " +
+      "durationMs is the whole fleet; p95TerminalMs is what one preserved terminal costs and " +
+      "snapshotKB is what it writes to disk. Every terminal's payload is checked individually so " +
+      "one healthy snapshot cannot mask eleven empty ones.",
+    tier: "heavy",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 5, ci: 9, nightly: 14 },
+    warmups: 1,
+    async run() {
+      const fleet = await getSnapshotFleet(SCROLLBACK_MAX, REPRESENTATIVE_FLEET);
+
+      const perTerminal: number[] = [];
+      const perTerminalBytes: number[] = [];
+
+      const start = performance.now();
+      for (const source of fleet.sources) {
+        const terminalStart = performance.now();
+        const payload = source.addon.serialize();
+        perTerminal.push(performance.now() - terminalStart);
+        // Byte length, not string length: the metric is named KB and the payload
+        // is written to disk as UTF-8, where SGR-heavy content is not 1:1.
+        perTerminalBytes.push(Buffer.byteLength(payload, "utf8"));
+      }
+      const durationMs = performance.now() - start;
+
+      perTerminalBytes.forEach((bytes, index) => {
+        if (bytes < MIN_LARGE_SNAPSHOT_BYTES) {
+          throw new Error(
+            `terminal ${index} serialized only ${bytes} bytes (expected >= ${MIN_LARGE_SNAPSHOT_BYTES}) — its buffer is empty or serialize is broken`
+          );
+        }
+      });
+
+      const totalBytes = perTerminalBytes.reduce((sum, bytes) => sum + bytes, 0);
+
+      return {
+        durationMs,
+        metrics: {
+          perTerminalMs: durationMs / fleet.sources.length,
+          p95TerminalMs: percentile(perTerminal, 95),
+          snapshotKB: totalBytes / 1024 / fleet.sources.length,
+          fleetSnapshotKB: totalBytes / 1024,
+          fleetSize: fleet.sources.length,
+        },
+      };
+    },
+  },
+  {
+    id: "PERF-196",
+    name: "Session Restore - Fleet Scrollback Reparse (parser floor)",
+    description:
+      "Feeds a 12-terminal fleet of serialized snapshots back through the real xterm parser and " +
+      "waits for each write to drain, at both the 1,000-line default and the 10,000-line maximum. " +
+      "This is the PARSER FLOOR, not wall-clock restore: production chunks payloads this size at " +
+      "32 KiB with UI yields via TerminalRestoreController, which cannot run in-process. Target " +
+      "terminals are built and disposed outside the bracket. Every target is verified to have been " +
+      "rebuilt to its full line count.",
+    tier: "heavy",
+    modes: ["ci", "nightly"],
+    iterations: { ci: 8, nightly: 12 },
+    warmups: 1,
+    async run() {
+      const largeFleet = await getSnapshotFleet(SCROLLBACK_MAX, REPRESENTATIVE_FLEET);
+      const smallFleet = await getSnapshotFleet(SCROLLBACK_DEFAULT, REPRESENTATIVE_FLEET);
+
+      // Snapshots and restore targets are both prepared outside the bracket:
+      // capture is PERF-195's subject, and the xterm instances already exist by
+      // the time production replays into them.
+      const largePayloads = largeFleet.sources.map((source) => source.addon.serialize());
+      const smallPayloads = smallFleet.sources.map((source) => source.addon.serialize());
+      const largeTargets = await createRestoreTargets(SCROLLBACK_MAX, largePayloads.length);
+      const smallTargets = await createRestoreTargets(SCROLLBACK_DEFAULT, smallPayloads.length);
+
+      try {
+        const start = performance.now();
+
+        const largeStart = performance.now();
+        for (let i = 0; i < largePayloads.length; i += 1) {
+          await replaySnapshot(largeTargets[i]!, largePayloads[i]!);
+        }
+        const largeMs = performance.now() - largeStart;
+
+        const smallStart = performance.now();
+        for (let i = 0; i < smallPayloads.length; i += 1) {
+          await replaySnapshot(smallTargets[i]!, smallPayloads[i]!);
+        }
+        const smallMs = performance.now() - smallStart;
+
+        const durationMs = performance.now() - start;
+
+        // Check EVERY target in both arms: a no-op write is the fastest possible
+        // result, so one verified terminal would happily hide 23 broken ones.
+        const verify = (targets: typeof largeTargets, expected: number, arm: string): number => {
+          let minLines = Infinity;
+          targets.forEach((terminal, index) => {
+            const lines = terminal.buffer.active.length;
+            minLines = Math.min(minLines, lines);
+            if (lines < expected) {
+              throw new Error(
+                `${arm} target ${index} holds ${lines} lines (expected >= ${expected}) — snapshot replay did not rebuild the buffer`
+              );
+            }
+          });
+          return minLines;
+        };
+        // Serialize emits the trimmed buffer, so a faithful replay lands on the
+        // full scrollback; allow a small margin for the trailing partial row.
+        const largeMinLines = verify(largeTargets, SCROLLBACK_MAX - 8, "large");
+        verify(smallTargets, SCROLLBACK_DEFAULT - 8, "small");
+
+        return {
+          durationMs,
+          metrics: {
+            largePerTerminalMs: largeMs / largePayloads.length,
+            smallPerTerminalMs: smallMs / smallPayloads.length,
+            msPerKLine: largeMs / largePayloads.length / (SCROLLBACK_MAX / 1000),
+            fleetReparseMs: largeMs,
+            restoredLines: largeMinLines,
+          },
+        };
+      } finally {
+        // Without this, warmups plus iterations leave hundreds of filled
+        // terminals for the GC to reclaim at an unpredictable moment — often
+        // inside a later timed bracket.
+        disposeTerminals(largeTargets);
+        disposeTerminals(smallTargets);
+      }
+    },
+  },
+];

--- a/scripts/perf/scenarios/terminalSearch.ts
+++ b/scripts/perf/scenarios/terminalSearch.ts
@@ -1,0 +1,301 @@
+import { performance } from "node:perf_hooks";
+import { SCROLLBACK_DEFAULT, SCROLLBACK_MAX } from "../../../shared/config/scrollback";
+import { buildSearchOptions } from "../../../src/components/Terminal/terminalSearchUtils";
+import { createSearchableTerminal, type SearchableTerminal } from "../lib/terminalSearchFixture";
+import { percentile } from "../lib/stats";
+import type { PerfScenario } from "../types";
+
+// Find-in-terminal (Cmd+F in a terminal panel). The search bar debounces input
+// by 150ms and then fires ONE search, so the number the user feels is the
+// latency of a single search over a full scrollback — not a per-keystroke cost.
+// Stepping with Enter is undebounced and fires straight into the addon.
+//
+// Cost scales with scrollback: `_highlightAllMatches` walks the buffer on every
+// search to collect matches up to the addon's 1,000-match highlight limit,
+// however close the next hit is.
+//
+// COLD vs WARM is the load-bearing distinction here. The addon memoizes the
+// buffer-cell-to-string translation for 15s and drops it on any line feed, so a
+// terminal still streaming agent output re-translates on essentially every
+// search while a quiet one translates once. Across this mixed-term sweep that
+// is worth roughly 1.3x (reported per run as coldToWarmRatio — trust the metric,
+// not this comment). Repeating the SAME term is far cheaper again, but that
+// measures the addon's per-term match cache rather than the translation, which
+// is why the sweep uses a different term every time. PERF-193 gates the cold
+// path because it is the one a live agent terminal actually pays.
+//
+// Sizes come from shared/config/scrollback.ts rather than being invented here,
+// so the benchmark tracks the real configurable range automatically.
+
+interface SearchCase {
+  label: string;
+  term: string;
+  caseSensitive: boolean;
+  regex: boolean;
+  wholeWord: boolean;
+  /** Asserted against the addon's return value — a search silently matching nothing is a broken benchmark, not a fast one. */
+  expectHit: boolean;
+}
+
+/** The query mix a developer actually runs against terminal output. */
+const SEARCH_CASES: SearchCase[] = [
+  {
+    label: "commonHit",
+    term: "error",
+    caseSensitive: false,
+    regex: false,
+    wholeWord: false,
+    expectHit: true,
+  },
+  {
+    label: "rareHit",
+    term: "TypeError",
+    caseSensitive: false,
+    regex: false,
+    wholeWord: false,
+    expectHit: true,
+  },
+  {
+    label: "pathHit",
+    term: "electron/services/PtyManager.ts",
+    caseSensitive: false,
+    regex: false,
+    wholeWord: false,
+    expectHit: true,
+  },
+  // Nothing matches, so the collection pass finds no candidates to highlight.
+  {
+    label: "miss",
+    term: "zzqq-not-present",
+    caseSensitive: false,
+    regex: false,
+    wholeWord: false,
+    expectHit: false,
+  },
+  // Alternation over corpus vocabulary, NOT over line numbers: cold mode feeds
+  // a line before each search, so the buffer rotates across iterations and any
+  // position-dependent term would eventually scroll out and flip to a miss.
+  {
+    label: "regex",
+    term: "(error|failed)",
+    caseSensitive: false,
+    regex: true,
+    wholeWord: false,
+    expectHit: true,
+  },
+  {
+    label: "caseSensitive",
+    term: "Error",
+    caseSensitive: true,
+    regex: false,
+    wholeWord: false,
+    expectHit: true,
+  },
+  {
+    label: "wholeWord",
+    term: "info",
+    caseSensitive: false,
+    regex: false,
+    wholeWord: true,
+    expectHit: true,
+  },
+];
+
+interface SweepResult {
+  totalMs: number;
+  p99SearchMs: number;
+  worstMs: number;
+  byLabel: Record<string, number>;
+  decorations: number;
+}
+
+/**
+ * Run every query case once, timing each search individually. Selection is
+ * cleared between cases so each starts its walk from the top of the buffer,
+ * which is what a freshly-typed term does.
+ *
+ * `cold` feeds a line before each search to drop the addon's translated-line
+ * cache, reproducing a terminal that is still receiving output. The feed itself
+ * is outside the timed bracket.
+ */
+async function runSearchSweep(fixture: SearchableTerminal, cold: boolean): Promise<SweepResult> {
+  const durations: number[] = [];
+  const byLabel: Record<string, number> = {};
+  fixture.resetDecorationCount();
+  const terminal = fixture.terminal as unknown as { clearSelection: () => void };
+
+  for (const testCase of SEARCH_CASES) {
+    if (cold) await fixture.invalidateLineCache();
+    terminal.clearSelection();
+    const options = buildSearchOptions(testCase.caseSensitive, testCase.regex, testCase.wholeWord);
+    const caseStart = performance.now();
+    const found = fixture.addon.findNext(testCase.term, options);
+    const elapsed = performance.now() - caseStart;
+
+    if (found !== testCase.expectHit) {
+      throw new Error(
+        `terminal search case '${testCase.label}' returned found=${found}, expected ${testCase.expectHit} — corpus or search path is broken`
+      );
+    }
+    durations.push(elapsed);
+    byLabel[testCase.label] = elapsed;
+  }
+
+  return {
+    totalMs: durations.reduce((sum, ms) => sum + ms, 0),
+    p99SearchMs: percentile(durations, 99),
+    worstMs: Math.max(...durations),
+    byLabel,
+    decorations: fixture.decorationCount(),
+  };
+}
+
+/**
+ * The addon registers one marker per highlighted match and releases it when the
+ * decoration is disposed. Markers outliving a sweep mean the fixture's disposal
+ * shim has drifted from the addon's contract, which silently inflates every
+ * later sample on this cached terminal.
+ */
+function assertMarkersReleased(fixture: SearchableTerminal, scenarioId: string): void {
+  const markers = fixture.markerCount();
+  // One sweep's worth of slack: the final search's decorations are still live.
+  if (markers > 2500) {
+    throw new Error(
+      `${scenarioId}: ${markers} markers still registered after the sweep — decoration disposal is leaking`
+    );
+  }
+}
+
+// Terminals are expensive to build and immutable once seeded, so both scenarios
+// share one per scrollback size for the life of the process. The seed is part
+// of the key so two callers asking for the same size with different corpora
+// cannot silently receive each other's terminal.
+const terminalCache = new Map<string, Promise<SearchableTerminal>>();
+
+function getTerminal(scrollbackLines: number, seed: number): Promise<SearchableTerminal> {
+  const key = `${scrollbackLines}:${seed}`;
+  let existing = terminalCache.get(key);
+  if (!existing) {
+    existing = createSearchableTerminal(scrollbackLines, seed);
+    terminalCache.set(key, existing);
+  }
+  return existing;
+}
+
+export const terminalSearchScenarios: PerfScenario[] = [
+  {
+    id: "PERF-193",
+    name: "Terminal Search - Cold Sweep at Max Scrollback",
+    description:
+      "Real @xterm/addon-search over a terminal filled to the 10,000-line scrollback maximum, " +
+      "running the query mix a developer types (common/rare/path literals, a no-match case, regex, " +
+      "case-sensitive, whole-word). Each search runs with the addon's translated-line cache dropped " +
+      "— the state a terminal still streaming agent output is always in — so durationMs and " +
+      "p99SearchMs are what a real post-debounce search costs. warmP99SearchMs reports the quiet " +
+      "terminal for contrast. Every case asserts its expected hit/miss.",
+    tier: "heavy",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 8, ci: 14, nightly: 20 },
+    warmups: 2,
+    async run() {
+      const fixture = await getTerminal(SCROLLBACK_MAX, 193);
+
+      const coldStart = performance.now();
+      const cold = await runSearchSweep(fixture, true);
+      const durationMs = performance.now() - coldStart;
+      const warm = await runSearchSweep(fixture, false);
+
+      // Every case hit its expected outcome above; this catches the highlight
+      // pass silently collapsing to zero decorations across the whole sweep.
+      if (cold.decorations === 0) {
+        throw new Error("terminal search produced no decorations — highlight path is broken");
+      }
+      assertMarkersReleased(fixture, "PERF-193");
+
+      return {
+        durationMs,
+        metrics: {
+          p99SearchMs: cold.p99SearchMs,
+          worstSearchMs: cold.worstMs,
+          warmP99SearchMs: warm.p99SearchMs,
+          coldToWarmRatio: warm.p99SearchMs > 0 ? cold.p99SearchMs / warm.p99SearchMs : 0,
+          missScanMs: cold.byLabel.miss ?? 0,
+          regexSearchMs: cold.byLabel.regex ?? 0,
+          decorations: cold.decorations,
+          bufferLines: fixture.bufferLines,
+        },
+      };
+    },
+  },
+  {
+    id: "PERF-194",
+    name: "Terminal Search - Scrollback Scaling + Match Stepping",
+    description:
+      "The cold sweep at the 1,000-line default and the 10,000-line maximum, plus 25 Enter-presses " +
+      "of findNext and findPrevious (undebounced, straight into the addon). The stepping term is " +
+      "primed outside the bracket so the metrics measure navigation only, not the first search's " +
+      "highlight pass. Budgets the per-1k-line search slope and the stepping cost, so a regression " +
+      "that only bites long-lived terminals — or one that defeats the addon's match cache and " +
+      "re-collects per step — trips the gate.",
+    tier: "heavy",
+    modes: ["ci", "nightly"],
+    iterations: { ci: 10, nightly: 16 },
+    warmups: 1,
+    async run() {
+      const small = await getTerminal(SCROLLBACK_DEFAULT, 194);
+      const large = await getTerminal(SCROLLBACK_MAX, 193);
+
+      const start = performance.now();
+      const smallSweep = await runSearchSweep(small, true);
+      const largeSweep = await runSearchSweep(large, true);
+
+      // Prime the stepping term OUTSIDE the timed loops: switching terms forces
+      // a full highlight pass, and folding that into the first "step" would
+      // report an enumeration as navigation cost.
+      const stepOptions = buildSearchOptions(false, false, false);
+      const STEP_TERM = "compiled";
+      const STEPS = 25;
+      if (!large.addon.findNext(STEP_TERM, stepOptions)) {
+        throw new Error(`stepping term '${STEP_TERM}' not present — corpus is broken`);
+      }
+
+      const forwardStart = performance.now();
+      let forwardHits = 0;
+      for (let i = 0; i < STEPS; i += 1) {
+        if (large.addon.findNext(STEP_TERM, stepOptions)) forwardHits += 1;
+      }
+      const forwardMs = performance.now() - forwardStart;
+
+      const backStart = performance.now();
+      let backHits = 0;
+      for (let i = 0; i < STEPS; i += 1) {
+        if (large.addon.findPrevious(STEP_TERM, stepOptions)) backHits += 1;
+      }
+      const backMs = performance.now() - backStart;
+      const durationMs = performance.now() - start;
+
+      // Every step must land. Accepting "at least one" would pass a navigation
+      // path stuck re-selecting the same match 25 times.
+      if (forwardHits !== STEPS || backHits !== STEPS) {
+        throw new Error(
+          `match stepping incomplete: ${forwardHits}/${STEPS} forward, ${backHits}/${STEPS} backward`
+        );
+      }
+      if (smallSweep.decorations === 0 || largeSweep.decorations === 0) {
+        throw new Error("a scrollback arm produced no decorations — highlight path is broken");
+      }
+      assertMarkersReleased(large, "PERF-194");
+
+      return {
+        durationMs,
+        metrics: {
+          smallP99SearchMs: smallSweep.p99SearchMs,
+          largeP99SearchMs: largeSweep.p99SearchMs,
+          msPerKLine: largeSweep.worstMs / (SCROLLBACK_MAX / 1000),
+          stepForwardMs: forwardMs / STEPS,
+          stepBackwardMs: backMs / STEPS,
+        },
+      };
+    },
+  },
+];

--- a/scripts/perf/types.ts
+++ b/scripts/perf/types.ts
@@ -55,6 +55,18 @@ export interface PerfRunSummary {
 export interface ScenarioBudget {
   p95Ms?: number;
   maxRegressionPct?: number;
+  /**
+   * Opt this scenario out of the baseline regression gate until a baseline
+   * generated on the CI runner exists for it.
+   *
+   * `defaultBudget` supplies `maxRegressionPct`, so a new scenario inherits a
+   * regression gate it has no baseline for — which fails the whole run in
+   * `checkBaselineCoverage`. Committing a locally-generated baseline is not the
+   * fix: baselines are runner-specific. Set this instead, then remove it once
+   * `perf-update-baselines` has published a baseline containing the scenario.
+   * Absolute `p95Ms` and `maxMetricValues` budgets still apply.
+   */
+  calibrating?: boolean;
   maxMetricValues?: Record<string, number>;
   comparison?: {
     maxPValue: number;

--- a/scripts/perf/verify-baselines.ts
+++ b/scripts/perf/verify-baselines.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { checkBaselineCoverage } from "./lib/baselineCoverage";
-import { loadBudgetConfig } from "./lib/budgets";
+import { getScenarioBudget, loadBudgetConfig } from "./lib/budgets";
 import { readJson } from "./lib/io";
 import { getScenariosForMode } from "./scenarios";
 import type { BaselineSummary, PerfMode } from "./types";
@@ -92,6 +92,19 @@ function verifyMode(
   const gaps = checkBaselineCoverage(baseline, budgetConfig, getScenariosForMode(mode));
   if (gaps.length > 0) {
     problems.push(`budgeted scenarios absent: ${gaps.map((gap) => gap.scenarioId).join(", ")}`);
+  }
+
+  // `calibrating` suppresses the regression gate until a runner-generated
+  // baseline exists. Once one does, the flag is doing nothing but hiding the
+  // gate, and nothing else would ever notice — this is the forcing function.
+  const staleCalibration = getScenariosForMode(mode)
+    .filter((scenario) => getScenarioBudget(budgetConfig, scenario.id).calibrating)
+    .map((scenario) => scenario.id)
+    .filter((id) => Number.isFinite(p95[id]));
+  if (staleCalibration.length > 0) {
+    problems.push(
+      `calibration complete but still flagged (remove \`calibrating\` from budgets.json to arm the regression gate): ${staleCalibration.join(", ")}`
+    );
   }
 
   return problems;


### PR DESCRIPTION
This adds seven benchmarks to the perf harness, covering interactions people hit many times a day. Each one drives real production code rather than a simulation.

- **PERF-190/191/192, file picker.** The `@`-mention completion and file palette, through the real `FileSearchService` against synthetic git repos of ~3,200 and ~12,000 files. PERF-192 is the one worth watching: it drops the cached path list and times `git ls-files` plus the directory-set build, which is the wait between pressing `@` and the picker showing anything.
- **PERF-193/194, terminal search.** Find-in-scrollback via the real `@xterm/addon-search` and our own `buildSearchOptions`. Sizes come from `shared/config/scrollback.ts` so it tracks the real configurable range.
- **PERF-195/196, session snapshot and reparse.** `SerializeAddon.serialize()` across a 12-terminal fleet at max scrollback, then feeding those payloads back through the parser.

Rough numbers on my Mac: cold picker open 132ms, fleet serialize 479ms for 7.2MB of snapshot, fleet reparse 271ms.

I also registered the `interactivity` and `scroll` Playwright benchmarks (PERF-120..122 and PERF-125..127). Those were fully written, about 2,000 lines, and reachable from nothing. Factoring the five duplicated Playwright runners into one helper made the dispatcher shorter while adding two commands.

## Gating

These are gated on absolute `p95Ms` and `maxMetricValues` only, with `calibrating: true` set. Every scenario inherits `maxRegressionPct` from `defaultBudget`, and `checkBaselineCoverage` fails the run when a scenario has a regression gate but no baseline entry. Baselines have to come from the CI runner, so the flag suppresses just the regression gate until then. Once `perf-update-baselines` publishes Linux baselines, remove the flag rather than adding a new gate. `verify-baselines` fails on any scenario still flagged after its baseline lands so it cannot rot.

## Things the assertions caught

Writing the guards turned up two cases where my own benchmark code was measuring the wrong thing, which is a good argument for the guards:

1. `git rev-parse --show-toplevel` resolves symlinks and `mkdtemp` does not, so `loadGitFiles` built a bogus pathspec, returned nothing, and fell through to the filesystem walker. PERF-192 was timing the walker while claiming to measure git.
2. The regex search case matched line numbers that get trimmed out of the buffer, so it was timing a no-match scan labelled as a regex hit.

Both now assert the path they claim to measure. PERF-192 checks that a git subprocess spawned and that the results contain a file only `git ls-files` can return.

There is also a real product bug behind the first one. Opening a project through a symlinked path silently degrades file search from `git ls-files` to the filesystem walker, which loses gitignore awareness and hides any real source under `dist/`, `build/`, `out/` or `target/`. Reproduced outside the benchmark. Not fixed here, happy to file it separately.

## Harness changes

Three changes were needed to land the above:

- `ScenarioBudget.calibrating`, described above.
- Metric ceilings now fail closed when the metric is not emitted. `averageMetrics` includes anything reported by at least one sample, so an absent entry means no sample emitted it, which is a gate that has silently disappeared. Verified against the full `ci` and `soak` matrices: no existing scenario trips it.
- `assertMatrixCoverage` enforces the matrix contract in both directions at runtime, not just in the unit test. The old `toHaveLength(63)` assertion in `scenarioMatrix.test.ts` was a copied inventory count, so it went.

## Testing

`npm run perf smoke`, `ci` and `soak` all pass with the seven new scenarios green. Perf harness unit tests 138 pass. `npm run typecheck` clean, prettier clean.

Worth knowing: `scripts/` sits outside the tsconfig includes and eslint config, so `npm run check` does not cover any of this. I typechecked the new files under a dedicated config separately.

Budgets are set at roughly 3x locally observed p95 on Apple Silicon and should be tightened once there are real ubuntu numbers.