### PR TITLE
feat(worktree): add Copy branch name to the worktree context menu

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -494,6 +494,15 @@ export function WorktreeCard({
     void copyWorktreePath(worktree.path);
   };
 
+  const { copy: copyBranchName } = useCopyWithFeedback({ announcement: "Branch name copied" });
+  const handleCopyBranchName = () => {
+    const branch = worktree.branch;
+    // The menu already hides the item in both cases; re-checking keeps a stale
+    // callback from copying the branch a detached worktree has left behind.
+    if (!branch || worktree.isDetached) return;
+    void copyBranchName(branch);
+  };
+
   const [showIssuePicker, setShowIssuePicker] = useState(false);
   const [showPlanViewer, setShowPlanViewer] = useState(false);
 
@@ -748,6 +757,7 @@ export function WorktreeCard({
     onCopyContextFull: handleCopyContextFull,
     onCopyContextModified: handleCopyContextModified,
     onCopyPath: handleCopyPath,
+    onCopyBranchName: handleCopyBranchName,
     onOpenEditor,
     onRevealInFinder: handlePathClick,
     onOpenIssueExternal: worktree.issueNumber ? handleOpenIssueExternal : undefined,

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -29,7 +29,7 @@ import { actionService } from "@/services/ActionService";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { cn } from "../../lib/utils";
-import { isExternalWorktree } from "@/lib/worktreeFilters";
+import { copyableBranchName, isExternalWorktree } from "@/lib/worktreeFilters";
 import { getAgentConfig, getAgentIds } from "@/config/agents";
 import { isAssistantOnlyAgentId } from "@shared/config/agentIds";
 import { getAgentSettingsEntry } from "@/types";
@@ -496,10 +496,8 @@ export function WorktreeCard({
 
   const { copy: copyBranchName } = useCopyWithFeedback({ announcement: "Branch name copied" });
   const handleCopyBranchName = () => {
-    const branch = worktree.branch;
-    // The menu already hides the item in both cases; re-checking keeps a stale
-    // callback from copying the branch a detached worktree has left behind.
-    if (!branch || worktree.isDetached) return;
+    const branch = copyableBranchName(worktree);
+    if (!branch) return;
     void copyBranchName(branch);
   };
 

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeActionsToolbar.keyboard.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeActionsToolbar.keyboard.test.tsx
@@ -35,6 +35,7 @@ const baseMenu = {
   onCopyContextFull: noop,
   onCopyContextModified: noop,
   onCopyPath: noop,
+  onCopyBranchName: noop,
   onOpenEditor: noop,
   onRevealInFinder: noop,
   onRunRecipe: noop,

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -97,6 +97,7 @@ const baseMenu: WorktreeHeaderProps["menu"] = {
   onCopyContextFull: noop,
   onCopyContextModified: noop,
   onCopyPath: noop,
+  onCopyBranchName: noop,
   onOpenEditor: noop,
   onRevealInFinder: noop,
   onRunRecipe: noop,

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -51,7 +51,7 @@ import {
   Zap,
 } from "lucide-react";
 import { Folders, Workflow } from "@/components/icons";
-import { isExternalWorktree } from "@/lib/worktreeFilters";
+import { copyableBranchName, isExternalWorktree } from "@/lib/worktreeFilters";
 import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
 import type { PluginContextMenuItemEntry } from "@/hooks/usePluginContextMenuItems";
 
@@ -221,6 +221,7 @@ export function WorktreeMenuItems({
   pluginItems,
 }: WorktreeMenuItemsProps) {
   const hasIssueItem = Boolean(worktree.issueNumber && onOpenIssueExternal);
+  const canCopyBranchName = copyableBranchName(worktree) !== null;
   const hasPRItem = Boolean(worktree.linked?.pr && onOpenPRExternal);
   const hasIssueOrPrSection = hasIssueItem || hasPRItem;
   const hasRecipes = recipes.length > 0;
@@ -533,10 +534,7 @@ export function WorktreeMenuItems({
         <Copy className="w-3.5 h-3.5 mr-2" />
         Copy Path
       </C.Item>
-      {/* `isDetached` has to gate this too, not just `branch`: the status pass
-          only overwrites `branch` when it reads a new one, so a worktree that
-          detaches keeps its pre-detach branch on the snapshot. */}
-      {worktree.branch && !worktree.isDetached && (
+      {canCopyBranchName && (
         <C.Item onSelect={onCopyBranchName}>
           <GitBranch className="w-3.5 h-3.5 mr-2" />
           Copy branch name

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -21,6 +21,7 @@ import {
   FileText,
   Folder,
   FolderTree,
+  GitBranch,
   GitCommitHorizontal,
   GitCompare,
   GitPullRequest,
@@ -108,6 +109,7 @@ export interface WorktreeMenuItemsProps {
   onCopyContextFull: () => void;
   onCopyContextModified: () => void;
   onCopyPath: () => void;
+  onCopyBranchName: () => void;
   onOpenEditor: () => void;
   onRevealInFinder: () => void;
   onOpenIssueExternal?: () => void;
@@ -177,6 +179,7 @@ export function WorktreeMenuItems({
   onCopyContextFull,
   onCopyContextModified,
   onCopyPath,
+  onCopyBranchName,
   onOpenEditor,
   onRevealInFinder,
   onOpenIssueExternal,
@@ -530,6 +533,15 @@ export function WorktreeMenuItems({
         <Copy className="w-3.5 h-3.5 mr-2" />
         Copy Path
       </C.Item>
+      {/* `isDetached` has to gate this too, not just `branch`: the status pass
+          only overwrites `branch` when it reads a new one, so a worktree that
+          detaches keeps its pre-detach branch on the snapshot. */}
+      {worktree.branch && !worktree.isDetached && (
+        <C.Item onSelect={onCopyBranchName}>
+          <GitBranch className="w-3.5 h-3.5 mr-2" />
+          Copy branch name
+        </C.Item>
+      )}
 
       {onTogglePin && !worktree.isMainWorktree && !isExternalWorktree(worktree) && (
         <C.Item onSelect={onTogglePin}>

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.copyBranchName.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.copyBranchName.test.tsx
@@ -81,10 +81,6 @@ describe("WorktreeMenuItems — Copy branch name (#11930)", () => {
   });
 
   it("withholds the item on a detached HEAD still carrying its pre-detach branch", () => {
-    // The status pass only overwrites `branch` when it reads a *new* one, so a
-    // worktree that detaches keeps the old name beside `isDetached: true`. The
-    // branch is no longer checked out — offering to copy it would hand back a
-    // name that doesn't describe this worktree any more.
     renderMenu(makeWorktree({ isDetached: true }));
 
     expect(screen.queryByText("Copy branch name")).toBeNull();
@@ -102,11 +98,12 @@ describe("WorktreeMenuItems — Copy branch name (#11930)", () => {
   it("places the item directly under Copy Path, so the two copy targets read together", () => {
     renderMenu(makeWorktree());
 
-    const labels = screen.getAllByRole("button").map((el) => el.textContent);
-    const copyPathAt = labels.findIndex((t) => t?.includes("Copy Path"));
-    const copyBranchAt = labels.findIndex((t) => t?.includes("Copy branch name"));
+    // Sibling order, not button indices: an index comparison stays green if a
+    // separator or label gets inserted between the two, since neither renders
+    // as a button.
+    const copyPath = screen.getByText("Copy Path");
+    const copyBranch = screen.getByText("Copy branch name");
 
-    expect(copyPathAt).toBeGreaterThanOrEqual(0);
-    expect(copyBranchAt).toBe(copyPathAt + 1);
+    expect(copyPath.nextElementSibling).toBe(copyBranch);
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.copyBranchName.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.copyBranchName.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type * as React from "react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { WorktreeState } from "../../../types";
+import { WorktreeMenuItems, type WorktreeMenuComponents } from "../WorktreeMenuItems";
+
+vi.mock("@/components/Plugin/PluginContextMenuSection", () => ({
+  PluginContextMenuSection: () => null,
+}));
+
+afterEach(cleanup);
+
+const components: WorktreeMenuComponents = {
+  Item: ({ children, onSelect }: { children?: React.ReactNode; onSelect?: () => void }) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+  Label: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Separator: () => <hr />,
+  Shortcut: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  Sub: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SubTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SubContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+};
+
+function makeWorktree(overrides: Partial<WorktreeState> = {}): WorktreeState {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- WorktreeState has ~60 fields and this render layer reads four of them; the sibling WorktreeMenuItems tests build their fixtures the same way.
+  return {
+    id: "wt-1",
+    name: "feature",
+    path: "/repo/wt-1",
+    branch: "feature/copy-branch-name",
+    ...overrides,
+  } as WorktreeState;
+}
+
+function renderMenu(worktree: WorktreeState, onCopyBranchName: () => void = vi.fn()) {
+  return render(
+    <WorktreeMenuItems
+      worktree={worktree}
+      components={components}
+      launchAgents={[]}
+      recipes={[]}
+      runningRecipeId={null}
+      counts={{ grid: 0, dock: 0, active: 0, completed: 0, all: 0, waiting: 0, working: 0 }}
+      onCopyContextFull={vi.fn()}
+      onCopyContextModified={vi.fn()}
+      onCopyPath={vi.fn()}
+      onCopyBranchName={onCopyBranchName}
+      onOpenEditor={vi.fn()}
+      onRevealInFinder={vi.fn()}
+      onRunRecipe={vi.fn()}
+      onDockAll={vi.fn()}
+      onMaximizeAll={vi.fn()}
+      onResetRenderers={vi.fn()}
+      onSelectAllAgents={vi.fn()}
+      onSelectWaitingAgents={vi.fn()}
+      onSelectWorkingAgents={vi.fn()}
+      onCloseAll={vi.fn()}
+      onTerminateAll={vi.fn()}
+      onClearHistory={vi.fn()}
+    />
+  );
+}
+
+describe("WorktreeMenuItems — Copy branch name (#11930)", () => {
+  it("offers the item for a worktree checked out on a branch", () => {
+    renderMenu(makeWorktree());
+
+    expect(screen.queryByText("Copy branch name")).not.toBeNull();
+  });
+
+  it("withholds the item when the worktree reports no branch", () => {
+    renderMenu(makeWorktree({ branch: undefined }));
+
+    expect(screen.queryByText("Copy branch name")).toBeNull();
+  });
+
+  it("withholds the item on a detached HEAD still carrying its pre-detach branch", () => {
+    // The status pass only overwrites `branch` when it reads a *new* one, so a
+    // worktree that detaches keeps the old name beside `isDetached: true`. The
+    // branch is no longer checked out — offering to copy it would hand back a
+    // name that doesn't describe this worktree any more.
+    renderMenu(makeWorktree({ isDetached: true }));
+
+    expect(screen.queryByText("Copy branch name")).toBeNull();
+  });
+
+  it("invokes the supplied callback when the item is chosen", () => {
+    const onCopyBranchName = vi.fn();
+    renderMenu(makeWorktree(), onCopyBranchName);
+
+    fireEvent.click(screen.getByText("Copy branch name"));
+
+    expect(onCopyBranchName).toHaveBeenCalledTimes(1);
+  });
+
+  it("places the item directly under Copy Path, so the two copy targets read together", () => {
+    renderMenu(makeWorktree());
+
+    const labels = screen.getAllByRole("button").map((el) => el.textContent);
+    const copyPathAt = labels.findIndex((t) => t?.includes("Copy Path"));
+    const copyBranchAt = labels.findIndex((t) => t?.includes("Copy branch name"));
+
+    expect(copyPathAt).toBeGreaterThanOrEqual(0);
+    expect(copyBranchAt).toBe(copyPathAt + 1);
+  });
+});

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.openChanges.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.openChanges.test.tsx
@@ -52,6 +52,7 @@ function renderMenu(onOpenChanges?: () => void, onOpenReviewHub?: () => void) {
       onCopyContextFull={vi.fn()}
       onCopyContextModified={vi.fn()}
       onCopyPath={vi.fn()}
+      onCopyBranchName={vi.fn()}
       onOpenEditor={vi.fn()}
       onRevealInFinder={vi.fn()}
       onRunRecipe={vi.fn()}

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.pin.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.pin.test.tsx
@@ -50,6 +50,7 @@ function renderMenu(worktree: WorktreeState, onTogglePin?: () => void, isPinned 
       onCopyContextFull={vi.fn()}
       onCopyContextModified={vi.fn()}
       onCopyPath={vi.fn()}
+      onCopyBranchName={vi.fn()}
       onOpenEditor={vi.fn()}
       onRevealInFinder={vi.fn()}
       onRunRecipe={vi.fn()}

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -15,6 +15,7 @@ import {
   matchesDevServerFilter,
   isLiveDevServerStatus,
   isExternalWorktree,
+  copyableBranchName,
   type DerivedWorktreeMeta,
   type FilterState,
 } from "../worktreeFilters";
@@ -455,6 +456,28 @@ describe("isExternalWorktree", () => {
     expect(isExternalWorktree(createMockWorktree({ isExternal: false }))).toBe(false);
     expect(isExternalWorktree(createMockWorktree({ isExternal: undefined }))).toBe(false);
     expect(isExternalWorktree(createMockWorktree())).toBe(false);
+  });
+});
+
+describe("copyableBranchName", () => {
+  it("offers the branch itself, not the display name, when one is checked out", () => {
+    const worktree = createMockWorktree({ branch: "feature/x", name: "some-other-label" });
+
+    expect(copyableBranchName(worktree)).toBe(worktree.branch);
+  });
+
+  it("offers nothing when the worktree reports no branch", () => {
+    expect(copyableBranchName(createMockWorktree({ branch: undefined }))).toBeNull();
+    expect(copyableBranchName(createMockWorktree({ branch: "" }))).toBeNull();
+  });
+
+  it("offers nothing on a detached HEAD still carrying its pre-detach branch", () => {
+    // The status pass only overwrites `branch` when it reads a new one, so the
+    // old name outlives the detach. Handing it back would name a branch this
+    // worktree no longer has checked out.
+    expect(
+      copyableBranchName(createMockWorktree({ branch: "feature/x", isDetached: true }))
+    ).toBeNull();
   });
 });
 

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -280,6 +280,18 @@ export function isExternalWorktree(worktree: Worktree | WorktreeState): boolean 
   return worktree.isExternal === true;
 }
 
+/**
+ * The branch name a worktree can offer to copy, or null when it has none to
+ * give. `isDetached` has to count alongside `branch`: the status pass only
+ * overwrites `branch` when it reads a new one, so a worktree that detaches
+ * keeps its pre-detach branch on the snapshot — a name it no longer has
+ * checked out. Same pairing `getWorktreeType` uses to classify "detached".
+ */
+export function copyableBranchName(worktree: Worktree | WorktreeState): string | null {
+  if (worktree.isDetached || !worktree.branch) return null;
+  return worktree.branch;
+}
+
 export function sortWorktrees<T extends Worktree | WorktreeState>(
   worktrees: T[],
   orderBy: OrderBy,


### PR DESCRIPTION
## Summary

- Adds a "Copy branch name" item to the worktree card context menu, directly under Copy Path, using the same clipboard-with-feedback pattern as that item.
- Wired into a single `menuActions` object, so it reaches both surfaces, the right-click menu and the ⋯ dropdown, from one place.
- The interesting part was getting the detached-HEAD guard right. Details below.

Resolves #11930

## The detached HEAD detail

The issue asked for the item to be hidden on a detached HEAD. The obvious guard is checking that `worktree.branch` is falsy, and that turns out not to be enough.

`GitStatusPass.readCurrentBranch()` returns `undefined` when `.git/HEAD` holds a raw SHA, and sets `isDetached` to `true`. But its caller at `GitStatusPass.ts:317` only writes the `branch` field when the read returns a defined value. So a worktree that detaches at runtime keeps its pre-detach branch name in the snapshot, and ends up emitting `{ branch: "old-branch", isDetached: true }` at the same time.

Guarding on `branch` alone would offer to copy a branch the worktree no longer has checked out, which is exactly the failure the issue was trying to avoid.

The real guard is a new function, `copyableBranchName()`, that checks both fields together, the same pairing `getWorktreeType` already uses to classify a worktree as detached. It lives in `src/lib/worktreeFilters.ts` so the menu's visibility check and the card's copy handler share one rule instead of each duplicating it.

## Other decisions worth noting

- The label is sentence case, "Copy branch name", per the microcopy rules in `CLAUDE.md`, matching the most recently added item in this menu, "Open changes". The adjacent legacy "Copy Path" is left alone; renaming it is out of scope here.
- `onCopyBranchName` is a required prop on `WorktreeMenuItems`, matching `onCopyPath`. That's deliberate: `WorktreeMenuActions` is defined as an `Omit` of the menu items props, so a required prop makes it a compile error to wire the item into one menu surface and forget the other, which has actually happened before on this same menu, for a Browse Files item.
- The new item gets its own `useCopyWithFeedback` instance so the screen-reader announcement can say "Branch name copied" instead of the generic "Copied", since the announcement is set per hook instance, not per call.
- `GitBranch` is imported directly from `lucide-react`, matching how the other ~40 icons in this file are already imported. The shared icon barrel is reserved for Daintree-specific metaphors, not generic git concepts.

## Testing

875 tests across 11 files pass locally:
- The new 5-case suite for the menu item (`WorktreeMenuItems.copyBranchName.test.tsx`)
- 3 new cases for `copyableBranchName` in `worktreeFilters.test.ts`
- Every existing suite covering the changed modules
- The three repo-wide contract suites in `src/config/__tests__`

Prettier and eslint are clean on the changed files. Two pre-existing `no-unsafe-type-assertion` warnings in `worktreeFilters.ts` remain (lines 100 and 526 on `develop`), unrelated to this change.

## Follow-ups (found, not fixed here)

These are pre-existing problems in the workspace host, not something a context menu PR should be fixing:

1. `readCurrentBranch()` only recognizes a detached HEAD when `.git/HEAD` holds exactly 40 lowercase hex characters. SHA-256 repositories use 64-character object IDs, so a detach there falls through as "not detached" and the previous branch name survives in the snapshot. `electron/utils/git.ts` already has a 40/64 OID rule that could be reused.
2. When reading `.git/HEAD` fails or times out, `readCurrentBranch()` returns `undefined` while also setting `isDetached` to `false` and clearing `head`. The caller reads `undefined` as "leave branch unchanged", producing an attached-looking snapshot paired with the old branch. It should distinguish confirmed-attached, confirmed-detached, and unknown, instead of collapsing unknown into attached.
3. `WorkspaceService.syncMonitors()` copies `branch` onto an existing monitor without `isDetached` or `head`, so topology reconciliation can briefly pair a new branch with stale detached metadata.
4. `WorktreeDeleteDialog.tsx:88` still uses `!worktree.branch` as its whole detached test, so on the stale-branch snapshot above it can offer to delete a branch the worktree doesn't actually have checked out.
