### PR TITLE
feat(panels): make the file browser panel dockable

### DIFF
--- a/e2e/full/panels/core-file-browser.spec.ts
+++ b/e2e/full/panels/core-file-browser.spec.ts
@@ -349,12 +349,14 @@ test.describe.serial("Core: File browser preview", () => {
     await panel.locator('[data-testid="panel-move-to-dock"]').click();
     await expect(gridBrowsers).toHaveCount(0, { timeout: T_MEDIUM });
 
+    // Anchored on this panel's own sortable wrapper rather than on the label:
+    // dock titles are not unique, so a same-named terminal chip would otherwise
+    // turn this into a strict-mode ambiguity instead of an assertion.
+    const chip = ctx.window.locator(`[data-dock-item-id="${panelId}"] [data-dock-item]`);
+    await expect(chip).toBeVisible({ timeout: T_MEDIUM });
     // The chip drops the composed title's "Files — " prefix, so what is left is
     // the branch that distinguishes this browser from another worktree's.
-    const chip = ctx.window.locator("[data-dock-item]", { hasText: "main" });
-    await expect(chip).toBeVisible({ timeout: T_MEDIUM });
-    // Exact rather than a substring: "Files — main" would satisfy `hasText`,
-    // and it is precisely the composed grid title this derivation trims.
+    // Exact, not a substring: "Files — main" is precisely what this trims.
     await expect(chip).toHaveText("main", { timeout: T_SHORT });
     await chip.click();
     await expect(

--- a/e2e/full/panels/core-file-browser.spec.ts
+++ b/e2e/full/panels/core-file-browser.spec.ts
@@ -325,4 +325,49 @@ test.describe.serial("Core: File browser preview", () => {
     await panel.locator(SEL.panel.close).first().click();
     await expect(panel).toHaveCount(0, { timeout: T_SHORT });
   });
+
+  // #11917 — the browser used to opt out of the dock entirely, so its header
+  // offered only maximize and close.
+  test("the grid browser moves to the dock, previews from the chip, and restores", async () => {
+    const worktreeId = await mainWorktreeId(ctx.window);
+
+    const opened = await dispatchAction(ctx.window, "worktree.openFileBrowserPanel", {
+      worktreeId,
+    });
+    expect(opened.ok, opened.error?.message).toBe(true);
+    const panelId = opened.result?.panelId;
+    const panel = ctx.window.locator(`[data-panel-id="${panelId}"]${SEL.panel.gridPanel}`);
+    await expect(panel).toBeVisible({ timeout: T_MEDIUM });
+
+    // The docked panel stays mounted in the offscreen parking container, so
+    // count GRID membership rather than total pane instances.
+    const gridBrowsers = ctx.window.locator(
+      `${SEL.panel.gridPanel}:has([data-testid="file-browser-sidebar-toggle"])`
+    );
+    await expect(gridBrowsers).toHaveCount(1, { timeout: T_MEDIUM });
+
+    await panel.locator('[data-testid="panel-move-to-dock"]').click();
+    await expect(gridBrowsers).toHaveCount(0, { timeout: T_MEDIUM });
+
+    // The chip drops the composed title's "Files — " prefix, so what is left is
+    // the branch that distinguishes this browser from another worktree's.
+    const chip = ctx.window.locator("[data-dock-item]", { hasText: "main" });
+    await expect(chip).toBeVisible({ timeout: T_MEDIUM });
+    // Exact rather than a substring: "Files — main" would satisfy `hasText`,
+    // and it is precisely the composed grid title this derivation trims.
+    await expect(chip).toHaveText("main", { timeout: T_SHORT });
+    await chip.click();
+    await expect(
+      ctx.window.locator('[data-dock-portal-target] [data-testid="file-browser-sidebar-toggle"]')
+    ).toBeVisible({ timeout: T_LONG });
+
+    // Double-click restores it to the grid, the same gesture docked file
+    // panels answer to.
+    await chip.dblclick();
+    await expect(gridBrowsers).toHaveCount(1, { timeout: T_MEDIUM });
+    await expect(chip).not.toBeVisible({ timeout: T_MEDIUM });
+
+    await panel.locator(SEL.panel.close).first().click();
+    await expect(panel).toHaveCount(0, { timeout: T_SHORT });
+  });
 });

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -549,8 +549,6 @@ describe("panelKindIsDockable", () => {
     expect(panelKindIsDockable("terminal")).toBe(true);
     expect(panelKindIsDockable("file")).toBe(true);
     expect(panelKindIsDockable("browser")).toBe(true);
-    // #11917 — the file browser dropped its opt-out; the dock popover hosts its
-    // two-pane layout the same way it hosts the file viewer.
     expect(panelKindIsDockable("file-browser")).toBe(true);
   });
 

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -549,10 +549,13 @@ describe("panelKindIsDockable", () => {
     expect(panelKindIsDockable("terminal")).toBe(true);
     expect(panelKindIsDockable("file")).toBe(true);
     expect(panelKindIsDockable("browser")).toBe(true);
+    // #11917 — the file browser dropped its opt-out; the dock popover hosts its
+    // two-pane layout the same way it hosts the file viewer.
+    expect(panelKindIsDockable("file-browser")).toBe(true);
   });
 
-  it("the four built-ins that opt out are not dockable", () => {
-    for (const kind of ["dev-preview", "review", "file-browser", "diff"]) {
+  it("the three built-ins that opt out are not dockable", () => {
+    for (const kind of ["dev-preview", "review", "diff"]) {
       expect(panelKindIsDockable(kind), `${kind} opts out via dockable:false`).toBe(false);
     }
   });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -237,7 +237,7 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     canRestart: false,
     canConvert: false,
     // Explicit opt-out: a live dev-server preview has no meaningful compact
-    // chip-row form (like file-browser, diff and review).
+    // chip-row form (like diff and review).
     dockable: false,
     usesTerminalUi: false,
     keepAliveOnProjectSwitch: true,
@@ -258,7 +258,7 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     canRestart: false,
     canConvert: false,
     // Explicit opt-out: a review surface has no meaningful compact chip-row
-    // form (like file-browser, diff and dev-preview).
+    // form (like diff and dev-preview).
     dockable: false,
     usesTerminalUi: false,
     keepAliveOnProjectSwitch: true,
@@ -299,10 +299,9 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
-    // Explicit opt-out: the dock chip row shows one compact title per panel,
-    // and a two-pane browser has no meaningful compact form (review, diff and
-    // dev-preview opt out for the same reason).
-    dockable: false,
+    // Dockable by default (no explicit flag). The chip row is only a label, and
+    // the panel itself is moved — not remounted — into the dock popover, so the
+    // two-pane browser has the same room there as the file viewer (#11917).
     dialogFullHeight: true,
     usesTerminalUi: false,
     keepAliveOnProjectSwitch: true,

--- a/shared/types/__tests__/panel.test.ts
+++ b/shared/types/__tests__/panel.test.ts
@@ -105,13 +105,23 @@ describe("panel variant guards", () => {
 
   it("isDockPanel admits dockable built-in kinds but not the opt-outs", () => {
     // Membership follows the registry (`panelKindIsDockable`), not a fixed kind
-    // list: terminal/file/browser are dockable by default; the four kinds that
-    // declare `dockable: false` are excluded, or they vanish from the dock.
+    // list: terminal/file/browser/file-browser are dockable by default; the
+    // three kinds that declare `dockable: false` are excluded, or they vanish
+    // from the dock.
     const filePanel = { id: "p4", kind: "file", title: "t", location: "dock" } as PanelInstance;
+    const fileBrowserPanel = {
+      id: "p5",
+      kind: "file-browser",
+      title: "t",
+      location: "dock",
+    } as PanelInstance;
     expect(isDockPanel(ptyPanel)).toBe(true);
     expect(isDockPanel(browserPanel)).toBe(true);
     expect(isDockPanel(filePanel)).toBe(true);
-    for (const kind of ["dev-preview", "review", "file-browser", "diff"]) {
+    // #11917 — the two-pane browser is moved, not remounted, into the dock
+    // popover, so it has the same room there as the file viewer.
+    expect(isDockPanel(fileBrowserPanel)).toBe(true);
+    for (const kind of ["dev-preview", "review", "diff"]) {
       const panel = { id: `opt-${kind}`, kind, title: "t", location: "grid" } as PanelInstance;
       expect(isDockPanel(panel), `${kind} opts out of the dock`).toBe(false);
     }

--- a/shared/types/__tests__/panel.test.ts
+++ b/shared/types/__tests__/panel.test.ts
@@ -118,8 +118,6 @@ describe("panel variant guards", () => {
     expect(isDockPanel(ptyPanel)).toBe(true);
     expect(isDockPanel(browserPanel)).toBe(true);
     expect(isDockPanel(filePanel)).toBe(true);
-    // #11917 — the two-pane browser is moved, not remounted, into the dock
-    // popover, so it has the same room there as the file viewer.
     expect(isDockPanel(fileBrowserPanel)).toBe(true);
     for (const kind of ["dev-preview", "review", "diff"]) {
       const panel = { id: `opt-${kind}`, kind, title: "t", location: "grid" } as PanelInstance;

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -8,16 +8,12 @@ import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePanelStore, useWorktreeSelectionStore } from "@/store";
 import {
-  isBrowserPanel,
   isDockPanel,
-  isFilePanel,
   isPtyPanel,
-  type BrowserPanelData,
   type DockPanelData,
-  type FilePanelData,
   type PanelInstance,
 } from "@shared/types/panel";
-import { extractHostPort } from "@/components/Browser/browserUtils";
+import { dockChipTitle } from "./dockChipTitle";
 import { getRenderablePanel } from "@/store/slices/panelRegistry/selectors";
 import {
   collectUngroupedCandidateIds,
@@ -86,35 +82,6 @@ const EMPTY_DOCK_TERMINALS: readonly DockPanelData[] = [];
 
 interface ContentDockProps {
   density?: DockDensity;
-}
-
-// File name beats the generic kind title in the chip, mirroring FilePane's own
-// title layering (a user-locked rename still wins).
-function fileChipTitle(panel: FilePanelData): string {
-  const fileName = panel.filePath?.split(/[/\\]/).filter(Boolean).pop();
-  return panel.titleMode === "user" ? panel.title : (fileName ?? panel.title);
-}
-
-// Host beats the generic "Browser" title in the chip, mirroring BrowserPane's
-// displayTitle (a page-supplied title still wins; a user-locked rename always
-// wins). Falls back to the kind title when there's no host to show (e.g.
-// about:blank, whose URL.host is empty) so the chip is never blank.
-function browserChipTitle(panel: BrowserPanelData): string {
-  if (panel.titleMode === "user") return panel.title;
-  if (panel.title && panel.title !== "Browser") return panel.title;
-  const currentUrl = panel.browserHistory?.present || panel.browserUrl || "";
-  const host = currentUrl ? extractHostPort(currentUrl) : "";
-  // Ultimate fallback so the chip is never blank (e.g. empty title + no URL).
-  return host || panel.title || "Browser";
-}
-
-// Chip label for a non-PTY dock panel. File and browser get their kind-specific
-// derivations; every other dockable kind (dev-preview if opted in, plugin view
-// panels — #11332) falls back to the panel title so the chip is never blank.
-function dockChipTitle(panel: PanelInstance): string {
-  if (isFilePanel(panel)) return fileChipTitle(panel);
-  if (isBrowserPanel(panel)) return browserChipTitle(panel);
-  return panel.title;
 }
 
 export function ContentDock({ density = "normal" }: ContentDockProps) {

--- a/src/components/Layout/DockedNonPtyPanelItem.tsx
+++ b/src/components/Layout/DockedNonPtyPanelItem.tsx
@@ -22,16 +22,17 @@ import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContex
 interface DockedNonPtyPanelItemProps {
   /**
    * Any non-PTY dock panel. The chip only reads `id`/`kind`/`title`, so it
-   * hosts file, browser, and plugin view kinds alike (#11332); the caller
-   * derives the label per kind via `dockChipTitle`.
+   * hosts file, browser, file-browser, and plugin view kinds alike (#11332,
+   * #11917); the caller derives the label per kind via `dockChipTitle`.
    */
   panel: PanelInstance;
-  /** Chip label, derived per-kind by the caller (file name, browser host, …). */
+  /** Chip label, derived per-kind by the caller (file name, host, folder, …). */
   displayTitle: string;
 }
 
 /**
- * Dock chip for a non-PTY content panel (file viewer, browser, plugin view).
+ * Dock chip for a non-PTY content panel (file viewer, browser, file browser,
+ * plugin view).
  * Mirrors DockedTerminalItem's popover + stable-wrapper relocation flow, minus
  * everything PTY: no renderer policies, no xterm fit, no agent state. The
  * panel's React subtree lives in DockPanelOffscreenContainer and is moved (not

--- a/src/components/Layout/__tests__/dockChipTitle.test.ts
+++ b/src/components/Layout/__tests__/dockChipTitle.test.ts
@@ -20,8 +20,7 @@ function fileBrowser(overrides: Partial<FileBrowserPanelData> = {}): FileBrowser
 
 describe("dockChipTitle — file browser (#11917)", () => {
   it("drops the composed prefix so the chip spends its width on the folder", () => {
-    // The point of the derivation: "Files — " is a constant eight characters of
-    // a ~140px label, so a long branch name would truncate to the half every
+    // Without the trim a long branch truncates to the constant half that every
     // browser shares.
     const title = dockChipTitle(
       fileBrowser({ title: composeFileBrowserTitle("feature/issue-11917-dockable") })
@@ -56,12 +55,34 @@ describe("dockChipTitle — file browser (#11917)", () => {
     expect(dockChipTitle(fileBrowser({ title: "Scratch files" }))).toBe("Scratch files");
   });
 
-  it("is never blank, even for a record carrying no title at all", () => {
-    expect(dockChipTitle(fileBrowser({ title: "" }))).toBe("Files");
+  it("leaves an automation-named title alone even when it looks composed", () => {
+    // `"custom"` is the rung an MCP `terminal.rename` pins, and the ownership
+    // ladder freezes it against derived rewrites. Trimming a name someone
+    // explicitly asked for would be exactly such a rewrite — and a name that
+    // happens to open with the prefix is the case that hides the bug.
+    const named = fileBrowser({
+      title: composeFileBrowserTitle("Archive"),
+      titleMode: "custom",
+      browserRootPath: "src/components",
+    });
+    expect(dockChipTitle(named)).toBe("Files — Archive");
   });
 
-  it("reads a scoped root written with either separator", () => {
-    expect(dockChipTitle(fileBrowser({ browserRootPath: "src\\components\\" }))).toBe("components");
+  it("still trims the composed title when nothing has claimed ownership of it", () => {
+    // The other side of the guard above, so it can't be widened into a no-op.
+    expect(dockChipTitle(fileBrowser({ titleMode: "default" }))).toBe("develop");
+  });
+
+  it("does not hand the chip a folder name that renders as nothing", () => {
+    // A directory named entirely of spaces survives `canonicalizeRootPath`, so
+    // the basename is truthy and would paint an empty chip.
+    expect(dockChipTitle(fileBrowser({ browserRootPath: "   " }))).toBe("develop");
+  });
+
+  it("is never blank, even for a corrupted record carrying no title at all", () => {
+    // The invariant, not the particular word: a blank chip is an unclickable
+    // gap in the rail, so what matters is that something renders.
+    expect(dockChipTitle(fileBrowser({ title: "" }))).not.toBe("");
   });
 });
 
@@ -72,7 +93,7 @@ describe("dockChipTitle — the derivations it dispatches to still hold", () => 
       kind: "file",
       title: "File",
       location: "dock",
-      filePath: "/repo/src/spec.md",
+      filePath: "C:\\repo\\src\\spec.md",
     } as FilePanelData;
     const browserPanel = {
       id: "b1",
@@ -82,6 +103,8 @@ describe("dockChipTitle — the derivations it dispatches to still hold", () => 
       browserUrl: "https://example.com:8080/some/path",
     } as BrowserPanelData;
 
+    // A Windows path, where the second separator the basename helper accepts is
+    // production-real — `browserRootPath` is canonicalized to forward slashes.
     expect(dockChipTitle(filePanel)).toBe("spec.md");
     expect(dockChipTitle(browserPanel)).toBe("example.com:8080");
   });

--- a/src/components/Layout/__tests__/dockChipTitle.test.ts
+++ b/src/components/Layout/__tests__/dockChipTitle.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import type {
+  BrowserPanelData,
+  FileBrowserPanelData,
+  FilePanelData,
+  PanelInstance,
+} from "@shared/types/panel";
+import { dockChipTitle } from "../dockChipTitle";
+import { composeFileBrowserTitle } from "@/panels/file-browser/title";
+
+function fileBrowser(overrides: Partial<FileBrowserPanelData> = {}): FileBrowserPanelData {
+  return {
+    id: "fb1",
+    kind: "file-browser",
+    title: composeFileBrowserTitle("develop"),
+    location: "dock",
+    ...overrides,
+  } as FileBrowserPanelData;
+}
+
+describe("dockChipTitle — file browser (#11917)", () => {
+  it("drops the composed prefix so the chip spends its width on the folder", () => {
+    // The point of the derivation: "Files — " is a constant eight characters of
+    // a ~140px label, so a long branch name would truncate to the half every
+    // browser shares.
+    const title = dockChipTitle(
+      fileBrowser({ title: composeFileBrowserTitle("feature/issue-11917-dockable") })
+    );
+    expect(title).toBe("feature/issue-11917-dockable");
+  });
+
+  it("names the scoped folder ahead of the root the panel was opened on", () => {
+    expect(dockChipTitle(fileBrowser({ browserRootPath: "src/components" }))).toBe("components");
+  });
+
+  it("ignores the viewer target so arrowing through the tree can't relabel the chip", () => {
+    // Deliberately NOT the file-panel derivation: the docked surface is the
+    // tree, and a label that moved with the selection would churn while reading.
+    const stable = fileBrowser({ browserSelectedPath: "src/app.ts" });
+    const moved = fileBrowser({ browserSelectedPath: "src/other.ts" });
+    expect(dockChipTitle(stable)).toBe(dockChipTitle(moved));
+    expect(dockChipTitle(stable)).toBe("develop");
+  });
+
+  it("keeps a user-locked rename over both structural fields", () => {
+    const renamed = fileBrowser({
+      title: "My notes",
+      titleMode: "user",
+      browserRootPath: "src/components",
+      browserSelectedPath: "src/app.ts",
+    });
+    expect(dockChipTitle(renamed)).toBe("My notes");
+  });
+
+  it("returns a title it did not compose unchanged rather than guessing at it", () => {
+    expect(dockChipTitle(fileBrowser({ title: "Scratch files" }))).toBe("Scratch files");
+  });
+
+  it("is never blank, even for a record carrying no title at all", () => {
+    expect(dockChipTitle(fileBrowser({ title: "" }))).toBe("Files");
+  });
+
+  it("reads a scoped root written with either separator", () => {
+    expect(dockChipTitle(fileBrowser({ browserRootPath: "src\\components\\" }))).toBe("components");
+  });
+});
+
+describe("dockChipTitle — the derivations it dispatches to still hold", () => {
+  it("labels a file panel with its basename and a browser with its host", () => {
+    const filePanel = {
+      id: "f1",
+      kind: "file",
+      title: "File",
+      location: "dock",
+      filePath: "/repo/src/spec.md",
+    } as FilePanelData;
+    const browserPanel = {
+      id: "b1",
+      kind: "browser",
+      title: "Browser",
+      location: "dock",
+      browserUrl: "https://example.com:8080/some/path",
+    } as BrowserPanelData;
+
+    expect(dockChipTitle(filePanel)).toBe("spec.md");
+    expect(dockChipTitle(browserPanel)).toBe("example.com:8080");
+  });
+
+  it("falls back to the panel title for a kind with no derivation of its own", () => {
+    // Plugin view panels (#11332) take this branch — the chip must not assume
+    // one of the built-in shapes.
+    const plugin = {
+      id: "x1",
+      kind: "acme.viewer",
+      title: "Acme Viewer",
+      location: "dock",
+    } as unknown as PanelInstance;
+    expect(dockChipTitle(plugin)).toBe("Acme Viewer");
+  });
+});

--- a/src/components/Layout/__tests__/dockChipTitle.test.ts
+++ b/src/components/Layout/__tests__/dockChipTitle.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type {
   BrowserPanelData,
+  DevPreviewPanelData,
   FileBrowserPanelData,
   FilePanelData,
-  PanelInstance,
 } from "@shared/types/panel";
 import { dockChipTitle } from "../dockChipTitle";
 import { composeFileBrowserTitle } from "@/panels/file-browser/title";
@@ -65,7 +65,7 @@ describe("dockChipTitle — file browser (#11917)", () => {
       titleMode: "custom",
       browserRootPath: "src/components",
     });
-    expect(dockChipTitle(named)).toBe("Files — Archive");
+    expect(dockChipTitle(named)).toBe(named.title);
   });
 
   it("still trims the composed title when nothing has claimed ownership of it", () => {
@@ -110,14 +110,16 @@ describe("dockChipTitle — the derivations it dispatches to still hold", () => 
   });
 
   it("falls back to the panel title for a kind with no derivation of its own", () => {
-    // Plugin view panels (#11332) take this branch — the chip must not assume
-    // one of the built-in shapes.
-    const plugin = {
+    // The branch plugin view panels (#11332) land in, exercised through an
+    // in-union kind so the fixture states a real shape rather than asserting
+    // its way past one — the dispatcher reaches it the same way for both.
+    const other = {
       id: "x1",
-      kind: "acme.viewer",
-      title: "Acme Viewer",
+      kind: "dev-preview",
+      title: "Dev Preview",
       location: "dock",
-    } as unknown as PanelInstance;
-    expect(dockChipTitle(plugin)).toBe("Acme Viewer");
+      cwd: "/repo",
+    } as DevPreviewPanelData;
+    expect(dockChipTitle(other)).toBe("Dev Preview");
   });
 });

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -163,9 +163,17 @@ describe("buildDockLaunchModel — panel offering", () => {
     const offered = [...model.dockPanels, ...model.gridPanels].map((p) => p.kindId);
     // Non-dockable kinds are present — previously they were dropped entirely.
     expect(offered).toEqual(expect.arrayContaining(["review", "file-browser", "dev-preview"]));
-    // ...and each landed in the grid group, not the dock group.
+    // ...and each non-dockable one landed in the grid group, not the dock group.
     const dockIds = model.dockPanels.map((p) => p.kindId);
-    expect(dockIds).not.toEqual(expect.arrayContaining(["review", "file-browser", "dev-preview"]));
+    expect(dockIds).not.toEqual(expect.arrayContaining(["review", "dev-preview"]));
+  });
+
+  it("includes File Browser in the dock group now that it is dockable (#11917)", () => {
+    // The heading is a promise about placement, so the kind that just gained
+    // `dockable` has to move sections with it.
+    const model = build();
+    expect(model.dockPanels.map((p) => p.kindId)).toContain("file-browser");
+    expect(model.gridPanels.map((p) => p.kindId)).not.toContain("file-browser");
   });
 
   it("includes File Viewer in the dock group (dockable but previously unlisted)", () => {

--- a/src/components/Layout/dockChipTitle.ts
+++ b/src/components/Layout/dockChipTitle.ts
@@ -48,8 +48,16 @@ export function browserChipTitle(panel: BrowserPanelData): string {
  * project, which is the only thing distinguishing one root browser from another.
  */
 export function fileBrowserChipTitle(panel: FileBrowserPanelData): string {
-  if (panel.titleMode === "user") return panel.title;
-  const scopedRoot = basename(panel.browserRootPath);
+  // Both explicit rungs of the title-ownership ladder, not just `"user"`:
+  // `"custom"` is a name automation asked for (an MCP `terminal.rename`), and
+  // the ladder freezes it against derived rewrites — which is exactly what
+  // trimming it here would be. Only a `"default"` title is this module's to
+  // take apart.
+  if (panel.titleMode === "user" || panel.titleMode === "custom") return panel.title;
+  // Trimmed before the truthiness test: a directory named entirely of spaces is
+  // a legal path segment `canonicalizeRootPath` keeps, and it would otherwise
+  // pass as a label and render the chip blank.
+  const scopedRoot = basename(panel.browserRootPath)?.trim();
   if (scopedRoot) return scopedRoot;
   // Both fallbacks are load-bearing: a title that carried no prefix comes back
   // unchanged, and an empty one still owes the chip a label.

--- a/src/components/Layout/dockChipTitle.ts
+++ b/src/components/Layout/dockChipTitle.ts
@@ -1,0 +1,68 @@
+import {
+  isBrowserPanel,
+  isFileBrowserPanel,
+  isFilePanel,
+  type BrowserPanelData,
+  type FileBrowserPanelData,
+  type FilePanelData,
+  type PanelInstance,
+} from "@shared/types/panel";
+import { extractHostPort } from "@/components/Browser/browserUtils";
+import { compactFileBrowserTitle } from "@/panels/file-browser/title";
+
+/** Last segment of a path, tolerating either separator and trailing slashes. */
+function basename(path: string | undefined): string | undefined {
+  return path?.split(/[/\\]/).filter(Boolean).pop();
+}
+
+// File name beats the generic kind title in the chip, mirroring FilePane's own
+// title layering (a user-locked rename still wins).
+export function fileChipTitle(panel: FilePanelData): string {
+  const fileName = basename(panel.filePath);
+  return panel.titleMode === "user" ? panel.title : (fileName ?? panel.title);
+}
+
+// Host beats the generic "Browser" title in the chip, mirroring BrowserPane's
+// displayTitle (a page-supplied title still wins; a user-locked rename always
+// wins). Falls back to the kind title when there's no host to show (e.g.
+// about:blank, whose URL.host is empty) so the chip is never blank.
+export function browserChipTitle(panel: BrowserPanelData): string {
+  if (panel.titleMode === "user") return panel.title;
+  if (panel.title && panel.title !== "Browser") return panel.title;
+  const currentUrl = panel.browserHistory?.present || panel.browserUrl || "";
+  const host = currentUrl ? extractHostPort(currentUrl) : "";
+  // Ultimate fallback so the chip is never blank (e.g. empty title + no URL).
+  return host || panel.title || "Browser";
+}
+
+/**
+ * The folder the tree is rooted at, not the file the viewer happens to be
+ * showing (#11917).
+ *
+ * `browserSelectedPath` is the obvious analogue of the file panel's `filePath`,
+ * and it is the wrong one: it changes on every arrow-key step through the tree,
+ * so the chip would relabel while the user reads, and two browsers with nothing
+ * selected would both collapse to the same label. Scoping the tree to a
+ * subfolder is a deliberate, sticky gesture, so that name leads; otherwise the
+ * composed title minus its "Files — " prefix is what names the worktree or
+ * project, which is the only thing distinguishing one root browser from another.
+ */
+export function fileBrowserChipTitle(panel: FileBrowserPanelData): string {
+  if (panel.titleMode === "user") return panel.title;
+  const scopedRoot = basename(panel.browserRootPath);
+  if (scopedRoot) return scopedRoot;
+  // Both fallbacks are load-bearing: a title that carried no prefix comes back
+  // unchanged, and an empty one still owes the chip a label.
+  return compactFileBrowserTitle(panel.title) || panel.title || "Files";
+}
+
+// Chip label for a non-PTY dock panel. File, browser and file-browser get their
+// kind-specific derivations; every other dockable kind (dev-preview if opted
+// in, plugin view panels — #11332) falls back to the panel title so the chip is
+// never blank.
+export function dockChipTitle(panel: PanelInstance): string {
+  if (isFilePanel(panel)) return fileChipTitle(panel);
+  if (isBrowserPanel(panel)) return browserChipTitle(panel);
+  if (isFileBrowserPanel(panel)) return fileBrowserChipTitle(panel);
+  return panel.title;
+}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -313,9 +313,9 @@ function PanelHeaderComponent({
   const isHibernated = useIsHibernated(id);
 
   // Whether the overflow "..." menu has any items to show.
-  // Dock membership is capability-gated: PTY kinds plus non-PTY kinds that
-  // opt in via the registry's `dockable` flag (file panels — #10985).
-  // Offering the affordance for any other kind would silently strand it.
+  // Dock membership is capability-gated by the registry: kinds are dockable by
+  // default and a handful opt out with `dockable: false` (#10985, #11917).
+  // Offering the affordance for an opted-out kind would silently strand it.
   const showMoveToDock =
     !!onMinimize && !isMaximized && location !== "dock" && panelKindIsDockable(kind);
   const hasOverflowItems = true;

--- a/src/panels/file-browser/title.ts
+++ b/src/panels/file-browser/title.ts
@@ -1,12 +1,9 @@
 /**
  * The file browser's panel title, composed in one place and taken apart in one
- * place.
- *
- * The grid header wants the kind spelled out ("Files — develop"); the dock chip
- * has a folder-tree icon already and roughly 140px of label, where a constant
- * 8-character prefix eats the only part that distinguishes one browser from
- * another. Both halves live here so the chip trims what the action composed
- * rather than pattern-matching a format it can't see change.
+ * place. The grid header wants the kind spelled out ("Files — develop"); a dock
+ * chip already carries the folder-tree icon and can only afford the part that
+ * tells one browser from another. Both halves live here so the chip trims what
+ * the action composed instead of pattern-matching a format it can't see change.
  */
 export const FILE_BROWSER_TITLE_PREFIX = "Files — ";
 

--- a/src/panels/file-browser/title.ts
+++ b/src/panels/file-browser/title.ts
@@ -1,0 +1,27 @@
+/**
+ * The file browser's panel title, composed in one place and taken apart in one
+ * place.
+ *
+ * The grid header wants the kind spelled out ("Files — develop"); the dock chip
+ * has a folder-tree icon already and roughly 140px of label, where a constant
+ * 8-character prefix eats the only part that distinguishes one browser from
+ * another. Both halves live here so the chip trims what the action composed
+ * rather than pattern-matching a format it can't see change.
+ */
+export const FILE_BROWSER_TITLE_PREFIX = "Files — ";
+
+/** Grid/dialog header title for a browser rooted at `name`. */
+export function composeFileBrowserTitle(name: string): string {
+  return `${FILE_BROWSER_TITLE_PREFIX}${name}`;
+}
+
+/**
+ * The distinguishing half of a composed title, for surfaces too narrow for the
+ * prefix. A user-renamed title (or any title this module didn't compose) is
+ * returned untouched — trimming a prefix it never carried would be a guess.
+ */
+export function compactFileBrowserTitle(title: string): string {
+  return title.startsWith(FILE_BROWSER_TITLE_PREFIX)
+    ? title.slice(FILE_BROWSER_TITLE_PREFIX.length)
+    : title;
+}

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -6003,7 +6003,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "worktree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Show a folder in a persistent read-only file browser panel, for a worktree or for the current project or scratch folder when no worktree is selected. It opens in the grid unless location is "dock". It focuses the existing browser for the same folder on the same surface rather than opening a second one, and applies an optional reveal path to it.",
+    "description": "Show a folder in a persistent read-only file browser panel, for a worktree or for the current project or scratch folder when no worktree is selected. It focuses the existing browser for the same folder on the same surface rather than opening a second one, and applies an optional reveal path to it.",
     "examples": undefined,
     "id": "worktree.openFileBrowserPanel",
     "keywords": [

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -6003,7 +6003,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "worktree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Show a folder in a persistent read-only file browser panel in the grid, for a worktree or for the current project or scratch folder when no worktree is selected. It focuses the existing grid browser for the same folder rather than opening a second one, and applies an optional reveal path to it.",
+    "description": "Show a folder in a persistent read-only file browser panel, for a worktree or for the current project or scratch folder when no worktree is selected. It opens in the grid unless location is "dock". It focuses the existing browser for the same folder on the same surface rather than opening a second one, and applies an optional reveal path to it.",
     "examples": undefined,
     "id": "worktree.openFileBrowserPanel",
     "keywords": [

--- a/src/services/actions/definitions/__tests__/worktreeOpenFileBrowserPanelAction.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeOpenFileBrowserPanelAction.test.ts
@@ -425,12 +425,10 @@ describe("worktree.openFileBrowserPanel", () => {
 
       const options = addPanelOptions();
       expect(options).toMatchObject({ location: "grid" });
-      // Not merely absent-and-falsy: `addPanel` reads the flag independently of
-      // the location, so a grid open must not carry dock activation at all.
-      expect(options).not.toHaveProperty("activateDockOnCreate");
+      expect(options.activateDockOnCreate).not.toBe(true);
     });
 
-    it("commits to the dock and opens the chip when the launcher asks for both", async () => {
+    it("forwards the dock placement and the activation the launcher asked for", async () => {
       seedWorktree("wt-1", { branch: "feature/x" });
       await getAction().run(
         { worktreeId: "wt-1", location: "dock", activateDockOnCreate: true },
@@ -444,11 +442,15 @@ describe("worktree.openFileBrowserPanel", () => {
       });
     });
 
-    it("parks a dock panel without opening the chip when activation was not asked for", async () => {
+    it("parks a dock panel without asking for the chip when activation was not requested", async () => {
       seedWorktree("wt-1");
       await getAction().run({ worktreeId: "wt-1", location: "dock" }, {} as ActionContext);
 
-      expect(addPanelOptions()).toMatchObject({ location: "dock", activateDockOnCreate: false });
+      const options = addPanelOptions();
+      expect(options).toMatchObject({ location: "dock" });
+      // Truthiness is what `addPanel` reads, so this is the whole contract —
+      // absent and explicitly false are the same request.
+      expect(options.activateDockOnCreate).not.toBe(true);
     });
 
     it("reuses the docked browser for a dock request rather than opening a second", async () => {

--- a/src/services/actions/definitions/__tests__/worktreeOpenFileBrowserPanelAction.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeOpenFileBrowserPanelAction.test.ts
@@ -116,7 +116,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // A suite-wide invariant rather than one test: this action opens a grid
+  // A suite-wide invariant rather than one test: this action opens a persistent
   // panel, and the whole point of the split is that it never presents the
   // ephemeral dialog its sibling owns — on any path, including the failures.
   expect(openPanelDialogMock).not.toHaveBeenCalled();
@@ -397,6 +397,114 @@ describe("worktree.openFileBrowserPanel", () => {
       await getAction().run({ worktreeId: "wt-1" }, {} as ActionContext);
 
       expect(addPanelMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("placement (#11917)", () => {
+    it("declares the placement fields the dock launcher forwards", () => {
+      // `getAction().run()` below is called directly, so it never sees
+      // `ActionService`'s parse. This is the half that would break silently:
+      // an undeclared field is DROPPED, not rejected, so the launcher's "Open
+      // in dock" heading would keep promising a surface the panel never
+      // reaches.
+      const parsed = getAction().argsSchema?.parse({
+        worktreeId: "wt-1",
+        location: "dock",
+        activateDockOnCreate: true,
+      });
+      expect(parsed).toMatchObject({ location: "dock", activateDockOnCreate: true });
+    });
+
+    it("rejects a placement that is neither surface", () => {
+      expect(() => getAction().argsSchema?.parse({ location: "dialog" })).toThrow();
+    });
+
+    it("defaults to the grid, so every caller predating the dock keeps its surface", async () => {
+      seedWorktree("wt-1", { branch: "feature/x" });
+      await getAction().run({ worktreeId: "wt-1" }, {} as ActionContext);
+
+      const options = addPanelOptions();
+      expect(options).toMatchObject({ location: "grid" });
+      // Not merely absent-and-falsy: `addPanel` reads the flag independently of
+      // the location, so a grid open must not carry dock activation at all.
+      expect(options).not.toHaveProperty("activateDockOnCreate");
+    });
+
+    it("commits to the dock and opens the chip when the launcher asks for both", async () => {
+      seedWorktree("wt-1", { branch: "feature/x" });
+      await getAction().run(
+        { worktreeId: "wt-1", location: "dock", activateDockOnCreate: true },
+        {} as ActionContext
+      );
+
+      expect(addPanelOptions()).toMatchObject({
+        kind: "file-browser",
+        location: "dock",
+        activateDockOnCreate: true,
+      });
+    });
+
+    it("parks a dock panel without opening the chip when activation was not asked for", async () => {
+      seedWorktree("wt-1");
+      await getAction().run({ worktreeId: "wt-1", location: "dock" }, {} as ActionContext);
+
+      expect(addPanelOptions()).toMatchObject({ location: "dock", activateDockOnCreate: false });
+    });
+
+    it("reuses the docked browser for a dock request rather than opening a second", async () => {
+      seedWorktree("wt-1");
+      panelsMock.byId = [browserPanel("fb-docked", { worktreeId: "wt-1", location: "dock" })];
+
+      const result = await getAction().run(
+        { worktreeId: "wt-1", location: "dock" },
+        {} as ActionContext
+      );
+
+      expect(addPanelMock).not.toHaveBeenCalled();
+      expect(activateTerminalMock).toHaveBeenCalledWith("fb-docked");
+      expect(result).toEqual({ panelId: "fb-docked" });
+    });
+
+    it("does not answer a dock request with the grid browser for the same folder", async () => {
+      // Reusing across surfaces would leave the dock empty after a gesture that
+      // named it — and moving the panel over instead would drag its whole tab
+      // group along.
+      seedWorktree("wt-1");
+      panelsMock.byId = [browserPanel("fb-grid", { worktreeId: "wt-1", location: "grid" })];
+
+      const result = await getAction().run(
+        { worktreeId: "wt-1", location: "dock" },
+        {} as ActionContext
+      );
+
+      expect(activateTerminalMock).not.toHaveBeenCalled();
+      expect(addPanelOptions()).toMatchObject({ location: "dock" });
+      expect(result).toEqual({ panelId: "fb-panel-1" });
+    });
+
+    it("does not answer a grid request with the docked browser for the same folder", async () => {
+      seedWorktree("wt-1");
+      panelsMock.byId = [browserPanel("fb-docked", { worktreeId: "wt-1", location: "dock" })];
+
+      await getAction().run({ worktreeId: "wt-1" }, {} as ActionContext);
+
+      expect(activateTerminalMock).not.toHaveBeenCalled();
+      expect(addPanelOptions()).toMatchObject({ location: "grid" });
+    });
+
+    it("applies a reveal to the docked browser it reuses", async () => {
+      seedWorktree("wt-1");
+      panelsMock.byId = [browserPanel("fb-docked", { worktreeId: "wt-1", location: "dock" })];
+
+      await getAction().run(
+        { worktreeId: "wt-1", location: "dock", revealPath: "src/app.ts" },
+        {} as ActionContext
+      );
+
+      expect(setFileBrowserViewMock).toHaveBeenCalledWith(
+        "fb-docked",
+        expect.objectContaining({ browserSelectedPath: "src/app.ts" })
+      );
     });
   });
 

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -22,6 +22,7 @@ import { useCopyTreeRunStore } from "@/store/copyTreeRunStore";
 import { deriveCommitMessageSeed } from "@/lib/worktreeAiNote";
 import { buildWorkingTreeDiffModel } from "@/lib/workingTreeDiff";
 import { basename } from "@shared/utils/path";
+import { composeFileBrowserTitle } from "@/panels/file-browser/title";
 // Static, unlike the stores below: this module carries the panel types plus a
 // handful of pure predicates over them, so it drags in no client or store graph.
 import {
@@ -167,30 +168,47 @@ function toReadinessResultItem(
  * become the thing that picks a surface, since revealing the root passes no
  * path while still carrying a `revealKind` (#11666).
  */
-const fileBrowserArgsSchema = z
-  .object({
-    // `.min(1)`, unlike the siblings above: an empty string here is not a
-    // harmless falsy worktree — it would slip past the unknown-worktree
-    // guard and open the workspace root instead of failing.
-    worktreeId: z.string().min(1).optional(),
-    /**
-     * Path to select and scroll into view on open, relative to the worktree or
-     * workspace root — the same base `browserSelectedPath` is stored against,
-     * not the tree's current scoped root. Every caller computes it that way,
-     * and a path relative to a scope the caller cannot see would be
-     * unresolvable from outside the panel.
-     */
-    revealPath: z.string().optional(),
-    /**
-     * What `revealPath` points at. A directory is also expanded so its
-     * children are visible; the caller knows (it validated the path),
-     * and re-statting here would be a second round-trip for one bit.
-     */
-    revealKind: z.enum(["file", "directory"]).optional(),
+const fileBrowserArgsObject = z.object({
+  // `.min(1)`, unlike the siblings above: an empty string here is not a
+  // harmless falsy worktree — it would slip past the unknown-worktree
+  // guard and open the workspace root instead of failing.
+  worktreeId: z.string().min(1).optional(),
+  /**
+   * Path to select and scroll into view on open, relative to the worktree or
+   * workspace root — the same base `browserSelectedPath` is stored against,
+   * not the tree's current scoped root. Every caller computes it that way,
+   * and a path relative to a scope the caller cannot see would be
+   * unresolvable from outside the panel.
+   */
+  revealPath: z.string().optional(),
+  /**
+   * What `revealPath` points at. A directory is also expanded so its
+   * children are visible; the caller knows (it validated the path),
+   * and re-statting here would be a second round-trip for one bit.
+   */
+  revealKind: z.enum(["file", "directory"]).optional(),
+});
+
+const fileBrowserArgsSchema = fileBrowserArgsObject.optional();
+
+/**
+ * The persistent opener also answers to the dock launcher, which forwards the
+ * placement it advertised in its heading (`launchPanelKind`). Declared only
+ * here: the dialog opener has no placement to take, and `ActionService` drops
+ * undeclared fields, so a shared schema would silently strand a dock request in
+ * the grid — the heading promising one surface and the panel landing on the
+ * other (#11917).
+ */
+const fileBrowserPanelArgsSchema = fileBrowserArgsObject
+  .extend({
+    location: z.enum(["grid", "dock"]).optional(),
+    /** Open the dock popover on create. Ignored unless `location` is "dock". */
+    activateDockOnCreate: z.boolean().optional(),
   })
   .optional();
 
 type FileBrowserArgs = z.infer<typeof fileBrowserArgsSchema>;
+type FileBrowserPanelArgs = z.infer<typeof fileBrowserPanelArgsSchema>;
 
 /**
  * A palette gate rather than `isEnabled`, for the same reason
@@ -260,11 +278,16 @@ function resolveFileBrowserTarget(
   }
 
   if (worktree) {
-    return { worktreeId: targetWorktreeId, title: `Files — ${worktree.branch ?? worktree.name}` };
+    return {
+      worktreeId: targetWorktreeId,
+      title: composeFileBrowserTitle(worktree.branch ?? worktree.name),
+    };
   }
   return {
     worktreeId: undefined,
-    title: `Files — ${ctx.projectName ?? ctx.scratchName ?? (workspacePath ? basename(workspacePath) : "workspace")}`,
+    title: composeFileBrowserTitle(
+      ctx.projectName ?? ctx.scratchName ?? (workspacePath ? basename(workspacePath) : "workspace")
+    ),
   };
 }
 
@@ -675,7 +698,7 @@ export function registerWorktreeContextActions(
       id: "worktree.openFileBrowserPanel",
       title: "Browse files",
       description:
-        "Show a folder in a persistent read-only file browser panel in the grid, for a worktree or for the current project or scratch folder when no worktree is selected. It focuses the existing grid browser for the same folder rather than opening a second one, and applies an optional reveal path to it.",
+        'Show a folder in a persistent read-only file browser panel, for a worktree or for the current project or scratch folder when no worktree is selected. It opens in the grid unless location is "dock". It focuses the existing browser for the same folder on the same surface rather than opening a second one, and applies an optional reveal path to it.',
       category: "worktree",
       kind: "command",
       danger: "safe",
@@ -686,11 +709,14 @@ export function registerWorktreeContextActions(
         isReady: fileBrowserIsReady,
         reason: "No folder to browse",
       },
-      argsSchema: fileBrowserArgsSchema,
-      run: async (args, ctx: ActionContext) => {
+      argsSchema: fileBrowserPanelArgsSchema,
+      run: async (args: FileBrowserPanelArgs, ctx: ActionContext) => {
         const { worktreeId, title } = resolveFileBrowserTarget(args, ctx);
         const reveal = await resolveFileBrowserReveal(args);
         const foreground = isForegroundDispatch(ctx.dispatchSource);
+        // Grid stays the default, so every caller that predates the dock
+        // launcher keeps landing exactly where it did.
+        const location = args?.location === "dock" ? "dock" : "grid";
 
         // The grid renders only the active worktree's bucket, so a panel opened
         // for any other worktree is created `background` and never appears —
@@ -724,12 +750,21 @@ export function registerWorktreeContextActions(
           .map((id) => store.panelsById[id])
           .find((panel): panel is FileBrowserPanelData => {
             if (panel === undefined || !isFileBrowserPanel(panel)) return false;
-            // Grid members only. A dialog browser is ephemeral modal content
-            // and reusing one would hand the grid an uncounted, unpersisted
-            // record; trashed and backgrounded panels surface nothing when
-            // activated. `isGridPanelLocation` is the one place that answer
-            // lives, so dock and overlay come along for free.
-            if (!isGridPanelLocation(panel.location)) return false;
+            // Matched against the surface that was ASKED for, not "anywhere":
+            // reusing the grid browser for a dock request would leave the dock
+            // empty after a gesture that named it, and moving the panel across
+            // instead would drag its whole tab group along. One browser per
+            // folder per surface is the smallest honest extension of the old
+            // grid-only rule (#11917).
+            //
+            // Either way a dialog browser is ephemeral modal content and
+            // reusing one would hand the grid an uncounted, unpersisted record;
+            // trashed and backgrounded panels surface nothing when activated.
+            // `isGridPanelLocation` is the one place that answer lives, so
+            // overlay comes along for free.
+            const onRequestedSurface =
+              location === "dock" ? panel.location === "dock" : isGridPanelLocation(panel.location);
+            if (!onRequestedSurface) return false;
             // Identity is the folder the tree is rooted at, not the placement
             // worktree: a workspace-rooted panel carries a worktreeId purely so
             // it lands in a rendered index bucket (#11489), and matching on
@@ -799,7 +834,12 @@ export function registerWorktreeContextActions(
           title,
           ...(worktreeId !== undefined && { worktreeId }),
           ...reveal,
-          location: "grid",
+          location,
+          // Folded into the same set() that commits the panel, so the offscreen
+          // container's watchdog can't close the popover in the render gap
+          // (#6590) — the reason `launchPanelKind` passes this rather than
+          // opening the chip afterwards.
+          ...(location === "dock" && { activateDockOnCreate: args?.activateDockOnCreate === true }),
           ...(foreground && { focusPolicy: "take" as const }),
         });
         if (!panelId) {

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -201,9 +201,14 @@ const fileBrowserArgsSchema = fileBrowserArgsObject.optional();
  */
 const fileBrowserPanelArgsSchema = fileBrowserArgsObject
   .extend({
-    location: z.enum(["grid", "dock"]).optional(),
-    /** Open the dock popover on create. Ignored unless `location` is "dock". */
-    activateDockOnCreate: z.boolean().optional(),
+    location: z
+      .enum(["grid", "dock"])
+      .optional()
+      .describe("Surface to open on (default: grid). `dock` parks it as a chip in the sidebar."),
+    activateDockOnCreate: z
+      .boolean()
+      .optional()
+      .describe("Open the dock popover immediately (default: false). Ignored unless docking."),
   })
   .optional();
 
@@ -698,7 +703,7 @@ export function registerWorktreeContextActions(
       id: "worktree.openFileBrowserPanel",
       title: "Browse files",
       description:
-        'Show a folder in a persistent read-only file browser panel, for a worktree or for the current project or scratch folder when no worktree is selected. It opens in the grid unless location is "dock". It focuses the existing browser for the same folder on the same surface rather than opening a second one, and applies an optional reveal path to it.',
+        "Show a folder in a persistent read-only file browser panel, for a worktree or for the current project or scratch folder when no worktree is selected. It focuses the existing browser for the same folder on the same surface rather than opening a second one, and applies an optional reveal path to it.",
       category: "worktree",
       kind: "command",
       danger: "safe",
@@ -759,9 +764,10 @@ export function registerWorktreeContextActions(
             //
             // Either way a dialog browser is ephemeral modal content and
             // reusing one would hand the grid an uncounted, unpersisted record;
-            // trashed and backgrounded panels surface nothing when activated.
-            // `isGridPanelLocation` is the one place that answer lives, so
-            // overlay comes along for free.
+            // trashed, backgrounded and overlay panels surface nothing when
+            // activated. `isGridPanelLocation` is the one place that answer
+            // lives, so every one of those exclusions — and the legacy
+            // `undefined` location that still counts as grid — comes for free.
             const onRequestedSurface =
               location === "dock" ? panel.location === "dock" : isGridPanelLocation(panel.location);
             if (!onRequestedSurface) return false;

--- a/src/store/slices/panelRegistry/__tests__/addPanelTitleMode.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelTitleMode.test.ts
@@ -5,6 +5,11 @@
  * `titleMode: "custom"` is how an assistant-named agent launch pins its title so
  * the identity reducer's agent-detected/exited rewrites skip it. The field was
  * previously dropped on the floor between AddPanelOptions and the panel object.
+ *
+ * The non-PTY half (#11917) kept dropping it long after the PTY half was fixed:
+ * persistence writes the mode and hydration forwards it, so a restored file
+ * viewer or file browser kept the name a rename gave it while losing the
+ * ownership that stops a derived surface — the dock chip — from overriding it.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -129,6 +134,37 @@ describe("addPanel titleMode propagation (#10439)", () => {
     expect(id).toBe("default-1");
     const panel = getPtyPanel("default-1");
     expect(panel?.titleMode).toBeUndefined();
+  });
+
+  it("stamps titleMode onto a non-PTY panel too, the way hydration replays it", async () => {
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "file-browser",
+      title: "My notes",
+      titleMode: "user",
+      requestedId: "fb-named",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("fb-named");
+    const panel = usePanelStore.getState().panelsById["fb-named"];
+    expect(panel?.title).toBe("My notes");
+    expect(panel?.titleMode).toBe("user");
+  });
+
+  it("leaves a non-PTY panel's titleMode unset when the caller supplies none", async () => {
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "file-browser",
+      title: "Files — develop",
+      requestedId: "fb-default",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("fb-default");
+    expect(usePanelStore.getState().panelsById["fb-default"]?.titleMode).toBeUndefined();
   });
 });
 

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -250,6 +250,12 @@ export const createAddPanelActions = (
         id,
         kind: requestedKind,
         title,
+        // Carried like the PTY branch does below. Hydration forwards the saved
+        // mode (`buildArgsForNonPtyRecreation`) and persistence writes it, so
+        // dropping it here silently demoted every restored non-PTY rename back
+        // to `"default"` — the panel kept the name but lost the ownership that
+        // stops a derived surface (the dock chip) from overriding it.
+        ...(options.titleMode && { titleMode: options.titleMode }),
         worktreeId: effectiveWorktreeId,
         location,
         isVisible: location === "grid",

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1762,6 +1762,34 @@ describe("buildArgsForNonPtyRecreation", () => {
     expect(result.browserSidebarWidth).toBe(360);
   });
 
+  it("restores a persisted file-browser to the dock it was left in (#11917)", () => {
+    // A combination that could not exist before the kind became dockable, and
+    // the rescue below is keyed on `panelKindIsDockable` — so a regression on
+    // the registry flag resurfaces here as a panel silently reappearing in the
+    // grid, with the layout state intact and the placement wrong.
+    const result = buildArgsForNonPtyRecreation(
+      {
+        id: "fb-dock",
+        kind: "file-browser",
+        title: "Files — develop",
+        location: "dock",
+        worktreeId: "wt-1",
+        browserRootPath: "src",
+        browserExpandedPaths: ["src", "src/components"],
+      },
+      "file-browser",
+      "/project",
+      "wt-active"
+    );
+
+    expect(result.location).toBe("dock");
+    // The rescue's worktree adoption is for panels it pulls back to the grid;
+    // a kept dock placement must not have its attribution rewritten.
+    expect(result.worktreeId).toBe("wt-1");
+    expect(result.browserRootPath).toBe("src");
+    expect(result.browserExpandedPaths).toEqual(["src", "src/components"]);
+  });
+
   it("falls back to projectRoot when a non-PTY saved cwd is relative", () => {
     const result = buildArgsForNonPtyRecreation(
       {


### PR DESCRIPTION
## Summary

- Makes the file browser panel dockable. It was the only kind carrying `dockable: false` in `shared/config/panelKindRegistry.ts`, so its header never showed the move-to-dock control, only maximize and close.
- The opt-out's reason (a two-pane browser has no meaningful compact form) doesn't hold any more: the chip row is only a label, and `DockedNonPtyPanelItem` moves the panel's React subtree into the popover instead of remounting it, so the browser gets the same room there as the file viewer already does.
- Scoped to `file-browser` only, per the issue. `review`, `diff` and `dev-preview` keep their opt-outs.

Resolves #11917

## Changes

1. Dropped `dockable: false` (kinds are dockable by default now) and cleaned the stale file-browser mention out of dev-preview's and review's opt-out comments. `panelKindIsDockable` turned out to be the single gate: `isDockPanel`, `terminal.moveToDock`/`toggleDock`/`toggleDockAll`, `PanelHeader.showMoveToDock`, and the dock membership selector all route through it, so flipping one flag was the whole change. All browser state (selection, expansion, root, sidebar width, collapse flags, sort, tree snapshot) already lives on the panel record, so reopening the chip restores the tree and viewer target for free.
2. Added a compact chip title derivation in `src/components/Layout/dockChipTitle.ts`: a user- or automation-locked title wins, else the scoped root's basename, else the composed title minus its `Files — ` prefix. Deliberately not the selected file: that changes on every arrow-key step through the tree, and the docked surface is the tree, not the viewer. The prefix is single-sourced in `src/panels/file-browser/title.ts`, so the trim is a contract rather than pattern matching. Pulled the chip title functions out of `ContentDock.tsx` into a pure module so they're unit testable (`ContentDock` itself can only be source-contract tested).
3. Taught `worktree.openFileBrowserPanel` the placement the dock launcher forwards. `launchPanelKind` passes `location`/`activateDockOnCreate` to a kind's launch action, and `ActionService` drops undeclared args, so without this the launcher's "Open in dock" row would have created a grid panel, contradicting its own heading. Reuse is now surface-aware: one browser per folder per surface, rather than handing a dock request the grid panel or dragging a panel's tab group across.
4. Fixed a pre-existing bug the chip made visible: `addPanel` dropped `options.titleMode` for every non-PTY kind while the PTY branch kept it. Persistence writes it and hydration forwards it, so a restored file viewer or file browser kept a rename's name but lost the ownership that stops a derived surface from overriding it.

## Testing

Registry and type-guard contracts updated (four built-in opt-outs are now three), new unit suites for the chip derivation and for the action's placement handling, a dock-restore case in `statePatcher`, non-PTY `titleMode` regression tests, and a dock lifecycle test in `e2e/full/panels/core-file-browser.spec.ts`.

Locally: 4239 targeted tests, `npm run typecheck`, and `npm run lint:ratchet` all pass. The e2e addition runs in the `full-panels` bucket (release/stabilize), not PR CI.