### PR TITLE
fix(worktree): let an externally deleted worktree clean up its agents

### DIFF
--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -467,6 +467,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
               // last-known title.
               title: worktree.branch,
               path: worktree.path,
+              gitDir: worktree.gitDir,
             })
           );
         }
@@ -585,7 +586,11 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           // them here — so this record is identical to the one the event
           // handler would build, and first-write-wins costs nothing.
           selectionStore.addDeletedWorktree(
-            createDeletedWorktreeRecord(id, { title: removed?.branch, path: removed?.path })
+            createDeletedWorktreeRecord(id, {
+              title: removed?.branch,
+              path: removed?.path,
+              gitDir: removed?.gitDir,
+            })
           );
         }
         // A host restart can re-hydrate a worktree we had already deleted
@@ -594,7 +599,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         if (useWorktreeSelectionStore.getState().deletedWorktrees.size > 0) {
           useWorktreeSelectionStore
             .getState()
-            .pruneDeletedWorktrees(new Set(state.worktrees.keys()));
+            .pruneDeletedWorktrees(new Set(state.worktrees.keys()), incomingGitDirs);
         }
       })
     );

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -511,6 +511,11 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // already-clean key — so on a normal single removal the `worktree-removed`
     // event path and this subscription each fire it once for the same id
     // (the second call re-publishes correct state, nothing more) (#9536).
+    //
+    // The last topology the host actually reported, held so a not-ready `[]`
+    // can't erase the baseline the removal diff below depends on. Scoped to
+    // this effect, so a remount starts from the store's own state again.
+    let lastReadyWorktrees: ReadonlyMap<string, WorktreeSnapshot> | null = null;
     cleanups.push(
       store.subscribe((state, prevState) => {
         if (state.worktrees === prevState.worktrees) return;
@@ -521,9 +526,33 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // worktree in the project at once.
         const removalsAreAuthoritative = state.worktrees.size > 0;
         for (const id of prevState.worktrees.keys()) {
+          if (!state.worktrees.has(id)) usePulseStore.getState().invalidate(id);
+        }
+        if (!removalsAreAuthoritative) return;
+
+        // Diff against the last READY topology, not simply the previous state.
+        // A not-ready `[]` still replaces the live map, so comparing with
+        // `prevState` would let a `[a, b] → [] → [a]` sequence lose `b`
+        // entirely: the first step declines to adopt (correctly) and the second
+        // compares against nothing. The removal would then never be observed
+        // again, which is the bug this backstop exists to close.
+        const baseline = lastReadyWorktrees ?? prevState.worktrees;
+        lastReadyWorktrees = state.worktrees;
+
+        // A worktree that merely moved reappears under a new path-derived id
+        // while keeping its `.git/worktrees/<name>` handle (#11388) — and ids
+        // can differ by spelling alone, since creation resolves symlinks and
+        // enumeration does not. Ghosting one of those would hand a LIVE
+        // worktree's agents to the cleanup sweep, which trashes them and lets
+        // the trash TTL kill the PTYs. Absence of an id is not proof of
+        // removal; a handle nothing claims is.
+        const incomingGitDirs = new Set<string>();
+        for (const worktree of state.worktrees.values()) {
+          if (worktree.gitDir) incomingGitDirs.add(worktree.gitDir);
+        }
+
+        for (const id of baseline.keys()) {
           if (state.worktrees.has(id)) continue;
-          usePulseStore.getState().invalidate(id);
-          if (!removalsAreAuthoritative) continue;
 
           // Same backstop, second symptom (#11911). A worktree that leaves the
           // map without a `worktree-removed` event strands every panel still
@@ -542,8 +571,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           // The main worktree is exempt for the same reason the event handler
           // blocks it: it cannot legitimately be deleted, so its absence here
           // is a host restart mid-hydration, not a removal.
-          const removed = prevState.worktrees.get(id);
+          const removed = baseline.get(id);
           if (removed?.isMainWorktree) continue;
+          if (removed?.gitDir && incomingGitDirs.has(removed.gitDir)) continue;
           const selectionStore = useWorktreeSelectionStore.getState();
           if (selectionStore.deletedWorktrees.has(id)) continue;
           if (getDeletedWorktreeTerminalIds(id).length === 0) continue;

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -11,7 +11,7 @@ import type { PluginWorktreeLinked } from "@shared/types/plugin";
 import {
   useWorktreeSelectionStore,
   getDeletedWorktreeTerminalIds,
-  getPinnedDeletedWorktreeAnchorId,
+  createDeletedWorktreeRecord,
 } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { startDeletedWorktreeCleanup } from "@/store/deletedWorktreeCleanup";
@@ -452,24 +452,23 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // `applyRemove` dropped it from the live map. Both delete entry points
         // (the delete dialog and the `worktree.delete` action) funnel through
         // this event, so they get identical behaviour from this one change.
+        // Ordinarily a no-op by the time it runs: `applyRemove` above fires the
+        // map-diff subscription synchronously, and that backstop has already
+        // recorded this row from the outgoing snapshot. It still matters for
+        // the removals the backstop cannot see — an id already absent from the
+        // map, which is how an externally-removed worktree usually arrives —
+        // and `createDeletedWorktreeRecord` keeps the two records identical, so
+        // `addDeletedWorktree`'s first-write-wins never loses a field (#11911).
         if (willBecomeGhost) {
-          selectionStore.addDeletedWorktree({
-            id: event.worktreeId,
-            // Detached-HEAD worktrees have no branch; fall back to the folder
-            // name so the row always carries a recognisable last-known title.
-            title:
-              worktree.branch ?? worktree.path.split(/[/\\]/).filter(Boolean).pop() ?? "Unknown",
-            path: worktree.path,
-            deletedAt: Date.now(),
-            // Recorded UNARMED on purpose: the sweep arms it on its first tick
-            // with this view awake, and only ever advances it across awake
-            // seconds. Stamping a wall-clock deadline here instead meant a
-            // project cached at deletion time came back with the countdown
-            // already spent and no window to rescue anything (#11259).
-            expiresAt: null,
-            holdReason: null,
-            pinnedBeforeWorktreeId: getPinnedDeletedWorktreeAnchorId(event.worktreeId),
-          });
+          selectionStore.addDeletedWorktree(
+            createDeletedWorktreeRecord(event.worktreeId, {
+              // Detached-HEAD worktrees have no branch; the helper falls back
+              // to the folder name so the row always carries a recognisable
+              // last-known title.
+              title: worktree.branch,
+              path: worktree.path,
+            })
+          );
         }
       })
     );
@@ -515,10 +514,49 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     cleanups.push(
       store.subscribe((state, prevState) => {
         if (state.worktrees === prevState.worktrees) return;
+        // An empty incoming map is never a removal: a successful `git worktree
+        // list` always reports at least the main worktree, so [] only ever
+        // means the host isn't ready (#11235). Pulse invalidation is harmless
+        // either way, but adopting off a not-ready read would ghost every live
+        // worktree in the project at once.
+        const removalsAreAuthoritative = state.worktrees.size > 0;
         for (const id of prevState.worktrees.keys()) {
-          if (!state.worktrees.has(id)) {
-            usePulseStore.getState().invalidate(id);
-          }
+          if (state.worktrees.has(id)) continue;
+          usePulseStore.getState().invalidate(id);
+          if (!removalsAreAuthoritative) continue;
+
+          // Same backstop, second symptom (#11911). A worktree that leaves the
+          // map without a `worktree-removed` event strands every panel still
+          // pointing at it: the sidebar groups by live worktree, so those
+          // panels render nowhere, while their PTYs stay alive and keep
+          // counting toward the project's attention tally. Adopting them onto
+          // a deleted-worktree row is what gives them a home again — and what
+          // lets `deletedWorktreeCleanup` eventually retire them, which it
+          // could never do for a row that was never recorded.
+          //
+          // Also covers the event path's own blind spot: its ghost branch is
+          // gated on the worktree still being in the live map, so an external
+          // removal that reconciles the map first (topology watcher →
+          // `applySnapshot`) reaches the handler with nothing left to read.
+          //
+          // The main worktree is exempt for the same reason the event handler
+          // blocks it: it cannot legitimately be deleted, so its absence here
+          // is a host restart mid-hydration, not a removal.
+          const removed = prevState.worktrees.get(id);
+          if (removed?.isMainWorktree) continue;
+          const selectionStore = useWorktreeSelectionStore.getState();
+          if (selectionStore.deletedWorktrees.has(id)) continue;
+          if (getDeletedWorktreeTerminalIds(id).length === 0) continue;
+          // A deleted id must never survive as the durable restore target —
+          // `deletedWorktrees` is in-memory, so it would resolve to nothing
+          // after a restart. No-ops unless the id IS the target.
+          selectionStore.clearRestoreTarget(id);
+          // Branch and path come off the outgoing snapshot, which still holds
+          // them here — so this record is identical to the one the event
+          // handler would build, and first-write-wins costs nothing.
+          selectionStore.addDeletedWorktree(
+            createDeletedWorktreeRecord(id, { title: removed?.branch, path: removed?.path })
+          );
         }
         // A host restart can re-hydrate a worktree we had already deleted
         // (#11232). The real row wins — its terminals were never detached, so

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -465,3 +465,159 @@ describe("WorktreeStoreProvider — surviving terminals on worktree removal", ()
     expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
   });
 });
+
+describe("WorktreeStoreProvider — worktrees dropped without a removal event (#11911)", () => {
+  it("adopts stranded panels onto a row when applySnapshot drops the worktree", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+    setPanels([
+      { id: "agent-a", worktreeId: "wt-2" },
+      { id: "agent-b", worktreeId: "wt-2" },
+      { id: "live", worktreeId: "wt-1" },
+    ]);
+
+    // An external `git worktree remove` reconciles the list before any per-id
+    // event arrives, so the survivors would otherwise render nowhere while
+    // their PTYs stayed alive and kept counting as needing input.
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+
+    const row = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-2");
+    expect(row).toBeDefined();
+    expect(row?.path).toBe("/repo/wt-2");
+    expect(row?.title).toBe("branch-wt-2");
+    // Panels survive: "worktree gone" and "PTY dead" stay independent (#11232).
+    expect(usePanelStore.getState().panelsById["agent-a"]).toBeDefined();
+    expect(usePanelStore.getState().panelsById["agent-b"]).toBeDefined();
+  });
+
+  it("records the adopted row unarmed so the sweep owns the countdown", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-2" }]);
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+
+    const row = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-2");
+    expect(row?.expiresAt).toBeNull();
+    expect(row?.holdReason).toBeNull();
+  });
+
+  it("anchors the adopted row to the neighbour it sat above", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    recordSidebarWorktreeOrder(["wt-1", "wt-2"]);
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-2")], nextV());
+    });
+
+    expect(
+      useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.pinnedBeforeWorktreeId
+    ).toBe("wt-2");
+  });
+
+  it("adopts nothing when the incoming snapshot is empty", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+    setPanels([
+      { id: "agent-a", worktreeId: "wt-1" },
+      { id: "agent-b", worktreeId: "wt-2" },
+    ]);
+
+    // A successful enumeration always reports the main worktree, so [] means
+    // the host isn't ready — never that every worktree was deleted (#11235).
+    act(() => {
+      store.getState().applySnapshot([], nextV());
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.size).toBe(0);
+  });
+
+  it("adopts nothing for a dropped worktree that held no terminals", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-2")).toBe(false);
+  });
+
+  it("adopts nothing when the dropped worktree is the main one", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applySnapshot(
+          [makeWorktree("wt-main", { isMainWorktree: true }), makeWorktree("wt-2")],
+          nextV()
+        );
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-main" }]);
+
+    // Main can't be deleted, so its absence is a host rebuild mid-hydration.
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-2")], nextV());
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-main")).toBe(false);
+  });
+
+  it("keeps the event handler's row identical to the backstop's", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    recordSidebarWorktreeOrder(["wt-1"]);
+
+    // The backstop fires synchronously inside `applyRemove`, so it — not the
+    // handler below it — is what actually records the row. Every field the
+    // handler used to own has to survive that reordering.
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    const row = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
+    expect(row?.title).toBe("branch-wt-1");
+    expect(row?.path).toBe("/repo/wt-1");
+    expect(row?.expiresAt).toBeNull();
+  });
+
+  it("demotes an adopted worktree from the durable restore target", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-2" }]);
+    act(() => {
+      useWorktreeSelectionStore.getState().selectWorktree("wt-2");
+    });
+    expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-2");
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+
+    // A deleted id resolves to nothing after a restart, so it must not persist
+    // as the restore point even while its ghost row is still on screen.
+    expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBeNull();
+  });
+});

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -660,6 +660,65 @@ describe("WorktreeStoreProvider — worktrees dropped without a removal event (#
     expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-2")).toBe(true);
   });
 
