### PR TITLE
fix(resource-badge): stop the cached-view poll and drop the biased memory number

### DIFF
--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -484,6 +484,11 @@ export function ProjectResourceBadge() {
     let cancelled = false;
 
     const fetchPopoverData = async () => {
+      // Guarded in the body, not only by the `open` teardown: closing on the
+      // cached phase costs a render pass, so a tick already queued when the
+      // view cached would still fire, and a hidden window suppresses nothing
+      // here at all — Radix keeps the popover open across both.
+      if (document.hidden || isProjectViewCached()) return;
       try {
         const [processMetrics, heapStats, diagnosticsInfo, snapshot] = await Promise.all([
           systemClient.getProcessMetrics(),

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -368,8 +368,12 @@ export function ProjectResourceBadge() {
 
   useEffect(() => {
     let cancelled = false;
-    let pending = false;
     let interval: ReturnType<typeof setInterval> | null = null;
+    // Suppression starts a new epoch. A request in flight across one is stale by
+    // an unbounded amount, so it must neither be applied on the other side nor
+    // coalesce against the resume refresh.
+    let generation = 0;
+    let inFlightGen: number | null = null;
 
     // Two independent suppressions, AND'd. `document.hidden` catches a
     // minimized/occluded window; it cannot catch a cached project view, which
@@ -384,24 +388,29 @@ export function ProjectResourceBadge() {
       // the resume paths too, and clearing an interval can't retract a callback
       // the event loop has already picked up.
       if (cancelled || !shouldPoll()) return;
-      // Skip if a previous poll is still in flight so a slow IPC round-trip
-      // can't stack overlapping calls or write results out of order.
-      if (pending) return;
-      pending = true;
+      // Skip if a poll from this epoch is still in flight so a slow IPC
+      // round-trip can't stack overlapping calls or write results out of order.
+      // Scoped to the epoch: a request stranded by a pause must not hold the
+      // resume's immediate refresh hostage for a whole interval.
+      if (inFlightGen === generation) return;
+      const gen = generation;
+      inFlightGen = gen;
       try {
         const result = await fetchStats();
-        if (!cancelled && result) {
-          samplesRef.current = result.nextSamples;
-          setSamples(result.nextSamples);
-          setStats({
-            runningProjects: result.runningProjects,
-            totalMemoryMB: result.totalMemoryMB,
-            projects: result.projects,
-          });
-          setIsLoading(false);
-        }
+        // A result that lands after its epoch closed carries a pre-pause
+        // reading, and the resume already cleared the trend window it would
+        // seed — dropping it is the other half of that discard.
+        if (cancelled || gen !== generation || !result) return;
+        samplesRef.current = result.nextSamples;
+        setSamples(result.nextSamples);
+        setStats({
+          runningProjects: result.runningProjects,
+          totalMemoryMB: result.totalMemoryMB,
+          projects: result.projects,
+        });
+        setIsLoading(false);
       } finally {
-        pending = false;
+        if (inFlightGen === gen) inFlightGen = null;
       }
     };
 
@@ -409,6 +418,7 @@ export function ProjectResourceBadge() {
       if (interval === null) return;
       clearInterval(interval);
       interval = null;
+      generation++;
     };
 
     // Single entry point for both gates so a repeated signal — visible while
@@ -452,6 +462,19 @@ export function ProjectResourceBadge() {
       stopInterval();
     };
   }, [fetchStats]);
+
+  // The popover's own 4s poll and 1s freshness tick are gated on `open` alone,
+  // and caching a view is `removeChildView` + `setVisible(false)` — no
+  // interaction inside this document, so Radix never sees a dismiss. Left open,
+  // it would out-poll the badge loop gated above in a view nobody can see.
+  // Closing is also what the switch implies: the user left this project.
+  useEffect(
+    () =>
+      subscribeProjectViewLifecycle((phase) => {
+        if (phase === "cached") setOpen(false);
+      }),
+    []
+  );
 
   // Stale-while-revalidate: keep the last snapshot across closes so reopening
   // shows data instantly; the poll below refreshes it silently.

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -4,6 +4,7 @@ import { useProjectStatsStore } from "@/store/projectStatsStore";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { logError } from "@/utils/logger";
+import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 import type { ProcessMetricEntry, HeapStats, DiagnosticsInfo } from "@shared/types/ipc/system";
 import type { BulkProjectStatsEntry } from "@shared/types/ipc/project";
 import type {
@@ -41,18 +42,6 @@ const STATE_DOT_CLASSES: Record<MemoryState, string> = {
   normal: "bg-daintree-text/25",
   elevated: "bg-daintree-text/25",
   critical: "bg-daintree-text/25",
-};
-
-const STATE_TEXT_CLASSES: Record<MemoryState, string> = {
-  normal: "text-daintree-text/30",
-  elevated: "text-daintree-text/30",
-  critical: "text-daintree-text/30",
-};
-
-const TREND_ARROWS: Record<TrendDirection, string> = {
-  up: "\u2191",
-  down: "\u2193",
-  stable: "",
 };
 
 interface AggregateStats {
@@ -101,9 +90,9 @@ function HeapBar({ heapStats }: { heapStats: HeapStats }) {
 
 function MemoryRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-center justify-between text-[10px]">
-      <span className="text-daintree-text/50">{label}</span>
-      <span className="font-mono tabular-nums text-daintree-text/40">{value}</span>
+    <div className="flex items-center justify-between gap-2 text-[10px]">
+      <span className="text-daintree-text/50 leading-tight">{label}</span>
+      <span className="font-mono tabular-nums text-daintree-text/40 shrink-0">{value}</span>
     </div>
   );
 }
@@ -144,7 +133,10 @@ function MemorySummary({
 
   return (
     <div className="space-y-1">
-      <MemoryRow label="Daintree app memory" value={formatMemory(appMemoryMB)} />
+      <MemoryRow
+        label="Working set (sums shared pages per process)"
+        value={formatMemory(appMemoryMB)}
+      />
       {(workloads !== null || shown !== null) && (
         <MemoryRow
           label="Terminal workloads"
@@ -379,7 +371,19 @@ export function ProjectResourceBadge() {
     let pending = false;
     let interval: ReturnType<typeof setInterval> | null = null;
 
+    // Two independent suppressions, AND'd. `document.hidden` catches a
+    // minimized/occluded window; it cannot catch a cached project view, which
+    // keeps reporting "visible" because caching is `removeChildView` +
+    // `setVisible(false)` and Chromium tracks occlusion per BrowserWindow
+    // (#11212). Polling a cached view charges main a full process-table walk
+    // per interval for a readout nobody can see.
+    const shouldPoll = () => !document.hidden && !isProjectViewCached();
+
     const runFetch = async () => {
+      // Re-checked here, not just where the interval is cleared: this runs from
+      // the resume paths too, and clearing an interval can't retract a callback
+      // the event loop has already picked up.
+      if (cancelled || !shouldPoll()) return;
       // Skip if a previous poll is still in flight so a slow IPC round-trip
       // can't stack overlapping calls or write results out of order.
       if (pending) return;
@@ -401,40 +405,50 @@ export function ProjectResourceBadge() {
       }
     };
 
-    const startInterval = () => {
-      if (interval !== null) return;
-      interval = setInterval(() => void runFetch(), BADGE_POLL_MS);
-    };
-
     const stopInterval = () => {
       if (interval === null) return;
       clearInterval(interval);
       interval = null;
     };
 
-    const handleVisibility = () => {
-      if (document.hidden) {
+    // Single entry point for both gates so a repeated signal — visible while
+    // already visible, `revealed` right after `active` — can't stack intervals
+    // or double-fetch. The interval handle is the polling-state sentinel.
+    const syncPolling = () => {
+      if (!shouldPoll()) {
         stopInterval();
-      } else {
-        // The poll pauses while hidden, so pre-hide samples are arbitrarily old
-        // relative to the resumed cadence — drop them so the trend slope isn't
-        // computed across the gap.
+        return;
+      }
+      if (interval !== null) return;
+
+      // The poll pauses while suppressed, so pre-pause samples are arbitrarily
+      // old relative to the resumed cadence — drop them so the trend slope
+      // isn't computed across the gap.
+      if (samplesRef.current.length > 0) {
         samplesRef.current = [];
         setSamples([]);
-        void runFetch();
-        startInterval();
       }
+      // Arm the sentinel before the immediate fetch so a signal arriving during
+      // that round-trip sees polling as already started.
+      interval = setInterval(() => void runFetch(), BADGE_POLL_MS);
+      void runFetch();
     };
 
+    const handleVisibility = () => syncPolling();
+    // Resume on any non-cached phase, not just `revealed`: a switch superseded
+    // mid-flight only ever reaches `active`, and keying resume on `revealed`
+    // would leave a reactivated view demoted forever.
+    const offViewLifecycle = subscribeProjectViewLifecycle(() => syncPolling());
+
     document.addEventListener("visibilitychange", handleVisibility);
-    if (!document.hidden) {
-      void runFetch();
-      startInterval();
-    }
+    // Not an early return when already cached — that would skip the
+    // subscription above and strand the badge. `syncPolling` declines instead.
+    syncPolling();
 
     return () => {
       cancelled = true;
       document.removeEventListener("visibilitychange", handleVisibility);
+      offViewLifecycle();
       stopInterval();
     };
   }, [fetchStats]);
@@ -502,7 +516,7 @@ export function ProjectResourceBadge() {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button className="px-4 py-2 border-t border-divider surface-chrome flex items-center justify-between shrink-0 w-full hover:bg-daintree-text/[0.02] transition-colors cursor-pointer">
+        <button className="px-4 py-2 border-t border-divider surface-chrome flex items-center shrink-0 w-full hover:bg-daintree-text/[0.02] transition-colors cursor-pointer">
           <div className="flex items-center gap-2 min-w-0">
             <span
               key={memoryState}
@@ -511,12 +525,6 @@ export function ProjectResourceBadge() {
             <span className="text-[10px] tabular-nums text-daintree-text/40 font-medium truncate">
               {stats.runningProjects} project{stats.runningProjects !== 1 ? "s" : ""} active
             </span>
-          </div>
-          <div
-            className={`text-[10px] font-mono tabular-nums tracking-tight shrink-0 ${STATE_TEXT_CLASSES[memoryState]}`}
-          >
-            {trend !== "stable" && <span className="mr-0.5">{TREND_ARROWS[trend]}</span>}
-            {formatMemory(stats.totalMemoryMB)}
           </div>
         </button>
       </PopoverTrigger>

--- a/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
@@ -160,7 +160,7 @@ function emitCached(): void {
 
 function findMemoryRow(container: HTMLElement, value: string): HTMLElement | undefined {
   return Array.from(container.querySelectorAll("div")).find(
-    (el) => el.children.length === 2 && el.children[1].textContent === value
+    (el) => el.children.length === 2 && el.children[1]?.textContent === value
   );
 }
 
@@ -234,7 +234,7 @@ describe("ProjectResourceBadge — popover memory honesty", () => {
     // disclose the double-count instead of claiming a footprint it isn't.
     const workingSetRow = findMemoryRow(container, "300MB");
     expect(workingSetRow).toBeDefined();
-    const workingSetLabel = workingSetRow?.children[0].textContent?.toLowerCase() ?? "";
+    const workingSetLabel = workingSetRow?.children[0]?.textContent?.toLowerCase() ?? "";
     expect(workingSetLabel).toContain("working set");
     expect(workingSetLabel).toContain("shared pages");
     expect(workingSetLabel).not.toContain("app memory");

--- a/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@/components/ui/popover", () => ({
 }));
 
 import { projectClient, systemClient } from "@/clients";
+import { __resetProjectViewCacheStateForTests } from "@/lib/viewCacheState";
 import type { Project } from "@shared/types";
 import type { BulkProjectStatsEntry } from "@shared/types/ipc/project";
 import type {
@@ -147,8 +148,35 @@ async function renderOpenBadge(): Promise<HTMLElement> {
   return container;
 }
 
+// Drives the real `viewCacheState` singleton through its preload boundary, the
+// same way ProjectResourceBadge.test.tsx does.
+let cachedHandlers: Set<() => void>;
+
+function emitCached(): void {
+  Array.from(cachedHandlers).forEach((h) => h());
+}
+
+function findMemoryRow(container: HTMLElement, value: string): HTMLElement | undefined {
+  return Array.from(container.querySelectorAll("div")).find(
+    (el) => el.children.length === 2 && el.children[1].textContent === value
+  );
+}
+
 function setupDefaultMocks(): void {
   vi.useFakeTimers();
+  cachedHandlers = new Set();
+  vi.stubGlobal("electron", {
+    app: {
+      onViewCached: (cb: () => void) => {
+        cachedHandlers.add(cb);
+        return () => cachedHandlers.delete(cb);
+      },
+      onViewWarmActivated: () => () => {},
+      onViewRevealed: () => () => {},
+      isViewCached: () => false,
+    },
+  });
+  __resetProjectViewCacheStateForTests();
   mockGetAll.mockReset().mockResolvedValue([makeProject()]);
   mockGetBulkStats.mockReset().mockResolvedValue({
     p1: makeBulkStatsEntry({
@@ -173,6 +201,9 @@ function setupDefaultMocks(): void {
 }
 
 function restoreTimersAndMocks(): void {
+  // Reset before unstubbing so the singleton still has a bridge to detach from.
+  __resetProjectViewCacheStateForTests();
+  vi.unstubAllGlobals();
   vi.useRealTimers();
   vi.restoreAllMocks();
 }
@@ -185,14 +216,47 @@ describe("ProjectResourceBadge — popover memory honesty", () => {
   it("labels measured app and workload memory from the composite snapshot", async () => {
     const container = await renderOpenBadge();
 
-    expect(container.textContent).toContain("Working set (sums shared pages per process)");
-    expect(container.textContent).toContain("300MB");
+    // Scoped to the row carrying the measured figure, and asserted on meaning
+    // rather than the exact sentence: the row must name what it measures and
+    // disclose the double-count instead of claiming a footprint it isn't.
+    const workingSetRow = findMemoryRow(container, "300MB");
+    expect(workingSetRow).toBeDefined();
+    const workingSetLabel = workingSetRow?.children[0].textContent?.toLowerCase() ?? "";
+    expect(workingSetLabel).toContain("working set");
+    expect(workingSetLabel).toContain("shared pages");
+    expect(workingSetLabel).not.toContain("app memory");
     expect(container.textContent).toContain("Terminal workloads");
     expect(container.textContent).toContain("900MB");
     // Measured per-project value renders without the estimate marker or legend.
     expect(container.textContent).toContain("750MB");
     expect(container.textContent).not.toContain("~");
     expect(container.textContent).not.toContain("estimated from terminal count");
+  });
+
+  it("stops the popover poll when the project view is cached", async () => {
+    await renderOpenBadge();
+    const onOpen = mockGetMemorySnapshot.mock.calls.length;
+    expect(onOpen).toBeGreaterThanOrEqual(1);
+
+    // Positive control: the 4s poll really is running while open.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000);
+    });
+    const whilePolling = mockGetMemorySnapshot.mock.calls.length;
+    expect(whilePolling).toBeGreaterThan(onOpen);
+
+    await act(async () => {
+      emitCached();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000);
+    });
+
+    // Caching is `removeChildView` + `setVisible(false)` — no interaction in
+    // this document, so Radix never dismisses on its own and this poll would
+    // otherwise outrun the badge poll in a view nobody can see.
+    expect(mockGetMemorySnapshot.mock.calls.length).toBe(whilePolling);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("shows Unavailable instead of a fake zero when nothing was ever measured", async () => {

--- a/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
@@ -151,6 +151,8 @@ async function renderOpenBadge(): Promise<HTMLElement> {
 // Drives the real `viewCacheState` singleton through its preload boundary, the
 // same way ProjectResourceBadge.test.tsx does.
 let cachedHandlers: Set<() => void>;
+let documentHidden = false;
+let originalHidden: boolean;
 
 function emitCached(): void {
   Array.from(cachedHandlers).forEach((h) => h());
@@ -165,6 +167,12 @@ function findMemoryRow(container: HTMLElement, value: string): HTMLElement | und
 function setupDefaultMocks(): void {
   vi.useFakeTimers();
   cachedHandlers = new Set();
+  documentHidden = false;
+  originalHidden = document.hidden;
+  Object.defineProperty(document, "hidden", {
+    get: () => documentHidden,
+    configurable: true,
+  });
   vi.stubGlobal("electron", {
     app: {
       onViewCached: (cb: () => void) => {
@@ -201,6 +209,11 @@ function setupDefaultMocks(): void {
 }
 
 function restoreTimersAndMocks(): void {
+  Object.defineProperty(document, "hidden", {
+    value: originalHidden,
+    configurable: true,
+    writable: true,
+  });
   // Reset before unstubbing so the singleton still has a bridge to detach from.
   __resetProjectViewCacheStateForTests();
   vi.unstubAllGlobals();
@@ -257,6 +270,31 @@ describe("ProjectResourceBadge — popover memory honesty", () => {
     // otherwise outrun the badge poll in a view nobody can see.
     expect(mockGetMemorySnapshot.mock.calls.length).toBe(whilePolling);
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("skips the popover poll while the window is hidden, and resumes after", async () => {
+    await renderOpenBadge();
+    const onOpen = mockGetMemorySnapshot.mock.calls.length;
+
+    // Positive control: the 4s poll is running.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000);
+    });
+    const whileVisible = mockGetMemorySnapshot.mock.calls.length;
+    expect(whileVisible).toBeGreaterThan(onOpen);
+
+    documentHidden = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000);
+    });
+    expect(mockGetMemorySnapshot.mock.calls.length).toBe(whileVisible);
+
+    // Nothing was torn down, so it picks back up without a reopen.
+    documentHidden = false;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000);
+    });
+    expect(mockGetMemorySnapshot.mock.calls.length).toBeGreaterThan(whileVisible);
   });
 
   it("shows Unavailable instead of a fake zero when nothing was ever measured", async () => {

--- a/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
@@ -185,7 +185,7 @@ describe("ProjectResourceBadge — popover memory honesty", () => {
   it("labels measured app and workload memory from the composite snapshot", async () => {
     const container = await renderOpenBadge();
 
-    expect(container.textContent).toContain("Daintree app memory");
+    expect(container.textContent).toContain("Working set (sums shared pages per process)");
     expect(container.textContent).toContain("300MB");
     expect(container.textContent).toContain("Terminal workloads");
     expect(container.textContent).toContain("900MB");

--- a/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
@@ -4,7 +4,7 @@
  *
  * Issue #6212: the 10s badge poll must pause while the project view is hidden
  * so we don't burn renderer CPU on inactive projects. The 4s popover sub-poll
- * is already gated on `open` and is intentionally untested here.
+ * is gated on `open` and is covered in ProjectResourceBadge.popover.test.tsx.
  *
  * Issue #11925: `document.hidden` alone can't see a cached project view — main
  * caches with `removeChildView` + `setVisible(false)`, neither of which flips
@@ -13,6 +13,10 @@
  * and a cached view suppress it independently. The same issue took the absolute
  * memory figure and trend arrow off the collapsed trigger, so the trigger now
  * carries only the state dot and the running-project count.
+ *
+ * Timer counts are asserted alongside call counts throughout: IPC counts alone
+ * can't distinguish "one interval" from "three intervals whose extra callbacks
+ * were swallowed by the in-flight guard".
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
@@ -193,12 +197,15 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     });
   }
 
+  /**
+   * Async advancement, deliberately: the sync variant fires every armed
+   * interval before any microtask runs, so a duplicate interval's callback
+   * would be swallowed by the in-flight guard and the extra timer would go
+   * unnoticed.
+   */
   async function advance(ms: number) {
     await act(async () => {
-      vi.advanceTimersByTime(ms);
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(ms);
     });
   }
 
@@ -207,11 +214,8 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
 
     render(<ProjectResourceBadge />);
 
-    await act(async () => {
-      await Promise.resolve();
-      vi.advanceTimersByTime(30_000);
-      await Promise.resolve();
-    });
+    await flush();
+    await advance(30_000);
 
     expect(mockGetAll).not.toHaveBeenCalled();
     expect(mockGetAppMetrics).not.toHaveBeenCalled();
@@ -225,27 +229,32 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     await advance(30_000);
 
     expect(mockGetAll).not.toHaveBeenCalled();
-    expect(mockGetAppMetrics).not.toHaveBeenCalled();
+
+    // Positive control: the same lifecycle route the assertions above rely on
+    // does start polling once the visibility gate opens, so "no calls" was a
+    // real suppression and not dead wiring.
+    visibilityState = "visible";
+    await act(async () => {
+      emitRevealed();
+    });
+    await flush();
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
   });
 
   it("stops polling when document becomes hidden after mount", async () => {
     render(<ProjectResourceBadge />);
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flush();
     const callsBeforeHide = mockGetAll.mock.calls.length;
     expect(callsBeforeHide).toBeGreaterThanOrEqual(1);
+    expect(vi.getTimerCount()).toBe(1);
 
     await act(async () => {
       fireVisibilityChange("hidden");
     });
+    expect(vi.getTimerCount()).toBe(0);
 
-    await act(async () => {
-      vi.advanceTimersByTime(30_000);
-      await Promise.resolve();
-    });
+    await advance(30_000);
 
     // No additional polls while hidden.
     expect(mockGetAll.mock.calls.length).toBe(callsBeforeHide);
@@ -256,28 +265,21 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
 
     render(<ProjectResourceBadge />);
 
-    await act(async () => {
-      await Promise.resolve();
-      vi.advanceTimersByTime(15_000);
-      await Promise.resolve();
-    });
+    await flush();
+    await advance(15_000);
     expect(mockGetAll).not.toHaveBeenCalled();
 
     await act(async () => {
       fireVisibilityChange("visible");
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    await flush();
     // Immediate fetch on restore.
-    expect(mockGetAll.mock.calls.length).toBeGreaterThanOrEqual(1);
-    const callsAfterRestore = mockGetAll.mock.calls.length;
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
 
-    // Polling resumes.
-    await act(async () => {
-      vi.advanceTimersByTime(10_000);
-      await Promise.resolve();
-    });
-    expect(mockGetAll.mock.calls.length).toBeGreaterThan(callsAfterRestore);
+    // Polling resumes, at one poll per period.
+    mockGetAll.mockClear();
+    await advance(10_000);
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
   });
 
   it("does not poll when mounted while the project view is cached", async () => {
@@ -293,6 +295,16 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     expect(visibilityState).toBe("visible");
     expect(mockGetAll).not.toHaveBeenCalled();
     expect(mockGetAppMetrics).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Positive control: the effect did mount and did subscribe — it was the
+    // seeded cache latch suppressing it, not absent wiring.
+    await act(async () => {
+      emitWarmActivated();
+    });
+    await flush();
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
   });
 
   it("stops polling when the project view becomes cached", async () => {
@@ -302,12 +314,17 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     const callsBeforeCache = mockGetAll.mock.calls.length;
     const metricCallsBeforeCache = mockGetAppMetrics.mock.calls.length;
     expect(callsBeforeCache).toBeGreaterThanOrEqual(1);
+    expect(vi.getTimerCount()).toBe(1);
 
     await act(async () => {
       emitCached();
     });
-    await advance(30_000);
 
+    // The interval is actually torn down, not merely short-circuited in its
+    // body — a cached view should own no armed timer at all.
+    expect(vi.getTimerCount()).toBe(0);
+
+    await advance(30_000);
     expect(mockGetAll.mock.calls.length).toBe(callsBeforeCache);
     expect(mockGetAppMetrics.mock.calls.length).toBe(metricCallsBeforeCache);
   });
@@ -330,6 +347,7 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
 
     expect(mockGetAll).toHaveBeenCalledTimes(1);
     expect(mockGetAppMetrics).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
 
     mockGetAll.mockClear();
     mockGetAppMetrics.mockClear();
@@ -338,6 +356,7 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     // One interval, so exactly one poll per period.
     expect(mockGetAll).toHaveBeenCalledTimes(1);
     expect(mockGetAppMetrics).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
   });
 
   it("resumes on reveal when warm activation was never observed", async () => {
@@ -353,6 +372,7 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     await flush();
 
     expect(mockGetAll).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
 
     mockGetAll.mockClear();
     await advance(10_000);
@@ -372,19 +392,100 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     await advance(30_000);
     expect(mockGetAll).not.toHaveBeenCalled();
 
-    // Reactivated, but the window is still hidden — still no polling.
-    await act(async () => {
-      emitWarmActivated();
-    });
-    await advance(30_000);
-    expect(mockGetAll).not.toHaveBeenCalled();
-
-    // Both gates clear.
+    // Visibility restored first, cache gate still closed. If the cache half
+    // were broken this would resume here — which is exactly the pre-fix bug.
     await act(async () => {
       fireVisibilityChange("visible");
     });
+    await advance(30_000);
+    expect(mockGetAll).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Second gate clears.
+    await act(async () => {
+      emitWarmActivated();
+    });
     await flush();
-    expect(mockGetAll.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores an interval callback that was already queued when the view cached", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    render(<ProjectResourceBadge />);
+    await flush();
+
+    const armed = setIntervalSpy.mock.calls.find((call) => call[1] === 10_000);
+    expect(armed).toBeDefined();
+    const tick = armed![0] as () => void;
+
+    // Positive control: this really is the live poll callback.
+    mockGetAll.mockClear();
+    await act(async () => {
+      tick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      emitCached();
+    });
+
+    // clearInterval can't retract a callback the event loop already picked up,
+    // so the body has to re-check the gates itself.
+    mockGetAll.mockClear();
+    await act(async () => {
+      tick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockGetAll).not.toHaveBeenCalled();
+  });
+
+  it("refetches on resume and drops a poll left in flight across the pause", async () => {
+    const stalled = [
+      makeProject({ id: "a", name: "A" }),
+      makeProject({ id: "b", name: "B" }),
+      makeProject({ id: "c", name: "C" }),
+    ];
+    statsStoreState.stats = {
+      a: { processCount: 1 },
+      b: { processCount: 1 },
+      c: { processCount: 1 },
+    };
+
+    let releaseStalled: (projects: Project[]) => void = () => {};
+    const stalledFetch = new Promise<Project[]>((resolve) => {
+      releaseStalled = resolve;
+    });
+    mockGetAll.mockReturnValueOnce(stalledFetch).mockResolvedValue([stalled[0]]);
+
+    const { container } = render(<ProjectResourceBadge />);
+    await flush();
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      emitCached();
+    });
+    await act(async () => {
+      emitWarmActivated();
+    });
+    await flush();
+
+    // The stranded request must not hold the resume refresh hostage for a whole
+    // interval — the badge would otherwise show pre-pause numbers for 10s.
+    expect(mockGetAll).toHaveBeenCalledTimes(2);
+    expect(container.querySelector("button")?.textContent).toBe("1 project active");
+
+    await act(async () => {
+      releaseStalled(stalled);
+    });
+    await flush();
+
+    // The pre-pause result lands last but is discarded: applying it would both
+    // rewrite the count and seed the trend window the resume just cleared.
+    expect(container.querySelector("button")?.textContent).toBe("1 project active");
   });
 
   it("keeps one interval across a StrictMode double mount", async () => {
@@ -395,20 +496,24 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     );
     await flush();
 
+    // Precondition: the effect really did run twice (vitest.config.ts pins
+    // NODE_ENV=development, so React double-invokes). If this drifts to one,
+    // the assertion below stops testing double-mount cleanup.
+    expect(mockGetAll).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(1);
+
     mockGetAll.mockClear();
     await advance(10_000);
 
     // A leaked interval from the discarded first mount would double this.
     expect(mockGetAll).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
   });
 
   it("probes hardware info once at mount to scale thresholds to the machine", async () => {
     render(<ProjectResourceBadge />);
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flush();
 
     expect(mockGetHardwareInfo).toHaveBeenCalledTimes(1);
   });
@@ -418,33 +523,40 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
 
     render(<ProjectResourceBadge />);
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flush();
 
     // Badge still polls stats using the fallback thresholds.
     expect(mockGetAll.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders only the running-project count on the collapsed trigger", async () => {
-    mockGetAll.mockResolvedValue([makeProject({ id: "p1", name: "Proj One" })]);
-    statsStoreState.stats = { p1: { processCount: 1 } };
-    mockGetAppMetrics.mockResolvedValue({ totalMemoryMB: 290 });
+    const projects = [
+      makeProject({ id: "p1", name: "Proj One" }),
+      makeProject({ id: "p2", name: "Proj Two" }),
+    ];
+    mockGetAll.mockResolvedValue(projects);
+    statsStoreState.stats = { p1: { processCount: 1 }, p2: { processCount: 3 } };
+    // A steadily rising series, so the trend the popover reports is "up" — the
+    // condition under which the removed trigger arrow used to render.
+    mockGetAppMetrics
+      .mockResolvedValueOnce({ totalMemoryMB: 200 })
+      .mockResolvedValueOnce({ totalMemoryMB: 400 })
+      .mockResolvedValue({ totalMemoryMB: 600 });
 
     const { container } = render(<ProjectResourceBadge />);
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flush();
+    await advance(10_000);
+    await advance(10_000);
 
-    // The reading is still collected — it drives the dot's state and the
-    // popover — but the trigger deliberately withholds it. Summed working set
-    // double-counts shared pages, so it isn't a footprint figure to lead with.
     const trigger = container.querySelector("button");
     expect(trigger).not.toBeNull();
-    expect(trigger?.textContent).toBe("1 project active");
+    // The reading is still collected — it drives the dot and the popover — but
+    // the trigger withholds it: summed working set double-counts shared pages,
+    // so it isn't a footprint figure to lead with.
+    expect(trigger?.textContent).toContain(`${projects.length} projects active`);
+    expect(trigger?.textContent).not.toMatch(/\d+\s*(MB|GB)/);
+    expect(trigger?.textContent).not.toMatch(/[↑↓]/);
   });
 
   it("suppresses the value (stays hidden) when metrics are unavailable", async () => {
@@ -454,10 +566,7 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
 
     const { container } = render(<ProjectResourceBadge />);
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flush();
 
     // No misleading "0MB"; the badge withholds the reading entirely.
     expect(container.textContent ?? "").not.toContain("0MB");
@@ -476,7 +585,20 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     const { unmount } = render(<ProjectResourceBadge />);
     await flush();
 
+    // Positive control: the lifecycle route is live while mounted, so the
+    // silence after unmount is an unsubscribe and not a broken bridge.
+    await act(async () => {
+      emitCached();
+    });
+    expect(vi.getTimerCount()).toBe(0);
+    await act(async () => {
+      emitWarmActivated();
+    });
+    await flush();
+    expect(vi.getTimerCount()).toBe(1);
+
     unmount();
+    expect(vi.getTimerCount()).toBe(0);
     mockGetAll.mockClear();
 
     await act(async () => {
@@ -487,5 +609,6 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     await advance(30_000);
 
     expect(mockGetAll).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
@@ -448,8 +448,9 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
   });
 
   it("refetches on resume and drops a poll left in flight across the pause", async () => {
+    const survivor = makeProject({ id: "a", name: "A" });
     const stalled = [
-      makeProject({ id: "a", name: "A" }),
+      survivor,
       makeProject({ id: "b", name: "B" }),
       makeProject({ id: "c", name: "C" }),
     ];
@@ -463,7 +464,7 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     const stalledFetch = new Promise<Project[]>((resolve) => {
       releaseStalled = resolve;
     });
-    mockGetAll.mockReturnValueOnce(stalledFetch).mockResolvedValue([stalled[0]]);
+    mockGetAll.mockReturnValueOnce(stalledFetch).mockResolvedValue([survivor]);
 
     const { container } = render(<ProjectResourceBadge />);
     await flush();

--- a/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
@@ -418,6 +418,10 @@ describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
     const armed = setIntervalSpy.mock.calls.find((call) => call[1] === 10_000);
     expect(armed).toBeDefined();
     const tick = armed![0] as () => void;
+    // Released here, not in teardown: `restoreAllMocks` runs after
+    // `useRealTimers`, so it would put this spy's original — an uninstalled
+    // fake `setInterval` — back on the global.
+    setIntervalSpy.mockRestore();
 
     // Positive control: this really is the live poll callback.
     mockGetAll.mockClear();

--- a/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
@@ -1,14 +1,22 @@
 // @vitest-environment jsdom
 /**
- * ProjectResourceBadge — visibility-aware polling.
+ * ProjectResourceBadge — visibility- and cache-aware polling.
  *
  * Issue #6212: the 10s badge poll must pause while the project view is hidden
  * so we don't burn renderer CPU on inactive projects. The 4s popover sub-poll
  * is already gated on `open` and is intentionally untested here.
+ *
+ * Issue #11925: `document.hidden` alone can't see a cached project view — main
+ * caches with `removeChildView` + `setVisible(false)`, neither of which flips
+ * page visibility, so the #6212 gate was dead code in exactly the case it was
+ * written for. The poll is now gated on both signals, AND'd: a minimized window
+ * and a cached view suppress it independently. The same issue took the absolute
+ * memory figure and trend arrow off the collapsed trigger, so the trigger now
+ * carries only the state dot and the running-project count.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
-import { act } from "react";
+import { act, StrictMode } from "react";
 
 vi.mock("@/clients", () => ({
   projectClient: {
@@ -38,6 +46,7 @@ vi.mock("@/components/ui/popover", () => ({
 }));
 
 import { projectClient, systemClient } from "@/clients";
+import { __resetProjectViewCacheStateForTests } from "@/lib/viewCacheState";
 import type { Project } from "@shared/types";
 import { ProjectResourceBadge } from "../ProjectResourceBadge";
 
@@ -58,10 +67,18 @@ function makeProject(overrides: Partial<Project> = {}): Project {
   };
 }
 
-describe("ProjectResourceBadge — visibility-aware polling", () => {
+describe("ProjectResourceBadge — visibility- and cache-aware polling", () => {
   let originalHidden: boolean;
   let visibilityState: DocumentVisibilityState;
   let visibilityListeners: Array<() => void>;
+  // Drives the real `viewCacheState` singleton through its preload boundary
+  // rather than mocking the module: the seed latch, the "state updates before
+  // listeners fire" ordering, and the unsubscribe are all part of what's under
+  // test here. Mirrors TerminalReconciliationWatchdog.test.ts.
+  let latchedCached: boolean;
+  let cachedHandlers: Set<() => void>;
+  let warmHandlers: Set<() => void>;
+  let revealedHandlers: Set<() => void>;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -93,6 +110,34 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
       return origRemove(type, handler, options);
     });
 
+    latchedCached = false;
+    cachedHandlers = new Set();
+    warmHandlers = new Set();
+    revealedHandlers = new Set();
+    vi.stubGlobal("electron", {
+      app: {
+        onViewCached: (cb: () => void) => {
+          cachedHandlers.add(cb);
+          return () => cachedHandlers.delete(cb);
+        },
+        onViewWarmActivated: (cb: () => void) => {
+          warmHandlers.add(cb);
+          return () => warmHandlers.delete(cb);
+        },
+        onViewRevealed: (cb: () => void) => {
+          revealedHandlers.add(cb);
+          return () => revealedHandlers.delete(cb);
+        },
+        // Preload's latch. Setting this before render reproduces the switch
+        // storm where the view was cached before this module ever evaluated,
+        // so no "cached" phase is ever delivered.
+        isViewCached: () => latchedCached,
+      },
+    });
+    // The singleton arms on first use and stays armed for the module's life,
+    // so an earlier test's arming would otherwise bind to a dead bridge.
+    __resetProjectViewCacheStateForTests();
+
     mockGetAll.mockReset();
     mockGetAll.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
@@ -106,6 +151,10 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
   });
 
   afterEach(() => {
+    // Reset before unstubbing so the singleton's stored unsubscribes still
+    // have a bridge to detach from.
+    __resetProjectViewCacheStateForTests();
+    vi.unstubAllGlobals();
     vi.useRealTimers();
     vi.restoreAllMocks();
     Object.defineProperty(document, "hidden", {
@@ -120,6 +169,39 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
     visibilityListeners.forEach((l) => l());
   }
 
+  function emitCached() {
+    latchedCached = true;
+    Array.from(cachedHandlers).forEach((h) => h());
+  }
+
+  function emitWarmActivated() {
+    latchedCached = false;
+    Array.from(warmHandlers).forEach((h) => h());
+  }
+
+  function emitRevealed() {
+    latchedCached = false;
+    Array.from(revealedHandlers).forEach((h) => h());
+  }
+
+  /** Let the poll's `Promise.all` fan-out and the state writes behind it settle. */
+  async function flush() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  async function advance(ms: number) {
+    await act(async () => {
+      vi.advanceTimersByTime(ms);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
   it("does not call getAll when mounted while hidden", async () => {
     visibilityState = "hidden";
 
@@ -130,6 +212,17 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
       vi.advanceTimersByTime(30_000);
       await Promise.resolve();
     });
+
+    expect(mockGetAll).not.toHaveBeenCalled();
+    expect(mockGetAppMetrics).not.toHaveBeenCalled();
+
+    // A non-cached lifecycle phase must not override the visibility gate — the
+    // two suppressions are AND'd, not alternatives.
+    await act(async () => {
+      emitWarmActivated();
+      emitRevealed();
+    });
+    await advance(30_000);
 
     expect(mockGetAll).not.toHaveBeenCalled();
     expect(mockGetAppMetrics).not.toHaveBeenCalled();
@@ -187,6 +280,128 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
     expect(mockGetAll.mock.calls.length).toBeGreaterThan(callsAfterRestore);
   });
 
+  it("does not poll when mounted while the project view is cached", async () => {
+    latchedCached = true;
+
+    render(<ProjectResourceBadge />);
+
+    await flush();
+    await advance(30_000);
+
+    // The view reports visibilityState "visible" throughout — only the cache
+    // signal can suppress this.
+    expect(visibilityState).toBe("visible");
+    expect(mockGetAll).not.toHaveBeenCalled();
+    expect(mockGetAppMetrics).not.toHaveBeenCalled();
+  });
+
+  it("stops polling when the project view becomes cached", async () => {
+    render(<ProjectResourceBadge />);
+
+    await flush();
+    const callsBeforeCache = mockGetAll.mock.calls.length;
+    const metricCallsBeforeCache = mockGetAppMetrics.mock.calls.length;
+    expect(callsBeforeCache).toBeGreaterThanOrEqual(1);
+
+    await act(async () => {
+      emitCached();
+    });
+    await advance(30_000);
+
+    expect(mockGetAll.mock.calls.length).toBe(callsBeforeCache);
+    expect(mockGetAppMetrics.mock.calls.length).toBe(metricCallsBeforeCache);
+  });
+
+  it("resumes once on warm activation and does not stack a second interval on reveal", async () => {
+    latchedCached = true;
+
+    render(<ProjectResourceBadge />);
+    await flush();
+    expect(mockGetAll).not.toHaveBeenCalled();
+
+    // `revealed` normally follows `active`, and a superseded switch can deliver
+    // `active` again — neither may start a second interval or a second fetch.
+    await act(async () => {
+      emitWarmActivated();
+      emitRevealed();
+      emitWarmActivated();
+    });
+    await flush();
+
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+    expect(mockGetAppMetrics).toHaveBeenCalledTimes(1);
+
+    mockGetAll.mockClear();
+    mockGetAppMetrics.mockClear();
+    await advance(10_000);
+
+    // One interval, so exactly one poll per period.
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+    expect(mockGetAppMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes on reveal when warm activation was never observed", async () => {
+    latchedCached = true;
+
+    render(<ProjectResourceBadge />);
+    await flush();
+    expect(mockGetAll).not.toHaveBeenCalled();
+
+    await act(async () => {
+      emitRevealed();
+    });
+    await flush();
+
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+
+    mockGetAll.mockClear();
+    await advance(10_000);
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays paused until both the cache gate and the visibility gate clear", async () => {
+    render(<ProjectResourceBadge />);
+    await flush();
+    expect(mockGetAll.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+    await act(async () => {
+      emitCached();
+      fireVisibilityChange("hidden");
+    });
+    mockGetAll.mockClear();
+    await advance(30_000);
+    expect(mockGetAll).not.toHaveBeenCalled();
+
+    // Reactivated, but the window is still hidden — still no polling.
+    await act(async () => {
+      emitWarmActivated();
+    });
+    await advance(30_000);
+    expect(mockGetAll).not.toHaveBeenCalled();
+
+    // Both gates clear.
+    await act(async () => {
+      fireVisibilityChange("visible");
+    });
+    await flush();
+    expect(mockGetAll.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("keeps one interval across a StrictMode double mount", async () => {
+    render(
+      <StrictMode>
+        <ProjectResourceBadge />
+      </StrictMode>
+    );
+    await flush();
+
+    mockGetAll.mockClear();
+    await advance(10_000);
+
+    // A leaked interval from the discarded first mount would double this.
+    expect(mockGetAll).toHaveBeenCalledTimes(1);
+  });
+
   it("probes hardware info once at mount to scale thresholds to the machine", async () => {
     render(<ProjectResourceBadge />);
 
@@ -212,7 +427,7 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
     expect(mockGetAll.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders the running-project count and memory once a project is active", async () => {
+  it("renders only the running-project count on the collapsed trigger", async () => {
     mockGetAll.mockResolvedValue([makeProject({ id: "p1", name: "Proj One" })]);
     statsStoreState.stats = { p1: { processCount: 1 } };
     mockGetAppMetrics.mockResolvedValue({ totalMemoryMB: 290 });
@@ -224,8 +439,12 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toContain("1 project active");
-    expect(container.textContent).toContain("290MB");
+    // The reading is still collected — it drives the dot's state and the
+    // popover — but the trigger deliberately withholds it. Summed working set
+    // double-counts shared pages, so it isn't a footprint figure to lead with.
+    const trigger = container.querySelector("button");
+    expect(trigger).not.toBeNull();
+    expect(trigger?.textContent).toBe("1 project active");
   });
 
   it("suppresses the value (stays hidden) when metrics are unavailable", async () => {
@@ -251,5 +470,22 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
 
     unmount();
     expect(visibilityListeners.length).toBe(0);
+  });
+
+  it("stops polling and ignores lifecycle phases after unmount", async () => {
+    const { unmount } = render(<ProjectResourceBadge />);
+    await flush();
+
+    unmount();
+    mockGetAll.mockClear();
+
+    await act(async () => {
+      emitCached();
+      emitWarmActivated();
+      emitRevealed();
+    });
+    await advance(30_000);
+
+    expect(mockGetAll).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- The sidebar memory badge summed `workingSetSize` across every Electron process, which double-counts shared framework and Blink pages once per process, and it showed that inflated absolute number by default.
- The badge also polled every 10 seconds in every cached project view, because its `document.hidden` gate never flips for a cached child `WebContentsView` (caching is `removeChildView` plus `setVisible(false)`, which Chromium doesn't treat as a document visibility change).
- This drops the misleading number from the default view and stops the dead polling, plus two more related bugs found while working through it.

Resolves #11925

## Changes

1. The collapsed trigger no longer shows the absolute MB figure or the trend arrow, just the state dot and an "N projects active" count. The reading is still collected: it drives the dot and the popover breakdown.
2. The poll is now gated on both `document.hidden` and a new `isProjectViewCached()` check (`src/lib/viewCacheState.ts`), AND'd rather than swapped in, since minimizing the window is a separate legitimate reason to suppress. The `visibilitychange` listener and a `subscribeProjectViewLifecycle` subscription both route through one idempotent `syncPolling()`, using the interval handle as state. The fetch body re-checks the gates too, since a queued interval tick can't be cancelled after the fact.
3. The popover row label changed from "Daintree app memory" to "Working set (sums shared pages per process)" so it stops contradicting the footnote directly below it.

Two more bugs turned up during review and are fixed here as well:

- An open popover kept its 4s metric poll and 1s freshness tick running after the view was cached, since caching doesn't involve any interaction that would let Radix dismiss it. It now closes on the cached phase, and `fetchPopoverData` guards itself against hidden-or-cached so a queued tick can't slip through anyway.
- The in-flight poll guard was a plain boolean spanning suppression periods, so a request stranded by a pause both blocked the resume's immediate refetch for a full interval and could land its stale pre-pause reading in the trend window the resume had just cleared. It's now scoped to a polling epoch that bumps on every suppression.

Native, per-process memory accounting (`phys_footprint` on macOS, `getProcessMemoryInfo().private`) stays out of scope, per the issue. `src/components/Diagnostics/WhySlowContent.tsx` has a separate `MetricTile` showing the same class of figure; that's left alone too, since the issue targets the sidebar badge specifically.

Files touched: `src/components/Project/ProjectResourceBadge.tsx`, `src/components/Project/__tests__/ProjectResourceBadge.test.tsx`, `src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx`.

## Testing

- `npm run typecheck`: exit 0, no errors.
- 80 tests passing across the badge component, popover, utils, sidebar context menu, and `viewCacheState` suites, plus 411 config contract tests.
- eslint and prettier clean on all three changed files (one pre-existing `no-unsafe-type-assertion` warning, unchanged from HEAD).
- Mutation tested: 8 mutations applied in isolation (removing the cache gate, the interval sentinel, the body re-guard, the epoch guard, the popover close, the popover body guard, restoring the trigger number, reverting the row label). Each was caught by exactly the test claiming to cover it, and the unmutated baseline was green.
