### PR TITLE
Condense the MCP tool surface sent to models every turn

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ From there, follow the architecture doc nearest the surface you're changing. Eac
 | [ipc-services.md](./architecture/ipc-services.md) | The backend/bridge surface — services, IPC handlers, `window.electron` namespaces, clients. |
 | [action-system.md](./architecture/action-system.md) | Central typed dispatch for menus, keybindings, context menus, and agent automation. |
 | [mcp-server.md](./architecture/mcp-server.md) | The local MCP HTTP server that lets agents drive the IDE via built-in actions — including how to connect an external client. |
+| [mcp-context-condensation.md](./architecture/mcp-context-condensation.md) | Authoring standard and CI budgets for the prose and schemas the MCP surface sends a model every turn. |
 | [notification-system.md](./architecture/notification-system.md) | How a runtime signal reaches the user — the five-surface taxonomy and routing machinery. |
 | [destructive-action-safeguards.md](./architecture/destructive-action-safeguards.md) | Living per-action audit and rubric for destructive UI surfaces. |
 | [dev-preview-event-routing.md](./architecture/dev-preview-event-routing.md) | Per-event routing audit for dev-preview lifecycle signals. |

--- a/docs/architecture/mcp-context-condensation.md
+++ b/docs/architecture/mcp-context-condensation.md
@@ -1,0 +1,134 @@
+# MCP context condensation
+
+The authoring standard for every string Daintree pays to send to a model on every turn: tool descriptions, field descriptions, and the JSON Schemas that carry them. It applies to the action manifest, because that manifest _is_ the tool surface of the [MCP server](./mcp-server.md).
+
+This is the Daintree-side half of a standard shared with the assistant CLI. The two repos condense different artifacts (the CLI owns its own tool schemas; this repo owns actions, their schemas, and the prose on both) but the rules below and the reasoning in [What must not be cut](#what-must-not-be-cut) are the same on both sides.
+
+## Why it exists
+
+The tool region is the largest single part of an MCP request, it is re-sent on every round including tool-continuation rounds where nothing the user typed changed, and clients cap what they will accept — Cursor silently truncates past its cap, Copilot hard-errors at 128 tools. #11585 already cut the external surface from 100 tools to 26 for exactly this reason. That cut attacked tool _count_; this standard attacks _bytes per tool_, which is the axis left over.
+
+Measured against the live registry, the wire surface is roughly 41 KB for a third-party client (26 tools) and 181 KB for the full in-app surface (152 tools).
+
+## The idempotency contract
+
+Every rule below is a **predicate on the finished text**, not an instruction to shorten. Applying a predicate that already holds changes nothing, which is what makes the rules safe to re-run in CI and safe to hand to a model as a rewrite instruction.
+
+"Shorten this" is not idempotent. It compounds on every pass and erodes meaning until something breaks, the same way iterated conversation compaction degrades a transcript. So:
+
+- Every rule names a **normal form**, not a direction of travel.
+- Budgets are **ceilings that gate**, never targets to approach. Text already under a ceiling is left alone; a ceiling never instructs a rewrite by itself.
+- No rule references the previous version of the text. "Remove redundancy with what came before" cannot be evaluated on the artifact alone and will not converge.
+- Anything still over a ceiling after one normalization pass gets **split or moved to a shared home** — never a second trim pass. A second trim is where idempotency dies.
+
+## What must not be cut
+
+Read this before the budgets. Over-compression is worse than no compression, and the failure is invisible until routing quality drops: the model picks the neighbouring tool, and nothing in the size numbers says so.
+
+The following is **protected content**. It may never be removed to meet a budget. If something cannot fit its ceiling with these intact, it is too big and must be split, not trimmed:
+
+1. **Disambiguation against a named sibling** — "use the batched wait for several terminals". This is what stops the model picking the neighbour, and it is the first thing a naive compressor deletes because it reads as an aside.
+2. **Negative constraints** — "Leave unset over MCP, where the bridge stamps its own origin." A prohibition is not padding.
+3. **Non-obvious shape requirements** — "supplying an empty list is rejected rather than treated as no scoping". These exist because a caller got it wrong.
+4. **Per-property semantics** — what a parameter _means_, as distinct from its type. `cadenceMs: integer` is not a substitute for the unit and the thing being timed.
+5. **Units, defaults, and return shape** — "defaults to 60s", "returns the panel id".
+
+The budgets target repetition, ceremony, and prose that restates the schema. They do not target meaning.
+
+## The wire/validation split
+
+The single structural change, and the reason the rest is safe.
+
+`argsSchema` (zod) is the authoritative schema. `ActionService.dispatch` validates every call against it; the emitted JSON Schema is never fed back into a validator, so it exists only to be advertised. That makes the two a projection rather than a fork — there is no second schema to hand-maintain, and none to rot.
+
+`toWireSchema` ([`shared/utils/mcpWireSchema.ts`](../../shared/utils/mcpWireSchema.ts)) drops the value-range family — `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `minItems`, `maxItems`, `minLength`, `maxLength`, `minProperties`, `maxProperties`, `minContains`, `maxContains`, `pattern` — from the **input** schemas that ride `tools/list`. Constrained-decoding backends do not enforce these at the token-masking level, so they arrive as plain prompt text: billed every turn, routinely violated anyway, and able to degrade output when the model's chosen path contradicts one.
+
+Server-side enforcement is untouched, though it is worth being precise about which enforcement, because it is not one mechanism. Renderer-dispatched actions are checked by `argsSchema.safeParse`; plugin-contributed actions by the plugin host's own AJV pass against the original descriptor schema; main-process tools (the idle waits, `skills.*`, `mcp.surface`, `project.runCheck`) by their own hand-written argument checks. None of the three reads this projection, so none of them weakens when it drops a keyword.
+
+**Output schemas are deliberately NOT projected.** An advertised `outputSchema` is not advertisement, it is an enforced contract: the MCP SDK compiles it and validates `structuredContent` against it with AJV on the client, and AJV does enforce the value-range family. Stripping it would delete real validation rather than dead prompt text, and it would bite hardest on main-process tools, which never reach the `resultSchema` check that covers renderer dispatches — for those the client's AJV pass is the only validation there is.
+
+Two consequences worth stating:
+
+- **A bound the caller needs is prose, not a keyword.** Put it in the field's `.describe()`, where it survives the projection and reads as the instruction it is.
+- **`additionalProperties: false` is deliberately not stripped.** With a complete `required` array it is what lets a strict backend build a deterministic mask, and it measurably reduces hallucinated keys. Stripping it would cost accuracy to save bytes.
+
+The walk is keyword-aware rather than name-aware, because a schema may legally declare a _property_ called `pattern` or `maximum`. A blind key-delete would silently un-advertise a required argument — a failure with no error anywhere.
+
+`actions.getSchema` is deliberately left un-projected. It is an on-demand single-entry fetch rather than a per-turn cost, which makes it the escape hatch where full constraints stay visible.
+
+The `mcp.surface` compatibility hash is likewise computed from the **unprojected** input schema. That digest answers "would my existing calls still work", and tightening a `maximum` from 100 to 50 breaks calls that used to succeed — hashing the projected view would let exactly that change pass silently. Compatibility is a property of what the server accepts, not of what the model is shown.
+
+## Normal forms
+
+### Tool description
+
+In order, and nothing else:
+
+1. **One imperative sentence** naming the action. Present tense, no leading article, no "This tool…", no restatement of the tool's own name.
+2. Optional — a **trigger clause** ("Use this to…"), only when the action sentence does not already imply it.
+3. Optional — **disambiguation** naming a sibling. In this repo siblings are named in _prose_, not by action id: a client rewrites every character outside `[A-Za-z0-9_-]` when it namespaces a tool, so a literal `terminal.list` in a description points at a name the model was never shown. `actionDefinitions.quality.test.ts` enforces this.
+4. Optional — **prohibitions and shape traps**.
+5. Optional — **return shape**, one clause.
+
+Predicates, all enforced:
+
+- No sentence restates a parameter's name, type, or default — the schema carries those adjacently and the model reads both.
+- No cross-reference to another tool by action id.
+- No marketing language ("powerful", "flexible", "comprehensive", "seamlessly").
+- No sentence that would still be true if the tool did the opposite thing.
+
+### Field description
+
+One clause: what the value means, and its unit. Not its type, not its presence rules — `required` already says that. A field whose meaning is fully carried by its name and `enum` takes **no** description.
+
+**Shared vocabulary is defined once.** Where a concept appears on many tools — worktree and project selectors, spawn provenance, focus policy — it is described on the shared schema and inherited, not restated per tool. `locationArgs.ts` is the worked example: four descriptions cover 94 advertised properties.
+
+## Budgets
+
+Enforced by [`src/services/actions/__tests__/mcpWireBudget.test.ts`](../../src/services/actions/__tests__/mcpWireBudget.test.ts), measured from the live registry rather than a fixture, so a captured copy cannot drift while the gates keep passing.
+
+|                                  | budget    | kind                                             |
+| -------------------------------- | --------- | ------------------------------------------------ |
+| Tool description                 | 400 B     | hard ceiling                                     |
+| Tool description                 | 120 B     | hard floor (`actionDefinitions.quality.test.ts`) |
+| Field description                | 160 B     | target, ratcheted by count                       |
+| Field description                | 320 B     | hard ceiling                                     |
+| Tool `parameters`                | 1,500 B   | hard ceiling, justified allowlist                |
+| External wire surface            | 42,000 B  | aggregate ratchet                                |
+| Full in-app wire surface         | 190,000 B | aggregate ratchet                                |
+| Value-range keywords on the wire | zero      | hard                                             |
+
+The aggregate ratchets bound the description-and-schema payload — the part authors control and the part that moves. They are deliberately not the full serialized `tools/list` byte count, which also carries tool names, annotations, `_meta.examples` and JSON framing that this standard does not govern.
+
+The field-description target is a **count ratchet** (paired with a total-excess ratchet, so the same thirty descriptions cannot each grow from 161 B to 319 B unnoticed) rather than a hard ceiling, and that is a deliberate local calibration. #11542 moved field semantics out of tool descriptions and into `.describe()` so the top-level prose could shrink; enforcing 160 B here would push that text back up into the tool description now capped at 400 B, or delete it. What sits above the target today is protected content. The ratchet may fall freely; raising it is a deliberate act that belongs in a commit message with a reason.
+
+Two allowlists carry a written reason per entry — oversized `parameters`, keyed by tool, and oversized field descriptions, keyed by `toolId :: schema path`. The second is path-scoped on purpose: exempting a whole tool would silently extend the exemption to every field added to it later. Both are checked for staleness against the ceiling they exempt, because an entry that no longer needs its exemption would otherwise go on covering the next regression.
+
+## Application order
+
+Fixed, so that two conforming passes cannot disagree about which rule fired first.
+
+1. Project the wire view (mechanical, no judgment).
+2. Delete restated types, defaults, and presence rules (mechanical).
+3. Delete hedges, boasts, and provenance (mechanical).
+4. Normalize to the forms above (judgment).
+5. Re-measure. Anything still over ceiling goes to step 6 — **never back to step 4**.
+6. Split the tool, or move the text to a shared schema.
+
+Steps 1–3 are safely automatable. Steps 4–6 touch meaning and are reviewed against [What must not be cut](#what-must-not-be-cut).
+
+## Measuring
+
+The gates fail with the offending ids and byte counts, so the suite is the report:
+
+```bash
+npx vitest run src/services/actions/__tests__/mcpWireBudget.test.ts
+```
+
+`measureWireSurface()` in [`src/services/actions/__tests__/helpers/wireSurface.ts`](../../src/services/actions/__tests__/helpers/wireSurface.ts) returns the per-tool breakdown (description, params, output, and every field description with its path) if you need to rank candidates rather than check a ceiling.
+
+## Open questions
+
+- **`$ref` / `$defs` deduplication.** Schemas are emitted with `reused: "inline"`, so a shared shape is duplicated at every use site. Deduplicating is legal, but whether it saves _prompt_ tokens is unresolved: providers generally dereference or compile the schema before it reaches the model's context, in which case `$ref` shrinks the HTTP payload and not the billed prompt. Resolve it by measuring reported prompt tokens on one tool both ways before adopting it anywhere.
+- **Output schemas.** They ride `tools/list` and are 43 KB of the in-app surface, a quarter of it, and nothing here governs them: the wire projection is deliberately withheld (it would delete client-side validation) and the prose rules were written for arguments. Shrinking them means returning less, or returning it in a flatter shape — a design question, not an authoring one.
+- **Whether the tool inventory has the right shape.** Orchestration tools are mostly verbs over a small set of nouns (terminal, agent, worktree, recipe), which invites collapsing each noun into one polymorphic tool. The atomicity ceiling deliberately pushes the other way, because overloaded multi-mode tools measure badly against atomic ones. The tension is real: the win may be entirely in bytes-per-tool rather than in tool count. Resolve it with a measurement, not an intuition.

--- a/docs/architecture/mcp-context-condensation.md
+++ b/docs/architecture/mcp-context-condensation.md
@@ -8,7 +8,7 @@ This is the Daintree-side half of a standard shared with the assistant CLI. The 
 
 The tool region is the largest single part of an MCP request, it is re-sent on every round including tool-continuation rounds where nothing the user typed changed, and clients cap what they will accept — Cursor silently truncates past its cap, Copilot hard-errors at 128 tools. #11585 already cut the external surface from 100 tools to 26 for exactly this reason. That cut attacked tool _count_; this standard attacks _bytes per tool_, which is the axis left over.
 
-Measured against the live registry, the wire surface is roughly 41 KB for a third-party client (26 tools) and 181 KB for the full in-app surface (152 tools).
+Measured against the live registry, the wire surface is roughly 42 KB for a third-party client (26 tools) and 184 KB for the full in-app surface (152 tools).
 
 ## The idempotency contract
 
@@ -94,7 +94,7 @@ Enforced by [`src/services/actions/__tests__/mcpWireBudget.test.ts`](../../src/s
 | Field description                | 160 B     | target, ratcheted by count                       |
 | Field description                | 320 B     | hard ceiling                                     |
 | Tool `parameters`                | 1,500 B   | hard ceiling, justified allowlist                |
-| External wire surface            | 42,000 B  | aggregate ratchet                                |
+| External wire surface            | 43,000 B  | aggregate ratchet                                |
 | Full in-app wire surface         | 190,000 B | aggregate ratchet                                |
 | Value-range keywords on the wire | zero      | hard                                             |
 

--- a/docs/architecture/mcp-context-condensation.md
+++ b/docs/architecture/mcp-context-condensation.md
@@ -104,6 +104,18 @@ The field-description target is a **count ratchet** (paired with a total-excess 
 
 Two allowlists carry a written reason per entry — oversized `parameters`, keyed by tool, and oversized field descriptions, keyed by `toolId :: schema path`. The second is path-scoped on purpose: exempting a whole tool would silently extend the exemption to every field added to it later. Both are checked for staleness against the ceiling they exempt, because an entry that no longer needs its exemption would otherwise go on covering the next regression.
 
+### Raising a ratchet
+
+Every budget above may fall freely. Raising one is a deliberate act, and the reason has to be one of these — anything else means the budget is doing its job and the change is what should give way:
+
+1. **The surface genuinely grew.** A new tool was added on purpose, or an existing one gained an argument it needs. The ratchet moves by roughly what that addition costs, in the same commit that adds it.
+2. **Protected content was restored.** A clause came back because it was cut in error — see [What must not be cut](#what-must-not-be-cut). Name the clause.
+3. **The measurement changed, not the surface.** The harness started counting something it should always have counted. Say what, and expect the number to jump once and then hold.
+
+What is **not** a reason: a tool that came in over budget and would fit if some unrelated prose were trimmed. That trade is the failure mode this whole standard exists to prevent — it pays for a new tool with the disambiguation clause on an old one, and the bill arrives as a routing regression nobody traces back. If a new tool does not fit, the options are to shrink _that tool_, to drop something from the tier, or to raise the ceiling on the record. Not to go hunting elsewhere.
+
+Headroom is deliberately thin — the external aggregate sits within a couple of percent of its ceiling — so this decision will come up on roughly the next tool added. It is written down here so it gets made on the merits rather than under deadline.
+
 ## Application order
 
 Fixed, so that two conforming passes cannot disagree about which rule fired first.

--- a/electron/services/mcp-server/__tests__/surfaceManifest.test.ts
+++ b/electron/services/mcp-server/__tests__/surfaceManifest.test.ts
@@ -398,12 +398,34 @@ describe("hash", () => {
     expect(hashOf(withEnum(["a", "b"]))).not.toBe(hashOf(withEnum(["b", "a"])));
   });
 
+  it("moves when a value bound is tightened", () => {
+    // The case the frozen fixture below cannot see, because it carries no bound
+    // at all. `maximum: 100` -> `maximum: 50` starts rejecting calls that used
+    // to succeed, so it is exactly the incompatibility this digest promises to
+    // report — and it is invisible in the ADVERTISED schema, which projects the
+    // value-range keywords away for the model. This is what pins the preimage to
+    // `entry.inputSchema` rather than to `buildToolInputSchema(entry)`.
+    const withMax = (maximum: number): ActionManifestEntry[] => [
+      entry({
+        id: "actions.list",
+        inputSchema: { type: "object", properties: { limit: { type: "number", maximum } } },
+      }),
+    ];
+
+    expect(hashOf(withMax(100))).not.toBe(hashOf(withMax(50)));
+  });
+
   it("pins the published digest for a frozen surface", () => {
     // The hash is a client-facing contract: a refactor that changed every
     // digest would keep every relative assertion above green while silently
     // breaking every client that stored one. This fixture is deliberately
     // hand-frozen — update it only alongside a MCP_SURFACE_MANIFEST_VERSION
     // bump and a note in the PR, never to make a failing run pass.
+    //
+    // Last moved for v2, which re-pointed the preimage at the unprojected
+    // `entry.inputSchema` (see MCP_SURFACE_MANIFEST_VERSION). That dropped the
+    // `additionalProperties: false` the advertised view injects, so every v1
+    // digest is stale by construction.
     const frozen: ActionManifestEntry[] = [
       entry({
         id: "actions.list",
@@ -419,7 +441,7 @@ describe("hash", () => {
     ];
 
     expect(buildSurfaceManifest(frozen, "action", APP_VERSION).hash).toBe(
-      "00c81d0089fa582bd988cf8fa8280cd703b69b523846f190b5fce5cf2340055b"
+      "e19447a203b1badebb082cd110c51768030ab6f4057afc804b9ba746a679efe4"
     );
   });
 

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -15,6 +15,8 @@ vi.mock("../../McpPaneConfigService.js", () => ({
 
 import {
   buildAnnotations,
+  buildToolInputSchema,
+  buildToolOutputSchema,
   extractBearerToken,
   filterIntrospectionResultForSession,
   getTierPermittedActionIds,
@@ -31,6 +33,7 @@ import {
   ACTIONS_SEARCH_MAX_LIMIT,
   INTROSPECTION_TOOL_IDS,
 } from "../tierAuth.js";
+import { findWireStrippedKeywords } from "../../../../shared/utils/mcpWireSchema.js";
 import { TIER_ALLOWLISTS } from "../shared.js";
 import { BUILT_IN_ACTION_IDS } from "../../../../shared/config/actionIds.js";
 import type { ActionManifestEntry } from "../../../../shared/types/actions.js";
@@ -305,6 +308,86 @@ function makeEntry(overrides: Partial<ActionManifestEntry> = {}): ActionManifest
     ...overrides,
   };
 }
+
+/**
+ * The wire/validation split, asserted against the SHIPPED builders rather than
+ * against a reimplementation of them. This is the pair `sessionServer` calls to
+ * fill `tools/list`, so deleting the projection from `buildToolInputSchema` —
+ * or accidentally adding one to `buildToolOutputSchema` — fails here.
+ *
+ * The budget suite in `src/services/actions/__tests__/mcpWireBudget.test.ts`
+ * measures the same projection over the live registry, but it necessarily
+ * re-applies it in the renderer (these builders are main-process modules). That
+ * makes it a measurement of the standard, not proof of the production path;
+ * this is the proof.
+ */
+describe("wire/validation schema split", () => {
+  const CONSTRAINED_SCHEMA = {
+    type: "object",
+    properties: {
+      limit: { type: "integer", minimum: 1, maximum: 100, description: "How many" },
+      tags: { type: "array", items: { type: "string", maxLength: 8 }, minItems: 1 },
+      // A property NAMED after a keyword: it must survive as an advertised argument.
+      pattern: { type: "string", pattern: "^a", description: "The glob" },
+    },
+    required: ["limit", "pattern"],
+  } as const;
+
+  it("advertises no value-range keyword on the input schema", () => {
+    const wire = buildToolInputSchema(
+      makeEntry({ inputSchema: structuredClone(CONSTRAINED_SCHEMA) as Record<string, unknown> })
+    );
+
+    expect(findWireStrippedKeywords(wire)).toEqual([]);
+  });
+
+  it("keeps every argument the schema declares, including keyword-named ones", () => {
+    const wire = buildToolInputSchema(
+      makeEntry({ inputSchema: structuredClone(CONSTRAINED_SCHEMA) as Record<string, unknown> })
+    );
+
+    const properties = (wire as { properties: Record<string, unknown> }).properties;
+    expect(Object.keys(properties).sort()).toEqual(["limit", "pattern", "tags"]);
+    // Prose and the mask-relevant keywords survive; only the bounds go.
+    expect(properties["pattern"]).toEqual({ type: "string", description: "The glob" });
+    expect((wire as { required: string[] }).required).toEqual(["limit", "pattern"]);
+  });
+
+  it("always advertises additionalProperties:false", () => {
+    // Load-bearing for strict/grammar-constrained backends, so it must survive
+    // the projection AND be added to a schema that omitted it.
+    expect(
+      buildToolInputSchema(makeEntry({ inputSchema: { type: "object", properties: {} } }))
+    ).toMatchObject({ additionalProperties: false });
+    expect(buildToolInputSchema(makeEntry())).toMatchObject({ additionalProperties: false });
+  });
+
+  it("does not mutate the manifest entry it projects", () => {
+    const inputSchema = structuredClone(CONSTRAINED_SCHEMA) as Record<string, unknown>;
+    const before = JSON.stringify(inputSchema);
+    buildToolInputSchema(makeEntry({ inputSchema }));
+
+    expect(JSON.stringify(inputSchema)).toBe(before);
+  });
+
+  it("leaves the OUTPUT schema unprojected", () => {
+    // An advertised `outputSchema` is compiled and enforced by the MCP SDK's AJV
+    // pass on the client, and main-process tools never get the `resultSchema`
+    // check that covers renderer dispatches. Stripping bounds here would delete
+    // real validation rather than dead prompt text.
+    const outputSchema = {
+      type: "object",
+      properties: { hash: { type: "string", pattern: "^[0-9a-f]{64}$", minLength: 64 } },
+    };
+
+    expect(buildToolOutputSchema(makeEntry({ outputSchema }))).toEqual(outputSchema);
+  });
+
+  it("still refuses a non-object output schema", () => {
+    expect(buildToolOutputSchema(makeEntry({ outputSchema: { type: "string" } }))).toBeUndefined();
+    expect(buildToolOutputSchema(makeEntry())).toBeUndefined();
+  });
+});
 
 describe("shouldExposeTool", () => {
   it("exposes core entries when tier-permitted", () => {

--- a/electron/services/mcp-server/surfaceManifest.ts
+++ b/electron/services/mcp-server/surfaceManifest.ts
@@ -4,7 +4,6 @@ import type { McpSurfaceManifest, McpSurfaceTool } from "../../../shared/types/m
 import { type McpTier, minimumPermittingTier } from "./shared.js";
 import {
   buildAnnotations,
-  buildToolInputSchema,
   buildToolOutputSchema,
   shouldExposeTool,
   UNBOUND_SESSION_SURFACE,
@@ -18,12 +17,21 @@ export const MCP_SURFACE_TOOL_ID = "mcp.surface";
  * removed, or given new meaning — never for a change in which tools the surface
  * contains, which is what `hash` is for.
  *
+ * v2: `hash` was given new meaning. Its preimage used to be the ADVERTISED input
+ * schema (`buildToolInputSchema`), which now projects away the value-range
+ * keywords for the model's benefit. Hashing that projection would have made a
+ * genuine incompatibility invisible — tightening a `maximum` from 100 to 50
+ * starts rejecting calls that used to succeed while the digest sat still — so
+ * the preimage moved to the unprojected `entry.inputSchema`. Every stored digest
+ * from v1 is therefore stale by construction, which is precisely what a version
+ * bump is for.
+ *
  * Lives here rather than beside the payload types in `shared/` on purpose: main
  * is the only process that stamps it, and keeping it out of the shared module
  * lets that module stay a type-only import from here, so its `zod` value import
  * never becomes an eager edge on the main-process boot path.
  */
-export const MCP_SURFACE_MANIFEST_VERSION = 1;
+export const MCP_SURFACE_MANIFEST_VERSION = 2;
 
 /** JSON Schema keywords whose value is itself a schema. */
 const SCHEMA_VALUED_KEYS = new Set([
@@ -220,6 +228,15 @@ export function buildSurfaceManifest(
     // `toCompatibilityShape`). They are model-facing prose that is reworded
     // often, and a compatibility check that cried drift on every wording edit
     // is one clients would learn to ignore.
+    //
+    // The INPUT schema is hashed unprojected — `entry.inputSchema`, not
+    // `buildToolInputSchema(entry)`. Those differ: the wire view drops the
+    // value-range keywords (`shared/utils/mcpWireSchema.ts`) because a model
+    // cannot act on them, but a *client* very much can. Tightening a `maximum`
+    // from 100 to 50 starts rejecting calls that used to succeed, which is
+    // exactly the incompatibility this digest promises to report, so hashing the
+    // projected view would let it pass silently. Compatibility is a property of
+    // what the server accepts, not of what the model is shown.
     hashRows.push([
       tool.id,
       tool.tier,
@@ -230,7 +247,7 @@ export function buildSurfaceManifest(
       entry.danger,
       annotations.destructiveHint ?? null,
       annotations.openWorldHint ?? null,
-      toCompatibilityShape(buildToolInputSchema(entry)),
+      toCompatibilityShape(entry.inputSchema ?? null),
       toCompatibilityShape(buildToolOutputSchema(entry) ?? null),
     ]);
   }

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -1,6 +1,7 @@
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { ActionDispatchResult, ActionManifestEntry } from "../../../shared/types/actions.js";
 import { deriveBand, BAND_OVERRIDES } from "../../../shared/utils/actionRiskBand.js";
+import { toWireSchema } from "../../../shared/utils/mcpWireSchema.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { mcpPaneConfigService } from "../McpPaneConfigService.js";
 import type { HelpTokenValidator } from "./shared.js";
@@ -414,6 +415,16 @@ export function readRequestedActionId(args: unknown): string | undefined {
   return typeof actionId === "string" && actionId.length > 0 ? actionId : undefined;
 }
 
+/**
+ * The advertised half of a tool's schema — the wire view.
+ *
+ * `toWireSchema` drops the value-range keywords, which a constrained-decoding
+ * backend never enforces and which therefore reach the model as prompt text
+ * billed on every turn. Nothing is weakened by their absence: `argsSchema` is
+ * what actually validates a dispatch, and it is untouched by this projection.
+ * See `shared/utils/mcpWireSchema.ts` for the full reasoning and for why
+ * `additionalProperties: false` is deliberately not in the stripped set.
+ */
 export function buildToolInputSchema(entry: ActionManifestEntry): Record<string, unknown> {
   if (
     entry.inputSchema &&
@@ -421,7 +432,10 @@ export function buildToolInputSchema(entry: ActionManifestEntry): Record<string,
     !Array.isArray(entry.inputSchema) &&
     entry.inputSchema["type"] === "object"
   ) {
-    return { ...entry.inputSchema, additionalProperties: false } as Record<string, unknown>;
+    return {
+      ...(toWireSchema(entry.inputSchema) as Record<string, unknown>),
+      additionalProperties: false,
+    };
   }
   return {
     type: "object",
@@ -442,6 +456,26 @@ export function buildAnnotations(entry: ActionManifestEntry): ToolAnnotations {
   };
 }
 
+/**
+ * The advertised return shape, emitted verbatim.
+ *
+ * Deliberately NOT projected through {@link toWireSchema}, even though it rides
+ * `tools/list` and costs bytes on every turn like the input half. An output
+ * schema is not advertisement — it is an enforced contract. The MCP SDK compiles
+ * every advertised `outputSchema` and validates `structuredContent` against it
+ * with AJV on the client side, and AJV genuinely enforces the value-range family
+ * that constrained decoding ignores.
+ *
+ * Stripping them would therefore delete real validation rather than dead prompt
+ * text, and it would bite hardest where there is no second line of defence: a
+ * main-process tool returns its result without going through `ActionService`, so
+ * it never gets the `resultSchema` check that covers renderer-dispatched
+ * actions, and the client's AJV pass is the only validation there is. That gap
+ * is latent rather than live today — the main-process tools do not currently opt
+ * into `mcpOutputSchema`, so no output schema is advertised for them at all —
+ * but the moment one does, this projection would be the thing that silently
+ * disarmed it.
+ */
 export function buildToolOutputSchema(
   entry: ActionManifestEntry
 ): Record<string, unknown> | undefined {

--- a/shared/types/terminalWaitUntilIdle.ts
+++ b/shared/types/terminalWaitUntilIdle.ts
@@ -104,7 +104,7 @@ export const WAIT_UNTIL_IDLE_OUTPUT_SCHEMA: Record<string, unknown> = {
 };
 
 export const WAIT_UNTIL_IDLE_DESCRIPTION =
-  "Block until the agent in one terminal stops working, so the next step runs against finished output. Use the batched wait for several terminals, or a status snapshot to poll without blocking. This can hold the call open for a minute in an interactive session and far longer in a headless one. Timing out is a normal result meaning still working, and an exit code appears only once the process has ended — confirm success there before acting irreversibly.";
+  "Block until the agent in one terminal stops working, so the next step sees finished output. Use the batched wait for several terminals, or a status snapshot to poll without blocking. It can hold open for a minute interactively, far longer headless. Timing out is normal and means still working; an exit code appears only once the process ends, so confirm success there before acting irreversibly.";
 
 // === Batched wait (fan-out orchestration) ===
 
@@ -177,4 +177,4 @@ export const WAIT_UNTIL_IDLE_BATCH_OUTPUT_SCHEMA: Record<string, unknown> = {
 };
 
 export const WAIT_UNTIL_IDLE_BATCH_DESCRIPTION =
-  "Block until the first of several agents stops working, or until all of them do — the fan-out primitive for agents that finish at different speeds. Use this rather than waiting on each terminal in turn, or a status snapshot to poll without blocking. This can hold the call open for a minute in an interactive session and far longer in a headless one. Timing out means the condition is not met yet, and terminals no longer tracked count as already finished.";
+  "Block until the first of several agents stops working, or until all of them do; the fan-out primitive when agents finish at different speeds. Use this rather than waiting on each terminal in turn, or a status snapshot to poll without blocking. It can hold the call open for a minute interactively, far longer headless. Timing out means not met yet; untracked terminals count as finished.";

--- a/shared/utils/__tests__/mcpWireSchema.test.ts
+++ b/shared/utils/__tests__/mcpWireSchema.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import {
+  toWireSchema,
+  findWireStrippedKeywords,
+  WIRE_STRIPPED_KEYWORDS,
+} from "../mcpWireSchema.js";
+
+describe("toWireSchema", () => {
+  it("drops value-range keywords from a schema position", () => {
+    const wire = toWireSchema({
+      type: "object",
+      properties: {
+        count: { type: "integer", minimum: 1, maximum: 100, description: "How many" },
+        name: { type: "string", minLength: 1, maxLength: 64, pattern: "^[a-z]+$" },
+      },
+      required: ["count"],
+    });
+
+    expect(wire).toEqual({
+      type: "object",
+      properties: {
+        count: { type: "integer", description: "How many" },
+        name: { type: "string" },
+      },
+      required: ["count"],
+    });
+  });
+
+  it("keeps the keywords a constrained backend actually masks on", () => {
+    // `enum`, `default`, `const` and `additionalProperties: false` are what let a
+    // strict backend build a deterministic mask. Stripping any of them would cost
+    // accuracy to save bytes, which is the opposite of the trade being made.
+    const wire = toWireSchema({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        mode: { type: "string", enum: ["fast", "slow"], default: "fast" },
+        kind: { const: "worktree" },
+      },
+      required: ["mode"],
+    });
+
+    expect(wire).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        mode: { type: "string", enum: ["fast", "slow"], default: "fast" },
+        kind: { const: "worktree" },
+      },
+      required: ["mode"],
+    });
+  });
+
+  it("never drops a property that happens to be NAMED like a keyword", () => {
+    // The trap this walk exists for: `pattern` and `maximum` are legal argument
+    // names. A blind key-delete would silently un-advertise a required argument,
+    // leaving the model unable to call the tool correctly and no error anywhere.
+    const wire = toWireSchema({
+      type: "object",
+      properties: {
+        pattern: { type: "string", description: "The glob to match", maxLength: 200 },
+        maximum: { type: "number", description: "Upper bound the caller wants", minimum: 0 },
+      },
+      required: ["pattern", "maximum"],
+    });
+
+    expect(wire).toEqual({
+      type: "object",
+      properties: {
+        pattern: { type: "string", description: "The glob to match" },
+        maximum: { type: "number", description: "Upper bound the caller wants" },
+      },
+      required: ["pattern", "maximum"],
+    });
+  });
+
+  it("descends through combinators, items and $defs", () => {
+    const wire = toWireSchema({
+      type: "object",
+      $defs: { tag: { type: "string", minLength: 2 } },
+      properties: {
+        tags: { type: "array", items: { type: "string", maxLength: 8 }, minItems: 1 },
+        either: {
+          anyOf: [
+            { type: "string", pattern: "^a" },
+            { type: "number", multipleOf: 5 },
+          ],
+        },
+      },
+    });
+
+    expect(wire).toEqual({
+      type: "object",
+      $defs: { tag: { type: "string" } },
+      properties: {
+        tags: { type: "array", items: { type: "string" } },
+        either: { anyOf: [{ type: "string" }, { type: "number" }] },
+      },
+    });
+  });
+
+  it("is idempotent", () => {
+    // The authoring standard's central requirement: a conforming artifact passed
+    // through the projection again comes back byte-identical. Without this the
+    // projection cannot be safely re-run, in CI or anywhere else.
+    const source = {
+      type: "object",
+      properties: {
+        a: { type: "string", minLength: 3, description: "A" },
+        b: { type: "array", items: { type: "integer", minimum: 0 }, maxItems: 4 },
+      },
+    };
+    const once = toWireSchema(source);
+    const twice = toWireSchema(once);
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+  });
+
+  it("leaves non-schema values alone", () => {
+    expect(toWireSchema(null)).toBeNull();
+    expect(toWireSchema("text")).toBe("text");
+    expect(toWireSchema(7)).toBe(7);
+  });
+});
+
+describe("findWireStrippedKeywords", () => {
+  it("reports what a projection would remove, and finds nothing in its output", () => {
+    const source = {
+      type: "object",
+      properties: {
+        count: { type: "integer", minimum: 1 },
+        tags: { type: "array", items: { type: "string", maxLength: 4 } },
+      },
+    };
+
+    expect(findWireStrippedKeywords(source).sort()).toEqual([
+      "properties.count.minimum",
+      "properties.tags.items.maxLength",
+    ]);
+    expect(findWireStrippedKeywords(toWireSchema(source))).toEqual([]);
+  });
+
+  it("does not report a property merely named after a keyword", () => {
+    expect(
+      findWireStrippedKeywords({ type: "object", properties: { pattern: { type: "string" } } })
+    ).toEqual([]);
+  });
+});
+
+describe("WIRE_STRIPPED_KEYWORDS", () => {
+  it("covers the whole value-range family rather than a sample of it", () => {
+    // Half-covering the family is the failure mode: `minimum` stripped while
+    // `exclusiveMinimum` survives reads as a decision nobody made, and holds the
+    // door open for exactly the bytes the projection removes.
+    for (const paired of [
+      ["minimum", "exclusiveMinimum"],
+      ["maximum", "exclusiveMaximum"],
+      ["minItems", "maxItems"],
+      ["minLength", "maxLength"],
+      ["minProperties", "maxProperties"],
+    ]) {
+      for (const keyword of paired) {
+        expect(WIRE_STRIPPED_KEYWORDS.has(keyword), `${keyword} must be stripped`).toBe(true);
+      }
+    }
+  });
+
+  it("never strips a keyword the model needs in order to call correctly", () => {
+    for (const keyword of [
+      "type",
+      "properties",
+      "required",
+      "enum",
+      "default",
+      "description",
+      "const",
+      "additionalProperties",
+      "items",
+      "anyOf",
+      "oneOf",
+      "allOf",
+    ]) {
+      expect(WIRE_STRIPPED_KEYWORDS.has(keyword), `${keyword} must survive`).toBe(false);
+    }
+  });
+});

--- a/shared/utils/mcpWireSchema.ts
+++ b/shared/utils/mcpWireSchema.ts
@@ -1,0 +1,160 @@
+/**
+ * The wire projection of a tool's JSON Schema — what the model is shown, as
+ * distinct from what actually validates the call.
+ *
+ * One authoritative schema per action already exists: the zod `argsSchema`.
+ * `ActionService.dispatch` validates every call against it, and the emitted JSON
+ * Schema is never fed back into a validator — it exists only to be advertised.
+ * That makes the two views a projection rather than a fork, which is the whole
+ * point: hand-maintaining two schemas rots on the first edit.
+ *
+ * What this strips is the value-range family. Constrained-decoding backends do
+ * not enforce these at the token-masking level, so they arrive as plain prompt
+ * text: paid for on every turn, routinely violated anyway, and capable of
+ * degrading output when the model's chosen path contradicts one.
+ *
+ * Server-side enforcement is unaffected, but it is worth being precise about
+ * *which* enforcement, because it is not one mechanism: renderer-dispatched
+ * actions are checked by `argsSchema.safeParse`, plugin-contributed actions by
+ * the plugin host's own AJV pass against the original descriptor schema, and
+ * main-process tools by their own hand-written argument checks. None of the
+ * three reads this projection, so none of them weakens when it drops a keyword.
+ *
+ * This applies to INPUT schemas only. An advertised `outputSchema` is a
+ * contract the MCP SDK compiles and enforces with AJV on the client, so it is
+ * deliberately not projected — see `buildToolOutputSchema` in
+ * `electron/services/mcp-server/tierAuth.ts`.
+ *
+ * A bound the caller genuinely needs in order to call correctly is therefore
+ * prose, not a keyword: put it in the field's `.describe()`, where it survives
+ * this projection and reads as the instruction it is.
+ *
+ * Deliberately kept OUT of this projection: `type`, `properties`, `required`,
+ * `enum`, `default`, `description`, `const`, the combinator keywords, and
+ * `additionalProperties`. The last one plus a complete `required` array is what
+ * lets a strict backend build a deterministic mask, and it measurably reduces
+ * hallucinated keys — stripping it would cost accuracy to save bytes.
+ */
+
+/**
+ * Value-range keywords, stripped from the wire view.
+ *
+ * `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `minContains` and
+ * `maxContains` are the same class of constraint as the rest and are stripped
+ * for the same reason, even though the authoring standard's list names only the
+ * nine common ones. Leaving them in would hold the door open for exactly the
+ * bytes this removes, and a reader would have no way to tell the omission from
+ * a decision.
+ */
+export const WIRE_STRIPPED_KEYWORDS: ReadonlySet<string> = new Set([
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+  "minItems",
+  "maxItems",
+  "minLength",
+  "maxLength",
+  "minProperties",
+  "maxProperties",
+  "minContains",
+  "maxContains",
+  "pattern",
+]);
+
+/** JSON Schema keywords whose value is itself a schema. */
+const SCHEMA_VALUED_KEYS: ReadonlySet<string> = new Set([
+  "items",
+  "additionalItems",
+  "additionalProperties",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+  "contains",
+  "contentSchema",
+  "propertyNames",
+  "not",
+  "if",
+  "then",
+  "else",
+]);
+
+/** Keywords whose value is a map of name → schema. */
+const SCHEMA_MAP_KEYS: ReadonlySet<string> = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+]);
+
+/** Keywords whose value is an array of schemas. */
+const SCHEMA_LIST_KEYS: ReadonlySet<string> = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
+
+/**
+ * Strip the value-range keywords from a JSON Schema, walking by keyword rather
+ * than by name.
+ *
+ * The distinction is load-bearing. A schema is free to declare a *property*
+ * called `pattern` or `maximum` — `{properties: {pattern: {type: "string"}}}` is
+ * a legal tool argument, and a blind key-delete would silently drop it from the
+ * advertised surface, leaving a required argument the model is never told about.
+ * So recursion only descends into positions that actually hold schemas, and the
+ * strip only fires on a keyword sitting in a schema position.
+ *
+ * Unrecognised keywords are copied verbatim rather than traversed. That errs
+ * toward keeping bytes: a range keyword nested under a keyword this function has
+ * never heard of survives into the wire view. The cost is a few bytes; the
+ * inverse error would be dropping a constraint that some other consumer needs,
+ * which is the direction worth avoiding.
+ */
+export function toWireSchema(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(toWireSchema);
+  if (node === null || typeof node !== "object") return node;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (WIRE_STRIPPED_KEYWORDS.has(key)) continue;
+
+    if (SCHEMA_VALUED_KEYS.has(key) || SCHEMA_LIST_KEYS.has(key)) {
+      out[key] = toWireSchema(value);
+    } else if (SCHEMA_MAP_KEYS.has(key) && value !== null && typeof value === "object") {
+      out[key] = Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([name, schema]) => [
+          name,
+          toWireSchema(schema),
+        ])
+      );
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/** Every value-range keyword still present in a schema, as `path → keyword`. */
+export function findWireStrippedKeywords(node: unknown, path = ""): string[] {
+  const found: string[] = [];
+  const walk = (value: unknown, at: string): void => {
+    if (Array.isArray(value)) {
+      value.forEach((item, i) => walk(item, `${at}[${i}]`));
+      return;
+    }
+    if (value === null || typeof value !== "object") return;
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (WIRE_STRIPPED_KEYWORDS.has(key)) {
+        found.push(`${at || "<root>"}.${key}`);
+        continue;
+      }
+      if (SCHEMA_VALUED_KEYS.has(key) || SCHEMA_LIST_KEYS.has(key)) {
+        walk(child, at ? `${at}.${key}` : key);
+      } else if (SCHEMA_MAP_KEYS.has(key) && child !== null && typeof child === "object") {
+        for (const [name, schema] of Object.entries(child as Record<string, unknown>)) {
+          walk(schema, at ? `${at}.${key}.${name}` : `${key}.${name}`);
+        }
+      }
+    }
+  };
+  walk(node, path);
+  return found;
+}

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -1995,7 +1995,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "List repository issues from the active forge provider, a page at a time. Use this to discover or filter issues; use the pull-request listing for PRs, and the single-issue lookup for a known number. Summary results keep responses small by dropping bodies and raw provider payloads; ask for full results only when the body is needed. Bypassing the cache spends a live round trip.",
+    "description": "List repository issues from the active forge provider, a page at a time. Use this to discover or filter issues; use the pull-request listing for PRs, and the single-issue lookup for a known number. Search takes a provider-native query fragment, not plain text, and routes through the provider's search API rather than the list cache pagination uses. Bypassing the cache spends a live round trip.",
     "examples": undefined,
     "id": "forge.listIssues",
     "keywords": undefined,

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -61,7 +61,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "introspection",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Enumerate the available actions as lightweight entries, filtered by domain or substring and returned a page at a time. Use ranked search instead when looking for a capability by intent; use this when the goal is to walk a domain systematically. Entries omit argument and result schemas to stay small — fetch one action's schema before dispatching it. Ordering is stable, so paging cannot skip or repeat entries.",
+    "description": "Enumerate the available actions as lightweight entries, filtered by domain or substring and returned a page at a time. Use ranked search instead when looking for a capability by intent; use this when walking a domain systematically. Entries omit argument and result schemas to stay small, so fetch one action's schema before dispatching. Ordering is stable, so paging cannot skip or repeat entries.",
     "examples": undefined,
     "id": "actions.list",
     "keywords": undefined,
