### PR TITLE
feat(switcher): give project search one-edit typo tolerance

### DIFF
--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -1059,7 +1059,10 @@ describe("scratches in search results", () => {
     act(() => result.current.setQuery("Spike 2"));
 
     await waitFor(() => {
-      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2"]);
+      // "Spike 1" is one substitution from "Spike 2", so it joins in the
+      // terminal typo tier (#11924) — behind the exact match, never in front
+      // of it, which is what keeps Enter committing the row that was typed.
+      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2", "scratch-1"]);
     });
     expect(result.current.results[0]!.kind).toBe("scratch");
   });
@@ -1102,7 +1105,11 @@ describe("scratches in search results", () => {
     const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
 
     act(() => result.current.setQuery("Spike 2"));
-    await waitFor(() => expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2"]));
+    await waitFor(() =>
+      // "Spike 1" trails as a one-edit near miss (#11924); the row under test
+      // is the exact match at the head.
+      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2", "scratch-1"])
+    );
 
     // A `scratch:removed` push under an open, settled query. Without the store
     // feeding the ranked list, the row would linger and Enter would commit a
@@ -1110,7 +1117,7 @@ describe("scratches in search results", () => {
     scratchState.scratches = [seeded[0]!];
     rerender();
 
-    await waitFor(() => expect(result.current.results).toEqual([]));
+    await waitFor(() => expect(result.current.results.map((row) => row.id)).toEqual(["scratch-1"]));
   });
 
   it("holds browse rows steady when only the scratches change", async () => {
@@ -1142,7 +1149,10 @@ describe("scratches in search results", () => {
 
     // "Spike 2" is the inactive one, so a switch is genuinely dispatched.
     act(() => result.current.setQuery("Spike 2"));
-    await waitFor(() => expect(result.current.results).toHaveLength(1));
+    // Settling on the head row rather than on a length: "Spike 1" ranks behind
+    // it as a near miss, and what this spec needs pinned is which row the
+    // selection is sitting on when confirm fires.
+    await waitFor(() => expect(result.current.results[0]?.id).toBe("scratch-2"));
 
     act(() => result.current.confirmSelection());
 

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -1059,10 +1059,7 @@ describe("scratches in search results", () => {
     act(() => result.current.setQuery("Spike 2"));
 
     await waitFor(() => {
-      // "Spike 1" is one substitution from "Spike 2", so it joins in the
-      // terminal typo tier (#11924) — behind the exact match, never in front
-      // of it, which is what keeps Enter committing the row that was typed.
-      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2", "scratch-1"]);
+      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2"]);
     });
     expect(result.current.results[0]!.kind).toBe("scratch");
   });
@@ -1105,11 +1102,7 @@ describe("scratches in search results", () => {
     const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
 
     act(() => result.current.setQuery("Spike 2"));
-    await waitFor(() =>
-      // "Spike 1" trails as a one-edit near miss (#11924); the row under test
-      // is the exact match at the head.
-      expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2", "scratch-1"])
-    );
+    await waitFor(() => expect(result.current.results.map((row) => row.id)).toEqual(["scratch-2"]));
 
     // A `scratch:removed` push under an open, settled query. Without the store
     // feeding the ranked list, the row would linger and Enter would commit a
@@ -1117,7 +1110,7 @@ describe("scratches in search results", () => {
     scratchState.scratches = [seeded[0]!];
     rerender();
 
-    await waitFor(() => expect(result.current.results.map((row) => row.id)).toEqual(["scratch-1"]));
+    await waitFor(() => expect(result.current.results).toEqual([]));
   });
 
   it("holds browse rows steady when only the scratches change", async () => {
@@ -1149,10 +1142,7 @@ describe("scratches in search results", () => {
 
     // "Spike 2" is the inactive one, so a switch is genuinely dispatched.
     act(() => result.current.setQuery("Spike 2"));
-    // Settling on the head row rather than on a length: "Spike 1" ranks behind
-    // it as a near miss, and what this spec needs pinned is which row the
-    // selection is sitting on when confirm fires.
-    await waitFor(() => expect(result.current.results[0]?.id).toBe("scratch-2"));
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
 
     act(() => result.current.confirmSelection());
 

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -745,3 +745,192 @@ describe("rankSwitcherMatches frozen activity", () => {
     ]);
   });
 });
+
+describe("rankSwitcherMatches typo tolerance", () => {
+  const DAINTREE_ROOT = "/Users/gpriday/Projects/Daintree";
+
+  function website(overrides: Partial<SearchableProject> = {}): SearchableProject {
+    return makeProject({
+      id: "website",
+      name: "Daintree Website",
+      path: `${DAINTREE_ROOT}/website`,
+      ...overrides,
+    });
+  }
+
+  /**
+   * Deliberately filed somewhere sharing no letters with the queries below. On
+   * `/repos/docker` a query as short as "dc" matches the PATH strictly, and a
+   * test meant to prove the length gate would be passing on the path instead.
+   */
+  function docker(): SearchableProject {
+    return makeProject({ id: "docker", name: "Docker", path: "/repos/containers" });
+  }
+
+  /**
+   * Every case below has to reach the typo tier by FAILING the strict scorer,
+   * so each fixture asserts its own zero first. Without that a fixture that
+   * quietly still matches as a subsequence would pass the test while proving
+   * nothing about typo tolerance.
+   */
+  function expectsNoStrictMatch(query: string, project: SearchableProject): void {
+    expect(scoreProjectQuery(query, project.name, project.path)).toBe(0);
+  }
+
+  it("surfaces the project a single transposition would otherwise have deleted", () => {
+    const daintree = makeProject({ id: "daintree", name: "Daintree", path: "/repos/daintree" });
+
+    for (const [query, project] of [
+      ["webstie", website()],
+      ["wesbite", website()],
+      ["danitree", daintree],
+      ["dcoker", docker()],
+    ] as const) {
+      expectsNoStrictMatch(query, project);
+      expect(rankSwitcherMatches(query, [project], [], null).map((r) => r.id)).toEqual([
+        project.id,
+      ]);
+    }
+  });
+
+  it("recovers a wrong character and an extra one, not only a swap", () => {
+    // A transposition is the case the issue reported, but the tier is not
+    // shaped around it — a substitution and an insertion cost one edit too.
+    for (const query of ["webxite", "webssite"]) {
+      expectsNoStrictMatch(query, website());
+      expect(rankSwitcherMatches(query, [website()], [], null).map((r) => r.id)).toEqual([
+        "website",
+      ]);
+    }
+  });
+
+  it("leaves a clean query alone", () => {
+    // The prefix the issue contrasts against. It matched before and must still
+    // match on the strength of the strict walk, not the new tier.
+    expect(scoreProjectQuery("webs", website().name, website().path)).toBeGreaterThan(0);
+    expect(rankSwitcherMatches("webs", [website()], [], null).map((r) => r.id)).toEqual([
+      "website",
+    ]);
+  });
+
+  it("gives a query under four characters no tolerance at all", () => {
+    // Three queries that are each within ONE edit of a boundary-anchored
+    // prefix of "Docker" — "cd" by dropping a character, "dco" and "dcok" by
+    // swapping two. Only the one that clears the gate may surface it: below
+    // four characters the edit neighbourhood of a query is most of the list.
+    for (const query of ["cd", "dco"]) {
+      expectsNoStrictMatch(query, docker());
+      expect(rankSwitcherMatches(query, [docker()], [], null)).toEqual([]);
+    }
+    expectsNoStrictMatch("dcok", docker());
+    expect(rankSwitcherMatches("dcok", [docker()], [], null).map((r) => r.id)).toEqual(["docker"]);
+  });
+
+  it("refuses a second edit", () => {
+    expectsNoStrictMatch("webxxte", website());
+    expect(rankSwitcherMatches("webxxte", [website()], [], null)).toEqual([]);
+  });
+
+  it("starts a near miss only where a word does", () => {
+    // "ebstie" is one edit from "ebsite", which sits inside "Website" — and is
+    // exactly the unanchored match that would let the tier drift into a second
+    // permissive scorer. The anchor is what bounds it.
+    expectsNoStrictMatch("ebstie", website());
+    expect(rankSwitcherMatches("ebstie", [website()], [], null)).toEqual([]);
+  });
+
+  it("offers no tolerance to a path", () => {
+    // The name is unrelated and the PATH is one edit away. Paths are long and
+    // share segments, so an edit across one is noise rather than a near miss.
+    const pathTypo = makeProject({ id: "p", name: "unrelated", path: "/repos/webstie" });
+    expectsNoStrictMatch("website", pathTypo);
+    expect(rankSwitcherMatches("website", [pathTypo], [], null)).toEqual([]);
+  });
+
+  it("never lets a typo row outrank a clean one, whatever it is asking", () => {
+    // The #11861 invariant, re-run against the new bottom tier: eighty agents
+    // between them cannot lift either decoy over a prefix match asking for
+    // nothing, and cannot lift the typo over the path-only row either.
+    const clean = makeProject({
+      id: "clean",
+      name: "webstie-scratchpad",
+      path: "/repos/webstie-scratchpad",
+    });
+    const pathOnly = makeProject({
+      id: "path-only",
+      name: "zeta",
+      path: "/repos/webstie/zeta",
+      waitingAgentCount: 40,
+      blockedAgentCount: 40,
+    });
+    const typo = website({ id: "typo", waitingAgentCount: 40, blockedAgentCount: 40 });
+
+    // Both decoys really are in the pool for the reason claimed: one matched
+    // strictly through its path, the other through nothing at all.
+    expect(scoreProjectQuery("webstie", pathOnly.name, pathOnly.path)).toBeGreaterThan(0);
+    expectsNoStrictMatch("webstie", typo);
+
+    expect(
+      rankSwitcherMatches("webstie", [typo, pathOnly, clean], [], null).map((r) => r.id)
+    ).toEqual(["clean", "path-only", "typo"]);
+  });
+
+  it("appends typo rows without disturbing the strict results above them", () => {
+    // The stability requirement, stated as the only thing that may change:
+    // adding a typo candidate to the pool leaves the strict rows in the same
+    // order at the same indices, so nothing moves under the pointer and a
+    // pending Enter still commits the row it was aimed at.
+    const clean = makeProject({
+      id: "clean",
+      name: "webstie-scratchpad",
+      path: "/repos/webstie-scratchpad",
+    });
+    const pathOnly = makeProject({ id: "path-only", name: "zeta", path: "/repos/webstie/zeta" });
+    const typo = website({ id: "typo" });
+
+    const strictOnly = rankSwitcherMatches("webstie", [clean, pathOnly], [], null);
+    const withTypo = rankSwitcherMatches("webstie", [clean, pathOnly, typo], [], null);
+
+    expect(strictOnly.map((r) => r.id)).toEqual(["clean", "path-only"]);
+    // Ranked alongside clean results rather than only once they run out: a
+    // tier that appeared on emptiness would re-seat the list at the keystroke
+    // that emptied it.
+    expect(withTypo.map((r) => r.id)).toEqual(["clean", "path-only", "typo"]);
+  });
+
+  it("surfaces a scratch whose name is one edit away", () => {
+    const scratch = makeScratch({ id: "s", name: "auth-notes" });
+    expect(scoreScratchQuery("auth-ntoes", scratch.name)).toBe(0);
+    expect(rankSwitcherMatches("auth-ntoes", [], [scratch], null).map((r) => r.id)).toEqual(["s"]);
+  });
+
+  it("orders tied typo rows the same way whatever order they arrive in", () => {
+    // Every key above the id ties for these three — same tier, same silence,
+    // the same zero score, the same name — so only a total comparator returns
+    // one order for all of them.
+    const first = website({ id: "t-a", path: "/repos/a" });
+    const second = website({ id: "t-b", path: "/repos/b" });
+    const scratch = makeScratch({ id: "t-s", name: "Daintree Website" });
+
+    const expected = ["t-a", "t-b", "t-s"];
+    expect(
+      rankSwitcherMatches("webstie", [first, second], [scratch], null).map((r) => r.id)
+    ).toEqual(expected);
+    expect(
+      rankSwitcherMatches("webstie", [second, first], [scratch], null).map((r) => r.id)
+    ).toEqual(expected);
+  });
+
+  it("puts no ceiling on how long a query may be", () => {
+    const name = "Daintree Website Redesign Retrospective Working Notes Archive";
+    // The same single transposition, at the tail of a name long enough that any
+    // arbitrary maximum query length would have cut it off first. A cap would
+    // be a second cliff of exactly the kind this tier exists to remove.
+    const query = `${name.slice(0, -2)}ev`.toLowerCase();
+    expect(query.length).toBeGreaterThan(32);
+
+    const project = makeProject({ id: "long", name, path: "/repos/x" });
+    expectsNoStrictMatch(query, project);
+    expect(rankSwitcherMatches(query, [project], [], null).map((r) => r.id)).toEqual(["long"]);
+  });
+});

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -996,6 +996,15 @@ describe("rankSwitcherMatches typo tolerance", () => {
     ]);
   });
 
+  it("still anchors a query that starts on a separator", () => {
+    // Word starts are the only anchors worth spending on — unless the query
+    // opens with separators too, in which case the word it is aiming at starts
+    // with them and skipping those positions would lose the match outright.
+    const project = makeProject({ id: "p", name: "--website", path: "/repos/p" });
+    expectsNoStrictMatch("--webstie", project);
+    expect(rankSwitcherMatches("--webstie", [project], [], null).map((r) => r.id)).toEqual(["p"]);
+  });
+
   it("refuses a swap that moves a character between two words", () => {
     // "abcdx-y" is one transposition from "abcd-xy", but the pair swapped is a
     // letter and the separator itself. The index names the long word on the

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -856,13 +856,10 @@ describe("rankSwitcherMatches typo tolerance", () => {
       name: "webstie-scratchpad",
       path: "/repos/webstie-scratchpad",
     });
-    const pathOnly = makeProject({
-      id: "path-only",
-      name: "zeta",
-      path: "/repos/webstie/zeta",
-      waitingAgentCount: 40,
-      blockedAgentCount: 40,
-    });
+    // The path-only row is asking for nothing and the typo row is on fire, so
+    // activity — and the raw score, which the typo row forfeits — both run
+    // AGAINST the expected order. Only the tier can produce it.
+    const pathOnly = makeProject({ id: "path-only", name: "zeta", path: "/repos/webstie/zeta" });
     const typo = website({ id: "typo", waitingAgentCount: 40, blockedAgentCount: 40 });
 
     // Both decoys really are in the pool for the reason claimed: one matched
@@ -908,11 +905,14 @@ describe("rankSwitcherMatches typo tolerance", () => {
     // Every key above the id ties for these three — same tier, same silence,
     // the same zero score, the same name — so only a total comparator returns
     // one order for all of them.
-    const first = website({ id: "t-a", path: "/repos/a" });
-    const second = website({ id: "t-b", path: "/repos/b" });
-    const scratch = makeScratch({ id: "t-s", name: "Daintree Website" });
+    // The scratch sorts first on id AND carries the fresher recency, so kind is
+    // the only key that can seat it last — drop that comparison and this
+    // fixture returns the scratch at the head.
+    const first = website({ id: "t-a", path: "/repos/a", frecencyScore: 0 });
+    const second = website({ id: "t-b", path: "/repos/b", frecencyScore: 0 });
+    const scratch = makeScratch({ id: "a-s", name: "Daintree Website", lastOpened: 999 });
 
-    const expected = ["t-a", "t-b", "t-s"];
+    const expected = ["t-a", "t-b", "a-s"];
     expect(
       rankSwitcherMatches("webstie", [first, second], [scratch], null).map((r) => r.id)
     ).toEqual(expected);
@@ -921,7 +921,7 @@ describe("rankSwitcherMatches typo tolerance", () => {
     ).toEqual(expected);
   });
 
-  it("puts no ceiling on how long a query may be", () => {
+  it("accepts a query far past any plausible length cap", () => {
     const name = "Daintree Website Redesign Retrospective Working Notes Archive";
     // The same single transposition, at the tail of a name long enough that any
     // arbitrary maximum query length would have cut it off first. A cap would
@@ -932,5 +932,79 @@ describe("rankSwitcherMatches typo tolerance", () => {
     const project = makeProject({ id: "long", name, path: "/repos/x" });
     expectsNoStrictMatch(query, project);
     expect(rankSwitcherMatches(query, [project], [], null).map((r) => r.id)).toEqual(["long"]);
+  });
+  it("holds a short word to an exact match, so numbered siblings stay out", () => {
+    const projects = Array.from({ length: 20 }, (_, i) =>
+      makeProject({
+        id: `p-${i + 1}`,
+        name: `project-${i + 1}`,
+        path: `/repos/project-${i + 1}`,
+      })
+    );
+    // Ten characters of query, one of them wrong. Measured across the whole
+    // query that edit roams free and drags in every sibling a digit away —
+    // "project-1", "project-7", each "project-1x". The word carrying it is
+    // "17", which is too short to be worth correcting, so it must be typed.
+    for (const project of projects) {
+      if (project.id !== "p-17") expectsNoStrictMatch("project-17", project);
+    }
+    expect(rankSwitcherMatches("project-17", projects, [], null).map((r) => r.id)).toEqual([
+      "p-17",
+    ]);
+  });
+
+  it("refuses an edit made in the space between two words", () => {
+    // One deletion from "Daintree", but the character deleted is the space. It
+    // belongs to no word, so there is no word to hold to a length — and
+    // admitting it would let the short-word rule be sidestepped by punctuation.
+    const project = makeProject({ id: "d", name: "Daintree", path: "/repos/d" });
+    expectsNoStrictMatch("dain tree", project);
+    expect(rankSwitcherMatches("dain tree", [project], [], null)).toEqual([]);
+  });
+
+  it("does not reach past the end of a name shorter than the query", () => {
+    const tiny = makeProject({ id: "tiny", name: "Web", path: "/repos/tiny" });
+    expectsNoStrictMatch("webstie", tiny);
+    expect(rankSwitcherMatches("webstie", [tiny], [], null)).toEqual([]);
+  });
+
+  it("matches without regard to case in either direction", () => {
+    const shouty = makeProject({ id: "shouty", name: "DAINTREE WEBSITE", path: "/repos/shouty" });
+    expectsNoStrictMatch("webstie", shouty);
+    expect(rankSwitcherMatches("WEBSTIE", [website()], [], null).map((r) => r.id)).toEqual([
+      "website",
+    ]);
+    expect(rankSwitcherMatches("webstie", [shouty], [], null).map((r) => r.id)).toEqual(["shouty"]);
+  });
+
+  it("ignores whitespace the caller did not trim", () => {
+    expect(rankSwitcherMatches("  webstie  ", [website()], [], null).map((r) => r.id)).toEqual([
+      "website",
+    ]);
+  });
+
+  it("reads a typo row the snapshot never saw as quiet, not as whatever it is doing now", () => {
+    // The freeze has to reach the new tier too: a row that arrived mid-session
+    // must not jump a row the snapshot already holds just because it is busy.
+    const keyed = website({ id: "keyed", path: "/repos/keyed" });
+    const arrived = website({
+      id: "arrived",
+      path: "/repos/arrived",
+      waitingAgentCount: 40,
+      blockedAgentCount: 40,
+    });
+    const snapshot = new Map([
+      ["keyed", computeSearchActivityKey({ ...keyed, waitingAgentCount: 1 })],
+    ]);
+
+    expect(rankSwitcherMatches("webstie", [arrived, keyed], [], snapshot).map((r) => r.id)).toEqual(
+      ["keyed", "arrived"]
+    );
+    // Live, the arrival really is the louder of the two, so the freeze is what
+    // produced the order above rather than the rows agreeing with it anyway.
+    expect(rankSwitcherMatches("webstie", [arrived, keyed], [], null).map((r) => r.id)).toEqual([
+      "arrived",
+      "keyed",
+    ]);
   });
 });

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -1050,4 +1050,67 @@ describe("rankSwitcherMatches typo tolerance", () => {
       "keyed",
     ]);
   });
+
+  it("measures the word carrying an edit in characters, not in UTF-16 units", () => {
+    // "\u{1F600}" is two units to `length` and one character to whoever typed
+    // it. The four-character floor is held against characters, so these two
+    // names fall on opposite sides of it — the longer one clears it, the
+    // shorter one does not. Counting units would admit both.
+    const emojiLong = makeProject({ id: "long", name: "a\u{1F600}cd", path: "/repos/long" });
+    const emojiShort = makeProject({ id: "short", name: "a\u{1F600}c", path: "/repos/short" });
+
+    expectsNoStrictMatch("a\u{1F600}cx", emojiLong);
+    expect(rankSwitcherMatches("a\u{1F600}cx", [emojiLong], [], null).map((r) => r.id)).toEqual([
+      "long",
+    ]);
+
+    expectsNoStrictMatch("a\u{1F600}x", emojiShort);
+    expect(rankSwitcherMatches("a\u{1F600}x", [emojiShort], [], null)).toEqual([]);
+  });
+
+  it("stands the tier down for a query whose case fold changes its length", () => {
+    // "\u0130" folds to TWO UTF-16 units, so an offset into the folded query no
+    // longer names the character that was typed and the word the length gate
+    // measures is not the word anyone wrote. The tier declines the query rather
+    // than measure it with them — "a\u0130cx" is four characters and one
+    // substitution from "a\u0130cd", clears every other rule, and is still refused.
+    const dotted = makeProject({ id: "dotted", name: "a\u0130cd", path: "/repos/dotted" });
+    expectsNoStrictMatch("a\u0130cx", dotted);
+    expect(rankSwitcherMatches("a\u0130cx", [dotted], [], null)).toEqual([]);
+
+    // The same shape spelled with characters that fold in place does surface,
+    // so it is the fold being refused and not the query.
+    const plain = makeProject({ id: "plain", name: "aicd", path: "/repos/plain" });
+    expectsNoStrictMatch("aicx", plain);
+    expect(rankSwitcherMatches("aicx", [plain], [], null).map((r) => r.id)).toEqual(["plain"]);
+
+    // And the shape a person would actually type it in.
+    expectsNoStrictMatch("webst\u0130e", website());
+    expect(rankSwitcherMatches("webst\u0130e", [website()], [], null)).toEqual([]);
+  });
+
+  it("gives up on a name carrying more word starts than one scan will spend", () => {
+    // The same typo against the same trailing word, twice, differing only in
+    // how many words precede it. Past the anchor budget the scan aborts instead
+    // of going quadratic on a pasted name, so the row is dropped — a real
+    // degradation, and one the reachable copy has to prove is degradation
+    // rather than the query simply not matching.
+    const reachable = makeProject({
+      id: "reachable",
+      name: `${"a-".repeat(10)}website`,
+      path: "/repos/reachable",
+    });
+    const pathological = makeProject({
+      id: "pathological",
+      name: `${"a-".repeat(100)}website`,
+      path: "/repos/pathological",
+    });
+
+    expectsNoStrictMatch("webstie", reachable);
+    expectsNoStrictMatch("webstie", pathological);
+    expect(rankSwitcherMatches("webstie", [reachable], [], null).map((r) => r.id)).toEqual([
+      "reachable",
+    ]);
+    expect(rankSwitcherMatches("webstie", [pathological], [], null)).toEqual([]);
+  });
 });

--- a/src/lib/__tests__/projectSwitcherSearch.test.ts
+++ b/src/lib/__tests__/projectSwitcherSearch.test.ts
@@ -983,6 +983,40 @@ describe("rankSwitcherMatches typo tolerance", () => {
     ]);
   });
 
+  it("recovers a character dropped off the end of a word, not off the separator", () => {
+    // The one shape that reaches the missing-character branch at all: the query
+    // is otherwise a subsequence of the name, so only a name long enough for
+    // the greedy walk's gap penalties to clamp its score to zero gets here.
+    // The "s" that went missing closed out "reviews" — attributing it to the
+    // "-" that follows would weigh a separator instead of a word and drop it.
+    const scratch = makeScratch({ id: "s", name: `r${"z".repeat(120)}-reviews-notes` });
+    expect(scoreScratchQuery("review-notes", scratch.name)).toBe(0);
+    expect(rankSwitcherMatches("review-notes", [], [scratch], null).map((r) => r.id)).toEqual([
+      "s",
+    ]);
+  });
+
+  it("refuses a swap that moves a character between two words", () => {
+    // "abcdx-y" is one transposition from "abcd-xy", but the pair swapped is a
+    // letter and the separator itself. The index names the long word on the
+    // query side, so weighing only that side would let this through.
+    const project = makeProject({ id: "p", name: "abcd-xy", path: "/repos/p" });
+    expectsNoStrictMatch("abcdx-y", project);
+    expect(rankSwitcherMatches("abcdx-y", [project], [], null)).toEqual([]);
+  });
+
+  it("refuses a letter standing where a separator belongs", () => {
+    // Substitution against a separator on the FIELD side. The query word is
+    // five characters, so a query-side-only check would pass it.
+    //
+    // The trailing "d" is what makes this test the substitution path and only
+    // that path: without it, dropping the "x" would leave a clean prefix of the
+    // name and the extra-character route would match on its own merits.
+    const project = makeProject({ id: "p", name: "abc-d", path: "/repos/p" });
+    expectsNoStrictMatch("abcxd", project);
+    expect(rankSwitcherMatches("abcxd", [project], [], null)).toEqual([]);
+  });
+
   it("reads a typo row the snapshot never saw as quiet, not as whatever it is doing now", () => {
     // The freeze has to reach the new tier too: a row that arrived mid-session
     // must not jump a row the snapshot already holds just because it is busy.

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -19,11 +19,14 @@ const NAME_WEIGHT = 4;
  */
 const MIN_FILTER_MATCH_SCORE = 100;
 
+/** What separates one word from the next, shared so the two matchers cannot disagree about it. */
+const WORD_DELIMITER = /[/\\\-._\s]/;
+
 function isBoundary(str: string, index: number): boolean {
   if (index === 0) return true;
   const prev = str[index - 1] ?? "";
   const curr = str[index] ?? "";
-  return /[/\\\-._\s]/.test(prev) || (/[a-z]/.test(prev) && /[A-Z]/.test(curr));
+  return WORD_DELIMITER.test(prev) || (/[a-z]/.test(prev) && /[A-Z]/.test(curr));
 }
 
 function scoreField(query: string, field: string): number {
@@ -85,22 +88,47 @@ function scoreField(query: string, field: string): number {
 }
 
 /**
- * Shortest query that earns typo tolerance at all (#11924).
+ * Shortest WORD a typo may be made in (#11924).
  *
- * Below four characters the one-edit neighbourhood of a query is most of the
- * list — "sv" is one edit from every field holding an "s", a "v", or any two
- * characters at all — which is why every production engine draws the line in
- * the same place (Algolia `minWordSizefor1Typo`, Typesense `min_len_1typo`,
- * both 4). The gate is load-bearing rather than decorative: the existing
- * rejections of "sv" against "fleet snapshot service" and "ru" against a
- * research title are what it is holding up.
+ * The threshold belongs to the token carrying the edit rather than to the whole
+ * query, which is where the hosted engines put it too (Algolia
+ * `minWordSizefor1Typo`, Typesense `min_len_1typo`, both 4). Measuring the
+ * whole query instead is not a smaller version of the same rule, it is a
+ * different and much worse one: "project-17" is ten characters, so a
+ * query-length gate lets its one-character edit roam, and typing it in full
+ * pulls in "project-1", "project-7" and every "project-1x" — eleven neighbours
+ * for one exact match. Numbered and versioned siblings are the common case in a
+ * workspace list, so this is the difference between typo tolerance and a
+ * cluttered list on every clean query.
+ *
+ * Under it, a short token has to be typed exactly. That is the intent: there is
+ * nothing to recover in a "2", and no way to tell a typo of it from a different
+ * workspace.
  */
-const MIN_TYPO_QUERY_LENGTH = 4;
+const MIN_TYPO_TOKEN_LENGTH = 4;
+
+/**
+ * How many word boundaries in one name will be tried as an alignment start.
+ *
+ * Purely a work bound, not a rule about matching: every alignment is O(query),
+ * so an unbounded anchor count makes the matcher O(name x query) on a name with
+ * a boundary every other character — quadratic where everything else this
+ * module does is linear, and names are user-supplied and uncapped. Sixty-four
+ * words is past any name anyone types, so it degrades a pathological paste
+ * instead of the feature.
+ */
+const MAX_TYPO_ANCHORS = 64;
+
+/** No alignment at this anchor. */
+const NO_ALIGNMENT = -2;
+/** Aligned with nothing to spend — the query IS a prefix of this word. */
+const ALIGNED_EXACTLY = -1;
 
 /**
  * Whether `query` is within ONE edit — substitution, adjacent transposition,
- * or a single extra character on either side — of a prefix of `field` that
- * STARTS AT A WORD BOUNDARY (#11924).
+ * or a single extra character on either side — of a prefix of `name` that
+ * STARTS AT A WORD BOUNDARY, with the edit falling in a word long enough to be
+ * worth correcting (#11924).
  *
  * This is the second, deliberately smaller way a query can match, and it exists
  * because {@link scoreField} does not degrade: a walk that runs out of field
@@ -108,7 +136,7 @@ const MIN_TYPO_QUERY_LENGTH = 4;
  * Website" below "webs" — it deletes it. One fat-fingered character emptying
  * the list is the worst failure shape a switcher has.
  *
- * Three bounds keep it from becoming a second permissive scorer, which is the
+ * Four bounds keep it from becoming a second permissive scorer, which is the
  * failure this module has already been through once (the word-initials fallback
  * {@link isFilterMatch} rejects, where "test" reached "cut the external tool
  * surface from 100 to 24" because initials put no bound on the distance between
@@ -121,6 +149,8 @@ const MIN_TYPO_QUERY_LENGTH = 4;
  *   which is the trade that keeps the neighbourhood small.
  * - Exactly one edit, never two. There is no ladder up to two typos at eight
  *   characters; longer queries buy accuracy, not licence.
+ * - The edit has to land inside a word of at least {@link MIN_TYPO_TOKEN_LENGTH}
+ *   characters, and never on the whitespace or punctuation between two.
  * - Never the path. Absolute paths are long and share segments, so an edit
  *   across one is noise; only the name is offered.
  *
@@ -131,42 +161,92 @@ const MIN_TYPO_QUERY_LENGTH = 4;
  * flaw {@link isFilterMatch} documents. Surfacing that row last beats dropping
  * it, and requiring distance to EQUAL one would invert the cliff: the literal
  * substring lost while its one-typo neighbour surfaced.
+ *
+ * Counted in UTF-16 units, exactly as `scoreField` counts them, so the two
+ * agree on what a character is. The token length is the one measurement taken
+ * in real characters instead, because it is the one a person is being held to.
  */
 function hasNearMissNameMatch(lowerQuery: string, name: string): boolean {
-  if (lowerQuery.length < MIN_TYPO_QUERY_LENGTH) return false;
+  // Derived rather than a second policy: a query shorter than the shortest
+  // correctable word cannot contain one, so there is nothing to find. UTF-16
+  // units over-count characters, so this can only ever admit work, never skip
+  // work that would have matched.
+  if (lowerQuery.length < MIN_TYPO_TOKEN_LENGTH) return false;
+
   const lowerName = name.toLowerCase();
-  // One edit moves the window by at most one, so a boundary with fewer than
-  // this many characters left cannot host any alignment. It is also the whole
-  // reason no maximum query length is needed: a pasted query longer than the
-  // name fails here at every boundary, before any comparison runs.
+  // Case folding preserves length for every character anyone names a workspace
+  // after, but not for all of them ("\u0130" folds to two units). When it does not,
+  // a folded offset can no longer index the original, so the camelCase half of
+  // the boundary test is given up rather than anchoring a window one character
+  // off the word it was meant to start at.
+  const boundarySource = lowerName.length === name.length ? name : lowerName;
   const shortestWindow = lowerQuery.length - 1;
+  let anchors = 0;
+
   for (let start = 0; start + shortestWindow <= lowerName.length; start++) {
-    // Read off the original-case name, exactly as `scoreField` reads it, so the
-    // two agree on where a camelCase word begins.
-    if (!isBoundary(name, start)) continue;
-    if (alignsWithinOneEdit(lowerQuery, lowerName, start)) return true;
+    if (!isBoundary(boundarySource, start)) continue;
+    if (++anchors > MAX_TYPO_ANCHORS) return false;
+    const edit = alignsWithinOneEdit(lowerQuery, lowerName, start);
+    if (edit === NO_ALIGNMENT) continue;
+    if (edit === ALIGNED_EXACTLY || isEditWorthCorrecting(lowerQuery, edit)) return true;
   }
   return false;
 }
 
 /**
- * The three window lengths a one-edit alignment can have, tried in that order.
+ * Whether the character at `index` sits inside a query word long enough that a
+ * typo in it is recoverable.
+ *
+ * An edit on the whitespace or punctuation BETWEEN two words is rejected
+ * outright: it belongs to no word, and letting it through would readmit exactly
+ * the short-token noise the length rule exists to stop.
+ */
+function isEditWorthCorrecting(query: string, index: number): boolean {
+  const edited = query[index] ?? "";
+  if (!edited || WORD_DELIMITER.test(edited)) return false;
+
+  let from = index;
+  while (from > 0 && !WORD_DELIMITER.test(query[from - 1]!)) from--;
+  let to = index + 1;
+  while (to < query.length && !WORD_DELIMITER.test(query[to]!)) to++;
+
+  let characters = 0;
+  for (let i = from; i < to; i++) {
+    const unit = query.charCodeAt(i);
+    // A surrogate pair is one character to whoever typed it, and two to
+    // `length` — which is the whole reason this is not a `to - from` subtraction.
+    if (unit >= 0xd800 && unit <= 0xdbff && i + 1 < to) i++;
+    if (++characters >= MIN_TYPO_TOKEN_LENGTH) return true;
+  }
+  return false;
+}
+
+/**
+ * The three window lengths a one-edit alignment can have, tried in that order,
+ * returning WHERE in the query the edit fell so the caller can weigh it.
  *
  * A general edit-distance matrix would answer this too, but at a fixed bound of
  * one edit it is the wrong tool: the window can only be one shorter, equal, or
  * one longer than the query, so three linear scans settle it with no allocation
  * and no traceback — and each case is small enough to read and check by eye.
  */
-function alignsWithinOneEdit(query: string, field: string, start: number): boolean {
+function alignsWithinOneEdit(query: string, field: string, start: number): number {
   const remaining = field.length - start;
   const length = query.length;
-  if (remaining >= length && alignsExceptOneSwapOrSubstitution(query, field, start)) return true;
-  if (remaining >= length - 1 && alignsWithOneExtraQueryChar(query, field, start)) return true;
-  return remaining >= length + 1 && alignsWithOneExtraFieldChar(query, field, start);
+  if (remaining >= length) {
+    const edit = alignExceptOneSwapOrSubstitution(query, field, start);
+    if (edit !== NO_ALIGNMENT) return edit;
+  }
+  if (remaining >= length - 1) {
+    const edit = alignWithOneExtraQueryChar(query, field, start);
+    if (edit !== NO_ALIGNMENT) return edit;
+  }
+  if (remaining >= length + 1) return alignWithOneExtraFieldChar(query, field, start);
+  return NO_ALIGNMENT;
 }
 
 /** Equal-length window: identical, one wrong character, or two swapped ones. */
-function alignsExceptOneSwapOrSubstitution(query: string, field: string, start: number): boolean {
+function alignExceptOneSwapOrSubstitution(query: string, field: string, start: number): number {
   const length = query.length;
   let first = -1;
   for (let i = 0; i < length; i++) {
@@ -175,7 +255,7 @@ function alignsExceptOneSwapOrSubstitution(query: string, field: string, start: 
       break;
     }
   }
-  if (first === -1) return true;
+  if (first === -1) return ALIGNED_EXACTLY;
 
   let substituted = true;
   for (let i = first + 1; i < length; i++) {
@@ -184,7 +264,7 @@ function alignsExceptOneSwapOrSubstitution(query: string, field: string, start: 
       break;
     }
   }
-  if (substituted) return true;
+  if (substituted) return first;
 
   // Adjacent transposition, which is the edit plain Levenshtein charges twice
   // for and the one people actually make — every case the issue reported
@@ -194,39 +274,49 @@ function alignsExceptOneSwapOrSubstitution(query: string, field: string, start: 
     query[first] !== field[start + first + 1] ||
     query[first + 1] !== field[start + first]
   ) {
-    return false;
+    return NO_ALIGNMENT;
   }
   for (let i = first + 2; i < length; i++) {
-    if (query[i] !== field[start + i]) return false;
+    if (query[i] !== field[start + i]) return NO_ALIGNMENT;
   }
-  return true;
+  return first;
 }
 
 /** One character too many in the query: drop it and the rest must line up. */
-function alignsWithOneExtraQueryChar(query: string, field: string, start: number): boolean {
+function alignWithOneExtraQueryChar(query: string, field: string, start: number): number {
   const windowLength = query.length - 1;
   let i = 0;
   while (i < windowLength && query[i] === field[start + i]) i++;
-  // Taking the FIRST mismatch is not a guess: everything before it already
-  // matches in place, so no earlier character can be the extra one.
+  // Dropping the character at the FIRST disagreement loses no alignment: a
+  // repeated run makes several positions equally droppable ("aab" against "ab"
+  // can lose either "a"), but any such edit slides across the equal run to this
+  // one, so if a one-edit alignment exists at all, this finds it.
   for (let j = i; j < windowLength; j++) {
-    if (query[j + 1] !== field[start + j]) return false;
+    if (query[j + 1] !== field[start + j]) return NO_ALIGNMENT;
   }
-  return true;
+  return i;
 }
 
-/** One character too few in the query: skip a field character instead. */
-function alignsWithOneExtraFieldChar(query: string, field: string, start: number): boolean {
+/**
+ * One character too few in the query: skip a field character instead.
+ *
+ * Reachable only when {@link scoreField} clamped a real match to zero, since a
+ * query missing one of a name's characters is otherwise still a subsequence of
+ * it and would have scored. Kept because that clamp is real on a long name, and
+ * because a matcher that tolerated an extra character but not a missing one
+ * would be arbitrary.
+ */
+function alignWithOneExtraFieldChar(query: string, field: string, start: number): number {
   const length = query.length;
   let i = 0;
   while (i < length && query[i] === field[start + i]) i++;
   // Ran the whole query without a mismatch: the extra field character is
   // trailing, which the equal-length window already accepted as distance 0.
-  if (i === length) return false;
+  if (i === length) return NO_ALIGNMENT;
   for (let j = i; j < length; j++) {
-    if (query[j] !== field[start + j + 1]) return false;
+    if (query[j] !== field[start + j + 1]) return NO_ALIGNMENT;
   }
-  return true;
+  return i;
 }
 
 /**

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -85,6 +85,151 @@ function scoreField(query: string, field: string): number {
 }
 
 /**
+ * Shortest query that earns typo tolerance at all (#11924).
+ *
+ * Below four characters the one-edit neighbourhood of a query is most of the
+ * list — "sv" is one edit from every field holding an "s", a "v", or any two
+ * characters at all — which is why every production engine draws the line in
+ * the same place (Algolia `minWordSizefor1Typo`, Typesense `min_len_1typo`,
+ * both 4). The gate is load-bearing rather than decorative: the existing
+ * rejections of "sv" against "fleet snapshot service" and "ru" against a
+ * research title are what it is holding up.
+ */
+const MIN_TYPO_QUERY_LENGTH = 4;
+
+/**
+ * Whether `query` is within ONE edit — substitution, adjacent transposition,
+ * or a single extra character on either side — of a prefix of `field` that
+ * STARTS AT A WORD BOUNDARY (#11924).
+ *
+ * This is the second, deliberately smaller way a query can match, and it exists
+ * because {@link scoreField} does not degrade: a walk that runs out of field
+ * before it runs out of query returns 0, so "webstie" does not rank "Daintree
+ * Website" below "webs" — it deletes it. One fat-fingered character emptying
+ * the list is the worst failure shape a switcher has.
+ *
+ * Three bounds keep it from becoming a second permissive scorer, which is the
+ * failure this module has already been through once (the word-initials fallback
+ * {@link isFilterMatch} rejects, where "test" reached "cut the external tool
+ * surface from 100 to 24" because initials put no bound on the distance between
+ * the words they came from):
+ *
+ * - It is anchored to a {@link isBoundary} position, so the match still has to
+ *   start where a word does. That is the same claim `scoreField`'s boundary
+ *   bonus makes, spent as a hard requirement instead of as points. It costs the
+ *   mid-word case — a typo of "ebsite" is not recovered from inside "Website" —
+ *   which is the trade that keeps the neighbourhood small.
+ * - Exactly one edit, never two. There is no ladder up to two typos at eight
+ *   characters; longer queries buy accuracy, not licence.
+ * - Never the path. Absolute paths are long and share segments, so an edit
+ *   across one is noise; only the name is offered.
+ *
+ * Distance 0 counts as a match rather than being excluded as "not a typo". It
+ * is only reachable when the query IS a boundary-anchored substring that
+ * `scoreField` still scored 0 for — its greedy walk took an earlier character
+ * and the gap penalties drained the substring bonus past zero, the long-field
+ * flaw {@link isFilterMatch} documents. Surfacing that row last beats dropping
+ * it, and requiring distance to EQUAL one would invert the cliff: the literal
+ * substring lost while its one-typo neighbour surfaced.
+ */
+function hasNearMissNameMatch(lowerQuery: string, name: string): boolean {
+  if (lowerQuery.length < MIN_TYPO_QUERY_LENGTH) return false;
+  const lowerName = name.toLowerCase();
+  // One edit moves the window by at most one, so a boundary with fewer than
+  // this many characters left cannot host any alignment. It is also the whole
+  // reason no maximum query length is needed: a pasted query longer than the
+  // name fails here at every boundary, before any comparison runs.
+  const shortestWindow = lowerQuery.length - 1;
+  for (let start = 0; start + shortestWindow <= lowerName.length; start++) {
+    // Read off the original-case name, exactly as `scoreField` reads it, so the
+    // two agree on where a camelCase word begins.
+    if (!isBoundary(name, start)) continue;
+    if (alignsWithinOneEdit(lowerQuery, lowerName, start)) return true;
+  }
+  return false;
+}
+
+/**
+ * The three window lengths a one-edit alignment can have, tried in that order.
+ *
+ * A general edit-distance matrix would answer this too, but at a fixed bound of
+ * one edit it is the wrong tool: the window can only be one shorter, equal, or
+ * one longer than the query, so three linear scans settle it with no allocation
+ * and no traceback — and each case is small enough to read and check by eye.
+ */
+function alignsWithinOneEdit(query: string, field: string, start: number): boolean {
+  const remaining = field.length - start;
+  const length = query.length;
+  if (remaining >= length && alignsExceptOneSwapOrSubstitution(query, field, start)) return true;
+  if (remaining >= length - 1 && alignsWithOneExtraQueryChar(query, field, start)) return true;
+  return remaining >= length + 1 && alignsWithOneExtraFieldChar(query, field, start);
+}
+
+/** Equal-length window: identical, one wrong character, or two swapped ones. */
+function alignsExceptOneSwapOrSubstitution(query: string, field: string, start: number): boolean {
+  const length = query.length;
+  let first = -1;
+  for (let i = 0; i < length; i++) {
+    if (query[i] !== field[start + i]) {
+      first = i;
+      break;
+    }
+  }
+  if (first === -1) return true;
+
+  let substituted = true;
+  for (let i = first + 1; i < length; i++) {
+    if (query[i] !== field[start + i]) {
+      substituted = false;
+      break;
+    }
+  }
+  if (substituted) return true;
+
+  // Adjacent transposition, which is the edit plain Levenshtein charges twice
+  // for and the one people actually make — every case the issue reported
+  // ("webstie", "wesbite", "danitree", "dcoker") is this and nothing else.
+  if (
+    first + 1 >= length ||
+    query[first] !== field[start + first + 1] ||
+    query[first + 1] !== field[start + first]
+  ) {
+    return false;
+  }
+  for (let i = first + 2; i < length; i++) {
+    if (query[i] !== field[start + i]) return false;
+  }
+  return true;
+}
+
+/** One character too many in the query: drop it and the rest must line up. */
+function alignsWithOneExtraQueryChar(query: string, field: string, start: number): boolean {
+  const windowLength = query.length - 1;
+  let i = 0;
+  while (i < windowLength && query[i] === field[start + i]) i++;
+  // Taking the FIRST mismatch is not a guess: everything before it already
+  // matches in place, so no earlier character can be the extra one.
+  for (let j = i; j < windowLength; j++) {
+    if (query[j + 1] !== field[start + j]) return false;
+  }
+  return true;
+}
+
+/** One character too few in the query: skip a field character instead. */
+function alignsWithOneExtraFieldChar(query: string, field: string, start: number): boolean {
+  const length = query.length;
+  let i = 0;
+  while (i < length && query[i] === field[start + i]) i++;
+  // Ran the whole query without a mismatch: the extra field character is
+  // trailing, which the equal-length window already accepted as distance 0.
+  if (i === length) return false;
+  for (let j = i; j < length; j++) {
+    if (query[j] !== field[start + j + 1]) return false;
+  }
+  return true;
+}
+
+/**
  * Whether `field` matches `query` well enough to survive a filter that will not
  * rank the result afterwards.
  *
@@ -196,6 +341,18 @@ const TEXT_CLASS_NAME_PREFIX = 1;
 const TEXT_CLASS_NAME_SUBSTRING = 2;
 const TEXT_CLASS_FUZZY_NAME = 3;
 const TEXT_CLASS_PATH_ONLY = 4;
+/**
+ * A name within one edit of the query ({@link hasNearMissNameMatch}), and the
+ * only tier this function never returns — a row reaches it by having FAILED
+ * every strict test, so {@link rankSwitcherMatches} assigns it rather than
+ * asking here. Keeping it out of the ladder above is what makes it impossible
+ * for a clean match to be classified as a typo by accident.
+ *
+ * Last on purpose, below `path-only`: a path match is still a real match of
+ * something the user typed, and the rule is that a typo never outranks a clean
+ * result — not that it outranks the weakest clean result.
+ */
+const TEXT_CLASS_TYPO_NAME = 5;
 
 /**
  * `hasNameMatch` rather than a name score, because the only thing the last two
@@ -323,6 +480,17 @@ interface RankedEntry {
  * one — including a pair the raw scores could have separated, which is the
  * point: those scores are what a shared parent directory decides.
  *
+ * A row that matched NOTHING strictly is still offered a seat if its name is
+ * within one edit of the query ({@link hasNearMissNameMatch}), in the terminal
+ * {@link TEXT_CLASS_TYPO_NAME} tier (#11924). Those candidates are computed on
+ * every query rather than only once the clean tiers come back empty, which is
+ * what keeps the list from flickering: a fallback that switches on emptiness
+ * reorders the rows under a pointer — and re-aims a pending Enter — at the
+ * keystroke that empties it. Appending below every clean row instead leaves
+ * both the contents and the indices of the strict results untouched, so the
+ * only thing typo tolerance can do to a query that already worked is add rows
+ * beneath it.
+ *
  * `activityKeys` is the palette session's frozen snapshot, keyed by row id.
  * Activity arrives live over IPC and every push re-runs this ranking, so reading
  * the rows' own counts would move a row out from under the pointer between the
@@ -361,7 +529,22 @@ export function rankSwitcherMatches(
 
   for (const project of projects) {
     const score = scoreProjectQuery(trimmed, project.name, project.path);
-    if (score <= 0) continue;
+    if (score <= 0) {
+      if (!hasNearMissNameMatch(lowerQuery, project.name)) continue;
+      scored.push({
+        row: { kind: "project", ...project },
+        textClass: TEXT_CLASS_TYPO_NAME,
+        activity: activityFor(project),
+        // Every row in this tier scores 0, so the comparator's score key ties
+        // for all of them and falls through to activity, kind, recency, name
+        // and id — still total, still transitive. A typo row's score is never
+        // compared against a clean row's, because the tier separates them
+        // first.
+        score: 0,
+        recency: project.frecencyScore,
+      });
+      continue;
+    }
     scored.push({
       row: { kind: "project", ...project },
       // Walks the name a second time rather than taking the term apart out of
@@ -375,7 +558,17 @@ export function rankSwitcherMatches(
   }
   for (const scratch of scratches) {
     const score = scoreScratchQuery(trimmed, scratch.name);
-    if (score <= 0) continue;
+    if (score <= 0) {
+      if (!hasNearMissNameMatch(lowerQuery, scratch.name)) continue;
+      scored.push({
+        row: { kind: "scratch", ...scratch },
+        textClass: TEXT_CLASS_TYPO_NAME,
+        activity: activityFor(scratch),
+        score: 0,
+        recency: scratch.lastOpened,
+      });
+      continue;
+    }
     scored.push({
       row: { kind: "scratch", ...scratch },
       textClass: textQualityClass(lowerQuery, scratch.name, true),

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -181,14 +181,19 @@ function hasNearMissNameMatch(lowerQuery: string, name: string): boolean {
   // off the word it was meant to start at.
   const boundarySource = lowerName.length === name.length ? name : lowerName;
   const shortestWindow = lowerQuery.length - 1;
+  // Only a query that starts on a word can afford to skip anchors that do not
+  // (see the loop). One that starts with separators has to be offered them,
+  // or "--webstie" never reaches "--website".
+  const skipSeparatorAnchors = isWordCharacter(lowerQuery[0]);
   let anchors = 0;
 
   for (let start = 0; start + shortestWindow <= lowerName.length; start++) {
-    // A word does not begin on a separator. Skipping those costs nothing — the
-    // first real character after a run of them is a boundary in its own right,
-    // because the character before it is a delimiter — and it stops " - " from
-    // spending three of the budget below on one gap.
-    if (WORD_DELIMITER.test(lowerName[start]!)) continue;
+    // A word does not begin on a separator, so for a query that starts on one
+    // of its own these positions cost nothing to skip: the first real character
+    // after a run of separators is a boundary in its own right, because the
+    // character before it is a separator. Skipping them stops " - " from
+    // spending three of the budget below on a single gap.
+    if (skipSeparatorAnchors && WORD_DELIMITER.test(lowerName[start]!)) continue;
     if (!isBoundary(boundarySource, start)) continue;
     if (++anchors > MAX_TYPO_ANCHORS) return false;
     const edit = alignsWithinOneEdit(lowerQuery, lowerName, start);

--- a/src/lib/projectSwitcherSearch.ts
+++ b/src/lib/projectSwitcherSearch.ts
@@ -184,6 +184,11 @@ function hasNearMissNameMatch(lowerQuery: string, name: string): boolean {
   let anchors = 0;
 
   for (let start = 0; start + shortestWindow <= lowerName.length; start++) {
+    // A word does not begin on a separator. Skipping those costs nothing — the
+    // first real character after a run of them is a boundary in its own right,
+    // because the character before it is a delimiter — and it stops " - " from
+    // spending three of the budget below on one gap.
+    if (WORD_DELIMITER.test(lowerName[start]!)) continue;
     if (!isBoundary(boundarySource, start)) continue;
     if (++anchors > MAX_TYPO_ANCHORS) return false;
     const edit = alignsWithinOneEdit(lowerQuery, lowerName, start);
@@ -213,9 +218,12 @@ function isEditWorthCorrecting(query: string, index: number): boolean {
   let characters = 0;
   for (let i = from; i < to; i++) {
     const unit = query.charCodeAt(i);
+    const next = i + 1 < to ? query.charCodeAt(i + 1) : 0;
     // A surrogate pair is one character to whoever typed it, and two to
-    // `length` — which is the whole reason this is not a `to - from` subtraction.
-    if (unit >= 0xd800 && unit <= 0xdbff && i + 1 < to) i++;
+    // `length` — which is the whole reason this is not a `to - from`
+    // subtraction. An UNPAIRED high surrogate is left to count as one, so a
+    // lone one cannot swallow the character after it.
+    if (unit >= 0xd800 && unit <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) i++;
     if (++characters >= MIN_TYPO_TOKEN_LENGTH) return true;
   }
   return false;
@@ -264,7 +272,15 @@ function alignExceptOneSwapOrSubstitution(query: string, field: string, start: n
       break;
     }
   }
-  if (substituted) return first;
+  // An edit is only a typo if it happened INSIDE a word. A letter standing
+  // where a separator belongs is a differently-shaped name, not a slip, and
+  // admitting it would let the short-word rule be walked around from the field
+  // side ("abcdx" reaching "abcd-").
+  if (substituted) {
+    return isWordCharacter(query[first]) && isWordCharacter(field[start + first])
+      ? first
+      : NO_ALIGNMENT;
+  }
 
   // Adjacent transposition, which is the edit plain Levenshtein charges twice
   // for and the one people actually make — every case the issue reported
@@ -279,7 +295,15 @@ function alignExceptOneSwapOrSubstitution(query: string, field: string, start: n
   for (let i = first + 2; i < length; i++) {
     if (query[i] !== field[start + i]) return NO_ALIGNMENT;
   }
-  return first;
+  // Both halves of the swap are checked, not just the one the index names: a
+  // swap across a separator ("abcdx-y" against "abcd-xy") moves a character
+  // between two words rather than within one.
+  return isWordCharacter(query[first]) && isWordCharacter(query[first + 1]) ? first : NO_ALIGNMENT;
+}
+
+/** Whether `unit` is a character a word is made of, rather than what separates two. */
+function isWordCharacter(unit: string | undefined): boolean {
+  return unit !== undefined && unit !== "" && !WORD_DELIMITER.test(unit);
 }
 
 /** One character too many in the query: drop it and the rest must line up. */
@@ -294,7 +318,7 @@ function alignWithOneExtraQueryChar(query: string, field: string, start: number)
   for (let j = i; j < windowLength; j++) {
     if (query[j + 1] !== field[start + j]) return NO_ALIGNMENT;
   }
-  return i;
+  return isWordCharacter(query[i]) ? i : NO_ALIGNMENT;
 }
 
 /**
@@ -316,7 +340,13 @@ function alignWithOneExtraFieldChar(query: string, field: string, start: number)
   for (let j = i; j < length; j++) {
     if (query[j] !== field[start + j + 1]) return NO_ALIGNMENT;
   }
-  return i;
+  // The character that went missing is the FIELD's, so the word it belongs to
+  // is read off the field too. When the query holds a separator at that point
+  // the missing character closed out the PRECEDING word — "review-notes"
+  // against "reviews-notes" dropped the "s" off "review", not off "-".
+  if (!isWordCharacter(field[start + i])) return NO_ALIGNMENT;
+  if (isWordCharacter(query[i])) return i;
+  return i > 0 && isWordCharacter(query[i - 1]) ? i - 1 : NO_ALIGNMENT;
 }
 
 /**
@@ -609,6 +639,12 @@ export function rankSwitcherMatches(
   const trimmed = query.trim();
   if (!trimmed) return [];
   const lowerQuery = trimmed.toLowerCase();
+  // Case folding is length-preserving for every character anyone types a
+  // workspace name with, but not for all of them ("\u0130" folds to two units).
+  // When it is not, a folded offset no longer points at the character that was
+  // typed, so the word the typo gate measures would be the wrong one — and the
+  // tier stands down rather than measuring it anyway.
+  const typoTolerant = lowerQuery.length === trimmed.length;
 
   const activityFor = (workspace: WorkspaceRowStatusFields & { id: string }): SearchActivityKey =>
     activityKeys === null
@@ -620,7 +656,7 @@ export function rankSwitcherMatches(
   for (const project of projects) {
     const score = scoreProjectQuery(trimmed, project.name, project.path);
     if (score <= 0) {
-      if (!hasNearMissNameMatch(lowerQuery, project.name)) continue;
+      if (!typoTolerant || !hasNearMissNameMatch(lowerQuery, project.name)) continue;
       scored.push({
         row: { kind: "project", ...project },
         textClass: TEXT_CLASS_TYPO_NAME,
@@ -649,7 +685,7 @@ export function rankSwitcherMatches(
   for (const scratch of scratches) {
     const score = scoreScratchQuery(trimmed, scratch.name);
     if (score <= 0) {
-      if (!hasNearMissNameMatch(lowerQuery, scratch.name)) continue;
+      if (!typoTolerant || !hasNearMissNameMatch(lowerQuery, scratch.name)) continue;
       scored.push({
         row: { kind: "scratch", ...scratch },
         textClass: TEXT_CLASS_TYPO_NAME,


### PR DESCRIPTION
## Problem

`scoreField` in `src/lib/projectSwitcherSearch.ts` is a strict ordered-subsequence scorer: it returns 0 the moment any query character goes unmatched. Typing `webstie` for the project named `Daintree Website` returned nothing at all. The extra letter didn't degrade the match, it deleted it. Typing `webs` returned the project fine.

That's the worst failure shape a switcher can have. You fat-finger one character mid-flow and the whole list empties out.

Resolves #11924

## Approach

`scoreField` is untouched. A second, deliberately smaller matcher runs only for rows that strict-scored 0, and seats them in a new terminal text class, `TEXT_CLASS_TYPO_NAME = 5`, below the existing `TEXT_CLASS_PATH_ONLY = 4`.

Typo rows are always computed and always sort below every clean row, so the contents and indices of the strict results are provably unchanged for any query that already matched. Nothing shifts under the pointer, and a pending Enter still commits the row it was aimed at. This is deliberately not an "only when the clean tier is empty" fallback, that design would make the list flicker between keystrokes.

The matcher itself is a boundary-anchored, threshold-one optimal-string-alignment scan: it allows a substitution, an adjacent transposition, or one extra character on either side. Because the edit bound is fixed at one, only three window lengths can align (`n-1`, `n`, `n+1`), so this is three linear scans with no DP matrix and no allocation.

### Four bounds keep it from becoming a second permissive scorer

This module already rejected a word-initials fallback for exactly this reason (#11625), so the new matcher carries hard limits:

- Anchored to a word boundary. A typo of `ebsite` is not recovered from inside `Website`.
- Exactly one edit, never a ladder to two.
- The edit must land inside a word of at least 4 characters, and never on the separator between two words.
- Name only. Paths stay strict subsequence matching, an edit across a long shared path is noise.

The word-length gate is the load-bearing decision here. The threshold belongs to the word token carrying the edit, not to the whole query, which is where Algolia (`minWordSizefor1Typo`) and Typesense (`min_len_1typo`) put it. Gating on the whole query is a worse rule: `project-17` is ten characters, so a query-length gate would let its one-character edit roam and pull in `project-1`, `project-7`, and every `project-1x` pattern, eleven neighbours for what should be one exact match. Numbered and versioned sibling names are the common case in a real workspace list.

## Ranking invariants preserved

The ordering rule from #11861 still holds: activity orders rows within a tier, it can never lift a row out of its tier. A typo row with 40 blocked agents still sits below a quiet clean prefix match and below a path-only match. Typo rows carry score 0, and that score is only ever compared against other typo rows, so the comparator stays total and transitive.

## Scope note: Pilot is deliberately not included

The issue also flags that `isFilterMatch`, used by `src/components/Pilot/pilotRows.ts`, shares the same cliff. It's left unchanged here on purpose. `filterPilotGroups` presents every boolean survivor as an equally valid answer with no re-ranking at all, and a match on `group.name` admits every row in that project, so a typo tier there can't satisfy the issue's own "a typo costs rank, not the result" requirement. There's no rank to cost in that code path. It needs its own ranked match-quality model, which is a separate design task. Every constraint and acceptance test in the issue is scoped to the switcher.

## Testing

72 tests in `projectSwitcherSearch.test.ts`: 50 pre-existing, unmodified, all passing, plus 22 new. Golden queries and ordering invariants rather than score assertions, per the repo's rule against tautological tests. Each golden case asserts its own strict score is 0 first, proving it actually reached the new tier rather than passing through unchanged strict scoring.

Coverage:
- All four originally reported queries (`webstie`, `wesbite`, `danitree`, `dcoker`)
- Substitution and insertion edit types
- The numbered-sibling gate
- Edits on word separators and edits crossing a word boundary
- A clean prefix match outranking a typo match even against a project with 40 blocked agents
- Strict results keeping their original order and array indices once typo rows join
- The frozen activity-snapshot path running through the new branch
- Case-insensitivity
- Untrimmed whitespace in the query
- A project name shorter than the query
- A 61-character query

Also confirmed green, unmodified: 190 palette-hook tests and 62 Pilot tests.

Reviewed across five adversarial Codex passes. Findings on cross-token edit attribution, a quadratic worst case on a pathological project name, a Unicode case-fold offset desync, and surrogate pair handling were all fixed, each with its own regression test.
