### PR TITLE
Project switcher: one alignment grid and a leading selection rail

### DIFF
--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -72,19 +72,23 @@ This document maps each interactive component role to its canonical Tailwind cla
 
 ### Selected State (List Item)
 
-**Role:** Selected list item in a picker. A raised neutral fill plus a neutral hairline — no accent, no rail.
+**Role:** Selected list item in a picker. A raised neutral fill plus a neutral leading rail — no accent.
 
 ```tsx
-"palette-row border border-transparent transition-colors aria-selected:bg-overlay-raised aria-selected:border-selection-outline aria-selected:text-daintree-text";
+"palette-row relative border border-transparent transition-colors aria-selected:bg-overlay-raised aria-selected:text-daintree-text";
 ```
 
-**Usage:** Do not respell this — import `PALETTE_ROW_CLASS` from `src/components/ui/paletteRowStyles.ts`, which 16 palette surfaces already share. Selected items do not add hover overlay; unselected items get `hover:bg-overlay-subtle`.
+**Usage:** Do not respell this — import `PALETTE_ROW_CLASS` from `src/components/ui/paletteRowStyles.ts`, which 15 production component files and 17 rendered row definitions already share. Selected items do not add hover overlay; unselected items get `hover:bg-overlay-subtle`.
 
-`selection-outline` is its own semantic token, not a member of the resting border ladder, because it is the row's only non-text indicator and so carries WCAG 1.4.11 alone: `overlay-raised` clears only ~1.1-1.2:1 against the palette surface, far short of 3:1. It is derived from each theme's `text-primary` (42% dark / 53% light) and gated at 3:1 against _both_ the selected fill and the surrounding surface by `getThemeContrastWarnings`. The fill is the binding pair — on dark the row lifts toward the outline, so an outline that looks safe against the surface can still vanish into the row it encloses.
+`selection-outline` is its own semantic token, not a member of the resting border ladder, because it is the row's only non-text indicator and so carries WCAG 1.4.11 alone: `overlay-raised` clears only ~1.1-1.2:1 against the palette surface, far short of 3:1. It is derived from each theme's `text-primary` (42% dark / 53% light) and gated at 3:1 against _both_ the selected fill and the surrounding surface by `getThemeContrastWarnings`. The fill is the binding pair — on dark the row lifts toward the rail, so a rail that looks safe against the surface can still vanish into the row it marks.
 
-The accent border and the 2px accent rail this recipe used to prescribe were removed in #11686: they put accent on the row, its rail and the focused input at once, breaking the one-load-bearing-signal rule. The palette input's focus lift draws the same `selection-outline` (ring at half strength), so the field and the selected row stay one treatment — change them together.
+The token paints a **leading rail**, drawn as `.palette-row::before` in `src/index.css`: 3px wide, `inset-block: 6px`, `inset-inline-start: -1px` so it sits on the card's outer boundary rather than inside its padding. Anything further in lands about 2px from the status mark these rows carry, and the two read as one cluttered gutter. It fades on the same 150ms slot as the fill — cross-fading one and popping the other put the mark on the new row while the surface behind it was still arriving — and `@variant reduce-motion` drops both together, covering the OS preference and Daintree's own toggle.
 
-`palette-row` is a forced-colors hook, not styling. Under `forced-colors: active` both the fill and the outline are stripped, so `src/index.css` falls back to a 2px `SelectedItem` outline. Deliberately an outline rather than a `SelectedItem` fill: these rows carry independently surfaced children (theme "Active" badges, action category chips, panel-kind icons with inline colour) that the engine maps to the forced palette on their own, and a fill would leave them painting `CanvasText` on `SelectedItem` — a pair with no contrast guarantee. The marker scopes the rule to palette rows, since `[role="option"]` is also used by the file pane, the settings selectors and the agent/forge dropdowns.
+Not four sides. The token has to hold 3:1 against both its neighbours, which lands it on a mid-grey stroke; drawn all the way round a row that is _not_ the DOM focus target, that reads as an empty form field. No shipping palette does it — VS Code leaves `list.focusOutline` unset in Quick Open, and Linear, Raycast, Spotlight, Arc and Slack are all fill-led. Making the fill carry 3:1 instead and dropping the mark entirely is not the escape: it needs ~33% white on these surfaces, far heavier than the stroke it replaces. WCAG 1.4.11 sets a ratio, not an area, so spending the same token on a rail is the cheaper way to buy the same guarantee. The reserved transparent border stays — it holds the row's content box on the palette's shared column, and the forced-colors fallback still draws an outline there.
+
+The accent border and the 2px **accent** rail this recipe used to prescribe were removed in #11686: they put accent on the row, its rail and the focused input at once, breaking the one-load-bearing-signal rule. The rail is back, but neutral — accent stays on the focused input alone. The palette input's focus lift draws the same `selection-outline` (ring at half strength), so the field and the selected row stay one treatment — change them together.
+
+`palette-row` is a forced-colors hook, not styling. Under `forced-colors: active` both the fill and the rail are stripped, so `src/index.css` falls back to a 2px `SelectedItem` outline. Deliberately an outline rather than a `SelectedItem` fill: these rows carry independently surfaced children (theme "Active" badges, action category chips, panel-kind icons with inline colour) that the engine maps to the forced palette on their own, and a fill would leave them painting `CanvasText` on `SelectedItem` — a pair with no contrast guarantee. The marker scopes the rule to palette rows, since `[role="option"]` is also used by the file pane, the settings selectors and the agent/forge dropdowns.
 
 ---
 
@@ -245,7 +249,7 @@ Each recipe is a class fragment to apply to a suitable base component, not a sta
 
 | Component | File | Key Pattern |
 | --- | --- | --- |
-| Quick Switcher Item | `QuickSwitcherItem.tsx` | Selected state with accent rail via `before:` |
+| Quick Switcher Item | `QuickSwitcherItem.tsx` | Selected state with neutral rail via `PALETTE_ROW_CLASS` |
 | Settings Input | `SettingsInput.tsx` | Input focus with outline ring |
 | Settings Textarea | `SettingsTextarea.tsx` | Input focus with outline ring |
 | Button Ghost | `button.tsx` (`ghost` variant) | Ghost button hover with overlay-soft |