@@ -85,7 +85,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "introspection",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Find actions by describing what you want to do, ranked by how well each matches. This is the discovery path: start here, then fetch the chosen action's schema before dispatching it. Use the plain listing instead when walking a domain systematically rather than searching by intent. Results omit argument and result schemas to stay small, and matching nothing returns an empty list rather than failing.",
+    "description": "Find actions by describing what you want to do, ranked by how well each matches. This is the discovery path: start here, then fetch the chosen action's schema before dispatching it. Use the plain listing when walking a domain systematically rather than searching by intent. Results omit argument and result schemas to stay small, and matching nothing returns an empty list rather than failing.",
     "examples": [
       {
         "args": {
@@ -370,7 +370,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "agent",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Start an AI agent in a new terminal and report where it landed, so parallel launches can be told apart without re-resolving the target. Success means the panel was created and its process is starting, not that the agent is ready — poll its state or a terminal status snapshot for that. A failure to launch may mean the agent's CLI is missing, in which case a setup diagnostic panel is opened instead. Launching consumes real resources, so keep concurrent launches modest.",
+    "description": "Start an AI agent in a new terminal and report where it landed, so parallel launches can be told apart without re-resolving the target. Success means the panel was created and its process is starting, not that the agent is ready; poll its state or a terminal status snapshot for that. A missing CLI opens a setup diagnostic panel instead. Keep concurrent launches modest.",
     "examples": undefined,
     "id": "agent.launch",
     "keywords": undefined,
@@ -382,7 +382,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "agent",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "List every registered agent — built-in, user-defined and plugin-contributed — from the authoritative registry, including ones that are not currently launchable. Use this before launching so an id is known to exist, and read each entry's launchability rather than assuming membership implies it. Those fields appear only once a live probe of each CLI finishes, and the result says so while that is incomplete.",
+    "description": "List every registered agent, built-in, user-defined and plugin-contributed, from the authoritative registry, including ones not currently launchable. Use this before launching so an id is known to exist, and read each entry's launchability rather than assuming membership implies it. Those fields appear only once a live probe of each CLI finishes, and the result says so while that is incomplete.",
     "examples": undefined,
     "id": "agent.listAvailable",
     "keywords": undefined,
@@ -485,7 +485,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "agent",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "List closed agent sessions that can be relaunched, read from the on-disk journal. This is a faithful record of which sessions exist, not a summary of what happened in them — it carries no transcript text. It must be scoped to a worktree or project and fails rather than listing every project when no scope can be resolved. Old sessions are pruned by the journal's retention policy, so absence does not mean a session never existed.",
+    "description": "List closed agent sessions that can be relaunched, read from the on-disk journal. This is a faithful record of which sessions exist, not a summary of what happened in them: it carries no transcript text. It must be scoped to a worktree or project and fails rather than listing every project when no scope resolves. Old sessions are pruned by retention, so absence does not prove one never existed.",
     "examples": [
       {
         "args": {
@@ -992,7 +992,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "copyTree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Bundle a worktree's file tree and selected file contents into a context dump written to a temporary file, and return its path. Use this to hand a large codebase context to something that can read a file; inject directly into a terminal instead when the target is an agent. The bundle routinely runs to tens of megabytes and is never returned inline. Check the budget flags before trusting it as complete, and read the file promptly — it is pruned by age.",
+    "description": "Bundle a worktree's file tree and selected file contents into a context dump on disk, and return its path. Use it to hand a large codebase context to something that can read a file; inject into a terminal when the target is an agent. The bundle routinely runs to tens of megabytes and is never returned inline. Check the budget flags before trusting it, and read it promptly: it is pruned by age.",
     "examples": undefined,
     "id": "copyTree.generate",
     "keywords": [
@@ -1009,7 +1009,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "copyTree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Bundle a worktree's context to a file and put it on the system clipboard, replacing what the user had copied. Selection can mix exact files with globs, so this assembles a curated bundle of scattered related files, their supporting code and tests, rather than the whole worktree. Agent and MCP callers must name the worktree instead of relying on whichever is active. macOS and Linux copy the file, Windows its path. Never returned inline; check the budget flags for completeness.",
+    "description": "Bundle a worktree's context to a file and onto the system clipboard, replacing what the user had copied. Selection mixes exact files with globs, so this assembles a curated bundle rather than the whole worktree. Agent and MCP callers must name the worktree, not rely on the active one. macOS and Linux copy the file, Windows its path. Never returned inline; check the budget flags for completeness.",
     "examples": undefined,
     "id": "copyTree.generateAndCopyFile",
     "keywords": undefined,
@@ -1584,7 +1584,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Read a snapshot of the in-app fleet broadcast the user is currently running, including per-terminal delivery and liveness. This only observes — it dispatches nothing, so driving a fan-out means sending to each terminal yourself and watching them with a status snapshot or batched wait. Agent state here is a passive heuristic and any parsed check result is not a process exit code, so confirm both before acting on them.",
+    "description": "Read a snapshot of the in-app fleet broadcast the user is currently running, including per-terminal delivery and liveness. This only observes and dispatches nothing, so drive a fan-out by sending to each terminal yourself and watching with a status snapshot or batched wait. Agent state here is a passive heuristic and a parsed check result is not an exit code; confirm both before acting.",
     "examples": undefined,
     "id": "fleet.getRunStatus",
     "keywords": undefined,
@@ -1880,7 +1880,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "List every CI check on one pull request — each check's name, whether it is still running, how it finished, and a link to its log where the forge reports one. Reach for it once the roll-up shows trouble and the question becomes which check broke and where to read its output. A check with no conclusion reported has not passed; the roll-up stays the authority on whether a PR is green. An empty list means no checks, a null one no such PR, and a provider that cannot read checks fails instead.",
+    "description": "List every CI check on one pull request: name, run state, conclusion, and a log link where the forge reports one. Reach for it once the roll-up shows trouble. A check with no conclusion has not passed; the roll-up stays the authority on whether a PR is green. An empty list means no checks, a null one no such PR, and a provider that cannot read checks fails instead.",
     "examples": [
       {
         "args": {
@@ -1899,7 +1899,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Fetch the roll-up CI verdict for one pull request from the active forge provider. Read the overall state for the answer: the accompanying counts cover required checks only, and a zero total also appears when the required-check list could not be read in full, so it is never evidence that nothing gates the merge. Values are provider-cached and can lag by around a minute, so poll for a settled verdict rather than treating a single success as final.",
+    "description": "Fetch the roll-up CI verdict for one pull request from the active forge provider. Read the overall state for the answer: the accompanying counts cover required checks only, and a zero total also appears when the required-check list could not be read in full, so it is never evidence that nothing gates the merge. Values are provider-cached and can lag by a minute, so poll for a settled verdict.",
     "examples": [
       {
         "args": {
@@ -1918,7 +1918,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Fetch one issue by number from the active forge provider, including its body. This is the direct lookup — reach for it instead of paging the issue listing to find a number you already have. An issue that does not exist comes back empty rather than failing, so treat an empty result as absence rather than an error. It reports how many comments exist but not their text; read the comment thread for that.",
+    "description": "Fetch one issue by number from the active forge provider, including its body. This is the direct lookup: reach for it instead of paging the issue listing to find a number you already have. An issue that does not exist comes back empty rather than failing, so treat empty as absence, not an error. It reports how many comments exist but not their text; read the comment thread for that.",
     "examples": [
       {
         "args": {
@@ -1944,7 +1944,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Fetch one pull request by number from the active forge provider, including its body, draft state and branches. This is the direct lookup — reach for it instead of paging the PR listing for a number you already have, and read it before editing or merging so the current state is known. A pull request that does not exist comes back empty rather than failing, so treat an empty result as absence rather than an error.",
+    "description": "Fetch one pull request by number from the active forge provider, including its body, draft state and branches. This is the direct lookup: reach for it instead of paging the PR listing for a number you already have, and read it before editing or merging so the current state is known. A pull request that does not exist comes back empty rather than failing, so treat empty as absence, not an error.",
     "examples": undefined,
     "id": "forge.getPR",
     "keywords": undefined,
@@ -1956,7 +1956,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Get headline repository counts — commits, issues and pull requests — from the active forge provider. Use this for a cheap overview rather than paging a list to count it. Results are cached and may be stale; bypassing the cache costs a live provider round trip against your rate limit. A provider failure comes back as an error field on an otherwise valid result rather than failing the call, so check it before trusting the counts.",
+    "description": "Get headline repository counts, commits, issues and pull requests, from the active forge provider. Use this for a cheap overview rather than paging a list to count it. Results are cached and may be stale; bypassing the cache costs a live round trip against your rate limit. A provider failure comes back as an error field on an otherwise valid result, so check it before trusting the counts.",
     "examples": undefined,
     "id": "forge.getRepoStats",
     "keywords": undefined,
@@ -1968,7 +1968,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Read one page of an issue's comment thread from the active forge provider. Use this when comment text matters — the single-issue lookup reports only how many comments exist. Comments arrive oldest first, so reaching the newest reply means paging to the end rather than reading the first page. An empty page genuinely means nobody has commented: a missing issue or a provider that cannot read threads fails instead, so silence is never ambiguous.",
+    "description": "Read one page of an issue's comment thread from the active forge provider. Use it when comment text matters: the single-issue lookup reports only how many exist. Comments arrive oldest first, so reaching the newest reply means paging to the end. An empty page genuinely means nobody has commented; a missing issue or a provider that cannot read threads fails instead, so silence is never ambiguous.",
     "examples": [
       {
         "args": {
@@ -1995,7 +1995,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "List repository issues from the active forge provider, one page at a time. Use this to discover or filter issues; use the pull-request listing for PRs, and the single-issue lookup when the number is already known. Summary results keep responses small by dropping bodies and raw provider payloads — ask for full results only when the body is needed. Results are cached, and bypassing the cache spends a live provider round trip against your rate limit.",
+    "description": "List repository issues from the active forge provider, a page at a time. Use this to discover or filter issues; use the pull-request listing for PRs, and the single-issue lookup for a known number. Summary results keep responses small by dropping bodies and raw provider payloads; ask for full results only when the body is needed. Bypassing the cache spends a live round trip.",
     "examples": undefined,
     "id": "forge.listIssues",
     "keywords": undefined,
@@ -2007,7 +2007,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "forge",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "List repository pull requests from the active forge provider, one page at a time. Use this to discover or filter PRs; use the issue listing for issues, and the single-PR lookup when the number is already known. Search takes a provider-native query fragment rather than plain text and routes through the provider's search API, which isn't served from the list cache that pagination uses. Summary results keep responses small, and bypassing the cache spends a live provider round trip.",
+    "description": "List repository pull requests from the active forge provider, a page at a time. Use this to discover or filter PRs; use the issue listing for issues, and the single-PR lookup for a known number. Search takes a provider-native query fragment, not plain text, and routes through the provider's search API rather than the list cache pagination uses. Bypassing the cache spends a live round trip.",
     "examples": undefined,
     "id": "forge.listPRs",
     "keywords": undefined,
@@ -2204,7 +2204,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "git",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Read one file's git diff as a byte-bounded window, so a large diff cannot flood the response. When the result is flagged truncated, call again from the offset it hands back to continue — a single call is not guaranteed to be the whole diff. Some files have no diff text at all: binary files, unchanged files and oversized files come back as a marker instead, which is a valid result rather than a failure.",
+    "description": "Read one file's git diff as a byte-bounded window, so a large diff cannot flood the response. When the result is flagged truncated, call again from the offset it hands back to continue: a single call is not guaranteed to be the whole diff. Some files have no diff text at all, and binary, unchanged and oversized files come back as a marker instead, which is a valid result rather than a failure.",
     "examples": [
       {
         "args": {
@@ -2352,7 +2352,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "help",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Show a documentation image inline in the assistant panel so an answer can point at it. Use this only when an image genuinely illustrates the answer, not for decorative ones. Reference the returned figure label as plain text at the insertion point rather than as markdown image syntax, which command-line renderers strip. Figure numbers are assigned by the app in sequence and must never be chosen yourself.",
+    "description": "Show a documentation image inline in the assistant panel so an answer can point at it. Use this only when an image genuinely illustrates the answer, not for decorative ones. Reference the returned figure label as plain text at the insertion point rather than as markdown image syntax, which command-line renderers strip. Figure numbers are assigned in sequence and must never be chosen yourself.",
     "examples": [
       {
         "args": {
@@ -3749,7 +3749,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "project",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Run one of a project's detected commands as a child process and report its exit code and output. A command that fails is reported as a failed check rather than as an error, so read the result rather than relying on the call succeeding. Detection finds every runnable script, not just checks — verify what a command actually is before running an unfamiliar one. Never use this for long-lived servers: they block until the timeout expires.",
+    "description": "Run one of a project's detected commands and report its exit code and output. A command that fails is reported as a failed check rather than an error, so read the result rather than relying on the call succeeding. Detection finds every runnable script, not just checks, so verify an unfamiliar command before running it. Never use this for long-lived servers: they block until the timeout expires.",
     "examples": undefined,
     "id": "project.runCheck",
     "keywords": undefined,
@@ -3989,7 +3989,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "agent",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Find plugin-contributed skills: reusable written instructions and workflows, such as a review rubric or a test-driven-development procedure, that plugins ship for an agent to follow. This returns names and summaries only; load a skill by id to read its actual instructions. Omitting a query lists available skills, but only up to the capped result limit, and the result never says whether more were left out.",
+    "description": "Find plugin-contributed skills: reusable written instructions and workflows, such as a review rubric or a test-driven-development procedure, that plugins ship for an agent to follow. This returns names and summaries only, so load a skill by id to read its instructions. Omitting a query lists available skills, but only to the capped limit, and the result never says whether more were left out.",
     "examples": undefined,
     "id": "skills.search",
     "keywords": undefined,
@@ -4069,7 +4069,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "system",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Read how much pressure the host machine is under and which adaptive performance mode is in effect. Use this to judge whether there is headroom before launching more agents or heavy work. Some readings are platform-specific and report as unknown elsewhere. It never fails — while the service is still starting it returns a neutral baseline, so treat an unremarkable reading early in a session with some caution.",
+    "description": "Read how much pressure the host machine is under and which adaptive performance mode is in effect. Use this to judge whether there is headroom before launching more agents or heavy work. Some readings are platform-specific and report as unknown elsewhere. It never fails: while the service is starting it returns a neutral baseline, so treat an unremarkable early reading with caution.",
     "examples": undefined,
     "id": "system.getResourceProfileSnapshot",
     "keywords": undefined,
@@ -4234,7 +4234,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Close a panel, usually moving it to the trash where it stays briefly recoverable before its process is killed. Recovery is not universal — panels set to remove on exit, and dialog panels, are discarded outright. This is not limited to terminals. Name the panel you mean; closing the wrong one discards someone's work. An untracked panel is rejected rather than reported closed, and the result names what actually closed — already gone from the listing when an automated caller sees it.",
+    "description": "Close a panel, usually to the trash, where it is briefly recoverable before its process is killed. Recovery is not universal: remove-on-exit and dialog panels are discarded outright. Not limited to terminals. Name the panel you mean; the wrong one discards someone's work. An untracked panel is rejected, not reported closed; the result names what closed, already gone from the listing by then.",
     "examples": undefined,
     "id": "terminal.close",
     "keywords": [
@@ -4568,7 +4568,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Read the trailing scrollback of one terminal, for inspecting what an agent or command actually printed. Use the terminal status snapshot instead when watching several terminals — it fetches output tails for a whole fleet in one call, and reading them one at a time is the common mistake here. Output has ANSI codes stripped by default and may be truncated to the requested tail; a terminal that no longer exists comes back as an error field in the result rather than failing the call.",
+    "description": "Read the trailing scrollback of one terminal, to inspect what an agent or command printed. Use the status snapshot when watching several terminals: it fetches tails for a whole fleet in one call, and reading one at a time is the common mistake. ANSI codes are stripped by default; output may be truncated to the requested tail, and a missing terminal returns an error field, not a failed call.",
     "examples": [
       {
         "args": {
@@ -4595,7 +4595,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Take a point-in-time snapshot of agent and process state across many terminals at once, optionally with recent output tails. This is the batched polling path: prefer it over listing terminals for agent state or reading each terminal's output in turn. It never blocks and never fails as a whole — an entry's own error can mean that terminal was missing or that the shared output fetch failed — so use the blocking wait instead when the goal is to proceed the moment an agent finishes.",
+    "description": "Snapshot agent and process state across many terminals, with optional output tails. This is the batched polling path: prefer it over listing terminals for agent state, or reading each terminal's output in turn. It never blocks or fails as a whole; an entry's error can mean that terminal was missing or the shared fetch failed. Use the blocking wait to proceed the moment an agent finishes.",
     "examples": undefined,
     "id": "terminal.getStatus",
     "keywords": undefined,
@@ -4672,7 +4672,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "confirm",
     "dangerRationale": "Permanently kills the PTY process. Scrollback and session state are lost.",
-    "description": "Permanently destroy a panel and any process behind it, with no trash step and no recovery. This is not limited to terminals — whatever panel the id names is removed. A panel running an agent session is left untouched unless the call itself is marked confirmed, so read back its state rather than assuming it went. Identify it explicitly: an automated caller cannot see what the user has focused. Close it instead when recoverability matters.",
+    "description": "Permanently destroy a panel and its process, with no trash step and no recovery. Not limited to terminals: whatever the id names is removed. A panel running an agent session is untouched unless the call is marked confirmed, so read back its state rather than assume it went. Identify it explicitly: an automated caller cannot see what the user focused. Close it instead when recovery matters.",
     "examples": undefined,
     "id": "terminal.kill",
     "keywords": [
@@ -4689,7 +4689,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "confirm",
     "dangerRationale": "Permanently kills every user-facing terminal. All scrollback and session state are lost.",
-    "description": "Permanently destroy every panel in the project at once — across all worktrees, of every kind, including trashed and backgrounded ones — with no trash step and no recovery. This takes the user's own shells and other agents' running work with it; only tooling-internal and dialog-hosted panels are spared. While any agent session is running it destroys nothing unless the call itself is marked confirmed. There is essentially never a reason for an automated caller to use this.",
+    "description": "Permanently destroy every panel in the project, across all worktrees and kinds, including trashed and backgrounded, with no trash step and no recovery. It takes the user's own shells and other agents' work with it; only tooling-internal and dialog-hosted panels are spared. While an agent session runs it destroys nothing unless the call is marked confirmed. Automated callers should never need this.",
     "examples": undefined,
     "id": "terminal.killAll",
     "keywords": [
@@ -4706,7 +4706,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Enumerate the open terminals and panels, with just enough metadata to pick one to act on. Start here to discover terminal ids, then read status or output for the ones that matter — this is a cheap inventory, not a polling path, and the status snapshot carries richer agent state for a whole fleet in one call. Ephemeral and internal panels are left out, and an empty result means no terminals are open rather than a failure.",
+    "description": "Enumerate the open terminals and panels, with just enough metadata to pick one. Start here to discover terminal ids, then read status or output for the ones that matter: this is a cheap inventory, not a polling path; the status snapshot carries richer agent state for a fleet in one call. Ephemeral and internal panels are left out; an empty result means none are open, not a failure.",
     "examples": undefined,
     "id": "terminal.list",
     "keywords": undefined,
@@ -4802,7 +4802,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Move a terminal panel to a different worktree. The process is never restarted: a live agent keeps running in the directory it launched from, and its pane offers to tell it to continue in the destination. A panel that shares a tab group travels with the rest of that group, so this can relocate more than the one panel named. The move is reversible. Name the target explicitly — an automated caller cannot see what the user has focused.",
+    "description": "Move a terminal panel to a different worktree. The process is never restarted: a live agent keeps running in the directory it launched from, and its pane offers to tell it to continue there. A panel sharing a tab group travels with the rest of that group, so this can relocate more than the panel named. The move is reversible. Name the target: an automated caller cannot see what the user focused.",
     "examples": undefined,
     "id": "terminal.moveToWorktree",
     "keywords": undefined,
@@ -4948,7 +4948,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "confirm",
     "dangerRationale": "Restarts the terminal process. Scrollback is lost and the process is re-spawned.",
-    "description": "Begin restarting a terminal's process in place, keeping the pane. This returns before the restart has finished, so the terminal is not ready yet when it does — watch its status before sending anything. A terminal running an agent session is left untouched unless the call itself is marked confirmed; otherwise whatever was running is terminated and unsaved in-process state is lost. A panel with no process is ignored rather than reported as an error.",
+    "description": "Restart a terminal's process in place, keeping the pane. This returns before the restart finishes, so it is not ready when it does; watch its status before sending anything. A terminal running an agent session is left untouched unless the call is marked confirmed; otherwise whatever was running is terminated and unsaved state is lost. A panel with no process is ignored, not an error.",
     "examples": undefined,
     "id": "terminal.restart",
     "keywords": [
@@ -5153,7 +5153,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Block until the agent in one terminal stops working, so the next step runs against finished output. Use the batched wait for several terminals, or a status snapshot to poll without blocking. This can hold the call open for a minute in an interactive session and far longer in a headless one. Timing out is a normal result meaning still working, and an exit code appears only once the process has ended — confirm success there before acting irreversibly.",
+    "description": "Block until the agent in one terminal stops working, so the next step sees finished output. Use the batched wait for several terminals, or a status snapshot to poll without blocking. It can hold open for a minute interactively, far longer headless. Timing out is normal and means still working; an exit code appears only once the process ends, so confirm success there before acting irreversibly.",
     "examples": undefined,
     "id": "terminal.waitUntilIdle",
     "keywords": undefined,
@@ -5165,7 +5165,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Block until the first of several agents stops working, or until all of them do — the fan-out primitive for agents that finish at different speeds. Use this rather than waiting on each terminal in turn, or a status snapshot to poll without blocking. This can hold the call open for a minute in an interactive session and far longer in a headless one. Timing out means the condition is not met yet, and terminals no longer tracked count as already finished.",
+    "description": "Block until the first of several agents stops working, or until all of them do; the fan-out primitive when agents finish at different speeds. Use this rather than waiting on each terminal in turn, or a status snapshot to poll without blocking. It can hold the call open for a minute interactively, far longer headless. Timing out means not met yet; untracked terminals count as finished.",
     "examples": undefined,
     "id": "terminal.waitUntilIdleBatch",
     "keywords": undefined,
@@ -5679,7 +5679,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "worktree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Create a git worktree with its branch, without launching terminals. Prefer the recipe-backed creation path when the worktree should also track a pull request or start a recipe's terminals. It writes to disk, may branch from a remote base or reuse an existing branch, and can provision a configured resource. Creation anchors on the repository root, not the active worktree, which is usually a linked one; setup can still fail after the worktree exists.",
+    "description": "Create a git worktree with its branch, without launching terminals. Prefer the recipe-backed path when it should also track a pull request or start a recipe's terminals. It writes to disk, may branch from a remote base or reuse a branch, and can provision a configured resource. Creation anchors on the repository root, not the active worktree; setup can still fail after the worktree exists.",
     "examples": undefined,
     "id": "worktree.create",
     "keywords": undefined,
@@ -5708,7 +5708,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "worktree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Create a git worktree with its branch, optionally tracking a pull request, and optionally launch a recipe's terminals in it. This is the heavy composite path: it writes to disk, may check out a remote branch, and may start several processes. Create the worktree alone when no pull request or terminals are wanted. Partial failure is possible — the worktree can exist while its recipe did not fully start.",
+    "description": "Create a git worktree with its branch, optionally tracking a pull request, and optionally launch a recipe's terminals in it. This is the heavy composite path: it writes to disk, may check out a remote branch, and may start several processes. Create the worktree alone when neither is wanted. Partial failure is possible: the worktree can exist while its recipe did not fully start.",
     "examples": undefined,
     "id": "worktree.createWithRecipe",
     "keywords": undefined,
@@ -6253,7 +6253,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "worktree",
     "danger": "confirm",
     "dangerRationale": "Runs the project's configured teardown commands for this worktree's cloud resource. What they destroy, and whether it can be recovered, is defined by the project rather than by Daintree.",
-    "description": "Run the project's configured teardown commands for a worktree's remote resource, typically to destroy a cloud devbox. These are arbitrary commands the project defines, so what they destroy — and whether anything can be recovered — depends entirely on that configuration; read it before running this. The project's pause commands are the intended lighter-weight path when the resource is still needed.",
+    "description": "Run the project's configured teardown commands for a worktree's remote resource, typically to destroy a cloud devbox. These are arbitrary commands the project defines, so what they destroy, and whether anything can be recovered, depends entirely on that configuration; read it before running this. The project's pause commands are the lighter path when the resource is still needed.",
     "examples": undefined,
     "id": "worktree.resource.teardown",
     "keywords": undefined,

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -203,26 +203,20 @@ function inputPropertyNames(argsSchema: z.ZodType | undefined): string[] | null 
 // is derived from the real allowlist rather than restated here, so this cannot
 // drift from the gate it is budgeting.
 describe("external MCP tool surface budget (#11585)", () => {
-  // Descriptions are the bulk of the text an MCP client re-reads every model
-  // turn. This ceiling sits a little above the current total rather than at an
-  // arbitrary round number, so a description that doubles trips it while
-  // ordinary wording edits do not. The tool COUNT is budgeted in
-  // tierAuth.test.ts, against the allowlist that is the actual gate — it is not
-  // duplicated here.
-  const MAX_DESCRIPTION_BYTES = 16_000;
+  // The summed external description budget that used to live here is gone: it
+  // capped the same bytes as MAX_EXTERNAL_TOTAL_BYTES below at a looser number,
+  // so it could never fail first and only offered a second place for the real
+  // figure to drift out of step. The tool COUNT is budgeted in tierAuth.test.ts
+  // against the allowlist that is the actual gate.
 
-  it("keeps the advertised description payload small", async () => {
+  it("every allowlisted external tool exists in the registry", async () => {
+    // Kept from the deleted budget: it was the half that caught an allowlist
+    // naming an id the registry no longer has, which the byte sum only noticed
+    // as a suspiciously small total.
     const { registry } = await createRegistryWithAudit();
 
-    const totalBytes = MCP_EXTERNAL_TIER_TOOLS.reduce((sum, id) => {
-      const def = registry.get(id as ActionId)?.();
-      // A missing definition means the allowlist names an id the registry no
-      // longer has — surface that as a failure rather than a zero-byte entry.
-      expect(def, `${id} is allowlisted but absent from the action registry`).toBeDefined();
-      return sum + Buffer.byteLength(def!.description ?? "", "utf8");
-    }, 0);
-
-    expect(totalBytes).toBeLessThanOrEqual(MAX_DESCRIPTION_BYTES);
+    const absent = MCP_EXTERNAL_TIER_TOOLS.filter((id) => !registry.get(id as ActionId)?.());
+    expect(absent).toEqual([]);
   });
 
   it("names only real actions that can actually be advertised and dispatched", async () => {
@@ -300,19 +294,19 @@ describe("LLM-facing tool descriptions (#11542)", () => {
     ...SYSTEM_TIER_ADDONS,
   ]);
 
-  // Below the floor a description says nothing a caller can act on; above the
-  // ceiling it is almost always restating the schema. Both are per-description,
-  // so neither can be averaged away by the aggregate budgets.
+  // Below the floor a description says nothing a caller can act on. The matching
+  // per-description CEILING lives in `mcpWireBudget.test.ts` alongside the rest
+  // of the context-condensation budgets — stating it in two files would let the
+  // two numbers drift and leave neither authoritative.
   const MIN_DESCRIPTION_BYTES = 120;
-  const MAX_SINGLE_DESCRIPTION_BYTES = 500;
 
   // Aggregate ceilings, set a little above the real totals so a description
   // that balloons trips them while ordinary wording edits do not. Same
   // reasoning as the external payload budget above, applied to the two
   // payloads that exist: what a third-party client is sent, and the largest
   // set the in-app assistant can be sent.
-  const MAX_EXTERNAL_TOTAL_BYTES = 10_000;
-  const MAX_COHORT_TOTAL_BYTES = 53_000;
+  const MAX_EXTERNAL_TOTAL_BYTES = 9_600;
+  const MAX_COHORT_TOTAL_BYTES = 48_000;
 
   const ARG_SECTION = /\b(?:args?|arguments?|parameters?)\s*(?:\([^)]*\))?\s*:|\btakes no args\b/i;
 
@@ -333,12 +327,12 @@ describe("LLM-facing tool descriptions (#11542)", () => {
     expect(rows.length).toBe(LLM_EXPOSED_TOOL_IDS.size);
   });
 
-  it("keeps every description within the readable range", async () => {
+  it("keeps every description above the readable floor", async () => {
     const rows = await cohortDefinitions();
 
     const violations = rows
       .map(({ id, def }) => ({ id, bytes: Buffer.byteLength(def.description ?? "", "utf8") }))
-      .filter((r) => r.bytes < MIN_DESCRIPTION_BYTES || r.bytes > MAX_SINGLE_DESCRIPTION_BYTES)
+      .filter((r) => r.bytes < MIN_DESCRIPTION_BYTES)
       .map((r) => `${r.id} (${r.bytes} bytes)`);
 
     expect(violations).toEqual([]);

--- a/src/services/actions/__tests__/helpers/wireSurface.ts
+++ b/src/services/actions/__tests__/helpers/wireSurface.ts
@@ -164,9 +164,18 @@ export async function measureWireSurface(): Promise<WireTool[]> {
     // bytes `tools/list` really carries and quietly flatter every budget below.
     let outputSchema: unknown;
     if (def.mcpOutputSchema) {
-      outputSchema = def.resultSchema
-        ? emitSchema(def.resultSchema, "output")
-        : def.rawOutputSchema;
+      const raw = def.resultSchema ? emitSchema(def.resultSchema, "output") : def.rawOutputSchema;
+      // `buildToolOutputSchema` advertises an output schema only when it is a
+      // top-level object, so anything else costs zero wire bytes. Mirrored here
+      // for the same reason the projection is: a harness that counts bytes
+      // production never sends is measuring a surface nobody receives.
+      outputSchema =
+        raw !== null &&
+        typeof raw === "object" &&
+        !Array.isArray(raw) &&
+        (raw as Record<string, unknown>)["type"] === "object"
+          ? raw
+          : undefined;
     }
 
     const propertyDescriptions: WirePropertyDescription[] = [];

--- a/src/services/actions/__tests__/helpers/wireSurface.ts
+++ b/src/services/actions/__tests__/helpers/wireSurface.ts
@@ -1,0 +1,197 @@
+import { z } from "zod";
+import type { ActionId } from "@shared/types/actions";
+import type { ActionRegistry, ActionCallbacks } from "../../actionTypes";
+import {
+  WORKBENCH_TIER_TOOLS,
+  ACTION_TIER_ADDONS,
+  SYSTEM_TIER_ADDONS,
+} from "@shared/config/helpAssistantTierAllowlists";
+import { MCP_EXTERNAL_TIER_TOOLS } from "@shared/config/mcpExternalTierAllowlist";
+import { toWireSchema } from "@shared/utils/mcpWireSchema";
+
+/**
+ * Measurement of the bytes an MCP client is actually sent, built from the live
+ * action registry rather than from a fixture.
+ *
+ * A fixture would be the wrong instrument here: the thing under budget is what
+ * `tools/list` emits today, so a captured copy would drift silently and the
+ * gates would go on passing against a surface that no longer exists.
+ */
+
+function noopCallbacks(): ActionCallbacks {
+  const noop = () => {};
+  return {
+    onOpenSettings: noop,
+    onOpenSettingsTab: noop,
+    onToggleSidebar: noop,
+    onToggleFocusMode: noop,
+    onFocusRegionNext: noop,
+    onFocusRegionPrev: noop,
+    onOpenActionPalette: noop,
+    onOpenQuickSwitcher: noop,
+    onOpenWorktreePalette: noop,
+    onOpenQuickCreatePalette: noop,
+    onToggleWorktreeOverview: noop,
+    onOpenWorktreeOverview: noop,
+    onCloseWorktreeOverview: noop,
+    onOpenPanelPalette: noop,
+    onOpenResumeSessionsPalette: noop,
+    onOpenProjectSwitcherPalette: noop,
+    onConfirmCloseActiveProject: noop,
+    onOpenShortcuts: noop,
+    onLaunchAgent: async () => null,
+    onInject: noop,
+    onAddTerminal: async () => {},
+    getDefaultCwd: () => "/",
+    getActiveWorktreeId: () => undefined,
+    getWorktrees: () => [],
+    getFocusedId: () => null,
+    getIsSettingsOpen: () => false,
+    getGridNavigation: () => ({
+      findNearest: () => null,
+      findByIndex: () => null,
+      findDockByIndex: () => null,
+      getCurrentLocation: () => null,
+    }),
+  } as unknown as ActionCallbacks;
+}
+
+export async function createActionRegistry(): Promise<ActionRegistry> {
+  // `actionDefinitions` reaches for `self` at module scope; the node test
+  // environment has no window to supply it. Restored afterwards because vitest
+  // reuses fork workers across files, and a leaked global is exactly the kind of
+  // cross-file contamination that makes an unrelated suite fail by ordering.
+  const globals = globalThis as unknown as { self?: unknown };
+  const hadSelf = "self" in globals;
+  const previousSelf = globals.self;
+  globals.self = globalThis;
+  try {
+    const { createActionDefinitions } = await import("../../actionDefinitions");
+    return createActionDefinitions(noopCallbacks(), new Map());
+  } finally {
+    if (hadSelf) globals.self = previousSelf;
+    else delete globals.self;
+  }
+}
+
+/** The exact conversion `ActionService.computeSchemas` performs. */
+export function emitSchema(schema: z.ZodType, io: "input" | "output"): unknown {
+  return z.toJSONSchema(schema, {
+    io,
+    unrepresentable: "any",
+    reused: "inline",
+    cycles: "ref",
+    target: "draft-2020-12",
+  });
+}
+
+export interface WirePropertyDescription {
+  /** Dotted path to the schema node carrying the text, for a legible failure. */
+  path: string;
+  bytes: number;
+  text: string;
+}
+
+export interface WireTool {
+  id: string;
+  external: boolean;
+  description: string;
+  descriptionBytes: number;
+  /** The advertised input schema, already projected to the wire view. */
+  inputSchema: unknown;
+  paramsBytes: number;
+  outputBytes: number;
+  propertyDescriptions: WirePropertyDescription[];
+}
+
+/** Every `description` string in an emitted schema, with the path that owns it. */
+function collectDescriptions(node: unknown, path: string, out: WirePropertyDescription[]): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => collectDescriptions(item, `${path}[${i}]`, out));
+    return;
+  }
+  if (typeof node !== "object" || node === null) return;
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (key === "description" && typeof value === "string") {
+      out.push({ path: path || "<root>", bytes: Buffer.byteLength(value, "utf8"), text: value });
+    } else {
+      collectDescriptions(value, path === "" ? key : `${path}.${key}`, out);
+    }
+  }
+}
+
+const bytes = (value: unknown): number =>
+  value === undefined ? 0 : Buffer.byteLength(JSON.stringify(value), "utf8");
+
+/**
+ * Every tool reachable at any MCP tier, measured as the wire view.
+ *
+ * The cohort is derived from the live allowlists rather than restated, so a tool
+ * added to a tier is held to these budgets the moment it is exposed.
+ */
+export async function measureWireSurface(): Promise<WireTool[]> {
+  const registry = await createActionRegistry();
+  const external = new Set<string>(MCP_EXTERNAL_TIER_TOOLS);
+  const cohort = new Set<string>([
+    ...WORKBENCH_TIER_TOOLS,
+    ...ACTION_TIER_ADDONS,
+    ...SYSTEM_TIER_ADDONS,
+    ...MCP_EXTERNAL_TIER_TOOLS,
+  ]);
+
+  const tools: WireTool[] = [];
+  const missing: string[] = [];
+  for (const id of [...cohort].sort()) {
+    const def = registry.get(id as ActionId)?.();
+    if (!def) {
+      missing.push(id);
+      continue;
+    }
+
+    let inputSchema: unknown = { type: "object", properties: {}, additionalProperties: false };
+    if (def.argsSchema) {
+      inputSchema = {
+        ...(toWireSchema(emitSchema(def.argsSchema, "input")) as Record<string, unknown>),
+        additionalProperties: false,
+      };
+    } else if (def.rawInputSchema) {
+      inputSchema = toWireSchema(def.rawInputSchema);
+    }
+
+    // NOT projected, mirroring `buildToolOutputSchema`: an advertised output
+    // schema is a contract the MCP SDK enforces client-side with AJV, so
+    // production emits it verbatim. Projecting it here would undercount the
+    // bytes `tools/list` really carries and quietly flatter every budget below.
+    let outputSchema: unknown;
+    if (def.mcpOutputSchema) {
+      outputSchema = def.resultSchema
+        ? emitSchema(def.resultSchema, "output")
+        : def.rawOutputSchema;
+    }
+
+    const propertyDescriptions: WirePropertyDescription[] = [];
+    collectDescriptions(inputSchema, "", propertyDescriptions);
+
+    tools.push({
+      id,
+      external: external.has(id),
+      description: def.description ?? "",
+      descriptionBytes: Buffer.byteLength(def.description ?? "", "utf8"),
+      inputSchema,
+      paramsBytes: bytes(inputSchema),
+      outputBytes: bytes(outputSchema),
+      propertyDescriptions,
+    });
+  }
+
+  // An allowlisted id with no registry entry is a broken tier, not a tool to
+  // skip. Silently dropping it would shrink every aggregate below and let the
+  // budgets pass by measuring less, which is the one failure a size gate must
+  // never have.
+  if (missing.length > 0) {
+    throw new Error(
+      `Tier allowlists name ${missing.length} action(s) absent from the registry: ${missing.join(", ")}`
+    );
+  }
+  return tools;
+}

--- a/src/services/actions/__tests__/mcpWireBudget.test.ts
+++ b/src/services/actions/__tests__/mcpWireBudget.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect } from "vitest";
+import { findWireStrippedKeywords } from "@shared/utils/mcpWireSchema";
+import { measureWireSurface, type WireTool } from "./helpers/wireSurface";
+
+/**
+ * The context-condensation budgets — see `docs/architecture/mcp-context-condensation.md`.
+ *
+ * Every string here is paid on every model turn, by every connected client, and
+ * the tool region is the single largest part of a request. These gates hold the
+ * shape of that region rather than its wording: each is a predicate on the
+ * finished text, so a conforming surface passes unchanged and re-running the
+ * standard over it changes nothing.
+ *
+ * What they deliberately do NOT do is push text toward a target. A ceiling gates;
+ * it never instructs a rewrite on its own. Prose already under a ceiling is left
+ * alone, because iterated "make it shorter" passes compound until meaning breaks,
+ * and the resulting failure is invisible — it shows up as the model picking the
+ * wrong tool, not as a size number.
+ */
+
+/** One imperative sentence, an optional trigger, disambiguation, traps, return shape. */
+const MAX_TOOL_DESCRIPTION_BYTES = 400;
+
+/**
+ * One clause: what the value means and its unit. This is the authoring standard's
+ * number, and it is enforced here as a ratchet on the tail rather than as a hard
+ * ceiling — see {@link MAX_PROPERTIES_OVER_TARGET}.
+ */
+const PROPERTY_DESCRIPTION_TARGET_BYTES = 160;
+
+/**
+ * The hard ceiling for a single property description.
+ *
+ * It sits well above the target on purpose, because this repo pulls in the
+ * opposite direction from the standard's calibration and did so deliberately:
+ * #11542 moved field semantics OUT of tool descriptions and INTO `.describe()`,
+ * precisely so the top-level prose could shrink. Enforcing 160 B here would undo
+ * that — the text has nowhere to go but back up into the tool description this
+ * suite has just capped at 400 B, or into deletion.
+ *
+ * So the target gates drift (below) while this catches an outright essay. What is
+ * left above the target is protected content under the standard: focus-drift
+ * warnings, invisibility side effects, provider-dialect traps. None of it can be
+ * cut to fit a number without removing the reason it was written.
+ */
+const MAX_PROPERTY_DESCRIPTION_BYTES = 320;
+
+/**
+ * How many property descriptions may exceed {@link PROPERTY_DESCRIPTION_TARGET_BYTES}.
+ *
+ * A ratchet: it may fall freely, and raising it is a deliberate act that belongs
+ * in a commit message with a reason. This is what makes the target load-bearing
+ * without pretending every field can reach it — a new over-target description
+ * fails the suite unless an existing one is brought under.
+ */
+const MAX_PROPERTIES_OVER_TARGET = 49;
+
+/**
+ * Total bytes spent above {@link PROPERTY_DESCRIPTION_TARGET_BYTES}, summed over
+ * every over-target description.
+ *
+ * Paired with the count because the count alone is gameable: the same thirty
+ * descriptions can each grow from 161 B to 319 B without moving it. Together
+ * they bound both how many descriptions run long and how far they run.
+ */
+const MAX_EXCESS_PROPERTY_BYTES = 3_000;
+
+/** Above this a tool is almost always polymorphic and wants splitting. */
+const MAX_TOOL_PARAMS_BYTES = 1_500;
+
+/**
+ * Tools whose advertised `parameters` exceed {@link MAX_TOOL_PARAMS_BYTES}, each
+ * with the reason it is not simply split.
+ *
+ * This list may shrink and must never grow without a reason written beside the
+ * entry. An unexplained addition is the failure this allowlist exists to make
+ * visible: it converts "we shipped a Swiss Army knife" from an invisible drift
+ * into a reviewable line.
+ */
+const OVERSIZED_PARAMS_ALLOWLIST: Readonly<Record<string, string>> = {
+  // The three copyTree tools share one options object whose field semantics are
+  // pinned clause-by-clause by regression tests (#11722, #11750) — each clause
+  // is there because a caller got it wrong. Trimming to fit would delete exactly
+  // the content the standard protects, so the honest fix is a narrower tool, not
+  // shorter prose.
+  "copyTree.generate": "shared CopyTreeOptions object; field semantics are regression-pinned",
+  "copyTree.generateAndCopyFile": "shared CopyTreeOptions object; see copyTree.generate",
+  "copyTree.injectToTerminal": "shared CopyTreeOptions object; see copyTree.generate",
+  // Launch takes the union of agent identity, preset, placement and terminal
+  // setup. Splitting it would force a caller to create a panel and then launch
+  // into it, which is two round trips and a partially-created panel to clean up
+  // on failure.
+  "agent.launch": "single-round-trip launch; splitting it leaks a half-created panel on failure",
+  // Forge list filters are wide because the underlying forge query is wide;
+  // every property maps to one query parameter rather than to a mode.
+  "forge.listIssues": "flat filter set over one forge query, not a polymorphic mode switch",
+  "forge.listPRs": "flat filter set over one forge query, not a polymorphic mode switch",
+  "workflow.startWorkOnIssue": "composite entry point; the arguments are one workflow's inputs",
+  "worktree.createWithRecipe": "composite create-plus-launch; splitting is the plain create tool",
+};
+
+/**
+ * Individual property descriptions permitted to exceed
+ * {@link MAX_PROPERTY_DESCRIPTION_BYTES}, keyed by `toolId :: schema path`.
+ *
+ * Scoped to the exact property rather than the whole tool on purpose. Exempting
+ * a tool would mean a brand-new 500-byte field on the same tool inherits the
+ * exemption and never trips anything — the allowlist would grow silent coverage
+ * it was never granted.
+ *
+ * Same contract as above: shrink freely, grow only with a reason. Everything
+ * here is protected content under the standard — a negative constraint, a shape
+ * requirement, or a disambiguation against a named sibling — which cannot be cut
+ * to fit a ceiling. The three copyTree tools share one options object, so the
+ * text is written once and advertised three times.
+ */
+const OVERSIZED_PROPERTY_ALLOWLIST: Readonly<Record<string, string>> = Object.fromEntries(
+  ["copyTree.generate", "copyTree.generateAndCopyFile", "copyTree.injectToTerminal"].flatMap(
+    (tool) =>
+      [
+        "properties.options.properties.scopeIgnoresIgnoreFiles",
+        "properties.options.properties.always",
+        "properties.options.properties.scopePaths",
+        "properties.options.properties.includePaths",
+        "properties.options.properties.filter",
+      ].map((path) => [
+        `${tool} :: ${path}`,
+        "CopyTreeOptions precedence rules; every clause is regression-pinned (#11722, #11750)",
+      ])
+  )
+);
+
+let cached: WireTool[] | undefined;
+async function surface(): Promise<WireTool[]> {
+  cached ??= await measureWireSurface();
+  return cached;
+}
+
+/** Every property description above the one-clause target, allowlist applied. */
+async function propertiesOverTarget(): Promise<Array<{ id: string; path: string; bytes: number }>> {
+  const tools = await surface();
+  return tools
+    .flatMap((t) => t.propertyDescriptions.map((p) => ({ id: t.id, path: p.path, bytes: p.bytes })))
+    .filter((p) => !(`${p.id} :: ${p.path}` in OVERSIZED_PROPERTY_ALLOWLIST))
+    .filter((p) => p.bytes > PROPERTY_DESCRIPTION_TARGET_BYTES)
+    .sort((a, b) => b.bytes - a.bytes);
+}
+
+describe("MCP wire budget — tool descriptions (§4.2)", () => {
+  it("keeps every advertised description within one screen of prose", async () => {
+    const tools = await surface();
+
+    const over = tools
+      .filter((t) => t.descriptionBytes > MAX_TOOL_DESCRIPTION_BYTES)
+      .map((t) => `${t.id} (${t.descriptionBytes}B)`);
+
+    expect(over).toEqual([]);
+  });
+
+  it("has a description on every tool it advertises", async () => {
+    const tools = await surface();
+    expect(tools.filter((t) => t.description.trim() === "").map((t) => t.id)).toEqual([]);
+  });
+});
+
+describe("MCP wire budget — property descriptions (§4.3)", () => {
+  it("lets no single property description run to an essay", async () => {
+    const tools = await surface();
+
+    const over: string[] = [];
+    for (const tool of tools) {
+      for (const prop of tool.propertyDescriptions) {
+        if (`${tool.id} :: ${prop.path}` in OVERSIZED_PROPERTY_ALLOWLIST) continue;
+        if (prop.bytes > MAX_PROPERTY_DESCRIPTION_BYTES) {
+          over.push(`${tool.id} :: ${prop.path} (${prop.bytes}B)`);
+        }
+      }
+    }
+
+    expect(over).toEqual([]);
+  });
+
+  it("ratchets down the number of properties above the one-clause target", async () => {
+    const overTarget = await propertiesOverTarget();
+
+    // Named in the failure so the ratchet says which descriptions to look at,
+    // rather than only that a count moved.
+    expect(
+      overTarget.length,
+      overTarget.map((p) => `${p.id} :: ${p.path} (${p.bytes}B)`).join("\n")
+    ).toBeLessThanOrEqual(MAX_PROPERTIES_OVER_TARGET);
+  });
+
+  it("ratchets down the total bytes spent above the target", async () => {
+    // The count alone is gameable: thirty descriptions can each grow from 161 B
+    // to 319 B without moving it. Summing the excess prices that growth, so the
+    // two together bound both how many descriptions run long and how far.
+    const overTarget = await propertiesOverTarget();
+    const excess = overTarget.reduce(
+      (sum, p) => sum + (p.bytes - PROPERTY_DESCRIPTION_TARGET_BYTES),
+      0
+    );
+
+    expect(excess).toBeLessThanOrEqual(MAX_EXCESS_PROPERTY_BYTES);
+  });
+
+  it("allowlists only properties that actually exceed the ceiling", async () => {
+    // A stale allowlist entry is worse than none: it silently exempts a tool
+    // whose prose has since been fixed, so the next regression there goes unseen.
+    const tools = await surface();
+    // Compared against the ceiling the allowlist actually exempts, not the
+    // target. Checking the target instead would keep an entry looking "fresh"
+    // long after its description fell back under the ceiling.
+    const stillOver = new Set(
+      tools.flatMap((t) =>
+        t.propertyDescriptions
+          .filter((p) => p.bytes > MAX_PROPERTY_DESCRIPTION_BYTES)
+          .map((p) => `${t.id} :: ${p.path}`)
+      )
+    );
+
+    const stale = Object.keys(OVERSIZED_PROPERTY_ALLOWLIST).filter((key) => !stillOver.has(key));
+    expect(stale).toEqual([]);
+  });
+});
+
+describe("MCP wire budget — atomicity (§4.4)", () => {
+  it("keeps each tool's advertised parameters small enough to reason over", async () => {
+    const tools = await surface();
+
+    const over = tools
+      .filter((t) => t.paramsBytes > MAX_TOOL_PARAMS_BYTES && !(t.id in OVERSIZED_PARAMS_ALLOWLIST))
+      .map((t) => `${t.id} (${t.paramsBytes}B)`);
+
+    expect(over).toEqual([]);
+  });
+
+  it("allowlists only tools that actually exceed the ceiling", async () => {
+    const tools = await surface();
+    const stillOver = new Set(
+      tools.filter((t) => t.paramsBytes > MAX_TOOL_PARAMS_BYTES).map((t) => t.id)
+    );
+
+    const stale = Object.keys(OVERSIZED_PARAMS_ALLOWLIST).filter((id) => !stillOver.has(id));
+    expect(stale).toEqual([]);
+  });
+});
+
+describe("MCP wire budget — the wire/validation split (§4.1)", () => {
+  it("advertises no value-range keyword anywhere in the tool surface", async () => {
+    // These are not enforced by constrained decoding, so they reach the model as
+    // prompt text and nothing else. `argsSchema` still rejects a bad value, so
+    // their absence costs no safety — a bound the caller genuinely needs belongs
+    // in the field's own description, where it survives the projection.
+    const tools = await surface();
+
+    const leaked: string[] = [];
+    for (const tool of tools) {
+      for (const path of findWireStrippedKeywords(tool.inputSchema)) {
+        leaked.push(`${tool.id} :: ${path}`);
+      }
+    }
+
+    expect(leaked).toEqual([]);
+  });
+
+  it("keeps additionalProperties:false on every advertised input schema", async () => {
+    // The half of the split that must NOT be projected away: with a complete
+    // `required` array it is what lets a strict backend build a deterministic
+    // mask, and it measurably reduces hallucinated keys.
+    const tools = await surface();
+
+    const missing = tools
+      .filter((t) => (t.inputSchema as Record<string, unknown>)["additionalProperties"] !== false)
+      .map((t) => t.id);
+
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("MCP wire budget — aggregate ratchets (§9)", () => {
+  // Ratchets, not targets. Each sits a little above the real total so ordinary
+  // wording edits pass while a doubling trips. They may fall freely; raising one
+  // is a deliberate act that belongs in a commit message with a reason.
+  //
+  // These bound the description-and-schema payload, which is the part authors
+  // control and the part that moves. They are deliberately NOT the full
+  // serialized `tools/list` byte count: that also carries tool names,
+  // annotations, `_meta.examples` and JSON framing, none of which this standard
+  // governs. Reading them as the wire total would overstate what a rewrite here
+  // can achieve.
+  const MAX_EXTERNAL_PAYLOAD_BYTES = 43_000;
+  const MAX_COHORT_PAYLOAD_BYTES = 190_000;
+
+  const wireBytes = (t: WireTool) => t.descriptionBytes + t.paramsBytes + t.outputBytes;
+
+  it("keeps the third-party client surface within budget", async () => {
+    const tools = await surface();
+    const total = tools.filter((t) => t.external).reduce((sum, t) => sum + wireBytes(t), 0);
+
+    expect(total).toBeLessThanOrEqual(MAX_EXTERNAL_PAYLOAD_BYTES);
+  });
+
+  it("keeps the full in-app surface within budget", async () => {
+    const tools = await surface();
+    const total = tools.reduce((sum, t) => sum + wireBytes(t), 0);
+
+    expect(total).toBeLessThanOrEqual(MAX_COHORT_PAYLOAD_BYTES);
+  });
+
+  it("measures a surface that is actually there", async () => {
+    // Guards the guard: a harness that silently returned nothing would satisfy
+    // every ceiling above while proving the opposite of what it claims.
+    const tools = await surface();
+    expect(tools.length).toBeGreaterThan(100);
+    expect(tools.filter((t) => t.external).length).toBeGreaterThan(15);
+  });
+});

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -292,7 +292,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     id: "agent.launch",
     title: "Launch Agent",
     description:
-      "Start an AI agent in a new terminal and report where it landed, so parallel launches can be told apart without re-resolving the target. Success means the panel was created and its process is starting, not that the agent is ready — poll its state or a terminal status snapshot for that. A failure to launch may mean the agent's CLI is missing, in which case a setup diagnostic panel is opened instead. Launching consumes real resources, so keep concurrent launches modest.",
+      "Start an AI agent in a new terminal and report where it landed, so parallel launches can be told apart without re-resolving the target. Success means the panel was created and its process is starting, not that the agent is ready; poll its state or a terminal status snapshot for that. A missing CLI opens a setup diagnostic panel instead. Keep concurrent launches modest.",
     category: "agent",
     kind: "command",
     danger: "safe",
@@ -353,7 +353,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         .boolean()
         .optional()
         .describe(
-          "Keeps the terminal out of the saved session, so it does not come back after a restart. It also hides the panel from terminal listings, status snapshots and agent-state reads, and spares it from bulk close and kill — so the launching caller cannot find or poll the terminal afterwards. Use for throwaway work the user should not inherit."
+          "Keeps the terminal out of the saved session, so it does not return after a restart. It also hides the panel from listings, status snapshots and agent-state reads, and spares it from bulk close and kill, so the caller cannot find or poll it afterwards. Use for throwaway work."
         ),
       removeOnExit: z
         .boolean()
@@ -386,7 +386,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         .max(200)
         .optional()
         .describe(
-          'Always provide a short, task-descriptive name for the terminal tab (e.g. "Claude: auth refactor") so the user can tell parallel agents apart. Pins the title so agent detection cannot overwrite it. Empty/whitespace falls back to the default title.'
+          'Always provide a short, task-descriptive name for the terminal tab, at most 200 characters (e.g. "Claude: auth refactor"), so the user can tell parallel agents apart. Pins the title so agent detection cannot overwrite it. Empty/whitespace falls back to the default title.'
         ),
     }),
     // Top-level object, never `.nullable()`: `buildToolOutputSchema` (tierAuth)
@@ -832,7 +832,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     id: "agentSessionHistory.list",
     title: "List Resumable Sessions",
     description:
-      "List closed agent sessions that can be relaunched, read from the on-disk journal. This is a faithful record of which sessions exist, not a summary of what happened in them — it carries no transcript text. It must be scoped to a worktree or project and fails rather than listing every project when no scope can be resolved. Old sessions are pruned by the journal's retention policy, so absence does not mean a session never existed.",
+      "List closed agent sessions that can be relaunched, read from the on-disk journal. This is a faithful record of which sessions exist, not a summary of what happened in them: it carries no transcript text. It must be scoped to a worktree or project and fails rather than listing every project when no scope resolves. Old sessions are pruned by retention, so absence does not prove one never existed.",
     category: "agent",
     kind: "query",
     danger: "safe",
@@ -1096,7 +1096,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     id: "agent.listAvailable",
     title: "List Available Agents",
     description:
-      "List every registered agent — built-in, user-defined and plugin-contributed — from the authoritative registry, including ones that are not currently launchable. Use this before launching so an id is known to exist, and read each entry's launchability rather than assuming membership implies it. Those fields appear only once a live probe of each CLI finishes, and the result says so while that is incomplete.",
+      "List every registered agent, built-in, user-defined and plugin-contributed, from the authoritative registry, including ones not currently launchable. Use this before launching so an id is known to exist, and read each entry's launchability rather than assuming membership implies it. Those fields appear only once a live probe of each CLI finishes, and the result says so while that is incomplete.",
     category: "agent",
     kind: "query",
     danger: "safe",

--- a/src/services/actions/definitions/browserActions.ts
+++ b/src/services/actions/definitions/browserActions.ts
@@ -10,7 +10,13 @@ const getConsoleMessagesArgsSchema = z
   .object({
     terminalId: z.string().optional(),
     level: z.enum(["log", "info", "warning", "error"]).optional(),
-    limit: z.number().int().positive().max(500).optional(),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(500)
+      .optional()
+      .describe("Maximum messages to return, newest first (max 500). Omit for all captured."),
   })
   .optional();
 

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -574,7 +574,7 @@ export function registerFleetActions(actions: ActionRegistry): void {
     palette: { mode: "hidden" },
     title: "Fleet: Get run status",
     description:
-      "Read a snapshot of the in-app fleet broadcast the user is currently running, including per-terminal delivery and liveness. This only observes — it dispatches nothing, so driving a fan-out means sending to each terminal yourself and watching them with a status snapshot or batched wait. Agent state here is a passive heuristic and any parsed check result is not a process exit code, so confirm both before acting on them.",
+      "Read a snapshot of the in-app fleet broadcast the user is currently running, including per-terminal delivery and liveness. This only observes and dispatches nothing, so drive a fan-out by sending to each terminal yourself and watching with a status snapshot or batched wait. Agent state here is a passive heuristic and a parsed check result is not an exit code; confirm both before acting.",
     category: "terminal",
     kind: "query",
     danger: "safe",

--- a/src/services/actions/definitions/forgeActions.ts
+++ b/src/services/actions/definitions/forgeActions.ts
@@ -734,7 +734,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.listIssues",
       title: "List Issues",
       description:
-        "List repository issues from the active forge provider, a page at a time. Use this to discover or filter issues; use the pull-request listing for PRs, and the single-issue lookup for a known number. Summary results keep responses small by dropping bodies and raw provider payloads; ask for full results only when the body is needed. Bypassing the cache spends a live round trip.",
+        "List repository issues from the active forge provider, a page at a time. Use this to discover or filter issues; use the pull-request listing for PRs, and the single-issue lookup for a known number. Search takes a provider-native query fragment, not plain text, and routes through the provider's search API rather than the list cache pagination uses. Bypassing the cache spends a live round trip.",
       category: "forge",
       kind: "query",
       danger: "safe",

--- a/src/services/actions/definitions/forgeActions.ts
+++ b/src/services/actions/definitions/forgeActions.ts
@@ -124,7 +124,7 @@ const ForgeListOptionsSchema = ForgeListPagingSchema.extend({
     .string()
     .optional()
     .describe(
-      "Provider-native query fragment — NOT a plain-text filter. The dialect is the active provider's own issue search, which typically supports negation: 'no:assignee -label:human-review'. It is trimmed and appended after the generated repo/type/state/sort qualifiers, and truncated to the provider's query-length cap. Routes via the provider's search API, which caps result depth."
+      "Provider-native query fragment, NOT plain text. The dialect is the provider's own issue search, typically supporting negation. Trimmed, appended after the generated repo/type/state/sort qualifiers, and truncated to the provider's length cap. Routes via the search API, which caps result depth."
     ),
 }).strict();
 
@@ -144,7 +144,7 @@ const ForgePRListOptionsSchema = ForgeListPagingSchema.extend({
     .string()
     .optional()
     .describe(
-      "Provider-native query fragment — NOT a plain-text filter. The dialect is the active provider's own pull-request search, which typically supports negation and PR-specific qualifiers: 'is:draft -label:wip'. It is trimmed and appended after the generated repo/type/state/sort qualifiers, and truncated to the provider's query-length cap. Routes via the provider's search API, which caps result depth."
+      "Provider-native query fragment, NOT plain text. The dialect is the provider's own PR search, typically supporting negation and PR qualifiers. Trimmed, appended after the generated repo/type/state/sort qualifiers, and truncated to the provider's length cap. Routes via the search API, which caps result depth."
     ),
 }).strict();
 
@@ -702,7 +702,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.getRepoStats",
       title: "Get Repo Stats",
       description:
-        "Get headline repository counts — commits, issues and pull requests — from the active forge provider. Use this for a cheap overview rather than paging a list to count it. Results are cached and may be stale; bypassing the cache costs a live provider round trip against your rate limit. A provider failure comes back as an error field on an otherwise valid result rather than failing the call, so check it before trusting the counts.",
+        "Get headline repository counts, commits, issues and pull requests, from the active forge provider. Use this for a cheap overview rather than paging a list to count it. Results are cached and may be stale; bypassing the cache costs a live round trip against your rate limit. A provider failure comes back as an error field on an otherwise valid result, so check it before trusting the counts.",
       category: "forge",
       kind: "query",
       danger: "safe",
@@ -734,7 +734,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.listIssues",
       title: "List Issues",
       description:
-        "List repository issues from the active forge provider, one page at a time. Use this to discover or filter issues; use the pull-request listing for PRs, and the single-issue lookup when the number is already known. Summary results keep responses small by dropping bodies and raw provider payloads — ask for full results only when the body is needed. Results are cached, and bypassing the cache spends a live provider round trip against your rate limit.",
+        "List repository issues from the active forge provider, a page at a time. Use this to discover or filter issues; use the pull-request listing for PRs, and the single-issue lookup for a known number. Summary results keep responses small by dropping bodies and raw provider payloads; ask for full results only when the body is needed. Bypassing the cache spends a live round trip.",
       category: "forge",
       kind: "query",
       danger: "safe",
@@ -767,7 +767,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.listPRs",
       title: "List Pull Requests",
       description:
-        "List repository pull requests from the active forge provider, one page at a time. Use this to discover or filter PRs; use the issue listing for issues, and the single-PR lookup when the number is already known. Search takes a provider-native query fragment rather than plain text and routes through the provider's search API, which isn't served from the list cache that pagination uses. Summary results keep responses small, and bypassing the cache spends a live provider round trip.",
+        "List repository pull requests from the active forge provider, a page at a time. Use this to discover or filter PRs; use the issue listing for issues, and the single-PR lookup for a known number. Search takes a provider-native query fragment, not plain text, and routes through the provider's search API rather than the list cache pagination uses. Bypassing the cache spends a live round trip.",
       category: "forge",
       kind: "query",
       danger: "safe",
@@ -798,7 +798,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.getIssue",
       title: "Get Issue",
       description:
-        "Fetch one issue by number from the active forge provider, including its body. This is the direct lookup — reach for it instead of paging the issue listing to find a number you already have. An issue that does not exist comes back empty rather than failing, so treat an empty result as absence rather than an error. It reports how many comments exist but not their text; read the comment thread for that.",
+        "Fetch one issue by number from the active forge provider, including its body. This is the direct lookup: reach for it instead of paging the issue listing to find a number you already have. An issue that does not exist comes back empty rather than failing, so treat empty as absence, not an error. It reports how many comments exist but not their text; read the comment thread for that.",
       category: "forge",
       kind: "query",
       danger: "safe",
@@ -832,7 +832,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.listIssueComments",
       title: "List Issue Comments",
       description:
-        "Read one page of an issue's comment thread from the active forge provider. Use this when comment text matters — the single-issue lookup reports only how many comments exist. Comments arrive oldest first, so reaching the newest reply means paging to the end rather than reading the first page. An empty page genuinely means nobody has commented: a missing issue or a provider that cannot read threads fails instead, so silence is never ambiguous.",
+        "Read one page of an issue's comment thread from the active forge provider. Use it when comment text matters: the single-issue lookup reports only how many exist. Comments arrive oldest first, so reaching the newest reply means paging to the end. An empty page genuinely means nobody has commented; a missing issue or a provider that cannot read threads fails instead, so silence is never ambiguous.",
       category: "forge",
       kind: "query",
       danger: "safe",
@@ -877,7 +877,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.getPR",
       title: "Get Pull Request",
       description:
-        "Fetch one pull request by number from the active forge provider, including its body, draft state and branches. This is the direct lookup — reach for it instead of paging the PR listing for a number you already have, and read it before editing or merging so the current state is known. A pull request that does not exist comes back empty rather than failing, so treat an empty result as absence rather than an error.",
+        "Fetch one pull request by number from the active forge provider, including its body, draft state and branches. This is the direct lookup: reach for it instead of paging the PR listing for a number you already have, and read it before editing or merging so the current state is known. A pull request that does not exist comes back empty rather than failing, so treat empty as absence, not an error.",
       category: "forge",
       kind: "query",
       danger: "safe",
@@ -899,7 +899,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.getCIStatus",
       title: "Get CI Status",
       description:
-        "Fetch the roll-up CI verdict for one pull request from the active forge provider. Read the overall state for the answer: the accompanying counts cover required checks only, and a zero total also appears when the required-check list could not be read in full, so it is never evidence that nothing gates the merge. Values are provider-cached and can lag by around a minute, so poll for a settled verdict rather than treating a single success as final.",
+        "Fetch the roll-up CI verdict for one pull request from the active forge provider. Read the overall state for the answer: the accompanying counts cover required checks only, and a zero total also appears when the required-check list could not be read in full, so it is never evidence that nothing gates the merge. Values are provider-cached and can lag by a minute, so poll for a settled verdict.",
       category: "forge",
       kind: "query",
       danger: "safe",
@@ -932,7 +932,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
       id: "forge.getChecks",
       title: "Get CI Checks",
       description:
-        "List every CI check on one pull request — each check's name, whether it is still running, how it finished, and a link to its log where the forge reports one. Reach for it once the roll-up shows trouble and the question becomes which check broke and where to read its output. A check with no conclusion reported has not passed; the roll-up stays the authority on whether a PR is green. An empty list means no checks, a null one no such PR, and a provider that cannot read checks fails instead.",
+        "List every CI check on one pull request: name, run state, conclusion, and a log link where the forge reports one. Reach for it once the roll-up shows trouble. A check with no conclusion has not passed; the roll-up stays the authority on whether a PR is green. An empty list means no checks, a null one no such PR, and a provider that cannot read checks fails instead.",
       category: "forge",
       kind: "query",
       danger: "safe",

--- a/src/services/actions/definitions/gitActions.ts
+++ b/src/services/actions/definitions/gitActions.ts
@@ -175,7 +175,7 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     id: "git.getFileDiff",
     title: "Get File Diff",
     description:
-      "Read one file's git diff as a byte-bounded window, so a large diff cannot flood the response. When the result is flagged truncated, call again from the offset it hands back to continue — a single call is not guaranteed to be the whole diff. Some files have no diff text at all: binary files, unchanged files and oversized files come back as a marker instead, which is a valid result rather than a failure.",
+      "Read one file's git diff as a byte-bounded window, so a large diff cannot flood the response. When the result is flagged truncated, call again from the offset it hands back to continue: a single call is not guaranteed to be the whole diff. Some files have no diff text at all, and binary, unchanged and oversized files come back as a marker instead, which is a valid result rather than a failure.",
     category: "git",
     kind: "query",
     danger: "safe",

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -62,7 +62,7 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
     id: "help.displayImage",
     title: "Display documentation image",
     description:
-      "Show a documentation image inline in the assistant panel so an answer can point at it. Use this only when an image genuinely illustrates the answer, not for decorative ones. Reference the returned figure label as plain text at the insertion point rather than as markdown image syntax, which command-line renderers strip. Figure numbers are assigned by the app in sequence and must never be chosen yourself.",
+      "Show a documentation image inline in the assistant panel so an answer can point at it. Use this only when an image genuinely illustrates the answer, not for decorative ones. Reference the returned figure label as plain text at the insertion point rather than as markdown image syntax, which command-line renderers strip. Figure numbers are assigned in sequence and must never be chosen yourself.",
     category: "help",
     kind: "command",
     danger: "safe",

--- a/src/services/actions/definitions/introspectionActions.ts
+++ b/src/services/actions/definitions/introspectionActions.ts
@@ -32,7 +32,7 @@ export function registerIntrospectionActions(
     id: "actions.list",
     title: "List Actions",
     description:
-      "Enumerate the available actions as lightweight entries, filtered by domain or substring and returned a page at a time. Use ranked search instead when looking for a capability by intent; use this when the goal is to walk a domain systematically. Entries omit argument and result schemas to stay small — fetch one action's schema before dispatching it. Ordering is stable, so paging cannot skip or repeat entries.",
+      "Enumerate the available actions as lightweight entries, filtered by domain or substring and returned a page at a time. Use ranked search instead when looking for a capability by intent; use this when walking a domain systematically. Entries omit argument and result schemas to stay small, so fetch one action's schema before dispatching. Ordering is stable, so paging cannot skip or repeat entries.",
     category: "introspection",
     kind: "query",
     danger: "safe",
@@ -288,7 +288,7 @@ export function registerIntrospectionActions(
     id: "actions.search",
     title: "Search Actions",
     description:
-      "Find actions by describing what you want to do, ranked by how well each matches. This is the discovery path: start here, then fetch the chosen action's schema before dispatching it. Use the plain listing instead when walking a domain systematically rather than searching by intent. Results omit argument and result schemas to stay small, and matching nothing returns an empty list rather than failing.",
+      "Find actions by describing what you want to do, ranked by how well each matches. This is the discovery path: start here, then fetch the chosen action's schema before dispatching it. Use the plain listing when walking a domain systematically rather than searching by intent. Results omit argument and result schemas to stay small, and matching nothing returns an empty list rather than failing.",
     category: "introspection",
     kind: "query",
     danger: "safe",

--- a/src/services/actions/definitions/locationArgs.ts
+++ b/src/services/actions/definitions/locationArgs.ts
@@ -67,7 +67,7 @@ const selectorField = (description: string) => z.string().min(1).optional().desc
  * so a literal `worktree.list` here refers to a name the model never sees.
  */
 const worktreeIdField = selectorField(
-  "Identifies the worktree to act on, using an id from the worktree-listing capability. Omit this and the path to target the active worktree; the call fails when neither is given and no worktree is active."
+  "The worktree to act on, by id from the worktree-listing capability. Omit this and the path to target the active worktree, which fails when none is active."
 );
 
 /**
@@ -78,15 +78,19 @@ const worktreeIdField = selectorField(
  * description, so emitting the fallback text here contradicted it on the wire.
  */
 const worktreeIdRequiredField = selectorField(
-  "Identifies the worktree to act on, using an id from the worktree-listing capability. This action has no active-worktree fallback: supply this or the path, or the call is rejected."
+  "The worktree to act on, by id from the worktree-listing capability. No active-worktree fallback here: supply this or the path, or the call is rejected."
 );
 
 const worktreePathField = selectorField(
-  "Identifies the worktree to act on by absolute root path, as an alternative to its id. The id wins when both are given, and the path is used as given — it is never silently replaced by the active worktree."
+  "The worktree to act on, by absolute root path, as an alternative to its id. The id wins when both are given; the path is never swapped for the active one."
 );
 
+// The trailing qualifier is load-bearing, not hedging: `resolveProjectLocation`
+// rejects an unknown id only when the project index can prove it unknown, and
+// falls back to the context project when the index is unavailable. Dropping it
+// would make this text claim a guarantee the resolver does not give.
 const projectIdField = selectorField(
-  "Identifies the project to act on, using an id from the project-listing capability. Omit this and the path to target the active project; an id naming no open project is rejected rather than silently retargeted, as long as the set of open projects is known."
+  "The project to act on, by id from the project-listing capability. Omit this and the path for the active project; an unknown id is rejected rather than retargeted, as long as the open-project set is known."
 );
 
 const projectPathField = selectorField(

--- a/src/services/actions/definitions/projectCheckActions.ts
+++ b/src/services/actions/definitions/projectCheckActions.ts
@@ -25,7 +25,7 @@ export function registerProjectCheckActions(
       id: "project.runCheck",
       title: "Run Project Check",
       description:
-        "Run one of a project's detected commands as a child process and report its exit code and output. A command that fails is reported as a failed check rather than as an error, so read the result rather than relying on the call succeeding. Detection finds every runnable script, not just checks — verify what a command actually is before running an unfamiliar one. Never use this for long-lived servers: they block until the timeout expires.",
+        "Run one of a project's detected commands and report its exit code and output. A command that fails is reported as a failed check rather than an error, so read the result rather than relying on the call succeeding. Detection finds every runnable script, not just checks, so verify an unfamiliar command before running it. Never use this for long-lived servers: they block until the timeout expires.",
       category: "project",
       kind: "command",
       danger: "safe",
@@ -62,7 +62,7 @@ export function registerProjectCheckActions(
           .max(PROJECT_CHECK_MAX_TIMEOUT_MS)
           .optional()
           .describe(
-            `Wall-clock ceiling in milliseconds (default ${PROJECT_CHECK_DEFAULT_TIMEOUT_MS}, max ${PROJECT_CHECK_MAX_TIMEOUT_MS}). The process tree is killed when it elapses.`
+            `Wall-clock ceiling in milliseconds (default ${PROJECT_CHECK_DEFAULT_TIMEOUT_MS}, min ${PROJECT_CHECK_MIN_TIMEOUT_MS}, max ${PROJECT_CHECK_MAX_TIMEOUT_MS}). The process tree is killed when it elapses.`
           ),
       }),
       resultSchema: z.object({

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -12,13 +12,13 @@ import {
 export const AgentIdSchema = z
   .union([z.enum([...BUILT_IN_AGENT_IDS, "terminal", "browser", "dev-preview"]), z.string().min(1)])
   .describe(
-    "Which agent CLI to run. The enumerated ids are the built-ins; any other non-empty string is accepted so user- and plugin-contributed agents work, which means an unrecognised id fails at launch rather than at validation. Query the agent-listing capability for the ids actually installed and launchable."
+    "Which agent CLI to run, from the agent-listing capability. Enumerated ids are built-ins; any other non-empty string is accepted, so a bad id fails at launch, not validation."
   );
 
 export const LaunchLocationSchema = z
   .enum(["grid", "dock", "overlay"])
   .describe(
-    'Where to place the panel. "grid" places it in the main panel grid (default). "dock" places it in the sidebar dock. "overlay" places it in a floating overlay (e.g. the Daintree Assistant), outside the grid and dock.'
+    'Where to place the panel: "grid" the main panel grid (default), "dock" the sidebar dock, "overlay" a floating overlay outside both.'
   );
 
 /**
@@ -32,7 +32,7 @@ export const LaunchLocationSchema = z
 export const TerminalSpawnSourceSchema = z
   .enum(["quickrun", "recipe", "agent", "palette", "mcp", "assistant"])
   .describe(
-    "Records which surface asked for the spawn, for provenance and run history only; it never changes what is launched. Leave it unset when dispatching over MCP — the bridge stamps its own origin."
+    "Provenance for run history only; never changes what is launched. Leave unset over MCP, where the bridge stamps its own origin."
   );
 
 /**
@@ -41,7 +41,7 @@ export const TerminalSpawnSourceSchema = z
 export const AddPanelFocusPolicySchema = z
   .enum(["auto", "preserve", "take"])
   .describe(
-    'Whether creating the panel moves keyboard focus to it. "auto" (the effective default) moves focus except while the assistant owns input, "preserve" always leaves focus where it is, and "take" always moves it. Prefer "preserve" when spawning in the background so the user\'s typing is not interrupted.'
+    'Whether the new panel takes keyboard focus: "auto" (default) takes it unless the assistant owns input, "preserve" never takes it, "take" always does. Prefer preserve for background spawns so the user is not interrupted.'
   );
 
 // Derived from the settingsTabIds tuples so the action schema can't drift from
@@ -156,7 +156,18 @@ export function paginationShape(options: PaginationOptions = {}): Record<string,
     : z.number().int().positive();
 
   const shape: Record<string, z.ZodTypeAny> = {
-    limit: limitField.optional().describe("Maximum number of items to return."),
+    // The ceiling is stated in prose, not left to `.max()` alone. The wire view
+    // strips value-range keywords (`shared/utils/mcpWireSchema.ts`), so a bound
+    // that lives only in the schema reaches no caller — it would surface as a
+    // validation error naming a cap the model was never shown. Interpolated from
+    // the same value that enforces it, so the two cannot drift.
+    limit: limitField
+      .optional()
+      .describe(
+        maxLimit
+          ? `Maximum number of items to return (max ${maxLimit}).`
+          : "Maximum number of items to return."
+      ),
   };
   if (offset) {
     shape.offset = z
@@ -277,7 +288,7 @@ export const CopyTreeOptionsSchema = z
       .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
       .optional()
       .describe(
-        "Selects which files to include, as worktree-relative exact file paths or glob patterns. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'; prefer `scopePaths` when selecting a folder. Combined with `includePaths` when both are given; omit both to include the whole worktree."
+        "Selects which files to include, as worktree-relative exact file paths or glob patterns. Patterns match file paths, so a folder needs a glob: pass 'src/panels/**', not 'src/panels'; prefer `scopePaths` when selecting a folder. Combined with `includePaths` when both are given; omit both to include the whole worktree. An empty list or blank entry is rejected rather than read as no filter."
       ),
     exclude: z.union([z.string(), z.array(z.string())]).optional(),
     // Undocumented on the wire until #11750, which is how a caller ended up
@@ -314,11 +325,36 @@ export const CopyTreeOptionsSchema = z
       ),
     modified: z.boolean().optional(),
     changed: z.string().optional(),
-    maxFileSize: z.number().int().positive().optional(),
-    maxTotalSize: z.number().int().positive().optional(),
-    maxFileCount: z.number().int().positive().optional(),
+    // Positivity is enforced but no longer advertised — the wire view strips
+    // value-range keywords — so each budget states its unit and that omitting it
+    // means "no cap from this field", which is not guessable from the name.
+    maxFileSize: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Per-file size cap in bytes; must be positive. Omit for no per-file cap."),
+    maxTotalSize: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Total bundle size cap in bytes; must be positive. Omit for no total cap."),
+    maxFileCount: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "Maximum number of files to include; must be positive. Omit for no file-count cap."
+      ),
     withLineNumbers: z.boolean().optional(),
-    charLimit: z.number().int().positive().optional(),
+    charLimit: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Character cap on the rendered bundle; must be positive. Omit for no cap."),
     // These actions validate against their own copy of the options schema, so a
     // field only the IPC schema knows about is stripped before the request ever
     // leaves the renderer. `sort` was missing here while `CopyTreeOptions` and the

--- a/src/services/actions/definitions/skillActions.ts
+++ b/src/services/actions/definitions/skillActions.ts
@@ -17,7 +17,7 @@ export function registerSkillActions(actions: ActionRegistry, _callbacks: Action
       id: "skills.search",
       title: "Search skills",
       description:
-        "Find plugin-contributed skills: reusable written instructions and workflows, such as a review rubric or a test-driven-development procedure, that plugins ship for an agent to follow. This returns names and summaries only; load a skill by id to read its actual instructions. Omitting a query lists available skills, but only up to the capped result limit, and the result never says whether more were left out.",
+        "Find plugin-contributed skills: reusable written instructions and workflows, such as a review rubric or a test-driven-development procedure, that plugins ship for an agent to follow. This returns names and summaries only, so load a skill by id to read its instructions. Omitting a query lists available skills, but only to the capped limit, and the result never says whether more were left out.",
       category: "agent",
       kind: "query",
       danger: "safe",

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -146,7 +146,7 @@ const copyTreeRunNameField = z
   .string()
   .optional()
   .describe(
-    "Short human-readable label for this copy tree, shown in the user's copy-tree history and in the completion notification. Use 2 to 4 words describing what the context is for, for example 'auth flow context'. Omit it and the notification stays unlabelled, while the history entry keeps the label it already has or, if this selection is new, one derived from it."
+    "Short human-readable label for this copy tree, shown in the user's copy-tree history and in the completion notification. Use 2 to 4 words, for example 'auth flow context'. Omitted, the notification is unlabelled and the history entry keeps or derives its own label."
   );
 
 /**
@@ -285,7 +285,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       id: "system.getResourceProfileSnapshot",
       title: "Get Resource Profile Snapshot",
       description:
-        "Read how much pressure the host machine is under and which adaptive performance mode is in effect. Use this to judge whether there is headroom before launching more agents or heavy work. Some readings are platform-specific and report as unknown elsewhere. It never fails — while the service is still starting it returns a neutral baseline, so treat an unremarkable reading early in a session with some caution.",
+        "Read how much pressure the host machine is under and which adaptive performance mode is in effect. Use this to judge whether there is headroom before launching more agents or heavy work. Some readings are platform-specific and report as unknown elsewhere. It never fails: while the service is starting it returns a neutral baseline, so treat an unremarkable early reading with caution.",
       category: "system",
       kind: "query",
       danger: "safe",
@@ -466,7 +466,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       id: "copyTree.generate",
       title: "Generate CopyTree Context",
       description:
-        "Bundle a worktree's file tree and selected file contents into a context dump written to a temporary file, and return its path. Use this to hand a large codebase context to something that can read a file; inject directly into a terminal instead when the target is an agent. The bundle routinely runs to tens of megabytes and is never returned inline. Check the budget flags before trusting it as complete, and read the file promptly — it is pruned by age.",
+        "Bundle a worktree's file tree and selected file contents into a context dump on disk, and return its path. Use it to hand a large codebase context to something that can read a file; inject into a terminal when the target is an agent. The bundle routinely runs to tens of megabytes and is never returned inline. Check the budget flags before trusting it, and read it promptly: it is pruned by age.",
       category: "copyTree",
       kind: "query",
       danger: "safe",
@@ -595,7 +595,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       id: "copyTree.generateAndCopyFile",
       title: "Generate And Copy Context",
       description:
-        "Bundle a worktree's context to a file and put it on the system clipboard, replacing what the user had copied. Selection can mix exact files with globs, so this assembles a curated bundle of scattered related files, their supporting code and tests, rather than the whole worktree. Agent and MCP callers must name the worktree instead of relying on whichever is active. macOS and Linux copy the file, Windows its path. Never returned inline; check the budget flags for completeness.",
+        "Bundle a worktree's context to a file and onto the system clipboard, replacing what the user had copied. Selection mixes exact files with globs, so this assembles a curated bundle rather than the whole worktree. Agent and MCP callers must name the worktree, not rely on the active one. macOS and Linux copy the file, Windows its path. Never returned inline; check the budget flags for completeness.",
       category: "copyTree",
       kind: "command",
       danger: "safe",

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -82,7 +82,7 @@ export function registerTerminalLifecycleActions(
     id: "terminal.close",
     title: "Close Terminal",
     description:
-      "Close a panel, usually moving it to the trash where it stays briefly recoverable before its process is killed. Recovery is not universal — panels set to remove on exit, and dialog panels, are discarded outright. This is not limited to terminals. Name the panel you mean; closing the wrong one discards someone's work. An untracked panel is rejected rather than reported closed, and the result names what actually closed — already gone from the listing when an automated caller sees it.",
+      "Close a panel, usually to the trash, where it is briefly recoverable before its process is killed. Recovery is not universal: remove-on-exit and dialog panels are discarded outright. Not limited to terminals. Name the panel you mean; the wrong one discards someone's work. An untracked panel is rejected, not reported closed; the result names what closed, already gone from the listing by then.",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -203,7 +203,7 @@ export function registerTerminalLifecycleActions(
     id: "terminal.kill",
     title: "Kill Terminal",
     description:
-      "Permanently destroy a panel and any process behind it, with no trash step and no recovery. This is not limited to terminals — whatever panel the id names is removed. A panel running an agent session is left untouched unless the call itself is marked confirmed, so read back its state rather than assuming it went. Identify it explicitly: an automated caller cannot see what the user has focused. Close it instead when recoverability matters.",
+      "Permanently destroy a panel and its process, with no trash step and no recovery. Not limited to terminals: whatever the id names is removed. A panel running an agent session is untouched unless the call is marked confirmed, so read back its state rather than assume it went. Identify it explicitly: an automated caller cannot see what the user focused. Close it instead when recovery matters.",
     category: "terminal",
     kind: "command",
     danger: "confirm",
@@ -250,7 +250,7 @@ export function registerTerminalLifecycleActions(
     id: "terminal.restart",
     title: "Restart Terminal",
     description:
-      "Begin restarting a terminal's process in place, keeping the pane. This returns before the restart has finished, so the terminal is not ready yet when it does — watch its status before sending anything. A terminal running an agent session is left untouched unless the call itself is marked confirmed; otherwise whatever was running is terminated and unsaved in-process state is lost. A panel with no process is ignored rather than reported as an error.",
+      "Restart a terminal's process in place, keeping the pane. This returns before the restart finishes, so it is not ready when it does; watch its status before sending anything. A terminal running an agent session is left untouched unless the call is marked confirmed; otherwise whatever was running is terminated and unsaved state is lost. A panel with no process is ignored, not an error.",
     category: "terminal",
     kind: "command",
     danger: "confirm",
@@ -570,7 +570,7 @@ export function registerTerminalLifecycleActions(
     id: "terminal.killAll",
     title: "Kill All Terminals",
     description:
-      "Permanently destroy every panel in the project at once — across all worktrees, of every kind, including trashed and backgrounded ones — with no trash step and no recovery. This takes the user's own shells and other agents' running work with it; only tooling-internal and dialog-hosted panels are spared. While any agent session is running it destroys nothing unless the call itself is marked confirmed. There is essentially never a reason for an automated caller to use this.",
+      "Permanently destroy every panel in the project, across all worktrees and kinds, including trashed and backgrounded, with no trash step and no recovery. It takes the user's own shells and other agents' work with it; only tooling-internal and dialog-hosted panels are spared. While an agent session runs it destroys nothing unless the call is marked confirmed. Automated callers should never need this.",
     category: "terminal",
     kind: "command",
     danger: "confirm",

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -29,7 +29,7 @@ export function registerTerminalQueryActions(
     id: "terminal.list",
     title: "List Terminals",
     description:
-      "Enumerate the open terminals and panels, with just enough metadata to pick one to act on. Start here to discover terminal ids, then read status or output for the ones that matter — this is a cheap inventory, not a polling path, and the status snapshot carries richer agent state for a whole fleet in one call. Ephemeral and internal panels are left out, and an empty result means no terminals are open rather than a failure.",
+      "Enumerate the open terminals and panels, with just enough metadata to pick one. Start here to discover terminal ids, then read status or output for the ones that matter: this is a cheap inventory, not a polling path; the status snapshot carries richer agent state for a fleet in one call. Ephemeral and internal panels are left out; an empty result means none are open, not a failure.",
     category: "terminal",
     kind: "query",
     danger: "safe",
@@ -101,7 +101,7 @@ export function registerTerminalQueryActions(
     id: "terminal.getOutput",
     title: "Get Terminal Output",
     description:
-      "Read the trailing scrollback of one terminal, for inspecting what an agent or command actually printed. Use the terminal status snapshot instead when watching several terminals — it fetches output tails for a whole fleet in one call, and reading them one at a time is the common mistake here. Output has ANSI codes stripped by default and may be truncated to the requested tail; a terminal that no longer exists comes back as an error field in the result rather than failing the call.",
+      "Read the trailing scrollback of one terminal, to inspect what an agent or command printed. Use the status snapshot when watching several terminals: it fetches tails for a whole fleet in one call, and reading one at a time is the common mistake. ANSI codes are stripped by default; output may be truncated to the requested tail, and a missing terminal returns an error field, not a failed call.",
     category: "terminal",
     kind: "query",
     danger: "safe",
@@ -193,7 +193,7 @@ export function registerTerminalQueryActions(
     id: "terminal.getStatus",
     title: "Get Terminal Status",
     description:
-      "Take a point-in-time snapshot of agent and process state across many terminals at once, optionally with recent output tails. This is the batched polling path: prefer it over listing terminals for agent state or reading each terminal's output in turn. It never blocks and never fails as a whole — an entry's own error can mean that terminal was missing or that the shared output fetch failed — so use the blocking wait instead when the goal is to proceed the moment an agent finishes.",
+      "Snapshot agent and process state across many terminals, with optional output tails. This is the batched polling path: prefer it over listing terminals for agent state, or reading each terminal's output in turn. It never blocks or fails as a whole; an entry's error can mean that terminal was missing or the shared fetch failed. Use the blocking wait to proceed the moment an agent finishes.",
     category: "terminal",
     kind: "query",
     danger: "safe",
@@ -457,7 +457,7 @@ export function registerTerminalQueryActions(
         .min(1)
         .max(MAX_WAIT_UNTIL_IDLE_BATCH_TERMINALS)
         .describe(
-          "Identifies the terminals to watch, using panel ids from the terminal-listing capability. Ids no longer tracked count as already finished rather than failing the batch."
+          `Identifies the terminals to watch (1-${MAX_WAIT_UNTIL_IDLE_BATCH_TERMINALS}), using panel ids from the terminal-listing capability. Ids no longer tracked count as already finished rather than failing the batch.`
         ),
       mode: z
         .enum(["first", "all"])

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -262,10 +262,9 @@ export function registerTerminalSpawnActions(
     description:
       "Move a terminal panel to a different worktree. The process is never restarted: a live " +
       "agent keeps running in the directory it launched from, and its pane offers to tell it " +
-      "to continue in the destination. A panel that shares a tab group travels with the " +
-      "rest of that group, so this can relocate more than the one panel named. The move is " +
-      "reversible. Name the target explicitly — an automated caller cannot see what the " +
-      "user has focused.",
+      "to continue there. A panel sharing a tab group travels with the rest of that group, " +
+      "so this can relocate more than the panel named. The move is reversible. Name the " +
+      "target: an automated caller cannot see what the user focused.",
     category: "terminal",
     kind: "command",
     // Relabelling a panel is reversible — drag it back — and nothing here

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -39,7 +39,7 @@ export function registerWorkflowCreationActions(
       id: "worktree.createWithRecipe",
       title: "Create Worktree with Recipe",
       description:
-        "Create a git worktree with its branch, optionally tracking a pull request, and optionally launch a recipe's terminals in it. This is the heavy composite path: it writes to disk, may check out a remote branch, and may start several processes. Create the worktree alone when no pull request or terminals are wanted. Partial failure is possible — the worktree can exist while its recipe did not fully start.",
+        "Create a git worktree with its branch, optionally tracking a pull request, and optionally launch a recipe's terminals in it. This is the heavy composite path: it writes to disk, may check out a remote branch, and may start several processes. Create the worktree alone when neither is wanted. Partial failure is possible: the worktree can exist while its recipe did not fully start.",
       category: "worktree",
       kind: "command",
       danger: "safe",

--- a/src/services/actions/definitions/worktreeCreateActions.ts
+++ b/src/services/actions/definitions/worktreeCreateActions.ts
@@ -48,7 +48,7 @@ export function registerWorktreeCreateActions(
       id: "worktree.create",
       title: "Create Worktree",
       description:
-        "Create a git worktree with its branch, without launching terminals. Prefer the recipe-backed creation path when the worktree should also track a pull request or start a recipe's terminals. It writes to disk, may branch from a remote base or reuse an existing branch, and can provision a configured resource. Creation anchors on the repository root, not the active worktree, which is usually a linked one; setup can still fail after the worktree exists.",
+        "Create a git worktree with its branch, without launching terminals. Prefer the recipe-backed path when it should also track a pull request or start a recipe's terminals. It writes to disk, may branch from a remote base or reuse a branch, and can provision a configured resource. Creation anchors on the repository root, not the active worktree; setup can still fail after the worktree exists.",
       category: "worktree",
       kind: "command",
       danger: "safe",

--- a/src/services/actions/definitions/worktreeResourceActions.ts
+++ b/src/services/actions/definitions/worktreeResourceActions.ts
@@ -122,7 +122,7 @@ export function registerWorktreeResourceActions(
       id: "worktree.resource.teardown",
       title: "Teardown Resource",
       description:
-        "Run the project's configured teardown commands for a worktree's remote resource, typically to destroy a cloud devbox. These are arbitrary commands the project defines, so what they destroy — and whether anything can be recovered — depends entirely on that configuration; read it before running this. The project's pause commands are the intended lighter-weight path when the resource is still needed.",
+        "Run the project's configured teardown commands for a worktree's remote resource, typically to destroy a cloud devbox. These are arbitrary commands the project defines, so what they destroy, and whether anything can be recovered, depends entirely on that configuration; read it before running this. The project's pause commands are the lighter path when the resource is still needed.",
       category: "worktree",
       kind: "command",
       danger: "confirm",


### PR DESCRIPTION
The MCP tool region is the largest single part of every request Daintree sends a model, it is re-sent on every round including tool-continuation rounds where nothing changed, and clients cap what they accept. #11585 attacked that on the **count** axis, cutting the external surface from 100 tools to 26. This attacks the axis that was left: **bytes per tool**.

Measured from the live registry:

| surface | before | after |
| --- | --- | --- |
| external (26 tools, third-party client) | 44,825 B | 42,540 B (-5.1%) |
| full in-app (152 tools) | 196,990 B | 183,549 B (-6.8%) |

## The structural change

`argsSchema` (zod) is the authoritative schema — `ActionService.dispatch` validates against it, and the emitted JSON Schema exists only to be advertised. So the two are a projection, not a fork, and `toWireSchema` drops the value-range family (`minimum`, `maximum`, `pattern`, `minItems`, …) from what rides `tools/list`. Constrained-decoding backends don't enforce those at the token-masking level, so they arrive as prompt text: billed every turn, routinely violated, and able to degrade output when the model's chosen path contradicts one.

Nothing server-side weakens, though it's worth being precise about which enforcement, because it isn't one mechanism — renderer actions go through `argsSchema.safeParse`, plugin actions through the plugin host's own AJV pass, main-process tools through their own checks. None reads this projection.

The walk is keyword-aware rather than name-aware: a schema may legally declare a *property* called `pattern`, and a blind key-delete would silently un-advertise a required argument with no error anywhere.

**Where a bound was genuinely needed to call correctly, it moved into prose** rather than disappearing — `paginationShape` now interpolates its own `maxLimit`, `project.runCheck.timeoutMs` states its minimum, `agent.launch.name` its 200-character cap, `terminal.waitUntilIdleBatch.terminalIds` its batch cap, and `browser.getConsoleMessages.limit` gained a description it never had.

## What is deliberately NOT projected

Two things, both because they are contracts rather than advertisement:

- **Output schemas.** The MCP SDK compiles every advertised `outputSchema` and validates `structuredContent` against it with AJV on the client. Stripping bounds there deletes real validation, and main-process tools never reach the `resultSchema` check that covers renderer dispatches.
- **The `mcp.surface` hash.** It answers "would my existing calls still work", so it is computed from the unprojected schema. Tightening a `maximum` from 100 to 50 breaks calls that used to succeed; hashing the projected view would let exactly that pass silently. `MCP_SURFACE_MANIFEST_VERSION` goes to 2 because the digest's meaning changed, and a new test pins that a tightened bound moves it.

`actions.getSchema` also stays unprojected — it's an on-demand single-entry fetch, so it's the escape hatch where full constraints remain visible.

## Prose

34 tool descriptions now fit a 400 B ceiling, and shared field vocabulary is defined once — four selector descriptions in `locationArgs.ts` cover 94 advertised properties that previously restated the same semantics per tool.

The governing rule is that **over-compression is worse than no compression**, because the failure is invisible: it shows up as the model picking the neighbouring tool, not as a size number. So disambiguation against a sibling, prohibitions, non-obvious shape requirements, per-property semantics, and units/defaults/return shape are protected and never cut to hit a budget. Where prose couldn't fit with those intact, the tool is allowlisted with a written reason instead of trimmed — the copyTree options object is the main case, since its clauses are pinned individually by regressions from #11722 and #11750.

## Gates

`src/services/actions/__tests__/mcpWireBudget.test.ts` measures the live registry rather than a fixture, so a captured copy can't drift while the gates keep passing. Ceilings on tool descriptions, field descriptions, and per-tool `parameters`; aggregate ratchets on both surfaces; and a hard "no value-range keyword on an input schema" check. Both allowlists carry a reason per entry and are checked for staleness, so an exemption that is no longer needed fails rather than silently covering the next regression.

The projection is additionally tested against the **shipped** builders in `tierAuth.test.ts`, not just the renderer-side measurement — deleting `toWireSchema` from `buildToolInputSchema` fails there.

Standard and rationale: `docs/architecture/mcp-context-condensation.md`.

## Testing

- Full unit suite: 50,430 passing, 0 failing
- `npm run typecheck` clean; lint ratchet unmoved at baseline
- Two adversarial Codex review rounds; the output-projection revert, the hash preimage, the path-scoped allowlist, and several restored prose clauses all came out of them