### PR TITLE
Project switcher bands: collapse, persist, align

### DIFF
--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -461,6 +461,7 @@ export function ModalHostLayer({
               isOpen={isProjectSwitcherModalOpen}
               query={projectSwitcherPalette.query}
               results={projectSwitcherPalette.results}
+              browseBands={projectSwitcherPalette.browseBands}
               selectedIndex={projectSwitcherPalette.selectedIndex}
               onQueryChange={projectSwitcherPalette.setQuery}
               onSelectPrevious={projectSwitcherPalette.selectPrevious}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -2061,6 +2061,7 @@ export function Toolbar({
                       isOpen={isDropdownOpen}
                       query={projectSwitcher.query}
                       results={projectSwitcher.results}
+                      browseBands={projectSwitcher.browseBands}
                       selectedIndex={projectSwitcher.selectedIndex}
                       onQueryChange={projectSwitcher.setQuery}
                       onSelectPrevious={projectSwitcher.selectPrevious}

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -221,6 +221,7 @@ export function ProjectSwitcher() {
             isOpen={isDropdownOpen}
             query={projectSwitcher.query}
             results={projectSwitcher.results}
+            browseBands={projectSwitcher.browseBands}
             selectedIndex={projectSwitcher.selectedIndex}
             onQueryChange={projectSwitcher.setQuery}
             onSelectPrevious={projectSwitcher.selectPrevious}
@@ -309,6 +310,7 @@ export function ProjectSwitcher() {
         isOpen={isDropdownOpen}
         query={projectSwitcher.query}
         results={projectSwitcher.results}
+        browseBands={projectSwitcher.browseBands}
         selectedIndex={projectSwitcher.selectedIndex}
         onQueryChange={projectSwitcher.setQuery}
         onSelectPrevious={projectSwitcher.selectPrevious}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -880,6 +880,13 @@ interface ProjectSection {
   /** Projects the band holds whether or not they are on screen. */
   itemCount: number;
   collapsed: boolean;
+  /**
+   * Whether this band's header offers the fold control. False for bands read
+   * off `results` rather than declared by a host: folding those would have to
+   * drop rows the arrow keys can still address, so the affordance would be a
+   * lie at best and #11071 at worst.
+   */
+  collapsible: boolean;
 }
 
 /**
@@ -901,6 +908,14 @@ interface ProjectSection {
  * the band and nothing else — the chevron is `aria-hidden`, but the id has to
  * sit on the text either way or a later sibling would join the computed name.
  */
+function BandLabel({ label, labelId }: { label: string; labelId: string }) {
+  return (
+    <span id={labelId} className="truncate tracking-wider uppercase">
+      {label}
+    </span>
+  );
+}
+
 function BandCollapseToggle({
   collapsed,
   label,
@@ -928,9 +943,7 @@ function BandCollapseToggle({
       className="flex items-center gap-1.5 min-w-0 hover:text-daintree-text/60 transition-colors"
     >
       <Chevron className="w-3 h-3 shrink-0" aria-hidden="true" />
-      <span id={labelId} className="truncate tracking-wider uppercase">
-        {label}
-      </span>
+      <BandLabel label={label} labelId={labelId} />
     </button>
   );
 }
@@ -994,6 +1007,7 @@ function OtherProjectsHeader({
   label,
   itemCount,
   collapsed,
+  collapsible,
   onToggleCollapsed,
   onReturnFocus,
 }: {
@@ -1001,6 +1015,7 @@ function OtherProjectsHeader({
   label: string;
   itemCount: number;
   collapsed: boolean;
+  collapsible: boolean;
   onToggleCollapsed: () => void;
   onReturnFocus?: () => void;
 }) {
@@ -1024,14 +1039,18 @@ function OtherProjectsHeader({
             "flex items-center justify-between gap-2 py-1 normal-case tracking-normal"
           )}
         >
-          <BandCollapseToggle
-            collapsed={collapsed}
-            label={label}
-            labelId={headerId}
-            controlsId={bandListId("other")}
-            testId="band-collapse-toggle-other"
-            onToggle={onToggleCollapsed}
-          />
+          {collapsible ? (
+            <BandCollapseToggle
+              collapsed={collapsed}
+              label={label}
+              labelId={headerId}
+              controlsId={bandListId("other")}
+              testId="band-collapse-toggle-other"
+              onToggle={onToggleCollapsed}
+            />
+          ) : (
+            <BandLabel label={label} labelId={headerId} />
+          )}
           {collapsed && <BandCollapsedCount count={itemCount} />}
           {!collapsed && itemCount >= OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS && (
             <DropdownMenu>
@@ -1185,17 +1204,17 @@ function ProjectListContent({
           items: [row],
           itemCount: 1,
           collapsed: false,
+          collapsible: false,
         });
       }
     }
 
     if (!browseBands || browseBands.length === 0) return bands.length > 0 ? bands : null;
 
-    // The declared bands own the order and the headers; the runs above own the
-    // rows. Merging the two rather than trusting either alone is what keeps a
-    // folded band's header on screen without ever dropping a row of `results`:
-    // anything the declared list doesn't account for is appended rather than
-    // discarded, since a row that renders nowhere is the #11071 failure again.
+    // The declared bands own the ORDER, the HEADERS and the counts; the runs
+    // above own the rows, and they keep owning them — metadata never removes a
+    // row. A band declared folded is expected to have contributed nothing to
+    // `results` in the first place, so its items come out empty on their own.
     const byKey = new Map(bands.map((band) => [band.key, band]));
     const merged: ProjectSection[] = browseBands.map((band) => {
       const rendered = byKey.get(band.key);
@@ -1203,12 +1222,21 @@ function ProjectListContent({
       return {
         key: band.key,
         label: band.label,
-        items: band.collapsed ? [] : (rendered?.items ?? []),
+        items: rendered?.items ?? [],
         itemCount: band.itemCount,
         collapsed: band.collapsed,
+        collapsible: true,
       };
     });
-    merged.push(...byKey.values());
+
+    // Skew between the two props — a row belonging to no declared band, or a
+    // band declaring itself folded while its rows are still in `results`. Both
+    // mean the declared list cannot render every row in the order the arrow
+    // keys walk, so drop the bands entirely rather than reordering rows or
+    // hiding one: a flat list of everything is worse-looking and correct, where
+    // a stranded row is #11071 all over again.
+    if (byKey.size > 0) return null;
+    if (merged.some((band) => band.collapsed && band.items.length > 0)) return null;
     return merged;
   }, [results, isSearching, browseBands]);
 
@@ -1282,6 +1310,7 @@ function ProjectListContent({
                       label={section.label}
                       itemCount={section.itemCount}
                       collapsed={section.collapsed}
+                      collapsible={section.collapsible}
                       onToggleCollapsed={toggle}
                       onReturnFocus={onReturnFocus}
                     />
@@ -1295,14 +1324,18 @@ function ProjectListContent({
                         "flex items-center justify-between gap-2 py-1"
                       )}
                     >
-                      <BandCollapseToggle
-                        collapsed={section.collapsed}
-                        label={section.label}
-                        labelId={headerId}
-                        controlsId={listId}
-                        testId={`band-collapse-toggle-${section.key}`}
-                        onToggle={toggle}
-                      />
+                      {section.collapsible ? (
+                        <BandCollapseToggle
+                          collapsed={section.collapsed}
+                          label={section.label}
+                          labelId={headerId}
+                          controlsId={listId}
+                          testId={`band-collapse-toggle-${section.key}`}
+                          onToggle={toggle}
+                        />
+                      ) : (
+                        <BandLabel label={section.label} labelId={headerId} />
+                      )}
                       {section.collapsed && <BandCollapsedCount count={section.itemCount} />}
                     </div>
                   )}
@@ -1780,9 +1813,16 @@ function ScratchSection({
  * switch, and a search-mode scratch row carries no context menu.
  */
 function ProjectSwitcherFooter({
+  hasSelection,
   isScratchSelected,
   onOpenPilot,
 }: {
+  /**
+   * False when nothing is highlighted — an empty list, or every band folded
+   * (#11943). Enter no-ops there, so naming it would be the footer promising an
+   * action the keypress does not perform.
+   */
+  hasSelection: boolean;
   isScratchSelected: boolean;
   onOpenPilot: () => void;
 }) {
@@ -1791,8 +1831,9 @@ function ProjectSwitcherFooter({
   // wrong for anyone who rebound or removed the binding.
   const pilotShortcut = useEffectiveCombo("pilot.toggle");
 
-  const hint =
-    modifiers.meta && !isScratchSelected
+  const hint = !hasSelection
+    ? null
+    : modifiers.meta && !isScratchSelected
       ? { keys: "⌘↵", label: "New window" }
       : { keys: "↵", label: "Switch" };
 
@@ -1810,10 +1851,16 @@ function ProjectSwitcherFooter({
     // width fix should decide. Remove stays reachable from the row's context
     // menu and from ⌘⌫ itself, and both open the same confirmation.
     <div className="@container/switcher-footer w-full flex items-center justify-between gap-3">
-      <span className="shrink-0">
-        <kbd className={KBD_CLASS}>{hint.keys}</kbd>
-        <span className="ml-1.5">{hint.label}</span>
-      </span>
+      {hint ? (
+        <span className="shrink-0">
+          <kbd className={KBD_CLASS}>{hint.keys}</kbd>
+          <span className="ml-1.5">{hint.label}</span>
+        </span>
+      ) : (
+        // Holds the rail's left slot so "All agents" stays put rather than
+        // sliding across as the last band folds.
+        <span className="shrink-0" />
+      )}
       <div className="flex items-center gap-3 min-w-0">
         {/*
           The switcher answers "which project", so the fleet-wide view belongs
@@ -1831,7 +1878,7 @@ function ProjectSwitcherFooter({
           {pilotShortcut && <KbdChord shortcut={pilotShortcut} />}
           <span className={pilotShortcut ? "ml-1.5" : undefined}>All agents</span>
         </button>
-        {!isScratchSelected && (
+        {hasSelection && !isScratchSelected && (
           <span className="text-daintree-text/50 shrink-0 @max-[520px]/switcher-footer:hidden">
             Right-click for more
           </span>
@@ -2168,6 +2215,7 @@ function ProjectPaletteInner({
 
       <AppPaletteDialog.Footer>
         <ProjectSwitcherFooter
+          hasSelection={activeResult !== undefined}
           isScratchSelected={activeResult?.kind === "scratch"}
           onOpenPilot={() => {
             onClose();

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -904,6 +904,14 @@ interface ProjectSection {
  * deliberately ignores it, so no band can fold a project out of a keyboard
  * user's reach, and there is nothing here they cannot get to by typing.
  *
+ * `tabIndex={-1}` keeps it out of the tab order but does NOT stop a pointer
+ * press from focusing it, and the header outlives the fold — so without the
+ * mousedown veto below, one click would leave focus on a chevron: typing would
+ * stop reaching the search box, arrows would stop stepping rows, and Enter
+ * would re-toggle the band instead of committing the highlighted project. The
+ * sort trigger beside it solves the same problem by handing focus back after
+ * its menu closes; refusing the focus outright is cheaper and never blinks.
+ *
  * The label is its own leaf so `aria-labelledby` on the surrounding group names
  * the band and nothing else — the chevron is `aria-hidden`, but the id has to
  * sit on the text either way or a later sibling would join the computed name.
@@ -937,6 +945,7 @@ function BandCollapseToggle({
       type="button"
       tabIndex={-1}
       data-testid={testId}
+      onMouseDown={(event) => event.preventDefault()}
       onClick={onToggle}
       aria-expanded={!collapsed}
       aria-controls={controlsId}
@@ -1211,6 +1220,12 @@ function ProjectListContent({
 
     if (!browseBands || browseBands.length === 0) return bands.length > 0 ? bands : null;
 
+    // A repeated key passes the order walk below — the second copy simply draws
+    // no rows — but React keys, the `aria-labelledby` leaf id and the
+    // `aria-controls` target are all derived from it, so the duplicate would
+    // collide on all three.
+    if (new Set(browseBands.map((band) => band.key)).size !== browseBands.length) return null;
+
     // The declared bands own the ORDER, the HEADERS and the counts; the runs
     // above own the rows, and they keep owning them — metadata never removes a
     // row. A band declared folded is expected to have contributed nothing to
@@ -1229,14 +1244,22 @@ function ProjectListContent({
       };
     });
 
-    // Skew between the two props — a row belonging to no declared band, or a
-    // band declaring itself folded while its rows are still in `results`. Both
-    // mean the declared list cannot render every row in the order the arrow
-    // keys walk, so drop the bands entirely rather than reordering rows or
-    // hiding one: a flat list of everything is worse-looking and correct, where
-    // a stranded row is #11071 all over again.
-    if (byKey.size > 0) return null;
-    if (merged.some((band) => band.collapsed && band.items.length > 0)) return null;
+    // The one check that makes the bands a VIEW over `results` rather than a
+    // claim about it: walked in order, they must reproduce `results` exactly.
+    // Enumerating the ways two props can disagree misses some — a section key
+    // appearing in two non-adjacent runs, a declared order that differs from
+    // the row order, a stale count — and each of those either hides a row or
+    // puts the DOM in an order the arrow keys don't follow, which is #11071
+    // again. Any mismatch drops to the flat branch: a list with no headers
+    // looks worse and is correct.
+    let cursor = 0;
+    for (const band of merged) {
+      for (const row of band.items) {
+        if (results[cursor] !== row) return null;
+        cursor += 1;
+      }
+    }
+    if (cursor !== results.length) return null;
     return merged;
   }, [results, isSearching, browseBands]);
 

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -70,6 +70,7 @@ import type {
   DeleteAllScratchesSnapshot,
   DeleteScratchTarget,
   ProjectSectionKey,
+  ProjectSwitcherBrowseBand,
   ProjectSwitcherMode,
   ProjectSwitcherProjectRow,
   ProjectSwitcherRow,
@@ -79,6 +80,7 @@ import type {
 } from "@/hooks/useProjectSwitcherPalette";
 import {
   PROJECT_SECTION_LABELS,
+  PROJECT_SWITCHER_SCRATCH_BAND_KEY,
   OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS,
 } from "@/hooks/useProjectSwitcherPalette";
 import { usePreferencesStore } from "@/store/preferencesStore";
@@ -105,6 +107,11 @@ export interface ProjectSwitcherPaletteProps {
    * scratch row doesn't carry.
    */
   results: ProjectSwitcherRow[];
+  /**
+   * Browse's bands, headers included for ones the user folded away — those hold
+   * no rows in `results`, so nothing else can report that they exist (#11943).
+   */
+  browseBands?: ProjectSwitcherBrowseBand[];
   selectedIndex: number;
   onQueryChange: (query: string) => void;
   onSelectPrevious: () => void;
@@ -868,7 +875,78 @@ function ScratchListItem({
 interface ProjectSection {
   key: ProjectSectionKey;
   label: string;
+  /** The band's VISIBLE rows — empty while collapsed. Always rows of `results`. */
   items: ProjectSwitcherProjectRow[];
+  /** Projects the band holds whether or not they are on screen. */
+  itemCount: number;
+  collapsed: boolean;
+}
+
+/**
+ * The fold control every band header carries (#11943).
+ *
+ * Deliberately neutral: it takes `PALETTE_SECTION_LABEL_CLASS`'s own muted tone
+ * from the header around it and never the accent, which this surface spends on
+ * the selected row alone — seven chevrons competing with it would leave the
+ * highlight as just one more coloured thing.
+ *
+ * `tabIndex={-1}` because section headers live inside the `role="listbox"`,
+ * where a focusable child is invalid and unreachable anyway — arrow keys move
+ * `aria-activedescendant` across rows and never land here, matching the Other
+ * band's sort trigger. Folding is a pointer convenience on purpose: searching
+ * deliberately ignores it, so no band can fold a project out of a keyboard
+ * user's reach, and there is nothing here they cannot get to by typing.
+ *
+ * The label is its own leaf so `aria-labelledby` on the surrounding group names
+ * the band and nothing else — the chevron is `aria-hidden`, but the id has to
+ * sit on the text either way or a later sibling would join the computed name.
+ */
+function BandCollapseToggle({
+  collapsed,
+  label,
+  labelId,
+  controlsId,
+  testId,
+  onToggle,
+}: {
+  collapsed: boolean;
+  label: string;
+  labelId: string;
+  controlsId: string;
+  testId: string;
+  onToggle: () => void;
+}) {
+  const Chevron = collapsed ? ChevronRight : ChevronDown;
+  return (
+    <button
+      type="button"
+      tabIndex={-1}
+      data-testid={testId}
+      onClick={onToggle}
+      aria-expanded={!collapsed}
+      aria-controls={controlsId}
+      className="flex items-center gap-1.5 min-w-0 hover:text-daintree-text/60 transition-colors"
+    >
+      <Chevron className="w-3 h-3 shrink-0" aria-hidden="true" />
+      <span id={labelId} className="truncate tracking-wider uppercase">
+        {label}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * How much a folded band is holding. Only while folded: expanded, the rows are
+ * the count, and printing it as well would be chrome naming what is already on
+ * screen.
+ */
+function BandCollapsedCount({ count }: { count: number }) {
+  return <span className="shrink-0 text-[10px] tabular-nums">{count}</span>;
+}
+
+/** Stable `aria-controls` target for a band's rows. */
+function bandListId(key: ProjectSectionKey): string {
+  return `project-section-list-${key}`;
 }
 
 // Keyed by mode rather than a list, so the lookup below is total: a new mode in
@@ -895,22 +973,35 @@ const OTHER_PROJECTS_SORT_OPTIONS: Record<
  * - The `id` stays on a leaf element holding ONLY the label text. It is the
  *   `aria-labelledby` target for the surrounding `role="group"`, and that name
  *   is computed from the element's whole subtree — nesting the mode inside it
- *   would name the band "Other projects Most used".
+ *   would name the band "Other projects Most used". The fold control added in
+ *   #11943 is a sibling around that leaf for the same reason.
  * - The trigger is `tabIndex={-1}`. Section headers live inside the
  *   `role="listbox"`, where a focusable child is invalid and unreachable
  *   anyway (arrow keys move `aria-activedescendant` across rows, never here).
  *   Right-click reaches the same options, matching every other secondary
  *   action in this palette.
+ *
+ * The right-hand slot says one thing at a time: how the band is sorted while it
+ * is open, and how much it is holding once it is folded — the sort order of
+ * rows nobody can see is not the fact worth the space.
+ *
+ * No horizontal padding of its own. The `px-2` on the band wrapper is the one
+ * inset that positions the row cards below, so a `px-3` here would float the
+ * label 12px inside the edge those cards line up on (#11943).
  */
 function OtherProjectsHeader({
   headerId,
   label,
   itemCount,
+  collapsed,
+  onToggleCollapsed,
   onReturnFocus,
 }: {
   headerId: string;
   label: string;
   itemCount: number;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
   onReturnFocus?: () => void;
 }) {
   const sortMode = usePreferencesStore((state) => state.projectSwitcherOtherSortMode);
@@ -930,13 +1021,19 @@ function OtherProjectsHeader({
           role="presentation"
           className={cn(
             PALETTE_SECTION_LABEL_CLASS,
-            "flex items-center justify-between px-3 py-1 normal-case tracking-normal"
+            "flex items-center justify-between gap-2 py-1 normal-case tracking-normal"
           )}
         >
-          <div id={headerId} className="tracking-wider uppercase">
-            {label}
-          </div>
-          {itemCount >= OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS && (
+          <BandCollapseToggle
+            collapsed={collapsed}
+            label={label}
+            labelId={headerId}
+            controlsId={bandListId("other")}
+            testId="band-collapse-toggle-other"
+            onToggle={onToggleCollapsed}
+          />
+          {collapsed && <BandCollapsedCount count={itemCount} />}
+          {!collapsed && itemCount >= OTHER_PROJECTS_SORT_CONTROL_MIN_ROWS && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -1004,6 +1101,13 @@ function OtherProjectsHeader({
 
 interface ProjectListContentProps {
   results: ProjectSwitcherRow[];
+  /**
+   * Every browse band, including ones the user folded away — those contribute
+   * no rows to `results`, so their headers have nowhere else to come from.
+   * Absent (a surface driving the list by hand) falls back to reading the bands
+   * off `results`, which is the same view whenever nothing is collapsed.
+   */
+  browseBands?: ProjectSwitcherBrowseBand[];
   selectedIndex: number;
   query: string;
   onSelect: (row: ProjectSwitcherRow) => void;
@@ -1026,6 +1130,7 @@ interface ProjectListContentProps {
 
 function ProjectListContent({
   results,
+  browseBands,
   selectedIndex,
   query,
   onSelect,
@@ -1059,7 +1164,7 @@ function ProjectListContent({
   // an off-screen project (#11071). Every row in every band is still a row of
   // `results`, at the same index the arrow keys use.
   const sections = useMemo<ProjectSection[] | null>(() => {
-    if (isSearching || results.length === 0) return null;
+    if (isSearching) return null;
 
     const bands: ProjectSection[] = [];
     for (const row of results) {
@@ -1072,22 +1177,48 @@ function ProjectListContent({
       const last = bands.at(-1);
       if (last && last.key === row.section) {
         last.items.push(row);
+        last.itemCount += 1;
       } else {
         bands.push({
           key: row.section,
           label: PROJECT_SECTION_LABELS[row.section],
           items: [row],
+          itemCount: 1,
+          collapsed: false,
         });
       }
     }
-    return bands;
-  }, [results, isSearching]);
+
+    if (!browseBands || browseBands.length === 0) return bands.length > 0 ? bands : null;
+
+    // The declared bands own the order and the headers; the runs above own the
+    // rows. Merging the two rather than trusting either alone is what keeps a
+    // folded band's header on screen without ever dropping a row of `results`:
+    // anything the declared list doesn't account for is appended rather than
+    // discarded, since a row that renders nowhere is the #11071 failure again.
+    const byKey = new Map(bands.map((band) => [band.key, band]));
+    const merged: ProjectSection[] = browseBands.map((band) => {
+      const rendered = byKey.get(band.key);
+      byKey.delete(band.key);
+      return {
+        key: band.key,
+        label: band.label,
+        items: band.collapsed ? [] : (rendered?.items ?? []),
+        itemCount: band.itemCount,
+        collapsed: band.collapsed,
+      };
+    });
+    merged.push(...byKey.values());
+    return merged;
+  }, [results, isSearching, browseBands]);
 
   // `results` is already scoped by the hook to exactly the rows this mode
   // renders, so it doubles as the arrow-key domain. Never re-filter it here:
   // a second, narrower array is what stranded the highlight and let Enter
   // commit an off-screen project (#11071).
   const selectedRowId = results[selectedIndex]?.id;
+
+  const setBandCollapsed = usePreferencesStore((state) => state.setProjectSwitcherBandCollapsed);
 
   const renderItem = (row: ProjectSwitcherRow) => {
     const isSelected = row.id === selectedRowId;
@@ -1125,7 +1256,68 @@ function ProjectListContent({
   return (
     <>
       <div ref={listRef} id="project-list" role="listbox" aria-label="Workspaces">
-        {results.length === 0 ? (
+        {sections && sections.length > 0 ? (
+          sections.map((section, sectionIdx) => {
+            const isLast = sectionIdx === sections.length - 1;
+            const headerId = `project-section-${section.key}`;
+            const listId = bandListId(section.key);
+            const toggle = () => setBandCollapsed(section.key, !section.collapsed);
+
+            // Bands wrap options, so they can't be bare `div`s inside the
+            // listbox: each is a `group` named by its own visible header. Every
+            // band carries one now that `current` is labelled (#11692), which
+            // is also what keeps this legal — an unnamed `group` is an ARIA
+            // violation, so a band without a header would have to flatten away.
+            return (
+              <div key={section.key} role="presentation">
+                {sectionIdx > 0 && <AppPaletteDialog.Divider />}
+                <div
+                  role="group"
+                  aria-labelledby={headerId}
+                  className={cn("px-2 py-1.5", sectionIdx === 0 && "pt-2", isLast && "pb-2")}
+                >
+                  {section.key === "other" ? (
+                    <OtherProjectsHeader
+                      headerId={headerId}
+                      label={section.label}
+                      itemCount={section.itemCount}
+                      collapsed={section.collapsed}
+                      onToggleCollapsed={toggle}
+                      onReturnFocus={onReturnFocus}
+                    />
+                  ) : (
+                    <div
+                      className={cn(
+                        PALETTE_SECTION_LABEL_CLASS,
+                        // No `px-*`: the wrapper's `px-2` above is the inset the
+                        // row cards below are drawn from, so any padding here
+                        // would push the label off the line they share (#11943).
+                        "flex items-center justify-between gap-2 py-1"
+                      )}
+                    >
+                      <BandCollapseToggle
+                        collapsed={section.collapsed}
+                        label={section.label}
+                        labelId={headerId}
+                        controlsId={listId}
+                        testId={`band-collapse-toggle-${section.key}`}
+                        onToggle={toggle}
+                      />
+                      {section.collapsed && <BandCollapsedCount count={section.itemCount} />}
+                    </div>
+                  )}
+                  {/*
+                    Stays mounted while collapsed, holding no options. The
+                    header's `aria-controls` has to resolve to something, and an
+                    element that comes and goes would leave it dangling on every
+                    fold.
+                  */}
+                  <div id={listId}>{section.items.map(renderItem)}</div>
+                </div>
+              </div>
+            );
+          })
+        ) : results.length === 0 ? (
           <div className="p-2">
             <div
               className="px-3 py-8 text-center text-daintree-text/50 text-sm"
@@ -1146,41 +1338,6 @@ function ProjectListContent({
               )}
             </div>
           </div>
-        ) : sections ? (
-          sections.map((section, sectionIdx) => {
-            const isLast = sectionIdx === sections.length - 1;
-            const headerId = `project-section-${section.key}`;
-
-            // Bands wrap options, so they can't be bare `div`s inside the
-            // listbox: each is a `group` named by its own visible header. Every
-            // band carries one now that `current` is labelled (#11692), which
-            // is also what keeps this legal — an unnamed `group` is an ARIA
-            // violation, so a band without a header would have to flatten away.
-            return (
-              <div key={section.key} role="presentation">
-                {sectionIdx > 0 && <AppPaletteDialog.Divider />}
-                <div
-                  role="group"
-                  aria-labelledby={headerId}
-                  className={cn("px-2 py-1.5", sectionIdx === 0 && "pt-2", isLast && "pb-2")}
-                >
-                  {section.key === "other" ? (
-                    <OtherProjectsHeader
-                      headerId={headerId}
-                      label={section.label}
-                      itemCount={section.items.length}
-                      onReturnFocus={onReturnFocus}
-                    />
-                  ) : (
-                    <div id={headerId} className={cn(PALETTE_SECTION_LABEL_CLASS, "px-3 py-1")}>
-                      {section.label}
-                    </div>
-                  )}
-                  {section.items.map(renderItem)}
-                </div>
-              </div>
-            );
-          })
         ) : (
           <div className="p-2" role="presentation">
             {results.map((project) => renderItem(project))}
@@ -1299,9 +1456,9 @@ interface ScratchSectionProps {
   scratches: SearchableScratch[];
   /**
    * True once a query is active, where the ranked list owns the scratches. The
-   * section hides rather than unmounting: remounting would reset `collapsed`,
-   * so a section the user deliberately collapsed would spring back open the
-   * moment they cleared the box.
+   * section hides rather than unmounting so the inline name editor survives the
+   * round trip — the fold itself is persisted now and no longer depends on
+   * staying mounted (#11943).
    */
   isSearching: boolean;
   onCreate?: (name?: string) => void;
@@ -1318,6 +1475,13 @@ interface ScratchSectionProps {
  * there are no scratches yet — discoverable but quiet. Once the user has
  * scratches, defaults to expanded.
  *
+ * That default is DERIVED, not stored, so it keeps tracking the scratch count
+ * until the user overrules it — which is why the preference stores an explicit
+ * `false` rather than dropping the key: an empty section someone deliberately
+ * opened has to stay open, and "absent" here still means "collapsed while
+ * empty". It also retires the effect that used to force the section open on the
+ * first scratch; the derived default does that on its own now (#11943).
+ *
  * Sort order is purely by `lastOpened` desc (the hook already does this).
  * Scratches deliberately do NOT participate in the project frecency ranking.
  */
@@ -1331,29 +1495,21 @@ function ScratchSection({
   onRename,
   onSaveAsProject,
 }: ScratchSectionProps) {
-  const [collapsed, setCollapsed] = useState<boolean>(scratches.length === 0);
+  const storedCollapsed = usePreferencesStore(
+    (state) => state.projectSwitcherCollapsedBands[PROJECT_SWITCHER_SCRATCH_BAND_KEY]
+  );
+  const setBandCollapsed = usePreferencesStore((state) => state.setProjectSwitcherBandCollapsed);
+  const collapsed = storedCollapsed ?? scratches.length === 0;
   const [editor, setEditor] = useState<ScratchEditorState>(null);
   // Radix restores focus to the context-menu trigger on close, but for a rename
   // that trigger has been swapped out for the editor — the restore would steal
   // focus from the input and blur-cancel the edit before it began.
   const suppressMenuFocusRestoreRef = useRef(false);
-  const previousScratchCountRef = useRef(scratches.length);
   // `now` is captured per-render so the countdown updates whenever the
   // surrounding component re-renders. Refresh is naturally driven by store
   // updates (loadScratches on palette open, scratch:updated push events) —
   // an interval here would be wasteful given the daily granularity.
   const now = Date.now();
-
-  // If a scratch was just created from the empty state, expand the section
-  // so the new entry is visible.
-  useEffect(() => {
-    const previousScratchCount = previousScratchCountRef.current;
-    previousScratchCountRef.current = scratches.length;
-
-    if (previousScratchCount === 0 && scratches.length > 0) {
-      setCollapsed(false);
-    }
-  }, [scratches.length]);
 
   // A rename target can vanish under the editor via a scratch:removed push.
   useEffect(() => {
@@ -1405,25 +1561,26 @@ function ScratchSection({
         <ContextMenuTrigger asChild>
           <button
             type="button"
-            onClick={() => setCollapsed((v) => !v)}
+            onClick={() => setBandCollapsed(PROJECT_SWITCHER_SCRATCH_BAND_KEY, !collapsed)}
             className={cn(
               PALETTE_SECTION_LABEL_CLASS,
-              "w-full flex items-center justify-between px-3 py-1 hover:text-daintree-text/60 transition-colors"
+              // No `px-*` — the wrapper's `px-2` is the inset the rows below are
+              // drawn from, and a second one here floats the label off it
+              // (#11943).
+              "w-full flex items-center justify-between gap-2 py-1 hover:text-daintree-text/60 transition-colors"
             )}
             aria-expanded={!collapsed}
             aria-controls="scratch-section-list"
           >
             <span className="flex items-center gap-1.5">
               {collapsed ? (
-                <ChevronRight className="w-3 h-3" aria-hidden="true" />
+                <ChevronRight className="w-3 h-3 shrink-0" aria-hidden="true" />
               ) : (
-                <ChevronDown className="w-3 h-3" aria-hidden="true" />
+                <ChevronDown className="w-3 h-3 shrink-0" aria-hidden="true" />
               )}
               Scratch
             </span>
-            {scratches.length > 0 && (
-              <span className="text-[10px] tabular-nums">{scratches.length}</span>
-            )}
+            {scratches.length > 0 && <BandCollapsedCount count={scratches.length} />}
           </button>
         </ContextMenuTrigger>
         {onDeleteAll && scratches.length > 0 && (
@@ -1708,6 +1865,7 @@ interface ProjectPaletteInnerProps {
   listRef: React.RefObject<HTMLDivElement | null>;
   query: string;
   results: ProjectSwitcherRow[];
+  browseBands?: ProjectSwitcherBrowseBand[];
   selectedIndex: number;
   mode?: ProjectSwitcherMode;
   onQueryChange: (query: string) => void;
@@ -1750,6 +1908,7 @@ function ProjectPaletteInner({
   listRef,
   query,
   results,
+  browseBands,
   selectedIndex,
   mode,
   onQueryChange,
@@ -1912,6 +2071,7 @@ function ProjectPaletteInner({
       >
         <ProjectListContent
           results={results}
+          browseBands={browseBands}
           selectedIndex={selectedIndex}
           query={query}
           onSelect={onSelect}
@@ -2053,6 +2213,7 @@ function ModalContent({
         listRef={listRef}
         query={innerProps.query}
         results={innerProps.results}
+        browseBands={innerProps.browseBands}
         selectedIndex={innerProps.selectedIndex}
         mode={mode}
         onQueryChange={innerProps.onQueryChange}
@@ -2173,6 +2334,7 @@ function DropdownContent({
           listRef={listRef}
           query={innerProps.query}
           results={innerProps.results}
+          browseBands={innerProps.browseBands}
           selectedIndex={innerProps.selectedIndex}
           mode={mode}
           onQueryChange={onQueryChange}
@@ -2298,6 +2460,7 @@ export function ProjectSwitcherPalette({
   isOpen,
   query,
   results,
+  browseBands,
   selectedIndex,
   onQueryChange,
   onSelectPrevious,
@@ -2367,6 +2530,7 @@ export function ProjectSwitcherPalette({
         isOpen={isOpen}
         query={query}
         results={results}
+        browseBands={browseBands}
         selectedIndex={selectedIndex}
         onQueryChange={onQueryChange}
         onSelectPrevious={onSelectPrevious}
@@ -2408,6 +2572,7 @@ export function ProjectSwitcherPalette({
         isOpen={isOpen}
         query={query}
         results={results}
+        browseBands={browseBands}
         selectedIndex={selectedIndex}
         onQueryChange={onQueryChange}
         onSelectPrevious={onSelectPrevious}

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.bulkScratchDelete.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.bulkScratchDelete.test.tsx
@@ -198,6 +198,7 @@ import type {
 import { primeRadix } from "@/components/ui/radix-loader";
 
 const { ProjectSwitcherPalette } = await import("../ProjectSwitcherPalette");
+const { usePreferencesStore } = await import("@/store/preferencesStore");
 
 beforeAll(async () => {
   // The context-menu primitives resolve through the lazy Radix loader; without
@@ -317,6 +318,9 @@ function consequenceNoun(): string {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Persisted and app-global (#11943): the collapse test below would otherwise
+  // leave every later case looking at a folded section.
+  usePreferencesStore.setState({ projectSwitcherCollapsedBands: {} });
 });
 
 // The action has to survive BOTH surfaces. The two hosts forward props through

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -2052,10 +2052,23 @@ describe("ProjectSwitcherPalette band collapse", () => {
   it("points each toggle at the rows it actually controls", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={banded} browseBands={bandsFor()} />);
 
-    for (const key of ["current", "running", "other"]) {
+    // Resolving to *something* is not enough — three toggles all naming the
+    // same element would pass that. Each target has to hold its own band's row
+    // and none of a neighbour's.
+    const rowNames: Record<string, string> = {
+      current: "Active Project",
+      running: "Running One",
+      other: "Other One",
+    };
+    for (const [key, ownRow] of Object.entries(rowNames)) {
       const controls = toggleFor(key).getAttribute("aria-controls");
-      expect(controls).toBeTruthy();
-      expect(document.getElementById(controls!)).toBeTruthy();
+      const target = controls ? document.getElementById(controls) : null;
+      expect(target).toBeTruthy();
+      const rendered = within(target!)
+        .getAllByRole("option")
+        .map((option) => option.textContent ?? "");
+      expect(rendered).toHaveLength(1);
+      expect(rendered[0]).toContain(ownRow);
     }
   });
 
@@ -2154,9 +2167,53 @@ describe("ProjectSwitcherPalette band collapse", () => {
     expect(toggleFor("other").getAttribute("aria-expanded")).toBe("false");
   });
 
+  it("offers no fold control on a surface that declares no bands", () => {
+    // Without declared bands the component reads them off `results`, where a
+    // fold would have to drop rows the arrow keys can still reach. Better no
+    // affordance than one that writes a preference nothing honours.
+    render(<ProjectSwitcherPalette {...modalProps} results={banded} />);
+
+    expect(screen.queryByTestId("band-collapse-toggle-running")).toBeNull();
+    // The headers themselves still name their bands.
+    expect(screen.getByRole("group", { name: "Running" })).toBeTruthy();
+  });
+
   it("still names an empty project list when there are genuinely no projects", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={[]} browseBands={[]} />);
     expect(screen.getByTestId("project-empty-state")).toBeTruthy();
+  });
+
+  it("renders a row the metadata claims is folded rather than hiding it", () => {
+    // Contradictory props: `running` says folded while its row is still in
+    // `results`. Honouring the metadata would strand that row — on screen
+    // nowhere, yet still reachable by arrow keys and committable by Enter.
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded}
+        browseBands={bandsFor(["running"])}
+      />
+    );
+
+    expect(screen.getByRole("option", { name: /Running One/ })).toBeTruthy();
+  });
+
+  it("keeps results in their arrow-key order when the metadata is incomplete", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded}
+        browseBands={[{ key: "current", label: "Current project", itemCount: 1, collapsed: false }]}
+      />
+    );
+
+    // Reordering rows to match a partial band list would make Arrow Down jump
+    // around the screen. Rendering flat keeps DOM order and key order equal.
+    const rendered = screen.getAllByRole("option").map((option) => option.textContent ?? "");
+    expect(rendered).toHaveLength(3);
+    expect(rendered[0]).toContain("Active Project");
+    expect(rendered[1]).toContain("Running One");
+    expect(rendered[2]).toContain("Other One");
   });
 
   it("renders every result even if the declared bands do not account for it", () => {
@@ -2208,6 +2265,27 @@ describe("ProjectSwitcherPalette band collapse", () => {
 
     expect(screen.getByRole("button", { name: /Scratch/ }).getAttribute("aria-expanded")).toBe(
       "true"
+    );
+  });
+
+  it("keeps Scratch folded through its first entry once the user has folded it", () => {
+    // The mirror of the test below: the derived default replaced an effect that
+    // forced the section open on 0 -> 1, and it must not do that over a fold the
+    // user chose.
+    const props = { ...modalProps, results: banded, onCreateScratch: vi.fn() };
+    const { rerender } = render(<ProjectSwitcherPalette {...props} scratchResults={[]} />);
+    fireEvent.click(screen.getByRole("button", { name: /Scratch/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Scratch/ }));
+    expect(screen.getByRole("button", { name: /Scratch/ }).getAttribute("aria-expanded")).toBe(
+      "false"
+    );
+
+    rerender(
+      <ProjectSwitcherPalette {...props} scratchResults={[makeScratchRow("scratch-1", "Spike")]} />
+    );
+
+    expect(screen.getByRole("button", { name: /Scratch/ }).getAttribute("aria-expanded")).toBe(
+      "false"
     );
   });
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -2072,6 +2072,89 @@ describe("ProjectSwitcherPalette band collapse", () => {
     }
   });
 
+  it("refuses the pointer focus that would take the keyboard off the search box", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={banded} browseBands={bandsFor()} />);
+
+    // `tabIndex={-1}` keeps the chevron out of the tab order but does not stop a
+    // press from focusing it, and the header outlives the fold — so a click
+    // would otherwise leave typing, arrow-stepping and Enter all pointed at a
+    // chevron instead of the palette. `fireEvent` returns false when the
+    // handler cancelled the event.
+    expect(fireEvent.mouseDown(toggleFor("running"))).toBe(false);
+
+    // The veto must not cost the click itself.
+    fireEvent.click(toggleFor("running"));
+    expect(usePreferencesStore.getState().projectSwitcherCollapsedBands).toEqual({
+      running: true,
+    });
+  });
+
+  it("keeps arrow-key order when a band's rows arrive in two separate runs", () => {
+    // The map from key to run keeps only the last run, so honouring this
+    // metadata would render the first `current` row nowhere while the arrow
+    // keys could still reach it.
+    const split = [
+      makeProject({ id: "a", name: "First Current", section: "current" }),
+      makeProject({ id: "b", name: "Middle Running", section: "running" }),
+      makeProject({ id: "c", name: "Second Current", section: "current" }),
+    ];
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={split}
+        browseBands={[
+          { key: "current", label: "Current project", itemCount: 2, collapsed: false },
+          { key: "running", label: "Running", itemCount: 1, collapsed: false },
+        ]}
+      />
+    );
+
+    const rendered = screen.getAllByRole("option").map((option) => option.textContent ?? "");
+    expect(rendered).toHaveLength(3);
+    expect(rendered[0]).toContain("First Current");
+    expect(rendered[1]).toContain("Middle Running");
+    expect(rendered[2]).toContain("Second Current");
+  });
+
+  it("keeps arrow-key order when the declared bands are ordered differently", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded}
+        browseBands={[
+          { key: "other", label: "Other projects", itemCount: 1, collapsed: false },
+          { key: "current", label: "Current project", itemCount: 1, collapsed: false },
+          { key: "running", label: "Running", itemCount: 1, collapsed: false },
+        ]}
+      />
+    );
+
+    const rendered = screen.getAllByRole("option").map((option) => option.textContent ?? "");
+    expect(rendered[0]).toContain("Active Project");
+    expect(rendered[1]).toContain("Running One");
+    expect(rendered[2]).toContain("Other One");
+  });
+
+  it("refuses a duplicated band key rather than colliding on its ids", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded}
+        browseBands={[
+          { key: "current", label: "Current project", itemCount: 1, collapsed: false },
+          { key: "current", label: "Current project", itemCount: 1, collapsed: false },
+          { key: "running", label: "Running", itemCount: 1, collapsed: false },
+          { key: "other", label: "Other projects", itemCount: 1, collapsed: false },
+        ]}
+      />
+    );
+
+    // One id per band or `aria-labelledby` and `aria-controls` both go
+    // ambiguous, so the whole band layout stands down.
+    expect(document.querySelectorAll("#project-section-current")).toHaveLength(0);
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
   it("records the fold in the preference the palette reads back on reopen", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={banded} browseBands={bandsFor()} />);
 

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach, beforeEach } from "vitest";
 import { render, screen, within, fireEvent, act, cleanup } from "@testing-library/react";
 
 const originalScrollIntoView = Element.prototype.scrollIntoView;
@@ -144,6 +144,7 @@ vi.mock("@/utils/timeAgo", () => ({
 }));
 
 import type {
+  ProjectSwitcherBrowseBand,
   ProjectSwitcherProjectRow,
   ProjectSwitcherScratchRow,
   SearchableProject,
@@ -153,6 +154,15 @@ import { SCRATCH_CLEANUP_TTL_MS } from "@shared/config/scratchCleanup";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 
 const { ProjectSwitcherPalette } = await import("../ProjectSwitcherPalette");
+const { usePreferencesStore } = await import("@/store/preferencesStore");
+
+// Band collapse is a persisted, app-global preference now (#11943), so a test
+// that folds one hands the fold to every test after it. Reset rather than mock
+// the store: these suites exercise the real fold, and a mock would only prove
+// the mock folds.
+beforeEach(() => {
+  usePreferencesStore.setState({ projectSwitcherCollapsedBands: {} });
+});
 
 function makeProject(overrides: Partial<SearchableProject> = {}): ProjectSwitcherProjectRow {
   // Deliberately dumb: `section` defaults to "other" and must be stated
@@ -1982,5 +1992,251 @@ describe("ProjectSwitcherPalette scratch resumable-agent dot", () => {
     const unmarked = screen.getByRole("option", { name: /Unmarked/ });
     expect(marked.querySelector("[data-testid='workspace-resume-dot']")).toBeTruthy();
     expect(unmarked.querySelector("[data-testid='workspace-resume-dot']")).toBeNull();
+  });
+});
+
+/**
+ * Folding a band (#11943). The component is handed `results` and `browseBands`
+ * separately — the hook filters the first and declares the second — so these
+ * drive both by hand the way the real hosts do.
+ */
+describe("ProjectSwitcherPalette band collapse", () => {
+  const banded = [
+    makeProject({ id: "active", name: "Active Project", isActive: true, section: "current" }),
+    makeProject({ id: "run-1", name: "Running One", section: "running" }),
+    makeProject({ id: "other-1", name: "Other One", section: "other" }),
+  ];
+
+  function bandsFor(collapsedKeys: string[] = []): ProjectSwitcherBrowseBand[] {
+    const bands: ProjectSwitcherBrowseBand[] = [
+      { key: "current", label: "Current project", itemCount: 1, collapsed: false },
+      { key: "running", label: "Running", itemCount: 1, collapsed: false },
+      { key: "other", label: "Other projects", itemCount: 1, collapsed: false },
+    ];
+    return bands.map((band) => ({ ...band, collapsed: collapsedKeys.includes(band.key) }));
+  }
+
+  function toggleFor(key: string): HTMLElement {
+    return screen.getByTestId(`band-collapse-toggle-${key}`);
+  }
+
+  function makeScratchRow(id: string, name: string): ProjectSwitcherScratchRow {
+    return {
+      kind: "scratch",
+      id,
+      name,
+      path: `/userData/scratch/${id}`,
+      createdAt: 0,
+      lastOpened: 0,
+      isActive: false,
+      processCount: 0,
+      activeAgentCount: 0,
+      waitingAgentCount: 0,
+      blockedAgentCount: 0,
+      completedAgentCount: 0,
+      unacknowledgedCompletedAgentCount: 0,
+      snoozedAgentCount: 0,
+    };
+  }
+
+  it("gives every band the affordance that used to be Scratch's alone", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={banded} browseBands={bandsFor()} />);
+
+    // Named by band rather than counted, so this still fails if the chevron
+    // lands on some bands and not others.
+    for (const key of ["current", "running", "other"]) {
+      expect(toggleFor(key).getAttribute("aria-expanded")).toBe("true");
+    }
+  });
+
+  it("points each toggle at the rows it actually controls", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={banded} browseBands={bandsFor()} />);
+
+    for (const key of ["current", "running", "other"]) {
+      const controls = toggleFor(key).getAttribute("aria-controls");
+      expect(controls).toBeTruthy();
+      expect(document.getElementById(controls!)).toBeTruthy();
+    }
+  });
+
+  it("records the fold in the preference the palette reads back on reopen", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={banded} browseBands={bandsFor()} />);
+
+    fireEvent.click(toggleFor("running"));
+
+    // The store, not local state: the point of the issue is that reopening the
+    // palette finds the band the way the user left it.
+    expect(usePreferencesStore.getState().projectSwitcherCollapsedBands).toEqual({
+      running: true,
+    });
+  });
+
+  it("unfolds a folded band on a second click rather than folding it harder", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded.filter((p) => p.section !== "running")}
+        browseBands={bandsFor(["running"])}
+      />
+    );
+
+    expect(toggleFor("running").getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(toggleFor("running"));
+
+    expect(usePreferencesStore.getState().projectSwitcherCollapsedBands).toEqual({
+      running: false,
+    });
+  });
+
+  it("keeps a folded band's named group and header with none of its rows", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded.filter((p) => p.section !== "running")}
+        browseBands={bandsFor(["running"])}
+      />
+    );
+
+    // The group has to survive: it is the only thing left to click to get the
+    // rows back, and an unnamed or absent one strands them.
+    const band = screen.getByRole("group", { name: "Running" });
+    expect(within(band).queryAllByRole("option")).toHaveLength(0);
+    expect(screen.queryByRole("option", { name: /Running One/ })).toBeNull();
+    // Its neighbours are untouched.
+    expect(screen.getByRole("option", { name: /Other One/ })).toBeTruthy();
+  });
+
+  it("says how much a folded band is holding, and stays quiet when it is open", () => {
+    const { rerender } = render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded.filter((p) => p.section !== "other")}
+        browseBands={[
+          { key: "current", label: "Current project", itemCount: 1, collapsed: false },
+          { key: "running", label: "Running", itemCount: 1, collapsed: false },
+          { key: "other", label: "Other projects", itemCount: 7, collapsed: true },
+        ]}
+      />
+    );
+
+    // Folded, the count is the only thing left that reports the band's size.
+    expect(
+      within(screen.getByRole("group", { name: "Other projects" })).getByText("7")
+    ).toBeTruthy();
+
+    rerender(<ProjectSwitcherPalette {...modalProps} results={banded} browseBands={bandsFor()} />);
+    expect(
+      within(screen.getByRole("group", { name: "Other projects" })).queryByText("7")
+    ).toBeNull();
+  });
+
+  it("does not lend the chevron's label to the band's accessible name", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={banded} browseBands={bandsFor()} />);
+
+    // The `id` has to stay on a leaf holding only the label text, or the count
+    // and the chevron would join the name the group announces.
+    expect(screen.getByRole("group", { name: "Running" })).toBeTruthy();
+  });
+
+  it("shows the bands rather than the no-projects empty state when all of them fold", () => {
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={[]}
+        browseBands={bandsFor(["current", "running", "other"])}
+      />
+    );
+
+    // "Add a project to get started" here would be a lie the user cannot argue
+    // with — and it would take away the headers that are the only way back.
+    expect(screen.queryByTestId("project-empty-state")).toBeNull();
+    expect(screen.getByRole("group", { name: "Running" })).toBeTruthy();
+    expect(toggleFor("other").getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("still names an empty project list when there are genuinely no projects", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={[]} browseBands={[]} />);
+    expect(screen.getByTestId("project-empty-state")).toBeTruthy();
+  });
+
+  it("renders every result even if the declared bands do not account for it", () => {
+    // Defensive: a row that renders nowhere is bug #11071 again — the highlight
+    // would address it while nothing on screen carried it.
+    render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded}
+        browseBands={[{ key: "current", label: "Current project", itemCount: 1, collapsed: false }]}
+      />
+    );
+
+    expect(screen.getByRole("option", { name: /Running One/ })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Other One/ })).toBeTruthy();
+  });
+
+  it("keeps the Scratch fold across a full unmount, which local state never did", () => {
+    const scratch = makeScratchRow("scratch-1", "Spike");
+    const props = { ...modalProps, results: banded, scratchResults: [scratch] };
+
+    const { unmount } = render(<ProjectSwitcherPalette {...props} />);
+    const header = screen.getByRole("button", { name: /Scratch/ });
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(header);
+
+    // Closing the palette really does unmount it, which is exactly what used to
+    // reseed the local `collapsed` from the scratch count.
+    unmount();
+    render(<ProjectSwitcherPalette {...props} />);
+
+    expect(screen.getByRole("button", { name: /Scratch/ }).getAttribute("aria-expanded")).toBe(
+      "false"
+    );
+  });
+
+  it("holds an empty Scratch open once the user says so, against its own default", () => {
+    // The default is "folded while empty", so an expand here is the case a
+    // delete-on-default setter would silently undo.
+    const props = { ...modalProps, results: banded, scratchResults: [], onCreateScratch: vi.fn() };
+
+    const { unmount } = render(<ProjectSwitcherPalette {...props} />);
+    const header = screen.getByRole("button", { name: /Scratch/ });
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(header);
+
+    unmount();
+    render(<ProjectSwitcherPalette {...props} />);
+
+    expect(screen.getByRole("button", { name: /Scratch/ }).getAttribute("aria-expanded")).toBe(
+      "true"
+    );
+  });
+
+  it("opens Scratch on its first entry without a stored preference", () => {
+    // The derived default replaces the effect that used to force this open, so
+    // it has to keep tracking the count on its own.
+    const scratch = makeScratchRow("scratch-1", "Spike");
+    const { rerender } = render(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded}
+        scratchResults={[]}
+        onCreateScratch={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: /Scratch/ }).getAttribute("aria-expanded")).toBe(
+      "false"
+    );
+
+    rerender(
+      <ProjectSwitcherPalette
+        {...modalProps}
+        results={banded}
+        scratchResults={[scratch]}
+        onCreateScratch={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: /Scratch/ }).getAttribute("aria-expanded")).toBe(
+      "true"
+    );
   });
 });

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
@@ -169,6 +169,14 @@ import type { SearchableScratch } from "@/hooks/useProjectSwitcherPalette";
 import { defaultScratchName } from "@shared/utils/scratchName";
 
 const { ProjectSwitcherPalette } = await import("../ProjectSwitcherPalette");
+const { usePreferencesStore } = await import("@/store/preferencesStore");
+
+// `expandScratchSection()` writes the fold preference now (#11943), and it is
+// app-global — without this, every case after the first starts explicitly
+// expanded instead of exercising the empty-band default.
+beforeEach(() => {
+  usePreferencesStore.setState({ projectSwitcherCollapsedBands: {} });
+});
 
 function makeScratch(overrides: Partial<SearchableScratch> = {}): SearchableScratch {
   return {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.sortControl.test.tsx
@@ -136,6 +136,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   usePreferencesStore.getState().setProjectSwitcherOtherSortMode(DEFAULT_OTHER_PROJECTS_SORT_MODE);
+  usePreferencesStore.setState({ projectSwitcherCollapsedBands: {} });
 });
 
 function makeProject(
@@ -164,16 +165,19 @@ function makeProject(
   } as ProjectSwitcherProjectRow;
 }
 
-function renderPalette(otherRows: number) {
+function renderPalette(otherRows: number, { collapsed = false }: { collapsed?: boolean } = {}) {
   const results = Array.from({ length: otherRows }, (_, i) =>
     makeProject({ id: `other-${i}`, lastOpened: 1_000 - i })
   );
+  // Mirrors the hook: a folded band declares its full count and contributes no
+  // rows, so nothing `selectedIndex` can address is missing from the DOM.
   return render(
     <ProjectSwitcherPalette
       isOpen
       mode="modal"
       query=""
-      results={results}
+      results={collapsed ? [] : results}
+      browseBands={[{ key: "other", label: "Other projects", itemCount: otherRows, collapsed }]}
       selectedIndex={0}
       onQueryChange={vi.fn()}
       onSelectPrevious={vi.fn()}
@@ -195,8 +199,11 @@ function trigger(): HTMLElement {
  */
 function headerRow(): HTMLElement {
   const label = document.getElementById("project-section-other");
-  if (!label?.parentElement) throw new Error("Other projects header not found");
-  return label.parentElement;
+  // Not `parentElement`: the leaf sits inside the fold control now (#11943), so
+  // walking one level up lands on the button rather than the row Radix is on.
+  const row = label?.closest('[role="presentation"]');
+  if (!(row instanceof HTMLElement)) throw new Error("Other projects header not found");
+  return row;
 }
 
 /** Radix opens a dropdown on primary-button pointerdown, not on click. */
@@ -273,5 +280,34 @@ describe("Other projects sort control (#11455)", () => {
     const group = screen.getByRole("group", { name: "Other projects" });
     // The control lives inside the header row but outside the labelling leaf.
     expect(within(group).getByTestId("other-projects-sort-trigger")).toBeTruthy();
+  });
+
+  it("shares the header row with the fold control without renaming the band", () => {
+    // Two controls now sit around the labelling leaf (#11943). Either one
+    // nested inside it would name the band "Other projects Most used" or
+    // "Other projects Other projects".
+    renderPalette(4);
+    const group = screen.getByRole("group", { name: "Other projects" });
+    expect(within(group).getByTestId("other-projects-sort-trigger")).toBeTruthy();
+    expect(within(group).getByTestId("band-collapse-toggle-other")).toBeTruthy();
+  });
+
+  it("keeps the fold control out of the tab order, like the sort trigger", () => {
+    // Section headers live inside the listbox, where a focusable child is
+    // invalid and unreachable anyway — arrow keys move across rows, never here.
+    renderPalette(4);
+    expect(screen.getByTestId("band-collapse-toggle-other").getAttribute("tabindex")).toBe("-1");
+    expect(trigger().getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("drops the sort control while the band is folded", () => {
+    // Naming the order of rows nobody can see spends the header's one free slot
+    // on the fact least worth having; the folded count takes it instead.
+    renderPalette(4, { collapsed: true });
+
+    expect(screen.queryByTestId("other-projects-sort-trigger")).toBeNull();
+    const group = screen.getByRole("group", { name: "Other projects" });
+    expect(within(group).getByText("4")).toBeTruthy();
+    expect(within(group).queryAllByRole("option")).toHaveLength(0);
   });
 });

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -171,7 +171,7 @@ import {
   OTHER_PROJECTS_SORT_MODES,
   type OtherProjectsSortMode,
 } from "@/lib/projectSort";
-import { useProjectSwitcherPalette } from "../useProjectSwitcherPalette";
+import { useProjectSwitcherPalette, PROJECT_SECTION_ORDER } from "../useProjectSwitcherPalette";
 import type { ProjectSwitcherProjectRow, ProjectSwitcherRow } from "../useProjectSwitcherPalette";
 
 /**
@@ -191,6 +191,10 @@ function asProject(row: ProjectSwitcherRow | undefined): ProjectSwitcherProjectR
 
 function setOtherSortMode(mode: OtherProjectsSortMode): void {
   usePreferencesStore.getState().setProjectSwitcherOtherSortMode(mode);
+}
+
+function collapseBand(key: string): void {
+  usePreferencesStore.getState().setProjectSwitcherBandCollapsed(key, true);
 }
 
 const emptyBulkStats = (projectIds: string[]) => {
@@ -246,6 +250,9 @@ describe("useProjectSwitcherPalette", () => {
       projectStatsState.stats = stats;
     });
     usePaletteStore.setState({ activePaletteId: null });
+    // Persisted and app-global (#11943) — a fold set by one case is otherwise
+    // still in force for every case after it.
+    usePreferencesStore.setState({ projectSwitcherCollapsedBands: {} });
   });
 
   // The header's "is it safe to look away?" total, tested against raw projects
@@ -3091,6 +3098,149 @@ describe("useProjectSwitcherPalette", () => {
       expect(new Set(backwards).size).toBe(size);
     });
 
+    // Folding a band (#11943) is the first thing that ever removed rows from
+    // browse, which puts it squarely on top of the invariant this describe
+    // exists to protect: whatever `results` holds must be on screen, because
+    // the highlight, `aria-activedescendant` and Enter all read it by index.
+    describe("folded bands", () => {
+      it("drops a folded band's rows from results while keeping its header", async () => {
+        collapseBand("current");
+        const result = await openIn("modal");
+
+        await waitFor(() => {
+          expect(result.current.results).toHaveLength(2);
+        });
+        expect(result.current.results.map(asProject).map((p) => p.section)).not.toContain(
+          "current"
+        );
+
+        // The band still has to say it exists, or there is no way to unfold it.
+        const current = result.current.browseBands.find((band) => band.key === "current");
+        expect(current).toMatchObject({ collapsed: true, itemCount: 1 });
+      });
+
+      it("counts a folded band's projects even though none of them render", async () => {
+        const result = await openIn("modal");
+        await waitFor(() => {
+          expect(result.current.results).toHaveLength(3);
+        });
+        const before = result.current.browseBands.map((band) => ({
+          key: band.key,
+          itemCount: band.itemCount,
+        }));
+
+        act(() => {
+          collapseBand("other");
+        });
+
+        await waitFor(() => {
+          expect(result.current.browseBands.some((band) => band.collapsed)).toBe(true);
+        });
+        // Same bands, same counts — folding changes what renders, not what exists.
+        expect(
+          result.current.browseBands.map((band) => ({ key: band.key, itemCount: band.itemCount }))
+        ).toEqual(before);
+      });
+
+      it("never steps onto a row that folding took off screen", async () => {
+        collapseBand("current");
+        const result = await openIn("modal");
+        await waitFor(() => {
+          expect(result.current.results).toHaveLength(2);
+        });
+
+        const visible = new Set(result.current.results.map((row) => row.id));
+        for (let step = 0; step < 6; step++) {
+          const selected = result.current.results[result.current.selectedIndex];
+          expect(selected).toBeDefined();
+          expect(visible.has(selected!.id)).toBe(true);
+          act(() => {
+            result.current.selectNext();
+          });
+        }
+      });
+
+      it("preselects a visible row rather than a folded band's project", async () => {
+        collapseBand("other");
+        const result = await openIn("modal");
+
+        await waitFor(() => {
+          expect(result.current.results.length).toBeGreaterThan(0);
+        });
+        const selected = result.current.results[result.current.selectedIndex];
+        expect(selected).toBeDefined();
+        expect(asProject(selected).section).not.toBe("other");
+      });
+
+      it("falls back to the first visible row when the selected band folds under it", async () => {
+        const result = await openIn("modal");
+        await waitFor(() => {
+          expect(result.current.results).toHaveLength(3);
+        });
+
+        const selected = asProject(result.current.results[result.current.selectedIndex]);
+        act(() => {
+          collapseBand(selected.section);
+        });
+
+        await waitFor(() => {
+          expect(result.current.results.map((row) => row.id)).not.toContain(selected.id);
+        });
+        // Derived at read time, so it lands on a rendered row in the same commit
+        // rather than pointing at the vanished one for a frame.
+        expect(result.current.selectedIndex).toBe(0);
+        expect(result.current.results[result.current.selectedIndex]).toBeDefined();
+      });
+
+      it("holds still and commits nothing when every band is folded", async () => {
+        for (const section of PROJECT_SECTION_ORDER) collapseBand(section);
+        const result = await openIn("modal");
+
+        await waitFor(() => {
+          expect(result.current.results).toHaveLength(0);
+        });
+
+        // Stepping an empty domain must be a no-op rather than a wrap that
+        // divides by its own length, and Enter must not reach for `results[0]`.
+        act(() => {
+          result.current.selectNext();
+          result.current.selectPrevious();
+          result.current.confirmSelection();
+        });
+        expect(result.current.selectedIndex).toBe(0);
+        expect(projectState.switchProject).not.toHaveBeenCalled();
+        expect(projectState.reopenProject).not.toHaveBeenCalled();
+        // The headers survive, which is the only way back.
+        expect(result.current.browseBands.length).toBeGreaterThan(0);
+      });
+
+      it("still finds a folded band's project by name", async () => {
+        // Folding is a browse-layout choice. A query that silently skipped its
+        // own matches would make projects look deleted.
+        collapseBand("other");
+        const result = await openIn("modal");
+        await waitFor(() => {
+          expect(result.current.results.length).toBeGreaterThan(0);
+        });
+
+        const hidden = "Background Project";
+        act(() => {
+          result.current.setQuery("Background");
+        });
+
+        await waitFor(() => {
+          expect(result.current.results.map((row) => row.name)).toContain(hidden);
+        });
+
+        act(() => {
+          result.current.setQuery("");
+        });
+        await waitFor(() => {
+          expect(result.current.results.map((row) => row.name)).not.toContain(hidden);
+        });
+      });
+    });
+
     it("confirmSelection switches to the highlighted project", async () => {
       const result = await openIn("modal");
       await waitFor(() => {
@@ -3348,6 +3498,9 @@ describe("assistant presence banding (#11806)", () => {
       projectStatsState.stats = stats;
     });
     usePaletteStore.setState({ activePaletteId: null });
+    // Persisted and app-global (#11943) — a fold set by one case is otherwise
+    // still in force for every case after it.
+    usePreferencesStore.setState({ projectSwitcherCollapsedBands: {} });
   });
 
   afterEach(() => {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -3228,9 +3228,14 @@ describe("useProjectSwitcherPalette", () => {
           result.current.setQuery("Background");
         });
 
+        // Settle first. The deferred-query frame serves the unfolded browse list
+        // by design, so asserting straight away would pass even if the ranking
+        // itself only ever saw the visible rows.
         await waitFor(() => {
-          expect(result.current.results.map((row) => row.name)).toContain(hidden);
+          expect(result.current.isRankedSearch).toBe(true);
+          expect(result.current.isFiltering).toBe(false);
         });
+        expect(result.current.results.map((row) => row.name)).toContain(hidden);
 
         act(() => {
           result.current.setQuery("");

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -146,6 +146,16 @@ export const PROJECT_SECTION_ORDER = [
 export type ProjectSectionKey = (typeof PROJECT_SECTION_ORDER)[number];
 
 /**
+ * The Scratch band's key in the persisted collapse map. Scratch is not a
+ * `ProjectSectionKey` — it renders outside `results` entirely — but it folds
+ * away on the same affordance, so it shares the one preference record.
+ */
+export const PROJECT_SWITCHER_SCRATCH_BAND_KEY = "scratch";
+
+/** Every band the switcher can fold away, project bands plus Scratch (#11943). */
+export type ProjectSwitcherBandKey = ProjectSectionKey | typeof PROJECT_SWITCHER_SCRATCH_BAND_KEY;
+
+/**
  * Header text per band.
  *
  * `current` went unlabelled while the keyboard cursor was the loudest thing on
@@ -239,15 +249,39 @@ function toProjectRow(project: SearchableProject): ProjectSwitcherProjectRow {
   return { kind: "project", ...project };
 }
 
+/**
+ * One browse band, WITHOUT its rows.
+ *
+ * A collapsed band contributes nothing to {@link UseProjectSwitcherPaletteReturn.results},
+ * so its header would vanish along with its rows and leave no way to unfold it
+ * again. This carries the header's facts — which bands exist, and how many
+ * projects each is holding — separately from the array the arrow keys walk, so
+ * bands stay a *view* over `results` rather than a second, wider list (#11071).
+ */
+export interface ProjectSwitcherBrowseBand {
+  key: ProjectSectionKey;
+  label: string;
+  /** Projects in the band, collapsed or not — what the header's count reports. */
+  itemCount: number;
+  collapsed: boolean;
+}
+
 export interface UseProjectSwitcherPaletteReturn {
   isOpen: boolean;
   mode: ProjectSwitcherMode;
   query: string;
   /**
    * The rows the palette renders, in render order — and the only array
-   * `selectedIndex` may be read against. Every mode lists every registered
-   * project: browse is section-ordered (see {@link PROJECT_SECTION_ORDER}) and
-   * search is rank-ordered, but neither is scoped or capped.
+   * `selectedIndex` may be read against. Browse is section-ordered (see
+   * {@link PROJECT_SECTION_ORDER}) and search is rank-ordered; neither is
+   * capped.
+   *
+   * Browse omits the rows of bands the user has folded away, which is what
+   * keeps every entry a RENDERED row: the highlight, `aria-activedescendant`
+   * and Enter all address this array, and none of them may name a row that is
+   * not on screen (#11071). Collapsed bands keep their headers via
+   * {@link browseBands}. Search never applies the collapse — a query that
+   * silently skipped its own matches would be worse than a band unfolding.
    *
    * Browse rows are all projects; the scratches belong to the pinned section
    * below the list. Search rows are mixed, so a scratch is reachable by name
@@ -255,6 +289,12 @@ export interface UseProjectSwitcherPaletteReturn {
    * scratch doesn't have.
    */
   results: ProjectSwitcherRow[];
+  /**
+   * Every browse band in render order, including ones holding no visible rows
+   * because the user collapsed them. Empty while searching, where the ranked
+   * list has no bands. See {@link ProjectSwitcherBrowseBand}.
+   */
+  browseBands: ProjectSwitcherBrowseBand[];
   /** True while `deferredQuery` has not yet caught up to `query` — the results shown are from the previous query. */
   isFiltering: boolean;
   /**
@@ -744,18 +784,29 @@ function compareWithinSection(
  * by within each tier of name-match quality. Browse ignores it: its own freeze
  * already holds that order.
  */
+/**
+ * `visibleBrowseRows` omits the bands the user folded away; `allBrowseRows`
+ * does not. Searching uses the unfolded list on BOTH its paths — not just the
+ * ranked one. The ranking runs on the deferred query, so a non-empty box spends
+ * a commit with no ranked rows yet, and serving the filtered browse list for
+ * that frame would blink a matching project out of existence on the way in.
+ */
 function buildResults(
-  browseRows: ProjectSwitcherRow[],
+  visibleBrowseRows: ProjectSwitcherRow[],
+  allBrowseRows: ProjectSwitcherRow[],
   browseOrdered: SearchableProject[],
   scratches: SearchableScratch[],
   rankQuery: string,
   isSearching: boolean,
   activityKeys: ReadonlyMap<string, SearchActivityKey> | null
 ): ProjectSwitcherRow[] {
-  if (isSearching && rankQuery.trim()) {
-    return rankSwitcherMatches(rankQuery, browseOrdered, scratches, activityKeys);
+  if (isSearching) {
+    if (rankQuery.trim()) {
+      return rankSwitcherMatches(rankQuery, browseOrdered, scratches, activityKeys);
+    }
+    return allBrowseRows;
   }
-  return browseRows;
+  return visibleBrowseRows;
 }
 
 /**
@@ -1024,6 +1075,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   }, [searchableProjects]);
 
   const otherProjectsSortMode = usePreferencesStore((state) => state.projectSwitcherOtherSortMode);
+  const collapsedBands = usePreferencesStore((state) => state.projectSwitcherCollapsedBands);
 
   const liveBrowseOrder = useMemo<SearchableProject[]>(() => {
     return [...searchableProjects].sort((a, b) => {
@@ -1393,6 +1445,38 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     [browseOrdered]
   );
 
+  // Derived from the COMPLETE ordered list, before any collapse filtering — a
+  // folded band still has to say it exists and how much it is holding.
+  const browseBands = useMemo<ProjectSwitcherBrowseBand[]>(() => {
+    const bands: ProjectSwitcherBrowseBand[] = [];
+    for (const project of browseOrdered) {
+      const last = bands.at(-1);
+      if (last && last.key === project.section) {
+        last.itemCount += 1;
+        continue;
+      }
+      bands.push({
+        key: project.section,
+        label: PROJECT_SECTION_LABELS[project.section],
+        itemCount: 1,
+        collapsed: collapsedBands[project.section] === true,
+      });
+    }
+    return bands;
+  }, [browseOrdered, collapsedBands]);
+
+  // Held apart from `browseRows` so an all-expanded switcher — the default, and
+  // the common case — keeps browse's array identity stable rather than minting
+  // a filtered copy on every unrelated re-render.
+  const hasCollapsedBand = useMemo(() => browseBands.some((band) => band.collapsed), [browseBands]);
+
+  const visibleBrowseRows = useMemo<ProjectSwitcherRow[]>(() => {
+    if (!hasCollapsedBand) return browseRows;
+    return browseRows.filter(
+      (row) => row.kind !== "project" || collapsedBands[row.section] !== true
+    );
+  }, [browseRows, hasCollapsedBand, collapsedBands]);
+
   // True exactly when `results` is the ranked, scratch-carrying list — which is
   // one commit behind `isSearching`, since the ranking runs on the deferred
   // query. The pinned scratch section hides on THIS, never on the live query:
@@ -1402,6 +1486,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const results = useMemo<ProjectSwitcherRow[]>(
     () =>
       buildResults(
+        visibleBrowseRows,
         browseRows,
         browseOrdered,
         scratchResults,
@@ -1409,7 +1494,15 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         isSearching,
         frozenSearchActivity?.keys ?? null
       ),
-    [browseRows, browseOrdered, scratchResults, resultsQuery, isSearching, frozenSearchActivity]
+    [
+      visibleBrowseRows,
+      browseRows,
+      browseOrdered,
+      scratchResults,
+      resultsQuery,
+      isSearching,
+      frozenSearchActivity,
+    ]
   );
 
   // The selected ROW is the state; its index is derived. Tracking an index
@@ -1507,10 +1600,19 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       // no active row, so it lands on row 1 rather than skipping past it
       // (#11085); an all-missing list still preselects something rather than
       // nothing.
+      //
+      // Folded bands are not candidates: their rows are absent from `results`,
+      // so preselecting one would leave the highlight addressing a row nobody
+      // can see. With every band folded there is nothing to preselect, and
+      // `null` is the honest answer — arrows and Enter both no-op on an empty
+      // list rather than committing something offscreen.
+      const selectable = liveBrowseOrder.filter(
+        (project) => collapsedBands[project.section] !== true
+      );
       const initial =
-        liveBrowseOrder.find((project) => !project.isActive && !project.isMissing) ??
-        liveBrowseOrder.find((project) => !project.isActive) ??
-        liveBrowseOrder[0];
+        selectable.find((project) => !project.isActive && !project.isMissing) ??
+        selectable.find((project) => !project.isActive) ??
+        selectable[0];
       setSelectedRowId(initial?.id ?? null);
     },
     [
@@ -1520,6 +1622,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       captureSearchActivity,
       searchableProjects,
       scratchResults,
+      collapsedBands,
     ]
   );
 
@@ -2315,6 +2418,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     mode,
     query,
     results,
+    browseBands,
     isFiltering,
     isRankedSearch,
     activeProject,

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -291,8 +291,9 @@ export interface UseProjectSwitcherPaletteReturn {
   results: ProjectSwitcherRow[];
   /**
    * Every browse band in render order, including ones holding no visible rows
-   * because the user collapsed them. Empty while searching, where the ranked
-   * list has no bands. See {@link ProjectSwitcherBrowseBand}.
+   * because the user collapsed them. Always describes the BROWSE layout — a
+   * surface rendering the ranked search list ignores it, since search has no
+   * bands. See {@link ProjectSwitcherBrowseBand}.
    */
   browseBands: ProjectSwitcherBrowseBand[];
   /** True while `deferredQuery` has not yet caught up to `query` — the results shown are from the previous query. */

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -228,6 +228,60 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.dockDensity).toBe("compact");
   });
 
+  it("keeps a sibling's folded band when this view folds a different one", async () => {
+    // Per-key, not whole-field: two project views each fold the bands they read
+    // past, and a whole-map write from either would take the other's fold with
+    // it. This is the failure `mergeRecordByWriterDelta` exists to prevent.
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setDockDensity("normal");
+
+    const disk = readBlob(backing);
+    disk.state.projectSwitcherCollapsedBands = { running: true };
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setProjectSwitcherBandCollapsed("other", true);
+
+    const written = readBlob(backing);
+    expect(written.state.projectSwitcherCollapsedBands).toEqual({ running: true, other: true });
+  });
+
+  it("does not resurrect a band this view unfolded, and keeps a sibling's", async () => {
+    // An unfolded band is stored as `false`, not deleted, so "this view unfolded
+    // it" and "this view never touched it" stay distinguishable to the merge.
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setProjectSwitcherBandCollapsed("other", true);
+
+    const disk = readBlob(backing);
+    disk.state.projectSwitcherCollapsedBands = { other: true, pinned: true };
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setProjectSwitcherBandCollapsed("other", false);
+
+    const written = readBlob(backing);
+    expect(written.state.projectSwitcherCollapsedBands).toEqual({ other: false, pinned: true });
+  });
+
+  it("keeps a sibling's fold through an unrelated preference write", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setDockDensity("normal");
+
+    const disk = readBlob(backing);
+    disk.state.projectSwitcherCollapsedBands = { scratch: false };
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setReduceAnimations(true);
+
+    const written = readBlob(backing);
+    expect(written.state.projectSwitcherCollapsedBands).toEqual({ scratch: false });
+    expect(written.state.reduceAnimations).toBe(true);
+  });
+
   it("keeps this view's sort mode when a sibling changes an unrelated scalar", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -265,6 +265,25 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.projectSwitcherCollapsedBands).toEqual({ other: false, pinned: true });
   });
 
+  it("does not write a stale copy of a band a sibling has since unfolded", async () => {
+    // The one a two-way `{ ...onDisk, ...incoming }` merge would fail: this
+    // view still holds `running: true` from hydration, so folding an unrelated
+    // band carries that stale value along and would undo the sibling's unfold.
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setProjectSwitcherBandCollapsed("running", true);
+
+    const disk = readBlob(backing);
+    disk.state.projectSwitcherCollapsedBands = { running: false };
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setProjectSwitcherBandCollapsed("other", true);
+
+    const written = readBlob(backing);
+    expect(written.state.projectSwitcherCollapsedBands).toEqual({ running: false, other: true });
+  });
+
   it("keeps a sibling's fold through an unrelated preference write", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -858,6 +858,101 @@ describe("preferencesStore migration", () => {
     });
   });
 
+  describe("projectSwitcherCollapsedBands (v17 migration, issue #11943)", () => {
+    it("starts empty so a fresh install opens with every band unfolded", async () => {
+      const store = await loadStore();
+      expect(store.getState().projectSwitcherCollapsedBands).toEqual({});
+    });
+
+    it("keeps each band's fold independent of the others", async () => {
+      const store = await loadStore();
+      store.getState().setProjectSwitcherBandCollapsed("other", true);
+      store.getState().setProjectSwitcherBandCollapsed("running", true);
+      store.getState().setProjectSwitcherBandCollapsed("other", false);
+
+      expect(store.getState().projectSwitcherCollapsedBands).toEqual({
+        other: false,
+        running: true,
+      });
+    });
+
+    it("records an unfolded band rather than dropping its key", async () => {
+      // The whole reason this map keeps `false` entries: Scratch's default is
+      // "folded while empty", so an absent key would re-fold a section the user
+      // deliberately opened. Dropping the key on `false` is what the
+      // neighbouring skip-confirm map does, and it would be wrong here.
+      const store = await loadStore();
+      store.getState().setProjectSwitcherBandCollapsed("scratch", false);
+
+      const persisted = JSON.parse(storage[STORAGE_KEY]!) as { state: Record<string, unknown> };
+      expect(persisted.state.projectSwitcherCollapsedBands).toEqual({ scratch: false });
+    });
+
+    it("survives a reload rather than unfolding on restart", async () => {
+      const first = await loadStore();
+      first.getState().setProjectSwitcherBandCollapsed("other", true);
+
+      vi.resetModules();
+      _resetPersistedStoreRegistryForTests();
+      const reloaded = await loadStore();
+      expect(reloaded.getState().projectSwitcherCollapsedBands).toEqual({ other: true });
+    });
+
+    it("no-ops when the band is already in the requested state", async () => {
+      const store = await loadStore();
+      store.getState().setProjectSwitcherBandCollapsed("other", true);
+      const before = store.getState().projectSwitcherCollapsedBands;
+      store.getState().setProjectSwitcherBandCollapsed("other", true);
+
+      expect(store.getState().projectSwitcherCollapsedBands).toBe(before);
+    });
+
+    it("supplies the field in the migration itself, not only in the sanitizer", async () => {
+      const store = await loadStore();
+      const migrated = store.persist
+        .getOptions()
+        .migrate?.({ dockDensity: "compact" }, 16) as Record<string, unknown>;
+
+      expect(migrated.projectSwitcherCollapsedBands).toEqual({});
+      expect(migrated.dockDensity).toBe("compact");
+    });
+
+    it("carries an existing map through the v17 migration untouched", async () => {
+      setStoredState({ projectSwitcherCollapsedBands: { other: true } }, 16);
+      const store = await loadStore();
+      expect(store.getState().projectSwitcherCollapsedBands).toEqual({ other: true });
+    });
+
+    it("discards a non-record blob instead of reading it as folded", async () => {
+      // A hand-edited string is truthy for every key it is asked about, which
+      // would open the switcher with nothing on screen and no way back.
+      setStoredState({ projectSwitcherCollapsedBands: "all" }, 17);
+      const store = await loadStore();
+      expect(store.getState().projectSwitcherCollapsedBands).toEqual({});
+    });
+
+    it("keeps the boolean entries of a partly corrupt map and drops the rest", async () => {
+      setStoredState(
+        { projectSwitcherCollapsedBands: { other: true, running: "yes", pinned: false } },
+        17
+      );
+      const store = await loadStore();
+      expect(store.getState().projectSwitcherCollapsedBands).toEqual({
+        other: true,
+        pinned: false,
+      });
+    });
+
+    it("keeps a key it does not recognise rather than dropping the user's fold", async () => {
+      // Keys are free-form on purpose. A band renamed by a newer build leaves an
+      // inert entry, which costs nothing — where validating against today's
+      // closed set would silently discard a fold that build still honours.
+      setStoredState({ projectSwitcherCollapsedBands: { somethingNew: true } }, 17);
+      const store = await loadStore();
+      expect(store.getState().projectSwitcherCollapsedBands).toEqual({ somethingNew: true });
+    });
+  });
+
   describe("keyboardLayoutConfirmationsByBinding (v16 migration, issue #11704)", () => {
     const KEY = "nav.toggleSidebar@Cmd+B";
 

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -133,6 +133,27 @@ interface PreferencesState {
    */
   projectSwitcherOtherSortMode: OtherProjectsSortMode;
   setProjectSwitcherOtherSortMode: (mode: OtherProjectsSortMode) => void;
+  /**
+   * Which project-switcher bands the user has folded away, keyed by band
+   * ({@link PROJECT_SECTION_ORDER}'s members plus `"scratch"`). Global for the
+   * same reason the sort mode above is: it names how the user reads their whole
+   * project set (#11943).
+   *
+   * Keys are free-form strings rather than the band union, matching
+   * `skipPushConfirmByWorktreePath`. Typing them would mean importing the
+   * palette hook's `ProjectSectionKey` into the store, and a band that is later
+   * renamed leaves an inert unused entry either way — which is what
+   * `persistWriteMerge` is built to tolerate.
+   *
+   * Unlike the skip map, an entry is NEVER dropped for looking like a default.
+   * Absent and `false` are different facts here: Scratch's default is dynamic
+   * (collapsed only while it is empty), so deleting the key on expand would
+   * silently re-collapse it on the next open. Storing the explicit boolean is
+   * what makes "the user has chosen" outlive the condition that set the
+   * default — and at eight possible keys there is nothing to garbage-collect.
+   */
+  projectSwitcherCollapsedBands: Record<string, boolean>;
+  setProjectSwitcherBandCollapsed: (bandKey: string, collapsed: boolean) => void;
   setDeletedWorktreeCleanupSeconds: (value: DeletedWorktreeCleanupSeconds) => void;
   /**
    * Basename globs always hidden in the file browser, across every panel. See
@@ -237,14 +258,15 @@ function sanitizePersistedPreferences(
   );
 
   // A truthy non-record value here would otherwise bypass the push-confirm gate.
-  const skip = sanitized.skipPushConfirmByWorktreePath;
-  const validatedSkip: Record<string, boolean> = {};
-  if (skip !== null && typeof skip === "object" && !Array.isArray(skip)) {
-    for (const [key, value] of Object.entries(skip)) {
-      if (typeof value === "boolean") validatedSkip[key] = value;
-    }
-  }
-  sanitized.skipPushConfirmByWorktreePath = validatedSkip;
+  sanitized.skipPushConfirmByWorktreePath = normalizeBooleanMap(
+    sanitized.skipPushConfirmByWorktreePath
+  );
+
+  // Same hazard in the other direction: a hand-edited string would read as
+  // "collapsed" for every band and leave the switcher looking empty.
+  sanitized.projectSwitcherCollapsedBands = normalizeBooleanMap(
+    sanitized.projectSwitcherCollapsedBands
+  );
 
   // A non-boolean here would be truthy for any hand-edited string, retiring the
   // hint for a user who never saw it.
@@ -280,6 +302,7 @@ type PreferencesPersistedState = Pick<
   | "markdownWrapLines"
   | "deletedWorktreeCleanupSeconds"
   | "projectSwitcherOtherSortMode"
+  | "projectSwitcherCollapsedBands"
   | "lastSelectedWorktreeRecipeIdByProject"
   | "skipPushConfirmByWorktreePath"
   | "fileBrowserAlwaysHiddenPatterns"
@@ -305,6 +328,7 @@ const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
   markdownWrapLines: true,
   deletedWorktreeCleanupSeconds: DELETED_WORKTREE_CLEANUP_DEFAULT,
   projectSwitcherOtherSortMode: DEFAULT_OTHER_PROJECTS_SORT_MODE,
+  projectSwitcherCollapsedBands: {},
   lastSelectedWorktreeRecipeIdByProject: {},
   skipPushConfirmByWorktreePath: {},
   fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN],
@@ -331,7 +355,12 @@ function normalizeRecipeMap(value: unknown): Record<string, string | null> {
   return result;
 }
 
-function normalizeSkipMap(value: unknown): Record<string, boolean> {
+/**
+ * Keep only the boolean-valued keys of a persisted string→boolean map. Shared
+ * by every such field: a non-boolean entry is dropped rather than coerced,
+ * because a hand-edited string is truthy and would flip the flag on.
+ */
+function normalizeBooleanMap(value: unknown): Record<string, boolean> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
   const result: Record<string, boolean> = {};
   for (const [key, entry] of Object.entries(value)) {
@@ -432,10 +461,11 @@ function toPreferencesPersisted(
     projectSwitcherOtherSortMode: isOtherProjectsSortMode(raw.projectSwitcherOtherSortMode)
       ? raw.projectSwitcherOtherSortMode
       : d.projectSwitcherOtherSortMode,
+    projectSwitcherCollapsedBands: normalizeBooleanMap(raw.projectSwitcherCollapsedBands),
     lastSelectedWorktreeRecipeIdByProject: normalizeRecipeMap(
       raw.lastSelectedWorktreeRecipeIdByProject
     ),
-    skipPushConfirmByWorktreePath: normalizeSkipMap(raw.skipPushConfirmByWorktreePath),
+    skipPushConfirmByWorktreePath: normalizeBooleanMap(raw.skipPushConfirmByWorktreePath),
     fileBrowserAlwaysHiddenPatterns: sanitizeAlwaysHiddenPatterns(
       raw.fileBrowserAlwaysHiddenPatterns
     ),
@@ -543,6 +573,14 @@ function mergePreferencesPersistedWrite({
         inc.projectSwitcherOtherSortMode,
         disk.projectSwitcherOtherSortMode
       ),
+      // Per-key, not whole-field: two project views each folding a different
+      // band must both survive, and a stale view's snapshot must not carry its
+      // hydration-time copy of a band the sibling has since toggled.
+      projectSwitcherCollapsedBands: mergeRecordByWriterDelta(
+        base.projectSwitcherCollapsedBands,
+        inc.projectSwitcherCollapsedBands,
+        disk.projectSwitcherCollapsedBands
+      ),
       lastSelectedWorktreeRecipeIdByProject: mergeRecordByWriterDelta(
         base.lastSelectedWorktreeRecipeIdByProject,
         inc.lastSelectedWorktreeRecipeIdByProject,
@@ -641,6 +679,19 @@ export const usePreferencesStore = create<PreferencesState>()(
       setDeletedWorktreeCleanupSeconds: (value) => set({ deletedWorktreeCleanupSeconds: value }),
       projectSwitcherOtherSortMode: DEFAULT_OTHER_PROJECTS_SORT_MODE,
       setProjectSwitcherOtherSortMode: (mode) => set({ projectSwitcherOtherSortMode: mode }),
+      projectSwitcherCollapsedBands: {},
+      // Writes the boolean either way — see the field's note on why an expanded
+      // band is stored rather than deleted.
+      setProjectSwitcherBandCollapsed: (bandKey, collapsed) =>
+        set((state) => {
+          if (state.projectSwitcherCollapsedBands[bandKey] === collapsed) return state;
+          return {
+            projectSwitcherCollapsedBands: {
+              ...state.projectSwitcherCollapsedBands,
+              [bandKey]: collapsed,
+            },
+          };
+        }),
       fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN],
       setFileBrowserAlwaysHiddenPatterns: (patterns) =>
         set({ fileBrowserAlwaysHiddenPatterns: sanitizeAlwaysHiddenPatterns(patterns) }),
@@ -686,7 +737,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       storage: createSafeJSONStorage<PreferencesPersistedState>({
         mergeOnWrite: mergePreferencesPersistedWrite,
       }),
-      version: 16,
+      version: 17,
       // Explicit persisted subset — matches the pre-existing default (setters are
       // dropped by JSON serialization); named so the write merge (#11351) has a
       // typed persisted shape to reconcile.
@@ -708,6 +759,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         markdownWrapLines: state.markdownWrapLines,
         deletedWorktreeCleanupSeconds: state.deletedWorktreeCleanupSeconds,
         projectSwitcherOtherSortMode: state.projectSwitcherOtherSortMode,
+        projectSwitcherCollapsedBands: state.projectSwitcherCollapsedBands,
         lastSelectedWorktreeRecipeIdByProject: state.lastSelectedWorktreeRecipeIdByProject,
         skipPushConfirmByWorktreePath: state.skipPushConfirmByWorktreePath,
         fileBrowserAlwaysHiddenPatterns: state.fileBrowserAlwaysHiddenPatterns,
@@ -842,6 +894,13 @@ export const usePreferencesStore = create<PreferencesState>()(
             persisted.keyboardLayoutConfirmationsByBinding = {};
           }
         }
+        if (version < 17 && isRecord(persisted)) {
+          // Only Scratch could be folded before this shipped, and it never
+          // persisted, so everyone starts with every band open (#11943).
+          if (!isRecord(persisted.projectSwitcherCollapsedBands)) {
+            persisted.projectSwitcherCollapsedBands = {};
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -852,5 +911,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; projectSwitcherCollapsedBands: Record<string, boolean>; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
 });


### PR DESCRIPTION
## Summary

Resolves #11943, which bundled three fixes to the project switcher palette's band layout:

- Every browsable band now gets the same collapse chevron the Scratch band already had: Current project, Needs attention, Pinned, Running, Snoozed, Other projects, and Unavailable.
- The collapsed/expanded state persists per band in `preferencesStore` (schema version 17), surviving palette close and app restart. Scratch's fold used to live in a local `useState` that reset every time the palette opened.
- Band header labels dropped their own `px-3`, so they now line up with the left edge of the row cards beneath them instead of sitting 12px further in.

## Why this way

The load-bearing decision is in `useProjectSwitcherPalette`: `results` is the one array that `selectedIndex`, arrow-key stepping, Enter-to-commit, and `aria-activedescendant` all read by index. Issue #11071 was caused by exactly this kind of thing going wrong, a second, narrower list that stranded the keyboard highlight and let Enter commit a project that wasn't even on screen.

Rather than teach `step()` to skip folded rows, this fix keeps folded rows out of `results` entirely. The hook returns separate, row-free band metadata (`browseBands`) so a folded band still keeps its header. That preserves the invariant architecturally instead of patching around it: everything in `results` is on screen, so `step()`, `confirmSelection()`, `activeDescendant`, and the scroll-into-view effect needed no changes. Collapsing the band that holds the current selection just makes the existing read-time `selectedIndex` memo fall back to the first visible row.

Searching ignores the fold completely, including during the deferred-query frame, so a query never skips its own matches.

## Persistence

New field `projectSwitcherCollapsedBands: Record<string, boolean>`, modeled on `skipPushConfirmByWorktreePath`: same sanitizer, persisted `Pick`, defaults, `toPreferencesPersisted`, `partialize`, version-17 migration, registry contract string. It merges per key with `mergeRecordByWriterDelta`, so two project views folding different bands both survive.

One deliberate departure from that precedent: the setter always stores an explicit boolean and never deletes a key. Scratch's default fold state is dynamic (folded while its list is empty), so deleting a key on "expanded" would silently re-fold a band the user deliberately opened. That also let the old effect that auto-expanded Scratch on its first item come out entirely, the derived default handles it now.

## Testing

5,474 tests pass locally across the store, hook, `Project`, `Layout`, and config contract suites. New coverage:

- Folded navigation: rows absent from `results` but headers kept, stepping never lands on an off-screen row, committing with every band folded does nothing, a project inside a folded band is still findable by typing its name.
- Persisted field: version-17 migration, sanitizing a corrupt stored map, an explicit `false` round-tripping correctly, unknown keys preserved.
- Cross-view merge: two views folding different bands each survive, a stale write to one key doesn't resurrect a sibling view's unfold.
- Component: every band shows the collapse affordance, each band's `aria-controls` targets the right element, prop-skew fallback behavior, the veto that keeps pointer-only focus from stealing keyboard focus.

## Known limitations

Calling these out rather than burying them:

- The band fold controls are pointer-only, `tabIndex={-1}`, because section headers live inside `role="listbox"`, where a focusable child isn't valid. That's the same constraint the Other projects band's sort control already lives under. Real keyboard reach needs the `role="group"` to `role="option"`/separator restructure already tracked under #9006, a separate, larger change. Nothing becomes unreachable in the meantime: search ignores the fold, so every project in a folded band is still findable by typing.
- Related and pre-existing: these bands use `role="group"` with `aria-labelledby` inside a listbox, the exact markup #9006 found breaks under VoiceOver on Chromium. Unchanged here and still unresolved upstream as of Chromium 148. Flagging it rather than fixing it, since fixing it means the same restructure and would break the existing `getByRole("group", …)` assertions.
- The Scratch band's `aria-controls` still points at a target that unmounts while it's collapsed. Pre-existing on `develop`, same structure as before.
- With every band folded, "All agents" in the footer shifts a few pixels as the Enter hint and "Right-click for more" drop out. Cosmetic, and only in that fully-collapsed state.