--- a/docs/themes/theme-tokens.md
+++ b/docs/themes/theme-tokens.md
@@ -83,18 +83,18 @@ Dim or disabled icons must use a solid token (`text-text-muted` for disabled/nee
 
 ## Border Tokens
 
-| Token                | Purpose                             | Dark default | Light default |
-| -------------------- | ----------------------------------- | ------------ | ------------- |
-| `border-default`     | Card outlines, input borders        | Required     | Required      |
-| `border-subtle`      | Panel-internal dividers             | `white 8%`   | `black 5%`    |
-| `border-strong`      | Focused panel borders               | `white 14%`  | `black 14%`   |
-| `border-divider`     | Structural separators               | `white 5%`   | `black 4%`    |
-| `border-interactive` | Hovered/focused interactive borders | `white 20%`  | `black 10%`   |
-| `selection-outline`  | Palette selected-row hairline       | `text 42%`   | `text 53%`    |
+| Token                | Purpose                               | Dark default | Light default |
+| -------------------- | ------------------------------------- | ------------ | ------------- |
+| `border-default`     | Card outlines, input borders          | Required     | Required      |
+| `border-subtle`      | Panel-internal dividers               | `white 8%`   | `black 5%`    |
+| `border-strong`      | Focused panel borders                 | `white 14%`  | `black 14%`   |
+| `border-divider`     | Structural separators                 | `white 5%`   | `black 4%`    |
+| `border-interactive` | Hovered/focused interactive borders   | `white 20%`  | `black 10%`   |
+| `selection-outline`  | Palette selected-row leading-rail ink | `text 42%`   | `text 53%`    |
 
 **Polarity pattern:** Dark themes use white-alpha; light themes use black-alpha.
 
-**`selection-outline` is deliberately outside that ladder.** It is derived from `text-primary` rather than the border ink, and sits 2-3x above `border-strong`, because it is the only border in the app that must satisfy WCAG 1.4.11 on its own — the raised fill it encloses clears barely 1.1-1.2:1 against the palette surface, so the outline is the whole non-text indicator. `getThemeContrastWarnings` gates it at 3:1 against both the selected fill and the surrounding surface, so retuning `text-primary` or the fill trips the theme contract rather than silently weakening the indicator. See [interaction-state-recipes.md](./interaction-state-recipes.md#selected-state-list-item).
+**`selection-outline` is deliberately outside that ladder.** The name is historical — the token drew an outline around all four sides of the selected row before the geometry moved to a leading rail; the job did not change. It is derived from `text-primary` rather than the border ink, and sits 2-3x above `border-strong`, because it is the only selection mark in the app that must satisfy WCAG 1.4.11 on its own — the raised fill it marks clears barely 1.1-1.2:1 against the palette surface, so the rail is the whole non-text indicator. The rail sits on the row's boundary, touching the fill on one side and the surrounding palette surface on the other, and `getThemeContrastWarnings` gates it at 3:1 against both — so retuning `text-primary` or the fill trips the theme contract rather than silently weakening the indicator. See [interaction-state-recipes.md](./interaction-state-recipes.md#selected-state-list-item).
 
 ## Accent Tokens
 

--- a/e2e/screenshots/theme-tour.spec.ts
+++ b/e2e/screenshots/theme-tour.spec.ts
@@ -470,7 +470,7 @@ const SCENES: TourScene[] = [
   {
     id: "action-palette",
     label: "Action palette",
-    note: "Selected row = raised fill + selection-outline, no accent. Is the selected row unambiguous?",
+    note: "Selected row = raised fill + neutral leading rail (`selection-outline`), no accent. Is the selected row unambiguous?",
     run: async (page) => {
       const dialog = page.locator(SEL.actionPalette.dialog);
       // Double-Shift is the only route to THIS palette. The Cmd/Ctrl+K fallback

--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -385,7 +385,7 @@ describe("getThemeContrastWarnings", () => {
       const selectionFailures = warnings.filter((w) => w.message.includes("selection-outline"));
       expect(
         selectionFailures,
-        `${scheme.id}: selection-outline is the palette row's only non-text indicator and must hit 3:1`
+        `${scheme.id}: selection-outline is the palette row's only non-text indicator (a leading rail) and must hit 3:1`
       ).toHaveLength(0);
     }
   });
@@ -404,10 +404,10 @@ describe("getThemeContrastWarnings", () => {
     });
   }
 
-  it("fails an outline that clears the surrounding surface but not the row fill it encloses", () => {
-    // The row lifts towards the outline on dark, so the surface pair is the
-    // permissive one — an outline can pass it while vanishing into the fill it
-    // actually borders. #5A5A5A is 3.04:1 on black and 1.52:1 on #767676.
+  it("fails a rail that clears the surrounding surface but not the row fill it touches", () => {
+    // The row lifts towards the rail on dark, so the surface pair is the
+    // permissive one — a rail can pass it while vanishing into the fill it
+    // touches. #5A5A5A is 3.04:1 on black and 1.52:1 on #767676.
     const scheme = makeFlatDarkScheme({
       "overlay-raised": "#767676" as AppColorSchemeTokens["overlay-raised"],
       "selection-outline": "#5A5A5A" as AppColorSchemeTokens["selection-outline"],
@@ -434,7 +434,7 @@ describe("getThemeContrastWarnings", () => {
     expect(messages.some((m) => m.includes("the surrounding palette surface"))).toBe(true);
   });
 
-  it("composites an rgba outline over the row fill rather than reading its raw alpha", () => {
+  it("composites an rgba rail token over the row fill rather than reading its raw alpha", () => {
     // Opaque white would score 16.67:1 on this fill and sail through; at 10%
     // alpha the pixel that actually renders is #353535, which is 1.36:1.
     const scheme = makeFlatDarkScheme({
@@ -447,7 +447,7 @@ describe("getThemeContrastWarnings", () => {
     expect(failures).toHaveLength(1);
   });
 
-  it("composites an alpha-hex outline instead of reading it as opaque", () => {
+  it("composites an alpha-hex rail token instead of reading it as opaque", () => {
     // `#FFFFFF10` is 6% white. Read as opaque it would score 19.30:1 and pass;
     // the pixel that renders is #1D1D1D on this fill.
     const scheme = makeFlatDarkScheme({
@@ -460,7 +460,7 @@ describe("getThemeContrastWarnings", () => {
     expect(failures).toHaveLength(1);
   });
 
-  it("reports the palette selection check as unevaluable when the outline is not hex or rgba", () => {
+  it("reports the palette selection check as unevaluable when the rail token is not hex or rgba", () => {
     const scheme = makeScheme({
       "selection-outline":
         "color-mix(in oklab, #ffffff 42%, transparent)" as AppColorSchemeTokens["selection-outline"],

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -570,7 +570,7 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
     }
   }
 
-  // Palette selected-row indicator (#11686) — the outline is the whole non-text
+  // Palette selected-row indicator (#11686) — the rail is the whole non-text
   // signal there, so it carries 1.4.11 on its own.
   warnings.push(...getPaletteSelectionWarnings(scheme));
   warnings.push(...getRecentActivityDotWarnings(scheme));
@@ -601,7 +601,7 @@ const ACCENT_OUTLINE_MIN_CONTRAST = 3.0;
 // sidebar is the flattering end of the range, not the conservative one. The
 // backdrop isn't knowable here, so we score against all of them and keep the
 // worst: a lighter backdrop lifts the surface and the fill together and closes
-// the gap the outline has to hold.
+// the gap the rail has to hold.
 const DARK_PALETTE_BACKDROPS: AppThemeTokenKey[] = [
   "surface-grid",
   "surface-canvas",
@@ -628,9 +628,9 @@ function resolvePaletteSurfaces(scheme: AppColorScheme): string[] | null {
   ];
 }
 
-const SELECTION_OUTLINE_MIN_CONTRAST = 3.0;
+const SELECTION_RAIL_MIN_CONTRAST = 3.0;
 
-/** WCAG 1.4.11's non-text floor, same basis as the selection outline above. */
+/** WCAG 1.4.11's non-text floor, same basis as the selection rail above. */
 const RECENT_ACTIVITY_DOT_MIN_CONTRAST = 3.0;
 
 // The pixel a token actually paints when it lands on `backdrop`. Tokens reach us
@@ -674,9 +674,11 @@ function splitHexAlpha(hex: string): { hex: string; opacity: number } | null {
 // WCAG 1.4.11 for the palette selected row. The raised fill clears barely
 // 1.1-1.2:1 against the surface in every built-in theme, so it cannot be the
 // indicator; `selection-outline` is, and it has to hold 3:1 against BOTH
-// neighbours it touches. The fill is the binding one — on dark the row lifts
-// *towards* the outline, so the pair that looks safe against the surrounding
-// surface can still fail against the row it encloses.
+// neighbours it touches. The token paints a leading rail sitting on the row's
+// boundary, so it really does touch both: the fill on one side, the surrounding
+// surface on the other. The fill is the binding one — on dark the row lifts
+// *towards* the rail, so the pair that looks safe against the surrounding
+// surface can still fail against the row it marks.
 /**
  * The switcher's "agents will resume" dot is a filled `text-secondary` disc
  * drawn in the project row's status slot (#11791, re-pointed by #11801).
@@ -756,7 +758,7 @@ function getRecentActivityDotWarnings(scheme: AppColorScheme): AppThemeValidatio
 
 function getPaletteSelectionWarnings(scheme: AppColorScheme): AppThemeValidationWarning[] {
   const warnings: AppThemeValidationWarning[] = [];
-  const outlineToken = scheme.tokens["selection-outline"];
+  const railToken = scheme.tokens["selection-outline"];
   const fillToken = scheme.tokens["overlay-raised"];
 
   const surfaces = resolvePaletteSurfaces(scheme);
@@ -785,11 +787,11 @@ function getPaletteSelectionWarnings(scheme: AppColorScheme): AppThemeValidation
       return warnings;
     }
 
-    const outline = resolveOverBackdrop(outlineToken, fill);
-    if (outline === null) {
+    const rail = resolveOverBackdrop(railToken, fill);
+    if (rail === null) {
       warnings.push({
         kind: "unevaluable",
-        message: `Cannot evaluate palette selection contrast: selection-outline="${outlineToken}" is neither hex nor rgba()`,
+        message: `Cannot evaluate palette selection contrast: selection-outline="${railToken}" is neither hex nor rgba()`,
       });
       return warnings;
     }
@@ -798,17 +800,17 @@ function getPaletteSelectionWarnings(scheme: AppColorScheme): AppThemeValidation
       ["the selected row fill", fill],
       ["the surrounding palette surface", surface],
     ] as const) {
-      const ratio = contrastRatio(outline, against);
+      const ratio = contrastRatio(rail, against);
       const seen = worstByLabel.get(label);
       if (seen === undefined || ratio < seen) worstByLabel.set(label, ratio);
     }
   }
 
   for (const [label, ratio] of worstByLabel) {
-    if (ratio < SELECTION_OUTLINE_MIN_CONTRAST) {
+    if (ratio < SELECTION_RAIL_MIN_CONTRAST) {
       warnings.push({
         kind: "low-contrast",
-        message: `selection-outline against ${label} is ${ratio.toFixed(2)}:1; target is ${SELECTION_OUTLINE_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
+        message: `selection-outline against ${label} is ${ratio.toFixed(2)}:1; target is ${SELECTION_RAIL_MIN_CONTRAST.toFixed(1)}:1 (WCAG 1.4.11 Non-text Contrast)`,
       });
     }
   }

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -28,12 +28,15 @@ export const APP_THEME_TOKEN_KEYS = [
   "border-strong",
   "border-divider",
   "border-interactive",
-  // The hairline that marks "this is the row Enter will act on" in the palettes.
+  // The ink of the leading rail that marks "this is the row Enter will act on"
+  // in the palettes. Named for the outline it used to draw around all four sides
+  // of the row; the geometry moved to a rail, the job did not.
+  //
   // Its own key rather than a reuse of `border-strong` because it is the only
-  // border in the app that has to satisfy WCAG 1.4.11 on its own: the raised
-  // fill it sits on clears barely 1.1-1.2:1 against the palette surface, so the
-  // outline is the whole non-text indicator and carries the full 3:1. That puts
-  // it 2-3x above the resting border ladder, which is tuned for separation
+  // mark of its kind in the app that has to satisfy WCAG 1.4.11 on its own: the
+  // raised fill it sits on clears barely 1.1-1.2:1 against the palette surface,
+  // so the rail is the whole non-text indicator and carries the full 3:1. That
+  // puts it 2-3x above the resting border ladder, which is tuned for separation
   // rather than for being the sole signal.
   "selection-outline",
 

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -245,7 +245,7 @@ export function Sidebar({
         {projectId != null && (
           <ContextMenuActionItem actionId="project.settings.open">
             <Settings className={ICON_CLASS} />
-            Project Settings…
+            Project settings…
           </ContextMenuActionItem>
         )}
         <ContextMenuSeparator />

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -21,11 +21,16 @@ import {
   X,
   AppWindow,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Moon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
-import { PALETTE_ROW_CLASS, PALETTE_SECTION_LABEL_CLASS } from "@/components/ui/paletteRowStyles";
+import {
+  PALETTE_ROW_CLASS,
+  PALETTE_ROW_FOCUS_CLASS,
+  PALETTE_SECTION_LABEL_CLASS,
+} from "@/components/ui/paletteRowStyles";
 import { KbdChord } from "@/components/ui/Kbd";
 import { AppPalettePopover } from "@/components/ui/AppPalettePopover";
 import {
@@ -619,7 +624,7 @@ function ProjectListItem({
       aria-current={project.isActive ? "true" : undefined}
       className={cn(
         PALETTE_ROW_CLASS,
-        "group w-full flex items-center gap-2 px-3 py-1 rounded-[var(--radius-md)] text-left cursor-pointer",
+        "group w-full flex items-center gap-2 px-2 py-1 rounded-[var(--radius-md)] text-left cursor-pointer",
         project.isActive
           ? // Hover still has to answer: the band wash used to sit under this
             // row permanently, which both marked it and made it look hovered
@@ -644,7 +649,7 @@ function ProjectListItem({
       <div
         className={cn(
           // Wash/shadow var fallbacks keep themes without the overrides byte-identical.
-          "flex items-center justify-center rounded-[var(--radius-lg)] shadow-[var(--project-tile-shadow,inset_0_1px_2px_rgba(0,0,0,0.3))] shrink-0 transition duration-150",
+          "flex items-center justify-center rounded-[var(--radius-lg)] shadow-[var(--project-tile-shadow,inset_0_1px_2px_rgba(0,0,0,0.3))] shrink-0",
           "h-8 w-8 text-base"
         )}
         style={{
@@ -661,7 +666,11 @@ function ProjectListItem({
           <span
             className={cn(
               "truncate text-sm font-semibold leading-tight",
-              project.isActive || isSelected ? "text-daintree-text" : "text-daintree-text/85"
+              project.isMissing
+                ? "text-daintree-text/50"
+                : project.isActive || isSelected
+                  ? "text-daintree-text"
+                  : "text-daintree-text/85"
             )}
           >
             {project.name}
@@ -839,7 +848,7 @@ function ScratchListItem({
       aria-current={scratch.isActive ? "true" : undefined}
       className={cn(
         PALETTE_ROW_CLASS,
-        "group w-full flex items-center gap-2 px-3 py-1 rounded-[var(--radius-md)] text-left cursor-pointer",
+        "group w-full flex items-center gap-2 px-2 py-1 rounded-[var(--radius-md)] text-left cursor-pointer",
         scratch.isActive
           ? "text-daintree-text hover:bg-overlay-subtle"
           : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
@@ -848,9 +857,7 @@ function ScratchListItem({
     >
       <StatusDot status={status} showResumeDot={showResumeDot} />
 
-      <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
-        <FileText className="h-4 w-4" aria-hidden="true" />
-      </div>
+      <CommandTile icon={FileText} tone="manage" />
       <div className="flex-1 min-w-0">
         {/*
          * Origin rides the name, not the status line. In the ranked list a
@@ -861,7 +868,14 @@ function ScratchListItem({
          * is the second line #11692 is trying to give back.
          */}
         <div className="flex items-baseline gap-1 min-w-0">
-          <span className="truncate text-sm font-semibold leading-tight">{scratch.name}</span>
+          <span
+            className={cn(
+              "truncate text-sm font-semibold leading-tight",
+              scratch.isActive || isSelected ? "text-daintree-text" : "text-daintree-text/85"
+            )}
+          >
+            {scratch.name}
+          </span>
           <span className="text-[11px] leading-none text-daintree-text/50 shrink-0">· Scratch</span>
           {scratch.isActive && <span className="sr-only">, current</span>}
           {showResumeDot && <ResumableAgentsLabel count={scratch.resumableAgentCount ?? 0} />}
@@ -1045,7 +1059,7 @@ function OtherProjectsHeader({
           role="presentation"
           className={cn(
             PALETTE_SECTION_LABEL_CLASS,
-            "flex items-center justify-between gap-2 py-1 normal-case tracking-normal"
+            "flex items-center justify-between gap-2 px-2 py-1 normal-case tracking-normal"
           )}
         >
           {collapsible ? (
@@ -1140,8 +1154,21 @@ interface ProjectListContentProps {
   query: string;
   onSelect: (row: ProjectSwitcherRow) => void;
   listRef: React.RefObject<HTMLDivElement | null>;
-  /** Whether this surface offers "Add Project…" — decides what the empty state can name. */
+  /** Whether this surface offers "Add project…" — decides what the empty state can name. */
   canAddProject: boolean;
+  /**
+   * Whether the Scratch band below this list offers a create row. It decides
+   * which action an empty list is allowed to name — the modal mounts without
+   * the project commands but keeps Scratch, so pointing at the File menu there
+   * sent the reader out of the app past a button two rows down.
+   */
+  canCreateScratch: boolean;
+  /**
+   * True when browse has scratches but no projects, which makes the Scratch
+   * band the palette's first content. The instructional empty state stands down
+   * for it — printed above real rows it contradicts them.
+   */
+  scratchesStandAlone: boolean;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
   onSleepProject?: (projectId: string) => void;
@@ -1164,6 +1191,8 @@ function ProjectListContent({
   onSelect,
   listRef,
   canAddProject,
+  canCreateScratch,
+  scratchesStandAlone,
   onStopProject,
   onCloseProject,
   onSleepProject,
@@ -1309,7 +1338,6 @@ function ProjectListContent({
       <div ref={listRef} id="project-list" role="listbox" aria-label="Workspaces">
         {sections && sections.length > 0 ? (
           sections.map((section, sectionIdx) => {
-            const isLast = sectionIdx === sections.length - 1;
             const headerId = `project-section-${section.key}`;
             const listId = bandListId(section.key);
             const toggle = () => setBandCollapsed(section.key, !section.collapsed);
@@ -1325,7 +1353,14 @@ function ProjectListContent({
                 <div
                   role="group"
                   aria-labelledby={headerId}
-                  className={cn("px-2 py-1.5", sectionIdx === 0 && "pt-2", isLast && "pb-2")}
+                  /*
+                   * One value on all four bands. The first/last overrides used
+                   * to buy the run of bands some end padding, but the scroller
+                   * carries that now — and while they were here a folded last
+                   * band sat 8px below its own label and 4px above it, which is
+                   * exactly the lopsided gap a collapsed band makes obvious.
+                   */
+                  className="px-1 py-1"
                 >
                   {section.key === "other" ? (
                     <OtherProjectsHeader
@@ -1341,10 +1376,11 @@ function ProjectListContent({
                     <div
                       className={cn(
                         PALETTE_SECTION_LABEL_CLASS,
-                        // No `px-*`: the wrapper's `px-2` above is the inset the
-                        // row cards below are drawn from, so any padding here
-                        // would push the label off the line they share (#11943).
-                        "flex items-center justify-between gap-2 py-1"
+                        // `px-2` matches the row padding below rather than the
+                        // wrapper's old inset: both now start from the bare band
+                        // edge, so the label and the rows' status column share
+                        // the palette's 12px rail (#11943).
+                        "flex items-center justify-between gap-2 px-2 py-1"
                       )}
                     >
                       {section.collapsible ? (
@@ -1374,28 +1410,34 @@ function ProjectListContent({
             );
           })
         ) : results.length === 0 ? (
-          <div className="p-2">
-            <div
-              className="px-3 py-8 text-center text-daintree-text/50 text-sm"
-              data-testid="project-empty-state"
-            >
-              {query.trim() ? (
-                // "Workspaces", not "projects": scratches are ranked into this
-                // same list now, so naming only half of what was searched would
-                // read as a scratch still being findable somewhere else.
-                <div>{`No workspaces match "${query}"`}</div>
-              ) : canAddProject ? (
-                // Names the button sitting directly below this list.
-                "Add a project to get started"
-              ) : (
-                // The modal mounts without the add/clone callbacks, so naming
-                // them here would point at an action this surface can't run.
-                "Open a project from the File menu to get started"
-              )}
+          scratchesStandAlone ? null : (
+            <div className="px-1 py-1">
+              <div
+                className="px-2 py-8 text-center text-daintree-text/50 text-sm"
+                data-testid="project-empty-state"
+              >
+                {query.trim() ? (
+                  // "Workspaces", not "projects": scratches are ranked into this
+                  // same list now, so naming only half of what was searched would
+                  // read as a scratch still being findable somewhere else.
+                  <div>{`No workspaces match "${query}"`}</div>
+                ) : canAddProject ? (
+                  // Names the button sitting directly below this list.
+                  "Add a project to get started"
+                ) : canCreateScratch ? (
+                  // No project commands on this surface, but Scratch is still
+                  // here — so the nearest action is the create row, not a menu.
+                  "Create a scratch workspace to get started"
+                ) : (
+                  // Nothing on this surface can open anything, so the only honest
+                  // instruction points outside it.
+                  "Open a project from the File menu to get started"
+                )}
+              </div>
             </div>
-          </div>
+          )
         ) : (
-          <div className="p-2" role="presentation">
+          <div className="px-1 py-1" role="presentation">
             {results.map((project) => renderItem(project))}
           </div>
         )}
@@ -1427,6 +1469,13 @@ interface ScratchNameEditorProps {
   onCommit: (name: string) => void;
   onCancel: () => void;
   testId: string;
+  /**
+   * Spacing the editor inherits from whatever it stands in for. A rename editor
+   * replaces a row in the run and takes nothing; the create editor replaces the
+   * separated create action and takes its `mt-1`, so starting to type doesn't
+   * shunt the list by 4px.
+   */
+  className?: string;
 }
 
 /**
@@ -1442,6 +1491,7 @@ function ScratchNameEditor({
   onCommit,
   onCancel,
   testId,
+  className,
 }: ScratchNameEditorProps) {
   const [value, setValue] = useState(initialValue);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -1485,10 +1535,14 @@ function ScratchNameEditor({
   );
 
   return (
-    <div className="w-full flex items-center gap-3 px-3 py-2 mt-1 rounded-[var(--radius-md)]">
-      <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
-        <FileText className="h-4 w-4" />
-      </div>
+    <div
+      className={cn(
+        "w-full flex items-center gap-2 px-2 py-1 rounded-[var(--radius-md)] border border-transparent",
+        className
+      )}
+    >
+      <StatusSlotSpacer />
+      <CommandTile icon={FileText} tone="manage" />
       <input
         ref={inputRef}
         data-scratch-name-input=""
@@ -1605,7 +1659,7 @@ function ScratchSection({
   const isCreating = editor?.kind === "create";
 
   return (
-    <div className="px-2 py-1.5" hidden={isSearching}>
+    <div className="px-1 py-1" hidden={isSearching}>
       {/*
        * The trigger stays mounted at zero scratches — only the menu content is
        * conditional. Swapping the button in and out of a ContextMenu as the last
@@ -1620,10 +1674,11 @@ function ScratchSection({
             onClick={() => setBandCollapsed(PROJECT_SWITCHER_SCRATCH_BAND_KEY, !collapsed)}
             className={cn(
               PALETTE_SECTION_LABEL_CLASS,
-              // No `px-*` — the wrapper's `px-2` is the inset the rows below are
-              // drawn from, and a second one here floats the label off it
-              // (#11943).
-              "w-full flex items-center justify-between gap-2 py-1 hover:text-daintree-text/60 transition-colors"
+              // `px-2` like the project bands' labels: the wrapper no longer
+              // carries the inset, so the label draws its own and lands on the
+              // same rail as the rows below it (#11943).
+              "w-full flex items-center justify-between gap-2 px-2 py-1 hover:text-daintree-text/60 transition-colors",
+              PALETTE_ROW_FOCUS_CLASS
             )}
             aria-expanded={!collapsed}
             aria-controls="scratch-section-list"
@@ -1649,10 +1704,10 @@ function ScratchSection({
         )}
       </ContextMenu>
       {!collapsed && (
-        <div id="scratch-section-list" className="mt-1">
+        <div id="scratch-section-list">
           {scratches.length === 0 ? (
-            <div className="px-3 py-2 text-xs text-daintree-text/40">
-              No scratch workspaces yet. Create one for a quick one-off task.
+            <div className="px-2 py-1 text-xs text-daintree-text/40">
+              Create a scratch workspace for a quick one-off task
             </div>
           ) : (
             <div role="listbox" aria-label="Scratch workspaces">
@@ -1686,8 +1741,19 @@ function ScratchSection({
                         type="button"
                         onClick={() => onSelect?.(scratch)}
                         className={cn(
-                          "w-full flex items-center gap-2 px-3 py-1 rounded-[var(--radius-md)] text-left transition-colors",
-                          scratch.isActive ? "bg-overlay-subtle" : "hover:bg-overlay-subtle"
+                          "w-full flex items-center gap-2 px-2 py-1 rounded-[var(--radius-md)] text-left transition-colors",
+                          scratch.isActive
+                            ? "text-daintree-text"
+                            : "text-daintree-text/70 hover:text-daintree-text",
+                          // Reserved like `PALETTE_ROW_CLASS` does, though this
+                          // row never draws one: the ranked scratch rows carry a
+                          // border, and without it here the same scratch shifted
+                          // 1px sideways between browse and search.
+                          "border border-transparent",
+                          PALETTE_ROW_FOCUS_CLASS,
+                          scratch.isActive
+                            ? "bg-overlay-subtle hover:bg-overlay-medium"
+                            : "hover:bg-overlay-subtle"
                         )}
                         role="option"
                         // No `aria-current` here, unlike the ranked rows above.
@@ -1698,11 +1764,14 @@ function ScratchSection({
                         aria-selected={scratch.isActive}
                       >
                         <StatusDot status={status} showResumeDot={showResumeDot} />
-                        <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
-                          <FileText className="h-4 w-4" aria-hidden="true" />
-                        </div>
+                        <CommandTile icon={FileText} tone="manage" />
                         <div className="flex-1 min-w-0">
-                          <div className="text-sm font-medium truncate leading-tight">
+                          <div
+                            className={cn(
+                              "truncate text-sm font-semibold leading-tight",
+                              scratch.isActive ? "text-daintree-text" : "text-daintree-text/85"
+                            )}
+                          >
                             {scratch.name}
                             {/*
                              * Inside the name element, not after it: this row
@@ -1789,6 +1858,7 @@ function ScratchSection({
                 initialValue={defaultScratchName(new Date())}
                 ariaLabel="Name for the new scratch workspace"
                 testId="scratch-create-input"
+                className="mt-1"
                 onCommit={handleCreateCommit}
                 onCancel={closeEditor}
               />
@@ -1796,15 +1866,17 @@ function ScratchSection({
               <button
                 type="button"
                 onClick={() => setEditor({ kind: "create" })}
-                className="w-full flex items-center gap-3 px-3 py-2 mt-1 rounded-[var(--radius-md)] text-left transition-colors hover:bg-overlay-subtle"
+                className={cn(
+                  "w-full flex items-center gap-2 px-2 py-1 mt-1 rounded-[var(--radius-md)] text-left transition-colors",
+                  "border border-transparent text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text",
+                  PALETTE_ROW_FOCUS_CLASS
+                )}
                 data-testid="scratch-create-button"
               >
-                <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
-                  <Plus className="h-4 w-4" />
-                </div>
-                <span className="font-medium text-sm text-muted-foreground">
-                  New scratch workspace
-                </span>
+                {/* Keeps the tile on the workspace column the scratches above use. */}
+                <StatusSlotSpacer />
+                <CommandTile icon={Plus} tone="create" />
+                <span className="font-medium text-sm leading-tight">New scratch workspace…</span>
               </button>
             ))}
           {/*
@@ -1817,11 +1889,21 @@ function ScratchSection({
             <button
               type="button"
               onClick={onDeleteAll}
-              className="w-full flex items-center gap-2 px-3 py-1.5 mt-1 rounded-[var(--radius-md)] text-left text-xs font-medium text-status-error transition-colors hover:bg-status-error/10"
+              className={cn(
+                // A grid, not a flex run: the row is deliberately shorter than
+                // the ones above it, so it has no 32px tile to push its label
+                // out to their text column. The middle track stands in for the
+                // tile and centres the smaller glyph inside it.
+                "w-full grid grid-cols-[0.5rem_2rem_minmax(0,1fr)] items-center gap-x-2",
+                "px-2 py-1.5 mt-1 rounded-[var(--radius-md)] border border-transparent text-left",
+                "text-xs font-medium text-status-error transition-colors hover:bg-status-error/10",
+                PALETTE_ROW_FOCUS_CLASS
+              )}
               data-testid="scratch-delete-all-button"
             >
-              <Trash2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-              Delete all scratch workspaces
+              <span aria-hidden="true" />
+              <Trash2 className="h-3.5 w-3.5 justify-self-center" aria-hidden="true" />
+              <span className="truncate">Delete all scratch workspaces</span>
             </button>
           )}
         </div>
@@ -1927,8 +2009,89 @@ function ProjectSwitcherFooter({
  * global `outline-offset: 2px !important` would otherwise push the ring back
  * out past that same edge.
  */
-const PROJECT_ACTION_ROW_CLASS =
-  "palette-command-row w-full flex items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent";
+/**
+ * The 32x32 icon tile every non-workspace row wears.
+ *
+ * Two treatments, and the split is semantic rather than decorative: `manage`
+ * acts on something that already exists, `create` brings something new in and
+ * wears the dashed outline that has always marked an add affordance here. Both
+ * ride the audited overlay ladder rather than a raw tint/muted alpha, so they
+ * hold their separation from the row underneath in every theme.
+ */
+function CommandTile({ icon: Icon, tone }: { icon: LucideIcon; tone: "manage" | "create" }) {
+  return (
+    <div
+      className={cn(
+        "flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-lg)] text-daintree-text/50",
+        tone === "create"
+          ? "border border-dashed border-border-strong bg-overlay-soft"
+          : "bg-overlay-medium"
+      )}
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+    </div>
+  );
+}
+
+/**
+ * A palette-level command: the actions under the divider, which act on the
+ * project list rather than on a workspace in it.
+ *
+ * Full-bleed rather than a card, because the cards above it are the arrow-key
+ * domain and these rows are reached by Tab. That distinction is carried by the
+ * focus ring, not by the shape — the shape only says which half of the palette
+ * a row belongs to.
+ */
+function ProjectCommandRow({
+  icon,
+  tone,
+  label,
+  onClick,
+  testId,
+}: {
+  icon: LucideIcon;
+  tone: "manage" | "create";
+  label: string;
+  onClick: () => void;
+  testId?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={PROJECT_ACTION_ROW_CLASS}
+      data-testid={testId}
+    >
+      <StatusSlotSpacer />
+      <CommandTile icon={icon} tone={tone} />
+      <span className="font-medium text-sm leading-tight">{label}</span>
+    </button>
+  );
+}
+
+/**
+ * The empty stand-in for `StatusDot` on a row that has no status to report.
+ *
+ * Every row in this palette puts its tile on one column, and on a workspace row
+ * that column is reached across an 8px status mark. A create/command row has no
+ * mark, so without this its tile climbed 16px left and the palette grew a
+ * second icon column for its actions (#11947).
+ */
+function StatusSlotSpacer() {
+  return <div className="w-2 h-2 shrink-0" aria-hidden="true" />;
+}
+
+const PROJECT_ACTION_ROW_CLASS = cn(
+  "palette-command-row w-full flex items-center gap-2 px-3 py-2 text-left transition-colors",
+  // Horizontal only. The rows above reserve a full border for their selected
+  // state, and matching it here keeps the two families' content boxes on the
+  // same pixel — but nothing ever draws a border on a command row, so the
+  // vertical halves were 2px of pure height, pushing the block off the 48px
+  // its tile and `py-2` add up to.
+  "border-x border-transparent",
+  "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text",
+  PALETTE_ROW_FOCUS_CLASS
+);
 
 interface ProjectPaletteInnerProps {
   inputRef: React.RefObject<HTMLInputElement | null>;
@@ -2101,6 +2264,10 @@ function ProjectPaletteInner({
   // that frame — and for a user whose only workspaces are scratches, that frame
   // reads as "no matches".
   const isRankedSearch = rankedSearch ?? query.trim().length > 0;
+  const hasProjectPresentation =
+    (browseBands?.length ?? 0) > 0 || results.some((row) => row.kind === "project");
+  const scratchesStandAlone =
+    !isRankedSearch && !hasProjectPresentation && (scratchResults?.length ?? 0) > 0;
 
   useWaitAgeTick(results.length > 0 || (scratchResults?.length ?? 0) > 0);
 
@@ -2134,7 +2301,38 @@ function ProjectPaletteInner({
       </AppPaletteDialog.Header>
 
       <AppPaletteDialog.Body
-        className="p-0"
+        /*
+         * The shell's 144px floor is a stability device for typing: it seats
+         * three rows so a narrowing result list doesn't resize the palette on
+         * every keystroke. Browse never narrows, and there the floor only
+         * propped the body open past its content — a fully folded list left its
+         * last band a hundred-odd pixels above the rule below it, which is the
+         * one gap in the palette the band padding couldn't answer for.
+         */
+        className={cn(
+          // The shell transitions `height`, but the property that actually
+          // changes between these two states is `min-height` — left off the
+          // list, clearing the query dropped the floor in one frame.
+          "p-0 transition-[height,min-height]",
+          !isRankedSearch && "min-h-0"
+        )}
+        /*
+         * No padding of its own — the bands carry all of it. Both halves matter.
+         *
+         * Horizontally, the band dividers are children of this scroller while
+         * the header and footer rules are not, so any inset here drew the
+         * palette's internal rules 4px shorter than its chrome rules. They are
+         * the same hairline doing the same job and have to be the same width.
+         *
+         * Vertically, this padding stacked on top of the first and last band's
+         * own, leaving the first band 4px lower than every band after it — the
+         * one rule-to-label gap in the palette that didn't match the rest.
+         *
+         * `space-y-0` for the same reason: the inherited 4px landed on one side
+         * of each divider only, so every rule sat off centre between the two
+         * bands it separates.
+         */
+        scrollClassName="space-y-0"
         ariaLabel="Workspaces"
         activeDescendant={activeDescendant}
         onNavigationKeyDown={handleKeyDown}
@@ -2147,6 +2345,8 @@ function ProjectPaletteInner({
           onSelect={onSelect}
           listRef={listRef}
           canAddProject={Boolean(onAddProject)}
+          canCreateScratch={Boolean(onCreateScratch)}
+          scratchesStandAlone={scratchesStandAlone}
           onStopProject={onStopProject}
           onCloseProject={onCloseProject}
           onSleepProject={onSleepProject}
@@ -2161,7 +2361,8 @@ function ProjectPaletteInner({
         />
         {(onCreateScratch || (scratchResults && scratchResults.length > 0)) && (
           <>
-            <AppPaletteDialog.Divider hidden={isRankedSearch} />
+            {/* Nothing above it to separate from once Scratch is the first content. */}
+            <AppPaletteDialog.Divider hidden={isRankedSearch || scratchesStandAlone} />
             <ScratchSection
               scratches={scratchResults ?? []}
               isSearching={isRankedSearch}
@@ -2179,58 +2380,40 @@ function ProjectPaletteInner({
       {(onOpenProjectSettings || onAddProject || onCloneRepo || onCreateFolder) && (
         <>
           <AppPaletteDialog.Divider />
-          <div className="py-2">
+          <div>
             {onOpenProjectSettings && (
-              <button
-                type="button"
-                onClick={() => onOpenProjectSettings()}
-                className={PROJECT_ACTION_ROW_CLASS}
-              >
-                <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground">
-                  <Settings2 className="h-4 w-4" />
-                </div>
-                <span className="font-medium text-sm text-muted-foreground">Project Settings…</span>
-              </button>
+              <ProjectCommandRow
+                icon={Settings2}
+                tone="manage"
+                label="Project settings…"
+                onClick={onOpenProjectSettings}
+              />
             )}
             {onAddProject && (
-              <button
-                type="button"
-                onClick={() => onAddProject()}
-                className={PROJECT_ACTION_ROW_CLASS}
-                data-testid="project-add-button"
-              >
-                <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
-                  <Plus className="h-4 w-4" />
-                </div>
-                <span className="font-medium text-sm text-muted-foreground">Add Project…</span>
-              </button>
+              <ProjectCommandRow
+                icon={Plus}
+                tone="create"
+                label="Add project…"
+                onClick={onAddProject}
+                testId="project-add-button"
+              />
             )}
             {onCloneRepo && (
-              <button
-                type="button"
-                onClick={() => onCloneRepo()}
-                className={PROJECT_ACTION_ROW_CLASS}
-                data-testid="project-clone-button"
-              >
-                <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
-                  <Download className="h-4 w-4" />
-                </div>
-                <span className="font-medium text-sm text-muted-foreground">Clone Repository…</span>
-              </button>
+              <ProjectCommandRow
+                icon={Download}
+                tone="create"
+                label="Clone repository…"
+                onClick={onCloneRepo}
+                testId="project-clone-button"
+              />
             )}
             {onCreateFolder && (
-              <button
-                type="button"
-                onClick={() => onCreateFolder()}
-                className={PROJECT_ACTION_ROW_CLASS}
-              >
-                <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
-                  <FolderPlus className="h-4 w-4" />
-                </div>
-                <span className="font-medium text-sm text-muted-foreground">
-                  Create New Folder…
-                </span>
-              </button>
+              <ProjectCommandRow
+                icon={FolderPlus}
+                tone="create"
+                label="Create new folder…"
+                onClick={onCreateFolder}
+              />
             )}
           </div>
         </>

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -800,7 +800,7 @@ describe("ProjectSwitcherPalette clone repo button", () => {
       <ProjectSwitcherPalette {...baseProps} onCloneRepo={vi.fn()} results={[makeProject()]} />
     );
     expect(screen.getByTestId("project-clone-button")).toBeTruthy();
-    expect(screen.getByText("Clone Repository…")).toBeTruthy();
+    expect(screen.getByText("Clone repository…")).toBeTruthy();
   });
 
   it("calls onCloneRepo when Clone Repository button is clicked", () => {
@@ -1028,23 +1028,23 @@ describe("ProjectSwitcherPalette modal mode", () => {
 
   it("names an action the surface it is rendered in can actually perform", () => {
     // The modal mounts without the add/clone callbacks, so an empty state that
-    // pointed at "Add Project…" would name a button that isn't there.
+    // pointed at "Add project…" would name a button that isn't there.
     const { unmount } = render(<ProjectSwitcherPalette {...modalProps} results={[]} />);
     const modalCopy = screen.getByTestId("project-empty-state").textContent;
-    expect(screen.queryByText("Add Project…")).toBeNull();
+    expect(screen.queryByText("Add project…")).toBeNull();
     unmount();
 
     render(<ProjectSwitcherPalette {...dropdownProps} results={[]} />);
-    expect(screen.getByText("Add Project…")).toBeTruthy();
+    expect(screen.getByText("Add project…")).toBeTruthy();
     expect(screen.getByTestId("project-empty-state").textContent).not.toBe(modalCopy);
   });
 
   it("does not show management action buttons in modal mode", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={multiProjects} />);
-    expect(screen.queryByText("Project Settings…")).toBeNull();
-    expect(screen.queryByText("Add Project…")).toBeNull();
-    expect(screen.queryByText("Clone Repository…")).toBeNull();
-    expect(screen.queryByText("Create New Folder…")).toBeNull();
+    expect(screen.queryByText("Project settings…")).toBeNull();
+    expect(screen.queryByText("Add project…")).toBeNull();
+    expect(screen.queryByText("Clone repository…")).toBeNull();
+    expect(screen.queryByText("Create new folder…")).toBeNull();
   });
 
   it("shows Right-click hint but not Remove shortcut in modal mode footer", () => {

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -473,6 +473,14 @@ interface AppPaletteBodyProps {
   /** Accessible name for the focusable results region. */
   ariaLabel: string;
   /**
+   * Overrides the scroller's own padding and child spacing. The default suits a
+   * palette whose list is a flat run of rows; a palette that draws its own bands
+   * needs the vertical gaps to come from the band padding alone, so that the
+   * space above and below a divider is symmetrical instead of the band padding
+   * on one side and band padding plus `space-y` on the other.
+   */
+  scrollClassName?: string;
+  /**
    * The same active-descendant IDREF the query input carries. Mirrored here so
    * the active option keeps being announced once focus moves off the input —
    * only the element holding DOM focus acts as the active-descendant owner, so
@@ -498,6 +506,7 @@ AppPaletteDialog.Body = function AppPaletteBody({
   ariaLabel,
   activeDescendant,
   onNavigationKeyDown,
+  scrollClassName = "p-2 space-y-1",
 }: AppPaletteBodyProps) {
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -535,7 +544,7 @@ AppPaletteDialog.Body = function AppPaletteBody({
         transitionDuration: `${UI_PALETTE_ENTER_DURATION}ms`,
         transitionTimingFunction: "ease-out",
       }}
-      scrollClassName="p-2 space-y-1"
+      scrollClassName={scrollClassName}
     >
       {children}
     </ScrollShadow>

--- a/src/components/ui/AppPalettePopover.tsx
+++ b/src/components/ui/AppPalettePopover.tsx
@@ -360,7 +360,15 @@ function AppPalettePopoverContent({
       // palette on a given tier is the same box whichever host it opens in.
       // `cn` merges, so a palette that genuinely needs another width can still
       // pass one.
-      className={cn(PALETTE_SURFACE_WIDTHS[tier], className)}
+      className={cn(
+        PALETTE_SURFACE_WIDTHS[tier],
+        // Palette tier, not the popover tier `PopoverContent` defaults to. The
+        // same palette opens as this and as `AppPaletteDialog`, and at the
+        // inherited 200/120 the anchored one felt heavier than the modal for no
+        // reason a user could name.
+        "data-[state=open]:duration-150 data-[state=closed]:duration-100",
+        className
+      )}
       aria-label={ariaLabel}
       // Radix does not set this itself. `aria-modal="false"` is noise, so the
       // non-modal form carries nothing rather than a negation.

--- a/src/components/ui/paletteRowStyles.ts
+++ b/src/components/ui/paletteRowStyles.ts
@@ -25,9 +25,13 @@ export const PALETTE_ROW_CLASS = cn(
   // block in `index.css` needs. There the raised fill is discarded and the row
   // has to redraw itself from system keywords, and `[role="option"]` is far too
   // broad a hook: the file pane, the settings selectors and the agent/forge
-  // dropdowns all use it too. The transparent resting border reserves the
-  // selected border's width so the row cannot shift when it arrives.
-  "palette-row border border-transparent transition-colors",
+  // dropdowns all use it too. The transparent border is not reserving a selected
+  // border any more — the mark is a rail now — but it still holds every row's
+  // content box on the column the palette's other families are drawn from.
+  //
+  // `relative` because that rail is a `::before` positioned against the row
+  // (`.palette-row` in `index.css`).
+  "palette-row relative border border-transparent transition-colors",
   // Neutral, not accent (#11686). The fill alone can't be the indicator — it
   // clears about 1.1-1.2:1 against the palette surface — so `selection-outline`
   // carries WCAG 1.4.11 at 3:1 for the pair. It is the same token the palette
@@ -36,7 +40,12 @@ export const PALETTE_ROW_CLASS = cn(
   // change them together. Earlier attempts at a neutral outline failed because
   // they reused the resting border ladder, which is tuned for separation and
   // sits inside its own noise when asked to be the only signal.
-  "aria-selected:bg-overlay-raised aria-selected:border-selection-outline aria-selected:text-daintree-text"
+  //
+  // The token is spent on a leading rail, not on all four sides — see
+  // `.palette-row::before` in `index.css` for why. The transparent border stays:
+  // it holds the row's content box on the same column as the palette's other
+  // families, and the `forced-colors` fallback still draws an outline there.
+  "aria-selected:bg-overlay-raised aria-selected:text-daintree-text"
 );
 
 /**
@@ -50,3 +59,15 @@ export const PALETTE_ROW_CLASS = cn(
  */
 export const PALETTE_SECTION_LABEL_CLASS =
   "text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none";
+
+/**
+ * The keyboard-focus ring every palette control wears.
+ *
+ * Inset on purpose: palette surfaces clip to `overflow-hidden`, so a ring drawn
+ * outside a full-width row loses its left and right sides at the dialog edge.
+ * Accent here is within the restraint budget because only one element in the
+ * palette can hold DOM focus at a time — it is the singleton focus anchor, not
+ * a second signal competing with the roving cursor's neutral highlight.
+ */
+export const PALETTE_ROW_FOCUS_CLASS =
+  "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent";

--- a/src/index.css
+++ b/src/index.css
@@ -2354,6 +2354,70 @@ label:focus-within .brand-mark,
   will-change: transform;
 }
 
+/* The palette's selected-row mark.
+ *
+ * A leading rail rather than the 1px ring this used to be. The ring was never a
+ * free choice: `overlay-raised` clears about 1.1:1 against the palette surface,
+ * so the fill cannot be the WCAG 1.4.11 indicator and `selection-outline` has to
+ * be — and an indicator that must hold 3:1 against both the surface and the fill
+ * lands on a mid-grey stroke. Drawn around all four sides of a row that is not
+ * the DOM focus target, that reads as an empty form field: a strong edge with no
+ * body. No shipping palette does it (VS Code leaves `list.focusOutline` unset in
+ * quick pick; Linear, Raycast, Spotlight, Arc and Slack are fill-led).
+ *
+ * Making the fill carry 3:1 instead is not the way out — it needs roughly 33%
+ * white on these surfaces, a light-grey block far heavier than the ring it
+ * replaces. A rail keeps the same token and the same 3:1 pair while spending a
+ * fraction of the ink on it, which is what 1.4.11 allows: the indicator has to
+ * meet the ratio, not enclose the component.
+ *
+ * Inset and separately rounded rather than an inset box-shadow, which would
+ * follow the card's own radius and taper to a crescent at both ends.
+ *
+ * Not stated in `forced-colors`, where `background-color` is stripped: the
+ * system-outline fallback further down already marks the row there.
+ */
+.palette-row::before {
+  content: "";
+  position: absolute;
+  /* On the card's outer edge, not inside its padding. An absolutely positioned
+     child is offset from the padding box, so an inset here would have started
+     the rail past the reserved border and landed it about 2px from the status
+     mark — two small marks clustered in one gutter, which is the collision that
+     makes leading rails a bad idea on rows that already carry a status dot.
+     Pulled back onto the boundary, the rail belongs to the card and the dot
+     belongs to the content grid, with 6px of clear space between them.
+
+     Logical, not `left`: this is the leading edge, which flips under RTL. */
+  inset-inline-start: -1px;
+  inset-block: 6px;
+  width: 3px;
+  /* A pill, not a scale step: the rail is 3px wide, so any radius above 1.5px
+     is the same shape and the scale would only make it theme-dependent. */
+  border-radius: 9999px;
+  background: var(--color-selection-outline);
+  opacity: 0;
+  pointer-events: none;
+  /* The same slot the row's fill fades in on. Cross-fading one and popping the
+     other put the mark on the new row while the surface behind it was still
+     arriving. */
+  transition: opacity var(--duration-150) ease-out;
+}
+
+.palette-row[aria-selected="true"]::before {
+  opacity: 1;
+}
+
+/* Both triggers, and both signals. The bare media query would honour the OS
+   preference but not Daintree's own "Reduce UI animations" toggle, and dropping
+   only the rail's transition would leave the fill still fading under it. */
+@variant reduce-motion {
+  .palette-row,
+  .palette-row::before {
+    transition: none;
+  }
+}
+
 /* Success fade - scale in then fade out */
 @keyframes forge-status-success-fade {
   0% {
@@ -2680,7 +2744,7 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     outline-offset: -2px;
   }
 
-  /* The palette selected row is a raised fill plus a neutral outline, both
+  /* The palette selected row is a raised fill plus a neutral leading rail, both
      stripped here, so it falls back to a system outline like the Radix rule
      above. Deliberately an outline and not a SelectedItem fill: these rows carry
      independently surfaced children (theme "Active" badges, action category


### PR DESCRIPTION
This is a fairly significant tidy-up of the project switcher. It was looking a little messy, and the design has been through repeated review with Codex.

The biggest issue was that three separate icon columns had slowly drifted apart. There was no alignment between the tiles and labels in the workspace rows, the new scratch row, and the command rows at the bottom. Everything now lands on one grid: status at 13px, tile at 29px, label at 69px, measured from the surface edge. `StatusSlotSpacer` gives a row with no status mark the same column, and `CommandTile` plus `ProjectCommandRow` replace four hand-rolled buttons.

The list inset has moved from the body scroller onto the bands. `AppPaletteDialog.Body` takes an optional `scrollClassName` (default unchanged) and the switcher passes `space-y-0` with no padding of its own. Two things were wrong before. The band dividers are children of the scroller while the header and footer rules are not, so any inset there drew the internal hairlines 4px shorter at each end. And the scroller's vertical padding stacked on the first and last band's own, so the first label sat 4px lower relative to the header rule than every later label sat to its divider. Every rule now has exactly 4px of band padding on each side.

The selected row's four-sided outline is gone, replaced by a neutral leading rail on the card boundary. Same `selection-outline` token, same 3:1 pair, so the theme contrast gate is unchanged. The outline was never really a free choice: the token has to clear 3:1 against both the surrounding surface and the fill, and that pair forces a mid-grey stroke. Drawn all the way round a row that never holds DOM focus, it read like a form field. Making the fill carry 3:1 instead and dropping the mark isn't the escape either, since it needs around 33% white on these surfaces, far heavier than the stroke it would replace. WCAG 1.4.11 sets a ratio, not an area.

A few smaller things:

- Browse drops the 144px body floor so a collapsed list hugs its bands. The floor stays for ranked search, where it does the job it was written for. `min-height` is now in the transition list, since that is the property that actually changes.
- The anchored dropdown was on the popover tier's 200/120ms while the modal ran the palette tier's 150/100ms. Same palette, two weights. Fixed in `AppPalettePopover`.
- Command labels are sentence case now (`Add project…`). The ellipses stay, they mean "opens a dialog" and this file already used them elsewhere.
- The empty state no longer names an action the surface can't run, or contradicts scratches that are already on screen.

Docs and the theme validation vocabulary follow the rail, so nothing left in the repo still describes this row as a border and quietly reintroduces the ring later.

Codex scored the surface 6/10 at the start and 10/10 at the end across eleven rounds.

One thing I deliberately left out of scope: `overlay-raised` is `rgba(255,255,255,0.04)` on dark, where Linear and Raycast sit at 0.07 to 0.12. Raising it is nearly free contrast-wise (minimum outline alpha only moves from 0.375 to 0.385, and we're at 0.42) and would probably improve this further, but the token is shared by 20 surfaces so it wants its own change.

## Testing

`npm run check` clean, 1732 tests passing including the full theme contrast suite. Worth a look in the real app at the rail on a row that also has a status dot, which is the case the research flagged as the risk.
