### PR TITLE
fix(file-browser): home Refresh in the tree header

### DIFF
--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1140,19 +1140,16 @@ export function FileBrowserPane({
               >
                 <EyeOff className="h-4 w-4" />
               </FileViewerToolbar.IconButton>
-              {/* Refresh follows what's on screen rather than sitting in both
-                  headers: with a file open the viewer's toolbar owns it, beside
-                  that file's own actions, and two buttons named "Refresh" wired
-                  to this same handler would read as two different actions to
-                  anyone who can't see which column they're in (#11496). Every
-                  other layout leaves it here — a collapsed viewer has no toolbar
-                  to hand it to, and with nothing open there is no file for the
-                  viewer's copy to be about. */}
-              {(viewerCollapsed || selectedFilePath === null) && (
-                <FileViewerToolbar.IconButton label="Refresh" onClick={handleRefresh}>
-                  <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-4 w-4" />
-                </FileViewerToolbar.IconButton>
-              )}
+              {/* Refresh stays here for as long as the tree is mounted. It
+                  re-reads the whole browser rather than just the open file, so
+                  letting a selection hand it to the viewer put it at the far
+                  edge of a column the eye isn't on — at grid width that reads
+                  as no Refresh at all (#11938). The viewer grows its own only
+                  once this header is collapsed away, so there is still exactly
+                  one in every layout (#11496). */}
+              <FileViewerToolbar.IconButton label="Refresh" onClick={handleRefresh}>
+                <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-4 w-4" />
+              </FileViewerToolbar.IconButton>
               {/* The viewer's disclosure, homed here rather than in the viewer —
                   the mirror of where the tree's toggle lives (#11496). That
                   placement is also what makes "both collapsed" unreachable:

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -481,19 +481,20 @@ export function FileBrowserViewer({
             />
           </>
         )}
-        {/* One slot, two occupants, following whatever the viewer is showing:
-            a list is sorted, a file is refreshed. Both are outside the
-            `filePath` gate that wraps the actions above — each has a job in the
-            no-selection layouts too. */}
+        {/* The right-aligned group, following whatever the viewer is showing:
+            a list is sorted, a file gets its own actions, and Refresh appears
+            only while the tree header that normally owns it is collapsed away.
+            Sort and Refresh both sit outside the `filePath` gate that wraps the
+            block above — each has a job in the no-selection layouts too. */}
         <FileViewerToolbar.Actions>
           {/* The single home for sort (#11620). Deliberately not duplicated as
               clickable column headers in the listing below: two controls for
-              one setting is the same trap the Refresh comment above avoids, and
-              a header that looks sortable in one column but has no counterpart
-              in the tree would misdescribe what the setting governs. Hidden
-              while a file is open: this cluster describes what the viewer is
-              showing, and a single document has no order — the slot goes to
-              Refresh instead. */}
+              one setting is the same trap the Refresh gate below avoids, and a
+              header that looks sortable in one column but has no counterpart in
+              the tree would misdescribe what the setting governs. Hidden while
+              a file is open: this cluster describes what the viewer is showing,
+              and a single document has no order — Reveal and Open in editor
+              take the room. */}
           {!filePath && (
             <DropdownMenu>
               <Tooltip>
@@ -560,16 +561,16 @@ export function FileBrowserViewer({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          {/* With a file open this is the file's own Refresh — it re-reads the
-              bytes on screen, which is the one freshness gesture a reader wants
-              and the sort menu can't be. The tree header yields its copy for
-              exactly these layouts (see `FileBrowserPane`), so there is still
-              only ever one Refresh in the panel (#11496). With nothing open the
-              older rule stands: the tree header owns it, and this one appears
-              only once that header is collapsed away (#11586) — a
-              workspace-rooted browser has no change tick at all (#11482), so
-              that layout would otherwise offer no refresh. */}
-          {(filePath || sidebarCollapsed) && (
+          {/* Only while the tree column is collapsed away. Its header owns the
+              browser-wide Refresh the rest of the time, open file or not: this
+              copy used to take over the moment something was selected, which
+              moved the control to the far edge of the panel for no gain — both
+              buttons have always run the same handler (#11938). One Refresh in
+              every layout either way (#11496), and this one still has to exist
+              for the collapsed-tree layouts (#11586), including with nothing
+              selected — a workspace-rooted browser has no change tick at all
+              (#11482), so it would otherwise offer no refresh. */}
+          {sidebarCollapsed && (
             <FileViewerToolbar.IconButton label="Refresh" onClick={onRefresh}>
               <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-4 w-4" />
             </FileViewerToolbar.IconButton>

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -568,8 +568,9 @@ export function FileBrowserViewer({
               buttons have always run the same handler (#11938). One Refresh in
               every layout either way (#11496), and this one still has to exist
               for the collapsed-tree layouts (#11586), including with nothing
-              selected — a workspace-rooted browser has no change tick at all
-              (#11482), so it would otherwise offer no refresh. */}
+              selected: a workspace root has no worktree tick, only the polled
+              reconcile (#11590), and a poll is not a gesture — nor does it
+              re-fetch an open media preview, which needs the manual nonce. */}
           {sidebarCollapsed && (
             <FileViewerToolbar.IconButton label="Refresh" onClick={onRefresh}>
               <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-4 w-4" />

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -2137,6 +2137,14 @@ describe("FileBrowserPane Refresh reachability and media wiring (#11586, #11938)
     )!;
     expect(refreshButtons()).toHaveLength(1);
     expect(treeColumn.contains(refreshButtons()[0]!)).toBe(true);
+
+    // And it works from here. Every other Refresh press in this file collapses
+    // the sidebar first, so without this the layout Refresh now lives in by
+    // default could go inert — visible, unwired — with the suite still green.
+    act(() => {
+      fireEvent.click(refreshButtons()[0]!);
+    });
+    expect(treeState.refresh).toHaveBeenCalledWith({ manual: true });
   });
 
   it("keeps the tree's Refresh when a selected file's viewer is collapsed", () => {
@@ -2156,8 +2164,8 @@ describe("FileBrowserPane Refresh reachability and media wiring (#11586, #11938)
 
   it("runs the pane's manual refresh from the viewer with nothing selected", () => {
     // Nothing selected is not a dead layout: Refresh re-reads the tree, and a
-    // browser whose source reports no change tick (a workspace root, #11482)
-    // has no other freshness signal at all.
+    // browser whose source has no worktree tick (a workspace root) is left with
+    // just the polled reconcile (#11590) until someone asks.
     mockPanel.browserSidebarCollapsed = true;
     renderPane();
 

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -2074,10 +2074,12 @@ describe("FileBrowserPane row activation (#11496)", () => {
   });
 });
 
-describe("FileBrowserPane Refresh reachability and media wiring (#11586)", () => {
-  // Refresh used to live only in the tree header, which unmounts with the tree
+describe("FileBrowserPane Refresh reachability and media wiring (#11586, #11938)", () => {
+  // Refresh once lived only in the tree header, which unmounts with the tree
   // column — so the viewer-only layout had no way to refresh at all. The viewer
-  // now grows its own, gated so exactly one is reachable in every layout.
+  // grows its own for exactly that layout. What decides which one is on screen
+  // is whether the tree is mounted, and nothing else: selection used to move it
+  // too, which is what made it read as missing at panel width (#11938).
   const AUDIO_ROW = {
     path: "media/track.mp3",
     name: "track.mp3",
@@ -2116,30 +2118,36 @@ describe("FileBrowserPane Refresh reachability and media wiring (#11586)", () =>
     expect(refreshButtons()).toHaveLength(1);
   });
 
-  it("hands its Refresh to the viewer while a file is open, rather than showing two", () => {
-    // The one layout where both headers are on screen at once. The viewer's
-    // copy sits beside that file's own actions and takes the slot the sort menu
-    // holds in the list layouts; the tree header stands down so the panel never
-    // offers two buttons named "Refresh" wired to the same handler.
+  it("keeps Refresh in the tree header while a file is open, without showing two", async () => {
+    // The one layout where both headers are on screen at once, and the one this
+    // suite used to assert the other way round: opening a file handed Refresh
+    // to the viewer, putting it at the far edge of a grid-width panel. It stays
+    // in the tree header now, and the viewer must not add a second button named
+    // "Refresh" wired to the same handler beside it.
     mockPanel.browserSelectedPath = "src/app.ts";
     renderPane();
+
+    // Wait for the file to actually be on screen. Asserting placement while the
+    // selection is still unresolved would pass for the wrong reason — the tree
+    // header owns Refresh with nothing open too.
+    await screen.findByTestId("code-viewer");
 
     const treeColumn = document.getElementById(
       screen.getByTestId("file-browser-sidebar-toggle").getAttribute("aria-controls")!
     )!;
     expect(refreshButtons()).toHaveLength(1);
-    expect(treeColumn.contains(refreshButtons()[0]!)).toBe(false);
+    expect(treeColumn.contains(refreshButtons()[0]!)).toBe(true);
   });
 
-  it("keeps the tree's Refresh when the viewer that would own it is collapsed", () => {
-    // A file is selected, but there is no viewer toolbar to hand it to — the
-    // handoff above must not strand the layout with no Refresh at all.
+  it("keeps the tree's Refresh when a selected file's viewer is collapsed", () => {
+    // A file is selected and the viewer that would once have owned Refresh is
+    // gone. The tree header is mounted, so it owns it — the same answer as the
+    // layout above, reached from the other direction.
     mockPanel.browserSelectedPath = "src/app.ts";
     mockPanel.browserViewerCollapsed = true;
     renderPane();
 
     // The viewer column is unmounted — its tree toggle is the tell — so the
-    // toolbar that would own Refresh for the open file doesn't exist, and the
     // tree column is the only place the remaining one can be.
     expect(screen.queryByTestId("file-browser-sidebar-toggle")).toBeNull();
     expect(screen.getByTestId("file-tree-view")).toBeTruthy();

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -636,8 +636,28 @@ describe("FileBrowserViewer Refresh control (#11586, #11938)", () => {
     renderViewer(null, { sidebarCollapsed: true, onRefresh });
 
     // Nothing selected still needs it: Refresh re-reads the tree too, and a
-    // workspace-rooted browser has no change tick to fall back on (#11482).
+    // workspace root has only the polled reconcile to fall back on (#11590).
     expect(screen.getByText("Nothing selected")).toBeTruthy();
+    const button = screen.getByRole("button", { name: "Refresh" });
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers Refresh over a folder listing once the tree is collapsed away", async () => {
+    // The third selection state. Refresh re-reads the browser whatever the
+    // viewer happens to be showing, so a listing must not be the one surface
+    // that loses it — the sort menu beside it orders rows, it can't re-read.
+    const onRefresh = vi.fn();
+    renderViewer(null, {
+      sidebarCollapsed: true,
+      folderPath: "src",
+      folderRows: [],
+      folderStatus: "ready",
+      onRefresh,
+    });
+
     const button = screen.getByRole("button", { name: "Refresh" });
     await act(async () => {
       button.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -610,7 +610,7 @@ describe("FileBrowserViewer PDF preview (#11427)", () => {
   });
 });
 
-describe("FileBrowserViewer Refresh control (#11586)", () => {
+describe("FileBrowserViewer Refresh control (#11586, #11938)", () => {
   it("leaves Refresh to the tree header while the tree column is mounted and nothing is open", () => {
     renderViewer(null, { sidebarCollapsed: false });
     // Two identical Refresh buttons in one panel would read as two different
@@ -618,20 +618,17 @@ describe("FileBrowserViewer Refresh control (#11586)", () => {
     expect(screen.queryByRole("button", { name: "Refresh" })).toBeNull();
   });
 
-  it("offers Refresh beside the open file's actions even with the tree column mounted", async () => {
-    // With a file open this is the file's own re-read, sitting among the file's
-    // controls. The tree header hands it over for this layout (asserted from
-    // the pane, which is the only place both headers exist at once).
-    const onRefresh = vi.fn();
-    renderViewer("/repo/src/notes.txt", { sidebarCollapsed: false, onRefresh });
+  it("leaves Refresh to the tree header while the tree column is mounted and a file is open", async () => {
+    // Opening a file used to move Refresh into this toolbar. It doesn't any
+    // more, and this is the only place that can be checked from the viewer's
+    // own side: the case above would still pass if the `filePath` half of the
+    // old gate came back, since it renders nothing at all.
+    renderViewer("/repo/src/notes.txt", { sidebarCollapsed: false });
     await screen.findByTestId("code-viewer-mock");
 
-    await act(async () => {
-      screen
-        .getByRole("button", { name: "Refresh" })
-        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Refresh" })).toBeNull();
+    // The group doesn't go empty in exchange — the file keeps its own actions.
+    expect(screen.getByRole("button", { name: "Open in editor" })).toBeTruthy();
   });
 
   it("offers Refresh once the tree column is collapsed away, even with nothing selected", async () => {
@@ -834,15 +831,14 @@ describe("sort menu (#11620)", () => {
   it("stays available for a selected folder, whose listing it orders", () => {
     renderViewer(null, { folderPath: "src", folderRows: [], folderStatus: "ready" });
     expect(screen.getByRole("button", { name: /^Sort files \(/ })).toBeTruthy();
-    // The other half of the swap: no Refresh crowding it while the tree header
-    // still owns that one.
+    // No Refresh crowding it: the mounted tree header still owns that one.
     expect(screen.queryByRole("button", { name: "Refresh" })).toBeNull();
   });
 
   it("gives its slot up once a file is open, having nothing left to order", async () => {
     // A single document has no order, so the control that describes one would
-    // be describing the tree it can no longer be reached from — Refresh, the
-    // gesture a reader of an agent-rewritten file actually wants, takes it.
+    // be describing the tree it can no longer be reached from. Reveal and Open
+    // in editor take the room; Refresh stays in the mounted tree header.
     renderViewer("/repo/src/notes.txt");
     await screen.findByTestId("code-viewer-mock");
     expect(screen.queryByRole("button", { name: /^Sort files \(/ })).toBeNull();


### PR DESCRIPTION
## Summary

- The Refresh button used to sit in one of two toolbars depending on layout. With the tree and the viewer both open and a file selected, it landed at the far right of the viewer toolbar, and at grid width that reads as no Refresh at all: the tree header shows only Hide dotfiles and the viewer toggle.
- Refresh now lives in the tree header for as long as the tree column is mounted. The viewer keeps its own copy only while the tree is collapsed away.
- No behavioral change, only placement. Both buttons have always called the same `handleRefresh` (`refreshAll({ manual: true })`, which bumps `surfaceRefreshNonce` and calls `refresh()` together).

Resolves #11938

## Changes

- `FileBrowserPane`: dropped the `viewerCollapsed || selectedFilePath === null` condition, so the tree header renders Refresh unconditionally. The tree column is already gated on `!sidebarCollapsed`, so that part doesn't change.
- `FileBrowserViewer`: narrowed the gate from `filePath || sidebarCollapsed` to `sidebarCollapsed` alone.
- The one-Refresh-per-layout invariant from #11496 still holds, and it's structural rather than incidental. `viewerCollapsed` is derived as `browserViewerCollapsed === true && browserSidebarCollapsed !== true`, so both columns collapsed at once is unreachable even from a corrupted persisted record. Tree mounted means the tree owns Refresh; tree collapsed means the viewer is necessarily open and owns it. Never zero, never two.
- The viewer's Actions group doesn't go empty in exchange: Reveal and Open in editor stay with an open file, and the sort menu takes the space otherwise.
- Rewrote the comments in both files that described the old split to describe the new rule instead.

## Testing

- Reversed the pane test that encoded the old handoff, and made it wait for the open file so the placement assertion can't pass vacuously (the tree owns Refresh with nothing selected too). That test now also clicks the tree-header Refresh and asserts `refresh({ manual: true })` was called, closing a wiring gap: every other Refresh press in the suite collapsed the sidebar first, so the layout this button now lives in by default had no coverage.
- Inverted the viewer test that asserted a file-open takeover. Kept it rather than deleting it, since it's the only viewer-level guard against someone reinstating the old `filePath ||` half of the gate.
- Added a folder-selected, tree-collapsed test case, which had no Refresh assertion before.
- `npx vitest run` on `FileBrowserPane.test.tsx` and `FileBrowserViewer.test.tsx`: 181 tests passing.
- `npx vitest run` on `accentGuard.contract.test.ts`: 60 tests passing (it scans `FileBrowserPane.tsx` by path).
- `npx prettier --check` and `npx eslint` on the four changed files: clean.
