### PR TITLE
fix(project-switcher): action row spacing and hover shape

### DIFF
--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1684,6 +1684,21 @@ function ProjectSwitcherFooter({
   );
 }
 
+/**
+ * The plain commands under the divider — Project Settings, Add Project, Clone,
+ * Create Folder. Full-bleed on purpose: they never take the roving cursor, so
+ * they must not wear the ranked rows' card shape, which is what marks the
+ * arrow-key domain (`PALETTE_ROW_CLASS`). Losing the inset means `px-3` is now
+ * the row's own edge, landing its content on the header's and footer's column
+ * instead of an inset nothing else in the palette shares.
+ *
+ * The focus ring is inset for the same reason. The palette clips to
+ * `overflow-hidden`, so a ring drawn outside a full-width row loses its left
+ * and right sides at the dialog edge; `-outline-offset-2` keeps all four.
+ */
+const PROJECT_ACTION_ROW_CLASS =
+  "w-full flex items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent";
+
 interface ProjectPaletteInnerProps {
   inputRef: React.RefObject<HTMLInputElement | null>;
   listRef: React.RefObject<HTMLDivElement | null>;
@@ -1930,12 +1945,12 @@ function ProjectPaletteInner({
       {(onOpenProjectSettings || onAddProject || onCloneRepo || onCreateFolder) && (
         <>
           <AppPaletteDialog.Divider />
-          <div className="px-2 pt-1 pb-2">
+          <div className="py-2">
             {onOpenProjectSettings && (
               <button
                 type="button"
                 onClick={() => onOpenProjectSettings()}
-                className="w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors hover:bg-overlay-subtle"
+                className={PROJECT_ACTION_ROW_CLASS}
               >
                 <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground">
                   <Settings2 className="h-4 w-4" />
@@ -1947,7 +1962,7 @@ function ProjectPaletteInner({
               <button
                 type="button"
                 onClick={() => onAddProject()}
-                className="w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors hover:bg-overlay-subtle"
+                className={PROJECT_ACTION_ROW_CLASS}
                 data-testid="project-add-button"
               >
                 <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
@@ -1960,7 +1975,7 @@ function ProjectPaletteInner({
               <button
                 type="button"
                 onClick={() => onCloneRepo()}
-                className="w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors hover:bg-overlay-subtle"
+                className={PROJECT_ACTION_ROW_CLASS}
                 data-testid="project-clone-button"
               >
                 <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
@@ -1973,7 +1988,7 @@ function ProjectPaletteInner({
               <button
                 type="button"
                 onClick={() => onCreateFolder()}
-                className="w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors hover:bg-overlay-subtle"
+                className={PROJECT_ACTION_ROW_CLASS}
               >
                 <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
                   <FolderPlus className="h-4 w-4" />

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1695,9 +1695,13 @@ function ProjectSwitcherFooter({
  * The focus ring is inset for the same reason. The palette clips to
  * `overflow-hidden`, so a ring drawn outside a full-width row loses its left
  * and right sides at the dialog edge; `-outline-offset-2` keeps all four.
+ * `palette-command-row` is not styling — like `palette-row` next to it, it is
+ * the handle the `forced-colors: active` block in `index.css` needs, where a
+ * global `outline-offset: 2px !important` would otherwise push the ring back
+ * out past that same edge.
  */
 const PROJECT_ACTION_ROW_CLASS =
-  "w-full flex items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent";
+  "palette-command-row w-full flex items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent";
 
 interface ProjectPaletteInnerProps {
   inputRef: React.RefObject<HTMLInputElement | null>;

--- a/src/index.css
+++ b/src/index.css
@@ -2696,6 +2696,18 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     outline-offset: -2px;
   }
 
+  /* The project switcher's command rows run full-bleed, so their border box
+     reaches the palette's own clipped edge. The blanket `outline-offset: 2px`
+     above would draw their focus ring outside that clip and lose its left and
+     right strokes entirely — the ring has to turn inward here. `!important`
+     because the rule it is answering carries one, and specificity alone does
+     not settle a contest between two important declarations. Same marker-class
+     approach as `.palette-row`, for the same reason: `button` is far too broad
+     a hook to hang this on. */
+  .palette-command-row:focus-visible {
+    outline-offset: -2px !important;
+  }
+
   /* Macro-focus regions use a Tailwind ring (box-shadow) which is removed here.
      Fall back to a system outline so the focused region stays visible. */
   [data-macro-focus="true"] {


### PR DESCRIPTION
## Summary

- The four command rows at the bottom of the project switcher (Project Settings…, Add Project…, Clone Repository…, Create New Folder…) sat in a wrapper with uneven vertical padding (`px-2 pt-1 pb-2`), 4px above the group and 8px below, so the first row pressed against the divider while the last had room to spare.
- Each row carried its own `rounded-[var(--radius-md)]` for its hover fill, so the highlight read as an inset card floating with no other edges around it, unlike a normal menu command.
- Fixed both: even 8px padding above and below, and a full-bleed hover fill using the rows' own `px-3` as the edge inset. That's the same column the palette's header and footer already use.

Resolves #11944

## Changes

- Wrapper padding changed to `py-2`, dropping the horizontal inset entirely.
- Rows lost their rounded corners and now run full width, so the hover fill spans the palette the way a menu command's does. The ranked project rows above the divider are untouched on purpose: they're a different interaction domain (arrow-key navigable) and their inset card look is what signals that.
- Pulled the four duplicated class strings into one `PROJECT_ACTION_ROW_CLASS` constant.
- Full-width rows exposed a side effect: they'd been relying on the browser's default focus outline, and once the rows spanned the full width, the outline's left and right edges landed on the palette's `overflow-hidden` clip and disappeared. Added an explicit inset ring (`focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent`), matching a pattern already used in 14+ other places in the codebase.
- Same clipping problem shows up in Windows High Contrast: the global `forced-colors: active` block in `src/index.css` forces `outline-offset: 2px` on every focused element, which would push the ring back outside the clip. Added a `palette-command-row` marker class and pulled the offset inward for it in that block, reusing the same technique already applied to the `palette-row` marker class right next to it.

## Testing

Ran `vitest` across `src/components/Project`, `src/config`, `src/components/Layout`, `src/components/Pulse`, `src/components/ui`, `src/lib`, and `src/hooks`: 364 files, 7150 tests, all passing. ESLint and Prettier clean on both changed files. The whole-repo source-contract scanners in `src/config/__tests__` (accentGuard, colorSystem, focusRingFallback, outlineHidden, forcedColorsStatusIndicators) all pass with no allowlist changes needed.

#11943 covers the layout of a different part of the same palette (the project bands and the scratch section), touching nearby but non-overlapping lines. Whichever of these two lands second should confirm the other's spacing still holds, which is exactly what the original issue asked for.