### PR TITLE
Rework the issue and PR dropdowns

### DIFF
--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -423,7 +423,7 @@ export const SEL = {
     noTokenEmptyState: 'text="GitHub not connected"',
     rateLimitedEmptyState: 'text="GitHub requests are paused"',
     // Bulk selection action bar + dialog
-    bulkActionBar: '[role="toolbar"][aria-label="Bulk actions"]',
+    bulkActionBar: '[role="group"][aria-label="Bulk actions"]',
     bulkCreateButton: '[data-testid="bulk-action-create-worktrees-button"]',
     bulkClearButton: '[aria-label="Clear selection"]',
     bulkCreateDialog: '[data-testid="bulk-create-worktree-dialog"]',

--- a/e2e/screenshots/forge-dropdown-review.spec.ts
+++ b/e2e/screenshots/forge-dropdown-review.spec.ts
@@ -1,0 +1,329 @@
+/**
+ * Issue / PR dropdown visual-review harness.
+ *
+ * Boots a fixture repo with a GitHub remote, seeds a fake token, stubs the
+ * forge list handlers with rich fixtures (labels, assignees, comments, linked
+ * PRs, CI status, drafts), then writes PNGs of the issues and pull-requests
+ * dropdowns so design work on them can be judged against real rendered pixels.
+ *
+ * Opt-in only — skips itself unless DAINTREE_SHOT_FORGE is set, so the
+ * marketing screenshots workflow never runs it.
+ *
+ *   DAINTREE_SHOT_FORGE=1 npx playwright test --project=screenshots forge-dropdown-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_FORGE   required — any truthy value
+ *   DAINTREE_SHOT_TAG     optional suffix to keep rounds side by side
+ *   DAINTREE_SHOT_THEME   optional theme id (default: the app default)
+ *   DAINTREE_SHOT_ONLY    comma-separated step filter
+ *
+ * Output: artifacts/forge-shots/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, type Page, type Locator, type ElectronApplication } from "@playwright/test";
+import { mkdtempSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { createFixtureRepo } from "../helpers/fixtures";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { connectGitHub, stubRepoStats } from "../helpers/githubHelpers";
+import { SEL } from "../helpers/selectors";
+import { T_MEDIUM } from "../helpers/timeouts";
+import type { Issue, PR } from "../../shared/types/forge";
+
+const ENABLED = Boolean(process.env.DAINTREE_SHOT_FORGE);
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+/** Comma-separated theme ids to sweep in one session (overrides DAINTREE_SHOT_THEME). */
+const THEMES = (process.env.DAINTREE_SHOT_THEMES ?? "").split(",").filter(Boolean);
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "forge-shots");
+
+const POLISH_CSS = `
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+const MIN = 60_000;
+const AVATAR =
+  "data:image/svg+xml;base64," +
+  Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><rect width="32" height="32" fill="#4a6b8a"/><circle cx="16" cy="12" r="6" fill="#c8d8e4"/><ellipse cx="16" cy="28" rx="11" ry="9" fill="#c8d8e4"/></svg>`
+  ).toString("base64");
+
+function issue(n: number, title: string, over: Partial<Issue> = {}): Issue {
+  const updatedAt = Date.now() - n * MIN;
+  return {
+    number: n,
+    title,
+    body: "",
+    state: "open",
+    rawState: "OPEN",
+    url: `https://github.com/daintreehq/daintree/issues/${n}`,
+    author: { login: "gregpriday", avatarUrl: AVATAR },
+    assignees: [],
+    labels: [],
+    commentCount: 0,
+    createdAt: updatedAt,
+    updatedAt,
+    rawData: {},
+    ...over,
+  };
+}
+
+function pr(n: number, title: string, over: Partial<PR> = {}): PR {
+  const updatedAt = Date.now() - n * MIN;
+  return {
+    number: n,
+    title,
+    body: "",
+    state: "open",
+    rawState: "OPEN",
+    isDraft: false,
+    merged: false,
+    url: `https://github.com/daintreehq/daintree/pull/${n}`,
+    author: { login: "gregpriday", avatarUrl: AVATAR },
+    baseRef: "develop",
+    headRef: `feature/issue-${n}`,
+    commentCount: 0,
+    createdAt: updatedAt,
+    updatedAt,
+    rawData: {},
+    ...over,
+  };
+}
+
+const L = (name: string, color: string) => ({ name, color });
+
+const ISSUES: Issue[] = [
+  issue(11958, "Restart into a scratch workspace restores an unnamed project shell", {
+    labels: [L("bug", "d73a4a"), L("backend", "e99695")],
+  }),
+  issue(11957, "Cmd+Alt+I falls back to the fleet view in most projects", {
+    labels: [L("bug", "d73a4a"), L("ui", "fbe1d5")],
+    commentCount: 3,
+  }),
+  issue(11949, "Show Claude Code subagents as inspectable child terminals", {
+    labels: [L("enhancement", "a2eeef"), L("terminal", "5319e7")],
+    assignees: [{ login: "gregpriday", avatarUrl: AVATAR }],
+  }),
+  issue(11755, "Publish Daintree to winget", {
+    labels: [L("enhancement", "a2eeef"), L("infrastructure", "0e8a16")],
+  }),
+  issue(11745, "Bundle the assistant CLI into release builds", {
+    labels: [L("infrastructure", "0e8a16"), L("future-work", "5aa9e6")],
+    commentCount: 1,
+  }),
+  issue(11244, "Fold the forge slot view seam into the panel contract", {
+    labels: [L("architecture", "c5def5"), L("plugins", "7cd44a")],
+    commentCount: 1,
+    assignees: [{ login: "gregpriday", avatarUrl: AVATAR }],
+    linkedPR: {
+      number: 11250,
+      state: "open",
+      url: "https://github.com/daintreehq/daintree/pull/11250",
+    },
+  }),
+  issue(11210, "Renderer memory climbs to 3.2GB across a long session", {
+    labels: [L("bug", "d73a4a"), L("performance", "fbca04")],
+    commentCount: 12,
+  }),
+  issue(11158, "Remote SSH workspace mode", {
+    labels: [L("epic", "3e4b9e")],
+    assignees: [{ login: "gregpriday", avatarUrl: AVATAR }],
+  }),
+];
+
+const PRS: PR[] = [
+  pr(11956, "fix(compiler-budget): close the regeneration wedges", {
+    ciStatus: "success",
+    commentCount: 2,
+  }),
+  pr(11955, "feature(pilot): group a project's agents", { ciStatus: "pending" }),
+  pr(11950, "refactor(panels): fold the forge slot view seam", {
+    isDraft: true,
+    ciStatus: "failure",
+    commentCount: 5,
+  }),
+  pr(11940, "perf(renderer): shard the worktree port broker", { ciStatus: "success" }),
+  pr(11930, "chore(deps): hold vite at 8.0.14", { ciStatus: "success", commentCount: 1 }),
+  pr(11920, "feat(brand): rework the brand-mark ink model", { ciStatus: "success" }),
+  pr(11910, "fix(terminal): guard the poisoned xterm open() wedge", { ciStatus: "failure" }),
+];
+
+async function stubList(
+  app: ElectronApplication,
+  channel: string,
+  items: unknown[]
+): Promise<void> {
+  await app.evaluate(
+    ({ ipcMain }, { channel, response }) => {
+      ipcMain.removeHandler(channel);
+      ipcMain.handle(channel, async () => response);
+    },
+    { channel, response: { items, nextCursor: null, hasMore: false, totalCount: items.length } }
+  );
+}
+
+async function settle(page: Page, ms = 600): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+async function snap(page: Page, slug: string, locator?: Locator): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await locator.first().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    console.warn(`[forge-shots] step "${name}" skipped:`, String(error).slice(0, 300));
+  }
+}
+
+/** The dropdown panel itself — the fixed-dropdown surface that holds the list. */
+function panel(page: Page, listSel: string): Locator {
+  return page
+    .locator(listSel)
+    .locator('xpath=ancestor::div[contains(@class,"surface-overlay")][1]');
+}
+
+test("forge dropdown review — issues and pull requests", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_FORGE is required for the forge dropdown capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_FORGE to run the forge dropdown capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo({ name: "forge-shots", withGitHubRemote: true });
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-forgeshot-"));
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      env: { DAINTREE_E2E_FAULT_MODE: "1" },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Daintree");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+
+    await stubList(ctx.app, "forge:list-issues", process.env.DAINTREE_SHOT_EMPTY ? [] : ISSUES);
+    await stubList(ctx.app, "forge:list-prs", PRS);
+    await connectGitHub(ctx.app, page);
+    await stubRepoStats(
+      ctx.app,
+      { issueCount: ISSUES.length, prCount: PRS.length, commitCount: 4 },
+      page
+    );
+    await settle(page, 1500);
+    await dismissBlockingPalette(page);
+
+    await step("issues", async () => {
+      const pill = page.locator(SEL.github.statPillIssues);
+      await pill.waitFor({ state: "visible", timeout: T_MEDIUM });
+      await pill.click();
+      await page.locator(SEL.github.listIssues).waitFor({ state: "visible", timeout: T_MEDIUM });
+      await settle(page, 1200);
+      await snap(
+        page,
+        process.env.DAINTREE_SHOT_EMPTY ? "26-issues-empty" : "20-issues-dropdown",
+        panel(page, SEL.github.listIssues)
+      );
+      await snap(page, "21-issues-in-context");
+    });
+
+    await step("issues-hover", async () => {
+      await page.locator(SEL.github.item(11957)).hover();
+      await settle(page, 400);
+      await snap(page, "22-issues-row-hover", panel(page, SEL.github.listIssues));
+      await page.keyboard.press("Escape");
+      await settle(page, 400);
+    });
+
+    await step("prs", async () => {
+      await page.keyboard.press("Escape").catch(() => {});
+      const pill = page.locator(SEL.github.statPillPrs);
+      await pill.waitFor({ state: "visible", timeout: T_MEDIUM });
+      await pill.click();
+      await page.locator(SEL.github.listPrs).waitFor({ state: "visible", timeout: T_MEDIUM });
+      await settle(page, 1200);
+      await snap(page, "30-prs-dropdown", panel(page, SEL.github.listPrs));
+      await page.keyboard.press("Escape");
+      await settle(page, 400);
+    });
+
+    await step("selection", async () => {
+      await page.locator(SEL.github.statPillIssues).click();
+      await page.locator(SEL.github.listIssues).waitFor({ state: "visible", timeout: T_MEDIUM });
+      await settle(page, 800);
+      // Keyboard route: the cursor lands on a row, Shift+Space takes it into
+      // the selection (bare Space stays a search character).
+      await page.keyboard.press("ArrowDown");
+      await settle(page, 200);
+      await page.keyboard.press("Shift+Space");
+      await settle(page, 300);
+      await page.keyboard.press("ArrowDown");
+      await settle(page, 200);
+      await page.keyboard.press("Shift+Space");
+      await settle(page, 500);
+      await snap(page, "25-issues-selection", panel(page, SEL.github.listIssues));
+      await page.keyboard.press("Escape");
+      await settle(page, 300);
+      await page.keyboard.press("Escape");
+      await settle(page, 400);
+    });
+
+    // Empty/loading states are captured by a separate opt-in run
+    // (DAINTREE_SHOT_EMPTY=1) that seeds an empty list before the first fetch.
+    // Swapping the live IPC handler mid-session crashes the project view — a
+    // harness limitation, reproducible on unmodified code.
+
+    // Cross-theme sweep: one shot of each dropdown per theme, same session.
+    await step("themes", async () => {
+      for (const themeId of THEMES) {
+        await setAppTheme(page, themeId);
+        await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+        await settle(page, 800);
+        await page.locator(SEL.github.statPillIssues).click();
+        await page.locator(SEL.github.listIssues).waitFor({ state: "visible", timeout: T_MEDIUM });
+        await settle(page, 900);
+        await snap(page, `40-theme-${themeId}-issues`, panel(page, SEL.github.listIssues));
+        await page.keyboard.press("Escape");
+        await settle(page, 400);
+        await page.locator(SEL.github.statPillPrs).click();
+        await page.locator(SEL.github.listPrs).waitFor({ state: "visible", timeout: T_MEDIUM });
+        await settle(page, 900);
+        await snap(page, `41-theme-${themeId}-prs`, panel(page, SEL.github.listPrs));
+        await page.keyboard.press("Escape");
+        await settle(page, 400);
+      }
+    });
+  } finally {
+    if (ctx) await closeApp(ctx);
+    repo.cleanup();
+  }
+});

--- a/e2e/screenshots/forge-dropdown-review.spec.ts
+++ b/e2e/screenshots/forge-dropdown-review.spec.ts
@@ -191,11 +191,16 @@ async function snap(page: Page, slug: string, locator?: Locator): Promise<void> 
 }
 
 const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+/* A step failure must not abort the remaining captures, but it must not pass
+   silently either — a run where every step blew up would otherwise report PASS
+   and write no PNGs. Failures are collected and rethrown at the end. */
+const stepFailures: string[] = [];
 async function step(name: string, fn: () => Promise<void>): Promise<void> {
   if (ONLY.length > 0 && !ONLY.includes(name)) return;
   try {
     await fn();
   } catch (error) {
+    stepFailures.push(`${name}: ${String(error).slice(0, 300)}`);
     console.warn(`[forge-shots] step "${name}" skipped:`, String(error).slice(0, 300));
   }
 }
@@ -325,5 +330,11 @@ test("forge dropdown review — issues and pull requests", async () => {
   } finally {
     if (ctx) await closeApp(ctx);
     repo.cleanup();
+  }
+
+  if (stepFailures.length > 0) {
+    throw new Error(
+      `[forge-shots] ${stepFailures.length} step(s) failed:\n${stepFailures.join("\n")}`
+    );
   }
 });

--- a/plugins/builtin/github/renderer/__tests__/BulkActionBar.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkActionBar.test.tsx
@@ -69,7 +69,7 @@ describe("BulkActionBar", () => {
       />
     );
 
-    expect(screen.getByRole("toolbar", { name: /bulk actions/i })).toBeTruthy();
+    expect(screen.getByRole("group", { name: /bulk actions/i })).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();
   });
 
@@ -88,7 +88,7 @@ describe("BulkActionBar", () => {
       />
     );
 
-    expect(screen.queryByRole("toolbar", { name: /bulk actions/i })).toBeNull();
+    expect(screen.queryByRole("group", { name: /bulk actions/i })).toBeNull();
     expect(container.firstChild).toBeNull();
   });
 
@@ -121,7 +121,7 @@ describe("BulkActionBar", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /create worktrees/i }));
+    fireEvent.click(screen.getByRole("button", { name: /create worktree/i }));
     expect(openBulkCreateDialog).toHaveBeenCalledWith(issues, onClear);
     expect(openBulkCreateDialogForPRs).not.toHaveBeenCalled();
   });
@@ -141,7 +141,7 @@ describe("BulkActionBar", () => {
 
     expect(screen.getByText("3")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: /create worktrees/i }));
+    fireEvent.click(screen.getByRole("button", { name: /create worktree/i }));
     expect(openBulkCreateDialogForPRs).toHaveBeenCalledWith(prs, onClear);
     expect(openBulkCreateDialog).not.toHaveBeenCalled();
   });
@@ -159,7 +159,7 @@ describe("BulkActionBar", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /create worktrees/i }));
+    fireEvent.click(screen.getByRole("button", { name: /create worktree/i }));
     expect(onCloseDropdown).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
