### PR TITLE
feat(pilot): make the fleet overview answer the question it exists for

### DIFF
--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -74,17 +74,36 @@ function cleanupWindowsElectronProcesses(): void {
   }
 }
 
+/**
+ * Every user-data-dir THIS worker has launched Electron with.
+ *
+ * The reap below matches on these and nothing else. It used to match the
+ * literal string `daintree-e2e`, which is on the command line of every
+ * e2e-launched Electron ever — `--daintree-e2e-mode` is unshifted onto the
+ * args of all of them — so a pre-launch reap on macOS local dev SIGKILLed
+ * every other worker's app as well as its own leftovers. One machine running
+ * two specs at once (two agents in two worktrees is the ordinary case here)
+ * had each launch killing the other's app, which surfaces as "the Daintree
+ * application can't start" in whichever one loses the race.
+ *
+ * Recording the dirs keeps the original intent — reap what this worker left
+ * behind, including prior specs' processes, which no single dir would cover —
+ * without the pattern reaching processes this worker never started.
+ */
+const launchedUserDataDirs = new Set<string>();
+
 function cleanupMacElectronE2eProcesses(): void {
   if (process.platform !== "darwin") return;
-  try {
-    // Kill only e2e-launched Electron processes (matched on `daintree-e2e`
-    // user-data-dir). Production Daintree.app and dev sessions are untouched.
-    // The -f full-command-line match catches every helper type (GPU, Renderer,
-    // network-service utility, crashpad_handler) since they all inherit the
-    // --user-data-dir argument.
-    execSync('pkill -f "node_modules/electron.*daintree-e2e"', { stdio: "ignore" });
-  } catch {
-    // Ignore "no matching process" errors.
+  for (const dir of launchedUserDataDirs) {
+    try {
+      // The -f full-command-line match catches every helper type (GPU,
+      // Renderer, network-service utility, crashpad_handler) since they all
+      // inherit the --user-data-dir argument. Production Daintree.app, dev
+      // sessions and other workers' e2e apps are all untouched.
+      execSync(`pkill -f ${JSON.stringify(`node_modules/electron.*${dir}`)}`, { stdio: "ignore" });
+    } catch {
+      // Ignore "no matching process" errors.
+    }
   }
 }
 
@@ -261,6 +280,7 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     beginAttempt(attempt, maxAttempts);
     const userDataDir = options.userDataDir ?? mkdtempSync(path.join(tmpdir(), "daintree-e2e-"));
+    launchedUserDataDirs.add(userDataDir);
     const args = [`--user-data-dir=${userDataDir}`, ROOT];
     args.unshift(E2E_MODE_ARG);
     if (options.env?.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS !== "0") {

--- a/e2e/screenshots/pilot-review.spec.ts
+++ b/e2e/screenshots/pilot-review.spec.ts
@@ -1,0 +1,486 @@
+/**
+ * Agent Pilot visual-review harness.
+ *
+ * The fleet overview is the one palette whose whole content is other people's
+ * work in flight, so it cannot be reviewed on an empty app: the bands, the
+ * demand chips, the park notes and the stall cue only exist when there is a
+ * fleet making them. This harness manufactures one — several projects, and a
+ * run in every band — and writes a tightly-cropped PNG of the surface so the
+ * design can be judged against rendered pixels.
+ *
+ * The fleet is injected as a snapshot on the real broadcast channel rather than
+ * grown from real agents. `FleetSnapshot` is main's whole contract with this
+ * surface, so a synthetic one exercises exactly the code path a real fleet
+ * does, and it lets a run be forty minutes old without the test waiting forty
+ * minutes. The projects underneath are real, because their names, emoji and
+ * recency come from the project store and not from the snapshot.
+ *
+ * Opt-in only, like its palette-review sibling:
+ *
+ *   DAINTREE_SHOT_THEME=daintree npx playwright test --project=screenshots pilot-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_THEME  theme id, or `all` to sweep every built-in theme
+ *   DAINTREE_SHOT_TAG    optional suffix, to keep before/after rounds side by side
+ *   DAINTREE_SCREENSHOT_SCALE  device scale factor (default 2)
+ *
+ * Output: artifacts/pilot-shots/<theme>/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, type Page, type ElectronApplication } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+import { BUILT_IN_THEME_SOURCES } from "../../shared/theme/builtInThemeSources";
+
+const THEME_INPUT = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const ARTIFACT_ROOT = path.resolve(process.cwd(), "artifacts", "pilot-shots");
+
+const THEMES =
+  THEME_INPUT === "all"
+    ? BUILT_IN_THEME_SOURCES.map((t) => t.id)
+    : THEME_INPUT
+      ? [THEME_INPUT]
+      : [];
+
+const MOD = process.platform === "darwin" ? "Meta" : "Control";
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+/** The projects the fleet is spread across, in the order they are opened. */
+const WORKSPACES = [
+  { slug: "daintree", name: "Daintree", emoji: "🌴" },
+  { slug: "daintree-website", name: "Daintree Website", emoji: "🌐" },
+  { slug: "daintree-payments", name: "Daintree Payments", emoji: "💳" },
+  { slug: "daintree-assistant", name: "Daintree Assistant", emoji: "🤖" },
+  { slug: "assistant-backend", name: "Assistant Backend", emoji: "☁️" },
+] as const;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+function createRepo(root: string, slug: string): string {
+  const dir = path.join(root, slug);
+  mkdirSync(dir, { recursive: true });
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  writeFileSync(path.join(dir, "README.md"), `# ${slug}\n`);
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  return dir;
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+async function snapSurface(
+  page: Page,
+  outDir: string,
+  slug: string,
+  selector: string,
+  pad = 48
+): Promise<void> {
+  await settle(page);
+  const box = await page.locator(selector).first().boundingBox();
+  const file = path.join(outDir, `${slug}${TAG}.png`);
+  if (!box) {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+    return;
+  }
+  const viewport = page.viewportSize() ?? { width: 1680, height: 1050 };
+  const x = Math.max(0, box.x - pad);
+  const y = Math.max(0, box.y - pad);
+  await page.screenshot({
+    path: file,
+    type: "png",
+    animations: "disabled",
+    caret: "hide",
+    clip: {
+      x,
+      y,
+      width: Math.min(box.width + pad * 2, viewport.width - x),
+      height: Math.min(box.height + pad * 2, viewport.height - y),
+    },
+  });
+}
+
+async function closeOverlay(page: Page): Promise<void> {
+  await page.keyboard.press("Escape").catch(() => {});
+  await settle(page, 200);
+  await page.keyboard.press("Escape").catch(() => {});
+  await settle(page, 200);
+}
+
+/**
+ * Push a fabricated fleet onto the real broadcast channel from main.
+ *
+ * Every renderer gets it, which is what the service itself does — the pilot
+ * lives in whichever project view is active, and targeting one by hand would
+ * make the harness guess at the window model.
+ */
+async function injectFleet(app: ElectronApplication, runs: unknown[]): Promise<void> {
+  await app.evaluate(
+    async ({ webContents }, payload) => {
+      for (const wc of webContents.getAllWebContents()) {
+        if (wc.isDestroyed()) continue;
+        wc.send("fleet:snapshot-updated", payload);
+      }
+    },
+    {
+      runs,
+      changedAt: Date.now(),
+      degraded: false,
+      lastSuccessfulAt: Date.now(),
+    }
+  );
+}
+
+/** Minutes ago, as an epoch stamp. */
+function mins(n: number): number {
+  return Date.now() - n * 60_000;
+}
+
+/**
+ * A fleet with a run in every band, spread the way a real morning is: most of
+ * the work running, one thing asking, one thing broken, one thing shelved.
+ */
+function buildRuns(ids: Record<string, string>): unknown[] {
+  const w = (slug: string) => ids[slug] ?? slug;
+  return [
+    // Daintree — the current project. Working, a stalled worker, a hand-back.
+    {
+      runId: "r-1",
+      workspaceId: w("daintree"),
+      agentId: "claude",
+      agentState: "working",
+      since: mins(33),
+      spawnedAt: mins(40),
+      title: "Daintree Assistant CLI version update",
+      cwd: "/repos/daintree",
+    },
+    {
+      runId: "r-2",
+      workspaceId: w("daintree"),
+      agentId: "claude",
+      agentState: "working",
+      since: mins(47),
+      spawnedAt: mins(50),
+      quietSince: mins(12),
+      title: "Terminal fabric sharding spike",
+      cwd: "/repos/daintree",
+    },
+    {
+      runId: "r-3",
+      workspaceId: w("daintree"),
+      agentId: "codex",
+      agentState: "completed",
+      since: mins(6),
+      spawnedAt: mins(60),
+      title: "Worktree design iteration",
+      cwd: "/repos/daintree",
+    },
+    {
+      runId: "r-4",
+      workspaceId: w("daintree"),
+      agentId: "claude",
+      agentState: "working",
+      since: mins(2),
+      spawnedAt: mins(3),
+      title: "Issues dropdown design review",
+      cwd: "/repos/daintree",
+    },
+    // Website — one plain worker.
+    {
+      runId: "r-5",
+      workspaceId: w("daintree-website"),
+      agentId: "claude",
+      agentState: "working",
+      since: mins(36),
+      spawnedAt: mins(38),
+      title: "Pricing page copy pass",
+      cwd: "/repos/daintree-website",
+    },
+    // Payments — the demand, and the failure.
+    {
+      runId: "r-6",
+      workspaceId: w("daintree-payments"),
+      agentId: "codex",
+      agentState: "waiting",
+      waitingReason: "approval",
+      since: mins(38),
+      spawnedAt: mins(45),
+      title: "Stripe webhook retry backoff",
+      cwd: "/repos/daintree-payments",
+    },
+    {
+      runId: "r-7",
+      workspaceId: w("daintree-payments"),
+      agentId: "gemini",
+      agentState: "waiting",
+      waitingReason: "error",
+      since: mins(21),
+      spawnedAt: mins(30),
+      title: "Invoice reconciliation job",
+      cwd: "/repos/daintree-payments",
+    },
+    // Assistant — a worker and a parked run carrying its reason.
+    {
+      runId: "r-8",
+      workspaceId: w("daintree-assistant"),
+      agentId: "claude",
+      agentState: "working",
+      since: mins(37),
+      spawnedAt: mins(40),
+      title: "Custom commands mirroring",
+      cwd: "/repos/daintree-assistant",
+    },
+    {
+      runId: "r-9",
+      workspaceId: w("daintree-assistant"),
+      agentId: "opencode",
+      agentState: "waiting",
+      waitingReason: "prompt",
+      since: mins(90),
+      spawnedAt: mins(120),
+      title: "Alt-screen corruption repro",
+      cwd: "/repos/daintree-assistant",
+      park: { parkedAt: mins(55), note: "waiting on the xterm 6.1 beta" },
+    },
+    // Backend — a worker, a snooze and an exited shell.
+    {
+      runId: "r-10",
+      workspaceId: w("assistant-backend"),
+      agentId: "claude",
+      agentState: "working",
+      since: mins(10),
+      spawnedAt: mins(12),
+      title: "Together rate-limit backoff",
+      cwd: "/repos/assistant-backend",
+    },
+    {
+      runId: "r-11",
+      workspaceId: w("assistant-backend"),
+      agentId: "grok",
+      agentState: "waiting",
+      waitingReason: "question",
+      since: mins(65),
+      spawnedAt: mins(70),
+      title: "Usage metering schema",
+      cwd: "/repos/assistant-backend",
+      snooze: { snoozedAt: mins(15), snoozedUntil: Date.now() + 45 * 60_000 },
+    },
+    {
+      runId: "r-12",
+      workspaceId: w("assistant-backend"),
+      agentId: "claude",
+      agentState: "exited",
+      since: mins(130),
+      spawnedAt: mins(180),
+      title: "Deploy smoke check",
+      cwd: "/repos/assistant-backend",
+    },
+  ];
+}
+
+/**
+ * Register the five projects and stamp their identity, idempotently.
+ *
+ * Re-run after every launch rather than once: the store persists in the shared
+ * user-data directory, so the second launch finds them all and only re-reads
+ * the ids. `lastOpened` is stamped explicitly so the groups sort the way a real
+ * morning does — the project you are in at the top, the rest behind it in the
+ * order you last touched them. Left to the store, the order would be whatever
+ * the harness's own loop produced.
+ */
+/**
+ * Get the fabricated fleet on screen, and keep it there long enough to shoot.
+ *
+ * Two races, both real, both silent:
+ *
+ * 1. A push is one-shot. One that arrives before the renderer has subscribed is
+ *    simply dropped, and since main suppresses unchanged broadcasts nothing
+ *    ever replaces it — the surface then renders its (true) empty state forever.
+ * 2. Main's own first real broadcast can land AFTER the rows appear, and an
+ *    empty fleet IS a change from the injected one, so it wins and the rows
+ *    vanish between the check and the shutter.
+ *
+ * So the check is repeated after the settle rather than before it, and the last
+ * thing this does is confirm the rows survived. It throws if they did not: a
+ * capture harness that quietly writes an empty-state PNG over a real one is
+ * worse than a failing run.
+ */
+async function holdFleet(
+  page: Page,
+  app: ElectronApplication,
+  ids: Record<string, string>
+): Promise<void> {
+  const rows = page.getByTestId("pilot-row");
+  for (let attempt = 0; attempt < 12; attempt++) {
+    if ((await rows.count()) === 0) {
+      await injectFleet(app, buildRuns(ids));
+      await settle(page, 500);
+      continue;
+    }
+    await settle(page, 600);
+    if ((await rows.count()) > 0) return;
+  }
+  throw new Error("fleet never stayed on screen long enough to capture");
+}
+
+async function ensureProjects(page: Page, dirs: string[]): Promise<Record<string, string>> {
+  return page.evaluate(
+    async ({ entries }) => {
+      const out: Record<string, string> = {};
+      for (const entry of entries) {
+        const existing = (await window.electron.project.getAll()).find(
+          (p: { path: string; id: string }) => p.path === entry.dir
+        );
+        const id = existing?.id ?? (await window.electron.project.add(entry.dir))?.id;
+        if (!id) continue;
+        await window.electron.project.update(id, {
+          name: entry.name,
+          emoji: entry.emoji,
+          lastOpened: entry.lastOpened,
+        });
+        out[entry.slug] = id;
+      }
+      return out;
+    },
+    {
+      entries: WORKSPACES.map((ws, i) => ({
+        slug: ws.slug,
+        name: ws.name,
+        emoji: ws.emoji,
+        dir: dirs[i]!,
+        lastOpened: Date.now() - i * 90 * 60_000,
+      })),
+    }
+  );
+}
+
+test("pilot review — the fleet overview, with a fleet", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_THEME is required for the pilot-review capture",
+  });
+  test.skip(THEMES.length === 0, "Set DAINTREE_SHOT_THEME (an id, or `all`) to run this capture");
+
+  const repoRoot = mkdtempSync(path.join(tmpdir(), "daintree-pilotshot-repos-"));
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-pilotshot-"));
+  const dirs = WORKSPACES.map((ws) => createRepo(repoRoot, ws.slug));
+
+  try {
+    // One app per theme, sharing the user-data directory.
+    //
+    // `setAppTheme` reloads the renderer, and fifteen reloads inside one
+    // session reliably crashed it around the fifth — this is a capture harness,
+    // not a resilience test, and a cold app per theme costs about ten seconds
+    // and never flakes. The projects survive in the store between launches, so
+    // only the first launch pays for onboarding.
+    for (const theme of THEMES) {
+      const outDir = path.join(ARTIFACT_ROOT, theme);
+      mkdirSync(outDir, { recursive: true });
+
+      let ctx: AppContext | undefined;
+      try {
+        ctx = await launchApp({
+          userDataDir,
+          screenshotScale: SCALE,
+          windowSize: { width: 1680, height: 1050 },
+          extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+        });
+
+        // The first project is opened for real, which is what makes one of the
+        // groups the current workspace. Later launches reopen it themselves.
+        const alreadyOpen = await ctx.window
+          .evaluate(async () => (await window.electron.project.getCurrent())?.id ?? null)
+          .catch(() => null);
+        const page =
+          alreadyOpen === null
+            ? await openAndOnboardProject(ctx.app, ctx.window, dirs[0]!, WORKSPACES[0]!.name)
+            : ctx.window;
+
+        const ids = await ensureProjects(page, dirs);
+
+        await setAppTheme(page, theme);
+        await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+        await dismissBlockingPalette(page);
+        await page
+          .locator(SEL.worktree.mainCard)
+          .waitFor({ state: "visible", timeout: T_LONG })
+          .catch(() => {});
+        await settle(page, 800);
+
+        // After the theme reload, so the snapshot lands on a live store.
+        await injectFleet(ctx.app, buildRuns(ids));
+        await settle(page, 400);
+
+        await page.keyboard.press(`${MOD}+Alt+O`);
+        const dialog = page.locator('[role="dialog"][aria-label="All agents"]');
+        await dialog.waitFor({ state: "visible", timeout: 8000 });
+
+        await holdFleet(page, ctx.app, ids);
+        await snapSurface(
+          page,
+          outDir,
+          "01-pilot-all-agents",
+          '[role="dialog"][aria-label="All agents"]'
+        );
+
+        // The demand-only cut: what the surface looks like once the footer's
+        // "agents need you" button has isolated the runs that are asking.
+        await page
+          .getByTestId("pilot-demand-action")
+          .click()
+          .catch(() => {});
+        await holdFleet(page, ctx.app, ids);
+        await snapSurface(
+          page,
+          outDir,
+          "02-pilot-needs-you",
+          '[role="dialog"][aria-label="All agents"]'
+        );
+
+        await closeOverlay(page);
+      } finally {
+        if (ctx) await closeApp(ctx).catch(() => {});
+      }
+    }
+  } finally {
+    // Best-effort, and never the reason a capture run reports failure. Electron
+    // helpers can still be flushing crashpad and cache files as the tree comes
+    // down, which surfaces as ENOTEMPTY on a directory the OS will reap anyway.
+    for (const dir of [repoRoot, userDataDir]) {
+      if (!existsSync(dir)) continue;
+      try {
+        rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      } catch (error) {
+        console.warn(`[pilot-shots] could not remove ${dir}:`, String(error).split("\n")[0]);
+      }
+    }
+  }
+});

