### PR TITLE
fix(detector): stop unrelated descendants branding a terminal with an agent

### DIFF
--- a/electron/services/ProcessDetector/ProcessDetector.ts
+++ b/electron/services/ProcessDetector/ProcessDetector.ts
@@ -1,9 +1,14 @@
 import type { BuiltInAgentId } from "../../../shared/config/agentIds.js";
 import type { ProcessInfo, ProcessTreeCache } from "../ProcessTreeCache.js";
 import type { ImagePathProbe } from "../pty/ImagePathProbe.js";
-import { logDebug, logWarn } from "../../utils/logger.js";
+import { logDebug, logInfo, logWarn } from "../../utils/logger.js";
 import { logIdentityDebug } from "../pty/identityDebug.js";
-import type { ChildProcess, DetectedProcessCandidate, CommandIdentity } from "./types.js";
+import type {
+  ChildProcess,
+  DetectedProcessCandidate,
+  CommandIdentity,
+  DetectionPass,
+} from "./types.js";
 import {
   makeAgentResult,
   makeNoAgentResult,
@@ -11,8 +16,8 @@ import {
   makeAmbiguousResult,
 } from "./types.js";
 import type { DetectionCallback } from "./types.js";
-import type { DetectionResult, DetectionEvidenceSource } from "./types.js";
-import { redactArgv } from "./commandParser.js";
+import type { DetectionEvidenceSource } from "./types.js";
+import { isChromiumChildProcess, redactArgv } from "./commandParser.js";
 import { buildDetectedCandidate, selectPreferredCandidate } from "./candidateHelpers.js";
 
 export { type DetectionResult } from "./types.js";
@@ -328,7 +333,7 @@ export class ProcessDetector {
         }
       }
 
-      const result = this.detectAgent();
+      const { result, treeMatch } = this.detectAgent();
 
       // Per-pass log is gated behind DAINTREE_IDENTITY_DEBUG_PASS=1 so the hot
       // path is silent by default. Enable when diagnosing "detector ran but
@@ -422,6 +427,10 @@ export class ProcessDetector {
             this.onStreak = 0;
             this.pendingDetected = null;
             gatedCommitted = true;
+
+            if (rawAgent !== null) {
+              this.logAgentCommit(rawAgent, this.lastEvidenceSource, treeMatch);
+            }
 
             // Anchor runtime-promoted agents once the process tree corroborates
             // them. A plain terminal the user typed `codex`/`claude` into starts
@@ -539,7 +548,7 @@ export class ProcessDetector {
     }
   }
 
