### PR TITLE
feat(mcp): expose target policy metadata on actions.getSchema

### DIFF
--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -60,12 +60,20 @@ function fakeSessionStore(
   // eviction via the optional `now` clock when they need to assert
   // expiry, and they call dispose() at teardown.
   const grantCache = new GrantCache({ sweepIntervalMs: 0 });
+  // Derived from `sessionOriginMap` exactly as the real store derives it, so a
+  // test that seeds an origin gets the grant-eligibility answer the shipped
+  // code would give rather than a hard-coded one (#11910).
+  const sessionOriginMap = new Map<string, string>();
   const store = {
     sessions: new Map(),
     httpSessions: new Map(),
     sessionTierMap: new Map(),
     sessionWebContentsMap: new Map(),
-    sessionOriginMap: new Map(),
+    sessionOriginMap,
+    isRendererOwnedOrigin: vi.fn((sessionId: string) => {
+      const origin = sessionOriginMap.get(sessionId) ?? "external";
+      return origin === "help" || origin === "assistant-pane";
+    }),
     sessionWorkspaceMap: new Map(),
     resourceSubscriptions: new Map(),
     dedupInFlight: new Map(),
@@ -3835,6 +3843,125 @@ describe("sessionServer introspection tier filtering", () => {
     const body = payload<{ totalMatches: number; results: ActionManifestEntry[] }>(res);
     expect(body.results.map((r) => r.id)).toEqual(["terminal.list"]);
     expect(body.totalMatches).toBe(1);
+  });
+
+  describe("actions.getSchema policy record (#11910)", () => {
+    interface GetSchemaBody {
+      ok: boolean;
+      entry: ActionManifestEntry | null;
+      policy: Record<string, unknown> | null;
+      error: { code: string; message: string } | null;
+    }
+
+    function schemaDeps(
+      tier: "workbench" | "action" | "system" | "external",
+      target: ActionManifestEntry,
+      overrides?: Partial<SessionServerDeps>
+    ) {
+      // The renderer's real return shape: it fills `entry` and leaves `policy`
+      // for main, which is the substitution under test.
+      return introspectionDeps(
+        tier,
+        { ok: true, entry: target, policy: null, error: null },
+        overrides
+      );
+    }
+
+    async function lookup(
+      deps: SessionServerDeps,
+      actionId: string,
+      sessionId = "s1"
+    ): Promise<GetSchemaBody> {
+      const server = createSessionServer(sessionId, deps);
+      const res = await callTool(server, {
+        name: ACTIONS_GET_SCHEMA_TOOL_ID,
+        arguments: { actionId },
+      });
+      return payload<GetSchemaBody>(res);
+    }
+
+    it("substitutes a real policy for the renderer's null placeholder", async () => {
+      const deps = schemaDeps("workbench", entry("terminal.list"));
+      const body = await lookup(deps, "terminal.list");
+
+      expect(body.ok).toBe(true);
+      expect(body.entry).not.toBeNull();
+      expect(body.error).toBeNull();
+      expect(body.policy).toMatchObject({
+        callable: true,
+        unavailableReason: null,
+        authorizedBy: "tier",
+        effectiveTier: "workbench",
+        minimumTier: "workbench",
+        danger: "safe",
+        requiresConfirmation: false,
+        dynamicInvocation: "allowed",
+        preferredTool: null,
+      });
+    });
+
+    // The origin is what grant issuance gates on, and a session that never
+    // declared one defaults to `external` — so the honest answer for it is that
+    // no approval flow exists, whatever tier admitted the call.
+    it("reports grantability from the session origin, not its tier", async () => {
+      const unowned = schemaDeps("workbench", entry("terminal.list"));
+      expect((await lookup(unowned, "terminal.list")).policy).toMatchObject({
+        grantable: false,
+      });
+
+      const owned = schemaDeps("workbench", entry("terminal.list"));
+      owned.sessionStore.sessionOriginMap.set("s1", "help");
+      expect((await lookup(owned, "terminal.list")).policy).toMatchObject({
+        grantable: true,
+      });
+    });
+
+    it("reports the flat external tier for an api-key caller", async () => {
+      const deps = schemaDeps("external", entry("terminal.list"));
+      const body = await lookup(deps, "terminal.list");
+
+      expect(body.ok).toBe(true);
+      expect(body.policy).toMatchObject({
+        minimumTier: "external",
+        effectiveTier: "external",
+        grantable: false,
+      });
+    });
+
+    // A live grant widens discovery, and the record must name the grant as what
+    // admits the call — the client's cue that this access can lapse.
+    it("names a live per-tool grant as the admitting mechanism", async () => {
+      const deps = schemaDeps("workbench", entry("git.push"));
+      deps.sessionStore.sessionOriginMap.set("s1", "help");
+      deps.sessionStore.grantCache.issueGrant("s1", "git.push");
+
+      const body = await lookup(deps, "git.push");
+
+      expect(body.ok).toBe(true);
+      expect(body.policy).toMatchObject({
+        authorizedBy: "grant",
+        minimumTier: "system",
+        effectiveTier: "workbench",
+      });
+    });
+
+    it("still collapses a tier-denied target with no policy attached", async () => {
+      const deps = schemaDeps("workbench", entry("git.push"));
+      const body = await lookup(deps, "git.push");
+
+      expect(body.ok).toBe(false);
+      expect(body.entry).toBeNull();
+      expect(body.policy).toBeNull();
+      expect(body.error?.code).toBe("NOT_FOUND");
+    });
+
+    it("never attaches a policy to a hidden target", async () => {
+      const deps = schemaDeps("workbench", entry("terminal.list", { mcpVisibility: "hidden" }));
+      const body = await lookup(deps, "terminal.list");
+
+      expect(body.ok).toBe(false);
+      expect(body.policy).toBeNull();
+    });
   });
 
   it("over-fetches the search page so denied top hits cannot starve it", async () => {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -3928,11 +3928,11 @@ describe("sessionServer introspection tier filtering", () => {
       const body = await lookup(deps, "git.push");
 
       expect(body.ok).toBe(true);
-      expect(body.policy).toMatchObject({
-        authorizedBy: "grant",
-        minimumTier: "system",
-        effectiveTier: "workbench",
-      });
+      expect(body.policy).toMatchObject({ authorizedBy: "grant", minimumTier: "system" });
+      // The grant is bridging a real gap rather than rubber-stamping a target
+      // the tier already allowed — stated as the relation, so it keeps meaning
+      // if the fixture's tier changes.
+      expect(body.policy?.effectiveTier).not.toBe(body.policy?.minimumTier);
     });
 
     it("still collapses a tier-denied target with no policy attached", async () => {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -3884,20 +3884,12 @@ describe("sessionServer introspection tier filtering", () => {
       const deps = schemaDeps("workbench", entry("terminal.list"));
       const body = await lookup(deps, "terminal.list");
 
+      // The renderer sent `policy: null`; anything non-null here is main's
+      // substitution, which is the wiring under test.
       expect(body.ok).toBe(true);
       expect(body.entry).not.toBeNull();
       expect(body.error).toBeNull();
-      expect(body.policy).toMatchObject({
-        callable: true,
-        unavailableReason: null,
-        authorizedBy: "tier",
-        effectiveTier: "workbench",
-        minimumTier: "workbench",
-        danger: "safe",
-        requiresConfirmation: false,
-        dynamicInvocation: "allowed",
-        preferredTool: null,
-      });
+      expect(body.policy).toMatchObject({ callable: true, authorizedBy: "tier" });
     });
 
     // The origin is what grant issuance gates on, and a session that never
@@ -3920,12 +3912,10 @@ describe("sessionServer introspection tier filtering", () => {
       const deps = schemaDeps("external", entry("terminal.list"));
       const body = await lookup(deps, "terminal.list");
 
+      // The point of the external branch: `minimumPermittingTier` never returns
+      // "external", so a tier derived from it alone would be wrong here.
       expect(body.ok).toBe(true);
-      expect(body.policy).toMatchObject({
-        minimumTier: "external",
-        effectiveTier: "external",
-        grantable: false,
-      });
+      expect(body.policy).toMatchObject({ minimumTier: "external" });
     });
 
     // A live grant widens discovery, and the record must name the grant as what
@@ -3955,12 +3945,46 @@ describe("sessionServer introspection tier filtering", () => {
       expect(body.error?.code).toBe("NOT_FOUND");
     });
 
-    it("never attaches a policy to a hidden target", async () => {
-      const deps = schemaDeps("workbench", entry("terminal.list", { mcpVisibility: "hidden" }));
-      const body = await lookup(deps, "terminal.list");
+    it("never attaches a policy to a hidden or restricted target", async () => {
+      for (const overrides of [
+        { mcpVisibility: "hidden" as const },
+        { danger: "restricted" as const },
+      ]) {
+        const deps = schemaDeps("workbench", entry("terminal.list", overrides));
+        const body = await lookup(deps, "terminal.list");
 
-      expect(body.ok).toBe(false);
-      expect(body.policy).toBeNull();
+        expect(body).toEqual({
+          ok: false,
+          entry: null,
+          policy: null,
+          error: { code: "NOT_FOUND", message: expect.stringContaining("terminal.list") },
+        });
+      }
+    });
+
+    // The policy is a snapshot, not a lease. A grant that lapses between two
+    // reads must stop admitting the target on the second one — otherwise a
+    // client caches an authorization the dispatch gate would already refuse.
+    it("stops reporting a grant once its TTL has lapsed", async () => {
+      let now = 1000;
+      const grantCache = new GrantCache({ ttlMs: 100, sweepIntervalMs: 0, now: () => now });
+      const store = fakeSessionStore("workbench");
+      (store as unknown as { grantCache: GrantCache }).grantCache = grantCache;
+      store.sessionOriginMap.set("s1", "help");
+
+      const deps = schemaDeps("workbench", entry("git.push"), { sessionStore: store });
+      grantCache.issueGrant("s1", "git.push");
+
+      const whileLive = await lookup(deps, "git.push");
+      expect(whileLive.ok).toBe(true);
+      expect(whileLive.policy).toMatchObject({ authorizedBy: "grant" });
+
+      now = 50_000;
+      const afterExpiry = await lookup(deps, "git.push");
+      expect(afterExpiry.ok).toBe(false);
+      expect(afterExpiry.policy).toBeNull();
+
+      grantCache.dispose();
     });
   });
 
@@ -4725,6 +4749,82 @@ describe("workspace-bound external sessions (#11789)", () => {
       await server.connect(makeMockTransport());
 
       expect((await listTools(server)).tools.map((t) => t.name)).toContain("recipe.run");
+    });
+
+    // The binding ceiling is applied by deleting withheld ids from
+    // `permittedActionIds` after the grant union, so a schema lookup must be
+    // refused the same way `tools/list` withholds the name — policy included.
+    // Handing back a policy here would describe a target this session provably
+    // cannot dispatch (#11910).
+    it("withholds the schema and policy for the confirm-gated tool", async () => {
+      const deps = boundDeps({
+        // `actions.getSchema` itself must be in the bound workspace's surface,
+        // or the guard that refuses a tool this workspace cannot describe fires
+        // before the lookup is ever filtered.
+        requestManifest: vi
+          .fn()
+          .mockResolvedValue([makeManifestEntry(ACTIONS_GET_SCHEMA_TOOL_ID), recipeRun()]),
+        dispatchAction: vi.fn().mockResolvedValue({
+          result: { ok: true, result: { ok: true, entry: recipeRun(), policy: null, error: null } },
+        }),
+      });
+      const server = createSessionServer(SESSION, deps);
+      await server.connect(makeMockTransport());
+
+      const res = await callTool(server, {
+        name: ACTIONS_GET_SCHEMA_TOOL_ID,
+        arguments: { actionId: "recipe.run" },
+      });
+      const body = JSON.parse((res.content as Array<{ text: string }>)[0]!.text) as {
+        ok: boolean;
+        entry: unknown;
+        policy: unknown;
+        error: { code: string } | null;
+      };
+
+      expect(body.ok).toBe(false);
+      expect(body.entry).toBeNull();
+      expect(body.policy).toBeNull();
+      expect(body.error?.code).toBe("NOT_FOUND");
+    });
+
+    it("still answers the schema lookup for a tool the binding does not withhold", async () => {
+      // Guards the test above against passing for the wrong reason — a bound
+      // session that could not answer ANY lookup would satisfy it too.
+      const deps = boundDeps({
+        requestManifest: vi
+          .fn()
+          .mockResolvedValue([
+            makeManifestEntry(ACTIONS_GET_SCHEMA_TOOL_ID),
+            makeManifestEntry("terminal.list"),
+            recipeRun(),
+          ]),
+        dispatchAction: vi.fn().mockResolvedValue({
+          result: {
+            ok: true,
+            result: {
+              ok: true,
+              entry: makeManifestEntry("terminal.list"),
+              policy: null,
+              error: null,
+            },
+          },
+        }),
+      });
+      const server = createSessionServer(SESSION, deps);
+      await server.connect(makeMockTransport());
+
+      const res = await callTool(server, {
+        name: ACTIONS_GET_SCHEMA_TOOL_ID,
+        arguments: { actionId: "terminal.list" },
+      });
+      const body = JSON.parse((res.content as Array<{ text: string }>)[0]!.text) as {
+        ok: boolean;
+        policy: { minimumTier: string } | null;
+      };
+
+      expect(body.ok).toBe(true);
+      expect(body.policy).toMatchObject({ minimumTier: "external" });
     });
 
     it("omits it from mcp.surface too, so discovery and listing agree", async () => {

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -32,11 +32,19 @@ import {
   ACTIONS_SEARCH_DEFAULT_LIMIT,
   ACTIONS_SEARCH_MAX_LIMIT,
   INTROSPECTION_TOOL_IDS,
+  buildTargetPolicy,
+  MCP_TARGET_POLICY_VERSION,
+  type TargetPolicySessionSnapshot,
 } from "../tierAuth.js";
 import { findWireStrippedKeywords } from "../../../../shared/utils/mcpWireSchema.js";
 import { TIER_ALLOWLISTS } from "../shared.js";
 import { BUILT_IN_ACTION_IDS } from "../../../../shared/config/actionIds.js";
 import type { ActionManifestEntry } from "../../../../shared/types/actions.js";
+import type { McpTargetPolicy } from "../../../../shared/types/mcpTargetPolicy.js";
+import {
+  McpGetSchemaResultSchema,
+  McpGetSchemaWireResultSchema,
+} from "../../../../shared/types/mcpTargetPolicy.js";
 
 beforeEach(() => {
   mockPaneConfigService.isValidPaneToken.mockReset();
@@ -1117,68 +1125,159 @@ describe("filterIntrospectionResultForSession", () => {
   });
 
   describe("actions.getSchema", () => {
-    it("returns a permitted entry unchanged", () => {
-      const entry = makeEntry({ id: "terminal.list" });
-      const filtered = filterIntrospectionResultForSession(
+    // A renderer-owned ladder session with no grants: the ordinary case, and the
+    // baseline every policy assertion below varies one axis away from.
+    function snapshot(
+      overrides: Partial<TargetPolicySessionSnapshot> = {}
+    ): TargetPolicySessionSnapshot {
+      return {
+        tier: "workbench",
+        rendererOwnedOrigin: true,
+        perToolGrantedActionIds: new Set<string>(),
+        nativeGrantedActionIds: new Set<string>(),
+        ...overrides,
+      };
+    }
+
+    function lookup(
+      entry: ActionManifestEntry,
+      opts: {
+        requestedActionId?: string;
+        permittedActionIds?: ReadonlySet<string>;
+        policySnapshot?: TargetPolicySessionSnapshot | null;
+      } = {}
+    ) {
+      const { policySnapshot = snapshot() } = opts;
+      return filterIntrospectionResultForSession(
         "actions.getSchema",
-        { ok: true as const, result: { ok: true, entry } },
-        permitted,
-        { callerLimit: 20, requestedActionId: "terminal.list" }
+        { ok: true as const, result: { ok: true, entry, policy: null, error: null } },
+        opts.permittedActionIds ?? permitted,
+        {
+          callerLimit: 20,
+          requestedActionId: opts.requestedActionId ?? entry.id,
+          ...(policySnapshot ? { policySnapshot } : {}),
+        }
       );
-      expect(filtered).toEqual({ ok: true, result: { ok: true, entry } });
+    }
+
+    function payloadOf(result: ReturnType<typeof filterIntrospectionResultForSession>) {
+      return (
+        result as {
+          result: {
+            ok: boolean;
+            entry: unknown;
+            policy: McpTargetPolicy | null;
+            error: { code: string; message: string } | null;
+          };
+        }
+      ).result;
+    }
+
+    function policyOf(result: ReturnType<typeof filterIntrospectionResultForSession>) {
+      const policy = payloadOf(result).policy;
+      if (policy === null) throw new Error("expected a policy record");
+      return policy;
+    }
+
+    it("returns a permitted entry alongside its policy", () => {
+      const entry = makeEntry({ id: "terminal.list" });
+      const payload = payloadOf(lookup(entry));
+
+      expect(payload.ok).toBe(true);
+      expect(payload.entry).toEqual(entry);
+      expect(payload.error).toBeNull();
+      expect(payload.policy).not.toBeNull();
     });
 
     it("keeps a core-marked entry reachable (visibility is not the gate)", () => {
       const entry = makeEntry({ id: "worktree.list", mcpVisibility: "core" });
-      const filtered = filterIntrospectionResultForSession(
-        "actions.getSchema",
-        { ok: true as const, result: { ok: true, entry } },
-        permitted,
-        { callerLimit: 20, requestedActionId: "worktree.list" }
-      );
-      expect(filtered).toEqual({ ok: true, result: { ok: true, entry } });
+      const payload = payloadOf(lookup(entry));
+
+      expect(payload.ok).toBe(true);
+      expect(payload.entry).toEqual(entry);
     });
 
     it("strips fields the renderer attached alongside an authorized entry", () => {
       const entry = makeEntry({ id: "terminal.list" });
       const filtered = filterIntrospectionResultForSession(
         "actions.getSchema",
-        { ok: true as const, result: { ok: true, entry, leaked: makeEntry({ id: "git.push" }) } },
+        {
+          ok: true as const,
+          result: {
+            ok: true,
+            entry,
+            policy: null,
+            error: null,
+            leaked: makeEntry({ id: "git.push" }),
+          },
+        },
         permitted,
-        { callerLimit: 20, requestedActionId: "terminal.list" }
+        { callerLimit: 20, requestedActionId: "terminal.list", policySnapshot: snapshot() }
       );
-      expect(filtered).toEqual({ ok: true, result: { ok: true, entry } });
+
+      expect(Object.keys(payloadOf(filtered)).sort()).toEqual(["entry", "error", "ok", "policy"]);
+    });
+
+    // The renderer cannot fill `policy` — it has no session state — so a read
+    // that reaches main without the session facts to build one has nothing
+    // authoritative to say about the target. Denying beats answering with an
+    // entry a client would read as unrestricted.
+    it("fails closed when no policy snapshot accompanies the read", () => {
+      const payload = payloadOf(
+        lookup(makeEntry({ id: "terminal.list" }), { policySnapshot: null })
+      );
+
+      expect(payload.ok).toBe(false);
+      expect(payload.policy).toBeNull();
+      expect(payload.error?.code).toBe("NOT_FOUND");
+    });
+
+    it("fails closed on a target no tier permits, even when a grant names it", () => {
+      // Neither issuance path can mint a grant for an id `minimumPermittingTier`
+      // does not place, so this is a stale-metadata backstop rather than a
+      // reachable state — and its safe answer is the same denial.
+      const orphan = "actions.persistedStores";
+      const payload = payloadOf(
+        lookup(makeEntry({ id: orphan }), {
+          permittedActionIds: new Set([...permitted, orphan]),
+          policySnapshot: snapshot({ perToolGrantedActionIds: new Set([orphan]) }),
+        })
+      );
+
+      expect(payload.ok).toBe(false);
+      expect(payload.policy).toBeNull();
     });
 
     it("fails closed when no requested id accompanies the answer", () => {
       const filtered = filterIntrospectionResultForSession(
         "actions.getSchema",
-        { ok: true as const, result: { ok: true, entry: makeEntry({ id: "terminal.list" }) } },
+        {
+          ok: true as const,
+          result: {
+            ok: true,
+            entry: makeEntry({ id: "terminal.list" }),
+            policy: null,
+            error: null,
+          },
+        },
         permitted,
-        { callerLimit: 20 }
+        { callerLimit: 20, policySnapshot: snapshot() }
       );
-      expect((filtered as { result: { ok: boolean } }).result.ok).toBe(false);
+      expect(payloadOf(filtered).ok).toBe(false);
     });
 
     // NOT_FOUND rather than a tier error: a distinct code would confirm the id
     // exists while offering no route to it, since grants are minted off a
     // denied dispatch and never off a schema read.
     it("collapses a denied entry onto the existing NOT_FOUND data shape", () => {
-      const result = {
-        ok: true as const,
-        result: { ok: true, entry: makeEntry({ id: "git.push" }) },
-      };
-      const filtered = filterIntrospectionResultForSession("actions.getSchema", result, permitted, {
-        callerLimit: 20,
-        requestedActionId: "git.push",
-      });
-      const payload = (
-        filtered as { result: { ok: boolean; error: { code: string; message: string } } }
-      ).result;
+      const payload = payloadOf(lookup(makeEntry({ id: "git.push" })));
+
       expect(payload.ok).toBe(false);
-      expect(payload.error.code).toBe("NOT_FOUND");
-      expect(payload.error.message).toContain("git.push");
-      expect(payload.error.message).toContain("actions.search");
+      expect(payload.entry).toBeNull();
+      expect(payload.policy).toBeNull();
+      expect(payload.error?.code).toBe("NOT_FOUND");
+      expect(payload.error?.message).toContain("git.push");
+      expect(payload.error?.message).toContain("actions.search");
     });
 
     it("collapses a denied hidden or restricted entry the same way", () => {
@@ -1186,14 +1285,10 @@ describe("filterIntrospectionResultForSession", () => {
         makeEntry({ id: "terminal.list", mcpVisibility: "hidden" }),
         makeEntry({ id: "terminal.list", danger: "restricted" }),
       ]) {
-        const filtered = filterIntrospectionResultForSession(
-          "actions.getSchema",
-          { ok: true as const, result: { ok: true, entry } },
-          permitted,
-          { callerLimit: 20, requestedActionId: "terminal.list" }
-        );
-        expect((filtered as { result: unknown }).result).toEqual({
+        expect(payloadOf(lookup(entry))).toEqual({
           ok: false,
+          entry: null,
+          policy: null,
           error: { code: "NOT_FOUND", message: expect.stringContaining("terminal.list") },
         });
       }
@@ -1211,13 +1306,364 @@ describe("filterIntrospectionResultForSession", () => {
           },
         },
         permitted,
-        { callerLimit: 20, requestedActionId: "git.push" }
+        { callerLimit: 20, requestedActionId: "git.push", policySnapshot: snapshot() }
       );
       // The smuggled `entry` is gone and the message names the requested id.
-      expect((filtered as { result: unknown }).result).toEqual({
+      expect(payloadOf(filtered)).toEqual({
         ok: false,
+        entry: null,
+        policy: null,
         error: { code: "NOT_FOUND", message: expect.stringContaining("git.push") },
       });
+    });
+
+    describe("policy record (#11910)", () => {
+      it("reports the tier as the admitting mechanism for a tier-permitted target", () => {
+        const policy = policyOf(lookup(makeEntry({ id: "terminal.list" })));
+
+        expect(policy.authorizedBy).toBe("tier");
+        expect(policy.callable).toBe(true);
+        expect(policy.unavailableReason).toBeNull();
+        expect(policy.effectiveTier).toBe("workbench");
+        expect(policy.minimumTier).toBe("workbench");
+        expect(policy.version).toBe(MCP_TARGET_POLICY_VERSION);
+        expect(policy.hash).toMatch(/^[0-9a-f]{64}$/);
+      });
+
+      // The distinction a client acts on: tier access is durable for the
+      // session, a grant lapses. Reporting only `callable` would collapse them.
+      it("reports a grant as the admitting mechanism, with the tier it would need", () => {
+        const policy = policyOf(
+          lookup(makeEntry({ id: "git.push" }), {
+            permittedActionIds: new Set([...permitted, "git.push"]),
+            policySnapshot: snapshot({ perToolGrantedActionIds: new Set(["git.push"]) }),
+          })
+        );
+
+        expect(policy.authorizedBy).toBe("grant");
+        expect(policy.minimumTier).toBe("system");
+        expect(policy.effectiveTier).toBe("workbench");
+        expect(policy.callable).toBe(true);
+      });
+
+      it("reports a native grant as the admitting mechanism", () => {
+        const policy = policyOf(
+          lookup(makeEntry({ id: "git.push" }), {
+            permittedActionIds: new Set([...permitted, "git.push"]),
+            policySnapshot: snapshot({ nativeGrantedActionIds: new Set(["git.push"]) }),
+          })
+        );
+
+        expect(policy.authorizedBy).toBe("nativeGrant");
+      });
+
+      // A native grant is an explicit user approval of the tool's scope, so the
+      // dispatch gate sets `dispatchConfirmed` from it. A per-tool grant only
+      // widens the floor, and the modal still fires.
+      it("clears requiresConfirmation for a native grant but not a per-tool grant", () => {
+        const confirmEntry = makeEntry({ id: "worktree.list", danger: "confirm" });
+
+        const nativelyGranted = policyOf(
+          lookup(confirmEntry, {
+            policySnapshot: snapshot({ nativeGrantedActionIds: new Set(["worktree.list"]) }),
+          })
+        );
+        expect(nativelyGranted.danger).toBe("confirm");
+        expect(nativelyGranted.requiresConfirmation).toBe(false);
+
+        const perToolGranted = policyOf(
+          lookup(confirmEntry, {
+            policySnapshot: snapshot({ perToolGrantedActionIds: new Set(["worktree.list"]) }),
+          })
+        );
+        expect(perToolGranted.requiresConfirmation).toBe(true);
+      });
+
+      it("reports the flat external tier rather than a rung the caller cannot climb", () => {
+        const policy = policyOf(
+          lookup(makeEntry({ id: "terminal.list" }), {
+            policySnapshot: snapshot({ tier: "external", rendererOwnedOrigin: false }),
+          })
+        );
+
+        expect(policy.minimumTier).toBe("external");
+        expect(policy.effectiveTier).toBe("external");
+        expect(policy.grantable).toBe(false);
+      });
+
+      // The divergence `resolveTokenTier` makes reachable: an unrecognised
+      // bearer token resolves to `workbench` while the origin still defaults to
+      // `external`. Both grant-issuance paths gate on the ORIGIN, so a
+      // tier-derived answer here would promise an approval flow that always
+      // throws.
+      it("reports grantable:false for a ladder tier whose origin cannot hold grants", () => {
+        const rendererOwned = policyOf(lookup(makeEntry({ id: "terminal.list" })));
+        expect(rendererOwned.grantable).toBe(true);
+
+        const foreignOrigin = policyOf(
+          lookup(makeEntry({ id: "terminal.list" }), {
+            policySnapshot: snapshot({ rendererOwnedOrigin: false }),
+          })
+        );
+        expect(foreignOrigin.grantable).toBe(false);
+      });
+
+      // A grant whose origin could not have been issued never admits the call at
+      // the dispatch gate either, so the policy must not claim it does.
+      it("ignores grants a non-renderer-owned origin could not have been issued", () => {
+        const payload = payloadOf(
+          lookup(makeEntry({ id: "git.push" }), {
+            permittedActionIds: new Set([...permitted, "git.push"]),
+            policySnapshot: snapshot({
+              rendererOwnedOrigin: false,
+              perToolGrantedActionIds: new Set(["git.push"]),
+            }),
+          })
+        );
+
+        expect(payload.ok).toBe(false);
+        expect(payload.policy).toBeNull();
+      });
+
+      it("reports a disabled target as reachable but not callable", () => {
+        const policy = policyOf(
+          lookup(makeEntry({ id: "terminal.list", enabled: false, disabledReason: "no terminals" }))
+        );
+
+        expect(policy.callable).toBe(false);
+        expect(policy.unavailableReason).toBe("DISABLED");
+        // Still authorized — this is a transient state of a visible action, not
+        // an authorization denial, so it does not collapse to NOT_FOUND.
+        expect(policy.authorizedBy).toBe("tier");
+      });
+
+      // `resolveEffectiveActionDanger` keys the elevation on the ARGUMENT, so a
+      // target that cannot accept a `recipeId` can never be elevated by one.
+      it("flags only targets whose arguments can escalate confirmation", () => {
+        const escalatable = policyOf(
+          lookup(
+            makeEntry({
+              id: "terminal.list",
+              inputSchema: { type: "object", properties: { recipeId: { type: "string" } } },
+            })
+          )
+        );
+        expect(escalatable.danger).toBe("safe");
+        expect(escalatable.confirmationMayEscalate).toBe(true);
+
+        const plain = policyOf(
+          lookup(
+            makeEntry({
+              id: "terminal.list",
+              inputSchema: { type: "object", properties: { limit: { type: "number" } } },
+            })
+          )
+        );
+        expect(plain.confirmationMayEscalate).toBe(false);
+      });
+
+      it("never reports escalation for a target already declared confirm", () => {
+        const policy = policyOf(
+          lookup(
+            makeEntry({
+              id: "worktree.list",
+              danger: "confirm",
+              inputSchema: { type: "object", properties: { recipeId: { type: "string" } } },
+            })
+          )
+        );
+
+        expect(policy.confirmationMayEscalate).toBe(false);
+      });
+
+      // The renderer's own `resultSchema` check runs before main substitutes the
+      // policy, so it only ever validates the null placeholder. Nothing else
+      // validates what main builds — this is the check that the finished record
+      // satisfies the contract the companion CLI codes against.
+      it("builds a record that satisfies the published wire contract", () => {
+        for (const target of [
+          makeEntry({ id: "terminal.list" }),
+          makeEntry({ id: "worktree.list", danger: "confirm" }),
+          makeEntry({ id: "terminal.list", enabled: false }),
+        ]) {
+          const parsed = McpGetSchemaWireResultSchema.safeParse(payloadOf(lookup(target)));
+          expect(parsed.success).toBe(true);
+        }
+      });
+
+      it("emits a denial that satisfies the same wire contract", () => {
+        const parsed = McpGetSchemaWireResultSchema.safeParse(
+          payloadOf(lookup(makeEntry({ id: "git.push" })))
+        );
+        expect(parsed.success).toBe(true);
+      });
+
+      // The looser staging schema exists only so the renderer's half-built value
+      // validates; it must not be mistaken for the wire contract.
+      it("rejects the renderer's staging shape as a wire result", () => {
+        const staging = {
+          ok: true,
+          entry: makeEntry({ id: "terminal.list" }),
+          policy: null,
+          error: null,
+        };
+
+        expect(McpGetSchemaResultSchema.safeParse(staging).success).toBe(true);
+        expect(McpGetSchemaWireResultSchema.safeParse(staging).success).toBe(false);
+      });
+
+      // The record is the caller's own authorization boundary and nothing more.
+      // Grant expiry, issuance times, actor ids and denial counts are either
+      // cross-session or abuse-signal internals with no legitimate client use,
+      // so a new field cannot arrive here without a deliberate edit to this list.
+      it("exposes exactly the agreed fields and no grant internals", () => {
+        const policy = policyOf(
+          lookup(makeEntry({ id: "terminal.list" }), {
+            policySnapshot: snapshot({ nativeGrantedActionIds: new Set(["terminal.list"]) }),
+          })
+        );
+
+        expect(Object.keys(policy).sort()).toEqual([
+          "authorizedBy",
+          "callable",
+          "confirmationMayEscalate",
+          "danger",
+          "dynamicInvocation",
+          "effectiveTier",
+          "grantable",
+          "hash",
+          "minimumTier",
+          "preferredTool",
+          "requiresConfirmation",
+          "unavailableReason",
+          "version",
+        ]);
+      });
+    });
+
+    describe("per-target hash", () => {
+      const base = makeEntry({
+        id: "terminal.list",
+        inputSchema: { type: "object", properties: { limit: { type: "number", maximum: 100 } } },
+      });
+
+      it("ignores prose so a reworded description is not a compatibility break", () => {
+        const reworded = {
+          ...base,
+          description: "Completely different wording",
+          title: "Renamed",
+          inputSchema: {
+            type: "object",
+            properties: { limit: { type: "number", maximum: 100, description: "how many" } },
+          },
+        };
+
+        expect(policyOf(lookup(reworded)).hash).toBe(policyOf(lookup(base)).hash);
+      });
+
+      it("changes when a constraint a caller's code depends on tightens", () => {
+        const tightened = {
+          ...base,
+          inputSchema: { type: "object", properties: { limit: { type: "number", maximum: 50 } } },
+        };
+
+        expect(policyOf(lookup(tightened)).hash).not.toBe(policyOf(lookup(base)).hash);
+      });
+
+      it("changes when the target's danger changes", () => {
+        const gated = { ...base, id: "worktree.list", danger: "confirm" as const };
+        const plain = { ...base, id: "worktree.list" };
+
+        expect(policyOf(lookup(gated)).hash).not.toBe(policyOf(lookup(plain)).hash);
+      });
+
+      // The output schema is hashed as the LOOKUP HANDS IT OVER, not as
+      // `tools/list` would advertise it. `buildToolOutputSchema` collapses
+      // anything without a top-level `type: "object"` to nothing, so hashing
+      // that view would let a top-level union swap its variants — visible right
+      // there in `entry.outputSchema` — without moving the digest.
+      it("covers an output schema tools/list would refuse to advertise", () => {
+        const union = (variant: string) => ({
+          ...base,
+          outputSchema: {
+            anyOf: [{ type: "object", properties: { [variant]: { type: "string" } } }],
+          },
+        });
+        expect(buildToolOutputSchema(union("a"))).toBeUndefined();
+
+        expect(policyOf(lookup(union("a"))).hash).not.toBe(policyOf(lookup(union("b"))).hash);
+      });
+
+      // Live session state is deliberately outside the preimage: a digest that
+      // flapped as grants came and went would describe a target no lookup ever
+      // returned, and clients would learn to ignore it.
+      it("holds still while only live session state moves", () => {
+        const granted = policyOf(
+          lookup(base, {
+            policySnapshot: snapshot({ nativeGrantedActionIds: new Set(["terminal.list"]) }),
+          })
+        );
+        const plain = policyOf(lookup(base));
+
+        expect(granted.requiresConfirmation).toBe(plain.requiresConfirmation);
+        expect(granted.hash).toBe(plain.hash);
+      });
+
+      // The caller's own ladder is part of the preimage for the same reason the
+      // surface hash carries `tier`: two callers of one build genuinely see
+      // different contracts for the same id.
+      it("differs between an external caller and a ladder caller", () => {
+        const ladder = policyOf(lookup(base));
+        const external = policyOf(
+          lookup(base, {
+            policySnapshot: snapshot({ tier: "external", rendererOwnedOrigin: false }),
+          })
+        );
+
+        expect(external.hash).not.toBe(ladder.hash);
+      });
+    });
+  });
+
+  describe("buildTargetPolicy fail-closed contract", () => {
+    const snap: TargetPolicySessionSnapshot = {
+      tier: "workbench",
+      rendererOwnedOrigin: true,
+      perToolGrantedActionIds: new Set<string>(),
+      nativeGrantedActionIds: new Set<string>(),
+    };
+
+    it("returns null rather than a partial record for anything it cannot describe", () => {
+      const malformed: unknown[] = [
+        null,
+        undefined,
+        "terminal.list",
+        {},
+        { id: 42 },
+        { id: "terminal.list" },
+        makeEntry({ id: "terminal.list", danger: "restricted" }),
+        makeEntry({ id: "terminal.list", mcpVisibility: "hidden" }),
+        { ...makeEntry({ id: "terminal.list" }), kind: "sideways" },
+        // A non-boolean `enabled` must not read as callable.
+        { ...makeEntry({ id: "terminal.list" }), enabled: "false" },
+        { ...makeEntry({ id: "terminal.list" }), enabled: undefined },
+      ];
+
+      for (const entry of malformed) {
+        expect(buildTargetPolicy(entry, snap)).toBeNull();
+      }
+    });
+
+    // A manifest entry is only as well-formed as whatever built it, and
+    // JSON.stringify throws on a cycle. Fail closed rather than letting it
+    // escape the tool call as an exception.
+    it("returns null instead of throwing on a schema that cannot be canonicalised", () => {
+      const cyclic: Record<string, unknown> = { type: "object" };
+      cyclic["self"] = cyclic;
+
+      expect(
+        buildTargetPolicy(makeEntry({ id: "terminal.list", inputSchema: cyclic }), snap)
+      ).toBeNull();
     });
   });
 });

--- a/electron/services/mcp-server/compatibilityHash.ts
+++ b/electron/services/mcp-server/compatibilityHash.ts
@@ -1,0 +1,116 @@
+/**
+ * Canonicalisation shared by the two compatibility digests main publishes: the
+ * whole-surface hash on `mcp.surface` (#11549) and the per-target hash on an
+ * `actions.getSchema` policy record (#11910).
+ *
+ * Extracted so the two cannot drift. A client that compares a per-target hash
+ * against a surface it captured earlier is comparing digests of the same
+ * normalised shape — if these normalisers diverged, one of the two would start
+ * reporting drift the other never saw, and neither would be wrong from its own
+ * side.
+ */
+
+/** JSON Schema keywords whose value is itself a schema. */
+const SCHEMA_VALUED_KEYS = new Set([
+  "items",
+  "additionalItems",
+  "additionalProperties",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+  "contains",
+  "propertyNames",
+  "not",
+  "if",
+  "then",
+  "else",
+]);
+
+/** Keywords whose value is a map of name → schema. */
+const SCHEMA_MAP_KEYS = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+]);
+
+/** Keywords whose value is an array of schemas. */
+const SCHEMA_LIST_KEYS = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
+
+/**
+ * Keywords that document a schema without constraining it. Stripped before
+ * hashing so rewording a `.describe()` cannot read as a compatibility break —
+ * the same promise the tool's own description gets, applied one level down.
+ */
+const SCHEMA_PROSE_KEYS = new Set(["description", "title", "$comment", "examples"]);
+
+/**
+ * A schema reduced to what a caller's compatibility actually depends on.
+ *
+ * Walks by keyword rather than blindly deleting every key named `description`,
+ * because a schema is free to declare a *property* called `description` — that
+ * one is part of the contract, and only the annotation slot beside it is prose.
+ *
+ * Unrecognised keywords are copied verbatim rather than traversed, which errs
+ * deliberately toward over-sensitivity: a constraint this function has never
+ * heard of stays in the digest, and the cost is that prose buried under such a
+ * keyword can still move the hash. That direction is the safe one — a spurious
+ * change costs a client one re-read, while a dropped constraint would hide a
+ * real incompatibility forever. The classified sets cover everything Zod v4
+ * emits; a plugin shipping a hand-written draft-07 schema is the case that can
+ * land in the verbatim branch.
+ *
+ * `required` is sorted: it is a set in JSON Schema semantics, so its emitted
+ * order is an artifact of the generator, not a contract. Every other array
+ * keeps its order — `enum`, `prefixItems`, and `allOf` all mean something
+ * different when reordered.
+ */
+export function toCompatibilityShape(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(toCompatibilityShape);
+  if (node === null || typeof node !== "object") return node;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (SCHEMA_PROSE_KEYS.has(key)) continue;
+    if (key === "required" && Array.isArray(value)) {
+      out[key] = [...(value as unknown[])].sort();
+    } else if (SCHEMA_VALUED_KEYS.has(key) || SCHEMA_LIST_KEYS.has(key)) {
+      out[key] = toCompatibilityShape(value);
+    } else if (SCHEMA_MAP_KEYS.has(key) && value !== null && typeof value === "object") {
+      out[key] = Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([name, schema]) => [
+          name,
+          toCompatibilityShape(schema),
+        ])
+      );
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Recursively key-sorted JSON, so the hash preimage depends on the surface's
+ * content rather than on the order a JSON Schema generator happened to emit
+ * object keys in. Arrays keep their order — {@link toCompatibilityShape} has
+ * already normalised the one array whose order is meaningless.
+ *
+ * Deliberately a local copy rather than a reuse of `sessionDedup`'s
+ * `canonicalArgsHash`: this canonical form is part of a published client
+ * contract, and it must not shift because the unrelated per-call dedup key
+ * changed shape.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, (_key, v: unknown) => {
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      const record = v as Record<string, unknown>;
+      const sorted: Record<string, unknown> = {};
+      for (const key of Object.keys(record).sort()) {
+        sorted[key] = record[key];
+      }
+      return sorted;
+    }
+    return v;
+  });
+}

--- a/electron/services/mcp-server/compatibilityHash.ts
+++ b/electron/services/mcp-server/compatibilityHash.ts
@@ -3,11 +3,16 @@
  * whole-surface hash on `mcp.surface` (#11549) and the per-target hash on an
  * `actions.getSchema` policy record (#11910).
  *
- * Extracted so the two cannot drift. A client that compares a per-target hash
- * against a surface it captured earlier is comparing digests of the same
- * normalised shape — if these normalisers diverged, one of the two would start
- * reporting drift the other never saw, and neither would be wrong from its own
- * side.
+ * Extracted so the NORMALISATION cannot drift: both digests must agree on what
+ * counts as prose, how `required` is ordered, and which keywords are traversed.
+ * Were these two copies, a fix applied to one would silently make the other
+ * report drift it never saw — or miss drift it should have.
+ *
+ * Shared normalisation, not shared preimages. The two digests deliberately
+ * cover different things: `mcp.surface` hashes the `tools/list` projection of a
+ * tool's output schema, while a target policy hashes the schema `getSchema`
+ * hands over verbatim. So a per-target hash can move while the surface hash
+ * holds still, and that is correct — they answer different questions.
  */
 
 /** JSON Schema keywords whose value is itself a schema. */

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -77,6 +77,7 @@ import {
   buildStructuredContent,
   parseToolArguments,
   filterIntrospectionResultForSession,
+  type TargetPolicySessionSnapshot,
   getTierPermittedActionIds,
   readSearchLimit,
   readListPaging,
@@ -582,18 +583,40 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     // would delete expired entries and push spurious `grant.expired` lifecycle
     // events on every discovery call.
     const introspectionSurface = INTROSPECTION_TOOL_IDS.has(actionId)
-      ? {
-          permittedActionIds: new Set<string>([
-            ...getTierPermittedActionIds(tier),
-            ...sessionStore.grantCache.getLiveGrants(sessionId).map((grant) => grant.toolId),
-            ...sessionStore.grantCache
+      ? (() => {
+          // Snapshotted once and reused for both the permitted set and the
+          // policy record (#11910), so the surface a lookup is filtered against
+          // and the authorization it reports can never describe two different
+          // instants.
+          const perToolGrantedActionIds = new Set<string>(
+            sessionStore.grantCache.getLiveGrants(sessionId).map((grant) => grant.toolId)
+          );
+          const nativeGrantedActionIds = new Set<string>(
+            sessionStore.grantCache
               .getLiveNativeGrants(sessionId)
-              .flatMap((grant) => [...grant.allowedTools]),
-          ]),
-          callerLimit: searchLimit ?? ACTIONS_SEARCH_DEFAULT_LIMIT,
-          requestedActionId: readRequestedActionId(args),
-          ...(listPaging ? { listPaging } : {}),
-        }
+              .flatMap((grant) => [...grant.allowedTools])
+          );
+          return {
+            permittedActionIds: new Set<string>([
+              ...getTierPermittedActionIds(tier),
+              ...perToolGrantedActionIds,
+              ...nativeGrantedActionIds,
+            ]),
+            callerLimit: searchLimit ?? ACTIONS_SEARCH_DEFAULT_LIMIT,
+            requestedActionId: readRequestedActionId(args),
+            ...(listPaging ? { listPaging } : {}),
+            policySnapshot: {
+              tier,
+              // Asked of the ORIGIN, never inferred from the tier: an
+              // unrecognised bearer token resolves to `workbench` while its
+              // origin still defaults to `external`, and grant issuance gates
+              // on the origin.
+              rendererOwnedOrigin: sessionStore.isRendererOwnedOrigin(sessionId),
+              perToolGrantedActionIds,
+              nativeGrantedActionIds,
+            } satisfies TargetPolicySessionSnapshot,
+          };
+        })()
       : null;
     // `actions.search` ranks and slices in the renderer, before main can see
     // tier. Over-fetching the schema's maximum page makes that slice the

--- a/electron/services/mcp-server/surfaceManifest.ts
+++ b/electron/services/mcp-server/surfaceManifest.ts
@@ -9,6 +9,7 @@ import {
   UNBOUND_SESSION_SURFACE,
   type SessionSurfacePolicy,
 } from "./tierAuth.js";
+import { canonicalJson, toCompatibilityShape } from "./compatibilityHash.js";
 
 export const MCP_SURFACE_TOOL_ID = "mcp.surface";
 
@@ -32,111 +33,6 @@ export const MCP_SURFACE_TOOL_ID = "mcp.surface";
  * never becomes an eager edge on the main-process boot path.
  */
 export const MCP_SURFACE_MANIFEST_VERSION = 2;
-
-/** JSON Schema keywords whose value is itself a schema. */
-const SCHEMA_VALUED_KEYS = new Set([
-  "items",
-  "additionalItems",
-  "additionalProperties",
-  "unevaluatedItems",
-  "unevaluatedProperties",
-  "contains",
-  "propertyNames",
-  "not",
-  "if",
-  "then",
-  "else",
-]);
-
-/** Keywords whose value is a map of name → schema. */
-const SCHEMA_MAP_KEYS = new Set([
-  "properties",
-  "patternProperties",
-  "$defs",
-  "definitions",
-  "dependentSchemas",
-]);
-
-/** Keywords whose value is an array of schemas. */
-const SCHEMA_LIST_KEYS = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
-
-/**
- * Keywords that document a schema without constraining it. Stripped before
- * hashing so rewording a `.describe()` cannot read as a compatibility break —
- * the same promise the tool's own description gets, applied one level down.
- */
-const SCHEMA_PROSE_KEYS = new Set(["description", "title", "$comment", "examples"]);
-
-/**
- * A schema reduced to what a caller's compatibility actually depends on.
- *
- * Walks by keyword rather than blindly deleting every key named `description`,
- * because a schema is free to declare a *property* called `description` — that
- * one is part of the contract, and only the annotation slot beside it is prose.
- *
- * Unrecognised keywords are copied verbatim rather than traversed, which errs
- * deliberately toward over-sensitivity: a constraint this function has never
- * heard of stays in the digest, and the cost is that prose buried under such a
- * keyword can still move the hash. That direction is the safe one — a spurious
- * change costs a client one re-read, while a dropped constraint would hide a
- * real incompatibility forever. The classified sets cover everything Zod v4
- * emits; a plugin shipping a hand-written draft-07 schema is the case that can
- * land in the verbatim branch.
- *
- * `required` is sorted: it is a set in JSON Schema semantics, so its emitted
- * order is an artifact of the generator, not a contract. Every other array
- * keeps its order — `enum`, `prefixItems`, and `allOf` all mean something
- * different when reordered.
- */
-function toCompatibilityShape(node: unknown): unknown {
-  if (Array.isArray(node)) return node.map(toCompatibilityShape);
-  if (node === null || typeof node !== "object") return node;
-
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
-    if (SCHEMA_PROSE_KEYS.has(key)) continue;
-    if (key === "required" && Array.isArray(value)) {
-      out[key] = [...(value as unknown[])].sort();
-    } else if (SCHEMA_VALUED_KEYS.has(key) || SCHEMA_LIST_KEYS.has(key)) {
-      out[key] = toCompatibilityShape(value);
-    } else if (SCHEMA_MAP_KEYS.has(key) && value !== null && typeof value === "object") {
-      out[key] = Object.fromEntries(
-        Object.entries(value as Record<string, unknown>).map(([name, schema]) => [
-          name,
-          toCompatibilityShape(schema),
-        ])
-      );
-    } else {
-      out[key] = value;
-    }
-  }
-  return out;
-}
-
-/**
- * Recursively key-sorted JSON, so the hash preimage depends on the surface's
- * content rather than on the order a JSON Schema generator happened to emit
- * object keys in. Arrays keep their order — {@link toCompatibilityShape} has
- * already normalised the one array whose order is meaningless.
- *
- * Deliberately a local copy rather than a reuse of `sessionDedup`'s
- * `canonicalArgsHash`: this canonical form is part of a published client
- * contract, and it must not shift because the unrelated per-call dedup key
- * changed shape.
- */
-function canonicalJson(value: unknown): string {
-  return JSON.stringify(value, (_key, v: unknown) => {
-    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
-      const record = v as Record<string, unknown>;
-      const sorted: Record<string, unknown> = {};
-      for (const key of Object.keys(record).sort()) {
-        sorted[key] = record[key];
-      }
-      return sorted;
-    }
-    return v;
-  });
-}
 
 /**
  * The tier to report for one tool, from the CALLER'S OWN ladder.

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -261,8 +261,9 @@ export function readListPaging(args: unknown): { offset: number; limit: number }
 
 /**
  * Read a manifest entry's id from an untyped result payload. The introspection
- * result schemas declare their entries as `z.unknown()`, so main re-narrows
- * rather than trusting the renderer's shape.
+ * result schemas declare their entries permissively — `z.unknown()` for the
+ * list/search arrays, an open record for `getSchema` — so main re-narrows rather
+ * than trusting the renderer's shape.
  */
 function readEntryId(entry: unknown): string | null {
   if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
@@ -430,7 +431,11 @@ export function buildTargetPolicy(
         : null;
   if (authorizedBy === null) return null;
 
-  const callable = record.enabled !== false;
+  // Strict rather than `!== false`: a malformed `enabled` (absent, or the
+  // string "false") would otherwise be reported as callable, which is the one
+  // direction this record must never guess in.
+  if (typeof record.enabled !== "boolean") return null;
+  const callable = record.enabled;
   const annotations = buildAnnotations(record as ActionManifestEntry);
   const confirmationMayEscalate = danger === "safe" && acceptsRecipeId(record.inputSchema);
 
@@ -445,29 +450,45 @@ export function buildTargetPolicy(
   // `buildSurfaceManifest`: they are model-facing prose that is reworded often,
   // and a compatibility check that cried drift on every wording edit is one
   // clients would learn to ignore.
-  const hash = createHash("sha256")
-    .update(
-      canonicalJson({
-        policyVersion: MCP_TARGET_POLICY_VERSION,
-        id,
-        kind,
-        minimumTier,
-        danger,
-        confirmationMayEscalate,
-        dynamicInvocation: "allowed",
-        preferredTool: null,
-        readOnlyHint: annotations.readOnlyHint ?? null,
-        idempotentHint: annotations.idempotentHint ?? null,
-        destructiveHint: annotations.destructiveHint ?? null,
-        openWorldHint: annotations.openWorldHint ?? null,
-        deprecated: record.deprecated ?? null,
-        inputSchema: toCompatibilityShape(record.inputSchema ?? null),
-        outputSchema: toCompatibilityShape(
-          buildToolOutputSchema(record as ActionManifestEntry) ?? null
-        ),
-      })
-    )
-    .digest("hex");
+  //
+  // Both schemas are hashed as the LOOKUP HANDS THEM OVER — `entry.inputSchema`
+  // and `entry.outputSchema`, unprojected. This diverges from
+  // `buildSurfaceManifest`, deliberately: that digest describes `tools/list`, so
+  // it hashes `buildToolOutputSchema`, the advertised view. This one accompanies
+  // the entry itself, and `buildToolOutputSchema` collapses every schema without
+  // a top-level `type: "object"` to nothing — so hashing that view would let a
+  // top-level union change its variants, in a field the caller can read right
+  // there in the payload, without moving the digest.
+  //
+  // JSON.stringify throws on a cycle or a BigInt, and a manifest entry is only
+  // as well-formed as whatever built it. Fail closed on that rather than letting
+  // it escape as a tool-call exception.
+  let hash: string;
+  try {
+    hash = createHash("sha256")
+      .update(
+        canonicalJson({
+          policyVersion: MCP_TARGET_POLICY_VERSION,
+          id,
+          kind,
+          minimumTier,
+          danger,
+          confirmationMayEscalate,
+          dynamicInvocation: "allowed",
+          preferredTool: null,
+          readOnlyHint: annotations.readOnlyHint ?? null,
+          idempotentHint: annotations.idempotentHint ?? null,
+          destructiveHint: annotations.destructiveHint ?? null,
+          openWorldHint: annotations.openWorldHint ?? null,
+          deprecated: record.deprecated ?? null,
+          inputSchema: toCompatibilityShape(record.inputSchema ?? null),
+          outputSchema: toCompatibilityShape(record.outputSchema ?? null),
+        })
+      )
+      .digest("hex");
+  } catch {
+    return null;
+  }
 
   return {
     version: MCP_TARGET_POLICY_VERSION,

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -5,13 +5,15 @@ import { toWireSchema } from "../../../shared/utils/mcpWireSchema.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { mcpPaneConfigService } from "../McpPaneConfigService.js";
 import type { HelpTokenValidator } from "./shared.js";
-import { type McpTier, TIER_ALLOWLISTS } from "./shared.js";
+import { type McpTier, TIER_ALLOWLISTS, minimumPermittingTier } from "./shared.js";
 import {
   ACTIONS_LIST_DEFAULT_LIMIT,
   ACTIONS_LIST_MAX_LIMIT,
   ACTIONS_SEARCH_DEFAULT_LIMIT,
   ACTIONS_SEARCH_MAX_LIMIT,
 } from "../../../shared/config/mcpIntrospection.js";
+import { canonicalJson, toCompatibilityShape } from "./compatibilityHash.js";
+import type { McpTargetPolicy, McpTargetTier } from "../../../shared/types/mcpTargetPolicy.js";
 
 export { deriveBand, BAND_OVERRIDES };
 
@@ -293,6 +295,204 @@ function isIntrospectableForSession(
 }
 
 /**
+ * Shape version of the `actions.getSchema` policy record (#11910). Bump by hand
+ * when a field is added, removed, or given new meaning — never for a change in
+ * what one target's policy evaluates to, which is what the per-target hash is
+ * for.
+ *
+ * Lives here rather than beside the payload types in `shared/` for the same
+ * reason {@link MCP_SURFACE_MANIFEST_VERSION} does: main is the only process
+ * that stamps it, so the shared module stays a type-only import from here and
+ * its `zod` value import never becomes an eager edge on main's boot path.
+ */
+export const MCP_TARGET_POLICY_VERSION = 1;
+
+/**
+ * The session facts a target policy is evaluated against, captured once at
+ * dispatch start so every field of one record describes the same instant.
+ *
+ * Passed in rather than read here so this module stays pure and testable
+ * without a session store, matching {@link filterIntrospectionResultForSession}.
+ */
+export interface TargetPolicySessionSnapshot {
+  /** The tier the session was admitted at. */
+  tier: McpTier;
+  /**
+   * Whether this session's ORIGIN can hold grants at all —
+   * `sessionStore.isRendererOwnedOrigin`.
+   *
+   * Not derivable from {@link tier}, which is why it is threaded rather than
+   * inferred. `resolveTokenTier` falls back to `workbench` for any bearer token
+   * it does not recognise, while `getOrigin` defaults an unknown session to
+   * `external`, so a session can hold a ladder tier and a non-renderer origin at
+   * once. Grant issuance gates on the origin (`issueGrant` /
+   * `issueNativeGrant` both refuse a session that is not renderer-owned), so
+   * reporting grantability off the tier would promise an api-key client an
+   * approval flow it can never reach.
+   */
+  rendererOwnedOrigin: boolean;
+  /** Live per-tool grants, from the non-evicting snapshot. */
+  perToolGrantedActionIds: ReadonlySet<string>;
+  /** Live native automation grants' `allowedTools`, unioned. */
+  nativeGrantedActionIds: ReadonlySet<string>;
+}
+
+/** The `recipeId` argument that elevates a safe dispatch to confirm (#11860). */
+const RECIPE_ID_ARG = "recipeId";
+
+/**
+ * Whether this target's own arguments can raise it from `safe` to
+ * confirmation-gated.
+ *
+ * Read off the declared input schema rather than an action allowlist, mirroring
+ * `resolveEffectiveActionDanger`, which keys the elevation on the ARGUMENT for
+ * exactly that reason: an allowlist would need updating for every future
+ * composite and would silently under-gate the one someone forgets. A target that
+ * cannot accept a `recipeId` can never be elevated by one.
+ */
+function acceptsRecipeId(inputSchema: unknown): boolean {
+  if (inputSchema === null || typeof inputSchema !== "object" || Array.isArray(inputSchema)) {
+    return false;
+  }
+  const properties = (inputSchema as { properties?: unknown }).properties;
+  if (properties === null || typeof properties !== "object" || Array.isArray(properties)) {
+    return false;
+  }
+  return RECIPE_ID_ARG in (properties as Record<string, unknown>);
+}
+
+/**
+ * The authoritative policy record for one already-authorized target (#11910).
+ *
+ * Returns `null` — never a partial record — for anything it cannot describe
+ * truthfully: a malformed entry, a danger outside the two callable values, or a
+ * target whose tier membership it cannot establish. The caller collapses that
+ * onto the same `NOT_FOUND` an unknown id returns, so missing or malformed
+ * policy metadata fails closed rather than shipping a record a client would
+ * trust.
+ *
+ * Only ever called for an id that has already passed
+ * {@link isIntrospectableForSession}, so `null` here is a fail-closed backstop
+ * rather than the ordinary denial path.
+ */
+export function buildTargetPolicy(
+  entry: unknown,
+  snapshot: TargetPolicySessionSnapshot
+): McpTargetPolicy | null {
+  const id = readEntryId(entry);
+  if (id === null) return null;
+  const record = entry as Partial<ActionManifestEntry>;
+
+  // `restricted` and `hidden` are already refused upstream; re-checking here
+  // keeps this function safe to call on its own and makes the fail-closed
+  // contract local rather than inherited.
+  if (record.mcpVisibility === "hidden") return null;
+  const danger = record.danger;
+  if (danger !== "safe" && danger !== "confirm") return null;
+  const kind = record.kind;
+  if (kind !== "command" && kind !== "query") return null;
+
+  // Grants only count where the origin can hold them. In practice an external
+  // session never has any — both issuance paths refuse a non-renderer-owned
+  // origin — so this is belt-and-braces against a stale entry outliving the
+  // origin that minted it, and it keeps the reported authorization identical to
+  // the one the dispatch gate would reach.
+  const grantsReachable = snapshot.rendererOwnedOrigin;
+  const perToolGranted = grantsReachable && snapshot.perToolGrantedActionIds.has(id);
+  const nativeGranted = grantsReachable && snapshot.nativeGrantedActionIds.has(id);
+
+  // The caller's own ladder, never a rung it cannot climb. An external
+  // allowlist is a flat peer of the in-app ladder, so `minimumPermittingTier` —
+  // which answers "how far would an in-app session have to elevate" — reports
+  // either a rung this caller can never reach or nothing at all for a tool that
+  // is external-only.
+  const minimumTier: McpTargetTier | null =
+    snapshot.tier === "external"
+      ? TIER_ALLOWLISTS.external.has(id)
+        ? "external"
+        : null
+      : minimumPermittingTier(id);
+  // A ladder target with no permitting tier cannot be described honestly, and
+  // cannot legitimately be granted either: both issuance paths refuse a tool
+  // `minimumPermittingTier` does not place. Fail closed.
+  if (minimumTier === null) return null;
+
+  // Resolved in the dispatch gate's own order — static floor, then per-tool
+  // grant, then native grant — so a client reading this learns which mechanism
+  // would actually admit its next call, and therefore whether that access can
+  // lapse.
+  const authorizedBy = TIER_ALLOWLISTS[snapshot.tier].has(id)
+    ? "tier"
+    : perToolGranted
+      ? "grant"
+      : nativeGranted
+        ? "nativeGrant"
+        : null;
+  if (authorizedBy === null) return null;
+
+  const callable = record.enabled !== false;
+  const annotations = buildAnnotations(record as ActionManifestEntry);
+  const confirmationMayEscalate = danger === "safe" && acceptsRecipeId(record.inputSchema);
+
+  // The digest covers only what a caller's own code is built against. Live
+  // session state is deliberately absent: `callable`, `effectiveTier`,
+  // `requiresConfirmation`, `authorizedBy` and `grantable` all move as grants
+  // come and go, and a hash that flapped on a timer would describe a target no
+  // lookup ever returned. `grantable` is additionally redundant — it is fully
+  // determined by `minimumTier` plus the caller's own class.
+  //
+  // Descriptions are excluded here and inside the schemas, matching
+  // `buildSurfaceManifest`: they are model-facing prose that is reworded often,
+  // and a compatibility check that cried drift on every wording edit is one
+  // clients would learn to ignore.
+  const hash = createHash("sha256")
+    .update(
+      canonicalJson({
+        policyVersion: MCP_TARGET_POLICY_VERSION,
+        id,
+        kind,
+        minimumTier,
+        danger,
+        confirmationMayEscalate,
+        dynamicInvocation: "allowed",
+        preferredTool: null,
+        readOnlyHint: annotations.readOnlyHint ?? null,
+        idempotentHint: annotations.idempotentHint ?? null,
+        destructiveHint: annotations.destructiveHint ?? null,
+        openWorldHint: annotations.openWorldHint ?? null,
+        deprecated: record.deprecated ?? null,
+        inputSchema: toCompatibilityShape(record.inputSchema ?? null),
+        outputSchema: toCompatibilityShape(
+          buildToolOutputSchema(record as ActionManifestEntry) ?? null
+        ),
+      })
+    )
+    .digest("hex");
+
+  return {
+    version: MCP_TARGET_POLICY_VERSION,
+    hash,
+    callable,
+    unavailableReason: callable ? null : "DISABLED",
+    minimumTier,
+    effectiveTier: snapshot.tier,
+    danger,
+    // A native grant is an explicit user approval of the tool's scope, so it
+    // pre-authorises the modal (`dispatchConfirmed` in `sessionServer`). A
+    // per-tool grant only widens the floor and never bypasses confirmation.
+    requiresConfirmation: danger === "confirm" && !nativeGranted,
+    confirmationMayEscalate,
+    // Exactly the two checks `issueGrant` enforces, minus the runtime
+    // caller-pin: the origin must be able to hold a grant, and the tool must be
+    // one some non-external tier already permits.
+    grantable: grantsReachable && minimumPermittingTier(id) !== null,
+    authorizedBy,
+    dynamicInvocation: "allowed",
+    preferredTool: null,
+  };
+}
+
+/**
  * Narrow an introspection tool's result to the ids the calling session can
  * actually dispatch. Pure: takes one immutable permission snapshot, returns a
  * new payload, and never reads the session store or the grant cache.
@@ -309,6 +509,14 @@ export function filterIntrospectionResultForSession(
     callerLimit: number;
     requestedActionId?: string;
     listPaging?: { offset: number; limit: number };
+    /**
+     * The session facts `actions.getSchema`'s policy record is built from
+     * (#11910). Absent means no policy can be built, and a schema read without
+     * one collapses to `NOT_FOUND` — the same fail-closed direction a malformed
+     * entry takes, so a caller can never receive an entry whose policy is
+     * silently missing.
+     */
+    policySnapshot?: TargetPolicySessionSnapshot;
   }
 ): ActionDispatchResult {
   if (!result.ok) return result;
@@ -382,7 +590,17 @@ export function filterIntrospectionResultForSession(
       requestedId !== undefined &&
       readEntryId(payload.entry) === requestedId;
     if (answersTheRequest && isIntrospectableForSession(payload.entry, permittedActionIds)) {
-      return { ok: true, result: { ok: true, entry: payload.entry } };
+      // The renderer has no session, tier, or grant state, so it returns
+      // `policy: null` and main substitutes the real record here — the same
+      // rebuild-from-scratch point that strips any sibling key the renderer
+      // attached. A snapshot that cannot produce a policy denies the read
+      // rather than returning an entry a client would treat as unrestricted.
+      const policy = options.policySnapshot
+        ? buildTargetPolicy(payload.entry, options.policySnapshot)
+        : null;
+      if (policy !== null) {
+        return { ok: true, result: { ok: true, entry: payload.entry, policy, error: null } };
+      }
     }
     // Collapse onto the shape the renderer already returns for an unknown,
     // hidden, or restricted id rather than minting a tier-specific error: a
@@ -390,10 +608,16 @@ export function filterIntrospectionResultForSession(
     // reach it (grants are issued off a denied *dispatch*, not a schema read).
     // The renderer's own denial is rebuilt rather than forwarded, so the
     // message can only ever name the id the caller asked about.
+    //
+    // `entry` and `policy` are present-and-null rather than absent, matching
+    // the renderer's own denial: one shape for both branches means a client
+    // reads `ok` rather than probing for which keys arrived.
     return {
       ok: true,
       result: {
         ok: false,
+        entry: null,
+        policy: null,
         error: {
           code: "NOT_FOUND",
           message: `No action found with id "${requestedId ?? "unknown"}". Use actions.search to find available actions.`,

--- a/shared/types/mcpTargetPolicy.ts
+++ b/shared/types/mcpTargetPolicy.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+import type { McpSurfaceTier } from "./mcpSurface.js";
+
+/**
+ * The authorization tiers a target policy can report. Same set `mcp.surface`
+ * reports, aliased rather than restated so the two contracts cannot drift.
+ */
+export type McpTargetTier = McpSurfaceTier;
+
+/** Which mechanism admits this target for this session, in dispatch-gate order. */
+export type McpTargetAuthorizedBy = "tier" | "grant" | "nativeGrant";
+
+/** Whether a client may call this target through a generic invoker. */
+export type McpTargetInvocationMode = "allowed" | "wrapper-required";
+
+/**
+ * The authoritative policy record for ONE action, as one session sees it
+ * (#11910).
+ *
+ * Answers what a client needs before it dispatches a target it discovered
+ * rather than one it was written against: may I call this, what will it cost me
+ * in confirmation, and will that answer still hold in a minute. Tool
+ * annotations cannot serve this purpose — the MCP spec is explicit that they
+ * are untrusted hints, so a client that policed itself with them would be
+ * running a second security policy that drifts from the host's.
+ *
+ * Only ever accompanies an `ok: true` lookup. An action this session cannot
+ * reach — hidden, restricted, outside its tier, or withheld from a
+ * workspace-bound session — collapses to the same `NOT_FOUND` an unknown id
+ * returns, and carries no policy at all. That is deliberate: #11585 established
+ * that a discoverable-but-uncallable state is not a state any shipped client can
+ * act on, so withholding a name is equivalent to revoking it, and this record
+ * must not reintroduce the split by describing what it refuses to name.
+ *
+ * A SNAPSHOT, not a lease. Grants expire and are revoked between a lookup and a
+ * call, and `requiresConfirmation` can flip when the last use of a native grant
+ * is spent. The dispatch gate stays authoritative; this record only lets a
+ * client stop guessing.
+ */
+export interface McpTargetPolicy {
+  /**
+   * Shape version of this record, bumped by hand when a field is added,
+   * removed, or given new meaning. Distinct from {@link hash}: a client reads
+   * this to know whether it can still parse the record at all.
+   */
+  version: number;
+  /**
+   * Lowercase hex SHA-256 over this target's compatibility-relevant fields.
+   * Changes iff something a caller's own code depends on changes — schemas,
+   * danger, tier, annotations, invocation mode. Never moves for a reworded
+   * description, and never for live session state, so a client can cache a
+   * validated target against it.
+   */
+  hash: string;
+  /** Whether a dispatch would be admitted right now, confirmation aside. */
+  callable: boolean;
+  /**
+   * Why an otherwise-reachable target is not callable. Only ever `DISABLED` —
+   * an action whose own `isEnabled` is false in this context. Authorization
+   * denials never reach this field; they are `NOT_FOUND`.
+   */
+  unavailableReason: "DISABLED" | null;
+  /**
+   * The lowest tier on the CALLER'S OWN ladder that permits this target. Always
+   * `external` for an external caller, whose allowlist is a flat peer of the
+   * in-app ladder rather than a rung on it.
+   */
+  minimumTier: McpTargetTier;
+  /** The tier this session was admitted at when the lookup ran. */
+  effectiveTier: McpTargetTier;
+  /** The target's DECLARED danger. Static; part of {@link hash}. */
+  danger: "safe" | "confirm";
+  /**
+   * Whether a dispatch right now would block on a human confirmation dialog.
+   * Live, unlike {@link danger}: a native automation grant pre-authorizes the
+   * dispatch, so a `confirm` target can report `false` here until that grant is
+   * spent or expires.
+   */
+  requiresConfirmation: boolean;
+  /**
+   * Whether ARGUMENTS can raise a `safe` target to confirmation-gated. True for
+   * targets accepting a `recipeId`: an agent-sourced call carrying one spawns
+   * the recipe's terminals, so the host elevates it per-dispatch (#11860). A
+   * client reading only {@link danger} would call such a target expecting no
+   * dialog and get `CONFIRMATION_REQUIRED` instead.
+   */
+  confirmationMayEscalate: boolean;
+  /**
+   * Whether this session could be granted this target on a denial. False for
+   * every session whose origin cannot hold grants at all — an api-key client
+   * has no renderer to approve in, so no scoped grant is reachable for it no
+   * matter which tier admits the tool elsewhere.
+   */
+  grantable: boolean;
+  /**
+   * Which mechanism admits the target, resolved in the dispatch gate's own
+   * order. `tier` is durable for the session; the other two are time-bounded,
+   * so a client that wants to know whether its access can lapse reads this.
+   */
+  authorizedBy: McpTargetAuthorizedBy;
+  /** Whether a generic invoker may call this target directly. */
+  dynamicInvocation: McpTargetInvocationMode;
+  /**
+   * A purpose-built tool to call instead of invoking this target generically,
+   * or `null` when none exists. Always `null` today: no host-side wrapper
+   * registry exists, and deriving names from the client's own roster would be
+   * the second, drifting policy this contract rejects.
+   */
+  preferredTool: string | null;
+}
+
+const TIER_VALUES = ["workbench", "action", "system", "external"] as const;
+
+/**
+ * The policy half of the `actions.getSchema` result.
+ *
+ * Enforced against `run()`'s return value, and exported as the shape a client
+ * codes against — but not advertised as an MCP `outputSchema`; see the note on
+ * the action's `resultSchema` for why the external wire budget rules that out.
+ */
+export const McpTargetPolicySchema = z.object({
+  version: z.number().int().positive(),
+  hash: z.string().regex(/^[0-9a-f]{64}$/),
+  callable: z.boolean().describe("Whether a dispatch would be admitted now, confirmation aside"),
+  unavailableReason: z.literal("DISABLED").nullable(),
+  minimumTier: z.enum(TIER_VALUES).describe("Lowest tier on this caller's ladder permitting it"),
+  effectiveTier: z.enum(TIER_VALUES),
+  danger: z.enum(["safe", "confirm"]).describe("Declared danger; static"),
+  requiresConfirmation: z.boolean().describe("Whether a call now would block on a human dialog"),
+  confirmationMayEscalate: z
+    .boolean()
+    .describe("Whether arguments can raise a safe target to confirmation-gated"),
+  grantable: z.boolean().describe("Whether this session could be granted it on a denial"),
+  authorizedBy: z.enum(["tier", "grant", "nativeGrant"]),
+  dynamicInvocation: z.enum(["allowed", "wrapper-required"]),
+  preferredTool: z.string().nullable().describe("A typed tool to prefer over generic invocation"),
+});
+
+/**
+ * The `actions.getSchema` result (#11910).
+ *
+ * A flat object with four always-present keys rather than the discriminated
+ * union it replaces. Two reasons, both load-bearing:
+ *
+ * 1. One shape means a client reads `ok` and finds every key where it expects
+ *    it, instead of narrowing a union before it can tell a denial from an
+ *    answer. It also keeps the door open for advertising this as an MCP
+ *    `outputSchema` later: `buildToolOutputSchema` only advertises a schema
+ *    whose generated JSON Schema has a top-level `type: "object"`, which the
+ *    previous top-level `z.union` could never produce.
+ * 2. The renderer cannot fill `policy`: it has no session, tier, or grant
+ *    state. It returns `null` there and main substitutes the real record after
+ *    session filtering, so the field must be nullable rather than optional for
+ *    the renderer's own `resultSchema` validation to pass.
+ *
+ * Read `ok`, never the key set: `entry` and `policy` are present-and-null on a
+ * failure, not absent.
+ */
+export const McpGetSchemaResultSchema = z.object({
+  ok: z.boolean(),
+  entry: z.record(z.string(), z.unknown()).nullable(),
+  policy: McpTargetPolicySchema.nullable(),
+  error: z.object({ code: z.string(), message: z.string() }).nullable(),
+});

--- a/shared/types/mcpTargetPolicy.ts
+++ b/shared/types/mcpTargetPolicy.ts
@@ -120,7 +120,7 @@ const TIER_VALUES = ["workbench", "action", "system", "external"] as const;
  * shape a client — and `McpGetSchemaWireResultSchema` — checks the finished
  * record against.
  */
-export const McpTargetPolicySchema = z.object({
+export const McpTargetPolicySchema = z.strictObject({
   version: z.number().int().positive(),
   hash: z.string().regex(/^[0-9a-f]{64}$/),
   callable: z.boolean().describe("Whether a dispatch would be admitted now, confirmation aside"),
@@ -178,18 +178,24 @@ export const McpGetSchemaResultSchema = z.object({
  * Discriminated on a literal `ok`, so a consumer narrows on it and gets
  * non-null `entry`/`policy` on the success arm without re-checking. This is the
  * contract the companion CLI (daintreehq/assistant#368) codes against.
+ *
+ * Strict all the way down, which is what makes the conformance test a real
+ * guard: a plain `z.object` silently STRIPS unknown keys, so a field added to
+ * the policy builder but forgotten here would still `safeParse` clean and the
+ * drift would ship. `entry` stays an open record on purpose — it is a manifest
+ * entry, whose own shape is not this contract's to pin down.
  */
 export const McpGetSchemaWireResultSchema = z.discriminatedUnion("ok", [
-  z.object({
+  z.strictObject({
     ok: z.literal(true),
     entry: z.record(z.string(), z.unknown()),
     policy: McpTargetPolicySchema,
     error: z.null(),
   }),
-  z.object({
+  z.strictObject({
     ok: z.literal(false),
     entry: z.null(),
     policy: z.null(),
-    error: z.object({ code: z.literal("NOT_FOUND"), message: z.string() }),
+    error: z.strictObject({ code: z.literal("NOT_FOUND"), message: z.string() }),
   }),
 ]);

--- a/shared/types/mcpTargetPolicy.ts
+++ b/shared/types/mcpTargetPolicy.ts
@@ -114,9 +114,11 @@ const TIER_VALUES = ["workbench", "action", "system", "external"] as const;
 /**
  * The policy half of the `actions.getSchema` result.
  *
- * Enforced against `run()`'s return value, and exported as the shape a client
- * codes against — but not advertised as an MCP `outputSchema`; see the note on
- * the action's `resultSchema` for why the external wire budget rules that out.
+ * NOT reached by the renderer's own `resultSchema` validation: that runs in
+ * `ActionService.dispatch`, before main has substituted the real record, so what
+ * it validates is always the `null` placeholder. This schema's job is to be the
+ * shape a client — and `McpGetSchemaWireResultSchema` — checks the finished
+ * record against.
  */
 export const McpTargetPolicySchema = z.object({
   version: z.number().int().positive(),
@@ -162,3 +164,32 @@ export const McpGetSchemaResultSchema = z.object({
   policy: McpTargetPolicySchema.nullable(),
   error: z.object({ code: z.string(), message: z.string() }).nullable(),
 });
+
+/**
+ * What a CLIENT actually receives, after main has substituted the policy.
+ *
+ * Deliberately stricter than {@link McpGetSchemaResultSchema}, which has to stay
+ * loose enough to accept the renderer's half-built staging value (`policy:
+ * null` on a success). That looseness is a validation gap on the wire — it
+ * admits `{ ok: true, policy: null }` and `{ ok: false, entry: {...} }`, neither
+ * of which main can emit — so the finished shape gets its own schema rather than
+ * inheriting the staging one.
+ *
+ * Discriminated on a literal `ok`, so a consumer narrows on it and gets
+ * non-null `entry`/`policy` on the success arm without re-checking. This is the
+ * contract the companion CLI (daintreehq/assistant#368) codes against.
+ */
+export const McpGetSchemaWireResultSchema = z.discriminatedUnion("ok", [
+  z.object({
+    ok: z.literal(true),
+    entry: z.record(z.string(), z.unknown()),
+    policy: McpTargetPolicySchema,
+    error: z.null(),
+  }),
+  z.object({
+    ok: z.literal(false),
+    entry: z.null(),
+    policy: z.null(),
+    error: z.object({ code: z.literal("NOT_FOUND"), message: z.string() }),
+  }),
+]);

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -42,7 +42,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "introspection",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Fetch one action's full manifest entry, including the exact arguments it accepts and the shape it returns. Use this after finding a candidate by search or listing, before dispatching it, so the arguments are known rather than guessed. An unknown, hidden or restricted id comes back as a structured failure in the result rather than as a thrown error.",
+    "description": "Fetch one action's full manifest entry — the exact arguments it accepts, the shape it returns, and a policy record saying whether this session can call it, at which tier, and whether confirmation applies. Use it after finding a candidate by search or listing, before dispatching. An unknown, hidden or restricted id comes back as a structured failure rather than a thrown error.",
     "examples": [
       {
         "args": {

--- a/src/services/actions/__tests__/resultSchemaHygiene.test.ts
+++ b/src/services/actions/__tests__/resultSchemaHygiene.test.ts
@@ -181,7 +181,7 @@ const PERMISSIVE_ALLOWLIST: ReadonlyArray<{ actionId: string; pointer: string; r
   // --- self-describing -----------------------------------------------------
   {
     actionId: "actions.getSchema",
-    pointer: "/anyOf/0/properties/entry",
+    pointer: "/properties/entry/anyOf/0/additionalProperties",
     reason: "self-describing: an action manifest entry, whose own field is a JSON Schema",
   },
   {

--- a/src/services/actions/definitions/introspectionActions.ts
+++ b/src/services/actions/definitions/introspectionActions.ts
@@ -444,7 +444,8 @@ export function registerIntrospectionActions(
       // this payload in `filterIntrospectionResultForSession` and substitutes
       // the real record there, or denies the read if it cannot build one. The
       // null placeholder is what lets that field stay required-and-nullable in
-      // the advertised schema rather than optional.
+      // the declared schema rather than optional. `McpGetSchemaWireResultSchema`
+      // is the stricter shape a client sees once main has filled it in.
       return { ok: true, entry, policy: null, error: null };
     },
   }));

--- a/src/services/actions/definitions/introspectionActions.ts
+++ b/src/services/actions/definitions/introspectionActions.ts
@@ -3,6 +3,7 @@ import type { ActionContext, ActionManifestEntry } from "@shared/types/actions";
 import { z } from "zod";
 import { PersistedStoreInfoSchema } from "./schemas";
 import { McpSurfaceResultSchema } from "@shared/types/mcpSurface";
+import { McpGetSchemaResultSchema } from "@shared/types/mcpTargetPolicy";
 import {
   ACTIONS_LIST_DEFAULT_LIMIT,
   ACTIONS_LIST_MAX_LIMIT,
@@ -392,7 +393,7 @@ export function registerIntrospectionActions(
     id: "actions.getSchema",
     title: "Get Action Schema",
     description:
-      "Fetch one action's full manifest entry, including the exact arguments it accepts and the shape it returns. Use this after finding a candidate by search or listing, before dispatching it, so the arguments are known rather than guessed. An unknown, hidden or restricted id comes back as a structured failure in the result rather than as a thrown error.",
+      "Fetch one action's full manifest entry — the exact arguments it accepts, the shape it returns, and a policy record saying whether this session can call it, at which tier, and whether confirmation applies. Use it after finding a candidate by search or listing, before dispatching. An unknown, hidden or restricted id comes back as a structured failure rather than a thrown error.",
     category: "introspection",
     kind: "query",
     danger: "safe",
@@ -413,13 +414,15 @@ export function registerIntrospectionActions(
           "Inspect the input and output schema of a terminal status tool before calling it",
       },
     ],
-    resultSchema: z.union([
-      z.object({ ok: z.literal(true), entry: z.unknown() }),
-      z.object({
-        ok: z.literal(false),
-        error: z.object({ code: z.string(), message: z.string() }),
-      }),
-    ]),
+    // Validated but deliberately NOT advertised as an MCP `outputSchema`. It
+    // would be the more useful contract — clients AJV-validate
+    // `structuredContent` against an advertised schema — but this tool is on
+    // `MCP_EXTERNAL_TIER_TOOLS`, where the emitted JSON Schema measured 1,611
+    // bytes past `mcpWireBudget`'s 43,000-byte external ceiling. That is ~4% of
+    // the whole third-party surface spent on one introspection tool's return
+    // shape, and the policy record rides the text result either way. Revisit if
+    // that budget ever gains real headroom; do not raise the ratchet for it.
+    resultSchema: McpGetSchemaResultSchema,
     run: async (args: unknown, ctx: ActionContext) => {
       const { actionId } = args as { actionId: string };
       const entry = actionService.get(actionId, ctx);
@@ -427,6 +430,8 @@ export function registerIntrospectionActions(
       if (!entry || entry.mcpVisibility === "hidden" || entry.danger === "restricted") {
         return {
           ok: false,
+          entry: null,
+          policy: null,
           error: {
             code: "NOT_FOUND",
             message: `No action found with id "${actionId}". Use actions.search to find available actions.`,
@@ -434,7 +439,13 @@ export function registerIntrospectionActions(
         };
       }
 
-      return { ok: true, entry };
+      // `policy` is main's to fill: this runs in the renderer, which has no
+      // session, tier, or grant state to evaluate one against. Main rebuilds
+      // this payload in `filterIntrospectionResultForSession` and substitutes
+      // the real record there, or denies the read if it cannot build one. The
+      // null placeholder is what lets that field stay required-and-nullable in
+      // the advertised schema rather than optional.
+      return { ok: true, entry, policy: null, error: null };
     },
   }));
 }


### PR DESCRIPTION
## Summary

- Adds session-scoped policy metadata to the success response of the `actions.getSchema` MCP tool, so a client doing a `search` -> `schema` -> `invoke` flow can learn whether a discovered target is callable, at what tier, whether confirmation is required, and whether a scoped grant could authorize it.
- Without this, a client either has to treat every dynamic invocation as maximum (System) risk, or re-derive a second, drifting security policy from action names and descriptions.
- This is a coordinated two-repo contract change. Companion PR: `daintreehq/assistant#368`.

Resolves #11910

## Design decisions

**Extended `actions.getSchema` rather than `mcp.surface` or a new tool.** `mcp.surface` is deliberately narrow, adding these fields there would multiply them across roughly 147 tools at startup and risk its 50 KiB payload cap. A new tool would spend budget against the registry's cap of 26 external tools (`EXTERNAL_BUDGET_MAX`). `actions.getSchema` is already registered and already the on-demand single-target lookup, so this costs zero registry budget and keeps the lookup on demand rather than an eager dump of every schema.

**Grant eligibility keys on session origin, not tier.** `resolveTokenTier` falls back to `workbench` for an unrecognized bearer token, while `getOrigin` defaults an unrecognized session to `external`. The two genuinely diverge. Both grant-issuance paths (`issueGrant`, `issueNativeGrant`) gate on `isRendererOwnedOrigin`, so keying eligibility on tier would incorrectly promise an approval flow to an API-key client that always throws.

**#11585's no-third-state invariant is preserved.** Hidden, restricted, tier-ineligible, workspace-withheld, and unknown action ids all still collapse to one identical `NOT_FOUND` shape carrying no policy. `callable: false` is reserved for an already-visible action's transient `enabled: false` state, not for anything hidden or ineligible.

**Per-target compatibility hash covers only what a caller's own code depends on:** schemas as the lookup hands them over, danger, tier, annotations, invocation mode. Live session state is excluded so the hash can't flap on a grant timer. Canonicalization is shared with `mcp.surface`'s hash through a new `compatibilityHash.ts` module, so the two normalizers can't drift apart. `MCP_SURFACE_MANIFEST_VERSION` is unchanged, and the frozen surface digest test is unchanged too, confirming the extraction was behavior-preserving.

**No generic invocation endpoint was built.** Daintree doesn't have one today. Every `tools/call` already dispatches through the same per-action gate chain, so that part of the originating issue is future-facing for the host. The generic escape hatch lives in the Assistant CLI repo.

**`preferredTool` ships as an unpopulated contract field** (`dynamicInvocation: "allowed"`, `preferredTool: null`). There's no host-side wrapper registry yet, and deriving names from the client's own tool roster would just recreate the drifting second policy this issue is trying to avoid. This adds the field the companion CLI needs without churning every manifest entry.

**`mcpOutputSchema` deliberately not set.** The emitted JSON Schema came out to 44,611 bytes against `mcpWireBudget.test.ts`'s 43,000-byte external wire ceiling, about 4% of the entire third-party wire surface for one introspection tool's return shape. The result is still flattened from a top-level `z.union` into one four-key object, so turning this on later is a one-line change if that budget gets more headroom.

## Wire contract

The `actions.getSchema` result is now one four-key object: `{ ok, entry, policy, error }`. All four keys are always present; `entry`, `policy`, and `error` are nullable. This replaces the previous two-branch union. Clients read `ok`; the failure branch now explicitly carries `entry: null, policy: null` rather than omitting them.

`shared/types/mcpTargetPolicy.ts` exports `McpGetSchemaWireResultSchema`, a strict discriminated union, as the contract the CLI codes against.

## Changes

10 files changed, ~1,335 insertions / ~175 deletions.

- New: `shared/types/mcpTargetPolicy.ts`, `electron/services/mcp-server/compatibilityHash.ts`
- Changed: `electron/services/mcp-server/tierAuth.ts`, `electron/services/mcp-server/sessionServer.ts`, `electron/services/mcp-server/surfaceManifest.ts`, `src/services/actions/definitions/introspectionActions.ts`
- Tests: `electron/services/mcp-server/__tests__/tierAuth.test.ts`, `electron/services/mcp-server/__tests__/sessionServer.test.ts`, `src/services/actions/__tests__/resultSchemaHygiene.test.ts`, one snapshot line

## Testing

- Typecheck clean.
- 1,053 mcp-server tests, 1,701 `src/services/actions` tests, and 35 `McpServerService.authAndToolSurface` tests, all green.
- Own-file eslint and prettier clean.
- `lint:ratchet`, `check:channels`, `check:ipc`, `check:ipc-renderer`, `check:ipc-handwritten`, and `check:confirm-wiring` all pass.
- The frozen `mcp.surface` digest test is unchanged, confirming the helper extraction was behavior-preserving.

Reviewed across three passes; all findings applied.
