### PR TITLE
fix(workspace-host): stop a failed git probe from reporting a real repo as non-git

### DIFF
--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -531,9 +531,10 @@ export class ProjectStore {
    * permissions, anything unrecognized) throws its own code instead, because
    * callers use a negative answer to withdraw a project's git identity and must
    * never do that off a transient failure. `WorkspaceService.isGitRepository`
-   * deliberately makes the opposite trade (any failure means "no repository")
-   * and is correct for withholding features, but must not drive a stored
-   * classification.
+   * once made the opposite trade — any failure meant "no repository" — which is
+   * what let a transient spawn failure empty a real repo's worktree sidebar
+   * behind a `success: true` load (#11922). It now draws the same line this
+   * does, so the two agree on what counts as a negative answer.
    */
   async classifyGitBacking(
     projectPath: string

--- a/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
+++ b/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
   attachStartupWorktreePort,
   describeStartupPortFailure,
+  describeStartupWorktreeLoadOutcome,
   runStartupWorktreeLoad,
   selectStatusTarget,
   sendStartupWorktreeLoadFailure,
   STARTUP_NO_WORKSPACE_CLIENT_MESSAGE,
+  type StartupWorktreeLoadOutcome,
 } from "../startupWorktreeLoad.js";
 
 /**
@@ -443,5 +445,70 @@ describe("startup worktree load orchestration (#11818)", () => {
 
     expect(outcome).toEqual({ status: "loaded" });
     expect(report).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Every outcome has to leave a line in `daintree.log`.
+   *
+   * The reporting these describe used to go through `console.log`/`console.error`
+   * at the call site. Production esbuild marks `console.log`/`console.warn` pure
+   * (`scripts/build-main.mjs`), and the logger never hooks `console`, so a
+   * diagnostics bundle captured from a packaged build while the worktree sidebar
+   * sat empty contained nothing about worktree loading at all (#11922).
+   */
+  describe("startup outcome logging", () => {
+    const OUTCOMES: StartupWorktreeLoadOutcome[] = [
+      { status: "loaded" },
+      { status: "no-client" },
+      { status: "load-failed", error: new Error("probe exploded") },
+      { status: "attach-failed", error: new Error("attach exploded") },
+      { status: "port-failed", reason: "no-host" },
+    ];
+
+    it("describes every outcome, naming the project each time", () => {
+      for (const outcome of OUTCOMES) {
+        const line = describeStartupWorktreeLoadOutcome(outcome, "/repo");
+        expect(line.message).not.toBe("");
+        expect(line.context).toMatchObject({ projectPath: "/repo" });
+      }
+    });
+
+    it("logs only the successful outcome below error level", () => {
+      const errorLevels = OUTCOMES.filter(
+        (outcome) => describeStartupWorktreeLoadOutcome(outcome, "/repo").level === "error"
+      );
+
+      // Anything that leaves the renderer without a port is an error: the
+      // sidebar is broken from the user's side either way.
+      expect(errorLevels).toHaveLength(OUTCOMES.length - 1);
+      expect(describeStartupWorktreeLoadOutcome({ status: "loaded" }, "/repo").level).toBe("info");
+    });
+
+    it("carries the failure detail, not just the status name", () => {
+      const loadFailed = describeStartupWorktreeLoadOutcome(
+        { status: "load-failed", error: new Error("probe exploded") },
+        "/repo"
+      );
+      expect(loadFailed.context).toMatchObject({ error: "probe exploded" });
+
+      // The reason alone is an internal token; the log carries the sentence the
+      // user was shown so the two can be matched up afterwards.
+      const portFailed = describeStartupWorktreeLoadOutcome(
+        { status: "port-failed", reason: "no-host" },
+        "/repo"
+      );
+      expect(portFailed.context).toMatchObject({
+        reason: "no-host",
+        detail: describeStartupPortFailure("no-host"),
+      });
+    });
+
+    it("survives a non-Error load failure without logging 'undefined'", () => {
+      const line = describeStartupWorktreeLoadOutcome(
+        { status: "load-failed", error: "just a string" },
+        "/repo"
+      );
+      expect(line.context).toMatchObject({ error: "just a string" });
+    });
   });
 });

