### PR TITLE
fix(files): let the file viewer reveal files outside project roots

### DIFF
--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -162,9 +162,13 @@ async function assertPathAllowed(
 }
 
 /**
- * Resolve a renderer-supplied path for the UNCONFINED reveal op — the
- * user-initiated recovery path for a file link that resolved outside project
- * roots. Unlike {@link assertPathAllowed}, this deliberately skips roots
+ * Resolve a renderer-supplied path for the UNCONFINED reveal op. Two
+ * user-initiated callers: the recovery action on a terminal file link that
+ * resolved outside project roots, and the file viewer's reveal button, whose
+ * read root falls back to the file's own parent, so the pane routinely
+ * displays files no project owns (#11934). Both arrive here only after the
+ * contained reveal has already been tried and refused with OUTSIDE_ROOT.
+ * Unlike {@link assertPathAllowed}, this deliberately skips roots
  * containment (that's the rejection the user is asking to bypass), but keeps
  * every other guard: absolute-only, executable deny-list on both the raw
  * input and the realpath target (defeats a safe-named symlink → Evil.app),
@@ -172,9 +176,11 @@ async function assertPathAllowed(
  * #6442), and a stat gate so a since-deleted path surfaces as INVALID_PATH
  * instead of `shell.showItemInFolder`'s silent no-op. The deny-list is
  * unconditional here — unlike the confined "editor" flavor, which relaxes it —
- * because an out-of-root path is untrusted terminal output and the historical
- * Windows ShellExecute("open") / Linux xdg-open fallbacks make reveal a launch
- * surface on some platforms.
+ * because an out-of-root path sits outside every root the app vouches for
+ * (parsed terminal output, or a path the viewer was merely pointed at), and the
+ * historical Windows ShellExecute("open") / Linux xdg-open fallbacks make
+ * reveal a launch surface on some platforms. So this op cannot reveal
+ * everything the contained one can, and callers must not promise it will.
  */
 async function resolveRevealTargetUnconfined(targetPath: string): Promise<string> {
   if (!nodePath.isAbsolute(targetPath)) {
@@ -288,8 +294,9 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
           }
         }
       ),
