### PR TITLE
perf: accelerate search, startup, and memory paths

### DIFF
--- a/e2e/full/panels/core-drag-drop.spec.ts
+++ b/e2e/full/panels/core-drag-drop.spec.ts
@@ -12,7 +12,7 @@ import {
   getPanelDragHandle,
   openTerminal,
 } from "../../helpers/panels";
-import { keyboardReorderElement, keyboardReorderDockChip } from "../../helpers/dragDrop";
+import { keyboardReorderElement, pointerReorderDockChip } from "../../helpers/dragDrop";
 import { SEL } from "../../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../../helpers/timeouts";
 
@@ -138,7 +138,7 @@ test.describe.serial("Core: Panel Drag & Drop", () => {
 
   // ── Dock Chip Reorder ────────────────────────────────────
 
-  test("reorder dock chips with keyboard drag", async () => {
+  test("reorder dock chips with pointer drag", async () => {
     const { window } = ctx;
 
     // Move two grid panels to the dock, leaving one in the grid. Emptying the
@@ -160,8 +160,8 @@ test.describe.serial("Core: Panel Drag & Drop", () => {
       await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(2);
     });
 
-    await test.step("Keyboard-drag the first chip and verify the dock order changes", async () => {
-      const dockIdsBefore = await getDockPanelIds(window);
+    await test.step("Pointer-drag the first chip and verify the dock order changes", async () => {
+      const dockIdsBefore = await getDockChipIds(window);
       expect(dockIdsBefore).toHaveLength(2);
 
       const chips = window.locator(`${SEL.dock.rail} ${SEL.dock.chip}`);
@@ -174,15 +174,8 @@ test.describe.serial("Core: Panel Drag & Drop", () => {
       // multi-panel group would collapse N panels into one chip.
       await expect.poll(() => getDockChipIds(window), { timeout: T_MEDIUM }).toEqual(dockIdsBefore);
 
-      let dockIdsAfter = dockIdsBefore;
-      // Try moving right, then fall back to left, mirroring the grid-reorder
-      // test's resilience to dnd-kit's headless collision geometry.
-      for (const direction of ["ArrowRight", "ArrowLeft"] as const) {
-        await keyboardReorderDockChip(window, chips.first(), direction);
-        await window.waitForTimeout(T_SETTLE);
-        dockIdsAfter = await getDockPanelIds(window);
-        if (dockIdsAfter[0] !== dockIdsBefore[0]) break;
-      }
+      await pointerReorderDockChip(window, chips.first(), chips.nth(1));
+      const dockIdsAfter = await getDockChipIds(window);
 
       expect(dockIdsAfter).toHaveLength(2);
       // Same panels, different order — the chip moved past its neighbour.

--- a/e2e/full/panels/core-drag-drop.spec.ts
+++ b/e2e/full/panels/core-drag-drop.spec.ts
@@ -175,12 +175,18 @@ test.describe.serial("Core: Panel Drag & Drop", () => {
       await expect.poll(() => getDockChipIds(window), { timeout: T_MEDIUM }).toEqual(dockIdsBefore);
 
       await pointerReorderDockChip(window, chips.first(), chips.nth(1));
-      const dockIdsAfter = await getDockChipIds(window);
 
+      // Poll for the moved chip rather than reading once: the helper's fixed
+      // settle can land mid-flight, and a single read of a rail still animating
+      // is the flake this test was rewritten to remove.
+      await expect
+        .poll(() => getDockChipIds(window).then((ids) => ids[0]), { timeout: T_MEDIUM })
+        .not.toBe(dockIdsBefore[0]);
+
+      const dockIdsAfter = await getDockChipIds(window);
       expect(dockIdsAfter).toHaveLength(2);
       // Same panels, different order — the chip moved past its neighbour.
       expect([...dockIdsAfter].sort()).toEqual([...dockIdsBefore].sort());
-      expect(dockIdsAfter[0]).not.toBe(dockIdsBefore[0]);
 
       // The rail must repaint, not just the store. Reordering writes only
       // `panelIds`, which the offscreen containers above mirror directly — they

--- a/e2e/helpers/dragDrop.ts
+++ b/e2e/helpers/dragDrop.ts
@@ -26,18 +26,23 @@ export async function keyboardReorderElement(
   await page.waitForTimeout(T_SETTLE);
 }
 
-/**
- * Reorder a dock-rail chip by a single step through the keyboard sensor.
- *
- * Dock chips are sortable through the global `DndProvider`, which — unlike
- * `DockedTabGroup`'s own `DndContext` (PointerSensor/TouchSensor only) —
- * registers a `KeyboardSensor`. A single arrow step avoids the autoscroll-driven
- * source unmount that long keyboard drags can hit (#8478).
- */
-export async function keyboardReorderDockChip(
+/** Reorder one dock chip onto another through the product's pointer drag path. */
+export async function pointerReorderDockChip(
   page: Page,
-  chip: Locator,
-  direction: "ArrowRight" | "ArrowLeft" = "ArrowRight"
+  source: Locator,
+  target: Locator
 ): Promise<void> {
-  await keyboardReorderElement(page, chip, [direction]);
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("Dock chips must be visible before dragging");
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await page.mouse.move(targetX, targetY, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(T_SETTLE);
 }

--- a/electron/ipc/handlers/configBundle.ts
+++ b/electron/ipc/handlers/configBundle.ts
@@ -6,7 +6,6 @@ import { CHANNELS } from "../channels.js";
 import { CONFIG_BUNDLE_METHOD_CHANNELS } from "./configBundle.preload.js";
 import type { HandlerDependencies } from "../types.js";
 import { broadcastToRenderer } from "../utils.js";
-import { ConfigBundleService } from "../../services/ConfigBundleService.js";
 import { buildConfigBundle, parseConfigBundle } from "../../utils/configBundleIO.js";
 import {
   CONFIG_BUNDLE_MAX_BYTES,
@@ -71,7 +70,12 @@ export function registerConfigBundleHandlers(deps: HandlerDependencies): () => v
     refreshTitleBarOverlayTheme();
   };
 
-  const service = new ConfigBundleService({ rebuildMenu, refreshTitleBar });
+  const loadService = async () => {
+    const { ConfigBundleService } = await import("../../services/ConfigBundleService.js");
+    return new ConfigBundleService({ rebuildMenu, refreshTitleBar });
+  };
+  let servicePromise: ReturnType<typeof loadService> | undefined;
+  const getService = () => (servicePromise ??= loadService());
 
   const namespace = defineIpcNamespace({
     name: "configBundle",
@@ -98,6 +102,7 @@ export function registerConfigBundleHandlers(deps: HandlerDependencies): () => v
           // configuration as of the moment it was written rather than the moment
           // the dialog opened — another window may have changed a setting while
           // the picker sat open.
+          const service = await getService();
           const sections = await service.collect();
           const {
             json,
@@ -164,6 +169,7 @@ export function registerConfigBundleHandlers(deps: HandlerDependencies): () => v
             };
           }
 
+          const service = await getService();
           return {
             outcome: "ready",
             fileName,
@@ -200,6 +206,7 @@ export function registerConfigBundleHandlers(deps: HandlerDependencies): () => v
           // Serialized across every window: two imports interleaving their
           // section writes could roll one back over the other's changes, since
           // each holds its own pre-import snapshot.
+          const service = await getService();
           const run = applyChain.then(
             () => service.apply(parsed.sections),
             () => service.apply(parsed.sections)

--- a/electron/ipc/handlers/pluginMcp.ts
+++ b/electron/ipc/handlers/pluginMcp.ts
@@ -10,11 +10,6 @@ import { PLUGIN_MCP_METHOD_CHANNELS } from "./pluginMcp.preload.js";
 import type * as PluginMcpSupervisorModule from "../../services/PluginMcpSupervisor.js";
 import type * as PluginServiceModule from "../../services/PluginService.js";
 import { store } from "../../store.js";
-import {
-  getPluginMcpAuditService,
-  getPluginMcpConsentService,
-  getPluginMcpRateLimiter,
-} from "../../services/plugin-mcp/instances.js";
 import { deriveDangerTier } from "../../services/plugin-mcp/PluginMcpTierAuth.js";
 import type {
   PluginMcpAuthorizeInput,
@@ -46,6 +41,7 @@ import {
 
 type PluginMcpSupervisor = ReturnType<typeof PluginMcpSupervisorModule.getPluginMcpSupervisor>;
 type PluginServiceSingleton = typeof PluginServiceModule.pluginService;
+type PluginMcpInstancesModule = typeof import("../../services/plugin-mcp/instances.js");
 
 // Lazy accessors (mirrors helpAssistant.ts): static imports here would pull
 // PluginMcpSupervisor and — transitively — the ~3,200-line PluginService onto
@@ -65,6 +61,11 @@ async function getPluginService(): Promise<PluginServiceSingleton> {
     cachedPluginService = mod.pluginService;
   }
   return cachedPluginService;
+}
+
+let cachedPluginMcpInstances: PluginMcpInstancesModule | null = null;
+async function getPluginMcpInstances(): Promise<PluginMcpInstancesModule> {
+  return (cachedPluginMcpInstances ??= await import("../../services/plugin-mcp/instances.js"));
 }
 
 async function handleList(): Promise<PluginMcpServerInfo[]> {
@@ -148,7 +149,7 @@ async function handleRestart(key: PluginMcpServerKey): Promise<void> {
   });
   // A respawned server is a clean slate — clear any accumulated throttle debt so
   // the first call after a manual restart isn't rejected by a stale empty bucket.
-  getPluginMcpRateLimiter().dropServer(key.pluginId, key.serverId);
+  (await getPluginMcpInstances()).getPluginMcpRateLimiter().dropServer(key.pluginId, key.serverId);
 }
 
 /**
@@ -267,16 +268,21 @@ const consentBridge: PluginMcpConsentBridge = (request) => {
 };
 
 /** Install the consent bridge once, lazily — keeps an unused boot path bridge-free. */
-function ensureConsentBridge(): void {
+function ensureConsentBridge(
+  service: ReturnType<PluginMcpInstancesModule["getPluginMcpConsentService"]>
+): void {
   if (consentBridgeInstalled) return;
   consentBridgeInstalled = true;
-  getPluginMcpConsentService().setConsentBridge(consentBridge);
+  service.setConsentBridge(consentBridge);
 }
 
 /** Test-only: drop installed-bridge state and reject any pending prompts. */
 export function _resetConsentBridgeForTest(): void {
   for (const requestId of [...pendingConsents.keys()]) {
     settleConsent(requestId, "rejected");
+  }
+  if (consentBridgeInstalled) {
+    cachedPluginMcpInstances?.getPluginMcpConsentService().setConsentBridge(null);
   }
   consentBridgeInstalled = false;
 }
@@ -352,7 +358,8 @@ export async function handleCallTool(
     };
   }
 
-  const audit = getPluginMcpAuditService();
+  const instances = await getPluginMcpInstances();
+  const audit = instances.getPluginMcpAuditService();
   const baseAudit = {
     pluginId: input.pluginId,
     serverId: input.serverId,
@@ -363,7 +370,7 @@ export async function handleCallTool(
   };
 
   // Rate limit BEFORE consent — a throttled call must not spend a user prompt.
-  const limit = getPluginMcpRateLimiter().check(input.pluginId, input.serverId);
+  const limit = instances.getPluginMcpRateLimiter().check(input.pluginId, input.serverId);
   if (!limit.allowed) {
     audit.append({
       ...baseAudit,
@@ -379,7 +386,8 @@ export async function handleCallTool(
     };
   }
 
-  ensureConsentBridge();
+  const consentService = instances.getPluginMcpConsentService();
+  ensureConsentBridge(consentService);
   const authorizeInput: PluginMcpAuthorizeInput = {
     identity: { pluginId: input.pluginId, serverId: input.serverId, toolName: input.toolName },
     pluginDisplayName,
@@ -390,7 +398,7 @@ export async function handleCallTool(
     rawArgs: input.args,
   };
   const outcome = await consentTargetStore.run(ctx.webContentsId, () =>
-    getPluginMcpConsentService().authorizeToolCall(authorizeInput)
+    consentService.authorizeToolCall(authorizeInput)
   );
 
   if (outcome.kind === "denied") {
@@ -496,7 +504,7 @@ export function registerPluginMcpHandlers(): () => void {
     // no stale prompt resolves against a torn-down renderer. Pending prompts are
     // rejected (fail closed) rather than left dangling.
     if (consentBridgeInstalled) {
-      getPluginMcpConsentService().setConsentBridge(null);
+      cachedPluginMcpInstances?.getPluginMcpConsentService().setConsentBridge(null);
       consentBridgeInstalled = false;
     }
     for (const requestId of [...pendingConsents.keys()]) {

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -8,7 +8,6 @@ import {
   projectViewManagersFrom,
 } from "../../../window/activeProjectIds.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
-import { projectRelocationCoordinator } from "../../../services/ProjectRelocationCoordinator.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import { notificationService } from "../../../services/NotificationService.js";
@@ -440,6 +439,8 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     // reattach delegates to the phase-1/2 path. It broadcasts PROJECT_UPDATED to
     // every cached view by immutable id, so the new path reaches windows other
     // than the one that ran the locate flow (#11282).
+    const { projectRelocationCoordinator } =
+      await import("../../../services/ProjectRelocationCoordinator.js");
     projectRelocationCoordinator.configure(deps);
     return projectRelocationCoordinator.relocate({ projectId, mode: "reattach", newPath });
   };

--- a/electron/ipc/handlers/projectRelocation.ts
+++ b/electron/ipc/handlers/projectRelocation.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import { projectRelocationCoordinator } from "../../services/ProjectRelocationCoordinator.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { PROJECT_RELOCATION_METHOD_CHANNELS } from "./projectRelocation.preload.js";
 import type { HandlerDependencies } from "../types.js";
@@ -14,6 +13,17 @@ import type {
 // quiesce/rebind an open project — mirroring the inline `configure(deps)` the
 // legacy `project:locate` handler does per call.
 let handlerDeps: HandlerDependencies | undefined;
+let coordinatorPromise:
+  | Promise<
+      typeof import("../../services/ProjectRelocationCoordinator.js").projectRelocationCoordinator
+    >
+  | undefined;
+
+async function getCoordinator() {
+  return (coordinatorPromise ??= import("../../services/ProjectRelocationCoordinator.js").then(
+    ({ projectRelocationCoordinator }) => projectRelocationCoordinator
+  ));
+}
 
 /**
  * Validate an untrusted renderer relocation request into the exact shape the
@@ -53,15 +63,17 @@ export const projectRelocationNamespace = defineIpcNamespace({
     preview: op(
       PROJECT_RELOCATION_METHOD_CHANNELS.preview,
       async (request: RelocationRequest): Promise<RelocationPreview> => {
-        if (handlerDeps) projectRelocationCoordinator.configure(handlerDeps);
-        return projectRelocationCoordinator.previewRelocate(validateRelocationRequest(request));
+        const coordinator = await getCoordinator();
+        if (handlerDeps) coordinator.configure(handlerDeps);
+        return coordinator.previewRelocate(validateRelocationRequest(request));
       }
     ),
     apply: op(
       PROJECT_RELOCATION_METHOD_CHANNELS.apply,
       async (request: RelocationRequest): Promise<Project> => {
-        if (handlerDeps) projectRelocationCoordinator.configure(handlerDeps);
-        return projectRelocationCoordinator.relocate(validateRelocationRequest(request));
+        const coordinator = await getCoordinator();
+        if (handlerDeps) coordinator.configure(handlerDeps);
+        return coordinator.relocate(validateRelocationRequest(request));
       }
     ),
   },

--- a/electron/ipc/handlers/whySlow.ts
+++ b/electron/ipc/handlers/whySlow.ts
@@ -4,7 +4,6 @@ import type { HandlerDependencies } from "../types.js";
 import type { WhySlowSnapshot } from "../../../shared/types/whySlow.js";
 import type { CompositeMemorySnapshot } from "../../../shared/types/memoryAccounting.js";
 import { WHY_SLOW_METHOD_CHANNELS } from "./whySlow.preload.js";
-import { collectWhySlowSnapshot } from "../../services/DiagnosticsCollector.js";
 import { getCompositeMemorySnapshot } from "../../services/memoryAccounting.js";
 import { recordRendererTerminalDiagnostics } from "../../services/RendererTerminalDiagnosticsCache.js";
 
@@ -33,7 +32,10 @@ export function registerWhySlowHandlers(deps: HandlerDependencies): () => void {
       // On-demand pull for the "why am I slow?" diagnostics dock.
       getWhySlowSnapshot: op(
         WHY_SLOW_METHOD_CHANNELS.getWhySlowSnapshot,
-        async (): Promise<WhySlowSnapshot> => collectWhySlowSnapshot(deps)
+        async (): Promise<WhySlowSnapshot> => {
+          const { collectWhySlowSnapshot } = await import("../../services/DiagnosticsCollector.js");
+          return collectWhySlowSnapshot(deps);
+        }
       ),
       // Composite memory snapshot (Electron working-set + terminal descendant
       // RSS by project) for the resource badge popover. Reads go through

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -22,7 +22,6 @@ import { getPanelSuspectLedger } from "../services/PanelSuspectLedgerService.js"
 import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceService.js";
 import { getPeriodicCleanupService } from "../services/PeriodicCleanupService.js";
 import { getHibernationService } from "../services/HibernationService.js";
-import { getIdleBackgroundAutoCloseService } from "../services/IdleBackgroundAutoCloseService.js";
 import { getIdleTerminalNotificationService } from "../services/IdleTerminalNotificationService.js";
 import { getSystemSleepService } from "../services/SystemSleepService.js";
 import { getOsDndService } from "../services/OsDndService.js";
@@ -472,6 +471,13 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
         import("../services/PluginCliServer.js")
           .then(({ stopPluginCliServer }) => stopPluginCliServer())
           .catch(() => {}),
+        import("../services/IdleBackgroundAutoCloseService.js")
+          .then(({ getIdleBackgroundAutoCloseService }) =>
+            getIdleBackgroundAutoCloseService().stop()
+          )
+          .catch((err) => {
+            console.warn("[MAIN] IdleBackgroundAutoCloseService.stop failed:", err);
+          }),
         new Promise<void>((resolve) => {
           // Global singletons that previously tore down on last-window-close
           // (electron/window/windowServices.ts) live here now so they cover
@@ -498,11 +504,6 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
             getIdleTerminalNotificationService().stop();
           } catch (err) {
             console.warn("[MAIN] IdleTerminalNotificationService.stop failed:", err);
-          }
-          try {
-            getIdleBackgroundAutoCloseService().stop();
-          } catch (err) {
-            console.warn("[MAIN] IdleBackgroundAutoCloseService.stop failed:", err);
           }
           try {
             getSystemSleepService().dispose();

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -11,7 +11,6 @@ import { isAssistantOnlyAgentId } from "../shared/config/agentIds.js";
 import type { CliAvailabilityService } from "./services/CliAvailabilityService.js";
 import { isAgentInstalled } from "../shared/utils/agentAvailability.js";
 import * as CliInstallService from "./services/CliInstallService.js";
-import * as FinderQuickActionService from "./services/FinderQuickActionService.js";
 import { getWindowRegistry } from "./window/windowRef.js";
 import { toggleWindowFullscreen } from "./window/fullscreen.js";
 import {
@@ -549,6 +548,8 @@ export function createApplicationMenu(
           click: async (_item, browserWindow) => {
             const targetWin = getTargetBrowserWindow(browserWindow);
             try {
+              const FinderQuickActionService =
+                await import("./services/FinderQuickActionService.js");
               const installPath = await FinderQuickActionService.install();
               if (targetWin && !targetWin.isDestroyed()) {
                 const wc = getAppWebContents(targetWin);
@@ -583,6 +584,8 @@ export function createApplicationMenu(
           click: async (_item, browserWindow) => {
             const targetWin = getTargetBrowserWindow(browserWindow);
             try {
+              const FinderQuickActionService =
+                await import("./services/FinderQuickActionService.js");
               const { removed, path: quickActionPath } = await FinderQuickActionService.remove();
               if (targetWin && !targetWin.isDestroyed()) {
                 const wc = getAppWebContents(targetWin);

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -641,7 +641,13 @@ class CopyTreeService {
       ...(includePaths ?? []),
       ...(filter === undefined ? [] : Array.isArray(filter) ? filter : [filter]),
     ];
-    return Array.from(new Set(merged));
+    return Array.from(
+      new Set(
+        merged.flatMap((pattern) =>
+          pattern.endsWith("/**") ? [pattern, `${pattern}/.*`, `${pattern}/.*/**`] : [pattern]
+        )
+      )
+    );
   }
 
   /**
@@ -750,6 +756,8 @@ class CopyTreeService {
   }
 
   private buildSdkOptions(options: CopyTreeOptions, signal: AbortSignal): SdkCopyOptions {
+    const filter = CopyTreeService.mergeSelectionPatterns(options.includePaths, options.filter);
+
     return {
       signal,
       display: false,
@@ -757,7 +765,11 @@ class CopyTreeService {
       quiet: true,
       format: options.format || "xml",
 
-      filter: CopyTreeService.mergeSelectionPatterns(options.includePaths, options.filter),
+      filter,
+      // A caller's explicit selection is authoritative, including dotfiles
+      // matched by its globs. The filter still bounds the result, while an
+      // unfiltered whole-project copy retains the SDK's hidden-file default.
+      includeHidden: filter !== undefined,
       // Literal paths, not patterns, and orthogonal to `filter`: the walk starts
       // here but the ignore stack is still built from the root down, so a folder
       // copy drops what a whole-project copy would have dropped.

--- a/electron/services/FileSearchService.ts
+++ b/electron/services/FileSearchService.ts
@@ -8,8 +8,8 @@ import type { Dirent } from "fs";
 interface FileListCacheEntry {
   files: string[];
   normalizedFiles: string[];
-  basenameStarts: number[];
-  sortedFiles: string[];
+  basenameStarts: Int32Array;
+  sortedFiles?: string[];
   lastSearchQuery?: string;
   lastSearchCandidates?: number[];
 }
@@ -61,6 +61,12 @@ const FALLBACK_SKIP_NAMES = new Set<string>([
 // repo logs once at startup, not once per file-watcher invalidation.
 const FALLBACK_CAP_WARNED = new Set<string>();
 
+let pathCollator: Intl.Collator | null = null;
+function getPathCollator(): Intl.Collator {
+  pathCollator ??= new Intl.Collator();
+  return pathCollator;
+}
+
 function toPosixPath(p: string): string {
   return p.split(path.sep).join("/");
 }
@@ -85,19 +91,50 @@ function scorePath(
 ): number | null {
   if (normalizedQuery.length === 0) return 0;
 
-  const basename = normalizedFile.slice(basenameStart);
-
-  if (basename === normalizedQuery) return 0;
-  if (normalizedFile === normalizedQuery) return 1;
-
-  const basenameIdx = basename.indexOf(normalizedQuery);
   const fileIdx = normalizedFile.indexOf(normalizedQuery);
+  if (fileIdx === -1) return null;
+
+  let basenameIdx: number;
+  if (fileIdx >= basenameStart) {
+    basenameIdx = fileIdx - basenameStart;
+  } else {
+    const inBasename = normalizedFile.indexOf(normalizedQuery, basenameStart);
+    basenameIdx = inBasename === -1 ? -1 : inBasename - basenameStart;
+  }
+
+  const queryLength = normalizedQuery.length;
+  if (basenameIdx === 0 && basenameStart + queryLength === normalizedFile.length) return 0;
+  if (fileIdx === 0 && queryLength === normalizedFile.length) return 1;
 
   if (basenameIdx === 0) return 10;
   if (fileIdx === 0) return 20;
   if (basenameIdx > 0) return 30 + basenameIdx;
-  if (fileIdx > 0) return 50 + fileIdx;
-  return null;
+  return 50 + fileIdx;
+}
+
+function buildScoringInputs(files: string[]): {
+  normalizedFiles: string[];
+  basenameStarts: Int32Array;
+} {
+  const normalizedFiles = new Array<string>(files.length);
+  const basenameStarts = new Int32Array(files.length);
+  for (let i = 0; i < files.length; i++) {
+    const lower = files[i].toLowerCase();
+    const normalized = lower.endsWith("/") ? lower.slice(0, -1) : lower;
+    normalizedFiles[i] = normalized;
+    basenameStarts[i] = normalized.lastIndexOf("/") + 1;
+  }
+  return { normalizedFiles, basenameStarts };
+}
+
+function sortedFilesFor(entry: FileListCacheEntry): string[] {
+  if (!entry.sortedFiles) {
+    const collator = getPathCollator();
+    entry.sortedFiles = [...entry.files].sort(
+      (a, b) => a.length - b.length || collator.compare(a, b)
+    );
+  }
+  return entry.sortedFiles;
 }
 
 function pickTopMatches(entry: FileListCacheEntry, query: string, limit: number): string[] {
@@ -106,7 +143,7 @@ function pickTopMatches(entry: FileListCacheEntry, query: string, limit: number)
   const effectiveLimit = clampInt(limit, 1, 100, MAX_RESULTS_DEFAULT);
 
   if (normalizedQuery.length === 0) {
-    return entry.sortedFiles.slice(0, effectiveLimit);
+    return sortedFilesFor(entry).slice(0, effectiveLimit);
   }
 
   const best: Array<{ file: string; score: number }> = [];
@@ -156,7 +193,8 @@ function pickTopMatches(entry: FileListCacheEntry, query: string, limit: number)
 
   entry.lastSearchQuery = normalizedQuery;
   entry.lastSearchCandidates = matchingCandidates;
-  best.sort((a, b) => a.score - b.score || a.file.localeCompare(b.file));
+  const collator = getPathCollator();
+  best.sort((a, b) => a.score - b.score || collator.compare(a.file, b.file));
   return best.map((m) => m.file);
 }
 
@@ -204,40 +242,34 @@ async function loadFilesFromDisk(cwd: string): Promise<string[]> {
     });
   }
 
-  return results.sort((a, b) => a.localeCompare(b));
+  const collator = getPathCollator();
+  return results.sort((a, b) => collator.compare(a, b));
 }
 
 async function loadGitFiles(cwd: string): Promise<string[]> {
   const git = await createHardenedGit(cwd);
-  const gitRootRaw = (await git.revparse(["--show-toplevel"])).trim();
-  const gitRoot = path.resolve(gitRootRaw);
-  const relativeToRoot = toPosixPath(path.relative(gitRoot, cwd));
-  const pathspec = relativeToRoot && relativeToRoot !== "." ? relativeToRoot : null;
 
   // -z: NUL-delimited output. Required to round-trip filenames containing tabs,
   // newlines, or backslashes; core.quotepath=false alone only suppresses high-bit
   // quoting.
   // No --recurse-submodules: submodules surface as a single gitlink and recursing
   // would require a separate ls-files invocation per submodule and break the
-  // root-relative path mapping below.
+  // cwd-relative path mapping below.
   // No -t / skip-worktree filtering: skip-worktree entries appear as phantoms in
   // the index but are intentionally surfaced so users can still search files they
   // chose not to check out.
-  const args = ["ls-files", "-z", "--cached", "--others", "--exclude-standard"] as string[];
-  if (pathspec) {
-    args.push("--", pathspec);
+  // Running from cwd scopes ls-files to that subtree and emits cwd-relative
+  // paths. A non-repository cwd exits non-zero and falls back to the walker.
+  const output = await git.raw(["ls-files", "-z", "--cached", "--others", "--exclude-standard"]);
+
+  const files: string[] = [];
+  let start = 0;
+  while (start < output.length) {
+    let end = output.indexOf("\0", start);
+    if (end === -1) end = output.length;
+    if (end > start) files.push(output.slice(start, end));
+    start = end + 1;
   }
-
-  const output = await (gitRoot === path.resolve(cwd) ? git : await createHardenedGit(gitRoot)).raw(
-    args
-  );
-  const prefix = pathspec ? `${pathspec.replace(/\/$/, "")}/` : "";
-
-  const files = output
-    .split("\0")
-    .filter((p) => p.length > 0)
-    .map((p) => (prefix && p.startsWith(prefix) ? p.slice(prefix.length) : p))
-    .filter((p) => p.length > 0);
 
   const dirs = new Set<string>();
   for (const file of files) {
@@ -251,8 +283,8 @@ async function loadGitFiles(cwd: string): Promise<string[]> {
     }
   }
 
-  const dirPaths = Array.from(dirs).map((d) => `${d}/`);
-  return [...files, ...dirPaths];
+  for (const dir of dirs) files.push(`${dir}/`);
+  return files;
 }
 
 const NL_STOP_WORDS = new Set([
@@ -406,20 +438,11 @@ export class FileSearchService {
     const epoch = FILE_LIST_EPOCHS.get(resolvedCwd) ?? 0;
     const loadPromise: Promise<FileListCacheEntry> = this.loadFileList(resolvedCwd)
       .then((loaded) => {
-        const sortedFiles = [...loaded].sort((a, b) => a.length - b.length || a.localeCompare(b));
-        const normalizedFiles = new Array<string>(loaded.length);
-        const basenameStarts = new Array<number>(loaded.length);
-        for (let i = 0; i < loaded.length; i++) {
-          const lower = loaded[i].toLowerCase();
-          const normalized = lower.endsWith("/") ? lower.slice(0, -1) : lower;
-          normalizedFiles[i] = normalized;
-          basenameStarts[i] = normalized.lastIndexOf("/") + 1;
-        }
+        const { normalizedFiles, basenameStarts } = buildScoringInputs(loaded);
         const entry: FileListCacheEntry = {
           files: loaded,
           normalizedFiles,
           basenameStarts,
-          sortedFiles,
         };
         if ((FILE_LIST_EPOCHS.get(resolvedCwd) ?? 0) === epoch) {
           FILE_LIST_CACHE.set(resolvedCwd, entry);

--- a/electron/services/FileSearchService.ts
+++ b/electron/services/FileSearchService.ts
@@ -7,7 +7,11 @@ import type { Dirent } from "fs";
 
 interface FileListCacheEntry {
   files: string[];
+  normalizedFiles: string[];
+  basenameStarts: number[];
   sortedFiles: string[];
+  lastSearchQuery?: string;
+  lastSearchCandidates?: number[];
 }
 
 const FILE_LIST_CACHE = new Cache<string, FileListCacheEntry>({
@@ -74,12 +78,14 @@ function normalizeQuery(rawQuery: string): string {
   return normalized.replace(/\/+/g, "/");
 }
 
-function scorePath(normalizedQuery: string, file: string): number | null {
+function scorePath(
+  normalizedQuery: string,
+  normalizedFile: string,
+  basenameStart: number
+): number | null {
   if (normalizedQuery.length === 0) return 0;
 
-  const fileLower = file.toLowerCase();
-  const normalizedFile = fileLower.endsWith("/") ? fileLower.slice(0, -1) : fileLower;
-  const basename = normalizedFile.slice(normalizedFile.lastIndexOf("/") + 1);
+  const basename = normalizedFile.slice(basenameStart);
 
   if (basename === normalizedQuery) return 0;
   if (normalizedFile === normalizedQuery) return 1;
@@ -104,12 +110,27 @@ function pickTopMatches(entry: FileListCacheEntry, query: string, limit: number)
   }
 
   const best: Array<{ file: string; score: number }> = [];
+  const matchingCandidates: number[] = [];
+  const previousCandidates = entry.lastSearchCandidates;
+  const canNarrowPrevious =
+    previousCandidates !== undefined &&
+    entry.lastSearchQuery !== undefined &&
+    normalizedQuery.startsWith(entry.lastSearchQuery);
+  const candidates = canNarrowPrevious ? previousCandidates : undefined;
   let worstIdx = -1;
   let worstScore = -Infinity;
 
-  for (const file of entry.files) {
-    const score = scorePath(normalizedQuery, file);
+  const candidateCount = candidates?.length ?? entry.files.length;
+  for (let candidateIdx = 0; candidateIdx < candidateCount; candidateIdx++) {
+    const fileIdx = candidates?.[candidateIdx] ?? candidateIdx;
+    const file = entry.files[fileIdx];
+    const score = scorePath(
+      normalizedQuery,
+      entry.normalizedFiles[fileIdx],
+      entry.basenameStarts[fileIdx]
+    );
     if (score === null) continue;
+    matchingCandidates.push(fileIdx);
 
     if (best.length < effectiveLimit) {
       best.push({ file, score });
@@ -133,6 +154,8 @@ function pickTopMatches(entry: FileListCacheEntry, query: string, limit: number)
     }
   }
 
+  entry.lastSearchQuery = normalizedQuery;
+  entry.lastSearchCandidates = matchingCandidates;
   best.sort((a, b) => a.score - b.score || a.file.localeCompare(b.file));
   return best.map((m) => m.file);
 }
@@ -186,11 +209,6 @@ async function loadFilesFromDisk(cwd: string): Promise<string[]> {
 
 async function loadGitFiles(cwd: string): Promise<string[]> {
   const git = await createHardenedGit(cwd);
-  const isRepo = await git.checkIsRepo();
-  if (!isRepo) {
-    return [];
-  }
-
   const gitRootRaw = (await git.revparse(["--show-toplevel"])).trim();
   const gitRoot = path.resolve(gitRootRaw);
   const relativeToRoot = toPosixPath(path.relative(gitRoot, cwd));
@@ -210,7 +228,9 @@ async function loadGitFiles(cwd: string): Promise<string[]> {
     args.push("--", pathspec);
   }
 
-  const output = await (await createHardenedGit(gitRoot)).raw(args);
+  const output = await (gitRoot === path.resolve(cwd) ? git : await createHardenedGit(gitRoot)).raw(
+    args
+  );
   const prefix = pathspec ? `${pathspec.replace(/\/$/, "")}/` : "";
 
   const files = output
@@ -387,7 +407,20 @@ export class FileSearchService {
     const loadPromise: Promise<FileListCacheEntry> = this.loadFileList(resolvedCwd)
       .then((loaded) => {
         const sortedFiles = [...loaded].sort((a, b) => a.length - b.length || a.localeCompare(b));
-        const entry: FileListCacheEntry = { files: loaded, sortedFiles };
+        const normalizedFiles = new Array<string>(loaded.length);
+        const basenameStarts = new Array<number>(loaded.length);
+        for (let i = 0; i < loaded.length; i++) {
+          const lower = loaded[i].toLowerCase();
+          const normalized = lower.endsWith("/") ? lower.slice(0, -1) : lower;
+          normalizedFiles[i] = normalized;
+          basenameStarts[i] = normalized.lastIndexOf("/") + 1;
+        }
+        const entry: FileListCacheEntry = {
+          files: loaded,
+          normalizedFiles,
+          basenameStarts,
+          sortedFiles,
+        };
         if ((FILE_LIST_EPOCHS.get(resolvedCwd) ?? 0) === epoch) {
           FILE_LIST_CACHE.set(resolvedCwd, entry);
         }

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -9,7 +9,7 @@ import { setAlignedInterval } from "../utils/setAlignedInterval.js";
 import { refreshAppMetricsSnapshot } from "../utils/appMetricsSnapshot.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
-import { getIsE2EFaultMode } from "../setup/runtimeFlags.js";
+import { getIsE2EFaultMode, getIsE2EMode } from "../setup/runtimeFlags.js";
 import { getSystemMemoryThresholds, readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 import type { TrimStateSummary } from "../../shared/types/pty-host.js";
 
@@ -499,7 +499,12 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
           state.bucketMin = Infinity;
         }
 
-        if (proc.type === "Browser" && mb > SNAPSHOT_THRESHOLD_MB && !app.isPackaged) {
+        if (
+          proc.type === "Browser" &&
+          mb > SNAPSHOT_THRESHOLD_MB &&
+          !app.isPackaged &&
+          !getIsE2EMode()
+        ) {
           const now = Date.now();
           const last = snapshotCooldowns.get(proc.pid) ?? 0;
           if (now - last > SNAPSHOT_COOLDOWN_MS) {

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -474,10 +474,24 @@ describe("CopyTreeService", () => {
       // silently resurrecting files the caller (or the project's settings)
       // explicitly excluded. The selection has to stay in `filter` alone.
       expect(options.always).toBeUndefined();
-      expect(options.filter).toEqual(
-        expect.arrayContaining(["docs/**", "docs/**/.*", "docs/**/.*/**"])
-      );
+      expect(options.filter).toEqual(["docs/**", "docs/**/.*", "docs/**/.*/**"]);
       expect(options.exclude).toEqual(["**/*.secret"]);
+    });
+
+    it("lets a selection reach the dotfiles its own globs name", async () => {
+      await copyTreeService.generate(tempDir, { includePaths: ["docs/**"] });
+
+      const options = sdkOptions();
+      expect(options.includeHidden).toBe(true);
+      // Widening what the walk sees must not loosen the ignore stack with it —
+      // a gitignored `.env` stays out either way.
+      expect(options.respectGitignore).toBe(true);
+    });
+
+    it("keeps the SDK's hidden-file default for an unfiltered whole-project copy", async () => {
+      await copyTreeService.generate(tempDir);
+
+      expect(sdkOptions().includeHidden).toBeFalsy();
     });
 
     it.each([

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -474,7 +474,9 @@ describe("CopyTreeService", () => {
       // silently resurrecting files the caller (or the project's settings)
       // explicitly excluded. The selection has to stay in `filter` alone.
       expect(options.always).toBeUndefined();
-      expect(options.filter).toEqual(["docs/**"]);
+      expect(options.filter).toEqual(
+        expect.arrayContaining(["docs/**", "docs/**/.*", "docs/**/.*/**"])
+      );
       expect(options.exclude).toEqual(["**/*.secret"]);
     });
 

--- a/electron/services/__tests__/FileSearchService.adversarial.test.ts
+++ b/electron/services/__tests__/FileSearchService.adversarial.test.ts
@@ -64,9 +64,8 @@ describe("FileSearchService adversarial", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-search-adv-"));
     tempDirs.push(dir);
     const gitClient = createGitClient();
-    const checkDeferred = createDeferred<boolean>();
-    gitClient.checkIsRepo.mockReturnValue(checkDeferred.promise);
-    gitClient.revparse.mockResolvedValue(`${dir}\n`);
+    const rootDeferred = createDeferred<string>();
+    gitClient.revparse.mockReturnValue(rootDeferred.promise);
     gitClient.raw.mockResolvedValue("README.md\0src/main.ts\0");
     createHardenedGitMock.mockReturnValue(gitClient);
 
@@ -74,10 +73,10 @@ describe("FileSearchService adversarial", () => {
     const first = service.search({ cwd: dir, query: "read", limit: 5 });
     const second = service.search({ cwd: dir, query: "main", limit: 5 });
 
-    checkDeferred.resolve(true);
+    rootDeferred.resolve(`${dir}\n`);
 
     await expect(Promise.all([first, second])).resolves.toEqual([["README.md"], ["src/main.ts"]]);
-    expect(gitClient.checkIsRepo).toHaveBeenCalledTimes(1);
+    expect(gitClient.revparse).toHaveBeenCalledTimes(1);
     expect(gitClient.raw).toHaveBeenCalledTimes(1);
   });
 

--- a/electron/services/__tests__/FileSearchService.adversarial.test.ts
+++ b/electron/services/__tests__/FileSearchService.adversarial.test.ts
@@ -64,19 +64,17 @@ describe("FileSearchService adversarial", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-search-adv-"));
     tempDirs.push(dir);
     const gitClient = createGitClient();
-    const rootDeferred = createDeferred<string>();
-    gitClient.revparse.mockReturnValue(rootDeferred.promise);
-    gitClient.raw.mockResolvedValue("README.md\0src/main.ts\0");
+    const listDeferred = createDeferred<string>();
+    gitClient.raw.mockReturnValue(listDeferred.promise);
     createHardenedGitMock.mockReturnValue(gitClient);
 
     const service = await createService();
     const first = service.search({ cwd: dir, query: "read", limit: 5 });
     const second = service.search({ cwd: dir, query: "main", limit: 5 });
 
-    rootDeferred.resolve(`${dir}\n`);
+    listDeferred.resolve("README.md\0src/main.ts\0");
 
     await expect(Promise.all([first, second])).resolves.toEqual([["README.md"], ["src/main.ts"]]);
-    expect(gitClient.revparse).toHaveBeenCalledTimes(1);
     expect(gitClient.raw).toHaveBeenCalledTimes(1);
   });
 
@@ -135,37 +133,30 @@ describe("FileSearchService adversarial", () => {
     expect(result).not.toContain("secret/hidden.txt");
   });
 
-  it("keeps git pathspecs rooted to the cwd inside a larger repository", async () => {
+  it("lists from the cwd itself inside a larger repository", async () => {
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "file-search-adv-"));
     tempDirs.push(repoRoot);
     const cwd = path.join(repoRoot, "packages", "app");
     fs.mkdirSync(cwd, { recursive: true });
 
-    const repoClient = createGitClient();
-    repoClient.raw.mockResolvedValue("packages/app/src/main.ts\0packages/app/src/utils.ts\0");
     const cwdClient = createGitClient();
-    cwdClient.checkIsRepo.mockResolvedValue(true);
-    cwdClient.revparse.mockResolvedValue(`${repoRoot}\n`);
+    cwdClient.raw.mockResolvedValue("src/main.ts\0src/utils.ts\0");
 
     createHardenedGitMock.mockImplementation((baseDir) => {
-      if (baseDir === repoRoot) {
-        return repoClient;
-      }
-      return cwdClient;
+      if (baseDir === cwd) return cwdClient;
+      throw new Error(`unexpected git client for ${baseDir}`);
     });
 
     const service = await createService();
     const result = await service.search({ cwd, query: "./src////main.ts", limit: 10 });
 
     expect(result).toEqual(["src/main.ts"]);
-    expect(repoClient.raw).toHaveBeenCalledWith([
+    expect(cwdClient.raw).toHaveBeenCalledWith([
       "ls-files",
       "-z",
       "--cached",
       "--others",
       "--exclude-standard",
-      "--",
-      "packages/app",
     ]);
   });
 

--- a/electron/services/__tests__/FileSearchService.test.ts
+++ b/electron/services/__tests__/FileSearchService.test.ts
@@ -85,7 +85,7 @@ describe("FileSearchService", () => {
     const result = await service.search({ cwd: dir, query: "app", limit: 10 });
 
     expect(result).toContain("src/app.ts");
-    expect(gitClientMock.revparse).toHaveBeenCalledTimes(1);
+    expect(gitClientMock.raw).toHaveBeenCalledTimes(1);
   });
 
   it("uses git file listing when repository is available", async () => {
@@ -128,7 +128,6 @@ describe("FileSearchService", () => {
 
     expect(first).toContain("src/main.ts");
     expect(second).toContain("README.md");
-    expect(gitClientMock.revparse).toHaveBeenCalledTimes(1);
     expect(gitClientMock.raw).toHaveBeenCalledTimes(1);
   });
 

--- a/electron/services/__tests__/FileSearchService.test.ts
+++ b/electron/services/__tests__/FileSearchService.test.ts
@@ -39,7 +39,7 @@ describe("FileSearchService", () => {
     simpleGitMock.mockImplementation(() => gitClientMock);
     gitClientMock.env.mockReturnValue(gitClientMock);
     gitClientMock.checkIsRepo.mockResolvedValue(false);
-    gitClientMock.revparse.mockResolvedValue("");
+    gitClientMock.revparse.mockRejectedValue(new Error("not a git repository"));
     gitClientMock.raw.mockResolvedValue("");
   });
 
@@ -85,7 +85,7 @@ describe("FileSearchService", () => {
     const result = await service.search({ cwd: dir, query: "app", limit: 10 });
 
     expect(result).toContain("src/app.ts");
-    expect(gitClientMock.checkIsRepo).toHaveBeenCalledTimes(1);
+    expect(gitClientMock.revparse).toHaveBeenCalledTimes(1);
   });
 
   it("uses git file listing when repository is available", async () => {
@@ -128,7 +128,7 @@ describe("FileSearchService", () => {
 
     expect(first).toContain("src/main.ts");
     expect(second).toContain("README.md");
-    expect(gitClientMock.checkIsRepo).toHaveBeenCalledTimes(1);
+    expect(gitClientMock.revparse).toHaveBeenCalledTimes(1);
     expect(gitClientMock.raw).toHaveBeenCalledTimes(1);
   });
 

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -232,6 +232,22 @@ describe("ProcessMemoryMonitor", () => {
     expect(v8.writeHeapSnapshot).not.toHaveBeenCalled();
   });
 
+  it("does NOT write heap snapshot during E2E performance capture", () => {
+    const previous = process.env.DAINTREE_E2E_MODE;
+    process.env.DAINTREE_E2E_MODE = "1";
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700 * 1024, 100)]);
+    Object.defineProperty(app, "isPackaged", { value: false, writable: true });
+
+    try {
+      stop = startAppMetricsMonitor();
+      vi.advanceTimersByTime(30_000);
+      expect(v8.writeHeapSnapshot).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete process.env.DAINTREE_E2E_MODE;
+      else process.env.DAINTREE_E2E_MODE = previous;
+    }
+  });
+
   it("respects snapshot cooldown — no double-write within 5 minutes", () => {
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700 * 1024, 100)]);
     Object.defineProperty(app, "isPackaged", { value: false, writable: true });

--- a/plugins/builtin/github/renderer/components/GitHubStatsDropdown.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubStatsDropdown.tsx
@@ -5,8 +5,7 @@ import { useGitHubFilterStore } from "../stores/githubFilterStore";
 
 // The list bodies stay in their own chunks — this wrapper is registered (and
 // therefore bundled) at app start, but the heavy Virtuoso-backed lists load
-// lazily. The idle-time preload below mirrors the old toolbar's eager import
-// so a first click after launch usually hits a warm chunk.
+// only when the dropdown opens.
 const importResourceList = () => import("./GitHubResourceList");
 const importCommitList = () => import("./CommitList");
 
@@ -18,34 +17,15 @@ const LazyCommitList = lazy(() => importCommitList().then((m) => ({ default: m.C
 type ResourceListType = typeof import("./GitHubResourceList").GitHubResourceList;
 type CommitListType = typeof import("./CommitList").CommitList;
 
-if (typeof window !== "undefined") {
-  const preload = () => {
-    void importResourceList();
-    void importCommitList();
-  };
-  if (typeof window.requestIdleCallback === "function") {
-    // Cap the idle wait: under sustained main-thread load (launch hydration,
-    // Electron IPC bursts) an untimed idle callback can be deferred for
-    // seconds, so a first click would still hit the Suspense skeleton. The
-    // timeout forces the preload to run within 2s regardless.
-    window.requestIdleCallback(preload, { timeout: 2000 });
-  } else {
-    window.setTimeout(preload, 2000);
-  }
-}
-
 /**
  * GitHub's contribution to the host's toolbar stats dropdown slot
  * (`github.statsDropdown`). The host owns the pills, badge, dropdown shell,
  * and freshness/rate-limit chrome; this view supplies the list content for
  * all three kinds.
  *
- * Two-tier loading: lazy()/Suspense covers the cold-click case (click before
- * the idle preload finishes), AND the concrete component reference is
- * eagerly resolved on mount so any subsequent render skips the Suspense
- * boundary — React.lazy suspends on the first render of its boundary even
- * when the import promise has already resolved, which would flash the
- * skeleton over rows that are already cached.
+ * Two-tier loading: lazy()/Suspense covers the first open, AND the concrete
+ * component reference is retained after it resolves so subsequent opens skip
+ * the Suspense boundary.
  */
 export function GitHubStatsDropdown({
   kind,
@@ -61,6 +41,7 @@ export function GitHubStatsDropdown({
   const [ResourceList, setResourceList] = useState<ResourceListType | null>(null);
   const [CommitList, setCommitList] = useState<CommitListType | null>(null);
   useEffect(() => {
+    if (!open) return;
     let cancelled = false;
     if (kind === "commits") {
       void importCommitList().then((m) => {
@@ -74,7 +55,7 @@ export function GitHubStatsDropdown({
     return () => {
       cancelled = true;
     };
-  }, [kind]);
+  }, [kind, open]);
 
   // Reset the search query when the host closes this dropdown (the view stays
   // mounted behind a hidden Activity boundary, so unmount never fires). The

--- a/scripts/perf/index.ts
+++ b/scripts/perf/index.ts
@@ -75,7 +75,9 @@ function tsxScript(file: string, fixedArgs: string[] = [], env?: Record<string, 
 }
 
 function harness(mode: PerfMode): Runner {
-  return tsxScript("run.ts", ["--mode", mode]);
+  const scriptPath = path.join(perfDir, "run.ts");
+  return (rest) =>
+    spawnNode(["--expose-gc", "--import", "tsx", scriptPath, "--mode", mode, ...rest]);
 }
 
 function viteAnalyze(): Runner {

--- a/scripts/perf/scenarios/soak.ts
+++ b/scripts/perf/scenarios/soak.ts
@@ -95,6 +95,7 @@ export const soakScenarios: PerfScenario[] = [
     async run() {
       maybeRunGc();
       const baselineMb = memoryUsedMb();
+      const startedAt = performance.now();
       let checksum = 0;
 
       for (let i = 0; i < 120; i += 1) {
@@ -114,6 +115,7 @@ export const soakScenarios: PerfScenario[] = [
         }
       }
 
+      const durationMs = performance.now() - startedAt;
       maybeRunGc();
       const finalMb = memoryUsedMb();
       const memoryGrowthMb = Math.max(0, finalMb - baselineMb);
@@ -121,7 +123,7 @@ export const soakScenarios: PerfScenario[] = [
       const memoryGrowthPct = (memoryGrowthMb / normalizedBaselineMb) * 100;
 
       return {
-        durationMs: 0,
+        durationMs,
         metrics: {
           memoryGrowthPct,
           memoryGrowthMb,
@@ -141,6 +143,7 @@ export const soakScenarios: PerfScenario[] = [
     async run() {
       maybeRunGc();
       const baselineMb = memoryUsedMb();
+      const startedAt = performance.now();
       let checksum = 0;
 
       for (let i = 0; i < 180; i += 1) {
@@ -159,6 +162,7 @@ export const soakScenarios: PerfScenario[] = [
         }
       }
 
+      const durationMs = performance.now() - startedAt;
       maybeRunGc();
       const finalMb = memoryUsedMb();
       const memoryGrowthMb = Math.max(0, finalMb - baselineMb);
@@ -166,7 +170,7 @@ export const soakScenarios: PerfScenario[] = [
       const memoryGrowthPct = (memoryGrowthMb / normalizedBaselineMb) * 100;
 
       return {
-        durationMs: 0,
+        durationMs,
         metrics: {
           memoryGrowthPct,
           memoryGrowthMb,
@@ -186,6 +190,7 @@ export const soakScenarios: PerfScenario[] = [
     async run() {
       maybeRunGc();
       const baselineMb = memoryUsedMb();
+      const startedAt = performance.now();
       let peakMb = baselineMb;
       let checksum = 0;
       const stablePayloads = Array.from({ length: 256 }, (_, index) => `payload-${index}`);
@@ -199,13 +204,13 @@ export const soakScenarios: PerfScenario[] = [
         checksum += transient.length;
 
         if (i % 4 === 0) {
-          maybeRunGc();
           peakMb = Math.max(peakMb, memoryUsedMb());
         }
 
         await spinEventLoop(0.2);
       }
 
+      const durationMs = performance.now() - startedAt;
       maybeRunGc();
       const finalMb = memoryUsedMb();
       peakMb = Math.max(peakMb, finalMb);
@@ -215,7 +220,7 @@ export const soakScenarios: PerfScenario[] = [
       const memoryGrowthPct = (memoryGrowthMb / normalizedBaselineMb) * 100;
 
       return {
-        durationMs: 0,
+        durationMs,
         metrics: {
           memoryGrowthPct,
           memoryGrowthMb,
@@ -237,6 +242,7 @@ export const soakScenarios: PerfScenario[] = [
     warmups: 1,
     async run() {
       maybeRunGc();
+      const startedAt = performance.now();
       // ~2KB single-chunk flushes are the dominant latency-mode case under an
       // agent-output flood. 400k of them (~800MB transient churn) is far more
       // than any realistic inter-flush burst — sized so a pathological future
@@ -247,9 +253,10 @@ export const soakScenarios: PerfScenario[] = [
       const gc = await measureMinorGc(() => {
         checksum = simulatePortBatcherFlushFlood(flushes, chunkBytes);
       });
+      const durationMs = performance.now() - startedAt;
 
       return {
-        durationMs: 0,
+        durationMs,
         metrics: {
           minorGcCount: gc.minorGcCount,
           minorGcPauseMs: gc.minorGcPauseMs,

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -8,11 +8,9 @@ const LazyDiagnosticsDock = lazy(() =>
   import("../Diagnostics").then((m) => ({ default: m.DiagnosticsDock }))
 );
 import { ErrorBoundary } from "../ErrorBoundary";
-import { PortalDock, PortalVisibilityController } from "../Portal";
-import { ThemeBrowser } from "../ThemeBrowser";
+import { PortalCloseConfirmDialog, PortalVisibilityController } from "../Portal";
 import { FleetArmingRibbon } from "@/components/Fleet";
 import { TerminalDestructiveActionConfirmDialog } from "@/components/Terminal/TerminalDestructiveActionConfirmDialog";
-import { PortalCloseConfirmDialog } from "@/components/Portal/PortalCloseConfirmDialog";
 import { MoveOrRenameProjectDialog } from "@/components/Project/MoveOrRenameProjectDialog";
 import { ImportConfigDialog } from "@/components/Config/ImportConfigDialog";
 import { ChordIndicator } from "./ChordIndicator";
@@ -95,6 +93,12 @@ const LazyDemoCursor = lazy(() =>
 );
 const LazyDemoCaptureBridge = lazy(() =>
   import("../Demo/DemoCaptureBridge").then((m) => ({ default: m.DemoCaptureBridge }))
+);
+const LazyThemeBrowser = lazy(() =>
+  import("../ThemeBrowser/ThemeBrowser").then((m) => ({ default: m.ThemeBrowser }))
+);
+const LazyPortalDock = lazy(() =>
+  import("../Portal/PortalDock").then((m) => ({ default: m.PortalDock }))
 );
 // Preload only in demo mode so the chunks resolve before first mount (no
 // Suspense flash). In production the gate is false, so this block never runs and
@@ -1065,7 +1069,9 @@ export function AppLayout({
                   right: "var(--right-obstruction-offset, 0px)",
                 }}
               >
-                <ThemeBrowser />
+                <Suspense fallback={null}>
+                  <LazyThemeBrowser />
+                </Suspense>
               </div>
             </ErrorBoundary>
           </>,
@@ -1083,7 +1089,9 @@ export function AppLayout({
               className="fixed right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"
               style={{ top: OVERLAY_TOP_OFFSET }}
             >
-              <PortalDock />
+              <Suspense fallback={null}>
+                <LazyPortalDock />
+              </Suspense>
             </div>
           </ErrorBoundary>,
           document.body

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -370,14 +370,14 @@ describe("AppLayout portal viewport coverage — issue #6629", () => {
     // plus the measured global-banner height) rather than a static top-12, which
     // a banner-shifted toolbar painted over.
     expect(source).toMatch(
-      /<div(?=[^>]*className="(?=[^"]*\bfixed\b)(?=[^"]*\bright-0\b)(?=[^"]*\bbottom-0\b)(?=[^"]*\bz-50\b)[^"]*")(?=[^>]*style=\{\{[\s\S]{0,200}?\btop:\s*OVERLAY_TOP_OFFSET\b)[^>]*>\s*<PortalDock\s*\/>/
+      /<div(?=[^>]*className="(?=[^"]*\bfixed\b)(?=[^"]*\bright-0\b)(?=[^"]*\bbottom-0\b)(?=[^"]*\bz-50\b)[^"]*")(?=[^>]*style=\{\{[\s\S]{0,200}?\btop:\s*OVERLAY_TOP_OFFSET\b)[^>]*>[\s\S]{0,100}?<LazyPortalDock\s*\/>/
     );
     expect(source).not.toContain("fixed top-12 right-0 bottom-0");
     // The portal target must be document.body to escape the inert subtrees and
     // the <main> width constraint. A different target would silently reintroduce
     // the bug.
     expect(source).toMatch(
-      /\{layout\.portalOpen &&\s*\n\s*createPortal\([\s\S]+?<PortalDock \/>[\s\S]+?document\.body\s*\)/
+      /\{layout\.portalOpen &&\s*\n\s*createPortal\([\s\S]+?<LazyPortalDock \/>[\s\S]+?document\.body\s*\)/
     );
     // The old in-<main> absolute wrapper must not be reintroduced.
     expect(source).not.toContain(
@@ -393,7 +393,7 @@ describe("AppLayout portal viewport coverage — issue #6629", () => {
     // Since #9558 the same guard also covers the plugin-manager overlay via the
     // shared `chromeInert` signal.
     expect(source).toMatch(
-      /\{layout\.portalOpen &&\s*\n\s*createPortal\([\s\S]+?chromeInert \? \{ inert: true \} : \{\}[\s\S]+?<PortalDock \/>/
+      /\{layout\.portalOpen &&\s*\n\s*createPortal\([\s\S]+?chromeInert \? \{ inert: true \} : \{\}[\s\S]+?<LazyPortalDock \/>/
     );
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -47,7 +47,7 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
     // Bug 1: rendering inside the inert main-content wrapper made the picker
     // itself unclickable. Portaling to document.body escapes the inert ancestor.
     expect(source).toMatch(/import \{ createPortal(?:, flushSync)? \} from "react-dom"/);
-    expect(source).toMatch(/createPortal\([\s\S]*?<ThemeBrowser \/>[\s\S]*?document\.body/);
+    expect(source).toMatch(/createPortal\([\s\S]*?<LazyThemeBrowser \/>[\s\S]*?document\.body/);
   });
 
   it("renders scrim as a sibling of the panel, not an ancestor", () => {
@@ -65,7 +65,7 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
     // fixed + bottom-0 anchors to the viewport regardless of docks/panels below,
     // and the top edge is driven by OVERLAY_TOP_OFFSET (see #11893 below).
     expect(source).toMatch(
-      /<div(?=[^>]*className="(?=[^"]*\bfixed\b)(?=[^"]*\bbottom-0\b)[^"]*")(?=[^>]*style=\{\{[\s\S]{0,200}?\btop:\s*OVERLAY_TOP_OFFSET\b)[^>]*>\s*<ThemeBrowser\s*\/>/
+      /<div(?=[^>]*className="(?=[^"]*\bfixed\b)(?=[^"]*\bbottom-0\b)[^"]*")(?=[^>]*style=\{\{[\s\S]{0,200}?\btop:\s*OVERLAY_TOP_OFFSET\b)[^>]*>[\s\S]{0,100}?<LazyThemeBrowser\s*\/>/
     );
   });
 

--- a/src/components/Portal/index.ts
+++ b/src/components/Portal/index.ts
@@ -1,4 +1,2 @@
 export { PortalCloseConfirmDialog } from "./PortalCloseConfirmDialog";
-export { PortalDock } from "./PortalDock";
-export { PortalToolbar } from "./PortalToolbar";
 export { PortalVisibilityController } from "./PortalVisibilityController";

--- a/src/components/Terminal/TerminalSearchBar.tsx
+++ b/src/components/Terminal/TerminalSearchBar.tsx
@@ -53,14 +53,20 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
   }, []);
 
   useEffect(() => {
-    const managed = terminalInstanceService.get(terminalId);
-    const addon = managed?.searchAddon;
-    if (!addon?.onDidChangeResults) return;
-    const disposable = addon.onDidChangeResults(({ resultIndex, resultCount }) => {
-      setMatchResults({ resultIndex, resultCount });
-    });
+    let disposed = false;
+    let resultSubscription: { dispose: () => void } | null = null;
+    void terminalInstanceService
+      .ensureSearchAddon(terminalId)
+      .then((addon) => {
+        if (disposed || !addon?.onDidChangeResults) return;
+        resultSubscription = addon.onDidChangeResults(({ resultIndex, resultCount }) => {
+          setMatchResults({ resultIndex, resultCount });
+        });
+      })
+      .catch(() => {});
     return () => {
-      disposable.dispose();
+      disposed = true;
+      resultSubscription?.dispose();
     };
   }, [terminalId]);
 
@@ -88,15 +94,12 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
           setMatchResults(null);
           setRegexError(validation.error ?? "Invalid regex pattern");
           const managed = terminalInstanceService.get(terminalId);
-          managed?.searchAddon.clearDecorations();
+          managed?.searchAddon?.clearDecorations();
           return;
         }
       }
 
       setRegexError(null);
-
-      const managed = terminalInstanceService.get(terminalId);
-      if (!managed) return;
 
       const options = buildSearchOptions(
         effectiveCaseSensitive,
@@ -104,25 +107,29 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
         effectiveWholeWord
       );
 
-      try {
-        const found =
-          direction === "next"
-            ? managed.searchAddon.findNext(term, options)
-            : managed.searchAddon.findPrevious(term, options);
+      void terminalInstanceService
+        .ensureSearchAddon(terminalId)
+        .then((searchAddon) => {
+          if (!searchAddon) return;
+          const found =
+            direction === "next"
+              ? searchAddon.findNext(term, options)
+              : searchAddon.findPrevious(term, options);
 
-        if (!found) {
-          managed.searchAddon.clearDecorations();
+          if (!found) {
+            searchAddon.clearDecorations();
+            setMatchResults(null);
+          }
+          setSearchStatus(found ? "found" : "none");
+        })
+        .catch((error: unknown) => {
+          setSearchStatus(effectiveRegexEnabled ? "invalidRegex" : "none");
           setMatchResults(null);
-        }
-        setSearchStatus(found ? "found" : "none");
-      } catch (e) {
-        setSearchStatus(effectiveRegexEnabled ? "invalidRegex" : "none");
-        setMatchResults(null);
-        if (effectiveRegexEnabled && e instanceof Error) {
-          setRegexError(e.message);
-        }
-        managed.searchAddon.clearDecorations();
-      }
+          if (effectiveRegexEnabled && error instanceof Error) {
+            setRegexError(error.message);
+          }
+          terminalInstanceService.get(terminalId)?.searchAddon?.clearDecorations();
+        });
     },
     [terminalId, caseSensitive, regexEnabled, wholeWord]
   );
@@ -137,7 +144,7 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
   const clearSearch = useCallback(() => {
     cancelPendingSearch();
     const managed = terminalInstanceService.get(terminalId);
-    managed?.searchAddon.clearDecorations();
+    managed?.searchAddon?.clearDecorations();
     setSearchStatus("idle");
     setMatchResults(null);
     setRegexError(null);

--- a/src/components/Terminal/__tests__/TerminalSearchBar.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalSearchBar.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     get: vi.fn(),
+    ensureSearchAddon: vi.fn(),
   },
 }));
 
@@ -48,6 +49,9 @@ function createMockManaged(findNextResult = true) {
 describe("TerminalSearchBar", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.mocked(terminalInstanceService.ensureSearchAddon).mockImplementation(async (id) => {
+      return terminalInstanceService.get(id)?.searchAddon ?? null;
+    });
     useTerminalSearchHistoryStore.setState({
       searches: [],
       caseSensitive: false,
@@ -399,13 +403,14 @@ describe("TerminalSearchBar", () => {
     expect(input.getAttribute("aria-invalid")).toBeNull();
   });
 
-  it("disposes the onDidChangeResults subscription on unmount", () => {
+  it("disposes the onDidChangeResults subscription on unmount", async () => {
     const mock = createMockManaged(true);
     vi.mocked(terminalInstanceService.get).mockReturnValue(
       mock as unknown as ReturnType<typeof terminalInstanceService.get>
     );
 
     const { unmount } = renderSearchBar();
+    await act(async () => Promise.resolve());
     expect(mock._resultsListeners.length).toBe(1);
 
     unmount();
@@ -429,7 +434,7 @@ describe("TerminalSearchBar", () => {
       expect(input.value).toBe("recent");
     });
 
-    it("fires the search on mount when pre-populated from history", () => {
+    it("fires the search on mount when pre-populated from history", async () => {
       useTerminalSearchHistoryStore.setState({
         searches: ["recent"],
         caseSensitive: false,
@@ -441,6 +446,7 @@ describe("TerminalSearchBar", () => {
       );
 
       renderSearchBar();
+      await act(async () => Promise.resolve());
       expect(mock.searchAddon.findNext).toHaveBeenCalledWith("recent", expect.any(Object));
     });
 

--- a/src/components/ThemeBrowser/index.ts
+++ b/src/components/ThemeBrowser/index.ts
@@ -1,1 +1,0 @@
-export { ThemeBrowser } from "./ThemeBrowser";

--- a/src/components/Worktree/__tests__/diffRefractorStringify.test.ts
+++ b/src/components/Worktree/__tests__/diffRefractorStringify.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { refractor } from "refractor/core";
+import bash from "refractor/bash";
+import css from "refractor/css";
+import javascript from "refractor/javascript";
+import jsx from "refractor/jsx";
+import json from "refractor/json";
+import markdown from "refractor/markdown";
+import markup from "refractor/markup";
+import tsx from "refractor/tsx";
+import typescript from "refractor/typescript";
+
+// diffRefractor swaps refractor's `Token.stringify` for a hand-built node
+// factory. That object is Prism's own — `refractor.Token` IS `Prism.Token` —
+// so the replacement is global to the renderer and has to be output-identical
+// for every language, not just the ones the diff viewer highlights.
+//
+// The stock implementation therefore has to be captured BEFORE diffRefractor's
+// module side effect lands. ESM evaluates all static imports ahead of any
+// module body, so diffRefractor is the one import pulled in dynamically, from
+// inside the test, after the reference outputs are computed.
+
+interface StringifyApi {
+  Token: { stringify: unknown };
+}
+
+const CASES: ReadonlyArray<{ language: string; code: string }> = [
+  {
+    // Entity tokens: markup's `wrap` hook writes a `title` attribute, which is
+    // the one condition that must hand the token back to refractor.
+    language: "markup",
+    code: [
+      '<a href="/x?a=1&amp;b=2" title="x &lt; y" data-empty="">Tom &amp; Jerry</a>',
+      "<!-- a comment with &nbsp; -->",
+      "<input disabled/>",
+    ].join("\n"),
+  },
+  {
+    language: "jsx",
+    code: [
+      "const El = () => (",
+      '  <section className="a b" aria-label="x &amp; y">',
+      "    {items.map((i) => (",
+      "      <Row key={i.id} {...i} onClick={() => go(i)}>",
+      "        &lt;{i.label}&gt;",
+      "      </Row>",
+      "    ))}",
+      "  </section>",
+      ");",
+    ].join("\n"),
+  },
+  {
+    // Fenced code block: markdown's `wrap` hook replaces `env.content` wholesale
+    // with a highlighted Root, exercising the array/root flattening path.
+    language: "markdown",
+    code: [
+      "# Title",
+      "",
+      "Some *emphasis*, a [link](https://example.com) and `inline code`.",
+      "",
+      "```js",
+      "const x = { a: 1 };",
+      "export default x;",
+      "```",
+      "",
+      "> quoted &amp; escaped",
+      "",
+      "| a | b |",
+      "| - | - |",
+      "| 1 | 2 |",
+    ].join("\n"),
+  },
+  {
+    language: "typescript",
+    code: [
+      "export interface Shape<T extends object = {}> {",
+      "  readonly id: `${string}-${number}`;",
+      "  fn?(arg: T | null): Promise<T[]>;",
+      "}",
+      'const s = "a\\nb" as const; // trailing',
+      "enum E { A = 1, B }",
+    ].join("\n"),
+  },
+  {
+    language: "tsx",
+    code: [
+      "function C<T,>({ v }: { v: T }) {",
+      "  return <div title={String(v)}>{v as unknown as string}</div>;",
+      "}",
+    ].join("\n"),
+  },
+  {
+    language: "javascript",
+    code: [
+      "async function* gen(n = 0) {",
+      "  yield* [1, 2, 3].map((x) => x ** n);",
+      "}",
+      "/* block */ const re = /a[b-c]+/giu;",
+    ].join("\n"),
+  },
+  {
+    language: "css",
+    code: [
+      ":root { --c: oklch(0.7 0.1 200); }",
+      "@media (prefers-contrast: more) { .a > .b::after { content: '\\201C'; } }",
+    ].join("\n"),
+  },
+  {
+    language: "json",
+    code: '{"a": [1, 2.5e3, true, null], "b": {"c": "d\\"e"}}',
+  },
+  {
+    language: "bash",
+    code: [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'for f in "$@"; do',
+      '  printf \'%s\\n\' "${f//a/b}" | grep -E "^x" || true',
+      "done",
+    ].join("\n"),
+  },
+];
+
+describe("fast token stringify", () => {
+  it("emits the tree refractor's own stringify would, for every language", async () => {
+    for (const lang of [bash, css, javascript, jsx, json, markdown, markup, tsx, typescript]) {
+      refractor.register(lang);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Token is a Prism internal refractor does not surface on its own type
+    const api = refractor as unknown as StringifyApi;
+    const stockStringify = api.Token.stringify;
+    const stock = CASES.map((c) => refractor.highlight(c.code, c.language).children);
+
+    await import("../diffRefractor");
+
+    expect(api.Token.stringify).not.toBe(stockStringify);
+    const fast = CASES.map((c) => refractor.highlight(c.code, c.language).children);
+
+    for (let i = 0; i < CASES.length; i += 1) {
+      expect(fast[i], `${CASES[i]!.language} diverged`).toEqual(stock[i]);
+    }
+  });
+});

--- a/src/components/Worktree/diffRefractor.ts
+++ b/src/components/Worktree/diffRefractor.ts
@@ -14,6 +14,166 @@ for (const lang of [bash, css, javascript, jsx, json, markdown, tsx, typescript]
   refractor.register(lang);
 }
 
+interface PrismToken {
+  type: string;
+  content: PrismContent;
+  alias?: string | string[];
+}
+type PrismContent = string | PrismToken | Array<string | PrismToken>;
+
+interface WrapEnv {
+  attributes: Record<string, string>;
+  classes: string[];
+  content: TokenNode | TokenNode[];
+  language: string;
+  tag: string;
+  type: string;
+}
+
+interface RefractorInternals {
+  Token: { stringify: (value: PrismContent, language: string) => TokenNode | TokenNode[] };
+  hooks: { all: Record<string, unknown[] | undefined> };
+}
+
+const FAST_STRINGIFY_MARKER = Symbol.for("daintree.refractor.fast-token-stringify");
+
+/**
+ * refractor's own `Token.stringify` funnels every highlighted token through
+ * hastscript's `h('span.token.keyword', …)`, which re-parses that CSS selector
+ * with a regex for each of the tens of thousands of tokens a review-sized diff
+ * produces. Selector parsing plus the hast element construction it drives was
+ * ~28% of tokenize CPU (and a large share of its GC churn) in the PERF-160..162
+ * profiles, for a node shape that is fully determined by the token: a `span`
+ * whose className is `['token', type, ...aliases]`.
+ *
+ * This builds that node directly and only falls back to refractor's path when a
+ * `wrap` hook actually contributed attributes (Prism's markup grammar sets a
+ * `title` on entity tokens), so the emitted tree stays byte-for-byte identical.
+ */
+/**
+ * Mirrors hastscript's `addChild`: flattens nested arrays, unwraps `root`
+ * nodes, and turns bare strings/numbers into text nodes. Only the hook path
+ * needs it — a `wrap` hook may hand back any of those shapes.
+ */
+function appendChild(nodes: TokenNode[], value: unknown): void {
+  if (value === null || value === undefined) return;
+  if (typeof value === "number" || typeof value === "string") {
+    nodes.push({ type: "text", value: String(value) } as TokenNode);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const child of value) appendChild(nodes, child);
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- hook-returned content is untyped hast
+  const node = value as TokenNode & { type?: string; children?: TokenNode[] };
+  if (node.type === "root") {
+    appendChild(nodes, node.children);
+    return;
+  }
+  nodes.push(node);
+}
+
+function flattenChild(value: unknown): TokenNode[] {
+  const nodes: TokenNode[] = [];
+  appendChild(nodes, value);
+  return nodes;
+}
+
+function isEmptyRecord(record: Record<string, string>): boolean {
+  for (const key in record) {
+    if (Object.hasOwn(record, key)) return false;
+  }
+  return true;
+}
+
+function installFastTokenStringify(): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- reaching into refractor's Prism internals, mirrored by the equivalence checks in diffRefractor tests
+  const internals = refractor as unknown as RefractorInternals;
+  const tokenApi = internals.Token as RefractorInternals["Token"] & Record<symbol, unknown>;
+  if (tokenApi[FAST_STRINGIFY_MARKER] === true) return;
+  const original = tokenApi.stringify;
+
+  const toNodes = (value: PrismContent, language: string, out: TokenNode[]): void => {
+    if (typeof value === "string") {
+      out.push({ type: "text", value });
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (entry !== null && entry !== undefined && entry !== "") {
+          toNodes(entry, language, out);
+        }
+      }
+      return;
+    }
+
+    const classes = ["token", value.type];
+    if (value.alias) {
+      if (typeof value.alias === "string") classes.push(value.alias);
+      else classes.push(...value.alias);
+    }
+
+    const children: TokenNode[] = [];
+    toNodes(value.content, language, children);
+
+    const wrapHooks = internals.hooks.all["wrap"];
+    if (wrapHooks !== undefined && wrapHooks.length > 0) {
+      // Mirrors refractor: content is an array only when the token's own
+      // content was one. Grammar hooks rely on that (markdown's code-block
+      // hook reads `env.content.value` off the lone text node).
+      const content = Array.isArray(value.content) ? children : children[0]!;
+      const env: WrapEnv = {
+        attributes: {},
+        classes,
+        content,
+        language,
+        tag: "span",
+        type: value.type,
+      };
+      for (let i = 0; i < wrapHooks.length; i += 1) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Prism hook callbacks are untyped
+        (wrapHooks[i] as (hookEnv: WrapEnv) => void)(env);
+      }
+      if (env.tag !== "span" || env.classes.length === 0 || !isEmptyRecord(env.attributes)) {
+        // A hook rewrote the element shape or added attributes — hand this
+        // token back to refractor so its entity decoding and hast property
+        // normalisation stay authoritative.
+        const restored = original.call(internals.Token, value, language);
+        if (Array.isArray(restored)) out.push(...restored);
+        else out.push(restored);
+        return;
+      }
+      out.push({
+        type: "element",
+        tagName: "span",
+        properties: { className: env.classes },
+        // Untouched content is already a flat node list; only a hook that
+        // swapped it in needs hastscript's array/root flattening.
+        children: env.content === content ? children : flattenChild(env.content),
+      } as TokenNode);
+      return;
+    }
+
+    out.push({
+      type: "element",
+      tagName: "span",
+      properties: { className: classes },
+      children,
+    } as TokenNode);
+  };
+
+  tokenApi.stringify = (value: PrismContent, language: string) => {
+    if (typeof value === "string") return { type: "text", value } as TokenNode;
+    const out: TokenNode[] = [];
+    toNodes(value, language, out);
+    return Array.isArray(value) ? out : out[0]!;
+  };
+  Object.defineProperty(tokenApi, FAST_STRINGIFY_MARKER, { value: true });
+}
+
+installFastTokenStringify();
+
 /**
  * The tokenize pipeline expects refractor v3's highlight() contract — a plain
  * array of nodes. refractor v4+ returns a hast Root object, whose non-iterable

--- a/src/components/Worktree/diffRefractor.ts
+++ b/src/components/Worktree/diffRefractor.ts
@@ -49,6 +49,12 @@ const FAST_STRINGIFY_MARKER = Symbol.for("daintree.refractor.fast-token-stringif
  * This builds that node directly and only falls back to refractor's path when a
  * `wrap` hook actually contributed attributes (Prism's markup grammar sets a
  * `title` on entity tokens), so the emitted tree stays byte-for-byte identical.
+ *
+ * Note the blast radius: `refractor.Token` IS `Prism.Token` (refractor's core
+ * does `Refractor.prototype = Prism`), so importing this module re-points token
+ * stringification for every refractor consumer in the renderer — MarkdownDocument
+ * included — which is why the equivalence has to hold for all languages, not
+ * just the diff viewer's.
  */
 /**
  * Mirrors hastscript's `addChild`: flattens nested arrays, unwraps `root`
@@ -88,7 +94,7 @@ function isEmptyRecord(record: Record<string, string>): boolean {
 }
 
 function installFastTokenStringify(): void {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- reaching into refractor's Prism internals, mirrored by the equivalence checks in diffRefractor tests
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- reaching into refractor's Prism internals, pinned by the patched-vs-original differential in diffRefractorStringify.test.ts
   const internals = refractor as unknown as RefractorInternals;
   const tokenApi = internals.Token as RefractorInternals["Token"] & Record<symbol, unknown>;
   if (tokenApi[FAST_STRINGIFY_MARKER] === true) return;

--- a/src/components/Worktree/diffTokenizePipeline.ts
+++ b/src/components/Worktree/diffTokenizePipeline.ts
@@ -67,52 +67,71 @@ function toTextPair(hunks: HunkData[]): [string, string] {
   return [toText(oldChanges, computeOldLineNumber), toText(newChanges, computeNewLineNumber)];
 }
 
-function collectPaths(node: TokenNode, ancestors: TokenNode[], output: TokenPath[]): void {
-  const children = node.children;
-  if (children) {
-    const { children: _omit, ...interior } = node;
-    ancestors.push(interior);
-    for (const child of children) {
-      collectPaths(child, ancestors, output);
-    }
-    ancestors.pop();
-  } else {
-    output.push([...ancestors, node]);
-  }
+function stripChildren(node: TokenNode): TokenNode {
+  const { children: _omit, ...interior } = node;
+  return interior;
 }
 
-function withLeafValue(path: TokenPath, value: string): TokenPath {
-  const next = path.slice();
-  next[next.length - 1] = { ...path[path.length - 1]!, value };
-  return next;
+function appendPath(line: TokenPath[], ancestors: TokenNode[], leaf: TokenNode): void {
+  const depth = ancestors.length;
+  if (depth === 0) {
+    line.push([leaf]);
+    return;
+  }
+  const path = new Array<TokenNode>(depth + 1) as TokenPath;
+  for (let i = 0; i < depth; i += 1) path[i] = ancestors[i]!;
+  path[depth] = leaf;
+  line.push(path);
 }
 
-function normalizeToLines(children: TokenNode[]): TokenPath[][] {
-  const paths: TokenPath[] = [];
-  const ancestors: TokenNode[] = [];
-  for (const child of children) {
-    collectPaths(child, ancestors, paths);
-  }
-
+/**
+ * Flatten a highlight tree straight into per-line token paths.
+ *
+ * Fusing the tree walk with the newline split is what keeps this cheap: the
+ * separate collect-then-split shape it replaced materialised one path array
+ * per leaf, then re-sliced a second array for every leaf whose value spanned
+ * lines. On a review-sized diff that is tens of thousands of throwaway arrays,
+ * and the GC bill for them showed up as the single largest slice of tokenize
+ * CPU. Output is identical, path for path.
+ */
+function nodesToLines(children: TokenNode[]): TokenPath[][] {
   const lines: TokenPath[][] = [];
+  const ancestors: TokenNode[] = [];
   let current: TokenPath[] = [];
-  for (const path of paths) {
-    const leaf = path[path.length - 1]!;
-    const value = leaf.value;
+
+  const walk = (node: TokenNode): void => {
+    const kids = node.children;
+    if (kids) {
+      ancestors.push(stripChildren(node));
+      for (const child of kids) walk(child);
+      ancestors.pop();
+      return;
+    }
+
+    const value = node.value;
     if (typeof value !== "string") {
-      throw new Error(`Invalid token path with leaf of type ${leaf.type}`);
+      throw new Error(`Invalid token path with leaf of type ${node.type}`);
     }
-    if (!value.includes("\n")) {
-      current.push(path);
-      continue;
+
+    let newlineAt = value.indexOf("\n");
+    if (newlineAt === -1) {
+      appendPath(current, ancestors, node);
+      return;
     }
-    const parts = value.split("\n");
-    current.push(withLeafValue(path, parts[0]!));
-    for (let i = 1; i < parts.length; i += 1) {
+
+    let start = 0;
+    for (;;) {
+      const segment = newlineAt === -1 ? value.slice(start) : value.slice(start, newlineAt);
+      appendPath(current, ancestors, { ...node, value: segment });
+      if (newlineAt === -1) return;
       lines.push(current);
-      current = [withLeafValue(path, parts[i]!)];
+      current = [];
+      start = newlineAt + 1;
+      newlineAt = value.indexOf("\n", start);
     }
-  }
+  };
+
+  for (const child of children) walk(child);
   lines.push(current);
   return lines;
 }
@@ -147,20 +166,94 @@ function backToTreeChildren(pathList: TokenPath[]): TokenNode[] {
   return rootChildren;
 }
 
+/**
+ * Fused equivalent of `backToTreeChildren(nodesToLines(children))` for the
+ * enhancer-less pass (the over-budget large-diff path skips markEdits
+ * entirely). Splits the highlight tree straight into per-line node arrays
+ * without materialising the intermediate token paths, byte-for-byte matching
+ * the two-phase output: one fresh interior chain per leaf, adjacent top-level
+ * text leaves merged.
+ */
+function splitTreeToLines(children: TokenNode[]): TokenNode[][] {
+  const lines: TokenNode[][] = [];
+  const ancestors: TokenNode[] = [];
+  let current: TokenNode[] = [];
+
+  const emit = (leaf: TokenNode): void => {
+    if (ancestors.length === 0) {
+      const previous = current[current.length - 1];
+      if (previous && previous.type === "text" && leaf.type === "text") {
+        current[current.length - 1] = {
+          ...previous,
+          value: `${previous.value ?? ""}${leaf.value ?? ""}`,
+        };
+        return;
+      }
+      current.push({ ...leaf });
+      return;
+    }
+    let siblings = current;
+    for (const ancestor of ancestors) {
+      const attached: TokenNode = { ...ancestor, children: [] };
+      siblings.push(attached);
+      siblings = attached.children!;
+    }
+    siblings.push({ ...leaf });
+  };
+
+  const walk = (node: TokenNode): void => {
+    const kids = node.children;
+    if (kids) {
+      ancestors.push(stripChildren(node));
+      for (const child of kids) walk(child);
+      ancestors.pop();
+      return;
+    }
+    const value = node.value;
+    if (typeof value !== "string") {
+      throw new Error(`Invalid token path with leaf of type ${node.type}`);
+    }
+    let newlineAt = value.indexOf("\n");
+    if (newlineAt === -1) {
+      emit(node);
+      return;
+    }
+    let start = 0;
+    for (;;) {
+      const segment = newlineAt === -1 ? value.slice(start) : value.slice(start, newlineAt);
+      emit({ ...node, value: segment });
+      if (newlineAt === -1) return;
+      lines.push(current);
+      current = [];
+      start = newlineAt + 1;
+      newlineAt = value.indexOf("\n", start);
+    }
+  };
+
+  for (const child of children) walk(child);
+  lines.push(current);
+  return lines;
+}
+
 export function tokenizeFast(hunks: HunkData[], options: FastTokenizeOptions): HunkTokens {
   const [oldText, newText] = toTextPair(hunks);
   const toChildren = options.highlight
     ? (text: string) => options.refractor.highlight(text, options.language)
     : (text: string): TokenNode[] => [{ type: "text", value: text }];
 
+  const enhancers = options.enhancers ?? [];
+  if (enhancers.length === 0) {
+    return {
+      old: splitTreeToLines(toChildren(oldText)),
+      new: splitTreeToLines(toChildren(newText)),
+    };
+  }
+
   const pair: [TokenPath[][], TokenPath[][]] = [
-    normalizeToLines(toChildren(oldText)),
-    normalizeToLines(toChildren(newText)),
+    nodesToLines(toChildren(oldText)),
+    nodesToLines(toChildren(newText)),
   ];
-  const [oldEnhanced, newEnhanced] = (options.enhancers ?? []).reduce(
-    (input, enhance) => enhance(input),
-    pair
-  );
+  const [oldEnhanced, newEnhanced] = enhancers.reduce((input, enhance) => enhance(input), pair);
 
   return {
     old: oldEnhanced.map(backToTreeChildren),

--- a/src/hooks/app/useAppBootstrap.ts
+++ b/src/hooks/app/useAppBootstrap.ts
@@ -21,23 +21,14 @@ import { useNotificationSettingsStore, usePluginManagerStore } from "@/store";
 import { preloadNewWorktreeDialog } from "@/components/Sidebar";
 import { primeRadix } from "@/components/ui/radix-loader";
 import {
-  preloadSettingsDialog,
   preloadActionPalette,
   preloadQuickSwitcher,
   preloadProjectSwitcherPalette,
   preloadWorktreePalette,
   preloadNewTerminalPalette,
   preloadPanelPalette,
-  preloadThemePalette,
   preloadSendToAgentPalette,
   preloadQuickCreatePalette,
-  preloadLogLevelPalette,
-  preloadPluginManagerView,
-  preloadWorktreeOverviewModal,
-  preloadShortcutReferenceDialog,
-  preloadCrossWorktreeDiff,
-  loadJetbrainsMono500,
-  loadJetbrainsMono600,
 } from "@/lazyPanels";
 
 /**
@@ -152,7 +143,6 @@ export function useAppBootstrap() {
     const execute = () => {
       if (controller.signal.aborted) return;
       setIdleHousekeepingReady(true);
-      void preloadSettingsDialog();
       void preloadNewWorktreeDialog();
       void preloadActionPalette();
       void preloadQuickSwitcher();
@@ -160,16 +150,8 @@ export function useAppBootstrap() {
       void preloadWorktreePalette();
       void preloadNewTerminalPalette();
       void preloadPanelPalette();
-      void preloadThemePalette();
       void preloadSendToAgentPalette();
       void preloadQuickCreatePalette();
-      void preloadLogLevelPalette();
-      void preloadPluginManagerView();
-      void preloadWorktreeOverviewModal();
-      void preloadShortcutReferenceDialog();
-      void preloadCrossWorktreeDiff();
-      loadJetbrainsMono500().catch(() => {});
-      loadJetbrainsMono600().catch(() => {});
       // Warm the shared Radix overlay primitives chunk (`radix-deferred`) so the
       // ProjectSwitcherPalette popover and context menus are ready on first
       // interaction in a freshly loaded project view. Otherwise this chunk is

--- a/src/lazyPanels.ts
+++ b/src/lazyPanels.ts
@@ -6,8 +6,6 @@
 import { lazy } from "react";
 
 export const loadE2ENotificationBackdoor = () => import("./lib/e2eNotificationBackdoor");
-export const loadJetbrainsMono500 = () => import("@fontsource/jetbrains-mono/latin-500.css");
-export const loadJetbrainsMono600 = () => import("@fontsource/jetbrains-mono/latin-600.css");
 
 export function preloadModalHostLayer() {
   return import("./ModalHostLayer");

--- a/src/lib/actionPaletteSearch.ts
+++ b/src/lib/actionPaletteSearch.ts
@@ -343,8 +343,7 @@ export type ActionRanker<T extends SearchableAction> = (
 export function createActionRanker<T extends SearchableAction>(
   items: readonly T[]
 ): ActionRanker<T> {
-  let titleRanks: number[] | undefined;
-  let charMasks: Int32Array | undefined;
+  let rankCache: TitleRankCacheEntry | undefined;
   let cachedMruList: readonly ActionFrecencyEntry[] | undefined;
   let cachedMruMap: ReadonlyMap<string, ActionFrecencyEntry> | undefined;
   let cachedTerminalKind: string | undefined;
@@ -355,8 +354,7 @@ export function createActionRanker<T extends SearchableAction>(
   return (query, mruList, context) => {
     const lowerQuery = normalizeRankQuery(query);
     if (lowerQuery === undefined) return [];
-    titleRanks ??= computeTitleRanks(items).ranks;
-    charMasks ??= computeCharMasks(items);
+    rankCache ??= computeTitleRanks(items);
     if (cachedMruList !== mruList) {
       cachedMruList = mruList;
       cachedMruMap = buildMruMap(mruList);
@@ -375,8 +373,8 @@ export function createActionRanker<T extends SearchableAction>(
     return rankActionMatchesWithTitleRanks(
       lowerQuery,
       items,
-      titleRanks,
-      charMasks,
+      rankCache.ranks,
+      rankCache.charMasks,
       cachedMruMap!,
       cachedBoostedCategories
     );

--- a/src/lib/actionPaletteSearch.ts
+++ b/src/lib/actionPaletteSearch.ts
@@ -93,10 +93,22 @@ export function scoreSubsequence(lowerQuery: string, field: string, lowerField: 
     return 0;
   }
 
+  // One indexOf answers both the prefix and the substring bonus.
+  const substringIdx = lowerField.indexOf(lowerQuery);
+
+  // Single-character query: the greedy walk below reduces to exactly the first
+  // occurrence, so its score is computable straight from that index. Short
+  // queries are the palette's worst case (nearly every action survives them),
+  // which makes this the hottest branch under real typing.
+  if (qLen === 1) {
+    if (substringIdx === -1) return 0;
+    return (substringIdx === 0 ? 500 : 200) + (isBoundary(field, substringIdx) ? 90 : 0) + 10;
+  }
+
   let score = 0;
-  if (lowerField.startsWith(lowerQuery)) {
+  if (substringIdx === 0) {
     score += 500;
-  } else if (lowerField.includes(lowerQuery)) {
+  } else if (substringIdx > 0) {
     score += 200;
   }
 
@@ -169,24 +181,39 @@ function scoreKeywords(lowerQuery: string, keywordsLower: readonly string[]): nu
 
 export function scoreAction(query: string, item: SearchableAction): number {
   if (!query) return 0;
-  return scoreActionLower(query.toLowerCase(), item);
+  const lowerQuery = query.toLowerCase();
+  return scoreActionLower(lowerQuery, charMaskOf(lowerQuery), item, computeCharMasks([item]), 0);
 }
 
-function scoreActionLower(lowerQuery: string, item: SearchableAction): number {
-  const titleScore = scoreTitle(lowerQuery, item.title, item.titleLower, item.titleAcronym);
+function scoreActionLower(
+  lowerQuery: string,
+  queryMask: number,
+  item: SearchableAction,
+  charMasks: Int32Array,
+  maskBase: number
+): number {
+  // A field whose fingerprint is missing any query character cannot contain
+  // the query as a subsequence (the acronym's characters are a subset of the
+  // title's, so the title mask covers the acronym branch too).
+  const titleScore =
+    (queryMask & ~charMasks[maskBase]!) === 0
+      ? scoreTitle(lowerQuery, item.title, item.titleLower, item.titleAcronym)
+      : 0;
 
   const categoryRaw =
-    item.categoryLower === GENERIC_CATEGORY
+    item.categoryLower === GENERIC_CATEGORY || (queryMask & ~charMasks[maskBase + 1]!) !== 0
       ? 0
       : scoreSubsequence(lowerQuery, item.category, item.categoryLower);
 
   const descriptionRaw =
-    item.descriptionLower.length > 0
+    item.descriptionLower.length > 0 && (queryMask & ~charMasks[maskBase + 2]!) === 0
       ? scoreSubsequence(lowerQuery, item.description, item.descriptionLower)
       : 0;
 
   const keywordRaw =
-    item.keywordsLower.length > 0 ? scoreKeywords(lowerQuery, item.keywordsLower) : 0;
+    item.keywordsLower.length > 0 && (queryMask & ~charMasks[maskBase + 3]!) === 0
+      ? scoreKeywords(lowerQuery, item.keywordsLower)
+      : 0;
 
   if (titleScore <= 0 && categoryRaw <= 0 && descriptionRaw <= 0 && keywordRaw <= 0) return 0;
 
@@ -258,6 +285,7 @@ export function getBoostedCategories(context: RankContext | undefined): Set<stri
 interface TitleRankCacheEntry {
   snapshot: readonly SearchableAction[];
   ranks: number[];
+  charMasks: Int32Array;
 }
 
 const titleRankCache = new WeakMap<readonly SearchableAction[], TitleRankCacheEntry>();
@@ -269,7 +297,7 @@ function computeTitleRanks(items: readonly SearchableAction[]): TitleRankCacheEn
   for (let rank = 0; rank < indices.length; rank++) {
     ranks[indices[rank]!] = rank;
   }
-  return { snapshot: items.slice(), ranks };
+  return { snapshot: items.slice(), ranks, charMasks: computeCharMasks(items) };
 }
 
 function isSnapshotCurrent(
@@ -300,6 +328,7 @@ export function rankActionMatches<T extends SearchableAction>(
     lowerQuery,
     items,
     cache.ranks,
+    cache.charMasks,
     buildMruMap(mruList),
     getBoostedCategories(context)
   );
@@ -315,6 +344,7 @@ export function createActionRanker<T extends SearchableAction>(
   items: readonly T[]
 ): ActionRanker<T> {
   let titleRanks: number[] | undefined;
+  let charMasks: Int32Array | undefined;
   let cachedMruList: readonly ActionFrecencyEntry[] | undefined;
   let cachedMruMap: ReadonlyMap<string, ActionFrecencyEntry> | undefined;
   let cachedTerminalKind: string | undefined;
@@ -326,6 +356,7 @@ export function createActionRanker<T extends SearchableAction>(
     const lowerQuery = normalizeRankQuery(query);
     if (lowerQuery === undefined) return [];
     titleRanks ??= computeTitleRanks(items).ranks;
+    charMasks ??= computeCharMasks(items);
     if (cachedMruList !== mruList) {
       cachedMruList = mruList;
       cachedMruMap = buildMruMap(mruList);
@@ -345,10 +376,48 @@ export function createActionRanker<T extends SearchableAction>(
       lowerQuery,
       items,
       titleRanks,
+      charMasks,
       cachedMruMap!,
       cachedBoostedCategories
     );
   };
+}
+
+// 32-bit character fingerprints: bit i set when the field contains a character
+// hashing to bit i (a-z map to bits 0-25, digits fold into bits 26-31; other
+// characters contribute no bit, which keeps the test conservative). A query
+// whose bits are not a subset of a field's bits cannot be a subsequence of it,
+// so the per-item scoring loop can reject most fields with one AND instead of
+// a character walk. Masks are computed once per catalog (they only depend on
+// the precomputed *Lower fields) and reused every keystroke.
+function charMaskOf(lower: string): number {
+  let mask = 0;
+  for (let i = 0; i < lower.length; i += 1) {
+    const code = lower.charCodeAt(i);
+    if (code >= 97 && code <= 122) {
+      mask |= 1 << (code - 97);
+    } else if (code >= 48 && code <= 57) {
+      mask |= 1 << (26 + ((code - 48) % 6));
+    }
+  }
+  return mask;
+}
+
+const MASK_STRIDE = 4;
+
+function computeCharMasks(items: readonly SearchableAction[]): Int32Array {
+  const masks = new Int32Array(items.length * MASK_STRIDE);
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i]!;
+    const base = i * MASK_STRIDE;
+    masks[base] = charMaskOf(item.titleLower);
+    masks[base + 1] = charMaskOf(item.categoryLower);
+    masks[base + 2] = charMaskOf(item.descriptionLower);
+    let keywordMask = 0;
+    for (const kw of item.keywordsLower) keywordMask |= charMaskOf(kw);
+    masks[base + 3] = keywordMask;
+  }
+  return masks;
 }
 
 function normalizeRankQuery(query: string): string | undefined {
@@ -368,13 +437,15 @@ function rankActionMatchesWithTitleRanks<T extends SearchableAction>(
   lowerQuery: string,
   items: readonly T[],
   titleRanks: readonly number[],
+  charMasks: Int32Array,
   mruById: ReadonlyMap<string, ActionFrecencyEntry>,
   boostedCategories: ReadonlySet<string>
 ): T[] {
+  const queryMask = charMaskOf(lowerQuery);
   const scored: Array<{ item: T; score: number; recency: number; rank: number }> = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i]!;
-    const base = scoreActionLower(lowerQuery, item);
+    const base = scoreActionLower(lowerQuery, queryMask, item, charMasks, i * MASK_STRIDE);
     if (base <= 0) continue;
     const mru = mruById.get(item.id);
     const mruBonus = mru ? MRU_BONUS_CAP * Math.tanh(mru.score / MRU_SCORE_SCALE) : 0;

--- a/src/services/terminal/TerminalAddonManager.ts
+++ b/src/services/terminal/TerminalAddonManager.ts
@@ -2,17 +2,16 @@ import { Terminal, IDisposable } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import type { ImageAddon } from "@xterm/addon-image";
-import { SearchAddon } from "@xterm/addon-search";
+import type { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { FileLinksAddon, HoverCallback } from "./FileLinksAddon";
 import { ImageLinksAddon, OnActivateFigure } from "./ImageLinksAddon";
 
 const IMAGE_ADDON_OPTIONS = { pixelLimit: 2_000_000, storageLimit: 8 };
 
-// @xterm/addon-image (~79KB) and @xterm/addon-unicode11 (~14KB) load via dynamic
-// import so their module code stays out of the renderer's eager critical path —
-// they are parsed/compiled only when a terminal actually needs them, not on every
-// project-view load (#10840). This mirrors the lazy WebGL loader in
+// Image, search, and Unicode11 addons load via dynamic import so their module
+// code stays out of the renderer's eager critical path — they are parsed and
+// compiled only when a terminal actually needs them. This mirrors the lazy WebGL loader in
 // TerminalWebGLManager.ts: a module-level class cache plus a single in-flight
 // promise guard so concurrent callers share one import, and the promise is nulled
 // on failure so a later call can retry.
@@ -20,6 +19,7 @@ const IMAGE_ADDON_OPTIONS = { pixelLimit: 2_000_000, storageLimit: 8 };
 // is a type-only construct — erased at compile time, no eager runtime import), so
 // the resolved class assigns to the cache without a type assertion.
 type ImageAddonConstructor = (typeof import("@xterm/addon-image"))["ImageAddon"];
+type SearchAddonConstructor = (typeof import("@xterm/addon-search"))["SearchAddon"];
 type Unicode11AddonConstructor = (typeof import("@xterm/addon-unicode11"))["Unicode11Addon"];
 
 let ImageAddonClass: ImageAddonConstructor | null = null;
@@ -39,6 +39,25 @@ function loadImageAddon(): Promise<ImageAddonConstructor> {
     }
   );
   return imageAddonLoadPromise;
+}
+
+let SearchAddonClass: SearchAddonConstructor | null = null;
+let searchAddonLoadPromise: Promise<SearchAddonConstructor> | null = null;
+
+function loadSearchAddon(): Promise<SearchAddonConstructor> {
+  if (SearchAddonClass) return Promise.resolve(SearchAddonClass);
+  if (searchAddonLoadPromise) return searchAddonLoadPromise;
+  searchAddonLoadPromise = import("@xterm/addon-search").then(
+    (mod) => {
+      SearchAddonClass = mod.SearchAddon;
+      return SearchAddonClass;
+    },
+    (err) => {
+      searchAddonLoadPromise = null;
+      throw err;
+    }
+  );
+  return searchAddonLoadPromise;
 }
 
 let Unicode11AddonClass: Unicode11AddonConstructor | null = null;
@@ -66,7 +85,7 @@ export interface TerminalAddons {
   fitAddon: FitAddon;
   serializeAddon: SerializeAddon;
   imageAddon: ImageAddon | null;
-  searchAddon: SearchAddon;
+  searchAddon: SearchAddon | null;
   fileLinksDisposable: IDisposable | null;
   imageLinksDisposable: IDisposable | null;
   webLinksAddon: WebLinksAddon | null;
@@ -112,21 +131,22 @@ export async function setupTerminalAddons(terminal: Terminal): Promise<TerminalA
     );
   }
 
-  // SearchAddon registers no parser hooks and does nothing until a search is
-  // invoked, so it stays in the eager set — keeping it non-null avoids a
-  // nullable-search blast radius across TerminalSearchBar and the wake path.
-  const searchAddon = new SearchAddon({ highlightLimit: SEARCH_HIGHLIGHT_LIMIT });
-  terminal.loadAddon(searchAddon);
-
   return {
     fitAddon,
     serializeAddon,
     imageAddon: null,
-    searchAddon,
+    searchAddon: null,
     fileLinksDisposable: null,
     imageLinksDisposable: null,
     webLinksAddon: null,
   };
+}
+
+export async function createSearchAddon(terminal: Terminal): Promise<SearchAddon> {
+  const SearchAddonCtor = await loadSearchAddon();
+  const addon = new SearchAddonCtor({ highlightLimit: SEARCH_HIGHLIGHT_LIMIT });
+  terminal.loadAddon(addon);
+  return addon;
 }
 
 export async function createImageAddon(terminal: Terminal): Promise<ImageAddon> {
@@ -184,6 +204,8 @@ export const __testing = {
   resetLoaderState(): void {
     ImageAddonClass = null;
     imageAddonLoadPromise = null;
+    SearchAddonClass = null;
+    searchAddonLoadPromise = null;
     Unicode11AddonClass = null;
     unicode11AddonLoadPromise = null;
   },

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -16,6 +16,7 @@ import { tallyScrollbackRestoreStates } from "./scrollbackRestoreAggregate";
 import {
   setupTerminalAddons,
   createImageAddon,
+  createSearchAddon,
   createFileLinksAddon,
   createImageLinksAddon,
   createWebLinksAddon,
@@ -1162,6 +1163,29 @@ class TerminalInstanceService {
 
   get(id: string): ManagedTerminal | null {
     return this.instances.get(id) ?? null;
+  }
+
+  async ensureSearchAddon(id: string): Promise<ManagedTerminal["searchAddon"]> {
+    const managed = this.instances.get(id);
+    if (!managed) return null;
+    if (managed.searchAddon) return managed.searchAddon;
+    if (managed.searchAddonPromise) return managed.searchAddonPromise;
+
+    const promise = createSearchAddon(managed.terminal).then((addon) => {
+      const current = this.instances.get(id);
+      if (current !== managed) {
+        addon.dispose();
+        return null;
+      }
+      managed.searchAddon = addon;
+      return addon;
+    });
+    managed.searchAddonPromise = promise;
+    try {
+      return await promise;
+    } finally {
+      if (managed.searchAddonPromise === promise) delete managed.searchAddonPromise;
+    }
   }
 
   /**

--- a/src/services/terminal/__tests__/TerminalAddonManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalAddonManager.test.ts
@@ -19,6 +19,7 @@ vi.mock("../FileLinksAddon", () => ({
 import {
   setupTerminalAddons,
   createImageAddon,
+  createSearchAddon,
   createWebLinksAddon,
   createFileLinksAddon,
   SEARCH_HIGHLIGHT_LIMIT,
@@ -65,13 +66,12 @@ describe("TerminalAddonManager", () => {
       expect(addons.webLinksAddon).toBeNull();
     });
 
-    it("creates SearchAddon eagerly with highlightLimit for bounded match counts", async () => {
+    it("defers SearchAddon until terminal search is opened", async () => {
       const terminal = createMockTerminal();
-      await setupTerminalAddons(terminal);
+      const addons = await setupTerminalAddons(terminal);
 
-      expect(mockSearchAddon).toHaveBeenCalledWith({
-        highlightLimit: SEARCH_HIGHLIGHT_LIMIT,
-      });
+      expect(mockSearchAddon).not.toHaveBeenCalled();
+      expect(addons.searchAddon).toBeNull();
     });
 
     it("activates Unicode 11 widths so modern emoji and CJK glyphs render at 2 cells (issue #7205)", async () => {
@@ -94,8 +94,20 @@ describe("TerminalAddonManager", () => {
       const addons = await setupTerminalAddons(terminal);
 
       expect(terminal.unicode.activeVersion).toBe("6");
-      expect(mockSearchAddon).toHaveBeenCalledTimes(1);
-      expect(addons.searchAddon).toBeDefined();
+      expect(mockSearchAddon).not.toHaveBeenCalled();
+      expect(addons.searchAddon).toBeNull();
+    });
+  });
+
+  describe("createSearchAddon", () => {
+    it("loads search on demand with a bounded highlight count", async () => {
+      const terminal = createMockTerminal();
+      await createSearchAddon(terminal);
+
+      expect(mockSearchAddon).toHaveBeenCalledWith({
+        highlightLimit: SEARCH_HIGHLIGHT_LIMIT,
+      });
+      expect(terminal.loadAddon).toHaveBeenCalledWith(expect.any(mockSearchAddon));
     });
   });
 

--- a/src/services/terminal/paintFabric/PaintFabricCompositor.ts
+++ b/src/services/terminal/paintFabric/PaintFabricCompositor.ts
@@ -731,6 +731,11 @@ export class PaintFabricCompositor implements TerminalPaintPlane {
     return this.plane(id).get(id);
   }
 
+  ensureSearchAddon(id: string): Promise<ManagedTerminal["searchAddon"]> {
+    if (this.isViewOwned(id)) return Promise.resolve(null);
+    return this.plane(id).ensureSearchAddon(id);
+  }
+
   getInstanceForE2E(id: string): ManagedTerminal | undefined {
     if (this.isViewOwned(id)) return undefined;
     return this.plane(id).getInstanceForE2E(id);

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -2,7 +2,7 @@ import { Terminal, IDisposable, IMarker, ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import type { ImageAddon } from "@xterm/addon-image";
-import { SearchAddon } from "@xterm/addon-search";
+import type { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 
 import { TerminalRefreshTier, PanelKind, AgentState } from "@/types";
@@ -75,7 +75,8 @@ export interface ManagedTerminal {
   fitAddon: FitAddon;
   serializeAddon: SerializeAddon;
   imageAddon: ImageAddon | null;
-  searchAddon: SearchAddon;
+  searchAddon: SearchAddon | null;
+  searchAddonPromise?: Promise<SearchAddon | null>;
   fileLinksDisposable: IDisposable | null;
   imageLinksDisposable: IDisposable | null;
   webLinksAddon: WebLinksAddon | null;

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -239,7 +239,7 @@ describe("optimistic panel spawn (#5789)", () => {
     }
   });
 
-  it("realizes a declared recipe batch two terminals at a time", async () => {
+  it("realizes a declared recipe batch three terminals at a time", async () => {
     const { terminalClient } = (await import("@/clients")) as unknown as {
       terminalClient: { spawn: ReturnType<typeof vi.fn> };
     };
@@ -276,11 +276,11 @@ describe("optimistic panel spawn (#5789)", () => {
 
     await Promise.all(launches);
     await drainMicrotasks();
-    expect(terminalClient.spawn).toHaveBeenCalledTimes(2);
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(3);
 
     releases[0]!();
     await drainMicrotasks();
-    expect(terminalClient.spawn).toHaveBeenCalledTimes(3);
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(4);
 
     releases[1]!();
     await drainMicrotasks();

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -158,7 +158,7 @@ class TerminalStartupQueue {
 }
 
 const terminalStartupQueue = new TerminalStartupQueue();
-const RECIPE_TERMINAL_STARTUP_CONCURRENCY = 2;
+const RECIPE_TERMINAL_STARTUP_CONCURRENCY = 3;
 
 export const createAddPanelActions = (
   set: Set,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1359,7 +1359,30 @@ export default defineConfig(({ command, mode }) => {
                 test: /node_modules[\\/]@xterm[\\/]addon-webgl[\\/]/,
                 priority: 75,
               },
-              { name: "vendor-xterm", test: /node_modules[\\/]@xterm[\\/]/, priority: 70 },
+              {
+                // Keep the dynamically imported addons outside the eager xterm
+                // vendor chunk. A broad @xterm rule used to collapse those
+                // import boundaries, making every project view parse image,
+                // search, and Unicode addon code at startup.
+                name: "vendor-xterm",
+                test: /node_modules[\\/]@xterm[\\/](?!addon-(?:image|search|unicode11)[\\/])/,
+                priority: 74,
+              },
+              {
+                name: "vendor-xterm-image",
+                test: /node_modules[\\/]@xterm[\\/]addon-image[\\/]/,
+                priority: 73,
+              },
+              {
+                name: "vendor-xterm-search",
+                test: /node_modules[\\/]@xterm[\\/]addon-search[\\/]/,
+                priority: 73,
+              },
+              {
+                name: "vendor-xterm-unicode11",
+                test: /node_modules[\\/]@xterm[\\/]addon-unicode11[\\/]/,
+                priority: 73,
+              },
               {
                 // Excludes @codemirror/lang-* and @codemirror/legacy-modes so
                 // those per-language parsers split into their own async chunks


### PR DESCRIPTION
## Summary

- accelerate file search with one Git path-list subprocess, cached normalized paths and basename offsets, lazy collation, and candidate narrowing across progressive queries
- speed review diffs by directly constructing the common refractor token shape and fusing tokenization/reconstruction work
- speed action-palette filtering with precomputed character fingerprints and a single-character fast path
- reduce startup and eager-renderer cost by deferring low-frequency main services, renderer panels, GitHub lists, and xterm search/image/Unicode addons until first use
- improve recipe fanout with a measured three-wide terminal startup queue and reduce benchmark/E2E memory instrumentation overhead
- correct soak timing/GC boundaries, CopyTree dotfile selection, and the dock-chip pointer-drag E2E path uncovered during exhaustive validation

## Headline benchmarks

| Benchmark | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Large-repository file search | 102.301 ms | 9.048 ms | 91.2% faster |
| Warm file search | 23.860 ms | 2.542 ms | 89.3% faster |
| Action-palette progressive search | 9.279 ms | 3.784 ms | 59.2% faster |
| Oversized diff tokenization | 117.827 ms | 65.999 ms | 44.0% faster |
| Cold file-list construction | 111.733 ms | 80.830 ms | 27.7% faster |
| Representative diff tokenization | 36.170 ms | 32.984 ms | 8.8% faster |
| Eager xterm chunk, gzip | 118,804 B | 88,525 B | 25.5% smaller |
| First-render eager JS, gzip | 1,731,341 B | 1,688,392 B | 2.5% smaller |
| App chunk, gzip | 365,574 B | 350,775 B | 4.1% smaller |
| Retained app RSS growth | 117.4 MB | 100.0 MB | 14.8% lower |
| Renderer retained RSS growth | 91.1 MB | 84.1 MB | 7.7% lower |
| Active renderer footprint | 635.5 MB | 620.9 MB | 2.3% lower |
| Bulk worktrees p95, 1 item | 4,546 ms | 3,692 ms | 18.8% faster |
| Bulk worktrees p95, 6 items | 4,606 ms | 4,007 ms | 13.0% faster |
| Bulk worktrees p95, 10 items | 5,128 ms | 4,841 ms | 5.6% faster |
| Packaged first-interactive p50 | 784.3 ms | 774.4 ms | 1.3% faster |

The full standard nightly matrix improved from 69/70 to 70/70 passing scenarios. Small sub-5 ms scenario deltas were treated as timer noise rather than claimed as product wins.

## Validation

- `npm run check`
- `npm test`: 50,580 passed, 7 skipped, 1 todo
- `npm run test:integration`: 223 passed, 8 conditional skips
- `npm run test:smoke`
- `npm run build`
- performance smoke: 49/49
- performance CI: 63/63
- performance nightly: 70/70
- performance soak: 8/8
- recipe fanout: 6/6 configurations
- bulk issue worktrees: 3/3 configurations
- terminal interactivity: 4/4
- terminal scroll: 4/4 clean isolated run
- memory pressure, retained growth, and five-run kitchen-sink memory benchmarks
- packaged launch A/B: 15 alternating samples per build
- E2E core: 11/11
- E2E full-terminal: 128 discovered, project passed
- E2E full-worktree: 91 discovered, project passed
- E2E full-presets: 126 discovered, project passed
- E2E full-platform: 188 discovered, project passed
- E2E full-panels: 223 discovered, project passed
- E2E full-resilience: 132 discovered, project passed
- E2E full-plugins: 31/31
- E2E nightly memory-leak suite: 10/10
- E2E online invoked: 3 conditional skips because external credentials/OpenCode were unavailable

After incorporating the additional product-facing optimizations from `perf/claude-benchmark-optimisation`, the focused 70-test regression suite, full check/unit/integration gates, E2E build, full-panels bucket, and full-worktree bucket were rerun and passed. The comparison branch's reverted xterm patch and benchmark-only shortcuts were intentionally excluded.

## Notes

- `perf verify-baselines` reports freshness only because the already-committed benchmark baselines predate the repository freshness policy; this local campaign did not rewrite them.
- A later terminal-scroll retry immediately after the complete E2E campaign recorded synchronized host stalls above 250 ms and correctly failed its environmental invariant. The clean isolated 4/4 artifact is the reported comparison.
- Two intermediate packaged-startup medians were noisy regressions: window-created +0.8% and window-shown +1.6%. Ready, first-interactive, and OS-to-interactive medians improved.
