### PR TITLE
fix(icons): resolve brand mark colour against its actual backdrop

### DIFF
--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -88,6 +88,29 @@ The accent border and the 2px accent rail this recipe used to prescribe were rem
 
 ---
 
+### Brand Mark States
+
+**Role:** Third-party brand marks (agent and product logos) in toolbars, dock rails, panel title bars and palettes. Two inks: the brand colour a step back at rest, the brand colour itself when the mark is active.
+
+```tsx
+<BrandSurface surface="surface-panel" extension="panel-header-focus-bg" lift="overlay-subtle">
+  {/* ...anything rendering a BrandMark... */}
+</BrandSurface>
+```
+
+**Usage:** Never hand a colour to a brand glyph. The SVG stays on `currentColor`, `BrandMark` publishes `--brand-mark-rest` / `--brand-mark-active`, and `.brand-mark` in `src/index.css` owns the swap. Active is reached by `:hover`, `:focus-visible`, `[role="option"]/[role="tab"][aria-selected="true"]`, and `[data-brand-active]` for a container whose own notion of active is none of those — a focused panel title bar being the case that asked for it. Put `data-brand-active` on the glyph's own wrapper, not on a container that also holds other marks, or a focused panel lights up every tab in its strip.
+
+These marks carry vendor hexes from `AgentConfig.color`, not theme tokens, so they are the one colour family the semantic palette cannot reach. `resolveBrandMarkInk` (`src/lib/brandIcon.ts`) places both states against the backdrop the mark is actually painted on:
+
+- **Active** is the brand colour untouched wherever it clears WCAG 1.4.11's 3:1 _and_ APCA Lc 35 against the weaker of its two backdrops (a mark is painted on the hover backdrop when hovered and on the plain surface when it sits in a selected tab or the focused pane). Where it falls short, the smallest move along its own hue line that gets it there — hue held, chroma re-fitted by CSS Color 4 chroma reduction, never by clipping channels. Lc 35 rather than 3:1 alone because a fine outlined glyph and a solid square at the same ratio are not the same thing to read, and several dark violets cleared 3:1 while landing below the resting state they came from.
+- **Rest** is that colour drawn back an OKLab ΔE of 0.07, _away from the backdrop_ — so on a light theme it sits darker than the brand and lightens into it, on a dark theme lighter and deepens into it. Most of the step is lightness; a fifth of the chroma goes with it so the reveal is a bloom of colour as well as a shift in weight. Fading toward the backdrop instead is what made the previous revision read as washed out.
+- **A ceiling** holds the resting mark within 11 Lc of the theme's own `text-secondary` ink. The neutral controls beside a mark are painted in that ink, and a brand arriving near-white on a dark theme would otherwise rest louder than every control around it. What the ceiling takes off the lightness move comes back as chroma, so the fade keeps its size.
+- **A brand with no chroma is not a colour**, so below OKLCH chroma 0.02 the mark is drawn as an icon instead: it rests at `text-secondary` and its active state is that ink one step _further_ from the backdrop. The direction is reversed on purpose — a colourless mark has no colour to gain on hover, so weight is the only reveal it has.
+
+Every state is checked across the whole 150ms crossfade rather than at its endpoints: the control repaints its background in the same 150ms the glyph recolours, so both are moving and the minimum can sit between the ends. Foreground and backdrop are sampled as a grid rather than in lockstep — the glyph eases out while the surfaces under it ease — so any monotone pair of easings is covered without either being assumed. `src/lib/__tests__/brandMarkMatrix.test.ts` runs the whole agent registry against every built-in theme and every surface a mark can land on.
+
+`BrandSurface` is how the backdrop is known. Wrap containers, not call sites — one on a title bar covers the header glyph and its whole tab strip. `extension` names a theme extension that replaces the surface where a theme defines one (several light themes repaint title bars through `panel-header-bg`), and `lift` names the overlay the container composites when it does not. Without a provider the mark answers to every surface at once, which is safe everywhere and generous nowhere. Floating material — menus, popovers — renders `BrandSurfaceReset` for that reason: React context reaches through a portal even though the DOM does not, so a menu opened from the toolbar would otherwise be measured against the toolbar.
+
 ## Focus States
 
 ### Default Focus Ring

--- a/e2e/full/presets/core-agent-preset-icon-color.spec.ts
+++ b/e2e/full/presets/core-agent-preset-icon-color.spec.ts
@@ -268,9 +268,11 @@ async function expectAgentIconColor(
   // The marker above is the canonical preset color contract. Nothing hands a
   // colour to a glyph any more: the SVG stays on `currentColor` and `BrandMark`
   // publishes the resolved inks as custom properties that `.brand-mark` reads.
-  // Asserting the painted colour EQUALS the resting ink is what proves the whole
-  // chain ran — resolver, custom property and stylesheet rule — rather than just
-  // that some variable exists and the glyph inherited a colour from somewhere.
+  // Asserting the painted colour EQUALS the ink for the mark's CURRENT state is
+  // what proves the whole chain ran — resolver, custom property and stylesheet
+  // rule — rather than just that some variable exists and the glyph inherited a
+  // colour from somewhere. The state matters: a title bar in the pane you are
+  // working in wears the active ink, and every other one wears the resting ink.
   await expect(icon.locator("path").first()).toHaveAttribute("fill", "currentColor");
   const svg = icon.locator("svg").first();
   await expect
@@ -279,7 +281,7 @@ async function expectAgentIconColor(
         svg.evaluate((el) => {
           const computed = getComputedStyle(el);
           const rest = computed.getPropertyValue("--brand-mark-rest").trim();
-          const hover = computed.getPropertyValue("--brand-mark-hover").trim();
+          const active = computed.getPropertyValue("--brand-mark-active").trim();
           const toRgb = (hex: string): string => {
             const raw = hex.replace("#", "");
             const body =
@@ -292,10 +294,20 @@ async function expectAgentIconColor(
             const [r, g, b] = [0, 2, 4].map((i) => parseInt(body.slice(i, i + 2), 16));
             return `rgb(${r}, ${g}, ${b})`;
           };
+          // The same ancestors the stylesheet's own selectors name. Deliberately
+          // not `closest(":hover")`: `html` and `body` match that whenever the
+          // pointer is anywhere in the window, which would call every mark on
+          // the page active.
+          const isActive =
+            el.closest("[data-brand-active]") !== null ||
+            el.closest('[role="tab"][aria-selected="true"]') !== null ||
+            el.closest('[role="option"][aria-selected="true"]') !== null;
+          const expected = isActive ? active : rest;
           return {
             restIsHex: /^#[0-9a-f]{6}$/i.test(rest),
-            hoverIsHex: /^#[0-9a-f]{6}$/i.test(hover),
-            paintedMatchesRest: rest !== "" && computed.color === toRgb(rest),
+            activeIsHex: /^#[0-9a-f]{6}$/i.test(active),
+            fadesIntoTheActiveInk: rest !== active,
+            paintedMatchesState: expected !== "" && computed.color === toRgb(expected),
             hasBrandClass: el.classList.contains("brand-mark"),
           };
         }),
@@ -303,8 +315,9 @@ async function expectAgentIconColor(
     )
     .toEqual({
       restIsHex: true,
-      hoverIsHex: true,
-      paintedMatchesRest: true,
+      activeIsHex: true,
+      fadesIntoTheActiveInk: true,
+      paintedMatchesState: true,
       hasBrandClass: true,
     });
 }

--- a/shared/theme/__tests__/apca.test.ts
+++ b/shared/theme/__tests__/apca.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { apcaContrast, apcaLc } from "../apca.js";
+import { contrastRatio } from "../contrast.js";
+
+/** The grey that sits at exactly `ratio` against `backdrop`, found by bisection. */
+function greyAtRatio(backdrop: string, ratio: number): string {
+  const toward = contrastRatio("#000000", backdrop) >= ratio ? 0 : 255;
+  let near = toward === 0 ? 255 : 0;
+  let far = toward;
+  for (let step = 0; step < 24; step++) {
+    const mid = Math.round((near + far) / 2);
+    const hex = `#${mid.toString(16).padStart(2, "0").repeat(3)}`;
+    if (contrastRatio(hex, backdrop) >= ratio) far = mid;
+    else near = mid;
+  }
+  return `#${far.toString(16).padStart(2, "0").repeat(3)}`;
+}
+
+describe("apcaContrast", () => {
+  it("reproduces the published APCA-W3 reference pair", () => {
+    // The two values every APCA-W3 implementation is checked against. They are
+    // the spec's, not ours — nothing in `apca.ts` contains either number, so
+    // this fails if a constant or an exponent is mistyped.
+    expect(apcaContrast("#000000", "#ffffff")).toBeCloseTo(106.04, 2);
+    expect(apcaContrast("#ffffff", "#000000")).toBeCloseTo(-107.88, 2);
+  });
+
+  it("signs dark-on-light positive and light-on-dark negative", () => {
+    expect(apcaContrast("#333333", "#eeeeee")).toBeGreaterThan(0);
+    expect(apcaContrast("#eeeeee", "#333333")).toBeLessThan(0);
+    expect(apcaLc("#eeeeee", "#333333")).toBeGreaterThan(0);
+  });
+
+  it("reports nothing for a foreground indistinguishable from its backdrop", () => {
+    expect(apcaContrast("#404040", "#404040")).toBe(0);
+    expect(apcaContrast("#404040", "#404142")).toBe(0);
+  });
+
+  it("weighs the same WCAG ratio differently in each polarity", () => {
+    // This asymmetry is the reason the module exists. WCAG's ratio has no
+    // polarity term, so it calls these two pairs equal; APCA does not, and a
+    // fade sized in WCAG ratios lands differently on a dark theme than on a
+    // light one for exactly this reason.
+    const onLight = { fg: greyAtRatio("#ffffff", 4.5), bg: "#ffffff" };
+    const onDark = { fg: greyAtRatio("#1a1a1a", 4.5), bg: "#1a1a1a" };
+    expect(contrastRatio(onLight.fg, onLight.bg)).toBeCloseTo(
+      contrastRatio(onDark.fg, onDark.bg),
+      1
+    );
+    expect(Math.abs(apcaLc(onLight.fg, onLight.bg) - apcaLc(onDark.fg, onDark.bg))).toBeGreaterThan(
+      5
+    );
+  });
+
+  it("grows monotonically as a foreground moves away from its backdrop", () => {
+    const steps = ["#2a2a2a", "#555555", "#808080", "#aaaaaa", "#d5d5d5", "#ffffff"];
+    const measured = steps.map((hex) => apcaLc(hex, "#1a1a1a"));
+    for (let i = 1; i < measured.length; i++) {
+      expect(measured[i]!).toBeGreaterThan(measured[i - 1]!);
+    }
+  });
+});

--- a/shared/theme/apca.ts
+++ b/shared/theme/apca.ts
@@ -1,0 +1,74 @@
+import { hexToRgb } from "./contrast.js";
+
+/**
+ * APCA-W3 (`0.98G-4g-W3`) perceptual lightness contrast.
+ *
+ * Used where WCAG 2.x relative luminance is the wrong instrument: ranking two
+ * states of the *same* hue against the *same* backdrop. WCAG's ratio is a
+ * ratio of luminances, so it compresses hard at the dark end — a step that
+ * reads as one notch on a light theme reads as three on a dark one — and it
+ * has no polarity term at all, which is exactly the axis a dark/light theme
+ * pair differs on. APCA models both, so a fixed Lc step is a fixed perceived
+ * step in either polarity.
+ *
+ * This is a scale, not a floor. WCAG 1.4.11 stays the accessibility contract
+ * (`contrastRatio`); Lc only decides how far apart two states sit on it.
+ */
+
+const MAIN_TRC = 2.4;
+const S_RCO = 0.2126729;
+const S_GCO = 0.7151522;
+const S_BCO = 0.072175;
+
+const NORM_BG = 0.56;
+const NORM_TXT = 0.57;
+const REV_TXT = 0.62;
+const REV_BG = 0.65;
+
+const BLK_THRS = 0.022;
+const BLK_CLMP = 1.414;
+const SCALE_BOW = 1.14;
+const SCALE_WOB = 1.14;
+const LO_BOW_OFFSET = 0.027;
+const LO_WOB_OFFSET = 0.027;
+const DELTA_Y_MIN = 0.0005;
+const LO_CLIP = 0.1;
+
+/**
+ * Screen luminance estimate, with APCA's soft black clamp folded in.
+ *
+ * Deliberately not `relativeLuminance` from `contrast.ts`: that one implements
+ * the IEC 61966-2-1 piecewise transfer function WCAG 2.x specifies, while APCA
+ * uses a plain 2.4 power curve plus a low-end clamp modelling screen flare.
+ * Mixing the two would silently mis-scale every Lc.
+ */
+function screenLuminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex);
+  const y =
+    (r / 255) ** MAIN_TRC * S_RCO + (g / 255) ** MAIN_TRC * S_GCO + (b / 255) ** MAIN_TRC * S_BCO;
+  return y > BLK_THRS ? y : y + (BLK_THRS - y) ** BLK_CLMP;
+}
+
+/**
+ * Signed Lc: positive for dark-on-light, negative for light-on-dark. Callers
+ * comparing weight across polarities want `Math.abs`; the sign is what tells
+ * you which way a correction has to move.
+ */
+export function apcaContrast(foregroundHex: string, backgroundHex: string): number {
+  const txtY = screenLuminance(foregroundHex);
+  const bgY = screenLuminance(backgroundHex);
+  if (Math.abs(bgY - txtY) < DELTA_Y_MIN) return 0;
+
+  if (bgY > txtY) {
+    const sapc = (bgY ** NORM_BG - txtY ** NORM_TXT) * SCALE_BOW;
+    return sapc < LO_CLIP ? 0 : (sapc - LO_BOW_OFFSET) * 100;
+  }
+
+  const sapc = (bgY ** REV_BG - txtY ** REV_TXT) * SCALE_WOB;
+  return sapc > -LO_CLIP ? 0 : (sapc + LO_WOB_OFFSET) * 100;
+}
+
+/** Unsigned perceived weight, which is what a target or a step is expressed in. */
+export function apcaLc(foregroundHex: string, backgroundHex: string): number {
+  return Math.abs(apcaContrast(foregroundHex, backgroundHex));
+}

