### PR TITLE
fix(launcher): stop pointer transit from stealing the keyboard selection

### DIFF
--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -71,9 +71,6 @@ const DOCK_LAUNCH_FUSE_OPTIONS: IFuseOptions<DockLaunchItem> = {
 };
 
 /** Ranked results are capped; the browse list always renders in full. */
-/** Keys that move the selection, so the list may scroll under the pointer. */
-const SELECTION_KEYS = new Set(["ArrowDown", "ArrowUp", "Home", "End"]);
-
 const SEARCH_RESULT_CAP = 30;
 
 /**
@@ -424,13 +421,10 @@ export function DockLaunchButton({
   // Pointer transit must not be read as a choice of row: sweeping past rows to
   // reach a lower one, and the scrollIntoView below sliding a row under a
   // resting cursor, are both movement rather than intent (#11919).
-  const {
-    listboxRef,
-    onHover: handleRowHover,
-    notifyKeyboardSelection,
-  } = useDockLaunchHoverSelection({
+  const { listboxRef, onHover: handleRowHover } = useDockLaunchHoverSelection({
     open,
     results,
+    selectedIndex: activeIndex,
     setSelectedIndex,
   });
 
@@ -635,11 +629,6 @@ export function DockLaunchButton({
       // itself, so this only covers keys arriving from the input.
       if (capturingRowKey !== null) return;
 
-      // Before the selection moves, not after: the scroll that follows it slides
-      // a row under a resting cursor, and that row's pointerenter must not be
-      // read as a choice (#11919).
-      if (SELECTION_KEYS.has(event.key)) notifyKeyboardSelection();
-
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         event.preventDefault();
         event.stopPropagation();
@@ -741,7 +730,6 @@ export function DockLaunchButton({
       results.length,
       selectedPinTarget,
       selectedRow,
-      notifyKeyboardSelection,
       selectNext,
       selectPrevious,
       setSelectedIndex,

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -71,6 +71,9 @@ const DOCK_LAUNCH_FUSE_OPTIONS: IFuseOptions<DockLaunchItem> = {
 };
 
 /** Ranked results are capped; the browse list always renders in full. */
+/** Keys that move the selection, so the list may scroll under the pointer. */
+const SELECTION_KEYS = new Set(["ArrowDown", "ArrowUp", "Home", "End"]);
+
 const SEARCH_RESULT_CAP = 30;
 
 /**
@@ -421,7 +424,11 @@ export function DockLaunchButton({
   // Pointer transit must not be read as a choice of row: sweeping past rows to
   // reach a lower one, and the scrollIntoView below sliding a row under a
   // resting cursor, are both movement rather than intent (#11919).
-  const { listboxRef, onHover: handleRowHover } = useDockLaunchHoverSelection({
+  const {
+    listboxRef,
+    onHover: handleRowHover,
+    notifyKeyboardSelection,
+  } = useDockLaunchHoverSelection({
     open,
     results,
     setSelectedIndex,
@@ -628,6 +635,11 @@ export function DockLaunchButton({
       // itself, so this only covers keys arriving from the input.
       if (capturingRowKey !== null) return;
 
+      // Before the selection moves, not after: the scroll that follows it slides
+      // a row under a resting cursor, and that row's pointerenter must not be
+      // read as a choice (#11919).
+      if (SELECTION_KEYS.has(event.key)) notifyKeyboardSelection();
+
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         event.preventDefault();
         event.stopPropagation();
@@ -729,6 +741,7 @@ export function DockLaunchButton({
       results.length,
       selectedPinTarget,
       selectedRow,
+      notifyKeyboardSelection,
       selectNext,
       selectPrevious,
       setSelectedIndex,

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
+import { useDockLaunchHoverSelection } from "./useDockLaunchHoverSelection";
 import { AppPalettePopover } from "@/components/ui/AppPalettePopover";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { PALETTE_ROW_CLASS, PALETTE_SECTION_LABEL_CLASS } from "@/components/ui/paletteRowStyles";
@@ -416,6 +417,15 @@ export function DockLaunchButton({
   const activeDescendant =
     selectedRow && !capturingRowKey ? getOptionId(selectedRow.rowKey) : undefined;
   const selectedPinTarget = selectedRow ? resolvePinTarget(selectedRow) : null;
+
+  // Pointer transit must not be read as a choice of row: sweeping past rows to
+  // reach a lower one, and the scrollIntoView below sliding a row under a
+  // resting cursor, are both movement rather than intent (#11919).
+  const { listboxRef, onHover: handleRowHover } = useDockLaunchHoverSelection({
+    open,
+    results,
+    setSelectedIndex,
+  });
 
   // Set when ArrowRight expands a row, spent once the preset children actually
   // exist. The selection cannot move in the same handler: `setSelectedIndex`
@@ -884,7 +894,7 @@ export function DockLaunchButton({
           {results.length === 0 ? (
             <AppPaletteDialog.Empty query={query} emptyMessage="Nothing to launch" />
           ) : (
-            <div id={listboxId} role="listbox" aria-label="Launcher results">
+            <div ref={listboxRef} id={listboxId} role="listbox" aria-label="Launcher results">
               {results.map((row, index) =>
                 capturingRowKey === row.rowKey ? (
                   <DockLaunchCaptureRow
@@ -902,7 +912,7 @@ export function DockLaunchButton({
                     optionId={getOptionId(row.rowKey)}
                     pinTarget={resolvePinTarget(row)}
                     isExpanded={expandedPresetParentKey === row.rowKey}
-                    onHover={setSelectedIndex}
+                    onHover={handleRowHover}
                     onActivate={activateRow}
                     onTogglePin={togglePin}
                     onStartCapture={setCapturingRowKey}
@@ -1009,7 +1019,7 @@ interface DockLaunchOptionProps {
   /** Null for rows with no toolbar button to pin — the slot is still reserved. */
   pinTarget: DockLaunchPinTarget | null;
   isExpanded: boolean;
-  onHover: (index: number) => void;
+  onHover: (index: number, rowKey: string, pointerType: string) => void;
   onActivate: (row: DockLaunchRow) => void;
   onTogglePin: (target: DockLaunchPinTarget) => void;
   onStartCapture: (rowKey: string) => void;
