### PR TITLE
Rebuild the create-worktree dialog as a dense form surface

### DIFF
--- a/e2e/full/platform/core-resource-settings-persistence.spec.ts
+++ b/e2e/full/platform/core-resource-settings-persistence.spec.ts
@@ -202,7 +202,7 @@ test.describe.serial("Full: Resource Settings Persistence", () => {
     const dialog = window.locator(SEL.worktree.newDialog);
     await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
 
-    const modeGroup = window.locator('[role="radiogroup"][aria-label="Worktree environment mode"]');
+    const modeGroup = window.locator(SEL.worktree.environmentGroup);
     await expect(modeGroup).toBeVisible({ timeout: T_MEDIUM });
 
     // Select "e2e-docker" environment
@@ -348,7 +348,7 @@ test.describe.serial("Full: Resource Settings Persistence", () => {
     const dialog = window.locator(SEL.worktree.newDialog);
     await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
 
-    const modeGroup = window.locator('[role="radiogroup"][aria-label="Worktree environment mode"]');
+    const modeGroup = window.locator(SEL.worktree.environmentGroup);
     await expect(modeGroup).toBeVisible({ timeout: T_MEDIUM });
 
     const dockerModeBtn = modeGroup.locator('[role="radio"]').filter({ hasText: "e2e-docker" });

--- a/e2e/full/worktree/new-worktree-dialog.spec.ts
+++ b/e2e/full/worktree/new-worktree-dialog.spec.ts
@@ -99,7 +99,7 @@ test.describe.serial("Full: New Worktree Dialog", () => {
     const { window } = ctx;
     await openDialog(window);
 
-    await expect(window.locator(SEL.worktree.newDialog)).toContainText("Create New Worktree");
+    await expect(window.locator(SEL.worktree.newDialog)).toContainText("Create worktree");
     await expect(window.locator(SEL.worktree.branchNameInput)).toBeVisible({ timeout: T_MEDIUM });
     await expect(window.locator(SEL.worktree.createButton)).toBeVisible();
   });

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -126,7 +126,7 @@ export const SEL = {
     quickCreateCustomize: "#quick-create-option-__customize__",
     newWorktreeButton: '[aria-label="Create new worktree"]',
     branchModeGroup: '[role="radiogroup"][aria-label="Branch mode"]',
-    environmentGroup: '[role="radiogroup"][aria-label="Worktree environment mode"]',
+    environmentGroup: '[role="radiogroup"][aria-label="Environment"]',
     recipeTrigger: "#recipe-selector-trigger",
     recipeListbox: "#recipe-selector",
     baseBranchTrigger: "#base-branch",

--- a/e2e/screenshots/worktree-dialog-review.spec.ts
+++ b/e2e/screenshots/worktree-dialog-review.spec.ts
@@ -1,0 +1,299 @@
+/**
+ * New-worktree dialog visual-review harness.
+ *
+ * Boots a small fixture repo with a few branches and recipes, opens the create
+ * dialog, and writes PNGs of every state that carries design weight (rest,
+ * existing-branch mode, open branch picker, linked issue, validation error) so
+ * the dialog redesign can be judged against real rendered pixels.
+ *
+ * Opt-in only, like theme-review: skips itself unless DAINTREE_SHOT_DIALOG is
+ * set, so the marketing screenshots workflow never executes it.
+ *
+ *   DAINTREE_SHOT_DIALOG=1 npx playwright test --project=screenshots worktree-dialog-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_DIALOG  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME   optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG     optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY    comma-separated step filter (see step names below)
+ *
+ * Output: artifacts/dialog-shots/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_DIALOG;
+/** The testid sits on the backdrop; the panel is its first child. */
+const PANEL = `${SEL.worktree.newDialog} > div`;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "dialog-shots");
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+const RECIPES = [
+  {
+    id: "recipe-pair",
+    name: "Claude + Codex pair",
+    terminals: [
+      { type: "claude", title: "Claude", env: {}, initialPrompt: "" },
+      { type: "codex", title: "Codex", env: {}, initialPrompt: "" },
+    ],
+    createdAt: 1775381905486,
+    showInEmptyState: true,
+  },
+  {
+    id: "recipe-work",
+    name: "Work the issue",
+    terminals: [{ type: "claude", title: "Work", env: {}, initialPrompt: "/work {{number}}" }],
+    createdAt: 1775381905487,
+    showInEmptyState: false,
+  },
+];
+
+/** Repo with a realistic branch list and a couple of saved recipes. */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-dialog-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  writeFileSync(path.join(dir, "src", "index.ts"), "export const main = (): number => 0;\n");
+
+  mkdirSync(path.join(dir, ".daintree", "recipes"), { recursive: true });
+  for (const recipe of RECIPES) {
+    writeFileSync(
+      path.join(dir, ".daintree", "recipes", `${recipe.id}.json`),
+      JSON.stringify(recipe, null, 2)
+    );
+  }
+
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  git("branch develop", dir);
+  for (const branch of [
+    "feature/streaming-uploads",
+    "fix/retry-backoff-jitter",
+    "chore/bump-electron",
+    "release/v0.22.0",
+  ]) {
+    git(`branch ${branch}`, dir);
+  }
+  git("checkout develop", dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 500): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+async function snap(page: Page, slug: string, locator?: string): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).first().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+}
+
+/**
+ * Every built-in theme. Switching themes in place crashes the project view
+ * under this harness, so the cross-theme sweep boots once per theme:
+ *
+ *   for t in <these ids>; do
+ *     DAINTREE_SHOT_DIALOG=1 DAINTREE_SHOT_THEME=$t DAINTREE_SHOT_TAG=$t \
+ *     DAINTREE_SHOT_ONLY=populated npx playwright test --project=screenshots \
+ *     worktree-dialog-review
+ *   done
+ */
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    console.warn(`[dialog-shots] step "${name}" skipped:`, String(error).slice(0, 300));
+  }
+}
+
+/** Open the create dialog from a clean workbench, routing past the quick-create palette. */
+async function openDialog(page: Page): Promise<void> {
+  await page.locator(SEL.worktree.newWorktreeButton).click();
+  const palette = page.locator(SEL.worktree.quickCreatePalette);
+  if (await palette.isVisible({ timeout: 3000 }).catch(() => false)) {
+    const customize = page.locator(SEL.worktree.quickCreateCustomize);
+    if (await customize.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await customize.click();
+    }
+  }
+  await page
+    .locator(SEL.worktree.newDialog)
+    .waitFor({ state: "visible", timeout: 6000 })
+    .catch(() => {});
+  await settle(page, 600);
+}
+
+async function closeDialog(page: Page): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+  }
+}
+
+test("new-worktree dialog review — rest and interactive states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_DIALOG is required for the dialog capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_DIALOG to run the dialog capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-dialogshot-"));
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 2500);
+    await dismissBlockingPalette(page);
+
+    // 1. Rest state — the shot the whole redesign is judged on.
+    await step("rest", async () => {
+      await openDialog(page);
+      await snap(page, "10-rest", PANEL);
+      await snap(page, "11-rest-in-window");
+      await closeDialog(page);
+    });
+
+    // 2. Populated — the real working state, and the only one that renders the
+    // footer's base -> branch preview.
+    await step("populated", async () => {
+      await openDialog(page);
+      const input = page.locator(SEL.worktree.branchNameInput);
+      await input.click().catch(() => {});
+      await input.fill("feature/streaming-uploads-v2").catch(() => {});
+      await page
+        .locator("h3", { hasText: "Destination" })
+        .first()
+        .click()
+        .catch(() => {});
+      await settle(page, 900);
+      await snap(page, "15-populated", PANEL);
+      await closeDialog(page);
+    });
+
+    // 3. Existing-branch mode — the other half of the branch control.
+    await step("existing", async () => {
+      await openDialog(page);
+      await page
+        .locator(`${SEL.worktree.branchModeGroup} [role="radio"]`)
+        .last()
+        .click()
+        .catch(() => {});
+      await settle(page, 400);
+      await snap(page, "20-existing-branch", PANEL);
+      await closeDialog(page);
+    });
+
+    // 3. Base-branch picker open — popover surface against the dialog surface.
+    await step("picker", async () => {
+      await openDialog(page);
+      await page
+        .locator(SEL.worktree.baseBranchTrigger)
+        .click()
+        .catch(() => {});
+      await settle(page, 500);
+      await snap(page, "30-base-branch-picker");
+      await closeDialog(page);
+    });
+
+    // 4. Validation error — the error surface in context.
+    await step("error", async () => {
+      await openDialog(page);
+      const input = page.locator(SEL.worktree.branchNameInput);
+      await input.click().catch(() => {});
+      await input.fill("").catch(() => {});
+      await settle(page, 300);
+      await page
+        .locator(SEL.worktree.createButton)
+        .click()
+        .catch(() => {});
+      await settle(page, 800);
+      await snap(page, "40-validation-error", PANEL);
+      await closeDialog(page);
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -1123,7 +1123,7 @@ export function NewWorktreeDialog({
                             />
                           )}
                         </span>
-                        Create from the remote branch
+                        Create from remote branch
                       </label>
                     }
                   >

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -1,8 +1,10 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback, Fragment } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { FolderGit2, Check, AlertCircle } from "lucide-react";
+import { FolderGit2, Check, AlertCircle, ArrowRight, GitBranch } from "lucide-react";
+import { isMac } from "@/lib/platform";
+import { cn } from "@/lib/utils";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import type { BranchInfo, CreateWorktreeOptions } from "@/types/electron";
 import type { Issue, PR } from "@shared/types/forge";
@@ -49,6 +51,9 @@ import {
   WorktreePathPicker,
   EnvironmentRadioGroup,
   RecipePickerPopover,
+  FormGrid,
+  FormSection,
+  FormRow,
 } from "./views";
 
 type BranchMode = "new" | "existing";
