### PR TITLE
Let the React Compiler optimize PilotView again

### DIFF
--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -493,6 +493,26 @@ function PilotFooter({
   );
 }
 
+/**
+ * The run `parkTargetId` names, resolved against the live fleet.
+ *
+ * A plain function rather than a `useMemo` in the component: the compiler could
+ * not preserve the manual memo here and skipped optimizing `PilotView` whole,
+ * so one hand-written cache was costing the entire component its automatic
+ * ones. Called bare, the compiler caches the result itself.
+ */
+function findParkTarget(
+  liveGroups: PilotProjectGroup[],
+  parkTargetId: string | null
+): PilotParkTarget | null {
+  if (parkTargetId === null) return null;
+  for (const group of liveGroups) {
+    const row = group.rows.find((r) => r.run.runId === parkTargetId);
+    if (row) return { row, group, existingPark: row.run.park };
+  }
+  return null;
+}
+
 export function PilotView() {
   const isOpen = usePilotStore((s) => s.isOpen);
   const close = usePilotStore((s) => s.close);
@@ -690,14 +710,7 @@ export function PilotView() {
    */
   const [parkTargetId, setParkTargetId] = useState<string | null>(null);
 
-  const parkTarget = useMemo<PilotParkTarget | null>(() => {
-    if (parkTargetId === null) return null;
-    for (const group of liveGroups) {
-      const row = group.rows.find((r) => r.run.runId === parkTargetId);
-      if (row) return { row, group, existingPark: row.run.park };
-    }
-    return null;
-  }, [parkTargetId, liveGroups]);
+  const parkTarget = findParkTarget(liveGroups, parkTargetId);
 
   const gateCandidates = useMemo<PilotGateCandidate[]>(() => {
     if (parkTargetId === null) return [];


### PR DESCRIPTION
This fixes a single `useMemo` in `PilotView` that the React Compiler couldn't preserve. One hand-written cache was enough for it to bail on the whole component, so that memo was costing `PilotView` every automatic one it would otherwise have got.

The lookup is now a module-level `findParkTarget()` called plainly. The compiled output caches the call on `liveGroups` and `parkTargetId`, exactly the pair the `useMemo` declared, so `parkTarget`'s identity is unchanged and the effect and the editor pane below it see the same thing they did before.

Drops the repo from 4 critical compiler diagnostics to 3. The remaining three are all `Cannot access refs during render` in Terminal and Worktree hooks.

Worth flagging separately: `scripts/baselines/compiler-bailout-baseline.json` is stale on `develop`. 11 entries no longer match the build output and the Hint count has grown from 217 to 269. Regenerating it rewrites about 2,600 lines, which has nothing to do with this fix, so I left it alone. `compiler-budget` is local-only and not in CI, so nothing is gated on it either way. Probably wants its own cleanup.

## Testing

`npm run check` clean, 197 Pilot tests passing. Confirmed with `npm run compiler-budget:critical` before and after.
