### PR TITLE
fix(pilot): derive the worktree axis from the project's worktrees, not its live agents

### DIFF
--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -8,6 +8,7 @@ import { usePilotStore } from "@/store/pilotStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
+import { useWorktreeStoreOptional } from "@/hooks/useWorktreeStore";
 import { actionService } from "@/services/ActionService";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
@@ -625,22 +626,38 @@ function findParkTarget(
 }
 
 /**
- * Whether this group is a project whose rows, as currently narrowed, span more
- * than one worktree.
+ * Whether this group is a project with a worktree axis to drill into.
  *
  * A type predicate so the drill target is proven to be a project group at the
  * one place that reads its workspace id. Computed from the DISPLAYED rows, so a
  * query that narrows a project down to a single worktree also withdraws the
  * affordance rather than offering a regrouping that would change nothing.
+ *
+ * `currentViewWorktreeCount` is the enrichment, and the `isCurrent` check is
+ * what keeps it honest: it is the count for the ONE project this renderer view
+ * owns, and lending it to a neighbouring project's group would draw a chevron
+ * on a heading using a number about somewhere else entirely (#11950 — worktree
+ * metadata exists for the view's own project and for no other). Every foreign
+ * project stays on the run-derived answer, which is all this view can prove
+ * about them. The scoped chord only ever asks about this view's own workspace,
+ * so the chevron and the chord still agree everywhere both are offered.
  */