+  it("withdraws the row when a live worktree turns up carrying its handle", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applySnapshot(
+          [makeWorktree("wt-main"), makeWorktree("/old/feature", { gitDir: "/repo/.git/wt/f" })],
+          nextV()
+        );
+    });
+    setPanels([{ id: "agent-a", worktreeId: "/old/feature" }]);
+
+    // Production ordering for a `git worktree move`: the host tears the old
+    // monitor down and announces the removal BEFORE the replacement monitor
+    // reports, so the adoption-time handle check has nothing to match against
+    // and a row is recorded.
+    act(() => {
+      store.getState().applyRemove("/old/feature", nextV());
+    });
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("/old/feature")).toBe(true);
+
+    // The replacement arrives a moment later under a new path-derived id but
+    // the same admin-dir handle. The row has to be withdrawn — otherwise it
+    // hands still-live agents to the cleanup sweep 60 seconds on.
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(makeWorktree("/new/feature", { gitDir: "/repo/.git/wt/f" }), nextV());
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("/old/feature")).toBe(false);
+  });
+
+  it("keeps a row whose handle no live worktree claims", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applySnapshot(
+          [makeWorktree("wt-main"), makeWorktree("/old/feature", { gitDir: "/repo/.git/wt/f" })],
+          nextV()
+        );
+    });
+    setPanels([{ id: "agent-a", worktreeId: "/old/feature" }]);
+
+    act(() => {
+      store.getState().applyRemove("/old/feature", nextV());
+    });
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(makeWorktree("/other", { gitDir: "/repo/.git/wt/other" }), nextV());
+    });
+
+    // A genuine deletion must survive the handle check, or nothing is ever
+    // cleaned up.
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("/old/feature")).toBe(true);
+  });
+
   it("does not ghost a worktree that only moved", async () => {
     const { store } = await renderProvider();
     act(() => {

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -580,25 +580,111 @@ describe("WorktreeStoreProvider — worktrees dropped without a removal event (#
     expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-main")).toBe(false);
   });
 
-  it("keeps the event handler's row identical to the backstop's", async () => {
+  it("records every field the event handler owns without the event firing", async () => {
     const { store } = await renderProvider();
     act(() => {
-      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("wt-2")], nextV());
     });
     setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
-    recordSidebarWorktreeOrder(["wt-1"]);
+    recordSidebarWorktreeOrder(["wt-1", "wt-2"]);
 
-    // The backstop fires synchronously inside `applyRemove`, so it — not the
-    // handler below it — is what actually records the row. Every field the
-    // handler used to own has to survive that reordering.
+    // `applyRemove` WITHOUT emitting the event: the backstop is then the only
+    // author, which is also what happens for real — it runs synchronously
+    // inside `applyRemove`, before the handler's own first-write-wins call.
+    // Anything the backstop can't reconstruct is lost for good, so assert the
+    // full record here rather than through the handler that used to own it.
     act(() => {
-      emit("worktree-removed", removeEvent("wt-1"));
+      store.getState().applyRemove("wt-1", nextV());
     });
 
     const row = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
     expect(row?.title).toBe("branch-wt-1");
     expect(row?.path).toBe("/repo/wt-1");
+    expect(row?.pinnedBeforeWorktreeId).toBe("wt-2");
     expect(row?.expiresAt).toBeNull();
+  });
+
+  it("adopts each dropped worktree independently, skipping trash-only ones", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applySnapshot(
+          [
+            makeWorktree("wt-live"),
+            makeWorktree("wt-a"),
+            makeWorktree("wt-b"),
+            makeWorktree("wt-trashed"),
+          ],
+          nextV()
+        );
+    });
+    setPanels([
+      { id: "agent-a", worktreeId: "wt-a" },
+      { id: "agent-b", worktreeId: "wt-b" },
+      { id: "gone", worktreeId: "wt-trashed", location: "trash" },
+      { id: "live", worktreeId: "wt-live" },
+    ]);
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-live")], nextV());
+    });
+
+    // Compared as a set: one id failing to adopt must not be masked by another
+    // succeeding, and insertion order is not part of the contract.
+    expect([...useWorktreeSelectionStore.getState().deletedWorktrees.keys()].sort()).toEqual([
+      "wt-a",
+      "wt-b",
+    ]);
+  });
+
+  it("still sees a removal that a not-ready snapshot straddled", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-main"), makeWorktree("wt-2")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-2" }]);
+
+    // `[main, wt-2] → [] → [main]`. The empty read is the host not being ready,
+    // and it replaces the live map — so a diff against the previous state alone
+    // would never observe that wt-2 left, and its panels would stay stranded.
+    act(() => {
+      store.getState().applySnapshot([], nextV());
+    });
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.size).toBe(0);
+
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-main")], nextV());
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-2")).toBe(true);
+  });
+
+  it("does not ghost a worktree that only moved", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applySnapshot(
+          [makeWorktree("wt-main"), makeWorktree("/old/feature", { gitDir: "/repo/.git/wt/f" })],
+          nextV()
+        );
+    });
+    setPanels([{ id: "agent-a", worktreeId: "/old/feature" }]);
+
+    // A `git worktree move` re-mints the path-derived id while keeping the
+    // stable admin-dir handle. Ghosting the old id would hand a LIVE
+    // worktree's agents to the cleanup sweep, which trashes and kills them.
+    act(() => {
+      store
+        .getState()
+        .applySnapshot(
+          [makeWorktree("wt-main"), makeWorktree("/new/feature", { gitDir: "/repo/.git/wt/f" })],
+          nextV()
+        );
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("/old/feature")).toBe(false);
   });
 
   it("demotes an adopted worktree from the durable restore target", async () => {

--- a/src/store/__tests__/createWorktreeStore.cleanupOrphans.test.ts
+++ b/src/store/__tests__/createWorktreeStore.cleanupOrphans.test.ts
@@ -81,7 +81,6 @@ beforeEach(() => {
       usePanelStore.setState((prev) => ({
         panelIds: prev.panelIds.filter((panelId) => panelId !== id),
       }));
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     }) as never,
   });
 });

