### PR TITLE
feat(codex): expose internal Codex subagent sessions

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -49,6 +49,7 @@ const registerMocks = vi.hoisted(() => ({
   registerWorktreeConfigHandlers: vi.fn(),
   registerNotificationHandlers: vi.fn(),
   registerGeminiHandlers: vi.fn(),
+  registerCodexHandlers: vi.fn(),
   registerEventsHandlers: vi.fn(),
   registerDevPreviewHandlers: vi.fn(),
   registerCommandHandlers: vi.fn(),
@@ -181,6 +182,9 @@ vi.mock("../handlers/notifications.js", () => ({
 }));
 vi.mock("../handlers/gemini.js", () => ({
   registerGeminiHandlers: registerMocks.registerGeminiHandlers,
+}));
+vi.mock("../handlers/codex.js", () => ({
+  registerCodexHandlers: registerMocks.registerCodexHandlers,
 }));
 vi.mock("../handlers/events.js", () => ({
   registerEventsHandlers: registerMocks.registerEventsHandlers,

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -498,6 +498,9 @@ export const CHANNELS = {
   GEMINI_GET_STATUS: "gemini:get-status",
   GEMINI_ENABLE_ALTERNATE_BUFFER: "gemini:enable-alternate-buffer",
 
+  CODEX_LIST_SUBAGENTS: "codex:list-subagents",
+  CODEX_READ_SUBAGENT_TRANSCRIPT: "codex:read-subagent-transcript",
+
   DEV_PREVIEW_ENSURE: "dev-preview:ensure",
   DEV_PREVIEW_RESTART: "dev-preview:restart",
   DEV_PREVIEW_RESTART_AND_CLEAR_CACHE: "dev-preview:restart-and-clear-cache",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -37,6 +37,7 @@ import { registerFileBrowserHandlers } from "./handlers/fileBrowser.js";
 import { registerFileWatchHandlers } from "./handlers/fileWatch.js";
 import { registerSlashCommandHandlers } from "./handlers/slashCommands.js";
 import { registerGeminiHandlers } from "./handlers/gemini.js";
+import { registerCodexHandlers } from "./handlers/codex.js";
 import { registerEventsHandlers } from "./handlers/events.js";
 import { registerDevPreviewHandlers } from "./handlers/devPreview.js";
 import { registerCommandHandlers } from "./handlers/commands.js";
@@ -166,6 +167,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerConfigBundleHandlers(deps));
     register(() => registerNotificationHandlers(deps));
     register(() => registerGeminiHandlers());
+    register(() => registerCodexHandlers());
     register(() => registerEventsHandlers(deps));
     register(() => registerDevPreviewHandlers(deps));
     register(() => registerCommandHandlers());

--- a/electron/ipc/handlers/codex.preload.ts
+++ b/electron/ipc/handlers/codex.preload.ts
@@ -1,0 +1,25 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const CODEX_METHOD_CHANNELS = {
+  listSubagents: "codex:list-subagents",
+  readSubagentTranscript: "codex:read-subagent-transcript",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof CODEX_METHOD_CHANNELS;
+
+export type CodexPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildCodexPreloadBindings(invoke: Invoker): CodexPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(CODEX_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = CODEX_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as CodexPreloadBindings;
+}

--- a/electron/ipc/handlers/codex.ts
+++ b/electron/ipc/handlers/codex.ts
@@ -10,11 +10,13 @@ import type {
 // resolves the cwd and the owning Codex thread from the pty-host record and
 // refuses any thread that isn't a child of it, so a wrong or forged id can't
 // reach an unrelated Codex conversation.
-const listSchema = z.object({ terminalId: z.string().min(1) });
-const readSchema = z.object({
-  terminalId: z.string().min(1),
-  threadId: z.string().min(1),
-});
+// Ids are UUIDs and terminal keys, not free text: bound them so a malformed
+// payload is rejected at the boundary rather than carried into a protocol query.
+const ID_MAX = 128;
+const id = z.string().trim().min(1).max(ID_MAX);
+
+const listSchema = z.object({ terminalId: id });
+const readSchema = z.object({ terminalId: id, threadId: id });
 
 export const codexNamespace = defineIpcNamespace({
   name: "codex",

--- a/electron/ipc/handlers/codex.ts
+++ b/electron/ipc/handlers/codex.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { defineIpcNamespace, opValidated } from "../define.js";
+import { CODEX_METHOD_CHANNELS } from "./codex.preload.js";
+import type {
+  CodexSubagentsResult,
+  CodexSubagentTranscriptResult,
+} from "../../../shared/types/ipc/codexSubagents.js";
+
+// The renderer names a terminal, never a folder or a bare thread id. Main
+// resolves the cwd and the owning Codex thread from the pty-host record and
+// refuses any thread that isn't a child of it, so a wrong or forged id can't
+// reach an unrelated Codex conversation.
+const listSchema = z.object({ terminalId: z.string().min(1) });
+const readSchema = z.object({
+  terminalId: z.string().min(1),
+  threadId: z.string().min(1),
+});
+
+export const codexNamespace = defineIpcNamespace({
+  name: "codex",
+  ops: {
+    listSubagents: opValidated(
+      CODEX_METHOD_CHANNELS.listSubagents,
+      listSchema,
+      async ({ terminalId }): Promise<CodexSubagentsResult> => {
+        // Imported lazily so the module graph (and the PtyClient singleton it
+        // reaches for) isn't pulled in at handler-registration time.
+        const { listCodexSubagents } = await import("../../services/codex/CodexSubagentService.js");
+        return listCodexSubagents(terminalId);
+      }
+    ),
+    readSubagentTranscript: opValidated(
+      CODEX_METHOD_CHANNELS.readSubagentTranscript,
+      readSchema,
+      async ({ terminalId, threadId }): Promise<CodexSubagentTranscriptResult> => {
+        const { readCodexSubagentTranscript } =
+          await import("../../services/codex/CodexSubagentService.js");
+        return readCodexSubagentTranscript(terminalId, threadId);
+      }
+    ),
+  },
+});
+
+export function registerCodexHandlers(): () => void {
+  return codexNamespace.register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -54,6 +54,7 @@ import { buildForgeAuditPreloadBindings } from "./ipc/handlers/forgeAudit.preloa
 import { buildRunHistoryPreloadBindings } from "./ipc/handlers/runHistory.preload.js";
 import { buildCopyTreeHistoryPreloadBindings } from "./ipc/handlers/copyTreeHistory.preload.js";
 import { buildGeminiPreloadBindings } from "./ipc/handlers/gemini.preload.js";
+import { buildCodexPreloadBindings } from "./ipc/handlers/codex.preload.js";
 import { buildMilestonesPreloadBindings } from "./ipc/handlers/milestones.preload.js";
 import { buildOnboardingPreloadBindings } from "./ipc/handlers/onboarding.preload.js";
 import { buildShortcutHintsPreloadBindings } from "./ipc/handlers/shortcutHints.preload.js";
@@ -2540,6 +2541,7 @@ function buildElectronApi(): ElectronAPI {
 
     // Gemini API
     gemini: buildGeminiPreloadBindings(_unwrappingInvoke),
+    codex: buildCodexPreloadBindings(_unwrappingInvoke),
 
     // Daintree CLI install API
     cli: buildCliPreloadBindings(_unwrappingInvoke),

--- a/electron/services/codex/CodexAppServerClient.ts
+++ b/electron/services/codex/CodexAppServerClient.ts
@@ -27,13 +27,21 @@ import { buildProbeEnv } from "../../utils/spawnEnv.js";
 import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
 import type { CodexSubagentUnavailableReason } from "../../../shared/types/ipc/codexSubagents.js";
 
-/** Read-only surface. `thread/start` is absent by design — see the file header. */
-export const CODEX_APP_SERVER_ALLOWED_METHODS = new Set([
+/**
+ * Read-only surface. `thread/start` is absent by design — see the file header.
+ * Held in a module-private frozen tuple rather than an exported `Set`, which
+ * any importer could have added to.
+ */
+const ALLOWED_METHODS = Object.freeze([
   "initialize",
   "thread/list",
   "thread/read",
   "thread/turns/list",
-]);
+] as const);
+
+export function isAllowedCodexAppServerMethod(method: string): boolean {
+  return (ALLOWED_METHODS as readonly string[]).includes(method);
+}
 
 /** Whole-session budget: spawn, handshake, every query, teardown. */
 const SESSION_TIMEOUT_MS = 15_000;
@@ -62,6 +70,34 @@ interface Pending {
   timer: ReturnType<typeof setTimeout>;
 }
 
+/**
+ * A project restore mounts every Codex pane at once, and each asks for its own
+ * subagents. Without a gate that is N concurrent `codex app-server` processes;
+ * with one it is a short queue, and each query is single-digit milliseconds
+ * once the server is up.
+ */
+const MAX_CONCURRENT_SESSIONS = 2;
+let activeSessions = 0;
+const sessionQueue: Array<() => void> = [];
+
+function acquireSessionSlot(): Promise<void> {
+  if (activeSessions < MAX_CONCURRENT_SESSIONS) {
+    activeSessions++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    sessionQueue.push(() => {
+      activeSessions++;
+      resolve();
+    });
+  });
+}
+
+function releaseSessionSlot(): void {
+  activeSessions--;
+  sessionQueue.shift()?.();
+}
+
 export interface CodexAppServerSessionOptions {
   /** Overridable so tests don't depend on a `codex` binary being installed. */
   command?: string;
@@ -84,10 +120,12 @@ function classifySpawnError(error: NodeJS.ErrnoException): CodexAppServerError {
  * default profile while the terminal itself runs against a relocated one.
  *
  * This inherits main's `CODEX_HOME`, not the terminal's own spawn env, so a
- * per-project override is invisible here. The failure is quiet rather than
- * wrong: the default profile holds no thread for that cwd, the lookup reports
- * `no-session`, and the UI stays hidden instead of showing another profile's
- * subagents.
+ * per-project override is invisible here. Usually that fails quiet — the
+ * default profile holds no thread for that cwd, so the lookup reports
+ * `no-session` and the UI stays hidden — but if the default profile also has
+ * threads for the same folder, spawn-time correlation runs against the wrong
+ * profile. Carrying the terminal's effective profile through pty-host metadata
+ * is the real fix and is not wired yet.
  */
 function buildAppServerEnv(): NodeJS.ProcessEnv {
   const env = buildProbeEnv();
@@ -105,6 +143,18 @@ function buildAppServerEnv(): NodeJS.ProcessEnv {
 export async function runCodexAppServerSession<T>(
   run: (call: CodexAppServerCall) => Promise<T>,
   options: CodexAppServerSessionOptions = {}
+): Promise<T> {
+  await acquireSessionSlot();
+  try {
+    return await spawnCodexAppServerSession(run, options);
+  } finally {
+    releaseSessionSlot();
+  }
+}
+
+async function spawnCodexAppServerSession<T>(
+  run: (call: CodexAppServerCall) => Promise<T>,
+  options: CodexAppServerSessionOptions
 ): Promise<T> {
   const command = options.command ?? "codex";
   const timeoutMs = options.timeoutMs ?? SESSION_TIMEOUT_MS;
@@ -189,6 +239,9 @@ export async function runCodexAppServerSession<T>(
     if (disposed) return;
     disposed = true;
     if (sessionTimer) clearTimeout(sessionTimer);
+    // Anything `run` left in flight settles now rather than idling until its
+    // own 10s timer. Harmless on the happy path, where nothing is pending.
+    failAll(new CodexAppServerError("protocol-error", "Codex app-server session ended"));
     if (reap) killTree();
     // Drop only `data`, keeping the no-op `error` sinks below alive: destroy()
     // can surface a pending EIO/EBADF on the next tick, and an unhandled
@@ -296,12 +349,16 @@ export async function runCodexAppServerSession<T>(
   });
 
   const call: CodexAppServerCall = <T>(method: string, params?: unknown): Promise<T> => {
-    if (!CODEX_APP_SERVER_ALLOWED_METHODS.has(method)) {
+    if (!isAllowedCodexAppServerMethod(method)) {
       return Promise.reject(
         new CodexAppServerError("protocol-error", `Method not permitted: ${method}`)
       );
     }
-    if (failure) return Promise.reject(failure);
+    if (disposed || failure) {
+      return Promise.reject(
+        failure ?? new CodexAppServerError("protocol-error", "Codex app-server session ended")
+      );
+    }
     const id = nextId++;
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {

--- a/electron/services/codex/CodexAppServerClient.ts
+++ b/electron/services/codex/CodexAppServerClient.ts
@@ -102,6 +102,7 @@ export interface CodexAppServerSessionOptions {
   /** Overridable so tests don't depend on a `codex` binary being installed. */
   command?: string;
   timeoutMs?: number;
+  requestTimeoutMs?: number;
 }
 
 function classifySpawnError(error: NodeJS.ErrnoException): CodexAppServerError {
@@ -158,6 +159,7 @@ async function spawnCodexAppServerSession<T>(
 ): Promise<T> {
   const command = options.command ?? "codex";
   const timeoutMs = options.timeoutMs ?? SESSION_TIMEOUT_MS;
+  const requestTimeoutMs = options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
   // POSIX process groups let the deadline reap a grandchild that inherited the
   // stdout pipe. Windows has none here, so it falls back to `taskkill /T`.
   const useGroup = process.platform !== "win32";
@@ -257,9 +259,18 @@ async function spawnCodexAppServerSession<T>(
     child.stderr?.destroy();
   };
 
+  let onDeadline: (() => void) | null = null;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    onDeadline = () => reject(new CodexAppServerError("timeout", "Codex app-server timed out"));
+  });
+  // Nothing awaits `deadline` unless the race below does, and an unawaited
+  // rejection is fatal in the main process.
+  deadline.catch(() => {});
+
   sessionTimer = setTimeout(() => {
     failAll(new CodexAppServerError("timeout", "Codex app-server timed out"));
     dispose(true);
+    onDeadline?.();
   }, timeoutMs);
   sessionTimer.unref?.();
 
@@ -364,7 +375,7 @@ async function spawnCodexAppServerSession<T>(
       const timer = setTimeout(() => {
         if (!pending.delete(id)) return;
         reject(new CodexAppServerError("timeout", `Codex app-server timed out on ${method}`));
-      }, REQUEST_TIMEOUT_MS);
+      }, requestTimeoutMs);
       timer.unref?.();
       pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timer });
       try {
@@ -401,7 +412,10 @@ async function spawnCodexAppServerSession<T>(
         `Codex app-server handshake failed: ${String(error)}`
       );
     }
-    return await run(call);
+    // Raced rather than awaited: `run` may be waiting on something this
+    // transport cannot see, and a callback that never settles would hold its
+    // concurrency slot for the life of the process.
+    return await Promise.race([run(call), deadline]);
   } finally {
     // Reap unconditionally: a session that returned normally still leaves the
     // server running, since it only exits when its stdin closes.

--- a/electron/services/codex/CodexAppServerClient.ts
+++ b/electron/services/codex/CodexAppServerClient.ts
@@ -1,0 +1,353 @@
+/**
+ * Short-lived JSON-RPC client for `codex app-server --listen stdio://`.
+ *
+ * Daintree reads a Codex session's spawned subagent threads through the
+ * documented app-server protocol instead of scraping the terminal or the
+ * legacy rollout JSONL. One process is spawned per logical operation — the
+ * handshake is ~40ms and a `useStateDbOnly` query is single-digit ms, so
+ * holding a server open would buy nothing and cost an ownership problem
+ * across panel unmount, view eviction, crash recovery and `app.quit()`.
+ *
+ * Two hard boundaries live here rather than in a caller:
+ *
+ *   1. `ALLOWED_METHODS` is enforced before anything reaches stdin. The
+ *      protocol's `thread/start` marks a project trusted in the user's
+ *      `~/.codex/config.toml`, and writing user-owned agent config is out of
+ *      bounds for this app. An allowlist in the transport means no future
+ *      caller — or bug — can reach it.
+ *   2. Every settle path that bypasses a clean `close` reaps the process
+ *      group, mirroring `AgentVersionService.runVersionProbe`. That reaping
+ *      must include the ordinary exit-grace path, not just the deadline
+ *      backstop: wiring it only to failure paths leaked a detached group per
+ *      call last time (#10705).
+ */
+
+import { spawn, spawnSync, type ChildProcess } from "child_process";
+import { buildProbeEnv } from "../../utils/spawnEnv.js";
+import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
+import type { CodexSubagentUnavailableReason } from "../../../shared/types/ipc/codexSubagents.js";
+
+/** Read-only surface. `thread/start` is absent by design — see the file header. */
+export const CODEX_APP_SERVER_ALLOWED_METHODS = new Set([
+  "initialize",
+  "thread/list",
+  "thread/read",
+  "thread/turns/list",
+]);
+
+/** Whole-session budget: spawn, handshake, every query, teardown. */
+const SESSION_TIMEOUT_MS = 15_000;
+/** Per-request budget, so one wedged call can't eat the whole session. */
+const REQUEST_TIMEOUT_MS = 10_000;
+/** Grace for stdout to flush after `exit` before the group is reaped. */
+const EXIT_DRAIN_MS = 200;
+/** Cap on buffered stdout. A page of threads is kilobytes; this is generous. */
+const MAX_BUFFER = 4 * 1024 * 1024;
+
+export class CodexAppServerError extends Error {
+  readonly reason: CodexSubagentUnavailableReason;
+
+  constructor(reason: CodexSubagentUnavailableReason, message: string, options?: ErrorOptions) {
+    super(scrubSecrets(message), options);
+    this.name = "CodexAppServerError";
+    this.reason = reason;
+  }
+}
+
+export type CodexAppServerCall = <T>(method: string, params?: unknown) => Promise<T>;
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface CodexAppServerSessionOptions {
+  /** Overridable so tests don't depend on a `codex` binary being installed. */
+  command?: string;
+  timeoutMs?: number;
+}
+
+function classifySpawnError(error: NodeJS.ErrnoException): CodexAppServerError {
+  if (error.code === "ENOENT") {
+    return new CodexAppServerError("cli-missing", "Codex CLI not found on PATH", { cause: error });
+  }
+  return new CodexAppServerError("protocol-error", `Codex app-server failed: ${error.message}`, {
+    cause: error,
+  });
+}
+
+/**
+ * `buildProbeEnv()` allowlists only what's needed to resolve and run a CLI, so
+ * it deliberately omits `CODEX_HOME`. That variable is a directory path rather
+ * than a credential, and omitting it would silently point the query at the
+ * default profile while the terminal itself runs against a relocated one.
+ *
+ * This inherits main's `CODEX_HOME`, not the terminal's own spawn env, so a
+ * per-project override is invisible here. The failure is quiet rather than
+ * wrong: the default profile holds no thread for that cwd, the lookup reports
+ * `no-session`, and the UI stays hidden instead of showing another profile's
+ * subagents.
+ */
+function buildAppServerEnv(): NodeJS.ProcessEnv {
+  const env = buildProbeEnv();
+  const codexHome = process.env.CODEX_HOME;
+  if (codexHome) env.CODEX_HOME = codexHome;
+  return env;
+}
+
+/**
+ * Spawn an app-server, complete the handshake, hand `run` a typed `call`, and
+ * tear the process down however `run` settles.
+ *
+ * `run` must not retain `call` past its own resolution — the process is gone.
+ */
+export async function runCodexAppServerSession<T>(
+  run: (call: CodexAppServerCall) => Promise<T>,
+  options: CodexAppServerSessionOptions = {}
+): Promise<T> {
+  const command = options.command ?? "codex";
+  const timeoutMs = options.timeoutMs ?? SESSION_TIMEOUT_MS;
+  // POSIX process groups let the deadline reap a grandchild that inherited the
+  // stdout pipe. Windows has none here, so it falls back to `taskkill /T`.
+  const useGroup = process.platform !== "win32";
+
+  let child: ChildProcess;
+  try {
+    child = spawn(command, ["app-server", "--listen", "stdio://"], {
+      shell: false,
+      windowsHide: true,
+      env: buildAppServerEnv(),
+      detached: useGroup,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (error) {
+    throw classifySpawnError(error as NodeJS.ErrnoException);
+  }
+
+  // Detached + unref'd so an in-flight query can't pin main-process teardown
+  // during `app.quit()`. unref only drops the event-loop ref-count; the
+  // ChildProcess object stays referenced here and its events still deliver.
+  child.unref();
+
+  const pending = new Map<number, Pending>();
+  let nextId = 1;
+  let stdoutBuffer = "";
+  let stderr = "";
+  let disposed = false;
+  let failure: Error | null = null;
+
+  const killTree = (): void => {
+    const pid = child.pid;
+    if (typeof pid !== "number") return;
+    if (!useGroup) {
+      try {
+        const result = spawnSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
+          windowsHide: true,
+          stdio: "ignore",
+          timeout: 3000,
+        });
+        // spawnSync reports failure in the result, not by throwing. status 0 =
+        // killed, 128 = already gone (benign). Anything else left the tree alive.
+        if (result?.error) {
+          console.warn(`[CodexAppServer] taskkill pid=${pid}: ${result.error.message}`);
+        } else if (result && result.status !== 0 && result.status !== 128) {
+          console.warn(`[CodexAppServer] taskkill pid=${pid} exited ${result.status}`);
+        }
+      } catch (error) {
+        console.warn(`[CodexAppServer] taskkill pid=${pid}: ${String(error)}`);
+      }
+      return;
+    }
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      // ESRCH means the group is already gone. EPERM/EINVAL mean it may still
+      // be alive and the operator needs to know.
+      if (code !== "ESRCH") {
+        console.warn(`[CodexAppServer] SIGKILL group pid=${pid}: ${String(error)}`);
+      }
+    }
+  };
+
+  /** Fail every in-flight request once, and refuse any that arrive after. */
+  const failAll = (error: Error): void => {
+    if (!failure) failure = error;
+    for (const [, entry] of pending) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    pending.clear();
+  };
+
+  // Declared before `dispose` so the clearTimeout below never reads a binding
+  // in its temporal dead zone, whatever order the child's events arrive in.
+  let sessionTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const dispose = (reap: boolean): void => {
+    if (disposed) return;
+    disposed = true;
+    if (sessionTimer) clearTimeout(sessionTimer);
+    if (reap) killTree();
+    // Drop only `data`, keeping the no-op `error` sinks below alive: destroy()
+    // can surface a pending EIO/EBADF on the next tick, and an unhandled
+    // stream error is fatal in the main process.
+    child.stdout?.removeAllListeners("data");
+    child.stderr?.removeAllListeners("data");
+    try {
+      child.stdin?.end();
+    } catch {
+      // stdin may already be closed; nothing to recover.
+    }
+    child.stdout?.destroy();
+    child.stderr?.destroy();
+  };
+
+  sessionTimer = setTimeout(() => {
+    failAll(new CodexAppServerError("timeout", "Codex app-server timed out"));
+    dispose(true);
+  }, timeoutMs);
+  sessionTimer.unref?.();
+
+  // A pipe error (EBADF/EIO on a dead fd) on a piped stream becomes an
+  // uncaughtException if unhandled. These sinks must outlive dispose().
+  child.stdout?.on("error", () => {});
+  child.stderr?.on("error", () => {});
+  child.stdin?.on("error", () => {});
+
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdoutBuffer += chunk.toString();
+    let newline = stdoutBuffer.indexOf("\n");
+    while (newline >= 0) {
+      const line = stdoutBuffer.slice(0, newline).trim();
+      stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      if (line) handleLine(line);
+      newline = stdoutBuffer.indexOf("\n");
+    }
+    // The cap guards the *unterminated* remainder, not total throughput: a
+    // long series of ordinary responses is fine, a single frame that never
+    // ends is a server we can't parse and shouldn't buffer forever.
+    if (stdoutBuffer.length > MAX_BUFFER) {
+      failAll(new CodexAppServerError("protocol-error", "Codex app-server output exceeded limit"));
+      dispose(true);
+    }
+  });
+
+  child.stderr?.on("data", (chunk: Buffer) => {
+    if (stderr.length >= MAX_BUFFER) return;
+    stderr += chunk.toString();
+  });
+
+  function handleLine(line: string): void {
+    let message: { id?: unknown; result?: unknown; error?: { message?: unknown } };
+    try {
+      message = JSON.parse(line);
+    } catch {
+      // Notifications and responses share the stream; a malformed line is the
+      // server's problem, not a reason to fail queries that may still succeed.
+      return;
+    }
+    if (typeof message.id !== "number") return;
+    const entry = pending.get(message.id);
+    if (!entry) return;
+    pending.delete(message.id);
+    clearTimeout(entry.timer);
+    if (message.error) {
+      const detail =
+        typeof message.error.message === "string"
+          ? message.error.message
+          : JSON.stringify(message.error);
+      entry.reject(new CodexAppServerError("protocol-error", `Codex app-server: ${detail}`));
+      return;
+    }
+    entry.resolve(message.result);
+  }
+
+  child.on("error", (error: NodeJS.ErrnoException) => {
+    failAll(classifySpawnError(error));
+    dispose(false);
+  });
+
+  // `exit` does not guarantee stdout is flushed, so we never settle on it
+  // directly — a short grace lets a queued response land, then the group is
+  // reaped so a grandchild holding the pipe can't outlive the query.
+  const earlyExitError = (): CodexAppServerError =>
+    new CodexAppServerError(
+      "protocol-error",
+      `Codex app-server exited early${stderr.trim() ? `: ${stderr.trim().slice(-400)}` : ""}`
+    );
+
+  child.on("exit", () => {
+    if (disposed) return;
+    const graceTimer = setTimeout(() => {
+      if (disposed) return;
+      failAll(earlyExitError());
+      dispose(true);
+    }, EXIT_DRAIN_MS);
+    graceTimer.unref?.();
+  });
+
+  child.on("close", () => {
+    if (disposed) return;
+    // Every fd-holder has exited, so there is nothing left to reap.
+    failAll(earlyExitError());
+    dispose(false);
+  });
+
+  const call: CodexAppServerCall = <T>(method: string, params?: unknown): Promise<T> => {
+    if (!CODEX_APP_SERVER_ALLOWED_METHODS.has(method)) {
+      return Promise.reject(
+        new CodexAppServerError("protocol-error", `Method not permitted: ${method}`)
+      );
+    }
+    if (failure) return Promise.reject(failure);
+    const id = nextId++;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (!pending.delete(id)) return;
+        reject(new CodexAppServerError("timeout", `Codex app-server timed out on ${method}`));
+      }, REQUEST_TIMEOUT_MS);
+      timer.unref?.();
+      pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timer });
+      try {
+        child.stdin?.write(`${JSON.stringify({ id, method, params: params ?? {} })}\n`);
+      } catch (error) {
+        pending.delete(id);
+        clearTimeout(timer);
+        reject(
+          new CodexAppServerError(
+            "protocol-error",
+            `Codex app-server write failed: ${String(error)}`
+          )
+        );
+      }
+    });
+  };
+
+  try {
+    await call("initialize", {
+      // `version` is this integration's protocol-client revision, not the app
+      // version — it only lands in the server's user-agent string, and pulling
+      // in `electron.app` here would cost the transport its plain-Node tests.
+      clientInfo: { name: "daintree", title: "Daintree", version: "1" },
+      // Unlocks the `parentThreadId` filter, `canAcceptDirectInput`, and
+      // `thread/turns/list`. Purely a client-capability declaration.
+      capabilities: { experimentalApi: true, requestAttestation: false },
+    });
+    // Notification, not a request — no id, no response.
+    try {
+      child.stdin?.write(`${JSON.stringify({ method: "initialized", params: {} })}\n`);
+    } catch (error) {
+      throw new CodexAppServerError(
+        "protocol-error",
+        `Codex app-server handshake failed: ${String(error)}`
+      );
+    }
+    return await run(call);
+  } finally {
+    // Reap unconditionally: a session that returned normally still leaves the
+    // server running, since it only exits when its stdin closes.
+    dispose(true);
+  }
+}

--- a/electron/services/codex/CodexSubagentService.ts
+++ b/electron/services/codex/CodexSubagentService.ts
@@ -1,0 +1,413 @@
+/**
+ * Resolves which Codex thread a live terminal is running, then reads that
+ * thread's spawned subagents. Read-only throughout — see CodexAppServerClient.
+ *
+ * Attribution is the hard part. Daintree only learns a Codex session id from
+ * the `codex resume` footer during post-quit teardown, so a *running* terminal
+ * has no id to key off. The fallback is the terminal's own cwd plus recency,
+ * which is exact per worktree and ambiguous when two Codex sessions share one.
+ * When it is ambiguous the caller is told so rather than silently shown some
+ * other session's children.
+ */
+
+import { realpath } from "fs/promises";
+import { getPtyClient } from "../PtyClient.js";
+import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import {
+  CodexAppServerError,
+  runCodexAppServerSession,
+  type CodexAppServerCall,
+} from "./CodexAppServerClient.js";
+import {
+  CODEX_SUBAGENT_MESSAGE_MAX_CHARS,
+  CODEX_SUBAGENT_TRANSCRIPT_TURN_LIMIT,
+  type CodexSessionCandidate,
+  type CodexSubagent,
+  type CodexSubagentMessage,
+  type CodexSubagentStatus,
+  type CodexSubagentTurn,
+  type CodexSubagentUnavailableReason,
+  type CodexSubagentsResult,
+  type CodexSubagentTranscriptResult,
+} from "../../../shared/types/ipc/codexSubagents.js";
+
+/** How many root threads in the cwd are considered as parent candidates. */
+const PARENT_CANDIDATE_LIMIT = 25;
+/** Cap on children returned for one parent. */
+const SUBAGENT_LIMIT = 50;
+/**
+ * A root thread created more than this long before the terminal started is a
+ * different session that merely shares the folder, not this terminal's.
+ * Generous because a resumed session keeps its original `createdAt`, so
+ * `recencyAt` is what actually pins it — this only trims obvious strangers.
+ */
+const PARENT_RECENCY_WINDOW_SECONDS = 6 * 60 * 60;
+/**
+ * Two candidates whose activity falls inside this window of each other are
+ * genuinely indistinguishable by recency, so the UI is told it is a guess.
+ */
+const AMBIGUITY_WINDOW_SECONDS = 60 * 60;
+
+/** Protocol timestamps are Unix seconds; the renderer works in milliseconds. */
+function secondsToMs(seconds: unknown): number {
+  return typeof seconds === "number" && Number.isFinite(seconds) ? Math.round(seconds * 1000) : 0;
+}
+
+function nullableSecondsToMs(seconds: unknown): number | null {
+  return typeof seconds === "number" && Number.isFinite(seconds)
+    ? Math.round(seconds * 1000)
+    : null;
+}
+
+/** Shape of the protocol's `Thread`, narrowed to the fields this feature reads. */
+interface RawThread {
+  id?: unknown;
+  parentThreadId?: unknown;
+  preview?: unknown;
+  cwd?: unknown;
+  status?: unknown;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+  recencyAt?: unknown;
+  agentNickname?: unknown;
+  agentRole?: unknown;
+  canAcceptDirectInput?: unknown;
+}
+
+const ACTIVE_FLAGS = new Set(["waitingOnApproval", "waitingOnUserInput"]);
+
+/**
+ * `ThreadStatus` is a tagged union, not a string enum. Unknown arms collapse to
+ * `notLoaded` rather than throwing: a protocol that grows a new status should
+ * degrade to "nothing to report", not blank the whole list.
+ */
+export function toSubagentStatus(raw: unknown): CodexSubagentStatus {
+  if (!raw || typeof raw !== "object") return { type: "notLoaded" };
+  const type = (raw as { type?: unknown }).type;
+  if (type === "idle") return { type: "idle" };
+  if (type === "systemError") return { type: "systemError" };
+  if (type === "active") {
+    const flags = (raw as { activeFlags?: unknown }).activeFlags;
+    return {
+      type: "active",
+      activeFlags: Array.isArray(flags)
+        ? flags.filter((flag): flag is "waitingOnApproval" | "waitingOnUserInput" =>
+            ACTIVE_FLAGS.has(flag as string)
+          )
+        : [],
+    };
+  }
+  return { type: "notLoaded" };
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function toSubagent(raw: RawThread): CodexSubagent | null {
+  const threadId = asString(raw.id);
+  if (!threadId) return null;
+  return {
+    threadId,
+    parentThreadId: asString(raw.parentThreadId),
+    nickname: asString(raw.agentNickname),
+    role: asString(raw.agentRole),
+    preview: typeof raw.preview === "string" ? raw.preview : "",
+    cwd: typeof raw.cwd === "string" ? raw.cwd : "",
+    status: toSubagentStatus(raw.status),
+    createdAt: secondsToMs(raw.createdAt),
+    updatedAt: secondsToMs(raw.updatedAt),
+    // Fail closed: the protocol reports `null` for unloaded threads, which is
+    // every child Daintree sees, and `false` for parent-owned subagents.
+    acceptsDirectInput: raw.canAcceptDirectInput === true,
+  };
+}
+
+export interface ParentSelection {
+  parentThreadId: string | null;
+  matchedBy: "session-id" | "cwd-recency";
+  candidates: CodexSessionCandidate[];
+}
+
+/**
+ * Pick the root thread that most likely belongs to this terminal.
+ *
+ * An exact `agentSessionId` wins outright. Otherwise: keep root threads (a
+ * thread with a `parentThreadId` is itself a subagent), drop any whose activity
+ * predates the terminal's launch by more than the window, order by recency, and
+ * take the newest. Candidates are reported whenever a second thread's activity
+ * lands close enough that recency cannot separate them.
+ */
+export function selectParentThread(
+  threads: RawThread[],
+  input: { spawnedAtMs?: number; agentSessionId?: string | null }
+): ParentSelection {
+  if (input.agentSessionId) {
+    return {
+      parentThreadId: input.agentSessionId,
+      matchedBy: "session-id",
+      candidates: [],
+    };
+  }
+
+  const spawnedAtSeconds =
+    typeof input.spawnedAtMs === "number" && input.spawnedAtMs > 0
+      ? Math.floor(input.spawnedAtMs / 1000)
+      : null;
+
+  const activityOf = (thread: RawThread): number => {
+    const recency = thread.recencyAt;
+    if (typeof recency === "number" && Number.isFinite(recency)) return recency;
+    const updated = thread.updatedAt;
+    if (typeof updated === "number" && Number.isFinite(updated)) return updated;
+    return typeof thread.createdAt === "number" ? thread.createdAt : 0;
+  };
+
+  const roots = threads
+    .filter((thread) => asString(thread.id) !== null && asString(thread.parentThreadId) === null)
+    .filter((thread) => {
+      if (spawnedAtSeconds === null) return true;
+      return activityOf(thread) >= spawnedAtSeconds - PARENT_RECENCY_WINDOW_SECONDS;
+    })
+    .sort((a, b) => activityOf(b) - activityOf(a));
+
+  const best = roots[0];
+  if (!best) return { parentThreadId: null, matchedBy: "cwd-recency", candidates: [] };
+
+  const bestActivity = activityOf(best);
+  const rivals = roots.filter(
+    (thread) => thread !== best && bestActivity - activityOf(thread) <= AMBIGUITY_WINDOW_SECONDS
+  );
+
+  return {
+    parentThreadId: asString(best.id),
+    matchedBy: "cwd-recency",
+    // Only meaningful when a rival exists — an unambiguous match reports none,
+    // so the renderer can treat a non-empty list as "we had to guess".
+    candidates:
+      rivals.length === 0
+        ? []
+        : [best, ...rivals].map((thread) => ({
+            threadId: asString(thread.id) ?? "",
+            preview: typeof thread.preview === "string" ? thread.preview : "",
+            createdAt: secondsToMs(thread.createdAt),
+          })),
+  };
+}
+
+interface RawTurnItem {
+  type?: unknown;
+  text?: unknown;
+  content?: unknown;
+}
+
+function itemText(item: RawTurnItem): string {
+  if (typeof item.text === "string") return item.text;
+  if (!Array.isArray(item.content)) return "";
+  return item.content
+    .map((part) =>
+      part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string"
+        ? (part as { text: string }).text
+        : ""
+    )
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Flatten a turn's items to the user/agent messages worth reading. Reasoning
+ * items are dropped: they are the child's scratchpad, not its output, and they
+ * dwarf the answer.
+ */
+export function toSubagentTurn(raw: unknown): CodexSubagentTurn | null {
+  if (!raw || typeof raw !== "object") return null;
+  const turn = raw as {
+    id?: unknown;
+    items?: unknown;
+    status?: unknown;
+    startedAt?: unknown;
+    completedAt?: unknown;
+  };
+  const turnId = asString(turn.id);
+  if (!turnId) return null;
+
+  const messages: CodexSubagentMessage[] = [];
+  if (Array.isArray(turn.items)) {
+    for (const item of turn.items as RawTurnItem[]) {
+      if (!item || typeof item !== "object") continue;
+      const role =
+        item.type === "userMessage" ? "user" : item.type === "agentMessage" ? "agent" : null;
+      if (!role) continue;
+      const text = itemText(item).trim();
+      if (!text) continue;
+      messages.push({ role, text: text.slice(0, CODEX_SUBAGENT_MESSAGE_MAX_CHARS) });
+    }
+  }
+
+  return {
+    turnId,
+    status: asString(turn.status),
+    startedAt: nullableSecondsToMs(turn.startedAt),
+    completedAt: nullableSecondsToMs(turn.completedAt),
+    messages,
+  };
+}
+
+function unavailable(
+  reason: CodexSubagentUnavailableReason,
+  detail?: string
+): { status: "unavailable"; reason: CodexSubagentUnavailableReason; detail?: string } {
+  return detail
+    ? { status: "unavailable", reason, detail: scrubSecrets(detail) }
+    : { status: "unavailable", reason };
+}
+
+function toUnavailable(error: unknown) {
+  if (error instanceof CodexAppServerError) return unavailable(error.reason, error.message);
+  return unavailable("protocol-error", formatErrorMessage(error, "Codex query failed"));
+}
+
+interface ResolvedTerminal {
+  cwds: string[];
+  spawnedAtMs?: number;
+  agentSessionId?: string | null;
+}
+
+/**
+ * Read the terminal's identity from the pty-host record rather than trusting
+ * the renderer. The renderer supplies only a terminal id, so a compromised or
+ * buggy caller cannot point this at an unrelated folder's Codex history.
+ */
+async function resolveTerminal(
+  terminalId: string
+): Promise<ResolvedTerminal | { status: "unavailable"; reason: CodexSubagentUnavailableReason }> {
+  const info = await getPtyClient().getTerminalAsync(terminalId);
+  if (!info) return { status: "unavailable", reason: "terminal-unknown" };
+  if (info.launchAgentId !== "codex" && info.detectedAgentId !== "codex") {
+    return { status: "unavailable", reason: "not-codex" };
+  }
+  if (!info.cwd) return { status: "unavailable", reason: "terminal-unknown" };
+
+  // `thread/list`'s cwd filter is an exact string match, so a path recorded
+  // through a symlink (macOS `/tmp` → `/private/tmp` being the common one)
+  // would match nothing. Query both spellings when they differ.
+  const cwds = [info.cwd];
+  try {
+    const resolved = await realpath(info.cwd);
+    if (resolved && resolved !== info.cwd) cwds.push(resolved);
+  } catch {
+    // A deleted or unreadable worktree just means the literal path is all we have.
+  }
+
+  return { cwds, spawnedAtMs: info.spawnedAt, agentSessionId: info.agentSessionId ?? null };
+}
+
+async function listThreadsInCwd(call: CodexAppServerCall, cwds: string[]): Promise<RawThread[]> {
+  const response = await call<{ data?: unknown }>("thread/list", {
+    cwd: cwds,
+    sortKey: "recency_at",
+    sortDirection: "desc",
+    limit: PARENT_CANDIDATE_LIMIT,
+    // Reads the state-DB index instead of rescanning JSONL rollouts to repair
+    // metadata: ~3ms against ~900ms, for data this feature only displays.
+    useStateDbOnly: true,
+  });
+  return Array.isArray(response?.data) ? (response.data as RawThread[]) : [];
+}
+
+async function listChildren(
+  call: CodexAppServerCall,
+  parentThreadId: string
+): Promise<RawThread[]> {
+  // `sourceKinds` is deliberately omitted: relationship-filtered requests
+  // include every source kind only when it is absent, and an explicit list
+  // would fall back to the interactive-only default and return nothing.
+  // Review and Guardian threads are excluded by the server, since they do not
+  // participate in the spawn-edge lifecycle this filter walks.
+  const response = await call<{ data?: unknown }>("thread/list", {
+    parentThreadId,
+    limit: SUBAGENT_LIMIT,
+    useStateDbOnly: true,
+  });
+  return Array.isArray(response?.data) ? (response.data as RawThread[]) : [];
+}
+
+/**
+ * An exact session id skips the cwd query entirely — a resumed terminal was
+ * launched with the thread id, so there is nothing to guess.
+ */
+async function resolveParent(
+  call: CodexAppServerCall,
+  terminal: ResolvedTerminal
+): Promise<ParentSelection> {
+  if (terminal.agentSessionId) return selectParentThread([], terminal);
+  return selectParentThread(await listThreadsInCwd(call, terminal.cwds), terminal);
+}
+
+export async function listCodexSubagents(terminalId: string): Promise<CodexSubagentsResult> {
+  const resolved = await resolveTerminal(terminalId);
+  if ("status" in resolved) return resolved;
+
+  try {
+    return await runCodexAppServerSession(async (call) => {
+      const selection = await resolveParent(call, resolved);
+      if (!selection.parentThreadId) return unavailable("no-session");
+
+      const children = await listChildren(call, selection.parentThreadId);
+      return {
+        status: "ok" as const,
+        parentThreadId: selection.parentThreadId,
+        matchedBy: selection.matchedBy,
+        subagents: children
+          .map(toSubagent)
+          .filter((child): child is CodexSubagent => child !== null)
+          .sort((a, b) => b.updatedAt - a.updatedAt),
+        candidates: selection.candidates,
+      };
+    });
+  } catch (error) {
+    return toUnavailable(error);
+  }
+}
+
+export async function readCodexSubagentTranscript(
+  terminalId: string,
+  threadId: string
+): Promise<CodexSubagentTranscriptResult> {
+  const resolved = await resolveTerminal(terminalId);
+  if ("status" in resolved) return resolved;
+
+  try {
+    return await runCodexAppServerSession(async (call) => {
+      const selection = await resolveParent(call, resolved);
+      if (!selection.parentThreadId) return unavailable("no-session");
+
+      // Membership check before any read: the renderer names a thread id, and
+      // without this a wrong or hostile id would read an unrelated Codex
+      // conversation that has nothing to do with this terminal.
+      const children = await listChildren(call, selection.parentThreadId);
+      if (!children.some((child) => asString(child.id) === threadId)) {
+        return unavailable("no-session");
+      }
+
+      const response = await call<{ data?: unknown }>("thread/turns/list", {
+        threadId,
+        limit: CODEX_SUBAGENT_TRANSCRIPT_TURN_LIMIT,
+        sortDirection: "desc",
+        // `summary` carries the user prompt and the agent's answer without the
+        // reasoning trace. `thread/read` with `includeTurns` would also work
+        // but is the deprecated full-hydration path.
+        itemsView: "summary",
+      });
+      const turns = Array.isArray(response?.data) ? response.data : [];
+      return {
+        status: "ok" as const,
+        threadId,
+        turns: turns.map(toSubagentTurn).filter((turn): turn is CodexSubagentTurn => turn !== null),
+      };
+    });
+  } catch (error) {
+    return toUnavailable(error);
+  }
+}

--- a/electron/services/codex/CodexSubagentService.ts
+++ b/electron/services/codex/CodexSubagentService.ts
@@ -38,16 +38,10 @@ const PARENT_CANDIDATE_LIMIT = 25;
 const SUBAGENT_LIMIT = 50;
 /**
  * A session whose last activity is older than this at the moment the terminal
- * launched cannot be the one the terminal is running — it went quiet before
- * the terminal existed. Small slack absorbs clock skew between the two.
+ * launched cannot be the one the terminal is running — it went quiet before the
+ * terminal existed. Small slack absorbs clock skew between the two.
  */
 const STALE_ACTIVITY_SLACK_SECONDS = 5 * 60;
-/**
- * Two roots whose start times sit this close to the terminal's own launch are
- * indistinguishable. Rather than pick one, the lookup reports
- * `ambiguous-session` — a wrong list is indistinguishable from a right one.
- */
-const AMBIGUITY_MARGIN_SECONDS = 5 * 60;
 
 /** Protocol timestamps are Unix seconds; the renderer works in milliseconds. */
 function secondsToMs(seconds: unknown): number {
@@ -101,6 +95,17 @@ export function toSubagentStatus(raw: unknown): CodexSubagentStatus {
   return { type: "notLoaded" };
 }
 
+function numberOf(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** Most recent sign of life, preferring the field that only a turn advances. */
+function activityOf(thread: RawThread): number {
+  return (
+    numberOf(thread.recencyAt) ?? numberOf(thread.updatedAt) ?? numberOf(thread.createdAt) ?? 0
+  );
+}
+
 function asString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
@@ -129,20 +134,24 @@ export type ParentSelection =
   | { parentThreadId: null; reason: "no-session" | "ambiguous-session" };
 
 /**
- * Pick the root thread this terminal is running.
+ * Identify the root thread this terminal is running, or refuse to.
  *
- * An exact `agentSessionId` wins outright. Otherwise the signal is *when the
- * terminal started*, not which thread is newest: a second Codex session in the
- * same folder is usually the more recently active one, so ranking by recency
- * hands terminal A the children of terminal B with nothing to show for it.
- * Ranking by |thread start − terminal start| separates them, because a session
- * a terminal launched begins when that terminal does.
+ * Folder plus timestamps is all we have, and it is not an identity. Two Codex
+ * sessions live in one worktree are genuinely indistinguishable from outside:
+ * ranking them by recency hands terminal A the children of terminal B, and
+ * ranking by proximity to launch does the same whenever A's session was started
+ * by hand some time after A itself. Either way the wrong list looks exactly
+ * like the right one, and the user has nothing to check it against.
  *
- * Two filters keep the field honest. A root that had already gone quiet before
- * the terminal launched is dropped — whatever this terminal is running, it
- * isn't that. And when the two closest roots start within
- * `AMBIGUITY_MARGIN_SECONDS` of each other, nothing distinguishes them, so the
- * lookup reports ambiguity instead of guessing.
+ * So the rule is a filter, not a ranking. Drop every root that had already gone
+ * quiet before this terminal launched — whatever the terminal is running, it
+ * isn't one of those. If exactly one survives, that is the session. If more
+ * than one does, say so and show nothing.
+ *
+ * The cost is real: two concurrent Codex terminals in one worktree both lose
+ * the list. That is the correct trade for a feature whose whole value is
+ * telling you what *your* agent delegated. An exact `agentSessionId` bypasses
+ * all of this.
  */
 export function selectParentThread(
   threads: RawThread[],
@@ -157,51 +166,26 @@ export function selectParentThread(
       ? Math.floor(input.spawnedAtMs / 1000)
       : null;
 
-  const numberOf = (value: unknown): number | null =>
-    typeof value === "number" && Number.isFinite(value) ? value : null;
-
-  const activityOf = (thread: RawThread): number =>
-    numberOf(thread.recencyAt) ?? numberOf(thread.updatedAt) ?? numberOf(thread.createdAt) ?? 0;
-
   const roots = threads.filter(
     (thread) => asString(thread.id) !== null && asString(thread.parentThreadId) === null
   );
 
-  if (spawnedAtSeconds === null) {
-    // With no launch time there is nothing to correlate against, so a single
-    // root is the only answer we can give honestly.
-    if (roots.length === 0) return { parentThreadId: null, reason: "no-session" };
-    if (roots.length > 1) return { parentThreadId: null, reason: "ambiguous-session" };
-    const only = asString(roots[0]?.id);
-    return only
-      ? { parentThreadId: only, matchedBy: "spawn-time" }
-      : { parentThreadId: null, reason: "no-session" };
-  }
+  // Without a launch time there is nothing to filter on, so every root stays a
+  // candidate and only a solitary one can be answered for.
+  const live =
+    spawnedAtSeconds === null
+      ? roots
+      : roots.filter(
+          (thread) => activityOf(thread) >= spawnedAtSeconds - STALE_ACTIVITY_SLACK_SECONDS
+        );
 
-  const live = roots.filter(
-    (thread) => activityOf(thread) >= spawnedAtSeconds - STALE_ACTIVITY_SLACK_SECONDS
-  );
+  if (live.length === 0) return { parentThreadId: null, reason: "no-session" };
+  if (live.length > 1) return { parentThreadId: null, reason: "ambiguous-session" };
 
-  const ranked = live
-    .map((thread) => ({
-      id: asString(thread.id),
-      // A resumed session keeps its original `createdAt`, so it ranks far from
-      // the terminal's launch — that path is served by `agentSessionId`, and
-      // when it isn't, the liveness filter usually leaves it as the sole root.
-      distance: Math.abs((numberOf(thread.createdAt) ?? activityOf(thread)) - spawnedAtSeconds),
-    }))
-    .filter((entry): entry is { id: string; distance: number } => entry.id !== null)
-    .sort((a, b) => a.distance - b.distance);
-
-  const best = ranked[0];
-  if (!best) return { parentThreadId: null, reason: "no-session" };
-
-  const runnerUp = ranked[1];
-  if (runnerUp && runnerUp.distance - best.distance <= AMBIGUITY_MARGIN_SECONDS) {
-    return { parentThreadId: null, reason: "ambiguous-session" };
-  }
-
-  return { parentThreadId: best.id, matchedBy: "spawn-time" };
+  const only = asString(live[0]?.id);
+  return only
+    ? { parentThreadId: only, matchedBy: "spawn-time" }
+    : { parentThreadId: null, reason: "no-session" };
 }
 
 interface RawTurnItem {
@@ -342,22 +326,32 @@ async function listChildren(
 }
 
 /**
- * Confirm a launch-recorded session id really names a Codex thread for this
- * folder before trusting it. `agentSessionId` is generic launch metadata — a
- * pane launched as another agent carries that agent's id, and a Codex pane
- * whose agent exited can be reused for a fresh session the recorded id no
- * longer describes. One cheap `thread/read` on an already-spawned server tells
- * us which it is; anything unexpected falls back to spawn-time correlation.
+ * Confirm a launch-recorded session id really names a live Codex thread for
+ * this folder before trusting it. `agentSessionId` is generic launch metadata:
+ * a pane launched as another agent carries that agent's id, and a reused pane
+ * carries the id of a session that has since been replaced. One cheap
+ * `thread/read` on an already-spawned server settles both.
  */
 async function verifySessionThread(
   call: CodexAppServerCall,
   threadId: string,
-  cwds: string[]
+  terminal: ResolvedTerminal
 ): Promise<boolean> {
   try {
     const response = await call<{ thread?: RawThread }>("thread/read", { threadId });
-    const cwd = response?.thread?.cwd;
-    return typeof cwd === "string" && cwds.includes(cwd);
+    const thread = response?.thread;
+    if (!thread || typeof thread.cwd !== "string" || !terminal.cwds.includes(thread.cwd)) {
+      return false;
+    }
+    // A pane whose agent exited can be reused for a fresh session the recorded
+    // id no longer describes. The prior session is in the right folder but went
+    // quiet before this launch, so liveness is what separates the two.
+    const spawnedAtSeconds =
+      typeof terminal.spawnedAtMs === "number" && terminal.spawnedAtMs > 0
+        ? Math.floor(terminal.spawnedAtMs / 1000)
+        : null;
+    if (spawnedAtSeconds === null) return true;
+    return activityOf(thread) >= spawnedAtSeconds - STALE_ACTIVITY_SLACK_SECONDS;
   } catch {
     // No such thread, or a server that won't answer — either way, don't trust it.
     return false;
@@ -369,7 +363,7 @@ async function resolveParent(
   terminal: ResolvedTerminal
 ): Promise<ParentSelection> {
   if (terminal.agentSessionId) {
-    if (await verifySessionThread(call, terminal.agentSessionId, terminal.cwds)) {
+    if (await verifySessionThread(call, terminal.agentSessionId, terminal)) {
       return selectParentThread([], terminal);
     }
   }

--- a/electron/services/codex/CodexSubagentService.ts
+++ b/electron/services/codex/CodexSubagentService.ts
@@ -22,8 +22,8 @@ import {
 import {
   CODEX_SUBAGENT_MESSAGE_MAX_CHARS,
   CODEX_SUBAGENT_TRANSCRIPT_TURN_LIMIT,
-  type CodexSessionCandidate,
   type CodexSubagent,
+  type CodexSubagentMatch,
   type CodexSubagentMessage,
   type CodexSubagentStatus,
   type CodexSubagentTurn,
@@ -37,17 +37,17 @@ const PARENT_CANDIDATE_LIMIT = 25;
 /** Cap on children returned for one parent. */
 const SUBAGENT_LIMIT = 50;
 /**
- * A root thread created more than this long before the terminal started is a
- * different session that merely shares the folder, not this terminal's.
- * Generous because a resumed session keeps its original `createdAt`, so
- * `recencyAt` is what actually pins it — this only trims obvious strangers.
+ * A session whose last activity is older than this at the moment the terminal
+ * launched cannot be the one the terminal is running — it went quiet before
+ * the terminal existed. Small slack absorbs clock skew between the two.
  */
-const PARENT_RECENCY_WINDOW_SECONDS = 6 * 60 * 60;
+const STALE_ACTIVITY_SLACK_SECONDS = 5 * 60;
 /**
- * Two candidates whose activity falls inside this window of each other are
- * genuinely indistinguishable by recency, so the UI is told it is a guess.
+ * Two roots whose start times sit this close to the terminal's own launch are
+ * indistinguishable. Rather than pick one, the lookup reports
+ * `ambiguous-session` — a wrong list is indistinguishable from a right one.
  */
-const AMBIGUITY_WINDOW_SECONDS = 60 * 60;
+const AMBIGUITY_MARGIN_SECONDS = 5 * 60;
 
 /** Protocol timestamps are Unix seconds; the renderer works in milliseconds. */
 function secondsToMs(seconds: unknown): number {
@@ -124,31 +124,32 @@ export function toSubagent(raw: RawThread): CodexSubagent | null {
   };
 }
 
-export interface ParentSelection {
-  parentThreadId: string | null;
-  matchedBy: "session-id" | "cwd-recency";
-  candidates: CodexSessionCandidate[];
-}
+export type ParentSelection =
+  | { parentThreadId: string; matchedBy: CodexSubagentMatch }
+  | { parentThreadId: null; reason: "no-session" | "ambiguous-session" };
 
 /**
- * Pick the root thread that most likely belongs to this terminal.
+ * Pick the root thread this terminal is running.
  *
- * An exact `agentSessionId` wins outright. Otherwise: keep root threads (a
- * thread with a `parentThreadId` is itself a subagent), drop any whose activity
- * predates the terminal's launch by more than the window, order by recency, and
- * take the newest. Candidates are reported whenever a second thread's activity
- * lands close enough that recency cannot separate them.
+ * An exact `agentSessionId` wins outright. Otherwise the signal is *when the
+ * terminal started*, not which thread is newest: a second Codex session in the
+ * same folder is usually the more recently active one, so ranking by recency
+ * hands terminal A the children of terminal B with nothing to show for it.
+ * Ranking by |thread start − terminal start| separates them, because a session
+ * a terminal launched begins when that terminal does.
+ *
+ * Two filters keep the field honest. A root that had already gone quiet before
+ * the terminal launched is dropped — whatever this terminal is running, it
+ * isn't that. And when the two closest roots start within
+ * `AMBIGUITY_MARGIN_SECONDS` of each other, nothing distinguishes them, so the
+ * lookup reports ambiguity instead of guessing.
  */
 export function selectParentThread(
   threads: RawThread[],
   input: { spawnedAtMs?: number; agentSessionId?: string | null }
 ): ParentSelection {
   if (input.agentSessionId) {
-    return {
-      parentThreadId: input.agentSessionId,
-      matchedBy: "session-id",
-      candidates: [],
-    };
+    return { parentThreadId: input.agentSessionId, matchedBy: "session-id" };
   }
 
   const spawnedAtSeconds =
@@ -156,44 +157,51 @@ export function selectParentThread(
       ? Math.floor(input.spawnedAtMs / 1000)
       : null;
 
-  const activityOf = (thread: RawThread): number => {
-    const recency = thread.recencyAt;
-    if (typeof recency === "number" && Number.isFinite(recency)) return recency;
-    const updated = thread.updatedAt;
-    if (typeof updated === "number" && Number.isFinite(updated)) return updated;
-    return typeof thread.createdAt === "number" ? thread.createdAt : 0;
-  };
+  const numberOf = (value: unknown): number | null =>
+    typeof value === "number" && Number.isFinite(value) ? value : null;
 
-  const roots = threads
-    .filter((thread) => asString(thread.id) !== null && asString(thread.parentThreadId) === null)
-    .filter((thread) => {
-      if (spawnedAtSeconds === null) return true;
-      return activityOf(thread) >= spawnedAtSeconds - PARENT_RECENCY_WINDOW_SECONDS;
-    })
-    .sort((a, b) => activityOf(b) - activityOf(a));
+  const activityOf = (thread: RawThread): number =>
+    numberOf(thread.recencyAt) ?? numberOf(thread.updatedAt) ?? numberOf(thread.createdAt) ?? 0;
 
-  const best = roots[0];
-  if (!best) return { parentThreadId: null, matchedBy: "cwd-recency", candidates: [] };
-
-  const bestActivity = activityOf(best);
-  const rivals = roots.filter(
-    (thread) => thread !== best && bestActivity - activityOf(thread) <= AMBIGUITY_WINDOW_SECONDS
+  const roots = threads.filter(
+    (thread) => asString(thread.id) !== null && asString(thread.parentThreadId) === null
   );
 
-  return {
-    parentThreadId: asString(best.id),
-    matchedBy: "cwd-recency",
-    // Only meaningful when a rival exists — an unambiguous match reports none,
-    // so the renderer can treat a non-empty list as "we had to guess".
-    candidates:
-      rivals.length === 0
-        ? []
-        : [best, ...rivals].map((thread) => ({
-            threadId: asString(thread.id) ?? "",
-            preview: typeof thread.preview === "string" ? thread.preview : "",
-            createdAt: secondsToMs(thread.createdAt),
-          })),
-  };
+  if (spawnedAtSeconds === null) {
+    // With no launch time there is nothing to correlate against, so a single
+    // root is the only answer we can give honestly.
+    if (roots.length === 0) return { parentThreadId: null, reason: "no-session" };
+    if (roots.length > 1) return { parentThreadId: null, reason: "ambiguous-session" };
+    const only = asString(roots[0]?.id);
+    return only
+      ? { parentThreadId: only, matchedBy: "spawn-time" }
+      : { parentThreadId: null, reason: "no-session" };
+  }
+
+  const live = roots.filter(
+    (thread) => activityOf(thread) >= spawnedAtSeconds - STALE_ACTIVITY_SLACK_SECONDS
+  );
+
+  const ranked = live
+    .map((thread) => ({
+      id: asString(thread.id),
+      // A resumed session keeps its original `createdAt`, so it ranks far from
+      // the terminal's launch — that path is served by `agentSessionId`, and
+      // when it isn't, the liveness filter usually leaves it as the sole root.
+      distance: Math.abs((numberOf(thread.createdAt) ?? activityOf(thread)) - spawnedAtSeconds),
+    }))
+    .filter((entry): entry is { id: string; distance: number } => entry.id !== null)
+    .sort((a, b) => a.distance - b.distance);
+
+  const best = ranked[0];
+  if (!best) return { parentThreadId: null, reason: "no-session" };
+
+  const runnerUp = ranked[1];
+  if (runnerUp && runnerUp.distance - best.distance <= AMBIGUITY_MARGIN_SECONDS) {
+    return { parentThreadId: null, reason: "ambiguous-session" };
+  }
+
+  return { parentThreadId: best.id, matchedBy: "spawn-time" };
 }
 
 interface RawTurnItem {
@@ -334,15 +342,40 @@ async function listChildren(
 }
 
 /**
- * An exact session id skips the cwd query entirely — a resumed terminal was
- * launched with the thread id, so there is nothing to guess.
+ * Confirm a launch-recorded session id really names a Codex thread for this
+ * folder before trusting it. `agentSessionId` is generic launch metadata — a
+ * pane launched as another agent carries that agent's id, and a Codex pane
+ * whose agent exited can be reused for a fresh session the recorded id no
+ * longer describes. One cheap `thread/read` on an already-spawned server tells
+ * us which it is; anything unexpected falls back to spawn-time correlation.
  */
+async function verifySessionThread(
+  call: CodexAppServerCall,
+  threadId: string,
+  cwds: string[]
+): Promise<boolean> {
+  try {
+    const response = await call<{ thread?: RawThread }>("thread/read", { threadId });
+    const cwd = response?.thread?.cwd;
+    return typeof cwd === "string" && cwds.includes(cwd);
+  } catch {
+    // No such thread, or a server that won't answer — either way, don't trust it.
+    return false;
+  }
+}
+
 async function resolveParent(
   call: CodexAppServerCall,
   terminal: ResolvedTerminal
 ): Promise<ParentSelection> {
-  if (terminal.agentSessionId) return selectParentThread([], terminal);
-  return selectParentThread(await listThreadsInCwd(call, terminal.cwds), terminal);
+  if (terminal.agentSessionId) {
+    if (await verifySessionThread(call, terminal.agentSessionId, terminal.cwds)) {
+      return selectParentThread([], terminal);
+    }
+  }
+  return selectParentThread(await listThreadsInCwd(call, terminal.cwds), {
+    spawnedAtMs: terminal.spawnedAtMs,
+  });
 }
 
 export async function listCodexSubagents(terminalId: string): Promise<CodexSubagentsResult> {
@@ -352,7 +385,7 @@ export async function listCodexSubagents(terminalId: string): Promise<CodexSubag
   try {
     return await runCodexAppServerSession(async (call) => {
       const selection = await resolveParent(call, resolved);
-      if (!selection.parentThreadId) return unavailable("no-session");
+      if (selection.parentThreadId === null) return unavailable(selection.reason);
 
       const children = await listChildren(call, selection.parentThreadId);
       return {
@@ -363,7 +396,6 @@ export async function listCodexSubagents(terminalId: string): Promise<CodexSubag
           .map(toSubagent)
           .filter((child): child is CodexSubagent => child !== null)
           .sort((a, b) => b.updatedAt - a.updatedAt),
-        candidates: selection.candidates,
       };
     });
   } catch (error) {
@@ -381,7 +413,9 @@ export async function readCodexSubagentTranscript(
   try {
     return await runCodexAppServerSession(async (call) => {
       const selection = await resolveParent(call, resolved);
-      if (!selection.parentThreadId) return unavailable("no-session");
+      // Ambiguity fails the read too, not just the list: an unresolved parent
+      // means we cannot say the requested thread belongs to this terminal.
+      if (selection.parentThreadId === null) return unavailable(selection.reason);
 
       // Membership check before any read: the renderer names a thread id, and
       // without this a wrong or hostile id would read an unrelated Codex
@@ -404,7 +438,11 @@ export async function readCodexSubagentTranscript(
       return {
         status: "ok" as const,
         threadId,
-        turns: turns.map(toSubagentTurn).filter((turn): turn is CodexSubagentTurn => turn !== null),
+        // A turn whose only items were reasoning has nothing to show, and an
+        // all-empty page would still read as "loaded" to the renderer.
+        turns: turns
+          .map(toSubagentTurn)
+          .filter((turn): turn is CodexSubagentTurn => turn !== null && turn.messages.length > 0),
       };
     });
   } catch (error) {

--- a/electron/services/codex/__tests__/CodexAppServerClient.test.ts
+++ b/electron/services/codex/__tests__/CodexAppServerClient.test.ts
@@ -1,0 +1,267 @@
+import { EventEmitter } from "events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const spawnSyncMock = vi.hoisted(() => vi.fn(() => ({ status: 0 })));
+
+vi.mock("child_process", () => ({
+  spawn: spawnMock,
+  spawnSync: spawnSyncMock,
+}));
+
+vi.mock("../../../utils/spawnEnv.js", () => ({
+  buildProbeEnv: () => ({ PATH: "/usr/bin" }),
+}));
+
+import {
+  CODEX_APP_SERVER_ALLOWED_METHODS,
+  CodexAppServerError,
+  runCodexAppServerSession,
+} from "../CodexAppServerClient.js";
+
+class FakeStream extends EventEmitter {
+  destroyed = false;
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+class FakeStdin extends EventEmitter {
+  readonly lines: string[] = [];
+  ended = false;
+  write(chunk: string) {
+    this.lines.push(chunk);
+    return true;
+  }
+  end() {
+    this.ended = true;
+  }
+}
+
+class FakeChild extends EventEmitter {
+  readonly stdout = new FakeStream();
+  readonly stderr = new FakeStream();
+  readonly stdin = new FakeStdin();
+  pid = 4242;
+  unref = vi.fn();
+
+  /** Parsed requests the client has written, in order. */
+  get requests(): Array<{ id?: number; method: string; params?: unknown }> {
+    return this.stdin.lines.map((line) => JSON.parse(line));
+  }
+
+  emitLines(...lines: string[]) {
+    this.stdout.emit("data", Buffer.from(lines.map((line) => `${line}\n`).join("")));
+  }
+
+  /** Answer whatever the client most recently asked, by request id. */
+  respondTo(method: string, result: unknown) {
+    const request = this.requests.find(
+      (entry) => entry.method === method && entry.id !== undefined
+    );
+    if (!request) throw new Error(`no pending request for ${method}`);
+    this.emitLines(JSON.stringify({ id: request.id, result }));
+  }
+}
+
+let child: FakeChild;
+
+/** Let queued microtasks (the client's promise plumbing) run. */
+const flush = async () => {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+};
+
+/** Complete the handshake so a test can get at the caller's `call`. */
+async function startSession<T>(run: Parameters<typeof runCodexAppServerSession<T>>[0]) {
+  const promise = runCodexAppServerSession(run, { command: "codex-test" });
+  await flush();
+  child.respondTo("initialize", { userAgent: "codex" });
+  await flush();
+  return promise;
+}
+
+beforeEach(() => {
+  child = new FakeChild();
+  spawnMock.mockReset();
+  spawnMock.mockImplementation(() => child);
+  spawnSyncMock.mockClear();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("runCodexAppServerSession", () => {
+  it("handshakes with experimental capabilities before running the caller", async () => {
+    const seen: string[] = [];
+    const result = await startSession(async (call) => {
+      seen.push(...child.requests.map((entry) => entry.method));
+      const listPromise = call<{ data: unknown[] }>("thread/list", { limit: 1 });
+      await flush();
+      child.respondTo("thread/list", { data: [{ id: "a" }] });
+      return listPromise;
+    });
+
+    expect(result).toEqual({ data: [{ id: "a" }] });
+    // initialize is a request; initialized is a notification with no id.
+    const initialize = child.requests[0];
+    expect(initialize.method).toBe("initialize");
+    expect(initialize.params).toMatchObject({ capabilities: { experimentalApi: true } });
+    const initialized = child.requests[1];
+    expect(initialized.method).toBe("initialized");
+    expect(initialized.id).toBeUndefined();
+    // The caller's own query must come after the handshake, never before.
+    expect(seen).toEqual(["initialize", "initialized"]);
+  });
+
+  it("refuses methods outside the read-only allowlist without writing to stdin", async () => {
+    expect(CODEX_APP_SERVER_ALLOWED_METHODS.has("thread/start")).toBe(false);
+
+    const error = await startSession(async (call) =>
+      call("thread/start", { cwd: "/repo" }).then(
+        () => null,
+        (err: unknown) => err
+      )
+    );
+
+    expect(error).toBeInstanceOf(CodexAppServerError);
+    expect((error as CodexAppServerError).message).toContain("thread/start");
+    // Only the two handshake frames were ever written.
+    expect(child.requests.map((entry) => entry.method)).toEqual(["initialize", "initialized"]);
+  });
+
+  it("resolves interleaved responses by id, ignoring notifications and split frames", async () => {
+    const result = await startSession(async (call) => {
+      const first = call<{ tag: string }>("thread/list");
+      const second = call<{ tag: string }>("thread/read");
+      await flush();
+      const ids = child.requests.filter((entry) => entry.id !== undefined).map((entry) => entry.id);
+      const [, listId, readId] = ids;
+
+      // A notification (no id) between responses must not consume either.
+      child.emitLines(JSON.stringify({ method: "thread/started", params: {} }));
+      // Answer out of order.
+      child.emitLines(JSON.stringify({ id: readId, result: { tag: "read" } }));
+      // Deliver the remaining response across two chunks, split mid-JSON.
+      const payload = `${JSON.stringify({ id: listId, result: { tag: "list" } })}\n`;
+      child.stdout.emit("data", Buffer.from(payload.slice(0, 12)));
+      child.stdout.emit("data", Buffer.from(payload.slice(12)));
+
+      return { list: await first, read: await second };
+    });
+
+    expect(result).toEqual({ list: { tag: "list" }, read: { tag: "read" } });
+  });
+
+  it("surfaces a JSON-RPC error as a protocol-error rejection", async () => {
+    const error = await startSession(async (call) => {
+      const pending = call("thread/list").then(
+        () => null,
+        (err: unknown) => err
+      );
+      await flush();
+      const id = child.requests.filter((entry) => entry.id !== undefined).at(-1)?.id;
+      child.emitLines(
+        JSON.stringify({ id, error: { code: -32001, message: "Server overloaded" } })
+      );
+      return pending;
+    });
+
+    expect(error).toBeInstanceOf(CodexAppServerError);
+    expect((error as CodexAppServerError).reason).toBe("protocol-error");
+    expect((error as CodexAppServerError).message).toContain("Server overloaded");
+  });
+
+  it("reports a missing CLI distinctly from a protocol failure", async () => {
+    spawnMock.mockImplementationOnce(() => {
+      const error = new Error("spawn codex ENOENT") as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      throw error;
+    });
+
+    await expect(runCodexAppServerSession(async () => "unused")).rejects.toMatchObject({
+      reason: "cli-missing",
+    });
+  });
+
+  it("rejects every in-flight request once when the server dies mid-query", async () => {
+    const outcome = await startSession(async (call) => {
+      const first = call("thread/list").then(
+        () => "resolved",
+        (err: unknown) => (err as Error).message
+      );
+      const second = call("thread/read").then(
+        () => "resolved",
+        (err: unknown) => (err as Error).message
+      );
+      await flush();
+      child.stderr.emit("data", Buffer.from("panicked at codex"));
+      child.emit("close");
+      return Promise.all([first, second]);
+    });
+
+    expect(outcome[0]).toContain("exited early");
+    expect(outcome[1]).toContain("exited early");
+    // stderr is folded into the message so a crash is diagnosable.
+    expect(outcome[0]).toContain("panicked at codex");
+  });
+
+  it("reaps the process group when the session ends", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    await startSession(async () => "done");
+
+    // Negative pid = whole group, so a grandchild holding the pipe goes too.
+    expect(killSpy).toHaveBeenCalledWith(-child.pid, "SIGKILL");
+    expect(child.stdin.ended).toBe(true);
+    expect(child.stdout.destroyed).toBe(true);
+  });
+
+  it("keeps stream error sinks alive after teardown so a late EIO is not fatal", async () => {
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    await startSession(async () => "done");
+
+    // An unhandled 'error' on a stream is fatal in the main process; emitting
+    // one after dispose must stay absorbed.
+    expect(() => child.stdout.emit("error", new Error("EIO"))).not.toThrow();
+    expect(() => child.stdin.emit("error", new Error("EPIPE"))).not.toThrow();
+  });
+
+  it("aborts on a frame that never terminates instead of buffering it forever", async () => {
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const error = await startSession(async (call) => {
+      const pending = call("thread/list").then(
+        () => null,
+        (err: unknown) => err
+      );
+      await flush();
+      // 5MB with no newline: not a response, just an unbounded frame.
+      child.stdout.emit("data", Buffer.from("x".repeat(5 * 1024 * 1024)));
+      return pending;
+    });
+
+    expect((error as CodexAppServerError).message).toContain("exceeded limit");
+  });
+
+  it("times the whole session out and reaps rather than hanging on a silent server", async () => {
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const promise = runCodexAppServerSession(async () => "unreachable", {
+      command: "codex-test",
+      timeoutMs: 50,
+    }).catch((error: unknown) => error);
+
+    // The server never answers `initialize`.
+    await vi.advanceTimersByTimeAsync(60);
+    const error = await promise;
+
+    expect(error).toBeInstanceOf(CodexAppServerError);
+    expect((error as CodexAppServerError).reason).toBe("timeout");
+    expect(killSpy).toHaveBeenCalledWith(-child.pid, "SIGKILL");
+  });
+});

--- a/electron/services/codex/__tests__/CodexAppServerClient.test.ts
+++ b/electron/services/codex/__tests__/CodexAppServerClient.test.ts
@@ -13,11 +13,7 @@ vi.mock("../../../utils/spawnEnv.js", () => ({
   buildProbeEnv: () => ({ PATH: "/usr/bin" }),
 }));
 
-import {
-  CODEX_APP_SERVER_ALLOWED_METHODS,
-  CodexAppServerError,
-  runCodexAppServerSession,
-} from "../CodexAppServerClient.js";
+import { CodexAppServerError, runCodexAppServerSession } from "../CodexAppServerClient.js";
 
 class FakeStream extends EventEmitter {
   destroyed = false;
@@ -117,8 +113,6 @@ describe("runCodexAppServerSession", () => {
   });
 
   it("refuses methods outside the read-only allowlist without writing to stdin", async () => {
-    expect(CODEX_APP_SERVER_ALLOWED_METHODS.has("thread/start")).toBe(false);
-
     const error = await startSession(async (call) =>
       call("thread/start", { cwd: "/repo" }).then(
         () => null,
@@ -245,6 +239,120 @@ describe("runCodexAppServerSession", () => {
     });
 
     expect((error as CodexAppServerError).message).toContain("exceeded limit");
+  });
+
+  it("classifies an asynchronous ENOENT the same as a synchronous one", async () => {
+    // `spawn` reports a missing binary through an 'error' event, not a throw,
+    // whenever the failure is detected after the call returns.
+    const promise = runCodexAppServerSession(async () => "unused", {
+      command: "codex-test",
+    }).catch((error: unknown) => error);
+    await flush();
+    const enoent = new Error("spawn codex-test ENOENT") as NodeJS.ErrnoException;
+    enoent.code = "ENOENT";
+    child.emit("error", enoent);
+
+    expect(await promise).toMatchObject({ reason: "cli-missing" });
+  });
+
+  it("drops a response that arrives after its request timed out, leaving others correlated", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const promise = runCodexAppServerSession(
+      async (call) => {
+        const stale = call("thread/list").then(
+          () => "resolved",
+          (err: unknown) => (err as CodexAppServerError).reason
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        const staleId = child.requests.filter((entry) => entry.id !== undefined).at(-1)?.id;
+
+        // Blow the per-request budget on the first call only.
+        await vi.advanceTimersByTimeAsync(10_001);
+        const staleOutcome = await stale;
+
+        const live = call<{ tag: string }>("thread/read");
+        await vi.advanceTimersByTimeAsync(0);
+        // The late response for the abandoned id must not satisfy the new call.
+        child.emitLines(JSON.stringify({ id: staleId, result: { tag: "stale" } }));
+        const liveId = child.requests.filter((entry) => entry.id !== undefined).at(-1)?.id;
+        expect(liveId).not.toBe(staleId);
+        child.emitLines(JSON.stringify({ id: liveId, result: { tag: "live" } }));
+
+        return { staleOutcome, live: await live };
+      },
+      { command: "codex-test", timeoutMs: 60_000 }
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    child.respondTo("initialize", { userAgent: "codex" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).resolves.toEqual({ staleOutcome: "timeout", live: { tag: "live" } });
+  });
+
+  it("rejects a call made after the session was torn down", async () => {
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    let escaped: ((method: string) => Promise<unknown>) | null = null;
+
+    await startSession(async (call) => {
+      escaped = call;
+      return "done";
+    });
+
+    await expect(escaped!("thread/list")).rejects.toBeInstanceOf(CodexAppServerError);
+  });
+
+  it("caps how many app-servers run at once so a project restore can't burst", async () => {
+    // Every Codex pane asks for its own subagents when a project restores;
+    // ungated that is one child process per pane, all at the same instant.
+    const children: FakeChild[] = [];
+    spawnMock.mockImplementation(() => {
+      const next = new FakeChild();
+      children.push(next);
+      return next;
+    });
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const handshakeAll = async () => {
+      await flush();
+      for (const spawned of children) {
+        if (
+          spawned.requests.some((entry) => entry.method === "initialize" && entry.id !== undefined)
+        ) {
+          try {
+            spawned.respondTo("initialize", {});
+          } catch {
+            // Already answered on an earlier pass.
+          }
+        }
+      }
+      await flush();
+    };
+
+    const release: Array<() => void> = [];
+    const sessions = Array.from({ length: 5 }, () =>
+      runCodexAppServerSession(
+        () => new Promise<string>((resolve) => release.push(() => resolve("done"))),
+        { command: "codex-test" }
+      )
+    );
+
+    await handshakeAll();
+    // The gate is what keeps this below the number of callers.
+    const spawnedWhileGated = children.length;
+
+    // Drain: each completion frees a slot, which spawns and handshakes the next.
+    while (release.length > 0) {
+      release.shift()?.();
+      await handshakeAll();
+    }
+    await Promise.all(sessions);
+
+    expect(spawnedWhileGated).toBeLessThan(sessions.length);
+    // Every queued session still runs once a slot frees.
+    expect(children.length).toBe(sessions.length);
   });
 
   it("times the whole session out and reaps rather than hanging on a silent server", async () => {

--- a/electron/services/codex/__tests__/CodexAppServerClient.test.ts
+++ b/electron/services/codex/__tests__/CodexAppServerClient.test.ts
@@ -35,6 +35,8 @@ class FakeStdin extends EventEmitter {
 }
 
 class FakeChild extends EventEmitter {
+  /** Request ids already answered, so a polling helper can't double-respond. */
+  readonly answered = new Set<number>();
   readonly stdout = new FakeStream();
   readonly stderr = new FakeStream();
   readonly stdin = new FakeStdin();
@@ -59,6 +61,9 @@ class FakeChild extends EventEmitter {
     this.emitLines(JSON.stringify({ id: request.id, result }));
   }
 }
+
+/** Injected rather than mirrored, so the test doesn't restate the default. */
+const REQUEST_BUDGET_MS = 250;
 
 let child: FakeChild;
 
@@ -268,8 +273,8 @@ describe("runCodexAppServerSession", () => {
         await vi.advanceTimersByTimeAsync(0);
         const staleId = child.requests.filter((entry) => entry.id !== undefined).at(-1)?.id;
 
-        // Blow the per-request budget on the first call only.
-        await vi.advanceTimersByTimeAsync(10_001);
+        // Blow the injected per-request budget on the first call only.
+        await vi.advanceTimersByTimeAsync(REQUEST_BUDGET_MS + 1);
         const staleOutcome = await stale;
 
         const live = call<{ tag: string }>("thread/read");
@@ -282,7 +287,7 @@ describe("runCodexAppServerSession", () => {
 
         return { staleOutcome, live: await live };
       },
-      { command: "codex-test", timeoutMs: 60_000 }
+      { command: "codex-test", timeoutMs: 60_000, requestTimeoutMs: REQUEST_BUDGET_MS }
     );
 
     await vi.advanceTimersByTimeAsync(0);
@@ -304,7 +309,7 @@ describe("runCodexAppServerSession", () => {
     await expect(escaped!("thread/list")).rejects.toBeInstanceOf(CodexAppServerError);
   });
 
-  it("caps how many app-servers run at once so a project restore can't burst", async () => {
+  it("holds a third app-server back until a running one finishes", async () => {
     // Every Codex pane asks for its own subagents when a project restores;
     // ungated that is one child process per pane, all at the same instant.
     const children: FakeChild[] = [];
@@ -318,21 +323,19 @@ describe("runCodexAppServerSession", () => {
     const handshakeAll = async () => {
       await flush();
       for (const spawned of children) {
-        if (
-          spawned.requests.some((entry) => entry.method === "initialize" && entry.id !== undefined)
-        ) {
-          try {
-            spawned.respondTo("initialize", {});
-          } catch {
-            // Already answered on an earlier pass.
-          }
+        const initialize = spawned.requests.find(
+          (entry) => entry.method === "initialize" && entry.id !== undefined
+        );
+        if (initialize && !spawned.answered.has(initialize.id!)) {
+          spawned.answered.add(initialize.id!);
+          spawned.emitLines(JSON.stringify({ id: initialize.id, result: {} }));
         }
       }
       await flush();
     };
 
     const release: Array<() => void> = [];
-    const sessions = Array.from({ length: 5 }, () =>
+    const sessions = Array.from({ length: 3 }, () =>
       runCodexAppServerSession(
         () => new Promise<string>((resolve) => release.push(() => resolve("done"))),
         { command: "codex-test" }
@@ -340,19 +343,18 @@ describe("runCodexAppServerSession", () => {
     );
 
     await handshakeAll();
-    // The gate is what keeps this below the number of callers.
-    const spawnedWhileGated = children.length;
+    // Two run; the third must not have spawned anything yet.
+    expect(children.length).toBe(2);
 
-    // Drain: each completion frees a slot, which spawns and handshakes the next.
+    release.shift()?.();
+    await handshakeAll();
+    expect(children.length).toBe(3);
+
     while (release.length > 0) {
       release.shift()?.();
       await handshakeAll();
     }
     await Promise.all(sessions);
-
-    expect(spawnedWhileGated).toBeLessThan(sessions.length);
-    // Every queued session still runs once a slot frees.
-    expect(children.length).toBe(sessions.length);
   });
 
   it("times the whole session out and reaps rather than hanging on a silent server", async () => {

--- a/electron/services/codex/__tests__/CodexSubagentService.test.ts
+++ b/electron/services/codex/__tests__/CodexSubagentService.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getTerminalAsync = vi.hoisted(() => vi.fn());
+const runSession = vi.hoisted(() => vi.fn());
+
+vi.mock("../../PtyClient.js", () => ({
+  getPtyClient: () => ({ getTerminalAsync }),
+}));
+
+vi.mock("../CodexAppServerClient.js", async () => {
+  const actual = await vi.importActual<typeof import("../CodexAppServerClient.js")>(
+    "../CodexAppServerClient.js"
+  );
+  return { ...actual, runCodexAppServerSession: runSession };
+});
+
+vi.mock("fs/promises", () => ({
+  realpath: vi.fn(async (input: string) =>
+    input.startsWith("/tmp/") ? input.replace("/tmp/", "/private/tmp/") : input
+  ),
+}));
+
+import { CodexAppServerError } from "../CodexAppServerClient.js";
+import {
+  listCodexSubagents,
+  readCodexSubagentTranscript,
+  selectParentThread,
+  toSubagent,
+  toSubagentStatus,
+  toSubagentTurn,
+} from "../CodexSubagentService.js";
+
+/** Params the service sends; every field is optional so a script can probe any. */
+type QueryParams = Record<string, unknown>;
+type Call = (method: string, params?: QueryParams) => Promise<unknown>;
+
+/** Drive the mocked session with a scripted responder keyed by method. */
+function scriptSession(responder: (method: string, params: QueryParams) => unknown) {
+  runSession.mockImplementation(async (run: (call: Call) => Promise<unknown>) =>
+    run(async (method: string, params: QueryParams = {}) => responder(method, params))
+  );
+}
+
+const codexTerminal = {
+  cwd: "/repo",
+  launchAgentId: "codex",
+  spawnedAt: 1_700_000_000_000,
+};
+
+beforeEach(() => {
+  getTerminalAsync.mockReset();
+  runSession.mockReset();
+});
+
+describe("toSubagentStatus", () => {
+  it("keeps the active flags that say why a child is blocked", () => {
+    expect(toSubagentStatus({ type: "active", activeFlags: ["waitingOnApproval"] })).toEqual({
+      type: "active",
+      activeFlags: ["waitingOnApproval"],
+    });
+  });
+
+  it("drops flags the protocol did not define rather than passing them through", () => {
+    expect(
+      toSubagentStatus({ type: "active", activeFlags: ["waitingOnUserInput", "bogus"] })
+    ).toEqual({ type: "active", activeFlags: ["waitingOnUserInput"] });
+  });
+
+  it("degrades an unknown or malformed status to notLoaded instead of throwing", () => {
+    expect(toSubagentStatus({ type: "somethingNew" })).toEqual({ type: "notLoaded" });
+    expect(toSubagentStatus(null)).toEqual({ type: "notLoaded" });
+  });
+});
+
+describe("toSubagent", () => {
+  it("converts the protocol's Unix seconds to milliseconds", () => {
+    const subagent = toSubagent({ id: "t", createdAt: 1_730_831_111, updatedAt: 1_730_831_222 });
+    expect(subagent?.createdAt).toBe(1_730_831_111_000);
+    expect(subagent?.updatedAt).toBe(1_730_831_222_000);
+  });
+
+  it("treats a null canAcceptDirectInput as not accepting input", () => {
+    // null is what the protocol reports for the unloaded threads this feature
+    // always sees, so an `=== false` check would read it as input-capable.
+    expect(toSubagent({ id: "t", canAcceptDirectInput: null })?.acceptsDirectInput).toBe(false);
+    expect(toSubagent({ id: "t", canAcceptDirectInput: false })?.acceptsDirectInput).toBe(false);
+    expect(toSubagent({ id: "t", canAcceptDirectInput: true })?.acceptsDirectInput).toBe(true);
+  });
+
+  it("drops a thread with no id rather than emitting an unaddressable row", () => {
+    expect(toSubagent({ preview: "orphan" })).toBeNull();
+  });
+});
+
+describe("selectParentThread", () => {
+  const spawnedAtMs = 1_700_000_000_000;
+  const spawnedAtSeconds = spawnedAtMs / 1000;
+
+  it("uses an exact session id without consulting the thread list", () => {
+    const selection = selectParentThread([{ id: "other", recencyAt: spawnedAtSeconds }], {
+      spawnedAtMs,
+      agentSessionId: "known-thread",
+    });
+    expect(selection).toEqual({
+      parentThreadId: "known-thread",
+      matchedBy: "session-id",
+      candidates: [],
+    });
+  });
+
+  it("ignores threads that are themselves subagents", () => {
+    const selection = selectParentThread(
+      [
+        { id: "child", parentThreadId: "root", recencyAt: spawnedAtSeconds + 100 },
+        { id: "root", parentThreadId: null, recencyAt: spawnedAtSeconds },
+      ],
+      { spawnedAtMs }
+    );
+    expect(selection.parentThreadId).toBe("root");
+  });
+
+  it("picks the most recently active root and reports no ambiguity when it stands alone", () => {
+    const selection = selectParentThread(
+      [
+        { id: "stale", recencyAt: spawnedAtSeconds - 10 * 60 * 60 },
+        { id: "live", recencyAt: spawnedAtSeconds + 60 },
+      ],
+      { spawnedAtMs }
+    );
+    expect(selection.parentThreadId).toBe("live");
+    expect(selection.matchedBy).toBe("cwd-recency");
+    // `stale` predates the terminal by more than the window, so it is not a rival.
+    expect(selection.candidates).toEqual([]);
+  });
+
+  it("reports every plausible root when recency cannot separate them", () => {
+    const selection = selectParentThread(
+      [
+        {
+          id: "a",
+          recencyAt: spawnedAtSeconds + 120,
+          preview: "first",
+          createdAt: spawnedAtSeconds,
+        },
+        {
+          id: "b",
+          recencyAt: spawnedAtSeconds + 60,
+          preview: "second",
+          createdAt: spawnedAtSeconds,
+        },
+      ],
+      { spawnedAtMs }
+    );
+    expect(selection.parentThreadId).toBe("a");
+    expect(selection.candidates.map((candidate) => candidate.threadId)).toEqual(["a", "b"]);
+  });
+
+  it("falls back to updatedAt then createdAt when recencyAt is absent", () => {
+    const selection = selectParentThread(
+      [
+        { id: "older", createdAt: spawnedAtSeconds, recencyAt: null },
+        { id: "newer", updatedAt: spawnedAtSeconds + 5000, recencyAt: null },
+      ],
+      { spawnedAtMs }
+    );
+    expect(selection.parentThreadId).toBe("newer");
+  });
+
+  it("returns no parent when the cwd has no root threads", () => {
+    expect(selectParentThread([], { spawnedAtMs }).parentThreadId).toBeNull();
+  });
+});
+
+describe("toSubagentTurn", () => {
+  it("keeps user and agent messages and drops reasoning items", () => {
+    const turn = toSubagentTurn({
+      id: "turn-1",
+      status: "completed",
+      startedAt: 1_700_000_000,
+      completedAt: 1_700_000_007,
+      items: [
+        { type: "userMessage", content: [{ type: "text", text: "review the diff" }] },
+        { type: "reasoning", summary: [], content: [] },
+        { type: "agentMessage", text: "Looks fine" },
+      ],
+    });
+
+    expect(turn?.messages).toEqual([
+      { role: "user", text: "review the diff" },
+      { role: "agent", text: "Looks fine" },
+    ]);
+    expect(turn?.startedAt).toBe(1_700_000_000_000);
+    expect(turn?.completedAt).toBe(1_700_000_007_000);
+  });
+
+  it("truncates a message that would otherwise flood IPC", () => {
+    const turn = toSubagentTurn({
+      id: "turn-2",
+      items: [{ type: "agentMessage", text: "x".repeat(9000) }],
+    });
+    expect(turn?.messages[0].text.length).toBe(4000);
+  });
+});
+
+describe("listCodexSubagents", () => {
+  it("refuses a terminal that is not running Codex", async () => {
+    getTerminalAsync.mockResolvedValue({ cwd: "/repo", launchAgentId: "claude" });
+    await expect(listCodexSubagents("t1")).resolves.toEqual({
+      status: "unavailable",
+      reason: "not-codex",
+    });
+    expect(runSession).not.toHaveBeenCalled();
+  });
+
+  it("reports terminal-unknown for an id the pty host has never heard of", async () => {
+    getTerminalAsync.mockResolvedValue(null);
+    await expect(listCodexSubagents("ghost")).resolves.toEqual({
+      status: "unavailable",
+      reason: "terminal-unknown",
+    });
+  });
+
+  it("queries both the recorded cwd and its realpath so a symlinked worktree matches", async () => {
+    getTerminalAsync.mockResolvedValue({ ...codexTerminal, cwd: "/tmp/wt" });
+    const seen: Array<{ method: string; params: QueryParams }> = [];
+    scriptSession((method, params) => {
+      seen.push({ method, params });
+      if (method === "thread/list" && params.cwd) {
+        return { data: [{ id: "root", recencyAt: codexTerminal.spawnedAt / 1000 }] };
+      }
+      return { data: [] };
+    });
+
+    await listCodexSubagents("t1");
+
+    expect(seen[0]?.params.cwd).toEqual(["/tmp/wt", "/private/tmp/wt"]);
+  });
+
+  it("returns the parent's children newest-first, without an explicit sourceKinds filter", async () => {
+    getTerminalAsync.mockResolvedValue(codexTerminal);
+    let childParams: QueryParams = {};
+    scriptSession((method, params) => {
+      if (method === "thread/list" && params.cwd) {
+        return { data: [{ id: "root", recencyAt: codexTerminal.spawnedAt / 1000 }] };
+      }
+      if (method === "thread/list") {
+        childParams = params;
+        return {
+          data: [
+            { id: "older", agentNickname: "Kant", updatedAt: 100 },
+            { id: "newer", agentNickname: "Meitner", updatedAt: 200 },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await listCodexSubagents("t1");
+
+    expect(result).toMatchObject({
+      status: "ok",
+      parentThreadId: "root",
+      matchedBy: "cwd-recency",
+    });
+    if (result.status !== "ok") throw new Error("expected ok");
+    expect(result.subagents.map((s) => s.threadId)).toEqual(["newer", "older"]);
+    expect(childParams.parentThreadId).toBe("root");
+    // An explicit sourceKinds list would fall back to the interactive-only
+    // default and return no subagents at all.
+    expect(childParams.sourceKinds).toBeUndefined();
+  });
+
+  it("reports no-session when nothing in the cwd could be the parent", async () => {
+    getTerminalAsync.mockResolvedValue(codexTerminal);
+    scriptSession(() => ({ data: [] }));
+    await expect(listCodexSubagents("t1")).resolves.toEqual({
+      status: "unavailable",
+      reason: "no-session",
+    });
+  });
+
+  it("carries the transport's reason through instead of flattening every failure", async () => {
+    getTerminalAsync.mockResolvedValue(codexTerminal);
+    runSession.mockRejectedValue(new CodexAppServerError("cli-missing", "Codex CLI not found"));
+    await expect(listCodexSubagents("t1")).resolves.toMatchObject({
+      status: "unavailable",
+      reason: "cli-missing",
+    });
+  });
+});
+
+describe("readCodexSubagentTranscript", () => {
+  it("refuses a thread that is not a child of this terminal's session", async () => {
+    getTerminalAsync.mockResolvedValue(codexTerminal);
+    const methods: string[] = [];
+    scriptSession((method, params) => {
+      methods.push(method);
+      if (method === "thread/list" && params.cwd) {
+        return { data: [{ id: "root", recencyAt: codexTerminal.spawnedAt / 1000 }] };
+      }
+      if (method === "thread/list") return { data: [{ id: "mine" }] };
+      return { data: [] };
+    });
+
+    const result = await readCodexSubagentTranscript("t1", "someone-elses-thread");
+
+    expect(result).toEqual({ status: "unavailable", reason: "no-session" });
+    // The membership check must run before any read of the requested thread.
+    expect(methods).not.toContain("thread/turns/list");
+  });
+
+  it("reads a verified child with the non-deprecated summary turn view", async () => {
+    getTerminalAsync.mockResolvedValue(codexTerminal);
+    let turnParams: QueryParams = {};
+    scriptSession((method, params) => {
+      if (method === "thread/list" && params.cwd) {
+        return { data: [{ id: "root", recencyAt: codexTerminal.spawnedAt / 1000 }] };
+      }
+      if (method === "thread/list") return { data: [{ id: "mine" }] };
+      if (method === "thread/turns/list") {
+        turnParams = params;
+        return { data: [{ id: "turn-1", items: [{ type: "agentMessage", text: "done" }] }] };
+      }
+      return {};
+    });
+
+    const result = await readCodexSubagentTranscript("t1", "mine");
+
+    expect(result).toMatchObject({ status: "ok", threadId: "mine" });
+    if (result.status !== "ok") throw new Error("expected ok");
+    expect(result.turns[0].messages).toEqual([{ role: "agent", text: "done" }]);
+    expect(turnParams.itemsView).toBe("summary");
+    expect(turnParams.sortDirection).toBe("desc");
+  });
+});

--- a/electron/services/codex/__tests__/CodexSubagentService.test.ts
+++ b/electron/services/codex/__tests__/CodexSubagentService.test.ts
@@ -119,37 +119,25 @@ describe("selectParentThread", () => {
       ],
       { spawnedAtMs }
     );
+    // A subagent is never a parent, so one root remains and it is answerable.
     expect(selection.parentThreadId).toBe("root");
   });
 
-  it("picks the session that started with this terminal, not the newest one", () => {
-    // The regression this guards: terminal A launches, then two hours later a
-    // second Codex session starts in the same folder and becomes the most
-    // recently active. Ranking by recency would hand A the other session.
+  it("refuses to choose whenever two sessions were live in this folder", () => {
+    // The regression this guards: any ranking — by recency, or by closeness to
+    // launch — picks one of these, and the wrong list is indistinguishable
+    // from the right one.
     const selection = selectParentThread(
       [
+        { id: "mine", createdAt: spawnedAt + 2, recencyAt: spawnedAt + 30 * 60 },
         {
           id: "other-terminal",
           createdAt: spawnedAt + 2 * 60 * 60,
           recencyAt: spawnedAt + 2 * 60 * 60,
         },
-        { id: "mine", createdAt: spawnedAt + 2, recencyAt: spawnedAt + 30 * 60 },
       ],
       { spawnedAtMs }
     );
-    expect(selection.parentThreadId).toBe("mine");
-    expect(selection).toMatchObject({ matchedBy: "spawn-time" });
-  });
-
-  it("refuses to choose between two sessions that started together", () => {
-    const selection = selectParentThread(
-      [
-        { id: "a", createdAt: spawnedAt + 1, recencyAt: spawnedAt + 60 },
-        { id: "b", createdAt: spawnedAt + 3, recencyAt: spawnedAt + 60 },
-      ],
-      { spawnedAtMs }
-    );
-    // Guessing here is indistinguishable from being right, so it doesn't guess.
     expect(selection).toEqual({ parentThreadId: null, reason: "ambiguous-session" });
   });
 
@@ -161,18 +149,31 @@ describe("selectParentThread", () => {
       ],
       { spawnedAtMs }
     );
-    // `abandoned` starts closer to launch, but nothing has touched it since —
-    // whatever this terminal is running, it isn't that.
-    expect(selection.parentThreadId).toBe("mine");
+    // Yesterday's session in the same folder must not make today's ambiguous.
+    expect(selection).toEqual({ parentThreadId: "mine", matchedBy: "spawn-time" });
   });
 
   it("keeps a lone live session even when it started long before the terminal", () => {
-    // A hand-typed `codex resume` carries an old createdAt and no session id.
+    // A hand-typed `codex resume` carries an old createdAt and no session id;
+    // its liveness is what identifies it.
     const selection = selectParentThread(
       [{ id: "resumed", createdAt: spawnedAt - 3 * 24 * 60 * 60, recencyAt: spawnedAt + 60 }],
       { spawnedAtMs }
     );
     expect(selection.parentThreadId).toBe("resumed");
+  });
+
+  it("falls back to updatedAt then createdAt when recencyAt is absent", () => {
+    const quiet = selectParentThread(
+      [{ id: "stale", recencyAt: null, updatedAt: spawnedAt - 60 * 60 }],
+      { spawnedAtMs }
+    );
+    expect(quiet.parentThreadId).toBeNull();
+
+    const live = selectParentThread([{ id: "live", recencyAt: null, updatedAt: spawnedAt + 60 }], {
+      spawnedAtMs,
+    });
+    expect(live.parentThreadId).toBe("live");
   });
 
   it("will not pick between roots when the terminal's launch time is unknown", () => {
@@ -314,9 +315,7 @@ describe("listCodexSubagents", () => {
     scriptSession((method, params) => {
       methods.push(method);
       if (method === "thread/list" && params.cwd) {
-        return {
-          data: [rootThread, { ...rootThread, id: "rival", createdAt: rootThread.createdAt + 2 }],
-        };
+        return { data: [rootThread, { ...rootThread, id: "rival" }] };
       }
       return { data: [] };
     });
@@ -346,9 +345,7 @@ describe("readCodexSubagentTranscript", () => {
     scriptSession((method, params) => {
       methods.push(method);
       if (method === "thread/list" && params.cwd) {
-        return {
-          data: [rootThread, { ...rootThread, id: "rival", createdAt: rootThread.createdAt + 2 }],
-        };
+        return { data: [rootThread, { ...rootThread, id: "rival" }] };
       }
       return { data: [] };
     });
@@ -359,6 +356,38 @@ describe("readCodexSubagentTranscript", () => {
       reason: "ambiguous-session",
     });
     expect(methods).not.toContain("thread/turns/list");
+  });
+
+  it("rejects a recorded session id whose thread went quiet before this launch", async () => {
+    // A pane whose agent exited and was reused carries the previous session's
+    // id — right folder, wrong session.
+    getTerminalAsync.mockResolvedValue({ ...codexTerminal, agentSessionId: "previous-session" });
+    const methods: string[] = [];
+    scriptSession((method, params) => {
+      methods.push(method);
+      if (method === "thread/read") {
+        return {
+          thread: {
+            id: params.threadId,
+            cwd: "/repo",
+            recencyAt: codexTerminal.spawnedAt / 1000 - 60 * 60,
+          },
+        };
+      }
+      if (method === "thread/list" && params.cwd) return { data: [rootThread] };
+      if (method === "thread/list") return { data: [{ id: "mine" }] };
+      if (method === "thread/turns/list") {
+        return { data: [{ id: "t", items: [{ type: "agentMessage", text: "done" }] }] };
+      }
+      return {};
+    });
+
+    const result = await readCodexSubagentTranscript("t1", "mine");
+
+    // The recorded id was in the right folder, so only liveness rules it out;
+    // resolution then falls through to the folder's live root.
+    expect(result).toMatchObject({ status: "ok" });
+    expect(methods.filter((method) => method === "thread/list")).toHaveLength(2);
   });
 
   it("falls back to spawn-time matching when a recorded session id names no thread here", async () => {

--- a/electron/services/codex/__tests__/CodexSubagentService.test.ts
+++ b/electron/services/codex/__tests__/CodexSubagentService.test.ts
@@ -47,6 +47,13 @@ const codexTerminal = {
   spawnedAt: 1_700_000_000_000,
 };
 
+/** The unambiguous parent: started with the terminal and still live. */
+const rootThread = {
+  id: "root",
+  createdAt: codexTerminal.spawnedAt / 1000 + 1,
+  recencyAt: codexTerminal.spawnedAt / 1000 + 60,
+};
+
 beforeEach(() => {
   getTerminalAsync.mockReset();
   runSession.mockReset();
@@ -94,80 +101,97 @@ describe("toSubagent", () => {
 
 describe("selectParentThread", () => {
   const spawnedAtMs = 1_700_000_000_000;
-  const spawnedAtSeconds = spawnedAtMs / 1000;
+  const spawnedAt = spawnedAtMs / 1000;
 
   it("uses an exact session id without consulting the thread list", () => {
-    const selection = selectParentThread([{ id: "other", recencyAt: spawnedAtSeconds }], {
+    const selection = selectParentThread([{ id: "other", recencyAt: spawnedAt }], {
       spawnedAtMs,
       agentSessionId: "known-thread",
     });
-    expect(selection).toEqual({
-      parentThreadId: "known-thread",
-      matchedBy: "session-id",
-      candidates: [],
-    });
+    expect(selection).toEqual({ parentThreadId: "known-thread", matchedBy: "session-id" });
   });
 
   it("ignores threads that are themselves subagents", () => {
     const selection = selectParentThread(
       [
-        { id: "child", parentThreadId: "root", recencyAt: spawnedAtSeconds + 100 },
-        { id: "root", parentThreadId: null, recencyAt: spawnedAtSeconds },
+        { id: "child", parentThreadId: "root", createdAt: spawnedAt, recencyAt: spawnedAt + 100 },
+        { id: "root", parentThreadId: null, createdAt: spawnedAt, recencyAt: spawnedAt + 100 },
       ],
       { spawnedAtMs }
     );
     expect(selection.parentThreadId).toBe("root");
   });
 
-  it("picks the most recently active root and reports no ambiguity when it stands alone", () => {
-    const selection = selectParentThread(
-      [
-        { id: "stale", recencyAt: spawnedAtSeconds - 10 * 60 * 60 },
-        { id: "live", recencyAt: spawnedAtSeconds + 60 },
-      ],
-      { spawnedAtMs }
-    );
-    expect(selection.parentThreadId).toBe("live");
-    expect(selection.matchedBy).toBe("cwd-recency");
-    // `stale` predates the terminal by more than the window, so it is not a rival.
-    expect(selection.candidates).toEqual([]);
-  });
-
-  it("reports every plausible root when recency cannot separate them", () => {
+  it("picks the session that started with this terminal, not the newest one", () => {
+    // The regression this guards: terminal A launches, then two hours later a
+    // second Codex session starts in the same folder and becomes the most
+    // recently active. Ranking by recency would hand A the other session.
     const selection = selectParentThread(
       [
         {
-          id: "a",
-          recencyAt: spawnedAtSeconds + 120,
-          preview: "first",
-          createdAt: spawnedAtSeconds,
+          id: "other-terminal",
+          createdAt: spawnedAt + 2 * 60 * 60,
+          recencyAt: spawnedAt + 2 * 60 * 60,
         },
-        {
-          id: "b",
-          recencyAt: spawnedAtSeconds + 60,
-          preview: "second",
-          createdAt: spawnedAtSeconds,
-        },
+        { id: "mine", createdAt: spawnedAt + 2, recencyAt: spawnedAt + 30 * 60 },
       ],
       { spawnedAtMs }
     );
-    expect(selection.parentThreadId).toBe("a");
-    expect(selection.candidates.map((candidate) => candidate.threadId)).toEqual(["a", "b"]);
+    expect(selection.parentThreadId).toBe("mine");
+    expect(selection).toMatchObject({ matchedBy: "spawn-time" });
   });
 
-  it("falls back to updatedAt then createdAt when recencyAt is absent", () => {
+  it("refuses to choose between two sessions that started together", () => {
     const selection = selectParentThread(
       [
-        { id: "older", createdAt: spawnedAtSeconds, recencyAt: null },
-        { id: "newer", updatedAt: spawnedAtSeconds + 5000, recencyAt: null },
+        { id: "a", createdAt: spawnedAt + 1, recencyAt: spawnedAt + 60 },
+        { id: "b", createdAt: spawnedAt + 3, recencyAt: spawnedAt + 60 },
       ],
       { spawnedAtMs }
     );
-    expect(selection.parentThreadId).toBe("newer");
+    // Guessing here is indistinguishable from being right, so it doesn't guess.
+    expect(selection).toEqual({ parentThreadId: null, reason: "ambiguous-session" });
+  });
+
+  it("drops a session that had already gone quiet before the terminal launched", () => {
+    const selection = selectParentThread(
+      [
+        { id: "abandoned", createdAt: spawnedAt - 10, recencyAt: spawnedAt - 6 * 60 * 60 },
+        { id: "mine", createdAt: spawnedAt + 120, recencyAt: spawnedAt + 600 },
+      ],
+      { spawnedAtMs }
+    );
+    // `abandoned` starts closer to launch, but nothing has touched it since —
+    // whatever this terminal is running, it isn't that.
+    expect(selection.parentThreadId).toBe("mine");
+  });
+
+  it("keeps a lone live session even when it started long before the terminal", () => {
+    // A hand-typed `codex resume` carries an old createdAt and no session id.
+    const selection = selectParentThread(
+      [{ id: "resumed", createdAt: spawnedAt - 3 * 24 * 60 * 60, recencyAt: spawnedAt + 60 }],
+      { spawnedAtMs }
+    );
+    expect(selection.parentThreadId).toBe("resumed");
+  });
+
+  it("will not pick between roots when the terminal's launch time is unknown", () => {
+    const threads = [
+      { id: "a", createdAt: 10, recencyAt: 10 },
+      { id: "b", createdAt: 20, recencyAt: 20 },
+    ];
+    expect(selectParentThread(threads, {})).toEqual({
+      parentThreadId: null,
+      reason: "ambiguous-session",
+    });
+    expect(selectParentThread([threads[0]!], {}).parentThreadId).toBe("a");
   });
 
   it("returns no parent when the cwd has no root threads", () => {
-    expect(selectParentThread([], { spawnedAtMs }).parentThreadId).toBeNull();
+    expect(selectParentThread([], { spawnedAtMs })).toEqual({
+      parentThreadId: null,
+      reason: "no-session",
+    });
   });
 });
 
@@ -193,12 +217,17 @@ describe("toSubagentTurn", () => {
     expect(turn?.completedAt).toBe(1_700_000_007_000);
   });
 
-  it("truncates a message that would otherwise flood IPC", () => {
-    const turn = toSubagentTurn({
-      id: "turn-2",
-      items: [{ type: "agentMessage", text: "x".repeat(9000) }],
-    });
-    expect(turn?.messages[0].text.length).toBe(4000);
+  it("truncates a message that would otherwise flood IPC, keeping its start", () => {
+    const text = `START${"x".repeat(20_000)}`;
+    const turn = toSubagentTurn({ id: "turn-2", items: [{ type: "agentMessage", text }] });
+    const kept = turn?.messages[0]?.text ?? "";
+    expect(kept.length).toBeLessThan(text.length);
+    expect(text.startsWith(kept)).toBe(true);
+  });
+
+  it("drops a turn that carried no readable message", () => {
+    const turn = toSubagentTurn({ id: "turn-3", items: [{ type: "reasoning", content: [] }] });
+    expect(turn?.messages).toEqual([]);
   });
 });
 
@@ -226,7 +255,7 @@ describe("listCodexSubagents", () => {
     scriptSession((method, params) => {
       seen.push({ method, params });
       if (method === "thread/list" && params.cwd) {
-        return { data: [{ id: "root", recencyAt: codexTerminal.spawnedAt / 1000 }] };
+        return { data: [rootThread] };
       }
       return { data: [] };
     });
@@ -241,7 +270,7 @@ describe("listCodexSubagents", () => {
     let childParams: QueryParams = {};
     scriptSession((method, params) => {
       if (method === "thread/list" && params.cwd) {
-        return { data: [{ id: "root", recencyAt: codexTerminal.spawnedAt / 1000 }] };
+        return { data: [rootThread] };
       }
       if (method === "thread/list") {
         childParams = params;
@@ -260,7 +289,7 @@ describe("listCodexSubagents", () => {
     expect(result).toMatchObject({
       status: "ok",
       parentThreadId: "root",
-      matchedBy: "cwd-recency",
+      matchedBy: "spawn-time",
     });
     if (result.status !== "ok") throw new Error("expected ok");
     expect(result.subagents.map((s) => s.threadId)).toEqual(["newer", "older"]);
@@ -279,6 +308,27 @@ describe("listCodexSubagents", () => {
     });
   });
 
+  it("reports ambiguity instead of showing another session's children", async () => {
+    getTerminalAsync.mockResolvedValue(codexTerminal);
+    const methods: string[] = [];
+    scriptSession((method, params) => {
+      methods.push(method);
+      if (method === "thread/list" && params.cwd) {
+        return {
+          data: [rootThread, { ...rootThread, id: "rival", createdAt: rootThread.createdAt + 2 }],
+        };
+      }
+      return { data: [] };
+    });
+
+    await expect(listCodexSubagents("t1")).resolves.toEqual({
+      status: "unavailable",
+      reason: "ambiguous-session",
+    });
+    // Nothing is listed for an unresolved parent, so nothing can be shown.
+    expect(methods.filter((method) => method === "thread/list")).toHaveLength(1);
+  });
+
   it("carries the transport's reason through instead of flattening every failure", async () => {
     getTerminalAsync.mockResolvedValue(codexTerminal);
     runSession.mockRejectedValue(new CodexAppServerError("cli-missing", "Codex CLI not found"));
@@ -290,13 +340,58 @@ describe("listCodexSubagents", () => {
 });
 
 describe("readCodexSubagentTranscript", () => {
+  it("refuses to read anything while the parent is ambiguous", async () => {
+    getTerminalAsync.mockResolvedValue(codexTerminal);
+    const methods: string[] = [];
+    scriptSession((method, params) => {
+      methods.push(method);
+      if (method === "thread/list" && params.cwd) {
+        return {
+          data: [rootThread, { ...rootThread, id: "rival", createdAt: rootThread.createdAt + 2 }],
+        };
+      }
+      return { data: [] };
+    });
+
+    // Even a genuine child id must not resolve: ownership is unproven.
+    await expect(readCodexSubagentTranscript("t1", "some-child")).resolves.toEqual({
+      status: "unavailable",
+      reason: "ambiguous-session",
+    });
+    expect(methods).not.toContain("thread/turns/list");
+  });
+
+  it("falls back to spawn-time matching when a recorded session id names no thread here", async () => {
+    // `agentSessionId` is generic launch metadata — a pane launched as another
+    // agent, or reused for a fresh session, carries an id that isn't ours.
+    getTerminalAsync.mockResolvedValue({ ...codexTerminal, agentSessionId: "stale-or-foreign" });
+    const methods: string[] = [];
+    scriptSession((method, params) => {
+      methods.push(method);
+      if (method === "thread/read") return { thread: { id: params.threadId, cwd: "/elsewhere" } };
+      if (method === "thread/list" && params.cwd) return { data: [rootThread] };
+      if (method === "thread/list") return { data: [{ id: "mine" }] };
+      if (method === "thread/turns/list") {
+        return { data: [{ id: "t", items: [{ type: "agentMessage", text: "done" }] }] };
+      }
+      return {};
+    });
+
+    const result = await readCodexSubagentTranscript("t1", "mine");
+
+    expect(result).toMatchObject({ status: "ok" });
+    // The cwd query ran, which only happens when the recorded id was rejected.
+    expect(methods).toContain("thread/read");
+    expect(methods.filter((method) => method === "thread/list")).toHaveLength(2);
+  });
+
   it("refuses a thread that is not a child of this terminal's session", async () => {
     getTerminalAsync.mockResolvedValue(codexTerminal);
     const methods: string[] = [];
     scriptSession((method, params) => {
       methods.push(method);
       if (method === "thread/list" && params.cwd) {
-        return { data: [{ id: "root", recencyAt: codexTerminal.spawnedAt / 1000 }] };
+        return { data: [rootThread] };
       }
       if (method === "thread/list") return { data: [{ id: "mine" }] };
       return { data: [] };
@@ -314,7 +409,7 @@ describe("readCodexSubagentTranscript", () => {
     let turnParams: QueryParams = {};
     scriptSession((method, params) => {
       if (method === "thread/list" && params.cwd) {
-        return { data: [{ id: "root", recencyAt: codexTerminal.spawnedAt / 1000 }] };
+        return { data: [rootThread] };
       }
       if (method === "thread/list") return { data: [{ id: "mine" }] };
       if (method === "thread/turns/list") {

--- a/shared/types/ipc/codexSubagents.ts
+++ b/shared/types/ipc/codexSubagents.ts
@@ -50,33 +50,37 @@ export interface CodexSubagent {
   acceptsDirectInput: boolean;
 }
 
-/** A root Codex thread in the terminal's cwd that could be its parent session. */
-export interface CodexSessionCandidate {
-  threadId: string;
-  preview: string;
-  createdAt: number;
-}
-
 /**
  * Why the subagent view has nothing to show. Stable slugs, not prose: the
  * renderer maps them to microcopy, and `detail` (scrubbed) is diagnostics only.
  */
 export type CodexSubagentUnavailableReason =
-  "not-codex" | "terminal-unknown" | "cli-missing" | "no-session" | "timeout" | "protocol-error";
+  | "not-codex"
+  | "terminal-unknown"
+  | "cli-missing"
+  | "no-session"
+  /**
+   * Two or more Codex sessions in this folder started close enough together
+   * that nothing distinguishes which one this terminal is running. Reported
+   * instead of a guess: the wrong session's children look exactly like the
+   * right ones, and the user has no way to tell which they got.
+   */
+  | "ambiguous-session"
+  | "timeout"
+  | "protocol-error";
 
-export type CodexSubagentMatch = "session-id" | "cwd-recency";
+/**
+ * `session-id` is exact — the terminal was launched against a known thread.
+ * `spawn-time` matched the folder's Codex threads against when this terminal
+ * started, which is a correlation rather than an identity.
+ */
+export type CodexSubagentMatch = "session-id" | "spawn-time";
 
 export interface CodexSubagentsOk {
   status: "ok";
   parentThreadId: string;
-  /** How the parent was resolved — `cwd-recency` is a heuristic, and says so. */
   matchedBy: CodexSubagentMatch;
   subagents: CodexSubagent[];
-  /**
-   * Populated only when more than one root thread in this cwd could be the
-   * parent. Empty means the match was unambiguous.
-   */
-  candidates: CodexSessionCandidate[];
 }
 
 export interface CodexSubagentsUnavailable {

--- a/shared/types/ipc/codexSubagents.ts
+++ b/shared/types/ipc/codexSubagents.ts
@@ -1,0 +1,117 @@
+/**
+ * Read-only view of the subagent threads a live Codex CLI session spawned.
+ *
+ * Sourced from the Codex app-server protocol (`thread/list`, `thread/read`,
+ * `thread/turns/list`) rather than `~/.codex/sessions/**\/rollout-*.jsonl`:
+ * Codex calls those "legacy local sessions" and its own migration leaves
+ * subagent threads with empty projected history (openai/codex#38762).
+ *
+ * Protocol timestamps are Unix SECONDS; everything below is milliseconds,
+ * converted once at the main-process boundary.
+ */
+
+/** Mirrors the protocol's `ThreadActiveFlag`. */
+export type CodexSubagentActiveFlag = "waitingOnApproval" | "waitingOnUserInput";
+
+/**
+ * Mirrors the protocol's `ThreadStatus` tagged union — deliberately not
+ * flattened to a string, because `active` carries the flags that say *why*.
+ *
+ * Daintree queries through its own short-lived app-server process, which sees
+ * only persisted state, so in practice this is `notLoaded` for every child.
+ * The other arms are kept because the protocol can return them and a status
+ * renderer that silently drops them would show a live child as dormant.
+ */
+export type CodexSubagentStatus =
+  | { type: "notLoaded" }
+  | { type: "idle" }
+  | { type: "systemError" }
+  | { type: "active"; activeFlags: CodexSubagentActiveFlag[] };
+
+export interface CodexSubagent {
+  threadId: string;
+  parentThreadId: string | null;
+  /** Random nickname Codex assigns a spawned sub-agent ("Meitner", "Kant"). */
+  nickname: string | null;
+  /** Role the parent gave the sub-agent, when it named one. */
+  role: string | null;
+  /** Usually the first user message — the task the parent delegated. */
+  preview: string;
+  cwd: string;
+  status: CodexSubagentStatus;
+  createdAt: number;
+  updatedAt: number;
+  /**
+   * Fail-closed projection of the protocol's `canAcceptDirectInput`, which is
+   * `null` (capability unavailable) for unloaded threads and `false` for
+   * parent-owned subagents. Only a literal `true` maps to `true` here, so an
+   * unloaded child can never be mistaken for one that accepts input.
+   */
+  acceptsDirectInput: boolean;
+}
+
+/** A root Codex thread in the terminal's cwd that could be its parent session. */
+export interface CodexSessionCandidate {
+  threadId: string;
+  preview: string;
+  createdAt: number;
+}
+
+/**
+ * Why the subagent view has nothing to show. Stable slugs, not prose: the
+ * renderer maps them to microcopy, and `detail` (scrubbed) is diagnostics only.
+ */
+export type CodexSubagentUnavailableReason =
+  "not-codex" | "terminal-unknown" | "cli-missing" | "no-session" | "timeout" | "protocol-error";
+
+export type CodexSubagentMatch = "session-id" | "cwd-recency";
+
+export interface CodexSubagentsOk {
+  status: "ok";
+  parentThreadId: string;
+  /** How the parent was resolved — `cwd-recency` is a heuristic, and says so. */
+  matchedBy: CodexSubagentMatch;
+  subagents: CodexSubagent[];
+  /**
+   * Populated only when more than one root thread in this cwd could be the
+   * parent. Empty means the match was unambiguous.
+   */
+  candidates: CodexSessionCandidate[];
+}
+
+export interface CodexSubagentsUnavailable {
+  status: "unavailable";
+  reason: CodexSubagentUnavailableReason;
+  detail?: string;
+}
+
+export type CodexSubagentsResult = CodexSubagentsOk | CodexSubagentsUnavailable;
+
+export interface CodexSubagentMessage {
+  role: "user" | "agent";
+  text: string;
+}
+
+export interface CodexSubagentTurn {
+  turnId: string;
+  /** Protocol turn status ("completed", "failed", ...) when reported. */
+  status: string | null;
+  startedAt: number | null;
+  completedAt: number | null;
+  messages: CodexSubagentMessage[];
+}
+
+export interface CodexSubagentTranscriptOk {
+  status: "ok";
+  threadId: string;
+  /** Newest turn first, matching the protocol's default ordering. */
+  turns: CodexSubagentTurn[];
+}
+
+export type CodexSubagentTranscriptResult = CodexSubagentTranscriptOk | CodexSubagentsUnavailable;
+
+/** Turns fetched per transcript read. Bounded so one child can't flood IPC. */
+export const CODEX_SUBAGENT_TRANSCRIPT_TURN_LIMIT = 12;
+
+/** Per-message character cap applied before a transcript crosses IPC. */
+export const CODEX_SUBAGENT_MESSAGE_MAX_CHARS = 4000;

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -66,6 +66,14 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["clipboard:write-text"]["args"]
     ): Promise<IpcInvokeMap["clipboard:write-text"]["result"]>;
   };
+  codex: {
+    listSubagents(
+      ...args: IpcInvokeMap["codex:list-subagents"]["args"]
+    ): Promise<IpcInvokeMap["codex:list-subagents"]["result"]>;
+    readSubagentTranscript(
+      ...args: IpcInvokeMap["codex:read-subagent-transcript"]["args"]
+    ): Promise<IpcInvokeMap["codex:read-subagent-transcript"]["result"]>;
+  };
   commands: {
     execute(
       ...args: IpcInvokeMap["commands:execute"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -146,6 +146,14 @@ export interface GeneratedIpcInvokeMap {
     args: [text: string];
     result: void;
   };
+  "codex:list-subagents": {
+    args: [__0: { terminalId: string }];
+    result: import("./codexSubagents.js").CodexSubagentsResult;
+  };
+  "codex:read-subagent-transcript": {
+    args: [__0: { terminalId: string; threadId: string }];
+    result: import("./codexSubagents.js").CodexSubagentTranscriptResult;
+  };
   "commands:execute": {
     args: [payload: import("../commands.js").CommandExecutePayload];
     result: import("../commands.js").CommandResult<unknown>;

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -25,6 +25,7 @@ export * from "./devPreview.js";
 export * from "./connectivity.js";
 export * from "./maps.js";
 export * from "./agentSessionHistory.js";
+export * from "./codexSubagents.js";
 export * from "./api.js";
 export * from "./crashRecovery.js";
 export * from "./webviewConsole.js";

--- a/src/clients/codexClient.ts
+++ b/src/clients/codexClient.ts
@@ -1,0 +1,22 @@
+import type {
+  CodexSubagentsResult,
+  CodexSubagentTranscriptResult,
+} from "@shared/types/ipc/codexSubagents";
+
+/**
+ * @example
+ * const result = await codexClient.listSubagents({ terminalId });
+ * if (result.status === "ok") console.log(result.subagents.length);
+ */
+export const codexClient = {
+  listSubagents: (payload: { terminalId: string }): Promise<CodexSubagentsResult> => {
+    return window.electron.codex.listSubagents(payload);
+  },
+
+  readSubagentTranscript: (payload: {
+    terminalId: string;
+    threadId: string;
+  }): Promise<CodexSubagentTranscriptResult> => {
+    return window.electron.codex.readSubagentTranscript(payload);
+  },
+} as const;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -26,6 +26,7 @@ export { systemClient } from "./systemClient";
 export { terminalClient } from "./terminalClient";
 export { worktreeClient } from "./worktreeClient";
 export { worktreeConfigClient } from "./worktreeConfigClient";
+export { codexClient } from "./codexClient";
 export { commandsClient } from "./commandsClient";
 export { editorClient } from "./editorClient";
 export { appThemeClient } from "./appThemeClient";

--- a/src/components/Terminal/CodexSubagentChip.tsx
+++ b/src/components/Terminal/CodexSubagentChip.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
+import { Network } from "@/components/icons";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/Spinner";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { cn } from "@/lib/utils";
+import { usePanelStore } from "@/store";
+import { isPtyPanel } from "@shared/types/panel";
+import { formatTimeAgo } from "@/utils/timeAgo";
+import { logWarn } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { codexClient } from "@/clients/codexClient";
+import { useCodexSubagents } from "@/hooks/useCodexSubagents";
+import {
+  codexUnavailableMessage,
+  subagentStatusLabel,
+  subagentStatusTone,
+  subagentSubtitle,
+  subagentTitle,
+} from "./codexSubagentDisplay";
+import type {
+  CodexSubagent,
+  CodexSubagentTranscriptResult,
+} from "@shared/types/ipc/codexSubagents";
+
+const TONE_CLASSES: Record<"error" | "active" | "muted", string> = {
+  error: "text-status-error",
+  active: "text-status-info",
+  muted: "text-daintree-text/40",
+};
+
+function TranscriptBody({ transcript }: { transcript: CodexSubagentTranscriptResult }) {
+  if (transcript.status === "unavailable") {
+    return (
+      <p className="text-xs text-daintree-text/50">{codexUnavailableMessage(transcript.reason)}</p>
+    );
+  }
+  if (transcript.turns.length === 0) {
+    return <p className="text-xs text-daintree-text/50">No turns recorded yet</p>;
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {transcript.turns.map((turn) => (
+        <div key={turn.turnId} className="flex flex-col gap-1">
+          {turn.messages.map((message, index) => (
+            <div key={`${turn.turnId}-${index}`} className="flex flex-col gap-0.5">
+              <span className="text-[10px] uppercase tracking-wider text-daintree-text/40">
+                {message.role === "user" ? "Task" : "Reply"}
+              </span>
+              <p className="text-xs text-daintree-text/80 whitespace-pre-wrap break-words">
+                {message.text}
+              </p>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SubagentRow({ terminalId, subagent }: { terminalId: string; subagent: CodexSubagent }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [transcript, setTranscript] = useState<CodexSubagentTranscriptResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const showSpinner = useDohertyGate(isLoading);
+  const subtitle = subagentSubtitle(subagent);
+  const tone = subagentStatusTone(subagent.status);
+
+  const toggle = useCallback(() => {
+    const next = !isOpen;
+    setIsOpen(next);
+    if (!next || transcript !== null || isLoading) return;
+    setIsLoading(true);
+    void codexClient
+      .readSubagentTranscript({ terminalId, threadId: subagent.threadId })
+      .then(setTranscript)
+      .catch((error: unknown) => {
+        logWarn(
+          `[CodexSubagentChip] transcript read failed: ${formatErrorMessage(error, "unknown error")}`
+        );
+        setTranscript({ status: "unavailable", reason: "protocol-error" });
+      })
+      .finally(() => setIsLoading(false));
+  }, [isOpen, isLoading, transcript, terminalId, subagent.threadId]);
+
+  const Chevron = isOpen ? ChevronDown : ChevronRight;
+
+  return (
+    <li className="border-b border-divider last:border-b-0">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={isOpen}
+        className="w-full flex items-start gap-2 px-3 py-2 text-left hover:bg-overlay-subtle transition-colors"
+      >
+        <Chevron className="w-3 h-3 mt-0.5 shrink-0 text-daintree-text/40" aria-hidden="true" />
+        <span className="flex-1 min-w-0 flex flex-col gap-0.5">
+          <span className="flex items-center gap-2">
+            <span className="text-xs font-medium text-daintree-text truncate">
+              {subagentTitle(subagent)}
+            </span>
+            <span className={cn("text-[10px] shrink-0", TONE_CLASSES[tone])}>
+              {subagentStatusLabel(subagent.status)}
+            </span>
+          </span>
+          {subtitle && (
+            <span className="text-[11px] text-daintree-text/50 truncate">{subtitle}</span>
+          )}
+        </span>
+        {subagent.updatedAt > 0 && (
+          <span className="text-[10px] text-daintree-text/35 shrink-0 mt-0.5 tabular-nums">
+            {formatTimeAgo(subagent.updatedAt)}
+          </span>
+        )}
+      </button>
+      {isOpen && (
+        <div className="px-3 pb-3 pl-8">
+          {transcript === null ? (
+            showSpinner ? (
+              <Spinner size="sm" />
+            ) : null
+          ) : (
+            <TranscriptBody transcript={transcript} />
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Read-only list of the subagent threads a Codex session spawned, hung off the
+ * terminal's own header rather than a floating overlay — the bottom-right
+ * corner of a pane already belongs to `ArtifactOverlay` and the fleet pill, and
+ * a Codex TUI is full-height, so a footer strip would cost it rows.
+ *
+ * Renders nothing until a query actually finds children, so a Codex terminal
+ * that never delegates never grows an affordance. Nothing here can steer a
+ * child: the protocol reports these threads as parent-owned, and Daintree only
+ * ever reads them.
+ */
+export function CodexSubagentChip({ terminalId }: { terminalId: string }) {
+  const { isCodex, agentState, hasPty } = usePanelStore(
+    useShallow((state) => {
+      const panel = state.panelsById[terminalId];
+      const pty = panel && isPtyPanel(panel) ? panel : undefined;
+      return {
+        // Live detection wins, but launch affinity keeps the chip alive across
+        // a restore before detection rehydrates.
+        isCodex: pty?.runtimeIdentity?.agentId === "codex" || pty?.launchAgentId === "codex",
+        agentState: pty?.agentState,
+        hasPty: pty?.hasPty !== false,
+      };
+    })
+  );
+
+  const enabled = isCodex && hasPty;
+  const { result, isLoading, refresh } = useCodexSubagents(terminalId, { enabled, agentState });
+
+  if (!enabled || result?.status !== "ok" || result.subagents.length === 0) return null;
+
+  const { subagents, candidates } = result;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 text-xs font-sans bg-overlay-soft text-daintree-text/60 px-1.5 py-0.5 rounded border border-divider hover:text-daintree-text transition-colors"
+          aria-label={`${subagents.length} Codex subagent${subagents.length === 1 ? "" : "s"}`}
+        >
+          <Network className="w-3 h-3" aria-hidden="true" />
+          <span className="tabular-nums">{subagents.length}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-divider">
+          <span className="text-xs font-medium text-daintree-text">Codex subagents</span>
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={isLoading}
+            className="text-daintree-text/40 hover:text-daintree-text transition-colors disabled:opacity-50 disabled:pointer-events-none"
+            aria-label="Refresh subagents"
+          >
+            <RefreshCw className={cn("w-3 h-3", isLoading && "animate-spin")} aria-hidden="true" />
+          </button>
+        </div>
+        {candidates.length > 0 && (
+          // Correlation is by folder plus recency, so a second Codex session in
+          // the same worktree makes the parent a guess. Say so rather than
+          // present another session's children as this terminal's.
+          <p className="px-3 py-2 text-[11px] text-status-warning border-b border-divider">
+            More than one Codex session ran here, so this list is a best guess
+          </p>
+        )}
+        <ul className="max-h-80 overflow-y-auto">
+          {subagents.map((subagent) => (
+            <SubagentRow key={subagent.threadId} terminalId={terminalId} subagent={subagent} />
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Terminal/CodexSubagentChip.tsx
+++ b/src/components/Terminal/CodexSubagentChip.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
 import { Network } from "@/components/icons";
@@ -31,10 +31,27 @@ const TONE_CLASSES: Record<"error" | "active" | "muted", string> = {
   muted: "text-daintree-text/40",
 };
 
-function TranscriptBody({ transcript }: { transcript: CodexSubagentTranscriptResult }) {
+function TranscriptBody({
+  transcript,
+  onRetry,
+}: {
+  transcript: CodexSubagentTranscriptResult;
+  onRetry: () => void;
+}) {
   if (transcript.status === "unavailable") {
     return (
-      <p className="text-xs text-daintree-text/50">{codexUnavailableMessage(transcript.reason)}</p>
+      <div className="flex flex-col items-start gap-1">
+        <p className="text-xs text-daintree-text/50">
+          {codexUnavailableMessage(transcript.reason)}
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="text-xs text-daintree-text/70 hover:text-daintree-text underline underline-offset-2 transition-colors"
+        >
+          Retry
+        </button>
+      </div>
     );
   }
   if (transcript.turns.length === 0) {
@@ -64,15 +81,19 @@ function SubagentRow({ terminalId, subagent }: { terminalId: string; subagent: C
   const [isOpen, setIsOpen] = useState(false);
   const [transcript, setTranscript] = useState<CodexSubagentTranscriptResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  // The child's `updatedAt` at the moment we last fetched. Holding the version
+  // rather than a boolean is what makes a child that ran again reload instead
+  // of showing turns from before its latest run.
+  const [loadedFor, setLoadedFor] = useState<number | null>(null);
   const showSpinner = useDohertyGate(isLoading);
   const subtitle = subagentSubtitle(subagent);
   const tone = subagentStatusTone(subagent.status);
+  const panelId = `codex-subagent-${subagent.threadId}`;
 
-  const toggle = useCallback(() => {
-    const next = !isOpen;
-    setIsOpen(next);
-    if (!next || transcript !== null || isLoading) return;
+  const load = useCallback(() => {
+    if (isLoading) return;
     setIsLoading(true);
+    setLoadedFor(subagent.updatedAt);
     void codexClient
       .readSubagentTranscript({ terminalId, threadId: subagent.threadId })
       .then(setTranscript)
@@ -83,7 +104,19 @@ function SubagentRow({ terminalId, subagent }: { terminalId: string; subagent: C
         setTranscript({ status: "unavailable", reason: "protocol-error" });
       })
       .finally(() => setIsLoading(false));
-  }, [isOpen, isLoading, transcript, terminalId, subagent.threadId]);
+  }, [isLoading, terminalId, subagent.threadId, subagent.updatedAt]);
+
+  // Fetch on expand, and again if the child has run since we last looked.
+  // Driving this from state rather than the click handler is what keeps an
+  // already-open row from going blank when its version changes.
+  useEffect(() => {
+    if (!isOpen || loadedFor === subagent.updatedAt) return;
+    load();
+  }, [isOpen, loadedFor, subagent.updatedAt, load]);
+
+  // Clearing the version is the retry: the effect above sees the mismatch and
+  // refetches, so there is one load path rather than two.
+  const retry = useCallback(() => setLoadedFor(null), []);
 
   const Chevron = isOpen ? ChevronDown : ChevronRight;
 
@@ -91,8 +124,9 @@ function SubagentRow({ terminalId, subagent }: { terminalId: string; subagent: C
     <li className="border-b border-divider last:border-b-0">
       <button
         type="button"
-        onClick={toggle}
+        onClick={() => setIsOpen((open) => !open)}
         aria-expanded={isOpen}
+        aria-controls={panelId}
         className="w-full flex items-start gap-2 px-3 py-2 text-left hover:bg-overlay-subtle transition-colors"
       >
         <Chevron className="w-3 h-3 mt-0.5 shrink-0 text-daintree-text/40" aria-hidden="true" />
@@ -115,17 +149,25 @@ function SubagentRow({ terminalId, subagent }: { terminalId: string; subagent: C
           </span>
         )}
       </button>
-      {isOpen && (
-        <div className="px-3 pb-3 pl-8">
-          {transcript === null ? (
+      <div
+        id={panelId}
+        role="region"
+        aria-label={`${subagentTitle(subagent)} transcript`}
+        hidden={!isOpen}
+        className="px-3 pb-3 pl-8"
+      >
+        {isOpen &&
+          (transcript === null ? (
             showSpinner ? (
-              <Spinner size="sm" />
+              <span className="flex items-center gap-2 text-xs text-daintree-text/50" role="status">
+                <Spinner size="sm" />
+                Loading transcript
+              </span>
             ) : null
           ) : (
-            <TranscriptBody transcript={transcript} />
-          )}
-        </div>
-      )}
+            <TranscriptBody transcript={transcript} onRetry={retry} />
+          ))}
+      </div>
     </li>
   );
 }
@@ -161,7 +203,7 @@ export function CodexSubagentChip({ terminalId }: { terminalId: string }) {
 
   if (!enabled || result?.status !== "ok" || result.subagents.length === 0) return null;
 
-  const { subagents, candidates } = result;
+  const { subagents } = result;
 
   return (
     <Popover>
@@ -188,14 +230,6 @@ export function CodexSubagentChip({ terminalId }: { terminalId: string }) {
             <RefreshCw className={cn("w-3 h-3", isLoading && "animate-spin")} aria-hidden="true" />
           </button>
         </div>
-        {candidates.length > 0 && (
-          // Correlation is by folder plus recency, so a second Codex session in
-          // the same worktree makes the parent a guess. Say so rather than
-          // present another session's children as this terminal's.
-          <p className="px-3 py-2 text-[11px] text-status-warning border-b border-divider">
-            More than one Codex session ran here, so this list is a best guess
-          </p>
-        )}
         <ul className="max-h-80 overflow-y-auto">
           {subagents.map((subagent) => (
             <SubagentRow key={subagent.threadId} terminalId={terminalId} subagent={subagent} />

--- a/src/components/Terminal/CodexSubagentChip.tsx
+++ b/src/components/Terminal/CodexSubagentChip.tsx
@@ -184,7 +184,7 @@ function SubagentRow({ terminalId, subagent }: { terminalId: string; subagent: C
  * ever reads them.
  */
 export function CodexSubagentChip({ terminalId }: { terminalId: string }) {
-  const { isCodex, agentState, hasPty } = usePanelStore(
+  const { isCodex, agentState, hasPty, generation } = usePanelStore(
     useShallow((state) => {
       const panel = state.panelsById[terminalId];
       const pty = panel && isPtyPanel(panel) ? panel : undefined;
@@ -194,12 +194,19 @@ export function CodexSubagentChip({ terminalId }: { terminalId: string }) {
         isCodex: pty?.runtimeIdentity?.agentId === "codex" || pty?.launchAgentId === "codex",
         agentState: pty?.agentState,
         hasPty: pty?.hasPty !== false,
+        // Distinguishes a respawn from the process that held this panel id
+        // before it, so a reused pane can't inherit the old session's list.
+        generation: pty?.startedAt,
       };
     })
   );
 
   const enabled = isCodex && hasPty;
-  const { result, isLoading, refresh } = useCodexSubagents(terminalId, { enabled, agentState });
+  const { result, isLoading, refresh } = useCodexSubagents(terminalId, {
+    enabled,
+    agentState,
+    generation,
+  });
 
   if (!enabled || result?.status !== "ok" || result.subagents.length === 0) return null;
 

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -23,6 +23,7 @@ import { useResourceMonitoringStore } from "@/store/resourceMonitoringStore";
 import { useErrorStore } from "@/store/errorStore";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { TerminalResourceSparkline } from "./TerminalResourceSparkline";
+import { CodexSubagentChip } from "./CodexSubagentChip";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 
 // FUTURE_SAB: the `flowStatus` prop is widened to `TerminalFlowStatus` (not
@@ -623,6 +624,10 @@ export function TerminalHeaderContent({
           <TooltipContent side="bottom">Input locked (read-only monitor mode)</TooltipContent>
         </Tooltip>
       )}
+
+      {/* Codex subagent count — self-gating, renders nothing unless this
+          terminal's Codex session actually spawned child threads. */}
+      <CodexSubagentChip terminalId={id} />
     </>
   );
 }

--- a/src/components/Terminal/__tests__/CodexSubagentChip.test.tsx
+++ b/src/components/Terminal/__tests__/CodexSubagentChip.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodexSubagent, CodexSubagentsResult } from "@shared/types/ipc/codexSubagents";
 
@@ -31,6 +31,7 @@ vi.mock("@/components/ui/popover", () => ({
 }));
 
 import { CodexSubagentChip } from "../CodexSubagentChip";
+import { __resetCodexSubagentThrottle } from "@/hooks/useCodexSubagents";
 
 function subagent(overrides: Partial<CodexSubagent> = {}): CodexSubagent {
   return {
@@ -52,9 +53,8 @@ function ok(subagents: CodexSubagent[]): CodexSubagentsResult {
   return {
     status: "ok",
     parentThreadId: "root",
-    matchedBy: "cwd-recency",
+    matchedBy: "spawn-time",
     subagents,
-    candidates: [],
   };
 }
 
@@ -69,6 +69,8 @@ beforeEach(() => {
   readSubagentTranscript.mockReset();
   mockPanel = { id: "t1", kind: "terminal", launchAgentId: "codex", cwd: "/repo" };
   setElectronBridge(true);
+  // Module-scoped so it survives remounts in the app; must not leak between tests.
+  __resetCodexSubagentThrottle();
 });
 
 afterEach(() => {
@@ -115,28 +117,90 @@ describe("CodexSubagentChip", () => {
     expect(screen.queryByRole("textbox")).toBeNull();
   });
 
-  it("says the parent is a guess when more than one session ran in the folder", async () => {
-    listSubagents.mockResolvedValue({
+  it("shows nothing at all when the parent session is ambiguous", async () => {
+    // Fail closed: another terminal's children are indistinguishable from
+    // this one's, so the chip must not appear rather than guess.
+    listSubagents.mockResolvedValue({ status: "unavailable", reason: "ambiguous-session" });
+    render(<CodexSubagentChip terminalId="t1" />);
+    await waitFor(() => expect(listSubagents).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /subagent/i })).toBeNull();
+  });
+
+  it("loads a child's transcript once on expand, addressed to that child alone", async () => {
+    listSubagents.mockResolvedValue(
+      ok([subagent(), subagent({ threadId: "child-2", nickname: "Kant" })])
+    );
+    readSubagentTranscript.mockResolvedValue({
       status: "ok",
-      parentThreadId: "root",
-      matchedBy: "cwd-recency",
-      subagents: [subagent()],
-      candidates: [
-        { threadId: "root", preview: "one", createdAt: 1 },
-        { threadId: "other", preview: "two", createdAt: 2 },
+      threadId: "child-1",
+      turns: [
+        {
+          turnId: "t1",
+          status: "completed",
+          startedAt: null,
+          completedAt: null,
+          messages: [{ role: "agent", text: "All good" }],
+        },
       ],
     });
 
     render(<CodexSubagentChip terminalId="t1" />);
+    fireEvent.click(await screen.findByText("Meitner"));
 
-    expect(await screen.findByText(/best guess/i)).toBeTruthy();
+    expect(await screen.findByText("All good")).toBeTruthy();
+    // Exactly the child that was expanded, and only once.
+    expect(readSubagentTranscript.mock.calls).toEqual([
+      [{ terminalId: "t1", threadId: "child-1" }],
+    ]);
+
+    // Collapsing and reopening must not refetch a transcript we already hold.
+    fireEvent.click(screen.getByText("Meitner"));
+    fireEvent.click(screen.getByText("Meitner"));
+    await waitFor(() => expect(readSubagentTranscript).toHaveBeenCalledTimes(1));
   });
 
-  it("shows no ambiguity warning when the match was unambiguous", async () => {
+  it("offers a way out of a failed transcript read instead of wedging the row", async () => {
     listSubagents.mockResolvedValue(ok([subagent()]));
+    readSubagentTranscript.mockResolvedValueOnce({
+      status: "unavailable",
+      reason: "protocol-error",
+    });
+
+    render(<CodexSubagentChip terminalId="t1" />);
+    fireEvent.click(await screen.findByText("Meitner"));
+
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    readSubagentTranscript.mockResolvedValueOnce({
+      status: "ok",
+      threadId: "child-1",
+      turns: [
+        {
+          turnId: "t1",
+          status: null,
+          startedAt: null,
+          completedAt: null,
+          messages: [{ role: "agent", text: "Second time" }],
+        },
+      ],
+    });
+    fireEvent.click(retry);
+
+    expect(await screen.findByText("Second time")).toBeTruthy();
+  });
+
+  it("exposes no way to send input to a child, even one the protocol says accepts it", async () => {
+    // `acceptsDirectInput` is fail-closed in the mapper, but the UI must be
+    // read-only regardless of what the protocol reports.
+    listSubagents.mockResolvedValue(ok([subagent({ acceptsDirectInput: true })]));
+
     render(<CodexSubagentChip terminalId="t1" />);
     await screen.findByText("Meitner");
-    expect(screen.queryByText(/best guess/i)).toBeNull();
+
+    expect(screen.queryByRole("textbox")).toBeNull();
+    const actions = screen
+      .getAllByRole("button")
+      .map((el) => el.getAttribute("aria-label") ?? el.textContent);
+    expect(actions.some((label) => /send|reply|steer|prompt/i.test(label ?? ""))).toBe(false);
   });
 
   it("does not query the pty host once the terminal has exited", async () => {

--- a/src/components/Terminal/__tests__/CodexSubagentChip.test.tsx
+++ b/src/components/Terminal/__tests__/CodexSubagentChip.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexSubagent, CodexSubagentsResult } from "@shared/types/ipc/codexSubagents";
+
+const listSubagents = vi.hoisted(() => vi.fn());
+const readSubagentTranscript = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients/codexClient", () => ({
+  codexClient: { listSubagents, readSubagentTranscript },
+}));
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+let mockPanel: Record<string, unknown> = {};
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ panelsById: { t1: mockPanel } }),
+}));
+
+// The real popover lazy-loads Radix and renders nothing until primed, which
+// would hide the list this suite is about. Trigger and content render inline.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { CodexSubagentChip } from "../CodexSubagentChip";
+
+function subagent(overrides: Partial<CodexSubagent> = {}): CodexSubagent {
+  return {
+    threadId: "child-1",
+    parentThreadId: "root",
+    nickname: "Meitner",
+    role: "reviewer",
+    preview: "Review the diff",
+    cwd: "/repo",
+    status: { type: "notLoaded" },
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    acceptsDirectInput: false,
+    ...overrides,
+  };
+}
+
+function ok(subagents: CodexSubagent[]): CodexSubagentsResult {
+  return {
+    status: "ok",
+    parentThreadId: "root",
+    matchedBy: "cwd-recency",
+    subagents,
+    candidates: [],
+  };
+}
+
+/** The hook short-circuits unless `window.electron` exists, so stand one up. */
+function setElectronBridge(present: boolean) {
+  if (present) Reflect.set(window, "electron", {});
+  else Reflect.deleteProperty(window, "electron");
+}
+
+beforeEach(() => {
+  listSubagents.mockReset();
+  readSubagentTranscript.mockReset();
+  mockPanel = { id: "t1", kind: "terminal", launchAgentId: "codex", cwd: "/repo" };
+  setElectronBridge(true);
+});
+
+afterEach(() => {
+  setElectronBridge(false);
+  vi.restoreAllMocks();
+});
+
+describe("CodexSubagentChip", () => {
+  it("never queries for a terminal that is not running Codex", async () => {
+    mockPanel = { id: "t1", kind: "terminal", launchAgentId: "claude" };
+    render(<CodexSubagentChip terminalId="t1" />);
+    await waitFor(() => expect(listSubagents).not.toHaveBeenCalled());
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("stays invisible while the session reports no subagents", async () => {
+    listSubagents.mockResolvedValue(ok([]));
+    render(<CodexSubagentChip terminalId="t1" />);
+    await waitFor(() => expect(listSubagents).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /subagent/i })).toBeNull();
+  });
+
+  it("stays invisible when the lookup could not resolve a session", async () => {
+    listSubagents.mockResolvedValue({ status: "unavailable", reason: "no-session" });
+    render(<CodexSubagentChip terminalId="t1" />);
+    await waitFor(() => expect(listSubagents).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /subagent/i })).toBeNull();
+  });
+
+  it("counts the children it found and names each one read-only", async () => {
+    listSubagents.mockResolvedValue(
+      ok([
+        subagent(),
+        subagent({ threadId: "child-2", nickname: "Kant", preview: "Run the tests" }),
+      ])
+    );
+
+    render(<CodexSubagentChip terminalId="t1" />);
+
+    expect(await screen.findByRole("button", { name: "2 Codex subagents" })).toBeTruthy();
+    expect(screen.getByText("Meitner")).toBeTruthy();
+    expect(screen.getByText("Kant")).toBeTruthy();
+    // Read-only surface: nothing here may take input for a child session.
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("says the parent is a guess when more than one session ran in the folder", async () => {
+    listSubagents.mockResolvedValue({
+      status: "ok",
+      parentThreadId: "root",
+      matchedBy: "cwd-recency",
+      subagents: [subagent()],
+      candidates: [
+        { threadId: "root", preview: "one", createdAt: 1 },
+        { threadId: "other", preview: "two", createdAt: 2 },
+      ],
+    });
+
+    render(<CodexSubagentChip terminalId="t1" />);
+
+    expect(await screen.findByText(/best guess/i)).toBeTruthy();
+  });
+
+  it("shows no ambiguity warning when the match was unambiguous", async () => {
+    listSubagents.mockResolvedValue(ok([subagent()]));
+    render(<CodexSubagentChip terminalId="t1" />);
+    await screen.findByText("Meitner");
+    expect(screen.queryByText(/best guess/i)).toBeNull();
+  });
+
+  it("does not query the pty host once the terminal has exited", async () => {
+    mockPanel = { id: "t1", kind: "terminal", launchAgentId: "codex", hasPty: false };
+    render(<CodexSubagentChip terminalId="t1" />);
+    await waitFor(() => expect(listSubagents).not.toHaveBeenCalled());
+  });
+});

--- a/src/components/Terminal/__tests__/codexSubagentDisplay.test.ts
+++ b/src/components/Terminal/__tests__/codexSubagentDisplay.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { CodexSubagent, CodexSubagentStatus } from "@shared/types/ipc/codexSubagents";
+import {
+  codexUnavailableMessage,
+  subagentStatusLabel,
+  subagentStatusTone,
+  subagentSubtitle,
+  subagentTitle,
+} from "../codexSubagentDisplay";
+
+function subagent(overrides: Partial<CodexSubagent> = {}): CodexSubagent {
+  return {
+    threadId: "0199aa11-2233-4455-6677-8899aabbccdd",
+    parentThreadId: "root",
+    nickname: null,
+    role: null,
+    preview: "",
+    cwd: "/repo",
+    status: { type: "notLoaded" },
+    createdAt: 0,
+    updatedAt: 0,
+    acceptsDirectInput: false,
+    ...overrides,
+  };
+}
+
+describe("subagentTitle", () => {
+  it("prefers the nickname, then the role, then the task, then the id", () => {
+    const full = subagent({ nickname: "Meitner", role: "reviewer", preview: "Review the diff" });
+    expect(subagentTitle(full)).toBe("Meitner");
+    expect(subagentTitle({ ...full, nickname: null })).toBe("reviewer");
+    expect(subagentTitle({ ...full, nickname: null, role: null })).toBe("Review the diff");
+
+    const bare = subagent();
+    // Falls back to a short id rather than rendering an empty row.
+    expect(subagentTitle(bare)).toBe(bare.threadId.slice(0, 8));
+  });
+
+  it("uses only the first line of a multi-line task and bounds its length", () => {
+    const multiline = subagent({ preview: "Check the parser\nthen report back" });
+    expect(subagentTitle(multiline)).toBe("Check the parser");
+
+    const long = subagent({ preview: "x".repeat(200) });
+    expect(subagentTitle(long).length).toBe(48);
+  });
+});
+
+describe("subagentSubtitle", () => {
+  it("does not repeat whatever the title already shows", () => {
+    // With no nickname or role the title IS the task, so the subtitle must not
+    // echo it back on the line underneath.
+    const taskOnly = subagent({ preview: "Review the diff" });
+    expect(subagentTitle(taskOnly)).toBe("Review the diff");
+    expect(subagentSubtitle(taskOnly)).toBeNull();
+  });
+
+  it("shows the task under a nicknamed child", () => {
+    const named = subagent({ nickname: "Kant", preview: "Run the tests" });
+    expect(subagentSubtitle(named)).toBe("Run the tests");
+  });
+
+  it("falls back to the role when there is no task text", () => {
+    expect(subagentSubtitle(subagent({ nickname: "Kant", role: "tester" }))).toBe("tester");
+    expect(subagentSubtitle(subagent())).toBeNull();
+  });
+});
+
+describe("subagentStatusLabel", () => {
+  it("reports the more urgent reason when a child is blocked on both", () => {
+    const both: CodexSubagentStatus = {
+      type: "active",
+      activeFlags: ["waitingOnUserInput", "waitingOnApproval"],
+    };
+    const approvalOnly: CodexSubagentStatus = {
+      type: "active",
+      activeFlags: ["waitingOnApproval"],
+    };
+    const inputOnly: CodexSubagentStatus = {
+      type: "active",
+      activeFlags: ["waitingOnUserInput"],
+    };
+
+    expect(subagentStatusLabel(both)).toBe(subagentStatusLabel(approvalOnly));
+    expect(subagentStatusLabel(both)).not.toBe(subagentStatusLabel(inputOnly));
+  });
+
+  it("distinguishes an unflagged active child from an idle one", () => {
+    const working = subagentStatusLabel({ type: "active", activeFlags: [] });
+    expect(working).not.toBe(subagentStatusLabel({ type: "idle" }));
+    expect(working).not.toBe(subagentStatusLabel({ type: "notLoaded" }));
+  });
+
+  it("does not claim a stored child is idle when we never observed it", () => {
+    // Daintree reads persisted state, so notLoaded is the common case; calling
+    // it "idle" would assert something we did not see.
+    expect(subagentStatusLabel({ type: "notLoaded" })).not.toBe(
+      subagentStatusLabel({ type: "idle" })
+    );
+  });
+});
+
+describe("subagentStatusTone", () => {
+  it("separates an error from a live child and from everything quiet", () => {
+    expect(subagentStatusTone({ type: "systemError" })).toBe("error");
+    expect(subagentStatusTone({ type: "active", activeFlags: [] })).toBe("active");
+    expect(subagentStatusTone({ type: "idle" })).toBe("muted");
+    expect(subagentStatusTone({ type: "notLoaded" })).toBe("muted");
+  });
+});
+
+describe("codexUnavailableMessage", () => {
+  it("gives each reason its own explanation", () => {
+    const reasons = [
+      "cli-missing",
+      "no-session",
+      "timeout",
+      "protocol-error",
+      "not-codex",
+    ] as const;
+    const messages = reasons.map(codexUnavailableMessage);
+    // "not-codex" and "terminal-unknown" deliberately share wording; the rest
+    // must not collapse into one another.
+    expect(new Set(messages).size).toBe(reasons.length);
+    for (const message of messages) {
+      expect(message.endsWith(".")).toBe(false);
+    }
+  });
+});

--- a/src/components/Terminal/__tests__/codexSubagentDisplay.test.ts
+++ b/src/components/Terminal/__tests__/codexSubagentDisplay.test.ts
@@ -32,16 +32,27 @@ describe("subagentTitle", () => {
     expect(subagentTitle({ ...full, nickname: null, role: null })).toBe("Review the diff");
 
     const bare = subagent();
-    // Falls back to a short id rather than rendering an empty row.
-    expect(subagentTitle(bare)).toBe(bare.threadId.slice(0, 8));
+    // Falls back to a fragment of the id rather than rendering an empty row.
+    const fallback = subagentTitle(bare);
+    expect(fallback).not.toBe("");
+    expect(fallback.length).toBeLessThan(bare.threadId.length);
+    expect(bare.threadId.startsWith(fallback)).toBe(true);
   });
 
   it("uses only the first line of a multi-line task and bounds its length", () => {
     const multiline = subagent({ preview: "Check the parser\nthen report back" });
     expect(subagentTitle(multiline)).toBe("Check the parser");
 
-    const long = subagent({ preview: "x".repeat(200) });
-    expect(subagentTitle(long).length).toBe(48);
+    const source = `START${"x".repeat(500)}`;
+    const long = subagent({ preview: source });
+    const title = subagentTitle(long);
+    expect(title.length).toBeLessThan(source.length);
+    expect(source.startsWith(title)).toBe(true);
+  });
+
+  it("does not render whitespace-only metadata as a title", () => {
+    const blankName = subagent({ nickname: "   ", role: "\n", preview: "Review the diff" });
+    expect(subagentTitle(blankName)).toBe("Review the diff");
   });
 });
 
@@ -62,6 +73,16 @@ describe("subagentSubtitle", () => {
   it("falls back to the role when there is no task text", () => {
     expect(subagentSubtitle(subagent({ nickname: "Kant", role: "tester" }))).toBe("tester");
     expect(subagentSubtitle(subagent())).toBeNull();
+  });
+
+  it("never restates the title, whichever field the title came from", () => {
+    // Every collision the fallback chain can produce: role doubling as the
+    // task, and a nickname identical to the role.
+    const roleIsTask = subagent({ role: "reviewer", preview: "reviewer" });
+    expect(subagentSubtitle(roleIsTask)).not.toBe(subagentTitle(roleIsTask));
+
+    const sameNameAndRole = subagent({ nickname: "reviewer", role: "reviewer" });
+    expect(subagentSubtitle(sameNameAndRole)).not.toBe(subagentTitle(sameNameAndRole));
   });
 });
 
@@ -113,6 +134,7 @@ describe("codexUnavailableMessage", () => {
     const reasons = [
       "cli-missing",
       "no-session",
+      "ambiguous-session",
       "timeout",
       "protocol-error",
       "not-codex",

--- a/src/components/Terminal/codexSubagentDisplay.ts
+++ b/src/components/Terminal/codexSubagentDisplay.ts
@@ -1,0 +1,71 @@
+import type {
+  CodexSubagent,
+  CodexSubagentStatus,
+  CodexSubagentUnavailableReason,
+} from "@shared/types/ipc/codexSubagents";
+
+/**
+ * Daintree reads persisted thread state through its own app-server process, so
+ * `notLoaded` is what a stored child normally reports. It is labelled honestly
+ * rather than smoothed into "idle" — the two mean different things, and only
+ * one of them is something we actually observed.
+ */
+export function subagentStatusLabel(status: CodexSubagentStatus): string {
+  switch (status.type) {
+    case "idle":
+      return "Idle";
+    case "systemError":
+      return "Error";
+    case "active":
+      if (status.activeFlags.includes("waitingOnApproval")) return "Waiting for approval";
+      if (status.activeFlags.includes("waitingOnUserInput")) return "Waiting for input";
+      return "Working";
+    case "notLoaded":
+    default:
+      return "Not loaded";
+  }
+}
+
+export function subagentStatusTone(status: CodexSubagentStatus): "error" | "active" | "muted" {
+  if (status.type === "systemError") return "error";
+  if (status.type === "active") return "active";
+  return "muted";
+}
+
+function firstLine(value: string): string {
+  return value.trim().split("\n")[0]?.trim() ?? "";
+}
+
+/** Nickname first — it's the handle the parent transcript uses for the child. */
+export function subagentTitle(subagent: CodexSubagent): string {
+  if (subagent.nickname) return subagent.nickname;
+  if (subagent.role) return subagent.role;
+  const preview = firstLine(subagent.preview);
+  if (preview) return preview.slice(0, 48);
+  return subagent.threadId.slice(0, 8);
+}
+
+/** Shown under the title when it would not merely repeat it. */
+export function subagentSubtitle(subagent: CodexSubagent): string | null {
+  const preview = firstLine(subagent.preview);
+  if (!preview) return subagent.nickname ? subagent.role : null;
+  if (preview === subagentTitle(subagent)) return subagent.role;
+  return preview.slice(0, 120);
+}
+
+export function codexUnavailableMessage(reason: CodexSubagentUnavailableReason): string {
+  switch (reason) {
+    case "cli-missing":
+      return "Codex CLI isn't available";
+    case "no-session":
+      return "Couldn't match this terminal to a Codex session";
+    case "timeout":
+      return "Codex took too long to respond";
+    case "not-codex":
+    case "terminal-unknown":
+      return "This terminal isn't running Codex";
+    case "protocol-error":
+    default:
+      return "Couldn't read Codex sessions";
+  }
+}

--- a/src/components/Terminal/codexSubagentDisplay.ts
+++ b/src/components/Terminal/codexSubagentDisplay.ts
@@ -32,25 +32,28 @@ export function subagentStatusTone(status: CodexSubagentStatus): "error" | "acti
   return "muted";
 }
 
-function firstLine(value: string): string {
-  return value.trim().split("\n")[0]?.trim() ?? "";
+function firstLine(value: string | null): string {
+  return value?.trim().split("\n")[0]?.trim() ?? "";
 }
 
 /** Nickname first — it's the handle the parent transcript uses for the child. */
 export function subagentTitle(subagent: CodexSubagent): string {
-  if (subagent.nickname) return subagent.nickname;
-  if (subagent.role) return subagent.role;
-  const preview = firstLine(subagent.preview);
-  if (preview) return preview.slice(0, 48);
-  return subagent.threadId.slice(0, 8);
+  // Every field goes through the same normalizer: a whitespace-only nickname
+  // is not a title, it's a blank row.
+  return (
+    firstLine(subagent.nickname) ||
+    firstLine(subagent.role) ||
+    firstLine(subagent.preview).slice(0, 48) ||
+    subagent.threadId.slice(0, 8)
+  );
 }
 
 /** Shown under the title when it would not merely repeat it. */
 export function subagentSubtitle(subagent: CodexSubagent): string | null {
-  const preview = firstLine(subagent.preview);
-  if (!preview) return subagent.nickname ? subagent.role : null;
-  if (preview === subagentTitle(subagent)) return subagent.role;
-  return preview.slice(0, 120);
+  const title = subagentTitle(subagent);
+  const candidate = firstLine(subagent.preview) || firstLine(subagent.role);
+  if (!candidate || candidate === title) return null;
+  return candidate.slice(0, 120);
 }
 
 export function codexUnavailableMessage(reason: CodexSubagentUnavailableReason): string {
@@ -59,6 +62,8 @@ export function codexUnavailableMessage(reason: CodexSubagentUnavailableReason):
       return "Codex CLI isn't available";
     case "no-session":
       return "Couldn't match this terminal to a Codex session";
+    case "ambiguous-session":
+      return "More than one Codex session ran in this folder, so we can't tell which is this terminal's";
     case "timeout":
       return "Codex took too long to respond";
     case "not-codex":

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -32,6 +32,7 @@ export {
   LayoutPanelTop, // workspace plugin category (panels, notes)
   Menu, // the application menu, surfaced in-app where the native menu bar can't render
   Moon, // sleep a project — shut it down the way quitting does, restored on reopen
+  Network, // Codex subagent tree — a parent session's spawned child threads
   Package, // plugin (a packaged extension) — plugin tray, unresolved plugin glyphs
   Plug, // agent (integration that plugs into the host system)
   Plus, // the toolbar launcher — "make me a new thing" (agent, panel)

--- a/src/hooks/useCodexSubagents.ts
+++ b/src/hooks/useCodexSubagents.ts
@@ -43,17 +43,33 @@ interface CachedLookup {
 }
 
 const lookupCache = new Map<string, CachedLookup>();
+/** Terminal keys with a request in flight, shared across hook instances. */
+const inFlightKeys = new Set<string>();
 
-/** Bound the map so a long session cycling through terminals can't grow it. */
+/** Hard bound on the cache — a long session cycles through many terminals. */
 const MAX_CACHED_TERMINALS = 64;
 
-function rememberLookup(terminalId: string, result: CodexSubagentsResult, at: number): void {
-  lookupCache.set(terminalId, { at, result });
+/**
+ * A reused panel id is not the same session. Folding the PTY's start time into
+ * the key means a respawned terminal looks up its own subagents instead of
+ * adopting the answer for the process that used to live there.
+ */
+function cacheKey(terminalId: string, generation: number | undefined): string {
+  return `${terminalId}:${generation ?? 0}`;
+}
+
+function rememberLookup(key: string, result: CodexSubagentsResult, at: number): void {
+  lookupCache.set(key, { at, result });
   if (lookupCache.size <= MAX_CACHED_TERMINALS) return;
-  for (const [key, entry] of lookupCache) {
-    if (lookupCache.size <= MAX_CACHED_TERMINALS) break;
-    // Anything past its throttle window is free to refetch anyway.
-    if (at - entry.at > CODEX_SUBAGENT_REFRESH_THROTTLE_MS) lookupCache.delete(key);
+  // Expired entries first — they would be refetched anyway — then oldest-first
+  // until the cap actually holds, since every entry can be fresh at once.
+  for (const [entryKey, entry] of lookupCache) {
+    if (lookupCache.size <= MAX_CACHED_TERMINALS) return;
+    if (at - entry.at > CODEX_SUBAGENT_REFRESH_THROTTLE_MS) lookupCache.delete(entryKey);
+  }
+  for (const entryKey of lookupCache.keys()) {
+    if (lookupCache.size <= MAX_CACHED_TERMINALS) return;
+    lookupCache.delete(entryKey);
   }
 }
 
@@ -63,14 +79,14 @@ function rememberLookup(terminalId: string, result: CodexSubagentsResult, at: nu
  */
 export function useCodexSubagents(
   terminalId: string,
-  options: { enabled: boolean; agentState?: AgentState }
+  options: { enabled: boolean; agentState?: AgentState; generation?: number }
 ): UseCodexSubagentsResult {
-  const { enabled, agentState } = options;
+  const { enabled, agentState, generation } = options;
+  const key = cacheKey(terminalId, generation);
   const [result, setResult] = useState<CodexSubagentsResult | null>(
-    () => lookupCache.get(terminalId)?.result ?? null
+    () => lookupCache.get(key)?.result ?? null
   );
   const [isLoading, setIsLoading] = useState(false);
-  const inFlightRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -83,37 +99,35 @@ export function useCodexSubagents(
   const fetchSubagents = useCallback(
     (force: boolean) => {
       if (!enabled || !isElectronAvailable()) return;
-      if (inFlightRef.current === terminalId) return;
+      // Module-scoped, so two panes remounting the same terminal at once issue
+      // one lookup rather than one each.
+      if (inFlightKeys.has(key)) return;
       const now = Date.now();
-      const cached = lookupCache.get(terminalId);
+      const cached = lookupCache.get(key);
       if (!force && cached && now - cached.at < CODEX_SUBAGENT_REFRESH_THROTTLE_MS) {
         // Still fresh: adopt it so a remount inside the window shows the same
         // list it had before, without spawning anything.
         setResult(cached.result);
         return;
       }
-      inFlightRef.current = terminalId;
+      inFlightKeys.add(key);
       setIsLoading(true);
       void codexClient
         .listSubagents({ terminalId })
         .then((next) => {
-          rememberLookup(terminalId, next, Date.now());
-          // A hook whose terminal changed mid-flight must not adopt the old
-          // one's answer.
-          if (mountedRef.current && inFlightRef.current === terminalId) setResult(next);
+          rememberLookup(key, next, Date.now());
+          if (mountedRef.current) setResult(next);
         })
         .catch((error: unknown) => {
           logWarn(`[useCodexSubagents] list failed: ${formatErrorMessage(error, "unknown error")}`);
-          if (mountedRef.current && inFlightRef.current === terminalId) {
-            setResult({ status: "unavailable", reason: "protocol-error" });
-          }
+          if (mountedRef.current) setResult({ status: "unavailable", reason: "protocol-error" });
         })
         .finally(() => {
-          if (inFlightRef.current === terminalId) inFlightRef.current = null;
+          inFlightKeys.delete(key);
           if (mountedRef.current) setIsLoading(false);
         });
     },
-    [enabled, terminalId]
+    [enabled, key, terminalId]
   );
 
   // First look. Throttled like any other automatic fetch — a restore remounts
@@ -135,4 +149,5 @@ export function useCodexSubagents(
 /** Test-only: the lookup cache is module state and outlives a render tree. */
 export function __resetCodexSubagentThrottle(): void {
   lookupCache.clear();
+  inFlightKeys.clear();
 }

--- a/src/hooks/useCodexSubagents.ts
+++ b/src/hooks/useCodexSubagents.ts
@@ -30,6 +30,34 @@ export interface UseCodexSubagentsResult {
 }
 
 /**
+ * Last answer per terminal, outliving the hook instance on purpose. Refs reset
+ * on every remount, and a project restore or hibernate/wake remounts every pane
+ * at once — a per-instance throttle would let that burst re-spawn a process per
+ * terminal. Keeping the result alongside the timestamp also means a remount
+ * inside the throttle window rehydrates instantly instead of showing nothing
+ * until the window expires.
+ */
+interface CachedLookup {
+  at: number;
+  result: CodexSubagentsResult;
+}
+
+const lookupCache = new Map<string, CachedLookup>();
+
+/** Bound the map so a long session cycling through terminals can't grow it. */
+const MAX_CACHED_TERMINALS = 64;
+
+function rememberLookup(terminalId: string, result: CodexSubagentsResult, at: number): void {
+  lookupCache.set(terminalId, { at, result });
+  if (lookupCache.size <= MAX_CACHED_TERMINALS) return;
+  for (const [key, entry] of lookupCache) {
+    if (lookupCache.size <= MAX_CACHED_TERMINALS) break;
+    // Anything past its throttle window is free to refetch anyway.
+    if (at - entry.at > CODEX_SUBAGENT_REFRESH_THROTTLE_MS) lookupCache.delete(key);
+  }
+}
+
+/**
  * Poll-free view of a Codex terminal's spawned subagents: one query on mount,
  * one whenever the parent settles, and one per manual refresh.
  */
@@ -38,10 +66,11 @@ export function useCodexSubagents(
   options: { enabled: boolean; agentState?: AgentState }
 ): UseCodexSubagentsResult {
   const { enabled, agentState } = options;
-  const [result, setResult] = useState<CodexSubagentsResult | null>(null);
+  const [result, setResult] = useState<CodexSubagentsResult | null>(
+    () => lookupCache.get(terminalId)?.result ?? null
+  );
   const [isLoading, setIsLoading] = useState(false);
-  const lastFetchRef = useRef(0);
-  const inFlightRef = useRef(false);
+  const inFlightRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -54,33 +83,43 @@ export function useCodexSubagents(
   const fetchSubagents = useCallback(
     (force: boolean) => {
       if (!enabled || !isElectronAvailable()) return;
-      if (inFlightRef.current) return;
+      if (inFlightRef.current === terminalId) return;
       const now = Date.now();
-      if (!force && now - lastFetchRef.current < CODEX_SUBAGENT_REFRESH_THROTTLE_MS) return;
-      inFlightRef.current = true;
-      lastFetchRef.current = now;
+      const cached = lookupCache.get(terminalId);
+      if (!force && cached && now - cached.at < CODEX_SUBAGENT_REFRESH_THROTTLE_MS) {
+        // Still fresh: adopt it so a remount inside the window shows the same
+        // list it had before, without spawning anything.
+        setResult(cached.result);
+        return;
+      }
+      inFlightRef.current = terminalId;
       setIsLoading(true);
       void codexClient
         .listSubagents({ terminalId })
         .then((next) => {
-          if (mountedRef.current) setResult(next);
+          rememberLookup(terminalId, next, Date.now());
+          // A hook whose terminal changed mid-flight must not adopt the old
+          // one's answer.
+          if (mountedRef.current && inFlightRef.current === terminalId) setResult(next);
         })
         .catch((error: unknown) => {
           logWarn(`[useCodexSubagents] list failed: ${formatErrorMessage(error, "unknown error")}`);
-          if (mountedRef.current) setResult({ status: "unavailable", reason: "protocol-error" });
+          if (mountedRef.current && inFlightRef.current === terminalId) {
+            setResult({ status: "unavailable", reason: "protocol-error" });
+          }
         })
         .finally(() => {
-          inFlightRef.current = false;
+          if (inFlightRef.current === terminalId) inFlightRef.current = null;
           if (mountedRef.current) setIsLoading(false);
         });
     },
     [enabled, terminalId]
   );
 
-  // First look. Forced so a freshly restored panel doesn't sit blank behind a
-  // throttle window inherited from a previous mount.
+  // First look. Throttled like any other automatic fetch — a restore remounts
+  // every pane at once, and the cache above already covers what it would show.
   useEffect(() => {
-    fetchSubagents(true);
+    fetchSubagents(false);
   }, [fetchSubagents]);
 
   useEffect(() => {
@@ -91,4 +130,9 @@ export function useCodexSubagents(
   const refresh = useCallback(() => fetchSubagents(true), [fetchSubagents]);
 
   return { result, isLoading, refresh };
+}
+
+/** Test-only: the lookup cache is module state and outlives a render tree. */
+export function __resetCodexSubagentThrottle(): void {
+  lookupCache.clear();
 }

--- a/src/hooks/useCodexSubagents.ts
+++ b/src/hooks/useCodexSubagents.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { codexClient } from "@/clients/codexClient";
+import { isElectronAvailable } from "./useElectron";
+import { logWarn } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { AgentState } from "@/types";
+import type { CodexSubagentsResult } from "@shared/types/ipc/codexSubagents";
+
+/**
+ * Floor between automatic refreshes. Each one spawns a short-lived
+ * `codex app-server`, so a terminal that flickers between states can't turn
+ * into a spawn storm. Manual refresh bypasses it — the user asked.
+ */
+export const CODEX_SUBAGENT_REFRESH_THROTTLE_MS = 20_000;
+
+/**
+ * States where the parent has stopped producing output, so any subagent it
+ * spawned has had a chance to be written to Codex's thread store.
+ */
+const SETTLED_STATES: ReadonlySet<AgentState> = new Set<AgentState>([
+  "idle",
+  "waiting",
+  "completed",
+]);
+
+export interface UseCodexSubagentsResult {
+  result: CodexSubagentsResult | null;
+  isLoading: boolean;
+  refresh: () => void;
+}
+
+/**
+ * Poll-free view of a Codex terminal's spawned subagents: one query on mount,
+ * one whenever the parent settles, and one per manual refresh.
+ */
+export function useCodexSubagents(
+  terminalId: string,
+  options: { enabled: boolean; agentState?: AgentState }
+): UseCodexSubagentsResult {
+  const { enabled, agentState } = options;
+  const [result, setResult] = useState<CodexSubagentsResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const lastFetchRef = useRef(0);
+  const inFlightRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchSubagents = useCallback(
+    (force: boolean) => {
+      if (!enabled || !isElectronAvailable()) return;
+      if (inFlightRef.current) return;
+      const now = Date.now();
+      if (!force && now - lastFetchRef.current < CODEX_SUBAGENT_REFRESH_THROTTLE_MS) return;
+      inFlightRef.current = true;
+      lastFetchRef.current = now;
+      setIsLoading(true);
+      void codexClient
+        .listSubagents({ terminalId })
+        .then((next) => {
+          if (mountedRef.current) setResult(next);
+        })
+        .catch((error: unknown) => {
+          logWarn(`[useCodexSubagents] list failed: ${formatErrorMessage(error, "unknown error")}`);
+          if (mountedRef.current) setResult({ status: "unavailable", reason: "protocol-error" });
+        })
+        .finally(() => {
+          inFlightRef.current = false;
+          if (mountedRef.current) setIsLoading(false);
+        });
+    },
+    [enabled, terminalId]
+  );
+
+  // First look. Forced so a freshly restored panel doesn't sit blank behind a
+  // throttle window inherited from a previous mount.
+  useEffect(() => {
+    fetchSubagents(true);
+  }, [fetchSubagents]);
+
+  useEffect(() => {
+    if (!agentState || !SETTLED_STATES.has(agentState)) return;
+    fetchSubagents(false);
+  }, [agentState, fetchSubagents]);
+
+  const refresh = useCallback(() => fetchSubagents(true), [fetchSubagents]);
+
+  return { result, isLoading, refresh };
+}


### PR DESCRIPTION
## Summary

- Codex CLI sessions can spawn subagent threads internally, and until now the Codex terminal panel only showed the parent session. A subagent's status and output were invisible except for what bled into the parent transcript.
- This adds a read-only view of those subagent threads, attached to the existing Codex terminal panel's header. Nothing in it can steer a child.
- Reads Codex's documented app-server protocol rather than scraping anything.

Resolves #11948

## Implementation

Alongside the terminal process (which is untouched), we spawn a short-lived `codex app-server --listen stdio://` query process. It performs the usual `initialize`/`initialized` handshake with `experimentalApi`, then calls `thread/list` filtered by `parentThreadId` and `thread/turns/list` for a child's recent turns.

We deliberately don't read `~/.codex/sessions/**/rollout-*.jsonl`. Codex calls those legacy local sessions, and [openai/codex#38762](https://github.com/openai/codex/issues/38762) leaves subagent threads with an empty projected history there, so those files wouldn't have the content anyway.

`thread/start` is unreachable by design. It marks a project trusted in the user's `~/.codex/config.toml`, and the transport enforces a module-private read-only method allowlist, so no caller or future bug can reach it.

## Design notes

- **IPC is terminal-scoped.** The renderer passes only a terminal id. Main resolves the cwd and owning Codex thread from the pty-host record and verifies a requested thread is actually a child of that parent before reading its transcript.
- **Attribution fails closed.** A running Codex terminal has no session id to key off (Daintree only learns one from the `codex resume` footer at teardown), so the parent is correlated by folder plus liveness against the terminal's launch time. Sessions that went quiet before the terminal launched are dropped. If more than one live session remains in the folder, the lookup reports `ambiguous-session` and the UI shows nothing rather than guessing, since the wrong session's children are indistinguishable from the right ones. Two concurrent Codex terminals in one worktree therefore both show nothing. That's the intended trade.
- **UI is a self-gating chip in the terminal panel header**, not a new panel kind and not a bottom-right overlay (that corner already belongs to `ArtifactOverlay` and the fleet pill, and a Codex TUI is full height anyway). It renders nothing until a query actually finds children.
- Spawns are concurrency-gated so a project restore can't burst one process per pane. The renderer caches lookups per terminal, keyed by PTY start time.

## Known limitation

The query process inherits the main process's `CODEX_HOME` rather than the terminal's own spawn environment, so a per-project override queries the wrong Codex profile. This usually fails quiet (no thread for that cwd means nothing shown). Carrying the terminal's effective profile through pty-host metadata is the real fix and isn't wired up yet. It's documented in the code.

## Out of scope for this version

Per the issue author: steering a child, promoting a child into its own terminal, and feeding child state into the parent's agent state machine (which stays PTY-driven).

## Changes

- `electron/services/codex/CodexAppServerClient.ts`: JSON-RPC client for the Codex app-server protocol (handshake, `thread/list`, `thread/turns/list`).
- `electron/services/codex/CodexSubagentService.ts`: spawns and manages the query process, correlates the parent thread to a terminal, enforces the read-only method allowlist.
- `electron/ipc/handlers/codex.ts` + `codex.preload.ts`, `shared/types/ipc/codexSubagents.ts`: terminal-scoped IPC surface, registered in the channel registry.
- `src/hooks/useCodexSubagents.ts`, `src/clients/codexClient.ts`: renderer-side lookup with per-terminal caching keyed by PTY start time.
- `src/components/Terminal/CodexSubagentChip.tsx`, `codexSubagentDisplay.ts`: the self-gating header chip and its display logic, wired into `TerminalHeaderContent.tsx`.

## Testing

- `npm run typecheck` clean.
- 464 tests pass: `electron/ipc/__tests__/`, `electron/services/codex/__tests__/`, three new/changed Terminal suites, plus the repo-scanning contract suites in `src/config/__tests__/` (411).
- `check:channels`, `check:ipc`, `check:ipc-renderer`, `check:ipc-handwritten` all pass.
- prettier and eslint clean on every changed file (one pre-existing warning in `TerminalHeaderContent.tsx`, outside the changed lines).
- Protocol facts verified live against the installed `codex-cli` 0.149.1 (the version the issue author tested), by running the real app-server rather than relying on docs alone.