### PR TITLE
fix(file-browser): list symbolic links instead of dropping them

### DIFF
--- a/electron/ipc/handlers/__tests__/fileBrowser.statPaths.test.ts
+++ b/electron/ipc/handlers/__tests__/fileBrowser.statPaths.test.ts
@@ -136,7 +136,7 @@ describe("fileBrowser statPaths", () => {
       await fs.mkdir(path.join(outside, "secret"));
       await fs.symlink(outside, path.join(root, "hop"));
       const { invoke } = makeHandler([]);
-      // Realpath equality rejects the intermediate symlink, so the escape is
+      // The canonical target lands outside the root, so the escape stays
       // indistinguishable from a missing path — same guarantee as a worktree.
       await expect(invoke(ctx, { paths: ["hop/secret"] })).resolves.toEqual([null]);
     } finally {
@@ -181,9 +181,48 @@ describe("fileBrowser statPaths", () => {
     }
   });
 
-  it("refuses in-root symlinks too — only paths the tree can render validate", async () => {
+  it("resolves in-root symlinks, and paths reached through one (#11939)", async () => {
+    // The tree lists symlinks now, so a reference in terminal output that
+    // points at or through an in-root link names something the browser can
+    // actually open — reporting it absent would be the wrong answer.
     await fs.symlink(path.join(root, "src"), path.join(root, "src-link"));
+    await fs.symlink(path.join(root, "src", "index.ts"), path.join(root, "index-link.ts"));
+
     const { invoke } = makeHandler([{ id: root, path: root }]);
-    await expect(invoke(ctx, { worktreeId: root, paths: ["src-link"] })).resolves.toEqual([null]);
+    await expect(
+      invoke(ctx, {
+        worktreeId: root,
+        paths: ["src-link", "index-link.ts", "src-link/index.ts"],
+      })
+    ).resolves.toEqual(["directory", "file", "file"]);
+  });
+
+  it("still reports a dangling in-root symlink as absent", async () => {
+    // Containment is not the only reason to answer null: a link whose target
+    // does not exist names nothing openable either, and `realpath` throws.
+    await fs.symlink(path.join(root, "gone.ts"), path.join(root, "dangling.ts"));
+    const { invoke } = makeHandler([{ id: root, path: root }]);
+    await expect(invoke(ctx, { worktreeId: root, paths: ["dangling.ts"] })).resolves.toEqual([
+      null,
+    ]);
+  });
+
+  it("rejects a sibling directory whose path merely starts with the root's", async () => {
+    // `${root}-sibling` passes a naive `startsWith(root)` prefix test while
+    // living entirely outside it. Containment is decided by `path.relative`
+    // precisely so that shape can't slip through.
+    const sibling = `${root}-sibling`;
+    await fs.mkdir(sibling, { recursive: true });
+    try {
+      await fs.writeFile(path.join(sibling, "secret.txt"), "x");
+      await fs.symlink(sibling, path.join(root, "near"));
+
+      const { invoke } = makeHandler([{ id: root, path: root }]);
+      await expect(
+        invoke(ctx, { worktreeId: root, paths: ["near", "near/secret.txt"] })
+      ).resolves.toEqual([null, null]);
+    } finally {
+      await fs.rm(sibling, { recursive: true, force: true });
+    }
   });
 });

--- a/electron/ipc/handlers/fileBrowser.ts
+++ b/electron/ipc/handlers/fileBrowser.ts
@@ -287,10 +287,18 @@ export function buildFileBrowserNamespace(deps: HandlerDependencies) {
     // now (#11939), so a reference in terminal output pointing through an
     // in-root link has to resolve rather than read as a non-existent file.
     //
-    // Note this is final-target containment: a chain that leaves the root and
-    // comes back inside is accepted, matching how `FileTreeService` decides
-    // what may be descended into. `path.relative` rather than a string prefix
-    // so a sibling root like `/workspace-other` can't pass.
+    // Note this is final-target containment only: a chain that leaves the root
+    // and comes back inside is accepted here. `FileTreeService` is slightly
+    // stricter — it also rejects a target that NAMES an outside path before
+    // resolving it — so an exotic leave-and-return link can resolve as a
+    // reference here while the browser row for it reads external. Both answers
+    // are safe (neither reports anything out of root); they differ because the
+    // listing has a second job this handler doesn't: classifying thousands of
+    // entries per directory without dereferencing each one. Unifying them
+    // wants a shared resolve-beneath primitive that doesn't exist yet.
+    //
+    // `path.relative` rather than a string prefix so a sibling root like
+    // `/workspace-other` can't pass.
     const rootRealPath = await fs.realpath(root.path).catch(() => null);
     if (rootRealPath === null) {
       return payload.paths.map(() => null);

--- a/electron/ipc/handlers/fileBrowser.ts
+++ b/electron/ipc/handlers/fileBrowser.ts
@@ -274,23 +274,40 @@ export function buildFileBrowserNamespace(deps: HandlerDependencies) {
     // an error: the caller is asking "which of these tokens are real?", and a
     // throw for one bad token would discard the whole batch's answer.
     //
-    // Realpath equality, not a bare stat: stat follows symlinks — including
+    // Realpath containment, not a bare stat: stat follows symlinks — including
     // INTERMEDIATE ones — so `escape/etc` through an in-root `escape → /`
     // symlink would report the target's kind, an existence probe beyond the
-    // root that FileTreeService's realpath containment otherwise keeps shut.
-    // Requiring `realpath(root + candidate) === realpath(root) + candidate`
-    // rejects any symlink component, which also matches what the tree can
-    // actually render (it omits symlink entries).
+    // root. Resolving first and requiring the CANONICAL result to stay under
+    // the canonical root keeps that shut: `/etc` is not under the root, so it
+    // still comes back null.
+    //
+    // This used to demand exact equality — `realpath(root + candidate) ===
+    // realpath(root) + candidate` — which rejected every symlink component and
+    // was justified by the tree omitting symlink entries. The tree lists them
+    // now (#11939), so a reference in terminal output pointing through an
+    // in-root link has to resolve rather than read as a non-existent file.
+    //
+    // Note this is final-target containment: a chain that leaves the root and
+    // comes back inside is accepted, matching how `FileTreeService` decides
+    // what may be descended into. `path.relative` rather than a string prefix
+    // so a sibling root like `/workspace-other` can't pass.
     const rootRealPath = await fs.realpath(root.path).catch(() => null);
     if (rootRealPath === null) {
       return payload.paths.map(() => null);
     }
 
+    const isContained = (candidateRealPath: string): boolean => {
+      const rel = path.relative(rootRealPath, candidateRealPath);
+      if (rel === "") return true;
+      if (rel === ".." || rel.startsWith(`..${path.sep}`)) return false;
+      return !path.isAbsolute(rel);
+    };
+
     return Promise.all(
       payload.paths.map(async (candidate): Promise<"file" | "directory" | null> => {
         try {
           const realPath = await fs.realpath(path.join(root.path, candidate));
-          if (realPath !== path.join(rootRealPath, candidate)) return null;
+          if (!isContained(realPath)) return null;
           const stats = await fs.stat(realPath);
           if (stats.isDirectory()) return "directory";
           if (stats.isFile()) return "file";

--- a/electron/services/FileTreeService.ts
+++ b/electron/services/FileTreeService.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs/promises";
 import * as path from "path";
-import type { FileTreeNode } from "../../shared/types/ipc.js";
+import type { FileTreeNode, FileTreeSymlink } from "../../shared/types/ipc.js";
 
 // Natural-numeric name ordering so `version_10` sorts after `version_9`
 // instead of between `version_1` and `version_2`. Locale is left undefined so
@@ -29,6 +29,91 @@ function _getBaseRealpath(resolvedBasePath: string): Promise<string> {
 }
 
 /**
+ * Whether `candidate` sits at or under `root`, both already canonical.
+ *
+ * The house containment idiom, shared by `electron/setup/protocols.ts` and
+ * `resolveContainedPath` in `electron/ipc/handlers/pathGuard.ts`: relativize
+ * and reject anything that climbs out or lands on another root. A raw
+ * `startsWith(root)` would accept a sibling like `/workspace-other`, and a
+ * bare `rel.startsWith("..")` would reject a directory legitimately named
+ * `..foo`, so the escape test is anchored on a separator instead.
+ *
+ * One predicate for the whole file rather than a second variant beside the
+ * first — this is exactly the reinvention `.lessons/10971.md` exists to stop.
+ */
+function isContained(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  if (rel === "") return true;
+  if (rel === ".." || rel.startsWith(`..${path.sep}`)) return false;
+  return !path.isAbsolute(rel);
+}
+
+/**
+ * Resolve one symlink entry into the metadata the browser needs, without ever
+ * dereferencing a target that points outside the root (#11939).
+ *
+ * The order matters and is the whole safety argument. `readlink` reads the
+ * stored target string and follows nothing, so it is the only call safe to
+ * make first. Its result is checked lexically before `realpath` — the first
+ * call that would actually traverse — because dereferencing an arbitrary
+ * absolute target turns any symlink in a cloned repository into two things we
+ * refuse to offer: an existence-and-kind probe for paths outside the
+ * workspace, and a `stat` that blocks forever on a dead network mount, which
+ * would hang this entry's whole `Promise.all` and with it the directory
+ * listing.
+ *
+ * So an out-of-root link costs exactly one extra syscall and reports
+ * `"unknown"` — honest, since we genuinely did not look. Only a link that
+ * survives both the lexical and the canonical containment checks is stat'd.
+ */
+async function describeSymlink(
+  linkPath: string,
+  resolvedBasePath: string,
+  resolvedBaseRealPath: string
+): Promise<{ symlink: FileTreeSymlink; targetStat?: Awaited<ReturnType<typeof fs.lstat>> }> {
+  const raw = await fs.readlink(linkPath);
+  const target = path.resolve(path.dirname(linkPath), raw);
+  const unresolved = (targetKind: FileTreeSymlink["targetKind"]) => ({
+    symlink: { target, targetKind, insideRoot: false },
+  });
+
+  if (!isContained(resolvedBasePath, target)) return unresolved("unknown");
+
+  let realTarget: string;
+  try {
+    realTarget = await fs.realpath(linkPath);
+  } catch (error: unknown) {
+    // ENOENT is a dangling link — the one failure that means something
+    // specific enough to show. ELOOP (a cycle, or the OS depth limit) and
+    // EACCES/EPERM are indistinguishable to a user and equally non-actionable.
+    const code = (error as NodeJS.ErrnoException).code;
+    return unresolved(code === "ENOENT" ? "broken" : "unknown");
+  }
+
+  // A target can be lexically inside the root and still canonically outside it
+  // — `link → ./sub/escape/etc` where `sub/escape → /`. The canonical check is
+  // what keeps `insideRoot` honest, so the renderer never draws a disclosure
+  // triangle on a row whose listing would be refused.
+  if (!isContained(resolvedBaseRealPath, realTarget)) return unresolved("unknown");
+
+  try {
+    // `lstat`, not `stat`: `realTarget` is fully resolved, so there is no link
+    // left to follow and the cheaper call answers the same question.
+    const targetStat = await fs.lstat(realTarget);
+    return {
+      symlink: {
+        target,
+        targetKind: targetStat.isDirectory() ? "directory" : "file",
+        insideRoot: true,
+      },
+      targetStat,
+    };
+  } catch {
+    return unresolved("unknown");
+  }
+}
+
+/**
  * Raw directory listing: filesystem identity and containment only, no opinion
  * about what belongs in a context.
  *
@@ -38,6 +123,13 @@ function _getBaseRealpath(resolvedBasePath: string): Promise<string> {
  * it would actually copy (`CopyTreeService.getFileTree`, #11439). This service
  * used to run a `git check-ignore` subprocess for the picker; that engine
  * disagreed with the one that builds the bundle, so it is gone.
+ *
+ * Symbolic links are entries too (#11939). Listing a link is not dereferencing
+ * it, so containment governs descent rather than visibility: a link is always
+ * shown, a link resolving inside the root reports its target's kind and can be
+ * expanded like the real thing, and a link resolving outside is a terminal
+ * node carrying where it points. `node_modules/.bin` is nothing but relative
+ * in-root links, and it used to render as an empty folder.
  */
 export class FileTreeService {
   async getFileTree(basePath: string, dirPath: string = ""): Promise<FileTreeNode[]> {
@@ -60,17 +152,18 @@ export class FileTreeService {
     const relativeDirPath =
       normalizedForCheck === "." ? "" : normalizedForCheck.replace(/^\.\/+/, "");
     const targetPath = path.resolve(resolvedBasePath, relativeDirPath);
-    const relativeTarget = path.relative(resolvedBasePath, targetPath);
 
-    if (relativeTarget.startsWith("..") || path.isAbsolute(relativeTarget)) {
+    if (!isContained(resolvedBasePath, targetPath)) {
       throw new Error("Invalid directory path: path traversal not allowed");
     }
 
     try {
       const resolvedBaseRealPath = await _getBaseRealpath(resolvedBasePath);
       const targetRealPath = await fs.realpath(targetPath).catch(() => targetPath);
-      const relativeRealTarget = path.relative(resolvedBaseRealPath, targetRealPath);
-      if (relativeRealTarget.startsWith("..") || path.isAbsolute(relativeRealTarget)) {
+      // Still the guard that makes an out-of-root link non-expandable: the
+      // listing marks such a node `insideRoot: false` so the renderer never
+      // asks, but this is what holds if something asks anyway.
+      if (!isContained(resolvedBaseRealPath, targetRealPath)) {
         throw new Error("Invalid directory path: path traversal not allowed");
       }
 
@@ -85,15 +178,26 @@ export class FileTreeService {
 
       const statResults = await Promise.all(
         entries.map(async (entry) => {
-          if (entry.isSymbolicLink()) return null;
-
           const relativePath = path.join(relativeDirPath, entry.name);
           const gitRelativePath = toGitPath(relativePath);
 
           const absolutePath = path.join(resolvedBasePath, relativePath);
           try {
             const fileStat = await fs.lstat(absolutePath);
-            return { fileStat, name: entry.name, gitRelativePath };
+            // The `Dirent` already said this is a link; `lstat` is asked again
+            // rather than trusted from the dirent because it is the same call
+            // every other entry makes and it re-confirms the entry still
+            // exists. A link deleted between `readdir` and here fails the
+            // `readlink` below and drops out exactly like any other race.
+            if (!fileStat.isSymbolicLink()) {
+              return { fileStat, name: entry.name, gitRelativePath };
+            }
+            const { symlink, targetStat } = await describeSymlink(
+              absolutePath,
+              resolvedBasePath,
+              resolvedBaseRealPath
+            );
+            return { fileStat, name: entry.name, gitRelativePath, symlink, targetStat };
           } catch {
             return null;
           }
@@ -103,29 +207,41 @@ export class FileTreeService {
       const nodes: FileTreeNode[] = [];
       for (const result of statResults) {
         if (!result) continue;
-        const { fileStat, name, gitRelativePath } = result;
+        const { fileStat, name, gitRelativePath, symlink, targetStat } = result;
 
         // Both branches read `mtimeMs` off the `lstat` above rather than
         // stat-ing again: the modified column in the file browser's folder
         // listing (#11620) is free here and would otherwise cost one extra
         // syscall per entry on every directory read and bulk scan.
-        const isDirectory = fileStat.isDirectory();
-        if (isDirectory) {
-          nodes.push({ name, path: gitRelativePath, isDirectory, mtimeMs: fileStat.mtimeMs });
-          continue;
-        }
+        //
+        // A resolved link reports its target's stat instead, because the
+        // columns describe what opening the row would give you. An unresolved
+        // one keeps the link's own mtime and reports no size at all: a
+        // symlink's `lstat.size` is the byte length of the stored target
+        // string, which renders as a real but meaningless file size.
+        const stat = targetStat ?? fileStat;
+        const isDirectory = stat.isDirectory();
+        const link = symlink ? { symlink } : {};
 
-        try {
+        if (isDirectory) {
           nodes.push({
             name,
             path: gitRelativePath,
             isDirectory,
-            size: fileStat.size,
-            mtimeMs: fileStat.mtimeMs,
+            mtimeMs: stat.mtimeMs,
+            ...link,
           });
-        } catch {
-          // skip entries where size read fails
+          continue;
         }
+
+        nodes.push({
+          name,
+          path: gitRelativePath,
+          isDirectory,
+          ...(targetStat || !symlink ? { size: stat.size } : {}),
+          mtimeMs: stat.mtimeMs,
+          ...link,
+        });
       }
 
       nodes.sort((a, b) => {

--- a/electron/services/FileTreeService.ts
+++ b/electron/services/FileTreeService.ts
@@ -50,11 +50,46 @@ function isContained(root: string, candidate: string): boolean {
 }
 
 /**
+ * Normalize a `readlink` result that came back in Win32 extended-length form.
+ *
+ * A Windows junction's stored target is an NT-namespace path: `readlink`
+ * returns `\\?\C:\repo\target`, not `C:\repo\target`. Left as-is,
+ * `path.relative` reads it as a different root and every in-root junction is
+ * classified external — the very thing the issue says must not be
+ * special-cased away from POSIX symlinks.
+ *
+ * This is not the `fs.realpath` prefix-stripping that no other call site in
+ * this codebase does, and shouldn't be: it normalizes `readlink` output, which
+ * genuinely carries the prefix for junctions, and it happens before any
+ * containment decision rather than after one.
+ *
+ * `\\?\UNC\server\share` is the trap. It is a network path wearing the
+ * prefix, and dropping four characters would leave `UNC\server\share` — a
+ * RELATIVE path, which then resolves inside the root and would let a remote
+ * share pass as local. It maps back to `\\server\share`, which stays a
+ * distinct root and is rejected. Anything else keeps the prefix and is
+ * rejected too; only the drive-letter form is an ordinary path in disguise.
+ */
+export function _normalizeWin32LinkTarget(target: string): string {
+  if (!target.startsWith("\\\\?\\")) return target;
+  const rest = target.slice(4);
+  if (/^UNC\\/i.test(rest)) return `\\\\${rest.slice(4)}`;
+  return /^[A-Za-z]:\\/.test(rest) ? rest : target;
+}
+
+function normalizeLinkTarget(target: string): string {
+  // Split from the logic above only so the Windows behaviour is testable off
+  // Windows — the rule itself has no business running on POSIX, where a file
+  // may legitimately be named `\\?\C:\x` and rewriting it would invent a path.
+  return path.sep === "\\" ? _normalizeWin32LinkTarget(target) : target;
+}
+
+/**
  * Resolve one symlink entry into the metadata the browser needs (#11939).
  *
- * What this guarantees, exactly: nothing outside the workspace root is ever
- * *reported*. `realpath` resolves the entire chain and the canonical result is
- * checked against the canonical root before any kind, size or mtime is read —
+ * What this guarantees, exactly: no out-of-root target's kind, size or mtime
+ * is ever reported. `realpath` resolves the entire chain and the canonical
+ * result is checked against the canonical root before any of them is read —
  * so an escaping link comes back `"external"` with no metadata attached, and
  * `isDirectory` stays false, which is what keeps it non-descendable.
  *
@@ -82,7 +117,7 @@ async function describeSymlink(
   resolvedBasePath: string,
   resolvedBaseRealPath: string
 ): Promise<{ symlink: FileTreeSymlink; targetStat?: Stats }> {
-  const raw = await fs.readlink(linkPath);
+  const raw = normalizeLinkTarget(await fs.readlink(linkPath));
   // Against the CANONICAL directory this entry was listed from, not the
   // lexical one. When the listed directory is itself reached through a link,
   // the two are different places, and only the canonical one interprets a
@@ -105,12 +140,14 @@ async function describeSymlink(
   try {
     realTarget = await fs.realpath(linkPath);
   } catch (error: unknown) {
-    // ENOENT is a dangling link — the one failure specific enough to show.
-    // ELOOP (a cycle, or the OS depth limit) and EACCES/EPERM are equally
-    // non-actionable, and reporting them as `"external"` would tell the user
-    // something false about where their link points.
+    // A dangling link is the one failure specific enough to show. ENOTDIR
+    // counts as dangling too: it means a component of the target is a file, so
+    // the target cannot exist either — reporting that as merely "unreadable"
+    // would hide a broken link behind a vaguer word. ELOOP (a cycle, or the OS
+    // depth limit) and EACCES/EPERM say nothing about existence, and calling
+    // any of them `"external"` would assert a location we never established.
     const code = (error as NodeJS.ErrnoException).code;
-    return unresolved(code === "ENOENT" ? "broken" : "unknown");
+    return unresolved(code === "ENOENT" || code === "ENOTDIR" ? "broken" : "unknown");
   }
 
   // The authoritative check. A target can be lexically inside the root and
@@ -144,10 +181,11 @@ async function describeSymlink(
  * disagreed with the one that builds the bundle, so it is gone.
  *
  * Symbolic links are entries too (#11939). Listing a link is not dereferencing
- * it, so containment governs descent rather than visibility: a link is always
- * shown, a link resolving inside the root reports its target's kind and can be
- * expanded like the real thing, and a link resolving outside is a terminal
- * node carrying where it points. `node_modules/.bin` is nothing but relative
+ * it, so containment governs descent rather than visibility: a link is shown
+ * whatever it points at (only an unreadable entry drops, as for any other
+ * dirent lost to a race), a link resolving inside the root reports its
+ * target's kind and can be expanded like the real thing, and a link resolving
+ * outside is a terminal node carrying where it points. `node_modules/.bin` is nothing but relative
  * in-root links, and it used to render as an empty folder.
  */
 export class FileTreeService {
@@ -180,7 +218,7 @@ export class FileTreeService {
       const resolvedBaseRealPath = await _getBaseRealpath(resolvedBasePath);
       const targetRealPath = await fs.realpath(targetPath).catch(() => targetPath);
       // Still the guard that makes an out-of-root link non-expandable: the
-      // listing marks such a node `insideRoot: false` so the renderer never
+      // listing leaves such a node `isDirectory: false` so the renderer never
       // asks, but this is what holds if something asks anyway.
       if (!isContained(resolvedBaseRealPath, targetRealPath)) {
         throw new Error("Invalid directory path: path traversal not allowed");

--- a/electron/services/FileTreeService.ts
+++ b/electron/services/FileTreeService.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs/promises";
+import type { Stats } from "node:fs";
 import * as path from "path";
 import type { FileTreeNode, FileTreeSymlink } from "../../shared/types/ipc.js";
 
@@ -49,63 +50,81 @@ function isContained(root: string, candidate: string): boolean {
 }
 
 /**
- * Resolve one symlink entry into the metadata the browser needs, without ever
- * dereferencing a target that points outside the root (#11939).
+ * Resolve one symlink entry into the metadata the browser needs (#11939).
  *
- * The order matters and is the whole safety argument. `readlink` reads the
- * stored target string and follows nothing, so it is the only call safe to
- * make first. Its result is checked lexically before `realpath` — the first
- * call that would actually traverse — because dereferencing an arbitrary
- * absolute target turns any symlink in a cloned repository into two things we
- * refuse to offer: an existence-and-kind probe for paths outside the
- * workspace, and a `stat` that blocks forever on a dead network mount, which
- * would hang this entry's whole `Promise.all` and with it the directory
- * listing.
+ * What this guarantees, exactly: nothing outside the workspace root is ever
+ * *reported*. `realpath` resolves the entire chain and the canonical result is
+ * checked against the canonical root before any kind, size or mtime is read —
+ * so an escaping link comes back `"external"` with no metadata attached, and
+ * `isDirectory` stays false, which is what keeps it non-descendable.
  *
- * So an out-of-root link costs exactly one extra syscall and reports
- * `"unknown"` — honest, since we genuinely did not look. Only a link that
- * survives both the lexical and the canonical containment checks is stat'd.
+ * What it does NOT guarantee: that the kernel never *traverses* outside during
+ * that resolution. The cheap `readlink` gate below rejects a target that
+ * directly names an outside path, which covers the ordinary case — a link to
+ * another checkout — and spares it a `realpath` that would block on a dead
+ * network mount. But a chain that only escapes on a later hop (`a → ./b`,
+ * `b → /elsewhere`), or one written to leave and return (`/elsewhere/../in`),
+ * passes that gate lexically and is resolved by the OS before the canonical
+ * check can refuse it. Two consequences worth naming rather than papering
+ * over: an out-of-root path's existence is observable through `"external"`
+ * (resolved, then refused) versus `"broken"` (did not resolve), and a dead
+ * mount reachable through such a chain can still stall this listing.
+ *
+ * Closing those would take component-by-component resolution validated at
+ * every hop, which is a shared containment primitive this codebase does not
+ * have yet — and inventing a private one here is exactly what `.lessons/10971`
+ * exists to prevent. The boundary that matters for disclosure is the canonical
+ * check, and it holds.
  */
 async function describeSymlink(
   linkPath: string,
+  listingRealDirPath: string,
   resolvedBasePath: string,
   resolvedBaseRealPath: string
-): Promise<{ symlink: FileTreeSymlink; targetStat?: Awaited<ReturnType<typeof fs.lstat>> }> {
+): Promise<{ symlink: FileTreeSymlink; targetStat?: Stats }> {
   const raw = await fs.readlink(linkPath);
-  const target = path.resolve(path.dirname(linkPath), raw);
+  // Against the CANONICAL directory this entry was listed from, not the
+  // lexical one. When the listed directory is itself reached through a link,
+  // the two are different places, and only the canonical one interprets a
+  // relative target the way the kernel will.
+  const target = path.resolve(listingRealDirPath, raw);
   const unresolved = (targetKind: FileTreeSymlink["targetKind"]) => ({
-    symlink: { target, targetKind, insideRoot: false },
+    symlink: { target, targetKind },
   });
 
-  if (!isContained(resolvedBasePath, target)) return unresolved("unknown");
+  // Either spelling of the root counts as inside it. A root reached through a
+  // symlink (macOS `/tmp` and `/var` both are) has two absolute names, and an
+  // absolute target written in whichever one the link's author had is still
+  // pointing at the same workspace — rejecting it would hide a genuinely
+  // in-root link. The canonical check below is what actually decides.
+  if (!isContained(resolvedBaseRealPath, target) && !isContained(resolvedBasePath, target)) {
+    return unresolved("external");
+  }
 
   let realTarget: string;
   try {
     realTarget = await fs.realpath(linkPath);
   } catch (error: unknown) {
-    // ENOENT is a dangling link — the one failure that means something
-    // specific enough to show. ELOOP (a cycle, or the OS depth limit) and
-    // EACCES/EPERM are indistinguishable to a user and equally non-actionable.
+    // ENOENT is a dangling link — the one failure specific enough to show.
+    // ELOOP (a cycle, or the OS depth limit) and EACCES/EPERM are equally
+    // non-actionable, and reporting them as `"external"` would tell the user
+    // something false about where their link points.
     const code = (error as NodeJS.ErrnoException).code;
     return unresolved(code === "ENOENT" ? "broken" : "unknown");
   }
 
-  // A target can be lexically inside the root and still canonically outside it
-  // — `link → ./sub/escape/etc` where `sub/escape → /`. The canonical check is
-  // what keeps `insideRoot` honest, so the renderer never draws a disclosure
-  // triangle on a row whose listing would be refused.
-  if (!isContained(resolvedBaseRealPath, realTarget)) return unresolved("unknown");
+  // The authoritative check. A target can be lexically inside the root and
+  // canonically outside it — `link → ./sub/escape/etc` where `sub/escape → /`
+  // — and this is what keeps such a link from ever reporting a kind, a size,
+  // or a disclosure triangle.
+  if (!isContained(resolvedBaseRealPath, realTarget)) return unresolved("external");
 
   try {
     // `lstat`, not `stat`: `realTarget` is fully resolved, so there is no link
     // left to follow and the cheaper call answers the same question.
     const targetStat = await fs.lstat(realTarget);
     return {
-      symlink: {
-        target,
-        targetKind: targetStat.isDirectory() ? "directory" : "file",
-        insideRoot: true,
-      },
+      symlink: { target, targetKind: targetStat.isDirectory() ? "directory" : "file" },
       targetStat,
     };
   } catch {
@@ -194,6 +213,7 @@ export class FileTreeService {
             }
             const { symlink, targetStat } = await describeSymlink(
               absolutePath,
+              targetRealPath,
               resolvedBasePath,
               resolvedBaseRealPath
             );

--- a/electron/services/__tests__/CopyTreeService.fileTree.test.ts
+++ b/electron/services/__tests__/CopyTreeService.fileTree.test.ts
@@ -93,6 +93,54 @@ describe("CopyTreeService.getFileTree", () => {
     expect(nodes.map((node) => node.name)).toEqual(["a.ts", "b.lock", "c.png", "d.md"]);
   });
 
+  it("routes a symlink by the kind the raw listing reports (#11939)", async () => {
+    // The verdict overlay branches on `isDirectory` to choose between the
+    // manifest's file set and the derived populated-directory set. Now that
+    // the raw listing surfaces symlinks — reporting the TARGET's kind — a link
+    // to a file has to be looked up as a file and a link to a directory as a
+    // directory, or each would be judged against the wrong set and vanish.
+    await fs.mkdir(path.join(tempDir, "real"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "real", "inner.ts"), "");
+    await fs.writeFile(path.join(tempDir, "app.ts"), "");
+    try {
+      await fs.symlink(path.join(tempDir, "app.ts"), path.join(tempDir, "app-link.ts"));
+      await fs.symlink(path.join(tempDir, "real"), path.join(tempDir, "dir-link"), "dir");
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EPERM" || code === "EACCES") return;
+      throw error;
+    }
+    // What the SDK walker would report having followed both links.
+    copyMock.mockResolvedValue(
+      dryRunResult(
+        manifest([["app.ts"], ["app-link.ts"], ["dir-link/inner.ts"], ["real/inner.ts"]])
+      )
+    );
+
+    const nodes = await copyTreeService.getFileTree(tempDir);
+
+    expect(nodes.map((node) => node.name)).toEqual(["dir-link", "real", "app-link.ts", "app.ts"]);
+  });
+
+  it("drops a symlink the dry run excluded, exactly like any other entry", async () => {
+    // CopyTree owns the bundling policy — `symlinkEscape` is one of its own
+    // exclusion reasons. The picker preview must inherit that verdict rather
+    // than acquire an opinion of its own now that links are listed.
+    await fs.writeFile(path.join(tempDir, "app.ts"), "");
+    try {
+      await fs.symlink(path.join(tempDir, "app.ts"), path.join(tempDir, "escaping.ts"));
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EPERM" || code === "EACCES") return;
+      throw error;
+    }
+    copyMock.mockResolvedValue(dryRunResult(manifest([["app.ts"]])));
+
+    const nodes = await copyTreeService.getFileTree(tempDir);
+
+    expect(nodes.map((node) => node.name)).toEqual(["app.ts"]);
+  });
+
   it("hides a file the dry run never recorded", async () => {
     // CopyTree's manifest lists only what survived, so an excluded path has no
     // entry at all. Absence is the exclusion signal, and it covers every layer

--- a/electron/services/__tests__/CopyTreeService.fileTree.test.ts
+++ b/electron/services/__tests__/CopyTreeService.fileTree.test.ts
@@ -51,6 +51,22 @@ describe("CopyTreeService.getFileTree", () => {
     };
   }
 
+  /** See the note in `FileTreeService.test.ts`: skip, never silently return. */
+  async function symlinkOrSkip(
+    ctx: { skip: () => void },
+    target: string,
+    linkPath: string,
+    type?: "file" | "dir"
+  ): Promise<void> {
+    try {
+      await fs.symlink(target, linkPath, type);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EPERM" || code === "EACCES") ctx.skip();
+      throw error;
+    }
+  }
+
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-context-tree-"));
     vi.clearAllMocks();
@@ -93,7 +109,7 @@ describe("CopyTreeService.getFileTree", () => {
     expect(nodes.map((node) => node.name)).toEqual(["a.ts", "b.lock", "c.png", "d.md"]);
   });
 
-  it("routes a symlink by the kind the raw listing reports (#11939)", async () => {
+  it("routes a symlink by the kind the raw listing reports (#11939)", async (ctx) => {
     // The verdict overlay branches on `isDirectory` to choose between the
     // manifest's file set and the derived populated-directory set. Now that
     // the raw listing surfaces symlinks — reporting the TARGET's kind — a link
@@ -102,14 +118,8 @@ describe("CopyTreeService.getFileTree", () => {
     await fs.mkdir(path.join(tempDir, "real"), { recursive: true });
     await fs.writeFile(path.join(tempDir, "real", "inner.ts"), "");
     await fs.writeFile(path.join(tempDir, "app.ts"), "");
-    try {
-      await fs.symlink(path.join(tempDir, "app.ts"), path.join(tempDir, "app-link.ts"));
-      await fs.symlink(path.join(tempDir, "real"), path.join(tempDir, "dir-link"), "dir");
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "EPERM" || code === "EACCES") return;
-      throw error;
-    }
+    await symlinkOrSkip(ctx, path.join(tempDir, "app.ts"), path.join(tempDir, "app-link.ts"));
+    await symlinkOrSkip(ctx, path.join(tempDir, "real"), path.join(tempDir, "dir-link"), "dir");
     // What the SDK walker would report having followed both links.
     copyMock.mockResolvedValue(
       dryRunResult(
@@ -122,22 +132,31 @@ describe("CopyTreeService.getFileTree", () => {
     expect(nodes.map((node) => node.name)).toEqual(["dir-link", "real", "app-link.ts", "app.ts"]);
   });
 
-  it("drops a symlink the dry run excluded, exactly like any other entry", async () => {
+  it("drops a symlink the dry run excluded, exactly like any other entry", async (ctx) => {
     // CopyTree owns the bundling policy — `symlinkEscape` is one of its own
     // exclusion reasons. The picker preview must inherit that verdict rather
     // than acquire an opinion of its own now that links are listed.
+    //
+    // Asserted through `includeExcluded` rather than by absence: a plain
+    // `["app.ts"]` expectation would hold just as well if the listing
+    // regressed to hiding every symlink, which is the bug this PR fixes.
     await fs.writeFile(path.join(tempDir, "app.ts"), "");
-    try {
-      await fs.symlink(path.join(tempDir, "app.ts"), path.join(tempDir, "escaping.ts"));
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "EPERM" || code === "EACCES") return;
-      throw error;
-    }
+    await symlinkOrSkip(ctx, path.join(tempDir, "app.ts"), path.join(tempDir, "escaping.ts"));
     copyMock.mockResolvedValue(dryRunResult(manifest([["app.ts"]])));
 
-    const nodes = await copyTreeService.getFileTree(tempDir);
+    const withExcluded = await copyTreeService.getFileTree(
+      tempDir,
+      "",
+      {},
+      { includeExcluded: true }
+    );
+    expect(withExcluded.map((node) => [node.name, node.excluded ?? false])).toEqual([
+      ["app.ts", false],
+      ["escaping.ts", true],
+    ]);
 
+    // ...and the default listing, which the picker uses, omits it entirely.
+    const nodes = await copyTreeService.getFileTree(tempDir);
     expect(nodes.map((node) => node.name)).toEqual(["app.ts"]);
   });
 

--- a/electron/services/__tests__/FileTreeService.adversarial.test.ts
+++ b/electron/services/__tests__/FileTreeService.adversarial.test.ts
@@ -7,6 +7,7 @@ const shared = vi.hoisted(() => ({
   stat: vi.fn(),
   readdir: vi.fn(),
   lstat: vi.fn(),
+  readlink: vi.fn(),
   spawn: vi.fn(() => {
     throw new Error("a raw listing must not spawn a subprocess");
   }),
@@ -17,6 +18,7 @@ vi.mock("fs/promises", () => ({
   stat: shared.stat,
   readdir: shared.readdir,
   lstat: shared.lstat,
+  readlink: shared.readlink,
 }));
 
 // Poisoned so reintroducing a subprocess to this listing fails loudly rather
@@ -85,6 +87,7 @@ describe("FileTreeService adversarial", () => {
     shared.stat.mockResolvedValue(createStats({ isDirectory: true }));
     shared.readdir.mockResolvedValue([]);
     shared.lstat.mockResolvedValue(createStats({ size: 0 }));
+    shared.readlink.mockResolvedValue("./target");
   });
 
   it("READDIR_EACCES_WRAPPED_CLEANLY", async () => {
@@ -114,12 +117,67 @@ describe("FileTreeService adversarial", () => {
     ]);
   });
 
-  it("SYMLINK_OMITTED_WITHOUT_FOLLOW", async () => {
+  it("SYMLINK_LISTED_WITH_ITS_TARGET", async () => {
+    // Was SYMLINK_OMITTED_WITHOUT_FOLLOW, which pinned the bug in #11939: a
+    // link used to be dropped before it was ever stat'd, so the file browser
+    // showed nothing and said nothing.
     shared.readdir.mockResolvedValueOnce([d("link", { symlink: true })]);
+    shared.lstat.mockImplementation(async (target: string) =>
+      createStats({ isSymbolicLink: target.endsWith("link"), size: 11 })
+    );
+    shared.readlink.mockResolvedValue("./target");
 
-    await expect(service.getFileTree("/repo")).resolves.toEqual([]);
-    expect(shared.stat).toHaveBeenCalledTimes(1);
-    expect(shared.lstat).not.toHaveBeenCalled();
+    await expect(service.getFileTree("/repo")).resolves.toEqual([
+      {
+        isDirectory: false,
+        name: "link",
+        path: "link",
+        size: 11,
+        symlink: { target: "/repo/target", targetKind: "file" },
+      },
+    ]);
+  });
+
+  it("OUT_OF_ROOT_LINK_IS_NOT_DEREFERENCED", async () => {
+    // The syscall-level half of the no-probe rule, which a real-filesystem
+    // test cannot express: a link naming an outside path must be classified
+    // from `readlink` ALONE. Any `realpath` or `lstat` aimed at that target
+    // would be the external existence probe (and the dead-mount stall) the
+    // lexical gate exists to avoid, so their absence is the assertion.
+    shared.readdir.mockResolvedValueOnce([d("outward", { symlink: true })]);
+    shared.lstat.mockResolvedValue(createStats({ isSymbolicLink: true, size: 15 }));
+    shared.readlink.mockResolvedValue("/elsewhere/secret");
+
+    const nodes = await service.getFileTree("/repo");
+
+    expect(nodes).toEqual([
+      {
+        isDirectory: false,
+        name: "outward",
+        path: "outward",
+        // No size: a link's own `lstat.size` is its target string's length.
+        symlink: { target: "/elsewhere/secret", targetKind: "external" },
+      },
+    ]);
+    expect(shared.readlink).toHaveBeenCalledWith("/repo/outward");
+    // Only the entry's own `lstat` — never one aimed at the target.
+    expect(shared.lstat.mock.calls.map(([target]) => target)).toEqual(["/repo/outward"]);
+    // The two directory-level realpaths only; none for the link.
+    expect(shared.realpath.mock.calls.map(([target]) => target)).toEqual(["/repo", "/repo"]);
+  });
+
+  it("LINK_READ_FAILURE_DROPS_ONE_ENTRY_NOT_THE_LISTING", async () => {
+    // A link deleted between `readdir` and `readlink` is an ordinary race, and
+    // it must cost exactly that one row.
+    shared.readdir.mockResolvedValueOnce([d("gone", { symlink: true }), d("good.txt")]);
+    shared.lstat.mockImplementation(async (target: string) =>
+      createStats({ isSymbolicLink: target.endsWith("gone"), size: 4 })
+    );
+    shared.readlink.mockRejectedValue(eacces("ENOENT: no such file"));
+
+    const nodes = await service.getFileTree("/repo");
+
+    expect(nodes.map((node) => node.name)).toEqual(["good.txt"]);
   });
 
   it("NO_SUBPROCESS_FOR_A_LISTING", async () => {

--- a/electron/services/__tests__/FileTreeService.test.ts
+++ b/electron/services/__tests__/FileTreeService.test.ts
@@ -150,26 +150,6 @@ describe("FileTreeService", () => {
     expect(nodes.map((node) => node.name).sort()).toEqual([".git", ".gitignore", "app.ts", "dist"]);
   });
 
-  it("omits symlinked entries", async () => {
-    // Containment property, independent of any ignore filtering.
-    await fs.writeFile(path.join(tempDir, "app.ts"), "export {};");
-    try {
-      await fs.symlink(path.join(tempDir, "app.ts"), path.join(tempDir, "link.ts"));
-    } catch (error) {
-      // Only platforms that genuinely forbid symlinks may skip: without a link
-      // on disk the assertion below proves nothing, so any other setup failure
-      // has to surface rather than pass as a silent no-op.
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "EPERM" || code === "EACCES") return;
-      throw error;
-    }
-
-    const nodes = await service.getFileTree(tempDir);
-
-    expect(nodes.some((node) => node.name === "app.ts")).toBe(true);
-    expect(nodes.some((node) => node.name === "link.ts")).toBe(false);
-  });
-
   it("blocks dirPath values that resolve through symlinks outside base path", async () => {
     const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-file-tree-outside-"));
     await fs.writeFile(path.join(outsideDir, "outside.txt"), "outside");
@@ -188,12 +168,214 @@ describe("FileTreeService", () => {
         throw error;
       }
 
+      // The link is listed now (#11939) — but only as a terminal node. Descent
+      // is still refused, which is the guard that makes it terminal: the
+      // renderer is told not to ask, and this is what holds if it asks anyway.
+      const nodes = await service.getFileTree(tempDir);
+      const link = nodes.find((node) => node.name === "external-link");
+      expect(link?.symlink?.insideRoot).toBe(false);
+      expect(link?.isDirectory).toBe(false);
+
       await expect(service.getFileTree(tempDir, "external-link")).rejects.toThrow(
         "path traversal not allowed"
       );
     } finally {
       await fs.rm(outsideDir, { recursive: true, force: true });
     }
+  });
+});
+
+/**
+ * Symlinks are entries, not omissions (#11939). Every test here builds real
+ * links on a real filesystem, because the behaviour under test is precisely
+ * how the OS resolves them — a mocked `fs` would assert the mock.
+ */
+describe("FileTreeService symlinks (#11939)", () => {
+  let tempDir: string;
+  let service: FileTreeService;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-file-tree-symlink-"));
+    service = new FileTreeService();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Create a link, or bail out of the calling test on a platform that forbids
+   * them outright. Scoped to the creation call alone: a later failure is a real
+   * failure, and swallowing it would turn the whole suite into a silent no-op
+   * on the platform that most needs it (Windows, where junctions take this
+   * same path).
+   */
+  async function symlinkOrSkip(
+    target: string,
+    linkPath: string,
+    type?: "file" | "dir"
+  ): Promise<boolean> {
+    try {
+      await fs.symlink(target, linkPath, type);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EPERM" || code === "EACCES") return false;
+      throw error;
+    }
+  }
+
+  it("lists a relative in-root symlink to a file and reports the target's kind", async () => {
+    // The `node_modules/.bin` shape from the issue: a link in one directory
+    // pointing at a file in a sibling one, written relative to the link's own
+    // directory rather than to any process cwd.
+    await fs.mkdir(path.join(tempDir, "acorn", "bin"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, ".bin"), { recursive: true });
+    const realFile = path.join(tempDir, "acorn", "bin", "acorn");
+    await fs.writeFile(realFile, "#!/usr/bin/env node\n");
+    if (!(await symlinkOrSkip("../acorn/bin/acorn", path.join(tempDir, ".bin", "acorn")))) return;
+
+    const nodes = await service.getFileTree(tempDir, ".bin");
+    const link = nodes.find((node) => node.name === "acorn");
+
+    expect(link).toBeDefined();
+    expect(link?.isDirectory).toBe(false);
+    expect(link?.symlink).toEqual({
+      target: realFile,
+      targetKind: "file",
+      insideRoot: true,
+    });
+  });
+
+  it("reports the target's size and mtime for a resolved link, not the link's own", async () => {
+    // A symlink's own `lstat.size` is the byte length of the stored target
+    // string — a real number that means nothing as a file size. Compared
+    // against the target's actual stat rather than a literal so this asserts
+    // the value is plumbed from the right syscall.
+    const realFile = path.join(tempDir, "app.ts");
+    await fs.writeFile(realFile, "export {};");
+    if (!(await symlinkOrSkip(realFile, path.join(tempDir, "link.ts")))) return;
+    const targetStat = await fs.stat(realFile);
+    const linkStat = await fs.lstat(path.join(tempDir, "link.ts"));
+
+    const link = (await service.getFileTree(tempDir)).find((node) => node.name === "link.ts");
+
+    expect(link?.size).toBe(targetStat.size);
+    expect(link?.mtimeMs).toBe(targetStat.mtimeMs);
+    // Non-vacuous: the two stats genuinely disagree, so reading the wrong one
+    // would have been caught.
+    expect(linkStat.size).not.toBe(targetStat.size);
+  });
+
+  it("lists an in-root symlink to a directory as a directory and descends through it", async () => {
+    await fs.mkdir(path.join(tempDir, "real"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "real", "inner.ts"), "export {};");
+    if (!(await symlinkOrSkip(path.join(tempDir, "real"), path.join(tempDir, "aliased"), "dir")))
+      return;
+
+    const link = (await service.getFileTree(tempDir)).find((node) => node.name === "aliased");
+    expect(link?.isDirectory).toBe(true);
+    expect(link?.symlink?.targetKind).toBe("directory");
+    expect(link?.symlink?.insideRoot).toBe(true);
+
+    // Descent through the link works and paths stay expressed through it, so
+    // the tree can address the rows it renders.
+    const children = await service.getFileTree(tempDir, "aliased");
+    expect(children.map((node) => node.path)).toEqual(["aliased/inner.ts"]);
+  });
+
+  it("sorts an in-root directory symlink with the directories", async () => {
+    // Ordering keys off `isDirectory`, which for a link means the target's
+    // kind — so a link to a folder must not sink into the file group.
+    await fs.mkdir(path.join(tempDir, "zzz-real"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, "aaa-file.ts"), "");
+    if (
+      !(await symlinkOrSkip(path.join(tempDir, "zzz-real"), path.join(tempDir, "mmm-link"), "dir"))
+    )
+      return;
+
+    const names = (await service.getFileTree(tempDir)).map((node) => node.name);
+
+    expect(names).toEqual(["mmm-link", "zzz-real", "aaa-file.ts"]);
+  });
+
+  it("marks a dangling in-root symlink broken", async () => {
+    if (!(await symlinkOrSkip(path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"))))
+      return;
+
+    const link = (await service.getFileTree(tempDir)).find((node) => node.name === "dangling.ts");
+
+    expect(link?.symlink?.targetKind).toBe("broken");
+    expect(link?.symlink?.insideRoot).toBe(false);
+    expect(link?.isDirectory).toBe(false);
+  });
+
+  it("reports no size for an unresolved link rather than the target string's length", async () => {
+    if (!(await symlinkOrSkip(path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"))))
+      return;
+    const linkStat = await fs.lstat(path.join(tempDir, "dangling.ts"));
+
+    const link = (await service.getFileTree(tempDir)).find((node) => node.name === "dangling.ts");
+
+    expect(link?.size).toBeUndefined();
+    // The link's own mtime is the only honest timestamp left, and it is shown.
+    expect(link?.mtimeMs).toBe(linkStat.mtimeMs);
+    // Non-vacuous: there really was a plausible-looking number to leak.
+    expect(linkStat.size).toBeGreaterThan(0);
+  });
+
+  it("never dereferences an out-of-root target, even to learn whether it exists", async () => {
+    // The distinction this pins: a link the listing DID follow and found
+    // missing reports "broken"; one it deliberately never followed reports
+    // "unknown". Both point at a path that does not exist, so the only thing
+    // separating the two answers is whether a syscall was made — which is
+    // exactly the probe (and, on a dead network mount, the hang) that
+    // out-of-root targets must not cost.
+    const outsideMissing = path.join(os.tmpdir(), "daintree-file-tree-absent-11939", "nope");
+    if (!(await symlinkOrSkip(outsideMissing, path.join(tempDir, "outward")))) return;
+    if (!(await symlinkOrSkip(path.join(tempDir, "gone.ts"), path.join(tempDir, "inward")))) return;
+
+    const nodes = await service.getFileTree(tempDir);
+
+    expect(nodes.find((node) => node.name === "outward")?.symlink).toEqual({
+      target: outsideMissing,
+      targetKind: "unknown",
+      insideRoot: false,
+    });
+    expect(nodes.find((node) => node.name === "inward")?.symlink?.targetKind).toBe("broken");
+  });
+
+  it("refuses a link that is lexically inside the root but canonically escapes it", async () => {
+    // `hop` resolves to the filesystem root, so `through-hop -> ./hop/etc`
+    // passes a purely lexical containment check and still lands outside. The
+    // canonical check is what catches it — and until it does, nothing stats
+    // the target.
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-file-tree-hop-"));
+    try {
+      await fs.writeFile(path.join(outsideDir, "secret.txt"), "x");
+      if (!(await symlinkOrSkip(outsideDir, path.join(tempDir, "hop"), "dir"))) return;
+      if (!(await symlinkOrSkip("./hop/secret.txt", path.join(tempDir, "through-hop")))) return;
+
+      const link = (await service.getFileTree(tempDir)).find((node) => node.name === "through-hop");
+
+      expect(link).toBeDefined();
+      expect(link?.symlink?.insideRoot).toBe(false);
+      expect(link?.symlink?.targetKind).toBe("unknown");
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps listing the rest of a directory when one link is unresolvable", async () => {
+    // One bad entry must not take the listing with it — the old behaviour
+    // dropped every link silently, and the new one must not swing to throwing.
+    await fs.writeFile(path.join(tempDir, "app.ts"), "export {};");
+    if (!(await symlinkOrSkip(path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"))))
+      return;
+
+    const names = (await service.getFileTree(tempDir)).map((node) => node.name);
+
+    expect(names).toEqual(["app.ts", "dangling.ts"]);
   });
 });
 

--- a/electron/services/__tests__/FileTreeService.test.ts
+++ b/electron/services/__tests__/FileTreeService.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { FileTreeService } from "../FileTreeService.js";
+import { FileTreeService, _normalizeWin32LinkTarget } from "../FileTreeService.js";
 
 // The temp dirs created below are NOT git repos, and that is no longer a
 // special case: this service is a raw listing with no git dependency at all.
@@ -150,7 +150,7 @@ describe("FileTreeService", () => {
     expect(nodes.map((node) => node.name).sort()).toEqual([".git", ".gitignore", "app.ts", "dist"]);
   });
 
-  it("blocks dirPath values that resolve through symlinks outside base path", async () => {
+  it("blocks dirPath values that resolve through symlinks outside base path", async (ctx) => {
     const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-file-tree-outside-"));
     await fs.writeFile(path.join(outsideDir, "outside.txt"), "outside");
 
@@ -160,11 +160,11 @@ describe("FileTreeService", () => {
       try {
         await fs.symlink(outsideDir, linkPath, "dir");
       } catch (error) {
-        // Some environments disallow symlink creation; skip instead of failing unrelated behavior.
+        // Some environments disallow symlink creation. Skipped, not returned:
+        // a returning test reports green with no assertions, which reads as
+        // coverage this suite would not actually have.
         const code = (error as NodeJS.ErrnoException).code;
-        if (code === "EPERM" || code === "EACCES") {
-          return;
-        }
+        if (code === "EPERM" || code === "EACCES") ctx.skip();
         throw error;
       }
 
@@ -494,5 +494,41 @@ describe("FileTreeService mtimeMs (#11620)", () => {
 
     expect(node).toMatchObject({ size: 5 });
     expect(node?.mtimeMs).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Windows junctions store their target in the NT namespace, so `readlink`
+ * hands back an extended-length path. The rule runs only on Windows, but the
+ * logic is pure and its failure mode — an in-root junction classified as
+ * external, or worse a remote share classified as local — is worth pinning on
+ * every platform rather than waiting for a Windows run to find it (#11939).
+ */
+describe("_normalizeWin32LinkTarget", () => {
+  it("unwraps the drive-letter form so an in-root junction stays in-root", () => {
+    expect(_normalizeWin32LinkTarget(String.raw`\\?\C:\repo\target`)).toBe(
+      String.raw`C:\repo\target`
+    );
+  });
+
+  it("maps the UNC form back to a share path instead of a relative one", () => {
+    // The trap: dropping four characters would leave `UNC\server\share`,
+    // which is RELATIVE — it would resolve under the workspace root and let a
+    // remote share pass as local. It has to become a real UNC path, which
+    // stays a distinct root and is rejected by containment.
+    const unwrapped = _normalizeWin32LinkTarget(String.raw`\\?\UNC\server\share\x`);
+    expect(unwrapped).toBe(String.raw`\\server\share\x`);
+    expect(path.win32.isAbsolute(unwrapped)).toBe(true);
+  });
+
+  it("leaves any other namespace path wearing its prefix, so it cannot be mistaken for local", () => {
+    const volumeGuid = String.raw`\\?\Volume{b75e2c83}\x`;
+    expect(_normalizeWin32LinkTarget(volumeGuid)).toBe(volumeGuid);
+  });
+
+  it("passes ordinary targets through untouched", () => {
+    expect(_normalizeWin32LinkTarget(String.raw`..\target`)).toBe(String.raw`..\target`);
+    expect(_normalizeWin32LinkTarget(String.raw`C:\repo\target`)).toBe(String.raw`C:\repo\target`);
+    expect(_normalizeWin32LinkTarget("../acorn/bin/acorn")).toBe("../acorn/bin/acorn");
   });
 });

--- a/electron/services/__tests__/FileTreeService.test.ts
+++ b/electron/services/__tests__/FileTreeService.test.ts
@@ -173,7 +173,7 @@ describe("FileTreeService", () => {
       // renderer is told not to ask, and this is what holds if it asks anyway.
       const nodes = await service.getFileTree(tempDir);
       const link = nodes.find((node) => node.name === "external-link");
-      expect(link?.symlink?.insideRoot).toBe(false);
+      expect(link?.symlink?.targetKind).toBe("external");
       expect(link?.isDirectory).toBe(false);
 
       await expect(service.getFileTree(tempDir, "external-link")).rejects.toThrow(
@@ -204,28 +204,31 @@ describe("FileTreeService symlinks (#11939)", () => {
   });
 
   /**
-   * Create a link, or bail out of the calling test on a platform that forbids
-   * them outright. Scoped to the creation call alone: a later failure is a real
-   * failure, and swallowing it would turn the whole suite into a silent no-op
-   * on the platform that most needs it (Windows, where junctions take this
-   * same path).
+   * Create a link, or mark the calling test SKIPPED on a platform that forbids
+   * them outright.
+   *
+   * `ctx.skip()` rather than an early `return`: a returning test reports green
+   * with no assertions, which is indistinguishable from real coverage in CI —
+   * and this is exactly the suite whose Windows result matters, since junctions
+   * take the same code path. Scoped to the creation call alone, so any other
+   * failure still surfaces.
    */
   async function symlinkOrSkip(
+    ctx: { skip: () => void },
     target: string,
     linkPath: string,
     type?: "file" | "dir"
-  ): Promise<boolean> {
+  ): Promise<void> {
     try {
       await fs.symlink(target, linkPath, type);
-      return true;
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
-      if (code === "EPERM" || code === "EACCES") return false;
+      if (code === "EPERM" || code === "EACCES") ctx.skip();
       throw error;
     }
   }
 
-  it("lists a relative in-root symlink to a file and reports the target's kind", async () => {
+  it("lists a relative in-root symlink to a file and reports the target's kind", async (ctx) => {
     // The `node_modules/.bin` shape from the issue: a link in one directory
     // pointing at a file in a sibling one, written relative to the link's own
     // directory rather than to any process cwd.
@@ -233,28 +236,68 @@ describe("FileTreeService symlinks (#11939)", () => {
     await fs.mkdir(path.join(tempDir, ".bin"), { recursive: true });
     const realFile = path.join(tempDir, "acorn", "bin", "acorn");
     await fs.writeFile(realFile, "#!/usr/bin/env node\n");
-    if (!(await symlinkOrSkip("../acorn/bin/acorn", path.join(tempDir, ".bin", "acorn")))) return;
+    await symlinkOrSkip(ctx, "../acorn/bin/acorn", path.join(tempDir, ".bin", "acorn"));
 
     const nodes = await service.getFileTree(tempDir, ".bin");
     const link = nodes.find((node) => node.name === "acorn");
 
     expect(link).toBeDefined();
     expect(link?.isDirectory).toBe(false);
+    // Canonical form, because that is how the kernel resolves it — on macOS
+    // `os.tmpdir()` itself sits under a symlinked prefix (`/var` →
+    // `/private/var`), so the two spellings genuinely differ here.
     expect(link?.symlink).toEqual({
-      target: realFile,
+      target: await fs.realpath(realFile),
       targetKind: "file",
-      insideRoot: true,
     });
   });
 
-  it("reports the target's size and mtime for a resolved link, not the link's own", async () => {
-    // A symlink's own `lstat.size` is the byte length of the stored target
-    // string — a real number that means nothing as a file size. Compared
-    // against the target's actual stat rather than a literal so this asserts
-    // the value is plumbed from the right syscall.
+  it("resolves a relative target against the real directory, not the lexical one", async (ctx) => {
+    // Listing happens THROUGH a directory link, and the entry inside it is a
+    // relative link that climbs. The kernel resolves `../target` against the
+    // link's real parent (`packages/pkg/bin`), giving `packages/pkg/target` —
+    // resolving against the lexical parent (`alias`) would name the wrong file
+    // at the root and misreport, or lose, a perfectly good in-root link.
+    await fs.mkdir(path.join(tempDir, "packages", "pkg", "bin"), { recursive: true });
+    const realTarget = path.join(tempDir, "packages", "pkg", "target");
+    await fs.writeFile(realTarget, "x");
+    await symlinkOrSkip(ctx, "packages/pkg/bin", path.join(tempDir, "alias"), "dir");
+    await symlinkOrSkip(ctx, "../target", path.join(tempDir, "packages", "pkg", "bin", "tool"));
+
+    const link = (await service.getFileTree(tempDir, "alias")).find((node) => node.name === "tool");
+
+    expect(link?.symlink?.target).toBe(await fs.realpath(realTarget));
+    expect(link?.symlink?.targetKind).toBe("file");
+  });
+
+  it("accepts an absolute in-root target written in canonical form", async (ctx) => {
+    // `tempDir` is the non-canonical spelling on macOS; a link written with
+    // the canonical one points at the very same workspace and must not read as
+    // external just because the two strings differ.
     const realFile = path.join(tempDir, "app.ts");
     await fs.writeFile(realFile, "export {};");
-    if (!(await symlinkOrSkip(realFile, path.join(tempDir, "link.ts")))) return;
+    const canonicalTarget = await fs.realpath(realFile);
+    await symlinkOrSkip(ctx, canonicalTarget, path.join(tempDir, "canonical-link.ts"));
+    // Non-vacuous: on a platform where the two spellings coincide this proves
+    // nothing, so skip rather than pass.
+    if (canonicalTarget === realFile) ctx.skip();
+
+    const link = (await service.getFileTree(tempDir)).find(
+      (node) => node.name === "canonical-link.ts"
+    );
+
+    expect(link?.symlink?.targetKind).toBe("file");
+  });
+
+  it("reports the target's size and mtime for a resolved link, not the link's own", async (ctx) => {
+    const realFile = path.join(tempDir, "app.ts");
+    await fs.writeFile(realFile, "export {};");
+    // Push the target's mtime somewhere the link's cannot coincidentally land:
+    // created milliseconds apart, the two would otherwise share a timestamp on
+    // a coarse filesystem and the assertion would hold for the wrong reason.
+    const distantPast = new Date(Date.now() - 86_400_000);
+    await fs.utimes(realFile, distantPast, distantPast);
+    await symlinkOrSkip(ctx, realFile, path.join(tempDir, "link.ts"));
     const targetStat = await fs.stat(realFile);
     const linkStat = await fs.lstat(path.join(tempDir, "link.ts"));
 
@@ -262,57 +305,63 @@ describe("FileTreeService symlinks (#11939)", () => {
 
     expect(link?.size).toBe(targetStat.size);
     expect(link?.mtimeMs).toBe(targetStat.mtimeMs);
-    // Non-vacuous: the two stats genuinely disagree, so reading the wrong one
-    // would have been caught.
+    // Non-vacuous on both axes: link and target genuinely disagree about size
+    // and about mtime, so reading either off the wrong stat fails here.
     expect(linkStat.size).not.toBe(targetStat.size);
+    expect(linkStat.mtimeMs).not.toBe(targetStat.mtimeMs);
   });
 
-  it("lists an in-root symlink to a directory as a directory and descends through it", async () => {
+  it("lists an in-root symlink to a directory as a directory and descends through it", async (ctx) => {
     await fs.mkdir(path.join(tempDir, "real"), { recursive: true });
     await fs.writeFile(path.join(tempDir, "real", "inner.ts"), "export {};");
-    if (!(await symlinkOrSkip(path.join(tempDir, "real"), path.join(tempDir, "aliased"), "dir")))
-      return;
+    await symlinkOrSkip(ctx, path.join(tempDir, "real"), path.join(tempDir, "aliased"), "dir");
 
     const link = (await service.getFileTree(tempDir)).find((node) => node.name === "aliased");
     expect(link?.isDirectory).toBe(true);
     expect(link?.symlink?.targetKind).toBe("directory");
-    expect(link?.symlink?.insideRoot).toBe(true);
 
-    // Descent through the link works and paths stay expressed through it, so
-    // the tree can address the rows it renders.
+    // Descent works, and paths stay expressed THROUGH the link so the tree can
+    // address the rows it renders.
     const children = await service.getFileTree(tempDir, "aliased");
     expect(children.map((node) => node.path)).toEqual(["aliased/inner.ts"]);
   });
 
-  it("sorts an in-root directory symlink with the directories", async () => {
+  it("follows a link that points at another link", async (ctx) => {
+    await fs.writeFile(path.join(tempDir, "app.ts"), "export {};");
+    await symlinkOrSkip(ctx, path.join(tempDir, "app.ts"), path.join(tempDir, "first.ts"));
+    await symlinkOrSkip(ctx, path.join(tempDir, "first.ts"), path.join(tempDir, "second.ts"));
+
+    const link = (await service.getFileTree(tempDir)).find((node) => node.name === "second.ts");
+
+    // `realpath` collapses the whole chain, so the far end is what is reported
+    // — not the intermediate link.
+    expect(link?.symlink?.targetKind).toBe("file");
+    expect(link?.isDirectory).toBe(false);
+  });
+
+  it("sorts an in-root directory symlink with the directories", async (ctx) => {
     // Ordering keys off `isDirectory`, which for a link means the target's
     // kind — so a link to a folder must not sink into the file group.
     await fs.mkdir(path.join(tempDir, "zzz-real"), { recursive: true });
     await fs.writeFile(path.join(tempDir, "aaa-file.ts"), "");
-    if (
-      !(await symlinkOrSkip(path.join(tempDir, "zzz-real"), path.join(tempDir, "mmm-link"), "dir"))
-    )
-      return;
+    await symlinkOrSkip(ctx, path.join(tempDir, "zzz-real"), path.join(tempDir, "mmm-link"), "dir");
 
     const names = (await service.getFileTree(tempDir)).map((node) => node.name);
 
     expect(names).toEqual(["mmm-link", "zzz-real", "aaa-file.ts"]);
   });
 
-  it("marks a dangling in-root symlink broken", async () => {
-    if (!(await symlinkOrSkip(path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"))))
-      return;
+  it("marks a dangling in-root symlink broken", async (ctx) => {
+    await symlinkOrSkip(ctx, path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"));
 
     const link = (await service.getFileTree(tempDir)).find((node) => node.name === "dangling.ts");
 
     expect(link?.symlink?.targetKind).toBe("broken");
-    expect(link?.symlink?.insideRoot).toBe(false);
     expect(link?.isDirectory).toBe(false);
   });
 
-  it("reports no size for an unresolved link rather than the target string's length", async () => {
-    if (!(await symlinkOrSkip(path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"))))
-      return;
+  it("reports no size for an unresolved link rather than the target string's length", async (ctx) => {
+    await symlinkOrSkip(ctx, path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"));
     const linkStat = await fs.lstat(path.join(tempDir, "dangling.ts"));
 
     const link = (await service.getFileTree(tempDir)).find((node) => node.name === "dangling.ts");
@@ -324,54 +373,57 @@ describe("FileTreeService symlinks (#11939)", () => {
     expect(linkStat.size).toBeGreaterThan(0);
   });
 
-  it("never dereferences an out-of-root target, even to learn whether it exists", async () => {
-    // The distinction this pins: a link the listing DID follow and found
-    // missing reports "broken"; one it deliberately never followed reports
-    // "unknown". Both point at a path that does not exist, so the only thing
-    // separating the two answers is whether a syscall was made — which is
-    // exactly the probe (and, on a dead network mount, the hang) that
-    // out-of-root targets must not cost.
+  it("classifies a link out of the root as external, never as broken", async (ctx) => {
+    // The semantic half of the no-probe rule; the syscall half — that no
+    // `realpath`/`lstat` is aimed at the target at all — is asserted against
+    // the filesystem mock in `FileTreeService.adversarial.test.ts`, which is
+    // the only place a *non*-call can be observed.
+    //
+    // Both links below name a path that does not exist. `"broken"` is the
+    // answer for the one the listing resolved and found missing; `"external"`
+    // is the answer for the one it classified without looking.
     const outsideMissing = path.join(os.tmpdir(), "daintree-file-tree-absent-11939", "nope");
-    if (!(await symlinkOrSkip(outsideMissing, path.join(tempDir, "outward")))) return;
-    if (!(await symlinkOrSkip(path.join(tempDir, "gone.ts"), path.join(tempDir, "inward")))) return;
+    await expect(fs.lstat(outsideMissing)).rejects.toThrow();
+    await symlinkOrSkip(ctx, outsideMissing, path.join(tempDir, "outward"));
+    await symlinkOrSkip(ctx, path.join(tempDir, "gone.ts"), path.join(tempDir, "inward"));
 
     const nodes = await service.getFileTree(tempDir);
 
     expect(nodes.find((node) => node.name === "outward")?.symlink).toEqual({
       target: outsideMissing,
-      targetKind: "unknown",
-      insideRoot: false,
+      targetKind: "external",
     });
     expect(nodes.find((node) => node.name === "inward")?.symlink?.targetKind).toBe("broken");
   });
 
-  it("refuses a link that is lexically inside the root but canonically escapes it", async () => {
-    // `hop` resolves to the filesystem root, so `through-hop -> ./hop/etc`
-    // passes a purely lexical containment check and still lands outside. The
-    // canonical check is what catches it — and until it does, nothing stats
-    // the target.
+  it("refuses a link that is lexically inside the root but canonically escapes it", async (ctx) => {
+    // `hop` resolves outside, so `through-hop → ./hop/secret.txt` passes a
+    // purely lexical containment check and still lands out of the workspace.
+    // The canonical check on the resolved path is what catches it, and that is
+    // the boundary the whole design rests on.
     const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-file-tree-hop-"));
     try {
       await fs.writeFile(path.join(outsideDir, "secret.txt"), "x");
-      if (!(await symlinkOrSkip(outsideDir, path.join(tempDir, "hop"), "dir"))) return;
-      if (!(await symlinkOrSkip("./hop/secret.txt", path.join(tempDir, "through-hop")))) return;
+      await symlinkOrSkip(ctx, outsideDir, path.join(tempDir, "hop"), "dir");
+      await symlinkOrSkip(ctx, "./hop/secret.txt", path.join(tempDir, "through-hop"));
 
       const link = (await service.getFileTree(tempDir)).find((node) => node.name === "through-hop");
 
       expect(link).toBeDefined();
-      expect(link?.symlink?.insideRoot).toBe(false);
-      expect(link?.symlink?.targetKind).toBe("unknown");
+      expect(link?.symlink?.targetKind).toBe("external");
+      // No metadata crosses the boundary with it.
+      expect(link?.isDirectory).toBe(false);
+      expect(link?.size).toBeUndefined();
     } finally {
       await fs.rm(outsideDir, { recursive: true, force: true });
     }
   });
 
-  it("keeps listing the rest of a directory when one link is unresolvable", async () => {
+  it("keeps listing the rest of a directory when one link is unresolvable", async (ctx) => {
     // One bad entry must not take the listing with it — the old behaviour
     // dropped every link silently, and the new one must not swing to throwing.
     await fs.writeFile(path.join(tempDir, "app.ts"), "export {};");
-    if (!(await symlinkOrSkip(path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"))))
-      return;
+    await symlinkOrSkip(ctx, path.join(tempDir, "gone.ts"), path.join(tempDir, "dangling.ts"));
 
     const names = (await service.getFileTree(tempDir)).map((node) => node.name);
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -147,6 +147,7 @@ export type {
   CopyTreeBudgetStats,
   CopyTreeTruncatedBy,
   FileTreeNode,
+  FileTreeSymlink,
   // Worktree IPC types
   WorktreeRemovePayload,
   WorktreeSetActivePayload,

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -363,35 +363,31 @@ export interface CopyTreeProgress {
  */
 export interface FileTreeSymlink {
   /**
-   * Absolute path the link points at, resolved against the link's own
-   * directory (a raw target like `../acorn/bin/acorn` is relative to where the
-   * link lives, not to the process cwd). This is the lexical resolution, not
-   * the canonical one: it is the only form available for a target the listing
-   * deliberately refuses to dereference, so carrying it uniformly keeps the
-   * field present on every symlink node.
+   * Absolute path the link points at, resolved the way the kernel resolves it
+   * — against the canonical directory the entry was listed from, since a raw
+   * target like `../acorn/bin/acorn` is relative to where the link lives. That
+   * matters when the listed directory is itself reached through a link: the
+   * lexical parent and the real parent are different directories, and only the
+   * second one gives the target the OS would actually open.
    */
   target: string;
   /**
-   * What the target turned out to be.
+   * What the target turned out to be, and the single field the browser reads
+   * to decide what a link row can do.
    *
-   * `"broken"` means the target genuinely does not exist. `"unknown"` covers
-   * both "not dereferenced on purpose" (the target resolves outside the root)
-   * and "could not be dereferenced" (permission denied, symlink loop) — the
-   * two are distinguishable through `insideRoot`, and neither is a state the
-   * browser can act on.
-   */
-  targetKind: "file" | "directory" | "broken" | "unknown";
-  /**
-   * Whether the target canonically resolves inside the workspace root — i.e.
-   * whether descending through this link is allowed at all.
+   * `"file"` and `"directory"` are the resolved, contained cases — the only
+   * two where `isDirectory` reflects the target and descent is allowed.
+   * `"broken"` is a target that does not exist. `"external"` is a target that
+   * resolves outside the workspace root. `"unknown"` is a target that could
+   * not be classified at all (a symlink loop, permission denied) — kept
+   * distinct from `"external"` so the UI never tells someone a link points
+   * outside their workspace when the truth is that it could not be read.
    *
-   * The listing only ever reports `isDirectory: true` for a symlink whose
-   * target it verified is a contained directory, so `isDirectory` already
-   * implies this. It is carried separately because "is a directory" and "may
-   * be descended into" are different questions, and the renderer needs the
-   * second one answered before it asks for a listing it would be refused.
+   * There is deliberately no separate "may I descend" flag. It would be fully
+   * derivable from this one, and two fields that must agree are two fields
+   * that can disagree.
    */
-  insideRoot: boolean;
+  targetKind: "file" | "directory" | "broken" | "external" | "unknown";
 }
 
 /** File tree node for file picker */
@@ -422,6 +418,11 @@ export interface FileTreeNode {
    * Present only on symbolic links (#11939). Absence means the entry is a
    * plain file or directory, which is why every consumer can keep reading
    * `isDirectory` and ignore this field entirely.
+   *
+   * `isDirectory` is true for a link only when `targetKind` is `"directory"`,
+   * so a consumer routing on `isDirectory` alone — the CopyTree verdict
+   * overlay, the tree's chevron, the expansion fetch — stays correct without
+   * ever reading this field.
    *
    * Not carried by the persisted tree snapshot, which stores structure only —
    * a restored out-of-root link comes back as `isDirectory: false` and is

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -353,6 +353,47 @@ export interface CopyTreeProgress {
   traceId?: string;
 }
 
+/**
+ * What a listed symbolic link points at (#11939).
+ *
+ * Windows junctions are covered by the same shape with no special-casing: a
+ * `Dirent` reports `isSymbolicLink()` true and `isDirectory()` false for both a
+ * junction and a directory symlink, and nothing short of reading the target's
+ * NT-namespace prefix tells them apart — so nothing here tries to.
+ */
+export interface FileTreeSymlink {
+  /**
+   * Absolute path the link points at, resolved against the link's own
+   * directory (a raw target like `../acorn/bin/acorn` is relative to where the
+   * link lives, not to the process cwd). This is the lexical resolution, not
+   * the canonical one: it is the only form available for a target the listing
+   * deliberately refuses to dereference, so carrying it uniformly keeps the
+   * field present on every symlink node.
+   */
+  target: string;
+  /**
+   * What the target turned out to be.
+   *
+   * `"broken"` means the target genuinely does not exist. `"unknown"` covers
+   * both "not dereferenced on purpose" (the target resolves outside the root)
+   * and "could not be dereferenced" (permission denied, symlink loop) — the
+   * two are distinguishable through `insideRoot`, and neither is a state the
+   * browser can act on.
+   */
+  targetKind: "file" | "directory" | "broken" | "unknown";
+  /**
+   * Whether the target canonically resolves inside the workspace root — i.e.
+   * whether descending through this link is allowed at all.
+   *
+   * The listing only ever reports `isDirectory: true` for a symlink whose
+   * target it verified is a contained directory, so `isDirectory` already
+   * implies this. It is carried separately because "is a directory" and "may
+   * be descended into" are different questions, and the renderer needs the
+   * second one answered before it asks for a listing it would be refused.
+   */
+  insideRoot: boolean;
+}
+
 /** File tree node for file picker */
 export interface FileTreeNode {
   /** File/folder name */
@@ -377,6 +418,17 @@ export interface FileTreeNode {
   mtimeMs?: number;
   /** Children (only populated for directories if expanded) */
   children?: FileTreeNode[];
+  /**
+   * Present only on symbolic links (#11939). Absence means the entry is a
+   * plain file or directory, which is why every consumer can keep reading
+   * `isDirectory` and ignore this field entirely.
+   *
+   * Not carried by the persisted tree snapshot, which stores structure only —
+   * a restored out-of-root link comes back as `isDirectory: false` and is
+   * therefore still non-descendable, and its decoration returns as soon as the
+   * live listing lands.
+   */
+  symlink?: FileTreeSymlink;
   /**
    * Set when the node contributes nothing to the context CopyTree would
    * generate — an excluded file, or a directory with no includable descendant.

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useId, useMemo, useRef } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
-import { ChevronDown, ChevronRight, Folder, FolderOpen } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileSymlink,
+  Folder,
+  FolderOpen,
+  FolderSymlink,
+} from "lucide-react";
 import { join } from "@shared/utils/path";
 import { cn } from "@/lib/utils";
 import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
@@ -522,7 +529,27 @@ function FileTreeRow({ row, isSelected, isOpen, context }: FileTreeRowProps) {
   // Files carry their type; folders keep the folder shape (#11596). Resolved
   // per render rather than memoized: it is an object lookup, and Virtuoso only
   // ever renders the visible window.
-  const RowIcon = row.isDirectory ? FolderIcon : getFileTypeIcon(row.name).Icon;
+  // A symlink says so in the glyph itself rather than through a badge layered
+  // over the type icon: the row's icon slot is a single bare element by
+  // contract (see below), and "this is a link" outranks the file's extension
+  // for a row that used to be invisible entirely (#11939).
+  const RowIcon = row.symlink
+    ? row.isDirectory
+      ? FolderSymlink
+      : FileSymlink
+    : row.isDirectory
+      ? FolderIcon
+      : getFileTypeIcon(row.name).Icon;
+  // What the link points at, and why it is inert when it is. Out-of-root
+  // targets are deliberately never dereferenced, so "unknown" is the honest
+  // word for what is on the other side rather than a failure to look.
+  const symlinkDescription = row.symlink
+    ? row.symlink.targetKind === "broken"
+      ? `Broken symlink to ${row.symlink.target}`
+      : !row.symlink.insideRoot
+        ? `Symlink to ${row.symlink.target}, outside this folder`
+        : `Symlink to ${row.symlink.target}`
+    : null;
 
   // A file's own status; a folder's is the worst thing anywhere beneath it, so a
   // collapsed branch still says that something inside it changed.
@@ -535,6 +562,10 @@ function FileTreeRow({ row, isSelected, isOpen, context }: FileTreeRowProps) {
     : null;
   const rowId = rowDomId(context.instanceId, row.path);
   const gitMarkerId = gitPresentation ? `${rowId}-git` : undefined;
+  const symlinkMarkerId = symlinkDescription ? `${rowId}-symlink` : undefined;
+  // Space-separated id list: a row can be both a link and changed, and the two
+  // descriptions are owned by different concerns.
+  const describedBy = [gitMarkerId, symlinkMarkerId].filter(Boolean).join(" ") || undefined;
 
   const menuItems = context.rowContextMenu?.(row);
   const rowSurface = (
@@ -548,7 +579,7 @@ function FileTreeRow({ row, isSelected, isOpen, context }: FileTreeRowProps) {
       // filename above, and rows are virtualized — folding status into the name
       // would rewrite every accessible row query and re-announce the row as a
       // different thing whenever an agent touched the file.
-      {...(gitMarkerId && { "aria-describedby": gitMarkerId })}
+      {...(describedBy && { "aria-describedby": describedBy })}
       aria-level={row.depth + 1}
       aria-selected={isSelected}
       // "The viewer is showing this one" — a different question from which row
@@ -619,7 +650,21 @@ function FileTreeRow({ row, isSelected, isOpen, context }: FileTreeRowProps) {
       {/* `min-w-0` is what lets `truncate` actually shrink here: a flex item
           defaults to `min-width: auto` and would otherwise push the trailing
           status marker out of the row instead of ellipsing the name. */}
-      <span className={cn("min-w-0 truncate", isSelected && "font-medium")}>{row.name}</span>
+      <span
+        className={cn("min-w-0 truncate", isSelected && "font-medium")}
+        title={symlinkDescription ?? undefined}
+      >
+        {row.name}
+      </span>
+      {symlinkMarkerId && (
+        // Screen-reader only, and layout-neutral (`sr-only` is absolutely
+        // positioned) so it can sit between the name and the `ml-auto` git
+        // marker without disturbing either. The title above is the mouse's
+        // half of the same answer.
+        <span id={symlinkMarkerId} className="sr-only">
+          {symlinkDescription}
+        </span>
+      )}
       {gitPresentation && (
         // `ml-auto` parks the marker at the trailing edge so a column of them
         // scans vertically, rather than tracking each name's ragged end.

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -540,15 +540,17 @@ function FileTreeRow({ row, isSelected, isOpen, context }: FileTreeRowProps) {
     : row.isDirectory
       ? FolderIcon
       : getFileTypeIcon(row.name).Icon;
-  // What the link points at, and why it is inert when it is. Out-of-root
-  // targets are deliberately never dereferenced, so "unknown" is the honest
-  // word for what is on the other side rather than a failure to look.
+  // Wording keys off the resolved kind, never off a bare "not inside" bit: a
+  // link we could not read at all must not be announced as pointing outside
+  // the workspace, which would be a claim we never verified.
   const symlinkDescription = row.symlink
     ? row.symlink.targetKind === "broken"
       ? `Broken symlink to ${row.symlink.target}`
-      : !row.symlink.insideRoot
+      : row.symlink.targetKind === "external"
         ? `Symlink to ${row.symlink.target}, outside this folder`
-        : `Symlink to ${row.symlink.target}`
+        : row.symlink.targetKind === "unknown"
+          ? `Symlink to ${row.symlink.target}, unreadable`
+          : `Symlink to ${row.symlink.target}`
     : null;
 
   // A file's own status; a folder's is the worst thing anywhere beneath it, so a

--- a/src/panels/file-browser/FolderListingView.tsx
+++ b/src/panels/file-browser/FolderListingView.tsx
@@ -182,12 +182,17 @@ function FolderListingRowView({ row, context }: FolderListingRowViewProps) {
     : row.isDirectory
       ? Folder
       : getFileTypeIcon(row.name).Icon;
+  // Wording keys off the resolved kind, never off a bare "not inside" bit: a
+  // link we could not read at all must not be announced as pointing outside
+  // the workspace, which would be a claim we never verified.
   const symlinkDescription = row.symlink
     ? row.symlink.targetKind === "broken"
       ? `Broken symlink to ${row.symlink.target}`
-      : !row.symlink.insideRoot
+      : row.symlink.targetKind === "external"
         ? `Symlink to ${row.symlink.target}, outside this folder`
-        : `Symlink to ${row.symlink.target}`
+        : row.symlink.targetKind === "unknown"
+          ? `Symlink to ${row.symlink.target}, unreadable`
+          : `Symlink to ${row.symlink.target}`
     : null;
 
   const menuItems = context.rowContextMenu?.(row);

--- a/src/panels/file-browser/FolderListingView.tsx
+++ b/src/panels/file-browser/FolderListingView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { Virtuoso } from "react-virtuoso";
-import { Folder } from "lucide-react";
+import { FileSymlink, Folder, FolderSymlink } from "lucide-react";
 import { join } from "@shared/utils/path";
 import { cn } from "@/lib/utils";
 import { formatBytes } from "@/lib/formatBytes";
@@ -173,7 +173,22 @@ function FolderListingRowView({ row, context }: FolderListingRowViewProps) {
     dataTransfer.setDragImage(event.currentTarget, 12, ROW_HEIGHT_PX / 2);
   };
 
-  const RowIcon = row.isDirectory ? Folder : getFileTypeIcon(row.name).Icon;
+  // Same rule as the tree: a link's glyph says "link" (#11939), and the
+  // description carries where it points and why it may be inert.
+  const RowIcon = row.symlink
+    ? row.isDirectory
+      ? FolderSymlink
+      : FileSymlink
+    : row.isDirectory
+      ? Folder
+      : getFileTypeIcon(row.name).Icon;
+  const symlinkDescription = row.symlink
+    ? row.symlink.targetKind === "broken"
+      ? `Broken symlink to ${row.symlink.target}`
+      : !row.symlink.insideRoot
+        ? `Symlink to ${row.symlink.target}, outside this folder`
+        : `Symlink to ${row.symlink.target}`
+    : null;
 
   const menuItems = context.rowContextMenu?.(row);
   const rowSurface = (
@@ -196,7 +211,10 @@ function FolderListingRowView({ row, context }: FolderListingRowViewProps) {
           className={cn(FILE_TREE_ICON_CLASS, "h-3.5 w-3.5 shrink-0", FILE_TREE_ICON_COLOR_CLASS)}
           aria-hidden="true"
         />
-        <span className="truncate">{row.name}</span>
+        <span className="truncate" title={symlinkDescription ?? undefined}>
+          {row.name}
+        </span>
+        {symlinkDescription && <span className="sr-only">{symlinkDescription}</span>}
       </span>
       <span className="w-20 shrink-0 text-right tabular-nums text-daintree-text/50">
         {formatSize(row)}

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -107,15 +107,10 @@ function renderTree(overrides: Partial<Parameters<typeof FileTreeView>[0]> = {})
 }
 
 describe("FileTreeView symlink rows (#11939)", () => {
-  function symlinkRow(overrides: Partial<FlatTreeRow["symlink"]> = {}): FlatTreeRow {
+  function symlinkRow(overrides: Partial<NonNullable<FlatTreeRow["symlink"]>> = {}): FlatTreeRow {
     return {
       ...row("aliased", true),
-      symlink: {
-        target: "/repo/real",
-        targetKind: "directory",
-        insideRoot: true,
-        ...overrides,
-      } as NonNullable<FlatTreeRow["symlink"]>,
+      symlink: { target: "/repo/real", targetKind: "directory", ...overrides },
     };
   }
 
@@ -144,7 +139,7 @@ describe("FileTreeView symlink rows (#11939)", () => {
 
   it("says a link points outside the folder, since that is why it is inert", () => {
     const { container } = renderTree({
-      rows: [symlinkRow({ targetKind: "unknown", insideRoot: false })],
+      rows: [symlinkRow({ targetKind: "external" })],
     });
 
     expect(describedText(container, "aliased")).toBe("Symlink to /repo/real, outside this folder");
@@ -154,10 +149,19 @@ describe("FileTreeView symlink rows (#11939)", () => {
     // Broken outranks the containment wording: the target not existing is the
     // more specific answer, and both states are non-actionable.
     const { container } = renderTree({
-      rows: [symlinkRow({ targetKind: "broken", insideRoot: false })],
+      rows: [symlinkRow({ targetKind: "broken" })],
     });
 
     expect(describedText(container, "aliased")).toBe("Broken symlink to /repo/real");
+  });
+
+  it("refuses to guess where an unreadable link points", () => {
+    // A loop or a permission error tells us nothing about location, so the
+    // copy must not borrow the external wording — that would state as fact
+    // something the listing deliberately never established.
+    const { container } = renderTree({ rows: [symlinkRow({ targetKind: "unknown" })] });
+
+    expect(describedText(container, "aliased")).toBe("Symlink to /repo/real, unreadable");
   });
 
   it("describes an ordinary row with no link wording at all", () => {
@@ -165,6 +169,11 @@ describe("FileTreeView symlink rows (#11939)", () => {
     // must gain no description from this change.
     const { container } = renderTree({ rows: [row("README.md")] });
 
+    // The row has to exist first — `describedText` also returns "" for a row
+    // that never rendered, which would pass for entirely the wrong reason.
+    const treeitem = container.querySelector('[role="treeitem"][aria-label="README.md"]');
+    expect(treeitem).toBeTruthy();
+    expect(treeitem?.hasAttribute("aria-describedby")).toBe(false);
     expect(describedText(container, "README.md")).toBe("");
   });
 });

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -106,6 +106,69 @@ function renderTree(overrides: Partial<Parameters<typeof FileTreeView>[0]> = {})
   return { onSelect, ...utils };
 }
 
+describe("FileTreeView symlink rows (#11939)", () => {
+  function symlinkRow(overrides: Partial<FlatTreeRow["symlink"]> = {}): FlatTreeRow {
+    return {
+      ...row("aliased", true),
+      symlink: {
+        target: "/repo/real",
+        targetKind: "directory",
+        insideRoot: true,
+        ...overrides,
+      } as NonNullable<FlatTreeRow["symlink"]>,
+    };
+  }
+
+  /** The row's own accessible description text, resolved through the id list. */
+  function describedText(container: HTMLElement, name: string): string {
+    const treeitem = container.querySelector<HTMLElement>(
+      `[role="treeitem"][aria-label="${name}"]`
+    );
+    const ids = treeitem?.getAttribute("aria-describedby")?.split(" ") ?? [];
+    // `getElementById`, not a `#id` selector: row ids are built from file
+    // paths, so they routinely carry characters a CSS selector would have to
+    // escape.
+    return ids
+      .map((id) => container.ownerDocument.getElementById(id)?.textContent ?? "")
+      .join(" ")
+      .trim();
+  }
+
+  it("names the target so a link is not just another folder row", () => {
+    // The bug was that these rows did not exist at all; a row that renders but
+    // says nothing about where it points would only half-fix that.
+    const { container } = renderTree({ rows: [symlinkRow()] });
+
+    expect(describedText(container, "aliased")).toBe("Symlink to /repo/real");
+  });
+
+  it("says a link points outside the folder, since that is why it is inert", () => {
+    const { container } = renderTree({
+      rows: [symlinkRow({ targetKind: "unknown", insideRoot: false })],
+    });
+
+    expect(describedText(container, "aliased")).toBe("Symlink to /repo/real, outside this folder");
+  });
+
+  it("calls a dangling link broken rather than merely external", () => {
+    // Broken outranks the containment wording: the target not existing is the
+    // more specific answer, and both states are non-actionable.
+    const { container } = renderTree({
+      rows: [symlinkRow({ targetKind: "broken", insideRoot: false })],
+    });
+
+    expect(describedText(container, "aliased")).toBe("Broken symlink to /repo/real");
+  });
+
+  it("describes an ordinary row with no link wording at all", () => {
+    // Guards the whole feature against becoming unconditional: a plain row
+    // must gain no description from this change.
+    const { container } = renderTree({ rows: [row("README.md")] });
+
+    expect(describedText(container, "README.md")).toBe("");
+  });
+});
+
 describe("FileTreeView context-menu interactions", () => {
   it("opens the menu on the right-clicked row without moving the selection", async () => {
     // Right-click must not swap the viewed file: the menu targets the

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -141,13 +141,34 @@ describe("flattenTree", () => {
 
   it("stops descending past the depth guard instead of recursing forever", () => {
     // A listings map where a directory contains itself — the shape a symlink
-    // cycle would produce if the service ever stopped skipping symlinks.
+    // cycle produces, now that the service lists symlinks (#11939). Reaching
+    // this bound takes one deliberate expansion per level, but the guard is
+    // what stops the render walk regardless.
     const listings = listingsOf({ "": [dir("loop")], loop: [dir("loop")] });
 
     const rows = flattenTree(listings, new Set(["loop"]), new Set());
 
     expect(rows.length).toBeGreaterThan(1);
     expect(rows.length).toBeLessThan(200);
+  });
+
+  it("carries a node's symlink metadata onto its row (#11939)", () => {
+    // The row is what both views read to pick a glyph and describe the link,
+    // so the field has to survive flattening rather than be re-fetched.
+    const link: FileTreeNode = {
+      name: "aliased",
+      path: "aliased",
+      isDirectory: true,
+      symlink: { target: "/repo/real", targetKind: "directory", insideRoot: true },
+    };
+    const listings = listingsOf({ "": [link, file("README.md")] });
+
+    const rows = flattenTree(listings, new Set(), new Set());
+
+    expect(rows[0]?.symlink).toEqual(link.symlink);
+    // Absent — not null, not a placeholder — on everything else, which is what
+    // lets every existing consumer keep ignoring it.
+    expect(rows[1]).not.toHaveProperty("symlink");
   });
 });
 
@@ -813,6 +834,18 @@ describe("flattenTree sorting", () => {
 });
 
 describe("buildFolderListingRows", () => {
+  it("carries symlink metadata onto a listing row (#11939)", () => {
+    const link: FileTreeNode = {
+      name: "acorn",
+      path: ".bin/acorn",
+      isDirectory: false,
+      symlink: { target: "/repo/acorn/bin/acorn", targetKind: "file", insideRoot: true },
+    };
+    const rows = buildFolderListingRows(listingsOf({ ".bin": [link] }), ".bin");
+
+    expect(rows?.[0]?.symlink).toEqual(link.symlink);
+  });
+
   it("returns null for a directory that has not been listed", () => {
     // Distinguishable from an empty array on purpose: null is "still pending",
     // [] is "this folder really holds nothing".

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -159,7 +159,7 @@ describe("flattenTree", () => {
       name: "aliased",
       path: "aliased",
       isDirectory: true,
-      symlink: { target: "/repo/real", targetKind: "directory", insideRoot: true },
+      symlink: { target: "/repo/real", targetKind: "directory" },
     };
     const listings = listingsOf({ "": [link, file("README.md")] });
 
@@ -696,6 +696,36 @@ describe("listingsFromSnapshot", () => {
       pathsOf(flattenTree(listings, new Set(["src"]), new Set()))
     );
   });
+
+  it("drops symlink metadata but keeps the bit that decides expandability (#11939)", () => {
+    // The snapshot is structure-only by design — no sizes, no timestamps, no
+    // symlink detail. What must survive is `isDirectory`, because that alone
+    // is what stops a restored external link from being fetched: the listing
+    // never sets it true for a link it could not resolve inside the root.
+    const external: FileTreeNode = {
+      name: "outward",
+      path: "outward",
+      isDirectory: false,
+      symlink: { target: "/elsewhere", targetKind: "external" },
+    };
+    const inRoot: FileTreeNode = {
+      name: "aliased",
+      path: "aliased",
+      isDirectory: true,
+      symlink: { target: "/repo/real", targetKind: "directory" },
+    };
+
+    const snapshot = snapshotFromListings(listingsOf({ "": [external, inRoot] }), WT_SOURCE, "");
+    const restored = listingsFromSnapshot(snapshot!)?.get("");
+
+    expect(restored?.map((node) => ({ name: node.name, isDirectory: node.isDirectory }))).toEqual([
+      { name: "outward", isDirectory: false },
+      { name: "aliased", isDirectory: true },
+    ]);
+    // Degraded to a plain row, not a wrong one: the glyph and the description
+    // come back with the next live listing.
+    expect(restored?.every((node) => node.symlink === undefined)).toBe(true);
+  });
 });
 
 describe("sortFileNodes", () => {
@@ -839,7 +869,7 @@ describe("buildFolderListingRows", () => {
       name: "acorn",
       path: ".bin/acorn",
       isDirectory: false,
-      symlink: { target: "/repo/acorn/bin/acorn", targetKind: "file", insideRoot: true },
+      symlink: { target: "/repo/acorn/bin/acorn", targetKind: "file" },
     };
     const rows = buildFolderListingRows(listingsOf({ ".bin": [link] }), ".bin");
 

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -1,4 +1,4 @@
-import type { FileTreeNode } from "@shared/types";
+import type { FileTreeNode, FileTreeSymlink } from "@shared/types";
 import type {
   FileBrowserSortDirection,
   FileBrowserSortKey,
@@ -54,6 +54,13 @@ export interface FlatTreeRow {
   isLoading: boolean;
   /** Byte size for files; undefined for directories */
   size?: number;
+  /**
+   * Present only on rows that are symbolic links (#11939). `isDirectory` still
+   * answers whether the row behaves as a directory — the listing reports the
+   * link's *target* kind — so nothing that reads that field needs to know
+   * about this one.
+   */
+  symlink?: FileTreeSymlink;
 }
 
 /**
@@ -90,6 +97,8 @@ export interface FolderListingRow {
    * folder the user has never opened is not an empty folder.
    */
   itemCount?: number;
+  /** Present only on rows that are symbolic links (#11939). */
+  symlink?: FileTreeSymlink;
 }
 
 export type { FileBrowserSortDirection, FileBrowserSortKey };
@@ -320,9 +329,15 @@ export function flattenTree(
   const rows: FlatTreeRow[] = [];
 
   const walk = (dirPath: string, depth: number): void => {
-    // Depth guard: a listings map assembled from a symlink cycle (or a bug in
-    // the caller) would otherwise recurse until the stack blows. The service
-    // skips symlinks, so this is a backstop, not the primary defense.
+    // Depth guard: a listings map whose directories contain one another — the
+    // shape a symlink cycle produces, now that the service lists symlinks
+    // (#11939) — would otherwise recurse until the stack blows.
+    //
+    // This is the bound on *rendering*, and it is the only one needed. A cycle
+    // cannot run away on its own: every listing is one level fetched on
+    // explicit expansion, nothing auto-expands, and a restored panel replays a
+    // finite recorded set. Reaching depth 64 through a loop takes 64 deliberate
+    // clicks, and the rows simply stop there.
     if (depth > MAX_TREE_DEPTH) return;
     const listed = listings.get(dirPath);
     if (!listed) return;
@@ -346,6 +361,7 @@ export function flattenTree(
         isExpanded,
         isLoading: node.isDirectory && loadingPaths.has(node.path) && !listings.has(node.path),
         ...(node.size != null && { size: node.size }),
+        ...(node.symlink && { symlink: node.symlink }),
       });
       if (isExpanded) walk(node.path, depth + 1);
     }
@@ -395,6 +411,7 @@ export function buildFolderListingRows(
       ...(node.size != null && { size: node.size }),
       ...(node.mtimeMs != null && { mtimeMs: node.mtimeMs }),
       ...(itemCount != null && { itemCount }),
+      ...(node.symlink && { symlink: node.symlink }),
     };
   });
 }


### PR DESCRIPTION
## Summary
- `FileTreeService.getFileTree` returned `null` for every symlink dirent, so symlinked files and folders vanished from both the tree and the folder listing with nothing to say anything had been filtered. `node_modules/.bin`, nothing but relative in-root symlinks, rendered as an empty folder.
- `FileSearchService`'s disk walker and `statPaths` carried the same policy, and `statPaths`' comment tied its realpath-equality check explicitly to the tree omitting symlinks.
- The rule now: listing a link is not dereferencing it, so containment governs descent rather than visibility. A link is shown whatever it points at; one resolving inside the root reports its target's kind and expands like the real thing; one resolving outside is a terminal node carrying where it points.

Resolves #11939

## Changes
- `FileTreeService.getFileTree` lists symlinks with resolved target metadata. Plain files and directories keep today's single `lstat`; the extra syscalls land on symlink entries only.
- `FileTreeNode` gains an optional `symlink: { target, targetKind }`, where `targetKind` is `"file" | "directory" | "broken" | "external" | "unknown"`. `isDirectory` reports the *target's* kind, so sorting, the disclosure triangle and the folder-listing columns all behave, and it is true for a link only when the target was verified to be a contained directory, which is what keeps every `isDirectory` consumer (the CopyTree verdict overlay, `isReachable`, the chevron) correct without reading the new field.
- `size`/`mtimeMs` come from the target when it resolves and from the link when it does not, with no `size` at all for an unresolved link, since a symlink's own `lstat.size` is the byte length of its target string.
- `statPaths` now accepts a candidate whose canonical target stays under the canonical root, replacing exact realpath equality with the `path.relative` containment idiom used by the rest of the codebase. A terminal reference pointing through an in-root link resolves instead of reading as a missing file.
- Tree and folder-listing rows draw `FileSymlink`/`FolderSymlink` and describe the target for pointer and screen reader alike.
- Corrected `flattenTree`'s depth-guard comment, which asserted the service skips symlinks.

### Design notes for reviewers
- **Out-of-root targets are never directly dereferenced.** `readlink` (which follows nothing) gates on lexical containment before `realpath` runs. That keeps the ordinary case (a link to another checkout) from becoming an external existence probe or a `stat` that blocks on a dead network mount. The `describeSymlink` doc comment states precisely what this does and does not guarantee: a chain that only escapes on a later hop is still resolved by the OS before the canonical check refuses it, leaving an out-of-root existence bit observable. Closing that needs a shared per-hop resolve-beneath primitive the codebase does not have, and inventing a private one is what `.lessons/10971` exists to prevent. The boundary that matters holds: no out-of-root kind, size or mtime is ever reported, and descent stays blocked.
- **Windows junctions take the same path as POSIX symlinks, deliberately.** A junction's `readlink` result is an NT-namespace path (`\\?\C:\repo\target`), which `path.relative` reads as a different root, so every in-root junction would have been classified external. `_normalizeWin32LinkTarget` unwraps the drive-letter form before any containment decision. It maps `\\?\UNC\server\share` back to `\\server\share` rather than dropping four characters, which would leave a *relative* path that resolves inside the root.
- **No new setting.** The in-root/out-of-root split already answers what `search.followSymlinks` and `follow_symlinks` exist to configure.
- **`CopyTreeService` needed no policy change.** The SDK walker already owns symlink handling (`symlinkEscape` is one of its exclusion reasons); the picker's preview tree was the only thing lying about what the bundle would contain. Tests were added pinning that the raw listing's `isDirectory` routes symlink files and symlink directories to the right side of the verdict overlay.

### Deliberately out of scope
Worth follow-up issues, noted so reviewers don't read them as omissions:
- `FileSearchService.loadFilesFromDisk` still drops symlinks. It has its own recursion, cap and cycle semantics, and the primary `git ls-files` path already lists tracked symlinks; a partial fix would create a third search policy.
- "Copy target path" in the row context menu: `useFileRowMenuItems` is shared across five surfaces that know nothing about symlinks.
- "Open as project" for an out-of-root directory link: a feature with its own navigation and external-path policy.
- Renderer cycle tracking: `getFileTree` lists one level and never recurses, nothing auto-expands, and `flattenTree` caps at depth 64; reaching that through a loop takes 64 deliberate clicks.

## Testing
741 targeted tests pass, plus `npm run typecheck`. Suites touched: `FileTreeService` (plus its adversarial mock suite, which is where the absent-syscall assertions live, since a non-call can only be observed against a mocked `fs`), `CopyTreeService.fileTree`, `fileBrowser.statPaths`, `fileBrowserTree`, `FileTreeView`, `FolderListingView`. Symlink tests build real links on a real filesystem and `ctx.skip()`, never silently return, where a platform forbids creating them.