### PR TITLE
fix(restore): bind a restored scratch workspace on relaunch

### DIFF
--- a/electron/ipc/handlers/scratch/__tests__/switch.test.ts
+++ b/electron/ipc/handlers/scratch/__tests__/switch.test.ts
@@ -42,6 +42,11 @@ vi.mock("../../../../services/ProjectStore.js", () => ({
   projectStore: projectStoreMock,
 }));
 
+const scheduleOpenWindowsSaveMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../../window/openWindowsTracker.js", () => ({
+  scheduleOpenWindowsSave: scheduleOpenWindowsSaveMock,
+}));
+
 const refreshProjectMenuStateMock = vi.hoisted(() => vi.fn());
 vi.mock("../../../../projectMenuState.js", () => ({
   refreshProjectMenuState: refreshProjectMenuStateMock,
@@ -216,6 +221,60 @@ describe("scratch:switch refreshes the File-menu project gates", () => {
     await expect(getHandler(CHANNELS.SCRATCH_SWITCH)(fakeEvent, "ghost")).rejects.toThrow();
 
     expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+  });
+});
+
+// The open-window manifest is what a relaunch reads to decide which workspace
+// each window comes back on. `project:switch` re-persists it after committing;
+// `scratch:switch` did not, so a hard crash straight after entering a scratch
+// relaunched into the workspace the user had left (#11958).
+describe("scratch:switch re-persists the open-window manifest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webContentsRegistryMock.getProjectForWebContents.mockReturnValue(null);
+    webContentsRegistryMock.getWindowForWebContents.mockReturnValue(null);
+    enterScratch(SCRATCH_ONE);
+  });
+
+  it("schedules a save once the pointers name the scratch", async () => {
+    registerScratchHandlers({ mainWindow: {} } as unknown as HandlerDependencies);
+
+    await getHandler(CHANNELS.SCRATCH_SWITCH)(fakeEvent, SCRATCH_ONE);
+
+    expect(scheduleOpenWindowsSaveMock).toHaveBeenCalled();
+    // The manifest is built from every window's committed active id, so saving
+    // before the pointers move would persist the workspace being left.
+    expect(scheduleOpenWindowsSaveMock.mock.invocationCallOrder[0]!).toBeGreaterThan(
+      scratchStoreMock.setCurrentScratch.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("schedules no save when the view swap fails", async () => {
+    const deps = {
+      mainWindow: { id: 91 },
+      projectViewManager: {
+        setPendingFocusIntent: vi.fn(),
+        switchTo: vi.fn().mockRejectedValue(new Error("swap failed")),
+      },
+    } as unknown as HandlerDependencies;
+    registerScratchHandlers(deps);
+
+    await expect(getHandler(CHANNELS.SCRATCH_SWITCH)(fakeEvent, SCRATCH_ONE)).rejects.toThrow(
+      "swap failed"
+    );
+
+    // Persisting a switch that threw would relaunch into a workspace this
+    // window never reached.
+    expect(scheduleOpenWindowsSaveMock).not.toHaveBeenCalled();
+  });
+
+  it("schedules no save when the scratch does not exist", async () => {
+    scratchStoreMock.getScratchById.mockReturnValue(null);
+    registerScratchHandlers({ mainWindow: {} } as unknown as HandlerDependencies);
+
+    await expect(getHandler(CHANNELS.SCRATCH_SWITCH)(fakeEvent, "ghost")).rejects.toThrow();
+
+    expect(scheduleOpenWindowsSaveMock).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/scratch/__tests__/switch.test.ts
+++ b/electron/ipc/handlers/scratch/__tests__/switch.test.ts
@@ -249,6 +249,34 @@ describe("scratch:switch re-persists the open-window manifest", () => {
     );
   });
 
+  it("waits for the view swap to resolve before scheduling", async () => {
+    // The manifest reads each window's ProjectViewManager, so a save that
+    // landed while `switchTo` was still in flight would snapshot the outgoing
+    // workspace. Held open deliberately to pin that ordering — asserting it
+    // against the pointer writes alone cannot see it.
+    let releaseSwitch: (() => void) | undefined;
+    const switchTo = vi.fn(
+      () =>
+        new Promise<{ view: null; isNew: boolean }>((resolve) => {
+          releaseSwitch = () => resolve({ view: null, isNew: false });
+        })
+    );
+    registerScratchHandlers({
+      mainWindow: {},
+      projectViewManager: { setPendingFocusIntent: vi.fn(), switchTo },
+    } as unknown as HandlerDependencies);
+
+    const pending = getHandler(CHANNELS.SCRATCH_SWITCH)(fakeEvent, SCRATCH_ONE);
+    await Promise.resolve();
+    expect(switchTo).toHaveBeenCalled();
+    expect(scheduleOpenWindowsSaveMock).not.toHaveBeenCalled();
+
+    releaseSwitch?.();
+    await pending;
+
+    expect(scheduleOpenWindowsSaveMock).toHaveBeenCalled();
+  });
+
   it("schedules no save when the view swap fails", async () => {
     const deps = {
       mainWindow: { id: 91 },

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -162,10 +162,13 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
           // same call `project:switch` makes after its own commit. Placed after
           // the PVM swap because the manifest is built from
           // `getActiveProjectId()` across every window — it has to read the
-          // committed state, not the switch that is still landing. A graceful
-          // quit snapshots this anyway; what this covers is the hard crash
-          // right after entering a scratch, which otherwise relaunches into
-          // the workspace the user had left (#11958).
+          // committed state, not the switch that is still landing.
+          //
+          // Best-effort for an abrupt exit, not a guarantee: the write is
+          // trailing-debounced, so a crash inside that window still relaunches
+          // into the workspace the user had left. A graceful quit is covered
+          // regardless — `freezeAndSnapshotOpenWindows()` captures whatever the
+          // pending debounce still owed (#11958).
           scheduleOpenWindowsSave();
 
           // A scratch is not a project: the window's PVM now holds a scratch id

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -17,6 +17,7 @@ import { defineIpcNamespace, op } from "../../define.js";
 import { SCRATCH_METHOD_CHANNELS } from "./preload.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { distributePortsToView } from "../../../window/portDistribution.js";
+import { scheduleOpenWindowsSave } from "../../../window/openWindowsTracker.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { getProjectHistory } from "../../../services/ProjectHistoryService.js";
@@ -156,6 +157,16 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
           // renderer's `getCurrentProject` does not race-restore the previous project.
           const updated = scratchStore.setCurrentScratch(scratchId);
           projectStore.clearCurrentProject();
+
+          // Re-persist which workspace each window is showing (#11492), the
+          // same call `project:switch` makes after its own commit. Placed after
+          // the PVM swap because the manifest is built from
+          // `getActiveProjectId()` across every window — it has to read the
+          // committed state, not the switch that is still landing. A graceful
+          // quit snapshots this anyway; what this covers is the hard crash
+          // right after entering a scratch, which otherwise relaunches into
+          // the workspace the user had left (#11958).
+          scheduleOpenWindowsSave();
 
           // A scratch is not a project: the window's PVM now holds a scratch id
           // with no project row, so the File-menu project gates must drop.

--- a/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
+++ b/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
@@ -33,65 +33,104 @@ vi.mock("better-sqlite3", () => ({
 }));
 
 import { resolvePrimaryRestoreProjectId } from "../../../lifecycle/windowRestore.js";
-import { readOpenWindowsManifestSync } from "../readLastProjectId.js";
+import { readLastActiveProjectIdSync, readOpenWindowsManifestSync } from "../readLastProjectId.js";
 
 const manifestJson = (windows: unknown[]): string =>
   JSON.stringify({ version: OPEN_WINDOWS_MANIFEST_VERSION, windows });
 
 /**
- * Wire the queries the reader issues: the app_state lookup, the batched
- * project-existence check, and the batched scratch-existence check.
+ * Wire the statements the readers issue: the `app_state` lookups, the schema
+ * probe, and the two batched existence checks.
  *
- * The scratch branch models a real `scratches` table — tombstoned rows are
- * present in it, and only a query that filters on `deleted_at` excludes them.
- * That way the soft-delete predicate is exercised by behaviour rather than
- * restated as a string assertion.
+ * The scratch side models an actual table rather than returning a canned list.
+ * `schema` decides which columns exist, tombstoned rows really are stored, and
+ * only a statement that filters on `deleted_at` leaves them out — so the
+ * soft-delete predicate and the pre-migration column states are exercised by
+ * behaviour instead of restated as string assertions.
+ *
+ * Routing is fail-closed: an unrecognised statement throws rather than being
+ * quietly answered by the projects branch.
  */
+type ScratchSchema = "full" | "no-deleted-at" | "no-table";
+
 function withDb(opts: {
   manifest?: string | undefined;
+  pointers?: Record<string, string>;
   existingProjectIds?: string[];
   liveScratchIds?: string[];
   tombstonedScratchIds?: string[];
+  scratchSchema?: ScratchSchema;
   onProjectQuery?: (sql: string, ids: unknown[]) => void;
   onScratchQuery?: (sql: string, ids: unknown[]) => void;
-  scratchQueryThrows?: boolean;
+  onSchemaProbe?: () => void;
 }) {
+  const schema: ScratchSchema = opts.scratchSchema ?? "full";
+  const storedRows = [
+    ...(opts.liveScratchIds ?? []).map((id) => ({ id, deleted: false })),
+    ...(opts.tombstonedScratchIds ?? []).map((id) => ({ id, deleted: true })),
+  ];
+
   prepare.mockImplementation((sql: string) => {
     if (sql.includes("app_state")) {
       return {
-        get: (key: unknown) =>
-          key === OPEN_WINDOWS_KEY && opts.manifest !== undefined
-            ? { value: opts.manifest }
-            : undefined,
+        get: (key: unknown) => {
+          if (key === OPEN_WINDOWS_KEY) {
+            return opts.manifest !== undefined ? { value: opts.manifest } : undefined;
+          }
+          const value = opts.pointers?.[key as string];
+          return value === undefined ? undefined : { value };
+        },
         all: () => [],
       };
     }
-    if (sql.includes("scratches")) {
-      if (opts.scratchQueryThrows) throw new Error("no such table: scratches");
+
+    if (sql.includes("PRAGMA table_info(scratches)")) {
+      opts.onSchemaProbe?.();
+      const columns =
+        schema === "no-table"
+          ? []
+          : schema === "no-deleted-at"
+            ? [{ name: "id" }, { name: "path" }]
+            : [{ name: "id" }, { name: "path" }, { name: "deleted_at" }];
+      return { get: () => undefined, all: () => columns };
+    }
+
+    if (sql.includes("FROM scratches")) {
       return {
         get: () => undefined,
         all: (...ids: unknown[]) => {
           opts.onScratchQuery?.(sql, ids);
-          const rows = /deleted_at\s+IS\s+NULL/i.test(sql)
-            ? (opts.liveScratchIds ?? [])
-            : [...(opts.liveScratchIds ?? []), ...(opts.tombstonedScratchIds ?? [])];
-          return rows.filter((id) => ids.includes(id)).map((id) => ({ id }));
+          const excludesTombstones = /deleted_at\s+IS\s+NULL/i.test(sql);
+          return storedRows
+            .filter((row) => ids.includes(row.id) && !(excludesTombstones && row.deleted))
+            .map((row) => ({ id: row.id }));
         },
       };
     }
-    return {
-      get: () => undefined,
-      all: (...ids: unknown[]) => {
-        opts.onProjectQuery?.(sql, ids);
-        return (opts.existingProjectIds ?? [])
-          .filter((id) => ids.includes(id))
-          .map((id) => ({ id }));
-      },
-    };
+
+    if (sql.includes("FROM projects")) {
+      return {
+        get: () => undefined,
+        all: (...ids: unknown[]) => {
+          opts.onProjectQuery?.(sql, ids);
+          return (opts.existingProjectIds ?? [])
+            .filter((id) => ids.includes(id))
+            .map((id) => ({ id }));
+        },
+      };
+    }
+
+    throw new Error(`Unexpected statement: ${sql}`);
   });
 }
 
-/** Scratch ids are dashed UUIDv4s; project ids are 64 hex characters. */
+/**
+ * Real id shapes: the reader routes each stored id to a table by its shape, so
+ * a fixture of the wrong shape would exercise a branch the app never takes.
+ */
+const PROJECT_A = "a".repeat(64);
+const PROJECT_B = "b".repeat(64);
+const PROJECT_GONE = "c".repeat(64);
 const SCRATCH_A = "11111111-1111-4111-8111-111111111111";
 const SCRATCH_B = "22222222-2222-4222-9222-222222222222";
 const SCRATCH_GONE = "33333333-3333-4333-a333-333333333333";
@@ -129,30 +168,34 @@ describe("readOpenWindowsManifestSync", () => {
   it("restores surviving windows and drops the deleted one, preserving order", () => {
     withDb({
       manifest: manifestJson([
-        { projectId: "a" },
+        { projectId: PROJECT_A },
         { projectId: null },
-        { projectId: "gone" },
-        { projectId: "b" },
+        { projectId: PROJECT_GONE },
+        { projectId: PROJECT_B },
       ]),
-      existingProjectIds: ["a", "b"],
+      existingProjectIds: [PROJECT_A, PROJECT_B],
     });
     const result = readOpenWindowsManifestSync();
     expect(result.hadManifest).toBe(true);
-    expect(ids(result.records)).toEqual(["a", null, "b"]);
+    expect(ids(result.records)).toEqual([PROJECT_A, null, PROJECT_B]);
   });
 
   it("keeps both windows when the same project appears twice", () => {
     withDb({
-      manifest: manifestJson([{ projectId: "a" }, { projectId: null }, { projectId: "a" }]),
-      existingProjectIds: ["a"],
+      manifest: manifestJson([
+        { projectId: PROJECT_A },
+        { projectId: null },
+        { projectId: PROJECT_A },
+      ]),
+      existingProjectIds: [PROJECT_A],
     });
-    expect(ids(readOpenWindowsManifestSync().records)).toEqual(["a", null, "a"]);
+    expect(ids(readOpenWindowsManifestSync().records)).toEqual([PROJECT_A, null, PROJECT_A]);
   });
 
   it("still reports a manifest existed when every project was deleted", () => {
     // The caller needs this to open a picker rather than falling back to the
     // global last-active project.
-    withDb({ manifest: manifestJson([{ projectId: "gone" }]), existingProjectIds: [] });
+    withDb({ manifest: manifestJson([{ projectId: PROJECT_GONE }]), existingProjectIds: [] });
     expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: true, records: [] });
   });
 
@@ -177,31 +220,35 @@ describe("readOpenWindowsManifestSync", () => {
     expect(ids(result.records)).toEqual([null, null]);
   });
 
-  it("binds project ids as parameters rather than interpolating them", () => {
-    let seenSql = "";
-    let seenIds: unknown[] = [];
+  it("sends an id of neither shape to no table at all", () => {
+    // Ids are routed by shape, so a hand-edited or corrupt manifest cannot put
+    // an arbitrary string on either side of the boot. The window is dropped for
+    // the same reason a deleted workspace's is: nothing vouched for it.
+    const onProjectQuery = vi.fn();
+    const onScratchQuery = vi.fn();
     withDb({
-      manifest: manifestJson([{ projectId: "a'; DROP TABLE projects;--" }]),
-      existingProjectIds: [],
-      onProjectQuery: (sql, boundIds) => {
-        seenSql = sql;
-        seenIds = boundIds;
-      },
+      manifest: manifestJson([{ projectId: "a'; DROP TABLE projects;--" }, { projectId: null }]),
+      onProjectQuery,
+      onScratchQuery,
     });
 
-    readOpenWindowsManifestSync();
+    const result = readOpenWindowsManifestSync();
 
-    expect(seenSql).not.toContain("DROP TABLE");
-    expect(seenSql).toContain("?");
-    expect(seenIds).toEqual(["a'; DROP TABLE projects;--"]);
+    expect(onProjectQuery).not.toHaveBeenCalled();
+    expect(onScratchQuery).not.toHaveBeenCalled();
+    expect(ids(result.records)).toEqual([null]);
   });
 
   it("binds one placeholder per deduplicated project id", () => {
     let seenSql = "";
     let seenIds: unknown[] = [];
     withDb({
-      manifest: manifestJson([{ projectId: "a" }, { projectId: "b" }, { projectId: "a" }]),
-      existingProjectIds: ["a", "b"],
+      manifest: manifestJson([
+        { projectId: PROJECT_A },
+        { projectId: PROJECT_B },
+        { projectId: PROJECT_A },
+      ]),
+      existingProjectIds: [PROJECT_A, PROJECT_B],
       onProjectQuery: (sql, boundIds) => {
         seenSql = sql;
         seenIds = boundIds;
@@ -210,7 +257,7 @@ describe("readOpenWindowsManifestSync", () => {
 
     readOpenWindowsManifestSync();
 
-    expect(seenIds).toEqual(["a", "b"]);
+    expect(seenIds).toEqual([PROJECT_A, PROJECT_B]);
     expect(seenSql.match(/\?/g)).toHaveLength(seenIds.length);
   });
 
@@ -228,23 +275,28 @@ describe("readOpenWindowsManifestSync", () => {
     withDb({
       manifest: manifestJson([
         { projectId: SCRATCH_A },
-        { projectId: "a" },
+        { projectId: PROJECT_A },
         { projectId: null },
         { projectId: SCRATCH_B },
       ]),
-      existingProjectIds: ["a"],
+      existingProjectIds: [PROJECT_A],
       liveScratchIds: [SCRATCH_A, SCRATCH_B],
     });
-    expect(ids(readOpenWindowsManifestSync().records)).toEqual([SCRATCH_A, "a", null, SCRATCH_B]);
+    expect(ids(readOpenWindowsManifestSync().records)).toEqual([
+      SCRATCH_A,
+      PROJECT_A,
+      null,
+      SCRATCH_B,
+    ]);
   });
 
   it("drops a scratch that no longer exists, keeping the surviving windows", () => {
     withDb({
-      manifest: manifestJson([{ projectId: SCRATCH_GONE }, { projectId: "a" }]),
-      existingProjectIds: ["a"],
+      manifest: manifestJson([{ projectId: SCRATCH_GONE }, { projectId: PROJECT_A }]),
+      existingProjectIds: [PROJECT_A],
       liveScratchIds: [SCRATCH_A],
     });
-    expect(ids(readOpenWindowsManifestSync().records)).toEqual(["a"]);
+    expect(ids(readOpenWindowsManifestSync().records)).toEqual([PROJECT_A]);
   });
 
   it("drops a tombstoned scratch — the cleanup sweep already retired it", () => {
@@ -260,8 +312,12 @@ describe("readOpenWindowsManifestSync", () => {
     let projectIds: unknown[] = [];
     let scratchIds: unknown[] = [];
     withDb({
-      manifest: manifestJson([{ projectId: SCRATCH_A }, { projectId: "a" }, { projectId: null }]),
-      existingProjectIds: ["a"],
+      manifest: manifestJson([
+        { projectId: SCRATCH_A },
+        { projectId: PROJECT_A },
+        { projectId: null },
+      ]),
+      existingProjectIds: [PROJECT_A],
       liveScratchIds: [SCRATCH_A],
       onProjectQuery: (_sql, bound) => (projectIds = bound),
       onScratchQuery: (_sql, bound) => (scratchIds = bound),
@@ -269,15 +325,15 @@ describe("readOpenWindowsManifestSync", () => {
 
     readOpenWindowsManifestSync();
 
-    expect(projectIds).toEqual(["a"]);
+    expect(projectIds).toEqual([PROJECT_A]);
     expect(scratchIds).toEqual([SCRATCH_A]);
   });
 
   it("skips the scratch query entirely when no record names a scratch", () => {
     const onScratchQuery = vi.fn();
     withDb({
-      manifest: manifestJson([{ projectId: "a" }, { projectId: null }]),
-      existingProjectIds: ["a"],
+      manifest: manifestJson([{ projectId: PROJECT_A }, { projectId: null }]),
+      existingProjectIds: [PROJECT_A],
       onScratchQuery,
     });
     readOpenWindowsManifestSync();
@@ -296,28 +352,67 @@ describe("readOpenWindowsManifestSync", () => {
       },
     });
 
-    readOpenWindowsManifestSync();
+    const result = readOpenWindowsManifestSync();
 
+    // Deduplicated for the lookup only — both windows still come back.
     expect(seenIds).toEqual([SCRATCH_A]);
     expect(seenSql.match(/\?/g)).toHaveLength(seenIds.length);
+    expect(ids(result.records)).toEqual([SCRATCH_A, SCRATCH_A]);
   });
 
-  // This reader runs before migrations, so a database written by a build that
-  // predates the scratches table has to degrade to "no scratches" rather than
-  // strand every project window on the picker.
+  // These readers run before migrations: `scratches` arrives in 0001 and its
+  // `deleted_at` column in 0002, so an upgrading install can present either
+  // partial shape and neither may cost the user their project windows.
   it("still restores project windows when the scratches table is missing", () => {
+    const onSchemaProbe = vi.fn();
+    const onScratchQuery = vi.fn();
     withDb({
-      manifest: manifestJson([{ projectId: SCRATCH_A }, { projectId: "a" }]),
-      existingProjectIds: ["a"],
-      scratchQueryThrows: true,
+      manifest: manifestJson([{ projectId: SCRATCH_A }, { projectId: PROJECT_A }]),
+      existingProjectIds: [PROJECT_A],
+      scratchSchema: "no-table",
+      onSchemaProbe,
+      onScratchQuery,
     });
+
     const result = readOpenWindowsManifestSync();
+
+    expect(onSchemaProbe).toHaveBeenCalled();
+    // Probed, not queried: asking a table that does not exist is what used to
+    // take the whole read — projects included — down with it.
+    expect(onScratchQuery).not.toHaveBeenCalled();
     expect(result.hadManifest).toBe(true);
-    expect(ids(result.records)).toEqual(["a"]);
+    expect(ids(result.records)).toEqual([PROJECT_A]);
+  });
+
+  it("treats every row as live on a schema that predates the tombstone column", () => {
+    // That schema cannot hold a tombstone, so filtering on the column would
+    // throw and drop a scratch the user still has.
+    withDb({
+      manifest: manifestJson([{ projectId: SCRATCH_A }]),
+      liveScratchIds: [SCRATCH_A],
+      scratchSchema: "no-deleted-at",
+    });
+    expect(ids(readOpenWindowsManifestSync().records)).toEqual([SCRATCH_A]);
+  });
+
+  it("lets a failing scratch query surface instead of reading it as no scratches", () => {
+    // A corrupt or locked database must not be mistaken for "the user has no
+    // scratches" — that answer looks clean, and the successful boot then
+    // rewrites the manifest without their windows.
+    prepare.mockImplementation((sql: string) => {
+      if (sql.includes("app_state")) {
+        return {
+          get: () => ({ value: manifestJson([{ projectId: SCRATCH_A }]) }),
+          all: () => [],
+        };
+      }
+      throw new Error("database disk image is malformed");
+    });
+    expect(readOpenWindowsManifestSync()).toEqual({ hadManifest: false, records: [] });
   });
 
   it("closes the connection it opened", () => {
-    withDb({ manifest: manifestJson([{ projectId: "a" }]), existingProjectIds: ["a"] });
+    withDb({ manifest: manifestJson([{ projectId: PROJECT_A }]), existingProjectIds: [PROJECT_A] });
     readOpenWindowsManifestSync();
     expect(close).toHaveBeenCalledTimes(1);
   });
@@ -340,7 +435,7 @@ describe("readOpenWindowsManifestSync", () => {
   it("reports no manifest when the projects table is missing", () => {
     prepare.mockImplementation((sql: string) => {
       if (sql.includes("app_state")) {
-        return { get: () => ({ value: manifestJson([{ projectId: "a" }]) }), all: () => [] };
+        return { get: () => ({ value: manifestJson([{ projectId: PROJECT_A }]) }), all: () => [] };
       }
       throw new Error("no such table: projects");
     });
@@ -353,7 +448,7 @@ describe("readOpenWindowsManifestSync", () => {
 // the caller's reading of `hadManifest`.
 describe("the launch a stored manifest produces", () => {
   const primaryProjectFor = (manifest: string): string | undefined => {
-    withDb({ manifest, existingProjectIds: ["a"] });
+    withDb({ manifest, existingProjectIds: [PROJECT_A] });
     const { hadManifest, records } = readOpenWindowsManifestSync();
     return resolvePrimaryRestoreProjectId(records, hadManifest, "last-active");
   };
@@ -363,16 +458,87 @@ describe("the launch a stored manifest produces", () => {
   });
 
   it("opens a picker when the manifest named only projects that are now deleted", () => {
-    expect(primaryProjectFor(manifestJson([{ projectId: "gone" }]))).toBeUndefined();
+    expect(primaryProjectFor(manifestJson([{ projectId: PROJECT_GONE }]))).toBeUndefined();
   });
 
   it("opens the manifest's own project when it still exists", () => {
-    expect(primaryProjectFor(manifestJson([{ projectId: "a" }]))).toBe("a");
+    expect(primaryProjectFor(manifestJson([{ projectId: PROJECT_A }]))).toBe(PROJECT_A);
   });
 
   it("opens the manifest's own scratch rather than collapsing to a picker", () => {
     withDb({ manifest: manifestJson([{ projectId: SCRATCH_A }]), liveScratchIds: [SCRATCH_A] });
     const { hadManifest, records } = readOpenWindowsManifestSync();
     expect(resolvePrimaryRestoreProjectId(records, hadManifest, "last-active")).toBe(SCRATCH_A);
+  });
+});
+
+// Closing the last window is the quit gesture on Windows and Linux: its
+// `closed` save persists a manifest naming zero windows, which the reader
+// deliberately treats as no manifest so the launch falls back to the workspace
+// the user was last in. `scratch:switch` deletes `currentProjectId`, so for a
+// session that ended inside a scratch that fallback has to read the scratch
+// pointer or there is nothing left to fall back to (#11958).
+describe("readLastActiveProjectIdSync", () => {
+  it("prefers the current project when one is set", () => {
+    withDb({
+      pointers: { currentProjectId: PROJECT_A, currentScratchId: SCRATCH_A },
+      liveScratchIds: [SCRATCH_A],
+    });
+    expect(readLastActiveProjectIdSync()).toBe(PROJECT_A);
+  });
+
+  it("falls back to the current scratch when no project is set", () => {
+    withDb({ pointers: { currentScratchId: SCRATCH_A }, liveScratchIds: [SCRATCH_A] });
+    expect(readLastActiveProjectIdSync()).toBe(SCRATCH_A);
+  });
+
+  it("refuses a tombstoned scratch", () => {
+    // Its directory is on its way out; launching into it would open a workspace
+    // with nothing behind it.
+    withDb({ pointers: { currentScratchId: SCRATCH_A }, tombstonedScratchIds: [SCRATCH_A] });
+    expect(readLastActiveProjectIdSync()).toBeNull();
+  });
+
+  it("refuses a scratch whose row is gone", () => {
+    withDb({ pointers: { currentScratchId: SCRATCH_GONE }, liveScratchIds: [SCRATCH_A] });
+    expect(readLastActiveProjectIdSync()).toBeNull();
+  });
+
+  it("refuses a stored pointer that is not scratch-shaped", () => {
+    const onScratchQuery = vi.fn();
+    withDb({ pointers: { currentScratchId: "not-a-uuid" }, onScratchQuery });
+    expect(readLastActiveProjectIdSync()).toBeNull();
+    expect(onScratchQuery).not.toHaveBeenCalled();
+  });
+
+  it("reports nothing when neither pointer is set", () => {
+    withDb({});
+    expect(readLastActiveProjectIdSync()).toBeNull();
+  });
+
+  it("reports nothing on first launch, without opening a database", () => {
+    existsSync.mockReturnValue(false);
+    expect(readLastActiveProjectIdSync()).toBeNull();
+    expect(databaseCtor).not.toHaveBeenCalled();
+  });
+});
+
+// The pairing that makes the fallback matter: a scratch session that ended by
+// closing its last window has no manifest to restore, so the scratch pointer is
+// the only thing standing between it and the project picker.
+describe("the launch a zero-window manifest produces for a scratch session", () => {
+  it("reopens the scratch instead of the picker", () => {
+    withDb({
+      manifest: manifestJson([]),
+      pointers: { currentScratchId: SCRATCH_A },
+      liveScratchIds: [SCRATCH_A],
+    });
+
+    const { hadManifest, records } = readOpenWindowsManifestSync();
+    const fallback = readLastActiveProjectIdSync();
+
+    expect(resolvePrimaryRestoreProjectId(records, hadManifest, fallback ?? undefined)).toBe(
+      SCRATCH_A
+    );
   });
 });

--- a/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
+++ b/electron/services/persistence/__tests__/readOpenWindowsManifest.test.ts
@@ -39,13 +39,22 @@ const manifestJson = (windows: unknown[]): string =>
   JSON.stringify({ version: OPEN_WINDOWS_MANIFEST_VERSION, windows });
 
 /**
- * Wire the two queries the reader issues: the app_state lookup and the batched
- * project-existence check.
+ * Wire the queries the reader issues: the app_state lookup, the batched
+ * project-existence check, and the batched scratch-existence check.
+ *
+ * The scratch branch models a real `scratches` table — tombstoned rows are
+ * present in it, and only a query that filters on `deleted_at` excludes them.
+ * That way the soft-delete predicate is exercised by behaviour rather than
+ * restated as a string assertion.
  */
 function withDb(opts: {
   manifest?: string | undefined;
   existingProjectIds?: string[];
+  liveScratchIds?: string[];
+  tombstonedScratchIds?: string[];
   onProjectQuery?: (sql: string, ids: unknown[]) => void;
+  onScratchQuery?: (sql: string, ids: unknown[]) => void;
+  scratchQueryThrows?: boolean;
 }) {
   prepare.mockImplementation((sql: string) => {
     if (sql.includes("app_state")) {
@@ -55,6 +64,19 @@ function withDb(opts: {
             ? { value: opts.manifest }
             : undefined,
         all: () => [],
+      };
+    }
+    if (sql.includes("scratches")) {
+      if (opts.scratchQueryThrows) throw new Error("no such table: scratches");
+      return {
+        get: () => undefined,
+        all: (...ids: unknown[]) => {
+          opts.onScratchQuery?.(sql, ids);
+          const rows = /deleted_at\s+IS\s+NULL/i.test(sql)
+            ? (opts.liveScratchIds ?? [])
+            : [...(opts.liveScratchIds ?? []), ...(opts.tombstonedScratchIds ?? [])];
+          return rows.filter((id) => ids.includes(id)).map((id) => ({ id }));
+        },
       };
     }
     return {
@@ -68,6 +90,11 @@ function withDb(opts: {
     };
   });
 }
+
+/** Scratch ids are dashed UUIDv4s; project ids are 64 hex characters. */
+const SCRATCH_A = "11111111-1111-4111-8111-111111111111";
+const SCRATCH_B = "22222222-2222-4222-9222-222222222222";
+const SCRATCH_GONE = "33333333-3333-4333-a333-333333333333";
 
 const ids = (records: OpenWindowRecord[]) => records.map((r) => r.projectId);
 
@@ -187,6 +214,108 @@ describe("readOpenWindowsManifestSync", () => {
     expect(seenSql.match(/\?/g)).toHaveLength(seenIds.length);
   });
 
+  // A scratch is a workspace with no `projects` row (#11484). Validating one
+  // against `projects` read it as a deleted project and dropped its window,
+  // which relaunched structurally unbound (#11958).
+  it("restores a window whose only workspace is a live scratch", () => {
+    withDb({ manifest: manifestJson([{ projectId: SCRATCH_A }]), liveScratchIds: [SCRATCH_A] });
+    const result = readOpenWindowsManifestSync();
+    expect(result.hadManifest).toBe(true);
+    expect(ids(result.records)).toEqual([SCRATCH_A]);
+  });
+
+  it("restores projects, scratches and pickers together, preserving order", () => {
+    withDb({
+      manifest: manifestJson([
+        { projectId: SCRATCH_A },
+        { projectId: "a" },
+        { projectId: null },
+        { projectId: SCRATCH_B },
+      ]),
+      existingProjectIds: ["a"],
+      liveScratchIds: [SCRATCH_A, SCRATCH_B],
+    });
+    expect(ids(readOpenWindowsManifestSync().records)).toEqual([SCRATCH_A, "a", null, SCRATCH_B]);
+  });
+
+  it("drops a scratch that no longer exists, keeping the surviving windows", () => {
+    withDb({
+      manifest: manifestJson([{ projectId: SCRATCH_GONE }, { projectId: "a" }]),
+      existingProjectIds: ["a"],
+      liveScratchIds: [SCRATCH_A],
+    });
+    expect(ids(readOpenWindowsManifestSync().records)).toEqual(["a"]);
+  });
+
+  it("drops a tombstoned scratch — the cleanup sweep already retired it", () => {
+    withDb({
+      manifest: manifestJson([{ projectId: SCRATCH_A }, { projectId: SCRATCH_B }]),
+      liveScratchIds: [SCRATCH_A],
+      tombstonedScratchIds: [SCRATCH_B],
+    });
+    expect(ids(readOpenWindowsManifestSync().records)).toEqual([SCRATCH_A]);
+  });
+
+  it("routes each id to the one table that could hold it", () => {
+    let projectIds: unknown[] = [];
+    let scratchIds: unknown[] = [];
+    withDb({
+      manifest: manifestJson([{ projectId: SCRATCH_A }, { projectId: "a" }, { projectId: null }]),
+      existingProjectIds: ["a"],
+      liveScratchIds: [SCRATCH_A],
+      onProjectQuery: (_sql, bound) => (projectIds = bound),
+      onScratchQuery: (_sql, bound) => (scratchIds = bound),
+    });
+
+    readOpenWindowsManifestSync();
+
+    expect(projectIds).toEqual(["a"]);
+    expect(scratchIds).toEqual([SCRATCH_A]);
+  });
+
+  it("skips the scratch query entirely when no record names a scratch", () => {
+    const onScratchQuery = vi.fn();
+    withDb({
+      manifest: manifestJson([{ projectId: "a" }, { projectId: null }]),
+      existingProjectIds: ["a"],
+      onScratchQuery,
+    });
+    readOpenWindowsManifestSync();
+    expect(onScratchQuery).not.toHaveBeenCalled();
+  });
+
+  it("binds scratch ids as parameters rather than interpolating them", () => {
+    let seenSql = "";
+    let seenIds: unknown[] = [];
+    withDb({
+      manifest: manifestJson([{ projectId: SCRATCH_A }, { projectId: SCRATCH_A }]),
+      liveScratchIds: [SCRATCH_A],
+      onScratchQuery: (sql, bound) => {
+        seenSql = sql;
+        seenIds = bound;
+      },
+    });
+
+    readOpenWindowsManifestSync();
+
+    expect(seenIds).toEqual([SCRATCH_A]);
+    expect(seenSql.match(/\?/g)).toHaveLength(seenIds.length);
+  });
+
+  // This reader runs before migrations, so a database written by a build that
+  // predates the scratches table has to degrade to "no scratches" rather than
+  // strand every project window on the picker.
+  it("still restores project windows when the scratches table is missing", () => {
+    withDb({
+      manifest: manifestJson([{ projectId: SCRATCH_A }, { projectId: "a" }]),
+      existingProjectIds: ["a"],
+      scratchQueryThrows: true,
+    });
+    const result = readOpenWindowsManifestSync();
+    expect(result.hadManifest).toBe(true);
+    expect(ids(result.records)).toEqual(["a"]);
+  });
+
   it("closes the connection it opened", () => {
     withDb({ manifest: manifestJson([{ projectId: "a" }]), existingProjectIds: ["a"] });
     readOpenWindowsManifestSync();
@@ -239,5 +368,11 @@ describe("the launch a stored manifest produces", () => {
 
   it("opens the manifest's own project when it still exists", () => {
     expect(primaryProjectFor(manifestJson([{ projectId: "a" }]))).toBe("a");
+  });
+
+  it("opens the manifest's own scratch rather than collapsing to a picker", () => {
+    withDb({ manifest: manifestJson([{ projectId: SCRATCH_A }]), liveScratchIds: [SCRATCH_A] });
+    const { hadManifest, records } = readOpenWindowsManifestSync();
+    expect(resolvePrimaryRestoreProjectId(records, hadManifest, "last-active")).toBe(SCRATCH_A);
   });
 });

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -17,6 +17,7 @@ import { app } from "electron";
 import fs from "node:fs";
 import path from "path";
 import type { Project } from "../../../shared/types/project.js";
+import { isScratchWorkspaceId } from "../../../shared/utils/workspaceIds.js";
 import {
   OPEN_WINDOWS_KEY,
   filterRestorableWindows,
@@ -95,10 +96,16 @@ export function readLastActiveProjectIdentitySync(
  * record's project id chooses that window's session partition — it has to be
  * known before the BrowserWindow is built, not corrected afterwards.
  *
- * Project existence is validated here, in one batched `IN (...)` query rather
- * than a query per record, so a deleted project is dropped before any window is
- * constructed around it. Records for the project picker (`projectId: null`)
+ * Workspace existence is validated here, in batched `IN (...)` queries rather
+ * than a query per record, so a deleted workspace is dropped before any window
+ * is constructed around it. Records for the project picker (`projectId: null`)
  * always survive.
+ *
+ * A record's id names a project OR a scratch — the two are disjoint id spaces
+ * and each lives in its own table, so the shape routes the id to the one table
+ * that could hold it (#11958). Validating scratches against `projects` treated
+ * every one of them as a deleted project, which dropped the window and
+ * restored it unbound: no panels, no assistant, no file browser.
  *
  * `hadManifest` is reported separately from `records` on purpose: a manifest
  * that named windows whose every project has since been deleted filters down to
@@ -146,17 +153,47 @@ export function readOpenWindowsManifestSync(): OpenWindowsManifestRead {
       const records = parseOpenWindowsManifest(row?.value ?? null);
       if (records.length === 0) return NO_MANIFEST;
 
-      const projectIds = [...new Set(records.map((r) => r.projectId).filter((id) => id !== null))];
-      if (projectIds.length === 0) return { hadManifest: true, records };
+      const workspaceIds = [
+        ...new Set(records.map((r) => r.projectId).filter((id) => id !== null)),
+      ];
+      if (workspaceIds.length === 0) return { hadManifest: true, records };
 
-      const placeholders = projectIds.map(() => "?").join(",");
-      const rows = sqlite
-        .prepare(`SELECT id FROM projects WHERE id IN (${placeholders})`)
-        .all(...projectIds) as { id: string }[];
+      const scratchIds = workspaceIds.filter((id) => isScratchWorkspaceId(id));
+      const projectIds = workspaceIds.filter((id) => !isScratchWorkspaceId(id));
+      const existingWorkspaceIds = new Set<string>();
+
+      if (projectIds.length > 0) {
+        const placeholders = projectIds.map(() => "?").join(",");
+        const rows = sqlite
+          .prepare(`SELECT id FROM projects WHERE id IN (${placeholders})`)
+          .all(...projectIds) as { id: string }[];
+        for (const row of rows) existingWorkspaceIds.add(row.id);
+      }
+
+      if (scratchIds.length > 0) {
+        // Scoped try, unlike the projects query above: this runs before
+        // migrations, so a database written by a build that predates the
+        // `scratches` table throws here — and an unscoped throw would take the
+        // whole read down and strand every *project* window on the picker too.
+        // A missing table means no scratch exists, which is the answer an empty
+        // result would have given anyway.
+        try {
+          const placeholders = scratchIds.map(() => "?").join(",");
+          const rows = sqlite
+            .prepare(
+              `SELECT id FROM scratches WHERE id IN (${placeholders}) AND deleted_at IS NULL`
+            )
+            .all(...scratchIds) as { id: string }[];
+          for (const row of rows) existingWorkspaceIds.add(row.id);
+        } catch {
+          // Leaves every scratch id unvalidated, dropping its window exactly as
+          // this reader did before scratches were routed at all.
+        }
+      }
 
       return {
         hadManifest: true,
-        records: filterRestorableWindows(records, new Set(rows.map((r) => r.id))),
+        records: filterRestorableWindows(records, existingWorkspaceIds),
       };
     } finally {
       sqlite.close();

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -17,7 +17,7 @@ import { app } from "electron";
 import fs from "node:fs";
 import path from "path";
 import type { Project } from "../../../shared/types/project.js";
-import { isScratchWorkspaceId } from "../../../shared/utils/workspaceIds.js";
+import { isProjectWorkspaceId, isScratchWorkspaceId } from "../../../shared/utils/workspaceIds.js";
 import {
   OPEN_WINDOWS_KEY,
   filterRestorableWindows,
@@ -26,6 +26,57 @@ import {
   type OpenWindowRecord,
 } from "./windowManifest.js";
 
+/**
+ * Which of `scratchIds` name a scratch that still exists.
+ *
+ * The schema is probed rather than assumed, because these readers run BEFORE
+ * migrations: `scratches` arrives in 0001 and its `deleted_at` column in 0002,
+ * so an upgrading install can present either partial shape. A missing table
+ * means no scratch exists; a table without the tombstone column cannot hold a
+ * tombstone, so every row in it is live.
+ *
+ * Probing rather than catching is deliberate. A blanket `catch` here would read
+ * a corrupt or locked database as "the user has no scratches", quietly drop
+ * their windows, and let the successful boot rewrite the manifest without them.
+ * Anything other than a shape the probe explains has to surface to the caller's
+ * own handler, exactly as a failure of the `projects` query does.
+ */
+function readExistingScratchIds(
+  sqlite: InstanceType<typeof Database>,
+  scratchIds: string[]
+): Set<string> {
+  const existing = new Set<string>();
+  if (scratchIds.length === 0) return existing;
+
+  // `PRAGMA table_info` on a table that does not exist returns no rows rather
+  // than throwing, which is what makes it usable as the presence check.
+  const columns = sqlite.prepare("PRAGMA table_info(scratches)").all() as { name: string }[];
+  if (columns.length === 0) return existing;
+
+  const tombstoneFilter = columns.some((column) => column.name === "deleted_at")
+    ? " AND deleted_at IS NULL"
+    : "";
+  const placeholders = scratchIds.map(() => "?").join(",");
+  const rows = sqlite
+    .prepare(`SELECT id FROM scratches WHERE id IN (${placeholders})${tombstoneFilter}`)
+    .all(...scratchIds) as { id: string }[];
+  for (const row of rows) existing.add(row.id);
+
+  return existing;
+}
+
+/**
+ * The workspace to fall back to when there is no manifest to restore — the last
+ * project switched to, or the current scratch when the user was in one.
+ *
+ * Both pointers have to be consulted because they are mutually exclusive:
+ * `scratch:switch` deletes `currentProjectId` outright, so a session that ended
+ * inside a scratch leaves only `currentScratchId` behind. Reading the project
+ * pointer alone answered "nothing" for that session, and closing the last
+ * window — the quit gesture on Windows and Linux, which persists a manifest
+ * naming zero windows — relaunched onto the project picker with the scratch
+ * gone even from the label (#11958).
+ */
 export function readLastActiveProjectIdSync(): string | null {
   try {
     const dbPath = path.join(app.getPath("userData"), "daintree.db");
@@ -36,10 +87,25 @@ export function readLastActiveProjectIdSync(): string | null {
 
     const sqlite = new Database(dbPath, { readonly: true });
     try {
-      const row = sqlite
-        .prepare("SELECT value FROM app_state WHERE key = ?")
-        .get("currentProjectId") as { value: string } | undefined;
-      return row?.value ?? null;
+      const readPointer = (key: string): string | null =>
+        (
+          sqlite.prepare("SELECT value FROM app_state WHERE key = ?").get(key) as
+            { value: string } | undefined
+        )?.value ?? null;
+
+      const projectId = readPointer("currentProjectId");
+      if (projectId) return projectId;
+
+      // Only a scratch that still exists: a tombstoned or reaped one would send
+      // the launch at a workspace whose directory is gone, and the manifest
+      // path already refuses exactly that.
+      const scratchId = readPointer("currentScratchId");
+      if (scratchId && isScratchWorkspaceId(scratchId)) {
+        const live = readExistingScratchIds(sqlite, [scratchId]);
+        if (live.has(scratchId)) return scratchId;
+      }
+
+      return null;
     } finally {
       sqlite.close();
     }
@@ -158,9 +224,13 @@ export function readOpenWindowsManifestSync(): OpenWindowsManifestRead {
       ];
       if (workspaceIds.length === 0) return { hadManifest: true, records };
 
+      // Positively shaped on both sides, so an id that is neither reaches no
+      // query at all. Sending it to `projects` would find nothing today, but it
+      // would also be the one route by which a hand-edited or corrupt manifest
+      // could put an unvalidated string on the project side of the boot.
       const scratchIds = workspaceIds.filter((id) => isScratchWorkspaceId(id));
-      const projectIds = workspaceIds.filter((id) => !isScratchWorkspaceId(id));
-      const existingWorkspaceIds = new Set<string>();
+      const projectIds = workspaceIds.filter((id) => isProjectWorkspaceId(id));
+      const existingWorkspaceIds = readExistingScratchIds(sqlite, scratchIds);
 
       if (projectIds.length > 0) {
         const placeholders = projectIds.map(() => "?").join(",");
@@ -168,27 +238,6 @@ export function readOpenWindowsManifestSync(): OpenWindowsManifestRead {
           .prepare(`SELECT id FROM projects WHERE id IN (${placeholders})`)
           .all(...projectIds) as { id: string }[];
         for (const row of rows) existingWorkspaceIds.add(row.id);
-      }
-
-      if (scratchIds.length > 0) {
-        // Scoped try, unlike the projects query above: this runs before
-        // migrations, so a database written by a build that predates the
-        // `scratches` table throws here — and an unscoped throw would take the
-        // whole read down and strand every *project* window on the picker too.
-        // A missing table means no scratch exists, which is the answer an empty
-        // result would have given anyway.
-        try {
-          const placeholders = scratchIds.map(() => "?").join(",");
-          const rows = sqlite
-            .prepare(
-              `SELECT id FROM scratches WHERE id IN (${placeholders}) AND deleted_at IS NULL`
-            )
-            .all(...scratchIds) as { id: string }[];
-          for (const row of rows) existingWorkspaceIds.add(row.id);
-        } catch {
-          // Leaves every scratch id unvalidated, dropping its window exactly as
-          // this reader did before scratches were routed at all.
-        }
       }
 
       return {

--- a/electron/services/persistence/windowManifest.ts
+++ b/electron/services/persistence/windowManifest.ts
@@ -36,7 +36,13 @@ export const OPEN_WINDOWS_MANIFEST_VERSION = 1;
 export const MAX_RESTORED_WINDOWS = 8;
 
 export interface OpenWindowRecord {
-  /** Stable project id, or null for a window on the project picker. */
+  /**
+   * Stable workspace id — a project id or a scratch id — or null for a window
+   * on the project picker. The two kinds are disjoint id spaces, so one opaque
+   * field carries both and the shape tells the reader which table to validate
+   * it against (#11958). The wire key stays `projectId`: renaming it would make
+   * every stored manifest unreadable for a purely cosmetic gain.
+   */
   projectId: string | null;
 }
 
@@ -133,17 +139,20 @@ export function serializeOpenWindowsManifest(records: OpenWindowRecord[]): strin
 }
 
 /**
- * Drop records whose project no longer exists, keeping picker windows.
+ * Drop records whose workspace no longer exists, keeping picker windows.
  *
  * Skipping is deliberate and matches VS Code: a deleted project must never be
  * silently replaced by a different one, and it must not stop the surviving
  * windows from restoring.
+ *
+ * `existingWorkspaceIds` spans both kinds — live projects and live scratches.
+ * A set built from `projects` alone reads every scratch as deleted (#11958).
  */
 export function filterRestorableWindows(
   records: OpenWindowRecord[],
-  existingProjectIds: ReadonlySet<string>
+  existingWorkspaceIds: ReadonlySet<string>
 ): OpenWindowRecord[] {
   return records.filter(
-    (record) => record.projectId === null || existingProjectIds.has(record.projectId)
+    (record) => record.projectId === null || existingWorkspaceIds.has(record.projectId)
   );
 }

--- a/electron/window/__tests__/windowServicesProjectBinding.test.ts
+++ b/electron/window/__tests__/windowServicesProjectBinding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveRestoreWorkspace } from "../restoreWorkspaceBinding.js";
+import { resolveRestoreWorkspace, resolveWorktreeLoadPath } from "../restoreWorkspaceBinding.js";
 
 /**
  * Tests the per-window workspace binding logic from windowServices.ts (#5492).
@@ -32,7 +32,7 @@ const bind = (opts: Opts, stores: Stores) =>
 
 function simulateBootstrap(opts: Opts, stores: Stores) {
   const actions: { action: string; args?: Record<string, unknown> }[] = [];
-  const { project: restoreProject, workspace: restoreWorkspace } = bind(opts, stores);
+  const { workspace: restoreWorkspace } = bind(opts, stores);
 
   // PTY active project (explicit null for unbound windows)
   if (restoreWorkspace) {
@@ -59,9 +59,12 @@ function simulateBootstrap(opts: Opts, stores: Stores) {
     });
   }
 
-  // Worktree loading — projects only. A scratch is a non-git directory that
-  // must never invoke WorktreeService.
-  const projectPathForWorktrees = opts.initialProjectPath ?? restoreProject?.path;
+  // Worktree loading — the production resolver, so "a scratch loads no
+  // worktrees" is asserted against the expression the app actually evaluates.
+  const projectPathForWorktrees = resolveWorktreeLoadPath(
+    opts.initialProjectPath,
+    bind(opts, stores)
+  );
   if (projectPathForWorktrees) {
     actions.push({ action: "loadWorktrees", args: { path: projectPathForWorktrees } });
   }
@@ -80,7 +83,12 @@ function simulateWorkspaceInit(opts: Opts, stores: Stores, prewarmThrows = false
 
   actions.push({ action: "getWorkspaceClient" });
 
-  const prewarmPath = opts.initialProjectPath ?? bind(opts, stores).project?.path;
+  // Mirrors windowServices.ts exactly: the prewarm runs long before the binding
+  // resolver is in scope and reads projectStore directly, so a scratch id finds
+  // no row and no host is prewarmed for it.
+  const prewarmPath =
+    opts.initialProjectPath ??
+    (opts.initialProjectId ? stores.getProjectById(opts.initialProjectId)?.path : undefined);
   if (prewarmPath) {
     try {
       if (prewarmThrows) throw new Error("synchronous prewarm failure");
@@ -96,7 +104,9 @@ function simulateWorkspaceInit(opts: Opts, stores: Stores, prewarmThrows = false
   return actions;
 }
 
-const PROJECT_A: Project = { id: "proj-a", name: "Project A", path: "/projects/a" };
+// Real shapes: production routes a scratch id to the scratch store by its
+// UUID form, and a project id is 64 hex characters.
+const PROJECT_A: Project = { id: "a".repeat(64), name: "Project A", path: "/projects/a" };
 
 const SCRATCH: Scratch = { id: "11111111-1111-4111-8111-111111111111", path: "/scratches/one" };
 
@@ -120,15 +130,15 @@ const storeWithScratch: Stores = {
 describe("windowServices project binding (#5492)", () => {
   describe("startup restore window (initialProjectId set)", () => {
     it("sets PTY active project, registers view, loads worktrees", () => {
-      const actions = simulateBootstrap({ initialProjectId: "proj-a" }, storeWithProjectA);
+      const actions = simulateBootstrap({ initialProjectId: PROJECT_A.id }, storeWithProjectA);
 
       expect(actions).toContainEqual({
         action: "ptySetActiveProject",
-        args: { id: "proj-a", path: "/projects/a" },
+        args: { id: PROJECT_A.id, path: PROJECT_A.path },
       });
       expect(actions).toContainEqual({
         action: "registerInitialView",
-        args: { id: "proj-a", path: "/projects/a" },
+        args: { id: PROJECT_A.id, path: PROJECT_A.path },
       });
       expect(actions).toContainEqual({
         action: "loadWorktrees",
@@ -137,12 +147,12 @@ describe("windowServices project binding (#5492)", () => {
     });
 
     it("skips default terminal spawn", () => {
-      const actions = simulateBootstrap({ initialProjectId: "proj-a" }, storeWithProjectA);
+      const actions = simulateBootstrap({ initialProjectId: PROJECT_A.id }, storeWithProjectA);
       expect(actions.find((a) => a.action === "spawnDefaultTerminal")).toBeUndefined();
     });
 
     it("handles missing project in store gracefully — clears PTY and spawns default terminal", () => {
-      const actions = simulateBootstrap({ initialProjectId: "proj-missing" }, emptyStore);
+      const actions = simulateBootstrap({ initialProjectId: "f".repeat(64) }, emptyStore);
       expect(actions).toContainEqual({
         action: "ptySetActiveProject",
         args: { id: null },
@@ -277,13 +287,13 @@ describe("windowServices project binding (#5492)", () => {
   });
 
   describe("both initialProjectId and initialProjectPath set", () => {
-    const opts: Opts = { initialProjectId: "proj-a", initialProjectPath: "/override/path" };
+    const opts: Opts = { initialProjectId: PROJECT_A.id, initialProjectPath: "/override/path" };
 
     it("sets PTY active project from initialProjectId", () => {
       const actions = simulateBootstrap(opts, storeWithProjectA);
       expect(actions).toContainEqual({
         action: "ptySetActiveProject",
-        args: { id: "proj-a", path: "/projects/a" },
+        args: { id: PROJECT_A.id, path: PROJECT_A.path },
       });
     });
 
@@ -302,7 +312,7 @@ describe("windowServices workspace prewarm ordering (#8828)", () => {
     actions.findIndex((a) => a.action === name);
 
   it("prewarms before awaiting PTY-ready for a restore window (initialProjectId)", () => {
-    const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA);
+    const actions = simulateWorkspaceInit({ initialProjectId: PROJECT_A.id }, storeWithProjectA);
     expect(actions).toContainEqual({ action: "prewarmProject", args: { path: "/projects/a" } });
     expect(order(actions, "prewarmProject")).toBeLessThan(order(actions, "ptyWaitForReady"));
   });
@@ -315,7 +325,7 @@ describe("windowServices workspace prewarm ordering (#8828)", () => {
 
   it("prefers initialProjectPath over the store lookup when both are set", () => {
     const actions = simulateWorkspaceInit(
-      { initialProjectId: "proj-a", initialProjectPath: "/override/path" },
+      { initialProjectId: PROJECT_A.id, initialProjectPath: "/override/path" },
       storeWithProjectA
     );
     expect(actions).toContainEqual({ action: "prewarmProject", args: { path: "/override/path" } });
@@ -327,25 +337,29 @@ describe("windowServices workspace prewarm ordering (#8828)", () => {
   });
 
   it("does NOT prewarm when the store has no matching project", () => {
-    const actions = simulateWorkspaceInit({ initialProjectId: "proj-missing" }, emptyStore);
+    const actions = simulateWorkspaceInit({ initialProjectId: "f".repeat(64) }, emptyStore);
     expect(actions.find((a) => a.action === "prewarmProject")).toBeUndefined();
   });
 
   it("constructs the workspace client before prewarming and PTY-ready", () => {
-    const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA);
+    const actions = simulateWorkspaceInit({ initialProjectId: PROJECT_A.id }, storeWithProjectA);
     expect(order(actions, "getWorkspaceClient")).toBeLessThan(order(actions, "prewarmProject"));
     expect(order(actions, "getWorkspaceClient")).toBeLessThan(order(actions, "ptyWaitForReady"));
   });
 
   it("only sets the IPC-visible ref after PTY-ready, never before", () => {
-    const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA);
+    const actions = simulateWorkspaceInit({ initialProjectId: PROJECT_A.id }, storeWithProjectA);
     expect(order(actions, "setWorkspaceClientRef")).toBeGreaterThan(
       order(actions, "ptyWaitForReady")
     );
   });
 
   it("continues startup when prewarm throws synchronously (PTY-ready and ref still happen)", () => {
-    const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA, true);
+    const actions = simulateWorkspaceInit(
+      { initialProjectId: PROJECT_A.id },
+      storeWithProjectA,
+      true
+    );
     expect(actions.find((a) => a.action === "prewarmProject")).toBeUndefined();
     expect(actions).toContainEqual({ action: "prewarmFailedSync" });
     expect(actions.find((a) => a.action === "ptyWaitForReady")).toBeDefined();

--- a/electron/window/__tests__/windowServicesProjectBinding.test.ts
+++ b/electron/window/__tests__/windowServicesProjectBinding.test.ts
@@ -1,64 +1,69 @@
 import { describe, expect, it } from "vitest";
+import { resolveRestoreWorkspace } from "../restoreWorkspaceBinding.js";
 
 /**
- * Tests the per-window project binding logic from windowServices.ts (#5492).
+ * Tests the per-window workspace binding logic from windowServices.ts (#5492).
  *
- * setupWindowServices cannot be imported directly (side effects, Electron deps),
- * so we replicate the decision logic: given initialProjectId and
- * initialProjectPath, what bootstrap actions occur?
+ * setupWindowServices cannot be imported directly (side effects, Electron
+ * deps), so this file replicates the *actions* that follow the binding — but
+ * the binding decision itself is imported from production rather than copied.
+ * A copied decision is how this suite came to assert an `initializeTaskQueue`
+ * step that windowServices.ts had already dropped: green, and testing nothing.
  */
 
 type Project = { id: string; name: string; path: string };
+type Scratch = { id: string; path: string };
 
 type Opts = {
   initialProjectId?: string;
   initialProjectPath?: string;
 };
 
-function simulateBootstrap(
-  opts: Opts,
-  projectStore: { getProjectById: (id: string) => Project | undefined }
-) {
-  const actions: { action: string; args?: Record<string, unknown> }[] = [];
+type Stores = {
+  getProjectById: (id: string) => Project | undefined;
+  getScratchById?: (id: string) => Scratch | undefined;
+};
 
-  // Replicate the binding logic from windowServices.ts
-  const restoreProject = opts.initialProjectId
-    ? projectStore.getProjectById(opts.initialProjectId)
-    : undefined;
+const bind = (opts: Opts, stores: Stores) =>
+  resolveRestoreWorkspace(opts.initialProjectId, {
+    getProjectById: stores.getProjectById,
+    getScratchById: stores.getScratchById ?? (() => undefined),
+  });
+
+function simulateBootstrap(opts: Opts, stores: Stores) {
+  const actions: { action: string; args?: Record<string, unknown> }[] = [];
+  const { project: restoreProject, workspace: restoreWorkspace } = bind(opts, stores);
 
   // PTY active project (explicit null for unbound windows)
-  if (restoreProject) {
+  if (restoreWorkspace) {
     actions.push({
       action: "ptySetActiveProject",
-      args: { id: restoreProject.id, path: restoreProject.path },
+      args: { id: restoreWorkspace.id, path: restoreWorkspace.path },
     });
   } else {
     actions.push({ action: "ptySetActiveProject", args: { id: null } });
   }
 
-  // Default terminal spawn (skip when restoreProject exists or explicit path)
-  const skipDefaultSpawn = opts.initialProjectPath || restoreProject;
+  // Default terminal spawn (skip when a workspace is bound or a path is given)
+  const skipDefaultSpawn = opts.initialProjectPath || restoreWorkspace;
   if (!skipDefaultSpawn) {
     actions.push({ action: "spawnDefaultTerminal" });
   }
 
-  // Initial view registration
-  if (restoreProject) {
+  // Initial view registration — the only caller of registerProjectView for the
+  // startup view, so a workspace that misses it stays unbound for its lifetime.
+  if (restoreWorkspace) {
     actions.push({
       action: "registerInitialView",
-      args: { id: restoreProject.id, path: restoreProject.path },
+      args: { id: restoreWorkspace.id, path: restoreWorkspace.path },
     });
   }
 
-  // Worktree loading
+  // Worktree loading — projects only. A scratch is a non-git directory that
+  // must never invoke WorktreeService.
   const projectPathForWorktrees = opts.initialProjectPath ?? restoreProject?.path;
   if (projectPathForWorktrees) {
     actions.push({ action: "loadWorktrees", args: { path: projectPathForWorktrees } });
-  }
-
-  // Task queue
-  if (restoreProject && !opts.initialProjectPath) {
-    actions.push({ action: "initializeTaskQueue", args: { id: restoreProject.id } });
   }
 
   return actions;
@@ -70,18 +75,12 @@ function simulateBootstrap(
  * the PTY-ready await, so the two utility-process forks overlap. The IPC-visible
  * ref must still only be set AFTER PTY-ready.
  */
-function simulateWorkspaceInit(
-  opts: Opts,
-  projectStore: { getProjectById: (id: string) => Project | undefined },
-  prewarmThrows = false
-) {
+function simulateWorkspaceInit(opts: Opts, stores: Stores, prewarmThrows = false) {
   const actions: { action: string; args?: Record<string, unknown> }[] = [];
 
   actions.push({ action: "getWorkspaceClient" });
 
-  const prewarmPath =
-    opts.initialProjectPath ??
-    (opts.initialProjectId ? projectStore.getProjectById(opts.initialProjectId)?.path : undefined);
+  const prewarmPath = opts.initialProjectPath ?? bind(opts, stores).project?.path;
   if (prewarmPath) {
     try {
       if (prewarmThrows) throw new Error("synchronous prewarm failure");
@@ -99,17 +98,28 @@ function simulateWorkspaceInit(
 
 const PROJECT_A: Project = { id: "proj-a", name: "Project A", path: "/projects/a" };
 
-const storeWithProjectA = {
+const SCRATCH: Scratch = { id: "11111111-1111-4111-8111-111111111111", path: "/scratches/one" };
+
+const storeWithProjectA: Stores = {
   getProjectById: (id: string) => (id === PROJECT_A.id ? PROJECT_A : undefined),
 };
 
-const emptyStore = {
+const emptyStore: Stores = {
   getProjectById: () => undefined,
+};
+
+/**
+ * Mirrors ScratchStore.getScratchById: only a live scratch resolves, and a
+ * project id resolves to nothing even when a scratch is present.
+ */
+const storeWithScratch: Stores = {
+  getProjectById: () => undefined,
+  getScratchById: (id: string) => (id === SCRATCH.id ? SCRATCH : undefined),
 };
 
 describe("windowServices project binding (#5492)", () => {
   describe("startup restore window (initialProjectId set)", () => {
-    it("sets PTY active project, registers view, loads worktrees, inits task queue", () => {
+    it("sets PTY active project, registers view, loads worktrees", () => {
       const actions = simulateBootstrap({ initialProjectId: "proj-a" }, storeWithProjectA);
 
       expect(actions).toContainEqual({
@@ -123,10 +133,6 @@ describe("windowServices project binding (#5492)", () => {
       expect(actions).toContainEqual({
         action: "loadWorktrees",
         args: { path: "/projects/a" },
-      });
-      expect(actions).toContainEqual({
-        action: "initializeTaskQueue",
-        args: { id: "proj-a" },
       });
     });
 
@@ -142,6 +148,64 @@ describe("windowServices project binding (#5492)", () => {
         args: { id: null },
       });
       expect(actions).toContainEqual({ action: "spawnDefaultTerminal" });
+    });
+  });
+
+  // A scratch is a workspace with no `projects` row (#11484). Restoring one
+  // has to bind the view exactly as a project does, while staying clear of
+  // every git-backed path (#11958).
+  describe("startup restore into a scratch (initialProjectId names a scratch)", () => {
+    const opts: Opts = { initialProjectId: SCRATCH.id };
+
+    it("binds the PTY to the scratch id and its directory", () => {
+      expect(simulateBootstrap(opts, storeWithScratch)).toContainEqual({
+        action: "ptySetActiveProject",
+        args: { id: SCRATCH.id, path: SCRATCH.path },
+      });
+    });
+
+    it("registers the initial view, so the sender resolves for the rest of its life", () => {
+      expect(simulateBootstrap(opts, storeWithScratch)).toContainEqual({
+        action: "registerInitialView",
+        args: { id: SCRATCH.id, path: SCRATCH.path },
+      });
+    });
+
+    it("skips the stray home-directory terminal", () => {
+      const actions = simulateBootstrap(opts, storeWithScratch);
+      expect(actions.find((a) => a.action === "spawnDefaultTerminal")).toBeUndefined();
+    });
+
+    it("does NOT load worktrees — a scratch never reaches WorktreeService", () => {
+      const actions = simulateBootstrap(opts, storeWithScratch);
+      expect(actions.find((a) => a.action === "loadWorktrees")).toBeUndefined();
+    });
+
+    it("does NOT prewarm the workspace host", () => {
+      const actions = simulateWorkspaceInit(opts, storeWithScratch);
+      expect(actions.find((a) => a.action === "prewarmProject")).toBeUndefined();
+    });
+
+    it("reports the scratch as the bound workspace but not as a project", () => {
+      const { project, workspace } = bind(opts, storeWithScratch);
+      expect(workspace).toEqual({ id: SCRATCH.id, path: SCRATCH.path, kind: "scratch" });
+      expect(project).toBeUndefined();
+    });
+
+    it("leaves a scratch that no longer exists unbound, like a deleted project", () => {
+      const actions = simulateBootstrap({ initialProjectId: SCRATCH.id }, emptyStore);
+      expect(actions).toContainEqual({ action: "ptySetActiveProject", args: { id: null } });
+      expect(actions.find((a) => a.action === "registerInitialView")).toBeUndefined();
+    });
+
+    it("prefers the project row when an id somehow resolves in both stores", () => {
+      const both: Stores = {
+        getProjectById: () => PROJECT_A,
+        getScratchById: () => SCRATCH,
+      };
+      const { project, workspace } = bind({ initialProjectId: PROJECT_A.id }, both);
+      expect(workspace?.kind).toBe("project");
+      expect(project?.path).toBe(PROJECT_A.path);
     });
   });
 
@@ -162,11 +226,6 @@ describe("windowServices project binding (#5492)", () => {
     it("does NOT load worktrees", () => {
       const actions = simulateBootstrap({}, storeWithProjectA);
       expect(actions.find((a) => a.action === "loadWorktrees")).toBeUndefined();
-    });
-
-    it("does NOT initialize task queue", () => {
-      const actions = simulateBootstrap({}, storeWithProjectA);
-      expect(actions.find((a) => a.action === "initializeTaskQueue")).toBeUndefined();
     });
 
     it("spawns a default terminal without projectId", () => {
@@ -215,11 +274,6 @@ describe("windowServices project binding (#5492)", () => {
       const actions = simulateBootstrap(opts, storeWithProjectA);
       expect(actions.find((a) => a.action === "spawnDefaultTerminal")).toBeUndefined();
     });
-
-    it("does NOT initialize task queue (not a restore window)", () => {
-      const actions = simulateBootstrap(opts, storeWithProjectA);
-      expect(actions.find((a) => a.action === "initializeTaskQueue")).toBeUndefined();
-    });
   });
 
   describe("both initialProjectId and initialProjectPath set", () => {
@@ -239,11 +293,6 @@ describe("windowServices project binding (#5492)", () => {
         action: "loadWorktrees",
         args: { path: "/override/path" },
       });
-    });
-
-    it("does NOT initialize task queue (initialProjectPath present)", () => {
-      const actions = simulateBootstrap(opts, storeWithProjectA);
-      expect(actions.find((a) => a.action === "initializeTaskQueue")).toBeUndefined();
     });
   });
 });

--- a/electron/window/restoreWorkspaceBinding.ts
+++ b/electron/window/restoreWorkspaceBinding.ts
@@ -1,0 +1,74 @@
+/**
+ * Which workspace a restored window binds to, resolved from the opaque id the
+ * open-window manifest stored for it (#11958).
+ *
+ * A window can be restored onto a project or onto a scratch, and the boot needs
+ * to tell them apart exactly once. Everything a *view* needs is identical for
+ * both: the PTY's active workspace, and the ProjectViewManager registration
+ * that makes `ctx.projectId` resolve for every IPC call that view ever sends.
+ * Everything that needs a git repository is project-only — scratches are
+ * non-git directories that deliberately never reach `WorktreeService`, so the
+ * startup worktree load and the workspace-host prewarm must stay keyed on
+ * {@link RestoreWorkspaceBinding.project} rather than the workspace.
+ *
+ * Split out of windowServices.ts, which a unit test cannot import (Electron
+ * dependencies, module side effects). Keeping the decision here is what lets
+ * the test exercise the real one rather than a copy that goes stale in silence.
+ */
+
+export interface RestoreWorkspace {
+  id: string;
+  path: string;
+  kind: "project" | "scratch";
+}
+
+/** Just enough of each store to answer "does this id name a live workspace?". */
+export interface RestoreWorkspaceLookups {
+  getProjectById: (id: string) => { id: string; path: string } | null | undefined;
+  /**
+   * Answers null for anything that is not a live scratch — a tombstoned one, a
+   * deleted one, and any id whose shape is not a scratch UUID.
+   */
+  getScratchById: (id: string) => { id: string; path: string } | null | undefined;
+}
+
+export interface RestoreWorkspaceBinding {
+  /**
+   * Set only when the id named a project row. The sole permitted input to the
+   * startup worktree load and the workspace-host prewarm.
+   */
+  project: RestoreWorkspace | undefined;
+  /** The project or the scratch — whichever this window's view binds to. */
+  workspace: RestoreWorkspace | undefined;
+}
+
+const NOTHING_TO_RESTORE: RestoreWorkspaceBinding = { project: undefined, workspace: undefined };
+
+export function resolveRestoreWorkspace(
+  initialProjectId: string | undefined,
+  lookups: RestoreWorkspaceLookups
+): RestoreWorkspaceBinding {
+  if (!initialProjectId) return NOTHING_TO_RESTORE;
+
+  // Projects first: a project row is the only result that may unlock the
+  // worktree path, so it has to be the answer whenever one exists.
+  const project = lookups.getProjectById(initialProjectId);
+  if (project) {
+    const resolved: RestoreWorkspace = { id: project.id, path: project.path, kind: "project" };
+    return { project: resolved, workspace: resolved };
+  }
+
+  // "No project row" is not the same claim as "deleted project": a scratch
+  // never has one. Asking the scratch store second is what separates the two —
+  // it validates the id shape itself, so a deleted project's 64-hex id still
+  // resolves to nothing and its window is still dropped.
+  const scratch = lookups.getScratchById(initialProjectId);
+  if (scratch) {
+    return {
+      project: undefined,
+      workspace: { id: scratch.id, path: scratch.path, kind: "scratch" },
+    };
+  }
+
+  return NOTHING_TO_RESTORE;
+}

--- a/electron/window/restoreWorkspaceBinding.ts
+++ b/electron/window/restoreWorkspaceBinding.ts
@@ -72,3 +72,21 @@ export function resolveRestoreWorkspace(
 
   return NOTHING_TO_RESTORE;
 }
+
+/**
+ * The project path the startup worktree load runs against, or undefined when
+ * this window has none to load.
+ *
+ * Lives here rather than inline at the call site so the "a scratch loads no
+ * worktrees" rule is one importable expression instead of a condition a test
+ * has to re-type. It reads {@link RestoreWorkspaceBinding.project}, never
+ * `.workspace`: a scratch is a non-git directory that must not reach
+ * `WorktreeService`, and an explicit path (CLI open, Dock drop) still wins
+ * because that window was opened by path in the first place.
+ */
+export function resolveWorktreeLoadPath(
+  initialProjectPath: string | undefined,
+  binding: RestoreWorkspaceBinding
+): string | undefined {
+  return initialProjectPath ?? binding.project?.path;
+}

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -29,6 +29,7 @@ import {
 } from "./startupWorktreeLoad.js";
 import { logError, logInfo, logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { resolveRestoreWorkspace } from "./restoreWorkspaceBinding.js";
 import { extractRestorePanelCwds } from "./restorePanelCwds.js";
 import { mergeProjectEnv } from "./restoreProjectEnv.js";
 import { store } from "../store.js";
@@ -562,11 +563,31 @@ export async function setupWindowServices(
     console.error("[MAIN] Unexpected error during service initialization:", error);
   }
 
-  // Per-window project binding: use opts.initialProjectId/initialProjectPath
+  // Per-window workspace binding: use opts.initialProjectId/initialProjectPath
   // instead of the global current project (which belongs to another window).
-  const restoreProject = opts.initialProjectId
-    ? projectStore.getProjectById(opts.initialProjectId)
-    : undefined;
+  //
+  // `restoreWorkspace` is a project OR a scratch and drives everything the view
+  // itself needs; `restoreProject` is set only for a project and stays the sole
+  // input to the worktree load below, which scratches must never reach (#11958).
+  const { project: restoreProject, workspace: restoreWorkspace } = resolveRestoreWorkspace(
+    opts.initialProjectId,
+    {
+      getProjectById: (id) => projectStore.getProjectById(id),
+      getScratchById: (id) => {
+        // The scratch lookup opens the shared DB; a failure there must leave
+        // the window unbound, not abort the boot.
+        try {
+          return scratchStore.getScratchById(id);
+        } catch (error) {
+          logWarn("[MAIN] Could not resolve a scratch for the restored window", {
+            scratchId: id,
+            error: formatErrorMessage(error, "Unknown error"),
+          });
+          return null;
+        }
+      },
+    }
+  );
 
   // A Linux file manager launching a cold Daintree via "Open With" on a folder
   // puts a `file://` directory URI in argv. Classified here — outside the PTY
@@ -595,11 +616,11 @@ export async function setupWindowServices(
       createAndDistributePorts(win, ctx);
     }
 
-    if (restoreProject) {
+    if (restoreWorkspace) {
       pty.setActiveProject(
         win.id,
-        restoreProject.id,
-        restoreProject.path,
+        restoreWorkspace.id,
+        restoreWorkspace.path,
         restorePanelCwds,
         restoreProjectEnv
       );
@@ -618,7 +639,7 @@ export async function setupWindowServices(
       opts.initialProjectPath ||
       processArgvCli ||
       getPendingCliPath() ||
-      restoreProject ||
+      restoreWorkspace ||
       getPendingOpenDirPaths().length > 0;
     if (skipDefaultSpawn) {
       console.log(
@@ -642,24 +663,31 @@ export async function setupWindowServices(
   }
 
   // Register the initial view with ProjectViewManager — only when this window
-  // has a project binding (startup restore). Unbound windows (Cmd+N) start
+  // has a workspace binding (startup restore). Unbound windows (Cmd+N) start
   // with the project picker and get their view registered on project open.
   //
-  // Skipped once the manager has already activated a project: a switch can land
-  // while the rest of this boot is still awaiting, and the manager will have
-  // swapped in its own view for it. Registering the restored project on top of
-  // that would point `activeProjectId` and the view map at a project the window
-  // is no longer showing.
+  // This is the only caller of `registerProjectView` for the startup view, so
+  // skipping it leaves `ctx.projectId` null for every IPC call that view sends
+  // for the rest of its life — no panel restore, no assistant, a file browser
+  // that throws. A restored scratch has to register here for the same reason a
+  // project does; the manager is keyed on opaque workspace ids and has no
+  // project-row assumption of its own (#11958).
+  //
+  // Skipped once the manager has already activated a workspace: a switch can
+  // land while the rest of this boot is still awaiting, and the manager will
+  // have swapped in its own view for it. Registering the restored one on top of
+  // that would point `activeProjectId` and the view map at a workspace the
+  // window is no longer showing.
   if (
     opts.projectViewManager &&
     opts.initialAppView &&
-    restoreProject &&
+    restoreWorkspace &&
     !opts.projectViewManager.getActiveProjectId()
   ) {
     opts.projectViewManager.registerInitialView(
       opts.initialAppView,
-      restoreProject.id,
-      restoreProject.path
+      restoreWorkspace.id,
+      restoreWorkspace.path
     );
     // The menu was built before this binding existed, so its project gates
     // resolved against a PVM with no active project. Converge them now (#11136).
@@ -669,6 +697,12 @@ export async function setupWindowServices(
 
   // Load worktrees — prefer initialProjectPath, else restoreProject for
   // startup windows. Unbound windows (no project) skip worktree loading.
+  //
+  // Deliberately `restoreProject`, never `restoreWorkspace`: a scratch is a
+  // non-git directory that must never invoke `WorktreeService`, and the
+  // renderer's no-port watchdog in `WorktreeStoreContext` intentionally stays
+  // disarmed for one. A restored scratch therefore falls through this block
+  // with no path, exactly as an unbound window does (#11958).
   const projectPathForWorktrees = opts.initialProjectPath ?? restoreProject?.path;
   // Skipped outright while the app is quitting: the captured client may already
   // be disposed, and a banner on a window that is going away helps nobody.

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -29,7 +29,7 @@ import {
 } from "./startupWorktreeLoad.js";
 import { logError, logInfo, logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { resolveRestoreWorkspace } from "./restoreWorkspaceBinding.js";
+import { resolveRestoreWorkspace, resolveWorktreeLoadPath } from "./restoreWorkspaceBinding.js";
 import { extractRestorePanelCwds } from "./restorePanelCwds.js";
 import { mergeProjectEnv } from "./restoreProjectEnv.js";
 import { store } from "../store.js";
@@ -569,25 +569,15 @@ export async function setupWindowServices(
   // `restoreWorkspace` is a project OR a scratch and drives everything the view
   // itself needs; `restoreProject` is set only for a project and stays the sole
   // input to the worktree load below, which scratches must never reach (#11958).
-  const { project: restoreProject, workspace: restoreWorkspace } = resolveRestoreWorkspace(
-    opts.initialProjectId,
-    {
-      getProjectById: (id) => projectStore.getProjectById(id),
-      getScratchById: (id) => {
-        // The scratch lookup opens the shared DB; a failure there must leave
-        // the window unbound, not abort the boot.
-        try {
-          return scratchStore.getScratchById(id);
-        } catch (error) {
-          logWarn("[MAIN] Could not resolve a scratch for the restored window", {
-            scratchId: id,
-            error: formatErrorMessage(error, "Unknown error"),
-          });
-          return null;
-        }
-      },
-    }
-  );
+  // Neither lookup is wrapped: a store that throws here is a failed boot, not a
+  // window to open unbound. Swallowing it would register nothing, still report
+  // "ok", and let the restore's `resumeSaves(true)` rewrite the manifest with a
+  // null workspace — destroying the very id this fix exists to preserve.
+  const binding = resolveRestoreWorkspace(opts.initialProjectId, {
+    getProjectById: (id) => projectStore.getProjectById(id),
+    getScratchById: (id) => scratchStore.getScratchById(id),
+  });
+  const { project: restoreProject, workspace: restoreWorkspace } = binding;
 
   // A Linux file manager launching a cold Daintree via "Open With" on a folder
   // puts a `file://` directory URI in argv. Classified here — outside the PTY
@@ -696,14 +686,11 @@ export async function setupWindowServices(
   }
 
   // Load worktrees — prefer initialProjectPath, else restoreProject for
-  // startup windows. Unbound windows (no project) skip worktree loading.
-  //
-  // Deliberately `restoreProject`, never `restoreWorkspace`: a scratch is a
-  // non-git directory that must never invoke `WorktreeService`, and the
-  // renderer's no-port watchdog in `WorktreeStoreContext` intentionally stays
-  // disarmed for one. A restored scratch therefore falls through this block
-  // with no path, exactly as an unbound window does (#11958).
-  const projectPathForWorktrees = opts.initialProjectPath ?? restoreProject?.path;
+  // startup windows. Unbound windows (no project) skip worktree loading, and so
+  // does a restored scratch: a non-git directory must never invoke
+  // `WorktreeService`, and the renderer's no-port watchdog in
+  // `WorktreeStoreContext` intentionally stays disarmed for one (#11958).
+  const projectPathForWorktrees = resolveWorktreeLoadPath(opts.initialProjectPath, binding);
   // Skipped outright while the app is quitting: the captured client may already
   // be disposed, and a banner on a window that is going away helps nobody.
   if (projectPathForWorktrees && !isCleaningUp()) {


### PR DESCRIPTION
## Summary

Quitting the app with a scratch workspace active and relaunching brought the window back structurally unbound in main: empty grid, dead assistant, file browser errors. The renderer's `loadScratches()` lands a moment later and cosmetically labels the window as the scratch, which is what made this easy to miss: the toolbar says you're in the scratch, but main never bound the view to it.

Two independent gates caused this, and fixing only one wouldn't have been enough:

- `readOpenWindowsManifestSync` validated every stored workspace id with `SELECT id FROM projects WHERE id IN (...)`. A scratch has no `projects` row, so `filterRestorableWindows` dropped its record exactly like a deleted project's, and `resolvePrimaryRestoreProjectId` correctly resolved that to a picker.
- Even had the record survived, `windowServices.ts` resolved `restoreProject` only through `projectStore.getProjectById`. `registerInitialView()`, the only caller of `registerProjectView` for the startup view, was gated on it, so `viewToProject` stayed empty and `ctx.projectId` was `null` for every IPC call that view sent, for its whole lifetime.

Resolves #11958

## Changes

- Manifest ids are now routed to the table that could hold them. Projects and scratches are disjoint id spaces (64 hex vs dashed UUIDv4), so shape is the discriminator. No manifest `kind` field, no `OPEN_WINDOWS_MANIFEST_VERSION` bump (that would have discarded every stored manifest on upgrade). An id matching neither shape now reaches no query at all.
- The scratch table is schema-probed with `PRAGMA table_info` instead of wrapped in a catch. These readers run before migrations, and `scratches` arrives in migration `0001` with `deleted_at` following in `0002`, so both partial schemas are real. Probing keeps a corrupt or locked database from being misread as "the user has no scratches".
- New `electron/window/restoreWorkspaceBinding.ts` resolves the restored workspace once. A project or a scratch drives the PTY binding, the default-spawn suppression, and `registerInitialView`; only a project reaches the startup worktree load and the workspace-host prewarm, so a scratch still never touches `WorktreeService`.
- The no-manifest fallback now reads `currentScratchId` when no project pointer survives. `scratch:switch` deletes `currentProjectId`, so closing the last window (the quit gesture on Windows and Linux, which persists a manifest naming zero windows) previously had nothing to fall back to and landed on the picker.
- `scratch:switch` now re-persists the manifest after committing, matching what `project:switch` already does.

Nothing was needed in `fileBrowser.ts` or `stateHydration/`. Both already do dual project/scratch resolution and self-heal once the sender is bound.

## Testing

178 tests across the six affected suites, plus a full typecheck pass.

No E2E test was added. The scenario needs a graceful quit and two relaunches, and `e2e/core/` gates every release, so the coverage sits at both real decision points as units instead.

## Follow-ups (out of scope, pre-existing)

- `readOpenWindowsManifestSync` has always equated a query error with absence: a SQLite failure yields `NO_MANIFEST`, the launch falls back, and `resumeSaves(true)` then rewrites the manifest. This change doesn't add that pathology (it actually removes some paths into it), but properly closing it means threading a "read failed" state through `readOpenWindowsManifestSync` → `restoreWindowFleet` → `resumeSaves`.
- `setupWindowServices` throwing leaves a registered-but-unbound background window alive, which a later focus/close save can persist as `projectId: null`. `projectStore.getProjectById` sits unguarded in that same position on `develop` today.
- A closed project still passes restore validation and can reach the worktree load, while project-scoped IPC refuses that same id. Predates this change.
