### PR TITLE
fix(assistant): honor the configured capability tier

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -190,7 +190,7 @@ const {
   mockSetAssistantPaneActionContextResolver,
   mockEnsureReady,
 } = vi.hoisted(() => ({
-  mockValidateToken: vi.fn<(token: string) => "action" | "system" | false>(),
+  mockValidateToken: vi.fn<(token: string) => "workbench" | "action" | "system" | false>(),
   mockIsRunning: vi.fn<() => boolean>(),
   mockCurrentPort: vi.fn<() => number | null>(),
   mockPreparePaneConfig: vi.fn(),
@@ -1248,9 +1248,12 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
-  it("injects DAINTREE_ASSISTANT_AUTO_APPROVE=1 when the Daintree Assistant launches with bypassPermissions on", async () => {
+  // Workbench on purpose (#11907): auto-approve rides the bypassPermissions
+  // snapshot, never the MCP capability tier. The assistant is no longer pinned
+  // to `system`, so a low-tier session must still inject the env var.
+  it("injects DAINTREE_ASSISTANT_AUTO_APPROVE=1 when the Daintree Assistant launches with bypassPermissions on, regardless of tier", async () => {
     mockValidateToken.mockImplementation((token) =>
-      token === "assistant-bypass" ? "system" : false
+      token === "assistant-bypass" ? "workbench" : false
     );
     mockGetBypassPermissions.mockImplementation((token) => token === "assistant-bypass");
 

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -1251,7 +1251,7 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
   // Workbench on purpose (#11907): auto-approve rides the bypassPermissions
   // snapshot, never the MCP capability tier. The assistant is no longer pinned
   // to `system`, so a low-tier session must still inject the env var.
-  it("injects DAINTREE_ASSISTANT_AUTO_APPROVE=1 when the Daintree Assistant launches with bypassPermissions on, regardless of tier", async () => {
+  it("injects DAINTREE_ASSISTANT_AUTO_APPROVE=1 when the Daintree Assistant launches with bypassPermissions on at the workbench tier", async () => {
     mockValidateToken.mockImplementation((token) =>
       token === "assistant-bypass" ? "workbench" : false
     );

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -10,7 +10,6 @@ import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { probeMcpServer, probeMcpSseServer } from "./mcp-server/readinessProbe.js";
 import { getAssistantWiredAgentIds } from "../../shared/config/agentRegistry.js";
-import { ASSISTANT_ONLY_AGENT_IDS } from "../../shared/config/agentIds.js";
 import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
 import type { ActionContext } from "../../shared/types/actions.js";
 import type { PtyClient } from "./PtyClient.js";
@@ -660,18 +659,15 @@ export class HelpSessionService {
     pathHash: string
   ): Promise<ProvisionResult | null> {
     const settings = this.readSettings();
-    // The Daintree Assistant is the workspace's first-class conductor: when the
-    // user explicitly selects it, it runs at the top `system` tier so the full
-    // action surface — forge writes, git mutations, worktree.delete — is reachable
-    // (still behind the per-action confirm gate; the tier opens the door, it does
-    // not skip confirmation). Other help-overlay agents (Claude/Codex) keep the
-    // deliberate `action` floor from settings, where irreversible mutations need a
-    // human-approved scoped grant. Policy locks live in
-    // `mcp-server/__tests__/tierAuth.test.ts`.
-    const isDaintreeAssistant = (ASSISTANT_ONLY_AGENT_IDS as readonly string[]).includes(
-      input.agentId
-    );
-    const tier: HelpAssistantTier = isDaintreeAssistant ? "system" : settings.tier;
+    // Every help agent — the Daintree Assistant included — provisions at the
+    // tier the user configured. Agent identity never widens the MCP surface,
+    // which restores the #10640/#10647 safety model: `action` is the default
+    // floor, where irreversible mutations (git.push, worktree.delete) sit above
+    // the line and need a human-approved scoped grant, while `workbench` and
+    // `system` stay explicit user choices. An identity override here would make
+    // the Settings tier selector lie about the surface it hands out (#11907).
+    // What each tier permits is locked in `mcp-server/__tests__/tierAuth.test.ts`.
+    const tier: HelpAssistantTier = settings.tier;
     const sessionId = randomUUID();
     const token = randomBytes(SESSION_TOKEN_BYTES).toString("hex");
     const sessionsRoot = this.getSessionsRoot();

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -475,32 +475,43 @@ describe("HelpSessionService", () => {
     expect(settings.defaultMode).toBeUndefined();
   });
 
-  it("provisions the Daintree Assistant at the system tier regardless of the stored setting", async () => {
-    // Selecting the Daintree Assistant grants full capability (system tier),
-    // overriding the action-tier floor that governs the Claude/Codex help
-    // overlays. The stored setting here says `action`; the agent identity wins.
-    mockStoreGet.mockReturnValue({ tier: "action", bypassPermissions: false });
+  // #11907: agent identity must never widen the MCP surface. The Daintree
+  // Assistant used to be pinned to `system` here regardless of the stored
+  // setting, which made the Settings tier selector promise a narrower surface
+  // than it handed out. Assert the bearer too, not just the returned payload —
+  // `validateToken` is what the MCP auth layer actually reads.
+  it.each(["workbench", "action", "system"] as const)(
+    "provisions the Daintree Assistant at the stored %s tier",
+    async (tier) => {
+      mockStoreGet.mockReturnValue({ tier, bypassPermissions: false });
 
-    const result = await service.provisionSession({
-      ...provisionInput(),
-      agentId: "daintree-assistant",
-    });
-    if (!result) throw new Error("expected result");
-    expect(result.tier).toBe("system");
-  });
+      const result = await service.provisionSession({
+        ...provisionInput(),
+        agentId: "daintree-assistant",
+      });
+      if (!result) throw new Error("expected result");
+      expect(result.tier).toBe(tier);
+      expect(service.validateToken(result.token)).toBe(tier);
+    }
+  );
 
-  it("leaves non-assistant help agents on the stored action tier", async () => {
-    // Contrast with the Daintree Assistant override above: a Claude help overlay
-    // keeps the deliberate action floor so irreversible mutations still need a grant.
-    mockStoreGet.mockReturnValue({ tier: "action", bypassPermissions: false });
+  it.each(["workbench", "action", "system"] as const)(
+    "provisions a non-assistant help agent at the stored %s tier",
+    async (tier) => {
+      // The non-assistant path stays independently configurable — a Claude
+      // overlay follows the same stored preference, unaffected by whatever the
+      // assistant path does.
+      mockStoreGet.mockReturnValue({ tier, bypassPermissions: false });
 
-    const result = await service.provisionSession({
-      ...provisionInput(),
-      agentId: "claude",
-    });
-    if (!result) throw new Error("expected result");
-    expect(result.tier).toBe("action");
-  });
+      const result = await service.provisionSession({
+        ...provisionInput(),
+        agentId: "claude",
+      });
+      if (!result) throw new Error("expected result");
+      expect(result.tier).toBe(tier);
+      expect(service.validateToken(result.token)).toBe(tier);
+    }
+  );
 
   it("getBypassPermissions returns the snapshot taken at provision time", async () => {
     mockStoreGet.mockReturnValue({ tier: "action", bypassPermissions: true });

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -764,15 +764,17 @@ describe("buildAnnotations", () => {
   });
 });
 
-// Policy guard for the help-session MCP tiers (#10640). NOTE: the Daintree
-// Assistant itself is now provisioned at the `system` tier (see
-// HelpSessionService.doProvision — selecting it grants full capability), so the
-// assertions below lock the `action` tier that still governs the Claude/Codex
-// help OVERLAYS, plus the system/external boundaries the assistant relies on.
+// Policy guard for the help-session MCP tiers (#10640). Every help agent —
+// the Daintree Assistant and the Claude/Codex overlays alike — provisions at
+// the tier the user configured, with `action` as the default floor (#11907
+// removed the identity override that used to pin the assistant to `system`).
+// So the assertions below lock the `action` tier that governs a default
+// session, plus the system/external boundaries above it.
 // The distinction is load-bearing: `action` leaves irreversible mutations
-// (git.push, worktree.delete) TIER_NOT_PERMITTED so the overlays need a
-// human-approved scoped grant, while `system` (the assistant) permits them
-// subject only to the confirm gate. `external` used to permit them too — #11585
+// (git.push, worktree.delete) TIER_NOT_PERMITTED so a default session needs a
+// human-approved scoped grant, while `system` — the tier a user has to select
+// deliberately — permits them subject only to the confirm gate. `external` used
+// to permit them too — #11585
 // removed them from that surface entirely, so `system` is now the only tier that
 // reaches them. These assertions lock those invariants against allowlist drift
 // (e.g. someone promoting git.push into the action tier). They test the runtime

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -492,8 +492,10 @@ export interface AssistantSupports {
   settingsOverlay: boolean;
   /**
    * Whether this agent exposes a `--dangerously-skip-*` CLI flag that the
-   * system tier appends to the spawn command. Corresponds to entries in
-   * `DEFAULT_DANGEROUS_ARGS`.
+   * help-session launch path appends when the user turns on bypass
+   * permissions. Keyed off the `bypassPermissions` snapshot, not the MCP
+   * capability tier — the two controls are orthogonal. Corresponds to entries
+   * in `DEFAULT_DANGEROUS_ARGS`.
    */
   permissionBypass: boolean;
   /**

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -195,8 +195,9 @@ export const SYSTEM_TIER_ADDONS = [
   // confined to the current project because it derives its own root. This one
   // takes an explicit root that is not validated against the session's
   // project, so an action-tier overlay could create a tree in another repo.
-  // System keeps that with the first-party assistant (forced to this tier in
-  // `HelpSessionService`) and leaves overlays a scoped grant (#11880).
+  // System keeps it there, so every help agent — the Daintree Assistant
+  // included — reaches it only at an explicitly selected `system` tier or
+  // through a scoped grant (#11880, #11907).
   "worktree.create",
   "worktree.delete",
   // The session-scoped form of `worktree.delete` (#11909), carried here for the

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -162,8 +162,13 @@ interface BypassCopy {
   warning: string;
 }
 
-const TIER_IS_LAST_SAFEGUARD =
-  "The capability tier above is the only remaining safeguard for Daintree actions.";
+// Names the tier rather than pointing at "the selector above" (#11907): with
+// the gate off, the tier is the entire remaining boundary, so the warning has
+// to say which one. Scoped to new sessions because both the tier and the
+// bypass preference are provision-time snapshots — a session already running
+// keeps the tier it was minted with, which the live-status card reports.
+const tierIsLastSafeguard = (tier: HelpAssistantTier): string =>
+  `New sessions run at the ${TIER_SHORT_LABEL[tier]} capability tier, which is the only remaining safeguard for Daintree actions.`;
 
 /**
  * Per-agent wording for the one stored `bypassPermissions` preference. The
@@ -172,18 +177,22 @@ const TIER_IS_LAST_SAFEGUARD =
  * sandbox alongside its approvals — and understating the blast radius is the
  * same failure as labelling every agent with Claude's flag.
  */
+// `warning` carries the agent-specific half only; `getBypassCopy` appends the
+// tier-naming safeguard sentence so every branch names the same effective tier.
 const BYPASS_COPY: Record<string, Omit<BypassCopy, "subtitle"> & { effect: string }> = {
   claude: {
     title: "Bypass Claude permission prompts",
     effect: "Skip Claude's per-tool confirmation gate",
     ariaLabel: "Bypass Claude permission prompts during help sessions",
-    warning: `With this on, Claude's permission gate is bypassed for all tools — built-in (Bash, Write) and MCP. ${TIER_IS_LAST_SAFEGUARD}`,
+    warning:
+      "With this on, Claude's permission gate is bypassed for all tools — built-in (Bash, Write) and MCP.",
   },
   codex: {
     title: "Bypass Codex approvals and sandbox",
     effect: "Skip Codex's approval prompts and run tools unsandboxed",
     ariaLabel: "Bypass Codex approvals and sandbox during help sessions",
-    warning: `With this on, Codex runs every tool without approval and outside its sandbox, so it reaches anywhere the process can. ${TIER_IS_LAST_SAFEGUARD}`,
+    warning:
+      "With this on, Codex runs every tool without approval and outside its sandbox, so it reaches anywhere the process can.",
   },
 };
 
@@ -195,8 +204,10 @@ const BYPASS_COPY: Record<string, Omit<BypassCopy, "subtitle"> & { effect: strin
  * path appends from (`electron/ipc/handlers/terminal/lifecycle.ts`) — so the
  * subtitle can't drift from what actually reaches the command line.
  */
-function getBypassCopy(agentId: string | null): BypassCopy | null {
+function getBypassCopy(agentId: string | null, tier: HelpAssistantTier): BypassCopy | null {
   if (!agentId) return null;
+
+  const safeguard = tierIsLastSafeguard(tier);
 
   // The assistant has no CLI flag: bypass skips its own confirm sheet via
   // DAINTREE_ASSISTANT_AUTO_APPROVE, which is why it carries no
@@ -206,7 +217,7 @@ function getBypassCopy(agentId: string | null): BypassCopy | null {
       title: "Auto-approve assistant actions",
       subtitle: "Skip the assistant's own per-action confirmation sheet",
       ariaLabel: "Auto-approve Daintree Assistant actions during help sessions",
-      warning: `With this on, the assistant acts without asking — no confirmation sheet for anything it does. ${TIER_IS_LAST_SAFEGUARD}`,
+      warning: `With this on, the assistant acts without asking — no confirmation sheet for anything it does. ${safeguard}`,
     };
   }
 
@@ -219,14 +230,14 @@ function getBypassCopy(agentId: string | null): BypassCopy | null {
   const agentName = config?.name ?? agentId;
   const known = BYPASS_COPY[agentId];
   if (known) {
-    const { effect, ...rest } = known;
-    return { ...rest, subtitle: `${effect} (passes ${flag})` };
+    const { effect, warning, ...rest } = known;
+    return { ...rest, subtitle: `${effect} (passes ${flag})`, warning: `${warning} ${safeguard}` };
   }
   return {
     title: `Bypass ${agentName} permission prompts`,
     subtitle: `Skip ${agentName}'s confirmation gate (passes ${flag})`,
     ariaLabel: `Bypass ${agentName} permission prompts during help sessions`,
-    warning: `With this on, ${agentName} runs every tool without asking. ${TIER_IS_LAST_SAFEGUARD}`,
+    warning: `With this on, ${agentName} runs every tool without asking. ${safeguard}`,
   };
 }
 
@@ -307,7 +318,10 @@ export function DaintreeAssistantSettingsTab() {
   // panel still in its empty state. The placeholder makes "no selection" explicit.
   const agentSelectValue = preferredAgentId ?? "";
 
-  const bypassCopy = useMemo(() => getBypassCopy(preferredAgentId), [preferredAgentId]);
+  const bypassCopy = useMemo(
+    () => getBypassCopy(preferredAgentId, settings.tier),
+    [preferredAgentId, settings.tier]
+  );
 
   // Resolved model catalog for the currently-preferred agent. `null` means "not
   // loaded / unavailable" (we render nothing); an empty array means "agent has

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -441,6 +441,39 @@ describe("DaintreeAssistantSettingsTab", () => {
     });
   });
 
+  // #11907: with the confirmation sheet off, the tier is the entire remaining
+  // boundary, so the warning has to name it — and keep naming the right one
+  // when the selector moves (a missing memo dependency would freeze the old
+  // tier in the copy while the selector reads the new one).
+  it("names the configured tier in the auto-approve warning and follows the selector", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex", "daintree-assistant"]);
+    helpPanelState.preferredAgentId = "daintree-assistant";
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Auto-approve assistant actions");
+
+    fireEvent.click(
+      screen.getByLabelText("Auto-approve Daintree Assistant actions during help sessions")
+    );
+
+    await waitForContent(
+      container,
+      "New sessions run at the Action capability tier, which is the only remaining safeguard"
+    );
+
+    fireEvent.change(screen.getByLabelText("Capability tier"), { target: { value: "system" } });
+
+    await waitForContent(
+      container,
+      "New sessions run at the System capability tier, which is the only remaining safeguard"
+    );
+    expect(container.textContent).not.toContain("the Action capability tier");
+  });
+
   // The gate is what keeps a switch off agents where flipping it does nothing.
   it("hides the bypass toggle for an agent with no bypass mechanism", async () => {
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "byoa"]);

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -456,9 +456,16 @@ describe("DaintreeAssistantSettingsTab", () => {
     );
     await waitForContent(container, "Auto-approve assistant actions");
 
-    fireEvent.click(
-      screen.getByLabelText("Auto-approve Daintree Assistant actions during help sessions")
+    // The switch stays disabled until the persisted settings resolve, and the
+    // heading above renders before that — clicking on the heading alone would
+    // drop the event and time out downstream.
+    const toggle = screen.getByLabelText(
+      "Auto-approve Daintree Assistant actions during help sessions"
     );
+    await waitFor(() => {
+      expect(toggle.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(toggle);
 
     await waitForContent(
       container,
@@ -1455,6 +1462,31 @@ describe("SessionLiveStatusCard (live help session)", () => {
     await waitFor(() => expect(container.textContent).toContain("Live session"), { timeout: 5000 });
     expect(container.textContent).toContain("below the configured system default");
     expect(container.textContent).not.toContain("matches the configured default");
+  });
+
+  // The equality branch is the one a default assistant session lands on now
+  // that agent identity no longer forces `system` (#11907) — before the fix it
+  // was unreachable for the assistant, so only the drift copy was ever proven.
+  it("reports a live tier equal to the configured default as a match", async () => {
+    installApi(
+      {
+        getSettings: vi.fn().mockResolvedValue(settingsWithTier("action")),
+        getLiveSessionStatus: vi
+          .fn()
+          .mockResolvedValue({ connected: true, tier: "action", activeGrants: [] }),
+      },
+      {}
+    );
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+
+    await waitFor(() => expect(container.textContent).toContain("Live session"), { timeout: 5000 });
+    expect(container.textContent).toContain("matches the configured default");
+    expect(container.textContent).not.toContain("elevated above");
+    expect(container.textContent).not.toContain("below the configured");
   });
 
   it("passes the public help-session id to the live-status bridge call", async () => {

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -456,9 +456,9 @@ describe("DaintreeAssistantSettingsTab", () => {
     );
     await waitForContent(container, "Auto-approve assistant actions");
 
-    // The switch stays disabled until the persisted settings resolve, and the
-    // heading above renders before that — clicking on the heading alone would
-    // drop the event and time out downstream.
+    // The switch stays disabled until the initial settings and MCP-status loads
+    // both settle, and the heading above renders before that — clicking while
+    // it's still disabled would drop the event and time out downstream.
     const toggle = screen.getByLabelText(
       "Auto-approve Daintree Assistant actions during help sessions"
     );
@@ -1464,9 +1464,9 @@ describe("SessionLiveStatusCard (live help session)", () => {
     expect(container.textContent).not.toContain("matches the configured default");
   });
 
-  // The equality branch is the one a default assistant session lands on now
-  // that agent identity no longer forces `system` (#11907) — before the fix it
-  // was unreachable for the assistant, so only the drift copy was ever proven.
+  // The equality branch is the one a default (action-tier) assistant session
+  // lands on now that agent identity no longer forces `system` (#11907). The
+  // copy was previously unasserted — only the two drift directions were.
   it("reports a live tier equal to the configured default as a match", async () => {
     installApi(
       {


### PR DESCRIPTION
## Summary

- `HelpSessionService.doProvision()` was forcing every `daintree-assistant` help session onto the `system` MCP tier, regardless of the user's stored `settings.tier`. The Settings tab, meanwhile, showed a fully functional Capability tier selector, a blast-radius tool-count preview, and auto-approve copy, all implying that Workbench or Action actually constrained the assistant. They didn't. The UI promised least privilege and handed out the full system surface.
- Fixed so agent identity never widens the MCP surface: `tier = settings.tier` for every help agent. That restores the safety model from #10640 and #10647, where `action` is the default floor, irreversible mutations like `git.push` and `worktree.delete` sit above the line and need a human-approved scoped grant, and `workbench`/`system` stay explicit user choices. The override was introduced in `1882fcd215` (2026-06-18) and reversed that earlier decision; this puts it back and makes the selector honest.

Resolves #11907

## Why this is a small, safe seam

`TIER_ALLOWLISTS` and `minimumPermittingTier` in `mcp-server/shared.ts` are pure functions of a tier string, with no knowledge of `agentId`. That tier string reaches them from exactly one place: `validateToken()` returning `record.tier`, stamped at provision time. There was no second hardcoded assistant-to-system check anywhere in the auth path, so enforcement just works once it receives a different value. No allowlist, IPC, schema, or generated-type changes needed.

## Behaviour change for existing users

The default tier is `action` at every layer (`DEFAULT_TIER`, electron-store defaults, IPC defaults, renderer defaults, the public type doc), so a default user's assistant moves one notch down from a forced System tier to Action. Anyone who explicitly chose System, or legacy users with `skipPermissions: true`, stays at System. There's no migration or notification for this: it's the intended least-privilege restoration, and there'd be no recovery action to offer anyway. Running sessions keep the tier they were minted with until revoked.

Worth flagging: `forge.createIssue` is the only System-only tool referenced in the bundled assistant workflows, and it's documented there as an exceptional user-approved operation, not startup behaviour. So a default Action-tier assistant degrades through the existing scoped-grant flow (Approve once / Always allow, which target the narrowest sufficient tier) rather than breaking.

## Also in this PR

- The auto-approve/bypass warning now names the effective tier instead of pointing at "the selector above." With the confirmation sheet off, the tier is the entire remaining boundary, so the warning has to say which one. Scoped to new sessions, since tier and bypass are both provision-time snapshots and the live-status card reports the current session.
- Corrected the `permissionBypass` doc comment in `agentRegistry.ts`, which credited the system tier for appending a `--dangerously-skip-*` flag that's actually keyed off `bypassPermissions`. The two controls are orthogonal.
- Refreshed the now-stale policy prose in `tierAuth.test.ts`. No assertion changes, since none of them ever branched on agent identity.

## Changes

- `electron/services/HelpSessionService.ts`: the core fix.
- `electron/services/__tests__/HelpSessionService.test.ts`: parametrized tier coverage.
- `electron/services/mcp-server/__tests__/tierAuth.test.ts`: comment fix only.
- `electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts`: fixture update.
- `shared/config/agentRegistry.ts`: doc comment fix.
- `src/components/Settings/DaintreeAssistantSettingsTab.tsx`: auto-approve warning now names the effective tier.
- `src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx`: new coverage.

## Testing

- New parametrized provisioning matrix: `daintree-assistant` at workbench/action/system, plus a non-assistant help agent (Claude) at all three, asserting both `result.tier` and the bearer via `validateToken`. The workbench and action assistant rows fail against the pre-fix implementation, so they genuinely lock the regression.
- New renderer test confirming the auto-approve warning names the configured tier and follows the selector (catches a missing memo dependency).
- Covered the live-status card's equality branch: a default assistant session now reports "matches the configured default," previously unasserted.
- Flipped the assistant spawn fixture to `workbench` to prove auto-approve rides `bypassPermissions`, never the capability tier.
- 576 tests green locally across the 7 affected suites. Prettier clean. Eslint 0 errors on changed files.