@@ -321,7 +321,6 @@ describe("GitHubListItem", () => {
     const activeOption = active.container.querySelector("[role='row']")!;
     expect(activeOption.getAttribute("aria-selected")).toBe("false");
     expect(activeOption.className).not.toBe(restingClass);
-    expect(activeOption.className).toContain("before:opacity-100");
     active.unmount();
 
     const selected = render(

--- a/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
@@ -7,6 +7,7 @@ import { Activity, type ReactNode } from "react";
 import { GitHubListItem } from "../components/GitHubListItem";
 import type { Issue, PR } from "@shared/types/forge";
 import { actionService } from "@/services/ActionService";
+import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
 
 vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
@@ -117,7 +118,7 @@ describe("GitHubListItem", () => {
       linkedPR: { number: 55, state: "open", url: "https://github.com/test/repo/pull/55" },
     };
     render(<GitHubListItem item={issueWithPR} type="issue" />);
-    fireEvent.click(screen.getByRole("button", { name: "Linked PR #55" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open linked pull request #55" }));
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "system.openExternal",
       { url: "https://github.com/test/repo/pull/55" },
@@ -144,9 +145,14 @@ describe("GitHubListItem", () => {
         { name: "enhancement", color: "a2eeef" },
       ],
     };
-    render(<GitHubListItem item={issueWithLabels} type="issue" />);
+    const { container } = render(<GitHubListItem item={issueWithLabels} type="issue" />);
+    // One label rendered whole plus a count — clipping the second to
+    // "enhanceme…" read as broken data, and anything past it used to vanish
+    // with nothing to say so.
     expect(screen.getByText("bug")).toBeTruthy();
-    expect(screen.getByText("enhancement")).toBeTruthy();
+    expect(screen.getByText("+1")).toBeTruthy();
+    // Every label is still reachable, in the tooltip (flattened by the mock).
+    expect(container.textContent).toContain("bug, enhancement");
   });
 
   it("clicking #number copies to clipboard", async () => {
@@ -173,7 +179,7 @@ describe("GitHubListItem", () => {
     expect(checkIcon).not.toBeNull();
 
     act(() => {
-      vi.advanceTimersByTime(1500);
+      vi.advanceTimersByTime(UI_ACTION_SUCCESS_DWELL_MS);
     });
 
     // Check icon should be gone
@@ -208,21 +214,21 @@ describe("GitHubListItem", () => {
     expect(checkIconAfter).toBeNull();
   });
 
-  it("renders ellipsis menu trigger button", () => {
+  it("names the row actions trigger per item so two rows never share a label", () => {
     render(<GitHubListItem item={baseIssue} type="issue" />);
-    expect(screen.getByLabelText("More actions")).toBeTruthy();
+    expect(screen.getByLabelText("Actions for #42")).toBeTruthy();
   });
 
-  it("ellipsis button is visible when isActive", () => {
+  it("keeps the row actions trigger in the DOM and rendered whether or not the row is active", () => {
+    // It used to be `opacity-0` until hover, which made it findable only by
+    // people who already knew it was there.
+    const { unmount } = render(<GitHubListItem item={baseIssue} type="issue" isActive={false} />);
+    const resting = screen.getByLabelText("Actions for #42");
+    expect(resting.className).not.toContain("opacity-0");
+    unmount();
+
     render(<GitHubListItem item={baseIssue} type="issue" isActive />);
-    const btn = screen.getByLabelText("More actions");
-    expect(btn.className).toContain("opacity-100");
-  });
-
-  it("ellipsis button is hidden when not active", () => {
-    render(<GitHubListItem item={baseIssue} type="issue" isActive={false} />);
-    const btn = screen.getByLabelText("More actions");
-    expect(btn.className).toContain("opacity-0");
+    expect(screen.getByLabelText("Actions for #42")).toBeTruthy();
   });
 
   it("renders CI status check icon for successful PRs", () => {
@@ -273,7 +279,7 @@ describe("GitHubListItem", () => {
       linkedPR: { number: 55, state: "open", url: "https://github.com/test/repo/pull/55" },
     };
     render(<GitHubListItem item={issueWithPR} type="issue" />);
-    const prButton = screen.getByRole("button", { name: "Linked PR #55" });
+    const prButton = screen.getByRole("button", { name: "Open linked pull request #55" });
     expect(prButton).toBeTruthy();
     expect(prButton.querySelector("svg")).not.toBeNull();
   });
@@ -288,10 +294,11 @@ describe("GitHubListItem", () => {
       linkedPR: { number: 55, state: "open", url: "https://github.com/test/repo/pull/55" },
       assignees: [{ login: "alice", avatarUrl: "https://example.com/alice.png", rawData: null }],
     };
-    render(<GitHubListItem item={issueWithBoth} type="issue" />);
+    const { container } = render(<GitHubListItem item={issueWithBoth} type="issue" />);
     expect(screen.getByText("bug")).toBeTruthy();
-    expect(screen.getByText("high-priority")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Linked PR #55" })).toBeTruthy();
+    expect(screen.getByText("+1")).toBeTruthy();
+    expect(container.textContent).toContain("bug, high-priority");
+    expect(screen.getByRole("button", { name: "Open linked pull request #55" })).toBeTruthy();
     expect(screen.getByAltText("alice")).toBeTruthy();
   });
 
@@ -301,15 +308,23 @@ describe("GitHubListItem", () => {
     expect(copyButton.textContent).toBe("#42");
   });
 
-  it("applies active highlight when isActive but not selected", () => {
-    const { container } = render(<GitHubListItem item={baseIssue} type="issue" isActive />);
-    const option = container.querySelector("[role='option']");
-    expect(option?.getAttribute("aria-selected")).toBe("false");
-    expect(option?.className).toContain("bg-muted/50");
-  });
+  it("separates the keyboard cursor from membership, and spends no accent on either", () => {
+    // Three distinct states have to stay distinguishable: resting, the row
+    // Enter would act on, and the rows bulk actions would act on. The cursor
+    // gets the leading rail; membership gets the heavier fill. Accent is
+    // reserved for the one focus anchor in the region (the search field).
+    const resting = render(<GitHubListItem item={baseIssue} type="issue" />);
+    const restingClass = resting.container.querySelector("[role='row']")!.className;
+    resting.unmount();
 
-  it("applies selected styling and aria-selected when isSelected", () => {
-    const { container } = render(
+    const active = render(<GitHubListItem item={baseIssue} type="issue" isActive />);
+    const activeOption = active.container.querySelector("[role='row']")!;
+    expect(activeOption.getAttribute("aria-selected")).toBe("false");
+    expect(activeOption.className).not.toBe(restingClass);
+    expect(activeOption.className).toContain("before:opacity-100");
+    active.unmount();
+
+    const selected = render(
       <GitHubListItem
         item={baseIssue}
         type="issue"
@@ -318,12 +333,17 @@ describe("GitHubListItem", () => {
         onToggleSelect={vi.fn()}
       />
     );
-    const option = container.querySelector("[role='option']");
-    expect(option?.getAttribute("aria-selected")).toBe("true");
-    expect(option?.className).toContain("bg-muted/80");
+    const selectedOption = selected.container.querySelector("[role='row']")!;
+    expect(selectedOption.getAttribute("aria-selected")).toBe("true");
+    expect(selectedOption.className).not.toBe(restingClass);
+    expect(selectedOption.className).not.toBe(activeOption.className);
+
+    for (const cls of [restingClass, activeOption.className, selectedOption.className]) {
+      expect(cls).not.toMatch(/daintree-accent/);
+    }
   });
 
-  it("shows checked checkbox when selected", () => {
+  it("fills the checkbox with neutral ink, never the accent", () => {
     const { container } = render(
       <GitHubListItem
         item={baseIssue}
@@ -334,10 +354,9 @@ describe("GitHubListItem", () => {
       />
     );
     const checkboxes = container.querySelectorAll("[aria-hidden='true']");
-    const checked = Array.from(checkboxes).find((el) =>
-      (el.getAttribute("class") ?? "").includes("bg-daintree-accent")
-    );
-    expect(checked).not.toBeUndefined();
+    const classes = Array.from(checkboxes).map((el) => el.getAttribute("class") ?? "");
+    expect(classes.some((c) => c.includes("bg-daintree-text"))).toBe(true);
+    expect(classes.some((c) => c.includes("bg-daintree-accent"))).toBe(false);
   });
 
   it("scopes checkbox hover to icon area via named group", () => {
@@ -428,34 +447,43 @@ describe("GitHubListItem", () => {
     expect(images).toHaveLength(0);
   });
 
-  it("shows create worktree button on open issues without worktree", () => {
+  it("makes creating a worktree the row's primary click, not a hover-only glyph", async () => {
     const onCreateWorktree = vi.fn();
-    render(<GitHubListItem item={baseIssue} type="issue" onCreateWorktree={onCreateWorktree} />);
-    const createBtn = screen.getByLabelText("Create worktree");
-    expect(createBtn).toBeTruthy();
-    expect(createBtn.className).toContain("opacity-0");
-  });
+    const { container } = render(
+      <GitHubListItem item={baseIssue} type="issue" onCreateWorktree={onCreateWorktree} />
+    );
+    // The old affordance was an `opacity-0` icon button that only appeared on
+    // hover, duplicating a menu item nobody needed twice.
+    expect(screen.queryByLabelText("Create worktree")).toBeNull();
 
-  it("create worktree button calls onCreateWorktree on click", async () => {
-    const onCreateWorktree = vi.fn();
-    render(<GitHubListItem item={baseIssue} type="issue" onCreateWorktree={onCreateWorktree} />);
-    const createBtn = screen.getByLabelText("Create worktree");
     await act(async () => {
-      fireEvent.click(createBtn);
+      fireEvent.click(container.querySelector("[role='row']")!);
     });
     expect(onCreateWorktree).toHaveBeenCalledWith(baseIssue);
   });
 
-  it("does not show create worktree for closed issues", () => {
+  it("does not create a worktree from a closed issue", async () => {
+    const onCreateWorktree = vi.fn();
     const closedIssue: Issue = { ...baseIssue, state: "closed" };
-    render(<GitHubListItem item={closedIssue} type="issue" onCreateWorktree={vi.fn()} />);
-    expect(screen.queryByLabelText("Create worktree")).toBeNull();
+    const { container } = render(
+      <GitHubListItem item={closedIssue} type="issue" onCreateWorktree={onCreateWorktree} />
+    );
+    await act(async () => {
+      fireEvent.click(container.querySelector("[role='row']")!);
+    });
+    expect(onCreateWorktree).not.toHaveBeenCalled();
   });
 
-  it("shows create worktree for fork PRs", () => {
+  it("creates a worktree from a fork PR row", async () => {
+    const onCreateWorktree = vi.fn();
     const forkPR: PR = { ...basePR, rawData: { isFork: true } };
-    render(<GitHubListItem item={forkPR} type="pr" onCreateWorktree={vi.fn()} />);
-    expect(screen.getByLabelText("Create worktree")).toBeTruthy();
+    const { container } = render(
+      <GitHubListItem item={forkPR} type="pr" onCreateWorktree={onCreateWorktree} />
+    );
+    await act(async () => {
+      fireEvent.click(container.querySelector("[role='row']")!);
+    });
+    expect(onCreateWorktree).toHaveBeenCalledWith(forkPR);
   });
 
   it("shows comment count for issues with commentCount >= 1", () => {
@@ -532,7 +560,8 @@ describe("GitHubListItem", () => {
     // After copy: Check icon replaces #
     const checkIcon = copyButton.querySelector(".text-status-success");
     expect(checkIcon).not.toBeNull();
-    // The # should not be visible during copied state
+    // The # yields to the check during the copied state, and the digits stay
+    // put so the row does not reflow.
     expect(copyButton.textContent).toBe("42");
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -13,6 +13,17 @@ import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
 import { FixedDropdownVisibleContext } from "@/components/ui/fixed-dropdown";
 
+// The header's refresh control is a real tooltip trigger now (it carries the
+// list's freshness). The shared `Tooltip` lazy-loads its Radix primitives, so
+// an unmocked provider swaps component types mid-test and remounts the subtree
+// under it — same flattening mock GitHubListItem's suite uses.
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
 const mockListIssues = vi.fn();
 const mockListPRs = vi.fn();
 const mockGetIssueByNumber = vi.fn();
@@ -26,6 +37,7 @@ vi.mock("@/clients/forgeClient", () => ({
     listPRs: (cwd: string, opts?: ListOptions) => mockListPRs({ cwd, ...opts }),
     getIssue: (cwd: string, issueNumber: number) => mockGetIssueByNumber(cwd, issueNumber),
     getPR: (cwd: string, prNumber: number) => mockGetPRByNumber(cwd, prNumber),
+    getIssueUrl: vi.fn().mockResolvedValue("https://github.com/acme/repo/issues/1"),
     getIssuesByNumbers: vi.fn().mockResolvedValue([]),
     getPRsByNumbers: vi.fn().mockResolvedValue([]),
   },
@@ -71,6 +83,9 @@ vi.mock("@/lib/notify", () => ({
 
 let mockIsSelectionActive = false;
 const mockSelectionClear = vi.fn();
+// Stable identities — the component memoizes and effects off these.
+const EMPTY_ITEMS = new Map();
+const mockReconcile = vi.fn();
 
 vi.mock("@/hooks/useIssueSelection", () => ({
   useIssueSelection: () => ({
@@ -78,9 +93,11 @@ vi.mock("@/hooks/useIssueSelection", () => ({
     get isSelectionActive() {
       return mockIsSelectionActive;
     },
+    selectedItems: EMPTY_ITEMS,
     toggle: vi.fn(),
     toggleRange: vi.fn(),
     selectAll: vi.fn(),
+    reconcile: mockReconcile,
     clear: mockSelectionClear,
   }),
 }));
@@ -564,8 +581,9 @@ describe("GitHubResourceList SWR behavior", () => {
       expect(screen.getByTestId("item-31")).toBeTruthy();
     });
     expect(screen.queryByText(/Network blip/)).toBeNull();
-    // The success-path freshness sub-row continues to surface lastUpdatedAt.
-    expect(screen.getByText(/^Updated/)).toBeTruthy();
+    // Freshness stays off the surface while the data is fresh — the retry just
+    // landed, so there is nothing for the footer to warn about.
+    expect(screen.queryByText(/^Updated/)).toBeNull();
   });
 
   it("does not bleed stale timestamp across filter changes", async () => {
@@ -1468,56 +1486,71 @@ describe("GitHubResourceList no-token empty state", () => {
 });
 
 describe("GitHubResourceList empty state branching", () => {
-  it("renders zero-data variant (no Clear filters button) when no filters are active and the list is empty", async () => {
+  it("renders zero-data with a create CTA (no clear action) when nothing is filtered and the list is empty", async () => {
     mockListIssues.mockResolvedValue(makeResponse([]));
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     await waitFor(() => {
-      expect(screen.getByText("No issues found")).toBeTruthy();
+      expect(screen.getByText("No open issues")).toBeTruthy();
     });
-    expect(screen.queryByRole("button", { name: /clear filters/i })).toBeNull();
+    // Nothing is narrowing the view, so the way out is creating the first item,
+    // not undoing a filter that was never applied.
+    expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /new issue/i })).toBeTruthy();
   });
 
-  it("renders filtered-empty with a Clear filters action when a search query is active", async () => {
+  it("renders filtered-empty with a Clear search action when only a search query is active", async () => {
     mockListIssues.mockResolvedValue(makeResponse([]));
     useGitHubFilterStore.getState().setIssueSearchQuery("nonexistent");
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No issues match "nonexistent"/)).toBeTruthy();
+      expect(screen.getByText(/No matches for "nonexistent"/)).toBeTruthy();
     });
-    const clearButton = screen.getByRole("button", { name: /clear filters/i });
+    // The state tab is still the default, so the action names only what it
+    // actually undoes.
+    // The search field's X carries the same accessible name, so pick the one
+    // whose label is its own text content.
+    const clearButton = screen
+      .getAllByRole("button", { name: "Clear search" })
+      .find((b) => b.textContent === "Clear search");
     expect(clearButton).toBeTruthy();
     // CLAUDE.md popover/palette empty-state rule: never render primary-weight
     // buttons. The Clear filters CTA must use the ghost variant — locking the
     // class signature catches a regression to outline (ring-border-strong) or
     // any other heavier variant.
-    expect(clearButton.className).toContain("text-text-secondary");
-    expect(clearButton.className).not.toContain("ring-border-strong");
+    expect(clearButton!.className).toContain("text-text-secondary");
+    expect(clearButton!.className).not.toContain("ring-border-strong");
   });
 
-  it("renders filtered-empty when a non-default state filter is active", async () => {
+  it("routes an empty non-default state tab back to the tab that has data", async () => {
     mockListIssues.mockResolvedValue(makeResponse([]));
     useGitHubFilterStore.getState().setIssueFilter("closed");
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     await waitFor(() => {
-      expect(screen.getByText("No issues in this view")).toBeTruthy();
+      expect(screen.getByText("No closed issues")).toBeTruthy();
     });
-    expect(screen.getByRole("button", { name: /clear filters/i })).toBeTruthy();
+    const showOpen = screen.getByRole("button", { name: /show open issues/i });
+    act(() => {
+      showOpen.click();
+    });
+    expect(useGitHubFilterStore.getState().issueFilter).toBe("open");
   });
 
-  it("Clear filters action resets search and state filter to defaults", async () => {
+  it("resets both search and state filter when both are narrowing the view", async () => {
     mockListIssues.mockResolvedValue(makeResponse([]));
     useGitHubFilterStore.getState().setIssueSearchQuery("foo");
     useGitHubFilterStore.getState().setIssueFilter("closed");
 
-    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
-
-    const clearButton = await screen.findByRole("button", { name: /clear filters/i });
+    // Both narrow, so the one action covers both — and says so.
+    const clearButton = await (async () => {
+      render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+      return screen.findByRole("button", { name: "Clear search and filters" });
+    })();
     act(() => {
       clearButton.click();
     });
@@ -1536,7 +1569,11 @@ describe("GitHubResourceList empty state branching", () => {
     await waitFor(() => {
       expect(screen.getByText(/No issue #999 in this view/)).toBeTruthy();
     });
-    expect(screen.getByRole("button", { name: /clear filters/i })).toBeTruthy();
+    expect(
+      screen
+        .getAllByRole("button", { name: "Clear search" })
+        .some((b) => b.textContent === "Clear search")
+    ).toBe(true);
   });
 
   it("renders filtered-empty for PRs with the right resource label", async () => {
@@ -1546,7 +1583,7 @@ describe("GitHubResourceList empty state branching", () => {
     render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No pull requests match "nonexistent"/)).toBeTruthy();
+      expect(screen.getByText(/No matches for "nonexistent"/)).toBeTruthy();
     });
   });
 
@@ -1556,9 +1593,10 @@ describe("GitHubResourceList empty state branching", () => {
     render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
 
     await waitFor(() => {
-      expect(screen.getByText("No pull requests found")).toBeTruthy();
+      expect(screen.getByText("No open pull requests")).toBeTruthy();
     });
-    expect(screen.queryByRole("button", { name: /clear filters/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /new pull request/i })).toBeTruthy();
   });
 
   it("Clear filters action on PR view resets PR-specific store slice, not issue slice", async () => {
@@ -1569,7 +1607,7 @@ describe("GitHubResourceList empty state branching", () => {
 
     render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
 
-    const clearButton = await screen.findByRole("button", { name: /clear filters/i });
+    const clearButton = await screen.findByRole("button", { name: "Clear search and filters" });
     act(() => {
       clearButton.click();
     });
@@ -2142,7 +2180,7 @@ describe("GitHubResourceList Activity reveal vs filter change — PR #6288", () 
     await waitFor(() => {
       expect(screen.queryByTestId("skeleton")).toBeNull();
     });
-    expect(screen.getByText("No issues in this view")).toBeTruthy();
+    expect(screen.getByText("No closed issues")).toBeTruthy();
   });
 
   it("clears rows and shows the skeleton when the filter changes while keepMounted", async () => {
@@ -2185,7 +2223,7 @@ describe("GitHubResourceList Activity reveal vs filter change — PR #6288", () 
 });
 
 describe("GitHubResourceList aria-busy placement (#6867)", () => {
-  it("sets aria-busy on the listbox during background revalidation, not on the refresh button", async () => {
+  it("sets aria-busy on the results grid during background revalidation, not on the refresh button", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(1)],
@@ -2198,7 +2236,7 @@ describe("GitHubResourceList aria-busy placement (#6867)", () => {
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
-    const listbox = screen.getByRole("listbox");
+    const listbox = screen.getByRole("grid");
     await waitFor(() => {
       expect(listbox.getAttribute("aria-busy")).toBe("true");
     });
@@ -2209,7 +2247,7 @@ describe("GitHubResourceList aria-busy placement (#6867)", () => {
 });
 
 describe("GitHubResourceList success-path freshness (#6867)", () => {
-  it("renders 'Updated …' below the header when data is fresh and no search is active", async () => {
+  it("keeps the footer quiet while the loaded page is fresh", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(1)],
@@ -2218,6 +2256,26 @@ describe("GitHubResourceList success-path freshness (#6867)", () => {
       timestamp: Date.now(),
     });
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("item-1")).toBeTruthy();
+    });
+    expect(screen.queryByText(/^Updated/)).toBeNull();
+  });
+
+  it("surfaces freshness in the footer once the loaded page goes stale", async () => {
+    // A cache entry old enough to cross FRESHNESS_VISIBLE_AFTER_MS, with the
+    // revalidation left pending so `lastUpdatedAt` keeps the stale timestamp.
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 10 * 60_000,
+    });
+    mockListIssues.mockReturnValue(new Promise(() => {}));
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
@@ -2483,7 +2541,7 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
     expect(refreshIcon?.classList.contains("animate-spin")).toBe(false);
   });
 
-  it("uses the shorter 250ms gate when the user clicks refresh", async () => {
+  it("holds an explicit refresh to the same 400ms gate as a background one", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(1)],
@@ -2514,11 +2572,14 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
       expect(mockListIssues).toHaveBeenCalledTimes(2);
     });
 
-    await vi.advanceTimersByTimeAsync(200);
+    // A press buys no exemption from the Doherty gate — the button's press
+    // state and the grid's `aria-busy` flip are the acknowledgement, so a
+    // refresh that resolves inside 400ms shows no spinner at all.
+    await vi.advanceTimersByTimeAsync(350);
     const refreshIconBefore = refreshButton.querySelector("svg");
     expect(refreshIconBefore?.classList.contains("animate-spin")).toBe(false);
 
-    await vi.advanceTimersByTimeAsync(150);
+    await vi.advanceTimersByTimeAsync(100);
     await waitFor(() => {
       const icon = refreshButton.querySelector("svg");
       expect(icon?.classList.contains("animate-spin")).toBe(true);
@@ -2645,35 +2706,36 @@ describe("GitHubResourceList polish (#7202)", () => {
     });
   });
 
-  it("sort trigger drops the accent tint when sort is non-default; only the dot remains", async () => {
+  it("marks a non-default sort with a neutral lift, never a status badge", async () => {
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
     useGitHubFilterStore.getState().setIssueSortOrder("updated");
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     const sortButton = await screen.findByRole("button", { name: /^sort/i });
+    // The old signal was a `bg-status-info` dot, which read as unread activity
+    // and said nothing about which order was in force.
+    expect(sortButton.querySelector("span.bg-status-info")).toBeNull();
     expect(sortButton.classList.contains("text-status-info")).toBe(false);
-
-    // The dot is the sole signal — find the absolutely-positioned status-info span inside the button.
-    const dot = sortButton.querySelector("span.bg-status-info");
-    expect(dot).not.toBeNull();
+    expect(sortButton.className).toContain("bg-overlay-soft");
+    // ...and the order itself is now stated, not implied.
+    expect(sortButton.getAttribute("title")).toMatch(/recently updated/i);
   });
 
-  it("listbox aria-multiselectable tracks selection.isSelectionActive", async () => {
+  it("declares aria-multiselectable as a capability, not as current state", async () => {
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    // It used to flip with `isSelectionActive`, which told a screen-reader user
+    // the grid could not be multi-selected right up until it already was.
     mockIsSelectionActive = false;
 
     const { unmount } = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
-
-    const listbox = await screen.findByRole("listbox");
-    expect(listbox.getAttribute("aria-multiselectable")).toBe("false");
+    expect((await screen.findByRole("grid")).getAttribute("aria-multiselectable")).toBe("true");
 
     unmount();
 
     mockIsSelectionActive = true;
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
-    const activeListbox = await screen.findByRole("listbox");
-    expect(activeListbox.getAttribute("aria-multiselectable")).toBe("true");
+    expect((await screen.findByRole("grid")).getAttribute("aria-multiselectable")).toBe("true");
   });
 
   it("refresh button aria-label flips to 'Refreshing…' once the spinner fires", async () => {
@@ -2735,21 +2797,23 @@ describe("GitHubResourceList dismissal preserves bulk selection", () => {
     // Bulk selection is keyed by `${type}:${projectPath}` in useIssueSelectionStore
     // so it survives the toolbar's lazy/direct remount. On a real project switch
     // the component must still clear the project it's leaving, otherwise a stale
-    // selection outlives the issue cache reset and the bulk bar shows a count
-    // with no backing objects.
+    // selection outlives the switch and the bulk bar offers to act on another
+    // project's issues.
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
-    useIssueSelectionStore.getState().selectAll("issue:/test/proj-a", [1, 2, 3]);
+    useIssueSelectionStore
+      .getState()
+      .selectAll("issue:/test/proj-a", [makeIssue(1), makeIssue(2), makeIssue(3)]);
 
     const { rerender } = render(<GitHubResourceList type="issue" projectPath="/test/proj-a" />);
-    expect(
-      useIssueSelectionStore.getState().selections.get("issue:/test/proj-a")?.selectedIds.size
-    ).toBe(3);
+    expect(useIssueSelectionStore.getState().selections.get("issue:/test/proj-a")?.items.size).toBe(
+      3
+    );
 
     rerender(<GitHubResourceList type="issue" projectPath="/test/proj-b" />);
 
-    expect(
-      useIssueSelectionStore.getState().selections.get("issue:/test/proj-a")?.selectedIds.size ?? 0
-    ).toBe(0);
+    // Cleared, and the entry is gone entirely — a visited project should not
+    // leave a resident empty entry behind.
+    expect(useIssueSelectionStore.getState().selections.has("issue:/test/proj-a")).toBe(false);
   });
 
   it("surfaces a failed open-in-GitHub dispatch as an error toast with retry", async () => {
@@ -2761,7 +2825,7 @@ describe("GitHubResourceList dismissal preserves bulk selection", () => {
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
-    screen.getByRole("button", { name: "GitHub" }).click();
+    screen.getByRole("button", { name: "View on GitHub" }).click();
 
     await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
     expect(dispatchMock).toHaveBeenCalledWith(
@@ -2798,7 +2862,7 @@ describe("GitHubResourceList dismissal preserves bulk selection", () => {
 
     render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
 
-    screen.getByRole("button", { name: "GitHub" }).click();
+    screen.getByRole("button", { name: "View on GitHub" }).click();
 
     await waitFor(() =>
       expect(dispatchMock).toHaveBeenCalledWith(

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -2708,8 +2708,14 @@ describe("GitHubResourceList polish (#7202)", () => {
 
   it("marks a non-default sort with a neutral lift, never a status badge", async () => {
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
-    useGitHubFilterStore.getState().setIssueSortOrder("updated");
 
+    // The default order is the baseline: whatever the lift is, it has to be a
+    // difference from this, not a fixed class.
+    const defaultView = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    const defaultSortClass = (await screen.findByRole("button", { name: /^sort/i })).className;
+    defaultView.unmount();
+
+    useGitHubFilterStore.getState().setIssueSortOrder("updated");
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     const sortButton = await screen.findByRole("button", { name: /^sort/i });
@@ -2717,7 +2723,7 @@ describe("GitHubResourceList polish (#7202)", () => {
     // and said nothing about which order was in force.
     expect(sortButton.querySelector("span.bg-status-info")).toBeNull();
     expect(sortButton.classList.contains("text-status-info")).toBe(false);
-    expect(sortButton.className).toContain("bg-overlay-soft");
+    expect(sortButton.className).not.toBe(defaultSortClass);
     // ...and the order itself is now stated, not implied.
     expect(sortButton.getAttribute("title")).toMatch(/recently updated/i);
   });

--- a/plugins/builtin/github/renderer/components/BulkActionBar.tsx
+++ b/plugins/builtin/github/renderer/components/BulkActionBar.tsx
@@ -10,6 +10,14 @@ interface BulkActionBarProps {
   selectedIssues: Issue[];
   selectedPRs: PR[];
   selectedCount: number;
+  /**
+   * How many selected items the list is not currently showing. Selection
+   * survives the search, the state tab, the sort order and pagination, so a
+   * bar reading "5 selected" over a list showing two of them was quietly
+   * lying about what the action would touch. "Not shown" rather than "hidden
+   * by filters" because an unloaded page produces the same count.
+   */
+  hiddenCount?: number;
   onClear: () => void;
   onCloseDropdown?: () => void;
 }
@@ -19,6 +27,7 @@ export function BulkActionBar({
   selectedIssues,
   selectedPRs,
   selectedCount,
+  hiddenCount = 0,
   onClear,
   onCloseDropdown,
 }: BulkActionBarProps) {
@@ -49,36 +58,46 @@ export function BulkActionBar({
   // DOM with stale closures even after count flips to 0.
   if (count <= 0) return null;
 
+  const noun = mode === "pr" ? "pull request" : "issue";
+  const hiddenNote = hiddenCount > 0 ? ` · ${hiddenCount} not shown` : "";
+
   return (
+    /* This REPLACES the standard footer rather than stacking under it. The bar
+       used to float below a footer that stayed put, so starting a selection
+       gave the panel two bottom bands and stole a row's worth of list. Same
+       band, same height, different contents. */
     <div
-      role="toolbar"
+      /* `group`, not `toolbar`: a toolbar promises arrow-key navigation
+         between its controls, and these are two ordinary tab stops. */
+      role="group"
       aria-label="Bulk actions"
-      className="mx-2 mb-2 rounded-xl shadow-[var(--theme-shadow-floating)] bg-surface-panel ring-1 ring-border-default inset-shadow-[0_1px_0_var(--color-overlay-soft)] flex items-center gap-3 px-4 py-3"
+      className="px-2 py-1.5 border-t border-[var(--border-divider)] flex items-center gap-2 shrink-0"
     >
-      <span className="inline-flex items-center gap-1.5 text-xs text-daintree-text/70">
-        <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded bg-status-info/15 text-status-info text-[10px] font-semibold tabular-nums">
-          {count}
-        </span>
-        selected
+      <span className="ps-2 text-xs text-text-secondary tabular-nums truncate">
+        {/* Neutral count. A `status-info` chip on a multi-select membership
+            total was reading as an alert about nothing. */}
+        <span className="font-medium text-daintree-text">{count}</span>{" "}
+        {count === 1 ? noun : `${noun}s`} selected{hiddenNote}
       </span>
-      <Button
-        variant="default"
-        size="xs"
-        onClick={handleOpenDialog}
-        data-testid="bulk-action-create-worktrees-button"
-      >
-        <FolderGit2 className="w-3 h-3" />
-        Create Worktrees
-      </Button>
       <div className="flex-1" />
       <Button
         variant="ghost"
-        size="icon-xs"
+        size="sm"
+        onClick={handleOpenDialog}
+        className="gap-1.5"
+        data-testid="bulk-action-create-worktrees-button"
+      >
+        <FolderGit2 className="w-3.5 h-3.5" />
+        {count === 1 ? "Create worktree" : "Create worktrees"}
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
         onClick={onClear}
         aria-label="Clear selection"
-        className="text-daintree-text/40 hover:text-daintree-text"
+        className="text-text-secondary hover:text-daintree-text"
       >
-        <X className="w-3 h-3" />
+        <X className="w-3.5 h-3.5" />
       </Button>
     </div>
   );

--- a/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
@@ -1,8 +1,15 @@
-import { Search, ExternalLink, Plus, Filter } from "lucide-react";
+import { Search, ExternalLink, Plus, ArrowUpDown, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSkeletonGate } from "@/hooks/useDeferredLoading";
 
-export const RESOURCE_ITEM_HEIGHT_PX = 68;
+/**
+ * The virtualized row height, in px, and the only definition of it. This used
+ * to be 68 against markup that measured about 58 — Virtuoso laid rows out on
+ * the constant while the fill and hit area drew to the shorter box, leaving a
+ * 10px strip between rows that belonged to no row at all. `GitHubListItem`
+ * now sets its own height from this constant, so the two cannot drift.
+ */
+export const RESOURCE_ITEM_HEIGHT_PX = 64;
 export const COMMIT_ITEM_HEIGHT_PX = 64;
 export const MAX_SKELETON_ITEMS = 6;
 
@@ -27,7 +34,6 @@ export function GitHubResourceListSkeleton({
 }: ResourceListSkeletonProps) {
   const renderCount = normalizeCount(count);
   const showImmediate = useSkeletonGate(Boolean(immediate));
-  const pulseClass = showImmediate ? "animate-pulse-immediate" : "animate-pulse-delayed";
 
   const stateTabs =
     type === "pr"
@@ -52,24 +58,29 @@ export function GitHubResourceListSkeleton({
       <span className="sr-only">Loading GitHub results</span>
 
       {/* Header — matches GitHubResourceList */}
-      <div className="p-3 border-b border-[var(--border-divider)] space-y-3 shrink-0">
+      <div className="p-3 border-b border-[var(--border-divider)] space-y-2 shrink-0">
         <div className="flex items-center gap-2">
           <div
             className={cn(
-              "flex items-center gap-1.5 px-2 py-1.5 rounded-[var(--radius-md)] flex-1 min-w-0",
+              "flex items-center gap-1.5 px-2.5 h-8 rounded-[var(--radius-md)] flex-1 min-w-0",
               "bg-overlay-soft border border-[var(--border-overlay)]"
             )}
           >
             <Search
-              className="w-3.5 h-3.5 shrink-0 text-daintree-text/40 pointer-events-none"
+              className="w-3.5 h-3.5 shrink-0 text-text-secondary pointer-events-none"
               aria-hidden="true"
             />
-            <span className="flex-1 min-w-0 text-sm text-muted-foreground select-none">
-              Search {type === "issue" ? "issues" : "pull requests"}...
+            <span className="flex-1 min-w-0 text-sm text-text-secondary select-none">
+              Search {type === "issue" ? "issues" : "pull requests"}…
             </span>
           </div>
-          <div className="flex items-center justify-center w-7 h-7 rounded shrink-0 text-daintree-text/60">
-            <Filter className="w-3.5 h-3.5" />
+          {/* Both icon slots, or the search field jumps narrower the moment
+              real content replaces this. */}
+          <div className="flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] shrink-0 text-text-secondary">
+            <RefreshCw className="w-3.5 h-3.5" />
+          </div>
+          <div className="flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] shrink-0 text-text-secondary">
+            <ArrowUpDown className="w-3.5 h-3.5" />
           </div>
         </div>
 
@@ -82,7 +93,7 @@ export function GitHubResourceListSkeleton({
               key={tab.id}
               className={cn(
                 "flex-1 px-3 py-1 text-xs font-medium rounded text-center",
-                tab.id === "open" ? "bg-overlay-medium text-daintree-text" : "text-muted-foreground"
+                tab.id === "open" ? "bg-overlay-medium text-daintree-text" : "text-text-secondary"
               )}
             >
               {tab.label}
@@ -92,38 +103,25 @@ export function GitHubResourceListSkeleton({
       </div>
 
       {/* List skeleton rows */}
-      <div className="overflow-y-auto flex-1 min-h-0">
-        <div aria-hidden="true" className="divide-y divide-[var(--border-divider)]">
-          {Array.from({ length: renderCount }).map((_, i) => (
-            <div
-              key={i}
-              className={`${pulseClass} box-border`}
-              style={{ height: `${RESOURCE_ITEM_HEIGHT_PX}px` }}
-            >
-              <div className="flex items-center gap-2 px-3 pt-2.5">
-                <div className="w-4 h-4 rounded-full bg-muted shrink-0" />
-                <div className="h-4 bg-muted rounded flex-1" />
-                <div className="h-4 bg-muted rounded w-8 shrink-0" />
-              </div>
-              <div className="flex items-center gap-1.5 px-3 mt-1.5 pb-2.5">
-                <div className="h-3 bg-muted rounded w-16" />
-                <div className="h-3 bg-muted rounded w-14" />
-              </div>
-            </div>
-          ))}
-        </div>
+      <div className="relative overflow-hidden flex-1 min-h-0">
+        <GitHubResourceRowsSkeleton count={renderCount} immediate={showImmediate} />
+        {/* Same fade the loaded list uses, so a skeleton row cut by the panel
+            edge dissolves instead of being guillotined. */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8 bg-gradient-to-t from-[var(--scroll-shadow-color)] to-transparent"
+        />
       </div>
 
       {/* Footer — matches GitHubResourceList */}
-      <div className="p-3 border-t border-[var(--border-divider)] grid grid-cols-[1fr_auto_1fr] items-center shrink-0">
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground justify-self-start">
+      <div className="px-2 py-1.5 border-t border-[var(--border-divider)] flex items-center justify-between shrink-0">
+        <div className="flex items-center gap-1.5 px-3 h-7 text-xs text-text-secondary">
           <ExternalLink className="h-3.5 w-3.5" />
-          GitHub
+          View on GitHub
         </div>
-        <span aria-hidden="true" />
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground justify-self-end">
+        <div className="flex items-center gap-1.5 px-3 h-7 text-xs text-text-secondary">
           <Plus className="h-3.5 w-3.5" />
-          New
+          {type === "issue" ? "New issue" : "New pull request"}
         </div>
       </div>
     </div>
@@ -135,21 +133,26 @@ export function GitHubResourceRowsSkeleton({ count, immediate }: SkeletonProps) 
   const pulseClass = immediate ? "animate-pulse-immediate" : "animate-pulse-delayed";
 
   return (
-    <div aria-hidden="true" className="divide-y divide-[var(--border-divider)]">
+    <div aria-hidden="true">
       {Array.from({ length: renderCount }).map((_, i) => (
         <div
           key={i}
-          className={`${pulseClass} box-border`}
+          className={`${pulseClass} box-border px-3 py-2.5 flex items-start gap-2.5`}
           style={{ height: `${RESOURCE_ITEM_HEIGHT_PX}px` }}
         >
-          <div className="flex items-center gap-2 px-3 pt-2.5">
-            <div className="w-4 h-4 rounded-full bg-muted shrink-0" />
-            <div className="h-4 bg-muted rounded flex-1" />
-            <div className="h-4 bg-muted rounded w-8 shrink-0" />
-          </div>
-          <div className="flex items-center gap-1.5 px-3 mt-1.5 pb-2.5">
-            <div className="h-3 bg-muted rounded w-16" />
-            <div className="h-3 bg-muted rounded w-14" />
+          <div className="w-4 h-4 rounded-full bg-muted shrink-0 mt-px" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 h-6">
+              <div className="h-4 bg-muted rounded flex-1" />
+              {/* The loaded row's persistent 24×24 actions slot — reserve the
+                  same box or the title bar shrinks the moment data lands. */}
+              <div className="h-6 w-6 -me-1 bg-muted rounded shrink-0" />
+            </div>
+            <div className="flex items-center gap-1.5 mt-1 h-4">
+              <div className="h-3 bg-muted rounded w-12" />
+              <div className="h-3 bg-muted rounded w-16" />
+              <div className="h-3 bg-muted rounded w-10" />
+            </div>
           </div>
         </div>
       ))}

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -3,11 +3,13 @@ import {
   CircleDot,
   CheckCircle2,
   GitPullRequest,
+  GitPullRequestDraft,
   GitMerge,
   GitPullRequestClosed,
   MoreHorizontal,
   ExternalLink,
   Check,
+  Copy,
   MessageSquare,
 } from "lucide-react";
 import { FolderGit2 } from "@/components/icons";
@@ -28,25 +30,40 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
+import { RESOURCE_ITEM_HEIGHT_PX } from "./GitHubDropdownSkeletons";
 
 interface GitHubListItemProps {
   item: Issue | PR;
   type: "issue" | "pr";
   onCreateWorktree?: (item: Issue | PR) => void;
   onSwitchToWorktree?: (worktreeId: string) => void;
+  onOpenExternalUrl?: (url: string) => void;
   optionId?: string;
+  /** DOM id for the row's actions trigger, so the grid can open it by key. */
+  menuTriggerId?: string;
+  /** One-based position in the grid, for `aria-rowindex` under virtualization. */
+  rowIndex?: number;
+  /** Whether this row's actions menu is open. Controlled by the grid so a
+   *  programmatic close of the panel can take its child overlays with it. */
+  menuOpen?: boolean;
+  onMenuOpenChange?: (open: boolean) => void;
+  /** Where focus belongs once the row's actions menu closes. */
+  onMenuClose?: () => void;
   isActive?: boolean;
   isSelected?: boolean;
   isSelectionActive?: boolean;
   onToggleSelect?: (e: React.MouseEvent) => void;
 }
 
-function getStateIcon(state: string, type: "issue" | "pr") {
+function getStateIcon(state: string, type: "issue" | "pr", isDraft?: boolean) {
   if (type === "issue") {
     return state === "open" ? CircleDot : CheckCircle2;
   }
   if (state === "merged") return GitMerge;
-  if (state === "open") return GitPullRequest;
+  // A draft reads as "open but not ready" — its own glyph, not the open one
+  // recoloured. Colour alone can't carry the distinction on a 16px mark.
+  if (state === "open") return isDraft ? GitPullRequestDraft : GitPullRequest;
   return GitPullRequestClosed;
 }
 
@@ -61,19 +78,28 @@ function isPR(item: Issue | PR): item is PR {
   return "isDraft" in item;
 }
 
+/** The trailing rail's only always-present slot, so rows share a right edge. */
+const RAIL_SLOT = "shrink-0 flex items-center justify-center";
+
 export function GitHubListItem({
   item,
   type,
   onCreateWorktree,
   onSwitchToWorktree,
+  onOpenExternalUrl,
   optionId,
+  menuTriggerId,
+  rowIndex,
+  menuOpen,
+  onMenuOpenChange,
+  onMenuClose,
   isActive,
   isSelected = false,
   isSelectionActive = false,
   onToggleSelect,
 }: GitHubListItemProps) {
   const isItemPR = isPR(item);
-  const StateIcon = getStateIcon(item.state, type);
+  const StateIcon = getStateIcon(item.state, type, isItemPR && item.isDraft);
   const stateColor = getStateColor(item.state, isItemPR && item.isDraft);
 
   const [copied, setCopied] = useState(false);
@@ -100,6 +126,10 @@ export function GitHubListItem({
   const isActiveWorktree = hasWorktree && matchedWorktree.id === activeWorktreeId;
 
   const handleOpenExternal = () => {
+    if (onOpenExternalUrl) {
+      onOpenExternalUrl(item.url);
+      return;
+    }
     void actionService.dispatch("system.openExternal", { url: item.url }, { source: "user" });
   };
 
@@ -110,30 +140,102 @@ export function GitHubListItem({
     try {
       await navigator.clipboard.writeText(`#${item.number}`);
       setCopied(true);
-      copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 1500);
+      copyTimeoutRef.current = window.setTimeout(
+        () => setCopied(false),
+        UI_ACTION_SUCCESS_DWELL_MS
+      );
     } catch {
       setCopied(false);
     }
   };
 
+  /**
+   * The row's primary action — the same one Enter runs from the search field,
+   * and total: a closed issue or a merged PR has no worktree to make, so it
+   * falls through to the forge rather than swallowing the activation.
+   */
+  const runPrimaryAction = () => {
+    if (hasWorktree && matchedWorktree && onSwitchToWorktree) {
+      onSwitchToWorktree(matchedWorktree.id);
+    } else if (item.state === "open" && onCreateWorktree) {
+      onCreateWorktree(item);
+    } else {
+      handleOpenExternal();
+    }
+  };
+
+  const handleOpenLinkedPR = () => {
+    const linked = !isItemPR && "linkedPR" in item ? item.linkedPR : undefined;
+    if (!linked) return;
+    if (onOpenExternalUrl) {
+      onOpenExternalUrl(linked.url);
+      return;
+    }
+    void actionService.dispatch("system.openExternal", { url: linked.url }, { source: "user" });
+  };
+
   const issueLabels: ForgeLabel[] = !isItemPR && "labels" in item ? (item.labels ?? []) : [];
+  const [firstLabel, ...restLabels] = issueLabels;
+  const assignees = !isItemPR ? item.assignees : [];
+  const [firstAssignee, ...restAssignees] = assignees;
+
+  const worktreeTooltip = isActiveWorktree
+    ? "Active worktree"
+    : hasWorktree && onSwitchToWorktree
+      ? "Switch to worktree"
+      : "Has worktree";
 
   return (
     <div
       id={optionId}
-      role="option"
+      /* A row, not an option. `option` admits no interactive descendants, and
+         these rows genuinely carry them — a title that opens the issue, a
+         number that copies, a linked-PR jump, an actions menu. The APG's
+         editable-combobox-with-grid-popup pattern is the one that models this
+         honestly: the input keeps DOM focus and points `aria-activedescendant`
+         at a row, and every control lives inside a legal `gridcell`. */
+      role="row"
+      /* Virtualization means the DOM holds a window, not the list — without an
+         explicit index a screen reader counts the handful of mounted rows. */
+      aria-rowindex={rowIndex}
       data-testid={`github-item-${item.number}`}
+      data-forge-row="true"
+      data-active={isActive ? "true" : undefined}
       aria-selected={isSelected}
       className={cn(
-        "hover:bg-muted/50 transition-colors group cursor-default select-none",
-        isActive && !isSelected && "bg-muted/50",
-        isSelected && "bg-muted/80 hover:bg-muted/80"
+        "forge-row group relative cursor-default select-none transition-colors duration-150 ease-out",
+        // Neutral three-step ladder. Hover is the lightest fill, the keyboard
+        // cursor adds the leading rail below, and membership is the heaviest
+        // fill plus a filled checkbox — no accent anywhere (accent restraint:
+        // the search field owns the one focus anchor in this region).
+        "hover:bg-overlay-subtle",
+        // Each step keeps its own floor under the pointer — otherwise hovering
+        // the cursor row ran the ladder backwards and the row got *lighter*.
+        isActive && "bg-overlay-soft hover:bg-overlay-soft",
+        isSelected && "bg-overlay-medium hover:bg-overlay-medium",
+        // The keyboard cursor's own mark, borrowed from `.palette-row`: a 3px
+        // leading rail on `selection-outline`, which is the token that carries
+        // 1.4.11's 3:1 against both the surface and the fill. Keyed on `isActive`
+        // rather than `aria-selected`, which this listbox spends on membership.
+        "before:absolute before:inset-y-1.5 before:-start-px before:w-[3px] before:rounded-full",
+        "before:bg-selection-outline before:opacity-0 before:transition-opacity before:duration-150",
+        "before:content-[''] before:pointer-events-none",
+        isActive && "before:opacity-100"
       )}
-      onClick={isSelectionActive && onToggleSelect ? (e) => onToggleSelect(e) : undefined}
+      // The row draws to exactly the height Virtuoso lays it out on, so the
+      // fill and the hit area cover the whole slot with no unowned strip.
+      style={{ height: RESOURCE_ITEM_HEIGHT_PX }}
+      onClick={(e) => {
+        if (isSelectionActive && onToggleSelect) {
+          onToggleSelect(e);
+        } else {
+          runPrimaryAction();
+        }
+      }}
     >
-      <div className="flex items-start gap-2 px-3 py-2.5">
+      <div role="gridcell" className="flex items-start gap-2.5 px-3 py-2.5 h-full">
         {onToggleSelect ? (
-          <span className="group/icon shrink-0 mt-0.5 relative w-4 h-4">
+          <span className="group/icon shrink-0 relative w-4 h-4 mt-1">
             {/* State icon: visible by default, hidden on hover or when selection active */}
             <span
               className={cn(
@@ -152,27 +254,29 @@ export function GitHubListItem({
                 onToggleSelect(e);
               }}
               className={cn(
-                "absolute inset-0 rounded border flex items-center justify-center transition-colors cursor-pointer",
+                "absolute inset-0 rounded border flex items-center justify-center cursor-pointer",
+                "transition-colors duration-150 ease-out",
                 isSelected
-                  ? "bg-daintree-accent border-daintree-accent"
-                  : "border-daintree-border hover:border-daintree-accent/60",
+                  ? "bg-daintree-text border-daintree-text"
+                  : "border-daintree-border hover:border-daintree-text/60",
                 isSelectionActive || isSelected ? "flex" : "hidden group-hover/icon:flex"
               )}
             >
-              {isSelected && <Check className="w-3 h-3 text-accent-primary-foreground" />}
+              {isSelected && <Check className="w-3 h-3 text-text-inverse" />}
             </span>
           </span>
         ) : (
-          <span className={cn("shrink-0 mt-0.5", stateColor)}>
+          <span className={cn("shrink-0 mt-1", stateColor)}>
             <StateIcon className="h-4 w-4" />
           </span>
         )}
 
         <div className="flex-1 min-w-0">
-          {/* Title row: title, CI dot, #number copy */}
+          {/* Title line: the title owns the width; status and actions sit in the rail. */}
           <div className="flex items-center gap-2">
             <button
               type="button"
+              tabIndex={-1}
               onClick={(e) => {
                 e.stopPropagation();
                 if (isSelectionActive && onToggleSelect) {
@@ -182,97 +286,240 @@ export function GitHubListItem({
                 }
               }}
               className={cn(
-                "flex-1 min-w-0 text-sm font-medium text-foreground truncate text-left cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded",
+                "flex-1 min-w-0 text-sm font-medium text-foreground truncate text-left cursor-pointer rounded",
+                "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
                 !isSelectionActive && "hover:underline"
               )}
             >
               {item.title}
             </button>
 
-            {isItemPR &&
-              item.state === "open" &&
-              item.ciStatus &&
-              (() => {
-                const ciVisual = getPRCIStatusVisual(toGitHubCIStatus(item.ciStatus));
-                const ciTooltip = getPRCIStatusTooltip(toGitHubCIStatus(item.ciStatus));
-                if (!ciVisual || !ciTooltip) return null;
-                return (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        className="inline-flex items-center justify-center w-3 h-3 shrink-0"
-                        aria-label={ciTooltip}
-                      >
-                        {ciVisual.kind === "icon" ? (
-                          <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
-                        ) : (
-                          <span className={cn("block w-2 h-2 rounded-full", ciVisual.colorClass)} />
-                        )}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">{ciTooltip}</TooltipContent>
-                  </Tooltip>
-                );
-              })()}
+            {/* Trailing rail — every slot is persistent ink, no hover-only reveals. */}
+            <div className="flex items-center gap-1.5 shrink-0">
+              {isItemPR &&
+                item.state === "open" &&
+                item.ciStatus &&
+                (() => {
+                  const ciVisual = getPRCIStatusVisual(toGitHubCIStatus(item.ciStatus));
+                  const ciTooltip = getPRCIStatusTooltip(toGitHubCIStatus(item.ciStatus));
+                  if (!ciVisual || !ciTooltip) return null;
+                  return (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className={cn(RAIL_SLOT, "w-3.5 h-3.5")} aria-label={ciTooltip}>
+                          {ciVisual.kind === "icon" ? (
+                            <ciVisual.Icon className={cn("w-3.5 h-3.5", ciVisual.colorClass)} />
+                          ) : (
+                            <span
+                              className={cn("block w-2 h-2 rounded-full", ciVisual.colorClass)}
+                            />
+                          )}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{ciTooltip}</TooltipContent>
+                    </Tooltip>
+                  );
+                })()}
 
+              {firstAssignee && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className={cn(RAIL_SLOT, "relative")}>
+                      <Avatar
+                        src={firstAssignee.avatarUrl ?? ""}
+                        alt={firstAssignee.login}
+                        className="w-4 h-4"
+                      />
+                      {restAssignees.length > 0 && (
+                        <span className="ml-0.5 text-[10px] text-text-secondary tabular-nums">
+                          +{restAssignees.length}
+                        </span>
+                      )}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {restAssignees.length > 0
+                      ? `Assigned to ${assignees.map((a) => a.login).join(", ")}`
+                      : `Assigned to ${firstAssignee.login}`}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              {hasWorktree && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className={cn(
+                        RAIL_SLOT,
+                        "w-3.5 h-3.5 rounded-[3px] border",
+                        isActiveWorktree
+                          ? // The one place a status colour is load-bearing in
+                            // this row: this is the worktree you are standing
+                            // in. The border carries the same distinction
+                            // without colour — and it is a real border, not a
+                            // `ring-*`, because that is a box-shadow and
+                            // forced-colors strips box-shadows outright.
+                            "text-status-info border-current"
+                          : "text-text-secondary border-transparent"
+                      )}
+                      aria-label={worktreeTooltip}
+                    >
+                      <FolderGit2 className="w-3 h-3" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{worktreeTooltip}</TooltipContent>
+                </Tooltip>
+              )}
+
+              <DropdownMenu open={menuOpen} onOpenChange={onMenuOpenChange}>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    tabIndex={-1}
+                    /* Stable id so the grid can open this menu from the
+                       keyboard (Shift+F10) while DOM focus stays in the search
+                       input — otherwise these commands would be pointer-only. */
+                    id={menuTriggerId}
+                    onClick={(e) => e.stopPropagation()}
+                    className={cn(
+                      RAIL_SLOT,
+                      // Persistent, not hover-revealed — a control that only
+                      // exists on hover is a control most people never find.
+                      // Emphasis comes from the secondary ink, not from an
+                      // opacity wash: 55% put it under the 3:1 floor a
+                      // graphical control has to clear.
+                      "w-6 h-6 -me-1 rounded text-text-secondary",
+                      "hover:bg-overlay-medium hover:text-daintree-text",
+                      "transition-[background-color,color] duration-150 ease-out",
+                      "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                    )}
+                    aria-label={`Actions for #${item.number}`}
+                  >
+                    <MoreHorizontal className="h-3.5 w-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  side="bottom"
+                  align="end"
+                  /* Radix restores focus to the trigger, which is `tabIndex={-1}`
+                     and not where this widget keeps focus. Hand it back to the
+                     search input, which is the grid's real focus holder. */
+                  onCloseAutoFocus={(e: Event) => {
+                    if (!onMenuClose) return;
+                    e.preventDefault();
+                    onMenuClose();
+                  }}
+                  /* The menu portals out of the dropdown's DOM, so without
+                     these `FixedDropdown` reads a click on "Copy number" as an
+                     outside click and closes the panel out from under the
+                     feedback. Same guard the sort popover carries. */
+                  onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                  onTouchStart={(e: React.TouchEvent) => e.stopPropagation()}
+                >
+                  <DropdownMenuItem onSelect={() => handleOpenExternal()}>
+                    <ExternalLink className="h-3.5 w-3.5 mr-2" />
+                    Open on GitHub
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void handleCopyNumber()}>
+                    <Copy className="h-3.5 w-3.5 mr-2" />
+                    Copy number
+                  </DropdownMenuItem>
+                  {!isItemPR && "linkedPR" in item && item.linkedPR && (
+                    <DropdownMenuItem onSelect={() => handleOpenLinkedPR()}>
+                      <GitPullRequest className="h-3.5 w-3.5 mr-2" />
+                      Open pull request #{item.linkedPR.number}
+                    </DropdownMenuItem>
+                  )}
+
+                  {hasWorktree && !isActiveWorktree && onSwitchToWorktree && matchedWorktree && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onSelect={() => onSwitchToWorktree(matchedWorktree.id)}>
+                        <FolderGit2 className="h-3.5 w-3.5 mr-2" />
+                        Switch to worktree
+                      </DropdownMenuItem>
+                    </>
+                  )}
+
+                  {!hasWorktree && onCreateWorktree && item.state === "open" && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onSelect={() => onCreateWorktree(item)}>
+                        <FolderGit2 className="h-3.5 w-3.5 mr-2" />
+                        Create worktree
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+
+          {/* Metadata line: identity first, then recency, then one label + count. */}
+          <div className="flex items-center gap-1.5 mt-1 text-xs text-text-secondary flex-nowrap overflow-hidden">
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   type="button"
+                  tabIndex={-1}
                   onClick={(e) => {
                     e.stopPropagation();
                     void handleCopyNumber();
                   }}
-                  className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
+                  className={cn(
+                    "shrink-0 inline-flex items-center tabular-nums rounded cursor-pointer",
+                    "hover:text-daintree-text transition-colors duration-150 ease-out",
+                    "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+                    copied && "text-status-success"
+                  )}
                   aria-label={`Copy number ${item.number}`}
                 >
-                  {copied ? <Check className="w-3 h-3 text-status-success" /> : <span>#</span>}
+                  {/* No gap between the sigil and the digits — the old
+                      `gap-0.5` rendered every row as "# 11958". */}
+                  {copied ? (
+                    <Check className="w-3 h-3 me-0.5 text-status-success" aria-hidden="true" />
+                  ) : (
+                    <span aria-hidden="true">#</span>
+                  )}
                   <span>{item.number}</span>
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">{copied ? "Copied!" : "Copy number"}</TooltipContent>
+              <TooltipContent side="bottom">{copied ? "Copied" : "Copy number"}</TooltipContent>
             </Tooltip>
-          </div>
 
-          {/* Metadata row: author, time, branch/labels, worktree, menu */}
-          <div className="flex items-center gap-1.5 mt-0.5 text-xs text-muted-foreground flex-nowrap overflow-hidden">
-            <span className="shrink-0">{item.author?.login ?? "unknown"}</span>
+            <span className="shrink-0">&middot;</span>
+            <span className="truncate max-w-[110px]">{item.author?.login ?? "unknown"}</span>
             <span className="shrink-0">&middot;</span>
             <span className="whitespace-nowrap shrink-0">{formatTimeAgo(item.updatedAt)}</span>
 
             {(item.commentCount ?? 0) >= 1 && (
               <>
                 <span className="shrink-0">&middot;</span>
-                <span className="inline-flex items-center gap-0.5 shrink-0">
-                  <MessageSquare className="w-3 h-3" />
-                  <span>{item.commentCount}</span>
-                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex items-center gap-0.5 shrink-0 tabular-nums">
+                      <MessageSquare className="w-3 h-3" aria-hidden="true" />
+                      <span>{item.commentCount}</span>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {item.commentCount === 1 ? "1 comment" : `${item.commentCount} comments`}
+                  </TooltipContent>
+                </Tooltip>
               </>
             )}
 
             {isItemPR && item.headRef && (
               <>
                 <span className="shrink-0">&middot;</span>
-                <span className="truncate max-w-[120px]">{item.headRef}</span>
-              </>
-            )}
-
-            {!isItemPR && issueLabels.length > 0 && (
-              <>
-                <span className="shrink-0">&middot;</span>
-                <span className="inline-flex items-center gap-1 min-w-0 shrink max-w-[180px]">
-                  {issueLabels.slice(0, 2).map((label) => (
-                    <span key={label.name} className="inline-flex items-center gap-1 min-w-0">
-                      {label.color ? (
-                        <span
-                          className="w-2 h-2 rounded-full shrink-0"
-                          style={{ backgroundColor: `#${label.color}` }}
-                        />
-                      ) : null}
-                      <span className="truncate min-w-0 max-w-[80px]">{label.name}</span>
-                    </span>
-                  ))}
-                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate max-w-[150px]">{item.headRef}</span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {item.headRef} &rarr; {item.baseRef}
+                  </TooltipContent>
+                </Tooltip>
               </>
             )}
 
@@ -283,131 +530,57 @@ export function GitHubListItem({
                   <TooltipTrigger asChild>
                     <button
                       type="button"
+                      tabIndex={-1}
                       onClick={(e) => {
                         e.stopPropagation();
-                        void actionService.dispatch(
-                          "system.openExternal",
-                          { url: item.linkedPR!.url },
-                          { source: "user" }
-                        );
+                        handleOpenLinkedPR();
                       }}
-                      className="shrink-0 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
-                      aria-label={`Linked PR #${item.linkedPR.number}`}
+                      className={cn(
+                        "shrink-0 inline-flex items-center gap-0.5 tabular-nums rounded cursor-pointer",
+                        "hover:text-daintree-text transition-colors duration-150 ease-out",
+                        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                      )}
+                      aria-label={`Open linked pull request #${item.linkedPR.number}`}
                     >
-                      <GitPullRequest className="w-3 h-3" />
+                      <GitPullRequest className="w-3 h-3" aria-hidden="true" />
+                      <span>{item.linkedPR.number}</span>
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">PR #{item.linkedPR.number}</TooltipContent>
+                  <TooltipContent side="bottom">
+                    Linked pull request #{item.linkedPR.number}
+                  </TooltipContent>
                 </Tooltip>
               </>
             )}
 
-            <span className="flex-1" />
-
-            {!isItemPR && item.assignees.length > 0 && (
-              <Avatar
-                src={item.assignees[0]!.avatarUrl ?? ""}
-                alt={item.assignees[0]!.login}
-                title={`Assigned to ${item.assignees[0]!.login}`}
-                className="w-4 h-4 shrink-0"
-              />
+            {firstLabel && (
+              <>
+                <span className="shrink-0">&middot;</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    {/* One complete label plus a count. A label clipped to
+                        "enhanceme…" reads as broken data, and the labels past
+                        the second used to vanish with nothing to say so. */}
+                    <span className="inline-flex items-center gap-1 min-w-0">
+                      {firstLabel.color ? (
+                        <span
+                          className="w-2 h-2 rounded-full shrink-0"
+                          style={{ backgroundColor: `#${firstLabel.color}` }}
+                          aria-hidden="true"
+                        />
+                      ) : null}
+                      <span className="truncate max-w-[130px]">{firstLabel.name}</span>
+                      {restLabels.length > 0 && (
+                        <span className="shrink-0 tabular-nums">+{restLabels.length}</span>
+                      )}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {issueLabels.map((l) => l.name).join(", ")}
+                  </TooltipContent>
+                </Tooltip>
+              </>
             )}
-
-            {hasWorktree ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  {isActiveWorktree ? (
-                    <span className="shrink-0 text-status-info">
-                      <FolderGit2 className="w-3.5 h-3.5" />
-                    </span>
-                  ) : onSwitchToWorktree && matchedWorktree ? (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSwitchToWorktree(matchedWorktree.id);
-                      }}
-                      className="shrink-0 text-pr-open hover:text-pr-open/80 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
-                      aria-label="Switch to worktree"
-                    >
-                      <FolderGit2 className="w-3.5 h-3.5" />
-                    </button>
-                  ) : (
-                    <span className="shrink-0 text-pr-open">
-                      <FolderGit2 className="w-3.5 h-3.5" />
-                    </span>
-                  )}
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {isActiveWorktree
-                    ? "Active worktree"
-                    : onSwitchToWorktree && matchedWorktree
-                      ? "Switch to worktree"
-                      : "Has worktree"}
-                </TooltipContent>
-              </Tooltip>
-            ) : item.state === "open" && onCreateWorktree ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onCreateWorktree(item);
-                    }}
-                    className="shrink-0 text-muted-foreground/40 hover:text-muted-foreground transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
-                    aria-label="Create worktree"
-                  >
-                    <FolderGit2 className="w-3.5 h-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Create worktree</TooltipContent>
-              </Tooltip>
-            ) : null}
-
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  onClick={(e) => e.stopPropagation()}
-                  className={cn(
-                    "shrink-0 p-0.5 rounded hover:bg-muted transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-                    isActive
-                      ? "opacity-100"
-                      : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                  )}
-                  aria-label="More actions"
-                >
-                  <MoreHorizontal className="h-3.5 w-3.5" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent side="bottom" align="end">
-                <DropdownMenuItem onSelect={() => handleOpenExternal()}>
-                  <ExternalLink className="h-3.5 w-3.5 mr-2" />
-                  Open in GitHub
-                </DropdownMenuItem>
-
-                {hasWorktree && !isActiveWorktree && onSwitchToWorktree && matchedWorktree && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onSelect={() => onSwitchToWorktree(matchedWorktree.id)}>
-                      <FolderGit2 className="h-3.5 w-3.5 mr-2" />
-                      Switch to Worktree
-                    </DropdownMenuItem>
-                  </>
-                )}
-
-                {!hasWorktree && onCreateWorktree && item.state === "open" && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onSelect={() => onCreateWorktree(item)}>
-                      <FolderGit2 className="h-3.5 w-3.5 mr-2" />
-                      Create Worktree
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -306,7 +306,11 @@ export function GitHubListItem({
                   return (
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className={cn(RAIL_SLOT, "w-3.5 h-3.5")} aria-label={ciTooltip}>
+                        <span
+                          className={cn(RAIL_SLOT, "w-3.5 h-3.5")}
+                          role="img"
+                          aria-label={ciTooltip}
+                        >
                           {ciVisual.kind === "icon" ? (
                             <ciVisual.Icon className={cn("w-3.5 h-3.5", ciVisual.colorClass)} />
                           ) : (
@@ -362,6 +366,7 @@ export function GitHubListItem({
                             "text-status-info border-current"
                           : "text-text-secondary border-transparent"
                       )}
+                      role="img"
                       aria-label={worktreeTooltip}
                     >
                       <FolderGit2 className="w-3 h-3" />

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -1,4 +1,12 @@
-import { useState, useEffect, useMemo, useCallback, useRef, type KeyboardEvent } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useContext,
+  useRef,
+  type KeyboardEvent,
+} from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import {
   Search,
@@ -8,7 +16,7 @@ import {
   Plus,
   Settings,
   X,
-  Filter,
+  ArrowUpDown,
   Clock,
 } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/brands";
@@ -16,6 +24,7 @@ import { isTokenRelatedError, isTransientNetworkError } from "@/lib/forgeErrors"
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
@@ -43,8 +52,47 @@ import {
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import { LiveRateLimitCountdown } from "@/components/Layout/RateLimitDetails";
 import { useGitHubResourceListSWR } from "../hooks/useGitHubResourceListSWR";
+import { forgeClient } from "@/clients/forgeClient";
+import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
+import { FixedDropdownVisibleContext } from "@/components/ui/fixed-dropdown";
+import { useGlobalMinuteClock } from "@/hooks/useGlobalMinuteTicker";
+import { UI_DOHERTY_THRESHOLD, UI_SKELETON_FLOOR_MS } from "@/lib/animationUtils";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 
 type StateFilter = IssueStateFilter | PRStateFilter;
+
+/**
+ * How old the loaded page has to be before the footer says so out loud.
+ *
+ * Freshness used to occupy a permanent centre slot that read "Updated now" on
+ * essentially every open — a whole column spent restating that nothing was
+ * wrong. It lives in the refresh control's tooltip now, where it answers the
+ * question that control raises, and only comes back onto the surface once the
+ * answer is worth interrupting for. Five minutes is the point at which the
+ * 30s stats poll and the on-open revalidation have both plainly not landed.
+ */
+const FRESHNESS_VISIBLE_AFTER_MS = 5 * 60_000;
+
+/**
+ * Spinner onset for a background revalidation — the standard Doherty gate.
+ * Work that finishes inside it is invisible, which is the whole point.
+ */
+const REVALIDATE_SPINNER_GATE_MS = UI_DOHERTY_THRESHOLD;
+
+/** Past this, a wait stops being a wait and starts needing acknowledgement. */
+const STILL_WORKING_AFTER_MS = 5_000;
+
+/**
+ * Spinner onset for an explicit click on Refresh. Also the Doherty gate — a
+ * press does not buy an exemption from it. The acknowledgement a press needs
+ * is already there without any spinner: the button takes its own press state
+ * and the results container flips `aria-busy` immediately. A sub-400ms refresh
+ * should resolve with no chrome having appeared at all.
+ */
+const MANUAL_REFRESH_SPINNER_GATE_MS = UI_DOHERTY_THRESHOLD;
+
+/** Minimum on-screen dwell once the spinner has crossed either gate. */
+const SPINNER_DWELL_MS = UI_SKELETON_FLOOR_MS * 2;
 
 function sanitizeIpcError(message: string): string {
   const cleaned = message.replace(/^Error invoking remote method '[^']+': (?:Error: )?/, "").trim();
@@ -54,63 +102,93 @@ function sanitizeIpcError(message: string): string {
 interface LoadMoreFooterContext {
   hasMore: boolean;
   loadingMore: boolean;
+  /** `loadingMore` past the Doherty gate — before it, the button says nothing. */
+  showLoadingMoreSpinner: boolean;
+  /** Past five seconds, where the wait needs acknowledging in words. */
+  isSlowLoadingMore: boolean;
   isLoadMoreActive: boolean;
   loadMoreError: string | null;
   type: "issue" | "pr";
+  /** One-based grid position — always the row after the last item. */
+  rowIndex: number;
   onLoadMore: () => void;
   onOpenSettings: () => void;
 }
 
+/**
+ * The list's last row, semantically as well as visually.
+ *
+ * It lives in Virtuoso's `Footer` slot, which puts it outside the virtualized
+ * row set — but it is still the thing the down-arrow reaches after the last
+ * item, so it has to BE a row: a bare `<div>` there left
+ * `aria-activedescendant` dangling the moment the cursor arrived on it.
+ */
 function LoadMoreFooter({ context }: { context?: LoadMoreFooterContext }) {
   if (!context || !context.hasMore) return null;
-  const { loadingMore, isLoadMoreActive, loadMoreError, type, onLoadMore, onOpenSettings } =
-    context;
+  const {
+    loadingMore,
+    showLoadingMoreSpinner,
+    isSlowLoadingMore,
+    isLoadMoreActive,
+    loadMoreError,
+    type,
+    rowIndex,
+    onLoadMore,
+    onOpenSettings,
+  } = context;
+  const isTokenError = loadMoreError !== null && isTokenRelatedError(loadMoreError);
   return (
-    <div className="p-3 space-y-2">
-      {loadMoreError && (
-        <div className="p-2 rounded-[var(--radius-md)] bg-overlay-soft border border-[var(--border-divider)]">
-          <p className="text-xs text-muted-foreground">{sanitizeIpcError(loadMoreError)}</p>
-          {isTokenRelatedError(loadMoreError) ? (
+    <div role="row" aria-rowindex={rowIndex} className="p-3">
+      <div role="gridcell">
+        {loadMoreError ? (
+          // ONE way out, not two. This used to render Retry-or-Settings AND
+          // the ordinary Load more button underneath, so a token failure
+          // offered a button guaranteed to fail again right below the one
+          // that could actually fix it.
+          <div className="p-2 rounded-[var(--radius-md)] bg-overlay-soft border border-[var(--border-divider)]">
+            <p className="text-xs text-text-secondary">{sanitizeIpcError(loadMoreError)}</p>
             <Button
+              id={`github-${type}-load-more`}
               variant="ghost"
               size="sm"
-              onClick={onOpenSettings}
-              className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
+              onClick={isTokenError ? onOpenSettings : onLoadMore}
+              className={cn("mt-1 h-6 text-xs", isLoadMoreActive && "bg-overlay-soft")}
             >
-              <Settings className="h-3 w-3" />
-              Open GitHub Settings
+              {isTokenError ? (
+                <>
+                  <Settings className="h-3 w-3" />
+                  Open GitHub settings
+                </>
+              ) : (
+                "Retry"
+              )}
             </Button>
-          ) : (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onLoadMore}
-              className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
-            >
-              Retry
-            </Button>
-          )}
-        </div>
-      )}
-      <Button
-        id={`github-${type}-load-more`}
-        variant="ghost"
-        onClick={onLoadMore}
-        disabled={loadingMore}
-        className={cn(
-          "w-full text-muted-foreground hover:text-daintree-text",
-          isLoadMoreActive && "ring-1 ring-daintree-accent text-daintree-text"
-        )}
-      >
-        {loadingMore ? (
-          <>
-            <RefreshCw className="animate-spin" />
-            Loading...
-          </>
+          </div>
         ) : (
-          "Load More"
+          <Button
+            id={`github-${type}-load-more`}
+            variant="ghost"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            className={cn(
+              "w-full",
+              // Neutral, not accent: the keyboard cursor uses the same neutral
+              // lift here that it uses on a row, so the two can never both claim
+              // the accent at once.
+              isLoadMoreActive && "bg-overlay-soft text-daintree-text"
+            )}
+          >
+            {showLoadingMoreSpinner ? (
+              <>
+                <RefreshCw className="animate-spin" />
+                {isSlowLoadingMore ? "Still working…" : "Loading…"}
+              </>
+            ) : (
+              "Load more"
+            )}
+          </Button>
         )}
-      </Button>
+      </div>
     </div>
   );
 }
@@ -207,9 +285,11 @@ export function GitHubResourceList({
   const inputRef = useRef<HTMLInputElement>(null);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
-  // Doherty Threshold gate for the refresh spinner. Sub-400ms background
-  // revalidations stay invisible (250ms for explicit clicks); once visible the
-  // spinner dwells ≥500ms so it never flashes on fast networks.
+  // Doherty Threshold gate for the refresh spinner: both an explicit click and
+  // a background revalidation stay invisible below 400ms, and once visible the
+  // spinner dwells so it never flashes on fast networks. A press does not buy
+  // an exemption — the button's own press state and the results grid's
+  // immediate `aria-busy` flip are the acknowledgement.
   const [showSpinner, setShowSpinner] = useState(false);
   const showSpinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const spinnerDwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -235,7 +315,9 @@ export function GitHubResourceList({
       }
       if (spinnerVisibleSinceRef.current !== null) return;
       if (showSpinnerTimerRef.current !== null) return;
-      const delay = isManualRefreshRef.current ? 250 : 400;
+      const delay = isManualRefreshRef.current
+        ? MANUAL_REFRESH_SPINNER_GATE_MS
+        : REVALIDATE_SPINNER_GATE_MS;
       isManualRefreshRef.current = false;
       showSpinnerTimerRef.current = setTimeout(() => {
         if (!mountedRef.current) return;
@@ -251,7 +333,7 @@ export function GitHubResourceList({
     }
     if (spinnerVisibleSinceRef.current !== null) {
       const elapsed = Date.now() - spinnerVisibleSinceRef.current;
-      const remaining = Math.max(0, 500 - elapsed);
+      const remaining = Math.max(0, SPINNER_DWELL_MS - elapsed);
       if (remaining === 0) {
         setShowSpinner(false);
         spinnerVisibleSinceRef.current = null;
@@ -272,8 +354,6 @@ export function GitHubResourceList({
   }, [handleManualRefresh]);
 
   const selection = useIssueSelection(type, projectPath);
-  const [issueCache, setIssueCache] = useState<Map<number, Issue>>(() => new Map());
-  const [prCache, setPrCache] = useState<Map<number, PR>>(() => new Map());
 
   // The toolbar reuses one keepMounted GitHubResourceList per type across
   // every project — switching projects only updates `projectPath`, it doesn't
@@ -287,37 +367,9 @@ export function GitHubResourceList({
     const prevProjectPath = prevProjectPathRef.current;
     if (prevProjectPath === projectPath) return;
     prevProjectPathRef.current = projectPath;
+    // Clearing the outgoing key drops its snapshots with it.
     useIssueSelectionStore.getState().clear(`${type}:${prevProjectPath}`);
-    setIssueCache(new Map());
-    setPrCache(new Map());
   }, [projectPath, type]);
-
-  // Accumulate item objects into the session cache whenever data changes
-  useEffect(() => {
-    const newIssues: Issue[] = [];
-    const newPRs: PR[] = [];
-    for (const item of data) {
-      if ("isDraft" in item) {
-        newPRs.push(item);
-      } else {
-        newIssues.push(item);
-      }
-    }
-    if (newIssues.length > 0) {
-      setIssueCache((prev) => {
-        const next = new Map(prev);
-        for (const issue of newIssues) next.set(issue.number, issue);
-        return next;
-      });
-    }
-    if (newPRs.length > 0) {
-      setPrCache((prev) => {
-        const next = new Map(prev);
-        for (const pr of newPRs) next.set(pr.number, pr);
-        return next;
-      });
-    }
-  }, [data]);
 
   const stateTabs = useMemo(() => {
     if (type === "pr") {
@@ -337,7 +389,7 @@ export function GitHubResourceList({
     onClose?.();
   }, [onClose]);
 
-  const handleOpenInGitHub = () => {
+  const handleOpenInGitHub = useCallback(() => {
     const query = searchQuery.trim() || undefined;
     const state = filterState as string;
     // dispatch() never throws — failures come back as { ok: false }, so they
@@ -383,13 +435,59 @@ export function GitHubResourceList({
     };
     open();
     handleClose();
-  };
+  }, [searchQuery, filterState, type, projectPath, handleClose]);
 
-  const handleCreateNew = () => {
-    // Use openIssues/openPRs with /new path would require a new IPC
-    // For now, just open the GitHub page
-    handleOpenInGitHub();
-  };
+  /**
+   * Open the forge's compose page. This used to call `handleOpenInGitHub()`,
+   * so "New" and "GitHub" were the same button wearing two labels — the
+   * control promised a compose form and delivered the list you were already
+   * looking at.
+   *
+   * The repo's web root is derived from an item URL rather than assumed: every
+   * `Issue`/`PR` carries an absolute `url` (`…/owner/repo/issues/123`), and
+   * `getIssueUrl` produces one on demand when the list is empty. That keeps the
+   * derivation inside the GitHub plugin, where GitHub's URL shapes are legal,
+   * without teaching the host about them.
+   */
+  const handleCreateNew = useCallback(() => {
+    const repoRootFrom = (url: string): string | null => {
+      const match = /^(https?:\/\/[^/]+\/[^/]+\/[^/]+)\/(?:issues|pull)\//.exec(url);
+      return match ? match[1]! : null;
+    };
+    void (async () => {
+      let root = data.length > 0 ? repoRootFrom(data[0]!.url) : null;
+      if (!root) {
+        try {
+          root = repoRootFrom(await forgeClient.getIssueUrl(projectPath, 1));
+        } catch {
+          root = null;
+        }
+      }
+      if (!root) {
+        // No web root to compose against — fall back to the list rather than
+        // leaving the click silently dead.
+        handleOpenInGitHub();
+        return;
+      }
+      const target = type === "issue" ? `${root}/issues/new` : `${root}/compare`;
+      // dispatch() resolves `{ ok: false }` rather than throwing, so an ignored
+      // result is a button that silently does nothing.
+      void actionService
+        .dispatch("system.openExternal", { url: target }, { source: "user" })
+        .then((result) => {
+          if (!result.ok) {
+            notify({
+              type: "error",
+              title:
+                type === "issue" ? "Couldn't open new issue" : "Couldn't open new pull request",
+              message: `Daintree couldn't hand off to the browser. Open ${target} manually, or try again.`,
+              action: { label: "Try again", onClick: () => handleCreateNew() },
+            });
+          }
+        });
+      handleClose();
+    })();
+  }, [data, projectPath, type, handleOpenInGitHub, handleClose]);
 
   const openCreateDialog = useWorktreeSelectionStore((s) => s.openCreateDialog);
   const openCreateDialogForPR = useWorktreeSelectionStore((s) => s.openCreateDialogForPR);
@@ -415,16 +513,193 @@ export function GitHubResourceList({
     [selectWorktree, handleClose]
   );
 
+  /**
+   * Opening an item hands off to the browser, so the dropdown has nothing left
+   * to show — closing it matches every other hand-off in the app and stops the
+   * panel hanging over the window the user just switched away to.
+   */
+  const handleOpenUrlExternal = useCallback(
+    (url: string) => {
+      // dispatch() resolves `{ ok: false }` instead of throwing, so an
+      // unchecked result is a row that silently does nothing. Same recovery
+      // shape the footer's "View on GitHub" uses.
+      void actionService
+        .dispatch("system.openExternal", { url }, { source: "user" })
+        .then((result) => {
+          if (!result.ok) {
+            notify({
+              type: "error",
+              title: "Couldn't open GitHub",
+              message: `Daintree couldn't hand off to the browser. Open ${url} manually, or try again.`,
+              coalesce: {
+                key: `forge-open-item-failed:${projectPath}`,
+                buildMessage: () => "Daintree couldn't hand off to the browser.",
+              },
+              action: { label: "Try again", onClick: () => handleOpenUrlExternal(url) },
+            });
+          }
+        });
+      handleClose();
+    },
+    [handleClose, projectPath]
+  );
+
+  /**
+   * The grid keeps DOM focus in the search input at all times — that is what
+   * makes `aria-activedescendant` legal. Anything that takes focus away
+   * (the row actions menu, the sort popover) has to hand it back here.
+   */
+  const focusSearchInput = useCallback(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // `autoFocus` only fires on the first mount, and this panel is `keepMounted`
+  // — every reopen after the first is an `<Activity>` reveal of a subtree that
+  // never unmounted, so without this the second open landed with focus
+  // wherever the click left it and none of the grid's keys worked.
+  // `open`, not "still painted" — see the provider in `fixed-dropdown.tsx`.
+  // The distinction matters here: this panel's overlays have to be torn down
+  // on the way out, not after the exit animation has already hidden the
+  // subtree that owns their effects.
+  const isDropdownOpen = useContext(FixedDropdownVisibleContext);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const wasDropdownOpenRef = useRef(isDropdownOpen);
+  useEffect(() => {
+    if (isDropdownOpen) return;
+    // Closing — nothing of ours may stay portaled on `document.body`.
+    setSortPopoverOpen(false);
+    setOpenRowMenuNumber(null);
+  }, [isDropdownOpen]);
+
+  useEffect(() => {
+    const wasOpen = wasDropdownOpenRef.current;
+    wasDropdownOpenRef.current = isDropdownOpen;
+    // Only on the hidden → visible edge. `autoFocus` already covers the first
+    // mount; this covers every reopen after it, which under `keepMounted` is
+    // an `<Activity>` reveal of a subtree that never unmounted. Running it on
+    // the initial pass too would let a late frame yank focus back off whatever
+    // the user had already reached inside the panel.
+    if (!isDropdownOpen || wasOpen) return;
+    // A frame late on purpose: the reveal un-hides the subtree in the same
+    // commit, and focusing a still-`display:none` input is a no-op.
+    const raf = requestAnimationFrame(() => {
+      // Never take focus off a child overlay that has since earned it — the
+      // sort popover and the row menus portal to `document.body`, outside
+      // `rootRef`, so they need naming explicitly.
+      const active = document.activeElement;
+      if (
+        active &&
+        active !== document.body &&
+        (rootRef.current?.contains(active) ||
+          active.closest('[role="menu"],[data-radix-popper-content-wrapper]'))
+      ) {
+        return;
+      }
+      focusSearchInput();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isDropdownOpen, focusSearchInput]);
+
   const handleClearSearch = useCallback(() => {
     setSearchQuery("");
-    inputRef.current?.focus();
-  }, [setSearchQuery]);
+    focusSearchInput();
+  }, [setSearchQuery, focusSearchInput]);
+
+  const { ref: scrollShadowRef, topShadow, bottomShadow } = useScrollShadowOverlays();
+  // Virtuoso hands back `HTMLElement | Window | null`; the shadow hook only
+  // ever wants the element.
+  const handleScrollerRef = useCallback(
+    (el: HTMLElement | Window | null) => {
+      scrollShadowRef(el instanceof HTMLElement ? el : null);
+    },
+    [scrollShadowRef]
+  );
+
+  /**
+   * True when the list is empty for the plainest possible reason: nothing is
+   * open and nothing is narrowing the view. That state owns the create CTA —
+   * the footer's copy of it stands down so the panel never shows the same
+   * action twice, 100px apart, in two different weights.
+   */
+  const isZeroData =
+    !loading &&
+    !error &&
+    !isRateLimited &&
+    data.length === 0 &&
+    exactNumberNotFound === null &&
+    numberQuery === null &&
+    debouncedSearch.trim().length === 0 &&
+    filterState === "open";
+
+  /**
+   * Which row's actions menu is open, if any.
+   *
+   * Controlled rather than left to Radix so the panel can take its child
+   * overlays down with it. `FixedDropdown`'s documented invariant is that
+   * portaled content escapes the `<Activity>` subtree entirely: a menu still
+   * open when the panel hides stays mounted on `document.body`, with stale
+   * state and, once Floating UI loses its anchor, at (0,0).
+   */
+  const [openRowMenuNumber, setOpenRowMenuNumber] = useState<number | null>(null);
+
+  // A background revalidation can rename an issue or move a PR's head ref
+  // under a selection made minutes ago. This refreshes the stored copies —
+  // membership and the range anchor are deliberately untouched.
+  const reconcileSelection = selection.reconcile;
+  useEffect(() => {
+    reconcileSelection(data);
+  }, [data, reconcileSelection]);
+
+  /** The selection as an array — the objects the bulk action will act on. */
+  const selectedItems = useMemo(
+    () => Array.from(selection.selectedItems.values()),
+    [selection.selectedItems]
+  );
+
+  /**
+   * Selected items the current search or state tab is not showing. Selection
+   * deliberately survives both, so the bulk bar has to say when it is about to
+   * act on rows that are not on screen.
+   */
+  const hiddenSelectedCount = useMemo(() => {
+    if (selection.selectedItems.size === 0) return 0;
+    const visible = new Set(data.map((item) => item.number));
+    let hidden = 0;
+    for (const id of selection.selectedItems.keys()) {
+      if (!visible.has(id)) hidden += 1;
+    }
+    return hidden;
+  }, [selection.selectedItems, data]);
+
+  // Silent while the list is fresh; speaks up once it plainly is not. The
+  // shared minute clock drives the flip. It has to be the CLOCK, not the bare
+  // ticker: React Compiler memoizes this body, so a `Date.now()` read here can
+  // be cached and freeze, and the note would only ever appear if something
+  // unrelated happened to re-render the panel.
+  const nowMs = useGlobalMinuteClock();
+  const showStaleFreshness =
+    !error &&
+    !loading &&
+    !debouncedSearch &&
+    lastUpdatedAt != null &&
+    nowMs - lastUpdatedAt >= FRESHNESS_VISIBLE_AFTER_MS;
 
   const listId = `github-${type}-list`;
-  const maxIndex = data.length - 1 + (hasMore ? 1 : 0);
+  // Rate-limited means `handleLoadMore` returns without fetching, so an
+  // enabled Load more button and a cursor stop on it were both promising
+  // something the hook would not do.
+  const canLoadMore = hasMore && !isRateLimited;
+  const maxIndex = data.length - 1 + (canLoadMore ? 1 : 0);
   const activeItem = activeIndex >= 0 && activeIndex < data.length ? data[activeIndex] : null;
-  const activeItemId = activeItem ? `github-${type}-option-${activeItem.number}` : undefined;
-  const isLoadMoreActive = hasMore && activeIndex === data.length;
+  const isLoadMoreActive = canLoadMore && activeIndex === data.length;
+  // The cursor can sit on Load more, and when it does `aria-activedescendant`
+  // has to name it — leaving the attribute undefined told assistive tech the
+  // cursor had left the grid entirely.
+  const activeItemId = activeItem
+    ? `github-${type}-option-${activeItem.number}`
+    : isLoadMoreActive
+      ? `github-${type}-load-more`
+      : undefined;
 
   useEffect(() => {
     setActiveIndex(-1);
@@ -443,6 +718,11 @@ export function GitHubResourceList({
 
   const handleInputKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
+      // During IME composition the browser owns the event lifecycle — an
+      // Enter that commits a candidate must not also activate a row. The
+      // keyCode check covers Safari/WebKit, where `isComposing` is not yet set
+      // on the first keydown. Mirrors `useGlobalKeybindings`.
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
@@ -461,11 +741,7 @@ export function GitHubResourceList({
             handleLoadMore();
           } else if (activeItem) {
             if (e.metaKey || e.ctrlKey) {
-              void actionService.dispatch(
-                "system.openExternal",
-                { url: activeItem.url },
-                { source: "user" }
-              );
+              handleOpenUrlExternal(activeItem.url);
             } else {
               const worktrees = getCurrentViewStore().getState().worktrees;
               let matchedWt: { id: string } | undefined;
@@ -483,9 +759,36 @@ export function GitHubResourceList({
                 handleSwitchToWorktree(matchedWt.id);
               } else if (activeItem.state === "open") {
                 handleCreateWorktree(activeItem);
+              } else {
+                // Closed issue, merged PR — nothing to make locally, so Enter
+                // falls through to the forge rather than doing nothing. Same
+                // fallback the row's click path takes.
+                handleOpenUrlExternal(activeItem.url);
               }
             }
           }
+          break;
+        }
+        case " ": {
+          // DOM focus never leaves the search input, so a bare Space belongs to
+          // the query — "fix crash" must stay typeable with a row under the
+          // cursor. Membership takes the modifier instead.
+          if (!e.shiftKey || activeIndex < 0 || !activeItem) break;
+          e.preventDefault();
+          e.stopPropagation();
+          selection.toggle(activeItem);
+          break;
+        }
+        case "F10":
+        case "ContextMenu": {
+          // The row's actions menu, opened without a pointer. The menu is
+          // controlled, so this is a state change rather than a synthesized
+          // click on a `tabIndex={-1}` trigger.
+          if (e.key === "F10" && !e.shiftKey) break;
+          if (!activeItem) break;
+          e.preventDefault();
+          e.stopPropagation();
+          setOpenRowMenuNumber(activeItem.number);
           break;
         }
         case "Escape":
@@ -506,10 +809,12 @@ export function GitHubResourceList({
     [
       maxIndex,
       isLoadMoreActive,
+      activeIndex,
       activeItem,
       handleLoadMore,
       handleSwitchToWorktree,
       handleCreateWorktree,
+      handleOpenUrlExternal,
       handleClose,
       type,
       searchQuery,
@@ -527,44 +832,62 @@ export function GitHubResourceList({
     handleClose();
   }, [handleClose]);
 
+  // Pagination gets the same Doherty gate as everything else: a page that
+  // arrives inside 400ms should not have flashed a spinner on the way, and one
+  // that takes longer than five seconds should say so rather than spin
+  // silently. `useDeferredLoading` owns the gate.
+  const showLoadingMoreSpinner = useDeferredLoading(loadingMore, UI_DOHERTY_THRESHOLD);
+  const isSlowLoadingMore = useDeferredLoading(loadingMore, STILL_WORKING_AFTER_MS);
+
   const footerContext = useMemo<LoadMoreFooterContext>(
     () => ({
-      hasMore,
+      hasMore: canLoadMore,
       loadingMore,
+      showLoadingMoreSpinner,
+      isSlowLoadingMore,
       isLoadMoreActive,
       loadMoreError,
       type,
+      rowIndex: data.length + 1,
       onLoadMore: handleLoadMore,
       onOpenSettings: handleOpenGitHubSettings,
     }),
     [
-      hasMore,
+      canLoadMore,
       loadingMore,
+      showLoadingMoreSpinner,
+      isSlowLoadingMore,
       isLoadMoreActive,
       loadMoreError,
       type,
+      data.length,
       handleLoadMore,
       handleOpenGitHubSettings,
     ]
   );
 
+  /**
+   * Empty states name the way out, not the absence. Each of the three ways a
+   * list can come back empty has a different next action, so each gets its own
+   * — a single "No issues found" made the search miss, the state filter and a
+   * genuinely empty tracker look like one indistinguishable dead end.
+   */
   const renderEmpty = () => {
     const trimmedSearch = debouncedSearch.trim();
-    const isFilterActive =
-      exactNumberNotFound !== null ||
-      numberQuery !== null ||
-      trimmedSearch.length > 0 ||
-      filterState !== "open";
     const resourceLabel = type === "issue" ? "issues" : "pull requests";
+    const singular = type === "issue" ? "issue" : "pull request";
 
-    if (isFilterActive) {
+    // 1. A query that matched nothing — the way out is clearing the query, and
+    //    the state tab too when that is also narrowing the view. The label says
+    //    which, so the button never undoes more than it claims to.
+    if (exactNumberNotFound !== null || numberQuery !== null || trimmedSearch.length > 0) {
+      const stateAlsoNarrows = filterState !== "open";
       const title =
         exactNumberNotFound !== null
-          ? `No ${type === "issue" ? "issue" : "PR"} #${exactNumberNotFound} in this view`
+          ? `No ${singular} #${exactNumberNotFound} in this view`
           : trimmedSearch.length > 0
-            ? `No ${resourceLabel} match "${trimmedSearch}"`
+            ? `No matches for "${trimmedSearch}"`
             : `No ${resourceLabel} in this view`;
-
       return (
         <EmptyState
           variant="filtered-empty"
@@ -575,11 +898,11 @@ export function GitHubResourceList({
               variant="ghost"
               size="sm"
               onClick={() => {
-                setSearchQuery("");
-                setFilterState("open" as StateFilter);
+                if (stateAlsoNarrows) setFilterState("open" as StateFilter);
+                handleClearSearch();
               }}
             >
-              Clear filters
+              {stateAlsoNarrows ? "Clear search and filters" : "Clear search"}
             </Button>
           }
           className="flex-1 justify-center"
@@ -587,11 +910,40 @@ export function GitHubResourceList({
       );
     }
 
+    // 2. A state tab with nothing in it — the way out is the tab that has data.
+    if (filterState !== "open") {
+      return (
+        <EmptyState
+          variant="filtered-empty"
+          scale="canvas"
+          title={`No ${filterState} ${resourceLabel}`}
+          action={
+            <Button variant="ghost" size="sm" onClick={() => setFilterState("open" as StateFilter)}>
+              {`Show open ${resourceLabel}`}
+            </Button>
+          }
+          className="flex-1 justify-center"
+        />
+      );
+    }
+
+    // 3. Genuinely nothing open — the way out is creating the first one.
     return (
       <EmptyState
         variant="zero-data"
         scale="canvas"
-        title={`No ${resourceLabel} found`}
+        title={`No open ${resourceLabel}`}
+        description={
+          type === "issue"
+            ? "Open an issue to track the next piece of work."
+            : "Open a pull request when a branch is ready to review."
+        }
+        action={
+          <Button variant="outline" size="sm" onClick={handleCreateNew}>
+            <Plus className="h-3.5 w-3.5" />
+            {type === "issue" ? "New issue" : "New pull request"}
+          </Button>
+        }
         className="flex-1 justify-center"
       />
     );
@@ -622,18 +974,22 @@ export function GitHubResourceList({
   }
 
   return (
-    <div className="relative w-[450px] flex flex-col h-[500px]">
-      <div className="p-3 border-b border-[var(--border-divider)] space-y-3 shrink-0">
+    <div ref={rootRef} className="relative w-[450px] flex flex-col h-[500px]">
+      <div className="p-3 border-b border-[var(--border-divider)] space-y-2 shrink-0">
         <div className="flex items-center gap-2">
           <div
             className={cn(
-              "flex items-center gap-1.5 px-2 py-1.5 rounded-[var(--radius-md)] flex-1 min-w-0",
+              "flex items-center gap-1.5 px-2.5 h-8 rounded-[var(--radius-md)] flex-1 min-w-0",
               "bg-overlay-soft border border-[var(--border-overlay)]",
-              "focus-within:border-daintree-accent/40 focus-within:ring-1 focus-within:ring-daintree-accent/20"
+              // Full-strength accent, and only here: the search input is the
+              // single focus anchor for this region, so it gets the whole
+              // accent budget rather than two washed-out fractions of it.
+              "transition-[border-color] duration-150 ease-out",
+              "focus-within:border-daintree-accent"
             )}
           >
             <Search
-              className="w-3.5 h-3.5 shrink-0 text-daintree-text/40 pointer-events-none"
+              className="w-3.5 h-3.5 shrink-0 text-text-secondary pointer-events-none"
               aria-hidden="true"
             />
             <input
@@ -647,46 +1003,67 @@ export function GitHubResourceList({
               role="combobox"
               aria-autocomplete="list"
               aria-expanded={true}
-              aria-haspopup="listbox"
+              aria-haspopup="grid"
               aria-controls={listId}
               aria-activedescendant={activeItemId}
               aria-label={`Search ${type === "issue" ? "issues" : "pull requests"}`}
-              className="flex-1 min-w-0 text-sm bg-transparent text-daintree-text placeholder:text-muted-foreground focus:outline-hidden"
+              aria-keyshortcuts="ArrowDown ArrowUp Enter Meta+Enter Control+Enter Shift+Space Shift+F10"
+              /* Claims Shift+F10 / ContextMenu for the row under the cursor.
+                 Without this the app's capture-phase global handler consumes
+                 them first and the row menu stays pointer-only. */
+              data-row-menu=""
+              className="flex-1 min-w-0 text-sm bg-transparent text-daintree-text placeholder:text-text-secondary focus:outline-hidden"
             />
             {searchQuery && (
               <button
                 type="button"
                 onClick={handleClearSearch}
                 aria-label="Clear search"
-                className="flex items-center justify-center w-5 h-5 rounded shrink-0 text-daintree-text/40 hover:text-daintree-text"
+                className={cn(
+                  "flex items-center justify-center w-5 h-5 rounded shrink-0",
+                  "text-text-secondary hover:text-daintree-text",
+                  "transition-colors duration-150 ease-out"
+                )}
               >
                 <X className="w-3 h-3" />
               </button>
             )}
           </div>
-          <button
-            type="button"
-            onClick={handleManualRefreshClick}
-            disabled={loading || refreshing}
-            aria-label={
-              showSpinner
-                ? "Refreshing…"
-                : `Refresh ${type === "issue" ? "issues" : "pull requests"}`
-            }
-            title={
-              showSpinner
-                ? "Refreshing…"
-                : `Refresh ${type === "issue" ? "issues" : "pull requests"}`
-            }
-            className={cn(
-              "flex items-center justify-center w-7 h-7 rounded shrink-0",
-              "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
-              "transition-colors disabled:cursor-default",
-              showSpinner && "text-status-info"
-            )}
-          >
-            <RefreshCw className={cn("w-3.5 h-3.5", showSpinner && "animate-spin")} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleManualRefreshClick}
+                disabled={loading || refreshing}
+                aria-label={
+                  showSpinner
+                    ? "Refreshing…"
+                    : `Refresh ${type === "issue" ? "issues" : "pull requests"}`
+                }
+                className={cn(
+                  "flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] shrink-0",
+                  "text-text-secondary hover:text-daintree-text hover:bg-overlay-medium",
+                  "transition-[background-color,color] duration-150 ease-out disabled:cursor-default",
+                  showSpinner && "text-status-info"
+                )}
+              >
+                <RefreshCw className={cn("w-3.5 h-3.5", showSpinner && "animate-spin")} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {showSpinner ? (
+                "Refreshing…"
+              ) : /* When a banner or the footer is already stating freshness,
+                     the tooltip stays out of it — one occurrence, not three. */
+              lastUpdatedAt != null && !error && !isRateLimited && !showStaleFreshness ? (
+                <>
+                  Refresh &middot; updated <LiveTimeAgo timestamp={lastUpdatedAt} />
+                </>
+              ) : (
+                "Refresh"
+              )}
+            </TooltipContent>
+          </Tooltip>
           <Popover open={sortPopoverOpen} onOpenChange={setSortPopoverOpen}>
             <PopoverTrigger asChild>
               <button
@@ -698,16 +1075,18 @@ export function GitHubResourceList({
                 }
                 aria-haspopup="dialog"
                 aria-expanded={sortPopoverOpen}
+                title={sortOrder === "created" ? "Sort" : "Sort: recently updated"}
                 className={cn(
-                  "relative flex items-center justify-center w-7 h-7 rounded shrink-0",
-                  "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
-                  "transition-colors"
+                  "flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] shrink-0",
+                  "text-text-secondary hover:text-daintree-text hover:bg-overlay-medium",
+                  "transition-[background-color,color] duration-150 ease-out",
+                  // A non-default sort is a neutral lifted state, not a badge.
+                  // The old blue dot read as unread activity and said nothing
+                  // about which order was in force.
+                  sortOrder !== "created" && "bg-overlay-soft text-daintree-text"
                 )}
               >
-                <Filter className="w-3.5 h-3.5" />
-                {sortOrder !== "created" && (
-                  <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-status-info" />
-                )}
+                <ArrowUpDown className="w-3.5 h-3.5" />
               </button>
             </PopoverTrigger>
             <PopoverContent
@@ -723,9 +1102,7 @@ export function GitHubResourceList({
                 }
               }}
             >
-              <div className="text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide mb-2">
-                Sort by
-              </div>
+              <div className="text-xs font-medium text-text-secondary mb-2">Sort by</div>
               <div className="flex flex-col gap-1" role="radiogroup" aria-label="Sort order">
                 {(() => {
                   const sortOptions = [
@@ -759,9 +1136,12 @@ export function GitHubResourceList({
                       }}
                       className={cn(
                         "flex items-center gap-2 px-2 py-1 text-xs rounded",
+                        "transition-[background-color,color] duration-150 ease-out",
+                        "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2",
+                        "focus-visible:outline-daintree-accent",
                         sortOrder === option.value
                           ? "bg-overlay-soft text-daintree-text"
-                          : "text-daintree-text/70 hover:bg-overlay-medium"
+                          : "text-text-secondary hover:bg-overlay-medium hover:text-daintree-text"
                       )}
                     >
                       <div
@@ -806,10 +1186,10 @@ export function GitHubResourceList({
                     if (allSelected) {
                       selection.clear();
                     } else {
-                      selection.selectAll(data.map((item) => item.number));
+                      selection.selectAll(data);
                     }
                   }}
-                  className="text-xs text-daintree-text/50 hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent transition-colors px-1 py-0.5 rounded"
+                  className="text-xs text-text-secondary hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent transition-colors duration-150 ease-out px-1 py-0.5 rounded"
                 >
                   {allSelected ? "Deselect all" : `Select all (${data.length})`}
                 </button>
@@ -817,9 +1197,9 @@ export function GitHubResourceList({
                   <button
                     type="button"
                     onClick={() => {
-                      selection.selectAll(unassigned.map((item) => item.number));
+                      selection.selectAll(unassigned);
                     }}
-                    className="text-xs text-daintree-text/50 hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent transition-colors px-1 py-0.5 rounded"
+                    className="text-xs text-text-secondary hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent transition-colors duration-150 ease-out px-1 py-0.5 rounded"
                   >
                     {`Select unassigned (${unassigned.length})`}
                   </button>
@@ -860,10 +1240,13 @@ export function GitHubResourceList({
                   });
                 }}
                 className={cn(
-                  "flex-1 px-3 py-1 text-xs font-medium rounded transition-colors",
+                  "flex-1 px-3 py-1 text-xs font-medium rounded",
+                  "transition-[background-color,color] duration-150 ease-out",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2",
+                  "focus-visible:outline-daintree-accent",
                   isActive
                     ? "bg-overlay-medium text-daintree-text"
-                    : "text-muted-foreground hover:text-daintree-text"
+                    : "text-text-secondary hover:text-daintree-text"
                 )}
               >
                 {tab.label}
@@ -896,14 +1279,50 @@ export function GitHubResourceList({
               label = `Showing #${numberQuery.from} and above`;
             }
             return (
-              <p className="bg-overlay-soft border border-[var(--border-divider)] rounded px-2 py-1 text-xs text-muted-foreground">
+              <p className="bg-overlay-soft border border-[var(--border-divider)] rounded px-2 py-1 text-xs text-text-secondary">
                 {label}
               </p>
             );
           })()}
       </div>
 
-      <div className="flex-1 min-h-0 flex flex-col relative">
+      {/* The combobox points `aria-controls` here, so this element exists in
+          every state — loading, empty, errored, rate-limited. It used to be
+          rendered only alongside data, which left an expanded combobox
+          controlling nothing at exactly the moments a screen-reader user most
+          needs to be told what happened. The per-state announcements live
+          inside it. */}
+      <div
+        id={listId}
+        role="grid"
+        aria-label={type === "issue" ? "Issues" : "Pull requests"}
+        /* Capability, not current state: these rows can always be
+           multi-selected, whether or not any are right now. */
+        aria-multiselectable
+        aria-busy={loading || refreshing || loadingMore}
+        /* -1 while more pages exist — the true total is unknown, and claiming
+           the loaded count is a lie a screen reader reads out as "row 20 of
+           20" on a list that keeps growing. */
+        aria-rowcount={hasMore ? -1 : data.length}
+        className="flex-1 min-h-0 flex flex-col relative"
+      >
+        {/* Covers only the states with no visible announcement of their own.
+            Errors are NOT in here: the banner below carries the message and is
+            an `alert`, so repeating it would announce it twice and put the
+            same string in the accessibility tree in two places. */}
+        <span role="status" aria-live="polite" className="sr-only">
+          {loading
+            ? `Loading ${type === "issue" ? "issues" : "pull requests"}…`
+            : isRateLimited
+              ? // Nothing here, but deliberately ahead of the zero-results
+                // branch: a paused list is empty for a reason, and "No issues"
+                // is the wrong thing to be told. The paused surface below is
+                // its own `status`, so it does the announcing.
+                ""
+              : !error && data.length === 0
+                ? `No ${type === "issue" ? "issues" : "pull requests"}`
+                : ""}
+        </span>
         {/* Plain conditional render — AnimatePresence is unsafe here because
             this subtree lives inside a `keepMounted` dropdown wrapped in
             <Activity mode="hidden">. Exit lifecycles get stuck under Activity,
@@ -917,25 +1336,31 @@ export function GitHubResourceList({
         ) : data.length > 0 ? (
           <div key="github-content" className="flex-1 min-h-0 flex flex-col">
             {isRateLimited && !error && (
-              <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft shrink-0">
+              <div
+                role="status"
+                className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-text-secondary bg-overlay-soft shrink-0"
+              >
                 <Clock className="h-3.5 w-3.5 shrink-0" />
                 <span className="text-xs truncate">
                   GitHub requests are paused. Showing last known results.
                 </span>
                 {rateLimitResetAt != null && rateLimitResetAt > Date.now() && (
-                  <span className="text-xs text-muted-foreground/70 shrink-0 whitespace-nowrap tabular-nums">
+                  <span className="text-xs text-text-secondary shrink-0 whitespace-nowrap tabular-nums">
                     · Resumes in <LiveRateLimitCountdown resetAt={rateLimitResetAt} />
                   </span>
                 )}
                 {lastUpdatedAt != null && !debouncedSearch && (
-                  <span className="text-xs text-muted-foreground/70 shrink-0 whitespace-nowrap">
+                  <span className="text-xs text-text-secondary shrink-0 whitespace-nowrap">
                     · Updated <LiveTimeAgo timestamp={lastUpdatedAt} />
                   </span>
                 )}
               </div>
             )}
             {error && (
-              <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft shrink-0">
+              <div
+                role="alert"
+                className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-text-secondary bg-overlay-soft shrink-0"
+              >
                 <WifiOff className="h-3.5 w-3.5 shrink-0" />
                 <span className="text-xs truncate">
                   {isTransientNetworkError(error)
@@ -943,7 +1368,7 @@ export function GitHubResourceList({
                     : sanitizeIpcError(error)}
                 </span>
                 {lastUpdatedAt != null && !debouncedSearch && (
-                  <span className="text-xs text-muted-foreground/70 shrink-0 whitespace-nowrap">
+                  <span className="text-xs text-text-secondary shrink-0 whitespace-nowrap">
                     · Updated <LiveTimeAgo timestamp={lastUpdatedAt} />
                   </span>
                 )}
@@ -952,7 +1377,7 @@ export function GitHubResourceList({
                     variant="ghost"
                     size="sm"
                     onClick={handleOpenGitHubSettings}
-                    className="ml-auto h-6 text-xs text-muted-foreground hover:text-daintree-text shrink-0"
+                    className="ml-auto h-6 text-xs shrink-0"
                   >
                     <Settings className="h-3 w-3" />
                     Settings
@@ -962,7 +1387,7 @@ export function GitHubResourceList({
                     variant="ghost"
                     size="sm"
                     onClick={handleRetry}
-                    className="ml-auto h-6 text-xs text-muted-foreground hover:text-daintree-text shrink-0"
+                    className="ml-auto h-6 text-xs shrink-0"
                   >
                     <RefreshCw className="h-3 w-3" />
                     Retry
@@ -970,15 +1395,17 @@ export function GitHubResourceList({
                 )}
               </div>
             )}
-            <div
-              id={listId}
-              role="listbox"
-              aria-multiselectable={selection.isSelectionActive}
-              aria-busy={loading || refreshing}
-              className="flex-1 min-h-0"
-            >
+            <div role="rowgroup" className="relative flex-1 min-h-0">
+              {/* The panel is a fixed 500px and rows are a fixed 64px, so the
+                  list almost never divides evenly — the bottom row was being
+                  guillotined through its own metadata line. The shared scroll
+                  shadow turns that cut into a fade, and doubles as the "more
+                  below" cue the fixed height otherwise hides. */}
+              {topShadow}
+              {bottomShadow}
               <Virtuoso
                 ref={virtuosoRef}
+                scrollerRef={handleScrollerRef}
                 data={data}
                 context={footerContext}
                 style={{ height: "100%" }}
@@ -986,7 +1413,7 @@ export function GitHubResourceList({
                 computeItemKey={(_, item) => item.number}
                 increaseViewportBy={{ top: 0, bottom: 200 }}
                 endReached={() => {
-                  if (!loadingMore && !loading && hasMore) handleLoadMore();
+                  if (!loadingMore && !loading && canLoadMore) handleLoadMore();
                 }}
                 components={{ Footer: LoadMoreFooter }}
                 itemContent={(index, item) => (
@@ -996,14 +1423,22 @@ export function GitHubResourceList({
                     onCreateWorktree={handleCreateWorktree}
                     onSwitchToWorktree={handleSwitchToWorktree}
                     optionId={`github-${type}-option-${item.number}`}
+                    menuTriggerId={`github-${type}-row-menu-${item.number}`}
+                    rowIndex={index + 1}
+                    menuOpen={openRowMenuNumber === item.number}
+                    onMenuOpenChange={(next: boolean) =>
+                      setOpenRowMenuNumber(next ? item.number : null)
+                    }
+                    onMenuClose={focusSearchInput}
+                    onOpenExternalUrl={handleOpenUrlExternal}
                     isActive={activeIndex === index}
                     isSelected={selection.selectedIds.has(item.number)}
                     isSelectionActive={selection.isSelectionActive}
                     onToggleSelect={(e: React.MouseEvent) => {
                       if (e.shiftKey) {
-                        selection.toggleRange(index, (i) => data[i]!.number);
+                        selection.toggleRange(item, data);
                       } else {
-                        selection.toggle(item.number, index);
+                        selection.toggle(item);
                       }
                     }}
                   />
@@ -1013,93 +1448,112 @@ export function GitHubResourceList({
           </div>
         ) : null}
         {!loading && !data.length && error && !isTokenError && !isRateLimited && (
-          <div className="p-8 text-center text-muted-foreground">
+          /* An alert, like the stale-data banner: the shared status node stays
+             quiet whenever an error is showing, so without this a cold-start
+             failure was announced by nothing at all. */
+          <div role="alert" className="p-8 text-center text-text-secondary">
             <WifiOff className="h-5 w-5 mx-auto mb-2 opacity-50" />
             <p className="text-sm">{sanitizeIpcError(error)}</p>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleRetry}
-              className="mt-2 text-muted-foreground hover:text-daintree-text"
-            >
+            <Button variant="ghost" size="sm" onClick={handleRetry} className="mt-2">
               <RefreshCw className="h-3.5 w-3.5" />
               Retry
             </Button>
           </div>
         )}
         {!loading && !data.length && error && isTokenError && (
-          <div className="p-8 text-center text-muted-foreground">
+          <div role="alert" className="p-8 text-center text-text-secondary">
             <WifiOff className="h-5 w-5 mx-auto mb-2 opacity-50" />
             <p className="text-sm">{sanitizeIpcError(error)}</p>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleOpenGitHubSettings}
-              className="mt-2 text-muted-foreground hover:text-daintree-text"
-            >
+            <Button variant="ghost" size="sm" onClick={handleOpenGitHubSettings} className="mt-2">
               <Settings className="h-3.5 w-3.5" />
-              Open GitHub Settings
+              Open GitHub settings
             </Button>
           </div>
         )}
         {!loading && !data.length && isRateLimited && !isTokenError && (
-          <EmptyState
-            variant="zero-data"
-            scale="canvas"
-            icon={<Clock />}
-            title="GitHub requests are paused"
-            description="The current rate-limit window has been exhausted. The dropdown will resume automatically once GitHub clears the quota."
-            className="flex-1 justify-center"
-          />
+          /* Its own status, like the error surfaces are their own alerts —
+             the shared announcer stays quiet here rather than reading the
+             same sentence out a second time. */
+          <div role="status" className="contents">
+            <EmptyState
+              variant="zero-data"
+              scale="canvas"
+              icon={<Clock />}
+              title="GitHub requests are paused"
+              /* One node shape either way: EmptyState keys its fade-through on
+               the description, so switching between a string and JSX made the
+               copy re-animate the moment a reset time arrived. */
+              description={
+                <>
+                  GitHub is holding new requests. This list resumes{" "}
+                  {rateLimitResetAt != null && rateLimitResetAt > Date.now() ? (
+                    <>
+                      in <LiveRateLimitCountdown resetAt={rateLimitResetAt} />
+                    </>
+                  ) : (
+                    "on its own once they're allowed again"
+                  )}
+                  .
+                </>
+              }
+              className="flex-1 justify-center"
+            />
+          </div>
         )}
         {!loading && !error && !isRateLimited && !data.length && renderEmpty()}
       </div>
 
-      <div className="p-3 border-t border-[var(--border-divider)] grid grid-cols-[1fr_auto_1fr] items-center shrink-0">
+      {/* Freshness is no longer a permanent third column here — it moved into
+          the refresh control's tooltip, where it answers the question the
+          control itself raises. A footer that reads "Updated now" on every
+          open spends a whole slot restating that nothing is wrong.
+
+          Hidden entirely while a selection is live: `BulkActionBar` takes over
+          this band at the same height, so the panel never grows a second
+          bottom bar or loses a row of list to one. */}
+      <div
+        className={cn(
+          "px-2 py-1.5 border-t border-[var(--border-divider)] grid grid-cols-[1fr_auto_1fr] items-center shrink-0",
+          selection.selectedItems.size > 0 && "hidden"
+        )}
+      >
         <Button
           variant="ghost"
           size="sm"
           onClick={handleOpenInGitHub}
-          className="text-muted-foreground hover:text-daintree-text gap-1.5 justify-self-start"
+          className="gap-1.5 justify-self-start"
         >
           <ExternalLink className="h-3.5 w-3.5" />
-          GitHub
+          View on GitHub
         </Button>
-        {!error && !loading && lastUpdatedAt != null && !debouncedSearch ? (
-          <p className="text-[10px] text-muted-foreground/60 whitespace-nowrap text-center">
-            Updated <LiveTimeAgo timestamp={lastUpdatedAt} />
+        {showStaleFreshness ? (
+          <p className="text-xs text-text-secondary whitespace-nowrap text-center">
+            Updated <LiveTimeAgo timestamp={lastUpdatedAt!} />
           </p>
         ) : (
           <span aria-hidden="true" />
         )}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleCreateNew}
-          className="text-muted-foreground hover:text-daintree-text gap-1.5 justify-self-end"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          New
-        </Button>
+        {isZeroData ? (
+          <span aria-hidden="true" />
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCreateNew}
+            className="gap-1.5 justify-self-end"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {type === "issue" ? "New issue" : "New pull request"}
+          </Button>
+        )}
       </div>
 
       <BulkActionBar
         mode={type === "issue" ? "issue" : "pr"}
-        selectedIssues={
-          type === "issue"
-            ? Array.from(selection.selectedIds)
-                .map((id) => issueCache.get(id))
-                .filter((issue): issue is Issue => issue !== undefined)
-            : []
-        }
-        selectedPRs={
-          type === "pr"
-            ? Array.from(selection.selectedIds)
-                .map((id) => prCache.get(id))
-                .filter((pr): pr is PR => pr !== undefined)
-            : []
-        }
-        selectedCount={selection.selectedIds.size}
+        hiddenCount={hiddenSelectedCount}
+        selectedIssues={type === "issue" ? (selectedItems as Issue[]) : []}
+        selectedPRs={type === "pr" ? (selectedItems as PR[]) : []}
+        selectedCount={selectedItems.length}
         onClear={selection.clear}
         onCloseDropdown={onClose}
       />

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -995,7 +995,7 @@ export function GitHubResourceList({
             <input
               ref={inputRef}
               type="text"
-              placeholder={`Search ${type === "issue" ? "issues" : "pull requests"}...`}
+              placeholder={`Search ${type === "issue" ? "issues" : "pull requests"}…`}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={handleInputKeyDown}

--- a/scripts/baselines/eslint-warnings-baseline.json
+++ b/scripts/baselines/eslint-warnings-baseline.json
@@ -1,9 +1,9 @@
 {
-  "count": 1091,
+  "count": 1090,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 51,
     "@typescript-eslint/no-floating-promises": 81,
-    "@typescript-eslint/no-unsafe-type-assertion": 478,
+    "@typescript-eslint/no-unsafe-type-assertion": 477,
     "no-restricted-imports": 5,
     "no-restricted-syntax": 369,
     "no-useless-assignment": 16,
@@ -11,5 +11,5 @@
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 34
   },
-  "updatedAt": "2026-08-16T07:59:56.549Z"
+  "updatedAt": "2026-08-26T16:20:37.585Z"
 }

--- a/src/components/CopyTree/__tests__/copyTreeFocus.test.tsx
+++ b/src/components/CopyTree/__tests__/copyTreeFocus.test.tsx
@@ -97,6 +97,17 @@ describe("copy-tree dropdown focus restoration", () => {
     vi.useFakeTimers();
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => frames.push(cb));
     vi.stubGlobal("cancelAnimationFrame", () => {});
+    // `unstubAllGlobals` below also clears the setup file's ResizeObserver
+    // shim, which the scroll-shadow hook constructs on every render after the
+    // first — reinstate it here rather than leaking the teardown.
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserverStub {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    );
     render(<Harness />);
   });
 

--- a/src/components/Layout/ForgeStatPill.tsx
+++ b/src/components/Layout/ForgeStatPill.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useId } from "react";
 import { Button } from "@/components/ui/button";
 import { FixedDropdown } from "@/components/ui/fixed-dropdown";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -59,6 +60,15 @@ export function ForgeStatPill({
   onPointerLeave,
   activityChip,
 }: ForgeStatPillProps) {
+  // A disclosure, and modelled as one. The panel is non-modal — focus is not
+  // trapped, the rest of the app stays reachable — so `dialog` was the wrong
+  // shape twice over: it promises modality this panel does not have, and a
+  // `keepMounted` dropdown leaves that dialog permanently in the tree, where it
+  // collided with the app's real modals (Settings stopped opening from this
+  // pill entirely). A `region` labelled by its own trigger says what this
+  // actually is, and only exists while it is open.
+  const dropdownId = useId();
+  const triggerId = useId();
   return (
     <>
       <Tooltip>
@@ -85,7 +95,10 @@ export function ForgeStatPill({
                   openRingClassName
                 )
             )}
+            id={triggerId}
             aria-label={ariaLabel}
+            aria-expanded={open}
+            aria-controls={open ? dropdownId : undefined}
             data-testid={testId}
           >
             <Icon className={cn("h-4 w-4", iconClassName)} />
@@ -111,7 +124,19 @@ export function ForgeStatPill({
         persistThroughChildOverlays={persistThroughChildOverlays}
         keepMounted={keepMounted}
       >
-        {dropdownContent}
+        <div
+          id={dropdownId}
+          role={open ? "region" : undefined}
+          aria-labelledby={open ? triggerId : undefined}
+          // `keepMounted` keeps this subtree in the DOM between opens. Hidden
+          // content that is still reachable by a screen reader's virtual
+          // cursor is worse than no content, so it is taken out of the tree
+          // and out of the tab order whenever the panel is not open.
+          aria-hidden={open ? undefined : true}
+          inert={!open}
+        >
+          {dropdownContent}
+        </div>
       </FixedDropdown>
     </>
   );

--- a/src/components/ui/ScrollShadow.tsx
+++ b/src/components/ui/ScrollShadow.tsx
@@ -1,6 +1,8 @@
 import {
   forwardRef,
   useRef,
+  useMemo,
+  useState,
   useCallback,
   useEffect,
   type ReactNode,
@@ -68,8 +70,14 @@ export const ScrollShadow = forwardRef<HTMLDivElement, ScrollShadowProps>(
 ScrollShadow.displayName = "ScrollShadow";
 
 export function useScrollShadowOverlays(externalRef?: Ref<HTMLElement>) {
-  const internalRef = useRef<HTMLElement>(null);
-  const { canScrollUp, canScrollDown } = useVerticalScrollShadows(internalRef);
+  // State, not a plain ref: `useVerticalScrollShadows` keys its observer effect
+  // on the ref OBJECT, so a node that arrives later — or is swapped for a new
+  // one — never gets observed if the object identity never changes. Callers
+  // that mount their scroller behind a loading or empty branch (the forge
+  // dropdown's virtualized list) hit exactly that.
+  const [node, setNode] = useState<HTMLElement | null>(null);
+  const nodeRef = useMemo(() => ({ current: node }), [node]);
+  const { canScrollUp, canScrollDown } = useVerticalScrollShadows(nodeRef);
 
   // Indirect the externalRef via a ref so the callback below doesn't mutate a
   // hook argument directly — the React Compiler rejects that pattern.
@@ -79,7 +87,7 @@ export function useScrollShadowOverlays(externalRef?: Ref<HTMLElement>) {
   }, [externalRef]);
 
   const ref = useCallback((el: HTMLElement | null) => {
-    (internalRef as React.MutableRefObject<HTMLElement | null>).current = el;
+    setNode(el);
     const ext = externalRefHolder.current;
     if (typeof ext === "function") {
       ext(el);

--- a/src/components/ui/fixed-dropdown.tsx
+++ b/src/components/ui/fixed-dropdown.tsx
@@ -26,6 +26,12 @@ const OVERLAY_RACE_GRACE_MS = 300;
 // caused by portaled overlay content escaping Activity's `display:none`
 // (issue #8001). Default `true` keeps non-keepMounted dropdowns and any
 // tooltip rendered outside a FixedDropdown unaffected.
+/**
+ * Whether the dropdown this subtree belongs to is OPEN — not whether it is
+ * still painted. Under `keepMounted` the two diverge for the exit animation;
+ * consumers that need to close something of their own want the intent, which
+ * is `open`. See the provider below.
+ */
 export const FixedDropdownVisibleContext = React.createContext<boolean>(true);
 
 interface FixedDropdownProps {
@@ -243,7 +249,16 @@ export function FixedDropdown({
     <div className="fixed inset-0 z-[var(--z-popover)] pointer-events-none">
       {keepMounted ? (
         <Activity mode={shouldRender ? "visible" : "hidden"}>
-          <FixedDropdownVisibleContext.Provider value={shouldRender}>
+          {/* The context carries `open`, NOT `shouldRender`.
+              `shouldRender` stays true for the whole 120ms exit so the
+              close can animate — which is exactly the window in which a
+              descendant needs to have already torn its portaled overlays
+              down. A consumer told "still visible" during the exit either
+              leaves a menu stranded on `document.body`, or races the
+              same-commit flip to hidden, where `<Activity>` defers effect
+              cleanups and the teardown never runs at all. `open` is the
+              intent, and it changes one frame earlier than the presence. */}
+          <FixedDropdownVisibleContext.Provider value={open}>
             {inner}
           </FixedDropdownVisibleContext.Provider>
         </Activity>

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -59,11 +59,12 @@ const Tooltip = ({
   ...props
 }: TooltipProps) => {
   const radix = useRadixPrimitives();
-  // When the surrounding keepMounted FixedDropdown has transitioned to the
-  // Activity-hidden state, force `open={false}` on the Radix Root so any
-  // tooltip whose dismiss path was skipped by the synchronous `display:none`
-  // gets explicitly closed before its portaled content can strand at (0,0)
-  // on document.body (issue #8001). Outside that subtree the context default
+  // When the surrounding keepMounted FixedDropdown closes, force
+  // `open={false}` on the Radix Root so any tooltip whose dismiss path was
+  // skipped by the synchronous `display:none` gets explicitly closed before
+  // its portaled content can strand at (0,0) on document.body (issue #8001).
+  // The context reports `open`, which flips a frame before the subtree is
+  // actually hidden — so the teardown lands while effects still run. Outside that subtree the context default
   // (`true`) preserves the caller's `open` value, so uncontrolled tooltips
   // and any explicit `open={true}` callers keep working unchanged.
   const dropdownVisible = React.useContext(FixedDropdownVisibleContext);

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -156,8 +156,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
   "#5978-5986-pre-existing": [
     "plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx",
     "plugins/builtin/github/renderer/components/CommitList.tsx",
-    "plugins/builtin/github/renderer/components/GitHubListItem.tsx",
-    "plugins/builtin/github/renderer/components/GitHubResourceList.tsx",
     "src/components/Browser/WebviewDialog.tsx",
     "src/components/Commands/CommandBuilder.tsx",
     "src/components/Commands/CommandPicker.tsx",

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -485,9 +485,12 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
   {
     file: "plugins/builtin/github/renderer/components/GitHubResourceList.tsx",
     fragment:
-      "flex-1 min-w-0 text-sm bg-transparent text-daintree-text placeholder:text-muted-foreground focus:outline-hidden",
+      "flex-1 min-w-0 text-sm bg-transparent text-daintree-text placeholder:text-text-secondary focus:outline-hidden",
     reason:
-      "PRE-EXISTING #8940: autoFocus issue/PR search input lacks a focus indicator — follow-up",
+      "RESOLVED, not deferred: the input is a bare transparent field inside a bordered shell, " +
+      "and the shell owns the indicator — `focus-within:border-daintree-accent` at full strength, " +
+      "the one accent signal this focus region is allowed. A same-element ring would draw a second " +
+      "indicator inside the first. Was the #8940 follow-up.",
   },
   {
     file: "src/components/Layout/ChordIndicator.tsx",

--- a/src/hooks/__tests__/useIssueSelection.test.ts
+++ b/src/hooks/__tests__/useIssueSelection.test.ts
@@ -4,9 +4,24 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useIssueSelection } from "../useIssueSelection";
-import { useIssueSelectionStore } from "@/store/issueSelectionStore";
+import { useIssueSelectionStore, type SelectableItem } from "@/store/issueSelectionStore";
 
 const PROJECT = "/test/project";
+
+/**
+ * A minimal item — the store only reads `number`, and holding the objects is
+ * the whole point of the shape under test. One instance per number, so
+ * `toggle` round-trips on identity as it does in the app.
+ */
+const ITEMS = new Map<number, SelectableItem>();
+function item(n: number): SelectableItem {
+  const existing = ITEMS.get(n);
+  if (existing) return existing;
+  const made = { number: n, title: `Item ${n}` } as SelectableItem;
+  ITEMS.set(n, made);
+  return made;
+}
+const items = (...ns: number[]): SelectableItem[] => ns.map(item);
 
 describe("useIssueSelection", () => {
   beforeEach(() => {
@@ -22,11 +37,11 @@ describe("useIssueSelection", () => {
   it("toggles an item on and off", () => {
     const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
 
-    act(() => result.current.toggle(42, 0));
+    act(() => result.current.toggle(item(42)));
     expect(result.current.selectedIds.has(42)).toBe(true);
     expect(result.current.isSelectionActive).toBe(true);
 
-    act(() => result.current.toggle(42, 0));
+    act(() => result.current.toggle(item(42)));
     expect(result.current.selectedIds.has(42)).toBe(false);
     expect(result.current.isSelectionActive).toBe(false);
   });
@@ -34,9 +49,9 @@ describe("useIssueSelection", () => {
   it("selects multiple items independently", () => {
     const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
 
-    act(() => result.current.toggle(1, 0));
-    act(() => result.current.toggle(2, 1));
-    act(() => result.current.toggle(3, 2));
+    act(() => result.current.toggle(item(1)));
+    act(() => result.current.toggle(item(2)));
+    act(() => result.current.toggle(item(3)));
 
     expect(result.current.selectedIds.size).toBe(3);
     expect(result.current.selectedIds.has(1)).toBe(true);
@@ -46,12 +61,12 @@ describe("useIssueSelection", () => {
 
   it("selects a range from the last toggled item", () => {
     const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
-    const getIdAt = (i: number) => [10, 20, 30, 40, 50][i]!;
+    const order = items(10, 20, 30, 40, 50);
 
-    // Select item at index 1
-    act(() => result.current.toggle(20, 1));
-    // Shift-click at index 4
-    act(() => result.current.toggleRange(4, getIdAt));
+    // Anchor on 20
+    act(() => result.current.toggle(item(20)));
+    // Shift-extend to 50
+    act(() => result.current.toggleRange(item(50), order));
 
     expect(result.current.selectedIds.has(20)).toBe(true);
     expect(result.current.selectedIds.has(30)).toBe(true);
@@ -61,10 +76,10 @@ describe("useIssueSelection", () => {
 
   it("handles reverse range selection", () => {
     const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
-    const getIdAt = (i: number) => [10, 20, 30, 40, 50][i]!;
+    const order = items(10, 20, 30, 40, 50);
 
-    act(() => result.current.toggle(50, 4));
-    act(() => result.current.toggleRange(1, getIdAt));
+    act(() => result.current.toggle(item(50)));
+    act(() => result.current.toggleRange(item(20), order));
 
     expect(result.current.selectedIds.has(20)).toBe(true);
     expect(result.current.selectedIds.has(30)).toBe(true);
@@ -75,14 +90,14 @@ describe("useIssueSelection", () => {
   it("selects all items", () => {
     const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
 
-    act(() => result.current.selectAll([1, 2, 3, 4, 5]));
+    act(() => result.current.selectAll(items(1, 2, 3, 4, 5)));
     expect(result.current.selectedIds.size).toBe(5);
   });
 
   it("clears all selection", () => {
     const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
 
-    act(() => result.current.selectAll([1, 2, 3]));
+    act(() => result.current.selectAll(items(1, 2, 3)));
     expect(result.current.selectedIds.size).toBe(3);
 
     act(() => result.current.clear());
@@ -92,10 +107,10 @@ describe("useIssueSelection", () => {
 
   it("range select without prior anchor defaults to single toggle", () => {
     const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
-    const getIdAt = (i: number) => [10, 20, 30][i]!;
+    const order = items(10, 20, 30);
 
     // No prior toggle, so no anchor — should fall back to single toggle
-    act(() => result.current.toggleRange(2, getIdAt));
+    act(() => result.current.toggleRange(item(30), order));
     expect(result.current.selectedIds.has(30)).toBe(true);
     expect(result.current.selectedIds.size).toBe(1);
   });
@@ -120,7 +135,7 @@ describe("useIssueSelection", () => {
     const prsA = renderHook(() => useIssueSelection("pr", "/proj/a"));
     const issuesB = renderHook(() => useIssueSelection("issue", "/proj/b"));
 
-    act(() => issuesA.result.current.toggle(1, 0));
+    act(() => issuesA.result.current.toggle(item(1)));
 
     expect(issuesA.result.current.selectedIds.has(1)).toBe(true);
     expect(prsA.result.current.selectedIds.size).toBe(0);
@@ -132,7 +147,7 @@ describe("useIssueSelection", () => {
     // dialog, then may remount before "Done" fires. A stale-but-key-bound
     // clear must still empty the live selection.
     const first = renderHook(() => useIssueSelection("issue", PROJECT));
-    act(() => first.result.current.selectAll([1, 2, 3]));
+    act(() => first.result.current.selectAll(items(1, 2, 3)));
     const staleClear = first.result.current.clear;
     first.unmount();
 
@@ -145,25 +160,85 @@ describe("useIssueSelection", () => {
 
   it("clear resets the range anchor", () => {
     const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
-    const getIdAt = (i: number) => [10, 20, 30][i]!;
+    const order = items(10, 20, 30);
 
-    act(() => result.current.toggle(20, 1));
+    act(() => result.current.toggle(item(20)));
     act(() => result.current.clear());
     // No anchor after clear — range select falls back to a single toggle.
-    act(() => result.current.toggleRange(2, getIdAt));
+    act(() => result.current.toggleRange(item(30), order));
 
     expect(result.current.selectedIds.size).toBe(1);
     expect(result.current.selectedIds.has(30)).toBe(true);
   });
 
+  it("starts a new range when the anchored item is no longer in the list", () => {
+    // The selection deliberately survives a search, a state-tab switch, a sort
+    // change and pagination — so the anchored row is routinely gone by the
+    // next shift-click. Anchoring by index used to index past the end of the
+    // shorter list and throw.
+    const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
+
+    act(() => result.current.toggle(item(50))); // anchor on an item...
+    act(() => result.current.toggleRange(item(20), items(10, 20, 30))); // ...that this list lacks
+
+    expect(result.current.selectedIds.has(20)).toBe(true);
+    expect(result.current.selectedIds.has(10)).toBe(false);
+    expect(result.current.selectedIds.has(30)).toBe(false);
+
+    // ...and 20 is the new anchor, so the next extend measures from it.
+    act(() => result.current.toggleRange(item(10), items(10, 20, 30)));
+    expect(result.current.selectedIds.has(10)).toBe(true);
+    expect(result.current.selectedIds.has(30)).toBe(false);
+  });
+
+  it("keeps selected item snapshots alive across a remount", () => {
+    // The bulk bar counts ids but acts on objects. The objects used to sit in
+    // the dropdown's own `useState`, so after a remount (project-view
+    // eviction, the toolbar's lazy/direct swap) the bar read "2 selected" and
+    // handed the create dialog an empty array.
+    const first = renderHook(() => useIssueSelection("issue", PROJECT));
+    act(() => first.result.current.toggle(item(1)));
+    act(() => first.result.current.toggle(item(2)));
+    first.unmount();
+
+    const second = renderHook(() => useIssueSelection("issue", PROJECT));
+    expect(second.result.current.selectedIds.size).toBe(2);
+    expect(second.result.current.selectedItems.get(1)).toBeDefined();
+    expect(second.result.current.selectedItems.get(2)).toBeDefined();
+
+    // Bounded by the selection itself — nothing unselected is retained.
+    expect(second.result.current.selectedItems.size).toBe(2);
+
+    act(() => second.result.current.clear());
+    expect(second.result.current.selectedItems.size).toBe(0);
+  });
+
+  it("refreshes stored copies from newer data without touching membership", () => {
+    // A background revalidation can rename an issue under a selection made
+    // minutes ago. The bulk action reads the stored object, so a selection
+    // that never re-reconciles plans from a stale title.
+    const { result } = renderHook(() => useIssueSelection("issue", PROJECT));
+    const stale = { number: 5, title: "Old title" } as SelectableItem;
+    const fresh = { number: 5, title: "New title" } as SelectableItem;
+
+    act(() => result.current.toggle(stale));
+    expect(result.current.selectedItems.get(5)).toBe(stale);
+
+    // A row that is NOT selected must not be added by reconciling.
+    act(() => result.current.reconcile([fresh, { number: 6 } as SelectableItem]));
+    expect(result.current.selectedItems.get(5)).toBe(fresh);
+    expect(result.current.selectedItems.size).toBe(1);
+    expect(result.current.selectedIds.has(6)).toBe(false);
+  });
+
   it("keeps range anchors isolated per key", () => {
     const a = renderHook(() => useIssueSelection("issue", "/proj/a"));
     const b = renderHook(() => useIssueSelection("issue", "/proj/b"));
-    const getIdAt = (i: number) => [10, 20, 30, 40][i]!;
+    const order = items(10, 20, 30, 40);
 
-    act(() => a.result.current.toggle(20, 1)); // anchor on /proj/a only
+    act(() => a.result.current.toggle(item(20))); // anchor on /proj/a only
     // /proj/b has no anchor → single toggle, unaffected by /proj/a's anchor.
-    act(() => b.result.current.toggleRange(3, getIdAt));
+    act(() => b.result.current.toggleRange(item(40), order));
 
     expect(b.result.current.selectedIds.size).toBe(1);
     expect(b.result.current.selectedIds.has(40)).toBe(true);
@@ -173,7 +248,7 @@ describe("useIssueSelection", () => {
     const first = renderHook(() => useIssueSelection("issue", PROJECT));
     const second = renderHook(() => useIssueSelection("issue", PROJECT));
 
-    act(() => first.result.current.toggle(7, 0));
+    act(() => first.result.current.toggle(item(7)));
     expect(second.result.current.selectedIds.has(7)).toBe(true);
 
     act(() => second.result.current.clear());

--- a/src/hooks/useIssueSelection.ts
+++ b/src/hooks/useIssueSelection.ts
@@ -1,12 +1,20 @@
-import { useCallback } from "react";
-import { useIssueSelectionStore, EMPTY_SELECTED_IDS } from "@/store/issueSelectionStore";
+import { useCallback, useMemo } from "react";
+import {
+  useIssueSelectionStore,
+  EMPTY_SELECTED_ITEMS,
+  type SelectableItem,
+} from "@/store/issueSelectionStore";
 
 export interface UseIssueSelectionReturn {
+  /** The selected items, keyed by number. The selection itself. */
+  selectedItems: Map<number, SelectableItem>;
+  /** The selected numbers, for membership checks in row rendering. */
   selectedIds: Set<number>;
   isSelectionActive: boolean;
-  toggle: (id: number, index: number) => void;
-  toggleRange: (toIndex: number, getIdAt: (index: number) => number) => void;
-  selectAll: (ids: number[]) => void;
+  toggle: (item: SelectableItem) => void;
+  toggleRange: (toItem: SelectableItem, ordered: readonly SelectableItem[]) => void;
+  selectAll: (items: readonly SelectableItem[]) => void;
+  reconcile: (latest: readonly SelectableItem[]) => void;
   clear: () => void;
 }
 
@@ -20,35 +28,46 @@ export function useIssueSelection(
 ): UseIssueSelectionReturn {
   const key = `${type}:${projectPath}`;
 
-  const selectedIds = useIssueSelectionStore(
-    (s) => s.selections.get(key)?.selectedIds ?? EMPTY_SELECTED_IDS
+  const selectedItems = useIssueSelectionStore(
+    (s) => s.selections.get(key)?.items ?? EMPTY_SELECTED_ITEMS
   );
   const toggleAction = useIssueSelectionStore((s) => s.toggle);
   const toggleRangeAction = useIssueSelectionStore((s) => s.toggleRange);
   const selectAllAction = useIssueSelectionStore((s) => s.selectAll);
+  const reconcileAction = useIssueSelectionStore((s) => s.reconcile);
   const clearAction = useIssueSelectionStore((s) => s.clear);
 
+  // Derived, never stored: a second container holding the same membership is
+  // exactly what used to drift out of step with the items.
+  const selectedIds = useMemo(() => new Set(selectedItems.keys()), [selectedItems]);
+
   const toggle = useCallback(
-    (id: number, index: number) => toggleAction(key, id, index),
+    (item: SelectableItem) => toggleAction(key, item),
     [toggleAction, key]
   );
   const toggleRange = useCallback(
-    (toIndex: number, getIdAt: (index: number) => number) =>
-      toggleRangeAction(key, toIndex, getIdAt),
+    (toItem: SelectableItem, ordered: readonly SelectableItem[]) =>
+      toggleRangeAction(key, toItem, ordered),
     [toggleRangeAction, key]
   );
   const selectAll = useCallback(
-    (ids: number[]) => selectAllAction(key, ids),
+    (items: readonly SelectableItem[]) => selectAllAction(key, items),
     [selectAllAction, key]
+  );
+  const reconcile = useCallback(
+    (latest: readonly SelectableItem[]) => reconcileAction(key, latest),
+    [reconcileAction, key]
   );
   const clear = useCallback(() => clearAction(key), [clearAction, key]);
 
   return {
+    selectedItems,
     selectedIds,
-    isSelectionActive: selectedIds.size > 0,
+    isSelectionActive: selectedItems.size > 0,
     toggle,
     toggleRange,
     selectAll,
+    reconcile,
     clear,
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2760,6 +2760,30 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     outline-offset: -2px;
   }
 
+  /* The forge issue/PR rows draw the same leading rail, but from a `data-active`
+     attribute rather than `aria-selected` — that grid spends `aria-selected` on
+     bulk membership, so the two marks have to be keyed apart. The rail is a
+     `background-color`, stripped here like every other, and the `.palette-row`
+     rule above is deliberately scoped away from `[role="row"]`, so without this
+     the keyboard cursor vanishes entirely in Windows High Contrast. Highlight
+     rather than SelectedItem: this is the cursor, not the selection. */
+  .forge-row[aria-selected="true"] {
+    outline: 2px solid SelectedItem;
+    outline-offset: -2px;
+  }
+
+  /* Two independent states on one row — the keyboard cursor and bulk
+     membership — so they cannot both be an outline: the later rule would
+     simply overwrite the earlier one and a selected row under the cursor would
+     lose the cursor. Membership keeps the outline (above); the cursor keeps
+     its leading rail, redrawn here from a system colour because the
+     `background-color` it normally paints with is stripped in this mode. */
+  .forge-row[data-active="true"]::before {
+    background: Highlight;
+    forced-color-adjust: none;
+    opacity: 1;
+  }
+
   /* The project switcher's command rows run full-bleed, so their border box
      reaches the palette's own clipped edge. The blanket `outline-offset: 2px`
      above would draw their focus ring outside that clip and lose its left and

--- a/src/store/issueSelectionStore.ts
+++ b/src/store/issueSelectionStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { Issue, PR } from "@shared/types/forge";
 
 // Bulk issue/PR selection for the GitHub toolbar dropdown, keyed by
 // `${type}:${projectPath}`. This lives in a module-level store rather than a
@@ -8,89 +9,147 @@ import { create } from "zustand";
 // dialog. The dialog's "Done" handler clears by key, so completion no longer
 // depends on a specific `GitHubResourceList` instance still being alive.
 
+export type SelectableItem = Issue | PR;
+
 interface SelectionEntry {
-  selectedIds: Set<number>;
-  lastSelectedIndex: number;
+  /**
+   * The selected items themselves, keyed by number. The ITEMS are the
+   * selection — there is no parallel set of ids to fall out of step with them.
+   *
+   * This used to be a `Set<number>` here and a `Map` of objects in the
+   * dropdown's own `useState`. Ids outlive the component and objects did not,
+   * so after a remount the bulk bar could read "5 selected" and hand the
+   * create dialog an empty array. A later fix kept snapshots in the store but
+   * refilled them from a `data` effect, which reintroduced the same skew by a
+   * different route: clearing emptied the map, `data` had not changed, so the
+   * effect never re-ran and the next toggle selected an id with no object
+   * behind it. One map, populated at the moment of selection, cannot skew.
+   */
+  items: Map<number, SelectableItem>;
+  /**
+   * The item the next shift-extend measures from, held as an ITEM ID rather
+   * than a list index. A selection outlives the search query, the state tab,
+   * the sort order and pagination, so a stored index routinely pointed past
+   * the end of a later, shorter list, and the shift-click threw. An id is
+   * either still in the current ordering or it is not, and "not" has an
+   * obvious meaning: start a new range.
+   */
+  anchorId: number | null;
 }
 
 interface IssueSelectionState {
   selections: Map<string, SelectionEntry>;
-  toggle: (key: string, id: number, index: number) => void;
-  toggleRange: (key: string, toIndex: number, getIdAt: (index: number) => number) => void;
-  selectAll: (key: string, ids: number[]) => void;
+  toggle: (key: string, item: SelectableItem) => void;
+  toggleRange: (key: string, toItem: SelectableItem, ordered: readonly SelectableItem[]) => void;
+  selectAll: (key: string, items: readonly SelectableItem[]) => void;
+  /** Refresh the stored copy of already-selected items from newer data. */
+  reconcile: (key: string, latest: readonly SelectableItem[]) => void;
   clear: (key: string) => void;
 }
 
-// Shared empty Set — entries are never mutated in place (mutations always
-// build a fresh Set), so handing the same reference back keeps selector
-// identity stable when a key has no selection yet.
-export const EMPTY_SELECTED_IDS: Set<number> = new Set();
+/** Shared empty Map — handing back one reference keeps selector identity
+ *  stable for every key that has no selection yet. Entries are never mutated
+ *  in place; every mutation builds a fresh Map. */
+export const EMPTY_SELECTED_ITEMS: Map<number, SelectableItem> = new Map();
 
 const EMPTY_ENTRY: SelectionEntry = {
-  selectedIds: EMPTY_SELECTED_IDS,
-  lastSelectedIndex: -1,
+  items: EMPTY_SELECTED_ITEMS,
+  anchorId: null,
 };
 
 export const useIssueSelectionStore = create<IssueSelectionState>((set) => ({
   selections: new Map(),
 
-  toggle: (key, id, index) =>
+  toggle: (key, item) =>
     set((state) => {
       const entry = state.selections.get(key) ?? EMPTY_ENTRY;
-      const next = new Set(entry.selectedIds);
-      if (next.has(id)) {
-        next.delete(id);
+      const items = new Map(entry.items);
+      if (items.has(item.number)) {
+        items.delete(item.number);
       } else {
-        next.add(id);
+        items.set(item.number, item);
       }
       const selections = new Map(state.selections);
-      selections.set(key, { selectedIds: next, lastSelectedIndex: index });
+      selections.set(key, { items, anchorId: item.number });
       return { selections };
     }),
 
-  toggleRange: (key, toIndex, getIdAt) =>
+  toggleRange: (key, toItem, ordered) =>
     set((state) => {
       const entry = state.selections.get(key) ?? EMPTY_ENTRY;
-      const next = new Set(entry.selectedIds);
-      const fromIndex = entry.lastSelectedIndex;
-      // No prior anchor: fall back to a single toggle and seat the anchor.
-      // With an anchor: extend the range but leave the anchor in place so a
-      // follow-up shift-click re-extends from the original point.
-      let lastSelectedIndex = entry.lastSelectedIndex;
-      if (fromIndex < 0) {
-        next.add(getIdAt(toIndex));
-        lastSelectedIndex = toIndex;
+      const items = new Map(entry.items);
+      const toIndex = ordered.findIndex((i) => i.number === toItem.number);
+      const fromIndex =
+        entry.anchorId === null ? -1 : ordered.findIndex((i) => i.number === entry.anchorId);
+
+      let anchorId = entry.anchorId;
+      if (fromIndex < 0 || toIndex < 0) {
+        // No usable anchor — none seated yet, or the anchored item has dropped
+        // out of the current ordering. Behave exactly like a plain click on
+        // this row (toggle, not add) and seat the new anchor, so a
+        // shift-click on an already-selected row still deselects it.
+        if (items.has(toItem.number)) {
+          items.delete(toItem.number);
+        } else {
+          items.set(toItem.number, toItem);
+        }
+        anchorId = toItem.number;
       } else {
+        // Extend, but leave the anchor where it is so a follow-up shift-click
+        // re-extends from the original point rather than walking.
         const start = Math.min(fromIndex, toIndex);
         const end = Math.max(fromIndex, toIndex);
         for (let i = start; i <= end; i++) {
-          next.add(getIdAt(i));
+          const item = ordered[i]!;
+          items.set(item.number, item);
         }
       }
       const selections = new Map(state.selections);
-      selections.set(key, { selectedIds: next, lastSelectedIndex });
+      selections.set(key, { items, anchorId });
       return { selections };
     }),
 
-  selectAll: (key, ids) =>
+  selectAll: (key, items) =>
     set((state) => {
-      const entry = state.selections.get(key) ?? EMPTY_ENTRY;
+      const next = new Map<number, SelectableItem>();
+      for (const item of items) next.set(item.number, item);
       const selections = new Map(state.selections);
-      selections.set(key, {
-        selectedIds: new Set(ids),
-        lastSelectedIndex: entry.lastSelectedIndex,
-      });
+      // A bulk select replaces the selection wholesale, so the old anchor no
+      // longer describes anything the user did — the next shift-click should
+      // start a fresh range rather than extend from a forgotten row.
+      selections.set(key, { items: next, anchorId: null });
+      return { selections };
+    }),
+
+  reconcile: (key, latest) =>
+    set((state) => {
+      const entry = state.selections.get(key);
+      if (!entry || entry.items.size === 0) return state;
+      let next: Map<number, SelectableItem> | null = null;
+      for (const item of latest) {
+        const held = entry.items.get(item.number);
+        // Membership and the anchor are untouched — this ONLY refreshes the
+        // copy of something already selected. Without it, a background
+        // revalidation that renames an issue or moves a PR's head ref leaves
+        // the bulk action planning from whatever the row looked like at the
+        // moment it was ticked.
+        if (held === undefined || held === item) continue;
+        if (!next) next = new Map(entry.items);
+        next.set(item.number, item);
+      }
+      if (!next) return state;
+      const selections = new Map(state.selections);
+      selections.set(key, { ...entry, items: next });
       return { selections };
     }),
 
   clear: (key) =>
     set((state) => {
-      const entry = state.selections.get(key);
-      if (!entry || (entry.selectedIds.size === 0 && entry.lastSelectedIndex === -1)) {
-        return state;
-      }
+      if (!state.selections.has(key)) return state;
       const selections = new Map(state.selections);
-      selections.set(key, EMPTY_ENTRY);
+      // Delete the entry outright rather than parking an empty one. Every
+      // project the user visits used to leave a resident entry behind.
+      selections.delete(key);
       return { selections };
     }),
 }));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -85,6 +85,22 @@ if (typeof globalThis.cancelAnimationFrame !== "function") {
   vi.stubGlobal("cancelAnimationFrame", () => {});
 }
 
+// jsdom does not implement ResizeObserver, which every scroll-shadow surface
+// constructs (`useVerticalScrollShadows`). Files that render one used to be
+// spared only because the hook silently failed to attach; now that it attaches
+// correctly, a missing global throws during commit. Same `vi.stubGlobal`
+// rationale as rAF above — tests that assert on resize behaviour override it.
+if (typeof globalThis.ResizeObserver !== "function") {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+}
+
 // Node 25 exposes a broken native `localStorage` stub on `globalThis` (no
 // `clear`/`getItem`/etc) that shadows JSDOM's Storage and leaks the warning
 // `--localstorage-file was provided without a valid path`. JSDOM's env setup


### PR DESCRIPTION
The issues and pull requests dropdowns are the same component with a `type` prop, and both had drifted a long way from where they should be. I put the design through five rounds of adversarial review, fixing everything each round turned up. It went 6.2 → 8.0 → 8.3 → 9.2 → 9.7 out of 10.

## What was wrong

- The title competed with a right-aligned number that actually rendered as `# 11958`, because a `gap-0.5` sat between the `#` and the digits.
- Labels clipped mid-word to `enhanceme…` / `infrastructu…`, and anything past the second one vanished with no count to say so. That reads as broken data, not as density.
- Create-worktree and the actions menu were both `opacity-0` until hover — controls that only appear on hover are controls most people never find. They still consumed width while invisible, so labels were being clipped to make room for affordances nobody could see.
- The list is 500px and rows were laid out on a 68px constant against markup that measured about 58px, so Virtuoso left a 10px strip between rows that belonged to no row, and the bottom row was guillotined through its own metadata line.
- `+ New` called the same handler as `GitHub`. It promised a compose form and delivered the list you were already looking at.
- The funnel icon opened a **sort** popover, and a non-default sort was marked with a blue `status-info` dot that reads as unread activity and says nothing about which order is in force.
- Almost every secondary element used `text-muted-foreground`, which has no dark contrast floor in several bundled themes.
- Clicking a row did nothing, while Enter on it created a worktree.

## The row

Three stable columns now: state glyph, content, and a trailing rail that is persistent ink only — CI status, assignee, a neutral worktree glyph when one exists, and an always-present actions button. No hover-only reveals.

The title gets the full width, and `#11958` leads the metadata line the way GitHub's own list does. Labels show one whole label plus `+N`, with the full set in the tooltip. Draft PRs get `GitPullRequestDraft` instead of the open glyph recoloured — colour alone can't carry that on a 16px mark.

Row states are a neutral three-step overlay ladder, with the keyboard cursor marked by the same 3px leading rail the command palette uses. No accent anywhere, which took both files off the accent-guard allowlist — the contract test flagged them as stale entries on its own.

Clicking a row now runs the same action Enter runs.

## Semantics

`role="listbox"` with `role="option"` was never legal here: an `option` admits no interactive descendants, and these rows genuinely carry them. This is now the APG editable-combobox-with-grid-popup pattern — a `grid` of `row`/`gridcell`, with focus staying in the search input and `aria-activedescendant` pointing at a row.

Every row command has a keyboard route: Enter for the primary action, Cmd/Ctrl+Enter to open on GitHub, Shift+Space for selection (bare Space stays a search character), Shift+F10 for the row menu. Enter is total — a closed issue or merged PR has no worktree to make, so it falls through to the forge instead of doing nothing.

The trigger is modelled as a disclosure: `aria-expanded` and `aria-controls` on the pill, and the panel is a `region` labelled by it, `inert` while closed. Not `dialog` — this panel isn't modal, and a `keepMounted` dialog sitting permanently in the tree stopped the Settings modal from opening at all.

## Selection

This was two containers pretending to be one: ids in a module store that outlives the component, objects in `useState` that don't. After a remount the bar could read "5 selected" and hand the create dialog an empty array. The items **are** the selection now — one map, populated at the moment of selection, so the count and the objects can't disagree.

The range anchor moved from a list index to an item id. That also fixes a real crash: selection deliberately survives the search, the state tab, the sort order and pagination, so the stored index routinely pointed past the end of a later, shorter list and the shift-click threw.

The bulk bar replaces the footer rather than stacking a second bar under it, and it says when it's about to act on rows you can't see: `3 issues selected · 2 not shown`.

## Everything else

- Sort is `ArrowUpDown` with the order stated in the tooltip and a neutral lift when non-default. The blue dot is gone.
- Freshness moved out of a permanent footer slot into the refresh tooltip, and only comes back onto the surface once the data is genuinely stale.
- Empty states split three ways, each naming its own way out: `No matches for "…"` → Clear search; `No closed issues` → Show open issues; `No open issues` → New issue. The footer's create button stands down when the empty state owns that CTA, so the panel never shows the same action twice.
- Every `text-muted-foreground` in these files became `text-text-secondary`.
- The bottom row fades instead of being cut, using the shared scroll shadow — which turned out not to attach at all when its scroller mounts late, so that hook is fixed too.
- Pagination gets the Doherty gate, a "Still working…" label past five seconds, and exactly one recovery route on failure instead of a Retry sitting above a button guaranteed to fail again.
- Forced colors: the cursor rail and the selection outline are keyed apart so a selected row under the cursor keeps both.

## Verification

`npm run check` clean. Full unit suite green (2330 files, 51k tests). `core-github-panels` E2E green. Rendered and checked in all 15 bundled themes, 8 dark and 7 light.

There's a new opt-in capture harness at `e2e/screenshots/forge-dropdown-review.spec.ts` for this surface:

```
DAINTREE_SHOT_FORGE=1 npx playwright test --project=screenshots forge-dropdown-review
```