@@ -948,141 +953,278 @@ export function NewWorktreeDialog({
     [handleIssueSelect, markTouched, clearErrors]
   );
 
+  const submitDisabled =
+    loading ||
+    isCheckingBranch ||
+    isGeneratingPath ||
+    (isExistingMode && !selectedExistingBranch) ||
+    (initialPR !== null && initialPR !== undefined && prBranchResolved === false);
+
+  // Cmd/Ctrl+Enter submits from anywhere in the dialog. Advertised on the
+  // primary button, so it has to actually work from the pickers too — a hint
+  // for a shortcut that only fires in one field is worse than no hint.
+  //
+  // `handleCreate` is not memoised and changes identity every render, so it is
+  // held in a ref: depending on it directly would tear down and re-add the
+  // window listener on every keystroke in the form.
+  const submitRef = useRef({ handleCreate, submitDisabled });
+  useEffect(() => {
+    submitRef.current = { handleCreate, submitDisabled };
+  });
+
+  useEffect(() => {
+    if (!isOpen || isDismissing) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Enter" || !(e.metaKey || e.ctrlKey) || e.isComposing) return;
+      const { handleCreate: create, submitDisabled: blocked } = submitRef.current;
+      if (blocked || isCreatingRef.current) return;
+      e.preventDefault();
+      void create();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isOpen, isDismissing]);
+
+  // What the form is actually about to do, said once. Replaces the mono echo
+  // line that used to sit under the branch input restating its own value.
+  const outcomeSummary = isExistingMode ? (
+    selectedExistingBranch ? (
+      <>
+        <GitBranch className="w-3 h-3 shrink-0" aria-hidden="true" />
+        <span className="truncate font-mono">{selectedExistingBranch}</span>
+      </>
+    ) : null
+  ) : parsedBranch.fullBranchName && baseBranch ? (
+    <>
+      <span className="truncate font-mono">{baseBranch}</span>
+      <ArrowRight className="w-3 h-3 shrink-0" aria-hidden="true" />
+      <span className="truncate font-mono text-daintree-text/80">
+        {parsedBranch.fullBranchName}
+      </span>
+    </>
+  ) : (
+    // Submit stays enabled on purpose — clicking it names what is missing,
+    // which beats a disabled button that explains nothing. This is what keeps
+    // the not-yet-ready state from looking identical to the ready one.
+    <span className="truncate">Name the branch to continue</span>
+  );
+
+  const showIssueRow = !initialPR && !!forgeEntry?.contribution.slots?.issueSelector;
+  const showRecipeRow = startingLayoutRecipes.length > 0;
+  const hasSetupSection = showIssueRow || hasAnyEnvironments || showRecipeRow;
+
+  // Same flags the real sections are built from, so the skeleton is the shape
+  // that is actually about to render rather than a generic three-block guess.
+  // Rows are modelled individually because a `hint` occupies its own grid row —
+  // counting only label/control pairs made Name jump down on resolve.
+  const skeletonSections: { title: string; rows: ("field" | "hint")[] }[] = [
+    {
+      title: "Branch",
+      rows: isExistingMode ? ["field"] : ["field", "hint", "field"],
+    },
+    { title: "Destination", rows: ["field"] },
+    ...(hasSetupSection
+      ? [
+          {
+            title: "Setup",
+            rows: Array<"field">(
+              Number(showIssueRow) + Number(hasAnyEnvironments) + Number(showRecipeRow)
+            ).fill("field"),
+          },
+        ]
+      : []),
+  ];
+
   return (
     <AppDialog
       isOpen={isOpen}
       onClose={onClose}
       onBeforeClose={handleBeforeClose}
-      size="md"
+      size="lg"
       data-testid="new-worktree-dialog"
     >
-      <AppDialog.Header>
-        <AppDialog.Title icon={<FolderGit2 className="w-5 h-5 text-daintree-accent" />}>
-          {initialPR ? "Checkout PR Branch" : "Create New Worktree"}
+      <AppDialog.Header className="py-3">
+        {/* Neutral, not accent: the header glyph is decoration, and the primary
+            action is this region's one load-bearing signal. */}
+        <AppDialog.Title icon={<FolderGit2 className="w-4 h-4 text-text-secondary" />}>
+          {initialPR ? "Check out PR branch" : "Create worktree"}
         </AppDialog.Title>
         <AppDialog.CloseButton />
       </AppDialog.Header>
 
-      <AppDialog.Body>
+      <AppDialog.Body className="space-y-5">
+        {initialPR && <PrHeader pr={initialPR} />}
         {loading ? (
-          <Skeleton label="Loading branches" className="space-y-4 py-2">
-            <div className="space-y-2">
-              <SkeletonBone className="h-4 w-24" />
-              <SkeletonBone className="h-9 w-full" />
-            </div>
-            <div className="space-y-2">
-              <SkeletonBone className="h-4 w-28" />
-              <SkeletonBone className="h-9 w-full" />
-            </div>
-            <div className="space-y-2">
-              <SkeletonBone className="h-4 w-20" />
-              <SkeletonBone className="h-9 w-full" />
-            </div>
+          <Skeleton label="Loading branches">
+            {/* Built from the same flags as the resolved form and rendered in
+                the same FormGrid, so the branch list resolving swaps content in
+                without moving anything. A fixed-shape skeleton would guess the
+                section list wrong whenever Setup is empty or carries extra rows. */}
+            <FormGrid>
+              {skeletonSections.map((section) => (
+                <FormSection key={section.title} title={section.title}>
+                  {section.rows.map((row, index) =>
+                    row === "hint" ? (
+                      // h-4, not h-3: the resolved hint row is as tall as its 16px
+                      // checkbox, and 12px here grew the row by 4px on resolve.
+                      <SkeletonBone key={index} className="col-start-2 h-4 w-44" />
+                    ) : (
+                      <Fragment key={index}>
+                        <SkeletonBone className="h-3 w-12" />
+                        <SkeletonBone className="h-8 w-full" />
+                      </Fragment>
+                    )
+                  )}
+                </FormSection>
+              ))}
+            </FormGrid>
           </Skeleton>
         ) : (
-          <div className="space-y-4">
-            {initialPR ? (
-              <PrHeader pr={initialPR} />
-            ) : (
-              <IssueLinkerView
-                projectPath={rootPath}
-                selectedIssue={selectedIssue}
-                onSelectIssue={handleIssueSelectWrapper}
-                canAssignIssue={canAssignIssue}
-                assignWorktreeToSelf={assignWorktreeToSelf}
-                onSetAssignWorktreeToSelf={setAssignWorktreeToSelf}
-                currentUser={currentUser}
-                currentUserAvatar={currentUserAvatar}
-              />
-            )}
+          <>
+            <FormGrid>
+              <FormSection
+                title="Branch"
+                action={
+                  !initialPR && (
+                    <BranchModeControl branchMode={branchMode} onChange={handleBranchModeChange} />
+                  )
+                }
+              >
+                {!isExistingMode && (
+                  <FormRow
+                    label="Base"
+                    htmlFor="base-branch"
+                    hint={
+                      <label className="flex w-fit cursor-pointer items-center gap-2 text-xs text-text-secondary hover:text-daintree-text">
+                        <span className="relative inline-flex shrink-0">
+                          <input
+                            id="from-remote"
+                            type="checkbox"
+                            checked={fromRemote}
+                            onChange={(e) => {
+                              baseBranchTouchedRef.current = true;
+                              setFromRemote(e.target.checked);
+                            }}
+                            className={cn(
+                              // A 16px box at the theme radius reads as a radio, not a checkbox.
+                              "h-4 w-4 appearance-none rounded-[4px] border",
+                              "transition-colors duration-150 ease-out",
+                              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+                              fromRemote
+                                ? "border-daintree-text bg-daintree-text"
+                                : "border-border-strong bg-surface-input"
+                            )}
+                          />
+                          {fromRemote && (
+                            <Check
+                              className="pointer-events-none absolute inset-0 m-auto h-3 w-3 text-text-inverse"
+                              strokeWidth={3.5}
+                              aria-hidden="true"
+                            />
+                          )}
+                        </span>
+                        Create from the remote branch
+                      </label>
+                    }
+                  >
+                    <BaseBranchCombobox
+                      baseBranch={baseBranch}
+                      controller={baseBranchPicker}
+                      errorField={errors.errorField}
+                    />
+                  </FormRow>
+                )}
 
-            {!initialPR && (
-              <BranchModeControl branchMode={branchMode} onChange={handleBranchModeChange} />
-            )}
+                {isExistingMode ? (
+                  <FormRow label="Branch" htmlFor="existing-branch">
+                    <ExistingBranchPicker
+                      selectedBranch={selectedExistingBranch}
+                      controller={existingBranchPicker}
+                    />
+                  </FormRow>
+                ) : (
+                  <FormRow label="Name" htmlFor="new-branch">
+                    <NewBranchInput
+                      value={branchInput}
+                      onChange={handleBranchInputChange}
+                      onBlur={handleBranchInputBlur}
+                      isCheckingBranch={isCheckingBranch}
+                      errorField={errors.errorField}
+                      branchWasAutoResolved={branchWasAutoResolved}
+                      prefixPickerOpen={prefixPickerOpen}
+                      onPrefixPickerOpenChange={setPrefixPickerOpen}
+                      prefixSuggestions={prefixSuggestions}
+                      prefixSelectedIndex={prefixSelectedIndex}
+                      onPrefixKeyDown={handlePrefixKeyDown}
+                      onPrefixSelect={handlePrefixSelectWrap}
+                      prefixListRef={prefixListRef}
+                      inputRef={newBranchInputRef}
+                    />
+                  </FormRow>
+                )}
+              </FormSection>
 
-            {!isExistingMode && (
-              <BaseBranchCombobox
-                baseBranch={baseBranch}
-                controller={baseBranchPicker}
-                errorField={errors.errorField}
-              />
-            )}
+              <FormSection title="Destination">
+                <FormRow label="Path" htmlFor="worktree-path">
+                  <WorktreePathPicker
+                    value={worktreePath}
+                    onChange={handleWorktreePathChange}
+                    isGeneratingPath={isGeneratingPath}
+                    errorField={errors.errorField}
+                    pathWasAutoResolved={pathWasAutoResolved}
+                    onBrowseClick={handleBrowseClick}
+                  />
+                </FormRow>
+              </FormSection>
 
-            {isExistingMode ? (
-              <ExistingBranchPicker
-                selectedBranch={selectedExistingBranch}
-                controller={existingBranchPicker}
-              />
-            ) : (
-              <NewBranchInput
-                value={branchInput}
-                onChange={handleBranchInputChange}
-                onBlur={handleBranchInputBlur}
-                isCheckingBranch={isCheckingBranch}
-                errorField={errors.errorField}
-                branchWasAutoResolved={branchWasAutoResolved}
-                parsedBranch={parsedBranch}
-                prefixPickerOpen={prefixPickerOpen}
-                onPrefixPickerOpenChange={setPrefixPickerOpen}
-                prefixSuggestions={prefixSuggestions}
-                prefixSelectedIndex={prefixSelectedIndex}
-                onPrefixKeyDown={handlePrefixKeyDown}
-                onPrefixSelect={handlePrefixSelectWrap}
-                prefixListRef={prefixListRef}
-                inputRef={newBranchInputRef}
-              />
-            )}
+              {hasSetupSection && (
+                <FormSection title="Setup">
+                  {showIssueRow && (
+                    <FormRow label="Issue">
+                      <IssueLinkerView
+                        projectPath={rootPath}
+                        selectedIssue={selectedIssue}
+                        onSelectIssue={handleIssueSelectWrapper}
+                        canAssignIssue={canAssignIssue}
+                        assignWorktreeToSelf={assignWorktreeToSelf}
+                        onSetAssignWorktreeToSelf={setAssignWorktreeToSelf}
+                        currentUser={currentUser}
+                        currentUserAvatar={currentUserAvatar}
+                      />
+                    </FormRow>
+                  )}
 
-            <WorktreePathPicker
-              value={worktreePath}
-              onChange={handleWorktreePathChange}
-              isGeneratingPath={isGeneratingPath}
-              errorField={errors.errorField}
-              pathWasAutoResolved={pathWasAutoResolved}
-              onBrowseClick={handleBrowseClick}
-            />
+                  {hasAnyEnvironments && (
+                    <FormRow label="Environment" selfLabelled>
+                      <EnvironmentRadioGroup
+                        worktreeMode={worktreeMode}
+                        onChange={setWorktreeMode}
+                        resourceEnvironments={resourceEnvironments}
+                        hasAnyEnvironments={hasAnyEnvironments}
+                      />
+                    </FormRow>
+                  )}
 
-            {!isExistingMode && (
-              <div className="flex items-center gap-2">
-                <input
-                  id="from-remote"
-                  type="checkbox"
-                  checked={fromRemote}
-                  onChange={(e) => {
-                    baseBranchTouchedRef.current = true;
-                    setFromRemote(e.target.checked);
-                  }}
-                  className="rounded border-daintree-border text-daintree-accent focus:ring-daintree-accent/30"
-                />
-                <label htmlFor="from-remote" className="text-sm text-daintree-text select-none">
-                  Create from remote branch
-                </label>
-              </div>
-            )}
-
-            <EnvironmentRadioGroup
-              worktreeMode={worktreeMode}
-              onChange={setWorktreeMode}
-              resourceEnvironments={resourceEnvironments}
-              hasAnyEnvironments={hasAnyEnvironments}
-            />
-
-            {startingLayoutRecipes.length > 0 && (
-              <RecipePickerPopover
-                recipes={startingLayoutRecipes}
-                selectedRecipeId={selectedRecipeId}
-                selectedRecipe={selectedRecipe}
-                defaultRecipeId={defaultRecipeId}
-                open={recipePickerOpen}
-                onOpenChange={setRecipePickerOpen}
-                onSelectRecipe={handleRecipeSelect}
-                onMarkTouched={() => {
-                  markTouched("recipe");
-                }}
-                label="Run Recipe (Optional)"
-                listId="recipe-selector"
-              />
-            )}
+                  {showRecipeRow && (
+                    <FormRow label="Recipe" htmlFor="recipe-selector-trigger">
+                      <RecipePickerPopover
+                        recipes={startingLayoutRecipes}
+                        selectedRecipeId={selectedRecipeId}
+                        selectedRecipe={selectedRecipe}
+                        defaultRecipeId={defaultRecipeId}
+                        open={recipePickerOpen}
+                        onOpenChange={setRecipePickerOpen}
+                        onSelectRecipe={handleRecipeSelect}
+                        onMarkTouched={() => {
+                          markTouched("recipe");
+                        }}
+                        listId="recipe-selector"
+                      />
+                    </FormRow>
+                  )}
+                </FormSection>
+              )}
+            </FormGrid>
 
             {initialPR && prBranchResolved === false && (
               <div className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)]">
@@ -1107,14 +1249,14 @@ export function NewWorktreeDialog({
                 <p className="text-sm text-status-error">{errors.validationError}</p>
               </div>
             )}
-          </div>
+          </>
         )}
       </AppDialog.Body>
 
-      <AppDialog.Footer>
+      <AppDialog.Footer hint={isDismissing ? undefined : outcomeSummary}>
         {isDismissing ? (
           <>
-            <span role="alert" className="flex-1 text-sm text-daintree-text/70">
+            <span role="alert" className="flex-1 text-sm text-text-secondary">
               Discard unsaved changes?
             </span>
             <Button
@@ -1129,26 +1271,27 @@ export function NewWorktreeDialog({
             </Button>
           </>
         ) : (
-          <>
-            <Button variant="ghost" onClick={handleRequestClose}>
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="sm" onClick={handleRequestClose}>
               Cancel
             </Button>
             <Button
+              variant="contrast"
+              size="sm"
               onClick={handleCreate}
-              disabled={
-                loading ||
-                isCheckingBranch ||
-                isGeneratingPath ||
-                (isExistingMode && !selectedExistingBranch) ||
-                (initialPR !== null && initialPR !== undefined && prBranchResolved === false)
-              }
-              className="min-w-[100px]"
+              disabled={submitDisabled}
+              aria-keyshortcuts="Meta+Enter Control+Enter"
               data-testid="create-worktree-button"
             >
-              <Check />
-              Create
+              {initialPR ? "Check out" : "Create worktree"}
+              <span
+                className="ml-1 rounded-[3px] bg-text-inverse/15 px-1 py-0.5 font-mono text-[10px] leading-none text-text-inverse"
+                aria-hidden="true"
+              >
+                {isMac() ? "\u2318\u21A9" : "Ctrl\u21A9"}
+              </span>
             </Button>
-          </>
+          </div>
         )}
       </AppDialog.Footer>
     </AppDialog>

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -993,7 +993,9 @@ export function NewWorktreeDialog({
         <GitBranch className="w-3 h-3 shrink-0" aria-hidden="true" />
         <span className="truncate font-mono">{selectedExistingBranch}</span>
       </>
-    ) : null
+    ) : (
+      <span className="truncate">Pick a branch to continue</span>
+    )
   ) : parsedBranch.fullBranchName && baseBranch ? (
     <>
       <span className="truncate font-mono">{baseBranch}</span>
@@ -1006,7 +1008,11 @@ export function NewWorktreeDialog({
     // Submit stays enabled on purpose — clicking it names what is missing,
     // which beats a disabled button that explains nothing. This is what keeps
     // the not-yet-ready state from looking identical to the ready one.
-    <span className="truncate">Name the branch to continue</span>
+    <span className="truncate">
+      {parsedBranch.fullBranchName
+        ? "Pick a base branch to continue"
+        : "Name the branch to continue"}
+    </span>
   );
 
   const showIssueRow = !initialPR && !!forgeEntry?.contribution.slots?.issueSelector;

--- a/src/components/Worktree/__tests__/BaseBranchCombobox.test.tsx
+++ b/src/components/Worktree/__tests__/BaseBranchCombobox.test.tsx
@@ -52,7 +52,7 @@ describe("BaseBranchCombobox trigger", () => {
 
   it("prompts when no branch is chosen yet", () => {
     renderCombobox();
-    expect(document.getElementById("base-branch")!.textContent).toContain("Select base branch...");
+    expect(document.getElementById("base-branch")!.textContent).toContain("Select base branch");
   });
 
   it("flags the field as invalid only for its own error", () => {

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -592,7 +592,7 @@ describe("NewWorktreeDialog — existing branch mode", () => {
       });
 
       expect(screen.getByTestId("existing-branch-picker").textContent).toContain(
-        "Select a local branch..."
+        "Select a local branch"
       );
     });
   });
@@ -1541,7 +1541,7 @@ describe("NewWorktreeDialog — deferred branch auto-resolve", () => {
     const branchInput = await typeBranch("feature/terrain");
 
     expect(branchInput.value).toBe("feature/terrain");
-    expect(screen.getByText(/auto-incremented/i)).toBeDefined();
+    expect(screen.getByText(/renamed to avoid a conflict/i)).toBeDefined();
   });
 
   it("does not clobber characters typed past the conflicting prefix", async () => {
@@ -1554,7 +1554,7 @@ describe("NewWorktreeDialog — deferred branch auto-resolve", () => {
     await typeBranch(`${branchInput.value}-shadows`);
 
     expect(branchInput.value).toBe("feature/terrain-shadows");
-    expect(screen.queryByText(/auto-incremented/i)).toBeNull();
+    expect(screen.queryByText(/renamed to avoid a conflict/i)).toBeNull();
   });
 
   it("applies the auto-incremented name on blur without re-checking or disabling Create", async () => {

--- a/src/components/Worktree/views/BaseBranchCombobox.tsx
+++ b/src/components/Worktree/views/BaseBranchCombobox.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverTrigger } from "@/components/ui/popover";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { ChevronsUpDown, Info } from "lucide-react";
+import { ChevronsUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { BranchPickerPanel } from "./BranchPickerPanel";
+import { FIELD_TRIGGER } from "./WorktreeFormLayout";
 import type { UseBranchPickerResult } from "../hooks/useBranchPicker";
 
 interface BaseBranchComboboxProps {
@@ -12,67 +13,46 @@ interface BaseBranchComboboxProps {
   disabled?: boolean;
 }
 
+/** Control only — "Base" and its help text live on the form's label rail. */
 export function BaseBranchCombobox({
   baseBranch,
   controller,
   errorField,
   disabled,
 }: BaseBranchComboboxProps) {
+  const hasError = errorField === "base-branch";
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <label htmlFor="base-branch" className="block text-sm font-medium text-daintree-text">
-          Base Branch
-        </label>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-              aria-label="Help for Base Branch field"
-              disabled={disabled}
-            >
-              <Info className="w-3.5 h-3.5" aria-hidden="true" />
-              <span className="sr-only">Help for Base Branch field</span>
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">
-            <p>The branch to create the new worktree from</p>
-          </TooltipContent>
-        </Tooltip>
-      </div>
-      <Popover open={controller.open} onOpenChange={controller.setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            id="base-branch"
-            variant="outline"
-            role="combobox"
-            aria-expanded={controller.open}
-            aria-haspopup="listbox"
-            aria-invalid={errorField === "base-branch" ? true : undefined}
-            aria-describedby={errorField === "base-branch" ? "validation-error" : undefined}
-            className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-            disabled={disabled}
-          >
-            {/* The trigger keeps the composed "(current)"/"(remote)" label — it has
-                one line for the whole answer. Rows draw those as badges instead. */}
-            <span className="truncate">
-              {controller.selectedOption?.labelText || "Select base branch..."}
-            </span>
-            <ChevronsUpDown className="text-text-muted shrink-0" />
-          </Button>
-        </PopoverTrigger>
-        <BranchPickerPanel
-          controller={controller}
-          selectedBranch={baseBranch}
-          listId="branch-list"
-          optionIdPrefix="branch-option-"
-          searchPlaceholder="Search branches..."
-          searchAriaLabel="Search base branches"
-          zeroDataTitle="No branches available"
-          showCurrentBadge
-        />
-      </Popover>
-    </div>
+    <Popover open={controller.open} onOpenChange={controller.setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id="base-branch"
+          variant="ghost"
+          role="combobox"
+          aria-expanded={controller.open}
+          aria-haspopup="listbox"
+          aria-invalid={hasError ? true : undefined}
+          aria-describedby={hasError ? "validation-error" : undefined}
+          className={cn(FIELD_TRIGGER, hasError && "border-status-error")}
+          disabled={disabled}
+        >
+          {/* The trigger keeps the composed "(current)"/"(remote)" label — it has
+              one line for the whole answer. Rows draw those as badges instead. */}
+          <span className="truncate font-mono text-xs">
+            {controller.selectedOption?.labelText || "Select base branch"}
+          </span>
+          <ChevronsUpDown className="text-text-secondary shrink-0" />
+        </Button>
+      </PopoverTrigger>
+      <BranchPickerPanel
+        controller={controller}
+        selectedBranch={baseBranch}
+        listId="branch-list"
+        optionIdPrefix="branch-option-"
+        searchPlaceholder="Search branches"
+        searchAriaLabel="Search base branches"
+        zeroDataTitle="No branches available"
+        showCurrentBadge
+      />
+    </Popover>
   );
 }

--- a/src/components/Worktree/views/BranchModeControl.tsx
+++ b/src/components/Worktree/views/BranchModeControl.tsx
@@ -1,6 +1,11 @@
-import { cn } from "@/lib/utils";
+import { SegmentedRadioGroup, type SegmentedRadioOption } from "./SegmentedRadioGroup";
 
 type BranchMode = "new" | "existing";
+
+const OPTIONS: SegmentedRadioOption<BranchMode>[] = [
+  { value: "new", label: "New branch" },
+  { value: "existing", label: "Existing branch" },
+];
 
 interface BranchModeControlProps {
   branchMode: BranchMode;
@@ -8,43 +13,15 @@ interface BranchModeControlProps {
   disabled?: boolean;
 }
 
+/** Sits on the Branch section header rather than claiming a row of its own. */
 export function BranchModeControl({ branchMode, onChange, disabled }: BranchModeControlProps) {
   return (
-    <div
-      className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
-      role="radiogroup"
+    <SegmentedRadioGroup
+      options={OPTIONS}
+      value={branchMode}
+      onChange={onChange}
       aria-label="Branch mode"
-    >
-      <button
-        type="button"
-        role="radio"
-        aria-checked={branchMode === "new"}
-        onClick={() => onChange("new")}
-        disabled={disabled}
-        className={cn(
-          "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-          branchMode === "new"
-            ? "bg-daintree-bg text-daintree-text shadow-sm"
-            : "text-daintree-text/60 hover:text-daintree-text"
-        )}
-      >
-        New Branch
-      </button>
-      <button
-        type="button"
-        role="radio"
-        aria-checked={branchMode === "existing"}
-        onClick={() => onChange("existing")}
-        disabled={disabled}
-        className={cn(
-          "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-          branchMode === "existing"
-            ? "bg-daintree-bg text-daintree-text shadow-sm"
-            : "text-daintree-text/60 hover:text-daintree-text"
-        )}
-      >
-        Existing Branch
-      </button>
-    </div>
+      disabled={disabled}
+    />
   );
 }

--- a/src/components/Worktree/views/EnvironmentRadioGroup.tsx
+++ b/src/components/Worktree/views/EnvironmentRadioGroup.tsx
@@ -1,6 +1,5 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Info } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { useMemo } from "react";
+import { SegmentedRadioGroup, type SegmentedRadioOption } from "./SegmentedRadioGroup";
 
 interface EnvironmentRadioGroupProps {
   worktreeMode: string;
@@ -10,6 +9,7 @@ interface EnvironmentRadioGroupProps {
   disabled?: boolean;
 }
 
+/** Control only — "Environment" lives on the form's label rail. */
 export function EnvironmentRadioGroup({
   worktreeMode,
   onChange,
@@ -17,73 +17,28 @@ export function EnvironmentRadioGroup({
   hasAnyEnvironments,
   disabled,
 }: EnvironmentRadioGroupProps) {
+  const options = useMemo<SegmentedRadioOption<string>[]>(
+    () => [
+      { value: "local", label: "Local" },
+      ...Object.keys(resourceEnvironments ?? {}).map((key) => ({ value: key, label: key })),
+    ],
+    [resourceEnvironments]
+  );
+
   if (!hasAnyEnvironments) return null;
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <label className="block text-sm font-medium text-daintree-text">Environment</label>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-              aria-label="Help for Environment field"
-              disabled={disabled}
-            >
-              <Info className="w-3.5 h-3.5" aria-hidden="true" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">
-            <p>
-              Choose where this worktree runs. Non-local environments provision remote compute from
-              project environment settings.
-            </p>
-          </TooltipContent>
-        </Tooltip>
-      </div>
-      <div
-        className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
-        role="radiogroup"
-        aria-label="Worktree environment mode"
-      >
-        <button
-          type="button"
-          role="radio"
-          aria-checked={worktreeMode === "local"}
-          onClick={() => onChange("local")}
-          disabled={disabled}
-          className={cn(
-            "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-            worktreeMode === "local"
-              ? "bg-daintree-bg text-daintree-text shadow-sm"
-              : "text-daintree-text/60 hover:text-daintree-text"
-          )}
-        >
-          Local
-        </button>
-        {Object.entries(resourceEnvironments ?? {}).map(([key]) => (
-          <button
-            key={key}
-            type="button"
-            role="radio"
-            aria-checked={worktreeMode === key}
-            onClick={() => onChange(key)}
-            disabled={disabled}
-            className={cn(
-              "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-              worktreeMode === key
-                ? "bg-daintree-bg text-daintree-text shadow-sm"
-                : "text-daintree-text/60 hover:text-daintree-text"
-            )}
-          >
-            {key}
-          </button>
-        ))}
-      </div>
+    <div className="space-y-1.5">
+      <SegmentedRadioGroup
+        options={options}
+        value={worktreeMode}
+        onChange={onChange}
+        aria-label="Environment"
+        disabled={disabled}
+      />
       {worktreeMode !== "local" && (
-        <p className="text-xs text-daintree-text/50">
-          Provisions {worktreeMode} environment after worktree setup
+        <p className="text-xs text-text-secondary">
+          Provisions the {worktreeMode} environment after setup
         </p>
       )}
     </div>

--- a/src/components/Worktree/views/ExistingBranchPicker.tsx
+++ b/src/components/Worktree/views/ExistingBranchPicker.tsx
@@ -1,7 +1,9 @@
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverTrigger } from "@/components/ui/popover";
 import { ChevronsUpDown, GitBranch } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { BranchPickerPanel } from "./BranchPickerPanel";
+import { FIELD_TRIGGER } from "./WorktreeFormLayout";
 import type { UseBranchPickerResult } from "../hooks/useBranchPicker";
 
 interface ExistingBranchPickerProps {
@@ -10,48 +12,47 @@ interface ExistingBranchPickerProps {
   disabled?: boolean;
 }
 
+/** Control only — "Branch" lives on the form's label rail. */
 export function ExistingBranchPicker({
   selectedBranch,
   controller,
   disabled,
 }: ExistingBranchPickerProps) {
   return (
-    <div className="space-y-2">
-      <label className="block text-sm font-medium text-daintree-text">Select Branch</label>
-      <Popover open={controller.open} onOpenChange={controller.setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            aria-expanded={controller.open}
-            aria-haspopup="listbox"
-            className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-            disabled={disabled}
-            data-testid="existing-branch-picker"
-          >
-            <span className="flex items-center gap-2 truncate">
-              {/* Muted, not accent: a decorative field glyph is not this region's
-                  one load-bearing signal. */}
-              <GitBranch className="w-4 h-4 shrink-0 text-text-muted" aria-hidden="true" />
-              {selectedBranch ? (
-                <span className="font-mono text-sm">{selectedBranch}</span>
-              ) : (
-                <span className="text-daintree-text/60">Select a local branch...</span>
-              )}
-            </span>
-            <ChevronsUpDown className="text-text-muted shrink-0" />
-          </Button>
-        </PopoverTrigger>
-        <BranchPickerPanel
-          controller={controller}
-          selectedBranch={selectedBranch}
-          listId="existing-branch-list"
-          optionIdPrefix="existing-branch-option-"
-          searchPlaceholder="Search local branches..."
-          searchAriaLabel="Search existing branches"
-          zeroDataTitle="No available local branches"
-        />
-      </Popover>
-    </div>
+    <Popover open={controller.open} onOpenChange={controller.setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id="existing-branch"
+          variant="ghost"
+          role="combobox"
+          aria-expanded={controller.open}
+          aria-haspopup="listbox"
+          className={cn(FIELD_TRIGGER, "gap-2")}
+          disabled={disabled}
+          data-testid="existing-branch-picker"
+        >
+          <span className="flex items-center gap-2 truncate">
+            {/* Muted, not accent: a decorative field glyph is not this region's
+                one load-bearing signal. */}
+            <GitBranch className="w-4 h-4 shrink-0 text-text-secondary" aria-hidden="true" />
+            {selectedBranch ? (
+              <span className="truncate font-mono text-xs">{selectedBranch}</span>
+            ) : (
+              <span className="text-text-secondary">Select a local branch</span>
+            )}
+          </span>
+          <ChevronsUpDown className="text-text-secondary shrink-0" />
+        </Button>
+      </PopoverTrigger>
+      <BranchPickerPanel
+        controller={controller}
+        selectedBranch={selectedBranch}
+        listId="existing-branch-list"
+        optionIdPrefix="existing-branch-option-"
+        searchPlaceholder="Search local branches"
+        searchAriaLabel="Search existing branches"
+        zeroDataTitle="No available local branches"
+      />
+    </Popover>
   );
 }

--- a/src/components/Worktree/views/IssueSelectorView.tsx
+++ b/src/components/Worktree/views/IssueSelectorView.tsx
@@ -4,8 +4,7 @@ import { useBuiltinView } from "@/registry/builtinRendererRegistry";
 import type { ForgeIssueSelectorProps } from "@/types/forgeSlotProps";
 import { useProjectStore } from "@/store/projectStore";
 import { useResolvedForgeProvider } from "@/hooks/useResolvedForgeProvider";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Info, UserPlus } from "lucide-react";
+import { UserPlus } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface IssueLinkerViewProps {
@@ -20,6 +19,11 @@ interface IssueLinkerViewProps {
   disabled?: boolean;
 }
 
+/**
+ * Control only — "Issue" lives on the form's label rail. The assign-to-me
+ * switch rides directly under the selector because it is meaningless without a
+ * linked issue, and it only renders once the forge can actually assign one.
+ */
 export function IssueLinkerView({
   projectPath,
   selectedIssue,
@@ -38,86 +42,61 @@ export function IssueLinkerView({
   const IssueSelector = useBuiltinView<ForgeIssueSelectorProps>(
     entry?.contribution.slots?.issueSelector ?? ""
   );
+
   return (
-    <>
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <label className="block text-sm font-medium text-daintree-text">
-            Link Issue (Optional)
-          </label>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                aria-label="Help for Link Issue field"
-                disabled={disabled}
-              >
-                <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                <span className="sr-only">Help for Link Issue field</span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              <p>Select an issue to auto-generate a branch name</p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-        {IssueSelector && (
-          <Suspense fallback={null}>
-            <IssueSelector
-              projectPath={projectPath}
-              selectedIssue={selectedIssue}
-              onSelect={onSelectIssue}
-              disabled={disabled}
-            />
-          </Suspense>
-        )}
-      </div>
+    <div className="space-y-1.5">
+      {IssueSelector && (
+        <Suspense fallback={null}>
+          <IssueSelector
+            projectPath={projectPath}
+            selectedIssue={selectedIssue}
+            onSelect={onSelectIssue}
+            disabled={disabled}
+          />
+        </Suspense>
+      )}
 
       {canAssignIssue && (
-        <div className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border bg-daintree-bg/50 border-daintree-border transition-colors">
-          {currentUserAvatar ? (
-            <img
-              src={`${currentUserAvatar}${currentUserAvatar.includes("?") ? "&" : "?"}s=64`}
-              alt={currentUser}
-              className="w-8 h-8 rounded-full shrink-0"
-            />
-          ) : (
-            <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-overlay-medium text-daintree-text/60">
-              <UserPlus className="w-4 h-4" />
-            </div>
-          )}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-daintree-text">Assign to me</span>
-              <span className="text-xs text-daintree-text/50 font-mono">@{currentUser}</span>
-            </div>
-          </div>
-          <label className="relative inline-flex items-center cursor-pointer">
+        <label className="flex cursor-pointer items-center gap-2 text-xs text-text-secondary hover:text-daintree-text">
+          <span className="relative inline-flex shrink-0">
             <input
               type="checkbox"
               checked={assignWorktreeToSelf}
               onChange={(e) => onSetAssignWorktreeToSelf(e.target.checked)}
               disabled={disabled}
-              className="sr-only peer"
               aria-label="Assign issue to me when creating worktree"
-            />
-            <div
               className={cn(
-                "w-9 h-5 rounded-full transition-colors",
-                "peer-focus-visible:ring-2 peer-focus-visible:ring-daintree-accent",
-                "after:content-[''] after:absolute after:top-0.5 after:left-0.5",
-                "after:rounded-full after:h-4 after:w-4",
-                "after:transition-transform after:duration-150",
+                "h-4 w-7 appearance-none rounded-full border transition-colors duration-150 ease-out",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                 assignWorktreeToSelf
-                  ? "bg-daintree-accent after:translate-x-4 after:bg-text-inverse"
-                  : "bg-daintree-border after:translate-x-0 after:bg-daintree-text",
-                disabled && "opacity-50 cursor-not-allowed"
+                  ? "border-daintree-text bg-daintree-text"
+                  : "border-border-strong bg-surface-inset",
+                disabled && "cursor-not-allowed opacity-50"
               )}
             />
-          </label>
-        </div>
+            <span
+              className={cn(
+                "pointer-events-none absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full",
+                "transition-[left] duration-150 ease-out",
+                assignWorktreeToSelf
+                  ? "left-[0.875rem] bg-text-inverse"
+                  : "left-0.5 bg-text-secondary"
+              )}
+              aria-hidden="true"
+            />
+          </span>
+          {currentUserAvatar ? (
+            <img
+              src={`${currentUserAvatar}${currentUserAvatar.includes("?") ? "&" : "?"}s=48`}
+              alt=""
+              className="h-4 w-4 shrink-0 rounded-full"
+            />
+          ) : (
+            <UserPlus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          )}
+          <span className="truncate">Assign to {currentUser ? `@${currentUser}` : "me"}</span>
+        </label>
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/Worktree/views/NewBranchInput.tsx
+++ b/src/components/Worktree/views/NewBranchInput.tsx
@@ -1,9 +1,9 @@
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { Spinner } from "@/components/ui/Spinner";
-import { Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { FIELD_INPUT } from "./WorktreeFormLayout";
 import type { PrefixSuggestion } from "../branchPrefixUtils";
 
 interface NewBranchInputProps {
@@ -14,7 +14,6 @@ interface NewBranchInputProps {
   isCheckingBranch: boolean;
   errorField?: "base-branch" | "new-branch" | "worktree-path" | null;
   branchWasAutoResolved: boolean;
-  parsedBranch: { hasPrefix: boolean; prefix: string; slug: string; fullBranchName: string };
   prefixPickerOpen: boolean;
   onPrefixPickerOpenChange: (open: boolean) => void;
   prefixSuggestions: PrefixSuggestion[];
@@ -25,6 +24,14 @@ interface NewBranchInputProps {
   inputRef: React.RefObject<HTMLInputElement | null>;
 }
 
+/**
+ * Control only — "Name" lives on the form's label rail.
+ *
+ * The old mono echo line under this input is gone: it restated the input's own
+ * value, and rendered a bare "..." before anything was typed, which read as a
+ * broken field. The base → branch preview in the dialog footer does that job
+ * once, for the whole form.
+ */
 export function NewBranchInput({
   value,
   onChange,
@@ -33,7 +40,6 @@ export function NewBranchInput({
   isCheckingBranch,
   errorField,
   branchWasAutoResolved,
-  parsedBranch,
   prefixPickerOpen,
   onPrefixPickerOpenChange,
   prefixSuggestions,
@@ -47,11 +53,10 @@ export function NewBranchInput({
   // the debounced check usually resolves fast — only show the spinner for
   // genuinely slow validations.
   const showCheckingSpinner = useDohertyGate(isCheckingBranch);
+  const hasError = errorField === "new-branch";
+
   return (
-    <div className="space-y-2">
-      <label htmlFor="new-branch" className="block text-sm font-medium text-daintree-text">
-        New Branch Name
-      </label>
+    <div className="space-y-1.5">
       <Popover open={prefixPickerOpen} onOpenChange={onPrefixPickerOpenChange}>
         <PopoverTrigger asChild>
           <div className="relative">
@@ -65,12 +70,16 @@ export function NewBranchInput({
               onBlur={onBlur}
               onKeyDown={onPrefixKeyDown}
               placeholder="feature/add-user-auth"
-              className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30 font-mono text-sm"
+              className={cn(
+                FIELD_INPUT,
+                "pr-9 font-mono text-xs",
+                hasError && "border-status-error"
+              )}
               disabled={isPending}
-              aria-invalid={errorField === "new-branch" ? true : undefined}
+              aria-invalid={hasError ? true : undefined}
               aria-describedby={
                 [
-                  errorField === "new-branch" ? "validation-error" : null,
+                  hasError ? "validation-error" : null,
                   branchWasAutoResolved ? "branch-resolved-hint" : null,
                 ]
                   .filter(Boolean)
@@ -83,8 +92,8 @@ export function NewBranchInput({
             />
             {showCheckingSpinner && (
               <Spinner
-                size="md"
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
+                size="sm"
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-text-secondary pointer-events-none"
               />
             )}
           </div>
@@ -103,7 +112,7 @@ export function NewBranchInput({
             scrollClassName="p-1"
           >
             {prefixSuggestions.length === 0 ? (
-              <div className="py-4 text-center text-sm text-daintree-text/60">
+              <div className="py-4 text-center text-sm text-text-secondary">
                 No matching prefixes
               </div>
             ) : (
@@ -114,37 +123,28 @@ export function NewBranchInput({
                   aria-selected={index === prefixSelectedIndex}
                   onClick={() => onPrefixSelect(suggestion)}
                   className={cn(
-                    "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                    "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-overlay-hover",
                     index === prefixSelectedIndex && "bg-overlay-selected"
                   )}
                 >
-                  <span className="font-mono text-daintree-text">{suggestion.type.prefix}/</span>
-                  <span className="text-daintree-text/60">{suggestion.type.displayName}</span>
+                  <span className="font-mono text-xs text-daintree-text">
+                    {suggestion.type.prefix}/
+                  </span>
+                  <span className="text-text-secondary">{suggestion.type.displayName}</span>
                 </div>
               ))
             )}
           </ScrollShadow>
         </PopoverContent>
       </Popover>
-      <p className="text-xs text-daintree-text/60 select-text">
-        {parsedBranch.hasPrefix ? (
-          <>
-            <span className="font-mono text-daintree-text">{parsedBranch.prefix}/</span>
-            <span className="font-mono">{parsedBranch.slug || "..."}</span>
-          </>
-        ) : (
-          <span className="font-mono">{parsedBranch.fullBranchName || "..."}</span>
-        )}
-      </p>
       {branchWasAutoResolved && (
         <p
           id="branch-resolved-hint"
-          className="text-xs text-status-success flex items-center gap-1.5 mt-1"
+          className="text-xs text-text-secondary"
           role="status"
           aria-live="polite"
         >
-          <Info className="w-3.5 h-3.5" aria-hidden="true" />
-          Name auto-incremented to avoid conflict with existing branch
+          Renamed to avoid a conflict with an existing branch
         </p>
       )}
     </div>

--- a/src/components/Worktree/views/RecipePickerPopover.tsx
+++ b/src/components/Worktree/views/RecipePickerPopover.tsx
@@ -3,6 +3,7 @@ import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { Button } from "@/components/ui/button";
 import { Check, ChevronsUpDown, Copy, Play } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { FIELD_TRIGGER } from "./WorktreeFormLayout";
 import type { TerminalRecipe } from "@/types";
 import { getRecipeScope } from "@/utils/recipeScope";
 import { CLONE_LAYOUT_ID } from "../hooks/useRecipePicker";
@@ -17,8 +18,13 @@ interface RecipePickerPopoverProps {
   onSelectRecipe: (id: string | null) => void;
   onMarkTouched: () => void;
   disabled?: boolean;
-  label: string;
   listId: string;
+  /**
+   * Renders a stacked label above the trigger. The create-worktree dialog omits
+   * it — that form carries labels on its own rail — while the bulk-create
+   * dialog still stacks them.
+   */
+  label?: string;
 }
 
 export function RecipePickerPopover({
@@ -31,8 +37,8 @@ export function RecipePickerPopover({
   onSelectRecipe,
   onMarkTouched,
   disabled,
-  label,
   listId,
+  label,
 }: RecipePickerPopoverProps) {
   const handleSelect = (id: string | null) => {
     onMarkTouched();
@@ -40,144 +46,146 @@ export function RecipePickerPopover({
     onOpenChange(false);
   };
 
+  const picker = (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          id={`${listId}-trigger`}
+          variant="ghost"
+          role="combobox"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-controls={listId}
+          className={FIELD_TRIGGER}
+          disabled={disabled}
+        >
+          <span className="flex items-center gap-2 truncate">
+            {selectedRecipeId === CLONE_LAYOUT_ID ? (
+              <>
+                <Copy className="shrink-0 text-text-secondary" />
+                <span>Clone current layout</span>
+              </>
+            ) : selectedRecipe ? (
+              <>
+                <Play className="shrink-0 text-text-secondary" />
+                <span>{selectedRecipe.name}</span>
+                <span className="text-xs text-text-secondary">
+                  ({selectedRecipe.terminals.length} terminal
+                  {selectedRecipe.terminals.length !== 1 ? "s" : ""})
+                </span>
+              </>
+            ) : (
+              <>
+                <Play className="shrink-0 text-text-secondary" />
+                <span className="text-text-secondary">No recipe</span>
+              </>
+            )}
+          </span>
+          <ChevronsUpDown className="text-text-secondary shrink-0" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[400px] p-0"
+        align="start"
+        onEscapeKeyDown={(e) => e.stopPropagation()}
+      >
+        <ScrollShadow id={listId} role="listbox" className="max-h-[300px]" scrollClassName="p-1">
+          <div
+            role="option"
+            aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                handleSelect(CLONE_LAYOUT_ID);
+              }
+            }}
+            onClick={() => handleSelect(CLONE_LAYOUT_ID)}
+            className={cn(
+              "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-overlay-hover",
+              selectedRecipeId === CLONE_LAYOUT_ID && "bg-overlay-selected"
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Copy className="h-3.5 w-3.5 text-text-secondary" />
+              <span>Clone current layout</span>
+            </div>
+            {selectedRecipeId === CLONE_LAYOUT_ID && (
+              <Check className="h-4 w-4 shrink-0 text-daintree-text" />
+            )}
+          </div>
+          <div
+            role="option"
+            aria-selected={selectedRecipeId === null}
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                handleSelect(null);
+              }
+            }}
+            onClick={() => handleSelect(null)}
+            className={cn(
+              "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-overlay-hover",
+              selectedRecipeId === null && "bg-overlay-selected"
+            )}
+          >
+            <span className="text-text-secondary">No recipe</span>
+            {selectedRecipeId === null && <Check className="h-4 w-4 shrink-0 text-daintree-text" />}
+          </div>
+          {recipes.map((recipe) => (
+            <div
+              key={recipe.id}
+              role="option"
+              aria-selected={recipe.id === selectedRecipeId}
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  handleSelect(recipe.id);
+                }
+              }}
+              onClick={() => handleSelect(recipe.id)}
+              className={cn(
+                "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-overlay-hover",
+                recipe.id === selectedRecipeId && "bg-overlay-selected",
+                recipe.shadowedBy && "opacity-60"
+              )}
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="truncate">{recipe.name}</span>
+                <span className="text-xs text-text-secondary shrink-0">
+                  {getRecipeScope(recipe).label}
+                </span>
+                <span className="text-xs text-text-secondary shrink-0">
+                  {recipe.terminals.length} terminal
+                  {recipe.terminals.length !== 1 ? "s" : ""}
+                </span>
+                {recipe.shadowedBy && (
+                  <span className="text-xs text-text-secondary shrink-0">Overridden by Team</span>
+                )}
+                {recipe.id === defaultRecipeId && (
+                  <span className="text-xs text-text-secondary shrink-0">(default)</span>
+                )}
+              </div>
+              {recipe.id === selectedRecipeId && (
+                <Check className="h-4 w-4 shrink-0 text-daintree-text" />
+              )}
+            </div>
+          ))}
+        </ScrollShadow>
+      </PopoverContent>
+    </Popover>
+  );
+
+  if (!label) return picker;
+
   return (
     <div className="space-y-2">
-      <label htmlFor={`${listId}-trigger`} className="block text-sm font-medium text-daintree-text">
+      <label htmlFor={`${listId}-trigger`} className="block text-sm text-text-secondary">
         {label}
       </label>
-      <Popover open={open} onOpenChange={onOpenChange}>
-        <PopoverTrigger asChild>
-          <Button
-            id={`${listId}-trigger`}
-            variant="outline"
-            role="combobox"
-            aria-expanded={open}
-            aria-haspopup="listbox"
-            aria-controls={listId}
-            className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-            disabled={disabled}
-          >
-            <span className="flex items-center gap-2 truncate">
-              {selectedRecipeId === CLONE_LAYOUT_ID ? (
-                <>
-                  <Copy className="shrink-0 text-daintree-accent" />
-                  <span>Clone current layout</span>
-                </>
-              ) : selectedRecipe ? (
-                <>
-                  <Play className="shrink-0 text-daintree-accent" />
-                  <span>{selectedRecipe.name}</span>
-                  <span className="text-xs text-daintree-text/50">
-                    ({selectedRecipe.terminals.length} terminal
-                    {selectedRecipe.terminals.length !== 1 ? "s" : ""})
-                  </span>
-                </>
-              ) : (
-                <>
-                  <Play className="shrink-0 text-daintree-accent" />
-                  <span className="text-daintree-text/60">Empty</span>
-                </>
-              )}
-            </span>
-            <ChevronsUpDown className="text-text-muted shrink-0" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          className="w-[400px] p-0"
-          align="start"
-          onEscapeKeyDown={(e) => e.stopPropagation()}
-        >
-          <ScrollShadow id={listId} role="listbox" className="max-h-[300px]" scrollClassName="p-1">
-            <div
-              role="option"
-              aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
-              tabIndex={0}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  handleSelect(CLONE_LAYOUT_ID);
-                }
-              }}
-              onClick={() => handleSelect(CLONE_LAYOUT_ID)}
-              className={cn(
-                "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                selectedRecipeId === CLONE_LAYOUT_ID && "bg-daintree-border"
-              )}
-            >
-              <div className="flex items-center gap-2">
-                <Copy className="h-3.5 w-3.5 text-daintree-text/50" />
-                <span>Clone current layout</span>
-              </div>
-              {selectedRecipeId === CLONE_LAYOUT_ID && (
-                <Check className="h-4 w-4 shrink-0 text-daintree-text" />
-              )}
-            </div>
-            <div
-              role="option"
-              aria-selected={selectedRecipeId === null}
-              tabIndex={0}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  handleSelect(null);
-                }
-              }}
-              onClick={() => handleSelect(null)}
-              className={cn(
-                "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                selectedRecipeId === null && "bg-daintree-border"
-              )}
-            >
-              <span className="text-daintree-text/60">Empty</span>
-              {selectedRecipeId === null && (
-                <Check className="h-4 w-4 shrink-0 text-daintree-text" />
-              )}
-            </div>
-            {recipes.map((recipe) => (
-              <div
-                key={recipe.id}
-                role="option"
-                aria-selected={recipe.id === selectedRecipeId}
-                tabIndex={0}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    handleSelect(recipe.id);
-                  }
-                }}
-                onClick={() => handleSelect(recipe.id)}
-                className={cn(
-                  "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                  recipe.id === selectedRecipeId && "bg-daintree-border",
-                  recipe.shadowedBy && "opacity-60"
-                )}
-              >
-                <div className="flex items-center gap-2 min-w-0">
-                  <span className="truncate">{recipe.name}</span>
-                  <span className="text-xs text-daintree-text/50 shrink-0">
-                    {getRecipeScope(recipe).label}
-                  </span>
-                  <span className="text-xs text-daintree-text/50 shrink-0">
-                    {recipe.terminals.length} terminal
-                    {recipe.terminals.length !== 1 ? "s" : ""}
-                  </span>
-                  {recipe.shadowedBy && (
-                    <span className="text-xs text-daintree-text/50 shrink-0">
-                      Overridden by Team
-                    </span>
-                  )}
-                  {recipe.id === defaultRecipeId && (
-                    <span className="text-xs text-daintree-text/50 shrink-0">(default)</span>
-                  )}
-                </div>
-                {recipe.id === selectedRecipeId && (
-                  <Check className="h-4 w-4 shrink-0 text-daintree-text" />
-                )}
-              </div>
-            ))}
-          </ScrollShadow>
-        </PopoverContent>
-      </Popover>
+      {picker}
     </div>
   );
 }

--- a/src/components/Worktree/views/RecipePickerPopover.tsx
+++ b/src/components/Worktree/views/RecipePickerPopover.tsx
@@ -20,9 +20,10 @@ interface RecipePickerPopoverProps {
   disabled?: boolean;
   listId: string;
   /**
-   * Renders a stacked label above the trigger. The create-worktree dialog omits
-   * it — that form carries labels on its own rail — while the bulk-create
-   * dialog still stacks them.
+   * Renders a stacked label above the trigger. The create-worktree dialog — the
+   * only caller today — omits it, since that form carries labels on its own
+   * rail. Reserved for the bulk-create dialog (issue #11964), which stacks
+   * them.
    */
   label?: string;
 }

--- a/src/components/Worktree/views/SegmentedRadioGroup.tsx
+++ b/src/components/Worktree/views/SegmentedRadioGroup.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useShouldSkipMotion } from "@/hooks/useShouldSkipMotion";
+import { cn } from "@/lib/utils";
+
+export interface SegmentedRadioOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface SegmentedRadioGroupProps<T extends string> {
+  options: SegmentedRadioOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  "aria-label": string;
+  disabled?: boolean;
+}
+
+/**
+ * The create-worktree form's one segmented language, shared by the branch-mode
+ * and environment switches.
+ *
+ * Radio semantics with a real radiogroup keyboard model: arrow keys and
+ * Home/End move the selection, and only the checked segment is a tab stop, so
+ * the group is one stop in the tab order rather than N. `SegmentedToggle` is
+ * the sibling control for `aria-pressed` toggles; this one exists because these
+ * two switches are single-choice pickers, and screen readers should say so.
+ *
+ * The thumb slides via a measured transform rather than framer's shared-layout
+ * projection: framer is a lint-restricted heavy import (#7659), and a segment's
+ * width is knowable from the DOM. Measurement runs in a layout effect and on
+ * container resize, so a late-loading font or a changed option list moves the
+ * thumb before paint instead of leaving it stranded.
+ */
+export function SegmentedRadioGroup<T extends string>({
+  options,
+  value,
+  onChange,
+  "aria-label": ariaLabel,
+  disabled,
+}: SegmentedRadioGroupProps<T>) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [thumb, setThumb] = useState<{ left: number; width: number } | null>(null);
+  const skipMotion = useShouldSkipMotion();
+
+  const activeIndex = options.findIndex((option) => option.value === value);
+
+  const measure = useCallback(() => {
+    const button = buttonRefs.current[activeIndex];
+    const container = containerRef.current;
+    if (!button || !container) {
+      setThumb(null);
+      return;
+    }
+    setThumb({ left: button.offsetLeft, width: button.offsetWidth });
+  }, [activeIndex]);
+
+  useLayoutEffect(() => {
+    measure();
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [measure, options.length]);
+
+  const select = (index: number) => {
+    const option = options[index];
+    if (!option) return;
+    onChange(option.value);
+    buttonRefs.current[index]?.focus();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (disabled || options.length === 0) return;
+    // Wrap from an unmatched value too: -1 still has to move somewhere sane.
+    const from = activeIndex === -1 ? 0 : activeIndex;
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        select((from + 1) % options.length);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        select((from - 1 + options.length) % options.length);
+        break;
+      case "Home":
+        event.preventDefault();
+        select(0);
+        break;
+      case "End":
+        event.preventDefault();
+        select(options.length - 1);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative isolate inline-flex shrink-0 rounded-[var(--radius-md)] bg-surface-inset p-0.5"
+      role="radiogroup"
+      aria-label={ariaLabel}
+      onKeyDown={handleKeyDown}
+    >
+      {thumb && (
+        <span
+          className={cn(
+            "absolute top-0.5 bottom-0.5 left-0 z-0 rounded-[var(--radius-sm)] pointer-events-none",
+            "bg-surface-panel-elevated border border-border-default shadow-[var(--theme-shadow-ambient)]",
+            // Only the thumb's own geometry animates, and reduced motion drops
+            // it entirely rather than shortening it.
+            !skipMotion && "transition-[translate,width] duration-150 ease-out",
+            "motion-reduce:transition-none",
+            disabled && "opacity-40"
+          )}
+          style={{ translate: `${thumb.left}px 0`, width: thumb.width }}
+          aria-hidden="true"
+        />
+      )}
+      {options.map((option, index) => {
+        const isActive = option.value === value;
+        return (
+          <button
+            key={option.value}
+            ref={(el) => {
+              buttonRefs.current[index] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            // Roving tabindex: the group is one tab stop, arrows move within it.
+            tabIndex={isActive || (activeIndex === -1 && index === 0) ? 0 : -1}
+            onClick={() => onChange(option.value)}
+            disabled={disabled}
+            className={cn(
+              "relative z-10 px-2.5 py-1 text-xs font-medium rounded-[var(--radius-sm)]",
+              "transition-colors duration-150 ease-out",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1",
+              "disabled:cursor-not-allowed disabled:pointer-events-none",
+              isActive ? "text-daintree-text" : "text-text-secondary hover:text-daintree-text",
+              disabled && "opacity-40"
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Worktree/views/WorktreeFormLayout.tsx
+++ b/src/components/Worktree/views/WorktreeFormLayout.tsx
@@ -1,0 +1,136 @@
+import { useId } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Field chrome for the create-worktree form. Deliberately the same language as
+ * `SettingsInput` — one recessed surface, one border weight — so the dialog
+ * reads as a single designed surface instead of a stack of separately-styled
+ * boxes. Focus is the global accent outline; nothing here paints accent at rest.
+ */
+export const FIELD_SURFACE =
+  "bg-surface-input border border-border-strong rounded-[var(--radius-md)] transition-colors duration-150 ease-out";
+
+export const FIELD_FOCUS =
+  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
+
+export const FIELD_INPUT = cn(
+  FIELD_SURFACE,
+  FIELD_FOCUS,
+  "w-full h-8 px-2.5 text-sm text-daintree-text placeholder:text-text-placeholder",
+  "disabled:opacity-50 disabled:cursor-not-allowed"
+);
+
+/**
+ * Combobox triggers are `Button`s. `ghost` is the base because it carries no
+ * ring/shadow of its own to fight — the field chrome below is the whole look.
+ */
+export const FIELD_TRIGGER = cn(
+  FIELD_SURFACE,
+  "w-full h-8 justify-between px-2.5 font-normal text-daintree-text",
+  "hover:bg-surface-hover hover:text-daintree-text hover:border-border-default"
+);
+
+const LABEL_CLASSES = "text-xs text-text-secondary";
+
+interface FormSectionProps {
+  title: string;
+  /** Section-level control (e.g. the branch-mode switch) pinned to the right of the rule. */
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+/**
+ * The single grid every section and row lands in. One grid for the whole form,
+ * not one per section, so the label rail is the same column everywhere — with a
+ * grid per section, a long label in one section would silently widen that
+ * section's rail and break alignment against the others.
+ *
+ * `max-content` sizes the rail to the longest label rather than a guessed
+ * width, which keeps it honest under translation; the `4rem` floor stops a form
+ * of short labels from collapsing it.
+ */
+export function FormGrid({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[minmax(4rem,max-content)_minmax(0,1fr)] items-center gap-x-3 gap-y-1.5">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * A titled group of rows. The hairline between title and action is what turns a
+ * flat field stack into readable sections without spending another border on
+ * every control.
+ *
+ * Renders a fragment: the header spans both columns of {@link FormGrid} and the
+ * rows drop straight into it, so sections group visually without taking the
+ * rows out of the shared rail.
+ */
+export function FormSection({ title, action, children }: FormSectionProps) {
+  return (
+    <>
+      <div className="col-span-2 flex items-center gap-3 [&:not(:first-child)]:mt-3">
+        <h3 className="text-xs font-semibold text-daintree-text shrink-0">{title}</h3>
+        <span className="h-px flex-1 bg-border-subtle" aria-hidden="true" />
+        {action}
+      </div>
+      {children}
+    </>
+  );
+}
+
+interface FormRowProps {
+  label?: string;
+  /** Id of the labelled control. Omit for composite controls — see below. */
+  htmlFor?: string;
+  /** Secondary content under the control — hints, inline toggles, status. */
+  hint?: React.ReactNode;
+  /**
+   * The control already carries its own accessible name (e.g. a radiogroup with
+   * `aria-label`). Skips the group wrapper, which would otherwise make screen
+   * readers announce the name twice — "Environment, group, Environment, radio
+   * group". Keep the control's name matching the visible label (WCAG 2.5.3).
+   */
+  selfLabelled?: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * One control on the section's shared label rail. Returns a fragment so its
+ * cells land directly in that grid — a wrapper element would give each row its
+ * own independent columns and the rail would stop lining up.
+ *
+ * A row whose control is a single element names it with a real `<label for>`.
+ * A row whose control is composite (a radiogroup, a forge-contributed slot)
+ * cannot be, so it labels the control region as a `role="group"` instead —
+ * visually aligned is not the same as programmatically named.
+ */
+export function FormRow({ label, htmlFor, hint, selfLabelled, children }: FormRowProps) {
+  const labelId = useId();
+  const needsGroupLabel = !!label && !htmlFor && !selfLabelled;
+
+  return (
+    <>
+      {label ? (
+        htmlFor ? (
+          <label htmlFor={htmlFor} className={LABEL_CLASSES}>
+            {label}
+          </label>
+        ) : (
+          <span id={labelId} className={LABEL_CLASSES}>
+            {label}
+          </span>
+        )
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      <div
+        className="min-w-0"
+        {...(needsGroupLabel ? { role: "group", "aria-labelledby": labelId } : {})}
+      >
+        {children}
+      </div>
+      {hint && <div className="col-start-2 min-w-0">{hint}</div>}
+    </>
+  );
+}

--- a/src/components/Worktree/views/WorktreePathPicker.tsx
+++ b/src/components/Worktree/views/WorktreePathPicker.tsx
@@ -1,8 +1,9 @@
-import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/Spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { FolderOpen, Info } from "lucide-react";
+import { FolderOpen } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { FIELD_SURFACE } from "./WorktreeFormLayout";
 
 interface WorktreePathPickerProps {
   value: string;
@@ -15,6 +16,14 @@ interface WorktreePathPickerProps {
   disabled?: boolean;
 }
 
+/**
+ * Control only — "Path" lives on the form's label rail.
+ *
+ * Input and browse action are one compound control rather than a field with a
+ * detached button beside it: they are a single decision, and the seam made the
+ * row read as assembled parts. The focus ring is hoisted to the wrapper via
+ * `focus-within` so the whole control lights up as one object.
+ */
 export function WorktreePathPicker({
   value,
   onChange,
@@ -29,62 +38,61 @@ export function WorktreePathPicker({
   // the debounced generation usually resolves fast — only show the spinner for
   // genuinely slow lookups.
   const showGeneratingSpinner = useDohertyGate(isGeneratingPath);
+  const hasError = errorField === "worktree-path";
+
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <label htmlFor="worktree-path" className="block text-sm font-medium text-daintree-text">
-          Worktree Path
-        </label>
+    <div className="space-y-1.5">
+      <div
+        className={cn(
+          FIELD_SURFACE,
+          "flex h-8 items-center overflow-hidden",
+          // Scoped to the input rather than focus-within: the browse button paints
+          // its own ring, and focus-within would stack a second one around the pair.
+          "has-[input:focus-visible]:outline has-[input:focus-visible]:outline-2 has-[input:focus-visible]:outline-daintree-accent has-[input:focus-visible]:outline-offset-2",
+          hasError && "border-status-error"
+        )}
+      >
+        <input
+          id="worktree-path"
+          data-testid="worktree-path-input"
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="/path/to/worktree"
+          className="min-w-0 flex-1 bg-transparent px-2.5 font-mono text-xs text-daintree-text placeholder:text-text-placeholder focus:outline-hidden disabled:opacity-50"
+          disabled={isPending}
+          aria-invalid={hasError ? true : undefined}
+          aria-describedby={hasError ? "validation-error" : undefined}
+        />
+        {showGeneratingSpinner && (
+          <Spinner size="sm" className="mr-1.5 shrink-0 text-text-secondary" />
+        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <button
               type="button"
-              className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-              aria-label="Help for Worktree Path field"
+              onClick={onBrowseClick}
               disabled={disabled}
+              aria-label="Browse for a worktree directory"
+              className={cn(
+                "flex h-full w-8 shrink-0 items-center justify-center border-l border-border-subtle",
+                "text-text-secondary transition-colors duration-150 ease-out",
+                "hover:bg-overlay-hover hover:text-daintree-text",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2",
+                "disabled:opacity-50 disabled:cursor-not-allowed"
+              )}
             >
-              <Info className="w-3.5 h-3.5" aria-hidden="true" />
-              <span className="sr-only">Help for Worktree Path field</span>
+              <FolderOpen className="h-3.5 w-3.5" aria-hidden="true" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="right">
-            <p>Directory where the worktree will be created</p>
+          <TooltipContent side="left">
+            <p>Browse for a directory</p>
           </TooltipContent>
         </Tooltip>
       </div>
-      <div className="flex gap-2 items-center">
-        <div className="relative flex-1">
-          <input
-            id="worktree-path"
-            data-testid="worktree-path-input"
-            type="text"
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            placeholder="/path/to/worktree"
-            className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
-            disabled={isPending}
-            aria-invalid={errorField === "worktree-path" ? true : undefined}
-            aria-describedby={errorField === "worktree-path" ? "validation-error" : undefined}
-          />
-          {showGeneratingSpinner && (
-            <Spinner
-              size="md"
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
-            />
-          )}
-        </div>
-        <Button variant="outline" size="sm" onClick={onBrowseClick} disabled={disabled}>
-          <FolderOpen />
-        </Button>
-      </div>
       {pathWasAutoResolved && (
-        <p
-          className="text-xs text-status-success flex items-center gap-1.5 mt-1"
-          role="status"
-          aria-live="polite"
-        >
-          <Info className="w-3.5 h-3.5" aria-hidden="true" />
-          Path auto-incremented to avoid conflict with existing directory
+        <p className="text-xs text-text-secondary" role="status" aria-live="polite">
+          Renamed to avoid a conflict with an existing directory
         </p>
       )}
     </div>

--- a/src/components/Worktree/views/WorktreePathPicker.tsx
+++ b/src/components/Worktree/views/WorktreePathPicker.tsx
@@ -21,8 +21,8 @@ interface WorktreePathPickerProps {
  *
  * Input and browse action are one compound control rather than a field with a
  * detached button beside it: they are a single decision, and the seam made the
- * row read as assembled parts. The focus ring is hoisted to the wrapper via
- * `focus-within` so the whole control lights up as one object.
+ * row read as assembled parts. The focus ring is hoisted to the wrapper, scoped
+ * to the input, so the whole control lights up as one object.
  */
 export function WorktreePathPicker({
   value,

--- a/src/components/Worktree/views/__tests__/ExistingBranchPicker.test.tsx
+++ b/src/components/Worktree/views/__tests__/ExistingBranchPicker.test.tsx
@@ -41,7 +41,7 @@ describe("ExistingBranchPicker trigger", () => {
   it("prompts for a local branch when none is chosen", () => {
     renderPicker();
     expect(screen.getByTestId("existing-branch-picker").textContent).toContain(
-      "Select a local branch..."
+      "Select a local branch"
     );
   });
 

--- a/src/components/Worktree/views/__tests__/RecipePickerPopover.test.tsx
+++ b/src/components/Worktree/views/__tests__/RecipePickerPopover.test.tsx
@@ -40,11 +40,11 @@ function renderPicker(recipes: TerminalRecipe[], props?: { defaultRecipeId?: str
   );
 }
 
-/** The rows for real recipes, minus the fixed "Clone current layout" / "Empty" entries. */
+/** The rows for real recipes, minus the fixed "Clone current layout" / "No recipe" entries. */
 function recipeRows() {
   return within(screen.getByRole("listbox"))
     .getAllByRole("option")
-    .filter((row) => !/Clone current layout|^Empty$/.test(row.textContent ?? ""));
+    .filter((row) => !/Clone current layout|^No recipe$/.test(row.textContent ?? ""));
 }
 
 afterEach(cleanup);

--- a/src/components/Worktree/views/__tests__/SegmentedRadioGroup.test.tsx
+++ b/src/components/Worktree/views/__tests__/SegmentedRadioGroup.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach, beforeAll, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { SegmentedRadioGroup } from "../SegmentedRadioGroup";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+});
+
+afterEach(cleanup);
+
+const OPTIONS = [
+  { value: "new", label: "New branch" },
+  { value: "existing", label: "Existing branch" },
+  { value: "third", label: "Third" },
+];
+
+function renderGroup(value = "new") {
+  const onChange = vi.fn();
+  render(
+    <SegmentedRadioGroup
+      options={OPTIONS}
+      value={value}
+      onChange={onChange}
+      aria-label="Branch mode"
+    />
+  );
+  return { onChange, group: screen.getByRole("radiogroup", { name: "Branch mode" }) };
+}
+
+describe("SegmentedRadioGroup keyboard model", () => {
+  it("keeps the group to a single tab stop by roving tabindex onto the checked segment", () => {
+    renderGroup("existing");
+
+    const tabbable = screen
+      .getAllByRole("radio")
+      .filter((radio) => radio.getAttribute("tabindex") === "0");
+
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0]?.textContent).toBe("Existing branch");
+  });
+
+  it("moves the selection forward and wraps past the last segment", () => {
+    const { onChange, group } = renderGroup("third");
+
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+
+    expect(onChange).toHaveBeenCalledWith("new");
+  });
+
+  it("moves the selection backward and wraps past the first segment", () => {
+    const { onChange, group } = renderGroup("new");
+
+    fireEvent.keyDown(group, { key: "ArrowLeft" });
+
+    expect(onChange).toHaveBeenCalledWith("third");
+  });
+
+  it("treats vertical arrows as equivalent to horizontal ones", () => {
+    const { onChange, group } = renderGroup("new");
+
+    fireEvent.keyDown(group, { key: "ArrowDown" });
+
+    expect(onChange).toHaveBeenCalledWith("existing");
+  });
+
+  it("jumps to the ends on Home and End", () => {
+    const { onChange, group } = renderGroup("existing");
+
+    fireEvent.keyDown(group, { key: "Home" });
+    expect(onChange).toHaveBeenCalledWith("new");
+
+    fireEvent.keyDown(group, { key: "End" });
+    expect(onChange).toHaveBeenCalledWith("third");
+  });
+
+  it("leaves unrelated keys to the surrounding form", () => {
+    const { onChange, group } = renderGroup();
+
+    fireEvent.keyDown(group, { key: "Enter" });
+    fireEvent.keyDown(group, { key: "a" });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("still exposes a tab stop when the value matches no segment", () => {
+    renderGroup("unknown-mode");
+
+    const tabbable = screen
+      .getAllByRole("radio")
+      .filter((radio) => radio.getAttribute("tabindex") === "0");
+
+    expect(tabbable).toHaveLength(1);
+    expect(
+      screen.getAllByRole("radio").every((r) => r.getAttribute("aria-checked") === "false")
+    ).toBe(true);
+  });
+
+  it("moves off an unmatched value rather than getting stuck", () => {
+    const { onChange, group } = renderGroup("unknown-mode");
+
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+
+    expect(onChange).toHaveBeenCalledWith("existing");
+  });
+});

--- a/src/components/Worktree/views/index.ts
+++ b/src/components/Worktree/views/index.ts
@@ -8,3 +8,4 @@ export { NewBranchInput } from "./NewBranchInput";
 export { WorktreePathPicker } from "./WorktreePathPicker";
 export { EnvironmentRadioGroup } from "./EnvironmentRadioGroup";
 export { RecipePickerPopover } from "./RecipePickerPopover";
+export { FormGrid, FormSection, FormRow } from "./WorktreeFormLayout";

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -209,13 +209,10 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Terminal/UpdateCwdDialog.tsx",
     "src/components/Terminal/VoiceInputButton.tsx",
     "src/components/TerminalRecipe/RecipeEditor.tsx",
-    "src/components/Worktree/NewWorktreeDialog.tsx",
     "src/components/Worktree/QuickCreatePalette.tsx",
     "src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx",
     "src/components/Worktree/WorktreeDeleteDialog.tsx",
     "src/components/Worktree/WorktreeFilterPopover.tsx",
-    "src/components/Worktree/views/IssueSelectorView.tsx",
-    "src/components/Worktree/views/RecipePickerPopover.tsx",
     "src/hooks/useUpdateListener.tsx",
   ],
 };

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -228,6 +228,12 @@ type FocusRingAllowlistEntry = {
 
 const ALLOWLIST: FocusRingAllowlistEntry[] = [
   {
+    file: "src/components/Worktree/views/WorktreePathPicker.tsx",
+    fragment: "focus:outline-hidden disabled:opacity-50",
+    reason:
+      "Path input and its browse button are one compound control — the ring is painted once on the wrapper via has-[input:focus-visible], so an element-owned ring here would draw a second ring around the pair",
+  },
+  {
     file: "src/components/HelpPanel/HelpPanel.tsx",
     fragment: "relative shrink-0 flex flex-col h-full overflow-hidden outline-hidden",
     reason:


### PR DESCRIPTION
The create-worktree dialog was a flat stack of seven equal-weight fields, each with its own label row, its own border and its own accent glyph. It worked, but it read like a web form that happened to be in a modal rather than part of the app.

## What changed

**Composition.** Three sections, Branch, Destination, Setup, with the branch decision leading and issue-linking demoted out of the first slot, where it used to sit directly above a segmented control it had nothing to do with.

**Label rail.** Labels move off their own rows onto a shared rail, which roughly halves the form's height. The rail is one grid for the whole form rather than one per section, so a long label anywhere sizes the column everywhere and the sections can't drift out of alignment.

**Branch mode as section chrome.** It sits on the Branch header now instead of claiming a row, and it finally has the keyboard model its `role="radiogroup"` was already promising: roving tabindex so the group is one tab stop, arrows that wrap, Home/End. Extracted to `SegmentedRadioGroup` and shared with the environment switch, so there's one segmented language instead of two copies. The thumb slides via a measured transform rather than framer, since framer is a lint-restricted heavy import (#7659) and a segment's width is knowable from the DOM.

**Compound path control.** The input and its browse button are one bordered object rather than a field with a detached button beside it.

**The footer says what will happen.** The mono echo line under the branch input is gone; it restated the input's own value and rendered a bare `...` before you'd typed anything, which read as a broken field. The footer shows `develop → feature/foo` when the form is ready and names what's missing when it isn't. Submit deliberately stays enabled while incomplete, because clicking it tells you what's wrong, which beats a disabled button that explains nothing.

**Cmd/Ctrl+Enter submits**, from inside the pickers too, and is exposed via `aria-keyshortcuts` rather than only drawn on the button.

## The primary button

The CTA is now the high-contrast neutral variant instead of the accent green. Previously the header icon, the focused field, the recipe glyph and the CTA were all painting accent at once; this leaves the focus ring as the only accent in the dialog. Accent also comes off the header icon, the recipe glyphs and the issue selector, and those three files come off the accent-guard allowlist, since the hygiene ratchet fails when a listed file no longer paints accent.

It stays theme-aware by construction. `variant="contrast"` is `bg-daintree-text text-text-inverse`, so the fill is the theme's own text colour: near-white on the dark themes, near-black on the light ones. Nothing here is a hardcoded white. Making this the standard for the rest of the app is #11963.

## A correctness fix along the way

`fromRemote` creates the branch from a remote ref, it does not set up upstream tracking. Mid-redesign I relabelled it "Track the remote branch", which is a different thing, so it's back to "Create from remote branch". The rest of the copy is now sentence case, and "(Optional)" is gone, since hierarchy already says that.

## Loading

The skeleton is built from the same flags as the resolved form (existing-branch mode, whether the forge offers an issue selector, whether there are environments or recipes) and renders through the same `FormGrid`/`FormSection`, including the hint row the remote-branch checkbox occupies. Resolving the branch list can't shift the layout.

## Verification

- `npm run check` clean. Full unit suite green: 51,182 passing. The `full-worktree` dialog spec passes 7/7.
- New unit coverage for the radiogroup keyboard model (roving tabindex, arrow wrapping, Home/End).
- Adds an opt-in screenshot harness, `e2e/screenshots/worktree-dialog-review.spec.ts`, modelled on the theme-review one. It renders the dialog's states and, per theme, the populated form. The dialog was checked in all 15 built-in themes, both polarities. Nothing paints a hardcoded colour.

Screenshots to follow as attachments.

One note for anyone running the harness locally: it needs `npm run build` first, since it launches the built app. A worktree without `node_modules` symlinked and without a build is why the app "won't start" there.

## Follow-ups

- #11963 makes the neutral CTA the standard across the ~65 other dialog surfaces
- #11964 rebuilds the bulk-create worktree dialog on the same form layout
- #11965 moves the remaining stacked-label forms onto the rail