-  private detectAgent(): DetectionResult {
+  private detectAgent(): DetectionPass {
     if (!Number.isInteger(this.ptyPid) || this.ptyPid <= 0) {
       const shellEvidenceValid = this.isShellCommandEvidenceValid(false);
       if (shellEvidenceValid) {
@@ -548,7 +557,7 @@ export class ProcessDetector {
       // Invalid PID — no evidence, not negative evidence. Hold committed
       // state rather than emitting a demotion.
       console.warn(`Invalid PTY PID for terminal ${this.terminalId}: ${this.ptyPid}`);
-      return makeUnknownResult({ isBusy: false });
+      return { result: makeUnknownResult({ isBusy: false }), treeMatch: null };
     }
 
     const children = this.cache.getChildren(this.ptyPid);
@@ -573,7 +582,7 @@ export class ProcessDetector {
       if (shellEvidenceValid) {
         return this.mergeWithShellEvidence(null, { isBusy: false, currentCommand: undefined });
       }
-      return makeUnknownResult({ isBusy: false });
+      return { result: makeUnknownResult({ isBusy: false }), treeMatch: null };
     }
 
     if (!isBusy) {
@@ -609,11 +618,21 @@ export class ProcessDetector {
     // visiting the same PID twice when a node appears under two parents.
     const scheduled = new Set<number>([this.ptyPid]);
 
-    let frontier = liveChildren.filter((proc) => {
+    // Chromium's own helpers mark a process-domain boundary. A nested Electron
+    // app launched from this terminal spawns its pty-host as one of them, and
+    // that host's descendants are the *inner* instance's agent terminals —
+    // walking into them brands the outer terminal with an agent it never ran.
+    // Refusing the node here (already marked scheduled, so it is never
+    // reconsidered under another parent) keeps it out of candidate matching,
+    // image probing, child expansion, and the descent budget in one place.
+    // The node stays in `liveChildren`, so the terminal is still busy. #11931
+    const shouldSchedule = (proc: ProcessInfo): boolean => {
       if (scheduled.has(proc.pid)) return false;
       scheduled.add(proc.pid);
-      return true;
-    });
+      return !isChromiumChildProcess(proc.command);
+    };
+
+    let frontier = liveChildren.filter((proc) => shouldSchedule(proc));
 
     for (let depth = 1; depth <= MAX_PROCESS_TREE_DEPTH && frontier.length > 0; depth++) {
       // Direct children are always scanned in full — they are the cheap,
@@ -627,7 +646,12 @@ export class ProcessDetector {
 
       for (const proc of level) {
         const command = proc.command || proc.comm;
-        const candidate = buildDetectedCandidate(proc.comm, command, order++);
+        const candidate = buildDetectedCandidate(proc.comm, command, order++, {
+          pid: proc.pid,
+          depth,
+          comm: proc.comm,
+          source: "comm",
+        });
         if (candidate) {
           bestMatch = selectPreferredCandidate(bestMatch, candidate);
         }
@@ -646,7 +670,12 @@ export class ProcessDetector {
           probedPids.add(proc.pid);
           const imageBasename = this.imagePathProbe.readBasename(proc.pid);
           if (imageBasename) {
-            const imageCandidate = buildDetectedCandidate(imageBasename, command, order++);
+            const imageCandidate = buildDetectedCandidate(imageBasename, command, order++, {
+              pid: proc.pid,
+              depth,
+              comm: proc.comm,
+              source: "image_path",
+            });
             if (imageCandidate) {
               bestMatch = selectPreferredCandidate(bestMatch, imageCandidate);
             }
@@ -665,8 +694,8 @@ export class ProcessDetector {
       const next: ProcessInfo[] = [];
       for (const proc of level) {
         for (const child of this.cache.getChildren(proc.pid)) {
-          if (child.command.includes("<defunct>") || scheduled.has(child.pid)) continue;
-          scheduled.add(child.pid);
+          if (child.command.includes("<defunct>")) continue;
+          if (!shouldSchedule(child)) continue;
           next.push(child);
         }
       }
@@ -753,7 +782,7 @@ export class ProcessDetector {
   private mergeWithShellEvidence(
     treeMatch: DetectedProcessCandidate | null,
     ctx: { isBusy: boolean; currentCommand?: string }
-  ): DetectionResult {
+  ): DetectionPass {
     const shellIdentity = this.shellCommandIdentity;
     // Merge uses the wider expiry window (30 s) — shell evidence stays valid
     // for merging even after the 12 s sticky window closes. Sticky governs
@@ -765,29 +794,38 @@ export class ProcessDetector {
     if (treeMatch?.agentType) {
       if (shellEvidenceValid && shellIdentity?.agentType) {
         if (shellIdentity.agentType === treeMatch.agentType) {
-          return makeAgentResult({
-            agentType: treeMatch.agentType,
-            processIconId: treeMatch.processIconId,
-            processName: treeMatch.processName,
-            isBusy: ctx.isBusy,
-            currentCommand: ctx.currentCommand,
-            evidenceSource: "both",
-          });
+          return {
+            result: makeAgentResult({
+              agentType: treeMatch.agentType,
+              processIconId: treeMatch.processIconId,
+              processName: treeMatch.processName,
+              isBusy: ctx.isBusy,
+              currentCommand: ctx.currentCommand,
+              evidenceSource: "both",
+            }),
+            treeMatch,
+          };
         }
         // Two distinct positive agent identities — genuinely ambiguous. Hold.
-        return makeAmbiguousResult({
+        return {
+          result: makeAmbiguousResult({
+            isBusy: ctx.isBusy,
+            currentCommand: ctx.currentCommand,
+          }),
+          treeMatch: null,
+        };
+      }
+      return {
+        result: makeAgentResult({
+          agentType: treeMatch.agentType,
+          processIconId: treeMatch.processIconId,
+          processName: treeMatch.processName,
           isBusy: ctx.isBusy,
           currentCommand: ctx.currentCommand,
-        });
-      }
-      return makeAgentResult({
-        agentType: treeMatch.agentType,
-        processIconId: treeMatch.processIconId,
-        processName: treeMatch.processName,
-        isBusy: ctx.isBusy,
-        currentCommand: ctx.currentCommand,
-        evidenceSource: "process_tree",
-      });
+          evidenceSource: "process_tree",
+        }),
+        treeMatch,
+      };
     }
 
     // Case B — no tree agent match, but shell is valid with an agent. The
@@ -796,42 +834,89 @@ export class ProcessDetector {
     // shell has vouched for the command; prompt-return/PTy exit/kill are the
     // explicit lifecycle signals that clear this evidence.
     if (shellEvidenceValid && shellIdentity?.agentType) {
-      return makeAgentResult({
-        agentType: shellIdentity.agentType,
-        processIconId: shellIdentity.processIconId ?? treeMatch?.processIconId,
-        processName: shellIdentity.processName ?? treeMatch?.processName,
-        isBusy: ctx.isBusy,
-        currentCommand: this.shellCommandText ?? ctx.currentCommand,
-        evidenceSource: "shell_command",
-      });
+      // The committed agent came from the shell, so the tree candidate (a
+      // generic icon at best) is not what produced it and must not be
+      // reported as its provenance.
+      return {
+        result: makeAgentResult({
+          agentType: shellIdentity.agentType,
+          processIconId: shellIdentity.processIconId ?? treeMatch?.processIconId,
+          processName: shellIdentity.processName ?? treeMatch?.processName,
+          isBusy: ctx.isBusy,
+          currentCommand: this.shellCommandText ?? ctx.currentCommand,
+          evidenceSource: "shell_command",
+        }),
+        treeMatch: null,
+      };
     }
 
     // Case C — tree has a non-agent icon match (npm/docker/etc). Shell icon
     // is only consulted when tree has nothing at all.
     if (treeMatch?.processIconId) {
-      return makeAgentResult({
-        processIconId: treeMatch.processIconId,
-        processName: treeMatch.processName,
-        isBusy: ctx.isBusy,
-        currentCommand: ctx.currentCommand,
-        evidenceSource: "process_tree",
-      });
+      return {
+        result: makeAgentResult({
+          processIconId: treeMatch.processIconId,
+          processName: treeMatch.processName,
+          isBusy: ctx.isBusy,
+          currentCommand: ctx.currentCommand,
+          evidenceSource: "process_tree",
+        }),
+        treeMatch,
+      };
     }
 
     // Case D — no tree evidence. If shell has a non-agent icon and is still
     // valid, surface it the same way a tree icon would be surfaced.
     if (shellEvidenceValid && shellIdentity?.processIconId) {
-      return makeAgentResult({
-        processIconId: shellIdentity.processIconId,
-        processName: shellIdentity.processName,
-        isBusy: ctx.isBusy,
-        currentCommand: this.shellCommandText ?? ctx.currentCommand,
-        evidenceSource: "shell_command",
-      });
+      return {
+        result: makeAgentResult({
+          processIconId: shellIdentity.processIconId,
+          processName: shellIdentity.processName,
+          isBusy: ctx.isBusy,
+          currentCommand: this.shellCommandText ?? ctx.currentCommand,
+          evidenceSource: "shell_command",
+        }),
+        treeMatch: null,
+      };
     }
 
     // Case E — no evidence from either source → genuine no_agent.
-    return makeNoAgentResult({ isBusy: ctx.isBusy, currentCommand: ctx.currentCommand });
+    return {
+      result: makeNoAgentResult({ isBusy: ctx.isBusy, currentCommand: ctx.currentCommand }),
+      treeMatch: null,
+    };
+  }
+
+  /**
+   * Always-on record of which process produced a committed agent identity.
+   *
+   * Agent commits are rare, high-consequence and sticky — `setLaunchAnchored`
+   * latches them until an explicit lifecycle signal — and they drive the
+   * pane's icon, title and placeholder. Every other identity log is gated
+   * behind `DAINTREE_DEBUG`, so a wrong label left no trace in a packaged
+   * build. `info` reaches the rotated log file at the default level; a correct
+   * commit is normal operation, not a warning. Fires only inside the
+   * committed-transition branch, so re-confirmation ticks stay silent. #11931
+   *
+   * Argv is reduced to argv[0]'s basename by `redactArgv` — users pass secrets
+   * inline (`claude --api-key=…`) and this line is persisted to disk.
+   */
+  private logAgentCommit(
+    agentType: BuiltInAgentId,
+    evidenceSource: DetectionEvidenceSource,
+    treeMatch: DetectedProcessCandidate | null
+  ): void {
+    const provenance = treeMatch?.provenance;
+    const argv0 = treeMatch ? redactArgv(treeMatch.processCommand) : "";
+    logInfo(
+      `[ProcessDetector ${this.terminalId.slice(-8)}] agent identity committed: ` +
+        `agent=${agentType} evidence=${evidenceSource} ` +
+        `match=${provenance?.matchSource ?? "<none>"} ` +
+        `pid=${provenance?.pid ?? "<none>"} ` +
+        `comm=${provenance ? JSON.stringify(provenance.comm) : "<none>"} ` +
+        `argv0=${argv0 || "<none>"} ` +
+        `depth=${provenance?.depth ?? "<none>"}`
+    );
   }
 
   getLastDetected(): BuiltInAgentId | null {

--- a/electron/services/ProcessDetector/candidateHelpers.ts
+++ b/electron/services/ProcessDetector/candidateHelpers.ts
@@ -1,5 +1,9 @@
 import type { BuiltInAgentId } from "../../../shared/config/agentIds.js";
-import type { DetectedProcessCandidate } from "./types.js";
+import type {
+  CandidateMatchSource,
+  CandidateProvenance,
+  DetectedProcessCandidate,
+} from "./types.js";
 import { getProcessToolPriority } from "../../../shared/config/processToolRegistry.js";
 import { AGENT_CLI_NAMES, getProcessIconMap } from "./registries.js";
 import {
@@ -25,10 +29,19 @@ export function getDetectionPriority(agentType?: BuiltInAgentId, processIconId?:
   return getProcessToolPriority(processIconId);
 }
 
+/** Where the caller read `processName` from, and which process it belongs to. */
+export interface CandidateOrigin {
+  pid: number;
+  depth: number;
+  comm: string;
+  source: Exclude<CandidateMatchSource, "argv">;
+}
+
 export function buildDetectedCandidate(
   processName: string,
   processCommand: string | undefined,
-  order: number
+  order: number,
+  origin?: CandidateOrigin
 ): DetectedProcessCandidate | null {
   const normalizedName = normalizeProcessName(processName);
   const lowerName = normalizedName.toLowerCase();
@@ -39,47 +52,63 @@ export function buildDetectedCandidate(
   let agentType = AGENT_CLI_NAMES[lowerName];
   let processIconId = processIconMap[lowerName];
   let effectiveName = normalizedName;
+  let matchSource: CandidateMatchSource = origin?.source ?? "comm";
 
   if (!agentType && processCommand) {
     const candidates = extractCommandNameCandidates(processCommand);
+    const positionLimit = executablePositionLimit(candidates);
     // Seed from the `comm` match so an argv name only displaces it by ranking
     // strictly better. That is what turns `node /path/to/vite.js` into Vite
     // while leaving `npm run dev` — whose argv names nothing registered — npm.
-    let iconMatch: { name: string; icon: string; priority: number } | null = processIconId
-      ? {
-          name: effectiveName,
-          icon: processIconId,
-          priority: getProcessToolPriority(processIconId),
-        }
-      : null;
+    let iconMatch: { name: string; icon: string; priority: number; fromArgv: boolean } | null =
+      processIconId
+        ? {
+            name: effectiveName,
+            icon: processIconId,
+            priority: getProcessToolPriority(processIconId),
+            fromArgv: false,
+          }
+        : null;
     for (const [index, candidate] of candidates.entries()) {
+      // The executable-position rule binds agents as well as icons: an
+      // argument that happens to name an agent is still an argument, and a
+      // repo full of paths like `shared/config/agents/opencode.ts` would
+      // otherwise brand any process that opens one. Candidates are in argv
+      // order, so nothing past the limit qualifies either. #11931
+      if (index > positionLimit) break;
+
       const lowerCandidate = candidate.toLowerCase();
       const candidateAgent = AGENT_CLI_NAMES[lowerCandidate];
       if (candidateAgent) {
         agentType = candidateAgent;
         processIconId = processIconMap[lowerCandidate] ?? processIconId;
         effectiveName = candidate;
+        matchSource = "argv";
         break;
       }
-      if (index > executablePositionLimit(candidates)) continue;
       const candidateIcon = processIconMap[lowerCandidate];
       if (candidateIcon) {
         const priority = getProcessToolPriority(candidateIcon);
         // Strict `<` keeps the leftmost argv name on ties, matching argv order.
         if (!iconMatch || priority < iconMatch.priority) {
-          iconMatch = { name: candidate, icon: candidateIcon, priority };
+          iconMatch = { name: candidate, icon: candidateIcon, priority, fromArgv: true };
         }
       }
     }
     if (!agentType && iconMatch) {
       processIconId = iconMatch.icon;
       effectiveName = iconMatch.name;
+      if (iconMatch.fromArgv) matchSource = "argv";
     }
   }
 
   if (!agentType && !processIconId) {
     return null;
   }
+
+  const provenance: CandidateProvenance | undefined = origin
+    ? { pid: origin.pid, depth: origin.depth, comm: origin.comm, matchSource }
+    : undefined;
 
   return {
     agentType,
@@ -88,6 +117,7 @@ export function buildDetectedCandidate(
     processCommand,
     priority: getDetectionPriority(agentType, processIconId),
     order,
+    provenance,
   };
 }
 

--- a/electron/services/ProcessDetector/commandParser.ts
+++ b/electron/services/ProcessDetector/commandParser.ts
@@ -1,5 +1,9 @@
 import type { CommandIdentity } from "./types.js";
-import { getProcessToolPriority } from "../../../shared/config/processToolRegistry.js";
+import {
+  getProcessToolConfig,
+  getProcessToolPriority,
+  PROCESS_TOOL_ICON_BY_COMMAND,
+} from "../../../shared/config/processToolRegistry.js";
 import { AGENT_CLI_NAMES, getProcessIconMap } from "./registries.js";
 
 const WINDOWS_LAUNCHER_EXTENSION_PATTERN = /\.(?:exe|cmd|bat|com|ps1)$/i;
@@ -126,16 +130,122 @@ export function redactArgv(command: string | undefined): string {
 export const BINARY_EXEC_SUBCOMMANDS = new Set(["exec", "dlx", "x"]);
 
 /**
- * Highest candidate index that can still name the tool being run. Normally
- * argv[0] and the token it executes; a package manager's exec subcommand
- * shifts that one further right (`pnpm exec vitest`).
+ * Commands that run another program named in their arguments but carry no
+ * process-tool registry entry: shells, environment/privilege prefixes, and
+ * version-manager shims. Registry entries at `runtime` or `package-manager`
+ * tier already mean exactly this, so those are derived instead of relisted.
+ */
+const SHELL_AND_PREFIX_EXECUTORS = new Set([
+  "sh",
+  "bash",
+  "zsh",
+  "fish",
+  "dash",
+  "ash",
+  "ksh",
+  "csh",
+  "tcsh",
+  "pwsh",
+  "powershell",
+  "cmd",
+  "env",
+  "sudo",
+  "doas",
+  "nohup",
+  "nice",
+  "time",
+  "stdbuf",
+  "setsid",
+  "command",
+  "exec",
+  "script",
+  "mise",
+  "asdf",
+  "rtx",
+  "direnv",
+  "pipx",
+  "rye",
+  "pdm",
+  "hatch",
+]);
+
+/**
+ * Does this command run *another* program named in its arguments? Only then
+ * can a later argv token be the executable.
+ *
+ * Built-in registry tiers only. A plugin-contributed command must not be able
+ * to widen how far right an agent name is allowed to sit — that is the
+ * positional guard this feeds, and plugins carry no tier to justify it.
+ */
+function isExecutorCommand(name: string | undefined): boolean {
+  if (!name) return false;
+  const lower = name.toLowerCase();
+  if (SHELL_AND_PREFIX_EXECUTORS.has(lower)) return true;
+  // Own-key check: this table is a plain object, so a process literally named
+  // `constructor` would otherwise index an inherited function.
+  if (!Object.hasOwn(PROCESS_TOOL_ICON_BY_COMMAND, lower)) return false;
+  const tier = getProcessToolConfig(PROCESS_TOOL_ICON_BY_COMMAND[lower])?.tier;
+  return tier === "runtime" || tier === "package-manager";
+}
+
+/**
+ * Highest candidate index that can still name the tool being run.
+ *
+ * argv[0] always can. Anything further right counts only when argv[0] is a
+ * command that runs another program named in its arguments — a shell, a
+ * runtime, a package manager, an env/privilege prefix. For everything else
+ * the remaining tokens are operands: `cat shared/config/agents/opencode.ts`,
+ * `git log -- …/opencode.ts` and an editor opened on that file all name a
+ * path, not an executable, and must not resolve to the agent. #11931
+ *
+ * A package manager's exec subcommand shifts the window one further right
+ * (`pnpm exec vitest`).
  *
  * This is positional, not a full argv grammar — a flag that takes a value
  * (`node --require ts-node/register app.js`) still consumes a slot, so the
  * process-tree walk remains the primary signal.
  */
 export function executablePositionLimit(candidates: string[]): number {
+  if (!isExecutorCommand(candidates[0])) return 0;
   return candidates[1] && BINARY_EXEC_SUBCOMMANDS.has(candidates[1].toLowerCase()) ? 2 : 1;
+}
+
+/**
+ * Chromium's own multi-process children, which every Electron app spawns and
+ * which all carry a `--type=` switch naming their role.
+ */
+const CHROMIUM_CHILD_PROCESS_TYPES = new Set([
+  "renderer",
+  "utility",
+  "gpu-process",
+  "zygote",
+  "sandbox-ipc",
+  "crashpad-handler",
+]);
+
+/**
+ * Is this process one of Chromium's internal helpers?
+ *
+ * Such a helper is never the identity of the terminal that launched the app,
+ * and everything below it belongs to that app's own process scope. A nested
+ * Daintree's pty-host is exactly this node, so its descendants are the *inner*
+ * instance's agent terminals — walking into them brands the outer terminal
+ * with an agent it never ran. #11931
+ *
+ * Matched on an exact argv token so an unrelated `--type=json` flag, a path
+ * containing the string, or an operand after `--` cannot trip it.
+ */
+export function isChromiumChildProcess(command: string | undefined): boolean {
+  if (!command || !command.includes("--type=")) return false;
+  for (const token of splitShellLikeCommand(command)) {
+    // Everything after a bare `--` is an operand, not a switch.
+    if (token === "--") return false;
+    if (!token.startsWith("--type=")) continue;
+    if (CHROMIUM_CHILD_PROCESS_TYPES.has(token.slice("--type=".length).toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -148,12 +258,19 @@ export function executablePositionLimit(candidates: string[]): number {
  */
 export function detectCommandIdentity(command: string | undefined): CommandIdentity | null {
   const candidates = extractCommandNameCandidates(command);
+  const positionLimit = executablePositionLimit(candidates);
   let iconMatch: { name: string; icon: string; priority: number } | null = null;
   // Captured once so every lookup in this resolution sees one consistent map,
   // even if a plugin loads mid-pass.
   const processIconMap = getProcessIconMap();
 
   for (const [index, candidate] of candidates.entries()) {
+    // Same executable-position rule as the process-tree path, and it binds
+    // agents too: an argument that happens to name an agent is still an
+    // argument. Candidates are in argv order, so nothing past the limit
+    // qualifies either. #11931
+    if (index > positionLimit) break;
+
     const lowerCandidate = candidate.toLowerCase();
     const candidateAgent = AGENT_CLI_NAMES[lowerCandidate];
     if (candidateAgent) {
@@ -164,8 +281,6 @@ export function detectCommandIdentity(command: string | undefined): CommandIdent
       };
     }
 
-    // Same executable-position rule as the process-tree path.
-    if (index > executablePositionLimit(candidates)) continue;
     const candidateIcon = processIconMap[lowerCandidate];
     if (candidateIcon) {
       // Tier preference, so a typed `npx vitest` reports Vitest rather than

--- a/electron/services/ProcessDetector/commandParser.ts
+++ b/electron/services/ProcessDetector/commandParser.ts
@@ -110,22 +110,40 @@ export function extractScriptBasenameFromCommand(command: string | undefined): s
 // argv[0]'s basename so log noise still identifies the runtime without
 // leaking credentials into console or into window.__daintreeIdentityEvents().
 /**
- * argv[0] as written — quotes removed, path separators intact.
+ * argv[0] as written — grouping quotes removed, path separators intact.
  *
  * Deliberately not `splitShellLikeCommand`, which treats `\` as an escape.
- * That flattens a Windows path (`"C:\Users\me\proj\claude.cmd"` becomes
- * `C:Usersmeprojclaude.cmd`), so the basename split below finds no separator
- * and the whole path — home directory and project name included — survives
- * into a log that is persisted to disk.
+ * This input is a command line as the OS *reports* it (`ps`, Win32
+ * `CommandLine`), not shell input: a backslash there is a Windows path
+ * separator. Eating it flattens `"C:\Users\me\proj\claude.cmd"` into one
+ * separator-less token, so the basename split below finds nothing and the
+ * whole path — home directory and project name included — survives into a log
+ * that is persisted to disk.
+ *
+ * A quote groups but does not end the token, so a compound path like
+ * `'/Users/me/my project'/claude` still resolves to `claude`. Unbalanced
+ * quoting is unparseable, and guessing at it is exactly how the rest of argv —
+ * an inline `--api-key=…` among it — reaches the log, so it fails closed.
  */
 function firstCommandToken(command: string): string {
-  const trimmed = command.trim();
-  const quote = trimmed[0];
-  if (quote === '"' || quote === "'") {
-    const end = trimmed.indexOf(quote, 1);
-    return end === -1 ? trimmed.slice(1) : trimmed.slice(1, end);
+  let token = "";
+  let quote: '"' | "'" | null = null;
+
+  for (const char of command.trim()) {
+    if (quote) {
+      if (char === quote) quote = null;
+      else token += char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) break;
+    token += char;
   }
-  return trimmed.split(/\s+/)[0] ?? "";
+
+  return quote === null ? token : "";
 }
 
 export function redactArgv(command: string | undefined): string {

--- a/electron/services/ProcessDetector/commandParser.ts
+++ b/electron/services/ProcessDetector/commandParser.ts
@@ -109,9 +109,28 @@ export function extractScriptBasenameFromCommand(command: string | undefined): s
 // secrets inline (e.g. `claude --api-key=…`, `gh auth --token …`). Keep only
 // argv[0]'s basename so log noise still identifies the runtime without
 // leaking credentials into console or into window.__daintreeIdentityEvents().
+/**
+ * argv[0] as written — quotes removed, path separators intact.
+ *
+ * Deliberately not `splitShellLikeCommand`, which treats `\` as an escape.
+ * That flattens a Windows path (`"C:\Users\me\proj\claude.cmd"` becomes
+ * `C:Usersmeprojclaude.cmd`), so the basename split below finds no separator
+ * and the whole path — home directory and project name included — survives
+ * into a log that is persisted to disk.
+ */
+function firstCommandToken(command: string): string {
+  const trimmed = command.trim();
+  const quote = trimmed[0];
+  if (quote === '"' || quote === "'") {
+    const end = trimmed.indexOf(quote, 1);
+    return end === -1 ? trimmed.slice(1) : trimmed.slice(1, end);
+  }
+  return trimmed.split(/\s+/)[0] ?? "";
+}
+
 export function redactArgv(command: string | undefined): string {
   if (!command) return "";
-  const first = splitShellLikeCommand(command)[0];
+  const first = firstCommandToken(command);
   if (!first) return "";
   const basename = first.split(/[\\/]/).pop() ?? first;
   return JSON.stringify(basename);
@@ -158,7 +177,6 @@ const SHELL_AND_PREFIX_EXECUTORS = new Set([
   "setsid",
   "command",
   "exec",
-  "script",
   "mise",
   "asdf",
   "rtx",
@@ -234,6 +252,11 @@ const CHROMIUM_CHILD_PROCESS_TYPES = new Set([
  *
  * Matched on an exact argv token so an unrelated `--type=json` flag, a path
  * containing the string, or an operand after `--` cannot trip it.
+ *
+ * The switch alone is the signal — no corroborating Chromium flag is required.
+ * That accepts a rare false positive (a non-Chromium process that happens to
+ * take `--type=utility` loses its subtree) to avoid a false negative, which
+ * would let the nested-instance bleed-through straight back in.
  */
 export function isChromiumChildProcess(command: string | undefined): boolean {
   if (!command || !command.includes("--type=")) return false;

--- a/electron/services/ProcessDetector/index.ts
+++ b/electron/services/ProcessDetector/index.ts
@@ -13,8 +13,6 @@ export {
   extractCommandNameCandidates,
   extractScriptBasenameFromCommand,
   stripCommandExecutableExtension,
-  executablePositionLimit,
-  isChromiumChildProcess,
   redactArgv,
   detectCommandIdentity,
 } from "./commandParser.js";

--- a/electron/services/ProcessDetector/index.ts
+++ b/electron/services/ProcessDetector/index.ts
@@ -13,6 +13,8 @@ export {
   extractCommandNameCandidates,
   extractScriptBasenameFromCommand,
   stripCommandExecutableExtension,
+  executablePositionLimit,
+  isChromiumChildProcess,
   redactArgv,
   detectCommandIdentity,
 } from "./commandParser.js";

--- a/electron/services/ProcessDetector/registries.ts
+++ b/electron/services/ProcessDetector/registries.ts
@@ -7,7 +7,7 @@ import { PROCESS_TOOL_ICON_BY_COMMAND } from "../../../shared/config/processTool
  * Is this package tail specific enough to stand alone as an agent name?
  *
  * The tail is a convenience alias, so it only earns registration when it
- * actually names its agent: one of its `-`/`_`-separated tokens must be the
+ * actually names its agent: one of its alphanumeric tokens must be the
  * agent's id or command. `@anthropic-ai/claude-code` → `claude-code` keeps its
  * alias; `@ampcode/cli` → `cli` loses it, because nothing about `cli` says
  * Amp, and registering it made every Node CLI launched as `node …/cli.js` —

--- a/electron/services/ProcessDetector/registries.ts
+++ b/electron/services/ProcessDetector/registries.ts
@@ -3,10 +3,20 @@ import { AGENT_REGISTRY } from "../../../shared/config/agentRegistry.js";
 import { getPluginProcessToolRegistry } from "../../../shared/config/pluginProcessToolRegistry.js";
 import { PROCESS_TOOL_ICON_BY_COMMAND } from "../../../shared/config/processToolRegistry.js";
 
+/**
+ * Package tails too generic to identify an agent. `@ampcode/cli` would
+ * otherwise register the bare name `cli`, and every Node CLI launched as
+ * `node …/cli.js` — `npx electron .` among them — would resolve to that
+ * agent. The tail is a convenience alias, so dropping an ambiguous one costs
+ * nothing: the agent's own command and id still register. #11931
+ */
+const GENERIC_PACKAGE_TAILS = new Set(["cli", "code", "agent", "app", "bin", "core", "main"]);
+
 function packageTail(pkg: string | undefined): string | undefined {
   if (!pkg) return undefined;
   const tail = pkg.split("/").pop();
-  return tail && tail.length > 0 ? tail : undefined;
+  if (!tail || tail.length === 0) return undefined;
+  return GENERIC_PACKAGE_TAILS.has(tail.toLowerCase()) ? undefined : tail;
 }
 
 /** Reads `packages.npm` first; falls back to deprecated top-level `npmGlobalPackage`. */

--- a/electron/services/ProcessDetector/registries.ts
+++ b/electron/services/ProcessDetector/registries.ts
@@ -4,19 +4,24 @@ import { getPluginProcessToolRegistry } from "../../../shared/config/pluginProce
 import { PROCESS_TOOL_ICON_BY_COMMAND } from "../../../shared/config/processToolRegistry.js";
 
 /**
- * Package tails too generic to identify an agent. `@ampcode/cli` would
- * otherwise register the bare name `cli`, and every Node CLI launched as
- * `node …/cli.js` — `npx electron .` among them — would resolve to that
- * agent. The tail is a convenience alias, so dropping an ambiguous one costs
- * nothing: the agent's own command and id still register. #11931
+ * Is this package tail specific enough to stand alone as an agent name?
+ *
+ * The tail is a convenience alias, so it only earns registration when it
+ * actually names its agent: one of its `-`/`_`-separated tokens must be the
+ * agent's id or command. `@anthropic-ai/claude-code` → `claude-code` keeps its
+ * alias; `@ampcode/cli` → `cli` loses it, because nothing about `cli` says
+ * Amp, and registering it made every Node CLI launched as `node …/cli.js` —
+ * `npx electron .` among them — resolve to that agent. #11931
  */
-const GENERIC_PACKAGE_TAILS = new Set(["cli", "code", "agent", "app", "bin", "core", "main"]);
+function isAgentSpecificTail(tail: string, id: string, command: string): boolean {
+  const tokens = tail.toLowerCase().split(/[^a-z0-9]+/);
+  return tokens.includes(id.toLowerCase()) || tokens.includes(command.toLowerCase());
+}
 
 function packageTail(pkg: string | undefined): string | undefined {
   if (!pkg) return undefined;
   const tail = pkg.split("/").pop();
-  if (!tail || tail.length === 0) return undefined;
-  return GENERIC_PACKAGE_TAILS.has(tail.toLowerCase()) ? undefined : tail;
+  return tail && tail.length > 0 ? tail : undefined;
 }
 
 /** Reads `packages.npm` first; falls back to deprecated top-level `npmGlobalPackage`. */
@@ -42,7 +47,12 @@ export const AGENT_CLI_NAMES: Record<string, BuiltInAgentId> = Object.assign(
         entries.push([id, id as BuiltInAgentId]);
       }
       const tail = packageTail(effectiveNpmPackage(config));
-      if (tail && tail !== config.command && tail !== id) {
+      if (
+        tail &&
+        tail !== config.command &&
+        tail !== id &&
+        isAgentSpecificTail(tail, id, config.command)
+      ) {
         entries.push([tail, id as BuiltInAgentId]);
       }
       return entries;
@@ -58,7 +68,12 @@ const AGENT_ICON_BY_COMMAND: Record<string, string> = Object.fromEntries(
       entries.push([config.command, config.iconId]);
     }
     const tail = packageTail(effectiveNpmPackage(config));
-    if (tail && tail !== config.command && tail !== id) {
+    if (
+      tail &&
+      tail !== config.command &&
+      tail !== id &&
+      isAgentSpecificTail(tail, id, config.command)
+    ) {
       entries.push([tail, config.iconId]);
     }
     return entries;

--- a/electron/services/ProcessDetector/types.ts
+++ b/electron/services/ProcessDetector/types.ts
@@ -6,6 +6,23 @@ export interface ChildProcess {
   command?: string;
 }
 
+/**
+ * Which signal inside a single process produced the winning name: its `comm`,
+ * a token in its argv, or the basename of its on-disk image. Recorded so a
+ * wrong committed identity says *how* it was resolved, not just to what. #11931
+ */
+export type CandidateMatchSource = "comm" | "argv" | "image_path";
+
+/** The process behind a candidate, carried for the agent-commit diagnostic. */
+export interface CandidateProvenance {
+  pid: number;
+  /** BFS level below the PTY; direct children are 1. */
+  depth: number;
+  /** Raw `comm` as the OS reported it, before basename/extension stripping. */
+  comm: string;
+  matchSource: CandidateMatchSource;
+}
+
 export interface DetectedProcessCandidate {
   agentType?: BuiltInAgentId;
   processIconId?: string;
@@ -13,6 +30,8 @@ export interface DetectedProcessCandidate {
   processCommand?: string;
   priority: number;
   order: number;
+  /** Absent when the caller supplied no origin (unit-level construction). */
+  provenance?: CandidateProvenance;
 }
 
 export interface CommandIdentity {
@@ -46,6 +65,19 @@ export interface DetectionResult {
 }
 
 export type DetectionCallback = (result: DetectionResult, spawnedAt: number) => void;
+
+/**
+ * One detection pass: the public result plus the tree candidate that actually
+ * supports it. The candidate rides alongside rather than inside
+ * `DetectionResult` because that type crosses to the renderer, and it is
+ * returned rather than stashed on the detector so it cannot go stale across
+ * the early-return paths (invalid PID, blind `ps`, empty tree). `treeMatch` is
+ * null whenever the identity did not come from the process tree.
+ */
+export interface DetectionPass {
+  result: DetectionResult;
+  treeMatch: DetectedProcessCandidate | null;
+}
 
 export function makeAgentResult(params: {
   agentType?: BuiltInAgentId;

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -10,6 +10,7 @@ import {
   setPluginProcessToolRegistry,
 } from "../../../shared/config/pluginProcessToolRegistry.js";
 import { AGENT_CLI_NAMES } from "../ProcessDetector/registries.js";
+import { AGENT_REGISTRY } from "../../../shared/config/agentRegistry.js";
 import { buildDetectedCandidate } from "../ProcessDetector/candidateHelpers.js";
 import {
   executablePositionLimit,
@@ -32,7 +33,7 @@ function agentCommitLogs(): string[] {
     .filter((message) => message.includes("agent identity committed"));
 }
 
-type ProcessNode = { pid: number; comm: string; command?: string };
+type ProcessNode = { pid: number; comm: string; command: string };
 
 function createCacheMock() {
   const listeners = new Set<() => void>();
@@ -1804,6 +1805,12 @@ describe("ProcessDetector", () => {
       cache.emitRefresh();
       cache.emitRefresh();
 
+      // Witness that the walk actually ran, so the absence below is a verdict
+      // rather than a detector that never started.
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ isBusy: true }),
+        expect.any(Number)
+      );
       expect(detector.getLastDetected()).toBeNull();
       for (const [result] of callback.mock.calls) {
         expect(result.agentType).toBeUndefined();
@@ -1848,9 +1855,11 @@ describe("ProcessDetector", () => {
       cache.setChildren(400, [
         {
           pid: 500,
-          comm: "Daintree Helper",
+          // `ProcessTreeCache.parseUnixLine` captures comm as `\S+`, so a real
+          // helper's comm arrives without the spaces its bundle path has.
+          comm: "Electron",
           command:
-            '"/Applications/Daintree.app/Contents/Frameworks/Daintree Helper.app/Contents/MacOS/Daintree Helper" --type=utility --utility-sub-type=node.mojom.NodeService',
+            "/repo/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Helper.app/Contents/MacOS/Electron Helper --type=utility --utility-sub-type=node.mojom.NodeService",
         },
       ]);
       cache.setChildren(500, [{ pid: 600, comm: "zsh", command: "/bin/zsh -l" }]);
@@ -1873,11 +1882,17 @@ describe("ProcessDetector", () => {
       cache.emitRefresh();
       cache.emitRefresh();
 
+      // The walk ran and descended: it reached the boundary node's parent.
+      expect(cache.getChildren).toHaveBeenCalledWith(400);
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ isBusy: true }),
+        expect.any(Number)
+      );
       expect(detector.getLastDetected()).toBeNull();
       for (const [result] of callback.mock.calls) {
         expect(result.agentType).toBeUndefined();
       }
-      // The boundary node's subtree is never even fetched.
+      // ...and stopped there: the boundary node's subtree is never fetched.
       expect(cache.getChildren).not.toHaveBeenCalledWith(500);
     });
 
@@ -1909,8 +1924,9 @@ describe("ProcessDetector", () => {
       cache.setChildren(100, [
         {
           pid: 200,
-          comm: "Daintree Helper",
-          command: "Daintree Helper --type=utility --utility-sub-type=node.mojom.NodeService",
+          comm: "Electron",
+          command:
+            "/repo/node_modules/electron/dist/Electron Helper --type=utility --utility-sub-type=node.mojom.NodeService",
         },
       ]);
       cache.setChildren(200, [{ pid: 300, comm: "opencode", command: "opencode" }]);
@@ -1935,6 +1951,11 @@ describe("ProcessDetector", () => {
       cache.emitRefresh();
       cache.emitRefresh();
 
+      // A pruned child is still a running process: the terminal stays busy.
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ isBusy: true }),
+        expect.any(Number)
+      );
       expect(detector.getLastDetected()).toBeNull();
       expect(imagePathProbe.readBasename).not.toHaveBeenCalledWith(200);
       expect(cache.getChildren).not.toHaveBeenCalledWith(200);
@@ -2049,6 +2070,97 @@ describe("ProcessDetector", () => {
       expect(line).toContain("pid=<none>");
       expect(line).toContain("depth=<none>");
       expect(line).not.toContain("pid=200");
+    });
+
+    it("keeps tree provenance when both signals agree", () => {
+      const cache = createCacheMock();
+      // The wrapper must not name the agent itself, or it wins at depth 1 and
+      // the walk never reaches the process this test is about.
+      cache.setChildren(100, [{ pid: 200, comm: "sh", command: "sh -c launch" }]);
+      cache.setChildren(200, [{ pid: 300, comm: "node", command: "node /opt/bin/opencode" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-commit-both",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        false
+      );
+      detector.injectShellCommandEvidence(
+        { agentType: "opencode", processIconId: "opencode", processName: "opencode" },
+        "opencode"
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      const [line] = agentCommitLogs();
+      expect(line).toContain("evidence=both");
+      expect(line).toContain("pid=300");
+      expect(line).toContain("depth=2");
+    });
+
+    it("names the image path when that is what identified the process", () => {
+      // The #8790 shape: the CLI rewrote comm and argv, and only the on-disk
+      // binary still says what it is.
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "Ask anything", command: "Ask anything" }]);
+      const imagePathProbe = {
+        readBasename: vi.fn((pid: number) => (pid === 200 ? "opencode" : null)),
+        evict: vi.fn(),
+        dispose: vi.fn(),
+      };
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-commit-image",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      const [line] = agentCommitLogs();
+      expect(line).toContain("agent=opencode");
+      expect(line).toContain("match=image_path");
+      expect(line).toContain("pid=200");
+    });
+
+    it("does not leak a Windows path through the redacted argv0", () => {
+      // `splitShellLikeCommand` eats backslashes as escapes, which would flatten
+      // the path into one separator-less token and persist the whole thing —
+      // home directory and project name included — to the log file.
+      const cache = createCacheMock();
+      cache.setChildren(100, [
+        {
+          pid: 200,
+          comm: "opencode.cmd",
+          command: '"C:\\Users\\alice\\secret-project\\opencode.cmd" --resume',
+        },
+      ]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-commit-winpath",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      const [line] = agentCommitLogs();
+      expect(line).toContain('argv0="opencode.cmd"');
+      expect(line).not.toContain("alice");
+      expect(line).not.toContain("secret-project");
     });
 
     it("does not log an agent commit for a non-agent icon", () => {
@@ -2423,14 +2535,16 @@ describe("executable position bounds (#11931)", () => {
   });
 
   it("stops detectCommandIdentity promoting an agent named by an argument", () => {
-    for (const command of [
-      `cat ${agentPath}`,
-      `git log -- ${agentPath}`,
-      `nvim ${agentPath}`,
-      "npm run opencode",
-      "uv run opencode",
+    // Compared against the same command over a neutral file: naming an agent
+    // in an operand must change nothing about how the command resolves.
+    for (const [agentArg, neutralArg] of [
+      [`cat ${agentPath}`, "cat /repo/README.md"],
+      [`git log -- ${agentPath}`, "git log -- /repo/README.md"],
+      [`nvim ${agentPath}`, "nvim /repo/README.md"],
+      ["npm run opencode", "npm run build"],
+      ["uv run opencode", "uv run build"],
     ]) {
-      expect(detectCommandIdentity(command)?.agentType, command).toBeUndefined();
+      expect(detectCommandIdentity(agentArg), agentArg).toEqual(detectCommandIdentity(neutralArg));
     }
   });
 
@@ -2453,10 +2567,18 @@ describe("executable position bounds (#11931)", () => {
 
   it("stops buildDetectedCandidate branding a file-reading process", () => {
     expect(buildDetectedCandidate("cat", `cat ${agentPath}`, 0)).toBeNull();
-    // Neovim keeps its own icon; it just does not become the agent.
-    const editor = buildDetectedCandidate("nvim", `nvim ${agentPath}`, 0);
-    expect(editor?.agentType).toBeUndefined();
-    expect(editor?.processIconId).toBe("neovim");
+    // Neovim keeps whatever identity it has over any other file; opening an
+    // agent-named one just does not change it.
+    const identityOf = (command: string) => {
+      const candidate = buildDetectedCandidate("nvim", command, 0);
+      expect(candidate, command).not.toBeNull();
+      return {
+        agentType: candidate?.agentType,
+        processIconId: candidate?.processIconId,
+        processName: candidate?.processName,
+      };
+    };
+    expect(identityOf(`nvim ${agentPath}`)).toEqual(identityOf("nvim /repo/README.md"));
   });
 
   it("records where the winning name was read from", () => {
@@ -2475,24 +2597,47 @@ describe("executable position bounds (#11931)", () => {
   });
 
   it("omits provenance when no origin is supplied", () => {
-    expect(buildDetectedCandidate("opencode", "opencode", 0)?.provenance).toBeUndefined();
+    const candidate = buildDetectedCandidate("opencode", "opencode", 0);
+    expect(candidate).not.toBeNull();
+    expect(candidate?.provenance).toBeUndefined();
   });
 });
 
 describe("agent CLI name aliases", () => {
-  it("does not register a generic package tail as an agent name", () => {
-    // `@ampcode/cli` would otherwise make every `node …/cli.js` an Amp
-    // terminal — `npx electron .` launches exactly that. #11931
-    for (const generic of ["cli", "code", "agent", "app", "bin", "core", "main"]) {
-      expect(AGENT_CLI_NAMES[generic], generic).toBeUndefined();
+  it("registers no alias that does not name its own agent", () => {
+    // The invariant, not a copy of any list: every registered name must carry
+    // its agent's id or command as a token. `@ampcode/cli` yielded the bare
+    // alias `cli`, which made every Node CLI launched as `node …/cli.js` — the
+    // Electron launcher `npx electron .` runs included — an Amp terminal. #11931
+    for (const [alias, agentId] of Object.entries(AGENT_CLI_NAMES)) {
+      const command = AGENT_REGISTRY[agentId].command.toLowerCase();
+      const lowerAlias = alias.toLowerCase();
+      const lowerId = agentId.toLowerCase();
+      const tokens = lowerAlias.split(/[^a-z0-9]+/);
+      const namesItsAgent =
+        lowerAlias === lowerId ||
+        lowerAlias === command ||
+        tokens.includes(lowerId) ||
+        tokens.includes(command);
+      expect(namesItsAgent, `${alias} -> ${agentId}`).toBe(true);
     }
   });
 
-  it("still registers each agent's own command and id", () => {
-    expect(AGENT_CLI_NAMES["amp"]).toBe("amp");
-    expect(AGENT_CLI_NAMES["opencode"]).toBe("opencode");
-    // A distinctive tail is still a useful alias.
-    expect(AGENT_CLI_NAMES["claude-code"]).toBe("claude");
+  it("keeps every agent reachable by its own command and id", () => {
+    for (const [agentId, config] of Object.entries(AGENT_REGISTRY)) {
+      expect(AGENT_CLI_NAMES[config.command], config.command).toBe(agentId);
+      expect(AGENT_CLI_NAMES[agentId], agentId).toBe(agentId);
+    }
+  });
+
+  it("does not resolve an agent from a generic Node CLI entry point", () => {
+    // The end-to-end shape of the `cli` regression, through the real registry.
+    expect(detectCommandIdentity("node /repo/node_modules/electron/cli.js .")).toEqual(
+      detectCommandIdentity("node /repo/node_modules/electron/launcher.js .")
+    );
+    expect(detectCommandIdentity("node /repo/node_modules/electron/cli.js .")?.agentType).toBe(
+      undefined
+    );
   });
 });
 
@@ -2508,6 +2653,13 @@ describe("isChromiumChildProcess", () => {
     ]) {
       expect(isChromiumChildProcess(command), command).toBe(true);
     }
+  });
+
+  it("treats the switch alone as sufficient, by design", () => {
+    // A non-Chromium process taking an exact `--type=utility` loses its
+    // subtree. That is the accepted cost of never missing a real boundary —
+    // a false negative here is the nested-instance bug returning. #11931
+    expect(isChromiumChildProcess("node orchestrator.js --type=utility")).toBe(true);
   });
 
   it("ignores unrelated, partial or operand `--type=` text", () => {

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -11,6 +11,26 @@ import {
 } from "../../../shared/config/pluginProcessToolRegistry.js";
 import { AGENT_CLI_NAMES } from "../ProcessDetector/registries.js";
 import { buildDetectedCandidate } from "../ProcessDetector/candidateHelpers.js";
+import {
+  executablePositionLimit,
+  isChromiumChildProcess,
+} from "../ProcessDetector/commandParser.js";
+import { logInfo } from "../../utils/logger.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
+/** Commit-diagnostic lines emitted so far, newest last. */
+function agentCommitLogs(): string[] {
+  return vi
+    .mocked(logInfo)
+    .mock.calls.map(([message]) => message)
+    .filter((message) => message.includes("agent identity committed"));
+}
 
 type ProcessNode = { pid: number; comm: string; command?: string };
 
@@ -1758,6 +1778,299 @@ describe("ProcessDetector", () => {
     });
   });
 
+  describe("argument paths are not executables (#11931)", () => {
+    // This repo is full of file paths that name agents, so a process that
+    // merely *opens* one must not inherit that agent's identity.
+    const agentPath = "/repo/shared/config/agents/opencode.ts";
+
+    it.each([
+      { label: "cat", comm: "cat", command: `cat ${agentPath}` },
+      { label: "git log", comm: "git", command: `git log -- ${agentPath}` },
+      { label: "an editor", comm: "nvim", command: `nvim ${agentPath}` },
+      { label: "a grep", comm: "rg", command: `rg opencode ${agentPath}` },
+    ])("does not brand the terminal OpenCode from $label", ({ label, comm, command }) => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm, command }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        `terminal-argpath-${label.replace(/\s+/g, "-")}`,
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBeNull();
+      for (const [result] of callback.mock.calls) {
+        expect(result.agentType).toBeUndefined();
+        expect(result.processIconId).not.toBe("opencode");
+      }
+    });
+
+    it("still resolves an agent a runtime is hosting", () => {
+      // The guard must not cost the real case it exists alongside: `claude`
+      // installed as a Node CLI shows comm="node" with the agent at argv[1].
+      const cache = createCacheMock();
+      cache.setChildren(100, [
+        { pid: 200, comm: "node", command: "node /opt/bin/opencode --continue" },
+      ]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-argpath-runtime",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBe("opencode");
+    });
+  });
+
+  describe("nested app process boundary (#11931)", () => {
+    /** The reported repro: `npx electron .` running Daintree from the repo. */
+    function seedNestedDaintree(cache: ReturnType<typeof createCacheMock>) {
+      cache.setChildren(100, [{ pid: 200, comm: "npm", command: "npm exec electron ." }]);
+      cache.setChildren(200, [
+        { pid: 300, comm: "node", command: "node /repo/node_modules/electron/cli.js ." },
+      ]);
+      cache.setChildren(300, [
+        { pid: 400, comm: "Electron", command: "/repo/node_modules/electron/dist/Electron ." },
+      ]);
+      cache.setChildren(400, [
+        {
+          pid: 500,
+          comm: "Daintree Helper",
+          command:
+            '"/Applications/Daintree.app/Contents/Frameworks/Daintree Helper.app/Contents/MacOS/Daintree Helper" --type=utility --utility-sub-type=node.mojom.NodeService',
+        },
+      ]);
+      cache.setChildren(500, [{ pid: 600, comm: "zsh", command: "/bin/zsh -l" }]);
+      cache.setChildren(600, [{ pid: 700, comm: "opencode", command: "opencode" }]);
+    }
+
+    it("does not inherit the inner instance's agent through its pty-host", () => {
+      const cache = createCacheMock();
+      seedNestedDaintree(cache);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-nested-daintree",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBeNull();
+      for (const [result] of callback.mock.calls) {
+        expect(result.agentType).toBeUndefined();
+      }
+      // The boundary node's subtree is never even fetched.
+      expect(cache.getChildren).not.toHaveBeenCalledWith(500);
+    });
+
+    it("still reaches an agent that is not behind a Chromium helper", () => {
+      // Same depth, same shape — only the boundary node is missing. Proves the
+      // prune is what stopped the walk above, not the depth budget.
+      const cache = createCacheMock();
+      seedNestedDaintree(cache);
+      cache.setChildren(400, [{ pid: 500, comm: "zsh", command: "/bin/zsh -l" }]);
+      cache.setChildren(500, [{ pid: 700, comm: "opencode", command: "opencode" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-nested-control",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBe("opencode");
+    });
+
+    it("never matches or probes the boundary node itself", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [
+        {
+          pid: 200,
+          comm: "Daintree Helper",
+          command: "Daintree Helper --type=utility --utility-sub-type=node.mojom.NodeService",
+        },
+      ]);
+      cache.setChildren(200, [{ pid: 300, comm: "opencode", command: "opencode" }]);
+      // Returning an agent basename here fails the test if the node is probed.
+      const imagePathProbe = {
+        readBasename: vi.fn((pid: number) => (pid === 200 ? "opencode" : null)),
+        evict: vi.fn(),
+        dispose: vi.fn(),
+      };
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-boundary-node",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBeNull();
+      expect(imagePathProbe.readBasename).not.toHaveBeenCalledWith(200);
+      expect(cache.getChildren).not.toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe("agent commit diagnostics (#11931)", () => {
+    it("logs the winning process once when a tree-sourced agent commits", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "sh", command: "sh -c launch" }]);
+      cache.setChildren(200, [
+        { pid: 300, comm: "node", command: "node /opt/bin/opencode --api-key=do-not-log" },
+      ]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-commit-log",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        false
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+      // A third agreeing poll must not log again — the commit already happened.
+      cache.emitRefresh();
+
+      const logs = agentCommitLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain("agent=opencode");
+      expect(logs[0]).toContain("evidence=process_tree");
+      expect(logs[0]).toContain("match=argv");
+      expect(logs[0]).toContain("pid=300");
+      expect(logs[0]).toContain('comm="node"');
+      expect(logs[0]).toContain('argv0="node"');
+      expect(logs[0]).toContain("depth=2");
+    });
+
+    it("never puts raw argv in the log", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [
+        { pid: 200, comm: "node", command: "node /opt/bin/opencode --api-key=sk-secret" },
+      ]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-commit-redaction",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      const [line] = agentCommitLogs();
+      expect(line).toBeDefined();
+      expect(line).not.toContain("sk-secret");
+      expect(line).not.toContain("/opt/bin/opencode");
+    });
+
+    it("reports comm as the match source when the process names itself", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "opencode", command: "opencode" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-commit-comm",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      const [line] = agentCommitLogs();
+      expect(line).toContain("match=comm");
+      expect(line).toContain("pid=200");
+      expect(line).toContain("depth=1");
+    });
+
+    it("claims no process provenance for a shell-sourced commit", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "npm", command: "npm install" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-commit-shell",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        false
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      detector.injectShellCommandEvidence(
+        { agentType: "opencode", processIconId: "opencode", processName: "opencode" },
+        "opencode"
+      );
+
+      const [line] = agentCommitLogs();
+      expect(line).toContain("agent=opencode");
+      expect(line).toContain("evidence=shell_command");
+      expect(line).toContain("match=<none>");
+      expect(line).toContain("pid=<none>");
+      expect(line).toContain("depth=<none>");
+      expect(line).not.toContain("pid=200");
+    });
+
+    it("does not log an agent commit for a non-agent icon", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "npm", command: "npm install" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-commit-icon-only",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(agentCommitLogs()).toHaveLength(0);
+    });
+  });
+
   describe("zombie child filtering", () => {
     it("does not set isBusy when children are all defunct", () => {
       const cache = createCacheMock();
@@ -2077,6 +2390,138 @@ describe("ProcessDetector", () => {
       );
       expect(imagePathProbe.readBasename).toHaveBeenCalledWith(300);
     });
+  });
+});
+
+describe("executable position bounds (#11931)", () => {
+  const agentPath = "/repo/shared/config/agents/opencode.ts";
+
+  it("allows only argv[0] for a command that takes file operands", () => {
+    expect(executablePositionLimit(["cat", "opencode"])).toBe(0);
+    expect(executablePositionLimit(["nvim", "opencode"])).toBe(0);
+    expect(executablePositionLimit(["git", "log", "opencode"])).toBe(0);
+  });
+
+  it("allows argv[1] for shells, runtimes, package managers and prefixes", () => {
+    for (const executor of ["sh", "node", "python3", "npx", "bunx", "env", "sudo", "mise"]) {
+      expect(executablePositionLimit([executor, "opencode"]), executor).toBe(1);
+    }
+  });
+
+  it("allows argv[2] only behind a package manager's exec subcommand", () => {
+    expect(executablePositionLimit(["pnpm", "exec", "opencode"])).toBe(2);
+    expect(executablePositionLimit(["npm", "exec", "opencode"])).toBe(2);
+    // `exec` after a non-executor is not a package-manager subcommand.
+    expect(executablePositionLimit(["docker", "exec", "opencode"])).toBe(0);
+    // `run` names a user-defined script, not a binary.
+    expect(executablePositionLimit(["npm", "run", "opencode"])).toBe(1);
+  });
+
+  it("does not treat an inherited Object member as an executor", () => {
+    expect(executablePositionLimit(["constructor", "opencode"])).toBe(0);
+    expect(executablePositionLimit(["toString", "opencode"])).toBe(0);
+  });
+
+  it("stops detectCommandIdentity promoting an agent named by an argument", () => {
+    for (const command of [
+      `cat ${agentPath}`,
+      `git log -- ${agentPath}`,
+      `nvim ${agentPath}`,
+      "npm run opencode",
+      "uv run opencode",
+    ]) {
+      expect(detectCommandIdentity(command)?.agentType, command).toBeUndefined();
+    }
+  });
+
+  it("keeps every supported agent launch form resolving", () => {
+    for (const command of [
+      "opencode --continue",
+      "/Users/me/.local/bin/opencode",
+      "node /opt/bin/opencode",
+      "npx opencode",
+      "bunx opencode",
+      "pnpm exec opencode",
+      "npm exec -- opencode",
+      "sh -c opencode",
+      "env FOO=bar opencode",
+      "sudo opencode",
+    ]) {
+      expect(detectCommandIdentity(command)?.agentType, command).toBe("opencode");
+    }
+  });
+
+  it("stops buildDetectedCandidate branding a file-reading process", () => {
+    expect(buildDetectedCandidate("cat", `cat ${agentPath}`, 0)).toBeNull();
+    // Neovim keeps its own icon; it just does not become the agent.
+    const editor = buildDetectedCandidate("nvim", `nvim ${agentPath}`, 0);
+    expect(editor?.agentType).toBeUndefined();
+    expect(editor?.processIconId).toBe("neovim");
+  });
+
+  it("records where the winning name was read from", () => {
+    const origin = { pid: 42, depth: 3, comm: "node", source: "comm" } as const;
+    expect(buildDetectedCandidate("node", "node /opt/bin/opencode", 0, origin)?.provenance).toEqual(
+      { pid: 42, depth: 3, comm: "node", matchSource: "argv" }
+    );
+    expect(
+      buildDetectedCandidate("opencode", "opencode", 0, { ...origin, comm: "opencode" })?.provenance
+        ?.matchSource
+    ).toBe("comm");
+    expect(
+      buildDetectedCandidate("opencode", "Claude Code", 0, { ...origin, source: "image_path" })
+        ?.provenance?.matchSource
+    ).toBe("image_path");
+  });
+
+  it("omits provenance when no origin is supplied", () => {
+    expect(buildDetectedCandidate("opencode", "opencode", 0)?.provenance).toBeUndefined();
+  });
+});
+
+describe("agent CLI name aliases", () => {
+  it("does not register a generic package tail as an agent name", () => {
+    // `@ampcode/cli` would otherwise make every `node …/cli.js` an Amp
+    // terminal — `npx electron .` launches exactly that. #11931
+    for (const generic of ["cli", "code", "agent", "app", "bin", "core", "main"]) {
+      expect(AGENT_CLI_NAMES[generic], generic).toBeUndefined();
+    }
+  });
+
+  it("still registers each agent's own command and id", () => {
+    expect(AGENT_CLI_NAMES["amp"]).toBe("amp");
+    expect(AGENT_CLI_NAMES["opencode"]).toBe("opencode");
+    // A distinctive tail is still a useful alias.
+    expect(AGENT_CLI_NAMES["claude-code"]).toBe("claude");
+  });
+});
+
+describe("isChromiumChildProcess", () => {
+  it("recognizes Chromium's own helper processes", () => {
+    for (const command of [
+      '"/Applications/Daintree.app/Contents/MacOS/Daintree Helper" --type=utility --utility-sub-type=node.mojom.NodeService',
+      "/opt/app/electron --type=renderer --lang=en-GB",
+      "/opt/app/electron --type=gpu-process",
+      "/opt/app/electron --type=zygote",
+      "/opt/app/electron --type=sandbox-ipc",
+      "/opt/app/electron --type=crashpad-handler",
+    ]) {
+      expect(isChromiumChildProcess(command), command).toBe(true);
+    }
+  });
+
+  it("ignores unrelated, partial or operand `--type=` text", () => {
+    for (const command of [
+      "jq --type=json .",
+      "mytool --type=utility-worker",
+      "mytool prefix--type=utility",
+      "cat /opt/notes/--type=utility.txt",
+      "mytool -- --type=utility",
+      "opencode",
+      undefined,
+    ]) {
+      expect(isChromiumChildProcess(command), String(command)).toBe(false);
+    }
   });
 });
 

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -4,6 +4,7 @@ import {
   detectCommandIdentity,
   extractCommandNameCandidates,
   extractScriptBasenameFromCommand,
+  redactArgv,
 } from "../ProcessDetector.js";
 import {
   clearPluginProcessToolRegistryForTests,
@@ -2179,6 +2180,12 @@ describe("ProcessDetector", () => {
       cache.emitRefresh();
       cache.emitRefresh();
 
+      // npm committed — the detector ran and reached a verdict; it just was
+      // not an agent, so nothing is logged.
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ processIconId: "npm", isBusy: true }),
+        expect.any(Number)
+      );
       expect(agentCommitLogs()).toHaveLength(0);
     });
   });
@@ -2638,6 +2645,39 @@ describe("agent CLI name aliases", () => {
     expect(detectCommandIdentity("node /repo/node_modules/electron/cli.js .")?.agentType).toBe(
       undefined
     );
+  });
+});
+
+describe("redactArgv", () => {
+  it("reduces a launch path to its basename on both platforms", () => {
+    expect(redactArgv('"C:\\Users\\alice\\secret-project\\opencode.cmd" --resume')).toBe(
+      '"opencode.cmd"'
+    );
+    expect(redactArgv("/Users/alice/secret-project/opencode --resume")).toBe('"opencode"');
+    // A quote groups the token, it does not end it.
+    expect(redactArgv("'/Users/alice/secret-project'/opencode --resume")).toBe('"opencode"');
+  });
+
+  it("emits nothing rather than guess at unbalanced quoting", () => {
+    // Returning the remainder here is how an inline secret reaches the log.
+    expect(redactArgv('"C:\\Users\\alice\\opencode.cmd --api-key=sk-secret')).toBe("");
+    expect(redactArgv("'/Users/alice/opencode --api-key=sk-secret")).toBe("");
+  });
+
+  it("never carries anything past argv[0]", () => {
+    for (const command of [
+      "opencode --api-key=sk-secret",
+      '"/opt/bin/opencode" --api-key=sk-secret',
+      "node /opt/bin/opencode --api-key=sk-secret",
+    ]) {
+      expect(redactArgv(command), command).not.toContain("sk-secret");
+    }
+  });
+
+  it("returns nothing for empty input", () => {
+    expect(redactArgv(undefined)).toBe("");
+    expect(redactArgv("")).toBe("");
+    expect(redactArgv("   ")).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary

A terminal running `npx electron .` (Daintree itself, launched from the repo for testing) showed OpenCode chrome: green icon, "OpenCode" title, "Ask OpenCode" placeholder. It never ran an OpenCode process. Identity comes from `ProcessDetector`'s BFS walk of the process tree below the PTY, and three separate bugs let an unrelated descendant win it.

Resolves #11931

## Changes

**Argument paths were being read as executables.** The icon lookup respected `executablePositionLimit`, but the agent lookup ran before that guard with no position rule at all. Combined with `.ts` extension stripping, any descendant whose argv held a path like `shared/config/agents/opencode.ts` resolved to the agent `opencode`, and so did `cat`, `git log`, or an editor opened on that file, since this repo is full of paths that name agents. The guard now binds agents too, and it's become executor-aware rather than a fixed index: `argv[0]` always counts, `argv[1]` only counts behind something that actually runs another program (a shell, runtime, package manager, or env/privilege prefix, derived from the existing `runtime`/`package-manager` registry tiers plus an explicit prefix set), and `argv[2]` only behind a package manager's `exec`/`dlx`/`x`. Reordering the old guard alone wouldn't have fixed this: with the limit at 1, `cat opencode.ts` still matched.

**The walk crossed into a nested app's own process scope.** Nothing stopped it at a process that itself hosts terminals, so the outer terminal inherited whichever agent the inner Daintree instance was running. The walk now prunes at Chromium's own helper processes, identified by an exact `--type=renderer|utility|gpu-process|zygote|sandbox-ipc|crashpad-handler` argv token, since a nested instance's pty-host is exactly that kind of node. Pruning happens at the scheduler, so the boundary node is never candidate-matched, image-probed, expanded, or counted against the descent budget, but it stays in the child list so the terminal is still reported busy. Env var markers were ruled out: macOS SIP blocks cross-process environ reads for signed Electron even at the same UID, and Linux depends on `yama/ptrace_scope`.

**A generic package tail was branding half the Node ecosystem.** `AGENT_CLI_NAMES` derived an alias from each agent's npm package tail, and `@ampcode/cli` registered the bare name `cli`, so every `node .../cli.js`, including the Electron launcher that `npx electron .` runs, resolved to Amp. Found while building the regression fixture for the nested-instance fix above. A tail now registers only when one of its tokens is that agent's `id` or `command`, which keeps `claude-code`, `gemini-cli`, and `qwen-code` but drops `cli`, with no list to maintain.

**Diagnostics.** Every log naming the winning pid, comm, or argv was gated behind `logIdentityDebug`, so a wrong label left no trace in a packaged build. Committing an agent identity now logs once at `info`, which reaches the rotated log at the default level, with pid, comm, redacted argv0, BFS depth, match source (comm/argv/image_path), and evidence source. It fires only on the committed transition, so re-confirmation polls stay silent. Provenance rides a private per-pass return value rather than a mutable field, so it can't go stale across the detector's early-return paths, and it's `null` whenever identity came from shell evidence rather than the tree. `DetectionResult`, which crosses to the renderer, is unchanged.

Anchoring and hysteresis (#10911) are deliberately untouched. The sticky wrong brand is a consequence of committing a wrong identity, not of the anchor policy, and that axis is fragile.

### Trade-offs

- Wrappers whose flag operands consume the argv window no longer resolve the agent from that wrapper's own argv (`node --loader tsx .../claude.ts`, `sudo -u build claude`, `uv run claude`, `cmd /c claude`). Most self-heal immediately: `env`/`timeout`/`cross-env` exec the agent so `ps` reports the agent itself, and `sudo`/`nix` fork it as a child the walk finds. The function is documented as positional, not a full argv grammar; the process-tree walk stays the primary signal.
- `npx @ampcode/cli` no longer resolves to Amp from that invocation form. Amp's own `amp` command and id still register, and the process it launches is detected normally.
- A non-Chromium process taking an exact `--type=utility` flag loses its subtree. Accepted deliberately: a false negative here is the nested-instance bug returning, and the behavior is pinned by a test.

## Testing

135 tests in `electron/services/__tests__/ProcessDetector.test.ts` (new coverage for argument-path branding, the nested-Daintree boundary, commit diagnostics including the `both` and image-path branches, executor position bounds, the alias invariant, the Chromium predicate, and argv0 redaction), plus 473 tests across every adjacent PTY/agent/schema suite, and a clean typecheck. Negative tests carry a positive execution witness so they can't pass on an inert detector.