--- a/src/store/__tests__/createWorktreeStore.cleanupOrphans.test.ts
+++ b/src/store/__tests__/createWorktreeStore.cleanupOrphans.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
+import {
+  createWorktreeStore,
+  setCurrentViewStore,
+  cleanupOrphanedTerminals,
+} from "@/store/createWorktreeStore";
+import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore, createDeletedWorktreeRecord } from "@/store/worktreeStore";
+
+// `cleanupOrphanedTerminals` is destructive — `removePanel` kills the PTY — so
+// what it declines to touch is as load-bearing as what it removes. These pin
+// the deleted-worktree exemption (#11911): a row's survivors are homed, not
+// orphaned, and removing them would empty the row and destroy the very agent
+// sessions #11232 exists to keep alive.
+
+const TEST_EPOCH = "test-epoch";
+let _seq = 0;
+function nextV(): WorktreeEventVersion {
+  return { epoch: TEST_EPOCH, seq: ++_seq };
+}
+
+function makeSnapshot(id: string): WorktreeSnapshot {
+  return {
+    id,
+    worktreeId: id,
+    name: id,
+    branch: "main",
+    path: `/repo/${id}`,
+    isCurrent: false,
+    isMainWorktree: false,
+    modifiedCount: 0,
+    summary: "",
+    gitDir: "",
+  };
+}
+
+function setPanels(entries: Array<{ id: string; worktreeId: string }>): void {
+  const panelsById: Record<string, unknown> = {};
+  const panelIdsByWorktreeId: Record<string, string[]> = {};
+  for (const entry of entries) {
+    panelsById[entry.id] = {
+      id: entry.id,
+      kind: "terminal",
+      title: entry.id,
+      worktreeId: entry.worktreeId,
+      location: "grid",
+    };
+    const bucket = panelIdsByWorktreeId[entry.worktreeId];
+    if (bucket) bucket.push(entry.id);
+    else panelIdsByWorktreeId[entry.worktreeId] = [entry.id];
+  }
+  usePanelStore.setState({
+    panelIds: entries.map((e) => e.id),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    panelsById: panelsById as never,
+    panelIdsByWorktreeId,
+  });
+}
+
+function livePanelIds(): string[] {
+  return usePanelStore.getState().panelIds;
+}
+
+function seedStore(liveWorktreeIds: string[]): void {
+  const store = createWorktreeStore();
+  store.getState().applySnapshot(liveWorktreeIds.map(makeSnapshot), nextV());
+  setCurrentViewStore(store);
+}
+
+beforeEach(() => {
+  _seq = 0;
+  useWorktreeSelectionStore.getState().reset();
+  setPanels([]);
+  // `removePanel` reaches into terminal teardown the real store owns; the
+  // question here is only which ids cleanup selects, so the removal itself is
+  // reduced to dropping the id.
+  usePanelStore.setState({
+    removePanel: ((id: string) => {
+      usePanelStore.setState((prev) => ({
+        panelIds: prev.panelIds.filter((panelId) => panelId !== id),
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    }) as never,
+  });
+});
+
+afterEach(() => {
+  useWorktreeSelectionStore.getState().reset();
+  vi.restoreAllMocks();
+});
+
+describe("cleanupOrphanedTerminals — deleted-worktree exemption (#11911)", () => {
+  it("removes a panel stranded on a worktree nothing accounts for", () => {
+    seedStore(["wt-live"]);
+    setPanels([{ id: "stale", worktreeId: "wt-gone" }]);
+
+    cleanupOrphanedTerminals();
+
+    expect(livePanelIds()).toEqual([]);
+  });
+
+  it("spares a panel whose dead worktree has a row holding it", () => {
+    seedStore(["wt-live"]);
+    setPanels([{ id: "survivor", worktreeId: "wt-gone" }]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(createDeletedWorktreeRecord("wt-gone"));
+
+    cleanupOrphanedTerminals();
+
+    // The row is this panel's home. Removing it would kill a live agent and
+    // leave the row empty — the outcome #11232 ruled out.
+    expect(livePanelIds()).toEqual(["survivor"]);
+  });
+
+  it("leaves panels on live worktrees alone", () => {
+    seedStore(["wt-live"]);
+    setPanels([{ id: "normal", worktreeId: "wt-live" }]);
+
+    cleanupOrphanedTerminals();
+
+    expect(livePanelIds()).toEqual(["normal"]);
+  });
+
+  it("exempts only the ghosted id, not every dead worktree", () => {
+    // The narrowness is the contract: one row must not switch cleanup off for
+    // unrelated stale ids, which would let genuinely abandoned panels pile up.
+    seedStore(["wt-live"]);
+    setPanels([
+      { id: "survivor", worktreeId: "wt-ghosted" },
+      { id: "stale", worktreeId: "wt-forgotten" },
+      { id: "normal", worktreeId: "wt-live" },
+    ]);
+    useWorktreeSelectionStore
+      .getState()
+      .addDeletedWorktree(createDeletedWorktreeRecord("wt-ghosted"));
+
+    cleanupOrphanedTerminals();
+
+    expect(livePanelIds().sort()).toEqual(["normal", "survivor"]);
+  });
+});

--- a/src/store/__tests__/createWorktreeStore.cleanupOrphans.test.ts
+++ b/src/store/__tests__/createWorktreeStore.cleanupOrphans.test.ts
@@ -8,6 +8,10 @@ import {
 } from "@/store/createWorktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore, createDeletedWorktreeRecord } from "@/store/worktreeStore";
+import {
+  setWorktreeSelectionAccessor,
+  resetStoreAccessorsForTesting,
+} from "@/store/storeAccessors";
 
 // `cleanupOrphanedTerminals` is destructive — `removePanel` kills the PTY — so
 // what it declines to touch is as load-bearing as what it removes. These pin
@@ -73,6 +77,14 @@ beforeEach(() => {
   _seq = 0;
   useWorktreeSelectionStore.getState().reset();
   setPanels([]);
+  // Cleanup reads the rows through the accessor, exactly as the renderer wires
+  // it — a direct store import would drag the terminal subgraph into the perf
+  // bundle that isolates this store.
+  setWorktreeSelectionAccessor(() => ({
+    activeWorktreeId: null,
+    restoreWorktreeId: null,
+    deletedWorktreeIds: new Set(useWorktreeSelectionStore.getState().deletedWorktrees.keys()),
+  }));
   // `removePanel` reaches into terminal teardown the real store owns; the
   // question here is only which ids cleanup selects, so the removal itself is
   // reduced to dropping the id.
@@ -87,6 +99,7 @@ beforeEach(() => {
 
 afterEach(() => {
   useWorktreeSelectionStore.getState().reset();
+  resetStoreAccessorsForTesting();
   vi.restoreAllMocks();
 });
 
@@ -137,5 +150,20 @@ describe("cleanupOrphanedTerminals — deleted-worktree exemption (#11911)", () 
     cleanupOrphanedTerminals();
 
     expect(livePanelIds().sort()).toEqual(["normal", "survivor"]);
+  });
+});
+
+describe("cleanupOrphanedTerminals — without the selection accessor wired", () => {
+  it("still removes genuinely stale panels", () => {
+    // No accessor means no known rows, which is the pre-#11911 reading: every
+    // panel on a dead worktree is orphaned. The destructive path must keep
+    // working rather than silently switching itself off.
+    resetStoreAccessorsForTesting();
+    seedStore(["wt-live"]);
+    setPanels([{ id: "stale", worktreeId: "wt-gone" }]);
+
+    cleanupOrphanedTerminals();
+
+    expect(livePanelIds()).toEqual([]);
   });
 });

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -146,6 +146,43 @@ describe("sweepDeletedWorktreeCleanup", () => {
     expect(bulkTrashByWorktree).toHaveBeenCalledWith("wt-1");
   });
 
+  it("retries on the next sweep when the trash dispatch throws", () => {
+    // `firedIds` is set before the dispatch, so a throw used to retire the row
+    // permanently — leaving its terminals on a row nothing would ever clear,
+    // which is the state this whole feature exists to end.
+    addRow({ expiresAt: NOW - 1 });
+    bulkTrashByWorktree.mockImplementationOnce(() => {
+      throw new Error("panel store busy");
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    sweepDeletedWorktreeCleanup(makeDeps());
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+
+    sweepDeletedWorktreeCleanup(makeDeps());
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(2);
+
+    // And the retry still settles: a third sweep must not re-fire the row.
+    sweepDeletedWorktreeCleanup(makeDeps());
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(2);
+
+    warn.mockRestore();
+  });
+
+  it("reports nothing to the inbox for a sweep whose dispatch threw", () => {
+    addRow({ expiresAt: NOW - 1 });
+    bulkTrashByWorktree.mockImplementationOnce(() => {
+      throw new Error("panel store busy");
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    // Nothing was trashed, so announcing a cleanup would be a lie.
+    expect(notify).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("fires only once even if the row lingers across further sweeps", () => {
     addRow({ expiresAt: NOW - 1 });
     sweepDeletedWorktreeCleanup(makeDeps());

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -21,6 +21,7 @@ import {
   getDeletedWorktreeTerminalIds,
   getPinnedDeletedWorktreeAnchorId,
   recordSidebarWorktreeOrder,
+  createDeletedWorktreeRecord,
   type DeletedWorktree,
 } from "@/store/worktreeStore";
 
@@ -336,5 +337,62 @@ describe("deleted-worktree group expansion (#11260)", () => {
     addRows(3);
 
     expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(false);
+  });
+});
+
+describe("createDeletedWorktreeRecord", () => {
+  beforeEach(() => {
+    recordSidebarWorktreeOrder([]);
+  });
+
+  it("names the row after the branch when one is known", () => {
+    const record = createDeletedWorktreeRecord("/repo/wt-1", {
+      title: "feature/x",
+      path: "/repo/wt-1",
+    });
+    expect(record.title).toBe("feature/x");
+    expect(record.path).toBe("/repo/wt-1");
+  });
+
+  it("falls back to the folder name for a detached-HEAD worktree", () => {
+    const record = createDeletedWorktreeRecord("/repo/wt-1", { path: "/repo/wt-1" });
+    expect(record.title).toBe("wt-1");
+  });
+
+  it("derives both path and title from the id when nothing else survives", () => {
+    // A worktree id IS its path, so a reconstructed row still has a
+    // recognisable name after git has forgotten the worktree entirely.
+    const record = createDeletedWorktreeRecord("/repo/feature-x");
+    expect(record.path).toBe("/repo/feature-x");
+    expect(record.title).toBe("feature-x");
+  });
+
+  it("reads the last segment of a Windows-style path", () => {
+    const record = createDeletedWorktreeRecord("C:\\repo\\feature-x");
+    expect(record.title).toBe("feature-x");
+  });
+
+  it("survives a path that is nothing but separators", () => {
+    const record = createDeletedWorktreeRecord("///");
+    expect(record.title).toBe("Unknown");
+  });
+
+  it("records the row unarmed so the cleanup sweep owns the countdown", () => {
+    const record = createDeletedWorktreeRecord("/repo/wt-1");
+    expect(record.expiresAt).toBeNull();
+    expect(record.holdReason).toBeNull();
+  });
+
+  it("stamps deletedAt from the clock at construction", () => {
+    const before = Date.now();
+    const record = createDeletedWorktreeRecord("/repo/wt-1");
+    expect(record.deletedAt).toBeGreaterThanOrEqual(before);
+    expect(record.deletedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("anchors the row to the neighbour it sat above in the sidebar", () => {
+    recordSidebarWorktreeOrder(["wt-a", "wt-b", "wt-c"]);
+    expect(createDeletedWorktreeRecord("wt-b").pinnedBeforeWorktreeId).toBe("wt-c");
+    expect(createDeletedWorktreeRecord("wt-c").pinnedBeforeWorktreeId).toBeNull();
   });
 });

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -372,9 +372,11 @@ describe("createDeletedWorktreeRecord", () => {
     expect(record.title).toBe("feature-x");
   });
 
-  it("survives a path that is nothing but separators", () => {
+  it("still produces a usable title for a path that is nothing but separators", () => {
+    // The invariant is that the sidebar always has something to render — the
+    // particular wording is not the contract.
     const record = createDeletedWorktreeRecord("///");
-    expect(record.title).toBe("Unknown");
+    expect(record.title.trim().length).toBeGreaterThan(0);
   });
 
   it("records the row unarmed so the cleanup sweep owns the countdown", () => {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1,6 +1,9 @@
 import { createStore, type StoreApi } from "zustand/vanilla";
 import type { WorktreeSnapshot, WorktreeEventVersion, AttachIssuePayload } from "@shared/types";
 import { usePanelStore } from "./panelStore";
+// Safe despite the store cycle: `worktreeStore` never imports this module, and
+// the read below happens inside a function, never at module evaluation.
+import { useWorktreeSelectionStore } from "./worktreeStore";
 import { worktreeClient } from "@/clients";
 import {
   captureWorktreeTerminalSnapshot,
@@ -1645,13 +1648,21 @@ export function cleanupOrphanedTerminals(): void {
     }
   }
 
+  // A deleted worktree whose terminals outlived it is not orphaned — it has a
+  // sidebar row holding exactly these panels, and removing them here would
+  // empty the row and destroy the survivors #11232 exists to keep (#11911).
+  // Read live rather than passed in: this runs after hydration has rebuilt the
+  // rows, and the live path can be holding rows at any time.
+  const ghostedWorktreeIds = useWorktreeSelectionStore.getState().deletedWorktrees;
+
   const terminalStore = usePanelStore.getState();
   const orphanedTerminals = terminalStore.panelIds
     .map((id) => terminalStore.panelsById[id])
     .filter((t): t is NonNullable<typeof t> => {
       if (!t) return false;
       const worktreeId = typeof t.worktreeId === "string" ? t.worktreeId.trim() : "";
-      return Boolean(worktreeId && !worktreeIds.has(worktreeId));
+      if (!worktreeId || worktreeIds.has(worktreeId)) return false;
+      return !ghostedWorktreeIds.has(worktreeId);
     });
 
   if (orphanedTerminals.length > 0) {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1,9 +1,7 @@
 import { createStore, type StoreApi } from "zustand/vanilla";
 import type { WorktreeSnapshot, WorktreeEventVersion, AttachIssuePayload } from "@shared/types";
 import { usePanelStore } from "./panelStore";
-// Safe despite the store cycle: `worktreeStore` never imports this module, and
-// the read below happens inside a function, never at module evaluation.
-import { useWorktreeSelectionStore } from "./worktreeStore";
+import { getWorktreeSelectionSnapshot } from "./storeAccessors";
 import { worktreeClient } from "@/clients";
 import {
   captureWorktreeTerminalSnapshot,
@@ -1653,7 +1651,12 @@ export function cleanupOrphanedTerminals(): void {
   // empty the row and destroy the survivors #11232 exists to keep (#11911).
   // Read live rather than passed in: this runs after hydration has rebuilt the
   // rows, and the live path can be holding rows at any time.
-  const ghostedWorktreeIds = useWorktreeSelectionStore.getState().deletedWorktrees;
+  //
+  // Through the accessor rather than importing the selection store directly:
+  // that store pulls in TerminalInstanceService, and esbuild links every static
+  // import whether or not it is reachable, so a direct import drags the whole
+  // terminal subgraph into the perf bundle that exists to isolate this store.
+  const ghostedWorktreeIds = getWorktreeSelectionSnapshot()?.deletedWorktreeIds;
 
   const terminalStore = usePanelStore.getState();
   const orphanedTerminals = terminalStore.panelIds
@@ -1662,7 +1665,7 @@ export function cleanupOrphanedTerminals(): void {
       if (!t) return false;
       const worktreeId = typeof t.worktreeId === "string" ? t.worktreeId.trim() : "";
       if (!worktreeId || worktreeIds.has(worktreeId)) return false;
-      return !ghostedWorktreeIds.has(worktreeId);
+      return ghostedWorktreeIds?.has(worktreeId) !== true;
     });
 
   if (orphanedTerminals.length > 0) {

--- a/src/store/deletedWorktreeCleanup.ts
+++ b/src/store/deletedWorktreeCleanup.ts
@@ -407,7 +407,19 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
     // Count first — the executor mirrors this exact filter, and once it runs
     // the panels have already left the row.
     const trashedCount = getDeletedWorktreeTerminalIds(entry.id).length;
-    usePanelStore.getState().bulkTrashByWorktree(entry.id);
+    try {
+      usePanelStore.getState().bulkTrashByWorktree(entry.id);
+    } catch (error) {
+      // `firedIds` is what stops a dispatched row re-firing every tick, so a
+      // throw after it was set would retire the row permanently while its
+      // terminals are still on it — the row would sit there forever and the
+      // PTYs would never be reclaimed. Retry is safe because the executor
+      // skips panels already in trash, so a partial batch resumes rather than
+      // re-trashing. Warned, not notified: the next tick is one second away.
+      firedIds.delete(entry.id);
+      console.warn("[DeletedWorktreeCleanup] Trash dispatch failed; retrying next tick", error);
+      continue;
+    }
     if (trashedCount > 0) {
       swept.push({ worktreeId: entry.id, title: entry.title, count: trashedCount });
     }

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -72,6 +72,7 @@ export function initStoreOrchestrator(): () => void {
   setWorktreeSelectionAccessor(() => ({
     activeWorktreeId: useWorktreeSelectionStore.getState().activeWorktreeId,
     restoreWorktreeId: useWorktreeSelectionStore.getState().restoreWorktreeId,
+    deletedWorktreeIds: new Set(useWorktreeSelectionStore.getState().deletedWorktrees.keys()),
   }));
   setWorktreeIdSetAccessor(() => {
     const viewStore = getCurrentViewStoreOrNull();

--- a/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
@@ -758,21 +758,52 @@ describe("hydrateTabGroups — repair never elects a deleted worktree (#11911)",
     }));
   });
 
-  it("prefers a live worktree even when the deleted one holds the majority", () => {
+  it("splits survivors out of a mixed group instead of reparenting either side", () => {
+    const survivorA = createMockTerminal("t1", "wt-dead", "grid");
+    const survivorB = createMockTerminal("t2", "wt-dead", "grid");
+    const respawned = createMockTerminal("t3", "wt-live", "grid");
+    const alsoLive = createMockTerminal("t4", "wt-live", "grid");
+    setTerminals([survivorA, survivorB, respawned, alsoLive]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    usePanelStore
+      .getState()
+      .hydrateTabGroups([createMockTabGroup("g1", "wt-dead", ["t1", "t2", "t3", "t4"])]);
+
+    const state = usePanelStore.getState();
+    // Neither side is relabelled. Electing the deleted worktree would hand the
+    // freshly respawned panels to the sweep; electing the live one would
+    // relabel real survivors, empty their row and exempt them from the
+    // cleanup that is supposed to retire them.
+    expect(state.panelsById["t1"]?.worktreeId).toBe("wt-dead");
+    expect(state.panelsById["t2"]?.worktreeId).toBe("wt-dead");
+    expect(state.panelsById["t3"]?.worktreeId).toBe("wt-live");
+    expect(state.panelsById["t4"]?.worktreeId).toBe("wt-live");
+    // The group keeps only the coherent live half.
+    const group = state.tabGroups.get("g1");
+    expect(group?.worktreeId).toBe("wt-live");
+    expect(group?.panelIds.sort()).toEqual(["t3", "t4"]);
+    warn.mockRestore();
+  });
+
+  it("dissolves the group when the split leaves it with one member", () => {
     const survivorA = createMockTerminal("t1", "wt-dead", "grid");
     const survivorB = createMockTerminal("t2", "wt-dead", "grid");
     const respawned = createMockTerminal("t3", "wt-live", "grid");
     setTerminals([survivorA, survivorB, respawned]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     usePanelStore
       .getState()
       .hydrateTabGroups([createMockTabGroup("g1", "wt-dead", ["t1", "t2", "t3"])]);
 
     const state = usePanelStore.getState();
-    // 2-vs-1 in favour of the deleted worktree, and it still loses: the sweep
-    // would otherwise take t3 with it.
-    expect(state.tabGroups.get("g1")?.worktreeId).toBe("wt-live");
+    expect(state.tabGroups.has("g1")).toBe(false);
+    // Every panel still keeps the worktree it restored onto.
+    expect(state.panelsById["t1"]?.worktreeId).toBe("wt-dead");
+    expect(state.panelsById["t2"]?.worktreeId).toBe("wt-dead");
     expect(state.panelsById["t3"]?.worktreeId).toBe("wt-live");
+    warn.mockRestore();
   });
 
   it("leaves an all-survivor group on its deleted worktree", () => {

--- a/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@/types";
 import type { PtyPanelData, TabGroup } from "@shared/types/panel";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { setWorktreeSelectionAccessor } from "@/store/storeAccessors";
 import { NO_WORKTREE } from "../worktreeIndex";
 
 vi.mock("@/clients", () => ({
@@ -724,5 +725,68 @@ describe("Tab Group Worktree Invariant", () => {
       const allIds = groups.flatMap((g) => g.panelIds);
       expect(allIds).toEqual(["recipe-1"]);
     });
+  });
+});
+
+describe("hydrateTabGroups — repair never elects a deleted worktree (#11911)", () => {
+  // Restoring a group whose worktree was deleted can now split: PTYs that
+  // survived keep the deleted id, while any whose process died cold-respawn
+  // onto a live worktree. The repair rewrites EVERY member to one worktree, so
+  // electing the deleted one would move a freshly spawned agent onto a row the
+  // cleanup sweep trashes.
+  beforeEach(() => {
+    usePanelStore.getState().reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: "wt-live",
+      restoreWorktreeId: null,
+      deletedWorktreeIds: new Set(["wt-dead"]),
+    }));
+  });
+
+  afterEach(() => {
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: null,
+      restoreWorktreeId: null,
+    }));
+  });
+
+  it("prefers a live worktree even when the deleted one holds the majority", () => {
+    const survivorA = createMockTerminal("t1", "wt-dead", "grid");
+    const survivorB = createMockTerminal("t2", "wt-dead", "grid");
+    const respawned = createMockTerminal("t3", "wt-live", "grid");
+    setTerminals([survivorA, survivorB, respawned]);
+
+    usePanelStore
+      .getState()
+      .hydrateTabGroups([createMockTabGroup("g1", "wt-dead", ["t1", "t2", "t3"])]);
+
+    const state = usePanelStore.getState();
+    // 2-vs-1 in favour of the deleted worktree, and it still loses: the sweep
+    // would otherwise take t3 with it.
+    expect(state.tabGroups.get("g1")?.worktreeId).toBe("wt-live");
+    expect(state.panelsById["t3"]?.worktreeId).toBe("wt-live");
+  });
+
+  it("leaves an all-survivor group on its deleted worktree", () => {
+    const survivorA = createMockTerminal("t1", "wt-dead", "grid");
+    const survivorB = createMockTerminal("t2", "wt-dead", "grid");
+    setTerminals([survivorA, survivorB]);
+
+    usePanelStore.getState().hydrateTabGroups([createMockTabGroup("g1", "wt-dead", ["t1", "t2"])]);
+
+    const state = usePanelStore.getState();
+    // Nothing restored onto a live worktree, so there is no safer destination —
+    // and the row is exactly where these panels belong until it is swept.
+    expect(state.tabGroups.get("g1")?.worktreeId).toBe("wt-dead");
+    expect(state.panelsById["t1"]?.worktreeId).toBe("wt-dead");
+    expect(state.panelsById["t2"]?.worktreeId).toBe("wt-dead");
   });
 });

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -692,35 +692,58 @@ export const createTabGroupActions = (
       });
 
       const uniquePanelIds = Array.from(new Set(validPanelIds));
-      const finalPanelIds = uniquePanelIds.filter((id) => !panelsAlreadyInGroups.has(id));
+      let finalPanelIds = uniquePanelIds.filter((id) => !panelsAlreadyInGroups.has(id));
 
       if (finalPanelIds.length <= 1) continue;
 
-      const panelWorktrees = new Map<string | undefined, number>();
-      for (const panelId of finalPanelIds) {
-        const terminal = state.panelsById[panelId];
-        if (terminal) {
-          const count = panelWorktrees.get(terminal.worktreeId) || 0;
-          panelWorktrees.set(terminal.worktreeId, count + 1);
+      const countWorktrees = (ids: readonly string[]) => {
+        const counts = new Map<string | undefined, number>();
+        for (const panelId of ids) {
+          const terminal = state.panelsById[panelId];
+          if (terminal) {
+            counts.set(terminal.worktreeId, (counts.get(terminal.worktreeId) || 0) + 1);
+          }
+        }
+        return counts;
+      };
+
+      // A group whose worktree was deleted can restore split: PTYs that
+      // survived keep the deleted worktree, while any whose process died
+      // cold-respawn onto a live one. Repair rewrites EVERY member to a single
+      // worktree, and both answers are wrong for a split like that — electing
+      // the deleted worktree drags a freshly spawned agent onto a row the
+      // cleanup sweep trashes, and electing the live one relabels genuine
+      // survivors as belonging to a worktree they never ran in, which empties
+      // their row and exempts them from the cleanup that should retire them.
+      //
+      // So don't repair across that line at all: drop the survivors out of the
+      // group and leave them on their row. Ungrouped is a real state, and each
+      // panel keeps the worktree it actually restored onto (#11911).
+      const ghosted = getWorktreeSelectionSnapshot()?.deletedWorktreeIds ?? new Set<string>();
+      if (ghosted.size > 0) {
+        const isGhosted = (id: string) => {
+          const wid = state.panelsById[id]?.worktreeId;
+          return wid !== undefined && ghosted.has(wid);
+        };
+        const ghostMembers = finalPanelIds.filter(isGhosted);
+        // Only a MIXED group needs splitting — one whose members all sit on the
+        // same deleted worktree is already coherent, and its row is where they
+        // belong until it is swept.
+        if (ghostMembers.length > 0 && ghostMembers.length < finalPanelIds.length) {
+          finalPanelIds = finalPanelIds.filter((id) => !isGhosted(id));
+          console.warn(
+            `[TabGroup] Hydration: Splitting ${ghostMembers.length} deleted-worktree survivor(s) out of group ${group.id}`
+          );
+          if (finalPanelIds.length <= 1) continue;
         }
       }
 
+      const panelWorktrees = countWorktrees(finalPanelIds);
+
       let repairedWorktreeId = group.worktreeId;
       if (panelWorktrees.size > 1 || !panelWorktrees.has(group.worktreeId)) {
-        // A repair rewrites every member's worktreeId, so the winner decides
-        // where the whole group lives. A deleted worktree's row is on its way
-        // to the trash (deletedWorktreeCleanup), so electing one would drag
-        // panels that restored onto a LIVE worktree into a sweep that kills
-        // them. Mixed groups only became reachable once survivors started
-        // keeping their deleted worktree instead of re-homing (#11911).
-        const ghosted = getWorktreeSelectionSnapshot()?.deletedWorktreeIds ?? new Set<string>();
-        const survivesRepair = (wid: string | undefined) => wid === undefined || !ghosted.has(wid);
-        const preferred = [...panelWorktrees.entries()].filter(([wid]) => survivesRepair(wid));
-        // Every candidate ghosted means nothing restored onto a live worktree,
-        // so there is no safe destination to prefer — leave the old ranking.
-        const candidates = preferred.length > 0 ? preferred : [...panelWorktrees.entries()];
         let maxCount = 0;
-        for (const [wid, count] of candidates) {
+        for (const [wid, count] of panelWorktrees.entries()) {
           if (count > maxCount) {
             maxCount = count;
             repairedWorktreeId = wid;

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -707,8 +707,20 @@ export const createTabGroupActions = (
 
       let repairedWorktreeId = group.worktreeId;
       if (panelWorktrees.size > 1 || !panelWorktrees.has(group.worktreeId)) {
+        // A repair rewrites every member's worktreeId, so the winner decides
+        // where the whole group lives. A deleted worktree's row is on its way
+        // to the trash (deletedWorktreeCleanup), so electing one would drag
+        // panels that restored onto a LIVE worktree into a sweep that kills
+        // them. Mixed groups only became reachable once survivors started
+        // keeping their deleted worktree instead of re-homing (#11911).
+        const ghosted = getWorktreeSelectionSnapshot()?.deletedWorktreeIds ?? new Set<string>();
+        const survivesRepair = (wid: string | undefined) => wid === undefined || !ghosted.has(wid);
+        const preferred = [...panelWorktrees.entries()].filter(([wid]) => survivesRepair(wid));
+        // Every candidate ghosted means nothing restored onto a live worktree,
+        // so there is no safe destination to prefer — leave the old ranking.
+        const candidates = preferred.length > 0 ? preferred : [...panelWorktrees.entries()];
         let maxCount = 0;
-        for (const [wid, count] of panelWorktrees.entries()) {
+        for (const [wid, count] of candidates) {
           if (count > maxCount) {
             maxCount = count;
             repairedWorktreeId = wid;

--- a/src/store/storeAccessors.ts
+++ b/src/store/storeAccessors.ts
@@ -17,6 +17,16 @@ export interface WorktreeSelectionSnapshot {
   activeWorktreeId: string | null;
   /** Durable selection that should round-trip across project switches (#9512). */
   restoreWorktreeId: string | null;
+  /**
+   * Worktrees that are gone but still hold surviving panels on a sidebar row
+   * (#11232). Exposed because these ids are destinations nothing should be
+   * moved TO: the row's cleanup sweep trashes whatever it holds, so a panel
+   * relocated onto one is scheduled for death (#11911).
+   *
+   * Optional so a harness that only cares about selection can keep supplying
+   * the two ids. Absent reads as "no rows", which is the pre-#11911 behavior.
+   */
+  deletedWorktreeIds?: ReadonlySet<string>;
 }
 
 let _getPanelStoreState: (() => PanelStoreSnapshot) | null = null;

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -62,6 +62,16 @@ export interface DeletedWorktree {
    */
   title: string;
   path: string;
+  /**
+   * The worktree's `.git/worktrees/<name>` handle, when it was known.
+   *
+   * Kept because the id is a path and paths are re-minted: a `git worktree
+   * move` — or the same worktree spelled through a symlink — produces a "new"
+   * worktree that is really this one. The handle is what identifies it across
+   * that, so a row recorded for a worktree that turns out to be alive can be
+   * withdrawn instead of quietly trashing its agents (#11388, #11911).
+   */
+  gitDir?: string;
   deletedAt: number;
   /**
    * When the row's auto-cleanup fires (terminals move to trash, row goes).
@@ -143,13 +153,14 @@ export function getPinnedDeletedWorktreeAnchorId(worktreeId: string): string | n
  */
 export function createDeletedWorktreeRecord(
   worktreeId: string,
-  metadata?: { title?: string | null; path?: string | null }
+  metadata?: { title?: string | null; path?: string | null; gitDir?: string | null }
 ): DeletedWorktree {
   const path = metadata?.path ?? worktreeId;
   return {
     id: worktreeId,
     title: metadata?.title ?? basenameOf(path) ?? "Unknown",
     path,
+    ...(metadata?.gitDir ? { gitDir: metadata.gitDir } : {}),
     deletedAt: Date.now(),
     // Recorded UNARMED: the sweep arms it on its first tick with the view
     // awake, and only ever advances across awake seconds. A wall-clock
@@ -315,7 +326,15 @@ interface WorktreeSelectionState {
   ) => void;
   clearRestoreTarget: (worktreeId: string) => void;
   retargetParkedFleetSelection: (worktreeId: string) => void;
-  pruneDeletedWorktrees: (liveWorktreeIds: ReadonlySet<string>) => void;
+  /**
+   * Retire rows that are no longer deleted worktrees. `liveGitDirs` catches the
+   * ones whose id was re-minted (a move, or a symlink spelling), which id
+   * comparison alone cannot see.
+   */
+  pruneDeletedWorktrees: (
+    liveWorktreeIds: ReadonlySet<string>,
+    liveGitDirs?: ReadonlySet<string>
+  ) => void;
   toggleDeletedWorktreeGroupExpanded: () => void;
   toggleWorktreeExpanded: (id: string) => void;
   setWorktreeExpanded: (id: string, expanded: boolean) => void;
@@ -985,16 +1004,28 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     set({ _previousActiveWorktreeId: worktreeId, _previousRestoreWorktreeId: worktreeId });
   },
 
-  pruneDeletedWorktrees: (liveWorktreeIds) => {
+  pruneDeletedWorktrees: (liveWorktreeIds, liveGitDirs) => {
     set((state) => {
       if (state.deletedWorktrees.size === 0) return state;
       const stale: string[] = [];
-      for (const id of state.deletedWorktrees.keys()) {
+      for (const [id, row] of state.deletedWorktrees) {
         // A row dies when its last terminal leaves (silently — the row
         // simply stops being useful), or when a real worktree reclaims the id,
         // which happens when the workspace host restarts and re-hydrates a
         // worktree we had already deleted.
-        if (liveWorktreeIds.has(id) || getDeletedWorktreeTerminalIds(id).length === 0) {
+        //
+        // A live worktree claiming the row's HANDLE retires it too. The host
+        // tears the old monitor down before standing the new one up, so a
+        // moved worktree is announced as a removal first and only reappears
+        // under its new id a moment later — too late for the adoption-time
+        // check, but well inside the row's countdown. Without this the row
+        // would sit there looking deleted and hand still-live agents to the
+        // cleanup sweep 60 seconds on.
+        if (
+          liveWorktreeIds.has(id) ||
+          (row.gitDir !== undefined && liveGitDirs?.has(row.gitDir) === true) ||
+          getDeletedWorktreeTerminalIds(id).length === 0
+        ) {
           stale.push(id);
         }
       }

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -126,6 +126,47 @@ export function getPinnedDeletedWorktreeAnchorId(worktreeId: string): string | n
 }
 
 /**
+ * Build the row a deleted worktree's surviving terminals live on.
+ *
+ * Shared because three paths reach this state and must produce byte-identical
+ * records: the `worktree-removed` event, the map-diff backstop that catches
+ * removals which never fired one, and hydration rebuilding a row whose store
+ * died with the project view. `addDeletedWorktree` is first-write-wins, so
+ * whichever path arrives first decides the row — and on a normal removal the
+ * backstop fires FIRST, synchronously inside `applyRemove`'s `set()`, before
+ * the event handler that used to be the only author. Anything the backstop
+ * couldn't reconstruct would therefore be silently lost, not merely deferred.
+ *
+ * `title` and `path` fall back to the id because a worktree id IS its path:
+ * git has forgotten the worktree, so the id is the only surviving description
+ * of it, and the basename is the closest thing to the branch name that's left.
+ */
+export function createDeletedWorktreeRecord(
+  worktreeId: string,
+  metadata?: { title?: string | null; path?: string | null }
+): DeletedWorktree {
+  const path = metadata?.path ?? worktreeId;
+  return {
+    id: worktreeId,
+    title: metadata?.title ?? basenameOf(path) ?? "Unknown",
+    path,
+    deletedAt: Date.now(),
+    // Recorded UNARMED: the sweep arms it on its first tick with the view
+    // awake, and only ever advances across awake seconds. A wall-clock
+    // deadline stamped here would come back already spent for a project that
+    // was cached at deletion time, with no window to rescue anything (#11259).
+    expiresAt: null,
+    holdReason: null,
+    pinnedBeforeWorktreeId: getPinnedDeletedWorktreeAnchorId(worktreeId),
+  };
+}
+
+/** Last path segment, or null when the path is empty or all separators. */
+function basenameOf(path: string): string | null {
+  return path.split(/[/\\]/).filter(Boolean).pop() ?? null;
+}
+
+/**
  * Terminals still held by a deleted worktree's row.
  *
  * Mirrors `bulkTrashByWorktree`'s filter exactly (trash + overlay + dialog

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -1246,7 +1246,12 @@ describe("restorePanelsPhase — panels outliving their worktree (issue #11232)"
       ctx
     );
 
+    // Assert BOTH landed on the dead id: one silently re-homed while the other
+    // kept it would still produce a single ghost id and pass a weaker check.
     expect(ctx.addPanel).toHaveBeenCalledTimes(2);
+    for (const call of ctx.addPanel.mock.calls) {
+      expect(call[0]).toMatchObject({ worktreeId: "deleted-wt" });
+    }
     expect([...ghostedWorktreeIds]).toEqual(["deleted-wt"]);
   });
 

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -538,16 +538,21 @@ describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {
   // re-homed.
   const resolvedWorktreeId = (tasks: { worktreeId?: string }[]) => tasks[0]?.worktreeId;
 
-  it("re-homes a stranded panel onto the active worktree when the active worktree is live", async () => {
+  it("ghosts a surviving PTY's dead worktree instead of re-homing it (#11911)", async () => {
     const ctx = makeContext({
       activeWorktreeId: "wMain",
       worktreesPromise: Promise.resolve(wtList("wMain")),
     });
     ctx.backendTerminalMap.set("t1", backend("t1"));
-    const { restoreTasks } = await restorePanelsPhase([panel("t1", { worktreeId: "wGone" })], ctx);
-    // wGone is absent from the complete list; wMain (the active worktree) is
-    // live, so the panel re-homes onto it — the existing #11234 behavior.
-    expect(resolvedWorktreeId(restoreTasks)).toBe("wMain");
+    const { restoreTasks, ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "wGone" })],
+      ctx
+    );
+    // wGone is absent from the complete list, but this PTY is still running in
+    // it. Re-homing onto wMain would hide that and erase the row the cleanup
+    // sweep needs to ever retire the run, so the dead id is kept and reported.
+    expect(resolvedWorktreeId(restoreTasks)).toBe("wGone");
+    expect([...ghostedWorktreeIds]).toEqual(["wGone"]);
   });
 
   it("keeps the saved worktreeId rather than re-homing onto a dead active worktree", async () => {
@@ -1205,21 +1210,149 @@ describe("restorePanelsPhase — panels outliving their worktree (issue #11232)"
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     Promise.resolve(ids.map((id) => ({ id, path: `/repo/${id}` })) as never);
 
-  it("re-homes a saved panel whose worktree no longer exists", async () => {
-    // Deleting a worktree now leaves its terminals running, and the sidebar row
+  it("keeps a saved panel on its deleted worktree and reports it for a row (#11911)", async () => {
+    // Deleting a worktree leaves its terminals running, and the sidebar row
     // holding them is in-memory only — so a saved panel can name a worktree
-    // that is gone. Restoring it as-is would strand a live PTY off-screen,
-    // since the grid and dock both filter by the active worktree.
+    // that is gone. Re-homing it onto the active worktree used to be the
+    // answer, but that laundered a run from a deleted worktree into a live
+    // one's identity and left nothing for the cleanup sweep to retire. The
+    // panel keeps the dead id; hydration rebuilds the row that holds it.
     const ctx = makeContext({
       activeWorktreeId: "wA",
       worktreesPromise: worktreeList("wA"),
     });
     ctx.backendTerminalMap.set("t1", backend("t1"));
 
-    await restorePanelsPhase([panel("t1", { worktreeId: "deleted-wt" })], ctx);
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "deleted-wt" })],
+      ctx
+    );
 
     expect(ctx.addPanel).toHaveBeenCalledTimes(1);
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "deleted-wt" });
+    expect([...ghostedWorktreeIds]).toEqual(["deleted-wt"]);
+  });
+
+  it("reports one ghost id for several panels sharing a deleted worktree", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList("wA"),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    ctx.backendTerminalMap.set("t2", backend("t2"));
+
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "deleted-wt" }), panel("t2", { worktreeId: "deleted-wt" })],
+      ctx
+    );
+
+    expect(ctx.addPanel).toHaveBeenCalledTimes(2);
+    expect([...ghostedWorktreeIds]).toEqual(["deleted-wt"]);
+  });
+
+  it("ghosts nothing when the worktree list is unknown", async () => {
+    // `null` is "not ready", never proof of absence (#11235) — ghosting off it
+    // would bury every live worktree in the project behind a deleted row.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: Promise.resolve(null),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "deleted-wt" })],
+      ctx
+    );
+
+    expect(ghostedWorktreeIds.size).toBe(0);
+  });
+
+  it("ghosts nothing when the worktree list is empty", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: Promise.resolve([]),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "deleted-wt" })],
+      ctx
+    );
+
+    expect(ghostedWorktreeIds.size).toBe(0);
+  });
+
+  it("ghosts nothing for a live worktree", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList("wA", "wB"),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "wB" })],
+      ctx
+    );
+
+    expect(ghostedWorktreeIds.size).toBe(0);
+  });
+
+  it("re-homes a cold respawn onto the active worktree and ghosts nothing", async () => {
+    // not_found means the PTY died on quit, so the respawn boots a NEW process
+    // that can pick any live worktree — and its cwd has to point somewhere that
+    // still exists. Recording a row for it would resurrect a dead worktree in
+    // the sidebar for a session that never ran there.
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "not_found" });
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList("wA"),
+    });
+
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "deleted-wt" })],
+      ctx
+    );
+
     expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wA" });
+    expect(ghostedWorktreeIds.size).toBe(0);
+  });
+
+  it("ghosts a reconnect-fallback survivor whose worktree is gone", async () => {
+    // No entry in backendTerminalMap, but the reconnect probe finds the PTY
+    // alive — same fact as the matched-backend path, so the same answer.
+    reconnectWithTimeoutMock.mockResolvedValue({
+      status: "found",
+      terminal: backend("t1"),
+    });
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList("wA"),
+    });
+
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "deleted-wt" })],
+      ctx
+    );
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "deleted-wt" });
+    expect([...ghostedWorktreeIds]).toEqual(["deleted-wt"]);
+  });
+
+  it("ghosts nothing for a panel that never named a worktree", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList("wA"),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: undefined })],
+      ctx
+    );
+
+    // Still homes onto the live active worktree, as before.
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wA" });
+    expect(ghostedWorktreeIds.size).toBe(0);
   });
 
   it("leaves a saved panel alone when its worktree still exists", async () => {
@@ -1404,33 +1537,59 @@ describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)
     expect(ctx.addPanel.mock.calls[1]![0]).toMatchObject({ worktreeId: "/new/feature" });
   });
 
-  it("still re-homes a genuinely-deleted worktree (no gitDir match)", async () => {
+  it("ghosts a genuinely-deleted worktree rather than remapping it (no gitDir match)", async () => {
     const ctx = makeContext({
       activeWorktreeId: "wA",
       worktreesPromise: worktreeList({ id: "wA", gitDir: "/repo/.git" }),
     });
     ctx.backendTerminalMap.set("t1", backend("t1"));
 
-    await restorePanelsPhase(
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
       [panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR })],
       ctx
     );
 
-    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wA" });
+    // No live worktree claims this gitDir, so the worktree really is gone —
+    // the panel keeps its id and earns a deleted-worktree row (#11911).
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "/old/feature" });
+    expect([...ghostedWorktreeIds]).toEqual(["/old/feature"]);
   });
 
-  it("re-homes a legacy snapshot with no stored gitDir handle", async () => {
-    // Pre-#11388 snapshots carry no gitDir, so a move can't be correlated — the
-    // panel falls through to the existing re-home behavior.
+  it("ghosts a legacy snapshot with no stored gitDir handle", async () => {
+    // Pre-#11388 snapshots carry no gitDir, so a move can't be correlated. The
+    // invariant under test is that the panel is NOT adopted by the moved
+    // worktree on a guess — it falls through to the deleted-worktree path.
     const ctx = makeContext({
       activeWorktreeId: "wA",
       worktreesPromise: worktreeList({ id: "wA" }, { id: "/new/feature", gitDir: GITDIR }),
     });
     ctx.backendTerminalMap.set("t1", backend("t1"));
 
-    await restorePanelsPhase([panel("t1", { worktreeId: "/old/feature" })], ctx);
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "/old/feature" })],
+      ctx
+    );
 
-    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wA" });
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "/old/feature" });
+    expect([...ghostedWorktreeIds]).toEqual(["/old/feature"]);
+  });
+
+  it("ghosts nothing when the worktree merely moved", async () => {
+    // The remap runs before the missing-id check, so a moved worktree is
+    // followed to its new id — never mistaken for a deleted one.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList({ id: "wA" }, { id: "/new/feature", gitDir: GITDIR }),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    const { ghostedWorktreeIds } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR })],
+      ctx
+    );
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "/new/feature" });
+    expect(ghostedWorktreeIds.size).toBe(0);
   });
 });
 

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -5,6 +5,7 @@ import { useScratchStore } from "@/store/scratchStore";
 import {
   suppressMruRecording,
   createDeletedWorktreeRecord,
+  getDeletedWorktreeTerminalIds,
   useWorktreeSelectionStore,
 } from "@/store/worktreeStore";
 import { useLayoutConfigStore } from "@/store";
@@ -571,6 +572,12 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         // membership lookup finds them; a row with nothing in it is pruned on
         // the sweep's next tick.
         for (const ghostedId of restoreResult.ghostedWorktreeIds) {
+          // The phase reports an id as soon as it resolves a panel onto it,
+          // before the `addPanel` that places it can reject. A row with nothing
+          // in it is not self-correcting — the sweep arms it, dispatches an
+          // empty trash and marks it fired — so confirm the membership that
+          // justifies the row actually exists before recording one.
+          if (getDeletedWorktreeTerminalIds(ghostedId).length === 0) continue;
           const selectionStore = useWorktreeSelectionStore.getState();
           // A deleted id can never be restored after a restart, so it must not
           // survive as the durable restore target — no-ops unless it is one.

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -2,7 +2,11 @@ import { appClient, terminalClient, worktreeClient, projectClient, systemClient 
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
-import { suppressMruRecording } from "@/store/worktreeStore";
+import {
+  suppressMruRecording,
+  createDeletedWorktreeRecord,
+  useWorktreeSelectionStore,
+} from "@/store/worktreeStore";
 import { useLayoutConfigStore } from "@/store";
 import type {
   AgentState,
@@ -554,6 +558,26 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         // panel respawned with a fresh id (#10440).
         savedIdToRestoredId = restoreResult.savedIdToRestoredId;
 
+        // Rebuild the deleted-worktree rows for panels whose PTY outlived its
+        // worktree (#11911). The rows are in-memory and die with the project
+        // view, so every path that rebuilds a view — cold start, reload, LRU
+        // recreation, or first open of a project whose worktrees were removed
+        // while it was closed — arrives with the survivors homeless. Without a
+        // row they render nowhere, `cleanupOrphanedTerminals` below deletes
+        // them, and the cleanup sweep that is supposed to retire them never
+        // sees them at all.
+        //
+        // Recorded AFTER the panels are restored so `addDeletedWorktree`'s
+        // membership lookup finds them; a row with nothing in it is pruned on
+        // the sweep's next tick.
+        for (const ghostedId of restoreResult.ghostedWorktreeIds) {
+          const selectionStore = useWorktreeSelectionStore.getState();
+          // A deleted id can never be restored after a restart, so it must not
+          // survive as the durable restore target — no-ops unless it is one.
+          selectionStore.clearRestoreTarget(ghostedId);
+          selectionStore.addDeletedWorktree(createDeletedWorktreeRecord(ghostedId));
+        }
+
         // Schedule scrollback restores at background priority — no blocking IPC
         // fetch on the critical path. The overlay can dismiss immediately and
         // scrollback fills in asynchronously.
@@ -670,7 +694,9 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     // removePanel kills the PTY — so it only runs on a coherent worktree
     // picture: restore keeps a saved worktreeId when the list is unknown
     // (#11234), and cleanup would read that survivor as a deleted worktree and
-    // kill a live agent terminal, the exact outcome #11232 ruled out.
+    // kill a live agent terminal, the exact outcome #11232 ruled out. Panels on
+    // a CONFIRMED-deleted worktree now keep their id too, and are exempted by
+    // the deleted-worktree row recorded for them above (#11911).
     if (worktreesAreKnown && activeWorktreeIsLive) {
       try {
         const { cleanupOrphanedTerminals } = await import("@/store/createWorktreeStore");

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -424,6 +424,16 @@ export interface PanelRestorePhaseResult {
    * Empty when every panel restored under its original saved id.
    */
   savedIdToRestoredId: Map<string, string>;
+  /**
+   * Worktree ids that are confirmed gone but still hold a restored panel whose
+   * PTY survived, so each needs a deleted-worktree row to live on (#11911).
+   *
+   * Only surviving PTYs qualify. A cold respawn boots a NEW process and can
+   * pick any live worktree, so it re-homes as before — recording a row for one
+   * would resurrect a dead worktree in the sidebar for a session that never
+   * ran there. Empty when nothing was stranded, which is the common case.
+   */
+  ghostedWorktreeIds: Set<string>;
 }
 
 /**
@@ -544,6 +554,43 @@ export async function restorePanelsPhase(
     // re-homing would be a guess — keep what was saved.
     if (known === null || known.has(worktreeId)) return worktreeId;
     return rehomeTarget ?? worktreeId;
+  };
+
+  // Worktrees proven gone that still hold a surviving PTY (#11911). Reported
+  // out of the phase so hydration can give each one a deleted-worktree row.
+  const ghostedWorktreeIds = new Set<string>();
+
+  /**
+   * Where a panel goes when its PTY outlived the worktree it was launched in.
+   *
+   * Re-homing is wrong for these: the process is still running in the deleted
+   * directory, so moving the panel under a live worktree hides that fact and
+   * throws away the only record of where the run came from. Worse, it erases
+   * the row `deletedWorktreeCleanup` needs in order to ever retire the
+   * survivors — which is how five finished agents can sit in a project for
+   * hours, counted as needing input and reachable from nowhere.
+   *
+   * Keeping the dead id is only safe because a row is recorded for it: without
+   * one, `cleanupOrphanedTerminals` treats the panel as orphaned and removes
+   * it. The two changes are a pair.
+   *
+   * Everything else defers to {@link resolveRestoredWorktreeId}, including the
+   * unknown-list case — a `null` list is "not ready", never proof of absence
+   * (#11235), and ghosting off it would bury every live worktree in the
+   * project behind a deleted row.
+   */
+  const resolveSurvivingPtyWorktreeId = async (
+    worktreeId: string | undefined
+  ): Promise<string | undefined> => {
+    if (!workspaceHasWorktrees || !worktreeId) {
+      return resolveRestoredWorktreeId(worktreeId);
+    }
+    const known = await getKnownWorktreeIds();
+    if (known === null || known.has(worktreeId)) {
+      return resolveRestoredWorktreeId(worktreeId);
+    }
+    ghostedWorktreeIds.add(worktreeId);
+    return worktreeId;
   };
 
   if (savedPanels && savedPanels.length > 0) {
@@ -679,9 +726,10 @@ export async function restorePanelsPhase(
             logHydrationInfo(`Reconnecting to terminal: ${saved.id}`);
 
             const args = buildArgsForBackendTerminal(backendTerminal, saved, projectRoot || "");
-            // Assign to the active worktree when the terminal has no worktree,
-            // or names one that no longer exists.
-            args.worktreeId = await resolveRestoredWorktreeId(args.worktreeId);
+            // Assign to the active worktree when the terminal has no worktree.
+            // A named-but-deleted worktree keeps its id instead: the PTY is
+            // still alive in it, and it earns a deleted-worktree row (#11911).
+            args.worktreeId = await resolveSurvivingPtyWorktreeId(args.worktreeId);
             // A surviving backend PTY reports its live (old-path) cwd; rebase it
             // onto the moved worktree's new root so persisted state and a later
             // respawn don't reference the vanished path (#11388).
@@ -754,10 +802,11 @@ export async function restorePanelsPhase(
                   saved,
                   projectRoot || ""
                 );
-                // Assign to the active worktree when a legacy saved panel has
-                // no worktreeId, or names a deleted one (mirrors the
-                // matched-backend path).
-                reconnectArgs.worktreeId = await resolveRestoredWorktreeId(
+                // Mirrors the matched-backend path: a legacy saved panel with
+                // no worktreeId takes the active worktree, while one naming a
+                // deleted worktree keeps that id and earns a row (#11911) —
+                // the reconnect just proved this PTY outlived it.
+                reconnectArgs.worktreeId = await resolveSurvivingPtyWorktreeId(
                   reconnectArgs.worktreeId
                 );
                 // Rebase the reconnected PTY's live (old-path) cwd onto the
@@ -1079,5 +1128,5 @@ export async function restorePanelsPhase(
     }
   }
 
-  return { restoreTasks, savedIdToRestoredId };
+  return { restoreTasks, savedIdToRestoredId, ghostedWorktreeIds };
 }


### PR DESCRIPTION
## Summary

Removing a worktree outside the app — a merge pipeline running `git worktree remove` from a shell — is a first-class, intended operation. Its agent terminals should be cleaned up: parked on a deleted-worktree row, then trashed once the 60s countdown expires, after which the trash TTL reclaims the PTYs. All of that machinery already exists (#11232).

It never ran, because **the row was never recorded**. So the terminals sat alive and invisible: the sidebar groups panels by live worktree, so they rendered nowhere, while the main-process attention tally kept counting them as needing input. A reporter saw "7 need input" with only 2 agents reachable and no way out except quitting the app.

This PR makes the row get recorded in every path that can strand a panel, so the existing cleanup actually fires.

Resolves #11911

## Root causes

Four separate places a panel could end up stranded:

1. `applySnapshot` replaces the worktree map wholesale from the host's authoritative list, so a worktree that disappears is dropped with no per-id `worktree-removed` event. External removal reconciles exactly this way, via `TopologyWatcher` force-reconcile.
2. The `worktree-removed` handler gated row creation on the worktree still being in the live map — which an external removal has usually already reconciled away, so that branch never ran.
3. Hydration (`resolveRestoredWorktreeId`) silently re-homed a surviving PTY onto the active worktree. That is the one that actively *rescued* these terminals from cleanup: relocated onto a live worktree, they no longer belonged to any row, so nothing would ever retire them. The rows are in-memory and die with the project view, so reload, LRU view recreation, and first open of a closed project all hit this.
4. `cleanupOrphanedTerminals` deletes any panel whose `worktreeId` isn't live, and `removePanel` kills the PTY outright — no trash, no restore window.

## Changes

- Added a shared `createDeletedWorktreeRecord` constructor, used by every path that records a row.
- The existing map-diff backstop in `WorktreeStoreContext` now adopts stranded panels onto a row, catching removals that fire no event. It diffs against the last ready topology, because a not-ready empty list still replaces the map: a `[a,b] -> [] -> [a]` sequence would otherwise lose `b` forever.
- Hydration keeps a surviving PTY on its deleted worktree and rebuilds the row instead of re-homing it, so the countdown starts. Cold respawns (`not_found` — the PTY died on quit) still re-home, since there is no live process to retire.
- `cleanupOrphanedTerminals` exempts ids that have a row, so those panels go through the reviewable trash path rather than being deleted outright.
- Rows carry the worktree's admin-dir handle (`gitDir`) and are withdrawn when a live worktree turns up claiming it. A `git worktree move` re-mints the path-derived id, and the host announces the removal before the replacement reports, so without this a moved worktree's still-live agents would be trashed 60 seconds later. This also closes that hazard on the pre-existing removal-event path.
- A mixed tab group is split rather than reparented. Repair rewrites every member, and both single answers were wrong: electing the deleted worktree dragged freshly respawned agents into the sweep, electing the live one relabelled real survivors and exempted them from the cleanup that should retire them.
- The cleanup sweep retries its trash dispatch. `firedIds` was set before the call, so a throw used to retire the row permanently with its terminals still stuck on it.

## Safety notes

- Nothing here kills a PTY directly or touches the agent state machine. Terminals are retired through the existing row countdown → trash → trash TTL path, which keeps the restore window intact.
- Recording a row requires a non-empty, authoritative worktree list (#11235): an empty enumeration means the host isn't ready, never that every worktree is gone.
- A moved worktree is not a deleted one — the handle check keeps its agents out of the sweep.

## Testing

- 631 tests across 21 files pass locally, plus `scripts/perf/__tests__/worktreeStoreBundle.test.ts`.
- `npm run typecheck` clean.
- prettier and eslint clean on all changed files.
- Lint ratchet passes at baseline 1091, no warnings introduced.

## Known limitations

- A live `git worktree move` still strands panels on the old id, a pre-existing gap (#11388). This change makes them stranded but alive rather than trashed.
- A session already stranded before this fix heals on its next hydration rather than instantly.

## Files

`src/contexts/WorktreeStoreContext.tsx`, `src/store/worktreeStore.ts`, `src/store/createWorktreeStore.ts`, `src/store/deletedWorktreeCleanup.ts`, `src/store/storeAccessors.ts`, `src/store/rendererStoreOrchestrator.ts`, `src/store/slices/panelRegistry/tabGroups.ts`, `src/utils/stateHydration/index.ts`, `src/utils/stateHydration/panelRestorePhase.ts`, plus six test files including one new one, `src/store/__tests__/createWorktreeStore.cleanupOrphans.test.ts`.