--- a/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
+++ b/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
@@ -3,6 +3,7 @@ import {
   attachStartupWorktreePort,
   describeStartupPortFailure,
   describeStartupWorktreeLoadOutcome,
+  logStartupWorktreeLoadOutcome,
   runStartupWorktreeLoad,
   selectStatusTarget,
   sendStartupWorktreeLoadFailure,
@@ -450,38 +451,76 @@ describe("startup worktree load orchestration (#11818)", () => {
   /**
    * Every outcome has to leave a line in `daintree.log`.
    *
-   * The reporting these describe used to go through `console.log`/`console.error`
-   * at the call site. Production esbuild marks `console.log`/`console.warn` pure
-   * (`scripts/build-main.mjs`), and the logger never hooks `console`, so a
-   * diagnostics bundle captured from a packaged build while the worktree sidebar
-   * sat empty contained nothing about worktree loading at all (#11922).
+   * This reporting used to go through `console.log`/`console.error` at the call
+   * site. Production esbuild marks `console.log`/`console.warn` pure
+   * (`scripts/build-main.mjs`) and the logger never hooks `console`, so a
+   * diagnostics bundle captured from a packaged build while the worktree
+   * sidebar sat empty contained nothing about worktree loading at all (#11922).
    */
   describe("startup outcome logging", () => {
-    const OUTCOMES: StartupWorktreeLoadOutcome[] = [
-      { status: "loaded" },
-      { status: "no-client" },
-      { status: "load-failed", error: new Error("probe exploded") },
-      { status: "attach-failed", error: new Error("attach exploded") },
-      { status: "port-failed", reason: "no-host" },
-    ];
+    // Keyed by status so a newly added outcome is a compile error here, not a
+    // silently unexercised branch.
+    const OUTCOMES: Record<
+      StartupWorktreeLoadOutcome["status"],
+      { outcome: StartupWorktreeLoadOutcome; level: "info" | "error" }
+    > = {
+      loaded: { outcome: { status: "loaded" }, level: "info" },
+      "no-client": { outcome: { status: "no-client" }, level: "error" },
+      "load-failed": {
+        outcome: { status: "load-failed", error: new Error("probe exploded") },
+        level: "error",
+      },
+      "attach-failed": {
+        outcome: { status: "attach-failed", error: new Error("attach exploded") },
+        level: "error",
+      },
+      "port-failed": { outcome: { status: "port-failed", reason: "no-host" }, level: "error" },
+    };
+
+    const cases = Object.entries(OUTCOMES);
 
     it("describes every outcome, naming the project each time", () => {
-      for (const outcome of OUTCOMES) {
+      for (const [status, { outcome }] of cases) {
         const line = describeStartupWorktreeLoadOutcome(outcome, "/repo");
-        expect(line.message).not.toBe("");
-        expect(line.context).toMatchObject({ projectPath: "/repo" });
+        expect(line.message, status).not.toBe("");
+        expect(line.context, status).toMatchObject({ projectPath: "/repo" });
       }
     });
 
-    it("logs only the successful outcome below error level", () => {
-      const errorLevels = OUTCOMES.filter(
-        (outcome) => describeStartupWorktreeLoadOutcome(outcome, "/repo").level === "error"
-      );
+    it("treats anything that left the renderer without a port as an error", () => {
+      // The sidebar is broken from the user's side in every one of those cases.
+      for (const [status, { outcome, level }] of cases) {
+        expect(describeStartupWorktreeLoadOutcome(outcome, "/repo").level, status).toBe(level);
+      }
+    });
 
-      // Anything that leaves the renderer without a port is an error: the
-      // sidebar is broken from the user's side either way.
-      expect(errorLevels).toHaveLength(OUTCOMES.length - 1);
-      expect(describeStartupWorktreeLoadOutcome({ status: "loaded" }, "/repo").level).toBe("info");
+    it("routes each outcome to the matching logger sink", () => {
+      // Pins the wiring, not just the mapping: reverting the call site to
+      // `console` has to fail something.
+      for (const [status, { outcome, level }] of cases) {
+        const sinks = { info: vi.fn(), error: vi.fn() };
+        logStartupWorktreeLoadOutcome(outcome, "/repo", sinks);
+
+        const used = level === "error" ? sinks.error : sinks.info;
+        const unused = level === "error" ? sinks.info : sinks.error;
+        expect(used, status).toHaveBeenCalledOnce();
+        expect(unused, status).not.toHaveBeenCalled();
+      }
+    });
+
+    it("calls the error sink with logError's (message, error, context) arity", () => {
+      // The outcome carries no error object — the detail is already flattened
+      // into the context — so the error slot must be an explicit undefined.
+      // Passing the context positionally where `logError` expects the error
+      // would silently drop it from the log.
+      const sinks = { info: vi.fn(), error: vi.fn() };
+      logStartupWorktreeLoadOutcome({ status: "port-failed", reason: "no-host" }, "/repo", sinks);
+
+      expect(sinks.error).toHaveBeenCalledWith(
+        expect.any(String),
+        undefined,
+        expect.objectContaining({ projectPath: "/repo", reason: "no-host" })
+      );
     });
 
     it("carries the failure detail, not just the status name", () => {

--- a/electron/window/startupWorktreeLoad.ts
+++ b/electron/window/startupWorktreeLoad.ts
@@ -208,3 +208,66 @@ export async function runStartupWorktreeLoad<
   report(new Error(describeStartupPortFailure(attachResult.reason)));
   return { status: "port-failed", reason: attachResult.reason };
 }
+
+/** A log line for a startup worktree-load outcome, ready for the app logger. */
+export interface StartupWorktreeLoadLogLine {
+  level: "info" | "error";
+  message: string;
+  context: Record<string, unknown>;
+}
+
+/**
+ * Describe a startup outcome for the log.
+ *
+ * Returned rather than logged so this module stays Electron-free — importing
+ * `utils/logger.js` would drag in `ipc/channels.js` and `LogBuffer`, and the
+ * suite exists precisely to test these branches without the Electron runtime.
+ * The caller in `windowServices.ts` dispatches the returned line.
+ *
+ * Every outcome gets a line, and every line goes through the logger rather than
+ * `console`: production esbuild marks `console.log`/`console.warn` pure, so the
+ * previous console reporting was stripped from packaged builds — which is why a
+ * diagnostics bundle captured while the sidebar was empty said nothing at all
+ * about worktree loading (#11922).
+ */
+export function describeStartupWorktreeLoadOutcome(
+  outcome: StartupWorktreeLoadOutcome,
+  projectPath: string
+): StartupWorktreeLoadLogLine {
+  switch (outcome.status) {
+    case "loaded":
+      return {
+        level: "info",
+        message: "[MAIN] Worktrees loaded; worktree port brokered",
+        context: { projectPath },
+      };
+    case "no-client":
+      return {
+        level: "error",
+        message: "[MAIN] Workspace client unavailable — cannot load worktrees",
+        context: { projectPath },
+      };
+    case "load-failed":
+      return {
+        level: "error",
+        message: "[MAIN] Failed to load worktrees",
+        context: { projectPath, error: formatErrorMessage(outcome.error, "Unknown error") },
+      };
+    case "attach-failed":
+      return {
+        level: "error",
+        message: "[MAIN] Failed to attach the worktree port",
+        context: { projectPath, error: formatErrorMessage(outcome.error, "Unknown error") },
+      };
+    case "port-failed":
+      return {
+        level: "error",
+        message: "[MAIN] Worktree port not brokered",
+        context: {
+          projectPath,
+          reason: outcome.reason,
+          detail: describeStartupPortFailure(outcome.reason),
+        },
+      };
+  }
+}

--- a/electron/window/startupWorktreeLoad.ts
+++ b/electron/window/startupWorktreeLoad.ts
@@ -217,12 +217,24 @@ export interface StartupWorktreeLoadLogLine {
 }
 
 /**
+ * The logger functions {@link logStartupWorktreeLoadOutcome} writes through.
+ *
+ * Injected rather than imported so this module stays Electron-free, and so the
+ * dispatch itself — including `logError`'s `(message, error, context)` arity —
+ * is testable rather than only the mapping that feeds it.
+ */
+export interface StartupWorktreeLoadLogSinks {
+  info(message: string, context: Record<string, unknown>): void;
+  error(message: string, error: undefined, context: Record<string, unknown>): void;
+}
+
+/**
  * Describe a startup outcome for the log.
  *
  * Returned rather than logged so this module stays Electron-free — importing
  * `utils/logger.js` would drag in `ipc/channels.js` and `LogBuffer`, and the
  * suite exists precisely to test these branches without the Electron runtime.
- * The caller in `windowServices.ts` dispatches the returned line.
+ * {@link logStartupWorktreeLoadOutcome} dispatches the returned line.
  *
  * Every outcome gets a line, and every line goes through the logger rather than
  * `console`: production esbuild marks `console.log`/`console.warn` pure, so the
@@ -270,4 +282,24 @@ export function describeStartupWorktreeLoadOutcome(
         },
       };
   }
+}
+
+/**
+ * Write one startup outcome to the app logger.
+ *
+ * The outcome carries no error object of its own — the failure detail is
+ * already flattened into `context` — so the error sink is called with an
+ * explicit `undefined` in `logError`'s error position.
+ */
+export function logStartupWorktreeLoadOutcome(
+  outcome: StartupWorktreeLoadOutcome,
+  projectPath: string,
+  sinks: StartupWorktreeLoadLogSinks
+): void {
+  const line = describeStartupWorktreeLoadOutcome(outcome, projectPath);
+  if (line.level === "error") {
+    sinks.error(line.message, undefined, line.context);
+    return;
+  }
+  sinks.info(line.message, line.context);
 }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -22,10 +22,12 @@ import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { isCleaningUp } from "../lifecycle/shutdownCoordinator.js";
 import {
+  describeStartupWorktreeLoadOutcome,
   runStartupWorktreeLoad,
   selectStatusTarget,
   sendStartupWorktreeLoadFailure,
 } from "./startupWorktreeLoad.js";
+import { logError, logInfo, logWarn } from "../utils/logger.js";
 import { extractRestorePanelCwds } from "./restorePanelCwds.js";
 import { mergeProjectEnv } from "./restoreProjectEnv.js";
 import { store } from "../store.js";
@@ -690,7 +692,10 @@ export async function setupWindowServices(
       try {
         statusProjectId = projectStore.resolveProjectIdForPath(projectPathForWorktrees);
       } catch (error) {
-        console.warn("[MAIN] Could not resolve a project id for worktree load status:", error);
+        logWarn("[MAIN] Could not resolve a project id for worktree load status", {
+          projectPath: projectPathForWorktrees,
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     }
 
@@ -707,7 +712,9 @@ export async function setupWindowServices(
 
     const workspaceClient = capturedWorkspaceClient;
     if (workspaceClient) {
-      console.log("[MAIN] Loading worktrees for project path:", projectPathForWorktrees);
+      logInfo("[MAIN] Loading worktrees for project path", {
+        projectPath: projectPathForWorktrees,
+      });
     }
 
     // Register the renderer in directPortViews so sendToEntryWindows routes
@@ -721,7 +728,9 @@ export async function setupWindowServices(
       getHost: () => workspaceClient?.getHostForProject(projectPathForWorktrees),
       attachDirectPort: (target) => {
         workspaceClient?.attachDirectPort(win.id, target);
-        console.log("[MAIN] Workspace direct port attached");
+        logInfo("[MAIN] Workspace direct port attached", {
+          projectPath: projectPathForWorktrees,
+        });
       },
       getBrokerPort: () => {
         const worktreePortBroker = getWorktreePortBrokerRef();
@@ -732,25 +741,16 @@ export async function setupWindowServices(
       report: reportFailure,
     });
 
-    switch (outcome.status) {
-      case "loaded":
-        console.log("[MAIN] Worktrees loaded; worktree port brokered");
-        break;
-      case "no-client":
-        console.error(
-          "[MAIN] Workspace client unavailable - cannot load worktrees for:",
-          projectPathForWorktrees
-        );
-        break;
-      case "load-failed":
-        console.error("[MAIN] Failed to load worktrees:", outcome.error);
-        break;
-      case "attach-failed":
-        console.error("[MAIN] Failed to attach the worktree port:", outcome.error);
-        break;
-      case "port-failed":
-        console.error("[MAIN] Worktree port not brokered:", outcome.reason);
-        break;
+    // Through the logger, never `console`: production esbuild marks
+    // `console.log`/`console.warn` pure, so this reporting was absent from
+    // exactly the packaged builds where an empty sidebar had to be diagnosed
+    // (#11922). The mapping itself lives beside the outcome type so all five
+    // branches stay covered without importing Electron.
+    const outcomeLog = describeStartupWorktreeLoadOutcome(outcome, projectPathForWorktrees);
+    if (outcomeLog.level === "error") {
+      logError(outcomeLog.message, undefined, outcomeLog.context);
+    } else {
+      logInfo(outcomeLog.message, outcomeLog.context);
     }
   }
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -28,6 +28,7 @@ import {
   sendStartupWorktreeLoadFailure,
 } from "./startupWorktreeLoad.js";
 import { logError, logInfo, logWarn } from "../utils/logger.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { extractRestorePanelCwds } from "./restorePanelCwds.js";
 import { mergeProjectEnv } from "./restoreProjectEnv.js";
 import { store } from "../store.js";
@@ -694,7 +695,7 @@ export async function setupWindowServices(
       } catch (error) {
         logWarn("[MAIN] Could not resolve a project id for worktree load status", {
           projectPath: projectPathForWorktrees,
-          error: error instanceof Error ? error.message : String(error),
+          error: formatErrorMessage(error, "Unknown error"),
         });
       }
     }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -22,7 +22,7 @@ import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { isCleaningUp } from "../lifecycle/shutdownCoordinator.js";
 import {
-  describeStartupWorktreeLoadOutcome,
+  logStartupWorktreeLoadOutcome,
   runStartupWorktreeLoad,
   selectStatusTarget,
   sendStartupWorktreeLoadFailure,
@@ -746,12 +746,10 @@ export async function setupWindowServices(
     // exactly the packaged builds where an empty sidebar had to be diagnosed
     // (#11922). The mapping itself lives beside the outcome type so all five
     // branches stay covered without importing Electron.
-    const outcomeLog = describeStartupWorktreeLoadOutcome(outcome, projectPathForWorktrees);
-    if (outcomeLog.level === "error") {
-      logError(outcomeLog.message, undefined, outcomeLog.context);
-    } else {
-      logInfo(outcomeLog.message, outcomeLog.context);
-    }
+    logStartupWorktreeLoadOutcome(outcome, projectPathForWorktrees, {
+      info: logInfo,
+      error: logError,
+    });
   }
 
   // Smoke test

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -22,7 +22,7 @@ import nodeV8 from "node:v8";
 nodeV8.setHeapSnapshotNearHeapLimit(2);
 
 import { MessagePort } from "node:worker_threads";
-import { initializeLogger, setLogLevelOverrides } from "./utils/logger.js";
+import { initializeLogger, logInfo, setLogLevelOverrides } from "./utils/logger.js";
 import { copytreeWorkerClient } from "./workspace-host/CopytreeWorkerClient.js";
 import { fileTreeService } from "./services/FileTreeService.js";
 import { projectPulseService } from "./services/ProjectPulseService.js";
@@ -291,7 +291,10 @@ function attachWorktreePort(newPort: MessagePort): void {
     if (idx >= 0) worktreePorts.splice(idx, 1);
   });
 
-  console.log(`[WorkspaceHost] Worktree port attached (${worktreePorts.length} active)`);
+  // `logInfo`, not `console.log`: production esbuild marks `console.log` pure,
+  // so this line never existed in a packaged build — the one place it was
+  // needed to tell a brokered port from a missing one (#11922).
+  logInfo("[WorkspaceHost] Worktree port attached", { activePorts: worktreePorts.length });
 }
 
 // Global error handlers to prevent silent crashes

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -13,7 +13,13 @@ import {
 import { settingsFilePath } from "../services/projectStorePaths.js";
 import { SimpleGit, BranchSummary } from "simple-git";
 import { createHardenedGit, createAuthenticatedGit } from "../utils/hardenedGit.js";
-import { classifyGitError, getGitRecoveryAction } from "../../shared/utils/gitOperationErrors.js";
+import {
+  classifyGitError,
+  extractGitErrorMessage,
+  getGitRecoveryAction,
+  getGitRecoveryHint,
+} from "../../shared/utils/gitOperationErrors.js";
+import { logWarn } from "../utils/logger.js";
 import { isBinaryDiffOutput } from "../../shared/utils/gitDiffParsing.js";
 import type { Worktree, WslGitEligibility } from "../../shared/types/worktree.js";
 import type {
@@ -28,6 +34,7 @@ import type {
   PluginWorktreeLinkedIssue,
   PluginWorktreeLinkedPR,
 } from "../../shared/types/plugin.js";
+import type { GitOperationReason } from "../../shared/types/ipc/errors.js";
 import type { CIStatus, NormalizedPRState } from "../../shared/types/forge.js";
 import type { WorktreeChanges } from "../../shared/types/git.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
@@ -168,6 +175,37 @@ const FORGE_CONFIG_POLL_INTERVAL_MS = 5 * 60 * 1000;
 // UUIDs (not path-keyed), so size-capping is the only viable pruning strategy;
 // a session sees well under 100 deletes, so 500 never evicts a live id.
 export const MAX_ACKNOWLEDGED_MUTATIONS = 500;
+
+/**
+ * A repository probe that could not answer, as distinct from one that answered
+ * "no".
+ *
+ * Carries user-facing copy only. simple-git's child-process error handler
+ * pushes `String(err.stack)` into the stderr buffer, so the `GitError` it
+ * rethrows has the whole Node stack trace as its `message` and no `code`,
+ * `syscall` or `cause` to discriminate on. `loadProject` forwards its caught
+ * message straight to the "Couldn't load worktrees" banner, so that stack would
+ * be what the user reads. The original is kept as `cause` for diagnostics and
+ * never reaches the renderer.
+ */
+class RepositoryProbeError extends Error {
+  readonly gitReason: GitOperationReason;
+
+  constructor(gitReason: GitOperationReason, cause?: unknown) {
+    // Reuses the classifier's own recovery copy rather than a parallel set of
+    // strings, so a new `GitOperationReason` gets a usable sentence here for
+    // free and there is one place to review git-failure wording.
+    const hint = getGitRecoveryHint(gitReason);
+    super(
+      `Couldn't check whether this folder is a git repository. ${
+        hint ?? "Make sure the folder is available and git can run, then try again."
+      }`,
+      cause === undefined ? undefined : { cause }
+    );
+    this.name = "RepositoryProbeError";
+    this.gitReason = gitReason;
+  }
+}
 
 export class WorkspaceService {
   private monitors = new Map<string, WorktreeMonitor>();
@@ -687,6 +725,13 @@ export class WorkspaceService {
       // registered as a repository whose `.git` was since deleted reaches this
       // same branch and is spared the self-deletion too, which trusting a
       // persisted flag would not do.
+      //
+      // Only a *resolved* `false` takes this branch. A probe that could not run
+      // throws out to the catch below and reports the load as failed, so an
+      // environment fault can no longer masquerade as a folder without a
+      // repository (#11922). For the same reason there is no persisted-row
+      // sanity check here: a row saying "git-backed" must not override a live
+      // `false`, which is exactly the deleted-`.git` case above.
       if (!(await this.isGitRepository())) {
         this.gitBacked = false;
         this.sendEvent({ type: "load-project-result", requestId, success: true });
@@ -749,11 +794,15 @@ export class WorkspaceService {
         }
       });
     } catch (error) {
+      // `formatErrorMessage`, not `(error as Error).message`: a non-Error throw
+      // put a literal `undefined` in the "Couldn't load worktrees" banner. A
+      // `RepositoryProbeError` arrives here already carrying safe copy — its
+      // `cause` (simple-git's stack-trace-as-message) stays out of the payload.
       this.sendEvent({
         type: "load-project-result",
         requestId,
         success: false,
-        error: (error as Error).message,
+        error: formatErrorMessage(error, "Failed to load worktrees"),
       });
     }
   }
@@ -2372,18 +2421,55 @@ export class WorkspaceService {
   /**
    * Whether the loaded folder is a git repository.
    *
-   * `checkIsRepo` rejects rather than returning false for permission denials,
-   * a missing git binary and other environment faults, so every failure is
-   * treated as "no repository" — the conservative answer, since it only ever
-   * withholds git features rather than pointing the status poller at a path
-   * that cannot serve it.
+   * Three outcomes, not two. `checkIsRepo()` resolves `false` only when git ran
+   * and answered no: simple-git's `checkIsRepoTask.onError` turns exit code 128
+   * plus a "not a git repository" message into a resolved `false` and *throws*
+   * everything else — a spawn failure against an unavailable cwd, the 30s
+   * `GIT_BLOCK_TIMEOUT_MS` abort, a OneDrive placeholder stall, an antivirus
+   * interposition. So a thrown probe means "couldn't answer", never "no
+   * repository", and the bare `catch { return false }` that used to conflate
+   * them was the sole route to reporting a healthy repo as unbacked (#11922).
+   *
+   * Failing here propagates to `loadProject`'s catch, which reports
+   * `load-project-result: success: false`. That is load-bearing twice: it drives
+   * the "Couldn't load worktrees" banner instead of an authoritative-looking
+   * empty list, and it rejects the pool entry's ready promise so Retry disposes
+   * the host and issues a genuine reload rather than re-foregrounding one whose
+   * `monitors` map is empty (`WorkspaceHostPool.loadProject`).
+   *
+   * `gitBacked` is deliberately left untouched on the throw path: its `null`
+   * default already means "not classified" to every consumer (#11650), and the
+   * `syncMonitors` self-deletion guard keys on `=== false`, so an unknown
+   * verdict can never arm the hazard #11405 closed.
    */
   private async isGitRepository(): Promise<boolean> {
-    if (!this.git) return false;
+    if (!this.git) {
+      // Unreachable from `loadProject`, which assigns `this.git` immediately
+      // above the call and throws out of `createHardenedGit` otherwise. A throw
+      // rather than a `false` so an impossible state can never be the thing
+      // that reports a repository as unbacked.
+      throw new RepositoryProbeError("unknown");
+    }
     try {
       return await this.git.checkIsRepo();
-    } catch {
-      return false;
+    } catch (error) {
+      const reason = classifyGitError(error);
+      // Defense in depth: simple-git's own `onError` should already have turned
+      // a genuine "fatal: not a git repository" into a resolved `false` before
+      // it could reach here. If it ever stops doing so, this is still a real
+      // answer from git and has to stay on the non-repository path.
+      if (reason === "not-a-repository") return false;
+      // `logWarn`, not `console.warn`: production esbuild marks `console.warn`
+      // pure (`scripts/build-main.mjs`), so a console call is stripped from the
+      // packaged build — the only build this failure has ever been seen in. The
+      // whole point of capturing it is that the next repro says which branch
+      // fired and why.
+      logWarn("Repository probe failed; folder left unclassified", {
+        projectRootPath: this.projectRootPath,
+        gitReason: reason,
+        probeError: extractGitErrorMessage(error),
+      });
+      throw new RepositoryProbeError(reason, error);
     }
   }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -195,7 +195,17 @@ class RepositoryProbeError extends Error {
     // Reuses the classifier's own recovery copy rather than a parallel set of
     // strings, so a new `GitOperationReason` gets a usable sentence here for
     // free and there is one place to review git-failure wording.
-    const hint = getGitRecoveryHint(gitReason);
+    //
+    // One exception. simple-git spawns with `{ cwd }` rather than `git -C`, so
+    // an unavailable working directory fails at spawn time with a `spawn git
+    // ENOENT` indistinguishable from a missing binary — and an unhydrated
+    // OneDrive placeholder is the leading suspect for #11922. The generic hint
+    // ("Install Git…") would tell a user with git plainly installed to install
+    // it, so this one path names both possibilities instead.
+    const hint =
+      gitReason === "git-not-installed"
+        ? "Check that the folder is available, and that git is installed and on your PATH."
+        : getGitRecoveryHint(gitReason);
     super(
       `Couldn't check whether this folder is a git repository. ${
         hint ?? "Make sure the folder is available and git can run, then try again."
@@ -821,7 +831,14 @@ export class WorkspaceService {
     // Guarding here rather than only at the callers covers the `sync` host
     // message, which arrives with a caller-supplied worktree list and is
     // fanned out to every live host by `WorkspaceClient.sync` (#11405).
-    if (this.gitBacked === false) return;
+    //
+    // `!== true`, not `=== false`: since #11922 a probe that could not answer
+    // leaves `gitBacked` at `null`, and `WorkspaceClient.sync` iterates the
+    // pool's entries with no readiness gate — so a host whose load failed is
+    // still reachable until the next `loadProject` disposes it. Minting a
+    // monitor for a folder we could not probe arms exactly the hazard this
+    // guard exists for. Unknown withholds; only a proven repository proceeds.
+    if (this.gitBacked !== true) return;
 
     // Derive the repository's main/integration branch from the actual main
     // worktree rather than trusting the caller. The legacy `mainBranch`
@@ -2477,7 +2494,11 @@ export class WorkspaceService {
     // Backstop for the `loadProject` gate: a topology reconcile or an explicit
     // refresh must not be the thing that mints the first monitor for a folder
     // with no repository (#11405).
-    if (!this.git || this.gitBacked === false) {
+    // `!== true` for the same reason as `syncMonitors`: an unanswerable probe
+    // leaves `gitBacked` at `null` with `this.git` already constructed, so a
+    // reconcile would otherwise enumerate a folder whose repository status is
+    // unknown (#11922).
+    if (!this.git || this.gitBacked !== true) {
       return;
     }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -2455,9 +2455,10 @@ export class WorkspaceService {
    * `monitors` map is empty (`WorkspaceHostPool.loadProject`).
    *
    * `gitBacked` is deliberately left untouched on the throw path: its `null`
-   * default already means "not classified" to every consumer (#11650), and the
-   * `syncMonitors` self-deletion guard keys on `=== false`, so an unknown
-   * verdict can never arm the hazard #11405 closed.
+   * default already means "not classified" to every consumer (#11650). The
+   * monitor-minting guards were tightened to `!== true` to match, so an unknown
+   * verdict withholds exactly like a proven non-repository and can never arm
+   * the hazard #11405 closed.
    */
   private async isGitRepository(): Promise<boolean> {
     if (!this.git) {
@@ -3720,6 +3721,11 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     // `forgeProbeCwd` falls back to the project root — so without this the
     // matcher relay would spawn `git remote -v` there and, on its bounded
     // re-arm, up to three more times per registry change (#11405 × #11408).
+    // Left at `=== false` where the monitor-minting guards moved to `!== true`:
+    // a matcher push reaching a host whose probe failed can still spawn one
+    // bounded, read-only `git remote -v` against that path. It fails fast and
+    // harmlessly, and tightening it here would block the legitimate cold-start
+    // reselect that lands before a load completes.
     if (this.gitBacked === false) return;
     if (this._shutdownController.signal.aborted) return;
     if (this.forgeReselectTimer) return;

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -5,6 +5,25 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
 import { createHardenedGit } from "../../utils/hardenedGit.js";
 import type { WorkspaceService } from "../WorkspaceService.js";
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
+import { getGitRecoveryHint } from "../../../shared/utils/gitOperationErrors.js";
+import {
+  GIT_BLOCK_TIMEOUT_MESSAGE,
+  GIT_DUBIOUS_OWNERSHIP_STDERR,
+  GIT_NOT_A_REPOSITORY_STDERR,
+  GIT_SYSTEM_IO_STDERR,
+  REPOSITORY_PROBE_COMMANDS,
+  simpleGitMissingBinaryError,
+  simpleGitStderrError,
+} from "../../../shared/testing/simpleGitErrorFixtures.js";
+
+// Spread the original: the module has a wide surface and other modules in this
+// graph import exports beyond `logWarn`. It pulls in no Electron, so importing
+// it here is safe.
+const logWarnMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/logger.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/logger.js")>()),
+  logWarn: logWarnMock,
+}));
 
 const mockSimpleGit = {
   raw: vi.fn(),
@@ -257,19 +276,149 @@ describe("WorkspaceService adversarial", () => {
       expect(monitorCount()).toBe(0);
     });
 
-    it("treats a throwing repository probe as no repository", async () => {
-      // simple-git rejects rather than answering false on permission denials
-      // and other environment faults.
-      mockSimpleGit.checkIsRepo.mockRejectedValue(new Error("EACCES"));
+    it("still takes the non-repository path when git's own answer arrives as a throw", async () => {
+      // simple-git's `checkIsRepoTask.onError` converts exit code 128 plus a
+      // "not a git repository" message into a resolved `false`, so this should
+      // be unreachable — the classifier backstop exists in case it ever stops
+      // doing so. Either way git ran and answered, which is not a failure.
+      mockSimpleGit.checkIsRepo.mockRejectedValue(
+        simpleGitStderrError(GIT_NOT_A_REPOSITORY_STDERR)
+      );
 
-      await service.loadProject("req-denied", "/downloads", "ws-plain");
+      await service.loadProject("req-backstop", "/downloads", "ws-plain");
 
       expect(sentEvents).toContainEqual({
         type: "load-project-result",
-        requestId: "req-denied",
+        requestId: "req-backstop",
         success: true,
       });
       expect(monitorCount()).toBe(0);
+      expect(logWarnMock).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * A probe that could not answer is not an answer of "no".
+   *
+   * The bare `catch { return false }` this replaces was the sole mechanism
+   * turning a transient environment fault — a spawn failure against a cwd
+   * OneDrive had not hydrated, the 30s block timeout, an antivirus
+   * interposition — into "this folder has no repository". The load then
+   * reported `success: true` with zero monitors, so the renderer got an
+   * authoritative empty worktree list, and Retry re-foregrounded the same warm
+   * host instead of reloading it: recovery was impossible without a restart.
+   */
+  describe("a repository probe that cannot answer (#11922)", () => {
+    function monitorCount(): number {
+      return (service["monitors"] as Map<string, unknown>).size;
+    }
+
+    const CANNOT_ANSWER = [
+      {
+        label: "a spawn failure whose provenance simple-git destroyed",
+        error: () => simpleGitMissingBinaryError(REPOSITORY_PROBE_COMMANDS),
+        reason: "git-not-installed",
+      },
+      {
+        label: "a filesystem or permission fault against the repo path",
+        error: () => simpleGitStderrError(GIT_SYSTEM_IO_STDERR),
+        reason: "system-io-error",
+      },
+      {
+        label: "the block timeout killing the child",
+        error: () => new Error(GIT_BLOCK_TIMEOUT_MESSAGE),
+        reason: "unknown",
+      },
+      {
+        label: "git refusing a repository it does not trust",
+        error: () => simpleGitStderrError(GIT_DUBIOUS_OWNERSHIP_STDERR),
+        reason: "dubious-ownership",
+      },
+    ] as const;
+
+    for (const probeCase of CANNOT_ANSWER) {
+      it(`reports the load as failed on ${probeCase.label}`, async () => {
+        mockSimpleGit.checkIsRepo.mockRejectedValue(probeCase.error());
+
+        await service.loadProject("req-probe", "/repo", "ws-probe");
+
+        const result = sentEvents.find((e) => e.type === "load-project-result");
+        expect(result).toMatchObject({ requestId: "req-probe", success: false });
+        // Rejecting the request is what makes `WorkspaceHostPool` dispose the
+        // entry and issue a real reload; a `success: true` here is what left
+        // Retry re-foregrounding an empty host forever.
+        expect(sentEvents.some((e) => e.type === "load-project-result" && e.success)).toBe(false);
+        expect(monitorCount()).toBe(0);
+      });
+
+      it(`logs the classified reason for ${probeCase.label}`, async () => {
+        mockSimpleGit.checkIsRepo.mockRejectedValue(probeCase.error());
+
+        await service.loadProject("req-probe", "/repo", "ws-probe");
+
+        // Through the app logger rather than `console.warn`, which production
+        // esbuild strips — the packaged build is the only one this has been
+        // seen in, and its diagnostics bundle said nothing at all.
+        expect(logWarnMock).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ projectRootPath: "/repo", gitReason: probeCase.reason })
+        );
+      });
+    }
+
+    it("leaves the folder unclassified rather than calling it non-git", async () => {
+      mockSimpleGit.checkIsRepo.mockRejectedValue(
+        simpleGitMissingBinaryError(REPOSITORY_PROBE_COMMANDS)
+      );
+
+      await service.loadProject("req-probe", "/repo", "ws-probe");
+      sentEvents.length = 0;
+      service.getAllStates("states-probe");
+
+      // `null`, never `false`: `false` is a probed verdict the renderer trusts
+      // enough to strip a real repo's restored worktree state (#11650), and
+      // `syncMonitors`' self-deletion guard keys on it (#11405).
+      const event = sentEvents.find((e) => e.type === "all-states");
+      expect(event).toMatchObject({ states: [], gitBacked: null });
+    });
+
+    it("never puts simple-git's stack trace in the banner message", async () => {
+      // simple-git pushes `String(err.stack)` into the stderr buffer, so the
+      // rethrown GitError's `message` is a whole Node stack trace — and
+      // `loadProject`'s catch forwards its message verbatim to the renderer's
+      // "Couldn't load worktrees" banner.
+      mockSimpleGit.checkIsRepo.mockRejectedValue(
+        simpleGitMissingBinaryError(REPOSITORY_PROBE_COMMANDS)
+      );
+
+      await service.loadProject("req-probe", "/repo", "ws-probe");
+
+      const result = sentEvents.find(
+        (e): e is Extract<WorkspaceHostEvent, { type: "load-project-result" }> =>
+          e.type === "load-project-result"
+      );
+      const message = result && "error" in result ? (result.error ?? "") : "";
+      expect(message).not.toContain("spawn git ENOENT");
+      expect(message).not.toContain("at ChildProcess");
+      expect(message).not.toContain("node:internal");
+      expect(message).toContain("git repository");
+    });
+
+    it("surfaces recovery copy matched to the classified reason", async () => {
+      // Dubious ownership is a repository git found and refused to touch.
+      // Reporting it as "no repository" hid both the cause and its fix.
+      mockSimpleGit.checkIsRepo.mockRejectedValue(
+        simpleGitStderrError(GIT_DUBIOUS_OWNERSHIP_STDERR)
+      );
+
+      await service.loadProject("req-probe", "/repo", "ws-probe");
+
+      const result = sentEvents.find(
+        (e): e is Extract<WorkspaceHostEvent, { type: "load-project-result" }> =>
+          e.type === "load-project-result"
+      );
+      const message = result && "error" in result ? (result.error ?? "") : "";
+      expect(message).toContain(getGitRecoveryHint("dubious-ownership"));
     });
   });
 

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -7,11 +7,12 @@ import type { WorkspaceService } from "../WorkspaceService.js";
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
 import { getGitRecoveryHint } from "../../../shared/utils/gitOperationErrors.js";
 import {
-  GIT_BLOCK_TIMEOUT_MESSAGE,
   GIT_DUBIOUS_OWNERSHIP_STDERR,
   GIT_NOT_A_REPOSITORY_STDERR,
-  GIT_SYSTEM_IO_STDERR,
   REPOSITORY_PROBE_COMMANDS,
+  SIMPLE_GIT_MISSING_BINARY_MESSAGE,
+  simpleGitBlockTimeoutError,
+  simpleGitCwdDeniedError,
   simpleGitMissingBinaryError,
   simpleGitStderrError,
 } from "../../../shared/testing/simpleGitErrorFixtures.js";
@@ -320,13 +321,16 @@ describe("WorkspaceService adversarial", () => {
         reason: "git-not-installed",
       },
       {
-        label: "a filesystem or permission fault against the repo path",
-        error: () => simpleGitStderrError(GIT_SYSTEM_IO_STDERR),
+        // simple-git spawns with `{ cwd }`, so a directory git cannot enter
+        // fails before git runs and is laundered the same way a missing binary
+        // is — git never prints a `fatal:` line for this at all.
+        label: "a working directory git cannot enter",
+        error: () => simpleGitCwdDeniedError(),
         reason: "system-io-error",
       },
       {
         label: "the block timeout killing the child",
-        error: () => new Error(GIT_BLOCK_TIMEOUT_MESSAGE),
+        error: () => simpleGitBlockTimeoutError(),
         reason: "unknown",
       },
       {
@@ -398,10 +402,127 @@ describe("WorkspaceService adversarial", () => {
           e.type === "load-project-result"
       );
       const message = result && "error" in result ? (result.error ?? "") : "";
+      // Non-empty first, so the three negative assertions below cannot pass
+      // vacuously against an implementation that reports no error at all.
+      expect(message).not.toBe("");
+      expect(message).not.toContain(SIMPLE_GIT_MISSING_BINARY_MESSAGE);
       expect(message).not.toContain("spawn git ENOENT");
       expect(message).not.toContain("at ChildProcess");
       expect(message).not.toContain("node:internal");
-      expect(message).toContain("git repository");
+    });
+
+    it("does not tell a user with git installed to install git", async () => {
+      // An unhydrated OneDrive placeholder makes the spawn cwd unavailable, and
+      // Node reports that as the same `spawn git ENOENT` a missing binary
+      // produces — simple-git strips every field that could tell them apart. The
+      // reporter of #11922 had git 2.55.0 on PATH, so the classifier's generic
+      // "Install Git" copy would have been actively misleading.
+      mockSimpleGit.checkIsRepo.mockRejectedValue(
+        simpleGitMissingBinaryError(REPOSITORY_PROBE_COMMANDS)
+      );
+
+      await service.loadProject("req-probe", "/repo", "ws-probe");
+
+      const result = sentEvents.find(
+        (e): e is Extract<WorkspaceHostEvent, { type: "load-project-result" }> =>
+          e.type === "load-project-result"
+      );
+      const message = result && "error" in result ? (result.error ?? "") : "";
+      expect(message).not.toContain("Install Git");
+      expect(message).toContain("folder is available");
+    });
+
+    it("touches nothing downstream of the gate", async () => {
+      const listService = service["listService"] as unknown as {
+        list: Mock;
+        setGit: Mock;
+        mapToWorktrees: Mock;
+      };
+      listService.list = vi.fn();
+      listService.setGit = vi.fn();
+      listService.mapToWorktrees = vi.fn();
+      const startWatcher = vi.spyOn(
+        service["topologyWatcher"] as unknown as { startWatcher: () => Promise<void> },
+        "startWatcher"
+      );
+      mockSimpleGit.checkIsRepo.mockRejectedValue(simpleGitCwdDeniedError());
+
+      await service.loadProject("req-probe", "/repo", "ws-probe");
+
+      // Everything the gate stands in front of. `worktree prune` in particular
+      // WRITES into `.git`, and this is a folder we could not even probe.
+      expect(listService.setGit).not.toHaveBeenCalled();
+      expect(listService.list).not.toHaveBeenCalled();
+      expect(listService.mapToWorktrees).not.toHaveBeenCalled();
+      expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+      expect(startWatcher).not.toHaveBeenCalled();
+    });
+
+    it("ignores a sync carrying worktrees from main after a failed probe", async () => {
+      // `WorkspaceClient.sync` fans out to every pool entry with no readiness
+      // gate, and a failed-load host stays in the pool until the next
+      // `loadProject` disposes it. A monitor minted here would raise
+      // `WorktreeRemovedError` on its first poll and delete the workspace — the
+      // #11405 hazard, reachable through the new `gitBacked: null` state.
+      mockSimpleGit.checkIsRepo.mockRejectedValue(simpleGitCwdDeniedError());
+      await service.loadProject("req-probe", "/repo", "ws-probe");
+
+      await service.syncMonitors(
+        [
+          {
+            id: "wt-1",
+            path: "/repo",
+            branch: "main",
+            isMainWorktree: true,
+          } as unknown as Parameters<typeof service.syncMonitors>[0][number],
+        ],
+        "wt-1",
+        "main"
+      );
+
+      expect(monitorCount()).toBe(0);
+    });
+
+    it("re-probes and re-classifies on a retry after the probe recovers", async () => {
+      // The whole point of failing the load: the rejected result is what makes
+      // the pool dispose the host and issue a real reload. The verdict has to
+      // come from that second probe — residual state from the failed attempt
+      // must neither survive as `null` nor short-circuit the re-classification.
+      mockSimpleGit.checkIsRepo.mockRejectedValueOnce(simpleGitCwdDeniedError());
+
+      await service.loadProject("req-probe", "/repo", "ws-probe");
+
+      expect(sentEvents.some((e) => e.type === "load-project-result" && !e.success)).toBe(true);
+      service.getAllStates("states-failed");
+      expect(sentEvents.find((e) => e.type === "all-states")).toMatchObject({ gitBacked: null });
+
+      sentEvents.length = 0;
+      mockSimpleGit.checkIsRepo.mockResolvedValue(true);
+
+      await service.loadProject("req-retry", "/repo", "ws-probe");
+      sentEvents.length = 0;
+      service.getAllStates("states-retry");
+
+      expect(mockSimpleGit.checkIsRepo).toHaveBeenCalledTimes(2);
+      expect(sentEvents.find((e) => e.type === "all-states")).toMatchObject({ gitBacked: true });
+    });
+
+    it("reports a non-Error throw without putting 'undefined' in the banner", async () => {
+      // `loadProject`'s catch used `(error as Error).message`, which is
+      // `undefined` for an opaque throw — and the banner renders it verbatim.
+      const listService = service["listService"] as unknown as { list: Mock };
+      listService.list = vi.fn().mockRejectedValue("git exploded, no Error involved");
+
+      await service.loadProject("req-opaque", "/repo", "ws-probe");
+
+      expect(sentEvents).toContainEqual(
+        expect.objectContaining({
+          type: "load-project-result",
+          requestId: "req-opaque",
+          success: false,
+          error: "git exploded, no Error involved",
+        })
+      );
     });
 
     it("surfaces recovery copy matched to the classified reason", async () => {
@@ -499,6 +620,10 @@ describe("WorkspaceService adversarial", () => {
     // callers pass the stale field straight back. syncMonitors must instead
     // read the actual main worktree's branch (e.g. "develop" in a gitflow
     // repo) so non-PR worktrees diff against the real integration branch.
+    //
+    // Primed rather than loaded: since #11922 `syncMonitors` mints monitors only
+    // for a proven repository, and this test drives it directly.
+    service["gitBacked"] = true;
     const mainWorktree = {
       id: "/repo",
       path: "/repo",

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -180,6 +180,10 @@ describe("WorkspaceService external worktree removal", () => {
 
     service["projectRootPath"] = "/test/root";
     service["git"] = mockSimpleGit as any;
+    // Stands in for the completed `loadProject` these tests skip. Since #11922
+    // only a proven repository gets monitors, so the probe verdict has to be
+    // part of the primed state rather than left at its `null` default.
+    service["gitBacked"] = true;
     service["listService"].setGit(mockSimpleGit as unknown as SimpleGit, "/test/root");
   });
 

--- a/electron/workspace-host/__tests__/WorkspaceService.wslGitPrune.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.wslGitPrune.test.ts
@@ -179,6 +179,10 @@ describe("WorkspaceService WSL git opt-in pruning (#9926)", () => {
 
     service["projectRootPath"] = "/test/root";
     service["git"] = mockSimpleGit as any;
+    // Stands in for the completed `loadProject` these tests skip. Since #11922
+    // only a proven repository gets monitors, so the probe verdict has to be
+    // part of the primed state rather than left at its `null` default.
+    service["gitBacked"] = true;
     service["listService"].setGit(mockSimpleGit as unknown as SimpleGit, "/test/root");
   });
 

--- a/shared/testing/simpleGitErrorFixtures.ts
+++ b/shared/testing/simpleGitErrorFixtures.ts
@@ -66,26 +66,57 @@ export function simpleGitStderrError(
 
 /**
  * Git's refusal to touch a repository whose on-disk owner differs from the
- * current user. A *repository is present* here — misreading it as "no
- * repository" is the failure #11922 fixed.
+ * current user, as git actually prints it — the advisory and trailing newline
+ * included, not just the `fatal:` line. A *repository is present* here;
+ * misreading it as "no repository" is the failure #11922 fixed.
  */
 export const GIT_DUBIOUS_OWNERSHIP_STDERR =
-  "fatal: detected dubious ownership in repository at 'C:/Users/greg/OneDrive/Documents/Daintree/daintree'";
+  "fatal: detected dubious ownership in repository at 'C:/Users/greg/OneDrive/Documents/Daintree/daintree'\n" +
+  "To add an exception for this directory, call:\n" +
+  "\n" +
+  "\tgit config --global --add safe.directory C:/Users/greg/OneDrive/Documents/Daintree/daintree\n";
 
 /**
  * The genuine "this folder has no repository" answer. simple-git's own
  * `checkIsRepoTask.onError` resolves this to `false` before it can ever be
- * thrown; the fixture exists to prove the classifier backstop agrees.
+ * thrown, so a test that throws it is exercising the classifier backstop
+ * deliberately, not a shape production produces here.
  */
 export const GIT_NOT_A_REPOSITORY_STDERR =
-  "fatal: not a git repository (or any of the parent directories): .git";
+  "fatal: not a git repository (or any of the parent directories): .git\n";
 
 /**
- * A filesystem/permission fault against the repository path — the shape a
- * OneDrive placeholder stall or an antivirus interposition surfaces as.
+ * What an inaccessible working directory actually produces.
+ *
+ * simple-git spawns with `{ cwd }` rather than `git -C <path>`, so a directory
+ * git cannot enter fails at spawn time — before git runs — and is laundered
+ * through the same stack-trace-as-message path as a missing binary. Git never
+ * gets to print a `fatal:` line at all. An earlier version of this fixture
+ * invented one; that is the #11764 mistake this module exists to prevent.
  */
-export const GIT_SYSTEM_IO_STDERR =
-  "fatal: cannot change to 'C:/Users/greg/OneDrive/Documents/Daintree/daintree': EACCES";
+export const SIMPLE_GIT_CWD_DENIED_MESSAGE =
+  "Error: spawn git EACCES\n" +
+  "    at ChildProcess._handle.onexit (node:internal/child_process:287:19)\n" +
+  "    at onErrorNT (node:internal/child_process:525:16)\n" +
+  "    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)";
 
-/** simple-git's `GitPluginError` message when its block timeout kills the child. */
+/** Build the laundered spawn failure for a working directory git cannot enter. */
+export function simpleGitCwdDeniedError(commands: string[] = REPOSITORY_PROBE_COMMANDS): Error {
+  const error = new Error(SIMPLE_GIT_CWD_DENIED_MESSAGE);
+  Object.assign(error, { task: { commands } });
+  return error;
+}
+
+/** simple-git's message when its block timeout kills the child. */
 export const GIT_BLOCK_TIMEOUT_MESSAGE = "block timeout reached";
+
+/**
+ * The block-timeout rejection is a `GitPluginError`, not a plain `Error`: it
+ * carries `plugin` alongside `task`, and the 30s `GIT_BLOCK_TIMEOUT_MS` this
+ * models is a prime suspect for #11922's OneDrive stalls.
+ */
+export function simpleGitBlockTimeoutError(commands: string[] = REPOSITORY_PROBE_COMMANDS): Error {
+  const error = new Error(GIT_BLOCK_TIMEOUT_MESSAGE);
+  Object.assign(error, { task: { commands }, plugin: "timeout" });
+  return error;
+}

--- a/shared/testing/simpleGitErrorFixtures.ts
+++ b/shared/testing/simpleGitErrorFixtures.ts
@@ -43,3 +43,49 @@ export function simpleGitMissingBinaryError(
  */
 export const SIMPLE_GIT_MISSING_CWD_MESSAGE =
   "Cannot use simple-git on a directory that does not exist";
+
+/** What `checkIsRepo()` runs — `CheckRepoActions` defaults to the in-tree check. */
+export const REPOSITORY_PROBE_COMMANDS = ["rev-parse", "--is-inside-work-tree"];
+
+/**
+ * Build the value simple-git throws when git itself *ran* and exited nonzero.
+ *
+ * Distinct from {@link simpleGitMissingBinaryError}: nothing is laundered here,
+ * because the child process started. simple-git concats stdout+stderr into
+ * `.message` verbatim, so git's own `fatal:` line is the message and the only
+ * discriminant a classifier ever gets.
+ */
+export function simpleGitStderrError(
+  stderr: string,
+  commands: string[] = REPOSITORY_PROBE_COMMANDS
+): Error {
+  const error = new Error(stderr);
+  Object.assign(error, { task: { commands } });
+  return error;
+}
+
+/**
+ * Git's refusal to touch a repository whose on-disk owner differs from the
+ * current user. A *repository is present* here — misreading it as "no
+ * repository" is the failure #11922 fixed.
+ */
+export const GIT_DUBIOUS_OWNERSHIP_STDERR =
+  "fatal: detected dubious ownership in repository at 'C:/Users/greg/OneDrive/Documents/Daintree/daintree'";
+
+/**
+ * The genuine "this folder has no repository" answer. simple-git's own
+ * `checkIsRepoTask.onError` resolves this to `false` before it can ever be
+ * thrown; the fixture exists to prove the classifier backstop agrees.
+ */
+export const GIT_NOT_A_REPOSITORY_STDERR =
+  "fatal: not a git repository (or any of the parent directories): .git";
+
+/**
+ * A filesystem/permission fault against the repository path — the shape a
+ * OneDrive placeholder stall or an antivirus interposition surfaces as.
+ */
+export const GIT_SYSTEM_IO_STDERR =
+  "fatal: cannot change to 'C:/Users/greg/OneDrive/Documents/Daintree/daintree': EACCES";
+
+/** simple-git's `GitPluginError` message when its block timeout kills the child. */
+export const GIT_BLOCK_TIMEOUT_MESSAGE = "block timeout reached";

--- a/shared/testing/simpleGitErrorFixtures.ts
+++ b/shared/testing/simpleGitErrorFixtures.ts
@@ -7,6 +7,14 @@
  * `"Error: spawn git ENOENT"` and a synthetic errno-bearing cause chain — that
  * satisfied detection which could never fire against the real thing. A fixture
  * that is easier to match than production input tests nothing.
+ *
+ * The fidelity boundary is the classifier's input surface: message text and the
+ * own properties it reads (`message`, `code`, `syscall`, `cause`), captured from
+ * the installed simple-git. These build plain `Error`s rather than simple-git's
+ * `GitError`/`GitPluginError` subclasses, and their `task` carries only
+ * `commands` where a real task also owns `format`, `onError` and `parser` —
+ * none of which any classifier consults. Anything that starts branching on the
+ * prototype or the task shape needs richer fixtures than these.
  */
 
 /**


### PR DESCRIPTION
## Summary

- On packaged Windows with a OneDrive-backed repo, the worktree sidebar went permanently empty for a healthy git repository, and Retry could never recover it without an app restart.
- `WorkspaceService.isGitRepository()` classifies the thrown error instead of swallowing it, so a real environment fault now fails the load honestly instead of being reported as "no repository".
- Fixes two hazards the review turned up along the way, and moves worktree-load diagnostics onto the app logger so they actually survive a production build.

Resolves #11922

## The bug

On a packaged Windows build with a OneDrive-backed repo, the worktree sidebar showed nothing for a known-good git repository, and clicking Retry never brought it back. The only fix was restarting the app.

## Root cause

`WorkspaceService.isGitRepository()` wrapped `checkIsRepo()` in a bare `try/catch { return false }`. simple-git's `checkIsRepoTask.onError` only resolves `false` for exit code 128 with a "not a git repository" message, and throws for everything else: a spawn failure against an unavailable working directory, the 30s block timeout, antivirus interposition, a OneDrive placeholder stall. That catch block was the sole mechanism converting an environment fault into "this folder has no repository".

From there, `loadProject` set `gitBacked = false`, reported `load-project-result` with `success: true`, and returned zero monitors before prune, list, `syncMonitors`, the topology watcher, and forge detection ever ran. The renderer received an authoritative empty worktree list. And because the host reported success, `WorkspaceHostPool`'s warm-entry short-circuit saw a resolved ready promise and just re-foregrounded the stale host, so Retry re-ran nothing.

## The fix

The probe now classifies the thrown error with the existing `classifyGitError`. Only `"not-a-repository"` still resolves `false`; everything else throws. That throw lands in `loadProject`'s existing catch, which reports `success: false`, which rejects the pool entry's ready promise, so Retry disposes the host and issues a genuine reload.

No new field, no wire-protocol change. A failed probe just leaves `gitBacked` at its `null` default, already the #11650 "unclassified" value.

## Two things the review caught

1. **Leaving `gitBacked` at `null` opened the #11405 self-deletion hazard from the other side.** `WorkspaceClient.sync` fans out to every pool entry with no readiness gate, and a failed-load host stays reachable until the next load disposes it. So the old `syncMonitors` guard (`=== false`) would have let a sync mint a monitor for a folder we couldn't probe, and that monitor's first `GitStatusPass` tick raises `WorktreeRemovedError`, which removes the workspace. `syncMonitors` and `discoverAndSyncWorktrees` now guard on `!== true`: unknown withholds exactly like a proven non-repository.
2. **simple-git spawns with `{ cwd }` rather than `git -C`**, so an unavailable working directory fails at spawn time with a `spawn git ENOENT` indistinguishable from a missing binary. The generic recovery hint would have told this reporter, who has git 2.55.0 on PATH, to install git. That path now names both causes.

## Diagnostics (the issue's fix 3)

`scripts/build-main.mjs` marks `console.log`/`console.info`/`console.warn`/`console.debug` pure in production, so the previous console reporting was dead-code-eliminated from exactly the packaged builds where this failure shows up. That's why a diagnostics bundle captured while the sidebar was empty had nothing about worktree loading in it. The probe failure, the five startup worktree-load outcomes, and the host's port-attach line now go through the app logger instead.

## Deliberately out of scope

- **The issue's fix 2** (sanity-check a zero-monitor load against the project's previously-known `gitBacked`) would break #11405. The only case it adds over this fix is a probe that legitimately answers `false` for a row persisted as git-backed, and that's exactly "the user deleted `.git`", the case #11405 exists to protect against. The folder is the authority, not a persisted row.
- **The issue's fix 4** (bounded retry on the probe) is unnecessary now that the load fails outright: `WorkspaceHostPool` disposes the entry and forks a fresh host, so the user's Retry click already is the retry, with no added boot latency and no collision with the two 30s timeouts sitting under a 45s renderer watchdog.
- **The suspected secondary UI defect isn't real.** `useWorkspaceRoot` builds `workspaceRoot` from the persisted project row, not the host's live verdict, so `workspaceRoot` stays non-null with `isGitBacked: true` and the render falls through to the zero-data nudge. That branch simply isn't reached anymore once the load fails honestly.

## Testing

The test that literally codified the bug as correct behavior (`"treats a throwing repository probe as no repository"`, asserting `success: true`) is rewritten. New coverage: four failure classes fail the load and log a classified reason, the folder stays unclassified rather than being called non-git, no stack trace reaches the banner, a sync after a failed probe mints no monitor, the probe is re-run on retry, and a non-Error throw no longer renders as `undefined`. The genuine-non-repo #11405 tests are unchanged. Fixtures were corrected to faithful reproductions after review found an invented `EACCES` stderr string that git never actually emits on this path.

Locally: 9635 tests pass across workspace-host, window, services, sidebar, and shared suites; typecheck clean; prettier clean; eslint 0 errors on changed files.