-      // User-initiated reveal of an OUTSIDE_ROOT path (the recovery action on
-      // a file-link toast). Bypasses roots containment but keeps the deny-list,
+      // User-initiated reveal of an OUTSIDE_ROOT path: the recovery action on a
+      // terminal file-link toast, or the file viewer's reveal of a file it is
+      // already displaying. Bypasses roots containment but keeps the deny-list,
       // realpath canonicalization, and a stat gate — see
       // resolveRevealTargetUnconfined.
       showItemInFolderUnconfined: opValidated(

--- a/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
@@ -311,6 +311,20 @@ describe("DiffPane toolbar — action routing", () => {
 
     expect(dispatchCall(0)[2]).toEqual({ source: "user" });
   });
+
+  // The out-of-root reveal opt-in belongs to the file viewer alone (#11934):
+  // its read root falls back to the file's own parent, so it displays files no
+  // project owns. A diff always has a worktree behind it, so relaxing
+  // containment here would widen the boundary for nothing.
+  it("reveals without the out-of-root opt-in the file viewer carries", async () => {
+    seedPanel("src/index.ts");
+    renderPane();
+
+    await click(revealButton());
+
+    expect(dispatchCall(0)[0]).toBe("file.showItemInFolder");
+    expect(dispatchCall(0)[1]).not.toHaveProperty("allowOutsideRoots");
+  });
 });
 
 describe("DiffPane toolbar — platform naming", () => {

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -930,9 +930,10 @@ export function FilePane({
   const handleOpenExternal = useCallback(
     async (target: ExternalTarget) => {
       if (!filePath) return;
-      // Only the file-browser target carries structured args; the rest are
-      // path-only. Built before the pending flip so a missing scope can't leave
-      // the button spinning on a dispatch that was never going to happen.
+      // File-browser carries worktree-scoped args and reveal opts into the
+      // guarded out-of-root fallback; browser/editor stay path-only. Built
+      // before the pending flip so a missing scope can't leave the button
+      // spinning on a dispatch that was never going to happen.
       let args: unknown;
       if (target === "file-browser") {
         if (!revealWorktreeId) return;
@@ -946,6 +947,14 @@ export function FilePane({
             relativeFilePath && relativeFilePath !== filePath ? relativeFilePath : undefined,
           revealKind: "file",
         };
+      } else if (target === "reveal") {
+        // Sent on every reveal, in-root or not: `effectiveRootPath` already
+        // falls back to the file's own parent, so this pane deliberately
+        // displays files no project owns, and reveal was the last surface in it
+        // still asking the project registry for permission (#11934). The action
+        // decides whether the fallback is needed — a second copy of the
+        // containment rule has no business living in the renderer.
+        args = { path: filePath, allowOutsideRoots: true };
       } else {
         args = { path: filePath };
       }

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -525,7 +525,7 @@ describe("FilePane reveal in file manager (#11386)", () => {
 
     expect(dispatchMock).toHaveBeenCalledWith(
       "file.showItemInFolder",
-      { path: PATH },
+      { path: PATH, allowOutsideRoots: true },
       { source: "user" }
     );
   });
@@ -540,7 +540,7 @@ describe("FilePane reveal in file manager (#11386)", () => {
     await click(findButton(container, revealLabel));
     expect(dispatchMock).toHaveBeenCalledWith(
       "file.showItemInFolder",
-      { path: "/repo/media/demo.mov" },
+      { path: "/repo/media/demo.mov", allowOutsideRoots: true },
       { source: "user" }
     );
   });
@@ -568,7 +568,7 @@ describe("FilePane reveal in file manager (#11386)", () => {
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     expect(dispatchMock).toHaveBeenCalledWith(
       "file.showItemInFolder",
-      { path: PATH },
+      { path: PATH, allowOutsideRoots: true },
       { source: "user" }
     );
     expect(container.querySelector('[role="alert"]')).toBeNull();
@@ -628,7 +628,7 @@ describe("FilePane reveal in file manager (#11386)", () => {
     // editor's own banner is untouched.
     expect(dispatchMock).toHaveBeenCalledWith(
       "file.showItemInFolder",
-      { path: PATH },
+      { path: PATH, allowOutsideRoots: true },
       { source: "user" }
     );
     expect(container.querySelector('[role="alert"]')?.textContent).toContain(
@@ -887,9 +887,10 @@ describe("FilePane show in file browser (#11483)", () => {
     });
   });
 
-  // The reveal target is path-only; regressing the args builder into a single
-  // shape would send {path} to the worktree action (or vice versa).
-  it("keeps the path-only args for the sibling reveal target", async () => {
+  // Reveal carries the path plus the out-of-root opt-in, which is a third shape
+  // alongside the worktree action's and the path-only editor/browser one.
+  // Regressing the args builder into a single branch would send the wrong one.
+  it("keeps reveal's own args shape alongside the sibling worktree target", async () => {
     worktreeState.worktrees.set("wt-1", { id: "wt-1", path: "/repo" });
     const { container } = renderPane("/repo/src/index.ts");
 
@@ -897,7 +898,7 @@ describe("FilePane show in file browser (#11483)", () => {
 
     expect(dispatchMock).toHaveBeenCalledWith(
       "file.showItemInFolder",
-      { path: "/repo/src/index.ts" },
+      { path: "/repo/src/index.ts", allowOutsideRoots: true },
       { source: "user" }
     );
   });

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -16,6 +16,7 @@ import { keybindingService } from "./KeybindingService";
 import { shortcutHintStore } from "../store/shortcutHintStore";
 import { useUIStore } from "@/store/uiStore";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { isClientAppError } from "@/utils/clientAppError";
 import { PartialSuccessError } from "@shared/utils/partialSuccess";
 import {
   WORKBENCH_TIER_TOOLS,
@@ -644,6 +645,17 @@ export class ActionService {
         this.emitShortcutHint(actionId, source, overlayEpochBeforeRun);
       return { ok: true, result: (validatedResult ? validatedResult.data : result) as Result };
     } catch (err) {
+      // An AppError that crossed the contextBridge carries its code in an
+      // `[AppError|CODE] ` message prefix and nowhere else (#6116), and
+      // `formatErrorMessage` hands the message back verbatim — so without this
+      // every pane that renders `error.message` shows the transport prefix.
+      // The guard strips it as a side effect, which is the whole point: one
+      // decode here clears FilePane, DiffPane and FileBrowserViewer together.
+      // `details` still points at the same throw, so consumers that decode it
+      // themselves (`reportFileLinkFailure`) hit the guard's same-realm path.
+      const message = isClientAppError(err)
+        ? err.message
+        : formatErrorMessage(err, `Action "${actionId}" failed`);
       const error: ActionError = {
         // `PartialSuccessError` is the one throw that carries a provenance
         // claim: a composite created a real worktree before failing, and the
@@ -653,7 +665,7 @@ export class ActionService {
         // upstream forge/git rejection reaching this line is an ordinary
         // `EXECUTION_ERROR` however its message happens to read.
         code: err instanceof PartialSuccessError ? "PARTIAL_SUCCESS" : "EXECUTION_ERROR",
-        message: formatErrorMessage(err, `Action "${actionId}" failed`),
+        message,
         details: err,
       };
       return { ok: false, error };

--- a/src/services/__tests__/ActionService.adversarial.test.ts
+++ b/src/services/__tests__/ActionService.adversarial.test.ts
@@ -131,6 +131,34 @@ describe("ActionService adversarial", () => {
     expect(observed).toEqual({ dispatchSource: "user" });
   });
 
+  // Definitions that refuse a conditional effect for one source (the recipe
+  // gate in `workflowCreationActions`, the out-of-root reveal opt-in in
+  // `fileActions`) are only as sound as this stamp: it has to be the resolved
+  // source and it has to beat anything the caller put on the context itself.
+  it.each(["plugin", "agent", "menu"] as const)(
+    "stamps the resolved %s source onto the run context, overriding the caller's claim",
+    async (source) => {
+      let observed: unknown = "unset";
+      service.register(
+        safeAction("actions.list", {
+          run: vi.fn(async (_args, ctx) => {
+            observed = ctx?.dispatchSource;
+            return "ok";
+          }),
+        })
+      );
+
+      const result = await service.dispatch("actions.list" as ActionId, undefined, {
+        source,
+        // A caller claiming to be someone else must not be believed.
+        contextOverride: { dispatchSource: "user" },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(observed).toBe(source);
+    }
+  );
+
   it("events.emit throwing during teardown does not block handler execution", async () => {
     const emit = vi.fn(() => {
       throw new Error("WebContents destroyed");

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -754,6 +754,38 @@ describe("ActionService", () => {
       }
     });
 
+    // A main-process AppError reaches the renderer with its own `code`/`name`
+    // stripped by contextBridge, carrying the discriminant only in the message
+    // prefix. Panes render `error.message` directly, so decoding has to happen
+    // here or the prefix ships to the user (#11934).
+    it("strips the AppError transport prefix from the surfaced message", async () => {
+      const transported = new Error("[AppError|OUTSIDE_ROOT] Path is outside all allowed roots");
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description:
+          "A test action for validating ActionService dispatch, registration, and manifest entry generation.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockRejectedValue(transported),
+      };
+
+      service.register(action);
+      const result = await service.dispatch("actions.list");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toBe("Path is outside all allowed roots");
+        // Decoding the message must not reclassify the failure: PARTIAL_SUCCESS
+        // stays the only carve-out from EXECUTION_ERROR.
+        expect(result.error.code).toBe("EXECUTION_ERROR");
+        // Consumers that decode `details` themselves still get the same throw.
+        expect(result.error.details).toBe(transported);
+      }
+    });
+
     it("returns BINDING_STALE when contextOverride projectId differs from live context (#8432)", async () => {
       const mockRun = vi.fn().mockResolvedValue(undefined);
       const action: ActionDefinition = {

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -810,9 +810,11 @@ describe("ActionService", () => {
         // The three-segment form is what the preload actually emits when the
         // AppError carried a userMessage; only the transport wrapper is removed.
         expect(result.error.message).toBe("Path is outside all allowed roots");
-        expect((result.error.details as { userMessage?: string }).userMessage).toBe(
-          "Path is not in a project root"
-        );
+        // `toMatchObject` rather than a cast: `details` is `unknown`, and the
+        // repo's lint ratchet counts every type assertion.
+        expect(result.error.details).toMatchObject({
+          userMessage: "Path is not in a project root",
+        });
       }
     });
 

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -786,6 +786,66 @@ describe("ActionService", () => {
       }
     });
 
+    it("carries the decoded userMessage through to details", async () => {
+      const transported = new Error(
+        `[AppError|OUTSIDE_ROOT|${encodeURIComponent("Path is not in a project root")}] Path is outside all allowed roots`
+      );
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description:
+          "A test action for validating ActionService dispatch, registration, and manifest entry generation.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockRejectedValue(transported),
+      };
+
+      service.register(action);
+      const result = await service.dispatch("actions.list");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        // The three-segment form is what the preload actually emits when the
+        // AppError carried a userMessage; only the transport wrapper is removed.
+        expect(result.error.message).toBe("Path is outside all allowed roots");
+        expect((result.error.details as { userMessage?: string }).userMessage).toBe(
+          "Path is not in a project root"
+        );
+      }
+    });
+
+    it.each([
+      [
+        "a prefix that is not at the start of the message",
+        new Error("wrapped: [AppError|OUTSIDE_ROOT] Path is outside all allowed roots"),
+        "wrapped: [AppError|OUTSIDE_ROOT] Path is outside all allowed roots",
+      ],
+      ["a rejection that is not an Error at all", "plain string failure", "plain string failure"],
+    ])("leaves %s alone", async (_label, rejection, expected) => {
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description:
+          "A test action for validating ActionService dispatch, registration, and manifest entry generation.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockRejectedValue(rejection),
+      };
+
+      service.register(action);
+      const result = await service.dispatch("actions.list");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toBe(expected);
+        expect(result.error.code).toBe("EXECUTION_ERROR");
+      }
+    });
+
     it("returns BINDING_STALE when contextOverride projectId differs from live context (#8432)", async () => {
       const mockRun = vi.fn().mockResolvedValue(undefined);
       const action: ActionDefinition = {

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -1468,7 +1468,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "files",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Reveal a file or directory in the OS file manager (Finder on macOS, Explorer on Windows, the default file manager on Linux) with the item selected. Args: \`path\` (required) — absolute file or directory path. Reveals only; it never opens or launches the item. Errors when the path is missing, outside your project roots, or no longer exists.",
+    "description": "Reveal a file or directory in the OS file manager (Finder on macOS, Explorer on Windows, the default file manager on Linux) with the item selected. Args: \`path\` (required) — absolute file or directory path; \`allowOutsideRoots\` (optional, default false) — when containment refuses the path, retry through a guarded fallback that skips project-root containment but still refuses executable targets, so it cannot reveal everything a root-contained reveal can. Plugins may not set it. Reveals only; it never opens or launches the item. Errors when the path is missing, no longer exists, or sits outside your project roots without \`allowOutsideRoots\`.",
     "examples": undefined,
     "id": "file.showItemInFolder",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/fileActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/fileActions.adversarial.test.ts
@@ -41,10 +41,13 @@ function setupActions() {
 beforeEach(() => {
   vi.clearAllMocks();
   openPanelDialogMock.mockReset().mockResolvedValue("file-panel-1");
-  systemClientMock.openInEditor.mockResolvedValue(undefined);
-  systemClientMock.openPath.mockResolvedValue(undefined);
-  systemClientMock.showItemInFolder.mockResolvedValue(undefined);
-  systemClientMock.showItemInFolderUnconfined.mockResolvedValue(undefined);
+  // `mockReset`, not `clearAllMocks` alone: the latter drains call records but
+  // NOT queued `...Once` implementations, so a test that aborts before consuming
+  // its rejection would hand it to the next one.
+  systemClientMock.openInEditor.mockReset().mockResolvedValue(undefined);
+  systemClientMock.openPath.mockReset().mockResolvedValue(undefined);
+  systemClientMock.showItemInFolder.mockReset().mockResolvedValue(undefined);
+  systemClientMock.showItemInFolderUnconfined.mockReset().mockResolvedValue(undefined);
   projectStoreMock.getState.mockReturnValue({
     currentProject: { id: "proj-1", path: "/repo" },
   });
@@ -176,13 +179,35 @@ describe("fileActions adversarial", () => {
       );
     });
 
-    it("rethrows OUTSIDE_ROOT untouched when the flag is left at its default", async () => {
+    it.each([
+      ["omitted, so Zod's default decides", {}],
+      ["passed explicitly as false", { allowOutsideRoots: false }],
+    ])("rethrows OUTSIDE_ROOT untouched when the flag is %s", async (_label, flag) => {
       const rejection = encoded("OUTSIDE_ROOT", "Path is outside all allowed roots");
       systemClientMock.showItemInFolder.mockRejectedValueOnce(rejection);
       const run = setupActions();
 
-      // No `allowOutsideRoots` key at all, so Zod's `.default(false)` decides.
-      await expect(run("file.showItemInFolder", { path: OUT_OF_ROOT })).rejects.toBe(rejection);
+      await expect(run("file.showItemInFolder", { path: OUT_OF_ROOT, ...flag })).rejects.toBe(
+        rejection
+      );
+      expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
+      // Identity alone would also hold for a decode-then-rethrow. What the five
+      // non-viewer dispatchers rely on is that a caller who never opted in hands
+      // its error onward exactly as it arrived: `isClientAppError` decodes by
+      // mutating, so reaching it at all would strip the prefix and stamp
+      // `name`/`code` here instead of at the one place that owns that decode.
+      expect(rejection.message).toBe("[AppError|OUTSIDE_ROOT] Path is outside all allowed roots");
+      expect(rejection.name).toBe("Error");
+      expect(Object.hasOwn(rejection, "code")).toBe(false);
+    });
+
+    it("rejects a non-boolean flag before reaching either client method", async () => {
+      const run = setupActions();
+
+      await expect(
+        run("file.showItemInFolder", { path: OUT_OF_ROOT, allowOutsideRoots: "yes" })
+      ).rejects.toThrow();
+      expect(systemClientMock.showItemInFolder).not.toHaveBeenCalled();
       expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
     });
 
@@ -208,17 +233,25 @@ describe("fileActions adversarial", () => {
       expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
     });
 
-    it("propagates a failure from the unconfined op rather than swallowing it", async () => {
+    // Every one of these, not just the deny-list case: an implementation that
+    // retried or swallowed the relaxed op's own OUTSIDE_ROOT would loop, and one
+    // that only rethrew decodable errors would eat a raw shell failure.
+    it.each([
+      ["a denied executable target", () => encoded("INVALID_PATH", "Path is not a valid file")],
+      ["OUTSIDE_ROOT again", () => encoded("OUTSIDE_ROOT", "Path is outside all allowed roots")],
+      ["an undecodable failure", () => new Error("shell unavailable")],
+    ])("propagates %s from the unconfined op rather than swallowing it", async (_label, make) => {
       systemClientMock.showItemInFolder.mockRejectedValueOnce(
         encoded("OUTSIDE_ROOT", "Path is outside all allowed roots")
       );
-      const denied = encoded("INVALID_PATH", "Executable targets cannot be revealed");
+      const denied = make();
       systemClientMock.showItemInFolderUnconfined.mockRejectedValueOnce(denied);
       const run = setupActions();
 
       await expect(
         run("file.showItemInFolder", { path: "/tmp/Evil.app", allowOutsideRoots: true })
       ).rejects.toBe(denied);
+      expect(systemClientMock.showItemInFolderUnconfined).toHaveBeenCalledTimes(1);
     });
 
     it("refuses the flag from a plugin dispatch before either client call", async () => {

--- a/src/services/actions/definitions/__tests__/fileActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/fileActions.adversarial.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+import type { ActionContext } from "@shared/types/actions";
 
 const systemClientMock = vi.hoisted(() => ({
   openInEditor: vi.fn(),
   openPath: vi.fn(),
   showItemInFolder: vi.fn(),
+  showItemInFolderUnconfined: vi.fn(),
 }));
 
 const projectStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
@@ -28,11 +30,11 @@ function setupActions() {
     getWorktrees: () => [],
   } as unknown as ActionCallbacks;
   registerFileActions(actions, callbacks);
-  return async (id: string, args?: unknown): Promise<unknown> => {
+  return async (id: string, args?: unknown, ctx?: Partial<ActionContext>): Promise<unknown> => {
     const factory = actions.get(id);
     if (!factory) throw new Error(`missing ${id}`);
     const def = factory() as AnyActionDefinition;
-    return def.run(args, {} as never);
+    return def.run(args, (ctx ?? {}) as never);
   };
 }
 
@@ -42,6 +44,7 @@ beforeEach(() => {
   systemClientMock.openInEditor.mockResolvedValue(undefined);
   systemClientMock.openPath.mockResolvedValue(undefined);
   systemClientMock.showItemInFolder.mockResolvedValue(undefined);
+  systemClientMock.showItemInFolderUnconfined.mockResolvedValue(undefined);
   projectStoreMock.getState.mockReturnValue({
     currentProject: { id: "proj-1", path: "/repo" },
   });
@@ -128,6 +131,7 @@ describe("fileActions adversarial", () => {
     await run("file.showItemInFolder", { path: "/repo/src/x.ts" });
 
     expect(systemClientMock.showItemInFolder).toHaveBeenCalledWith("/repo/src/x.ts");
+    expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
   });
 
   it("file.showItemInFolder propagates systemClient errors to caller", async () => {
@@ -137,6 +141,107 @@ describe("fileActions adversarial", () => {
     await expect(run("file.showItemInFolder", { path: "/repo/x.ts" })).rejects.toThrow(
       "outside root"
     );
+  });
+
+  // The out-of-root reveal fallback (#11934). These exercise the action directly
+  // because it is the only layer where both client methods are observable: the
+  // pane's own tests mock `actionService.dispatch` wholesale. Rejections carry
+  // the `[AppError|CODE] ` prefix and NO own `code`/`name`, which is the shape a
+  // main-process AppError actually has once contextBridge has stripped it twice.
+  describe("file.showItemInFolder out-of-root fallback", () => {
+    const OUT_OF_ROOT = "/var/folders/t/daintree-clipboard/clipboard-1.png";
+    const encoded = (code: string, message: string): Error =>
+      new Error(`[AppError|${code}] ${message}`);
+
+    it("never reaches the unconfined op when the contained reveal succeeds", async () => {
+      const run = setupActions();
+      await run("file.showItemInFolder", { path: OUT_OF_ROOT, allowOutsideRoots: true });
+
+      expect(systemClientMock.showItemInFolder).toHaveBeenCalledWith(OUT_OF_ROOT);
+      expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
+    });
+
+    it("retries through the unconfined op on OUTSIDE_ROOT, with the same path", async () => {
+      systemClientMock.showItemInFolder.mockRejectedValueOnce(
+        encoded("OUTSIDE_ROOT", "Path is outside all allowed roots")
+      );
+      const run = setupActions();
+      await run("file.showItemInFolder", { path: OUT_OF_ROOT, allowOutsideRoots: true });
+
+      expect(systemClientMock.showItemInFolder).toHaveBeenCalledWith(OUT_OF_ROOT);
+      expect(systemClientMock.showItemInFolderUnconfined).toHaveBeenCalledWith(OUT_OF_ROOT);
+      // Contained first, always: the relaxed op is a fallback, never the opener.
+      expect(systemClientMock.showItemInFolder.mock.invocationCallOrder[0]!).toBeLessThan(
+        systemClientMock.showItemInFolderUnconfined.mock.invocationCallOrder[0]!
+      );
+    });
+
+    it("rethrows OUTSIDE_ROOT untouched when the flag is left at its default", async () => {
+      const rejection = encoded("OUTSIDE_ROOT", "Path is outside all allowed roots");
+      systemClientMock.showItemInFolder.mockRejectedValueOnce(rejection);
+      const run = setupActions();
+
+      // No `allowOutsideRoots` key at all, so Zod's `.default(false)` decides.
+      await expect(run("file.showItemInFolder", { path: OUT_OF_ROOT })).rejects.toBe(rejection);
+      expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
+    });
+
+    it("does not fall back on INVALID_PATH even with the flag set", async () => {
+      const rejection = encoded("INVALID_PATH", "Could not resolve path");
+      systemClientMock.showItemInFolder.mockRejectedValueOnce(rejection);
+      const run = setupActions();
+
+      await expect(
+        run("file.showItemInFolder", { path: OUT_OF_ROOT, allowOutsideRoots: true })
+      ).rejects.toBe(rejection);
+      expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
+    });
+
+    it("does not fall back on an undecodable error even with the flag set", async () => {
+      const rejection = new Error("shell unavailable");
+      systemClientMock.showItemInFolder.mockRejectedValueOnce(rejection);
+      const run = setupActions();
+
+      await expect(
+        run("file.showItemInFolder", { path: OUT_OF_ROOT, allowOutsideRoots: true })
+      ).rejects.toBe(rejection);
+      expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
+    });
+
+    it("propagates a failure from the unconfined op rather than swallowing it", async () => {
+      systemClientMock.showItemInFolder.mockRejectedValueOnce(
+        encoded("OUTSIDE_ROOT", "Path is outside all allowed roots")
+      );
+      const denied = encoded("INVALID_PATH", "Executable targets cannot be revealed");
+      systemClientMock.showItemInFolderUnconfined.mockRejectedValueOnce(denied);
+      const run = setupActions();
+
+      await expect(
+        run("file.showItemInFolder", { path: "/tmp/Evil.app", allowOutsideRoots: true })
+      ).rejects.toBe(denied);
+    });
+
+    it("refuses the flag from a plugin dispatch before either client call", async () => {
+      const run = setupActions();
+
+      await expect(
+        run(
+          "file.showItemInFolder",
+          { path: OUT_OF_ROOT, allowOutsideRoots: true },
+          { dispatchSource: "plugin" }
+        )
+      ).rejects.toThrow(/Plugins cannot reveal paths outside/);
+      expect(systemClientMock.showItemInFolder).not.toHaveBeenCalled();
+      expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
+    });
+
+    it("leaves a plugin's ordinary contained reveal alone", async () => {
+      const run = setupActions();
+      await run("file.showItemInFolder", { path: "/repo/src/x.ts" }, { dispatchSource: "plugin" });
+
+      expect(systemClientMock.showItemInFolder).toHaveBeenCalledWith("/repo/src/x.ts");
+      expect(systemClientMock.showItemInFolderUnconfined).not.toHaveBeenCalled();
+    });
   });
 
   it("file.view opens with only a path supplied, omitting the optional hints", async () => {

--- a/src/services/actions/definitions/fileActions.ts
+++ b/src/services/actions/definitions/fileActions.ts
@@ -10,6 +10,7 @@ import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
 import { isAbsolute, isPathInside, join, normalize, toWorktreeRelative } from "@shared/utils/path";
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
+import { isClientAppError } from "@/utils/clientAppError";
 import { isForegroundDispatch } from "./dispatchSource";
 import { PANEL_LIMIT_ERROR_SUFFIX } from "./panelLimitError";
 
@@ -90,6 +91,7 @@ const openImageViewerArgsSchema = z.object({
 
 const showItemInFolderArgsSchema = z.object({
   path: z.string().min(1),
+  allowOutsideRoots: z.boolean().default(false),
 });
 
 function resolveFilePanelPath(path: string, rootPath: string | undefined): string {
@@ -367,15 +369,44 @@ export function registerFileActions(actions: ActionRegistry, callbacks: ActionCa
     id: "file.showItemInFolder",
     title: "Reveal in File Manager",
     description:
-      "Reveal a file or directory in the OS file manager (Finder on macOS, Explorer on Windows, the default file manager on Linux) with the item selected. Args: `path` (required) — absolute file or directory path. Reveals only; it never opens or launches the item. Errors when the path is missing, outside your project roots, or no longer exists.",
+      "Reveal a file or directory in the OS file manager (Finder on macOS, Explorer on Windows, the default file manager on Linux) with the item selected. Args: `path` (required) — absolute file or directory path; `allowOutsideRoots` (optional, default false) — when containment refuses the path, retry through a guarded fallback that skips project-root containment but still refuses executable targets, so it cannot reveal everything a root-contained reveal can. Plugins may not set it. Reveals only; it never opens or launches the item. Errors when the path is missing, no longer exists, or sits outside your project roots without `allowOutsideRoots`.",
     category: "files",
     kind: "command",
     danger: "safe",
     scope: "renderer",
     argsSchema: showItemInFolderArgsSchema,
-    run: async (args: unknown) => {
-      const { path } = showItemInFolderArgsSchema.parse(args);
-      await systemClient.showItemInFolder(path);
+    run: async (args: unknown, ctx?: ActionContext) => {
+      const { path, allowOutsideRoots } = showItemInFolderArgsSchema.parse(args);
+
+      // The plugin system gates its own reveal capability; letting a plugin set
+      // the flag would hand it the unconfined op for free. Refused ahead of the
+      // confined call so it is the flag being rejected, not the reveal — a
+      // plugin dispatching `{ path }` keeps today's contained behavior. Plain
+      // `Error` rather than an AppError, mirroring the recipe-terminal gate in
+      // `workflowCreationActions.ts`.
+      if (allowOutsideRoots && ctx?.dispatchSource === "plugin") {
+        throw new Error(
+          "Plugins cannot reveal paths outside your project roots. Dispatch file.showItemInFolder without `allowOutsideRoots`."
+        );
+      }
+
+      try {
+        await systemClient.showItemInFolder(path);
+      } catch (error) {
+        // Flag first so a caller that never opted in gets an untouched rethrow:
+        // `isClientAppError` decodes by mutating the error in place. Then the
+        // decode, which is the only sound read of the discriminant — contextBridge
+        // strips the error's own `code`/`name` on the way to the renderer, leaving
+        // the encoded message prefix as the sole carrier (#6116). Narrowed to the
+        // exact containment rejection: INVALID_PATH, a denied extension, or any
+        // other failure must never reach the relaxed op.
+        if (!allowOutsideRoots || !isClientAppError(error) || error.code !== "OUTSIDE_ROOT") {
+          throw error;
+        }
+        // Deliberately not wrapped: a rejection here is the user's answer, and
+        // the unconfined op keeps its own deny-list, realpath and stat guards.
+        await systemClient.showItemInFolderUnconfined(path);
+      }
     },
   }));
 }

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -966,7 +966,10 @@ describe("FileLinksAddon", () => {
       expect(payload.action?.label).toBe("Reveal in File Manager");
 
       // Clicking Reveal routes the resolved absolute path (line/col stripped)
-      // through the unconfined IPC op — never auto, always user-initiated.
+      // through the unconfined IPC op — never auto, always user-initiated. The
+      // negative assertion is the load-bearing half: surfacing the toast must
+      // not have already relaxed containment on the user's behalf.
+      expect(systemClient.showItemInFolderUnconfined).not.toHaveBeenCalled();
       payload.action?.onClick?.();
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(systemClient.showItemInFolderUnconfined).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- The file viewer could display a file living outside every project root (an agent-generated image under a temp clipboard directory, a `.codex/generated_images` artifact) but couldn't reveal it: clicking reveal always went through the root-confined path and failed with `OUTSIDE_ROOT`.
- When that failure happened, the raw transport string leaked straight into the UI instead of a readable message.
- Both are fixed renderer-side. No IPC, preload, or handler behavior changes beyond the new optional flag.

Resolves #11934

## Changes

- `showItemInFolderArgsSchema` gains `allowOutsideRoots` (defaults to `false`). `file.showItemInFolder` tries the root-confined client first, and only on a decoded `OUTSIDE_ROOT` with the flag set does it retry the existing guarded `showItemInFolderUnconfined` path, which keeps its executable deny-list, realpath canonicalization, and existence/type checks untouched.
- `FilePane` is the only caller that sets the flag. The other five reveal call sites (`DiffPane`, `FileBrowserViewer`, `TerminalContextMenu`, `SelectedFileMenuItems`, `useFileRowMenuItems`) are unchanged.
- A `dispatchSource === "plugin"` caller that tries to set the flag is refused before either client call, matching the existing gate in `workflowCreationActions.ts`.
- `ActionService`'s dispatch catch now decodes the app error via `isClientAppError` before formatting it, so `FilePane`, `DiffPane`, and `FileBrowserViewer` all show a readable message instead of `[AppError|OUTSIDE_ROOT] Path is outside all allowed roots`. `ActionError.code` still comes out as `EXECUTION_ERROR` and `details` still carries the original throw, so anything decoding it downstream is unaffected.
- `electron/ipc/handlers/systemShell.ts` only picked up docblock edits; the ShellExecute/xdg-open deny-list rationale at line 181 is untouched, since that's the reason the unconfined path stays guarded rather than open.

## Testing

3,695 tests across 163 files pass, covering every `__tests__` directory touched by this branch (`src/services/actions/definitions/`, `src/services/actions/`, `src/panels/file/`, `src/panels/diff/`, `src/services/terminal/`, plus `systemShell.handlers.test.ts`). Prettier is clean and eslint reports zero errors on all changed files, with the lint-ratchet delta at zero against `origin/develop`.