-function canDrill(group: PilotDisplayGroup): group is PilotProjectGroup {
-  return group.axis === "workspace" && hasWorktreeAxis(group.rows.map((row) => row.run));
+function canDrill(
+  group: PilotDisplayGroup,
+  currentViewWorktreeCount: number
+): group is PilotProjectGroup {
+  if (group.axis !== "workspace") return false;
+  return hasWorktreeAxis(
+    group.rows.map((row) => row.run),
+    group.isCurrent ? currentViewWorktreeCount : undefined
+  );
 }
 
 export function PilotView() {
   const isOpen = usePilotStore((s) => s.isOpen);
   const close = usePilotStore((s) => s.close);
   const scope = usePilotStore((s) => s.scope);
+  const fellBackFrom = usePilotStore((s) => s.fellBackFrom);
   const showFleet = usePilotStore((s) => s.showFleet);
   const openProject = usePilotStore((s) => s.openProject);
   const snapshot = useFleetSnapshotStore((s) => s.snapshot);
@@ -648,6 +665,29 @@ export function PilotView() {
   const scratches = useScratchStore((s) => s.scratches);
   const pilotShortcut = useEffectiveCombo("pilot.toggle");
   const scopedShortcut = useEffectiveCombo("pilot.openProject");
+
+  /**
+   * What this view's own project knows about its worktrees, as opposed to what
+   * its live agents happen to reveal (#11957).
+   *
+   * Subscribed rather than read once, because closing the last agent in a
+   * worktree — or creating a worktree while the overview is open — has to move
+   * the chevron with it. Both selectors return a primitive, which is what keeps
+   * an unrelated worktree update (a git-status poll rewriting a snapshot) from
+   * re-rendering this surface: only the count or the identity of the main
+   * worktree changing does.
+   *
+   * Optional because this is an overlay, not the project view. It renders in
+   * tests and could render before the provider mounts; a missing store just
+   * means no enrichment, which is exactly the pre-#11957 behavior.
+   */
+  const viewWorktreeCount = useWorktreeStoreOptional((s) => s.worktrees.size, 0);
+  const viewMainWorktreeId = useWorktreeStoreOptional<string | null>((s) => {
+    for (const [id, worktree] of s.worktrees) {
+      if (worktree.isMainWorktree === true) return id;
+    }
+    return null;
+  }, null);
 
   useOverlayClaim("pilot", isOpen);
 
@@ -775,8 +815,30 @@ export function PilotView() {
    */
   const displayGroups = useMemo<PilotDisplayGroup[]>(() => {
     if (scope.kind === "fleet") return liveGroups;
-    return scopedProject === null ? [] : buildPilotWorktreeGroups(scopedProject);
-  }, [scope.kind, liveGroups, scopedProject]);
+    if (scopedProject === null) return [];
+    // The root checkout leads, and only where this view can name it: the drill
+    // is reachable on a neighbouring project's heading too, and this view's
+    // worktree store describes its own project only. A foreign project keeps
+    // the label order, which is the honest answer there.
+    return buildPilotWorktreeGroups(
+      scopedProject,
+      scopedProject.isCurrent ? viewMainWorktreeId : null
+    );
+  }, [scope.kind, liveGroups, scopedProject, viewMainWorktreeId]);
+
+  /**
+   * The project a scoped opening asked for and could not give, named.
+   *
+   * Null unless this opening is the fallback, so a later back-out to the fleet
+   * from a scope the user chose does not inherit an explanation about a
+   * different gesture. Null too when the map cannot name the workspace: a line
+   * that says something has no worktree axis without saying WHICH something is
+   * worse than the silence it replaces.
+   */
+  const fallbackName =
+    scope.kind === "fleet" && fellBackFrom !== null
+      ? (workspaces.get(fellBackFrom)?.name ?? null)
+      : null;
 
   /** The scoped project's name, for the breadcrumb and the copy around it. */
   const scopedName =
@@ -1078,7 +1140,7 @@ export function PilotView() {
    */
   const drillTarget =
     scope.kind === "fleet" && selectedRow !== null && selectedRow.kind === "item"
-      ? canDrill(selectedRow.group)
+      ? canDrill(selectedRow.group, viewWorktreeCount)
         ? selectedRow.group.workspaceId
         : null
       : null;
@@ -1424,6 +1486,32 @@ export function PilotView() {
               </div>
             )}
 
+            {/*
+              Why this is the fleet when a project was asked for.
+
+              The scoped chord's fallback lands on a surface byte for byte
+              identical to the one the unscoped chord gives, so without a word
+              here the key is indistinguishable from a dead one (#11957). It
+              stays a line of text: nothing has gone wrong, there is nothing to
+              retry, and the user is already looking at the surface it describes
+              — a toast or an inbox entry would outlive the opening it belongs
+              to and interrupt for a routine outcome.
+
+              `role="status"` because the whole point is that the surface is not
+              the one that was asked for, and a screen reader hearing only the
+              dialog's "All agents" label would be told the same thing the
+              unscoped chord says.
+            */}
+            {fallbackName !== null && (
+              <p
+                role="status"
+                data-testid="pilot-fallback-note"
+                className="mb-1.5 min-w-0 text-[11px] leading-snug text-daintree-text/60"
+              >
+                {fallbackName} has nothing to group by worktree, so this is every agent
+              </p>
+            )}
+
             <AppPaletteDialog.Input
               inputRef={searchRef}
               value={query}
@@ -1605,7 +1693,7 @@ export function PilotView() {
             // Bound to a const so the discriminant narrows inside the drill
             // handler's closure as well as at the branch.
             const group = header.group;
-            const drillTo = canDrill(group) ? group.workspaceId : null;
+            const drillTo = canDrill(group, viewWorktreeCount) ? group.workspaceId : null;
             return (
               // `role="group"` is a permitted listbox child and carries the
               // group's name as the label for every option inside it, which is

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -8,6 +8,7 @@ import { usePilotStore } from "@/store/pilotStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
+import { isScratchWorkspaceId } from "@shared/utils/workspaceIds";
 import { useWorktreeStoreOptional } from "@/hooks/useWorktreeStore";
 import { actionService } from "@/services/ActionService";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
@@ -637,19 +638,26 @@ function findParkTarget(
  * `isCurrent`, because it is the count for the ONE project this renderer view
  * owns, and lending it to a neighbouring project's group would draw a chevron
  * on a heading using a number about somewhere else entirely (#11950 — worktree
- * metadata exists for the view's own project and for no other). And `kind`,
- * because a scratch is not a git repository: no count of its worktrees can be
- * anything but zero, whatever an unparameterized current-view accessor happens
- * to be holding. `pilot.openProject` refuses a scratch on the same grounds, and
- * the two have to refuse it the same way or the chevron and the chord disagree
- * about a workspace — the one property #11955 established by construction.
+ * metadata exists for the view's own project and for no other). And the scratch
+ * check, because a scratch is not a git repository: no count of its worktrees
+ * can be anything but zero, whatever an unparameterized current-view accessor
+ * happens to be holding. `pilot.openProject` refuses a scratch on the same
+ * grounds, and the two have to refuse it the same way or the chevron and the
+ * chord disagree about a workspace — the one property #11955 established by
+ * construction.
+ *
+ * Structural, off the id, rather than off `group.kind`. The kind is metadata
+ * and arrives asynchronously — a scratch reads `"unknown"` until its name
+ * hydrates — so keying on it would open a window where the chevron enriches a
+ * workspace the chord is already refusing. The id shape is true immediately and
+ * is the same test the action applies.
  */
 function canDrill(
   group: PilotDisplayGroup,
   currentViewWorktreeCount: number
 ): group is PilotProjectGroup {
   if (group.axis !== "workspace") return false;
-  const enriched = group.isCurrent && group.kind !== "scratch";
+  const enriched = group.isCurrent && !isScratchWorkspaceId(group.workspaceId);
   return hasWorktreeAxis(
     group.rows.map((row) => row.run),
     enriched ? currentViewWorktreeCount : undefined
@@ -846,18 +854,21 @@ export function PilotView() {
    * through the same predicates the affordance reads, on the UNNARROWED groups,
    * so the line answers "would a fresh press scope now" rather than "is the
    * chevron drawn under this query". Where the workspace has no runs at all
-   * there is no group to ask, and its own worktrees are the whole answer —
-   * safe to consult unguarded here because the only writer of `fellBackFrom`
-   * passes this view's own workspace, and refuses a scratch before it does.
+   * there is no group to ask and its own worktrees are the whole answer, so the
+   * count carries `canDrill`'s scratch guard with it: a scratch DOES record a
+   * fallback (its none is a real none), and letting the current view's worktrees
+   * answer for it would suppress the very explanation it just earned.
    */
   const fallbackGroup =
     fellBackFrom === null
       ? null
       : (liveGroups.find((group) => group.workspaceId === fellBackFrom) ?? null);
+  const fallbackWorktreeCount =
+    fellBackFrom !== null && !isScratchWorkspaceId(fellBackFrom) ? viewWorktreeCount : 0;
   const fallbackHasAxis =
     fallbackGroup !== null
-      ? canDrill(fallbackGroup, viewWorktreeCount)
-      : hasWorktreeAxis([], viewWorktreeCount);
+      ? canDrill(fallbackGroup, fallbackWorktreeCount)
+      : hasWorktreeAxis([], fallbackWorktreeCount);
   const fallbackName =
     scope.kind === "fleet" && fellBackFrom !== null && !fallbackHasAxis
       ? (workspaces.get(fellBackFrom)?.name ?? null)

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -633,23 +633,26 @@ function findParkTarget(
  * query that narrows a project down to a single worktree also withdraws the
  * affordance rather than offering a regrouping that would change nothing.
  *
- * `currentViewWorktreeCount` is the enrichment, and the `isCurrent` check is
- * what keeps it honest: it is the count for the ONE project this renderer view
+ * `currentViewWorktreeCount` is the enrichment, and two checks keep it honest.
+ * `isCurrent`, because it is the count for the ONE project this renderer view
  * owns, and lending it to a neighbouring project's group would draw a chevron
  * on a heading using a number about somewhere else entirely (#11950 — worktree
- * metadata exists for the view's own project and for no other). Every foreign
- * project stays on the run-derived answer, which is all this view can prove
- * about them. The scoped chord only ever asks about this view's own workspace,
- * so the chevron and the chord still agree everywhere both are offered.
+ * metadata exists for the view's own project and for no other). And `kind`,
+ * because a scratch is not a git repository: no count of its worktrees can be
+ * anything but zero, whatever an unparameterized current-view accessor happens
+ * to be holding. `pilot.openProject` refuses a scratch on the same grounds, and
+ * the two have to refuse it the same way or the chevron and the chord disagree
+ * about a workspace — the one property #11955 established by construction.
  */
 function canDrill(
   group: PilotDisplayGroup,
   currentViewWorktreeCount: number
 ): group is PilotProjectGroup {
   if (group.axis !== "workspace") return false;
+  const enriched = group.isCurrent && group.kind !== "scratch";
   return hasWorktreeAxis(
     group.rows.map((row) => row.run),
-    group.isCurrent ? currentViewWorktreeCount : undefined
+    enriched ? currentViewWorktreeCount : undefined
   );
 }
 
@@ -834,9 +837,29 @@ export function PilotView() {
    * different gesture. Null too when the map cannot name the workspace: a line
    * that says something has no worktree axis without saying WHICH something is
    * worse than the silence it replaces.
+   *
+   * And null once the premise stops holding. The explanation describes a
+   * decision taken at press time, and the world moves under it — create a
+   * worktree, or launch an agent in a second one, and the same press would now
+   * scope. Left up, it would put a chevron offering the drill beside a sentence
+   * saying there is nothing to group: one screen, two answers. Recomputed
+   * through the same predicates the affordance reads, on the UNNARROWED groups,
+   * so the line answers "would a fresh press scope now" rather than "is the
+   * chevron drawn under this query". Where the workspace has no runs at all
+   * there is no group to ask, and its own worktrees are the whole answer —
+   * safe to consult unguarded here because the only writer of `fellBackFrom`
+   * passes this view's own workspace, and refuses a scratch before it does.
    */
+  const fallbackGroup =
+    fellBackFrom === null
+      ? null
+      : (liveGroups.find((group) => group.workspaceId === fellBackFrom) ?? null);
+  const fallbackHasAxis =
+    fallbackGroup !== null
+      ? canDrill(fallbackGroup, viewWorktreeCount)
+      : hasWorktreeAxis([], viewWorktreeCount);
   const fallbackName =
-    scope.kind === "fleet" && fellBackFrom !== null
+    scope.kind === "fleet" && fellBackFrom !== null && !fallbackHasAxis
       ? (workspaces.get(fellBackFrom)?.name ?? null)
       : null;
 
@@ -1111,6 +1134,30 @@ export function PilotView() {
   }, []);
 
   /**
+   * Whether either narrowing is in play, which is what an empty list means.
+   *
+   * A query or a filter turning up nothing is a true statement about the
+   * narrowing. A fleet with nothing in it at all is a statement about the
+   * fleet, and only live data can make that one.
+   *
+   * Declared up here rather than beside the empty state because the drill reads
+   * it too: the affordance is computed from the rows actually drawn, so a
+   * narrowing that hides most of a project has to withdraw the enrichment along
+   * with them.
+   */
+  const hasNarrowing = query.trim().length > 0 || bandFilter !== "all";
+
+  /**
+   * The project's own worktree count, as the drill may use it.
+   *
+   * Zeroed under a narrowing, which keeps #11955's rule intact: a query that
+   * cuts a project down to one visible worktree withdraws the chevron rather
+   * than offering a regrouping of what is already one section. Unnarrowed, the
+   * project's real topology decides, which is the whole point of #11957.
+   */
+  const drillWorktreeCount = hasNarrowing ? 0 : viewWorktreeCount;
+
+  /**
    * Alt+Enter on the highlighted row opens the park editor — a second verb on
    * the same selection, so it lives beside Enter in both key paths rather
    * than in the navigation model, which owns structure and not actions.
@@ -1140,7 +1187,7 @@ export function PilotView() {
    */
   const drillTarget =
     scope.kind === "fleet" && selectedRow !== null && selectedRow.kind === "item"
-      ? canDrill(selectedRow.group, viewWorktreeCount)
+      ? canDrill(selectedRow.group, drillWorktreeCount)
         ? selectedRow.group.workspaceId
         : null
       : null;
@@ -1346,15 +1393,6 @@ export function PilotView() {
     status.kind === "stale" && fleetPhrase !== "" ? `Last known: ${fleetPhrase}` : fleetPhrase;
 
   const hasTree = renderGroups.length > 0;
-
-  /**
-   * Whether either narrowing is in play, which is what an empty list means.
-   *
-   * A query or a filter turning up nothing is a true statement about the
-   * narrowing. A fleet with nothing in it at all is a statement about the
-   * fleet, and only live data can make that one.
-   */
-  const hasNarrowing = query.trim().length > 0 || bandFilter !== "all";
 
   // Stale narrows honestly — retained runs are real rows, so a query matching
   // none of them says something true — but a retained EMPTY fleet may not
@@ -1693,7 +1731,7 @@ export function PilotView() {
             // Bound to a const so the discriminant narrows inside the drill
             // handler's closure as well as at the branch.
             const group = header.group;
-            const drillTo = canDrill(group, viewWorktreeCount) ? group.workspaceId : null;
+            const drillTo = canDrill(group, drillWorktreeCount) ? group.workspaceId : null;
             return (
               // `role="group"` is a permitted listbox child and carries the
               // group's name as the label for every option inside it, which is

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -116,6 +116,25 @@ function seedWorkspaceOpenings(daintreeOpened: number, spikeOpened: number): voi
   } as Partial<ReturnType<typeof useScratchStore.getState>>);
 }
 
+/**
+ * A structurally real scratch id.
+ *
+ * The `s1` placeholder above is enough wherever a scratch is just another
+ * workspace in the list, but not where the code under test asks WHAT KIND an id
+ * is: `isScratchWorkspaceId` reads the shape, deliberately, because the stores
+ * that would answer hydrate asynchronously and say "not a scratch" while they
+ * load. A placeholder id would route through the project path and prove nothing.
+ */
+const SCRATCH_ID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+
+/** Replaces the default `s1` scratch with one the shape test recognises. */
+function seedRealScratch(): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: only id/name/lastOpened are read
+  useScratchStore.setState({
+    scratches: [{ id: SCRATCH_ID, name: "spike", lastOpened: NOW - 60_000 }],
+  } as Partial<ReturnType<typeof useScratchStore.getState>>);
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(NOW);
@@ -2509,11 +2528,12 @@ describe("PilotView worktree axis from the project's own store", () => {
     // A scratch is not a git repository, so no count of its worktrees can be
     // anything but zero. `pilot.openProject` refuses one on those grounds, and
     // a chevron drawn here would be the chord and the affordance disagreeing.
-    seedViewWorkspace("s1");
+    seedRealScratch();
+    seedViewWorkspace(SCRATCH_ID);
     seed([
       run({
         runId: "a",
-        workspaceId: "s1",
+        workspaceId: SCRATCH_ID,
         worktreeId: "/scratch/one",
         agentState: "working",
         since: NOW - 60_000,
@@ -2552,7 +2572,13 @@ describe("PilotView worktree axis from the project's own store", () => {
     expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
     fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
 
+    // Both call sites, or the chord could go on drilling through a chevron
+    // that is no longer drawn — which is the disagreement this suite exists
+    // to prevent.
     expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
+    expect(screen.queryByTestId("pilot-drill-hint")).toBeNull();
+    fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "Enter", ...DRILL_MODIFIER });
+    expect(usePilotStore.getState().scope).toEqual({ kind: "fleet" });
   });
 
   it("grows the affordance when a worktree appears under the open surface", () => {
@@ -2732,6 +2758,47 @@ describe("PilotView fallback explanation", () => {
 
     expect(screen.queryByTestId("pilot-fallback-note")).toBeNull();
     expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
+  });
+
+  it("keeps explaining a scratch that has no runs of its own", () => {
+    // The scratch earns the explanation — its none IS a none — and the current
+    // view's worktrees must not answer on its behalf and take it away. With no
+    // scratch runs there is no group to ask, which is the branch where the
+    // count would otherwise be consulted unguarded.
+    seedRealScratch();
+    seedViewWorkspace(SCRATCH_ID);
+    seed([
+      run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working", since: NOW - 60_000 }),
+    ]);
+    usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" }, fellBackFrom: SCRATCH_ID });
+
+    const store = createWorktreeStore();
+    store.getState().applySnapshot(
+      [
+        {
+          id: "/repo/zebra",
+          worktreeId: "/repo/zebra",
+          path: "/repo/zebra",
+          name: "zebra",
+          isCurrent: false,
+        },
+        {
+          id: "/repo/wt/alpha",
+          worktreeId: "/repo/wt/alpha",
+          path: "/repo/wt/alpha",
+          name: "alpha",
+          isCurrent: false,
+        },
+      ],
+      { epoch: "test", seq: 1 }
+    );
+    render(
+      <WorktreeStoreContext.Provider value={store}>
+        <PilotView />
+      </WorktreeStoreContext.Provider>
+    );
+
+    expect(screen.getByTestId("pilot-fallback-note").textContent).toContain("spike");
   });
 
   it("says nothing when the workspace cannot be named", () => {

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -41,6 +41,9 @@ import { useFleetSnapshotStore } from "@/store/fleetSnapshotStore";
 import { usePilotStore } from "@/store/pilotStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
+import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
+import { createWorktreeStore } from "@/store/createWorktreeStore";
+import type { WorktreeSnapshot } from "@shared/types";
 
 const NOW = 1_830_000_000_000;
 
@@ -121,7 +124,7 @@ beforeEach(() => {
   seed(null);
   // Scope reset with the open flag: a leaked project scope would silently
   // narrow every later test's population to one workspace's worktrees.
-  usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" } });
+  usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" }, fellBackFrom: null });
   seedWorkspaceOpenings(NOW, NOW - 60_000);
 });
 
@@ -1882,8 +1885,8 @@ describe("PilotView worktree scope", () => {
 
       fireEvent.click(drillHeader());
 
-      // Root work first — burying it under the checkouts hides the runs most
-      // likely to be the ones being worked right now.
+      // The unbucketed run leads. With no worktree store behind this render
+      // there is no root to name, so nothing can be promoted over it.
       expect(sections()).toEqual(["No worktree", "alpha", "beta"]);
       expect(screen.getAllByTestId("pilot-row")).toHaveLength(3);
     });
@@ -2405,5 +2408,192 @@ describe("PilotView worktree scope", () => {
       expect(screen.getByText("Start an agent in daintree")).toBeTruthy();
       expect(screen.getByTestId("pilot-scope-back")).toBeTruthy();
     });
+  });
+});
+
+describe("PilotView worktree axis from the project's own store", () => {
+  const DRILL_MODIFIER = isMac() ? { metaKey: true } : { ctrlKey: true };
+
+  /** A root whose basename sorts last, so only the lead rule can move it. */
+  const ZEBRA_ROOT = "/repo/zebra";
+
+  function worktree(id: string, isMain = false): WorktreeSnapshot {
+    return {
+      id,
+      worktreeId: id,
+      path: id,
+      name: id.split("/").pop() ?? id,
+      isCurrent: false,
+      isMainWorktree: isMain,
+    };
+  }
+
+  /**
+   * `PilotView` inside a real view store, which is the only place the project's
+   * actual worktrees exist. The store is returned so a test can move the
+   * topology under a mounted surface.
+   */
+  function renderWithWorktrees(worktrees: WorktreeSnapshot[]) {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot(worktrees, { epoch: "test", seq: 1 });
+    render(
+      <WorktreeStoreContext.Provider value={store}>
+        <PilotView />
+      </WorktreeStoreContext.Provider>
+    );
+    return store;
+  }
+
+  function sections(): string[] {
+    return [...screen.getByRole("listbox").querySelectorAll('[role="group"]')].map(
+      (group) => (group.getAttribute("aria-label") ?? "").split(",")[0] ?? ""
+    );
+  }
+
+  /** Two agents sharing one worktree — the shape that used to lose the drill. */
+  function seedOneBucket(): void {
+    seed([
+      run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working", since: NOW - 60_000 }),
+      run({ runId: "b", worktreeId: "/repo/wt/alpha", agentState: "working", since: NOW - 60_000 }),
+    ]);
+  }
+
+  it("offers the drill where the runs share a worktree but the project has several", () => {
+    // The measured bug (#11957): a fleet row exists only for a terminal
+    // classified an agent, so the affordance tracked where agents happened to
+    // be sitting rather than whether the project has an axis at all.
+    seedViewWorkspace("p1");
+    seedOneBucket();
+    renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
+
+    expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
+  });
+
+  it("keeps the chord and the chevron saying the same thing", () => {
+    // The constraint #11955 established by construction, which the fix has to
+    // keep: the two forms of one gesture cannot disagree about drillability.
+    seedViewWorkspace("p1");
+    seedOneBucket();
+    renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
+
+    fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "Enter", ...DRILL_MODIFIER });
+
+    expect(usePilotStore.getState().scope).toEqual({ kind: "project", workspaceId: "p1" });
+  });
+
+  it("withholds the drill where the project has only its own root", () => {
+    seedViewWorkspace("p1");
+    seedOneBucket();
+    renderWithWorktrees([worktree(ZEBRA_ROOT, true)]);
+
+    expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
+  });
+
+  it("never lends this view's worktrees to another project's heading", () => {
+    // The store answers for the workspace this renderer owns and for no other,
+    // so a foreign heading stays on what its own runs prove.
+    seedViewWorkspace("s1");
+    seedOneBucket();
+    renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
+
+    expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
+  });
+
+  it("grows the affordance when a worktree appears under the open surface", () => {
+    // Subscribed, not read once: creating a worktree while the overview is up
+    // has to move the chevron with it.
+    seedViewWorkspace("p1");
+    seedOneBucket();
+    const store = renderWithWorktrees([worktree(ZEBRA_ROOT, true)]);
+
+    expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
+
+    act(() => {
+      store.getState().applySnapshot([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")], {
+        epoch: "test",
+        seq: 2,
+      });
+    });
+
+    expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
+  });
+
+  it("leads the scoped list with the root even where its name sorts last", () => {
+    // #11957's second half: a root run carries a worktree id like any other
+    // checkout, so root work sorted alphabetically among the branches.
+    seedViewWorkspace("p1");
+    seed([
+      run({ runId: "root", worktreeId: ZEBRA_ROOT, agentState: "working", since: NOW - 60_000 }),
+      run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working", since: NOW - 60_000 }),
+      run({ runId: "b", worktreeId: "/repo/wt/beta", agentState: "working", since: NOW - 60_000 }),
+    ]);
+    usePilotStore.setState({ isOpen: true, scope: { kind: "project", workspaceId: "p1" } });
+    renderWithWorktrees([
+      worktree(ZEBRA_ROOT, true),
+      worktree("/repo/wt/alpha"),
+      worktree("/repo/wt/beta"),
+    ]);
+
+    expect(sections()).toEqual(["zebra", "alpha", "beta"]);
+  });
+
+  it("keeps the label order when no worktree is tagged as the root", () => {
+    // A miss costs the lead position and nothing else, which is what makes the
+    // one id comparison here safe against the two mint sites.
+    seedViewWorkspace("p1");
+    seed([
+      run({ runId: "root", worktreeId: ZEBRA_ROOT, agentState: "working", since: NOW - 60_000 }),
+      run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working", since: NOW - 60_000 }),
+    ]);
+    usePilotStore.setState({ isOpen: true, scope: { kind: "project", workspaceId: "p1" } });
+    renderWithWorktrees([worktree(ZEBRA_ROOT), worktree("/repo/wt/alpha")]);
+
+    expect(sections()).toEqual(["alpha", "zebra"]);
+  });
+});
+
+describe("PilotView fallback explanation", () => {
+  it("says which project it could not scope to", () => {
+    // Without this the scoped chord lands on a surface byte for byte identical
+    // to the unscoped one, which reads as a dead key (#11957).
+    seed([run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working" })]);
+    usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" }, fellBackFrom: "p1" });
+    render(<PilotView />);
+
+    expect(screen.getByTestId("pilot-fallback-note").textContent).toContain("daintree");
+  });
+
+  it("stays out of an ordinary fleet opening", () => {
+    seed([run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working" })]);
+    render(<PilotView />);
+
+    expect(screen.queryByTestId("pilot-fallback-note")).toBeNull();
+  });
+
+  it("goes away when the user scopes somewhere from the fleet", () => {
+    seed([
+      run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working", since: NOW - 60_000 }),
+      run({ runId: "b", worktreeId: "/repo/wt/beta", agentState: "working", since: NOW - 60_000 }),
+    ]);
+    usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" }, fellBackFrom: "p1" });
+    render(<PilotView />);
+
+    fireEvent.click(screen.getAllByTestId("pilot-group-header")[0]!);
+
+    expect(screen.queryByTestId("pilot-fallback-note")).toBeNull();
+  });
+
+  it("says nothing when the workspace cannot be named", () => {
+    // A line claiming something has no worktree axis without saying WHICH
+    // something is worse than the silence it replaces.
+    seed([run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working" })]);
+    usePilotStore.setState({
+      isOpen: true,
+      scope: { kind: "fleet" },
+      fellBackFrom: "not-a-workspace",
+    });
+    render(<PilotView />);
+
+    expect(screen.queryByTestId("pilot-fallback-note")).toBeNull();
   });
 });

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -2476,6 +2476,9 @@ describe("PilotView worktree axis from the project's own store", () => {
     seedOneBucket();
     renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
 
+    // Both halves asserted, or this passes for a chord that works beside a
+    // heading drawing nothing — which is the disagreement under test.
+    expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
     fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "Enter", ...DRILL_MODIFIER });
 
     expect(usePilotStore.getState().scope).toEqual({ kind: "project", workspaceId: "p1" });
@@ -2483,7 +2486,10 @@ describe("PilotView worktree axis from the project's own store", () => {
 
   it("withholds the drill where the project has only its own root", () => {
     seedViewWorkspace("p1");
-    seedOneBucket();
+    seed([
+      run({ runId: "a", worktreeId: ZEBRA_ROOT, agentState: "working", since: NOW - 60_000 }),
+      run({ runId: "b", worktreeId: ZEBRA_ROOT, agentState: "working", since: NOW - 60_000 }),
+    ]);
     renderWithWorktrees([worktree(ZEBRA_ROOT, true)]);
 
     expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
@@ -2495,6 +2501,56 @@ describe("PilotView worktree axis from the project's own store", () => {
     seedViewWorkspace("s1");
     seedOneBucket();
     renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
+
+    expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
+  });
+
+  it("never lends them to the current workspace either, when that is a scratch", () => {
+    // A scratch is not a git repository, so no count of its worktrees can be
+    // anything but zero. `pilot.openProject` refuses one on those grounds, and
+    // a chevron drawn here would be the chord and the affordance disagreeing.
+    seedViewWorkspace("s1");
+    seed([
+      run({
+        runId: "a",
+        workspaceId: "s1",
+        worktreeId: "/scratch/one",
+        agentState: "working",
+        since: NOW - 60_000,
+      }),
+    ]);
+    renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
+
+    expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
+    fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "Enter", ...DRILL_MODIFIER });
+    expect(usePilotStore.getState().scope).toEqual({ kind: "fleet" });
+  });
+
+  it("withdraws the drill when a query narrows the project to one worktree", () => {
+    // #11955's rule survives the enrichment: the affordance is computed from
+    // the rows actually drawn, so a narrowing that hides the axis takes the
+    // chevron with it even where the project's own topology could prove one.
+    seedViewWorkspace("p1");
+    seed([
+      run({
+        runId: "a",
+        worktreeId: "/repo/wt/alpha",
+        title: "auth refactor",
+        agentState: "working",
+        since: NOW - 60_000,
+      }),
+      run({
+        runId: "b",
+        worktreeId: "/repo/wt/beta",
+        title: "docs pass",
+        agentState: "working",
+        since: NOW - 60_000,
+      }),
+    ]);
+    renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
+
+    expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
+    fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
 
     expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
   });
@@ -2516,6 +2572,47 @@ describe("PilotView worktree axis from the project's own store", () => {
     });
 
     expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
+  });
+
+  it("withdraws it again when the worktree goes away under the open surface", () => {
+    // The other direction of the same subscription. A chevron surviving the
+    // last worktree's deletion would offer a regrouping the drill then declines.
+    seedViewWorkspace("p1");
+    seedOneBucket();
+    const store = renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
+
+    expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
+
+    act(() => {
+      store.getState().applySnapshot([worktree(ZEBRA_ROOT, true)], { epoch: "test", seq: 2 });
+    });
+
+    expect(screen.queryByTestId("pilot-group-drill")).toBeNull();
+    fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "Enter", ...DRILL_MODIFIER });
+    expect(usePilotStore.getState().scope).toEqual({ kind: "fleet" });
+  });
+
+  it("renders the named empty state when a proven axis scopes a project with no agents", () => {
+    // Newly reachable: the old gate made an empty scoped list impossible, so
+    // this is the first opening that can land straight on one. It has to name
+    // the project and leave the way back on screen rather than look broken.
+    seedViewWorkspace("p1");
+    seed([
+      run({
+        runId: "elsewhere",
+        workspaceId: "s1",
+        worktreeId: "/scratch/one",
+        agentState: "working",
+        since: NOW - 60_000,
+      }),
+    ]);
+    usePilotStore.setState({ isOpen: true, scope: { kind: "project", workspaceId: "p1" } });
+    renderWithWorktrees([worktree(ZEBRA_ROOT, true), worktree("/repo/wt/alpha")]);
+
+    expect(screen.getByText("Start an agent in daintree")).toBeTruthy();
+    expect(screen.getByTestId("pilot-scope-back")).toBeTruthy();
+    // The scratch's run belongs to the fleet behind this scope, not in it.
+    expect(screen.queryAllByTestId("pilot-row")).toHaveLength(0);
   });
 
   it("leads the scoped list with the root even where its name sorts last", () => {
@@ -2563,6 +2660,17 @@ describe("PilotView fallback explanation", () => {
     expect(screen.getByTestId("pilot-fallback-note").textContent).toContain("daintree");
   });
 
+  it("announces itself rather than riding only the dialog's label", () => {
+    // The whole point is that this is NOT the surface that was asked for, and
+    // the dialog announces "All agents" either way — the same thing the
+    // unscoped chord says.
+    seed([run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working" })]);
+    usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" }, fellBackFrom: "p1" });
+    render(<PilotView />);
+
+    expect(screen.getByRole("status")).toBe(screen.getByTestId("pilot-fallback-note"));
+  });
+
   it("stays out of an ordinary fleet opening", () => {
     seed([run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working" })]);
     render(<PilotView />);
@@ -2571,16 +2679,59 @@ describe("PilotView fallback explanation", () => {
   });
 
   it("goes away when the user scopes somewhere from the fleet", () => {
+    // Seeded with a project that IS drillable, so the note is on screen before
+    // the click — otherwise this passes for a component that never drew it.
     seed([
       run({ runId: "a", worktreeId: "/repo/wt/alpha", agentState: "working", since: NOW - 60_000 }),
       run({ runId: "b", worktreeId: "/repo/wt/beta", agentState: "working", since: NOW - 60_000 }),
     ]);
-    usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" }, fellBackFrom: "p1" });
+    usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" }, fellBackFrom: "s1" });
     render(<PilotView />);
+    expect(screen.getByTestId("pilot-fallback-note")).toBeTruthy();
 
     fireEvent.click(screen.getAllByTestId("pilot-group-header")[0]!);
 
+    expect(usePilotStore.getState().scope).toEqual({ kind: "project", workspaceId: "p1" });
     expect(screen.queryByTestId("pilot-fallback-note")).toBeNull();
+  });
+
+  it("withdraws itself once the project it names gains an axis", () => {
+    // The explanation describes a decision taken at press time. Create a
+    // worktree while the surface is open and the same press would scope — a
+    // chevron beside a line saying there is nothing to group is one screen
+    // giving two answers.
+    seedViewWorkspace("p1");
+    seed([
+      run({ runId: "a", worktreeId: "/repo/zebra", agentState: "working", since: NOW - 60_000 }),
+    ]);
+    usePilotStore.setState({ isOpen: true, scope: { kind: "fleet" }, fellBackFrom: "p1" });
+
+    const store = createWorktreeStore();
+    const snap = (id: string): WorktreeSnapshot => ({
+      id,
+      worktreeId: id,
+      path: id,
+      name: id.split("/").pop() ?? id,
+      isCurrent: false,
+      isMainWorktree: id === "/repo/zebra",
+    });
+    store.getState().applySnapshot([snap("/repo/zebra")], { epoch: "test", seq: 1 });
+    render(
+      <WorktreeStoreContext.Provider value={store}>
+        <PilotView />
+      </WorktreeStoreContext.Provider>
+    );
+
+    expect(screen.getByTestId("pilot-fallback-note")).toBeTruthy();
+
+    act(() => {
+      store
+        .getState()
+        .applySnapshot([snap("/repo/zebra"), snap("/repo/wt/alpha")], { epoch: "test", seq: 2 });
+    });
+
+    expect(screen.queryByTestId("pilot-fallback-note")).toBeNull();
+    expect(screen.getByTestId("pilot-group-drill")).toBeTruthy();
   });
 
   it("says nothing when the workspace cannot be named", () => {

--- a/src/components/Pilot/__tests__/pilotOpenProject.test.ts
+++ b/src/components/Pilot/__tests__/pilotOpenProject.test.ts
@@ -332,10 +332,11 @@ describe("pilot.openProject against the project's own worktrees", () => {
     });
   });
 
-  it("counts rather than joins, so unrelated spellings still scope", async () => {
+  it("scopes even where the store and the runs spell the same worktree differently", async () => {
     // The rule the fix has to keep: a worktree id has two mint sites that can
-    // spell one directory differently, so the two sources are OR'd as counts
-    // and their ids never meet.
+    // spell one directory differently (`realpath` at creation, `pathResolve`
+    // over porcelain at enumeration), so the two sources are OR'd as counts and
+    // their ids never meet. A join here would find nothing and refuse.
     seedWorktrees(["/private/repo", "/private/repo/wt/alpha"]);
     seedFleet([run({ runId: "a", worktreeId: "/repo/wt/alpha" })]);
 
@@ -368,6 +369,33 @@ describe("pilot.openProject fallback explanation", () => {
     await openProject();
 
     expect(usePilotStore.getState().fellBackFrom).toBe(PROJECT_HERE);
+  });
+
+  it("says nothing when the project's own worktrees have not been read yet", async () => {
+    // A project carries its own root the moment its view store hydrates, so a
+    // zero is "not told yet". Claiming a project has nothing to group on the
+    // strength of an answer nobody gave is the explanation lying.
+    seedWorktrees([]);
+    seedFleet([run({ runId: "a", worktreeId: ROOT })]);
+
+    await openProject();
+
+    expect(usePilotStore.getState()).toMatchObject({
+      isOpen: true,
+      scope: { kind: "fleet" },
+      fellBackFrom: null,
+    });
+  });
+
+  it("still explains itself for a scratch, whose none is a real none", async () => {
+    // A scratch is not a git repository, so zero worktrees there is an answer
+    // rather than a silence — and the user still pressed a key.
+    seedView(SCRATCH_HERE);
+    seedFleet([run({ runId: "a", workspaceId: SCRATCH_HERE })]);
+
+    await openProject();
+
+    expect(usePilotStore.getState().fellBackFrom).toBe(SCRATCH_HERE);
   });
 
   it("says nothing when the fleet has not been read yet", async () => {

--- a/src/components/Pilot/__tests__/pilotOpenProject.test.ts
+++ b/src/components/Pilot/__tests__/pilotOpenProject.test.ts
@@ -10,6 +10,7 @@ import { useFleetSnapshotStore } from "@/store/fleetSnapshotStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { usePilotStore } from "@/store/pilotStore";
+import { resetStoreAccessorsForTesting, setWorktreeIdSetAccessor } from "@/store/storeAccessors";
 import type { ActionCallbacks, ActionRegistry } from "@/services/actions/actionTypes";
 import type { ActionContext } from "@shared/types/actions";
 import type { FleetRunRow } from "@shared/types/ipc/fleet";
@@ -22,6 +23,9 @@ import type { FleetRunRow } from "@shared/types/ipc/fleet";
 const PROJECT_HERE = "a".repeat(64);
 const PROJECT_ELSEWHERE = "b".repeat(64);
 const SCRATCH_HERE = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+
+/** The project root, which carries a worktree id like any other checkout. */
+const ROOT = "/repo";
 
 const NOW = 1_830_000_000_000;
 
@@ -44,6 +48,15 @@ function seedView(workspaceId: string | null): void {
   viewWorkspaceId.current = workspaceId;
 }
 
+/**
+ * The worktrees the VIEW's own store knows about — the project's real topology,
+ * which the fleet snapshot cannot report because it only carries agent runs.
+ * `null` is a view with no store mounted, which is what a bare test process has.
+ */
+function seedWorktrees(ids: string[] | null): void {
+  setWorktreeIdSetAccessor(() => (ids === null ? null : new Set(ids)));
+}
+
 function seedFleet(runs: FleetRunRow[] | null): void {
   useFleetSnapshotStore.setState({
     snapshot:
@@ -59,7 +72,8 @@ function openProject(): Promise<unknown> {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  usePilotStore.setState({ isOpen: false, scope: { kind: "fleet" } });
+  resetStoreAccessorsForTesting();
+  usePilotStore.setState({ isOpen: false, scope: { kind: "fleet" }, fellBackFrom: null });
   // The globally-replicated pointers, deliberately seeded to CONTRADICT the
   // view below, so a regression that reads either of them fails loudly.
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: only the pointer's id matters, and the action must not read it at all
@@ -120,9 +134,11 @@ describe("pilot.openProject", () => {
   });
 
   it("falls back for a project worked only in its own root", async () => {
-    // A root launch carries no worktree id at all, so there is no axis to cut
-    // on — one of the two cases the issue left open.
-    seedFleet([run({ runId: "a" }), run({ runId: "b" })]);
+    // A root launch DOES carry a worktree id — the project root path (#11957) —
+    // so this is one bucket by both counts: one worktree in the store, one
+    // among the runs. There is no axis to cut on either way.
+    seedWorktrees([ROOT]);
+    seedFleet([run({ runId: "a", worktreeId: ROOT }), run({ runId: "b", worktreeId: ROOT })]);
 
     await openProject();
 
@@ -139,6 +155,19 @@ describe("pilot.openProject", () => {
       run({ runId: "a", workspaceId: SCRATCH_HERE }),
       run({ runId: "b", workspaceId: SCRATCH_HERE }),
     ]);
+
+    await openProject();
+
+    expect(usePilotStore.getState()).toMatchObject({ isOpen: true, scope: { kind: "fleet" } });
+  });
+
+  it("refuses a worktree count in a scratch view even where one is on offer", async () => {
+    // The accessor is unparameterized current-view state. A scratch is not a
+    // git repository, so no count of its worktrees can be anything but zero
+    // whatever a store happens to be holding at the time.
+    seedView(SCRATCH_HERE);
+    seedWorktrees(["/repo/wt/alpha", "/repo/wt/beta", "/repo/wt/gamma"]);
+    seedFleet([run({ runId: "a", workspaceId: SCRATCH_HERE })]);
 
     await openProject();
 
@@ -253,6 +282,135 @@ describe("pilot.openProject", () => {
     expect(usePilotStore.getState().scope).toEqual({
       kind: "project",
       workspaceId: PROJECT_HERE,
+    });
+  });
+});
+
+describe("pilot.openProject against the project's own worktrees", () => {
+  it("scopes where every agent shares one worktree but the project has three", async () => {
+    // The measured bug (#11957): a fleet row exists only for a terminal
+    // classified an agent, so drillability tracked where agents happened to be
+    // sitting. Four of five real projects fell back on this.
+    seedWorktrees([ROOT, "/repo/wt/alpha", "/repo/wt/beta"]);
+    seedFleet([
+      run({ runId: "a", worktreeId: "/repo/wt/alpha" }),
+      run({ runId: "b", worktreeId: "/repo/wt/alpha" }),
+    ]);
+
+    await openProject();
+
+    expect(usePilotStore.getState().scope).toEqual({
+      kind: "project",
+      workspaceId: PROJECT_HERE,
+    });
+  });
+
+  it("keeps the chord working when the second agent exits", async () => {
+    // Closing an agent used to take the shortcut away with nothing to say so.
+    seedWorktrees([ROOT, "/repo/wt/alpha"]);
+    seedFleet([run({ runId: "a", worktreeId: ROOT })]);
+
+    await openProject();
+
+    expect(usePilotStore.getState().scope).toEqual({
+      kind: "project",
+      workspaceId: PROJECT_HERE,
+    });
+  });
+
+  it("scopes a project with no agents at all once its worktrees prove the axis", async () => {
+    // "None here yet" answers the question the user asked. The whole fleet
+    // answers a different one.
+    seedWorktrees([ROOT, "/repo/wt/alpha"]);
+    seedFleet([run({ runId: "x", workspaceId: PROJECT_ELSEWHERE, worktreeId: "/o/a" })]);
+
+    await openProject();
+
+    expect(usePilotStore.getState().scope).toEqual({
+      kind: "project",
+      workspaceId: PROJECT_HERE,
+    });
+  });
+
+  it("counts rather than joins, so unrelated spellings still scope", async () => {
+    // The rule the fix has to keep: a worktree id has two mint sites that can
+    // spell one directory differently, so the two sources are OR'd as counts
+    // and their ids never meet.
+    seedWorktrees(["/private/repo", "/private/repo/wt/alpha"]);
+    seedFleet([run({ runId: "a", worktreeId: "/repo/wt/alpha" })]);
+
+    await openProject();
+
+    expect(usePilotStore.getState().scope).toEqual({
+      kind: "project",
+      workspaceId: PROJECT_HERE,
+    });
+  });
+
+  it("falls back where the project has exactly one worktree", async () => {
+    // The root is a first-class entry in that count, so one means root-only.
+    seedWorktrees([ROOT]);
+    seedFleet([run({ runId: "a", worktreeId: ROOT })]);
+
+    await openProject();
+
+    expect(usePilotStore.getState()).toMatchObject({ isOpen: true, scope: { kind: "fleet" } });
+  });
+});
+
+describe("pilot.openProject fallback explanation", () => {
+  it("names the project it could not scope to", async () => {
+    // The fleet it lands on is byte for byte what the unscoped chord gives, so
+    // without this the key is indistinguishable from a dead one.
+    seedWorktrees([ROOT]);
+    seedFleet([run({ runId: "a", worktreeId: ROOT })]);
+
+    await openProject();
+
+    expect(usePilotStore.getState().fellBackFrom).toBe(PROJECT_HERE);
+  });
+
+  it("says nothing when the fleet has not been read yet", async () => {
+    // Nothing was decided, so there is nothing to explain — an explanation here
+    // would blame a project for a snapshot that has not arrived.
+    seedFleet(null);
+
+    await openProject();
+
+    expect(usePilotStore.getState()).toMatchObject({ isOpen: true, fellBackFrom: null });
+  });
+
+  it("says nothing when the view has no workspace identity", async () => {
+    seedView(null);
+    seedFleet([run({ runId: "a", worktreeId: "/repo/wt/alpha" })]);
+
+    await openProject();
+
+    expect(usePilotStore.getState()).toMatchObject({ isOpen: true, fellBackFrom: null });
+  });
+
+  it("says nothing when the scope succeeds", async () => {
+    seedFleet([
+      run({ runId: "a", worktreeId: "/repo/wt/alpha" }),
+      run({ runId: "b", worktreeId: "/repo/wt/beta" }),
+    ]);
+
+    await openProject();
+
+    expect(usePilotStore.getState().fellBackFrom).toBeNull();
+  });
+
+  it("clears a stale explanation when a later press does scope", async () => {
+    seedWorktrees([ROOT]);
+    seedFleet([run({ runId: "a", worktreeId: ROOT })]);
+    await openProject();
+
+    seedWorktrees([ROOT, "/repo/wt/alpha"]);
+    await openProject();
+
+    expect(usePilotStore.getState()).toMatchObject({
+      scope: { kind: "project", workspaceId: PROJECT_HERE },
+      fellBackFrom: null,
     });
   });
 });

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -1182,22 +1182,16 @@ describe("hasWorktreeAxis", () => {
       expect(hasWorktreeAxis([], 0)).toBe(false);
     });
 
-    it("still passes on the runs alone when no count is available", () => {
-      // The count is `undefined` for a scratch, and for any view whose store
-      // has not mounted — neither may take an axis the runs already proved.
+    it("never lets an absent or zero count veto an axis the runs proved", () => {
+      // The count is `undefined` for a view whose store has not mounted and
+      // zero for one that has not hydrated. Neither is evidence AGAINST an
+      // axis, so neither may take one the runs already established.
       expect(
         hasWorktreeAxis([{ worktreeId: "/repo/wt/a" }, { worktreeId: "/repo/wt/b" }], undefined)
       ).toBe(true);
       expect(hasWorktreeAxis([{ worktreeId: "/repo/wt/a" }, { worktreeId: "/repo/wt/b" }], 0)).toBe(
         true
       );
-    });
-
-    it("never joins the two sources, so unrelated spellings still count", () => {
-      // The one rule the fix has to keep: two mint sites can spell the same
-      // worktree differently, so the counts are OR'd and the ids never meet.
-      // Runs in one worktree, a store describing two entirely different ones.
-      expect(hasWorktreeAxis([{ worktreeId: "/private/repo/wt/a" }], 2)).toBe(true);
     });
   });
 });

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -1151,13 +1151,65 @@ describe("hasWorktreeAxis", () => {
       true
     );
   });
+
+  describe("with the project's own worktree count", () => {
+    it("is true where every agent shares one worktree but the project has several", () => {
+      // The bug: a fleet row exists only for a terminal classified an agent, so
+      // drillability tracked where agents happened to be sitting rather than
+      // whether the project has an axis at all (#11957).
+      expect(hasWorktreeAxis([{ worktreeId: "/repo/wt/a" }, { worktreeId: "/repo/wt/a" }], 3)).toBe(
+        true
+      );
+    });
+
+    it("is true for a lone agent in a project with two worktrees", () => {
+      expect(hasWorktreeAxis([{ worktreeId: "/repo/wt/a" }], 2)).toBe(true);
+    });
+
+    it("is true with no runs at all once the project is known to have two", () => {
+      // A scoped view of a project with no agents says "none here yet", which
+      // answers the question asked. The whole fleet answers a different one.
+      expect(hasWorktreeAxis([], 2)).toBe(true);
+    });
+
+    it("is false where the project has exactly one worktree", () => {
+      // The root checkout is a first-class entry in that count, so one means a
+      // project worked only in its own root.
+      expect(hasWorktreeAxis([{ worktreeId: "/repo" }], 1)).toBe(false);
+    });
+
+    it("is false where the project has no worktrees to speak of", () => {
+      expect(hasWorktreeAxis([], 0)).toBe(false);
+    });
+
+    it("still passes on the runs alone when no count is available", () => {
+      // The count is `undefined` for a scratch, and for any view whose store
+      // has not mounted — neither may take an axis the runs already proved.
+      expect(
+        hasWorktreeAxis([{ worktreeId: "/repo/wt/a" }, { worktreeId: "/repo/wt/b" }], undefined)
+      ).toBe(true);
+      expect(hasWorktreeAxis([{ worktreeId: "/repo/wt/a" }, { worktreeId: "/repo/wt/b" }], 0)).toBe(
+        true
+      );
+    });
+
+    it("never joins the two sources, so unrelated spellings still count", () => {
+      // The one rule the fix has to keep: two mint sites can spell the same
+      // worktree differently, so the counts are OR'd and the ids never meet.
+      // Runs in one worktree, a store describing two entirely different ones.
+      expect(hasWorktreeAxis([{ worktreeId: "/private/repo/wt/a" }], 2)).toBe(true);
+    });
+  });
 });
 
 describe("buildPilotWorktreeGroups", () => {
   /** One project's rows, cut on the worktree axis, named in rendered order. */
-  function worktreeGroups(runs: FleetRunRow[]): ReturnType<typeof buildPilotWorktreeGroups> {
+  function worktreeGroups(
+    runs: FleetRunRow[],
+    mainWorktreeId?: string | null
+  ): ReturnType<typeof buildPilotWorktreeGroups> {
     const [project] = buildPilotGroups(runs, ctx());
-    return buildPilotWorktreeGroups(project!);
+    return buildPilotWorktreeGroups(project!, mainWorktreeId);
   }
 
   it("groups a project's runs by worktree and keeps every run", () => {
@@ -1172,8 +1224,10 @@ describe("buildPilotWorktreeGroups", () => {
   });
 
   it("keeps runs with no worktree, in a bucket ahead of the named ones", () => {
-    // Dropping them would hide a live agent because a field was absent, and
-    // burying them under thirty checkouts hides the project's own root work.
+    // Dropping them would hide a live agent because a field was absent. The
+    // bucket leads because a live agent filed under no worktree at all is an
+    // anomaly worth seeing — NOT because it holds the root, which carries an id
+    // of its own and gets its own section (#11957).
     const groups = worktreeGroups([
       run({ runId: "wt", worktreeId: "/repo/wt/alpha", agentState: "working" }),
       run({ runId: "root", agentState: "working" }),
@@ -1375,6 +1429,88 @@ describe("buildPilotWorktreeGroups", () => {
     expect(worktreeGroups(runs).map((g) => g.groupId)).toEqual(
       worktreeGroups([...runs].reverse()).map((g) => g.groupId)
     );
+  });
+
+  describe("with the main worktree named", () => {
+    /** A root whose basename sorts last, so only the lead rule can move it. */
+    const ZEBRA_ROOT = "/repo/zebra";
+
+    it("leads with the root even where its name sorts last", () => {
+      // The complaint in #11957: root work sorted alphabetically among branch
+      // checkouts, first by luck in a project called `daintree` and buried in
+      // one called `zebra`.
+      const groups = worktreeGroups(
+        [
+          run({ runId: "root", worktreeId: ZEBRA_ROOT }),
+          run({ runId: "a", worktreeId: "/repo/wt/alpha" }),
+          run({ runId: "b", worktreeId: "/repo/wt/beta" }),
+        ],
+        ZEBRA_ROOT
+      );
+
+      expect(groups.map((g) => g.worktreeId)).toEqual([
+        ZEBRA_ROOT,
+        "/repo/wt/alpha",
+        "/repo/wt/beta",
+      ]);
+    });
+
+    it("keeps the alphabetical order when the id resolves to nothing", () => {
+      // The two mint sites can spell one directory differently, so a miss has
+      // to cost nothing but the lead position.
+      const runs = [
+        run({ runId: "root", worktreeId: ZEBRA_ROOT }),
+        run({ runId: "a", worktreeId: "/repo/wt/alpha" }),
+      ];
+
+      expect(worktreeGroups(runs, "/private/repo/zebra").map((g) => g.worktreeId)).toEqual(
+        worktreeGroups(runs).map((g) => g.worktreeId)
+      );
+    });
+
+    it("puts the root ahead of the runs filed under no worktree", () => {
+      const groups = worktreeGroups(
+        [
+          run({ runId: "root", worktreeId: ZEBRA_ROOT }),
+          run({ runId: "orphan" }),
+          run({ runId: "a", worktreeId: "/repo/wt/alpha" }),
+        ],
+        ZEBRA_ROOT
+      );
+
+      expect(groups.map((g) => g.worktreeId)).toEqual([ZEBRA_ROOT, null, "/repo/wt/alpha"]);
+    });
+
+    it("does not let a null or empty id claim the no-worktree bucket", () => {
+      // `null` would otherwise equal every unbucketed group and promote a
+      // section of orphans as though it were the project root.
+      const runs = [
+        run({ runId: "orphan" }),
+        run({ runId: "a", worktreeId: "/repo/wt/alpha" }),
+        run({ runId: "root", worktreeId: ZEBRA_ROOT }),
+      ];
+
+      for (const absent of [null, undefined, ""]) {
+        expect(worktreeGroups(runs, absent).map((g) => g.worktreeId)).toEqual([
+          null,
+          "/repo/wt/alpha",
+          ZEBRA_ROOT,
+        ]);
+      }
+    });
+
+    it("stays a total order with the root named", () => {
+      const runs = [
+        run({ runId: "a", worktreeId: "/repo/wt/beta" }),
+        run({ runId: "root", worktreeId: ZEBRA_ROOT }),
+        run({ runId: "b", worktreeId: "/repo/wt/alpha" }),
+        run({ runId: "c" }),
+      ];
+
+      expect(worktreeGroups(runs, ZEBRA_ROOT).map((g) => g.groupId)).toEqual(
+        worktreeGroups([...runs].reverse(), ZEBRA_ROOT).map((g) => g.groupId)
+      );
+    });
   });
 });
 

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -116,10 +116,16 @@ export interface PilotWorktreeGroup extends PilotGroupCore {
    * The run's normalized worktree path, or null for the bucket holding runs the
    * snapshot files under no worktree at all.
    *
-   * Opaque here: a grouping key and a source of basename, never joined against
-   * a worktree store. The id has two mint sites that can spell the same
+   * Opaque to everything that derives display from it: a grouping key and a
+   * source of basename, never resolved through a worktree store for a label, a
+   * path or a branch. The id has two mint sites that can spell the same
    * worktree differently, and the store that would answer only exists for the
    * one project a renderer view owns.
+   *
+   * {@link buildPilotWorktreeGroups} is the single exception, and only for
+   * ORDER: it may be matched against a `mainWorktreeId` the caller took from
+   * that view's own store, where a mismatch costs nothing but the lead position.
+   * See its docblock for the three conditions that keep that safe.
    */
   worktreeId: string | null;
 }
@@ -527,21 +533,35 @@ function countWorktreeBuckets(runs: readonly Pick<FleetRunRow, "worktreeId">[]):
  * false — so the affordance and the chord can never disagree about whether a
  * project has a worktree axis.
  *
- * Two buckets is the floor because one bucket regroups a project into a single
- * section holding the rows it already had. That is also, for free, the right
- * answer to the two cases the issue left open: a scratch workspace's runs never
- * carry a worktree id, and neither does a project being worked only in its own
- * root, so both fall back rather than opening a list that tells the user
- * nothing. A project with no runs at all has no buckets and falls back too,
- * which is what keeps an empty scoped list unreachable.
+ * Two is the floor on either count, because one worktree regroups a project
+ * into a single section holding the rows it already had.
  *
- * Deliberately derived from the runs alone. The tempting alternative — compare
- * each `worktreeId` against the project's own path — joins two independently
- * minted spellings of the same directory, and the app has been bitten by that
- * before; there is no version of it that is worth a correct answer here.
+ * `knownWorktreeCount` is how many worktrees the project ACTUALLY has, which
+ * the runs cannot answer (#11957). A fleet row exists only for a terminal
+ * `classifyRun` calls an agent, so a plain shell, a dev-preview pane, a trashed
+ * panel and the help terminal all contribute no bucket — and a worktree nobody
+ * has opened a terminal in contributes none either. Deriving the axis from runs
+ * alone therefore tracked where agents happened to be sitting rather than
+ * whether the project has an axis at all: a project with three worktrees whose
+ * agents share one of them failed, and closing an agent could take the chord
+ * away. Callers pass it ONLY for the workspace their own view owns, because the
+ * store that answers exists for that project and for no other.
+ *
+ * The two counts are OR'd and never joined. Comparing individual ids — a run's
+ * `worktreeId` against a worktree store key, or against the project's own path
+ * — puts two independently minted spellings of one directory beside each other
+ * (`realpath` at creation, `pathResolve` over porcelain at enumeration), and
+ * the app has been bitten by that before. Aggregates cannot diverge that way.
+ *
+ * Omitting the count leaves the pre-#11957 behavior exactly: a scratch
+ * workspace, a project with no runs, and a project the store cannot describe
+ * all fall back rather than opening a list that tells the user nothing.
  */
-export function hasWorktreeAxis(runs: readonly Pick<FleetRunRow, "worktreeId">[]): boolean {
-  return countWorktreeBuckets(runs) >= 2;
+export function hasWorktreeAxis(
+  runs: readonly Pick<FleetRunRow, "worktreeId">[],
+  knownWorktreeCount?: number
+): boolean {
+  return countWorktreeBuckets(runs) >= 2 || (knownWorktreeCount ?? 0) >= 2;
 }
 
 /**
@@ -555,15 +575,33 @@ export function hasWorktreeAxis(runs: readonly Pick<FleetRunRow, "worktreeId">[]
  *
  * Group ORDER is severity-independent, exactly as it is across projects
  * (#11678). A worktree whose agent blocks does not climb over the others; it
- * turns its own header's chip on and stays where it was. Position is the
- * no-worktree bucket first, then the disambiguated label, then the full id so
- * the comparator is a true total order.
+ * turns its own header's chip on and stays where it was. Position is the main
+ * worktree first, then the no-worktree bucket, then the disambiguated label,
+ * then the full id so the comparator is a true total order.
  *
- * The no-worktree bucket leads because it holds the project's root work, and
- * burying that under thirty alphabetically-sorted checkouts hides the runs
- * most likely to be the ones being worked right now.
+ * `mainWorktreeId` is the project's root checkout, and it leads because root
+ * work is the most likely to be what is being worked right now — burying it
+ * under thirty alphabetically-sorted branch checkouts hides it. The no-worktree
+ * bucket used to carry that job on the premise that a root run has no worktree
+ * id; it does (#11957 measured one whose id is the project root path), so that
+ * bucket is now what it says it is — runs the snapshot files under no worktree
+ * at all — and it stays high because a live agent with no worktree is an
+ * anomaly worth seeing, not because it holds the root.
+ *
+ * This is the one place a `worktreeId` is matched against a worktree store, and
+ * it is safe for exactly three reasons, all of which have to hold: the caller
+ * passes an id only for the project its OWN view owns (the store answers for no
+ * other), the id it passes is one the store positively tagged `isMainWorktree`
+ * rather than a path matched against the project root (#2251), and a miss just
+ * means no group leads. So when the two mint sites spell one directory
+ * differently — `realpath` at creation against `pathResolve` over porcelain at
+ * enumeration — the order falls back to the label/id total order below rather
+ * than promoting the wrong worktree.
  */
-export function buildPilotWorktreeGroups(project: PilotProjectGroup): PilotWorktreeGroup[] {
+export function buildPilotWorktreeGroups(
+  project: PilotProjectGroup,
+  mainWorktreeId?: string | null
+): PilotWorktreeGroup[] {
   const byWorktree = new Map<string | null, PilotRow[]>();
   for (const row of project.rows) {
     const key = worktreeKey(row.run);
@@ -601,7 +639,14 @@ export function buildPilotWorktreeGroups(project: PilotProjectGroup): PilotWorkt
     );
   }
 
+  // A null id would match every bucket that has no worktree, so the leader is
+  // only ever a real id the caller vouched for.
+  const leadId = mainWorktreeId != null && mainWorktreeId !== "" ? mainWorktreeId : null;
+
   groups.sort((a, b) => {
+    const aLeads = leadId !== null && a.worktreeId === leadId;
+    const bLeads = leadId !== null && b.worktreeId === leadId;
+    if (aLeads !== bLeads) return aLeads ? -1 : 1;
     if ((a.worktreeId === null) !== (b.worktreeId === null)) return a.worktreeId === null ? -1 : 1;
     const byName = a.name.localeCompare(b.name);
     if (byName !== 0) return byName;

--- a/src/hooks/__tests__/useWorktreeStoreOptional.test.tsx
+++ b/src/hooks/__tests__/useWorktreeStoreOptional.test.tsx
@@ -83,22 +83,33 @@ describe("useWorktreeStoreOptional", () => {
     expect(result.current).toBe("wt-a");
   });
 
-  it("stops reading a store the tree has dropped", () => {
+  it("releases its subscription when the tree drops it", () => {
+    // Asserted on the unsubscribe call, not on the value: a hook that leaked
+    // its subscription would ALSO leave `result.current` at its last render,
+    // because React drops an update aimed at an unmounted tree. Only the store
+    // can say whether anyone is still listening.
     const store = createWorktreeStore();
     store.getState().applySnapshot([snap("wt-a")], { epoch: "test", seq: 1 });
 
-    const { result, unmount } = renderHook(
-      () => useWorktreeStoreOptional((s) => s.worktrees.size, -1),
-      { wrapper: withStore(store) }
-    );
+    let unsubscribed = false;
+    const watched = {
+      ...store,
+      subscribe: (listener: Parameters<typeof store.subscribe>[0]) => {
+        const release = store.subscribe(listener);
+        return () => {
+          unsubscribed = true;
+          release();
+        };
+      },
+    };
+
+    const { unmount } = renderHook(() => useWorktreeStoreOptional((s) => s.worktrees.size, -1), {
+      wrapper: withStore(watched),
+    });
+    expect(unsubscribed).toBe(false);
+
     unmount();
 
-    act(() => {
-      store.getState().applySnapshot([snap("wt-a"), snap("wt-b")], { epoch: "test", seq: 2 });
-    });
-
-    // An update landing on an unmounted subscriber is a leak that React warns
-    // about; the value simply stops moving.
-    expect(result.current).toBe(1);
+    expect(unsubscribed).toBe(true);
   });
 });

--- a/src/hooks/__tests__/useWorktreeStoreOptional.test.tsx
+++ b/src/hooks/__tests__/useWorktreeStoreOptional.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useWorktreeStoreOptional } from "../useWorktreeStore";
+import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
+import { createWorktreeStore } from "@/store/createWorktreeStore";
+import type { WorktreeSnapshot } from "@shared/types";
+
+function snap(id: string): WorktreeSnapshot {
+  return { id, worktreeId: id, path: id, name: id, isCurrent: false };
+}
+
+function withStore(store: ReturnType<typeof createWorktreeStore> | null) {
+  return ({ children }: { children: ReactNode }) => (
+    <WorktreeStoreContext.Provider value={store}>{children}</WorktreeStoreContext.Provider>
+  );
+}
+
+describe("useWorktreeStoreOptional", () => {
+  it("hands back the fallback where no provider is mounted", () => {
+    // The reason this variant exists: an overlay that only ENRICHES itself with
+    // the current project's worktrees must render without them rather than take
+    // the whole surface down over a detail it can do without.
+    const { result } = renderHook(() => useWorktreeStoreOptional((s) => s.worktrees.size, -1));
+
+    expect(result.current).toBe(-1);
+  });
+
+  it("hands back the fallback where the context holds no store", () => {
+    const { result } = renderHook(() => useWorktreeStoreOptional((s) => s.worktrees.size, -1), {
+      wrapper: withStore(null),
+    });
+
+    expect(result.current).toBe(-1);
+  });
+
+  it("reads the mounted store rather than the fallback", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([snap("wt-a"), snap("wt-b")], { epoch: "test", seq: 1 });
+
+    const { result } = renderHook(() => useWorktreeStoreOptional((s) => s.worktrees.size, -1), {
+      wrapper: withStore(store),
+    });
+
+    expect(result.current).toBe(2);
+  });
+
+  it("re-renders on a store change instead of holding the first read", () => {
+    // Read once, this would go stale the moment a worktree is created or
+    // deleted under an open surface — which is the whole reason it subscribes.
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([snap("wt-a")], { epoch: "test", seq: 1 });
+
+    const { result } = renderHook(() => useWorktreeStoreOptional((s) => s.worktrees.size, -1), {
+      wrapper: withStore(store),
+    });
+    expect(result.current).toBe(1);
+
+    act(() => {
+      store.getState().applySnapshot([snap("wt-a"), snap("wt-b")], { epoch: "test", seq: 2 });
+    });
+
+    expect(result.current).toBe(2);
+  });
+
+  it("settles rather than looping on a selector that recomputes each call", () => {
+    // `useSyncExternalStore` re-renders until two consecutive snapshots compare
+    // equal, so a selector returning a fresh object would spin forever. This
+    // one derives a string, which is the contract the hook documents.
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([snap("wt-a"), snap("wt-b")], { epoch: "test", seq: 1 });
+
+    const { result } = renderHook(
+      () =>
+        useWorktreeStoreOptional<string | null>((s) => {
+          for (const [id] of s.worktrees) return id;
+          return null;
+        }, null),
+      { wrapper: withStore(store) }
+    );
+
+    expect(result.current).toBe("wt-a");
+  });
+
+  it("stops reading a store the tree has dropped", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([snap("wt-a")], { epoch: "test", seq: 1 });
+
+    const { result, unmount } = renderHook(
+      () => useWorktreeStoreOptional((s) => s.worktrees.size, -1),
+      { wrapper: withStore(store) }
+    );
+    unmount();
+
+    act(() => {
+      store.getState().applySnapshot([snap("wt-a"), snap("wt-b")], { epoch: "test", seq: 2 });
+    });
+
+    // An update landing on an unmounted subscriber is a leak that React warns
+    // about; the value simply stops moving.
+    expect(result.current).toBe(1);
+  });
+});

--- a/src/hooks/useWorktreeStore.ts
+++ b/src/hooks/useWorktreeStore.ts
@@ -1,4 +1,4 @@
-import { use } from "react";
+import { use, useSyncExternalStore } from "react";
 import { useStore } from "zustand";
 import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
 import type { WorktreeViewState, WorktreeViewActions } from "@/store/createWorktreeStore";
@@ -11,4 +11,33 @@ export function useWorktreeStore<T>(
     throw new Error("useWorktreeStore must be used within WorktreeStoreProvider");
   }
   return useStore(store, selector);
+}
+
+/** A subscription to nothing, for the renders where there is no store to watch. */
+const NEVER_CHANGES = () => () => {};
+
+/**
+ * The same read, for a component that legitimately renders outside the provider.
+ *
+ * {@link useWorktreeStore} throws where no view store is mounted, which is the
+ * right answer for the sidebar and the panes — they are the project view, and a
+ * missing store there is a wiring bug. It is the wrong answer for an overlay
+ * that only ENRICHES itself with the current project's worktrees and has to
+ * render without them: throwing would take the whole surface down over a detail
+ * it can do without.
+ *
+ * The selector must return a primitive or a stable reference. `useSyncExternalStore`
+ * re-renders until two consecutive snapshots compare equal, so a selector minting
+ * a fresh object or array each call loops forever.
+ */
+export function useWorktreeStoreOptional<T>(
+  selector: (state: WorktreeViewState & WorktreeViewActions) => T,
+  fallback: T
+): T {
+  const store = use(WorktreeStoreContext);
+  return useSyncExternalStore(
+    store?.subscribe ?? NEVER_CHANGES,
+    () => (store ? selector(store.getState()) : fallback),
+    () => (store ? selector(store.getState()) : fallback)
+  );
 }

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -10,6 +10,7 @@ import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { usePilotStore } from "@/store/pilotStore";
 import { useFleetSnapshotStore } from "@/store/fleetSnapshotStore";
 import { hasWorktreeAxis } from "@/components/Pilot/pilotRows";
+import { getWorktreeIdSet } from "@/store/storeAccessors";
 import { actionService } from "@/services/ActionService";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { notify, EVENT_KIND_TO_SETTING_KEY, EVENT_KIND_LABEL } from "@/lib/notify";
@@ -139,22 +140,36 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
         return;
       }
 
-      // Scoping is offered only where regrouping would say something new. A
-      // scratch workspace's runs carry no worktree id, and neither does a
-      // project being worked only in its own root, so both land here — and so
-      // does a project with no runs at all, which is what keeps an empty scoped
-      // list unreachable. The unscoped fleet is the honest fallback: it is
-      // still the surface the user asked for, just without a narrowing it
-      // cannot support.
+      // Two states where the question cannot be asked yet, as opposed to
+      // answered no: a view with no workspace identity has no project to scope
+      // to, and a fleet nobody has reported cannot be filtered. Both open the
+      // plain fleet and say nothing — an explanation naming a project would be
+      // describing a decision that was never taken.
       const runs = useFleetSnapshotStore.getState().snapshot?.runs;
       if (workspaceId === null || runs === undefined) {
         pilot.open();
         return;
       }
 
+      // Scoping is offered only where regrouping would say something new, and
+      // the project's own worktrees are the half of that the runs cannot answer
+      // (#11957). Read here rather than inside the gate because this is the one
+      // place the two identities are known to agree: `getWorktreeIdSet` is the
+      // CURRENT VIEW's store and `getViewWorkspaceId` is that view's workspace,
+      // so the count belongs to the project being asked about. A scratch is
+      // excluded outright — it is not a git repository, so no count of its
+      // worktrees can be anything but zero, whatever a store happens to hold.
       const projectRuns = runs.filter((run) => run.workspaceId === workspaceId);
-      if (!hasWorktreeAxis(projectRuns)) {
-        pilot.open();
+      const knownWorktreeCount = isScratchWorkspaceId(workspaceId)
+        ? undefined
+        : getWorktreeIdSet()?.size;
+
+      if (!hasWorktreeAxis(projectRuns, knownWorktreeCount)) {
+        // The unscoped fleet is the honest fallback — still the surface the
+        // user asked for, just without a narrowing it cannot support — but it
+        // is byte for byte what the unscoped chord already gives, so it goes
+        // through the fallback opening, which carries the reason with it.
+        pilot.openFleetFallback(workspaceId);
         return;
       }
 

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -160,16 +160,24 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
       // excluded outright — it is not a git repository, so no count of its
       // worktrees can be anything but zero, whatever a store happens to hold.
       const projectRuns = runs.filter((run) => run.workspaceId === workspaceId);
-      const knownWorktreeCount = isScratchWorkspaceId(workspaceId)
-        ? undefined
-        : getWorktreeIdSet()?.size;
+      const isScratch = isScratchWorkspaceId(workspaceId);
+      const knownWorktreeCount = isScratch ? 0 : (getWorktreeIdSet()?.size ?? 0);
+
+      // A project carries its own root as a first-class entry the moment its
+      // view store hydrates, so a zero there is "not told yet" rather than "no
+      // worktrees" — and a decision taken on an answer nobody gave has no
+      // business explaining itself. A scratch IS a real answer: it is not a git
+      // repository, so its none is a none.
+      const topologyIsKnown = isScratch || knownWorktreeCount > 0;
 
       if (!hasWorktreeAxis(projectRuns, knownWorktreeCount)) {
         // The unscoped fleet is the honest fallback — still the surface the
         // user asked for, just without a narrowing it cannot support — but it
-        // is byte for byte what the unscoped chord already gives, so it goes
-        // through the fallback opening, which carries the reason with it.
-        pilot.openFleetFallback(workspaceId);
+        // is byte for byte what the unscoped chord already gives, so where the
+        // refusal is informed it goes through the fallback opening, which
+        // carries the reason with it.
+        if (topologyIsKnown) pilot.openFleetFallback(workspaceId);
+        else pilot.open();
         return;
       }
 

--- a/src/store/__tests__/pilotStore.test.ts
+++ b/src/store/__tests__/pilotStore.test.ts
@@ -5,7 +5,7 @@ const PROJECT = "a".repeat(64);
 const OTHER = "b".repeat(64);
 
 beforeEach(() => {
-  usePilotStore.setState({ isOpen: false, scope: { kind: "fleet" } });
+  usePilotStore.setState({ isOpen: false, scope: { kind: "fleet" }, fellBackFrom: null });
 });
 
 describe("pilotStore scope", () => {
@@ -78,5 +78,49 @@ describe("pilotStore scope", () => {
 
     expect(usePilotStore.getState().isOpen).toBe(true);
     expect(usePilotStore.getState().scope).toEqual({ kind: "fleet" });
+  });
+});
+
+describe("pilotStore fallback context", () => {
+  it("opens the fleet and records which project asked for a scope", () => {
+    // The fleet it lands on is the same surface the unscoped chord gives, so
+    // the workspace has to ride along or the two openings are indistinguishable.
+    usePilotStore.getState().openFleetFallback(PROJECT);
+
+    expect(usePilotStore.getState()).toMatchObject({
+      isOpen: true,
+      scope: { kind: "fleet" },
+      fellBackFrom: PROJECT,
+    });
+  });
+
+  it.each([
+    ["open", (): void => usePilotStore.getState().open()],
+    ["openProject", (): void => usePilotStore.getState().openProject(OTHER)],
+    ["showFleet", (): void => usePilotStore.getState().showFleet()],
+    ["close", (): void => usePilotStore.getState().close()],
+    ["toggle", (): void => usePilotStore.getState().toggle()],
+  ])("clears the explanation on %s", (_name, transition) => {
+    // An explanation belongs to the opening that needed it. One surviving a
+    // gesture would be describing something the user has already moved past.
+    usePilotStore.getState().openFleetFallback(PROJECT);
+    transition();
+
+    expect(usePilotStore.getState().fellBackFrom).toBeNull();
+  });
+
+  it("does not carry the explanation into the next opening", () => {
+    usePilotStore.getState().openFleetFallback(PROJECT);
+    usePilotStore.getState().close();
+    usePilotStore.getState().open();
+
+    expect(usePilotStore.getState()).toMatchObject({ isOpen: true, fellBackFrom: null });
+  });
+
+  it("replaces rather than accumulates when a second project falls back", () => {
+    usePilotStore.getState().openFleetFallback(PROJECT);
+    usePilotStore.getState().openFleetFallback(OTHER);
+
+    expect(usePilotStore.getState().fellBackFrom).toBe(OTHER);
   });
 });

--- a/src/store/pilotStore.ts
+++ b/src/store/pilotStore.ts
@@ -14,9 +14,22 @@ const FLEET_SCOPE: PilotScope = { kind: "fleet" };
 interface PilotState {
   isOpen: boolean;
   scope: PilotScope;
+  /**
+   * The workspace a scoped opening asked for and could not give, or null.
+   *
+   * Set for exactly one opening, by the one caller that decided this project has
+   * no worktree axis to cut on. `PilotView` turns it into a line saying so, which
+   * is what stops the scoped chord from being indistinguishable from a dead key:
+   * the fleet it lands on is byte for byte the surface the unscoped chord already
+   * gives, so without this the user has no way to tell a fallback from a misfire
+   * (#11957).
+   */
+  fellBackFrom: string | null;
   open: () => void;
   /** Open (or re-scope) the overview to one project's worktrees. */
   openProject: (workspaceId: string) => void;
+  /** Open the fleet BECAUSE this workspace has no worktree axis, and say so. */
+  openFleetFallback: (workspaceId: string) => void;
   /** Back out to the whole fleet without closing. */
   showFleet: () => void;
   close: () => void;
@@ -49,15 +62,25 @@ interface PilotState {
 export const usePilotStore = create<PilotState>((set) => ({
   isOpen: false,
   scope: FLEET_SCOPE,
+  fellBackFrom: null,
   // Opening from anywhere that did not name a project means the whole fleet.
   // Carrying the last scope forward would reopen the surface already hiding
   // most of it, with the reason two openings in the past.
-  open: () => set({ isOpen: true, scope: FLEET_SCOPE }),
-  openProject: (workspaceId) => set({ isOpen: true, scope: { kind: "project", workspaceId } }),
-  showFleet: () => set({ scope: FLEET_SCOPE }),
-  close: () => set({ isOpen: false, scope: FLEET_SCOPE }),
+  //
+  // Every transition but the fallback itself clears `fellBackFrom` — an
+  // explanation is about the opening that needed it, and one still on screen a
+  // gesture later is describing something the user has already moved past.
+  open: () => set({ isOpen: true, scope: FLEET_SCOPE, fellBackFrom: null }),
+  openProject: (workspaceId) =>
+    set({ isOpen: true, scope: { kind: "project", workspaceId }, fellBackFrom: null }),
+  openFleetFallback: (workspaceId) =>
+    set({ isOpen: true, scope: FLEET_SCOPE, fellBackFrom: workspaceId }),
+  showFleet: () => set({ scope: FLEET_SCOPE, fellBackFrom: null }),
+  close: () => set({ isOpen: false, scope: FLEET_SCOPE, fellBackFrom: null }),
   toggle: () =>
-    set((state) =>
-      state.isOpen ? { isOpen: false, scope: FLEET_SCOPE } : { isOpen: true, scope: FLEET_SCOPE }
-    ),
+    set((state) => ({
+      isOpen: !state.isOpen,
+      scope: FLEET_SCOPE,
+      fellBackFrom: null,
+    })),
 }));


### PR DESCRIPTION
**The bug.** `Cmd+Alt+I` (`pilot.openProject`) is meant to open the agent overview scoped to the current project and grouped by worktree. `hasWorktreeAxis` gated that on counting distinct worktree buckets among the project's LIVE AGENT RUNS in the fleet snapshot, needing two or more. `FleetSnapshotService` only emits a row for a terminal `classifyRun` calls an agent, so plain shells, dev-preview panes, trashed panels and the help terminal contribute no bucket, and a worktree nobody has a terminal in contributes none either. Drillability tracked where agents happened to be sitting, not whether the project has an axis at all. Measured against a running instance with five projects open, four of the five fell back; closing a second agent took the shortcut away with nothing to say so.

**The fix.** `hasWorktreeAxis(runs, knownWorktreeCount?)` now ORs the run-bucket count with the number of worktrees the project actually has, read from the calling view's own `WorktreeViewStore` through the already-wired `getWorktreeIdSet()` accessor, renderer-only, no new IPC. The two sources are combined as AGGREGATE COUNTS and never joined: `WorktreeSnapshot.id` has two mint sites (`realpath()` at creation, `pathResolve()` over porcelain at enumeration) that can spell one directory differently, which is exactly the trap #11659 documented. Counts cannot diverge that way.

**Scoping rules.** The accessor is unparameterized current-view state, so it is consulted only for the workspace the calling view owns: `pilot.openProject` already resolves `getViewWorkspaceId()`, and `PilotView`'s `canDrill` applies it only when `group.isCurrent`. Every foreign project keeps the run-derived answer, which is all a renderer can prove about them. Scratches are refused structurally via `isScratchWorkspaceId` rather than via `group.kind`, because kind is metadata that reads "unknown" until it hydrates, a window where the chevron would enrich a workspace the chord was already refusing. The count is also withdrawn under a query or band filter, keeping #11955's rule that the drill is computed from the rows actually drawn. Net effect: the header chevron and the keyboard chord still agree everywhere both are offered, which the issue required.

**Root work now leads.** The issue is right that root runs DO carry a `worktreeId`, the project root path, so the "No worktree" bucket was effectively unreachable and root work sorted alphabetically among branch checkouts (first by luck in `daintree`, buried in a project called `zebra`). `buildPilotWorktreeGroups` takes an optional `mainWorktreeId` and leads with it. This is the one place a group's `worktreeId` is matched against a worktree store, and it is safe on three conditions that all have to hold: the caller passes an id only for the project its own view owns, the id is one the store positively tagged `isMainWorktree` rather than a path matched against the project root (#2251), and a miss costs only the lead position: under symlink or porcelain divergence the order falls back to today's label/id total order rather than promoting the wrong worktree. The `PilotWorktreeGroup.worktreeId` docblock is rewritten to record that exception rather than left contradicting the code. The "No worktree" bucket stays high, but now for the reason it deserves: a live agent filed under no worktree at all is an anomaly worth seeing.

**The silent half.** A fallback used to land on a surface byte for byte identical to `Cmd+Alt+O`, so the key was indistinguishable from a dead one. `pilotStore` gains an ephemeral `fellBackFrom` and `openFleetFallback`, and the Pilot header carries one line naming the project. No `notify()` and no `console.warn`: nothing has gone wrong, there is nothing to retry, and the user is already looking at the surface being described. A toast would outlive the opening it belongs to and interrupt for a routine outcome. It carries `role="status"` so a screen reader hears more than the dialog's unchanged "All agents" label. It is recorded only when the refusal is informed: an unhydrated worktree store reads as "not told yet" rather than "no worktrees", so that case falls back silently as before. And it withdraws itself the moment the project gains an axis under the open surface, so a chevron never sits beside a line denying one.

**Behaviour change worth calling out.** A project with two or more worktrees and no live agents now scopes to the project's own empty state ("Start an agent in X") instead of dumping the user into the cross-project fleet. The old code documented that empty scoped list as deliberately unreachable; it was a consequence of the run-derived gate. Answering "none here yet" is the honest answer to the question the user asked, and the breadcrumb and the way back are both on screen.

**Testing.** 831 tests across 18 files pass locally: every Pilot suite, `pilotStore`, the action-definition and manifest-snapshot suites, the api-surface guard, and a sample of eight `useWorktreeStore` consumers. New coverage pins the gate enrichment, the current-project-only scoping, the structural scratch refusal, query withdrawal, worktree appearance and removal under the open surface, main-worktree ordering plus its fail-closed miss, the newly reachable scoped-empty mount, and the fallback note's lifecycle. `useWorktreeStoreOptional`, a null-tolerant sibling of `useWorktreeStore` for overlays that legitimately render outside the provider, gets its own suite, including that it releases its subscription on unmount. Typecheck clean; eslint and prettier clean on all changed files.

**Not done, deliberately.** `classifyRun` and `FleetSnapshotService` are untouched: they answer "is this terminal an agent run", which is a different and legitimate question, and widening them would not solve a worktree with no terminals in it either. A scratch whose runs somehow carried two distinct worktree ids would still scope on the run-derived count; that is pre-existing #11955 behaviour, the chevron and the chord agree on it, and changing it is outside this issue.

Resolves #11957