--- a/shared/theme/index.ts
+++ b/shared/theme/index.ts
@@ -1,3 +1,4 @@
+export * from "./apca.js";
 export * from "./colorValidator.js";
 export * from "./contrast.js";
 export * from "./oklch.js";

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -28,7 +28,7 @@ import {
   X,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
-import { FolderTree, Folders } from "@/components/icons";
+import { BrandSurface, FolderTree, Folders } from "@/components/icons";
 import { buildPluginToolbarMeta } from "./pluginToolbarMeta";
 import {
   TOOLBAR_BUTTON_METADATA,
@@ -1986,248 +1986,252 @@ export function Toolbar({
 
   return (
     <header>
-      <div
-        ref={toolbarRef}
-        role="toolbar"
-        aria-label="Main toolbar"
-        onKeyDown={handleToolbarKeyDown}
-        onFocusCapture={handleToolbarFocusCapture}
-        className="@container/toolbar relative z-[60] grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] h-12 items-center px-4 pt-1 shrink-0 app-drag-region surface-toolbar border-b border-divider"
-      >
-        {!isLinux() && <div className="window-resize-strip" />}
-
-        {/* LEFT GROUP */}
+      {/* Brand marks in the toolbar are painted on the toolbar surface, not on
+          whichever surface the theme happens to make hardest. */}
+      <BrandSurface surface="surface-toolbar">
         <div
-          role="group"
-          aria-label="Navigation and agents"
-          className="flex items-center gap-1.5 z-20"
+          ref={toolbarRef}
+          role="toolbar"
+          aria-label="Main toolbar"
+          onKeyDown={handleToolbarKeyDown}
+          onFocusCapture={handleToolbarFocusCapture}
+          className="@container/toolbar relative z-[60] grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] h-12 items-center px-4 pt-1 shrink-0 app-drag-region surface-toolbar border-b border-divider"
         >
-          {isMac() && (
-            <div
-              data-fullscreen={isFullscreen ? "true" : undefined}
-              className={cn(
-                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
-                isFullscreen ? "w-0" : "w-16"
-              )}
-            />
-          )}
-          {/* Fixed chrome, never part of buttonRegistry/overflow: this is the
+          {!isLinux() && <div className="window-resize-strip" />}
+
+          {/* LEFT GROUP */}
+          <div
+            role="group"
+            aria-label="Navigation and agents"
+            className="flex items-center gap-1.5 z-20"
+          >
+            {isMac() && (
+              <div
+                data-fullscreen={isFullscreen ? "true" : undefined}
+                className={cn(
+                  "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
+                  isFullscreen ? "w-0" : "w-16"
+                )}
+              />
+            )}
+            {/* Fixed chrome, never part of buttonRegistry/overflow: this is the
               recovery surface for the application menu itself, so it must not
               be hideable or reorderable into an overflow popover (#11813).
               Gated here as well as inside the component so macOS doesn't keep
               an empty flex item, which would add a stray gap-1.5 column. */}
-          {!isMac() && (
-            <div className="app-no-drag">
-              <AppMenuButton />
-            </div>
-          )}
-          <div className="app-no-drag">{buttonRegistry["sidebar-toggle"]!.render()}</div>
-
-          <div className={toolbarDividerClass} />
-
-          <div
-            ref={leftGroupRef}
-            className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden"
-          >
-            {renderLeftButtons(effectiveLeftButtons, leftVisibleSet)}
-          </div>
-          <div className="app-no-drag">
-            {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
-          </div>
-        </div>
-
-        {/* CENTER GROUP - Grid-centered, shrinks gracefully on narrow windows */}
-        <div
-          role="group"
-          aria-label="Project"
-          className="app-no-drag relative flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
-        >
-          {/* Sibling of the pill, not a child — see ProjectIdentityEditor. */}
-          {currentProject && <ProjectIdentityEditor project={currentProject} />}
-          <Tooltip
-            open={workspaceIdentity.kind !== "none" ? pillTooltipOpen : false}
-            onOpenChange={
-              workspaceIdentity.kind !== "none" ? handlePillTooltipOpenChange : undefined
-            }
-          >
-            <ContextMenu>
-              {shouldMountProjectSwitcherDropdown ? (
-                <Suspense fallback={projectSwitcherTrigger}>
-                  <LazyProjectSwitcherPalette
-                    mode="dropdown"
-                    isOpen={isDropdownOpen}
-                    query={projectSwitcher.query}
-                    results={projectSwitcher.results}
-                    selectedIndex={projectSwitcher.selectedIndex}
-                    onQueryChange={projectSwitcher.setQuery}
-                    onSelectPrevious={projectSwitcher.selectPrevious}
-                    onSelectNext={projectSwitcher.selectNext}
-                    onSelect={projectSwitcher.selectRow}
-                    onHoverProject={projectSwitcher.onHoverProject}
-                    onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
-                    fleetLiveness={projectSwitcher.fleetLiveness}
-                    onClose={handlePillDropdownClose}
-                    onDropdownCloseAutoFocus={suppressPillTooltipForFocusRestore}
-                    onAddProject={projectSwitcher.addProject}
-                    onCloneRepo={projectSwitcher.cloneRepo}
-                    onStopProject={handleStopProject}
-                    onCloseProject={handleCloseProject}
-                    onSleepProject={handleSleepProject}
-                    onLocateProject={handleLocateProject}
-                    onMoveOrRenameProject={handleMoveOrRenameProject}
-                    onTogglePinProject={projectSwitcher.togglePinProject}
-                    onCopyPath={projectSwitcher.copyPath}
-                    onOpenProjectSettings={currentProject ? handleOpenProjectSettings : undefined}
-                    onSelectNewWindow={handleSelectNewWindow}
-                    dropdownAlign="center"
-                    removeConfirmProject={projectSwitcher.removeConfirmProject}
-                    onRemoveConfirmClose={handleRemoveConfirmClose}
-                    onConfirmRemove={projectSwitcher.confirmRemoveProject}
-                    isRemovingProject={projectSwitcher.isRemovingProject}
-                    sleepConfirmProject={projectSwitcher.sleepConfirmProject}
-                    onSleepConfirmClose={() => projectSwitcher.setSleepConfirmProject(null)}
-                    onConfirmSleep={projectSwitcher.confirmSleep}
-                    isSleepingProject={projectSwitcher.isSleepingProject}
-                    rankedSearch={projectSwitcher.isRankedSearch}
-                    scratchResults={projectSwitcher.scratchResults}
-                    onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
-                    onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
-                    onRequestDeleteScratch={projectSwitcher.requestDeleteScratch}
-                    deleteScratchConfirm={projectSwitcher.deleteScratchConfirm}
-                    onDismissDeleteScratchConfirm={projectSwitcher.dismissDeleteScratchConfirm}
-                    onConfirmDeleteScratch={() => void projectSwitcher.confirmDeleteScratch()}
-                    isDeletingScratch={projectSwitcher.isDeletingScratch}
-                    onRequestDeleteAllScratches={projectSwitcher.requestDeleteAllScratches}
-                    deleteAllScratchesConfirm={projectSwitcher.deleteAllScratchesConfirm}
-                    onDismissDeleteAllScratchesConfirm={
-                      projectSwitcher.dismissDeleteAllScratchesConfirm
-                    }
-                    onConfirmDeleteAllScratches={() =>
-                      void projectSwitcher.confirmDeleteAllScratches()
-                    }
-                    isDeletingAllScratches={projectSwitcher.isDeletingAllScratches}
-                    onRenameScratch={(scratchId, name) =>
-                      void projectSwitcher.renameScratch(scratchId, name)
-                    }
-                    onSaveAsProject={(scratchId) => void projectSwitcher.saveAsProject(scratchId)}
-                    saveAsProjectConfirm={projectSwitcher.saveAsProjectConfirm}
-                    onDismissSaveAsProjectConfirm={projectSwitcher.dismissSaveAsProjectConfirm}
-                    onConfirmDeleteOriginalScratch={() =>
-                      void projectSwitcher.confirmDeleteOriginalScratch()
-                    }
-                    isDeletingOriginalScratch={projectSwitcher.isDeletingOriginalScratch}
-                  >
-                    {projectSwitcherTrigger}
-                  </LazyProjectSwitcherPalette>
-                </Suspense>
-              ) : (
-                projectSwitcherTrigger
-              )}
-              {currentProject && (
-                <ContextMenuContent
-                  className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto"
-                  onCloseAutoFocus={(e) => {
-                    suppressPillTooltipForFocusRestore();
-                    e.preventDefault();
-                  }}
-                >
-                  <ContextMenuItem onSelect={handlePillTogglePin}>
-                    {activeSearchableProject?.isPinned ? (
-                      <>
-                        <PinOff className="mr-2 h-3.5 w-3.5" />
-                        Unpin project
-                      </>
-                    ) : (
-                      <>
-                        <Pin className="mr-2 h-3.5 w-3.5" />
-                        Pin project
-                      </>
-                    )}
-                  </ContextMenuItem>
-                  <ContextMenuItem onSelect={handleCopyProjectPath}>
-                    <Clipboard className="mr-2 h-3.5 w-3.5" />
-                    Copy path
-                  </ContextMenuItem>
-                  <ContextMenuSeparator />
-                  <ContextMenuItem onSelect={handleOpenProjectSettings}>
-                    Project settings
-                  </ContextMenuItem>
-                  {activeSearchableProject && activeSearchableProject.processCount > 0 && (
-                    <ContextMenuItem onSelect={() => handleStopProject(currentProject.id)}>
-                      <Square className="mr-2 h-3.5 w-3.5" />
-                      Stop all agents
-                    </ContextMenuItem>
-                  )}
-                  <ContextMenuItem
-                    onSelect={() => handleCloseProject(currentProject.id)}
-                    className="text-status-error focus:text-status-error"
-                  >
-                    <X className="mr-2 h-3.5 w-3.5" />
-                    Close project
-                  </ContextMenuItem>
-                </ContextMenuContent>
-              )}
-            </ContextMenu>
-            {currentProject && (
-              <TooltipContent side="bottom" className="max-w-[28rem]">
-                <div className="flex flex-col gap-0.5">
-                  <div className="text-xs font-medium">
-                    {currentProject.name}
-                    {branchName ? ` · ${branchName}` : ""}
-                  </div>
-                  <div className="text-text-muted font-mono text-[11px] truncate">
-                    {currentProject.path}
-                  </div>
-                </div>
-              </TooltipContent>
+            {!isMac() && (
+              <div className="app-no-drag">
+                <AppMenuButton />
+              </div>
             )}
-            {!currentProject && currentScratch && (
-              <TooltipContent side="bottom" className="max-w-[28rem]">
-                <div className="flex flex-col gap-0.5">
-                  <div className="text-xs font-medium">{currentScratch.name}</div>
-                  <div className="text-text-muted text-[11px]">Scratch workspace</div>
-                </div>
-              </TooltipContent>
-            )}
-          </Tooltip>
-        </div>
+            <div className="app-no-drag">{buttonRegistry["sidebar-toggle"]!.render()}</div>
 
-        {/* RIGHT GROUP */}
-        <div
-          role="group"
-          aria-label="Tools and settings"
-          className="flex items-center justify-end gap-1.5 z-20"
-        >
-          <div
-            ref={rightGroupRef}
-            className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden justify-end"
-          >
-            {renderButtons(effectiveRightButtons, rightVisibleSet)}
-          </div>
-          <div className="app-no-drag">
-            {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
-          </div>
+            <div className={toolbarDividerClass} />
 
-          <div className={toolbarDividerClass} />
-
-          <div className="app-no-drag flex items-center gap-0.5">
-            {buttonRegistry["assistant-toggle"]!.render()}
-            {buttonRegistry["portal-toggle"]!.render()}
-          </div>
-
-          {isWindows() && (
             <div
-              aria-hidden="true"
-              data-fullscreen={isFullscreen ? "true" : undefined}
-              className={cn(
-                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
-                isFullscreen && "w-0"
+              ref={leftGroupRef}
+              className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden"
+            >
+              {renderLeftButtons(effectiveLeftButtons, leftVisibleSet)}
+            </div>
+            <div className="app-no-drag">
+              {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
+            </div>
+          </div>
+
+          {/* CENTER GROUP - Grid-centered, shrinks gracefully on narrow windows */}
+          <div
+            role="group"
+            aria-label="Project"
+            className="app-no-drag relative flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
+          >
+            {/* Sibling of the pill, not a child — see ProjectIdentityEditor. */}
+            {currentProject && <ProjectIdentityEditor project={currentProject} />}
+            <Tooltip
+              open={workspaceIdentity.kind !== "none" ? pillTooltipOpen : false}
+              onOpenChange={
+                workspaceIdentity.kind !== "none" ? handlePillTooltipOpenChange : undefined
+              }
+            >
+              <ContextMenu>
+                {shouldMountProjectSwitcherDropdown ? (
+                  <Suspense fallback={projectSwitcherTrigger}>
+                    <LazyProjectSwitcherPalette
+                      mode="dropdown"
+                      isOpen={isDropdownOpen}
+                      query={projectSwitcher.query}
+                      results={projectSwitcher.results}
+                      selectedIndex={projectSwitcher.selectedIndex}
+                      onQueryChange={projectSwitcher.setQuery}
+                      onSelectPrevious={projectSwitcher.selectPrevious}
+                      onSelectNext={projectSwitcher.selectNext}
+                      onSelect={projectSwitcher.selectRow}
+                      onHoverProject={projectSwitcher.onHoverProject}
+                      onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
+                      fleetLiveness={projectSwitcher.fleetLiveness}
+                      onClose={handlePillDropdownClose}
+                      onDropdownCloseAutoFocus={suppressPillTooltipForFocusRestore}
+                      onAddProject={projectSwitcher.addProject}
+                      onCloneRepo={projectSwitcher.cloneRepo}
+                      onStopProject={handleStopProject}
+                      onCloseProject={handleCloseProject}
+                      onSleepProject={handleSleepProject}
+                      onLocateProject={handleLocateProject}
+                      onMoveOrRenameProject={handleMoveOrRenameProject}
+                      onTogglePinProject={projectSwitcher.togglePinProject}
+                      onCopyPath={projectSwitcher.copyPath}
+                      onOpenProjectSettings={currentProject ? handleOpenProjectSettings : undefined}
+                      onSelectNewWindow={handleSelectNewWindow}
+                      dropdownAlign="center"
+                      removeConfirmProject={projectSwitcher.removeConfirmProject}
+                      onRemoveConfirmClose={handleRemoveConfirmClose}
+                      onConfirmRemove={projectSwitcher.confirmRemoveProject}
+                      isRemovingProject={projectSwitcher.isRemovingProject}
+                      sleepConfirmProject={projectSwitcher.sleepConfirmProject}
+                      onSleepConfirmClose={() => projectSwitcher.setSleepConfirmProject(null)}
+                      onConfirmSleep={projectSwitcher.confirmSleep}
+                      isSleepingProject={projectSwitcher.isSleepingProject}
+                      rankedSearch={projectSwitcher.isRankedSearch}
+                      scratchResults={projectSwitcher.scratchResults}
+                      onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
+                      onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
+                      onRequestDeleteScratch={projectSwitcher.requestDeleteScratch}
+                      deleteScratchConfirm={projectSwitcher.deleteScratchConfirm}
+                      onDismissDeleteScratchConfirm={projectSwitcher.dismissDeleteScratchConfirm}
+                      onConfirmDeleteScratch={() => void projectSwitcher.confirmDeleteScratch()}
+                      isDeletingScratch={projectSwitcher.isDeletingScratch}
+                      onRequestDeleteAllScratches={projectSwitcher.requestDeleteAllScratches}
+                      deleteAllScratchesConfirm={projectSwitcher.deleteAllScratchesConfirm}
+                      onDismissDeleteAllScratchesConfirm={
+                        projectSwitcher.dismissDeleteAllScratchesConfirm
+                      }
+                      onConfirmDeleteAllScratches={() =>
+                        void projectSwitcher.confirmDeleteAllScratches()
+                      }
+                      isDeletingAllScratches={projectSwitcher.isDeletingAllScratches}
+                      onRenameScratch={(scratchId, name) =>
+                        void projectSwitcher.renameScratch(scratchId, name)
+                      }
+                      onSaveAsProject={(scratchId) => void projectSwitcher.saveAsProject(scratchId)}
+                      saveAsProjectConfirm={projectSwitcher.saveAsProjectConfirm}
+                      onDismissSaveAsProjectConfirm={projectSwitcher.dismissSaveAsProjectConfirm}
+                      onConfirmDeleteOriginalScratch={() =>
+                        void projectSwitcher.confirmDeleteOriginalScratch()
+                      }
+                      isDeletingOriginalScratch={projectSwitcher.isDeletingOriginalScratch}
+                    >
+                      {projectSwitcherTrigger}
+                    </LazyProjectSwitcherPalette>
+                  </Suspense>
+                ) : (
+                  projectSwitcherTrigger
+                )}
+                {currentProject && (
+                  <ContextMenuContent
+                    className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto"
+                    onCloseAutoFocus={(e) => {
+                      suppressPillTooltipForFocusRestore();
+                      e.preventDefault();
+                    }}
+                  >
+                    <ContextMenuItem onSelect={handlePillTogglePin}>
+                      {activeSearchableProject?.isPinned ? (
+                        <>
+                          <PinOff className="mr-2 h-3.5 w-3.5" />
+                          Unpin project
+                        </>
+                      ) : (
+                        <>
+                          <Pin className="mr-2 h-3.5 w-3.5" />
+                          Pin project
+                        </>
+                      )}
+                    </ContextMenuItem>
+                    <ContextMenuItem onSelect={handleCopyProjectPath}>
+                      <Clipboard className="mr-2 h-3.5 w-3.5" />
+                      Copy path
+                    </ContextMenuItem>
+                    <ContextMenuSeparator />
+                    <ContextMenuItem onSelect={handleOpenProjectSettings}>
+                      Project settings
+                    </ContextMenuItem>
+                    {activeSearchableProject && activeSearchableProject.processCount > 0 && (
+                      <ContextMenuItem onSelect={() => handleStopProject(currentProject.id)}>
+                        <Square className="mr-2 h-3.5 w-3.5" />
+                        Stop all agents
+                      </ContextMenuItem>
+                    )}
+                    <ContextMenuItem
+                      onSelect={() => handleCloseProject(currentProject.id)}
+                      className="text-status-error focus:text-status-error"
+                    >
+                      <X className="mr-2 h-3.5 w-3.5" />
+                      Close project
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                )}
+              </ContextMenu>
+              {currentProject && (
+                <TooltipContent side="bottom" className="max-w-[28rem]">
+                  <div className="flex flex-col gap-0.5">
+                    <div className="text-xs font-medium">
+                      {currentProject.name}
+                      {branchName ? ` · ${branchName}` : ""}
+                    </div>
+                    <div className="text-text-muted font-mono text-[11px] truncate">
+                      {currentProject.path}
+                    </div>
+                  </div>
+                </TooltipContent>
               )}
-              style={isFullscreen ? undefined : { width: `${WINDOWS_CAPTION_WIDTH_PX}px` }}
-            />
-          )}
+              {!currentProject && currentScratch && (
+                <TooltipContent side="bottom" className="max-w-[28rem]">
+                  <div className="flex flex-col gap-0.5">
+                    <div className="text-xs font-medium">{currentScratch.name}</div>
+                    <div className="text-text-muted text-[11px]">Scratch workspace</div>
+                  </div>
+                </TooltipContent>
+              )}
+            </Tooltip>
+          </div>
+
+          {/* RIGHT GROUP */}
+          <div
+            role="group"
+            aria-label="Tools and settings"
+            className="flex items-center justify-end gap-1.5 z-20"
+          >
+            <div
+              ref={rightGroupRef}
+              className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden justify-end"
+            >
+              {renderButtons(effectiveRightButtons, rightVisibleSet)}
+            </div>
+            <div className="app-no-drag">
+              {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
+            </div>
+
+            <div className={toolbarDividerClass} />
+
+            <div className="app-no-drag flex items-center gap-0.5">
+              {buttonRegistry["assistant-toggle"]!.render()}
+              {buttonRegistry["portal-toggle"]!.render()}
+            </div>
+
+            {isWindows() && (
+              <div
+                aria-hidden="true"
+                data-fullscreen={isFullscreen ? "true" : undefined}
+                className={cn(
+                  "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
+                  isFullscreen && "w-0"
+                )}
+                style={isFullscreen ? undefined : { width: `${WINDOWS_CAPTION_WIDTH_PX}px` }}
+              />
+            )}
+          </div>
         </div>
-      </div>
+      </BrandSurface>
     </header>
   );
 }

--- a/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
@@ -35,7 +35,16 @@ describe("ARIA page landmarks — issue #5416", () => {
       // The roving-tabindex contract relies on toolbarRef pointing at the
       // role=toolbar container so its [data-toolbar-item] descendants can be
       // queried. Moving the ref onto <header> would break that lookup.
-      expect(source).toMatch(/<header>\s*<div\s+ref=\{toolbarRef\}\s+role="toolbar"/);
+      //
+      // Matched on the div rather than on `<header>` being adjacent to it: the
+      // toolbar's brand marks are wrapped in a `BrandSurface` provider, which
+      // renders no DOM of its own and so leaves the landmark shape untouched
+      // while sitting between the two tags in source.
+      expect(source).toMatch(/<div\s+ref=\{toolbarRef\}\s+role="toolbar"/);
+      expect(source).not.toMatch(/<header[^>]*(?:role=|ref=)/);
+      // The banner still has to CONTAIN the toolbar — only a provider, which
+      // renders no DOM, is allowed between the two tags.
+      expect(source).toMatch(/<header>[\s\S]{0,400}?<div\s+ref=\{toolbarRef\}\s+role="toolbar"/);
     });
   });
 

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -89,6 +89,7 @@ import { fireWatchNotification } from "@/lib/watchNotification";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import type { TerminalChromeDescriptor } from "@/utils/terminalChrome";
+import type { BrandMarkSurface } from "@/lib/brandIcon";
 
 export interface PanelHeaderProps {
   id: string;
@@ -625,6 +626,22 @@ function PanelHeaderComponent({
   const headerHasDrag = !!dragListeners;
   const headerActivatorRef = headerHasDrag ? dragHandle?.setActivatorNodeRef : undefined;
 
+  // The backdrop this title bar's brand marks are measured against — the same
+  // colour the header paints below, named rather than re-derived. Several light
+  // themes repaint title bars outright through `panel-header-*`, so the
+  // extension is part of the answer rather than a refinement of it.
+  const brandSurface: BrandMarkSurface = isMaximized
+    ? { surface: "surface-sidebar" }
+    : location === "dock"
+      ? { surface: "surface-panel" }
+      : isFocused || isSelected
+        ? {
+            surface: "surface-panel",
+            extension: "panel-header-focus-bg",
+            lift: "overlay-subtle",
+          }
+        : { surface: "surface-panel", extension: "panel-header-bg" };
+
   return (
     // Compact density supplies the shared frame (h-8, px-3, border-b
     // border-divider, flex alignment, shrink-0); everything panel-only —
@@ -633,6 +650,7 @@ function PanelHeaderComponent({
     // primitive.
     <SurfaceHeader
       density="compact"
+      brandSurface={brandSurface}
       ref={headerActivatorRef}
       {...dragListeners}
       tabIndex={headerHasDrag ? 0 : undefined}
@@ -750,7 +768,14 @@ function PanelHeaderComponent({
         )
       ) : (
         <div className="flex items-center gap-2 min-w-0">
-          <span className="shrink-0 flex items-center justify-center w-3.5 h-3.5 text-daintree-text">
+          {/* The pane you are working in wears its agent's real brand colour;
+              the ones you are not sit a step back. `data-brand-active` goes on
+              the glyph's own wrapper rather than the header so it cannot leak
+              onto the tab strip, where selection is each tab's to signal. */}
+          <span
+            data-brand-active={isFocused || isSelected || undefined}
+            className="shrink-0 flex items-center justify-center w-3.5 h-3.5 text-daintree-text"
+          >
             <TerminalIcon
               kind={kind}
               chrome={chrome}

--- a/src/components/Terminal/__tests__/TerminalIcon.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalIcon.test.tsx
@@ -83,7 +83,7 @@ describe("TerminalIcon", () => {
     const svg = icon?.querySelector("svg");
     expect(svg?.querySelector("path")?.getAttribute("fill")).toBe("currentColor");
     expect(svg?.style.getPropertyValue("--brand-mark-rest")).toMatch(/^#[0-9a-f]{6}$/i);
-    expect(svg?.style.getPropertyValue("--brand-mark-hover")).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(svg?.style.getPropertyValue("--brand-mark-active")).toMatch(/^#[0-9a-f]{6}$/i);
   });
 
   it("lets an explicit brandColor override the chrome color marker", () => {

--- a/src/components/icons/BrandMark.tsx
+++ b/src/components/icons/BrandMark.tsx
@@ -1,6 +1,7 @@
 import { cloneElement, type CSSProperties, type ReactElement } from "react";
 import { cn } from "@/lib/utils";
 import { resolveBrandMarkInk } from "@/lib/brandIcon";
+import { useBrandSurface } from "./BrandSurface";
 import { useActiveAppScheme } from "@/hooks/useActiveAppScheme";
 
 interface BrandMarkProps {
@@ -14,15 +15,20 @@ interface BrandMarkProps {
  * `currentColor` — nothing hands a colour to an SVG — so this is the one place
  * that decides what a logo is allowed to look like on the active theme.
  *
- * Publishes the resting and hover inks as custom properties and tags the glyph
+ * Publishes the resting and active inks as custom properties and tags the glyph
  * with `.brand-mark`; `src/index.css` reads both and owns the swap, which is
- * what gets keyboard focus the same treatment as the mouse without every call
- * site wiring up hover state. Deliberately no inline `color`: an inline
- * declaration outranks the `:hover` rule and would strand the mark at rest.
+ * what gets keyboard focus, a selected tab and a focused panel the same
+ * treatment as the mouse without every call site wiring up state. Deliberately
+ * no inline `color`: an inline declaration outranks those rules and would
+ * strand the mark at rest.
+ *
+ * The inks answer to the backdrop the mark is painted on, which `BrandSurface`
+ * declares on the container above.
  */
 export function BrandMark({ brandColor, className, children }: BrandMarkProps) {
   const scheme = useActiveAppScheme();
-  const ink = resolveBrandMarkInk(brandColor, scheme);
+  const surface = useBrandSurface();
+  const ink = resolveBrandMarkInk(brandColor, scheme, surface);
   // `cn` collapses to "" when nothing is supplied; pass className only when it
   // has content so the untouched path leaves the child's props exactly as they were.
   const merged = cn(children.props.className, ink && "brand-mark", className);
@@ -38,7 +44,7 @@ export function BrandMark({ brandColor, className, children }: BrandMarkProps) {
     style: {
       ...children.props.style,
       "--brand-mark-rest": ink.rest,
-      "--brand-mark-hover": ink.hover,
+      "--brand-mark-active": ink.active,
     } as CSSProperties,
   });
 }

--- a/src/components/icons/BrandSurface.tsx
+++ b/src/components/icons/BrandSurface.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { BrandMarkSurface } from "@/lib/brandIcon";
+
+const BrandSurfaceContext = createContext<BrandMarkSurface | null>(null);
+
+/**
+ * Declares which surface the brand marks below it are painted on.
+ *
+ * A mark's two inks are placed by measuring against their backdrop, so the
+ * backdrop has to be known. Without this the resolver falls back to the theme's
+ * hardest surface, which is safe everywhere and generous nowhere — it spends
+ * the whole contrast budget on a surface the mark may not even be sitting on.
+ *
+ * Providers go on containers, not call sites: one on a panel title bar covers
+ * the header glyph and every tab in the strip. `lift` names an overlay the
+ * container already composites over `surface` in its current state — a focused
+ * panel header is `surface-panel` *plus* its focus lift, and measuring the bare
+ * token there would answer for a pixel that is not on screen.
+ */
+export function BrandSurface({
+  surface,
+  extension,
+  lift,
+  children,
+}: BrandMarkSurface & { children: ReactNode }) {
+  // Destructured to primitives and rebuilt, so a caller passing a fresh object
+  // literal every render does not re-render every mark below it.
+  const value = useMemo(() => ({ surface, extension, lift }), [surface, extension, lift]);
+  return <BrandSurfaceContext.Provider value={value}>{children}</BrandSurfaceContext.Provider>;
+}
+
+/**
+ * Withdraws whatever surface an ancestor declared.
+ *
+ * For floating material — menus, popovers — whose backdrop is a blur over
+ * whatever happens to be behind it. React context reaches through a portal even
+ * though the DOM does not, so a menu opened from the toolbar would otherwise
+ * measure its marks against the toolbar. Declining sends them back to the
+ * conservative fallback, which is the honest answer for a surface no one can
+ * name.
+ */
+export function BrandSurfaceReset({ children }: { children: ReactNode }) {
+  return <BrandSurfaceContext.Provider value={null}>{children}</BrandSurfaceContext.Provider>;
+}
+
+export function useBrandSurface(): BrandMarkSurface | null {
+  return useContext(BrandSurfaceContext);
+}

--- a/src/components/icons/__tests__/BrandMark.test.tsx
+++ b/src/components/icons/__tests__/BrandMark.test.tsx
@@ -2,6 +2,7 @@
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BrandMark } from "../BrandMark";
+import { BrandSurface, BrandSurfaceReset } from "../BrandSurface";
 
 const resolveInkMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/brandIcon", () => ({
@@ -15,7 +16,7 @@ function TestIcon({ className, style }: { className?: string; style?: React.CSSP
   return <svg data-testid="icon" className={className} style={style} />;
 }
 
-const INK = { rest: "#9a8b84", hover: "#cc785c" };
+const INK = { rest: "#9a8b84", active: "#cc785c" };
 
 beforeEach(() => {
   resolveInkMock.mockReset();
@@ -33,13 +34,13 @@ describe("BrandMark", () => {
 
     const icon = getByTestId("icon");
     expect(icon.style.getPropertyValue("--brand-mark-rest")).toBe(INK.rest);
-    expect(icon.style.getPropertyValue("--brand-mark-hover")).toBe(INK.hover);
+    expect(icon.style.getPropertyValue("--brand-mark-active")).toBe(INK.active);
     expect(icon.getAttribute("class")).toContain("brand-mark");
   });
 
-  it("never sets colour inline, so the hover rule can win", () => {
+  it("never sets colour inline, so the active rule can win", () => {
     // An inline `color` outranks `button:hover .brand-mark` and would strand the
-    // mark at its resting tint for the whole interaction.
+    // mark at its resting colour for the whole interaction.
     resolveInkMock.mockReturnValue(INK);
 
     const { getByTestId } = render(
@@ -52,6 +53,47 @@ describe("BrandMark", () => {
     expect(style.color).toBe("");
     expect(style.backgroundColor).toBe("");
     expect(style.filter).toBe("");
+  });
+
+  it("hands the resolver the whole surface descriptor, not part of it", () => {
+    // The bug this pins shipped once: the provider destructured `surface` and
+    // `lift` and quietly dropped `extension`, so the panel-header backgrounds
+    // several light themes paint never reached the resolver and every mark in a
+    // title bar was measured against a colour that was not on screen. Resolver
+    // tests could not see it — they pass the descriptor directly.
+    resolveInkMock.mockReturnValue(INK);
+
+    render(
+      <BrandSurface surface="surface-panel" extension="panel-header-focus-bg" lift="overlay-subtle">
+        <BrandMark brandColor="#cc785c">
+          <TestIcon />
+        </BrandMark>
+      </BrandSurface>
+    );
+
+    expect(resolveInkMock).toHaveBeenCalledWith("#cc785c", expect.anything(), {
+      surface: "surface-panel",
+      extension: "panel-header-focus-bg",
+      lift: "overlay-subtle",
+    });
+  });
+
+  it("withdraws the surface for floating material", () => {
+    // Context reaches through a portal even though the DOM does not, so a menu
+    // opened from the toolbar would measure against the toolbar without this.
+    resolveInkMock.mockReturnValue(INK);
+
+    render(
+      <BrandSurface surface="surface-toolbar">
+        <BrandSurfaceReset>
+          <BrandMark brandColor="#cc785c">
+            <TestIcon />
+          </BrandMark>
+        </BrandSurfaceReset>
+      </BrandSurface>
+    );
+
+    expect(resolveInkMock).toHaveBeenCalledWith("#cc785c", expect.anything(), null);
   });
 
   it("renders no wrapper element around the glyph", () => {

--- a/src/components/icons/__tests__/brandIconsRender.test.tsx
+++ b/src/components/icons/__tests__/brandIconsRender.test.tsx
@@ -3,12 +3,10 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AGENT_ICON_MAP } from "@/config/agentIcons";
 import { AGENT_REGISTRY } from "@/config/agents";
-import { BUILT_IN_APP_SCHEMES } from "@shared/theme";
 import { BrandMark } from "../BrandMark";
 import { ClaudeIcon } from "../brands/ClaudeIcon";
 import { KiroIcon } from "../brands/KiroIcon";
 
-const scheme = BUILT_IN_APP_SCHEMES[0]!;
 vi.mock("@/hooks/useActiveAppScheme", async () => {
   const { BUILT_IN_APP_SCHEMES: schemes } = await import("@shared/theme");
   return { useActiveAppScheme: () => schemes[0]! };
@@ -103,7 +101,7 @@ describe("brand icons paint from the ink BrandMark chose", () => {
       const svg = result.container.querySelector("svg")!;
       return {
         rest: svg.style.getPropertyValue("--brand-mark-rest"),
-        hover: svg.style.getPropertyValue("--brand-mark-hover"),
+        active: svg.style.getPropertyValue("--brand-mark-active"),
       };
     };
     const warm = read(render1);
@@ -111,15 +109,15 @@ describe("brand icons paint from the ink BrandMark chose", () => {
 
     for (const ink of [warm, cyan]) {
       expect(ink.rest).toMatch(/^#[0-9a-f]{6}$/i);
-      expect(ink.hover).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(ink.active).toMatch(/^#[0-9a-f]{6}$/i);
     }
     // Different brand colours must produce different inks, or the colour is not
     // reaching the resolver at all.
     expect(warm.rest).not.toBe(cyan.rest);
-    expect(warm.hover).not.toBe(cyan.hover);
-    // And the resting ink must actually be derived from the active theme rather
-    // than from the brand hex alone.
+    expect(warm.active).not.toBe(cyan.active);
+    // And the resting ink must be a faded version of the brand rather than the
+    // brand hex handed straight through.
     expect(warm.rest.toLowerCase()).not.toBe("#cc785c");
-    expect(scheme.tokens["text-secondary"]).toBeTruthy();
+    expect(warm.rest.toLowerCase()).not.toBe(warm.active.toLowerCase());
   });
 });

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -2,6 +2,7 @@ export { DaintreeIcon } from "./DaintreeIcon";
 export { McpServerIcon } from "./McpServerIcon";
 export * from "./AgentStateCircles";
 export { BrandMark } from "./BrandMark";
+export { BrandSurface, BrandSurfaceReset, useBrandSurface } from "./BrandSurface";
 export * from "./brands";
 
 // Daintree's product-concept icons resolve to Lucide icons. Re-exported

--- a/src/components/ui/SurfaceHeader.tsx
+++ b/src/components/ui/SurfaceHeader.tsx
@@ -3,6 +3,8 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { BrandSurface } from "@/components/icons";
+import type { BrandMarkSurface } from "@/lib/brandIcon";
 
 // Full literal strings per density rather than a shared base: the comfortable
 // output stays byte-identical to the markup the 35 AppDialog consumers render
@@ -23,14 +25,20 @@ const surfaceHeaderVariants = cva("", {
 export interface SurfaceHeaderProps
   extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof surfaceHeaderVariants> {
   children: React.ReactNode;
+  /**
+   * The backdrop this header paints, for the brand marks inside it. Declared
+   * here rather than wrapped at the call site so a header can name its own
+   * surface without re-nesting its whole subtree — the provider renders no DOM.
+   */
+  brandSurface?: BrandMarkSurface;
 }
 
 // Composition stays open (children, not leading/trailing slots): consumers nest
 // search rows, badge clusters and multi-line title stacks inside the frame.
 const SurfaceHeader = React.forwardRef<HTMLDivElement, SurfaceHeaderProps>(
-  ({ density, className, children, ...props }, ref) => (
+  ({ density, className, children, brandSurface, ...props }, ref) => (
     <div ref={ref} className={cn(surfaceHeaderVariants({ density }), className)} {...props}>
-      {children}
+      {brandSurface ? <BrandSurface {...brandSurface}>{children}</BrandSurface> : children}
     </div>
   )
 );

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import type * as DropdownMenuPrimitiveType from "@radix-ui/react-dropdown-menu";
 import { Slot } from "@radix-ui/react-slot";
 import { Check, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { BrandSurfaceReset } from "@/components/icons/BrandSurface";
 import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
@@ -266,22 +267,30 @@ const DropdownMenuContent = React.forwardRef<
   const Content = radix.DropdownMenuPrimitive.Content;
   return (
     <Portal>
-      <Content
-        ref={shadowRef}
-        sideOffset={sideOffset}
-        style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
-        className={cn(
-          "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
-          className
-        )}
-        {...props}
-        data-dock-popover-child={isDockPopoverChild ? "" : undefined}
-      >
-        {topShadow}
-        {children}
-        {bottomShadow}
-      </Content>
+      {/* Context reaches through a portal even though the DOM does not, so a
+          menu opened from the toolbar would otherwise measure its brand marks
+          against the toolbar's surface instead of this floating one. */}
+      <BrandSurfaceReset>
+        <Content
+          ref={shadowRef}
+          sideOffset={sideOffset}
+          style={{
+            transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)",
+            ...style,
+          }}
+          className={cn(
+            "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+            className
+          )}
+          {...props}
+          data-dock-popover-child={isDockPopoverChild ? "" : undefined}
+        >
+          {topShadow}
+          {children}
+          {bottomShadow}
+        </Content>
+      </BrandSurfaceReset>
     </Portal>
   );
 });

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import type * as PopoverPrimitiveType from "@radix-ui/react-popover";
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@/lib/utils";
+import { BrandSurfaceReset } from "@/components/icons/BrandSurface";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 
 let portalBoundary: HTMLDivElement | null = null;
@@ -225,21 +226,26 @@ const PopoverContent = React.forwardRef<
   const Content = radix.PopoverPrimitive.Content;
   return (
     <Portal>
-      <Content
-        ref={ref}
-        align={align}
-        sideOffset={sideOffset}
-        collisionBoundary={collisionBoundary ?? boundary ?? undefined}
-        style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
-        className={cn(
-          "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
-          className
-        )}
-        {...props}
-        // Internal reposition trigger must win over any caller-supplied value.
-        data-reposition-tick={repositionTick}
-      />
+      {/* Context reaches through a portal even though the DOM does not, so a
+          popover opened from the toolbar would otherwise measure its brand
+          marks against the toolbar's surface instead of this floating one. */}
+      <BrandSurfaceReset>
+        <Content
+          ref={ref}
+          align={align}
+          sideOffset={sideOffset}
+          collisionBoundary={collisionBoundary ?? boundary ?? undefined}
+          style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
+          className={cn(
+            "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+            className
+          )}
+          {...props}
+          // Internal reposition trigger must win over any caller-supplied value.
+          data-reposition-tick={repositionTick}
+        />
+      </BrandSurfaceReset>
     </Portal>
   );
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1930,10 +1930,10 @@ body,
 
 /* Third-party brand marks (agent and product logos). These carry vendor hexes
    from `AgentConfig.color`, not theme tokens, so they sit outside the semantic
-   palette entirely. `BrandMark.tsx` resolves both inks and publishes them here:
-   at rest the mark wears the theme's own icon-ink lightness pulled toward the
-   brand hue, so a row of them reads as icons rather than as logos; the full
-   brand colour is the hover reveal, where identity actually matters.
+   palette entirely. `BrandMark.tsx` resolves both inks against the backdrop the
+   mark is actually painted on and publishes them here: at rest the brand colour
+   one perceptual step back, and the brand colour itself once the mark is active
+   — hovered, keyboard-focused, in a selected tab, or in a focused panel.
 
    Unlayered on purpose — a Tailwind `text-*` utility on the same glyph sits in
    `@layer utilities` and would otherwise win, repainting a mark the resolver
@@ -1950,7 +1950,13 @@ body,
    rule covers a listbox row the keyboard has landed on without the row itself
    taking focus. `label` is here because the onboarding agent rows wrap their
    checkbox in one, and `:focus-within` is that row's keyboard state: focus
-   lands on the input inside, never on the label. */
+   lands on the input inside, never on the label.
+
+   Selection is the third way in, and it is not transient: the selected tab and
+   the focused panel's title bar hold the brand colour for as long as they are
+   the ones you are working in. `[data-brand-active]` is what a container sets
+   when its own notion of "active" is neither hover nor a standard ARIA
+   selection — a focused panel header being the case that asked for it. */
 a:hover .brand-mark,
 button:hover .brand-mark,
 label:hover .brand-mark,
@@ -1964,8 +1970,10 @@ label:focus-within .brand-mark,
 [role="menuitem"]:focus-visible .brand-mark,
 [role="tab"]:focus-visible .brand-mark,
 [role="option"][aria-selected="true"] .brand-mark,
+[role="tab"][aria-selected="true"] .brand-mark,
+[data-brand-active] .brand-mark,
 :focus-visible > .brand-mark {
-  color: var(--brand-mark-hover);
+  color: var(--brand-mark-active);
 }
 
 /* Panel Agent State Borders — grid panel container state-driven styling */

--- a/src/lib/__tests__/brandIcon.test.ts
+++ b/src/lib/__tests__/brandIcon.test.ts
@@ -1,19 +1,14 @@
 import { describe, expect, it } from "vitest";
-import {
-  clampChroma,
-  converter,
-  formatHex,
-  modeOklch,
-  modeRgb,
-  useMode as registerMode,
-} from "culori/fn";
-import { blendOverBackground, contrastRatio, parseRgba } from "@shared/theme";
+import { converter, modeOklab, modeOklch, modeRgb, useMode as registerMode } from "culori/fn";
+import { apcaLc, blendOverBackground, contrastRatio, parseRgba } from "@shared/theme";
 import type { AppColorScheme } from "@shared/theme";
-import { resolveBrandMarkInk } from "../brandIcon";
+import { resolveBrandMarkInk, type BrandMarkSurface } from "../brandIcon";
 
 registerMode(modeRgb);
 registerMode(modeOklch);
+registerMode(modeOklab);
 const toOklch = converter("oklch");
+const toOklab = converter("oklab");
 
 const FLOOR = 3;
 
@@ -25,19 +20,25 @@ const SURFACE_KEYS = [
   "surface-panel-elevated",
 ] as const;
 
-function makeScheme(type: "dark" | "light", tokens: Record<string, string>): AppColorScheme {
+function makeScheme(
+  type: "dark" | "light",
+  tokens: Record<string, string>,
+  extensions?: Record<string, string>
+): AppColorScheme {
   return {
     id: "test",
     name: "Test",
     type,
     builtin: true,
     tokens: tokens as AppColorScheme["tokens"],
+    ...(extensions ? { extensions: extensions as AppColorScheme["extensions"] } : null),
   };
 }
 
 const DARK = makeScheme("dark", {
   "text-secondary": "#a8a8a8",
   "overlay-elevated": "rgba(255, 255, 255, 0.06)",
+  "overlay-subtle": "rgba(255, 255, 255, 0.03)",
   "surface-grid": "#141414",
   "surface-sidebar": "#181818",
   "surface-canvas": "#101010",
@@ -48,6 +49,7 @@ const DARK = makeScheme("dark", {
 const LIGHT = makeScheme("light", {
   "text-secondary": "#525252",
   "overlay-elevated": "rgba(0, 0, 0, 0.1)",
+  "overlay-subtle": "rgba(0, 0, 0, 0.04)",
   "surface-grid": "#f4f4f4",
   "surface-sidebar": "#efefef",
   "surface-canvas": "#ffffff",
@@ -55,17 +57,13 @@ const LIGHT = makeScheme("light", {
   "surface-panel-elevated": "#ffffff",
 });
 
-/** Rebuilds the backdrop set independently of the resolver's own helper. */
-function backdrops(scheme: AppColorScheme): string[] {
-  const overlay = parseRgba(scheme.tokens["overlay-elevated"] ?? "");
-  return SURFACE_KEYS.flatMap((key) => {
-    const base = scheme.tokens[key]!;
-    return overlay ? [base, blendOverBackground(overlay.hex, base, overlay.opacity)] : [base];
-  });
-}
+const PANEL: BrandMarkSurface = { surface: "surface-panel" };
 
-function worstRatio(ink: string, scheme: AppColorScheme): number {
-  return Math.min(...backdrops(scheme).map((bg) => contrastRatio(ink, bg)));
+/** The two backdrops a mark on `surface` actually meets: at rest, and under hover. */
+function backdrops(scheme: AppColorScheme, surface: BrandMarkSurface, base?: string) {
+  const overlay = parseRgba(scheme.tokens["overlay-elevated"] ?? "");
+  const rest = base ?? scheme.tokens[surface.surface]!;
+  return { rest, active: blendOverBackground(overlay!.hex, rest, overlay!.opacity) };
 }
 
 /** Channel-wise sRGB interpolation, matching how a `color` transition crossfades. */
@@ -80,6 +78,39 @@ function mix(from: string, to: string, ratio: number): string {
   return `#${channels.join("")}`;
 }
 
+/** Worst contrast across the whole correlated crossfade, both ends included. */
+function worstAcrossFade(
+  rest: string,
+  active: string,
+  pair: { rest: string; active: string }
+): number {
+  let worst = Infinity;
+  for (let step = 0; step <= 40; step++) {
+    const t = step / 40;
+    worst = Math.min(worst, contrastRatio(mix(rest, active, t), mix(pair.rest, pair.active, t)));
+  }
+  return worst;
+}
+
+/** OKLab distance — the space the fade is sized in. */
+function deltaE(a: string, b: string): number {
+  const one = toOklab(a)!;
+  const two = toOklab(b)!;
+  return Math.hypot(one.l - two.l, one.a - two.a, one.b - two.b);
+}
+
+/** Formats an OKLCH-shaped object as the hex the screen would paint. */
+function hexOf(color: { l: number; c?: number; h?: number }): string {
+  const rgb = converter("rgb")({ mode: "oklch", l: color.l, c: color.c ?? 0, h: color.h });
+  return `#${[rgb.r, rgb.g, rgb.b]
+    .map((channel) =>
+      Math.round(Math.max(0, Math.min(1, channel)) * 255)
+        .toString(16)
+        .padStart(2, "0")
+    )
+    .join("")}`;
+}
+
 /** Shortest angular distance between two hues, in degrees. */
 function hueGap(a: number, b: number): number {
   const diff = Math.abs(a - b) % 360;
@@ -87,114 +118,266 @@ function hueGap(a: number, b: number): number {
 }
 
 describe("resolveBrandMarkInk", () => {
-  it("holds the ink's lightness and takes the brand's hue at rest", () => {
-    const ink = resolveBrandMarkInk("#cc785c", DARK)!;
+  it("shows a legible brand colour exactly as the brand ships it", () => {
+    const brand = "#cc785c";
+    const pair = backdrops(DARK, PANEL);
+    expect(contrastRatio(brand, pair.rest)).toBeGreaterThanOrEqual(FLOOR);
+    expect(resolveBrandMarkInk(brand, DARK, PANEL)!.active).toBe(brand);
+  });
+
+  it("rests away from the backdrop, not toward it", () => {
+    // The direction is the whole point. A resting mark drawn toward the backdrop
+    // spends contrast to signal a state the hover background already signals,
+    // and a row of them reads as washed out. Drawn the other way it keeps every
+    // bit of that contrast and the reveal is the brand colour arriving.
+    const backdrop = toOklch(DARK.tokens["surface-panel"])!;
+    const ink = resolveBrandMarkInk("#cc785c", DARK, PANEL)!;
     const rest = toOklch(ink.rest)!;
-    const token = toOklch(DARK.tokens["text-secondary"])!;
-    const brand = toOklch("#cc785c")!;
+    const active = toOklch(ink.active)!;
 
-    expect(rest.l).toBeCloseTo(token.l, 2);
-    expect(hueGap(rest.h!, brand.h!)).toBeLessThan(5);
+    expect(ink.rest).not.toBe(ink.active);
+    expect(hueGap(rest.h!, active.h!)).toBeLessThan(3);
+    expect(Math.abs(rest.l - backdrop.l)).toBeGreaterThan(Math.abs(active.l - backdrop.l));
+    // Which on a dark theme means lighter, and deepening into the brand on hover.
+    expect(rest.l).toBeGreaterThan(active.l);
+    expect(contrastRatio(ink.rest, DARK.tokens["surface-panel"]!)).toBeGreaterThan(
+      contrastRatio(ink.active, DARK.tokens["surface-panel"]!)
+    );
   });
 
-  it("tints two brands of wildly different chroma by the same amount", () => {
-    // The source hexes are all over the place — one of these sits near C=0.11 and
-    // the other near C=0.25. Scaling each brand's own chroma would preserve that
-    // gap; a constant target closes it, which is what makes marks read as equally
-    // tinted rather than one shouting over the other.
-    const warm = toOklch(resolveBrandMarkInk("#cc785c", DARK)!.rest)!;
-    const violet = toOklch(resolveBrandMarkInk("#8b5cf6", DARK)!.rest)!;
-    const sourceGap = Math.abs(toOklch("#cc785c")!.c! - toOklch("#8b5cf6")!.c!);
-    const restGap = Math.abs(warm.c! - violet.c!);
-
-    expect(restGap).toBeLessThan(0.01);
-    expect(sourceGap).toBeGreaterThan(restGap * 5);
+  it("reverses that direction on a light theme without a second rule", () => {
+    const ink = resolveBrandMarkInk("#cc785c", LIGHT, PANEL)!;
+    expect(toOklch(ink.rest)!.l).toBeLessThan(toOklch(ink.active)!.l);
+    expect(contrastRatio(ink.rest, LIGHT.tokens["surface-panel"]!)).toBeGreaterThan(
+      contrastRatio(ink.active, LIGHT.tokens["surface-panel"]!)
+    );
   });
 
-  it("resolves a hueless brand to the plain theme ink", () => {
-    // A goose-style near-black has no hue to borrow, so it stays grey rather
-    // than having one invented for it.
-    expect(resolveBrandMarkInk("#1c1c1c", DARK)!.rest).toBe(DARK.tokens["text-secondary"]);
-    expect(resolveBrandMarkInk("#e8e8e8", LIGHT)!.rest).toBe(LIGHT.tokens["text-secondary"]);
-  });
-
-  it("keeps the resting tint legible on every surface", () => {
-    for (const scheme of [DARK, LIGHT]) {
-      for (const brand of ["#cc785c", "#3ee6eb", "#1c1c1c", "#8b5cf6"]) {
-        expect(worstRatio(resolveBrandMarkInk(brand, scheme)!.rest, scheme)).toBeGreaterThanOrEqual(
-          FLOOR
-        );
-      }
+  it("takes only a slice of the fade out of chroma", () => {
+    // Spending the fade on chroma is the wash this treatment exists to undo: at
+    // rest the mark has to still be the brand's colour, not a grey hint of it.
+    for (const [brand, scheme] of [
+      ["#cc785c", DARK],
+      ["#7c3aed", LIGHT],
+      ["#615ced", DARK],
+    ] as const) {
+      const ink = resolveBrandMarkInk(brand, scheme, PANEL)!;
+      expect(toOklch(ink.rest)!.c!).toBeGreaterThan(toOklch(ink.active)!.c! * 0.7);
     }
   });
 
-  it("leaves a brand colour untouched on hover when it is already legible", () => {
-    const brand = "#ff8a3d";
-    expect(worstRatio(brand, DARK)).toBeGreaterThanOrEqual(FLOOR);
-    expect(resolveBrandMarkInk(brand, DARK)!.hover).toBe(brand);
-  });
-
-  it("corrects an illegible brand colour while holding its hue", () => {
-    const brand = "#102a1e";
-    expect(worstRatio(brand, DARK)).toBeLessThan(FLOOR);
-
-    const ink = resolveBrandMarkInk(brand, DARK)!;
-    expect(ink.hover).not.toBe(brand);
-    expect(worstRatio(ink.hover, DARK)).toBeGreaterThanOrEqual(FLOOR);
-
-    const before = toOklch(brand)!;
-    const after = toOklch(ink.hover)!;
-    expect(hueGap(after.h!, before.h!)).toBeLessThan(5);
-    expect(after.l).toBeGreaterThan(before.l);
-  });
-
-  it("moves lightness no further than legibility requires", () => {
+  it("holds a resting mark to the weight of the row it sits in", () => {
+    // A near-white cyan on a dark theme already starts above the theme's own
+    // icon ink. Another step away from the backdrop would leave the *resting*
+    // mark shouting over every neutral control beside it, so it comes back down
+    // to the row's weight and pays for the fade in chroma instead.
     const brand = "#3ee6eb";
-    const ink = resolveBrandMarkInk(brand, LIGHT)!;
-    const source = toOklch(brand)!;
-    const corrected = toOklch(ink.hover)!;
-    expect(worstRatio(ink.hover, LIGHT)).toBeGreaterThanOrEqual(FLOOR);
+    const surface = DARK.tokens["surface-panel"]!;
+    const ceiling = apcaLc(DARK.tokens["text-secondary"]!, surface) + 11;
+    const ink = resolveBrandMarkInk(brand, DARK, PANEL)!;
 
-    // Give back a fifth of the correction. If that still cleared the floor, the
-    // resolver moved further than it had to — this is what makes the result the
-    // *minimum* correction rather than merely one that happens to pass.
-    const slacker = corrected.l + (source.l - corrected.l) * 0.2;
-    const relaxed = formatHex(
-      clampChroma({ mode: "oklch", l: slacker, c: source.c, h: source.h }, "oklch", "rgb")
-    );
-    expect(worstRatio(relaxed, LIGHT)).toBeLessThan(FLOOR);
+    expect(apcaLc(ink.active, surface)).toBeGreaterThan(ceiling);
+    expect(apcaLc(ink.rest, surface)).toBeLessThanOrEqual(ceiling + 1);
+    // And it is still cyan: the ceiling took weight, not the brand.
+    expect(toOklch(ink.rest)!.c!).toBeGreaterThan(toOklch(ink.active)!.c! * 0.7);
+    expect(toOklch(ink.rest)!.c!).toBeLessThan(toOklch(ink.active)!.c!);
   });
 
-  it("stays legible through the whole crossfade, not just at its ends", () => {
+  it("draws a brand with no colour as the theme's own icon, and reveals by weight", () => {
+    // Black and white are not colours a theme can carry, so those marks stop
+    // pretending: they sit level with the neutral controls and their reveal is
+    // the one axis they still have.
+    for (const [brand, scheme] of [
+      ["#1c1c1c", DARK],
+      ["#e8e8e8", LIGHT],
+    ] as const) {
+      const ink = resolveBrandMarkInk(brand, scheme, PANEL)!;
+      const surface = scheme.tokens["surface-panel"]!;
+      expect(ink.rest).toBe(scheme.tokens["text-secondary"]);
+      expect(apcaLc(ink.active, surface)).toBeGreaterThan(apcaLc(ink.rest, surface));
+      expect(contrastRatio(ink.active, surface)).toBeGreaterThan(contrastRatio(ink.rest, surface));
+    }
+  });
+
+  it("gives a colourless brand the same size of reveal a hued one gets", () => {
+    // The axis differs — weight rather than colour — but the step does not, so a
+    // row of marks reacts by the same amount whatever each one is made of.
+    const ink = resolveBrandMarkInk("#1c1c1c", DARK, PANEL)!;
+    expect(ink.rest).not.toBe(ink.active);
+    expect(deltaE(ink.rest, ink.active)).toBeGreaterThan(0.04);
+  });
+
+  it("keeps both states legible across the whole crossfade, not just at its ends", () => {
     // The control repaints its own background in the same 150ms the glyph
     // recolours, so both ends passing is not the same as the transition passing.
-    const overlay = parseRgba(LIGHT.tokens["overlay-elevated"]!)!;
-    for (const brand of ["#3ee6eb", "#e8e8e8", "#cc785c"]) {
-      const ink = resolveBrandMarkInk(brand, LIGHT)!;
-      for (const key of SURFACE_KEYS) {
-        const base = LIGHT.tokens[key]!;
-        const hovered = blendOverBackground(overlay.hex, base, overlay.opacity);
-        for (let step = 0; step <= 10; step++) {
-          const t = step / 10;
+    for (const scheme of [DARK, LIGHT]) {
+      for (const surface of SURFACE_KEYS) {
+        for (const brand of ["#3ee6eb", "#e8e8e8", "#cc785c", "#1c1c1c", "#615ced"]) {
+          const ink = resolveBrandMarkInk(brand, scheme, { surface })!;
           expect(
-            contrastRatio(mix(ink.rest, ink.hover, t), mix(base, hovered, t))
+            worstAcrossFade(ink.rest, ink.active, backdrops(scheme, { surface }))
           ).toBeGreaterThanOrEqual(FLOOR);
         }
       }
     }
   });
 
-  it("treats an arbitrary runtime preset hex exactly like a shipped brand", () => {
-    // Nothing in the resolver knows this colour. A new CLI is just a preset we
-    // happened to ship, so if this path holds, adding an agent costs one hex.
-    const preset = "#3366ff";
-    const ink = resolveBrandMarkInk(preset, LIGHT)!;
-    expect(worstRatio(ink.rest, LIGHT)).toBeGreaterThanOrEqual(FLOOR);
-    expect(worstRatio(ink.hover, LIGHT)).toBeGreaterThanOrEqual(FLOOR);
+  it("nudges a brand that only just misses, and holds its hue doing it", () => {
+    const brand = "#102a1e";
+    const pair = backdrops(DARK, PANEL);
+    expect(contrastRatio(brand, pair.rest)).toBeLessThan(FLOOR);
+
+    const ink = resolveBrandMarkInk(brand, DARK, PANEL)!;
+    expect(ink.active).not.toBe(brand);
+    expect(contrastRatio(ink.active, pair.rest)).toBeGreaterThanOrEqual(FLOOR);
+
+    const before = toOklch(brand)!;
+    const after = toOklch(ink.active)!;
+    expect(hueGap(after.h!, before.h!)).toBeLessThan(5);
+    expect(after.l).toBeGreaterThan(before.l);
+  });
+
+  it("stops a correction as soon as the mark clears what was holding it back", () => {
+    // Minimality, tested against the conjunction rather than against one of its
+    // halves: on a dark theme it is usually APCA weight that binds and on a
+    // light one the WCAG ratio, so a test that named either would be checking
+    // the wrong constraint half the time. Give a fifth of the correction back
+    // and at least one of the two has to break — otherwise the resolver moved
+    // further than it had to.
+    for (const [brand, scheme] of [
+      ["#3ee6eb", LIGHT],
+      ["#cc785c", LIGHT],
+      ["#615ced", DARK],
+    ] as const) {
+      const ink = resolveBrandMarkInk(brand, scheme, PANEL)!;
+      if (ink.active.toLowerCase() === brand.toLowerCase()) continue;
+
+      const source = toOklch(brand)!;
+      const corrected = toOklch(ink.active)!;
+      // Past the fidelity limit the mark is placed rather than nudged, and
+      // "minimal" stops being the claim — that branch has its own test.
+      if (Math.abs(corrected.l - source.l) > 0.15) continue;
+      const relaxed = hexOf({
+        ...source,
+        l: corrected.l + (source.l - corrected.l) * 0.2,
+      });
+
+      const pair = backdrops(scheme, PANEL);
+      const ratio = Math.min(
+        contrastRatio(relaxed, pair.rest),
+        contrastRatio(relaxed, pair.active)
+      );
+      const weight = Math.min(apcaLc(relaxed, pair.rest), apcaLc(relaxed, pair.active));
+      // 3.05 rather than 3, because the resolver holds a small guard over the
+      // floor to cover the gaps between its crossfade samples.
+      expect(`${brand}/${scheme.type}: ${ratio < 3.05 || weight < 35}`).toBe(
+        `${brand}/${scheme.type}: true`
+      );
+    }
+  });
+
+  it("places a brand it cannot show at a weight that reads, not on the floor", () => {
+    // A near-black mark on a dark theme is going to be grey whatever we do, so
+    // the minimum legal move buys nothing — it just makes it a murkier grey with
+    // nowhere left to fade to.
+    const ink = resolveBrandMarkInk("#1c1c1c", DARK, PANEL)!;
+    const pair = backdrops(DARK, PANEL);
+    expect(apcaLc(ink.active, pair.rest)).toBeGreaterThanOrEqual(58);
+    expect(contrastRatio(ink.rest, pair.rest)).toBeGreaterThan(FLOOR);
+  });
+
+  it("darkens a near-white brand on a light theme instead of letting it vanish", () => {
+    const ink = resolveBrandMarkInk("#e8e8e8", LIGHT, PANEL)!;
+    const pair = backdrops(LIGHT, PANEL);
+    expect(toOklch(ink.active)!.l).toBeLessThan(toOklch("#e8e8e8")!.l);
+    expect(
+      Math.min(contrastRatio(ink.active, pair.rest), contrastRatio(ink.active, pair.active))
+    ).toBeGreaterThanOrEqual(FLOOR);
+  });
+
+  it("answers to the surface it is told it is painted on", () => {
+    // The whole point of threading provenance: the same brand on the theme's
+    // darkest and lightest surfaces is not the same colour problem.
+    const onCanvas = resolveBrandMarkInk("#615ced", DARK, { surface: "surface-canvas" })!;
+    const onElevated = resolveBrandMarkInk("#615ced", DARK, {
+      surface: "surface-panel-elevated",
+    })!;
+    expect(onCanvas.rest).not.toBe(onElevated.rest);
+    expect(contrastRatio(onCanvas.rest, DARK.tokens["surface-canvas"]!)).toBeGreaterThanOrEqual(
+      FLOOR
+    );
+    expect(
+      contrastRatio(onElevated.rest, DARK.tokens["surface-panel-elevated"]!)
+    ).toBeGreaterThanOrEqual(FLOOR);
+  });
+
+  it("measures against the container's own lift, not the bare surface token", () => {
+    const lifted = resolveBrandMarkInk("#615ced", DARK, {
+      surface: "surface-panel",
+      lift: "overlay-subtle",
+    })!;
+    const bare = resolveBrandMarkInk("#615ced", DARK, PANEL)!;
+    expect(lifted.rest).not.toBe(bare.rest);
+    expect(
+      contrastRatio(
+        lifted.rest,
+        blendOverBackground("#ffffff", DARK.tokens["surface-panel"]!, 0.03)
+      )
+    ).toBeGreaterThanOrEqual(FLOOR);
+  });
+
+  it("uses a theme extension that repaints the surface outright", () => {
+    // Several light themes repaint panel title bars through `panel-header-bg`,
+    // so the bare surface token there answers for a pixel never painted.
+    const repainted = makeScheme("light", LIGHT.tokens, { "panel-header-bg": "#c8c8c8" });
+    const ink = resolveBrandMarkInk("#cc785c", repainted, {
+      surface: "surface-panel",
+      extension: "panel-header-bg",
+    })!;
+    expect(contrastRatio(ink.rest, "#c8c8c8")).toBeGreaterThanOrEqual(FLOOR);
+    expect(ink.rest).not.toBe(resolveBrandMarkInk("#cc785c", repainted, PANEL)!.rest);
+  });
+
+  it("composites a translucent extension over the surface below it", () => {
+    const tinted = makeScheme("dark", DARK.tokens, {
+      "panel-header-focus-bg": "rgba(255,255,255,0.06)",
+    });
+    const ink = resolveBrandMarkInk("#615ced", tinted, {
+      surface: "surface-panel",
+      extension: "panel-header-focus-bg",
+    })!;
+    const composited = blendOverBackground("#ffffff", DARK.tokens["surface-panel"]!, 0.06);
+    expect(contrastRatio(ink.rest, composited)).toBeGreaterThanOrEqual(FLOOR);
+  });
+
+  it("stays safe on every surface when it is not told which one it is on", () => {
+    // No provider is a real state — an unwrapped call site, a plugin panel — so
+    // the fallback has to clear the floor everywhere rather than merely somewhere.
+    for (const scheme of [DARK, LIGHT]) {
+      for (const brand of ["#cc785c", "#3ee6eb", "#1c1c1c", "#e8e8e8", "#615ced"]) {
+        const ink = resolveBrandMarkInk(brand, scheme)!;
+        for (const surface of SURFACE_KEYS) {
+          expect(
+            worstAcrossFade(ink.rest, ink.active, backdrops(scheme, { surface }))
+          ).toBeGreaterThanOrEqual(FLOOR);
+        }
+      }
+    }
+  });
+
+  it("falls back rather than declining when the named surface cannot be measured", () => {
+    const translucent = makeScheme("dark", { ...DARK.tokens, "surface-panel": "#1e1e1e80" });
+    const ink = resolveBrandMarkInk("#cc785c", translucent, PANEL);
+    expect(ink).not.toBeNull();
+    // A translucent backdrop composites over whatever is behind it, so it is
+    // never read as opaque — the conservative surface answers instead.
+    expect(ink).toEqual(resolveBrandMarkInk("#cc785c", translucent));
   });
 
   it("accepts the shorthand hex form", () => {
-    expect(resolveBrandMarkInk("#c75", DARK)).toEqual(resolveBrandMarkInk("#cc7755", DARK));
+    expect(resolveBrandMarkInk("#c75", DARK, PANEL)).toEqual(
+      resolveBrandMarkInk("#cc7755", DARK, PANEL)
+    );
   });
 
   it("takes an alpha preset colour at full opacity rather than giving up on it", () => {
@@ -202,43 +385,21 @@ describe("resolveBrandMarkInk", () => {
     // reach here. A translucent mark has no single contrast ratio, so alpha is
     // dropped rather than composited — but dropping the brand treatment
     // entirely would leave the user's chosen colour with no effect at all.
-    expect(resolveBrandMarkInk("#cc785c80", DARK)).toEqual(resolveBrandMarkInk("#cc785c", DARK));
-    expect(resolveBrandMarkInk("#c75f", DARK)).toEqual(resolveBrandMarkInk("#cc7755", DARK));
-  });
-
-  it("declines a theme whose surfaces are translucent, rather than mis-measuring them", () => {
-    // The asymmetry with the brand input above is deliberate. A translucent
-    // FOREGROUND has an opaque colour to fall back to; a translucent BACKDROP
-    // composites over whatever is behind it, so reading it as opaque would
-    // measure a pixel that never gets painted. Declining is the honest answer.
-    const translucent = makeScheme("dark", { ...DARK.tokens, "surface-panel": "#1e1e1e80" });
-    const resolved = resolveBrandMarkInk("#cc785c", translucent)!;
-    const opaqueOnly = backdrops(translucent);
-    expect(opaqueOnly.every((bg) => /^#[0-9a-f]{6}$/i.test(bg) || bg.startsWith("#1e1e1e80"))).toBe(
-      true
+    expect(resolveBrandMarkInk("#cc785c80", DARK, PANEL)).toEqual(
+      resolveBrandMarkInk("#cc785c", DARK, PANEL)
     );
-    // The remaining four surfaces still carry the guarantee.
-    for (const key of SURFACE_KEYS.filter((k) => k !== "surface-panel")) {
-      expect(contrastRatio(resolved.rest, translucent.tokens[key]!)).toBeGreaterThanOrEqual(FLOOR);
-    }
-
-    const allTranslucent = makeScheme("dark", {
-      ...DARK.tokens,
-      "text-secondary": "#a8a8a880",
-    });
-    expect(resolveBrandMarkInk("#cc785c", allTranslucent)).toBeNull();
+    expect(resolveBrandMarkInk("#c75f", DARK, PANEL)).toEqual(
+      resolveBrandMarkInk("#cc7755", DARK, PANEL)
+    );
   });
 
   it("declines colours it cannot measure", () => {
-    expect(resolveBrandMarkInk("not-a-color", DARK)).toBeNull();
-    expect(resolveBrandMarkInk("#12345", DARK)).toBeNull();
-    expect(resolveBrandMarkInk(undefined, DARK)).toBeNull();
+    expect(resolveBrandMarkInk("not-a-color", DARK, PANEL)).toBeNull();
+    expect(resolveBrandMarkInk("#12345", DARK, PANEL)).toBeNull();
+    expect(resolveBrandMarkInk(undefined, DARK, PANEL)).toBeNull();
   });
 
-  it("declines a theme missing the tokens it reads", () => {
-    expect(
-      resolveBrandMarkInk("#cc785c", makeScheme("dark", { "surface-panel": "#1e1e1e" }))
-    ).toBeNull();
+  it("declines a theme with no surface it can read", () => {
     expect(
       resolveBrandMarkInk("#cc785c", makeScheme("dark", { "text-secondary": "#a8a8a8" }))
     ).toBeNull();
@@ -247,8 +408,8 @@ describe("resolveBrandMarkInk", () => {
   it("re-resolves when a theme is edited in place under a stable id", () => {
     // Custom themes keep their id across an edit, so anything cached against the
     // id alone would hand back the pre-edit colour forever.
-    const before = resolveBrandMarkInk("#cc785c", DARK)!;
-    const edited = makeScheme("dark", { ...DARK.tokens, "text-secondary": "#6e6e6e" });
-    expect(resolveBrandMarkInk("#cc785c", edited)!.rest).not.toBe(before.rest);
+    const before = resolveBrandMarkInk("#cc785c", DARK, PANEL)!;
+    const edited = makeScheme("dark", { ...DARK.tokens, "surface-panel": "#3a3a3a" });
+    expect(resolveBrandMarkInk("#cc785c", edited, PANEL)!.rest).not.toBe(before.rest);
   });
 });

--- a/src/lib/__tests__/brandMarkMatrix.test.ts
+++ b/src/lib/__tests__/brandMarkMatrix.test.ts
@@ -1,21 +1,21 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { converter, modeOklch, modeRgb, useMode as registerMode } from "culori/fn";
+import { converter, modeOklab, modeRgb, useMode as registerMode } from "culori/fn";
 import {
   BUILT_IN_APP_SCHEMES,
-  DISPLAY_SURFACES,
+  apcaLc,
   blendOverBackground,
   contrastRatio,
   parseRgba,
 } from "@shared/theme";
-import type { AppColorScheme } from "@shared/theme";
+import type { AppColorScheme, AppThemeTokenKey } from "@shared/theme";
 import { AGENT_REGISTRY } from "@shared/config/agentRegistry";
-import { resolveBrandMarkInk } from "../brandIcon";
+import { BRAND_MARK_SURFACES, resolveBrandMarkInk } from "../brandIcon";
 
 registerMode(modeRgb);
-registerMode(modeOklch);
-const toOklch = converter("oklch");
+registerMode(modeOklab);
+const toOklab = converter("oklab");
 
 const FLOOR = 3;
 
@@ -46,14 +46,41 @@ function mix(from: string, to: string, ratio: number): string {
  * resolver, so the suite measures against backdrops it derived itself rather
  * than trusting the implementation's own idea of where a mark lands.
  */
-function surfacePairs(scheme: AppColorScheme): Array<{ base: string; hovered: string }> {
+function backdropsFor(
+  scheme: AppColorScheme,
+  surface: AppThemeTokenKey
+): { rest: string; active: string } {
   const overlay = parseRgba(scheme.tokens["overlay-elevated"] ?? "");
-  return DISPLAY_SURFACES.map((key) => scheme.tokens[key]!)
-    .filter((base) => /^#[0-9a-f]{6}$/i.test(base))
-    .map((base) => ({
-      base,
-      hovered: overlay ? blendOverBackground(overlay.hex, base, overlay.opacity) : base,
-    }));
+  const rest = scheme.tokens[surface]!;
+  return {
+    rest,
+    active: overlay ? blendOverBackground(overlay.hex, rest, overlay.opacity) : rest,
+  };
+}
+
+function opaqueSurfaces(scheme: AppColorScheme): AppThemeTokenKey[] {
+  return BRAND_MARK_SURFACES.filter((key) => /^#[0-9a-f]{6}$/i.test(scheme.tokens[key] ?? ""));
+}
+
+/** Worst contrast anywhere in the correlated crossfade, sampled far finer than the resolver does. */
+function worstAcrossFade(
+  rest: string,
+  active: string,
+  pair: { rest: string; active: string }
+): number {
+  let worst = Infinity;
+  for (let step = 0; step <= 40; step++) {
+    const t = step / 40;
+    worst = Math.min(worst, contrastRatio(mix(rest, active, t), mix(pair.rest, pair.active, t)));
+  }
+  return worst;
+}
+
+/** OKLab distance — the space the fade is sized in. */
+function deltaE(a: string, b: string): number {
+  const one = toOklab(a)!;
+  const two = toOklab(b)!;
+  return Math.hypot(one.l - two.l, one.a - two.a, one.b - two.b);
 }
 
 describe("brand marks across the whole registry", () => {
@@ -64,44 +91,47 @@ describe("brand marks across the whole registry", () => {
     expect(AGENTS).toHaveLength(Object.keys(AGENT_REGISTRY).length);
     expect(BUILT_IN_APP_SCHEMES.length).toBeGreaterThan(1);
     for (const scheme of BUILT_IN_APP_SCHEMES) {
-      expect(surfacePairs(scheme)).toHaveLength(DISPLAY_SURFACES.length);
-      expect(toOklch(scheme.tokens["text-secondary"])?.l).toBeDefined();
+      expect(opaqueSurfaces(scheme)).toHaveLength(BRAND_MARK_SURFACES.length);
     }
   });
 
-  it("resolves an ink for every agent on every built-in theme", () => {
-    const unresolved = AGENTS.flatMap(([id, color]) =>
-      BUILT_IN_APP_SCHEMES.filter((scheme) => resolveBrandMarkInk(color, scheme) === null).map(
-        (scheme) => `${id} on ${scheme.id}`
-      )
-    );
+  it("resolves an ink for every agent on every theme, surface and un-named placement", () => {
+    const unresolved: string[] = [];
+    for (const [id, color] of AGENTS) {
+      for (const scheme of BUILT_IN_APP_SCHEMES) {
+        for (const surface of [...BRAND_MARK_SURFACES, null]) {
+          const ink = resolveBrandMarkInk(color, scheme, surface ? { surface } : null);
+          if (!ink) unresolved.push(`${id} on ${scheme.id} / ${surface ?? "unnamed"}`);
+        }
+      }
+    }
     expect(unresolved).toEqual([]);
   });
 
-  it("clears the non-text contrast floor at rest, on hover, and mid-transition", () => {
+  it("clears the non-text contrast floor at rest, when active, and mid-transition", () => {
     const failures: string[] = [];
 
     for (const [id, color] of AGENTS) {
       for (const scheme of BUILT_IN_APP_SCHEMES) {
-        const ink = resolveBrandMarkInk(color, scheme);
-        if (!ink) continue;
+        for (const surface of opaqueSurfaces(scheme)) {
+          const pair = backdropsFor(scheme, surface);
+          const ink = resolveBrandMarkInk(color, scheme, { surface })!;
 
-        for (const { base, hovered } of surfacePairs(scheme)) {
-          const samples: Array<[string, string, string]> = [
-            ["rest/resting", ink.rest, base],
-            ["rest/hovered", ink.rest, hovered],
-            ["hover/resting", ink.hover, base],
-            ["hover/hovered", ink.hover, hovered],
-            // The correlated midpoint: foreground and backdrop are both halfway
-            // through the same 150ms crossfade. Endpoints passing does not imply
-            // the frames between them pass.
-            ["midpoint", mix(ink.rest, ink.hover, 0.5), mix(base, hovered, 0.5)],
-          ];
-          for (const [label, fg, bg] of samples) {
-            const ratio = contrastRatio(fg, bg);
-            if (ratio < FLOOR) {
-              failures.push(`${id} on ${scheme.id} ${base} ${label}: ${ratio.toFixed(2)}:1`);
-            }
+          // A selected tab is not a hovered one, so the active ink is painted on
+          // the resting backdrop as well as the lifted one.
+          for (const [label, hex, bg] of [
+            ["active/resting", ink.active, pair.rest],
+            ["active/hovered", ink.active, pair.active],
+          ] as const) {
+            const ratio = contrastRatio(hex, bg);
+            if (ratio < FLOOR) failures.push(`${id}/${scheme.id}/${surface} ${label}: ${ratio}`);
+          }
+
+          // The correlated crossfade: foreground and backdrop are both moving,
+          // and the minimum can sit between the endpoints rather than at one.
+          const worst = worstAcrossFade(ink.rest, ink.active, pair);
+          if (worst < FLOOR) {
+            failures.push(`${id}/${scheme.id}/${surface} crossfade: ${worst.toFixed(3)}`);
           }
         }
       }
@@ -110,65 +140,138 @@ describe("brand marks across the whole registry", () => {
     expect(failures).toEqual([]);
   });
 
-  it("gives every hued brand the same resting chroma and its own hue", () => {
-    for (const scheme of BUILT_IN_APP_SCHEMES) {
-      const inkLightness = toOklch(scheme.tokens["text-secondary"])?.l;
-      if (inkLightness === undefined) continue;
-
-      const chromas: number[] = [];
-      for (const [, color] of AGENTS) {
-        const brand = toOklch(color);
-        const resolved = resolveBrandMarkInk(color, scheme);
-        if (!brand || !resolved) continue;
-
-        const rest = toOklch(resolved.rest)!;
-        // Rest never departs from the theme's own icon-ink lightness — that is
-        // what carries the contrast guarantee, with no surface provenance
-        // threaded anywhere.
-        expect(rest.l).toBeCloseTo(inkLightness, 2);
-
-        // Achromatic brands are identified by conversion, not by an id list, so
-        // a new one degrades on its own rather than needing an exception entry.
-        if (brand.h === undefined || (brand.c ?? 0) <= 1e-4) {
-          expect(resolved.rest.toLowerCase()).toBe(scheme.tokens["text-secondary"]!.toLowerCase());
-        } else {
-          chromas.push(rest.c ?? 0);
+  it("stays safe on every surface when the placement is not declared", () => {
+    // An un-wrapped call site is a real state, so the fallback has to clear the
+    // floor on every surface rather than on the one it happened to pick.
+    const failures: string[] = [];
+    for (const [id, color] of AGENTS) {
+      for (const scheme of BUILT_IN_APP_SCHEMES) {
+        const ink = resolveBrandMarkInk(color, scheme)!;
+        for (const surface of opaqueSurfaces(scheme)) {
+          const worst = worstAcrossFade(ink.rest, ink.active, backdropsFor(scheme, surface));
+          if (worst < FLOOR) {
+            failures.push(`${id}/${scheme.id}/${surface}: ${worst.toFixed(3)}`);
+          }
         }
       }
-
-      // Eighteen marks read as *equally* tinted only if the spread is tight;
-      // a chroma scaled off each brand's own would blow this apart.
-      if (chromas.length > 1) {
-        expect(Math.max(...chromas) - Math.min(...chromas)).toBeLessThan(0.01);
-      }
     }
+    expect(failures).toEqual([]);
   });
 
-  it("leaves a brand colour untouched wherever it is already legible", () => {
+  it("gives every mark a reveal to hover into", () => {
+    // The failure this pins is silent: a mark that never reacts to being hovered
+    // or selected is perfectly legible and completely dead. Every pair gets a
+    // step, none of them gets so much that the resting state reads as a
+    // different colour — except where the resting weight ceiling is what set the
+    // distance, which is a normalisation of an over-loud brand rather than a
+    // fade, and is allowed to be longer.
+    const failures: string[] = [];
+    for (const [id, color] of AGENTS) {
+      for (const scheme of BUILT_IN_APP_SCHEMES) {
+        for (const surface of opaqueSurfaces(scheme)) {
+          const ink = resolveBrandMarkInk(color, scheme, { surface })!;
+          const fade = deltaE(ink.rest, ink.active);
+          const bg = scheme.tokens[surface]!;
+          const ceiling = apcaLc(scheme.tokens["text-secondary"]!, bg) + 11;
+          const atCeiling = Math.abs(apcaLc(ink.rest, bg) - ceiling) < 1.5;
+          const ceilingFor = atCeiling ? 0.16 : 0.09;
+          if (fade < 0.04 || fade > ceilingFor) {
+            failures.push(`${id}/${scheme.id}/${surface}: ${fade.toFixed(3)}`);
+          }
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("carries the documented weight when active", () => {
+    // docs/themes/interaction-state-recipes.md says an active mark carries APCA
+    // Lc 35 against the weaker of its two backdrops. Nothing else in the suite
+    // measures that: the APCA module's own tests prove the calculator, not that
+    // the resolver applies it.
+    const failures: string[] = [];
+    for (const [id, color] of AGENTS) {
+      for (const scheme of BUILT_IN_APP_SCHEMES) {
+        for (const surface of opaqueSurfaces(scheme)) {
+          const pair = backdropsFor(scheme, surface);
+          const ink = resolveBrandMarkInk(color, scheme, { surface })!;
+          const carried = Math.min(apcaLc(ink.active, pair.rest), apcaLc(ink.active, pair.active));
+          if (carried < 35) {
+            failures.push(`${id}/${scheme.id}/${surface}: Lc ${carried.toFixed(0)}`);
+          }
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("never rests louder than the row it sits in", () => {
+    // The neutral controls beside a mark are painted in `text-secondary`. A
+    // resting mark that lands well above them reads as a primary control, which
+    // is the failure the ceiling exists to stop.
+    const failures: string[] = [];
+    for (const [id, color] of AGENTS) {
+      for (const scheme of BUILT_IN_APP_SCHEMES) {
+        for (const surface of opaqueSurfaces(scheme)) {
+          const bg = scheme.tokens[surface]!;
+          const ink = resolveBrandMarkInk(color, scheme, { surface })!;
+          const over = apcaLc(ink.rest, bg) - apcaLc(scheme.tokens["text-secondary"]!, bg);
+          if (over > 12) failures.push(`${id}/${scheme.id}/${surface}: +${over.toFixed(0)} Lc`);
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("holds the brand's own hue in both states", () => {
+    // Correcting by clipping sRGB channels would shift the hue, which is the one
+    // property a mark cannot give up and still be the brand's.
+    const failures: string[] = [];
+    for (const [id, color] of AGENTS) {
+      const brand = toOklab(color)!;
+      const brandHue = (Math.atan2(brand.b, brand.a) * 180) / Math.PI;
+      const brandChroma = Math.hypot(brand.a, brand.b);
+      if (brandChroma < 0.02) continue; // No hue to hold.
+
+      for (const scheme of BUILT_IN_APP_SCHEMES) {
+        for (const surface of BRAND_MARK_SURFACES) {
+          const ink = resolveBrandMarkInk(color, scheme, { surface })!;
+          for (const [label, hex] of [
+            ["rest", ink.rest],
+            ["active", ink.active],
+          ] as const) {
+            const lab = toOklab(hex)!;
+            if (Math.hypot(lab.a, lab.b) < 0.01) continue; // Faded past the point of having one.
+            const hue = (Math.atan2(lab.b, lab.a) * 180) / Math.PI;
+            const gap = Math.abs(((hue - brandHue + 540) % 360) - 180);
+            if (gap > 3) failures.push(`${id}/${scheme.id}/${surface} ${label}: ${gap.toFixed(1)}`);
+          }
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("shows a brand colour untouched wherever it can carry both states", () => {
     let exercised = 0;
     for (const [id, color] of AGENTS) {
       for (const scheme of BUILT_IN_APP_SCHEMES) {
-        const ink = resolveBrandMarkInk(color, scheme);
-        if (!ink) continue;
-
-        const pairs = surfacePairs(scheme);
-        const alreadySafe = pairs.every(
-          ({ base, hovered }) =>
-            contrastRatio(color, base) >= FLOOR &&
-            contrastRatio(color, hovered) >= FLOOR &&
-            contrastRatio(mix(ink.rest, color, 0.5), mix(base, hovered, 0.5)) >= FLOOR
-        );
-        if (alreadySafe) {
+        for (const surface of opaqueSurfaces(scheme)) {
+          const ink = resolveBrandMarkInk(color, scheme, { surface })!;
+          if (ink.active.toLowerCase() !== color.toLowerCase()) continue;
           exercised++;
-          expect(`${id}/${scheme.id}:${ink.hover.toLowerCase()}`).toBe(
-            `${id}/${scheme.id}:${color.toLowerCase()}`
-          );
+          // Untouched is only allowed where it is also correct: the mark clears
+          // the floor on both backdrops and still has room for its fade.
+          const pair = backdropsFor(scheme, surface);
+          expect(
+            `${id}/${scheme.id}/${surface}:${worstAcrossFade(ink.rest, ink.active, pair) >= FLOOR}`
+          ).toBe(`${id}/${scheme.id}/${surface}:true`);
         }
       }
     }
-    // Correction is meant to be the exception, not the rule. If nothing reached
-    // the assertion the test proved nothing.
-    expect(exercised).toBeGreaterThan(0);
+    // Correction is meant to be the exception on the themes with headroom. If
+    // nothing reached the assertion the test proved nothing.
+    expect(exercised).toBeGreaterThan(AGENTS.length);
   });
 
   it("transitions colour alone, never a widened property list", () => {

--- a/src/lib/brandIcon.ts
+++ b/src/lib/brandIcon.ts
@@ -6,8 +6,15 @@ import {
   modeRgb,
   useMode as registerMode,
 } from "culori/fn";
-import { DISPLAY_SURFACES, blendOverBackground, contrastRatio, parseRgba } from "@shared/theme";
-import type { AppColorScheme } from "@shared/theme";
+import {
+  DISPLAY_SURFACES,
+  apcaLc,
+  blendOverBackground,
+  contrastRatio,
+  parseRgba,
+  relativeLuminance,
+} from "@shared/theme";
+import type { AppColorScheme, AppThemeTokenKey, ExtensionKey } from "@shared/theme";
 
 // `culori/fn` ships mode definitions without registering them, which is what
 // makes it tree-shakable (the root `culori` entry calls `useMode` for ~30 spaces
@@ -19,41 +26,178 @@ registerMode(modeRgb);
 registerMode(modeOklch);
 const toOklch = converter("oklch");
 
-/** WCAG 1.4.11 non-text contrast. A mark is a non-text UI component. */
+/** WCAG 1.4.11 non-text contrast. The accessibility contract, never traded away. */
 const CONTRAST_FLOOR = 3;
 
-// One chroma for every mark on every theme. Deliberately NOT a fraction of the
-// brand's own chroma: the source hexes are all over the place, spanning roughly
-// C = 0.11 to C = 0.25, so scaling them by a common factor preserves that
-// disparity and the saturated end shouts while the muted end reads grey. A
-// constant target is what makes a row of marks read as *equally* tinted. 0.05
-// sits mid-band for a 16px glyph — below ~0.02 it is indistinguishable from
-// grey, above ~0.08 it stops being a tint and becomes a full colour mark, which
-// is the failure mode #11903 backed out of.
-const TINT_CHROMA = 0.05;
+/**
+ * How far the resting mark sits from the active one, as an OKLab distance.
+ *
+ * One number sets the whole move: mostly lightness, a fixed slice of chroma,
+ * and never hue — hue is the half of a brand mark that has to survive.
+ *
+ * 0.07 is roughly three times the ~0.02 just-noticeable difference: read as
+ * "the same colour, slightly back" rather than as a second colour. The bracket
+ * published for a state change that should be obvious without being jarring is
+ * 0.06–0.10, and a 16px glyph sits at the low end of it because small fields
+ * desaturate — the same move reads as less at this size than on a swatch.
+ */
+const FADE_DELTA_E = 0.07;
 
-// Below this the OKLCH hue is meaningless (and culori reports it as `undefined`
-// rather than 0). The near-black and near-white monochrome marks land here: no
-// hue to borrow, so they resolve to the plain ink. That is correct, not a bug.
-const ACHROMATIC_CHROMA = 1e-4;
+/**
+ * The slice of the fade taken out of chroma rather than lightness.
+ *
+ * Small on purpose. A fade spent on chroma is the wash the previous revision
+ * shipped — eighteen brands flattened into one grey — so chroma gives up just
+ * enough for the hover to read as a bloom of colour on top of the shift in
+ * weight, and lightness carries the rest.
+ */
+const REST_CHROMA_GIVE = 0.2;
+
+/**
+ * Perceived weight, in APCA Lc, that an active mark has to carry.
+ *
+ * WCAG's 3:1 is a compliance floor, not evidence that an intricate 16px glyph
+ * is comfortable: a fine outlined mark and a solid square at the same ratio
+ * are not the same thing to read. Several dark violets clear 3:1 on a
+ * near-black theme while landing around Lc 25, which puts the *active* state —
+ * the one you are looking at — below the resting one it came from. Lc 35 is the
+ * smallest floor that removes that inversion, and it moves only the marks that
+ * were in it.
+ */
+const ACTIVE_MIN_LC = 35;
+
+/**
+ * How far above the theme's own icon ink, in Lc, a resting mark is allowed to
+ * get.
+ *
+ * A resting mark is not the loudest thing in its row — the neutral controls
+ * beside it are painted in `text-secondary`, and a brand that arrives near
+ * white on a dark theme or near black on a light one lands well above them and
+ * reads as a primary control rather than as something at rest. The ceiling pulls
+ * those back to the row's own weight; the active state is still the brand.
+ *
+ * The margin is what keeps this an exception rather than a coin toss. Without
+ * it, a brand landing a point or two above `text-secondary` would be clamped
+ * while its neighbour a point below faded normally, and the row would lose its
+ * common treatment. 11 is where the brightest brand that reaches its resting
+ * state *unclamped* already sits, so the ceiling lands the loud ones level with
+ * it instead of a visible step above.
+ */
+const REST_CEILING_LC_MARGIN = 11;
+
+/**
+ * Chroma below which a brand has no colour to honour.
+ *
+ * A few vendors ship a mark that is simply black, or simply white. There is no
+ * hue to carry into a theme, so what identifies those is their silhouette, and
+ * the honest way to draw a silhouette is in the ink the theme already uses for
+ * its own icons. Below this threshold a mark stops trying to be a colour and
+ * becomes an icon: it rests at `text-secondary` and its reveal is weight rather
+ * than colour.
+ */
+const COLOURLESS_CHROMA = 0.02;
+
+/**
+ * Perceived weight, in APCA Lc, that a mark is placed at once it can no longer
+ * be shown as the brand ships it at all. The APCA bracket for a standalone
+ * meaningful glyph — where an ordinary icon would sit if the theme had drawn
+ * one, which is the honest place for a mark that has lost its colour.
+ *
+ * Lc rather than a contrast ratio because this is a placement, not a floor, and
+ * WCAG ratios compress at the dark end: the same ratio buys much less perceived
+ * weight on a dark theme than on a light one, which is the axis this has to be
+ * stable across.
+ */
+const CORRECTED_LC = 60;
+
+/**
+ * Lightness move, in OKLab L, past which a correction has stopped preserving
+ * the brand colour and starts being a substitute for it.
+ *
+ * Under it the correction is a nudge — a brand a shade too pale for a cream
+ * theme comes down a little and still reads as itself, so the minimum move is
+ * exactly right. Over it, fidelity is already gone: a near-black mark on a dark
+ * theme is going to be grey whatever we do, and the only question left is
+ * whether it is a murky grey sitting on the floor or a legible one. That case
+ * gets placed at `CORRECTED_LC` instead of at the bare minimum.
+ */
+const FIDELITY_LIMIT = 0.15;
 
 /** Halvings of the lightness interval. 2^-16 is far finer than 8-bit output. */
 const SEARCH_STEPS = 16;
 
+/**
+ * Correlated samples across the 150ms crossfade, endpoints included.
+ *
+ * Contrast across the crossfade is smooth but not monotonic — foreground and
+ * backdrop are both moving, and their channels need not move the same way — so
+ * the minimum can sit between two samples. Nine points on each axis put that
+ * gap in the third decimal of a ratio; `SAMPLING_GUARD` covers what is left,
+ * which is why the floor is enforced with headroom rather than exactly.
+ */
+const CROSSFADE_SAMPLES = Array.from({ length: 9 }, (_, index) => index / 8);
+
+/** Headroom over the floor, covering the gap between crossfade samples. */
+const SAMPLING_GUARD = 0.02;
+
 const CACHE_LIMIT = 512;
 
 export interface BrandMarkInk {
-  /** Theme ink lightness carrying the brand hue at `TINT_CHROMA`. */
+  /** The brand colour one perceptual step back — what the mark wears at rest. */
   rest: string;
-  /** The brand colour, lightness-corrected only as far as legibility demands. */
-  hover: string;
+  /** The brand colour itself, corrected only as far as legibility demands. */
+  active: string;
 }
 
-/** Resting surface and the backdrop it becomes while the control is hovered. */
-interface Backdrop {
-  base: string;
-  hovered: string;
+/**
+ * Where a mark is actually painted. Supplied by `BrandSurface` (see
+ * `src/components/icons/BrandSurface.tsx`), which is how a mark in a panel
+ * title bar gets measured against the panel and one in a popover against the
+ * popover, rather than every mark answering to whichever surface is hardest.
+ */
+export interface BrandMarkSurface {
+  /** The surface token the container paints. */
+  surface: AppThemeTokenKey;
+  /**
+   * A theme extension that replaces `surface` where the active theme defines
+   * one — the `var(--panel-header-bg, ...)` half of the container's own
+   * background declaration. Opaque values stand in for the surface outright; a
+   * translucent one composites over it, exactly as the paint does.
+   */
+  extension?: ExtensionKey;
+  /** Overlay composited over `surface` when `extension` supplies nothing — the fallback half. */
+  lift?: AppThemeTokenKey;
 }
+
+/** One backdrop a mark can meet: at rest, and the same backdrop under the hover overlay. */
+interface Backdrops {
+  rest: string;
+  active: string;
+}
+
+/**
+ * Where a mark is placed, and everywhere it has to hold.
+ *
+ * The two are not the same when nobody declared a surface. Placement — which
+ * way the fade travels, where the ceiling sits — needs one reference backdrop,
+ * and the honest choice is the one that leaves the least room. Legibility is
+ * not a matter of choice: it has to hold on every surface the mark could land
+ * on, so the predicates answer to all of them.
+ */
+interface Placement {
+  primary: Backdrops;
+  all: Backdrops[];
+}
+
+/**
+ * Every surface a brand mark can be painted on.
+ *
+ * `DISPLAY_SURFACES` is the theme audit's set and does not include the toolbar,
+ * which is where the densest row of marks in the product actually lives.
+ * Exported so the matrix test iterates the same list rather than a copy that
+ * could drift.
+ */
+export const BRAND_MARK_SURFACES: AppThemeTokenKey[] = [...DISPLAY_SURFACES, "surface-toolbar"];
 
 /**
  * Normalizes an opaque 3- or 6-digit hex, rejecting everything else.
@@ -111,59 +255,147 @@ function mixHex(from: string, to: string, ratio: number): string {
   return `#${channels.join("")}`;
 }
 
-/**
- * The five display surfaces, each paired with itself under the hover overlay.
- * A mark carries no surface provenance — the same component renders on the grid,
- * the sidebar and the panels — so the correction answers to the worst of all of
- * them at once. Stricter than any single placement needs, and the price of not
- * threading a surface prop through every call site.
- */
-function collectBackdrops(scheme: AppColorScheme): Backdrop[] {
-  const overlay = parseRgba(scheme.tokens["overlay-elevated"] ?? "");
-  const backdrops: Backdrop[] = [];
-  for (const key of DISPLAY_SURFACES) {
-    const base = opaqueHex(scheme.tokens[key]);
-    if (!base) continue;
-    // A theme whose overlay is a `color-mix()` rather than an `rgba()` leaves the
-    // hovered backdrop unknowable here; measuring against the resting surface
-    // alone is the honest floor rather than a guessed composite.
-    const hovered = overlay ? blendOverBackground(overlay.hex, base, overlay.opacity) : base;
-    backdrops.push({ base, hovered });
-  }
-  return backdrops;
+/** Composites an overlay token over a base, or returns the base unchanged. */
+function lift(base: string, token: string | undefined): string {
+  // An opaque overlay is not an overlay at all — it replaces what is under it,
+  // and reading it as "no overlay" would measure a pixel that is covered.
+  const opaque = opaqueHex(token);
+  if (opaque) return opaque;
+  const overlay = parseRgba(token ?? "");
+  // A theme whose overlay is a `color-mix()` rather than an `rgba()` leaves the
+  // composite unknowable here; measuring the base alone is the honest floor
+  // rather than a guessed one.
+  return overlay ? blendOverBackground(overlay.hex, base, overlay.opacity) : base;
 }
 
 /**
- * Whether `ink` stays legible across the whole 150ms crossfade, not just at its
- * endpoints. `.toolbar-agent-button:hover` repaints its background in the same
- * 150ms the glyph recolours, so foreground and backdrop are both moving.
+ * The backdrop a mark actually sits on, and what that becomes under hover.
  *
- * Backdrop luminance is monotonic along the composite line, so the resting and
- * hovered surfaces bound every intermediate backdrop. The foreground is not so
- * well behaved: its channels can move in opposite directions, which puts an
- * interior extremum inside the interval. Sampling the correlated midpoint — the
- * halfway foreground against the halfway backdrop — is what catches that, and it
- * is also what catches a rest/hover pair straddling the backdrop, where the
- * crossfade passes through it and contrast collapses to ~1:1 mid-transition.
+ * With no `BrandMarkSurface` supplied the placement is unknown, so the mark has
+ * to answer to every surface at once — the way it did before provenance was
+ * threaded at all. Placement geometry still needs a single reference, and takes
+ * the hardest surface: the one whose luminance leaves a legible mark the least
+ * room.
  */
-function staysLegible(ink: string, backdrops: Backdrop[], rest?: string): boolean {
-  for (const { base, hovered } of backdrops) {
-    if (contrastRatio(ink, base) < CONTRAST_FLOOR) return false;
-    if (contrastRatio(ink, hovered) < CONTRAST_FLOOR) return false;
-    if (
-      rest &&
-      contrastRatio(mixHex(rest, ink, 0.5), mixHex(base, hovered, 0.5)) < CONTRAST_FLOOR
-    ) {
-      return false;
+function resolveBackdrops(
+  scheme: AppColorScheme,
+  surface?: BrandMarkSurface | null
+): Placement | null {
+  const withHover = (base: string): Backdrops => ({
+    rest: base,
+    active: lift(base, scheme.tokens["overlay-elevated"]),
+  });
+
+  // A named surface that cannot be read as an opaque colour (a translucent
+  // token, a `color-mix()`) falls back to the same conservative answer as no
+  // declaration at all, rather than leaving the mark unresolved.
+  const declared = surface ? surfaceBase(scheme, surface) : null;
+  if (declared) {
+    const primary = withHover(declared);
+    return { primary, all: [primary] };
+  }
+
+  const surfaces = BRAND_MARK_SURFACES.map((key) => opaqueHex(scheme.tokens[key])).filter(
+    (hex): hex is string => hex !== null
+  );
+  if (surfaces.length === 0) return null;
+  return { primary: withHover(hardestSurface(scheme, surfaces)), all: surfaces.map(withHover) };
+}
+
+/**
+ * Reproduces the container's own background declaration in colour rather than
+ * in CSS: the extension when the theme defines one, the token under the
+ * fallback overlay when it does not. Several light themes repaint panel title
+ * bars outright, so reading the bare surface token there would answer for a
+ * pixel that is never painted.
+ */
+function surfaceBase(scheme: AppColorScheme, surface: BrandMarkSurface): string | null {
+  const token = opaqueHex(scheme.tokens[surface.surface]);
+  if (!token) return null;
+
+  const extension = surface.extension ? scheme.extensions?.[surface.extension] : undefined;
+  if (extension) return opaqueHex(extension) ?? lift(token, extension);
+  return surface.lift ? lift(token, scheme.tokens[surface.lift]) : token;
+}
+
+/**
+ * The surface that leaves a legible mark the least room.
+ *
+ * Ordered by relative luminance rather than by OKLCH lightness, because
+ * luminance is what contrast is a ratio of. The two orderings disagree across
+ * hues — a saturated blue can be lighter than a dark green and still carry less
+ * luminance — and only the luminance ordering makes "hardest" provable rather
+ * than usually true. This is a placement anchor, not a safety claim: safety
+ * comes from every surface being checked, not from picking the right one.
+ */
+function hardestSurface(scheme: AppColorScheme, surfaces: string[]): string {
+  const wantBrightest = scheme.type === "dark";
+  return surfaces.reduce((worst, candidate) =>
+    (
+      wantBrightest
+        ? relativeLuminance(candidate) > relativeLuminance(worst)
+        : relativeLuminance(candidate) < relativeLuminance(worst)
+    )
+      ? candidate
+      : worst
+  );
+}
+
+/**
+ * Whether the pair stays legible through the whole 150ms crossfade, on every
+ * backdrop the mark can meet.
+ *
+ * Both ends passing is not the transition passing: the control repaints its
+ * background in the same 150ms the glyph recolours, so foreground and backdrop
+ * are both in flight, and the channels of the two inks can move in opposite
+ * directions — which puts an extremum inside the interval — while a pair
+ * straddling the backdrop passes at both ends and collapses to ~1:1 in the
+ * middle.
+ *
+ * The two are sampled as a *grid* rather than in lockstep, because they are not
+ * in lockstep: the glyph transitions on `ease-out` and the surfaces it sits on
+ * variously on `ease`, so the frames actually painted trace some curve through
+ * the square rather than its diagonal. Every monotone pair of easings stays
+ * inside the grid, so checking the grid is checking all of them, and no single
+ * pairing has to be assumed. `SAMPLING_GUARD` covers what falls between points.
+ */
+function staysLegible(rest: string, active: string, placement: Placement): boolean {
+  for (const backdrops of placement.all) {
+    for (const foreground of CROSSFADE_SAMPLES) {
+      const ink = mixHex(rest, active, foreground);
+      for (const background of CROSSFADE_SAMPLES) {
+        const behind = mixHex(backdrops.rest, backdrops.active, background);
+        if (contrastRatio(ink, behind) < CONTRAST_FLOOR + SAMPLING_GUARD) return false;
+      }
     }
   }
   return true;
 }
 
+/** The weakest contrast this ink carries anywhere it can be painted. */
+function worstContrast(hex: string, placement: Placement): number {
+  return Math.min(
+    ...placement.all.flatMap((backdrops) => [
+      contrastRatio(hex, backdrops.rest),
+      contrastRatio(hex, backdrops.active),
+    ])
+  );
+}
+
+/** The least perceived weight this ink carries anywhere it can be painted. */
+function worstWeight(hex: string, placement: Placement): number {
+  return Math.min(
+    ...placement.all.flatMap((backdrops) => [
+      apcaLc(hex, backdrops.rest),
+      apcaLc(hex, backdrops.active),
+    ])
+  );
+}
+
 /**
  * The brand's hue and chroma held at a different lightness, re-fitted into sRGB
- * by CSS Color 4 chroma reduction rather than by clipping channels — clipping
- * shifts the hue, which is the one thing the correction has to preserve.
+ * by reducing chroma until it fits rather than by clipping channels — clipping
+ * shifts the hue, which is the one thing a correction has to preserve.
  */
 function atLightness(hue: number | undefined, chroma: number, lightness: number): string | null {
   const fitted = clampChroma({ mode: "oklch", l: lightness, c: chroma, h: hue }, "oklch", "rgb");
@@ -171,87 +403,100 @@ function atLightness(hue: number | undefined, chroma: number, lightness: number)
 }
 
 /**
- * Smallest lightness move toward `target` (0 or 1) that clears the floor.
+ * The lightness closest to `desired` that still satisfies `ok`, given that
+ * `safe` does.
  *
  * Bisection rather than stepping: gamut mapping and 8-bit quantization sit
- * between the lightness we pick and the contrast we measure, so there is no
- * closed form to solve, and a fixed step either lands visibly coarse or wastes
- * work. Every candidate is measured on the *formatted* hex for that reason —
- * the pre-clamp OKLCH value is not what the screen paints.
+ * between the lightness we pick and the value we measure, so there is no closed
+ * form, and a fixed step either lands visibly coarse or wastes work. Every
+ * candidate is measured on the *formatted* hex for that reason — the pre-clamp
+ * OKLCH value is not what the screen paints.
  *
- * Those same two steps also make the predicate very slightly non-monotonic in
- * lightness: near a rounding boundary a candidate can clear the floor while one
- * a fraction closer to the extreme misses it by a hundredth of a ratio point.
- * That costs a hair of optimality, never the floor itself — `passing` only ever
- * holds a lightness whose formatted hex was measured and passed (it starts at
- * the verified extreme), and `atLightness` is deterministic, so the value
- * returned below is that same verified hex. Keep that invariant if you touch
- * this loop: the contrast guarantee rests on it, not on monotonicity.
+ * Those same two steps make `ok` very slightly non-monotonic near a rounding
+ * boundary, which costs a hair of optimality and never the guarantee: `passing`
+ * only ever holds a lightness whose formatted hex was measured and passed (it
+ * starts at `safe`), and `atLightness` is deterministic, so the hex returned is
+ * that same measured hex. Keep that invariant if you touch this loop.
  */
-function searchLightness(
+function approach(
   hue: number | undefined,
   chroma: number,
-  from: number,
-  target: 0 | 1,
-  backdrops: Backdrop[],
-  rest: string
-): { hex: string; delta: number } | null {
-  const extreme = atLightness(hue, chroma, target);
-  if (!extreme || !staysLegible(extreme, backdrops, rest)) return null;
+  safe: number,
+  desired: number,
+  ok: (hex: string) => boolean
+): { hex: string; lightness: number } | null {
+  const target = atLightness(hue, chroma, desired);
+  if (target && ok(target)) return { hex: target, lightness: desired };
 
-  let failing = from;
-  let passing: number = target;
+  const safeHex = atLightness(hue, chroma, safe);
+  if (!safeHex || !ok(safeHex)) return null;
+
+  let failing = desired;
+  let passing = safe;
   for (let step = 0; step < SEARCH_STEPS; step++) {
     const midpoint = (failing + passing) / 2;
     const candidate = atLightness(hue, chroma, midpoint);
-    if (candidate && staysLegible(candidate, backdrops, rest)) {
+    if (candidate && ok(candidate)) {
       passing = midpoint;
     } else {
       failing = midpoint;
     }
   }
   const hex = atLightness(hue, chroma, passing);
-  return hex ? { hex, delta: Math.abs(passing - from) } : null;
+  return hex ? { hex, lightness: passing } : null;
 }
 
 const cache = new Map<string, BrandMarkInk | null>();
 
 /**
- * Resolves the two colours a brand mark wears: a lightly tinted resting state and
- * the full brand colour on hover.
+ * Resolves the two colours a brand mark wears: at rest the brand colour drawn
+ * back toward the theme's own icon ink, and when the mark is active — hovered,
+ * keyboard-focused, in a selected tab or in the focused panel — the brand
+ * colour itself.
  *
- * At rest the mark sits at the theme's own icon-ink lightness carrying the
- * brand's hue at one global chroma, so a row of marks reads as a row of icons
- * that happen to be tinted rather than as a row of logos. On hover it goes to
- * the brand colour, corrected by the minimum lightness move that keeps it
- * readable — legibility wins, brand fidelity yields, decided per brand and per
- * theme rather than once for the roster.
+ * The direction matters and it is not "fade into the background". A resting
+ * mark moves *toward the ink*, so on a light theme it sits darker than the
+ * brand and lightens into it, and on a dark theme it sits lighter and deepens
+ * into it. Fading toward the backdrop instead is what makes a row of marks read
+ * as washed out: it spends contrast to signal a state that the control's own
+ * hover background is already signalling.
  *
- * Derives entirely from the brand hex, the active theme's tokens and the one
- * chroma constant: no per-agent table, no per-theme number, no knowledge of the
- * agent registry. An arbitrary preset hex arriving at runtime takes the same
- * path a shipped agent does, which is what makes adding a CLI cost one hex.
+ * Both states are placed by measuring against the backdrop the mark is actually
+ * painted on, with WCAG 1.4.11's 3:1 as a hard floor underneath — checked on
+ * every frame of the crossfade rather than only at its endpoints — and APCA Lc
+ * deciding where a mark goes when its brand colour cannot be shown at all.
+ *
+ * Derives entirely from the brand hex, the theme's tokens and the constants
+ * above: no per-agent table, no per-theme number. An arbitrary preset hex
+ * arriving at runtime takes the same path a shipped agent does, which is what
+ * makes adding a CLI cost one hex.
  */
 export function resolveBrandMarkInk(
   brandColor: string | undefined,
-  scheme: AppColorScheme
+  scheme: AppColorScheme,
+  surface?: BrandMarkSurface | null
 ): BrandMarkInk | null {
   const brand = brandHex(brandColor);
-  const inkHex = opaqueHex(scheme.tokens["text-secondary"]);
-  if (!brand || !inkHex) return null;
+  if (!brand) return null;
 
-  // Keyed on the token values themselves, not the scheme id: a custom theme can
-  // be edited in place and keep its id, so an id-keyed entry would go stale.
+  const placement = resolveBackdrops(scheme, surface);
+  if (!placement) return null;
+  // The theme's own icon ink, as a ceiling on how loud a resting mark may get.
+  const ink = opaqueHex(scheme.tokens["text-secondary"]);
+
+  // Keyed on the resolved backdrops rather than the scheme id: a custom theme
+  // can be edited in place and keep its id, and the same theme resolves
+  // differently per surface.
   const key = [
     brand,
-    inkHex,
-    scheme.tokens["overlay-elevated"] ?? "",
-    ...DISPLAY_SURFACES.map((surface) => scheme.tokens[surface] ?? ""),
+    ink ?? "",
+    ...placement.all.flatMap((backdrops) => [backdrops.rest, backdrops.active]),
+    placement.primary.rest,
   ].join("|");
   const cached = cache.get(key);
   if (cached !== undefined) return cached;
 
-  const resolved = computeInk(brand, inkHex, scheme);
+  const resolved = computeInk(brand, placement, ink);
   if (cache.size >= CACHE_LIMIT) {
     // Oldest-first eviction. Preset colours are arbitrary hexes arriving at
     // runtime, so the key space is unbounded and the map needs a ceiling.
@@ -262,39 +507,236 @@ export function resolveBrandMarkInk(
   return resolved;
 }
 
-function computeInk(brandHex: string, inkHex: string, scheme: AppColorScheme): BrandMarkInk | null {
-  const backdrops = collectBackdrops(scheme);
-  if (backdrops.length === 0) return null;
-
+function computeInk(
+  brandHex: string,
+  placement: Placement,
+  inkHex: string | null
+): BrandMarkInk | null {
   const brand = toOklch(brandHex);
+  if (!brand) return null;
+
+  // A brand with no chroma has nothing for a theme to carry. Drawn as a
+  // silhouette in the theme's own icon ink it sits exactly level with the
+  // neutral controls beside it, and its reveal becomes weight — the one axis it
+  // still has — instead of a colour that never arrives.
+  if ((brand.c ?? 0) < COLOURLESS_CHROMA && inkHex) {
+    const silhouette = resolveColourless(inkHex, placement);
+    if (silhouette) return silhouette;
+  }
+
+  const active = resolveActive(brandHex, brand.h, brand.c ?? 0, brand.l, placement);
+  if (!active) return null;
+
+  return { rest: resolveRest(active.hex, brand.h, placement, inkHex), active: active.hex };
+}
+
+/**
+ * The theme's icon ink at rest, and the same ink one step further from the
+ * backdrop when active.
+ *
+ * The direction is the reverse of a coloured mark's, and deliberately so. A
+ * coloured mark rests brighter and *gains colour* on hover, which is a reveal
+ * even though it loses a little weight. A colourless one has no colour to gain,
+ * so weight is the only reveal available and it has to move the other way.
+ * Moving away from the backdrop only adds contrast, so the ink's own contrast
+ * guarantee carries both states.
+ */
+function resolveColourless(inkHex: string, placement: Placement): BrandMarkInk | null {
   const ink = toOklch(inkHex);
-  if (!brand || !ink) return null;
+  const backdrop = toOklch(placement.primary.rest);
+  if (!ink || !backdrop) return null;
 
-  const brandChroma = brand.c ?? 0;
-  const hasHue = brand.h !== undefined && brandChroma > ACHROMATIC_CHROMA;
+  const away = (ink.l ?? 0) >= (backdrop.l ?? 0) ? 1 : -1;
+  const active = atLightness(
+    ink.h,
+    ink.c ?? 0,
+    Math.min(1, Math.max(0, ink.l + away * FADE_DELTA_E))
+  );
+  if (!active || !staysLegible(inkHex, active, placement)) return null;
+  return { rest: inkHex, active };
+}
 
-  // The tint only earns its place if it is no less legible than the ink it
-  // replaces; a hue that cannot hold the floor at this lightness stays grey.
-  let rest = inkHex;
-  if (hasHue) {
-    const tinted = atLightness(brand.h, TINT_CHROMA, ink.l);
-    if (tinted && staysLegible(tinted, backdrops)) rest = tinted;
+/**
+ * The brand colour, untouched wherever it is legible, and otherwise moved along
+ * its own hue line — hue held, chroma reduced until it fits sRGB rather than
+ * clipped channel-wise, since clipping shifts the hue.
+ *
+ * Both directions are tried and the shorter move wins: a near-black brand on a
+ * dark theme has to come up, a near-white one on a light theme has to come
+ * down, and which of those a given brand needs is a property of the pair, not
+ * of the brand.
+ */
+function resolveActive(
+  brandHex: string,
+  hue: number | undefined,
+  chroma: number,
+  lightness: number,
+  placement: Placement
+): { hex: string; lightness: number } | null {
+  // An active mark is painted on the resting backdrop too — a selected tab is
+  // not a hovered one — so every backdrop has to hold, and the weakest of them
+  // is the one that decides.
+  const legible = (hex: string) =>
+    worstContrast(hex, placement) >= CONTRAST_FLOOR + SAMPLING_GUARD &&
+    worstWeight(hex, placement) >= ACTIVE_MIN_LC;
+
+  if (legible(brandHex)) return { hex: brandHex, lightness };
+
+  const minimal = [
+    approach(hue, chroma, 0, lightness, legible),
+    approach(hue, chroma, 1, lightness, legible),
+  ]
+    .filter((result): result is { hex: string; lightness: number } => result !== null)
+    .sort((a, b) => Math.abs(a.lightness - lightness) - Math.abs(b.lightness - lightness))[0];
+  if (!minimal) return null;
+
+  if (Math.abs(minimal.lightness - lightness) <= FIDELITY_LIMIT) return minimal;
+
+  // The minimum move was already large enough that this is not the brand colour
+  // any more. Sitting on the floor buys nothing at that point — it just makes it
+  // a murkier grey — so place it at a weight that reads. Direction is the one
+  // the minimum move chose; it is the near side.
+  const toward = minimal.lightness > lightness ? 1 : 0;
+  const comfortable = approach(
+    hue,
+    chroma,
+    toward,
+    lightness,
+    (hex) => legible(hex) && worstWeight(hex, placement) >= CORRECTED_LC
+  );
+  return comfortable ?? minimal;
+}
+
+/**
+ * The active ink drawn `FADE_DELTA_E` back from the brand colour, away from the
+ * backdrop, and never louder than the row it sits in.
+ *
+ * Away, not toward. Both directions read as "less brand colour", but only one
+ * keeps the mark legible while it does: a mark pulled toward its backdrop gives
+ * up contrast to signal a state the control's own hover background is already
+ * signalling, and a row of them reads as washed out. Pulled the other way, a
+ * resting mark on a light theme sits *darker* than the brand and lightens into
+ * it, and on a dark theme sits *lighter* and deepens into it.
+ *
+ * Most of the step is lightness and a fixed slice is chroma, so the reveal is a
+ * small bloom of colour as well as a shift in weight. The chroma slice is
+ * deliberately small: taking the fade out of chroma is what flattens eighteen
+ * marks into one grey wash, which is the failure this treatment exists to undo.
+ *
+ * The ceiling is what stops the step running away with an already-loud brand.
+ * A near-white cyan on a dark theme starts above the theme's own icon ink;
+ * another step away from the backdrop would leave a *resting* mark shouting
+ * over every control beside it. Those come back down to the row's
+ * weight instead, which inverts their direction — and that is the right trade,
+ * because the state you look at all day is rest.
+ */
+function resolveRest(
+  activeHex: string,
+  hue: number | undefined,
+  placement: Placement,
+  inkHex: string | null
+): string {
+  const active = toOklch(activeHex);
+  const backdrop = toOklch(placement.primary.rest);
+  if (!active || !backdrop) return activeHex;
+
+  const away = (active.l ?? 0) >= (backdrop.l ?? 0) ? 1 : -1;
+  const brandChroma = active.c ?? 0;
+  // Pythagoras on the OKLab plane: at a fixed hue the distance from the active
+  // ink is `hypot(ΔL, ΔC)`, so the chroma slice decides what is left for
+  // lightness rather than the two being set independently.
+  const slice = brandChroma * REST_CHROMA_GIVE;
+  let lightness = Math.min(
+    1,
+    Math.max(0, (active.l ?? 0) + away * Math.sqrt(Math.max(0, FADE_DELTA_E ** 2 - slice ** 2)))
+  );
+
+  // Whatever the ceiling takes off the lightness move comes back as chroma, so
+  // the fade is the same size wherever it lands. A mark held down to the row's
+  // weight fades by losing colour instead of by gaining brightness — which is
+  // the only axis it has left, and still reads as the same mark one step back.
+  //
+  // Chroma and the ceiling depend on each other: a lower chroma changes the
+  // weight a lightness carries, which changes where the ceiling bites, which
+  // changes how much chroma is owed. Two passes settle it — the second measures
+  // the chroma the first arrived at — and the loop below re-checks the result
+  // either way, so this converges rather than merely approximating.
+  const ceiling = inkHex
+    ? apcaLc(inkHex, placement.primary.rest) + REST_CEILING_LC_MARGIN
+    : Infinity;
+  const spend = (from: number) =>
+    Math.min(
+      brandChroma,
+      Math.max(slice, Math.sqrt(Math.max(0, FADE_DELTA_E ** 2 - ((active.l ?? 0) - from) ** 2)))
+    );
+
+  let chroma = brandChroma - spend(lightness);
+  for (let pass = 0; pass < 2 && Number.isFinite(ceiling); pass++) {
+    const candidate = atLightness(hue, chroma, lightness);
+    if (!candidate || apcaLc(candidate, placement.primary.rest) <= ceiling) break;
+    lightness = atWeight(hue, chroma, ceiling, backdrop.l ?? 0, lightness, placement.primary.rest);
+    chroma = brandChroma - spend(lightness);
   }
 
-  if (staysLegible(brandHex, backdrops, rest)) {
-    return { rest, hover: brandHex };
+  const at = (ratio: number): string | null =>
+    atLightness(
+      hue,
+      (active.c ?? 0) + (chroma - (active.c ?? 0)) * ratio,
+      (active.l ?? 0) + (lightness - (active.l ?? 0)) * ratio
+    );
+
+  const ok = (hex: string) => staysLegible(hex, activeHex, placement);
+  const target = at(1);
+  if (target && ok(target)) return target;
+
+  // Bisect back toward the active ink, which is legible by construction. Every
+  // candidate is measured on the formatted hex, since gamut mapping and 8-bit
+  // rounding both sit between the ratio picked and the contrast measured, and
+  // only a hex that was measured and passed is ever returned — falling all the
+  // way back to the active ink rather than to a ratio nothing verified.
+  let failing = 1;
+  let passing: string | null = null;
+  let floor = 0;
+  for (let step = 0; step < SEARCH_STEPS; step++) {
+    const midpoint = (failing + floor) / 2;
+    const candidate = at(midpoint);
+    if (candidate && ok(candidate)) {
+      passing = candidate;
+      floor = midpoint;
+    } else {
+      failing = midpoint;
+    }
   }
+  return passing ?? activeHex;
+}
 
-  // Both directions, then the smaller move — the correction is a last resort and
-  // should be as close to the untouched brand colour as legibility allows.
-  const darker = searchLightness(brand.h, brandChroma, brand.l, 0, backdrops, rest);
-  const lighter = searchLightness(brand.h, brandChroma, brand.l, 1, backdrops, rest);
-  const best = [darker, lighter]
-    .filter((result): result is { hex: string; delta: number } => result !== null)
-    .sort((a, b) => a.delta - b.delta)[0];
-
-  // Nothing on the lightness axis clears the floor against every surface at
-  // once, so the mark holds its resting ink through the hover rather than
-  // animating into something unreadable.
-  return { rest, hover: best?.hex ?? rest };
+/**
+ * The lightness at which this hue carries `targetLc` against `backdrop`,
+ * searched between the backdrop's own lightness (where weight is nil) and a
+ * lightness known to exceed the target.
+ *
+ * Bisection for the same reason every other search here uses it: gamut mapping
+ * and 8-bit rounding sit between the lightness picked and the weight measured,
+ * so the relationship has no closed form.
+ */
+function atWeight(
+  hue: number | undefined,
+  chroma: number,
+  targetLc: number,
+  backdropLightness: number,
+  overLightness: number,
+  backdrop: string
+): number {
+  let under = backdropLightness;
+  let over = overLightness;
+  for (let step = 0; step < SEARCH_STEPS; step++) {
+    const midpoint = (under + over) / 2;
+    const candidate = atLightness(hue, chroma, midpoint);
+    if (candidate && apcaLc(candidate, backdrop) > targetLc) {
+      over = midpoint;
+    } else {
+      under = midpoint;
+    }
+  }
+  return over;
 }


### PR DESCRIPTION
Follow-up to #11906, which went too far the other way. That one set every mark to a constant chroma of `0.05` at the theme's `text-secondary` lightness, so all eighteen brands came out as the same faint grey tint with a hue you had to look for. This keeps the vendor's actual colour and only fades it slightly at rest.

## The two states

**Rest** is the brand colour drawn back a fixed perceptual step (OKLab ΔE 0.07) *away from* the backdrop. So on a dark theme it sits lighter than the brand and deepens into it, on a light theme it sits darker and lightens into it. That direction matters: fading toward the backdrop spends contrast to signal a state the control's own hover background is already signalling, which is what made the last version read as washed out. A fifth of the step comes out of chroma so the reveal is a bloom of colour as well as a shift in weight. Hue never moves.

**Active** is the brand colour itself, untouched wherever it clears WCAG 3:1 and APCA Lc 35 against the weaker of its two backdrops. Where it falls short, the smallest move along its own hue line that gets it there (hue held, chroma reduced until it fits sRGB rather than clipped channel-wise). Where even the minimum move has already cost the brand its identity, a near-black mark on a dark theme, it goes to Lc 60 instead of parking on the floor.

Two rules keep the row honest. A resting mark is never more than 11 Lc above the theme's own `text-secondary`, because the neutral controls beside it are painted in that ink and a near-white brand would otherwise rest louder than every control around it. And a brand with no chroma at all is not a colour: below OKLCH chroma `0.02` the mark is drawn as an icon, resting at `text-secondary` with its active state one step further from the backdrop. Weight is the only reveal those have.

## Knowing the backdrop

The colours are computed against the backdrop each mark is actually painted on, declared by a new `BrandSurface` context on containers rather than call sites. A panel title bar measures against the header it paints, including the `panel-header-bg` / `panel-header-focus-bg` extensions several light themes repaint title bars with. Menus and popovers render `BrandSurfaceReset`, since React context reaches through a portal even though the DOM does not, and a menu opened from the toolbar would otherwise be measured against the toolbar. With no provider a mark answers to every surface at once, which is where the old behaviour lives on.

Selected tabs and the focused pane's title bar now reach the active ink too, not just hover and keyboard focus. `data-brand-active` sits on the glyph's own wrapper rather than the header, or a focused panel would light up every tab in its strip.

## Contrast

`shared/theme/apca.ts` is new: APCA-W3 (`0.98G-4g-W3`), validated against the two published reference values. It decides weight and placement, where WCAG's ratio is the wrong instrument (it has no polarity term, and it compresses at the dark end, so a step that reads as one notch on a light theme reads as three on a dark one). WCAG 1.4.11's 3:1 stays the hard floor underneath.

Both states are checked across the whole 150ms crossfade rather than at its endpoints, because the control repaints its background in the same 150ms the glyph recolours. Foreground and backdrop are sampled as a grid rather than in lockstep: the glyph eases out and the surfaces under it ease, so any monotone pair of easings is covered without either being assumed.

## Review

Five rounds against real screenshots of the running app, all eighteen marks on one toolbar in Daintree and Bondi, at rest, with one button hovered, and with the whole row forced active. Three findings came out of it and are in the code: the Lc 35 active floor (several dark violets cleared 3:1 while landing below the resting state they came from, so the state you were looking at was the weakest one), the resting ceiling, and the colourless-brands-are-icons rule.

`src/lib/__tests__/brandMarkMatrix.test.ts` runs the whole agent registry against every built-in theme and every surface a mark can land on: the floor at rest, active and mid-crossfade, the Lc 35 contract, the ceiling, hue preservation, and that every mark has a reveal to hover into. Adding a CLI still costs one hex, and a test reads the resolver's source to prove it holds no agent table.

## Known gaps

- Toolbar and tab hover backgrounds can be overridden by theme extensions (`toolbar-agent-hover-bg`, the tab's `bg-tint`); the resolver models the standard `overlay-elevated`. Every built-in theme uses the fallback so it is exact today, but a theme that overrides it would be measured against the wrong composite.
- Aider's mark reads optically smaller than its neighbours at 16px. That is glyph geometry, not colour, and it wants its own change.