--- a/src/components/Pilot/PilotFilterBar.tsx
+++ b/src/components/Pilot/PilotFilterBar.tsx
@@ -22,16 +22,29 @@ const NEUTRAL_TONE_FADED = "text-text-secondary/40";
  * the faded variant is spelled out rather than derived — the same constraint
  * `QuickStateFilterBar` documents.
  *
- * `working` is hued unconditionally — see `segmentIsHued`. The other two carry
- * the hue of the demand they can reveal, and only while they are actually
- * holding one; see `bandFilterHasDemand`.
+ * `working` and `quiet` are hued unconditionally — see `segmentIsHued`. The
+ * others carry the hue of the demand they can reveal, and only while they are
+ * actually holding one; see `bandFilterHasDemand`. A mixed segment's glyph is
+ * resolved at render time by `segmentVisual`, not read straight from here.
  */
-const SEGMENT_TONE: Record<
-  Exclude<PilotBandFilter, "all">,
-  { Icon: ComponentType<{ className?: string }>; tone: string; toneFaded: string }
-> = {
+interface SegmentVisual {
+  Icon: ComponentType<{ className?: string }> | null;
+  tone: string;
+  toneFaded: string;
+}
+
+const SEGMENT_TONE: Record<Exclude<PilotBandFilter, "all">, SegmentVisual> = {
   "needs-you": {
     Icon: BAND_GLYPH["needs-you"],
+    tone: "text-state-waiting",
+    toneFaded: "text-state-waiting/40",
+  },
+  // The working mark in the waiting hue, and static — the same pairing the row
+  // draws, because a silent run is a working run that may need a hand. No new
+  // glyph: the spinner means working everywhere in this app and does not stop
+  // meaning it here.
+  quiet: {
+    Icon: BAND_GLYPH.quiet,
     tone: "text-state-waiting",
     toneFaded: "text-state-waiting/40",
   },
@@ -45,10 +58,19 @@ const SEGMENT_TONE: Record<
     tone: "text-category-blue",
     toneFaded: "text-category-blue/40",
   },
-  // Parked never earns a hue: it is the user's own quiet, and a coloured
+  // Parked never earns a hue: it is the user's own silence, and a coloured
   // segment would re-demand the attention parking just released.
   parked: {
     Icon: BAND_GLYPH.parked,
+    tone: NEUTRAL_TONE,
+    toneFaded: NEUTRAL_TONE_FADED,
+  },
+  // No glyph at all. "Other" holds a snooze and an exited shell, which share
+  // nothing but their absence from the four questions this bar asks — any mark
+  // would have to stand for one of them and misdescribe the rest. It exists so
+  // the counts add up to All, and it is drawn as quietly as that job allows.
+  other: {
+    Icon: null,
     tone: NEUTRAL_TONE,
     toneFaded: NEUTRAL_TONE_FADED,
   },
@@ -68,10 +90,80 @@ function segmentIsHued(
   bands: Readonly<FleetBandCounts>,
   segment: Exclude<PilotBandFilter, "all">
 ): boolean {
-  return segment === "working" || bandFilterHasDemand(bands, segment);
+  // `quiet` joins `working` in the exemption for the mirror-image reason: it
+  // is not a demand either — nobody is asking — but a run that has gone silent
+  // is a live fact about the fleet, which is exactly what this surface hues.
+  // The empty-bucket fade below still mutes it when it holds nothing.
+  return segment === "working" || segment === "quiet" || bandFilterHasDemand(bands, segment);
+}
+
+/**
+ * The glyph a mixed segment wears, which is the band it is currently ABOUT.
+ *
+ * "Attention" admits `blocked` as well as `needs-you`, and drawing it with the
+ * amber hollow circle while it held an errored run said the calmer of the two
+ * things it was holding. A segment whose glyph never moves can only ever
+ * describe one of its members.
+ *
+ * Only `needs-you` escalates, and only because it has somewhere to escalate
+ * TO: `blocked` has a mark of its own. `finished` holds `review` and `done`,
+ * which are the same app-standard check circle at two tones — that mark is not
+ * this surface's to reinterpret, so its distinction rides the hue
+ * (`bandFilterHasDemand` already owns that) and, for anyone the hue cannot
+ * reach, `segmentQualifier` below puts it into the segment's spoken name.
+ *
+ * Escalation is also why the first segment could not stay called "Waiting": a
+ * red prohibition sign beside that word contradicted itself, where beside
+ * "Attention" it reads correctly — two runs want you, and the worse of them is
+ * blocked. The accessible name says the same thing in words.
+ */
+function segmentVisual(
+  bands: Readonly<FleetBandCounts>,
+  segment: Exclude<PilotBandFilter, "all">
+): SegmentVisual {
+  if (segment === "needs-you" && bands.blocked > 0) {
+    return {
+      Icon: BAND_GLYPH.blocked,
+      tone: "text-status-danger",
+      toneFaded: "text-status-danger/40",
+    };
+  }
+  return SEGMENT_TONE[segment];
+}
+
+/**
+ * The part of a mixed segment its glyph encodes, in words.
+ *
+ * Colour and shape carry it visually; this is the same fact in the channel a
+ * screen reader can reach. Null for a segment holding one kind of thing, so a
+ * pure bucket is never padded with a clause that adds nothing.
+ */
+function segmentQualifier(
+  bands: Readonly<FleetBandCounts>,
+  segment: PilotBandFilter
+): string | null {
+  if (segment === "needs-you" && bands.blocked > 0) return `including ${bands.blocked} blocked`;
+  if (segment === "finished" && bands.review > 0) {
+    // "all", not "including", when the bucket is pure. Qualifying only the
+    // MIXED case left a segment holding three hand-backs and one holding three
+    // acknowledged completions with the same accessible name — the glyph tells
+    // them apart, and a glyph is not a channel a screen reader can reach.
+    return bands.done > 0 ? `including ${bands.review} ready for review` : `all ready for review`;
+  }
+  return null;
 }
 
 const SEGMENTS: readonly PilotBandFilter[] = ["all", ...PILOT_BAND_FILTERS];
+
+function agents(count: number): string {
+  return `${count} ${count === 1 ? "agent" : "agents"}`;
+}
+
+/** A segment's spoken name, carrying whatever its glyph choice encodes. */
+function segmentName(label: string, count: number, qualifier: string | null): string {
+  const base = `${label}, ${agents(count)}`;
+  return qualifier === null ? base : `${base}, ${qualifier}`;
+}
 
 export interface PilotFilterBarProps {
   value: PilotBandFilter;
@@ -185,10 +277,11 @@ export function PilotFilterBar({
       {SEGMENTS.map((segment, idx) => {
         const isActive = segment === value;
         const count = counts[segment];
-        const visual = segment === "all" ? null : SEGMENT_TONE[segment];
+        const visual = segment === "all" ? null : segmentVisual(bands, segment);
         const label = PILOT_BAND_FILTER_LABEL[segment];
         const Icon = visual?.Icon;
         const isSpinning = segment === "working" && count > 0;
+        const qualifier = segmentQualifier(bands, segment);
         const isHued = segment !== "all" && segmentIsHued(bands, segment);
         const tone = isHued ? visual?.tone : NEUTRAL_TONE;
         // An empty bucket keeps its glyph and its "0" but mutes the glyph, so
@@ -205,7 +298,11 @@ export function PilotFilterBar({
             // stop, so Tab from the search box lands on the active filter
             // rather than walking four controls to reach the list.
             tabIndex={isActive ? 0 : -1}
-            aria-label={`${label}, ${count} ${count === 1 ? "agent" : "agents"}`}
+            // What the glyph encodes is named, not left in the drawing. A
+            // segment that escalates to the danger mark and then announces a
+            // flat "Needs you, 2 agents" has put the worse half of what it
+            // holds into a channel a screen reader cannot reach.
+            aria-label={segmentName(label, count, qualifier)}
             ref={(el) => {
               refs.current.set(segment, el);
             }}
@@ -213,7 +310,12 @@ export function PilotFilterBar({
               onChange(segment);
             }}
             className={cn(
-              "inline-flex min-w-0 flex-1 items-center justify-center gap-1 px-2 py-1.5 transition-colors",
+              // `grow`, not `flex-1`: a zero basis divides the bar into equal
+              // shares, and seven equal shares of a 608px palette truncated
+              // "Needs you" and "Finished" into "Need…" and "Finis…". Sizing
+              // from content and sharing only the SLACK keeps every label whole
+              // and still fills the bar edge to edge.
+              "inline-flex min-w-0 grow items-center justify-center gap-1 px-1.5 py-1.5 transition-colors",
               "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent",
               idx > 0 && "border-l border-border-default",
               isActive

--- a/src/components/Pilot/PilotParkEditor.tsx
+++ b/src/components/Pilot/PilotParkEditor.tsx
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { cn } from "@/lib/utils";
+import { Spinner } from "@/components/ui/Spinner";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { PilotRunState } from "./PilotRunState";
 import type { PilotProjectGroup, PilotRow } from "./pilotRows";
@@ -24,6 +27,9 @@ export interface PilotParkTarget {
 }
 
 const GATE_NONE = "__none__";
+
+/** Where "this is taking a while" stops being noise and starts being news. */
+const PARK_STILL_WORKING_MS = 5_000;
 
 function gateOptionDomId(runId: string): string {
   return `pilot-park-gate-${runId}`;
@@ -60,6 +66,21 @@ export function PilotParkEditor({
   const [gateId, setGateId] = useState<string>(target.existingPark?.gateRunId ?? GATE_NONE);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Submitting disables the whole form, and a disabled form with no other sign
+   * of life is indistinguishable from a broken one.
+   *
+   * Doherty-gated, so a park that lands in 80ms — which is nearly all of them,
+   * the write being a local record — flashes nothing on the way. Past the gate
+   * the button says it is working; past five seconds a polite status says so
+   * in words, for the case where the pty host is the thing not answering.
+   *
+   * The form's values stay on screen throughout. A note the user typed is the
+   * one thing here that cannot be recovered by trying again.
+   */
+  const showBusy = useDeferredLoading(busy, UI_DOHERTY_THRESHOLD);
+  const showStillWorking = useDeferredLoading(busy, PARK_STILL_WORKING_MS);
 
   const noteRef = useRef<HTMLInputElement>(null);
   const gateRefs = useRef(new Map<string, HTMLButtonElement | null>());
@@ -195,11 +216,11 @@ export function PilotParkEditor({
           brandColor={target.row.presetColor ?? target.row.chrome.color}
         />
         <span className="min-w-0 truncate text-sm text-daintree-text">{target.row.title}</span>
-        <span className="shrink-0 text-xs text-daintree-text/40">{target.group.name}</span>
+        <span className="shrink-0 text-xs text-text-secondary">{target.group.name}</span>
       </div>
 
       <label className="flex flex-col gap-1">
-        <span className="text-[10px] font-medium tracking-wide text-daintree-text/50 uppercase">
+        <span className="text-[10px] font-medium tracking-wide text-text-secondary uppercase">
           Note
         </span>
         <input
@@ -213,7 +234,7 @@ export function PilotParkEditor({
           data-testid="pilot-park-note"
           className={cn(
             "w-full rounded-[var(--radius-sm)] border border-border-default bg-transparent px-2 py-1.5",
-            "text-sm text-daintree-text placeholder:text-daintree-text/35"
+            "text-sm text-daintree-text placeholder:text-text-secondary"
           )}
         />
       </label>
@@ -221,7 +242,7 @@ export function PilotParkEditor({
       <div className="flex flex-col gap-1">
         <span
           id="pilot-park-gate-label"
-          className="text-[10px] font-medium tracking-wide text-daintree-text/50 uppercase"
+          className="text-[10px] font-medium tracking-wide text-text-secondary uppercase"
         >
           Park until
         </span>
@@ -282,7 +303,7 @@ export function PilotParkEditor({
                       brandColor={candidate.row.presetColor ?? candidate.row.chrome.color}
                     />
                     <span className="min-w-0 flex-1 truncate">{candidate.row.title}</span>
-                    <span className="shrink-0 text-xs text-daintree-text/40">
+                    <span className="shrink-0 text-xs text-text-secondary">
                       {candidate.group.name}
                     </span>
                   </>
@@ -291,7 +312,7 @@ export function PilotParkEditor({
             );
           })}
         </div>
-        <p className="text-[11px] leading-snug text-daintree-text/40">
+        <p className="text-[11px] leading-snug text-text-secondary">
           Gated parks lift when that agent next finishes working — the run pops back into Waiting
           with your note.
         </p>
@@ -300,6 +321,12 @@ export function PilotParkEditor({
       {error !== null && (
         <p role="alert" className="text-xs text-status-danger">
           {error}
+        </p>
+      )}
+
+      {showStillWorking && error === null && (
+        <p role="status" data-testid="pilot-park-slow" className="text-xs text-text-secondary">
+          Still working…
         </p>
       )}
 
@@ -315,7 +342,10 @@ export function PilotParkEditor({
             "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
           )}
         >
-          {isReparking ? "Update park" : "Park"}
+          <span className="flex items-center gap-1.5">
+            {showBusy && <Spinner size="sm" />}
+            {isReparking ? "Update park" : "Park"}
+          </span>
         </button>
         {isReparking && (
           <button
@@ -340,7 +370,7 @@ export function PilotParkEditor({
           data-no-submit
           data-testid="pilot-park-cancel"
           className={cn(
-            "ml-auto rounded-[var(--radius-sm)] px-3 py-1 text-sm text-daintree-text/50 transition-colors",
+            "ml-auto rounded-[var(--radius-sm)] px-3 py-1 text-sm text-text-secondary transition-colors",
             "hover:bg-overlay-subtle hover:text-daintree-text disabled:opacity-50",
             "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
           )}

--- a/src/components/Pilot/PilotRunState.tsx
+++ b/src/components/Pilot/PilotRunState.tsx
@@ -6,6 +6,7 @@ import {
   ExitedCircle,
   CircleCheck,
   CircleDashed,
+  CircleDot,
   CirclePause,
   CircleSlash,
 } from "@/components/icons";
@@ -18,7 +19,9 @@ interface PilotRunStateProps {
 }
 
 /**
- * The neutral tone the quiet states carry.
+ * The neutral tone the settled states carry.
+ *
+ * "Settled", not "quiet" — `quiet` is a band now, and it is hued.
  *
  * `done` and `idle` are finished business: nothing is in flight and nothing is
  * being asked, so they read as ordinary text. Deliberately `text-text-secondary`
@@ -44,20 +47,49 @@ const NEUTRAL_TONE = "text-text-secondary";
  * channel separating "the agent errored" from "the agent asked you a question";
  * with that word gone, the shapes have to carry it. Same circle family as every
  * other glyph here, so it still reads as one of the set.
+ *
+ * Three of these marks are the app's own standards and are not this surface's
+ * to reinterpret: the green spinner is working, the amber hollow circle is
+ * waiting, and the blue circle-with-a-check is finished. The sidebar, the dock,
+ * the assistant header and the panel chrome all say the same three things the
+ * same three ways.
+ *
+ * So the invariant here is NOT that every band draws a different shape — it is
+ * that no two bands share a shape AND a tone, and that among the bands wearing
+ * the SAME tone, every shape differs. Hue does the work where the vocabulary
+ * already assigns it; geometry does the work everywhere hue cannot.
+ *
+ * - `quiet` is the working spinner in the waiting hue, and no new glyph at all.
+ *   A silent run IS working — that is the whole difficulty with it — so it
+ *   keeps working's mark and takes the colour of the thing that may need a
+ *   hand. It does not animate, which is the other half of what it means. The
+ *   row spells "quiet 12m" beside it in words, so the pair is never separated
+ *   by colour alone.
+ * - `done` is the finished mark in the settled tone: the same check the app
+ *   uses for finished work, greyed because an acknowledged completion has left
+ *   the attention model.
+ * - `idle` takes the dotted circle — alive, at rest, nothing running. It used
+ *   to share the hollow circle with `needs-you`, which is the one collision
+ *   worth removing: it left the amber hollow circle meaning waiting while a
+ *   grey one meant something else entirely. Now the hollow circle means
+ *   waiting and only waiting. The exited refinement below keeps the
+ *   struck-through circle, so a dead shell and a resting one stay tellable
+ *   apart too.
  */
 export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>> = {
   blocked: CircleSlash,
   "needs-you": HollowCircle,
+  quiet: SpinnerCircle,
   review: CircleCheck,
   running: SpinnerCircle,
   done: CircleCheck,
   parked: CirclePause,
-  // Dashed rather than paused: a park is held, a snooze is merely quiet for
+  // Dashed rather than paused: a park is held, a snooze is merely silent for
   // now, and the two must not share a shape when the row's only other
   // difference between them is a word. The dash is the same signal the project
   // switcher's snoozed dot uses, so one vocabulary covers both surfaces.
   snoozed: CircleDashed,
-  idle: HollowCircle,
+  idle: CircleDot,
 };
 
 /**
@@ -87,6 +119,11 @@ export const BAND_GLYPH: Record<FleetBand, ComponentType<{ className?: string }>
 export const BAND_GLYPH_TONE: Record<FleetBand, string> = {
   blocked: "text-status-danger",
   "needs-you": "text-state-waiting",
+  // Amber, and the same amber a demand wears. A stall is not a demand — nobody
+  // is asking — but it is the other thing on this surface that may need a hand,
+  // and inventing a third hue for it would spend a colour on a distinction the
+  // shape already carries.
+  quiet: "text-state-waiting",
   review: "text-category-blue",
   running: "text-state-working",
   done: NEUTRAL_TONE,

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -14,7 +14,7 @@ import { actionService } from "@/services/ActionService";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { agoPhrase, formatWaitAge } from "@/lib/projectRowStatus";
-import { isDemandBand } from "@/lib/fleetAttention";
+import { bandTimestamp, FLEET_BANDS, isAttentionBand, type FleetBand } from "@/lib/fleetAttention";
 import {
   buildPilotGroups,
   buildPilotWorktreeGroups,
@@ -146,9 +146,55 @@ function agentCount(count: number): string {
   return count === 1 ? "1 agent" : `${count} agents`;
 }
 
+/**
+ * The group's attention chips, in words, for the heading's accessible name.
+ *
+ * Built from the same per-band array the chips are drawn from, so the two
+ * cannot say different things. It used to collapse to "2 agents need you",
+ * which folded a blocked run in with a waiting one, dropped `quiet` entirely,
+ * and described a review hand-back as somebody needing you.
+ *
+ * Empty string rather than null, because it is concatenated into a label.
+ */
+function attentionPhrase(attention: PilotGroupCore["attention"]): string {
+  if (attention.length === 0) return "";
+  return `, ${attention.map(({ band, count }) => `${count} ${ATTENTION_WORD[band]}`).join(", ")}`;
+}
+
+/**
+ * One word per band, in the band's own vocabulary.
+ *
+ * Only the four `isAttentionBand` admits can reach a chip; the rest are here
+ * so the map is total and a new band cannot silently fall through to nothing.
+ */
+const ATTENTION_WORD: Record<FleetBand, string> = {
+  blocked: "blocked",
+  "needs-you": "waiting",
+  quiet: "quiet",
+  review: "ready for review",
+  running: "working",
+  done: "finished",
+  parked: "parked",
+  snoozed: "snoozed",
+  idle: "idle",
+};
+
 /** Work handed back, plural-aware. The footer's sentence when nothing is asking. */
 function reviewPhrase(count: number): string {
   return count === 1 ? "Ready for review" : `${count} agents ready for review`;
+}
+
+/**
+ * Silence, plural-aware — the footer's sentence when nothing is asking but
+ * something has stopped talking.
+ *
+ * "Gone quiet", not "stalled": the fleet observes the silence and infers
+ * nothing about the cause. An agent mid-way through a long compile and one
+ * wedged on a dead socket look identical from here, and only one of them is a
+ * problem.
+ */
+function quietPhrase(count: number): string {
+  return count === 1 ? "Agent has gone quiet" : `${count} agents have gone quiet`;
 }
 
 /** The resting tone. Selected is the shared row class's to own, off the attribute. */
@@ -215,30 +261,41 @@ function WorkspaceTile({ group }: { group: PilotProjectGroup }) {
  * The header's whole job now is to file the rows underneath it.
  */
 /**
- * The group's demand, at a glance: glyph and hue come from the worst row
- * beneath (which is always a demand band whenever the count is non-zero, since
- * demands outrank everything else), so five headers answer "which one is on
- * fire" without reading a single row. Hidden with the rest of the header — the
- * group's aria-label carries the same fact in words.
+ * What is worth pointing at in this group, counted per band, worst first — so
+ * five headers answer "which one is on fire" without reading a single row.
  *
- * Shared by both axes so a worktree's chip cannot come to mean something
- * different from a project's.
+ * One chip per band rather than one chip for the group. The old form drew the
+ * WORST band's glyph beside the TOTAL demand count, which for a project holding
+ * one blocked run and one waiting one rendered as a red prohibition sign beside
+ * "2" — and there is no reading of that which isn't "two blocked". A pair of
+ * chips costs about twenty pixels and says the true thing.
+ *
+ * Two is the realistic ceiling and three the absolute one (blocked, waiting,
+ * quiet, review is four bands but review only reaches a header that has no
+ * demand above it), so this never grows into a strip that outweighs the name
+ * beside it.
+ *
+ * Hidden from the accessibility tree — the group's `aria-label` carries the
+ * same counts in words. Shared by both axes so a worktree's chip cannot come to
+ * mean something different from a project's.
  */
 function GroupDemandChip({ group }: { group: PilotGroupCore }) {
-  if (group.demandCount === 0) return null;
-  const chipBand = isDemandBand(group.topBand) ? group.topBand : "needs-you";
-  const ChipGlyph = BAND_GLYPH[chipBand];
+  if (group.attention.length === 0) return null;
   return (
     <span
       aria-hidden="true"
       data-testid="pilot-group-demand"
-      className={cn(
-        "flex shrink-0 items-center gap-1 text-[10px] leading-none tabular-nums",
-        BAND_GLYPH_TONE[chipBand]
-      )}
+      className="flex shrink-0 items-center gap-2 text-[10px] leading-none tabular-nums"
     >
-      <ChipGlyph className="h-2.5 w-2.5" />
-      {group.demandCount}
+      {group.attention.map(({ band, count }) => {
+        const ChipGlyph = BAND_GLYPH[band];
+        return (
+          <span key={band} className={cn("flex items-center gap-1", BAND_GLYPH_TONE[band])}>
+            <ChipGlyph className="h-2.5 w-2.5" />
+            {count}
+          </span>
+        );
+      })}
     </span>
   );
 }
@@ -303,7 +360,7 @@ function GroupHeader({
           textual — membership is never an accent signal.
         */}
         {group.isCurrent && (
-          <span className="shrink-0 text-[10px] leading-none text-daintree-text/30">Current</span>
+          <span className="shrink-0 text-[10px] leading-none text-text-secondary">Current</span>
         )}
       </div>
 
@@ -398,8 +455,9 @@ function RunRow({
    *
    * The row's own spans are inline, so a computed name concatenates them with
    * no separators at all: "Fix auth2m". Naming the parts here is what turns the
-   * row back into a sentence, and it lets the age be announced as an age
-   * ("2m ago") instead of a bare token a screen reader reads as "two em".
+   * row back into a sentence, and the age arrives as a phrase its band chose
+   * ("waiting for 38m", "finished 6m ago") rather than a bare token a screen
+   * reader would read as "two em".
    *
    * The state is here and nowhere else on the row now. The worktree is neither:
    * it is a scratch project's UUID as often as it is a branch, and dropping it
@@ -411,8 +469,8 @@ function RunRow({
     agentLabel,
     row.statusLabel,
     row.parkNote,
-    row.quietFor !== null ? `quiet for ${row.quietFor}` : null,
-    row.age !== null ? agoPhrase(row.age) : null,
+    row.agePhrase,
+    row.secondaryPhrase,
   ]
     .filter((part): part is string => part !== null)
     .join(", ");
@@ -470,52 +528,92 @@ function RunRow({
       {row.parkNote !== null && (
         <span
           aria-hidden="true"
-          className="max-w-[45%] min-w-0 shrink truncate text-xs leading-tight text-daintree-text/45"
+          className="max-w-[45%] min-w-0 shrink truncate text-xs leading-tight text-text-secondary"
         >
           {row.parkNote}
         </span>
       )}
 
       {/*
-        The stall cue: a working glyph beside ten minutes of silence is the
-        one combination the age column cannot express — "Working · 47m" and
-        "working but wedged" render identically without it. Amber because it
-        is a live fact that may need a hand, worded because the hue alone
-        must never carry it (the accessible name says "quiet for 12m").
-      */}
-      {row.quietFor !== null && (
-        <span
-          aria-hidden="true"
-          className="shrink-0 text-[11px] leading-none text-state-waiting/80"
-        >
-          quiet {row.quietFor}
-        </span>
-      )}
+        The scan column, and the row's only clock.
 
-      {/*
-        The scan column, now a single fact wide.
-
-        `aria-hidden` — the row's own label above says this in order and with
-        separators, so announcing it here would read the age twice. Right-
-        aligned, tabular, and given a floor width so "just now" and "2h 15m"
-        start at the same x: without that the ages sit at eight different
-        offsets and "how long has this been stuck" goes back to being eight
-        separate reads instead of one scan.
+        `aria-hidden` — the row's own label above says this as a phrase, in
+        order and with separators, so announcing it here would read the age
+        twice. Right-aligned, tabular, and given a floor width so "just now"
+        and "2h 15m" start at the same x: without that the ages sit at eight
+        different offsets and "how long has this been stuck" goes back to being
+        eight separate reads instead of one scan.
 
         The status word and the worktree used to sit to its left. The glyph in
-        the chevron column already says the state, and the worktree was as often
+        the state column already says the state, and the worktree was as often
         a scratch project's UUID as a branch name — both were charging the
         truncating title for width to say nothing it needed.
+
+        A quiet row draws its qualifier HERE rather than as a separate chip
+        further left. It used to carry both — an amber "quiet 12m" mid-row and
+        a plain "47m" at the edge — which put two unlabelled-looking durations
+        on the one row whose whole question is "how long has this been silent".
+        One number, in the one column clocks live in, with the word that says
+        which clock it is. Amber for the same reason the glyph is: it is a live
+        fact that may need a hand, and the word is there because hue may never
+        carry it alone.
       */}
       {row.age !== null && (
         <span
           aria-hidden="true"
-          className="min-w-[3.5rem] shrink-0 text-right text-[11px] leading-none tabular-nums text-daintree-text/50"
+          data-testid="pilot-row-age"
+          className={cn(
+            "shrink-0 text-right text-[11px] leading-none tabular-nums",
+            row.ageLabel === null ? "min-w-[3.5rem] text-text-secondary" : "text-state-waiting"
+          )}
         >
-          {row.age}
+          {row.ageLabel === null ? row.age : `${row.ageLabel} ${row.age}`}
         </span>
       )}
     </div>
+  );
+}
+
+/**
+ * The footer's key hints, which are also its buttons.
+ *
+ * They were `<span>`s carrying a keycap, which made Park and Worktrees
+ * keyboard-only in practice: a user driving the palette with the mouse could
+ * open a run by clicking it and had no way at all to park one, and the drill
+ * gesture's only pointer form was an undiscoverable click on a heading that
+ * gives no sign of being a control. A `<button>` costs nothing visually — the
+ * keycap and the verb are unchanged — and it makes the hint the thing it was
+ * already describing.
+ *
+ * The keycap stays inside the button rather than beside it, so the accessible
+ * name is "⌥↵ Park" and voice control's "click Park" still matches on the
+ * visible word.
+ */
+function FooterHint({
+  keys,
+  label,
+  onClick,
+  testId,
+}: {
+  keys: string;
+  label: string;
+  onClick: () => void;
+  testId: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      className={cn(
+        "flex shrink-0 items-center rounded-[var(--radius-sm)] px-1 py-0.5 transition-colors",
+        "hover:bg-overlay-subtle hover:text-daintree-text",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+      )}
+    >
+      <kbd className={KBD_CLASS}>{keys}</kbd>
+      <span className="ml-1.5">{label}</span>
+    </button>
   );
 }
 
@@ -528,19 +626,23 @@ function RunRow({
  * keys moving a selection is a convention every list already teaches, so the
  * footer no longer spends a slot restating it.
  *
- * `onShowDemand` turns the demand sentence into the control it was already
+ * `onShowSummary` turns the summary sentence into the control it was already
  * implying. "2 agents need you" stated a fact the surface gave no way to act
- * on; as a button it isolates exactly the two agents it counted. Present only
- * when there is a demand to isolate, so the footer never grows a control that
- * would filter to nothing.
+ * on; as a button it isolates exactly the agents it counted. Present only when
+ * the sentence names a population one segment reproduces EXACTLY — the demand
+ * and the quiet — so pressing it can never reveal a different number to the
+ * one that was read. The review sentence stays inert for that reason: its
+ * segment, "Finished", also admits acknowledged completions.
  */
 function PilotFooter({
   actionLabel,
   parkLabel,
   drillLabel,
   summary,
-  demandCount,
-  onShowDemand,
+  onOpen,
+  onPark,
+  onDrill,
+  onShowSummary,
 }: {
   actionLabel: string | null;
   /** The park verb for the highlighted row, or null while no row is selected. */
@@ -552,36 +654,40 @@ function PilotFooter({
    */
   drillLabel: string | null;
   summary: string;
-  demandCount: number;
-  onShowDemand: () => void;
+  onOpen: () => void;
+  onPark: () => void;
+  onDrill: () => void;
+  /** Null when the sentence names nothing a single segment reproduces exactly. */
+  onShowSummary: (() => void) | null;
 }) {
   return (
     <div className="flex w-full items-center justify-between gap-3">
-      <div className="flex items-center gap-3">
+      <div className="-ml-1 flex items-center gap-2">
         {actionLabel !== null && (
-          <span>
-            <kbd className={KBD_CLASS}>↵</kbd>
-            <span className="ml-1.5">{actionLabel}</span>
-          </span>
+          <FooterHint keys="↵" label={actionLabel} onClick={onOpen} testId="pilot-open-hint" />
         )}
         {parkLabel !== null && (
-          <span data-testid="pilot-park-hint">
-            <kbd className={KBD_CLASS}>{isMac() ? "⌥↵" : "Alt+↵"}</kbd>
-            <span className="ml-1.5">{parkLabel}</span>
-          </span>
+          <FooterHint
+            keys={isMac() ? "⌥↵" : "Alt+↵"}
+            label={parkLabel}
+            onClick={onPark}
+            testId="pilot-park-hint"
+          />
         )}
         {drillLabel !== null && (
-          <span data-testid="pilot-drill-hint">
-            <kbd className={KBD_CLASS}>{isMac() ? "⌘↵" : "Ctrl+↵"}</kbd>
-            <span className="ml-1.5">{drillLabel}</span>
-          </span>
+          <FooterHint
+            keys={isMac() ? "⌘↵" : "Ctrl+↵"}
+            label={drillLabel}
+            onClick={onDrill}
+            testId="pilot-drill-hint"
+          />
         )}
       </div>
       {summary &&
-        (demandCount > 0 ? (
+        (onShowSummary !== null ? (
           <button
             type="button"
-            onClick={onShowDemand}
+            onClick={onShowSummary}
             data-testid="pilot-demand-action"
             // No `aria-label`. An action-phrased one ("Show 2 agents that need
             // you") would not contain the visible sentence, which is a
@@ -598,7 +704,7 @@ function PilotFooter({
             {summary}
           </button>
         ) : (
-          <span data-testid="pilot-summary" className="truncate text-daintree-text/50">
+          <span data-testid="pilot-summary" className="truncate text-text-secondary">
             {summary}
           </span>
         ))}
@@ -978,6 +1084,57 @@ export function PilotView() {
   );
 
   /**
+   * The run the highlight starts on: the worst thing on the list, oldest first.
+   *
+   * Project groups are ordered most-recently-opened first, which answers "where
+   * was I" — the right question for finding a project and the wrong one for
+   * finding a fire. Left alone, opening the palette put the cursor on whatever
+   * happened to be top of the project you were last in, so the surface built to
+   * answer "is anything asking me for something" opened with Enter aimed at
+   * something that wasn't.
+   *
+   * Moving the GROUPS by severity would answer it too, and was considered and
+   * rejected: `lastOpened` is the one ordering that doesn't move while the
+   * palette is open (#11678), and buying triage with a list that reshuffles
+   * under a reader costs more than it returns. Moving the cursor costs nothing
+   * — the rows are already ranked worst-first inside every group, so the worst
+   * row in the fleet is just the best of those firsts, and the surface scrolls
+   * to it on open.
+   *
+   * A starting point only. `usePaletteTreeNavigation` drops it the moment the
+   * user arrows, so a run that blocks while they are reading cannot pull the
+   * highlight off the row they are on.
+   */
+  const urgentRowId = useMemo(() => {
+    let best: { rowId: string; rank: number; since: number } | null = null;
+    for (const group of visibleGroups) {
+      // Rows are sorted worst-first within a group, so only the first can win.
+      const row = group.rows[0];
+      if (row === undefined || !isAttentionBand(row.band)) continue;
+      const candidate = {
+        rowId: row.run.runId,
+        rank: FLEET_BANDS.indexOf(row.band),
+        // Oldest outstanding first, the same anti-starvation tiebreak the rows
+        // inside a group already use — and off `bandTimestamp`, so it measures
+        // whatever the row's own clock is showing. Reading `since` here instead
+        // ranked two silent runs by how long they had been WORKING while the
+        // column beside them counted the silence, which is the surface picking
+        // one row and pointing at another. An unknown age never outranks a
+        // known one.
+        since: bandTimestamp(row.run, row.band) ?? Number.MAX_SAFE_INTEGER,
+      };
+      if (
+        best === null ||
+        candidate.rank < best.rank ||
+        (candidate.rank === best.rank && candidate.since < best.since)
+      ) {
+        best = candidate;
+      }
+    }
+    return best?.rowId ?? null;
+  }, [visibleGroups]);
+
+  /**
    * The run whose park is being edited, held by id so the pane always renders
    * live data: titles, bands and the candidate list keep updating underneath
    * the editor exactly as they do under the list.
@@ -1080,6 +1237,7 @@ export function PilotView() {
     // scope belongs here for the same reason, since drilling in replaces the
     // whole population rather than narrowing it.
     selectionScopeKey: `${scope.kind === "project" ? scope.workspaceId : "fleet"}|${query}|${bandFilter}`,
+    preferredInitialRowId: urgentRowId,
     onActivate: activate,
     shouldPreserveInputCaretKey: () => query.length > 0,
   });
@@ -1373,23 +1531,45 @@ export function PilotView() {
    * instead of being folded into somebody else's.
    */
   const needsYou = filterCounts["needs-you"];
+  const quiet = fleet.bands.quiet;
   const review = fleet.bands.review;
 
   // Counted by band, never off the raw row total: a fleet holding two working
   // agents and six exited ones is not "8 agents running".
   const live = fleet.bands.running;
-  const fleetPhrase =
+
+  /**
+   * The one thing the footer says, and which segment reproduces it exactly.
+   *
+   * Ordered the way the bands are, so the sentence and the list agree about
+   * what is most urgent: something asking, then something that has stopped
+   * talking, then work handed back, then the all-clear. The silence earns a
+   * place above review for the reason the band does — an unnoticed stall costs
+   * the rest of the morning, an unread hand-back costs a minute.
+   *
+   * `filter` is what makes the sentence pressable, and it is null wherever no
+   * segment holds exactly the population the sentence counted. Review is the
+   * case that matters: "Finished" admits acknowledged completions too, so a
+   * button there would answer "3 ready for review" with a list of five.
+   */
+  const fleetSummary: { phrase: string; filter: PilotBandFilter | null } =
     status.kind === "loading" || status.kind === "unavailable"
-      ? ""
+      ? { phrase: "", filter: null }
       : needsYou > 0
-        ? demandPhrase(needsYou)
-        : review > 0
-          ? reviewPhrase(review)
-          : live > 0
-            ? `Nothing needs you · ${live} ${live === 1 ? "agent" : "agents"} working`
-            : fleet.total > 0
-              ? `Nothing needs you · ${agentCount(fleet.total)}`
-              : "";
+        ? { phrase: demandPhrase(needsYou), filter: "needs-you" }
+        : quiet > 0
+          ? { phrase: quietPhrase(quiet), filter: "quiet" }
+          : review > 0
+            ? { phrase: reviewPhrase(review), filter: null }
+            : live > 0
+              ? {
+                  phrase: `Nothing needs you · ${live} ${live === 1 ? "agent" : "agents"} working`,
+                  filter: null,
+                }
+              : fleet.total > 0
+                ? { phrase: `Nothing needs you · ${agentCount(fleet.total)}`, filter: null }
+                : { phrase: "", filter: null };
+  const fleetPhrase = fleetSummary.phrase;
 
   /**
    * The same sentence, qualified when the feed is dead.
@@ -1402,6 +1582,17 @@ export function PilotView() {
    */
   const summary =
     status.kind === "stale" && fleetPhrase !== "" ? `Last known: ${fleetPhrase}` : fleetPhrase;
+
+  /**
+   * Null over stale data as well as over a sentence no segment reproduces.
+   *
+   * "Last known: 2 agents need you" describes retained rows; pressing it would
+   * narrow the list to a live filter over data the banner above has just said
+   * it cannot see. The sentence is allowed to be historical — a control acting
+   * on it is not.
+   */
+  const summaryFilter =
+    status.kind === "stale" || fleetSummary.filter === bandFilter ? null : fleetSummary.filter;
 
   const hasTree = renderGroups.length > 0;
 
@@ -1480,7 +1671,7 @@ export function PilotView() {
         parkEditing ? () => closeParkEditor(false) : scope.kind === "project" ? showFleet : close
       }
       ariaLabel={scopedName === null ? "All agents" : `Agents in ${scopedName}`}
-      tier="command"
+      tier="overview"
     >
       <AppPaletteDialog.Header
         label={scopedName === null ? "All agents" : "Agents by worktree"}
@@ -1515,7 +1706,7 @@ export function PilotView() {
                   onClick={showFleet}
                   className={cn(
                     "flex shrink-0 items-center gap-0.5 rounded-[var(--radius-sm)] py-0.5 pr-1.5 pl-0.5",
-                    "text-daintree-text/60 transition-colors",
+                    "text-text-secondary transition-colors",
                     "hover:bg-overlay-subtle hover:text-daintree-text",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
                   )}
@@ -1528,7 +1719,7 @@ export function PilotView() {
                 </span>
                 <span
                   data-testid="pilot-scope-name"
-                  className="min-w-0 truncate text-daintree-text/70"
+                  className="min-w-0 truncate text-daintree-text/85"
                 >
                   {scopedName}
                 </span>
@@ -1644,7 +1835,7 @@ export function PilotView() {
               so a control that does what the app is doing anyway would be a
               promise the user has to keep pressing.
             */}
-            <p className="mt-1 text-xs text-daintree-text/40">
+            <p className="mt-1 text-xs text-text-secondary">
               Agents keep running. This reconnects on its own.
             </p>
           </div>
@@ -1761,7 +1952,7 @@ export function PilotView() {
                 key={header.domId}
                 id={header.domId}
                 role="group"
-                aria-label={`${group.name}${group.axis === "workspace" && group.isCurrent ? ", current workspace" : ""}${group.demandCount > 0 ? `, ${demandPhrase(group.demandCount)}` : ""}`}
+                aria-label={`${group.name}${group.axis === "workspace" && group.isCurrent ? ", current workspace" : ""}${attentionPhrase(group.attention)}`}
                 // The scroller spaces siblings equally, so after a long run list
                 // the next group arrives with no more separation than one more
                 // agent. Only between groups — a leading gap would push the list
@@ -1805,16 +1996,32 @@ export function PilotView() {
             parkLabel={parkLabel}
             drillLabel={drillLabel}
             summary={summary}
-            demandCount={needsYou}
-            onShowDemand={() => {
-              setBandFilter("needs-you");
-              // This button leaves focus on itself, where the body's handler
-              // bails on events that did not come from the scroller — so the
-              // arrows stop moving the selection until focus goes back. The
-              // Clear-filter button in the empty state already makes exactly
-              // this handoff.
+            onOpen={() => {
+              if (selectedRow !== null) navigation.activateRow(selectedRow.rowId);
+            }}
+            onPark={() => {
+              if (selectedRow?.kind === "item") setParkTargetId(selectedRow.item.run.runId);
+              // Every footer control hands focus back for the same reason: it
+              // leaves focus on itself, where the body's handler bails on
+              // events that did not come from the scroller, so the arrows
+              // would stop moving the selection until focus went back.
               searchRef.current?.focus();
             }}
+            onDrill={() => {
+              if (drillTarget !== null) openProject(drillTarget);
+              // Scoping unmounts this button, so the handoff matters more here
+              // than anywhere else in the footer: without it focus is left on
+              // the document body over a list the arrows can no longer drive.
+              searchRef.current?.focus();
+            }}
+            onShowSummary={
+              summaryFilter === null
+                ? null
+                : () => {
+                    setBandFilter(summaryFilter);
+                    searchRef.current?.focus();
+                  }
+            }
           />
         </AppPaletteDialog.Footer>
       )}

--- a/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
+++ b/src/components/Pilot/__tests__/PilotFilterBar.test.tsx
@@ -7,7 +7,16 @@ import type { PilotBandFilter, PilotBandFilterCounts } from "../pilotRows";
 import { emptyBandCounts, type FleetBandCounts } from "@/lib/fleetAttention";
 
 function counts(overrides: Partial<PilotBandFilterCounts> = {}): PilotBandFilterCounts {
-  return { all: 0, "needs-you": 0, working: 0, finished: 0, parked: 0, ...overrides };
+  return {
+    all: 0,
+    "needs-you": 0,
+    quiet: 0,
+    working: 0,
+    finished: 0,
+    parked: 0,
+    other: 0,
+    ...overrides,
+  };
 }
 
 function bands(overrides: Partial<FleetBandCounts> = {}): FleetBandCounts {
@@ -66,7 +75,7 @@ describe("PilotFilterBar", () => {
     renderBar();
 
     expect(screen.getByRole("radiogroup")).toBeTruthy();
-    expect(screen.getAllByRole("radio")).toHaveLength(5);
+    expect(screen.getAllByRole("radio")).toHaveLength(7);
   });
 
   it("reports exactly one checked segment", () => {
@@ -91,21 +100,28 @@ describe("PilotFilterBar", () => {
   });
 
   it("carries the count in each segment's name, so it is never colour-and-digit alone", () => {
-    renderBar("all", counts({ all: 7, "needs-you": 2, working: 4, finished: 1, parked: 3 }));
+    renderBar(
+      "all",
+      counts({ all: 12, "needs-you": 2, quiet: 1, working: 4, finished: 1, parked: 3, other: 1 })
+    );
 
+    // The narrowing segments partition the fleet, so their counts sum to All —
+    // a bar that leaves runs unaccounted for asks a question it can't answer.
     expect(segmentNames()).toEqual([
-      "All, 7 agents",
-      "Waiting, 2 agents",
+      "All, 12 agents",
+      "Attention, 2 agents",
+      "Quiet, 1 agent",
       "Working, 4 agents",
       "Finished, 1 agent",
       "Parked, 3 agents",
+      "Other, 1 agent",
     ]);
   });
 
   it("selects a segment on click", () => {
     const { onChange } = renderBar();
 
-    fireEvent.click(screen.getByRole("radio", { name: /Waiting/ }));
+    fireEvent.click(screen.getByRole("radio", { name: /Attention/ }));
 
     expect(onChange).toHaveBeenCalledWith("needs-you");
   });
@@ -122,6 +138,69 @@ describe("PilotFilterBar", () => {
     expect(onChange).not.toHaveBeenCalledWith("all");
   });
 
+  describe("mixed segments", () => {
+    // Two segments hold two bands each, and a glyph that never moves makes a
+    // claim about every run it counts. They resolve in opposite directions:
+    // the demands escalate to the worst member, the completions fall back to
+    // the quiet one when nothing is outstanding.
+    const glyphOfSegment = (name: RegExp) =>
+      screen.getByRole("radio", { name }).querySelector("svg")?.getAttribute("class") ?? "";
+
+    it("escalates Needs you to the blocked mark, and names the blocked runs", () => {
+      renderBar("all", counts({ all: 2, "needs-you": 2 }), bands({ blocked: 1, "needs-you": 1 }));
+
+      expect(glyphOfSegment(/Attention/)).toContain("text-status-danger");
+      expect(screen.getByRole("radio", { name: /Attention/ }).getAttribute("aria-label")).toBe(
+        "Attention, 2 agents, including 1 blocked"
+      );
+    });
+
+    it("leaves Needs you on the waiting mark when nothing has errored", () => {
+      renderBar("all", counts({ all: 2, "needs-you": 2 }), bands({ "needs-you": 2 }));
+
+      expect(glyphOfSegment(/Attention/)).toContain("text-state-waiting");
+      expect(screen.getByRole("radio", { name: /Attention/ }).getAttribute("aria-label")).toBe(
+        "Attention, 2 agents"
+      );
+    });
+
+    it("drops Finished's hue once nothing is outstanding", () => {
+      // Review and done are the same app-standard check circle, so the hue is
+      // what separates them here — and the accessible name below is what
+      // carries the same fact to a reader the hue cannot reach.
+      renderBar("all", counts({ all: 3, finished: 3 }), bands({ review: 3 }));
+      const withReview = glyphOfSegment(/Finished/);
+
+      cleanup();
+      renderBar("all", counts({ all: 3, finished: 3 }), bands({ done: 3 }));
+      const acknowledged = glyphOfSegment(/Finished/);
+
+      expect(withReview).toContain("text-category-blue");
+      expect(acknowledged).not.toContain("text-category-blue");
+    });
+
+    it("names the outstanding work whether the Finished bucket is mixed or pure", () => {
+      // The glyph tells a pure review bucket from a pure acknowledged one; a
+      // screen reader cannot see a glyph, so the two must not share a name.
+      renderBar("all", counts({ all: 3, finished: 3 }), bands({ review: 1, done: 2 }));
+      expect(screen.getByRole("radio", { name: /Finished/ }).getAttribute("aria-label")).toBe(
+        "Finished, 3 agents, including 1 ready for review"
+      );
+
+      cleanup();
+      renderBar("all", counts({ all: 3, finished: 3 }), bands({ review: 3 }));
+      const pureReview = screen.getByRole("radio", { name: /Finished/ }).getAttribute("aria-label");
+
+      cleanup();
+      renderBar("all", counts({ all: 3, finished: 3 }), bands({ done: 3 }));
+      const pureDone = screen.getByRole("radio", { name: /Finished/ }).getAttribute("aria-label");
+
+      expect(pureReview).toBe("Finished, 3 agents, all ready for review");
+      expect(pureDone).toBe("Finished, 3 agents");
+      expect(pureReview).not.toBe(pureDone);
+    });
+  });
+
   describe("keyboard", () => {
     /** Arrows are bound on the group, so they are dispatched there. */
     function press(key: string): void {
@@ -136,16 +215,16 @@ describe("PilotFilterBar", () => {
 
       press("ArrowRight");
       expect(liveState()).toEqual({
-        checked: "Working",
-        tabbable: "Working",
-        focused: "Working",
+        checked: "Quiet",
+        tabbable: "Quiet",
+        focused: "Quiet",
       });
 
       press("ArrowLeft");
       expect(liveState()).toEqual({
-        checked: "Waiting",
-        tabbable: "Waiting",
-        focused: "Waiting",
+        checked: "Attention",
+        tabbable: "Attention",
+        focused: "Attention",
       });
     });
 
@@ -154,11 +233,11 @@ describe("PilotFilterBar", () => {
 
       press("ArrowLeft");
 
-      expect(liveState().checked).toBe("Parked");
+      expect(liveState().checked).toBe("Other");
     });
 
     it("wraps forwards off the last segment", () => {
-      render(<StatefulBar initial="parked" />);
+      render(<StatefulBar initial="other" />);
 
       press("ArrowRight");
 
@@ -172,7 +251,7 @@ describe("PilotFilterBar", () => {
       expect(liveState().checked).toBe("All");
 
       press("End");
-      expect(liveState().checked).toBe("Parked");
+      expect(liveState().checked).toBe("Other");
     });
 
     it("keeps exactly one tab stop through every move", () => {
@@ -221,8 +300,8 @@ describe("PilotFilterBar", () => {
       // fleet moved, and take away the control that proves the bucket is empty.
       const { onChange } = renderBar("all", counts({ all: 2, working: 2 }));
 
-      const empty = screen.getByRole("radio", { name: /Waiting/ });
-      expect(empty.getAttribute("aria-label")).toBe("Waiting, 0 agents");
+      const empty = screen.getByRole("radio", { name: /Attention/ });
+      expect(empty.getAttribute("aria-label")).toBe("Attention, 0 agents");
 
       fireEvent.click(empty);
       expect(onChange).toHaveBeenCalledWith("needs-you");
@@ -233,12 +312,12 @@ describe("PilotFilterBar", () => {
       // proved nothing — their base tones already differ, so deleting the fade
       // rule entirely would still have passed.
       renderBar("all", counts({ all: 0 }), bands());
-      const empty = glyphOf(/Waiting/)?.getAttribute("class") ?? "";
+      const empty = glyphOf(/Attention/)?.getAttribute("class") ?? "";
 
       cleanup();
 
       renderBar("all", counts({ all: 1, "needs-you": 1 }), bands({ "needs-you": 1 }));
-      const populated = glyphOf(/Waiting/)?.getAttribute("class") ?? "";
+      const populated = glyphOf(/Attention/)?.getAttribute("class") ?? "";
 
       expect(empty).not.toBe("");
       expect(empty).not.toBe(populated);

--- a/src/components/Pilot/__tests__/PilotRunState.test.tsx
+++ b/src/components/Pilot/__tests__/PilotRunState.test.tsx
@@ -43,14 +43,14 @@ function shapeOf(band: FleetBand, agentState?: AgentState): string {
 
 const DEMAND_BANDS = FLEET_BANDS.filter(isDemandBand);
 /** Nothing in flight and nothing being asked — the states that stay grey. */
-const QUIET_BANDS: FleetBand[] = ["done", "parked", "idle"];
+const SETTLED_BANDS: FleetBand[] = ["done", "parked", "idle"];
 
 describe("PilotRunState", () => {
   it("paints one shared neutral tone across the states that are not news", () => {
     // An acknowledged completion and an exited shell are finished business.
     // Hueing them would put back the competing signals that made two waiting
     // agents invisible among five working ones.
-    const tones = new Set(QUIET_BANDS.map((band) => toneOf(band)));
+    const tones = new Set(SETTLED_BANDS.map((band) => toneOf(band)));
 
     expect(tones.size).toBe(1);
     // A set of one is also what "no tone at all" produces, and an uncoloured
@@ -91,7 +91,36 @@ describe("PilotRunState", () => {
     expect(new Set(DEMAND_BANDS.map((band) => toneOf(band))).size).toBe(DEMAND_BANDS.length);
   });
 
-  it("keeps shape as a second channel, so the quiet states stay tellable apart", () => {
+  it("never draws two bands the same way", () => {
+    // The pair, not the shape alone: three of these marks are the app's own
+    // standards — green spinner, amber hollow circle, blue check circle — and
+    // this surface does not get to reinterpret them to buy itself a distinct
+    // silhouette. What it may not do is render two bands identically.
+    const drawn = [
+      ...FLEET_BANDS.map((band) => `${shapeOf(band)}|${toneOf(band)}`),
+      `${shapeOf("running", "directing")}|${toneOf("running", "directing")}`,
+      `${shapeOf("idle", "exited")}|${toneOf("idle", "exited")}`,
+    ];
+
+    expect(new Set(drawn).size).toBe(drawn.length);
+  });
+
+  it("separates every band that shares a tone by shape alone", () => {
+    // Where hue is doing the work, geometry may repeat — `quiet` is the working
+    // spinner in the waiting hue on purpose. Where hue is NOT available to
+    // separate two bands, shape has to, or forced colours collapses them.
+    const byTone = new Map<string, string[]>();
+    for (const band of FLEET_BANDS) {
+      const tone = toneOf(band);
+      byTone.set(tone, [...(byTone.get(tone) ?? []), shapeOf(band)]);
+    }
+
+    for (const [tone, shapes] of byTone) {
+      expect(new Set(shapes).size, `bands sharing ${tone}`).toBe(shapes.length);
+    }
+  });
+
+  it("keeps shape as a second channel, so the settled states stay tellable apart", () => {
     // Working, finished and exited carry no demand between them, so geometry is
     // what separates them — never colour alone, and never its absence.
     const shapes = [

--- a/src/components/Pilot/__tests__/PilotView.test.tsx
+++ b/src/components/Pilot/__tests__/PilotView.test.tsx
@@ -250,8 +250,11 @@ describe("PilotView", () => {
     ]);
     render(<PilotView />);
 
+    // The age arrives as the phrase its band chose, not a bare "2m ago" — a
+    // demand's duration is how long it has been left, and that is the half a
+    // screen reader would otherwise have to infer.
     expect(screen.getByTestId("pilot-row").getAttribute("aria-label")).toBe(
-      "Fix auth, Claude, Waiting, 2m ago"
+      "Fix auth, Claude, Waiting, waiting for 2m"
     );
   });
 
@@ -844,7 +847,7 @@ describe("PilotView", () => {
       render(<PilotView />);
       expect(rowTitles()).toHaveLength(4);
 
-      fireEvent.click(segment(/Waiting/));
+      fireEvent.click(segment(/Attention/));
 
       expect(rowTitles()).toHaveLength(2);
       expect(rowTitles().join(" ")).toContain("auth blocked");
@@ -859,7 +862,7 @@ describe("PilotView", () => {
       fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
       expect(rowTitles()).toHaveLength(2);
 
-      fireEvent.click(segment(/Waiting/));
+      fireEvent.click(segment(/Attention/));
 
       expect(rowTitles()).toHaveLength(1);
       expect(rowTitles()[0]).toContain("auth blocked");
@@ -875,7 +878,9 @@ describe("PilotView", () => {
       fireEvent.change(screen.getByTestId("pilot-search"), { target: { value: "auth" } });
 
       expect(segment(/^All/).getAttribute("aria-label")).toBe("All, 2 agents");
-      expect(segment(/Waiting/).getAttribute("aria-label")).toBe("Waiting, 1 agent");
+      expect(segment(/Attention/).getAttribute("aria-label")).toBe(
+        "Attention, 1 agent, including 1 blocked"
+      );
       expect(segment(/Working/).getAttribute("aria-label")).toBe("Working, 1 agent");
     });
 
@@ -886,14 +891,14 @@ describe("PilotView", () => {
       render(<PilotView />);
       const before = screen.getAllByRole("radio").map((el) => el.getAttribute("aria-label"));
 
-      fireEvent.click(segment(/Waiting/));
+      fireEvent.click(segment(/Attention/));
 
       expect(screen.getAllByRole("radio").map((el) => el.getAttribute("aria-label"))).toEqual(
         before
       );
     });
 
-    it("sorts review into Finished and out of Waiting", () => {
+    it("sorts review into Finished and out of Attention", () => {
       // The asymmetry worth pinning: `review` IS a demand band, so it counts
       // toward `demandCount`, but the Needs-you segment is blocked + needs-you
       // only. A review row must land in exactly one of the two segments.
@@ -903,8 +908,10 @@ describe("PilotView", () => {
       ]);
       render(<PilotView />);
 
-      expect(segment(/Waiting/).getAttribute("aria-label")).toBe("Waiting, 1 agent");
-      expect(segment(/Finished/).getAttribute("aria-label")).toBe("Finished, 1 agent");
+      expect(segment(/Attention/).getAttribute("aria-label")).toBe("Attention, 1 agent");
+      expect(segment(/Finished/).getAttribute("aria-label")).toBe(
+        "Finished, 1 agent, all ready for review"
+      );
 
       fireEvent.click(segment(/Finished/));
       expect(rowTitles()).toHaveLength(1);
@@ -1090,7 +1097,7 @@ describe("PilotView", () => {
           }),
         ]);
       });
-      fireEvent.click(screen.getByRole("radio", { name: /Waiting/ }));
+      fireEvent.click(screen.getByRole("radio", { name: /Attention/ }));
       // Asserted WHILE narrowed, not only after returning to All: a filter that
       // re-derived the order would be invisible if the check waited until the
       // held order had been restored anyway.
@@ -1118,7 +1125,7 @@ describe("PilotView", () => {
     it("starts every opening back at All", () => {
       seedMixedFleet();
       const view = render(<PilotView />);
-      fireEvent.click(segment(/Waiting/));
+      fireEvent.click(segment(/Attention/));
       expect(rowTitles()).toHaveLength(2);
 
       usePilotStore.setState({ isOpen: false });
@@ -1552,6 +1559,85 @@ describe("PilotView", () => {
     });
   });
 
+  describe("where the cursor opens", () => {
+    /** The row `aria-activedescendant` currently names, by its title. */
+    function selectedTitle(): string | undefined {
+      const id = screen.getByTestId("pilot-search").getAttribute("aria-activedescendant");
+      return screen
+        .getAllByTestId("pilot-row")
+        .find((row) => row.id === id)
+        ?.getAttribute("aria-label")
+        ?.split(",")[0];
+    }
+
+    it("seats on the fleet's worst run, not on the top of the most recent project", () => {
+      // Groups are ordered most-recently-opened first, which answers "where
+      // was I". The cursor answers the other question.
+      seed([
+        run({ runId: "a", workspaceId: "p1", agentState: "working", title: "busy", since: NOW }),
+        run({
+          runId: "b",
+          workspaceId: "s1",
+          agentState: "waiting",
+          waitingReason: "error",
+          title: "broken",
+          since: NOW - 60_000,
+        }),
+      ]);
+      render(<PilotView />);
+
+      expect(screen.getAllByTestId("pilot-row")[0]!.getAttribute("aria-label")).toContain("busy");
+      expect(selectedTitle()).toBe("broken");
+    });
+
+    it("breaks a cross-project tie on the clock the rows are actually showing", () => {
+      // Two silent runs in two projects. The one that has WORKED longest is not
+      // the one that has been SILENT longest, and the column shows the silence
+      // — so a cursor ranking on `since` would point at the row whose visible
+      // age is the smaller of the two.
+      seed([
+        run({
+          runId: "long-work",
+          workspaceId: "p1",
+          agentState: "working",
+          title: "long work",
+          since: NOW - 5 * 3_600_000,
+          quietSince: NOW - 60_000,
+        }),
+        run({
+          runId: "long-silence",
+          workspaceId: "s1",
+          agentState: "working",
+          title: "long silence",
+          since: NOW - 20 * 60_000,
+          quietSince: NOW - 15 * 60_000,
+        }),
+      ]);
+      render(<PilotView />);
+
+      expect(selectedTitle()).toBe("long silence");
+    });
+
+    it("stays a starting point — the user's own selection outranks it", () => {
+      seed([
+        run({ runId: "a", workspaceId: "p1", agentState: "working", title: "busy", since: NOW }),
+        run({
+          runId: "b",
+          workspaceId: "s1",
+          agentState: "waiting",
+          title: "asking",
+          since: NOW - 60_000,
+        }),
+      ]);
+      render(<PilotView />);
+      expect(selectedTitle()).toBe("asking");
+
+      fireEvent.keyDown(screen.getByTestId("pilot-search"), { key: "ArrowUp" });
+
+      expect(selectedTitle()).toBe("busy");
+    });
+  });
+
   describe("group demand chips", () => {
     it("summarises each project's demand on its header, worst band first", () => {
       seed([
@@ -1567,8 +1653,9 @@ describe("PilotView", () => {
       expect(chips).toHaveLength(1);
       expect(chips[0]!.textContent).toContain("1");
 
-      // The group's accessible name says the same thing in words.
-      expect(screen.getByRole("group", { name: /daintree, Agent needs you/ })).toBeTruthy();
+      // The group's accessible name says the same thing in words, band by band
+      // — never a total under one band's noun.
+      expect(screen.getByRole("group", { name: /daintree, 1 waiting/ })).toBeTruthy();
     });
 
     it("drops the chip when the query filters the demand away", () => {
@@ -1600,7 +1687,10 @@ describe("PilotView", () => {
       expect(screen.queryByRole("group", { name: /needs you/ })).toBeNull();
     });
 
-    it("counts every demand band, not just waiting", () => {
+    it("counts each band separately rather than totalling them under one glyph", () => {
+      // One blocked, one waiting and one handed back is three facts, and the
+      // old single chip drew the worst glyph beside "3" — which reads as
+      // "three blocked". Three ones, worst first, is the only honest form.
       seed([
         run({
           runId: "a",
@@ -1614,12 +1704,16 @@ describe("PilotView", () => {
       ]);
       render(<PilotView />);
 
-      expect(screen.getByTestId("pilot-group-demand").textContent).toContain("3");
+      expect(screen.getByTestId("pilot-group-demand").textContent).toBe("111");
+      // The words are on the group, where they are not colour-and-digit alone.
+      expect(
+        screen.getByRole("group", { name: /1 blocked, 1 waiting, 1 ready for review/ })
+      ).toBeTruthy();
     });
   });
 
-  describe("stall cue", () => {
-    it("marks a working run that main flagged as quiet", () => {
+  describe("quiet runs", () => {
+    it("gives a flagged run one labelled clock instead of two unlabelled ones", () => {
       seed([
         run({
           agentState: "working",
@@ -1630,10 +1724,34 @@ describe("PilotView", () => {
       ]);
       render(<PilotView />);
 
-      expect(screen.getByText("quiet 12m")).toBeTruthy();
-      // And the fact reaches the accessible name, since the cue itself is
-      // decoration.
-      expect(screen.getByRole("option", { name: /quiet for 12m/ })).toBeTruthy();
+      // The silence is the row's clock, in the column clocks live in, with the
+      // word that says which clock it is. The working duration is NOT drawn —
+      // two durations on the row is what made "how long has this been silent"
+      // a question the reader had to answer twice.
+      expect(screen.getByTestId("pilot-row-age").textContent).toBe("quiet 12m");
+      expect(screen.queryByText("1h")).toBeNull();
+      // Both facts still reach the accessible name, which has room for them.
+      expect(screen.getByRole("option", { name: /quiet for 12m, working for 1h/ })).toBeTruthy();
+    });
+
+    it("says so in the footer, and the sentence isolates them", () => {
+      seed([
+        run({
+          runId: "a",
+          agentState: "working",
+          since: NOW - 3_600_000,
+          quietSince: NOW - 12 * 60_000,
+        }),
+        run({ runId: "b", agentState: "working", since: NOW }),
+      ]);
+      render(<PilotView />);
+
+      const action = screen.getByTestId("pilot-demand-action");
+      expect(action.textContent).toBe("Agent has gone quiet");
+
+      fireEvent.click(action);
+
+      expect(screen.getAllByTestId("pilot-row")).toHaveLength(1);
     });
   });
 
@@ -2267,10 +2385,11 @@ describe("PilotView worktree scope", () => {
       }
     });
 
-    it("drops the highlight back to the top when the scope changes", () => {
+    it("re-seats the highlight on the scope's own worst row", () => {
       // Drilling replaces the whole population, so a highlight carried across
       // would land on whatever row inherited its position rather than on the
-      // one the user can see is selected.
+      // one the user can see is selected. It re-seats where every fresh
+      // population seats it: on the thing that needs somebody.
       seed([
         run({
           runId: "waiting",
@@ -2292,9 +2411,14 @@ describe("PilotView worktree scope", () => {
 
       fireEvent.click(drillHeader());
 
-      const firstRow = screen.getAllByTestId("pilot-row")[0]!;
-      expect(search.getAttribute("aria-activedescendant")).toBe(firstRow.id);
+      const waitingRow = screen
+        .getAllByTestId("pilot-row")
+        .find((row) => row.getAttribute("aria-label")?.includes("Waiting"))!;
+      expect(search.getAttribute("aria-activedescendant")).toBe(waitingRow.id);
       expect(search.getAttribute("aria-activedescendant")).not.toBe(beforeDrill);
+      // And not merely the first row it happens to sit above — the no-worktree
+      // bucket sorts first on this axis and holds a plain working run.
+      expect(screen.getAllByTestId("pilot-row")[0]!.id).not.toBe(waitingRow.id);
     });
 
     it("lets the pointer take a fresh hold after a scope change", () => {

--- a/src/components/Pilot/__tests__/pilotRows.test.ts
+++ b/src/components/Pilot/__tests__/pilotRows.test.ts
@@ -912,8 +912,8 @@ describe("parked rows", () => {
   });
 });
 
-describe("stalled runs", () => {
-  it("carries the quiet duration only for a working run main flagged", () => {
+describe("quiet runs", () => {
+  it("clocks a flagged run from its silence and a healthy one from its state", () => {
     const [group] = buildPilotGroups(
       [
         run({
@@ -928,13 +928,25 @@ describe("stalled runs", () => {
     );
 
     const byId = new Map(group!.rows.map((r) => [r.run.runId, r]));
-    expect(byId.get("stalled")?.quietFor).toBe("12m");
-    expect(byId.get("busy")?.quietFor).toBeNull();
+    // One clock per row: the flagged run's column measures the silence and
+    // names it, the healthy one's measures the work and does not.
+    expect(byId.get("stalled")?.band).toBe("quiet");
+    expect(byId.get("stalled")?.age).toBe("12m");
+    expect(byId.get("stalled")?.ageLabel).toBe("quiet");
+    expect(byId.get("stalled")?.agePhrase).toBe("quiet for 12m");
+    // The working duration survives into the accessible name, where there is
+    // room for the second fact the column had to drop.
+    expect(byId.get("stalled")?.secondaryPhrase).toBe("working for 1h");
+
+    expect(byId.get("busy")?.band).toBe("running");
+    expect(byId.get("busy")?.ageLabel).toBeNull();
+    expect(byId.get("busy")?.agePhrase).toBe("working for 1h");
+    expect(byId.get("busy")?.secondaryPhrase).toBeNull();
   });
 
   it("drops the cue when the run is no longer in the running band", () => {
     // A stale quietSince arriving alongside a state change (one poll of skew)
-    // must not paint a waiting or parked row as a stalled worker.
+    // must not paint a waiting or parked row as a silent worker.
     const [group] = buildPilotGroups(
       [
         run({
@@ -947,7 +959,8 @@ describe("stalled runs", () => {
       ctx()
     );
 
-    expect(group!.rows[0]!.quietFor).toBeNull();
+    expect(group!.rows[0]!.band).toBe("parked");
+    expect(group!.rows[0]!.ageLabel).toBeNull();
   });
 });
 
@@ -982,13 +995,16 @@ describe("bandFilterHasDemand", () => {
 });
 
 describe("state vocabulary", () => {
-  it("calls a waiting run the same thing on the row as on the segment that filters to it", () => {
-    // The segment and the row's status word are two surfaces naming one state.
-    // They drifted once — "Needs you" here against the sidebar's "Waiting" —
-    // and one state with two names is a vocabulary the user has to learn twice.
+  it("names the bucket wider than the states inside it, never after one of them", () => {
+    // The segment holds `blocked` AND `needs-you`, so it cannot borrow either
+    // one's word: "Waiting 2" over an errored run and a waiting one is a claim
+    // about both that is only true of one. The ROW keeps the exact state.
     const waiting = run({ agentState: "waiting", waitingReason: "question" });
+    const blocked = run({ agentState: "waiting", waitingReason: "error" });
 
-    expect(bandLabel(bandForRun(waiting), waiting)).toBe(PILOT_BAND_FILTER_LABEL["needs-you"]);
+    expect(bandLabel(bandForRun(waiting), waiting)).toBe("Waiting");
+    expect(bandLabel(bandForRun(blocked), blocked)).toBe("Blocked");
+    expect(PILOT_BAND_FILTER_LABEL["needs-you"]).toBe("Attention");
   });
 });
 

--- a/src/components/Pilot/pilotRows.ts
+++ b/src/components/Pilot/pilotRows.ts
@@ -3,12 +3,14 @@ import type { FleetBand, FleetBandCounts } from "@/lib/fleetAttention";
 import {
   bandForRun,
   bandLabel,
+  bandTimestamp,
   compareWithinBand,
   emptyBandCounts,
   FLEET_BANDS,
+  isAttentionBand,
   isDemandBand,
 } from "@/lib/fleetAttention";
-import { formatWaitAge } from "@/lib/projectRowStatus";
+import { agoPhrase, formatWaitAge } from "@/lib/projectRowStatus";
 import { isFilterMatch } from "@/lib/projectSwitcherSearch";
 import { composeTitledPanel } from "@/utils/terminalTitleDisplay";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
@@ -40,8 +42,36 @@ export interface PilotRow {
    * to find a run is useful whether or not the label is on screen.
    */
   worktreeLabel: string | null;
-  /** Compact age of the current state, or null when the run never recorded one. */
+  /**
+   * The row's ONE clock, compact, for the right-hand column.
+   *
+   * Which duration it measures depends on the band, because the useful
+   * question does: a parked row is dated from the park, a quiet row from the
+   * silence, everything else from its last transition. Null when the run
+   * recorded nothing to measure.
+   *
+   * A quiet row used to draw two clocks — a mid-row `quiet 12m` chip and a
+   * right-hand `47m` — with only the chip labelled, so the reader had to work
+   * out which of the two the surface wanted them to act on. One column, one
+   * number, and {@link ageLabel} names it where naming is what disambiguates.
+   */
   age: string | null;
+  /**
+   * The word the age column wears in front of the number, or null when the
+   * number needs no qualifier. Only `quiet` takes one: it is the one band
+   * whose clock measures something other than "how long has it been like
+   * this", and an unlabelled 12m beside a working glyph is the ambiguity the
+   * chip was invented to solve in the first place.
+   */
+  ageLabel: string | null;
+  /**
+   * The age as a sentence, for the row's accessible name.
+   *
+   * Spelled out per band rather than left as a bare "2m ago": "waiting for 38
+   * minutes" and "finished 38 minutes ago" are different facts, and a screen
+   * reader given only the second half has to infer which one it just heard.
+   */
+  agePhrase: string | null;
   /**
    * The park's note, drawn on the row: a parked run's one line of intent is
    * the whole reason to look at it. Null for everything unparked, and also on
@@ -50,11 +80,13 @@ export interface PilotRow {
    */
   parkNote: string | null;
   /**
-   * How long a working run has been silent, once main judged the silence
-   * worth reporting. Null for a healthy busy agent — so the row only ever
-   * says "quiet 12m" when there is genuinely something to look at.
+   * How long the run has been WORKING, on a row whose clock is measuring
+   * something else. Only a quiet row has one, and it exists purely for the
+   * accessible name: the column can hold one number, and the silence is the
+   * one worth drawing, but "quiet for 12 minutes, working for 47" is the whole
+   * fact and a screen reader has room for it.
    */
-  quietFor: string | null;
+  secondaryPhrase: string | null;
 }
 
 export type PilotWorkspaceKind = "project" | "scratch" | "unknown";
@@ -91,6 +123,17 @@ export interface PilotGroupCore {
   rows: PilotRow[];
   /** Runs in this group that constitute a demand on the user. */
   demandCount: number;
+  /**
+   * Per-band counts for the bands worth pointing at, worst first and empty
+   * bands omitted.
+   *
+   * The header used to draw the WORST band's glyph beside the TOTAL demand
+   * count, which reads as a claim about every run it counts: a project holding
+   * one blocked run and one waiting one rendered as a red prohibition sign
+   * beside "2", and the only honest reading of that is "2 blocked". Counting
+   * each band separately is the only version of this chip that cannot lie.
+   */
+  attention: readonly { band: FleetBand; count: number }[];
   /**
    * Worst band among the rows below, recomputed rather than inherited whenever
    * the group is narrowed. A derived summary of the group's contents only —
@@ -237,12 +280,15 @@ export function composePilotRunTitle(run: FleetRunRow, chrome?: TerminalChromeDe
  * guaranteed to be the worst one present. Inheriting either field would put a
  * group's derived facts at odds with the rows directly underneath it.
  */
-function narrowGroup<T extends PilotGroupCore>(group: T, rows: PilotRow[]): T {
+function summarizeRows(
+  rows: readonly PilotRow[]
+): Pick<PilotGroupCore, "demandCount" | "topBand" | "attention"> {
   let topBand: FleetBand = "idle";
   // Annotated: `FLEET_BANDS` is a const tuple, so its `length` narrows to a
   // literal and the accumulator would refuse every rank assigned below it.
   let best: number = FLEET_BANDS.length;
   let demandCount = 0;
+  const perBand = new Map<FleetBand, number>();
   for (const row of rows) {
     const rowRank = rank(row.band);
     if (rowRank < best) {
@@ -250,11 +296,22 @@ function narrowGroup<T extends PilotGroupCore>(group: T, rows: PilotRow[]): T {
       topBand = row.band;
     }
     if (isDemandBand(row.band)) demandCount++;
+    if (isAttentionBand(row.band)) perBand.set(row.band, (perBand.get(row.band) ?? 0) + 1);
   }
+  // Worst first, which is the order the rows themselves are in, so the chip
+  // reads left-to-right as the same ranking the list below it uses.
+  const attention = FLEET_BANDS.filter((band) => perBand.has(band)).map((band) => ({
+    band,
+    count: perBand.get(band) ?? 0,
+  }));
+  return { demandCount, topBand, attention };
+}
+
+function narrowGroup<T extends PilotGroupCore>(group: T, rows: PilotRow[]): T {
   // `Object.assign` rather than a spread: spreading a generic widens it to an
   // intersection the return type will not accept, and the alternative is a cast
   // that would stop the compiler from checking this at all.
-  return Object.assign({}, group, { rows, demandCount, topBand });
+  return Object.assign({}, group, { rows }, summarizeRows(rows));
 }
 
 /**
@@ -296,6 +353,68 @@ function openedAt(value: number | undefined): number {
  * first, then oldest `since`. A project's demands still surface at the top of
  * its own rows — they just no longer move the project itself.
  */
+/**
+ * The row's clock, in every form the row needs it: the number, the word in
+ * front of it, and the sentence a screen reader gets.
+ *
+ * One function because the three must agree. They were three expressions in
+ * three places, which is how the drawn row came to say `47m` while the
+ * accessible name said "quiet for 12m" about the same run.
+ *
+ * A parked row is dated from the PARK, not from `since`. Dating it from the
+ * state read "Parked · 3h" the moment a three-hour-old waiting run was parked,
+ * which answers "how long has it waited" when the row is now about "how long
+ * ago did I shelve this". A quiet row is dated from the silence for the same
+ * reason: the silence is the thing that might need a hand.
+ */
+function ageOf(
+  run: FleetRunRow,
+  band: FleetBand,
+  nowMs: number
+): Pick<PilotRow, "age" | "ageLabel" | "agePhrase" | "secondaryPhrase"> {
+  const at = bandTimestamp(run, band);
+  if (at === undefined) {
+    return { age: null, ageLabel: null, agePhrase: null, secondaryPhrase: null };
+  }
+  const age = formatWaitAge(at, nowMs);
+
+  // The one band whose column needs a word: its clock is measuring something
+  // other than "how long has it been like this", and an unlabelled 12m beside
+  // a run that is nominally working is exactly the ambiguity this exists to
+  // remove. The working duration goes to the accessible name, which has room.
+  if (band === "quiet") {
+    return {
+      age,
+      ageLabel: "quiet",
+      agePhrase: `quiet for ${age}`,
+      secondaryPhrase:
+        run.since === undefined ? null : `working for ${formatWaitAge(run.since, nowMs)}`,
+    };
+  }
+
+  return { age, ageLabel: null, agePhrase: AGE_VERB[band](age), secondaryPhrase: null };
+}
+
+/**
+ * How each band says its own age.
+ *
+ * The verb is what makes the duration mean something: a demand's age is how
+ * long it has been left, a completion's is how long ago it landed, and a
+ * running agent's is how long it has been at it. `agoPhrase` keeps "just now"
+ * from becoming "just now ago".
+ */
+const AGE_VERB: Record<FleetBand, (age: string) => string> = {
+  blocked: (age) => `blocked for ${age}`,
+  "needs-you": (age) => `waiting for ${age}`,
+  quiet: (age) => `quiet for ${age}`,
+  review: (age) => `finished ${agoPhrase(age)}`,
+  running: (age) => `working for ${age}`,
+  done: (age) => `finished ${agoPhrase(age)}`,
+  parked: (age) => `parked ${agoPhrase(age)}`,
+  snoozed: (age) => `snoozed ${agoPhrase(age)}`,
+  idle: (age) => agoPhrase(age),
+};
+
 export function buildPilotGroups(
   runs: readonly FleetRunRow[],
   ctx: PilotRowContext
@@ -319,14 +438,11 @@ export function buildPilotGroups(
       const bandA = bandForRun(a, acknowledgedAt);
       const byBand = rank(bandA) - rank(bandForRun(b, acknowledgedAt));
       if (byBand !== 0) return byBand;
-      // Parked rows order on the park, not the underlying state: `since` is
-      // whenever the agent last transitioned, which predates the decision the
-      // band is actually about. Oldest park first, same anti-starvation rule.
-      if (bandA === "parked" && a.park !== undefined && b.park !== undefined) {
-        if (a.park.parkedAt !== b.park.parkedAt) return a.park.parkedAt - b.park.parkedAt;
-        return a.runId < b.runId ? -1 : a.runId > b.runId ? 1 : 0;
-      }
-      return compareWithinBand(a, b);
+      // Same band, so one clock governs the pair — and which clock that is
+      // belongs to the band, not to this call site. `bandTimestamp` is what the
+      // row's own age reads too, so a list ordered oldest-first can't put a
+      // smaller number above a larger one.
+      return compareWithinBand(a, b, bandA);
     });
 
     const rows: PilotRow[] = sorted.map((run) => {
@@ -342,21 +458,8 @@ export function buildPilotGroups(
         presetColor: run.agentPresetColor,
         statusLabel: bandLabel(band, run),
         worktreeLabel: disambiguatingLabel(directoryLabel(run.cwd), name),
-        // A parked row's age is the age of the PARK. Dating it from `since`
-        // read "Parked · 3h" the moment a three-hour-old waiting run was
-        // parked, which answers "how long has it waited" when the row is now
-        // about "how long ago did I shelve this".
-        age:
-          band === "parked" && run.park !== undefined
-            ? formatWaitAge(run.park.parkedAt, ctx.nowMs)
-            : run.since !== undefined
-              ? formatWaitAge(run.since, ctx.nowMs)
-              : null,
+        ...ageOf(run, band, ctx.nowMs),
         parkNote: run.park?.note ?? null,
-        quietFor:
-          band === "running" && run.quietSince !== undefined
-            ? formatWaitAge(run.quietSince, ctx.nowMs)
-            : null,
       };
     });
 
@@ -372,8 +475,7 @@ export function buildPilotGroups(
       color: meta?.color ?? null,
       isCurrent: workspaceId === ctx.currentWorkspaceId,
       rows,
-      demandCount: rows.filter((r) => isDemandBand(r.band)).length,
-      topBand: rows[0]?.band ?? "idle",
+      ...summarizeRows(rows),
       lastOpened: openedAt(meta?.lastOpened),
     });
   }
@@ -633,6 +735,7 @@ export function buildPilotWorktreeGroups(
           rows,
           demandCount: 0,
           topBand: "idle",
+          attention: [],
         },
         rows
       )
@@ -725,16 +828,19 @@ export function filterPilotGroups<T extends PilotGroupCore>(
  * The state filter's vocabulary, declared beside the bands so a segment and the
  * count under it can never drift apart.
  */
-export type PilotBandFilter = "all" | "needs-you" | "working" | "finished" | "parked";
+export type PilotBandFilter =
+  "all" | "needs-you" | "quiet" | "working" | "finished" | "parked" | "other";
 
 /**
  * Which bands each segment admits.
  *
- * `idle` is deliberately in no bucket but All: an exited terminal isn't
- * working, isn't finished, and isn't asking for anything, so putting it
- * anywhere else would make that segment lie about what it holds.
+ * The narrowing segments PARTITION the fleet: every band is in exactly one, so
+ * their counts sum to All. That is not decoration — a bar reading "All 12"
+ * over segments totalling ten invites the reader to work out which two runs
+ * the surface is not telling them about, and there is no answer they can reach
+ * from the bar.
  *
- * "Needs you" is `blocked` + `needs-you` and NOT `review`, even though
+ * "Attention" is `blocked` + `needs-you` and NOT `review`, even though
  * `isDemandBand` counts review as a demand. Review is a hand-back, not a
  * block — folding it in would make the footer's demand count promise more
  * agents than applying the filter actually reveals.
@@ -746,17 +852,32 @@ export type PilotBandFilter = "all" | "needs-you" | "working" | "finished" | "pa
  */
 const BAND_FILTER_SETS: Record<Exclude<PilotBandFilter, "all">, ReadonlySet<FleetBand>> = {
   "needs-you": new Set<FleetBand>(["blocked", "needs-you"]),
+  // Its own segment rather than a corner of Working, and the segments stay
+  // disjoint so the four counts still add up under All. "Which of my agents
+  // has gone silent" is the second question this surface answers, and before
+  // this it had no control, no count and no summary — only an annotation on
+  // whichever row you happened to scroll past.
+  quiet: new Set<FleetBand>(["quiet"]),
   working: new Set<FleetBand>(["running"]),
   finished: new Set<FleetBand>(["review", "done"]),
   parked: new Set<FleetBand>(["parked"]),
+  // The remainder, and the only reason it exists: `snoozed` and `idle` are the
+  // two bands that belong to none of the questions above. An exited shell is
+  // not working, not finished and not asking; a snooze is the user's own
+  // silence and must not read as a demand. Named for what it is rather than
+  // given a state's name it would then misapply to the other member, and given
+  // no glyph and no hue, because nothing in it is news.
+  other: new Set<FleetBand>(["snoozed", "idle"]),
 };
 
 /** The narrowing segments, in the order the bar renders them after All. */
 export const PILOT_BAND_FILTERS: readonly Exclude<PilotBandFilter, "all">[] = [
   "needs-you",
+  "quiet",
   "working",
   "finished",
   "parked",
+  "other",
 ];
 
 /**
@@ -764,16 +885,33 @@ export const PILOT_BAND_FILTERS: readonly Exclude<PilotBandFilter, "all">[] = [
  * say it: the segment itself, and the empty state that has to name which filter
  * produced no rows.
  *
- * "Waiting", not "Needs you", so the four segments read the same here as they
- * do in the sidebar's `QuickStateFilterBar`. The key stays `needs-you` — it
- * names the band set, which has not changed.
+ * "Attention", not "Waiting". This bucket holds `blocked` as well as `needs-you`,
+ * and calling the pair by the name of one of its members made the segment
+ * contradict itself the moment it drew the blocked glyph: a red prohibition
+ * sign beside the word "Waiting" is two different claims about the same two
+ * runs. The sidebar's `QuickStateFilterBar` bucket is the same union — it
+ * filters on `agentState === "waiting"`, which is where an errored agent lives
+ * too — so it carries the same word rather than being left to drift. The ROW
+ * still says "Blocked" or "Waiting"; only the bucket that holds both takes a
+ * name wide enough to cover them.
+ *
+ * One word, and a calm one. "Stuck" was tried first and reads as a fault: an
+ * agent holding for your approval is not broken, and a bucket that says it is
+ * teaches the reader to flinch at the ordinary case. "Attention" says what the
+ * bucket wants — a look — without claiming anything about why, which is the
+ * only thing true of both an errored run and a polite question.
  */
 export const PILOT_BAND_FILTER_LABEL: Record<PilotBandFilter, string> = {
   all: "All",
-  "needs-you": "Waiting",
+  "needs-you": "Attention",
+  // Observed, not inferred. The fleet knows the agent has said nothing for
+  // twelve minutes; it does not know the agent is stuck, and a segment called
+  // "Stalled" would be the surface guessing on the user's behalf.
+  quiet: "Quiet",
   working: "Working",
   finished: "Finished",
   parked: "Parked",
+  other: "Other",
 };
 
 export type PilotBandFilterCounts = Record<PilotBandFilter, number>;
@@ -791,9 +929,11 @@ export function countPilotBands(groups: readonly PilotGroupCore[]): PilotBandFil
   const counts: PilotBandFilterCounts = {
     all: 0,
     "needs-you": 0,
+    quiet: 0,
     working: 0,
     finished: 0,
     parked: 0,
+    other: 0,
   };
   for (const group of groups) {
     for (const row of group.rows) {
@@ -813,7 +953,7 @@ export function countPilotBands(groups: readonly PilotGroupCore[]): PilotBandFil
  * alongside `done`, which is not. Colouring the segment on membership alone
  * would paint a project whose every completion has been acknowledged in the
  * hue reserved for work still waiting to be looked at — putting back one of the
- * false signals this surface exists to remove. "Needs you" holds only demands,
+ * false signals this surface exists to remove. "Attention" holds only demands,
  * so it is hued whenever it holds anything at all, which this returns for free.
  */
 export function bandFilterHasDemand(

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -127,9 +127,10 @@ function formatButtonTitle(label: string, shortcut?: string | null): string {
 
 const NO_MATCH_QUERY_MAX = 40;
 
+/** Mirrors `QuickStateFilterBar`'s own labels — see the rationale there. */
 const QUICK_STATE_LABELS: Record<"working" | "waiting" | "finished", string> = {
   working: "Working",
-  waiting: "Waiting",
+  waiting: "Attention",
   finished: "Finished",
 };
 

--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -5,10 +5,27 @@ import { HollowCircle, SpinnerCircle } from "@/components/icons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { STATE_COLORS } from "./terminalStateConfig";
 
+/**
+ * "Attention", not "Waiting", for the bucket that filters on a waiting agent.
+ *
+ * `agentState === "waiting"` covers an agent stopped on an error as well as one
+ * asking a question, so this bucket has always been wider than the word — and
+ * Pilot's matching segment, which can tell the two apart, ended up drawing an
+ * errored run's glyph beside it. "Attention" is what both members want — a
+ * look — without claiming anything about why, which is the only thing true of
+ * an errored run and a polite question at once. Renamed on both surfaces at
+ * once rather than on one: `PILOT_BAND_FILTER_LABEL` carries the same string,
+ * and one bucket with two names across two surfaces is a vocabulary to learn
+ * twice.
+ *
+ * The worktree filter popover's session checkbox keeps "Waiting", because there
+ * it sits beside "Completed" and "Exited" as one state among states rather than
+ * as a bucket over them.
+ */
 const FILTER_OPTIONS: { value: QuickStateFilter; label: string }[] = [
   { value: "all", label: "All" },
   { value: "working", label: "Working" },
-  { value: "waiting", label: "Waiting" },
+  { value: "waiting", label: "Attention" },
   { value: "finished", label: "Finished" },
 ];
 

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -16,10 +16,10 @@ describe("QuickStateFilterBar", () => {
     // "All" keeps its visible text anchor; the status segments go icon-only.
     expect(screen.getByText("All")).toBeTruthy();
     expect(screen.queryByText("Working")).toBeNull();
-    expect(screen.queryByText("Waiting")).toBeNull();
+    expect(screen.queryByText("Attention")).toBeNull();
     expect(screen.queryByText("Finished")).toBeNull();
     expect(screen.getByRole("button", { name: "Working" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Waiting" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Attention" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Finished" })).toBeTruthy();
   });
 
@@ -33,7 +33,7 @@ describe("QuickStateFilterBar", () => {
     );
     const all = screen.getByRole("button", { name: /^All/ });
     const working = screen.getByRole("button", { name: /Working/ });
-    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const waiting = screen.getByRole("button", { name: /Attention/ });
     const finished = screen.getByRole("button", { name: /Finished/ });
     expect(within(all).getByText("9")).toBeTruthy();
     expect(within(working).getByText("3")).toBeTruthy();
@@ -52,7 +52,7 @@ describe("QuickStateFilterBar", () => {
       />
     );
     const working = screen.getByRole("button", { name: /Working/ });
-    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const waiting = screen.getByRole("button", { name: /Attention/ });
     const finished = screen.getByRole("button", { name: /Finished/ });
     // Empty buckets still show "0" — a missing digit reads as broken, not empty.
     expect(within(working).getByText("0")).toBeTruthy();
@@ -88,7 +88,7 @@ describe("QuickStateFilterBar", () => {
     );
     expect(screen.getByRole("button", { name: "All, 9 worktrees" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Working, 3 worktrees" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Waiting, 1 worktree" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Attention, 1 worktree" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Finished, 2 worktrees" })).toBeTruthy();
   });
 
@@ -104,7 +104,7 @@ describe("QuickStateFilterBar", () => {
       "true"
     );
     expect(screen.getByRole("button", { name: /^All/ }).getAttribute("aria-pressed")).toBe("false");
-    expect(screen.getByRole("button", { name: /Waiting/ }).getAttribute("aria-pressed")).toBe(
+    expect(screen.getByRole("button", { name: /Attention/ }).getAttribute("aria-pressed")).toBe(
       "false"
     );
     expect(screen.getByRole("button", { name: /Finished/ }).getAttribute("aria-pressed")).toBe(
@@ -134,7 +134,7 @@ describe("QuickStateFilterBar", () => {
         counts={{ all: 9, working: 0, waiting: 3, finished: 0 }}
       />
     );
-    fireEvent.click(screen.getByRole("button", { name: /Waiting/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Attention/ }));
     expect(onChange).toHaveBeenCalledWith("all");
   });
 
@@ -153,7 +153,7 @@ describe("QuickStateFilterBar", () => {
     );
     const all = screen.getByRole("button", { name: /^All/ });
     const working = screen.getByRole("button", { name: /Working/ });
-    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const waiting = screen.getByRole("button", { name: /Attention/ });
     const finished = screen.getByRole("button", { name: /Finished/ });
     expect(all.querySelector("svg")).toBeNull();
     expect(working.querySelector("svg")).not.toBeNull();
@@ -224,7 +224,7 @@ describe("QuickStateFilterBar", () => {
         counts={{ all: 9, working: 3, waiting: 2, finished: 4 }}
       />
     );
-    for (const name of [/Waiting/, /Finished/]) {
+    for (const name of [/Attention/, /Finished/]) {
       const svg = screen.getByRole("button", { name }).querySelector("svg");
       expect(svg).not.toBeNull();
       expect(svg?.getAttribute("class") ?? "").not.toContain("animate-spin-slow");
@@ -239,7 +239,7 @@ describe("QuickStateFilterBar", () => {
         counts={{ all: 9, working: 1, waiting: 1, finished: 1 }}
       />
     );
-    for (const name of [/Working/, /Waiting/, /Finished/]) {
+    for (const name of [/Working/, /Attention/, /Finished/]) {
       const button = screen.getByRole("button", { name });
       const svg = button.querySelector("svg");
       expect(svg).not.toBeNull();
@@ -259,7 +259,7 @@ describe("QuickStateFilterBar", () => {
       />
     );
     const working = screen.getByRole("button", { name: /Working/ });
-    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const waiting = screen.getByRole("button", { name: /Attention/ });
     const activeCount = within(working).getByText("3");
     const inactiveCount = within(waiting).getByText("1");
     const activeClass = activeCount.getAttribute("class") ?? "";
@@ -279,7 +279,7 @@ describe("QuickStateFilterBar", () => {
     );
     const fadedBySegment: [RegExp, string][] = [
       [/Working/, "text-state-working/40"],
-      [/Waiting/, "text-state-waiting/40"],
+      [/Attention/, "text-state-waiting/40"],
       [/Finished/, "text-category-blue/40"],
     ];
     for (const [name, fadedClass] of fadedBySegment) {
@@ -299,7 +299,7 @@ describe("QuickStateFilterBar", () => {
     );
     const colorBySegment: [RegExp, string][] = [
       [/Working/, "text-state-working"],
-      [/Waiting/, "text-state-waiting"],
+      [/Attention/, "text-state-waiting"],
       [/Finished/, "text-category-blue"],
     ];
     for (const [name, colorClass] of colorBySegment) {
@@ -326,7 +326,7 @@ describe("QuickStateFilterBar", () => {
         ?.getAttribute("class") ?? "";
     const waitingClass =
       screen
-        .getByRole("button", { name: /Waiting/ })
+        .getByRole("button", { name: /Attention/ })
         .querySelector("svg")
         ?.getAttribute("class") ?? "";
     const finishedClass =
@@ -342,7 +342,7 @@ describe("QuickStateFilterBar", () => {
 
   it("does not fade icons when the counts prop is omitted", () => {
     renderBar(<QuickStateFilterBar value="all" onChange={() => {}} />);
-    for (const name of ["Working", "Waiting", "Finished"]) {
+    for (const name of ["Working", "Attention", "Finished"]) {
       const svg = screen.getByRole("button", { name }).querySelector("svg");
       expect(svg).not.toBeNull();
       expect(svg?.getAttribute("class") ?? "").not.toContain("/40");
@@ -359,7 +359,7 @@ describe("QuickStateFilterBar", () => {
         counts={{ all: 2, working: 1, waiting: 0, finished: 1 }}
       />
     );
-    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const waiting = screen.getByRole("button", { name: /Attention/ });
     expect(waiting.getAttribute("aria-pressed")).toBe("true");
     expect(waiting.querySelector("svg")?.getAttribute("class") ?? "").toContain(
       "text-state-waiting/40"

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -14,8 +14,9 @@ export {
   AtSign, // @file reference handed to an agent's prompt
   BellDot, // watch alert / notify on completion
   ChartNoAxesColumn, // frecency sort order ("Most used" — decayed access score)
-  CircleCheck, // finished run awaiting review (Pilot's review band)
+  CircleCheck, // finished run — blue awaiting review, neutral once acknowledged (Pilot's review and done bands)
   CircleDashed, // run the user snoozed — quiet until it wakes (Pilot's snoozed band)
+  CircleDot, // shell that is alive and doing nothing, so the amber hollow circle means waiting and only waiting (Pilot's idle band)
   CircleHelp, // workspace whose metadata is missing (removed while its agents ran)
   CirclePause, // run the user parked — shelved on purpose (Pilot's parked band)
   CircleSlash, // agent stopped on an error, distinct in shape from a waiting one (Pilot's blocked band)

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -54,11 +54,19 @@ export { KBD_CLASS };
  * that wrong: sized as if it were a menu, the switcher's dropdown could not
  * hold what it was still being asked to show.
  *
- * Two tiers, not a free width per palette — palettes open from the same
+ * `overview` is the third and widest step, for a palette that is a TABLE
+ * rather than a list: the fleet overview carries five columns on every row —
+ * state, agent, title, a park note or a stall clock, an age — under a
+ * seven-segment filter bar, and at the command tier the titles truncate to pay
+ * for chrome that is doing real work. It is a declared step and not a
+ * one-off measurement, so a second surface that grows the same shape takes
+ * this rather than inventing its own number.
+ *
+ * Three tiers, not a free width per palette — palettes open from the same
  * keyboard reflex and often in sequence, so unconstrained per-surface sizing
  * reads as the box jumping around rather than as a deliberate size.
  */
-export type PaletteSurfaceTier = "anchored" | "command";
+export type PaletteSurfaceTier = "anchored" | "command" | "overview";
 
 /**
  * Tailwind needs each class present in source for the JIT compiler, so these
@@ -68,6 +76,7 @@ export type PaletteSurfaceTier = "anchored" | "command";
 export const PALETTE_SURFACE_WIDTHS: Record<PaletteSurfaceTier, string> = {
   anchored: "w-[484px] max-w-[calc(100vw-2rem)]",
   command: "w-[608px] max-w-[calc(100vw-2rem)]",
+  overview: "w-[672px] max-w-[calc(100vw-2rem)]",
 };
 
 export interface AppPaletteDialogProps {

--- a/src/components/ui/paletteRowStyles.ts
+++ b/src/components/ui/paletteRowStyles.ts
@@ -56,9 +56,17 @@ export const PALETTE_ROW_CLASS = cn(
  * same structural element read as two different things depending on which
  * palette you opened. Padding stays out of it where a palette's list inset
  * differs; the type treatment is what has to match.
+ *
+ * `text-text-secondary`, not a percentage of the body colour. At 10px this is
+ * small text under WCAG's ordinary 4.5:1 rule, and `text-daintree-text/40`
+ * measured about 3.3:1 on the palette surface in the dark themes — below the
+ * floor for a label that names which project every row beneath it belongs to.
+ * The token is the theme's own answer to "muted but readable" (6.57:1 in
+ * Daintree) and it is defined in all fifteen; the treatment is unchanged
+ * otherwise, because the size and the tracking were never the problem.
  */
 export const PALETTE_SECTION_LABEL_CLASS =
-  "text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none";
+  "text-[10px] font-medium tracking-wider uppercase text-text-secondary select-none";
 
 /**
  * The keyboard-focus ring every palette control wears.

--- a/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
+++ b/src/hooks/__tests__/usePaletteTreeNavigation.test.tsx
@@ -85,6 +85,7 @@ function setup(
     shouldPreserveInputCaretKey?: (event: KeyboardEvent<HTMLInputElement>) => boolean;
     selectionScopeKey?: string;
     isActive?: boolean;
+    preferredInitialRowId?: string | null;
   } = {}
 ) {
   const onActivate = options.onActivate ?? vi.fn();
@@ -94,6 +95,7 @@ function setup(
         groups,
         isActive: options.isActive ?? true,
         selectionScopeKey: scope ?? null,
+        preferredInitialRowId: options.preferredInitialRowId ?? null,
         onActivate,
         shouldPreserveInputCaretKey: options.shouldPreserveInputCaretKey,
       }),
@@ -223,6 +225,82 @@ describe("usePaletteTreeNavigation", () => {
       act(() => result.current.step(1));
       // Third entry in `rows` (h:a, i:a1, h:b, i:b1) but second navigable one.
       expect(result.current.selectedNavigableIndex).toBe(1);
+    });
+  });
+
+  describe("preferred initial row", () => {
+    /**
+     * The caller names where the highlight should start; every movement key has
+     * to agree with what is drawn. They did not: the index shown came from the
+     * preferred row while `step` and `page` counted from zero, so the first
+     * arrow after opening jumped somewhere the user had not been.
+     */
+    it("seats the highlight on the preferred row", () => {
+      const { result } = setup(
+        [
+          ["a", ["a1", "a2"]],
+          ["b", ["b1"]],
+        ],
+        { preferredInitialRowId: "i:a2" }
+      );
+
+      expect(result.current.selectedRow?.rowId).toBe("i:a2");
+      expect(result.current.selectedNavigableIndex).toBe(1);
+    });
+
+    it("moves the FIRST arrow relative to the preferred row, not to the top", () => {
+      const { result } = setup(
+        [
+          ["a", ["a1", "a2"]],
+          ["b", ["b1"]],
+        ],
+        { preferredInitialRowId: "i:a2" }
+      );
+
+      act(() => result.current.step(1));
+      expect(result.current.selectedRow?.rowId).toBe("i:b1");
+    });
+
+    it("moves the first ArrowUp and the first page key from it too", () => {
+      const { result } = setup(
+        [
+          ["a", ["a1", "a2"]],
+          ["b", ["b1"]],
+        ],
+        { preferredInitialRowId: "i:a2" }
+      );
+
+      act(() => result.current.step(-1));
+      expect(result.current.selectedRow?.rowId).toBe("i:a1");
+
+      const paged = setup(
+        [
+          ["a", ["a1", "a2"]],
+          ["b", ["b1"]],
+        ],
+        { preferredInitialRowId: "i:a2" }
+      );
+      // Page keys clamp rather than wrap, so a page down from the middle of a
+      // three-row list lands on the last row.
+      act(() => paged.result.current.handleInputKeyDown(keyEvent("PageDown").event));
+      expect(paged.result.current.selectedRow?.rowId).toBe("i:b1");
+    });
+
+    it("yields to the user's own selection, and to a preference that no longer exists", () => {
+      const { result } = setup(
+        [
+          ["a", ["a1", "a2"]],
+          ["b", ["b1"]],
+        ],
+        { preferredInitialRowId: "i:a2" }
+      );
+
+      act(() => result.current.selectRow("i:b1"));
+      act(() => result.current.step(-1));
+      expect(result.current.selectedRow?.rowId).toBe("i:a2");
+
+      const missing = setup([["a", ["a1", "a2"]]], { preferredInitialRowId: "i:gone" });
+      expect(missing.result.current.selectedRow?.rowId).toBe("i:a1");
     });
   });
 

--- a/src/hooks/usePaletteTreeNavigation.ts
+++ b/src/hooks/usePaletteTreeNavigation.ts
@@ -107,6 +107,16 @@ export interface UsePaletteTreeNavigationOptions<TGroup, TItem> {
    * highlight somewhere down the new ranking rather than on its best match.
    */
   selectionScopeKey?: string | number | null;
+  /**
+   * The row the highlight starts on, before the user has moved it.
+   *
+   * Falls back to the first navigable row when absent or when the id names
+   * nothing currently rendered, which is what every palette without an opinion
+   * gets. It is deliberately only a STARTING point: once the user arrows, their
+   * selection wins until the scope key changes, so a list whose preferred row
+   * moves around underneath them cannot drag the cursor with it.
+   */
+  preferredInitialRowId?: string | null;
   onActivate: (row: NavigablePaletteTreeRow<TGroup, TItem>) => void;
   /**
    * Whether a caret exists that the structural keys must stand down for.
@@ -169,6 +179,7 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
   groups,
   isActive,
   selectionScopeKey = null,
+  preferredInitialRowId = null,
   onActivate,
   shouldPreserveInputCaretKey,
 }: UsePaletteTreeNavigationOptions<TGroup, TItem>): UsePaletteTreeNavigationResult<TGroup, TItem> {
@@ -213,14 +224,21 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
    */
   const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
 
-  /** Unmoved, the highlight sits on the first row the arrows can reach. */
+  /**
+   * Unmoved, the highlight sits on the caller's preferred row, or on the first
+   * row the arrows can reach when there isn't one.
+   */
   const selectedNavigableIndex = useMemo(() => {
     if (navigableRows.length === 0) return -1;
     const index = selectedRowId
       ? navigableRows.findIndex((row) => row.rowId === selectedRowId)
       : -1;
-    return index >= 0 ? index : 0;
-  }, [navigableRows, selectedRowId]);
+    if (index >= 0) return index;
+    const preferred = preferredInitialRowId
+      ? navigableRows.findIndex((row) => row.rowId === preferredInitialRowId)
+      : -1;
+    return preferred >= 0 ? preferred : 0;
+  }, [navigableRows, selectedRowId, preferredInitialRowId]);
 
   const selectedRow =
     selectedNavigableIndex >= 0 ? (navigableRows[selectedNavigableIndex] ?? null) : null;
@@ -255,16 +273,35 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
     document.getElementById(activeDescendantId)?.scrollIntoView({ block: "nearest" });
   }, [isActive, activeDescendantId, selectedRowPosition]);
 
+  /**
+   * Where a movement key starts counting from.
+   *
+   * The stored id when the user has moved, and otherwise the SAME row
+   * `selectedNavigableIndex` is drawing as selected — which is the preferred
+   * row when the caller named one. Falling back to 0 here instead was a real
+   * bug: the highlight sat on the fleet's blocked run and the first ArrowDown
+   * jumped to row two of the list, because the two answers to "what is
+   * selected" disagreed for exactly as long as the user had not yet moved.
+   */
+  const originOf = useCallback(
+    (previousId: string | null): number => {
+      const current = previousId ? navigableRows.findIndex((row) => row.rowId === previousId) : -1;
+      if (current >= 0) return current;
+      const preferred = preferredInitialRowId
+        ? navigableRows.findIndex((row) => row.rowId === preferredInitialRowId)
+        : -1;
+      return preferred >= 0 ? preferred : 0;
+    },
+    [navigableRows, preferredInitialRowId]
+  );
+
   const step = useCallback(
     (delta: number) => {
       if (navigableRows.length === 0) return;
       // Resolve the current row from the id inside the updater so two calls
       // batched into one tick compose instead of collapsing into one.
       setSelectedRowId((previousId) => {
-        const current = previousId
-          ? navigableRows.findIndex((row) => row.rowId === previousId)
-          : -1;
-        const from = current >= 0 ? current : 0;
+        const from = originOf(previousId);
         // Normalised both ways: a single `+ length` only rescues a delta of -1,
         // and this is a shared API that may be handed a page-sized jump.
         const size = navigableRows.length;
@@ -272,7 +309,7 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
         return navigableRows[next]!.rowId;
       });
     },
-    [navigableRows]
+    [navigableRows, originOf]
   );
 
   /**
@@ -288,15 +325,12 @@ export function usePaletteTreeNavigation<TGroup, TItem>({
     (delta: number) => {
       if (navigableRows.length === 0) return;
       setSelectedRowId((previousId) => {
-        const current = previousId
-          ? navigableRows.findIndex((row) => row.rowId === previousId)
-          : -1;
-        const from = current >= 0 ? current : 0;
+        const from = originOf(previousId);
         const next = Math.min(navigableRows.length - 1, Math.max(0, from + delta));
         return navigableRows[next]!.rowId;
       });
     },
-    [navigableRows]
+    [navigableRows, originOf]
   );
 
   const selectRow = useCallback((rowId: string) => setSelectedRowId(rowId), []);

--- a/src/lib/__tests__/fleetAttention.test.ts
+++ b/src/lib/__tests__/fleetAttention.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   bandForRun,
   bandLabel,
+  bandTimestamp,
   compareWithinBand,
   emptyBandCounts,
   FLEET_BANDS,
+  isAttentionBand,
   isDemandBand,
 } from "../fleetAttention";
 import type { FleetRunRow } from "@shared/types/ipc/fleet";
@@ -154,6 +156,67 @@ describe("band presentation", () => {
   });
 });
 
+describe("band timestamps", () => {
+  it("dates each band from the decision it is actually about", () => {
+    const parked = run({ since: NOW - 3 * 3_600_000, park: { parkedAt: NOW - 60_000 } });
+    expect(bandTimestamp(parked, "parked")).toBe(NOW - 60_000);
+
+    const snoozed = run({ since: NOW - 3 * 3_600_000, snooze: { snoozedAt: NOW - 60_000 } });
+    expect(bandTimestamp(snoozed, "snoozed")).toBe(NOW - 60_000);
+
+    const silent = run({ since: NOW - 3 * 3_600_000, quietSince: NOW - 60_000 });
+    expect(bandTimestamp(silent, "quiet")).toBe(NOW - 60_000);
+
+    expect(bandTimestamp(run({ since: NOW - 60_000 }), "needs-you")).toBe(NOW - 60_000);
+  });
+
+  it("orders two silent runs by their silence, not by how long they have worked", () => {
+    // The one that has been quiet longest is the one worth looking at, even if
+    // it is the one that started most recently.
+    const longWorkShortSilence = run({
+      runId: "a",
+      since: NOW - 5 * 3_600_000,
+      quietSince: NOW - 60_000,
+    });
+    const shortWorkLongSilence = run({
+      runId: "b",
+      since: NOW - 20 * 60_000,
+      quietSince: NOW - 15 * 60_000,
+    });
+
+    expect(
+      [longWorkShortSilence, shortWorkLongSilence]
+        .sort((x, y) => compareWithinBand(x, y, "quiet"))
+        .map((r) => r.runId)
+    ).toEqual(["b", "a"]);
+  });
+});
+
+describe("quiet runs", () => {
+  it("splits a silent worker out of running, on presence of the stamp alone", () => {
+    // Main only puts `quietSince` on the wire once the silence has crossed its
+    // stall threshold, so this needs no clock of its own.
+    expect(bandForRun(run({ agentState: "working", quietSince: NOW - 12 * 60_000 }))).toBe("quiet");
+    expect(bandForRun(run({ agentState: "working" }))).toBe("running");
+    expect(bandForRun(run({ agentState: "directing", quietSince: NOW - 60_000 }))).toBe("quiet");
+  });
+
+  it("keeps a park or a snooze above it, so a shelved run cannot resurface as quiet", () => {
+    const silent = { agentState: "working" as const, quietSince: NOW - 12 * 60_000 };
+    expect(bandForRun(run({ ...silent, park: { parkedAt: NOW } }))).toBe("parked");
+    expect(bandForRun(run({ ...silent, snooze: { snoozedAt: NOW } }))).toBe("snoozed");
+  });
+
+  it("outranks finished work but is never counted as a demand", () => {
+    // A stall nobody sees costs the rest of the morning; an unread hand-back
+    // costs a minute. But nothing is asking, so the demand count stays honest.
+    expect(FLEET_BANDS.indexOf("quiet")).toBeLessThan(FLEET_BANDS.indexOf("review"));
+    expect(FLEET_BANDS.indexOf("quiet")).toBeGreaterThan(FLEET_BANDS.indexOf("needs-you"));
+    expect(isDemandBand("quiet")).toBe(false);
+    expect(isAttentionBand("quiet")).toBe(true);
+  });
+});
+
 describe("isDemandBand", () => {
   it("classifies at least one band as a demand and at least one as not", () => {
     const demands = FLEET_BANDS.filter(isDemandBand);
@@ -163,51 +226,52 @@ describe("isDemandBand", () => {
 });
 
 describe("compareWithinBand", () => {
+  /** These cases are all about the ordering itself, so they bind one band. */
+  const byNeed = (a: FleetRunRow, b: FleetRunRow) => compareWithinBand(a, b, "needs-you");
+
   it("orders oldest demand first so fresh work cannot starve a stuck run", () => {
     const old = run({ runId: "a", since: NOW - 40 * 60_000 });
     const fresh = run({ runId: "b", since: NOW - 60_000 });
-    expect([fresh, old].sort(compareWithinBand).map((r) => r.runId)).toEqual(["a", "b"]);
+    expect([fresh, old].sort(byNeed).map((r) => r.runId)).toEqual(["a", "b"]);
   });
 
   it("sorts an unknown age last, never first", () => {
     const unknown = run({ runId: "a" });
     const known = run({ runId: "b", since: NOW - 60_000 });
-    expect([unknown, known].sort(compareWithinBand).map((r) => r.runId)).toEqual(["b", "a"]);
+    expect([unknown, known].sort(byNeed).map((r) => r.runId)).toEqual(["b", "a"]);
   });
 
   it("is a total order: reflexive on identity and antisymmetric", () => {
     const x = run({ runId: "a", since: NOW });
     const y = run({ runId: "b", since: NOW - 1000 });
-    expect(compareWithinBand(x, x)).toBe(0);
-    expect(Math.sign(compareWithinBand(x, y))).toBe(-Math.sign(compareWithinBand(y, x)));
+    expect(byNeed(x, x)).toBe(0);
+    expect(Math.sign(byNeed(x, y))).toBe(-Math.sign(byNeed(y, x)));
   });
 
   it("ranks unknown ages consistently from either argument position", () => {
     const unknown = run({ runId: "a" });
     const other = run({ runId: "b" });
     const known = run({ runId: "c", since: NOW });
-    expect(compareWithinBand(unknown, known)).toBeGreaterThan(0);
-    expect(compareWithinBand(known, unknown)).toBeLessThan(0);
+    expect(byNeed(unknown, known)).toBeGreaterThan(0);
+    expect(byNeed(known, unknown)).toBeLessThan(0);
     // Two unknowns must still rank against each other rather than tying.
-    expect(Math.sign(compareWithinBand(unknown, other))).toBe(
-      -Math.sign(compareWithinBand(other, unknown))
-    );
+    expect(Math.sign(byNeed(unknown, other))).toBe(-Math.sign(byNeed(other, unknown)));
   });
 
   it("is transitive across known, equal and unknown ages", () => {
     const oldest = run({ runId: "a", since: NOW - 10_000 });
     const newer = run({ runId: "b", since: NOW });
     const unknown = run({ runId: "c" });
-    expect(compareWithinBand(oldest, newer)).toBeLessThan(0);
-    expect(compareWithinBand(newer, unknown)).toBeLessThan(0);
-    expect(compareWithinBand(oldest, unknown)).toBeLessThan(0);
+    expect(byNeed(oldest, newer)).toBeLessThan(0);
+    expect(byNeed(newer, unknown)).toBeLessThan(0);
+    expect(byNeed(oldest, unknown)).toBeLessThan(0);
   });
 
   it("breaks ties by run id so equal ages produce a stable order", () => {
     const first = run({ runId: "a", since: NOW });
     const second = run({ runId: "b", since: NOW });
-    expect([second, first].sort(compareWithinBand).map((r) => r.runId)).toEqual(["a", "b"]);
-    expect([first, second].sort(compareWithinBand).map((r) => r.runId)).toEqual(["a", "b"]);
+    expect([second, first].sort(byNeed).map((r) => r.runId)).toEqual(["a", "b"]);
+    expect([first, second].sort(byNeed).map((r) => r.runId)).toEqual(["a", "b"]);
   });
 });
 

--- a/src/lib/fleetAttention.ts
+++ b/src/lib/fleetAttention.ts
@@ -13,6 +13,16 @@ import type { FleetRunRow } from "@shared/types/ipc/fleet";
  * disagreeing about which agent is most urgent is worse than either ordering
  * being individually wrong.
  *
+ * `quiet` sits directly under `needs-you`. A run that is nominally working but
+ * has been silent past main's stall threshold is the second question this
+ * surface exists to answer, and while it is not a demand — nobody is asking
+ * the user for anything — it outranks finished work, because a stall that goes
+ * unseen costs the rest of the morning and a hand-back costs a minute. It sat
+ * inside `running` until #11957, where the only trace of it was an annotation
+ * on one row: the fleet counts, the filter bar and the group summaries all
+ * reported it as ordinary work in flight, so the one run worth finding was the
+ * one nothing pointed at.
+ *
  * `parked` sits between `done` and `idle`: the user has explicitly shelved the
  * run, so it must never read as a demand — but unlike an idle shell it carries
  * intent (a note, maybe a gate) worth finding above the dead rows.
@@ -27,6 +37,7 @@ import type { FleetRunRow } from "@shared/types/ipc/fleet";
 export const FLEET_BANDS = [
   "blocked",
   "needs-you",
+  "quiet",
   "review",
   "running",
   "done",
@@ -37,11 +48,27 @@ export const FLEET_BANDS = [
 
 export type FleetBand = (typeof FLEET_BANDS)[number];
 
-/** Bands that constitute a demand on the user — the ones a quiet fleet has none of. */
+/** Bands that constitute a demand on the user — the ones an idle fleet has none of. */
 const DEMAND_BANDS: ReadonlySet<FleetBand> = new Set<FleetBand>(["blocked", "needs-you", "review"]);
 
 export function isDemandBand(band: FleetBand): boolean {
   return DEMAND_BANDS.has(band);
+}
+
+/**
+ * Bands worth pointing at, which is a wider set than the demands.
+ *
+ * `quiet` is deliberately NOT a demand: nothing is asking the user for
+ * anything, and folding it into the demand count would make "3 agents need
+ * you" promise three conversations and deliver two — the exact overstatement
+ * the acknowledged-completion watermark exists to prevent. It is still the
+ * thing a group header has to be able to point at, so the chip and the summary
+ * read this set rather than the demand one.
+ */
+const ATTENTION_BANDS: ReadonlySet<FleetBand> = new Set<FleetBand>([...DEMAND_BANDS, "quiet"]);
+
+export function isAttentionBand(band: FleetBand): boolean {
+  return ATTENTION_BANDS.has(band);
 }
 
 /**
@@ -80,7 +107,10 @@ export function bandForRun(run: FleetRunRow, acknowledgedAt?: number): FleetBand
         : "review";
     case "working":
     case "directing":
-      return "running";
+      // Presence alone, like the park and snooze records above: main only puts
+      // `quietSince` on the wire once the silence has crossed its stall
+      // threshold, so this needs no clock and no threshold of its own.
+      return run.quietSince !== undefined ? "quiet" : "running";
     default:
       return "idle";
   }
@@ -95,11 +125,12 @@ export function bandForRun(run: FleetRunRow, acknowledgedAt?: number): FleetBand
  * `running` and `idle` split on state because they each cover two situations
  * the user can tell apart and would want to.
  *
- * "Waiting" rather than "Needs you" for the same reason the filter segment says
- * it: the sidebar has called this state waiting since it shipped, and one state
- * with two names across two surfaces is a vocabulary the user has to learn
- * twice. The prose sentences elsewhere ("2 agents need you") are sentences, not
- * state labels, and keep their own phrasing.
+ * These are STATE names, and they stay narrow. The filter segment above them
+ * says "Attention", which is a BUCKET name and deliberately wider: it holds
+ * `blocked` and `needs-you` together, so it cannot borrow either one's word
+ * without making a claim about the other. A row is never ambiguous, so it gets
+ * to be exact. The prose sentences elsewhere ("2 agents need you") are
+ * sentences, not state labels, and keep their own phrasing again.
  */
 export function bandLabel(band: FleetBand, run: FleetRunRow): string {
   switch (band) {
@@ -111,6 +142,8 @@ export function bandLabel(band: FleetBand, run: FleetRunRow): string {
       return "Ready for review";
     case "running":
       return run.agentState === "directing" ? "Directing" : "Working";
+    case "quiet":
+      return "Quiet";
     case "done":
       return "Finished";
     case "parked":
@@ -128,6 +161,34 @@ export function bandLabel(band: FleetBand, run: FleetRunRow): string {
 }
 
 /**
+ * The moment a band is actually about.
+ *
+ * `since` is when the agent last changed STATE, which is the right clock for
+ * most bands and the wrong one for the three whose band was decided by
+ * something else entirely. A park is dated from the park, a snooze from the
+ * snooze, and a silence from the silence — otherwise a run parked ten seconds
+ * ago reads as three hours old because that is how long it waited first, and
+ * two silent agents rank by how long they have been WORKING rather than by how
+ * long they have said nothing.
+ *
+ * One function, read by the row's clock, by the within-band ordering and by
+ * the initial cursor, so the number on screen, the position in the list and
+ * the row Enter opens can never be measuring three different things.
+ */
+export function bandTimestamp(run: FleetRunRow, band: FleetBand): number | undefined {
+  switch (band) {
+    case "parked":
+      return run.park?.parkedAt ?? run.since;
+    case "snoozed":
+      return run.snooze?.snoozedAt ?? run.since;
+    case "quiet":
+      return run.quietSince ?? run.since;
+    default:
+      return run.since;
+  }
+}
+
+/**
  * Sort key within a band: oldest demand first.
  *
  * Oldest-first rather than newest-first is the anti-starvation choice. A stream
@@ -135,13 +196,17 @@ export function bandLabel(band: FleetBand, run: FleetRunRow): string {
  * minutes — that is the exact failure that teaches a user to stop trusting the
  * top of the list.
  *
- * A run with no `since` sorts last within its band rather than first: an
+ * A run with no timestamp sorts last within its band rather than first: an
  * unknown age is not evidence of urgency, and treating it as infinitely old
  * would let a pre-detection boot window outrank a genuine forty-minute block.
+ *
+ * `band` is required rather than re-derived: callers have already computed it
+ * to decide that these two belong in the same bucket, and computing it twice
+ * is a second chance for the ordering to disagree with the band it is ordering.
  */
-export function compareWithinBand(a: FleetRunRow, b: FleetRunRow): number {
-  const aSince = a.since;
-  const bSince = b.since;
+export function compareWithinBand(a: FleetRunRow, b: FleetRunRow, band: FleetBand): number {
+  const aSince = bandTimestamp(a, band);
+  const bSince = bandTimestamp(b, band);
   if (aSince !== undefined && bSince !== undefined && aSince !== bSince) return aSince - bSince;
   // An unknown age sorts after a known one, and two unknowns fall through to
   // the id tiebreak — so the comparator stays a total order rather than
@@ -166,6 +231,7 @@ export function emptyBandCounts(): FleetBandCounts {
   return {
     blocked: 0,
     "needs-you": 0,
+    quiet: 0,
     review: 0,
     running: 0,
     done: 0,


### PR DESCRIPTION
Agent Pilot (⌥⌘O) lists every agent across every project. When you come back to the machine you ask it two things: is anything asking me for something, and is anything stuck. It answered the first well and the second not at all.

## The one that matters

A working agent that has said nothing for twelve minutes had no band, no count, no filter and no summary — just an amber annotation on whichever row you happened to scroll past. Every global signal reported it as ordinary work in flight. At thirty agents it disappears.

`quiet` is a band now, ranked between `needs-you` and `review`: an unnoticed stall costs the rest of the morning, an unread hand-back costs a minute. It is deliberately **not** a demand band — nothing is asking, and "3 agents need you" must not promise three conversations and deliver two — so the group chips and the footer read a wider `isAttentionBand` set instead.

It is called Quiet, not Stalled. The fleet knows the agent has said nothing for twelve minutes; it does not know the agent is stuck.

## The rest

- **The cursor opens on the fleet's worst run**, not the top of the most recently opened project. Group order stays most-recently-opened (#11678) — moving the cursor buys nearly the same thing and costs nothing. This also fixed a real bug: the movement keys counted from row zero while the highlight was drawn elsewhere, so the first arrow after opening jumped.
- **Every band is drawn distinctly.** `idle` gives up the hollow circle it shared with `needs-you`, so the amber hollow circle means waiting and only waiting. The three app-standard marks are untouched — green spinner is working, amber circle is waiting, blue check circle is finished. `quiet` is the working spinner in the waiting hue, static: a silent run *is* a working run, which is the whole difficulty with it.
- **One clock per row**, in one column, measuring whatever its band is about. `bandTimestamp` is read by the row's age, the within-band ordering and the cursor, so the drawn number, the position in the list and the row Enter opens can't be measuring three different things. A quiet row draws `quiet 12m` and drops the second, unlabelled duration; the working age moves to the accessible name, which now carries a phrase per band ("waiting for 38m", "finished 6m ago") rather than a bare "2m ago".
- **Group headers count each band separately.** `⊘ 2` over one blocked run and one waiting one has no honest reading. `⊘1 ○1` does.
- **"Waiting" is "Attention"**, here and in the worktree sidebar. Both filter on `agentState === "waiting"`, which covers an errored agent too, so both were named after one of the two states they hold. Rows still say "Blocked" and "Waiting" — only the bucket that holds both took a wider name. It escalates to the blocked mark when anything has errored, and says "including 1 blocked" out loud. "Stuck" was the first attempt and reads as a fault — an agent holding for your approval is not broken, and a bucket that says it is teaches you to flinch at the ordinary case.
- **The segments partition the fleet.** `Other` holds snoozed and idle, so the counts sum to All instead of leaving two runs unexplained. At seven segments the bar sizes from content and shares only the slack — equal shares truncated the labels.
- **Footer key hints are buttons.** Park and Worktrees were keyboard-only in practice, and the drill gesture's only pointer form was an unmarked click on a heading.
- **Contrast.** Project names, park notes, ages, the summary and the park editor's copy move off percentage opacities onto `text-text-secondary`. The shared section-label constant measured about 3.3:1 on the palette surface in the dark themes, and it names which project every row beneath it belongs to — so every palette in the family gains with it.
- **The park editor's busy state** gets the Doherty gate: spinner past 400ms, "Still working…" past five seconds, typed note left on screen throughout.

- **The palette is wider.** A third `overview` tier in `AppPaletteDialog` at 672px, up from the command tier's 608. This surface is a table rather than a list — five columns a row under a seven-segment bar — and it was paying for that chrome by truncating titles. A declared tier rather than a one-off width, so the family keeps its "sizes are decisions, not measurements" rule.

## How it was reviewed

`e2e/screenshots/pilot-review.spec.ts` is new. It opens five real projects, injects a fabricated `FleetSnapshot` on the real broadcast channel from the main process — so the surface renders a run in every band without anyone waiting forty minutes for one to age — and sweeps all fifteen built-in themes:

```
DAINTREE_SHOT_THEME=all npx playwright test --project=screenshots pilot-review
```

Five rounds of Codex review against those renders, 7.4 → 9.9. Two of its calls were wrong and got argued down (severity-ordered groups, and a generic glyph for the mixed segment); the rest are in here. Rendering rather than reasoning is what caught the ellipsis glyph reading as a smiley face at 14px, and the seven-segment bar truncating — the arithmetic said both were fine.

## One drive-by, worth knowing about

`e2e/helpers/launch.ts` reaped Electron by matching `node_modules/electron.*daintree-e2e`, and `--daintree-e2e-mode` is on the command line of every E2E-launched app. On macOS local dev the pre-launch reap therefore SIGKILLed every *other* worker's app as well as its own leftovers — two agents running specs in two worktrees each killed the other, which surfaces as "the Daintree application can't start" in whichever loses. The reap now matches only the user-data dirs the worker itself launched, which keeps the original intent.

## Checks

`npm run check` green. Full unit suite green (51,193 passing). All fifteen themes capture cleanly.