@@ -1171,7 +1181,7 @@ function DockLaunchOption({
         // DismissableLayer, which needs to see it to classify the next outside
         // click as a dismissal.
         onPointerDown={(event) => event.preventDefault()}
-        onPointerEnter={() => onHover(index)}
+        onPointerEnter={(event) => onHover(index, row.rowKey, event.pointerType)}
         onClick={() => onActivate(row)}
         className={cn(
           PALETTE_ROW_CLASS,

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, createEvent, waitFor, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import {
   getPanelKindIds,
@@ -402,6 +402,56 @@ function searchInput(container: HTMLElement): HTMLInputElement {
   const input = container.querySelector("input");
   if (!input) throw new Error("search input not found");
   return input;
+}
+
+function listbox(container: HTMLElement): HTMLElement {
+  const node = container.querySelector<HTMLElement>('[role="listbox"]');
+  if (!node) throw new Error("listbox not found");
+  return node;
+}
+
+const POINTER_FACTORIES = {
+  pointerenter: createEvent.pointerEnter,
+  pointermove: createEvent.pointerMove,
+  pointerleave: createEvent.pointerLeave,
+  pointerover: createEvent.pointerOver,
+} as const;
+
+/**
+ * jsdom defaults `pointerType` to "" and offers no way to set `timeStamp`
+ * through the init dict, so a plain `fireEvent.pointerMove` exercises neither
+ * the mouse-only guard nor the velocity sampler — it just passes through.
+ */
+function firePointer(
+  target: Element,
+  type: keyof typeof POINTER_FACTORIES,
+  sample: { x: number; y: number; t: number }
+): void {
+  const event = POINTER_FACTORIES[type](target, {
+    pointerType: "mouse",
+    clientX: sample.x,
+    clientY: sample.y,
+  });
+  Object.defineProperty(event, "timeStamp", { value: sample.t, configurable: true });
+  fireEvent(target, event);
+}
+
+/**
+ * A row's `onPointerEnter` is synthesised by React from `pointerover`, so a
+ * real `pointerenter` never reaches it — which is why react-testing-library
+ * aliases `fireEvent.pointerEnter` to `pointerOver`. The gate's own listeners
+ * are native and take the real thing.
+ */
+function fireRowEnter(row: Element, sample: { x: number; y: number; t: number }): void {
+  firePointer(row, "pointerover", sample);
+}
+
+/** Two samples 30px apart in 10ms — well past the sweep threshold. */
+function startSweep(container: HTMLElement): void {
+  const list = listbox(container);
+  firePointer(list, "pointerenter", { x: 0, y: 0, t: 0 });
+  firePointer(list, "pointermove", { x: 0, y: 0, t: 0 });
+  firePointer(list, "pointermove", { x: 0, y: 30, t: 10 });
 }
 
 // jsdom implements no layout, so it ships no scrollIntoView at all. The
@@ -1150,6 +1200,141 @@ describe("DockLaunchButton", () => {
       fireEvent.pointerEnter(rows[1]!);
       expect(selectedOption(container)).toBe(rows[1]);
       expect(fireEvent.pointerDown(rows[1]!)).toBe(false);
+    });
+
+    describe("pointer transit is not a choice of row (#11919)", () => {
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      /** The gate only watches an open launcher, and this mock renders rows regardless. */
+      function openLauncher(): void {
+        act(() => popoverOpenChangeSpy!(true));
+      }
+
+      it("leaves the selection alone while a sweep crosses rows to reach a lower one", () => {
+        const { container } = renderButton();
+        openLauncher();
+        const input = searchInput(container);
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        const chosen = selectedOption(container);
+        expect(chosen).not.toBeNull();
+
+        startSweep(container);
+
+        // Every row the sweep passes announces itself; none of them was picked.
+        const rows = options(container);
+        expect(rows.length).toBeGreaterThan(2);
+        rows.slice(1).forEach((row, offset) => {
+          fireRowEnter(row, { x: 0, y: 32 + offset * 32, t: 12 + offset });
+          expect(selectedOption(container)).toBe(chosen);
+        });
+      });
+
+      it("settles onto the row the sweep stopped on", () => {
+        const { container } = renderButton();
+        openLauncher();
+        const rows = options(container);
+        expect(rows.length).toBeGreaterThan(2);
+        const target = rows[2]!;
+
+        startSweep(container);
+        fireRowEnter(target, { x: 0, y: 30, t: 12 });
+        expect(selectedOption(container)).not.toBe(target);
+
+        // The pointer comes to rest: same position, far enough past the
+        // minimum-suppression floor for the gesture to read as finished.
+        firePointer(listbox(container), "pointermove", { x: 0, y: 30, t: 70 });
+        expect(selectedOption(container)).toBe(target);
+      });
+
+      it("keeps the keyboard's row when the list scrolls under a resting cursor", () => {
+        const { container } = renderButton();
+        openLauncher();
+        const input = searchInput(container);
+        const list = listbox(container);
+        // The cursor is parked in the list and never moves again.
+        firePointer(list, "pointerenter", { x: 0, y: 0, t: 0 });
+
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        const chosen = selectedOption(container);
+        expect(chosen).not.toBeNull();
+
+        vi.useFakeTimers();
+        // What scrollIntoView does to a stationary pointer: the list moves, and
+        // a row it never chose slides underneath.
+        fireEvent.scroll(list);
+        const slidUnder = options(container).find((row) => row !== chosen)!;
+        fireRowEnter(slidUnder, { x: 0, y: 0, t: 200 });
+        expect(selectedOption(container)).toBe(chosen);
+
+        // And it must still be the keyboard's row once the list stops moving —
+        // a scroll settling says nothing about where the user is pointing.
+        act(() => {
+          vi.advanceTimersByTime(500);
+        });
+        expect(selectedOption(container)).toBe(chosen);
+      });
+
+      it("drops the row it was tracking rather than settling on whatever replaced it", () => {
+        const { container } = renderButton();
+        openLauncher();
+        const rows = options(container);
+        expect(rows.length).toBeGreaterThan(2);
+        const trackedLabel = rows[2]!.textContent;
+
+        startSweep(container);
+        fireRowEnter(rows[2]!, { x: 0, y: 30, t: 12 });
+
+        fireEvent.change(searchInput(container), { target: { value: "claude" } });
+        const filtered = options(container);
+        expect(filtered.length).toBeGreaterThan(0);
+        expect(filtered.map((row) => row.textContent)).not.toContain(trackedLabel);
+        const before = selectedOption(container);
+
+        firePointer(listbox(container), "pointermove", { x: 0, y: 30, t: 70 });
+        expect(selectedOption(container)).toBe(before);
+      });
+
+      it("does not settle a sweep that left the list", () => {
+        const { container } = renderButton();
+        openLauncher();
+        const input = searchInput(container);
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        const chosen = selectedOption(container);
+        const target = options(container).find((row) => row !== chosen)!;
+
+        vi.useFakeTimers();
+        startSweep(container);
+        fireRowEnter(target, { x: 0, y: 30, t: 12 });
+        firePointer(listbox(container), "pointerleave", { x: 0, y: 400, t: 20 });
+
+        act(() => {
+          vi.advanceTimersByTime(500);
+        });
+        expect(selectedOption(container)).toBe(chosen);
+      });
+
+      it("re-arms after the list empties and comes back", () => {
+        const { container } = renderButton();
+        openLauncher();
+        const input = searchInput(container);
+
+        // Zero results tears the listbox out entirely, taking the gate with it.
+        fireEvent.change(input, { target: { value: "zzzznotarealrow" } });
+        expect(container.querySelector('[role="listbox"]')).toBeNull();
+        fireEvent.change(input, { target: { value: "" } });
+
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        const chosen = selectedOption(container);
+        expect(chosen).not.toBeNull();
+
+        startSweep(container);
+        const target = options(container).find((row) => row !== chosen)!;
+        fireRowEnter(target, { x: 0, y: 32, t: 12 });
+        expect(selectedOption(container)).toBe(chosen);
+      });
     });
   });
 

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -411,7 +411,6 @@ function listbox(container: HTMLElement): HTMLElement {
 }
 
 const POINTER_FACTORIES = {
-  pointerenter: createEvent.pointerEnter,
   pointermove: createEvent.pointerMove,
   pointerleave: createEvent.pointerLeave,
   pointerover: createEvent.pointerOver,
@@ -449,7 +448,6 @@ function fireRowEnter(row: Element, sample: { x: number; y: number; t: number })
 /** Two samples 30px apart in 10ms — well past the sweep threshold. */
 function startSweep(container: HTMLElement): void {
   const list = listbox(container);
-  firePointer(list, "pointerenter", { x: 0, y: 0, t: 0 });
   firePointer(list, "pointermove", { x: 0, y: 0, t: 0 });
   firePointer(list, "pointermove", { x: 0, y: 30, t: 10 });
 }
@@ -1231,6 +1229,18 @@ describe("DockLaunchButton", () => {
         });
       });
 
+      it("selects immediately on an ordinary mouse hover", () => {
+        // The two bare-pointerEnter tests above carry no pointerType, so they
+        // only prove the non-mouse bypass. This is the path a real mouse takes.
+        const { container } = renderButton();
+        openLauncher();
+        const rows = options(container);
+        const target = rows[1]!;
+
+        fireRowEnter(target, { x: 0, y: 32, t: 0 });
+        expect(selectedOption(container)).toBe(target);
+      });
+
       it("settles onto the row the sweep stopped on", () => {
         const { container } = renderButton();
         openLauncher();
@@ -1244,7 +1254,7 @@ describe("DockLaunchButton", () => {
 
         // The pointer comes to rest: same position, far enough past the
         // minimum-suppression floor for the gesture to read as finished.
-        firePointer(listbox(container), "pointermove", { x: 0, y: 30, t: 70 });
+        firePointer(listbox(container), "pointermove", { x: 0, y: 30, t: 200 });
         expect(selectedOption(container)).toBe(target);
       });
 
@@ -1253,8 +1263,6 @@ describe("DockLaunchButton", () => {
         openLauncher();
         const input = searchInput(container);
         const list = listbox(container);
-        // The cursor is parked in the list and never moves again.
-        firePointer(list, "pointerenter", { x: 0, y: 0, t: 0 });
 
         fireEvent.keyDown(input, { key: "ArrowDown" });
         fireEvent.keyDown(input, { key: "ArrowDown" });
@@ -1286,6 +1294,8 @@ describe("DockLaunchButton", () => {
 
         startSweep(container);
         fireRowEnter(rows[2]!, { x: 0, y: 30, t: 12 });
+        // Without this the test passes whether or not hover is gated at all.
+        expect(selectedOption(container)).not.toBe(rows[2]!);
 
         fireEvent.change(searchInput(container), { target: { value: "claude" } });
         const filtered = options(container);
@@ -1293,7 +1303,7 @@ describe("DockLaunchButton", () => {
         expect(filtered.map((row) => row.textContent)).not.toContain(trackedLabel);
         const before = selectedOption(container);
 
-        firePointer(listbox(container), "pointermove", { x: 0, y: 30, t: 70 });
+        firePointer(listbox(container), "pointermove", { x: 0, y: 30, t: 200 });
         expect(selectedOption(container)).toBe(before);
       });
 
@@ -1309,6 +1319,29 @@ describe("DockLaunchButton", () => {
         startSweep(container);
         fireRowEnter(target, { x: 0, y: 30, t: 12 });
         firePointer(listbox(container), "pointerleave", { x: 0, y: 400, t: 20 });
+
+        act(() => {
+          vi.advanceTimersByTime(500);
+        });
+        expect(selectedOption(container)).toBe(chosen);
+      });
+
+      it("lets a keystroke override a sweep that has not settled yet", () => {
+        const { container } = renderButton();
+        openLauncher();
+        const input = searchInput(container);
+        const rows = options(container);
+        const swept = rows[2]!;
+
+        vi.useFakeTimers();
+        startSweep(container);
+        fireRowEnter(swept, { x: 0, y: 30, t: 12 });
+
+        // The keyboard makes a choice mid-gesture. The sweep's row is now an
+        // older opinion and must not come back when the gesture settles.
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        const chosen = selectedOption(container);
+        expect(chosen).not.toBe(swept);
 
         act(() => {
           vi.advanceTimersByTime(500);

--- a/src/components/Layout/__tests__/useDockLaunchHoverSelection.test.tsx
+++ b/src/components/Layout/__tests__/useDockLaunchHoverSelection.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, fireEvent, createEvent, act } from "@testing-library/react";
+import { useDockLaunchHoverSelection } from "../useDockLaunchHoverSelection";
+
+interface Row {
+  rowKey: string;
+}
+
+const ROWS: Row[] = [{ rowKey: "a" }, { rowKey: "b" }, { rowKey: "c" }];
+
+function Harness({
+  results,
+  setSelectedIndex,
+  open = true,
+}: {
+  results: readonly Row[];
+  setSelectedIndex: (index: number) => void;
+  open?: boolean;
+}) {
+  const { listboxRef, onHover, notifyKeyboardSelection } = useDockLaunchHoverSelection({
+    open,
+    results,
+    setSelectedIndex,
+  });
+  return (
+    <div>
+      <div ref={listboxRef} data-testid="listbox">
+        {results.map((row, index) => (
+          <button
+            key={row.rowKey}
+            data-testid={`row-${row.rowKey}`}
+            onPointerEnter={(event) => onHover(index, row.rowKey, event.pointerType)}
+          >
+            {row.rowKey}
+          </button>
+        ))}
+      </div>
+      <button data-testid="navigate" onClick={notifyKeyboardSelection}>
+        navigate
+      </button>
+    </div>
+  );
+}
+
+function setup(results: readonly Row[] = ROWS) {
+  const setSelectedIndex = vi.fn();
+  const view = render(<Harness results={results} setSelectedIndex={setSelectedIndex} />);
+  return { ...view, setSelectedIndex };
+}
+
+/** jsdom defaults pointerType to "", and timeStamp is not settable through init. */
+function fireMouse(
+  target: Element,
+  type: "pointermove" | "pointerleave" | "pointerover",
+  { x, y, t }: { x: number; y: number; t: number }
+): void {
+  const factory = {
+    pointermove: createEvent.pointerMove,
+    pointerleave: createEvent.pointerLeave,
+    pointerover: createEvent.pointerOver,
+  }[type];
+  const event = factory(target, { pointerType: "mouse", clientX: x, clientY: y });
+  Object.defineProperty(event, "timeStamp", { value: t, configurable: true });
+  fireEvent(target, event);
+}
+
+/** React synthesises onPointerEnter from pointerover, never from pointerenter. */
+function enterRow(row: Element, sample: { x: number; y: number; t: number }): void {
+  fireMouse(row, "pointerover", sample);
+}
+
+function startSweep(listbox: Element): void {
+  fireMouse(listbox, "pointermove", { x: 0, y: 0, t: 0 });
+  fireMouse(listbox, "pointermove", { x: 0, y: 30, t: 10 });
+}
+
+/** Comes to rest well past the minimum-suppression floor. */
+function settlePointer(listbox: Element): void {
+  fireMouse(listbox, "pointermove", { x: 0, y: 30, t: 400 });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDockLaunchHoverSelection", () => {
+  it("passes an unsuppressed mouse hover straight through", () => {
+    const { getByTestId, setSelectedIndex } = setup();
+    enterRow(getByTestId("row-b"), { x: 0, y: 32, t: 0 });
+    expect(setSelectedIndex).toHaveBeenCalledWith(1);
+  });
+
+  it.each(["touch", "pen"])("never gates %s, which has no hover to protect", (pointerType) => {
+    const { getByTestId, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+
+    const row = getByTestId("row-c");
+    const event = createEvent.pointerOver(row, { pointerType, clientX: 0, clientY: 64 });
+    fireEvent(row, event);
+    expect(setSelectedIndex).toHaveBeenCalledWith(2);
+  });
+
+  it("swallows the rows a sweep crosses and spends only the last one", () => {
+    const { getByTestId, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+
+    enterRow(getByTestId("row-b"), { x: 0, y: 32, t: 12 });
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 14 });
+    expect(setSelectedIndex).not.toHaveBeenCalled();
+
+    settlePointer(listbox);
+    expect(setSelectedIndex).toHaveBeenCalledTimes(1);
+    expect(setSelectedIndex).toHaveBeenCalledWith(2);
+  });
+
+  it("spends the row it tracked at the index that row now holds", () => {
+    const { getByTestId, rerender, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
+
+    // The list reshuffles under the suppressed sweep: "c" is still there, but
+    // the index it was hovered at now belongs to a different row.
+    const reshuffled: Row[] = [{ rowKey: "c" }, { rowKey: "a" }];
+    rerender(<Harness results={reshuffled} setSelectedIndex={setSelectedIndex} />);
+
+    settlePointer(listbox);
+    expect(setSelectedIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("spends nothing when the row it tracked is filtered away", () => {
+    const { getByTestId, rerender, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
+
+    rerender(<Harness results={[{ rowKey: "a" }]} setSelectedIndex={setSelectedIndex} />);
+
+    settlePointer(listbox);
+    expect(setSelectedIndex).not.toHaveBeenCalled();
+  });
+
+  it("never spends a row when the gesture that ends is the list moving", () => {
+    vi.useFakeTimers();
+    const { getByTestId, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+
+    // A pointer gesture is already suppressed with a row recorded, and then the
+    // list moves. Spending that row on the scroll's settle is the bug itself.
+    startSweep(listbox);
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
+    fireEvent.scroll(listbox);
+    enterRow(getByTestId("row-b"), { x: 0, y: 32, t: 14 });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(setSelectedIndex).not.toHaveBeenCalled();
+  });
+
+  it("ignores a scroll that cannot have moved its own rows", () => {
+    const { getByTestId, setSelectedIndex } = setup();
+    // A sibling scroller — a terminal streaming output — must not stand the
+    // launcher's hover down.
+    fireEvent.scroll(getByTestId("navigate"));
+    enterRow(getByTestId("row-b"), { x: 0, y: 32, t: 0 });
+    expect(setSelectedIndex).toHaveBeenCalledWith(1);
+  });
+
+  it("drops a sweep's pending row when the keyboard makes a choice first", () => {
+    vi.useFakeTimers();
+    const { getByTestId, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
+
+    fireEvent.click(getByTestId("navigate"));
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(setSelectedIndex).not.toHaveBeenCalled();
+  });
+
+  it("drops a sweep's pending row when the pointer leaves the list", () => {
+    vi.useFakeTimers();
+    const { getByTestId, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
+    fireMouse(listbox, "pointerleave", { x: 0, y: 400, t: 20 });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(setSelectedIndex).not.toHaveBeenCalled();
+  });
+
+  it("suppresses again after the pointer leaves and comes back", () => {
+    const { getByTestId, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+    fireMouse(listbox, "pointerleave", { x: 0, y: 400, t: 20 });
+
+    // A fresh gesture: the sampler was cleared, so these two samples are the
+    // whole window and must engage on their own.
+    fireMouse(listbox, "pointermove", { x: 0, y: 0, t: 100 });
+    fireMouse(listbox, "pointermove", { x: 0, y: 30, t: 110 });
+    enterRow(getByTestId("row-b"), { x: 0, y: 32, t: 112 });
+    expect(setSelectedIndex).not.toHaveBeenCalled();
+  });
+
+  it("takes an armed gesture down with the component, timer and all", () => {
+    vi.useFakeTimers();
+    const { getByTestId, setSelectedIndex, unmount } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
+
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(setSelectedIndex).not.toHaveBeenCalled();
+  });
+
+  it("stays out of the way entirely while the launcher is closed", () => {
+    const setSelectedIndex = vi.fn();
+    const { getByTestId } = render(
+      <Harness results={ROWS} setSelectedIndex={setSelectedIndex} open={false} />
+    );
+    startSweep(getByTestId("listbox"));
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
+    expect(setSelectedIndex).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/components/Layout/__tests__/useDockLaunchHoverSelection.test.tsx
+++ b/src/components/Layout/__tests__/useDockLaunchHoverSelection.test.tsx
@@ -12,15 +12,18 @@ const ROWS: Row[] = [{ rowKey: "a" }, { rowKey: "b" }, { rowKey: "c" }];
 function Harness({
   results,
   setSelectedIndex,
+  selectedIndex = 0,
   open = true,
 }: {
   results: readonly Row[];
   setSelectedIndex: (index: number) => void;
+  selectedIndex?: number;
   open?: boolean;
 }) {
-  const { listboxRef, onHover, notifyKeyboardSelection } = useDockLaunchHoverSelection({
+  const { listboxRef, onHover } = useDockLaunchHoverSelection({
     open,
     results,
+    selectedIndex,
     setSelectedIndex,
   });
   return (
@@ -36,9 +39,7 @@ function Harness({
           </button>
         ))}
       </div>
-      <button data-testid="navigate" onClick={notifyKeyboardSelection}>
-        navigate
-      </button>
+      <div data-testid="sibling-scroller" />
     </div>
   );
 }
@@ -91,7 +92,9 @@ describe("useDockLaunchHoverSelection", () => {
     expect(setSelectedIndex).toHaveBeenCalledWith(1);
   });
 
-  it.each(["touch", "pen"])("never gates %s, which has no hover to protect", (pointerType) => {
+  // Mouse-only by design: #11919 states plainly that touch and pen get no
+  // suppression logic at all.
+  it.each(["touch", "pen"])("never gates %s", (pointerType) => {
     const { getByTestId, setSelectedIndex } = setup();
     const listbox = getByTestId("listbox");
     startSweep(listbox);
@@ -165,24 +168,41 @@ describe("useDockLaunchHoverSelection", () => {
     const { getByTestId, setSelectedIndex } = setup();
     // A sibling scroller — a terminal streaming output — must not stand the
     // launcher's hover down.
-    fireEvent.scroll(getByTestId("navigate"));
+    fireEvent.scroll(getByTestId("sibling-scroller"));
     enterRow(getByTestId("row-b"), { x: 0, y: 32, t: 0 });
     expect(setSelectedIndex).toHaveBeenCalledWith(1);
   });
 
-  it("drops a sweep's pending row when the keyboard makes a choice first", () => {
+  it("drops a sweep's pending row when something else moves the selection first", () => {
     vi.useFakeTimers();
-    const { getByTestId, setSelectedIndex } = setup();
+    const { getByTestId, rerender, setSelectedIndex } = setup();
     const listbox = getByTestId("listbox");
     startSweep(listbox);
     enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
 
-    fireEvent.click(getByTestId("navigate"));
+    // A keystroke, a query narrowing the list, a preset expanding — the gate
+    // does not care which. The selection moved and the sweep did not move it.
+    rerender(<Harness results={ROWS} selectedIndex={1} setSelectedIndex={setSelectedIndex} />);
 
     act(() => {
       vi.advanceTimersByTime(500);
     });
     expect(setSelectedIndex).not.toHaveBeenCalled();
+  });
+
+  it("does not stand itself down when the flush is what moved the selection", () => {
+    const { getByTestId, rerender, setSelectedIndex } = setup();
+    const listbox = getByTestId("listbox");
+    startSweep(listbox);
+    enterRow(getByTestId("row-c"), { x: 0, y: 64, t: 12 });
+    settlePointer(listbox);
+    expect(setSelectedIndex).toHaveBeenCalledWith(2);
+
+    // The selection this gate just asked for comes back as a prop. Reading that
+    // as somebody else's move would suppress hover after every hover.
+    rerender(<Harness results={ROWS} selectedIndex={2} setSelectedIndex={setSelectedIndex} />);
+    enterRow(getByTestId("row-b"), { x: 0, y: 32, t: 500 });
+    expect(setSelectedIndex).toHaveBeenLastCalledWith(1);
   });
 
   it("drops a sweep's pending row when the pointer leaves the list", () => {

--- a/src/components/Layout/useDockLaunchHoverSelection.ts
+++ b/src/components/Layout/useDockLaunchHoverSelection.ts
@@ -15,6 +15,8 @@ interface UseDockLaunchHoverSelection {
   /** Goes on the listbox host element. Not on a row — see `onHover`. */
   listboxRef: (node: HTMLDivElement | null) => void;
   onHover: (index: number, rowKey: string, pointerType: string) => void;
+  /** Call before any keystroke that moves the selection. */
+  notifyKeyboardSelection: () => void;
 }
 
 /**
@@ -78,7 +80,6 @@ export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
     });
     controllerRef.current = controller;
 
-    const handleEnter = (event: PointerEvent) => controller.pointerEnter(event);
     const handleMove = (event: PointerEvent) => controller.pointerMove(event);
     // Both of these clear the pending row for any pointer type: once the
     // pointer is off the list, or a scroll has taken authority, the row it was
@@ -87,12 +88,16 @@ export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
       pendingRowKeyRef.current = null;
       controller.pointerLeave(event);
     };
-    const handleScroll = () => {
+    const handleScroll = (event: Event) => {
+      // Only a scroller the list actually sits inside can move rows under the
+      // cursor. This app is full of independent scrollers, and a terminal
+      // streaming output must not stand the launcher's hover down.
+      const target = event.target;
+      if (!(target instanceof Node) || !target.contains(listboxNode)) return;
       pendingRowKeyRef.current = null;
-      controller.scroll();
+      controller.listMoved();
     };
 
-    listboxNode.addEventListener("pointerenter", handleEnter);
     listboxNode.addEventListener("pointermove", handleMove, { passive: true });
     listboxNode.addEventListener("pointerleave", handleLeave);
     // Scroll does not bubble and the scroller is the palette body wrapping this
@@ -101,7 +106,6 @@ export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
     document.addEventListener("scroll", handleScroll, { passive: true, capture: true });
 
     return () => {
-      listboxNode.removeEventListener("pointerenter", handleEnter);
       listboxNode.removeEventListener("pointermove", handleMove);
       listboxNode.removeEventListener("pointerleave", handleLeave);
       document.removeEventListener("scroll", handleScroll, { capture: true });
@@ -135,5 +139,15 @@ export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
     pendingRowKeyRef.current = source === "pointer" ? rowKey : null;
   }, []);
 
-  return { listboxRef, onHover };
+  // A keystroke that moves the selection makes the pointer's last opinion
+  // stale, and the row that lands under a resting cursor when the new selection
+  // scrolls into view is not a choice either. Standing hover down here rather
+  // than waiting for the scroll event keeps this off the boundary event the
+  // scroll fires, whichever order the browser emits the two in.
+  const notifyKeyboardSelection = useCallback(() => {
+    pendingRowKeyRef.current = null;
+    controllerRef.current?.listMoved();
+  }, []);
+
+  return { listboxRef, onHover, notifyKeyboardSelection };
 }

--- a/src/components/Layout/useDockLaunchHoverSelection.ts
+++ b/src/components/Layout/useDockLaunchHoverSelection.ts
@@ -8,6 +8,8 @@ interface HoverSelectionRow {
 interface UseDockLaunchHoverSelectionArgs<Row extends HoverSelectionRow> {
   open: boolean;
   results: readonly Row[];
+  /** The index actually rendered as selected, whoever last moved it. */
+  selectedIndex: number;
   setSelectedIndex: (index: number) => void;
 }
 
@@ -15,8 +17,6 @@ interface UseDockLaunchHoverSelection {
   /** Goes on the listbox host element. Not on a row — see `onHover`. */
   listboxRef: (node: HTMLDivElement | null) => void;
   onHover: (index: number, rowKey: string, pointerType: string) => void;
-  /** Call before any keystroke that moves the selection. */
-  notifyKeyboardSelection: () => void;
 }
 
 /**
@@ -36,6 +36,7 @@ interface UseDockLaunchHoverSelection {
 export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
   open,
   results,
+  selectedIndex,
   setSelectedIndex,
 }: UseDockLaunchHoverSelectionArgs<Row>): UseDockLaunchHoverSelection {
   // Paired in one object so a deferred flush can never combine one render's
@@ -51,6 +52,31 @@ export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
   // captured then points at a different row by the time it is spent.
   const pendingRowKeyRef = useRef<string | null>(null);
   const controllerRef = useRef<HoverSettleController | null>(null);
+
+  // What this gate last asked for, so the effect below can tell its own writes
+  // apart from everybody else's.
+  const selfSetIndexRef = useRef<number | null>(null);
+  const applySelection = useCallback((index: number) => {
+    selfSetIndexRef.current = index;
+    latestRef.current.setSelectedIndex(index);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (selectedIndex === selfSetIndexRef.current) return;
+    selfSetIndexRef.current = null;
+    // Something other than this gate moved the selection: a keystroke, a query
+    // narrowing the list, a preset expansion splicing rows in. Keying off the
+    // selection rather than off a list of key names is the point — every one of
+    // those routes ends here, and a new one cannot forget to.
+    //
+    // The pointer's last opinion is stale now, and the row that lands under a
+    // resting cursor when the new selection scrolls into view is not a choice
+    // either. Standing hover down here rather than waiting for the scroll event
+    // keeps this ahead of the boundary event that scroll fires, whichever order
+    // the browser emits the two in.
+    pendingRowKeyRef.current = null;
+    controllerRef.current?.listMoved();
+  }, [selectedIndex]);
 
   // State rather than a ref, because the attach effect has to re-run when the
   // node arrives. Radix loads the popover's content lazily, so the listbox can
@@ -71,11 +97,11 @@ export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
         // A scroll settling says only that the list stopped moving. Where the
         // cursor happens to have landed is the bug, not the answer.
         if (source !== "pointer" || rowKey === null) return;
-        const { results: liveResults, setSelectedIndex: select } = latestRef.current;
+        const { results: liveResults } = latestRef.current;
         const index = liveResults.findIndex((row) => row.rowKey === rowKey);
         // Filtered away mid-sweep: no fallback. Selecting whatever now sits at
         // that index would be the same guess this whole gate exists to refuse.
-        if (index >= 0) select(index);
+        if (index >= 0) applySelection(index);
       },
     });
     controllerRef.current = controller;
@@ -115,39 +141,33 @@ export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
       // intent left to spend.
       controller.destroy();
     };
-  }, [open, listboxNode]);
+  }, [open, listboxNode, applySelection]);
 
   // Stable for the lifetime of the component: every per-render value it needs
   // is read through a ref, so the rows never re-render for this prop and an
   // in-flight suppression is never reset by a keystroke.
-  const onHover = useCallback((index: number, rowKey: string, pointerType: string) => {
-    // Touch and pen have no hover state to protect.
-    if (pointerType !== "mouse") {
-      latestRef.current.setSelectedIndex(index);
-      return;
-    }
+  const onHover = useCallback(
+    (index: number, rowKey: string, pointerType: string) => {
+      // Touch and pen have no hover state to protect (the issue is explicit that
+      // neither gets suppression logic).
+      if (pointerType !== "mouse") {
+        applySelection(index);
+        return;
+      }
 
-    const source = controllerRef.current?.suppressionSource() ?? null;
-    if (source === null) {
-      latestRef.current.setSelectedIndex(index);
-      return;
-    }
+      const source = controllerRef.current?.suppressionSource() ?? null;
+      if (source === null) {
+        applySelection(index);
+        return;
+      }
 
-    // Only a pointer gesture earns a flush when it settles. Nothing needs
-    // clearing when a new episode starts: settle, leave, scroll takeover and
-    // teardown all clear this, so it is already null by then.
-    pendingRowKeyRef.current = source === "pointer" ? rowKey : null;
-  }, []);
+      // Only a pointer gesture earns a flush when it settles. Nothing needs
+      // clearing when a new episode starts: settle, leave, scroll takeover and
+      // teardown all clear this, so it is already null by then.
+      pendingRowKeyRef.current = source === "pointer" ? rowKey : null;
+    },
+    [applySelection]
+  );
 
-  // A keystroke that moves the selection makes the pointer's last opinion
-  // stale, and the row that lands under a resting cursor when the new selection
-  // scrolls into view is not a choice either. Standing hover down here rather
-  // than waiting for the scroll event keeps this off the boundary event the
-  // scroll fires, whichever order the browser emits the two in.
-  const notifyKeyboardSelection = useCallback(() => {
-    pendingRowKeyRef.current = null;
-    controllerRef.current?.listMoved();
-  }, []);
-
-  return { listboxRef, onHover, notifyKeyboardSelection };
+  return { listboxRef, onHover };
 }

--- a/src/components/Layout/useDockLaunchHoverSelection.ts
+++ b/src/components/Layout/useDockLaunchHoverSelection.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createHoverSettle, type HoverSettleController } from "@/lib/pointerTransit";
+
+interface HoverSelectionRow {
+  rowKey: string;
+}
+
+interface UseDockLaunchHoverSelectionArgs<Row extends HoverSelectionRow> {
+  open: boolean;
+  results: readonly Row[];
+  setSelectedIndex: (index: number) => void;
+}
+
+interface UseDockLaunchHoverSelection {
+  /** Goes on the listbox host element. Not on a row — see `onHover`. */
+  listboxRef: (node: HTMLDivElement | null) => void;
+  onHover: (index: number, rowKey: string, pointerType: string) => void;
+}
+
+/**
+ * Keeps pointer transit from being read as a choice of row (#11919).
+ *
+ * Hover is wired to the palette's selection setter, so sweeping down the list
+ * used to drag the selection through every row passed, and the
+ * `scrollIntoView` that follows keyboard navigation used to slide a row under a
+ * resting cursor and hand the selection back to the mouse. Both are the same
+ * bug: a row treating transit as intent.
+ *
+ * The gate lives here rather than inside the row so no ref crosses a component
+ * boundary as a prop, which is a silent React Compiler bailout. Suppression is
+ * held in refs, never state: pointermove arrives at 60-120Hz and must not
+ * render.
+ */
+export function useDockLaunchHoverSelection<Row extends HoverSelectionRow>({
+  open,
+  results,
+  setSelectedIndex,
+}: UseDockLaunchHoverSelectionArgs<Row>): UseDockLaunchHoverSelection {
+  // Paired in one object so a deferred flush can never combine one render's
+  // rows with another render's setter — `setSelectedIndex` closes over the
+  // `results` it was built from, and both take a new identity every render.
+  const latestRef = useRef({ results, setSelectedIndex });
+  useLayoutEffect(() => {
+    latestRef.current = { results, setSelectedIndex };
+  }, [results, setSelectedIndex]);
+
+  // The row the pointer was last over while suppressed. Recorded by key, never
+  // index: results can reshuffle underneath a suppressed sweep, and an index
+  // captured then points at a different row by the time it is spent.
+  const pendingRowKeyRef = useRef<string | null>(null);
+  const controllerRef = useRef<HoverSettleController | null>(null);
+
+  // State rather than a ref, because the attach effect has to re-run when the
+  // node arrives. Radix loads the popover's content lazily, so the listbox can
+  // mount without `DockLaunchButton` rendering again — a lookup by id in an
+  // effect keyed on `open` would miss that mount outright and never recover.
+  const [listboxNode, setListboxNode] = useState<HTMLDivElement | null>(null);
+  const listboxRef = useCallback((node: HTMLDivElement | null) => {
+    setListboxNode(node);
+  }, []);
+
+  useEffect(() => {
+    if (!open || !listboxNode) return;
+
+    const controller = createHoverSettle({
+      onSettle: (source) => {
+        const rowKey = pendingRowKeyRef.current;
+        pendingRowKeyRef.current = null;
+        // A scroll settling says only that the list stopped moving. Where the
+        // cursor happens to have landed is the bug, not the answer.
+        if (source !== "pointer" || rowKey === null) return;
+        const { results: liveResults, setSelectedIndex: select } = latestRef.current;
+        const index = liveResults.findIndex((row) => row.rowKey === rowKey);
+        // Filtered away mid-sweep: no fallback. Selecting whatever now sits at
+        // that index would be the same guess this whole gate exists to refuse.
+        if (index >= 0) select(index);
+      },
+    });
+    controllerRef.current = controller;
+
+    const handleEnter = (event: PointerEvent) => controller.pointerEnter(event);
+    const handleMove = (event: PointerEvent) => controller.pointerMove(event);
+    // Both of these clear the pending row for any pointer type: once the
+    // pointer is off the list, or a scroll has taken authority, the row it was
+    // over is no longer where it is pointing.
+    const handleLeave = (event: PointerEvent) => {
+      pendingRowKeyRef.current = null;
+      controller.pointerLeave(event);
+    };
+    const handleScroll = () => {
+      pendingRowKeyRef.current = null;
+      controller.scroll();
+    };
+
+    listboxNode.addEventListener("pointerenter", handleEnter);
+    listboxNode.addEventListener("pointermove", handleMove, { passive: true });
+    listboxNode.addEventListener("pointerleave", handleLeave);
+    // Scroll does not bubble and the scroller is the palette body wrapping this
+    // list, not the list itself, so this watches the document in the capture
+    // phase rather than reaching for a ref it has no path to.
+    document.addEventListener("scroll", handleScroll, { passive: true, capture: true });
+
+    return () => {
+      listboxNode.removeEventListener("pointerenter", handleEnter);
+      listboxNode.removeEventListener("pointermove", handleMove);
+      listboxNode.removeEventListener("pointerleave", handleLeave);
+      document.removeEventListener("scroll", handleScroll, { capture: true });
+      pendingRowKeyRef.current = null;
+      if (controllerRef.current === controller) controllerRef.current = null;
+      // Cancels the backstop without settling — a torn-down gesture has no
+      // intent left to spend.
+      controller.destroy();
+    };
+  }, [open, listboxNode]);
+
+  // Stable for the lifetime of the component: every per-render value it needs
+  // is read through a ref, so the rows never re-render for this prop and an
+  // in-flight suppression is never reset by a keystroke.
+  const onHover = useCallback((index: number, rowKey: string, pointerType: string) => {
+    // Touch and pen have no hover state to protect.
+    if (pointerType !== "mouse") {
+      latestRef.current.setSelectedIndex(index);
+      return;
+    }
+
+    const source = controllerRef.current?.suppressionSource() ?? null;
+    if (source === null) {
+      latestRef.current.setSelectedIndex(index);
+      return;
+    }
+
+    // Only a pointer gesture earns a flush when it settles. Nothing needs
+    // clearing when a new episode starts: settle, leave, scroll takeover and
+    // teardown all clear this, so it is already null by then.
+    pendingRowKeyRef.current = source === "pointer" ? rowKey : null;
+  }, []);
+
+  return { listboxRef, onHover };
+}

--- a/src/lib/__tests__/pointerTransit.test.ts
+++ b/src/lib/__tests__/pointerTransit.test.ts
@@ -33,9 +33,8 @@ function harness(options?: Parameters<typeof createHoverSettle>[1]) {
   return { controller, settled };
 }
 
-/** Arms `inside` and gets a suppressed pointer episode running. */
+/** Gets a suppressed pointer episode running; returns the last sample's time. */
 function engagePointer(controller: HoverSettleController): number {
-  controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
   return sweep(controller, { from: 0, stepPx: 8, stepMs: 8, count: 4 });
 }
 
@@ -49,6 +48,20 @@ describe("createSampler", () => {
     sampler.push(0, 0, 0);
     expect(sampler.speed()).toBeNull();
     expect(sampler.recentSpeed()).toBeNull();
+  });
+
+  it("keeps exactly the trailing pair once everything else has aged out", () => {
+    const stale = createSampler(50);
+    stale.push(0, 0, 0);
+    stale.push(200, 0, 5);
+    stale.push(10, 0, 100);
+    stale.push(20, 0, 110);
+    // Same trailing pair, no history at all: the windowed reading has to agree,
+    // which it cannot if any of the earlier samples survived the cutoff.
+    const fresh = createSampler(50);
+    fresh.push(10, 0, 100);
+    fresh.push(20, 0, 110);
+    expect(stale.speed()).toBe(fresh.speed());
   });
 
   it("reads tremor around a point as still, while a flick still registers instantly", () => {
@@ -98,7 +111,6 @@ describe("createSampler", () => {
 describe("createHoverSettle — pointer authority", () => {
   it("treats an isolated move as intent rather than transit", () => {
     const { controller } = harness();
-    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
     move(controller, 0, 0, 0);
     expect(controller.suppressionSource()).toBeNull();
   });
@@ -111,7 +123,6 @@ describe("createHoverSettle — pointer authority", () => {
 
   it("engages on a flick the windowed reading alone would have missed", () => {
     const { controller } = harness();
-    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
     move(controller, 0, 0, 0);
     move(controller, 0, -4, 10);
     expect(controller.suppressionSource()).toBeNull();
@@ -123,8 +134,9 @@ describe("createHoverSettle — pointer authority", () => {
   });
 
   it("holds a flick through its cold window, then settles once the floor elapses", () => {
-    const { controller, settled } = harness();
-    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    // An explicit floor rather than the shipped one, so tuning the default does
+    // not force this arithmetic to be rewritten.
+    const { controller, settled } = harness({ minSuppressMs: 30 });
     move(controller, 0, 0, 0);
     move(controller, 0, -4, 10);
     move(controller, 0, 2.5, 14);
@@ -133,11 +145,11 @@ describe("createHoverSettle — pointer authority", () => {
     // is exactly the cold-window problem the floor exists for — so without it
     // the very next sample would release the flick it just engaged.
     move(controller, 0, 2.5, 24);
-    move(controller, 0, 2.5, 54);
+    move(controller, 0, 2.5, 34);
     expect(controller.suppressionSource()).toBe("pointer");
     expect(settled).toEqual([]);
 
-    move(controller, 0, 2.5, 64);
+    move(controller, 0, 2.5, 44);
     expect(settled).toEqual(["pointer"]);
   });
 
@@ -153,7 +165,6 @@ describe("createHoverSettle — pointer authority", () => {
 
   it("settles on braking, before the pointer has stopped", () => {
     const { controller, settled } = harness();
-    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
     // A ballistic peak of 3px/ms, then a decelerating tail.
     move(controller, 0, 0, 0);
     move(controller, 0, 30, 10);
@@ -170,7 +181,6 @@ describe("createHoverSettle — pointer authority", () => {
     // A slow-but-sweeping gesture halving its speed is the adaptive band
     // wobbling, not a decision — releasing here flashes rows mid-sweep.
     const { controller, settled } = harness();
-    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
     move(controller, 0, 0, 0);
     move(controller, 0, 8, 10);
     expect(controller.suppressionSource()).toBe("pointer");
@@ -196,6 +206,7 @@ describe("createHoverSettle — pointer authority", () => {
     vi.useFakeTimers();
     const { controller, settled } = harness();
     engagePointer(controller);
+    expect(controller.suppressionSource()).toBe("pointer");
     controller.pointerLeave({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
     expect(controller.suppressionSource()).toBeNull();
     await vi.advanceTimersByTimeAsync(1000);
@@ -206,51 +217,33 @@ describe("createHoverSettle — pointer authority", () => {
     vi.useFakeTimers();
     const { controller, settled } = harness();
     engagePointer(controller);
+    expect(controller.suppressionSource()).toBe("pointer");
     controller.destroy();
     await vi.advanceTimersByTimeAsync(1000);
     expect(settled).toEqual([]);
   });
 
-  it("ignores touch and pen entirely", () => {
+  it.each(["touch", "pen"])("ignores %s entirely", (pointerType) => {
     const { controller } = harness();
-    controller.pointerEnter({ pointerType: "touch", clientX: 0, clientY: 0, timeStamp: 0 });
     for (let i = 0; i < 5; i += 1) {
-      controller.pointerMove({
-        pointerType: "touch",
-        clientX: 0,
-        clientY: i * 20,
-        timeStamp: i * 8,
-      });
+      controller.pointerMove({ pointerType, clientX: 0, clientY: i * 20, timeStamp: i * 8 });
     }
     expect(controller.suppressionSource()).toBeNull();
   });
 });
 
-describe("createHoverSettle — scroll authority", () => {
-  it("ignores a scroll while the pointer is elsewhere", () => {
+describe("createHoverSettle — list movement authority", () => {
+  it("engages on movement alone, with no pointer event to read", () => {
+    // The keyboard case: the cursor is resting and the rows come to it, so
+    // there is no velocity anywhere to derive intent from.
     const { controller } = harness();
-    controller.scroll();
-    expect(controller.suppressionSource()).toBeNull();
-  });
-
-  it("engages on a scroll under a cursor that never moved", () => {
-    const { controller } = harness();
-    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
-    controller.scroll();
-    expect(controller.suppressionSource()).toBe("scroll");
-  });
-
-  it("arms itself from a move alone, for a list that mounts under a resting cursor", () => {
-    const { controller } = harness();
-    move(controller, 0, 0, 0);
-    controller.scroll();
+    controller.listMoved();
     expect(controller.suppressionSource()).toBe("scroll");
   });
 
   it("cannot be released by pointer samples", () => {
     const { controller, settled } = harness();
-    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
-    controller.scroll();
+    controller.listMoved();
     // Stray near-stationary samples: under pointer authority these would home
     // in and release, which mid-scroll would strobe the list.
     move(controller, 0, 0, 100);
@@ -260,12 +253,12 @@ describe("createHoverSettle — scroll authority", () => {
     expect(settled).toEqual([]);
   });
 
-  it("takes over a pointer episode and settles as a scroll", async () => {
+  it("takes over a pointer episode and settles as movement, never as a pointer", async () => {
     vi.useFakeTimers();
     const { controller, settled } = harness();
     engagePointer(controller);
     expect(controller.suppressionSource()).toBe("pointer");
-    controller.scroll();
+    controller.listMoved();
     await vi.advanceTimersByTimeAsync(1000);
     expect(settled).toEqual(["scroll"]);
   });
@@ -273,9 +266,8 @@ describe("createHoverSettle — scroll authority", () => {
   it("keeps re-arming its backstop for as long as the list is moving", async () => {
     vi.useFakeTimers();
     const { controller, settled } = harness();
-    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
     for (let i = 0; i < 6; i += 1) {
-      controller.scroll();
+      controller.listMoved();
       await vi.advanceTimersByTimeAsync(20);
       expect(settled).toEqual([]);
     }

--- a/src/lib/__tests__/pointerTransit.test.ts
+++ b/src/lib/__tests__/pointerTransit.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  createSampler,
+  createHoverSettle,
+  type HoverSettleController,
+  type HoverSuppressionSource,
+} from "../pointerTransit";
+
+const MOUSE = { pointerType: "mouse" } as const;
+
+function move(controller: HoverSettleController, x: number, y: number, t: number): void {
+  controller.pointerMove({ ...MOUSE, clientX: x, clientY: y, timeStamp: t });
+}
+
+/** Feeds samples `stepPx` apart every `stepMs`, i.e. a steady stepPx/stepMs. */
+function sweep(
+  controller: HoverSettleController,
+  { from, stepPx, stepMs, count }: { from: number; stepPx: number; stepMs: number; count: number }
+): number {
+  let t = from;
+  let y = 0;
+  for (let i = 0; i < count; i += 1) {
+    t += stepMs;
+    y += stepPx;
+    move(controller, 0, y, t);
+  }
+  return t;
+}
+
+function harness(options?: Parameters<typeof createHoverSettle>[1]) {
+  const settled: HoverSuppressionSource[] = [];
+  const controller = createHoverSettle({ onSettle: (source) => settled.push(source) }, options);
+  return { controller, settled };
+}
+
+/** Arms `inside` and gets a suppressed pointer episode running. */
+function engagePointer(controller: HoverSettleController): number {
+  controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+  return sweep(controller, { from: 0, stepPx: 8, stepMs: 8, count: 4 });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createSampler", () => {
+  it("reports no reading until it has two samples", () => {
+    const sampler = createSampler(50);
+    sampler.push(0, 0, 0);
+    expect(sampler.speed()).toBeNull();
+    expect(sampler.recentSpeed()).toBeNull();
+  });
+
+  it("reads tremor around a point as still, while a flick still registers instantly", () => {
+    const sampler = createSampler(50);
+    // Oscillation: far apart consecutively, no net displacement across the window.
+    sampler.push(0, 0, 0);
+    sampler.push(6, 0, 8);
+    sampler.push(0, 0, 16);
+    const settledSpeed = sampler.speed();
+    expect(settledSpeed).not.toBeNull();
+    expect(settledSpeed!).toBeLessThan(sampler.recentSpeed()!);
+
+    // One genuinely fast frame reads fast even though the window is still cold.
+    sampler.push(30, 0, 24);
+    expect(sampler.recentSpeed()!).toBeGreaterThan(sampler.speed()!);
+  });
+
+  it("stays finite when two samples share a timestamp", () => {
+    const sampler = createSampler(50);
+    sampler.push(0, 0, 100);
+    sampler.push(40, 0, 100);
+    expect(Number.isFinite(sampler.speed()!)).toBe(true);
+    expect(Number.isFinite(sampler.recentSpeed()!)).toBe(true);
+  });
+
+  it("keeps the two most recent samples even when both are older than the window", () => {
+    const sampler = createSampler(50);
+    sampler.push(0, 0, 0);
+    sampler.push(10, 0, 10);
+    // A long pause: everything predates the cutoff, but a reading must survive.
+    sampler.push(10, 0, 5000);
+    expect(sampler.speed()).not.toBeNull();
+  });
+
+  it("drops samples that fall out of the window", () => {
+    const sampler = createSampler(50);
+    sampler.push(0, 0, 0);
+    sampler.push(100, 0, 10);
+    sampler.push(110, 0, 20);
+    const withStale = sampler.speed()!;
+    // Same trailing motion, but far enough on that the 100px jump ages out.
+    sampler.push(120, 0, 80);
+    expect(sampler.speed()!).toBeLessThan(withStale);
+  });
+});
+
+describe("createHoverSettle — pointer authority", () => {
+  it("treats an isolated move as intent rather than transit", () => {
+    const { controller } = harness();
+    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    move(controller, 0, 0, 0);
+    expect(controller.suppressionSource()).toBeNull();
+  });
+
+  it("engages on a sustained sweep", () => {
+    const { controller } = harness();
+    engagePointer(controller);
+    expect(controller.suppressionSource()).toBe("pointer");
+  });
+
+  it("engages on a flick the windowed reading alone would have missed", () => {
+    const { controller } = harness();
+    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    move(controller, 0, 0, 0);
+    move(controller, 0, -4, 10);
+    expect(controller.suppressionSource()).toBeNull();
+    // Back across the start and away: net displacement over the window is 2.5px
+    // in 14ms, far too slow to engage, while that last frame alone is 6.5px in
+    // 4ms. Waiting for the window to agree is a window's worth of rows flashing.
+    move(controller, 0, 2.5, 14);
+    expect(controller.suppressionSource()).toBe("pointer");
+  });
+
+  it("holds a flick through its cold window, then settles once the floor elapses", () => {
+    const { controller, settled } = harness();
+    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    move(controller, 0, 0, 0);
+    move(controller, 0, -4, 10);
+    move(controller, 0, 2.5, 14);
+
+    // Dead still from here. The windowed reading collapses immediately — which
+    // is exactly the cold-window problem the floor exists for — so without it
+    // the very next sample would release the flick it just engaged.
+    move(controller, 0, 2.5, 24);
+    move(controller, 0, 2.5, 54);
+    expect(controller.suppressionSource()).toBe("pointer");
+    expect(settled).toEqual([]);
+
+    move(controller, 0, 2.5, 64);
+    expect(settled).toEqual(["pointer"]);
+  });
+
+  it("settles once the pointer homes in after the floor has elapsed", () => {
+    const { controller, settled } = harness();
+    const t = engagePointer(controller);
+    // Far enough past the floor that homing is allowed, and barely moving.
+    move(controller, 0, 33, t + 60);
+    move(controller, 0, 33, t + 70);
+    expect(controller.suppressionSource()).toBeNull();
+    expect(settled).toEqual(["pointer"]);
+  });
+
+  it("settles on braking, before the pointer has stopped", () => {
+    const { controller, settled } = harness();
+    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    // A ballistic peak of 3px/ms, then a decelerating tail.
+    move(controller, 0, 0, 0);
+    move(controller, 0, 30, 10);
+    expect(controller.suppressionSource()).toBe("pointer");
+    for (let t = 20, y = 34; t <= 60; t += 10, y += 4) move(controller, 0, y, t);
+
+    // The tail is still covering 4px every 10ms when this fires — a stillness
+    // test would still be waiting, which is the dwell timer this replaces.
+    expect(settled).toEqual(["pointer"]);
+    expect(controller.suppressionSource()).toBeNull();
+  });
+
+  it("does not brake out of a gesture whose peak was never ballistic", () => {
+    // A slow-but-sweeping gesture halving its speed is the adaptive band
+    // wobbling, not a decision — releasing here flashes rows mid-sweep.
+    const { controller, settled } = harness();
+    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    move(controller, 0, 0, 0);
+    move(controller, 0, 8, 10);
+    expect(controller.suppressionSource()).toBe("pointer");
+    // Decays to 0.35px/ms — the same braked band that settles the case above,
+    // reached from a peak too low for halving to mean anything.
+    for (let t = 20, y = 11.5; t <= 70; t += 10, y += 3.5) move(controller, 0, y, t);
+
+    expect(controller.suppressionSource()).toBe("pointer");
+    expect(settled).toEqual([]);
+  });
+
+  it("settles a stalled gesture on the backstop", async () => {
+    vi.useFakeTimers();
+    const { controller, settled } = harness();
+    engagePointer(controller);
+    expect(settled).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(settled).toEqual(["pointer"]);
+    expect(controller.suppressionSource()).toBeNull();
+  });
+
+  it("cancels silently when the pointer leaves", async () => {
+    vi.useFakeTimers();
+    const { controller, settled } = harness();
+    engagePointer(controller);
+    controller.pointerLeave({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    expect(controller.suppressionSource()).toBeNull();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(settled).toEqual([]);
+  });
+
+  it("cancels silently on destroy, leaving no backstop behind", async () => {
+    vi.useFakeTimers();
+    const { controller, settled } = harness();
+    engagePointer(controller);
+    controller.destroy();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(settled).toEqual([]);
+  });
+
+  it("ignores touch and pen entirely", () => {
+    const { controller } = harness();
+    controller.pointerEnter({ pointerType: "touch", clientX: 0, clientY: 0, timeStamp: 0 });
+    for (let i = 0; i < 5; i += 1) {
+      controller.pointerMove({
+        pointerType: "touch",
+        clientX: 0,
+        clientY: i * 20,
+        timeStamp: i * 8,
+      });
+    }
+    expect(controller.suppressionSource()).toBeNull();
+  });
+});
+
+describe("createHoverSettle — scroll authority", () => {
+  it("ignores a scroll while the pointer is elsewhere", () => {
+    const { controller } = harness();
+    controller.scroll();
+    expect(controller.suppressionSource()).toBeNull();
+  });
+
+  it("engages on a scroll under a cursor that never moved", () => {
+    const { controller } = harness();
+    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    controller.scroll();
+    expect(controller.suppressionSource()).toBe("scroll");
+  });
+
+  it("arms itself from a move alone, for a list that mounts under a resting cursor", () => {
+    const { controller } = harness();
+    move(controller, 0, 0, 0);
+    controller.scroll();
+    expect(controller.suppressionSource()).toBe("scroll");
+  });
+
+  it("cannot be released by pointer samples", () => {
+    const { controller, settled } = harness();
+    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    controller.scroll();
+    // Stray near-stationary samples: under pointer authority these would home
+    // in and release, which mid-scroll would strobe the list.
+    move(controller, 0, 0, 100);
+    move(controller, 0, 1, 108);
+    move(controller, 0, 1, 116);
+    expect(controller.suppressionSource()).toBe("scroll");
+    expect(settled).toEqual([]);
+  });
+
+  it("takes over a pointer episode and settles as a scroll", async () => {
+    vi.useFakeTimers();
+    const { controller, settled } = harness();
+    engagePointer(controller);
+    expect(controller.suppressionSource()).toBe("pointer");
+    controller.scroll();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(settled).toEqual(["scroll"]);
+  });
+
+  it("keeps re-arming its backstop for as long as the list is moving", async () => {
+    vi.useFakeTimers();
+    const { controller, settled } = harness();
+    controller.pointerEnter({ ...MOUSE, clientX: 0, clientY: 0, timeStamp: 0 });
+    for (let i = 0; i < 6; i += 1) {
+      controller.scroll();
+      await vi.advanceTimersByTimeAsync(20);
+      expect(settled).toEqual([]);
+    }
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(settled).toEqual(["scroll"]);
+  });
+});

--- a/src/lib/pointerTransit.ts
+++ b/src/lib/pointerTransit.ts
@@ -245,8 +245,10 @@ export function createHoverSettle(
       // No "is the pointer inside" precondition, unlike the source: that watches
       // every scroll on the page and needs one to tell its own list's movement
       // from the rest. The caller here only reports movement of the list itself,
-      // which is the question `inside` was approximating — and suppressing while
-      // the pointer is elsewhere costs one timer and gates nothing.
+      // which is the question `inside` was approximating. Suppressing while the
+      // pointer is elsewhere costs one timer and, at worst, drops a row entered
+      // inside the settle window — cheap next to reading the list's own movement
+      // as a choice.
       //
       // Whatever the pointer was doing before the list moved is no longer a
       // reading of where it is relative to the rows.

--- a/src/lib/pointerTransit.ts
+++ b/src/lib/pointerTransit.ts
@@ -1,0 +1,276 @@
+/**
+ * Pointer transit detection: telling a deliberate hover apart from a pointer
+ * merely passing through.
+ *
+ * Ported from the marketing site's `hover-settle`, which stands CSS `:hover`
+ * down during transit. Here the thing being stood down is a state setter, so
+ * this module is DOM-free and reports its suppression state to a caller that
+ * owns the listeners. `createPointerIntent`'s forward projection is
+ * deliberately not ported: it exists to hold a ~700px panel open while the
+ * cursor travels toward it, and the best published endpoint prediction is off
+ * by 39px at 90% through a gesture — more than one row of a list.
+ */
+
+const MIN_DT = 2;
+
+export interface PointerSample {
+  x: number;
+  y: number;
+  t: number;
+}
+
+export function createSampler(windowMs: number) {
+  let samples: PointerSample[] = [];
+
+  return {
+    // `t` must come from event.timeStamp, never performance.now() read inside
+    // the handler. Same time origin, but one is when the pointer moved and the
+    // other is when the main thread got around to saying so. Under contention
+    // the handler runs late, dt inflates, and a real sweep reads as a slow one.
+    push(x: number, y: number, t: number): void {
+      samples.push({ x, y, t });
+      const cutoff = t - windowMs;
+      while (samples.length > 2 && samples[0]!.t < cutoff) samples.shift();
+    },
+    // Velocity across the whole window, not the last two samples. This is what
+    // makes it tremor-tolerant: involuntary oscillation runs 3-12Hz around a
+    // point, so net displacement across the window is near zero even while
+    // consecutive samples are far apart. A two-sample delta reads that as fast
+    // movement and strips the highlight off someone who has firmly landed.
+    speed(): number | null {
+      if (samples.length < 2) return null;
+      const first = samples[0]!;
+      const last = samples[samples.length - 1]!;
+      const dt = Math.max(last.t - first.t, MIN_DT);
+      return Math.hypot(last.x - first.x, last.y - first.y) / dt;
+    },
+    // Last two samples only, one frame. The window cannot answer "has a flick
+    // just started" until it has filled, which is a whole window of rows
+    // flashing before suppression engages.
+    recentSpeed(): number | null {
+      if (samples.length < 2) return null;
+      const a = samples[samples.length - 2]!;
+      const b = samples[samples.length - 1]!;
+      const dt = Math.max(b.t - a.t, MIN_DT);
+      return Math.hypot(b.x - a.x, b.y - a.y) / dt;
+    },
+    clear(): void {
+      samples = [];
+    },
+  };
+}
+
+/**
+ * Which gesture currently owns suppression. Pointer and scroll are separate
+ * authorities and neither may release the other: a scroll offers no
+ * deceleration to read, so letting a stray pointer sample end it means two
+ * samples release, the next scroll event re-engages, and the list strobes
+ * through the whole gesture.
+ */
+export type HoverSuppressionSource = "pointer" | "scroll";
+
+/** The fields this module reads off a `PointerEvent`, and nothing more. */
+export interface PointerTransitEvent {
+  pointerType: string;
+  clientX: number;
+  clientY: number;
+  timeStamp: number;
+}
+
+export interface HoverSettleOptions {
+  /** Windowed px/ms at which a move reads as transit rather than a choice. */
+  sweepSpeed?: number;
+  /** Single-frame px/ms no oscillation could produce, so it engages instantly. */
+  instantSweepSpeed?: number;
+  /** Windowed px/ms below which the pointer has homed in. */
+  releaseSpeed?: number;
+  /** Fraction of the peak that counts as braking. */
+  brakeRatio?: number;
+  /** Peak below which halving is noise rather than a decision. */
+  brakeMinPeak?: number;
+  /** Floor holding the instant path up while its window is still cold. */
+  minSuppressMs?: number;
+  /** Backstop for a gesture that simply stops producing events. */
+  settleMs?: number;
+  sampleWindowMs?: number;
+}
+
+/**
+ * Tuned against ~32px rows. Every one of these is load-bearing — read the
+ * comments at each use site before changing a number.
+ */
+const DEFAULTS = {
+  sweepSpeed: 0.5,
+  instantSweepSpeed: 1.5,
+  releaseSpeed: 0.28,
+  brakeRatio: 0.5,
+  brakeMinPeak: 1.5,
+  minSuppressMs: 50,
+  settleMs: 60,
+  sampleWindowMs: 50,
+} as const;
+
+export interface HoverSettleController {
+  pointerEnter(event: PointerTransitEvent): void;
+  pointerMove(event: PointerTransitEvent): void;
+  pointerLeave(event: PointerTransitEvent): void;
+  scroll(): void;
+  /** Null while the pointer's position is a statement of intent. */
+  suppressionSource(): HoverSuppressionSource | null;
+  destroy(): void;
+}
+
+/**
+ * `onSettle` fires only when a gesture ends on its own terms — homing, braking,
+ * or the backstop expiring. A pointer that leaves the region, or a controller
+ * torn down, cancels silently: there is no settled intent to act on.
+ */
+export interface HoverSettleCallbacks {
+  onSettle: (source: HoverSuppressionSource) => void;
+}
+
+export function createHoverSettle(
+  { onSettle }: HoverSettleCallbacks,
+  options: HoverSettleOptions = {}
+): HoverSettleController {
+  const opts = { ...DEFAULTS, ...options };
+  const sampler = createSampler(opts.sampleWindowMs);
+
+  let source: HoverSuppressionSource | null = null;
+  let peakSpeed = 0;
+  let releasableAt = 0;
+  let inside = false;
+  let backstopTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function armBackstop(): void {
+    clearTimeout(backstopTimer);
+    backstopTimer = setTimeout(settle, opts.settleMs);
+  }
+
+  function reset(): void {
+    clearTimeout(backstopTimer);
+    backstopTimer = undefined;
+    source = null;
+    peakSpeed = 0;
+    releasableAt = 0;
+  }
+
+  /** The gesture ended on its own terms, so the caller may act on where it ended. */
+  function settle(): void {
+    const ended = source;
+    reset();
+    if (ended !== null) onSettle(ended);
+  }
+
+  /** The gesture was abandoned. Same state teardown, no notification. */
+  function cancel(): void {
+    reset();
+  }
+
+  function engage(next: HoverSuppressionSource, windowedPeak: number, now: number): void {
+    if (source === null) releasableAt = now + opts.minSuppressMs;
+    source = next;
+    peakSpeed = Math.max(peakSpeed, windowedPeak);
+    armBackstop();
+  }
+
+  return {
+    pointerEnter(event) {
+      if (event.pointerType !== "mouse") return;
+      inside = true;
+    },
+
+    pointerMove(event) {
+      if (event.pointerType !== "mouse") return;
+      // Also set here, not only on enter: a list that mounts under a resting
+      // cursor never fires an enter, and without this the scroll path below
+      // would sit disarmed for the whole gesture.
+      inside = true;
+
+      const now = event.timeStamp;
+      sampler.push(event.clientX, event.clientY, now);
+
+      const speed = sampler.speed();
+      if (speed === null) return;
+
+      // A scroll owns its own suppression and its own timer. Keep sampling so
+      // the reading is warm when it ends, but decide nothing here.
+      if (source === "scroll") return;
+
+      if (source === null) {
+        // Either signal engages: the smoothed one, or a single frame fast
+        // enough that no oscillation could have produced it. Only the smoothed
+        // one sets the peak — seeding it from the instant reading and testing
+        // release against the windowed one compares two different rulers, and
+        // collapses suppression on the next sample.
+        if (speed >= opts.sweepSpeed || (sampler.recentSpeed() ?? 0) >= opts.instantSweepSpeed) {
+          engage("pointer", speed, now);
+        }
+        return;
+      }
+
+      peakSpeed = Math.max(peakSpeed, speed);
+
+      // The floor gates every pointer-driven release, homing included. The
+      // instant path engages precisely when the window is still cold, and a
+      // cold window reads slow, so without this the very next sample released
+      // again.
+      if (now < releasableAt) {
+        armBackstop();
+        return;
+      }
+
+      // Homing: whatever the pointer was doing, it is not doing it any more.
+      // Release on deceleration rather than stillness — human pointing is
+      // ballistic then corrective, so braking is the earliest honest evidence
+      // of intent, and waiting for stillness turns this into the dwell timer it
+      // replaces.
+      if (speed < opts.releaseSpeed) {
+        settle();
+        return;
+      }
+
+      // Braking, but only from a peak high enough for halving to mean
+      // something. Without the floor, windowed speeds of .80, .35, .55, .27
+      // inside one continuous gesture release, re-engage and release again.
+      if (
+        peakSpeed >= opts.brakeMinPeak &&
+        speed < opts.sweepSpeed &&
+        speed <= peakSpeed * opts.brakeRatio
+      ) {
+        settle();
+        return;
+      }
+
+      armBackstop();
+    },
+
+    pointerLeave(event) {
+      if (event.pointerType !== "mouse") return;
+      inside = false;
+      sampler.clear();
+      cancel();
+    },
+
+    scroll() {
+      if (!inside) return;
+      // Whatever the pointer was doing before the list moved is no longer a
+      // reading of where it is relative to the rows.
+      sampler.clear();
+      if (source === null) releasableAt = 0;
+      source = "scroll";
+      peakSpeed = 0;
+      armBackstop();
+    },
+
+    suppressionSource() {
+      return source;
+    },
+
+    destroy() {
+      inside = false;
+      sampler.clear();
+      cancel();
+    },
+  };
+}

--- a/src/lib/pointerTransit.ts
+++ b/src/lib/pointerTransit.ts
@@ -111,10 +111,10 @@ const DEFAULTS = {
 } as const;
 
 export interface HoverSettleController {
-  pointerEnter(event: PointerTransitEvent): void;
   pointerMove(event: PointerTransitEvent): void;
   pointerLeave(event: PointerTransitEvent): void;
-  scroll(): void;
+  /** The rows moved under the pointer, by any means. */
+  listMoved(): void;
   /** Null while the pointer's position is a statement of intent. */
   suppressionSource(): HoverSuppressionSource | null;
   destroy(): void;
@@ -139,7 +139,6 @@ export function createHoverSettle(
   let source: HoverSuppressionSource | null = null;
   let peakSpeed = 0;
   let releasableAt = 0;
-  let inside = false;
   let backstopTimer: ReturnType<typeof setTimeout> | undefined;
 
   function armBackstop(): void {
@@ -175,17 +174,8 @@ export function createHoverSettle(
   }
 
   return {
-    pointerEnter(event) {
-      if (event.pointerType !== "mouse") return;
-      inside = true;
-    },
-
     pointerMove(event) {
       if (event.pointerType !== "mouse") return;
-      // Also set here, not only on enter: a list that mounts under a resting
-      // cursor never fires an enter, and without this the scroll path below
-      // would sit disarmed for the whole gesture.
-      inside = true;
 
       const now = event.timeStamp;
       sampler.push(event.clientX, event.clientY, now);
@@ -247,13 +237,17 @@ export function createHoverSettle(
 
     pointerLeave(event) {
       if (event.pointerType !== "mouse") return;
-      inside = false;
       sampler.clear();
       cancel();
     },
 
-    scroll() {
-      if (!inside) return;
+    listMoved() {
+      // No "is the pointer inside" precondition, unlike the source: that watches
+      // every scroll on the page and needs one to tell its own list's movement
+      // from the rest. The caller here only reports movement of the list itself,
+      // which is the question `inside` was approximating — and suppressing while
+      // the pointer is elsewhere costs one timer and gates nothing.
+      //
       // Whatever the pointer was doing before the list moved is no longer a
       // reading of where it is relative to the rows.
       sampler.clear();
@@ -268,7 +262,6 @@ export function createHoverSettle(
     },
 
     destroy() {
-      inside = false;
       sampler.clear();
       cancel();
     },


### PR DESCRIPTION
Resolves #11919

What was wrong: the dock launcher wired `onHover` straight to `setSelectedIndex`, so a row treated pointer transit as a deliberate choice. Two symptoms fell out of that — sweeping the mouse down the list dragged the selection through every row it passed, and the `scrollIntoView` that follows keyboard navigation slid a row under a cursor that never moved, firing `pointerenter` and handing the selection back to the mouse. The second one is the correctness half: the launcher is keyboard-first with a search box on top, so type-then-arrow is the normal path.

The fix ports the hover-settle transit detector from the daintree-website repo, as the issue asked. Thresholds are unchanged (they were tuned against ~32px rows, which is what the launcher has), and `createPointerIntent`'s trajectory prediction is deliberately not ported — best published endpoint prediction is off by more than one row at this size.

Files:
- `src/lib/pointerTransit.ts` (new) — `createSampler` plus a DOM-free `createHoverSettle` state machine. No listeners of its own; the caller owns those, so it unit-tests without a DOM.
- `src/components/Layout/useDockLaunchHoverSelection.ts` (new) — owns the listeners and the flush. The gate lives in the parent's `onHover` wrapper, so no ref crosses a component boundary as a prop.
- `src/components/Layout/DockLaunchButton.tsx` — wires the two together.

Three things worth knowing in review:

1. The source gates a CSS attribute, so the browser's own `:hover` keeps tracking the true row underneath and the right row lights up the instant suppression lifts. Gating a discrete callback has no such continuing truth — sweep to a row, stop dead, and every `pointerenter` was already swallowed. So a pointer gesture that settles flushes the row it ended on. A scroll settling never does; that flush would be the reported bug.
2. The pending row is stored by `rowKey` and re-resolved against the live results when it is spent, because the list can reshuffle under a suppressed sweep. If it was filtered away, nothing is selected — no index fallback.
3. Hover invalidation keys off the rendered selection, not off a list of key names. Review's first cut checked ArrowDown/ArrowUp/Home/End, which missed ArrowRight/ArrowLeft splicing preset rows in and out and a query change re-ranking results — each another route for a stale pointer row to override a newer choice. Watching the selection means a new route cannot forget to.

Two deliberate deviations from the ported source, both because the app is not a marketing site: the scroll listener is scoped to scrollers the list actually sits inside (an auto-scrolling terminal must not stand launcher hover down), and the source's `inside` flag is gone with it — it was approximating "did my own list move", which the scoped listener now answers directly. That also fixes a list mounted under a genuinely stationary cursor, which never armed `inside` at all.

Testing: 189 tests across three suites — a pure state-machine suite (`src/lib/__tests__/pointerTransit.test.ts`), a hook suite (`src/components/Layout/__tests__/useDockLaunchHoverSelection.test.tsx`), and the existing launcher suite. The two pre-existing hover tests pass unchanged.

Not covered: no new e2e case. Verifying one locally needs a full build, and an unrun spec in the release-gating `full-panels` bucket is a flake shipped blind. The existing `core-dock-launcher-search.spec.ts` still passes by inspection — it asserts only that exactly one row is selected, never which, and waits `T_SETTLE` after each hover. The one thing jsdom genuinely cannot prove is Chromium's real ordering of the scroll event against the boundary event a reflow fires; arming suppression at the selection change rather than on the scroll event is what removes the dependence on that ordering.