### PR TITLE
Move the remaining stacked-label forms onto the shared label rail

### DIFF
--- a/src/components/Commands/CommandBuilder.tsx
+++ b/src/components/Commands/CommandBuilder.tsx
@@ -11,6 +11,13 @@ import type {
 } from "@shared/types/commands";
 import { ChevronLeft, ChevronRight, AlertCircle, CheckCircle } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
+import {
+  FIELD_FOCUS,
+  FIELD_INPUT,
+  FIELD_SURFACE,
+  FormGrid,
+  FormRow,
+} from "@/components/Worktree/views";
 
 interface CommandBuilderProps {
   command: CommandManifestEntry;
@@ -76,6 +83,42 @@ function validateField(field: BuilderField, value: unknown): string | null {
   return null;
 }
 
+// Command labels come from a manifest we don't author, so the rail can't rely on
+// them staying short: cap the cell rather than let one field's label set the
+// column width for the whole step.
+const BUILDER_LABEL = "max-w-48 break-words";
+
+// A plain function, not a component: `FormRow` skips its hint row on a falsy
+// hint, and an element is truthy even when it renders nothing.
+function builderFieldHint({
+  error,
+  helpText,
+  errorId,
+  helpId,
+}: {
+  error?: string;
+  helpText?: string;
+  errorId: string;
+  helpId: string;
+}): React.ReactNode {
+  if (error) {
+    return (
+      <p id={errorId} className="text-xs text-status-error flex items-center gap-1" role="alert">
+        <AlertCircle className="h-3 w-3" aria-hidden="true" />
+        {error}
+      </p>
+    );
+  }
+  if (helpText) {
+    return (
+      <p id={helpId} className="text-xs text-text-muted">
+        {helpText}
+      </p>
+    );
+  }
+  return null;
+}
+
 function BuilderTextField({
   field,
   value,
@@ -93,10 +136,12 @@ function BuilderTextField({
   const helpId = `${inputId}-help`;
 
   return (
-    <div className="space-y-1.5">
-      <label htmlFor={inputId} className="block text-sm font-medium text-daintree-text">
-        {field.label}
-      </label>
+    <FormRow
+      label={field.label}
+      htmlFor={inputId}
+      labelClassName={BUILDER_LABEL}
+      hint={builderFieldHint({ error, helpText: field.helpText, errorId, helpId })}
+    >
       <input
         ref={inputRef}
         id={inputId}
@@ -106,27 +151,9 @@ function BuilderTextField({
         placeholder={field.placeholder}
         aria-describedby={error ? errorId : field.helpText ? helpId : undefined}
         aria-invalid={error ? "true" : undefined}
-        className={cn(
-          "w-full px-3 py-2 text-sm rounded-[var(--radius-md)]",
-          "bg-daintree-bg border text-daintree-text placeholder:text-text-placeholder",
-          "focus:outline-hidden focus:ring-1",
-          error
-            ? "border-status-error focus:border-status-error focus:ring-status-error"
-            : "border-daintree-border focus:border-daintree-accent/40 focus:ring-daintree-accent/30"
-        )}
+        className={cn(FIELD_INPUT, error && "border-status-error")}
       />
-      {field.helpText && !error && (
-        <p id={helpId} className="text-xs text-daintree-text/50">
-          {field.helpText}
-        </p>
-      )}
-      {error && (
-        <p id={errorId} className="text-xs text-status-error flex items-center gap-1" role="alert">
-          <AlertCircle className="h-3 w-3" />
-          {error}
-        </p>
-      )}
-    </div>
+    </FormRow>
   );
 }
 
@@ -146,10 +173,14 @@ function BuilderTextareaField({
   const helpId = `${inputId}-help`;
 
   return (
-    <div className="space-y-1.5">
-      <label htmlFor={inputId} className="block text-sm font-medium text-daintree-text">
-        {field.label}
-      </label>
+    <FormRow
+      label={field.label}
+      htmlFor={inputId}
+      // The grid centres every cell; a four-row textarea would leave its label
+      // floating halfway down the box.
+      labelClassName={cn(BUILDER_LABEL, "self-start pt-2")}
+      hint={builderFieldHint({ error, helpText: field.helpText, errorId, helpId })}
+    >
       <textarea
         id={inputId}
         value={value}
@@ -159,26 +190,14 @@ function BuilderTextareaField({
         aria-describedby={error ? errorId : field.helpText ? helpId : undefined}
         aria-invalid={error ? "true" : undefined}
         className={cn(
-          "w-full px-3 py-2 text-sm rounded-[var(--radius-md)] resize-y min-h-[100px]",
-          "bg-daintree-bg border text-daintree-text placeholder:text-text-placeholder",
-          "focus:outline-hidden focus:ring-1",
-          error
-            ? "border-status-error focus:border-status-error focus:ring-status-error"
-            : "border-daintree-border focus:border-daintree-accent/40 focus:ring-daintree-accent/30"
+          FIELD_SURFACE,
+          FIELD_FOCUS,
+          "w-full px-2.5 py-2 text-sm resize-y min-h-[100px]",
+          "text-daintree-text placeholder:text-text-placeholder",
+          error && "border-status-error"
         )}
       />
-      {field.helpText && !error && (
-        <p id={helpId} className="text-xs text-daintree-text/50">
-          {field.helpText}
-        </p>
-      )}
-      {error && (
-        <p id={errorId} className="text-xs text-status-error flex items-center gap-1" role="alert">
-          <AlertCircle className="h-3 w-3" />
-          {error}
-        </p>
-      )}
-    </div>
+    </FormRow>
   );
 }
 
@@ -198,24 +217,19 @@ function BuilderSelectField({
   const helpId = `${inputId}-help`;
 
   return (
-    <div className="space-y-1.5">
-      <label htmlFor={inputId} className="block text-sm font-medium text-daintree-text">
-        {field.label}
-      </label>
+    <FormRow
+      label={field.label}
+      htmlFor={inputId}
+      labelClassName={BUILDER_LABEL}
+      hint={builderFieldHint({ error, helpText: field.helpText, errorId, helpId })}
+    >
       <select
         id={inputId}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         aria-describedby={error ? errorId : field.helpText ? helpId : undefined}
         aria-invalid={error ? "true" : undefined}
-        className={cn(
-          "w-full px-3 py-2 text-sm rounded-[var(--radius-md)]",
-          "bg-daintree-bg border text-daintree-text",
-          "focus:outline-hidden focus:ring-1",
-          error
-            ? "border-status-error focus:border-status-error focus:ring-status-error"
-            : "border-daintree-border focus:border-daintree-accent/40 focus:ring-daintree-accent/30"
-        )}
+        className={cn(FIELD_INPUT, "pr-8", error && "border-status-error")}
       >
         <option value="">{field.placeholder ?? "Select an option..."}</option>
         {field.options?.map((opt) => (
@@ -224,18 +238,7 @@ function BuilderSelectField({
           </option>
         ))}
       </select>
-      {field.helpText && !error && (
-        <p id={helpId} className="text-xs text-daintree-text/50">
-          {field.helpText}
-        </p>
-      )}
-      {error && (
-        <p id={errorId} className="text-xs text-status-error flex items-center gap-1" role="alert">
-          <AlertCircle className="h-3 w-3" />
-          {error}
-        </p>
-      )}
-    </div>
+    </FormRow>
   );
 }
 
@@ -248,25 +251,35 @@ function BuilderCheckboxField({
   value: boolean;
   onChange: (value: boolean) => void;
 }) {
+  const inputId = `field-${field.name}`;
+  const helpId = `${inputId}-help`;
+
   return (
-    <div className="space-y-1.5">
-      <label className="flex items-center gap-3 cursor-pointer group">
-        <input
-          type="checkbox"
-          checked={value}
-          onChange={(e) => onChange(e.target.checked)}
-          className={cn(
-            "h-4 w-4 rounded border-daintree-border bg-daintree-bg",
-            "text-daintree-accent focus:ring-daintree-accent/30 focus:ring-offset-0",
-            "cursor-pointer"
-          )}
-        />
-        <span className="text-sm font-medium text-daintree-text group-hover:text-daintree-text/90">
-          {field.label}
-        </span>
-      </label>
-      {field.helpText && <p className="text-xs text-daintree-text/50 ml-7">{field.helpText}</p>}
-    </div>
+    <FormRow
+      label={field.label}
+      htmlFor={inputId}
+      labelClassName={BUILDER_LABEL}
+      hint={
+        field.helpText && (
+          <p id={helpId} className="text-xs text-text-muted">
+            {field.helpText}
+          </p>
+        )
+      }
+    >
+      <input
+        id={inputId}
+        type="checkbox"
+        checked={value}
+        onChange={(e) => onChange(e.target.checked)}
+        aria-describedby={field.helpText ? helpId : undefined}
+        className={cn(
+          "h-4 w-4 rounded border-daintree-border bg-daintree-bg",
+          "text-daintree-accent focus:ring-daintree-accent/30 focus:ring-offset-0",
+          "cursor-pointer"
+        )}
+      />
+    </FormRow>
   );
 }
 
@@ -480,7 +493,7 @@ export function CommandBuilder({
                   <p className="text-sm text-daintree-text/70">{currentStep.description}</p>
                 )}
 
-                <div className="space-y-4">
+                <FormGrid>
                   {currentStep.fields.map((field) => (
                     <BuilderFieldRenderer
                       key={field.name}
@@ -490,7 +503,7 @@ export function CommandBuilder({
                       onChange={(value) => handleFieldChange(field.name, value, field)}
                     />
                   ))}
-                </div>
+                </FormGrid>
               </>
             )}
 

--- a/src/components/Commands/__tests__/CommandBuilder.test.tsx
+++ b/src/components/Commands/__tests__/CommandBuilder.test.tsx
@@ -117,7 +117,12 @@ describe("CommandBuilder field rendering", () => {
     fireEvent.click(screen.getByLabelText("Open as draft"));
     fireEvent.click(screen.getByRole("button", { name: "Execute" }));
 
-    await vi.waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    // Settle on the success state, not on the call: `onExecute` is invoked
+    // before its promise resolves, so waiting on the spy would leave the
+    // resulting state update to land outside React's act boundary.
+    await screen.findByText("Command completed.");
+
+    expect(onExecute).toHaveBeenCalledTimes(1);
     expect(onExecute.mock.calls[0]?.[0]).toMatchObject({
       title: "Crash on open",
       priority: "high",

--- a/src/components/Commands/__tests__/CommandBuilder.test.tsx
+++ b/src/components/Commands/__tests__/CommandBuilder.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CommandBuilder } from "../CommandBuilder";
+import type { BuilderStep, CommandManifestEntry } from "@shared/types/commands";
+
+const command: CommandManifestEntry = {
+  id: "test:build",
+  label: "Test command",
+  description: "",
+  category: "workflow",
+  hasBuilder: true,
+  enabled: true,
+};
+
+const steps: BuilderStep[] = [
+  {
+    id: "step-1",
+    title: "Details",
+    fields: [
+      { name: "title", label: "Issue title", type: "text", helpText: "Keep it short" },
+      { name: "body", label: "Description", type: "textarea" },
+      {
+        name: "priority",
+        label: "Priority",
+        type: "select",
+        options: [
+          { value: "low", label: "Low" },
+          { value: "high", label: "High" },
+        ],
+      },
+      { name: "draft", label: "Open as draft", type: "checkbox" },
+    ],
+  },
+];
+
+function renderBuilder(overrides: Partial<Parameters<typeof CommandBuilder>[0]> = {}) {
+  const onExecute = vi.fn().mockResolvedValue({ success: true });
+  render(
+    <CommandBuilder
+      command={command}
+      steps={steps}
+      context={{}}
+      isExecuting={false}
+      executionError={null}
+      onExecute={onExecute}
+      onCancel={vi.fn()}
+      {...overrides}
+    />
+  );
+  return { onExecute };
+}
+
+describe("CommandBuilder field rendering", () => {
+  it("names every manifest-supplied field, whatever its type", () => {
+    renderBuilder();
+
+    // Manifest labels are the only names these controls have — a rail row that
+    // dropped the association would leave them anonymous.
+    expect(screen.getByLabelText("Issue title").tagName).toBe("INPUT");
+    expect(screen.getByLabelText("Description").tagName).toBe("TEXTAREA");
+    expect(screen.getByLabelText("Priority").tagName).toBe("SELECT");
+    expect(screen.getByLabelText("Open as draft")).toHaveProperty("type", "checkbox");
+  });
+
+  it("points a field at its own help text", () => {
+    renderBuilder();
+
+    const described = screen.getByLabelText("Issue title").getAttribute("aria-describedby");
+    expect(described).toBeTruthy();
+    expect(document.getElementById(described!)?.textContent).toBe("Keep it short");
+  });
+
+  it("describes a field by its validation error instead of its help text once it fails", async () => {
+    const longMin: BuilderStep[] = [
+      {
+        id: "step-1",
+        title: "Details",
+        fields: [
+          {
+            name: "title",
+            label: "Issue title",
+            type: "text",
+            helpText: "Keep it short",
+            validation: { min: 5, message: "Too short" },
+          },
+        ],
+      },
+    ];
+    const onExecute = vi.fn().mockResolvedValue({ success: true });
+    render(
+      <CommandBuilder
+        command={command}
+        steps={longMin}
+        context={{}}
+        isExecuting={false}
+        executionError={null}
+        onExecute={onExecute}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Issue title"), { target: { value: "abc" } });
+    fireEvent.click(screen.getByRole("button", { name: "Execute" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Too short");
+    expect(screen.getByLabelText("Issue title").getAttribute("aria-describedby")).toBe(alert.id);
+    expect(onExecute).not.toHaveBeenCalled();
+  });
+
+  it("carries each field's value through to execution", async () => {
+    const { onExecute } = renderBuilder();
+
+    fireEvent.change(screen.getByLabelText("Issue title"), { target: { value: "Crash on open" } });
+    fireEvent.change(screen.getByLabelText("Priority"), { target: { value: "high" } });
+    fireEvent.click(screen.getByLabelText("Open as draft"));
+    fireEvent.click(screen.getByRole("button", { name: "Execute" }));
+
+    await vi.waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute.mock.calls[0]?.[0]).toMatchObject({
+      title: "Crash on open",
+      priority: "high",
+      draft: true,
+    });
+  });
+});

--- a/src/components/Project/CodeForgeTab.tsx
+++ b/src/components/Project/CodeForgeTab.tsx
@@ -3,6 +3,8 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
 import type { RemoteInfo } from "@shared/types/ipc/forge";
 import type { RegisteredForgeProvider } from "@shared/types/forge";
+import { FIELD_INPUT, FormGrid, FormRow } from "@/components/Worktree/views";
+import { cn } from "@/lib/utils";
 
 interface CodeForgeTabProps {
   forgeRemote: string | undefined;
@@ -106,70 +108,86 @@ export function CodeForgeTab({
     );
 
   return (
-    <div id="project-code-forge-remote" className="space-y-6">
-      <div>
-        <label className="block text-sm font-medium text-daintree-text mb-1">Forge remote</label>
-        <p className="text-xs text-daintree-text/60 mb-2">
-          Select which git remote to use for forge integration (issues, PRs, and pulse data).
-          Auto-detect prefers origin, then any other remote a forge provider recognizes.
-        </p>
-        {loading ? (
-          <div className="text-sm text-daintree-text/60">Loading remotes...</div>
-        ) : error ? (
-          <div className="text-sm text-status-error">{error}</div>
-        ) : (
-          <select
-            value={forgeRemote || ""}
-            onChange={(e) => onForgeRemoteChange(e.target.value || undefined)}
-            className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
-          >
-            <option value="">Auto-detect</option>
-            {remotes.map((r) => (
-              <option key={r.name} value={r.name}>
-                {r.name}
-                {r.parsedRepo ? ` — ${r.parsedRepo.owner}/${r.parsedRepo.repo}` : ""}
-              </option>
-            ))}
-            {!savedRemoteKnown && forgeRemote ? (
-              <option value={forgeRemote}>{forgeRemote} (unavailable)</option>
-            ) : null}
-          </select>
-        )}
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-daintree-text mb-1">Forge provider</label>
-        <p className="text-xs text-daintree-text/60 mb-2">
-          Pin this project to a specific forge provider. Auto-detects from the remote URL when no
-          override is set.
-        </p>
-        {providersLoading ? (
-          <div className="text-sm text-daintree-text/60">Loading providers...</div>
-        ) : providersError ? (
-          <div className="text-sm text-status-error">{providersError}</div>
-        ) : (
-          <select
-            value={forgeProviderOverride ?? ""}
-            onChange={(e) =>
-              onForgeProviderOverrideChange(e.target.value === "" ? null : e.target.value)
-            }
-            className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
-          >
-            <option value="">Auto-detect</option>
-            {providers.map((p) => {
-              const providerId = makeForgeProviderId(p.pluginId, p.contribution.id);
-              return (
-                <option key={providerId} value={providerId}>
-                  {p.contribution.name}
+    <div id="project-code-forge-remote">
+      <FormGrid>
+        <FormRow
+          // A dangling `for` names nothing: while the remotes are still
+          // loading — or failed to — there is no select to point at.
+          label="Forge remote"
+          htmlFor={loading || error ? undefined : "forge-remote-select"}
+          hint={
+            <p id="forge-remote-hint" className="text-xs text-text-secondary">
+              Select which git remote to use for forge integration (issues, PRs, and pulse data).
+              Auto-detect prefers origin, then any other remote a forge provider recognizes.
+            </p>
+          }
+        >
+          {loading ? (
+            <div className="text-sm text-text-secondary">Loading remotes...</div>
+          ) : error ? (
+            <div className="text-sm text-status-error">{error}</div>
+          ) : (
+            <select
+              id="forge-remote-select"
+              value={forgeRemote || ""}
+              onChange={(e) => onForgeRemoteChange(e.target.value || undefined)}
+              aria-describedby="forge-remote-hint"
+              className={cn(FIELD_INPUT, "pr-8")}
+            >
+              <option value="">Auto-detect</option>
+              {remotes.map((r) => (
+                <option key={r.name} value={r.name}>
+                  {r.name}
+                  {r.parsedRepo ? ` — ${r.parsedRepo.owner}/${r.parsedRepo.repo}` : ""}
                 </option>
-              );
-            })}
-            {!savedProviderKnown && forgeProviderOverride !== null ? (
-              <option value={forgeProviderOverride}>{forgeProviderOverride} (unavailable)</option>
-            ) : null}
-          </select>
-        )}
-      </div>
+              ))}
+              {!savedRemoteKnown && forgeRemote ? (
+                <option value={forgeRemote}>{forgeRemote} (unavailable)</option>
+              ) : null}
+            </select>
+          )}
+        </FormRow>
+
+        <FormRow
+          label="Forge provider"
+          htmlFor={providersLoading || providersError ? undefined : "forge-provider-select"}
+          hint={
+            <p id="forge-provider-hint" className="text-xs text-text-secondary">
+              Pin this project to a specific forge provider. Auto-detects from the remote URL when
+              no override is set.
+            </p>
+          }
+        >
+          {providersLoading ? (
+            <div className="text-sm text-text-secondary">Loading providers...</div>
+          ) : providersError ? (
+            <div className="text-sm text-status-error">{providersError}</div>
+          ) : (
+            <select
+              id="forge-provider-select"
+              value={forgeProviderOverride ?? ""}
+              onChange={(e) =>
+                onForgeProviderOverrideChange(e.target.value === "" ? null : e.target.value)
+              }
+              aria-describedby="forge-provider-hint"
+              className={cn(FIELD_INPUT, "pr-8")}
+            >
+              <option value="">Auto-detect</option>
+              {providers.map((p) => {
+                const providerId = makeForgeProviderId(p.pluginId, p.contribution.id);
+                return (
+                  <option key={providerId} value={providerId}>
+                    {p.contribution.name}
+                  </option>
+                );
+              })}
+              {!savedProviderKnown && forgeProviderOverride !== null ? (
+                <option value={forgeProviderOverride}>{forgeProviderOverride} (unavailable)</option>
+              ) : null}
+            </select>
+          )}
+        </FormRow>
+      </FormGrid>
     </div>
   );
 }

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import type { ResourceEnvironment } from "@shared/types/project";
+import { FIELD_INPUT, FormGrid, FormRow, FormSection } from "@/components/Worktree/views";
 
 interface EnvironmentSettingsTabProps {
   resourceEnvironments?: Record<string, ResourceEnvironment>;
@@ -92,9 +93,10 @@ function CommandList({
   };
 
   return (
-    <div>
-      <h3 className="text-sm font-medium text-text-primary mb-2">{label}</h3>
-      <div className="space-y-2">
+    // A repeated-row editor is not a row on the rail — it gets the section
+    // header its caption used to be, and its rows span both columns.
+    <FormSection title={label}>
+      <div className="col-span-2 space-y-2">
         {commands.map((cmd, index) => (
           <div key={index} className="flex items-center gap-2">
             <span className="text-xs text-text-muted w-5 text-right font-mono select-none">
@@ -146,9 +148,9 @@ function CommandList({
           <Plus className="h-3.5 w-3.5" />
           Add command
         </button>
+        <p className="text-xs text-text-muted mt-1">{helpText}</p>
       </div>
-      <p className="text-xs text-text-muted mt-1">{helpText}</p>
-    </div>
+    </FormSection>
   );
 }
 
@@ -293,38 +295,57 @@ export function ResourceEnvironmentsSection({
   };
 
   return (
-    <div id="tab-nav-project:environments" className="space-y-6 p-1">
-      <div className="flex items-center gap-2 mb-2">
+    <div id="tab-nav-project:environments" className="p-1">
+      <div className="flex items-center gap-2 mb-4">
         <Server className="h-5 w-5 text-daintree-text/60" />
         <h2 className="text-base font-semibold text-text-primary">Resource Environments</h2>
       </div>
 
-      {/* Environment selector dropdown */}
-      {envKeys.length > 0 && (
-        <div data-testid="environment-selector-bar" className="flex items-center gap-2">
-          <select
-            value={currentEnvName}
-            onChange={(e) => handleSelectEnv(e.target.value)}
-            aria-label="Select environment"
-            className="flex-1 px-3 py-1.5 text-sm bg-surface-inset border border-border-default rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30"
-          >
-            {envKeys.map((name) => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ))}
-          </select>
-          <IconPickerButton currentIcon={env.icon} onChange={(icon) => updateEnv({ icon })} />
-          {envKeys.length > 1 && (
-            <button
-              type="button"
-              onClick={() => setPendingDeleteEnvironment(currentEnvName)}
-              className="p-1 rounded hover:bg-status-error/15 transition-colors"
-              aria-label={`Remove ${currentEnvName} environment`}
-            >
-              <X className="h-4 w-4 text-status-error" />
-            </button>
-          )}
+      <FormGrid>
+        {/* Environment selector dropdown */}
+        {envKeys.length > 0 && (
+          <FormRow label="Environment" selfLabelled>
+            <div data-testid="environment-selector-bar" className="flex items-center gap-2">
+              <select
+                value={currentEnvName}
+                onChange={(e) => handleSelectEnv(e.target.value)}
+                aria-label="Environment"
+                className={cn(FIELD_INPUT, "flex-1 min-w-0 pr-8")}
+              >
+                {envKeys.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+              <IconPickerButton currentIcon={env.icon} onChange={(icon) => updateEnv({ icon })} />
+              {envKeys.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => setPendingDeleteEnvironment(currentEnvName)}
+                  className="p-1 rounded hover:bg-status-error/15 transition-colors"
+                  aria-label={`Remove ${currentEnvName} environment`}
+                >
+                  <X className="h-4 w-4 text-status-error" />
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  setIsAddingEnvironment(true);
+                  setAddEnvironmentError(null);
+                }}
+                aria-label="Add environment"
+                className="flex items-center gap-1 px-2 py-1.5 text-xs text-daintree-text/60 hover:text-daintree-text transition-colors"
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          </FormRow>
+        )}
+
+        {/* Empty state: no environments yet */}
+        {envKeys.length === 0 && (
           <button
             type="button"
             onClick={() => {
@@ -332,231 +353,238 @@ export function ResourceEnvironmentsSection({
               setAddEnvironmentError(null);
             }}
             aria-label="Add environment"
-            className="flex items-center gap-1 px-2 py-1.5 text-xs text-daintree-text/60 hover:text-daintree-text transition-colors"
+            className="col-span-2 flex w-fit items-center gap-1.5 text-xs text-daintree-text/60 hover:text-daintree-text transition-colors px-1 py-1"
           >
             <Plus className="h-3.5 w-3.5" />
+            Add environment
           </button>
-        </div>
-      )}
+        )}
 
-      {/* Empty state: no environments yet */}
-      {envKeys.length === 0 && (
-        <button
-          type="button"
-          onClick={() => {
-            setIsAddingEnvironment(true);
-            setAddEnvironmentError(null);
-          }}
-          aria-label="Add environment"
-          className="flex items-center gap-1.5 text-xs text-daintree-text/60 hover:text-daintree-text transition-colors px-1 py-1"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          Add environment
-        </button>
-      )}
-
-      {isAddingEnvironment && (
-        <div
-          data-testid="add-environment-form"
-          className="space-y-2 p-3 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg"
-        >
-          <label
-            className="block text-sm font-medium text-text-primary"
+        {isAddingEnvironment && (
+          <FormRow
+            label="Environment Name"
             htmlFor="new-environment-name"
+            hint={
+              addEnvironmentError && (
+                <p
+                  id="new-environment-name-error"
+                  className="text-xs text-status-error"
+                  role="alert"
+                >
+                  {addEnvironmentError}
+                </p>
+              )
+            }
           >
-            Environment Name
-          </label>
-          <div className="flex items-center gap-2">
-            <input
-              id="new-environment-name"
-              type="text"
-              value={newEnvironmentName}
-              onChange={(e) => {
-                setNewEnvironmentName(e.target.value);
-                setAddEnvironmentError(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleAddEnv();
-                } else if (e.key === "Escape") {
+            <div data-testid="add-environment-form" className="flex items-center gap-2">
+              <input
+                id="new-environment-name"
+                type="text"
+                value={newEnvironmentName}
+                onChange={(e) => {
+                  setNewEnvironmentName(e.target.value);
+                  setAddEnvironmentError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleAddEnv();
+                  } else if (e.key === "Escape") {
+                    setIsAddingEnvironment(false);
+                    setNewEnvironmentName("");
+                    setAddEnvironmentError(null);
+                  }
+                }}
+                autoFocus
+                spellCheck={false}
+                placeholder="docker-local"
+                aria-invalid={!!addEnvironmentError}
+                aria-describedby={addEnvironmentError ? "new-environment-name-error" : undefined}
+                className={cn(FIELD_INPUT, "flex-1 min-w-0 font-mono")}
+              />
+              <Button type="button" size="sm" onClick={handleAddEnv}>
+                Add
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => {
                   setIsAddingEnvironment(false);
                   setNewEnvironmentName("");
                   setAddEnvironmentError(null);
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </FormRow>
+        )}
+
+        {/* Variables hint */}
+        <div className="col-span-2 mt-3 px-3 py-2 rounded-[var(--radius-md)] bg-surface-inset border border-border-default text-xs text-text-muted space-y-1">
+          <div>
+            <span className="font-medium text-daintree-text/70">Variables</span>{" "}
+            <span className="text-daintree-text/40">(replaced at runtime in all commands):</span>
+          </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+            <div>
+              <code className="text-text-secondary">{"{branch}"}</code>
+              <span className="text-daintree-text/40"> — branch name</span>
+            </div>
+            <div>
+              <code className="text-text-secondary">{"{branch-slug}"}</code>
+              <span className="text-daintree-text/40"> — sanitized branch</span>
+            </div>
+            <div>
+              <code className="text-text-secondary">{"{repo-name}"}</code>
+              <span className="text-daintree-text/40"> — repository folder</span>
+            </div>
+            <div>
+              <code className="text-text-secondary">{"{base-folder}"}</code>
+              <span className="text-daintree-text/40"> — alias for repo-name</span>
+            </div>
+            <div>
+              <code className="text-text-secondary">{"{parent-dir}"}</code>
+              <span className="text-daintree-text/40"> — parent directory</span>
+            </div>
+            <div>
+              <code className="text-text-secondary">{"{worktree_name}"}</code>
+              <span className="text-daintree-text/40"> — worktree name</span>
+            </div>
+            <div>
+              <code className="text-text-secondary">{"{worktree_path}"}</code>
+              <span className="text-daintree-text/40"> — full worktree path</span>
+            </div>
+            <div>
+              <code className="text-text-secondary">{"{project_root}"}</code>
+              <span className="text-daintree-text/40"> — project root path</span>
+            </div>
+          </div>
+        </div>
+
+        {envKeys.length > 0 && (
+          <>
+            {/* Provision Commands */}
+            <CommandList
+              commands={env.provision ?? []}
+              onChange={(provision) => updateEnv({ provision })}
+              placeholder="e.g. docker compose up -d"
+              label="Provision Commands"
+              helpText="Commands to run when provisioning a remote environment"
+            />
+
+            {/* Teardown Commands */}
+            <CommandList
+              commands={env.teardown ?? []}
+              onChange={(teardown) => updateEnv({ teardown })}
+              placeholder="e.g. docker compose down"
+              label="Teardown Commands"
+              helpText="Commands to run when destroying the environment"
+            />
+
+            {/* Resume Commands */}
+            <CommandList
+              commands={env.resume ?? []}
+              onChange={(resume) => updateEnv({ resume })}
+              placeholder="e.g. docker unpause container"
+              label="Resume Commands"
+              helpText="Commands to resume a paused environment without destroying"
+            />
+
+            {/* Pause Commands */}
+            <CommandList
+              commands={env.pause ?? []}
+              onChange={(pause) => updateEnv({ pause })}
+              placeholder="e.g. docker pause container"
+              label="Pause Commands"
+              helpText="Commands to pause the environment while preserving state"
+            />
+
+            <FormSection title="Status and connect">
+              <FormRow
+                label="Status Command"
+                htmlFor="resource-status-command"
+                hint={
+                  <p id="resource-status-command-help" className="text-xs text-text-muted">
+                    Must output JSON with {'{ "status": "<string>" }'}
+                  </p>
                 }
-              }}
-              autoFocus
-              spellCheck={false}
-              placeholder="docker-local"
-              className="flex-1 px-3 py-1.5 text-sm bg-surface-inset border border-border-default rounded-[var(--radius-md)] text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30"
-            />
-            <Button type="button" size="sm" onClick={handleAddEnv}>
-              Add
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setIsAddingEnvironment(false);
-                setNewEnvironmentName("");
-                setAddEnvironmentError(null);
-              }}
-            >
-              Cancel
-            </Button>
-          </div>
-          {addEnvironmentError && (
-            <p className="text-xs text-status-error">{addEnvironmentError}</p>
-          )}
-        </div>
-      )}
+              >
+                <input
+                  id="resource-status-command"
+                  type="text"
+                  value={env.status ?? ""}
+                  onChange={(e) => updateEnv({ status: e.target.value || undefined })}
+                  placeholder="e.g. docker compose ps --format json"
+                  spellCheck={false}
+                  aria-describedby="resource-status-command-help"
+                  className={cn(FIELD_INPUT, "font-mono")}
+                />
+              </FormRow>
 
-      {/* Variables hint */}
-      <div className="px-3 py-2 rounded-[var(--radius-md)] bg-surface-inset border border-border-default text-xs text-text-muted space-y-1">
-        <div>
-          <span className="font-medium text-daintree-text/70">Variables</span>{" "}
-          <span className="text-daintree-text/40">(replaced at runtime in all commands):</span>
-        </div>
-        <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
-          <div>
-            <code className="text-text-secondary">{"{branch}"}</code>
-            <span className="text-daintree-text/40"> — branch name</span>
-          </div>
-          <div>
-            <code className="text-text-secondary">{"{branch-slug}"}</code>
-            <span className="text-daintree-text/40"> — sanitized branch</span>
-          </div>
-          <div>
-            <code className="text-text-secondary">{"{repo-name}"}</code>
-            <span className="text-daintree-text/40"> — repository folder</span>
-          </div>
-          <div>
-            <code className="text-text-secondary">{"{base-folder}"}</code>
-            <span className="text-daintree-text/40"> — alias for repo-name</span>
-          </div>
-          <div>
-            <code className="text-text-secondary">{"{parent-dir}"}</code>
-            <span className="text-daintree-text/40"> — parent directory</span>
-          </div>
-          <div>
-            <code className="text-text-secondary">{"{worktree_name}"}</code>
-            <span className="text-daintree-text/40"> — worktree name</span>
-          </div>
-          <div>
-            <code className="text-text-secondary">{"{worktree_path}"}</code>
-            <span className="text-daintree-text/40"> — full worktree path</span>
-          </div>
-          <div>
-            <code className="text-text-secondary">{"{project_root}"}</code>
-            <span className="text-daintree-text/40"> — project root path</span>
-          </div>
-        </div>
-      </div>
+              <FormRow
+                label="Connect Command"
+                htmlFor="resource-connect-command"
+                hint={
+                  <p id="resource-connect-command-help" className="text-xs text-text-muted">
+                    Shell command for connecting (ssh, docker exec, kubectl exec)
+                  </p>
+                }
+              >
+                <input
+                  id="resource-connect-command"
+                  type="text"
+                  value={env.connect ?? ""}
+                  onChange={(e) => updateEnv({ connect: e.target.value || undefined })}
+                  placeholder="e.g. docker exec -it container /bin/bash"
+                  spellCheck={false}
+                  aria-describedby="resource-connect-command-help"
+                  className={cn(FIELD_INPUT, "font-mono")}
+                />
+              </FormRow>
+            </FormSection>
+          </>
+        )}
 
-      {envKeys.length > 0 && (
-        <>
-          {/* Provision Commands */}
-          <CommandList
-            commands={env.provision ?? []}
-            onChange={(provision) => updateEnv({ provision })}
-            placeholder="e.g. docker compose up -d"
-            label="Provision Commands"
-            helpText="Commands to run when provisioning a remote environment"
-          />
-
-          {/* Teardown Commands */}
-          <CommandList
-            commands={env.teardown ?? []}
-            onChange={(teardown) => updateEnv({ teardown })}
-            placeholder="e.g. docker compose down"
-            label="Teardown Commands"
-            helpText="Commands to run when destroying the environment"
-          />
-
-          {/* Resume Commands */}
-          <CommandList
-            commands={env.resume ?? []}
-            onChange={(resume) => updateEnv({ resume })}
-            placeholder="e.g. docker unpause container"
-            label="Resume Commands"
-            helpText="Commands to resume a paused environment without destroying"
-          />
-
-          {/* Pause Commands */}
-          <CommandList
-            commands={env.pause ?? []}
-            onChange={(pause) => updateEnv({ pause })}
-            placeholder="e.g. docker pause container"
-            label="Pause Commands"
-            helpText="Commands to pause the environment while preserving state"
-          />
-
-          {/* Status Command */}
-          <div>
-            <h3 className="text-sm font-medium text-text-primary mb-2">Status Command</h3>
-            <input
-              type="text"
-              value={env.status ?? ""}
-              onChange={(e) => updateEnv({ status: e.target.value || undefined })}
-              placeholder="e.g. docker compose ps --format json"
-              spellCheck={false}
-              className="w-full px-3 py-1.5 text-sm bg-surface-inset border border-border-default rounded-[var(--radius-md)] text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30"
-            />
-            <p className="text-xs text-text-muted mt-1">
-              Must output JSON with {'{ "status": "<string>" }'}
-            </p>
-          </div>
-
-          {/* Connect Command */}
-          <div>
-            <h3 className="text-sm font-medium text-text-primary mb-2">Connect Command</h3>
-            <input
-              type="text"
-              value={env.connect ?? ""}
-              onChange={(e) => updateEnv({ connect: e.target.value || undefined })}
-              placeholder="e.g. docker exec -it container /bin/bash"
-              spellCheck={false}
-              className="w-full px-3 py-1.5 text-sm bg-surface-inset border border-border-default rounded-[var(--radius-md)] text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30"
-            />
-            <p className="text-xs text-text-muted mt-1">
-              Shell command for connecting (ssh, docker exec, kubectl exec)
-            </p>
-          </div>
-        </>
-      )}
-
-      {/* Default Worktree Mode */}
-      <div>
-        <h3 className="text-sm font-medium text-text-primary mb-2">Default Worktree Mode</h3>
-        <div className="flex items-center gap-4 flex-wrap">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="radio"
-              name="worktreeMode"
-              value="local"
-              checked={(defaultWorktreeMode ?? "local") === "local"}
-              onChange={() => onDefaultWorktreeModeChange("local")}
-              className="accent-daintree-accent"
-            />
-            <span className="text-sm text-daintree-text">Local</span>
-          </label>
-          {envKeys.map((key) => (
-            <label key={key} className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="radio"
-                name="worktreeMode"
-                value={key}
-                checked={defaultWorktreeMode === key}
-                onChange={() => onDefaultWorktreeModeChange(key)}
-                className="accent-daintree-accent"
-              />
-              <span className="text-sm text-daintree-text">{key}</span>
-            </label>
-          ))}
-        </div>
-        <p className="text-xs text-text-muted mt-1">Default mode when creating new worktrees</p>
-      </div>
+        <FormSection title="Defaults">
+          {/* No htmlFor: a set of radios has no single control to name, so the
+              rail's label names the group instead. */}
+          <FormRow
+            label="Default Worktree Mode"
+            hint={
+              <p className="text-xs text-text-muted">Default mode when creating new worktrees</p>
+            }
+          >
+            <div className="flex items-center gap-4 flex-wrap">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="worktreeMode"
+                  value="local"
+                  checked={(defaultWorktreeMode ?? "local") === "local"}
+                  onChange={() => onDefaultWorktreeModeChange("local")}
+                  className="accent-daintree-accent"
+                />
+                <span className="text-sm text-daintree-text">Local</span>
+              </label>
+              {envKeys.map((key) => (
+                <label key={key} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="worktreeMode"
+                    value={key}
+                    checked={defaultWorktreeMode === key}
+                    onChange={() => onDefaultWorktreeModeChange(key)}
+                    className="accent-daintree-accent"
+                  />
+                  <span className="text-sm text-daintree-text">{key}</span>
+                </label>
+              ))}
+            </div>
+          </FormRow>
+        </FormSection>
+      </FormGrid>
 
       <ConfirmDialog
         isOpen={pendingDeleteEnvironment !== null}

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -160,8 +160,8 @@ export function WorktreeSettingsTab() {
     }
   };
 
-  // One hint slot, so validation and save failures can't stack two error rows
-  // under the field. Validation wins: it blocks the save that would report the other.
+  // A failed load leaves the pattern empty, which trips validation too — so
+  // these are reported together rather than one masking the other's cause.
   const patternError = !isLoading && !validation.valid ? validation.error : undefined;
 
   const handleReset = () => {
@@ -196,11 +196,15 @@ export function WorktreeSettingsTab() {
                 (patternError || error) && (
                   <div
                     id="path-pattern-error"
-                    className="flex items-start gap-2 text-xs text-status-error"
+                    className="space-y-1 text-xs text-status-error"
                     role="alert"
                   >
-                    <AlertCircle className="w-3 h-3 mt-0.5 flex-shrink-0" aria-hidden="true" />
-                    <span>{patternError ?? error}</span>
+                    {[patternError, error].filter(Boolean).map((message) => (
+                      <div key={message} className="flex items-start gap-2">
+                        <AlertCircle className="w-3 h-3 mt-0.5 flex-shrink-0" aria-hidden="true" />
+                        <span>{message}</span>
+                      </div>
+                    ))}
                   </div>
                 )
               }

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -14,6 +14,7 @@ import {
   isDeletedWorktreeCleanupSeconds,
   DELETED_WORKTREE_CLEANUP_DEFAULT,
 } from "@/store/preferencesStore";
+import { FIELD_INPUT, FormGrid, FormRow } from "@/components/Worktree/views";
 import { FileBrowserVisibilitySettings } from "./FileBrowserVisibilitySettings";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSelect } from "./SettingsSelect";
@@ -159,6 +160,10 @@ export function WorktreeSettingsTab() {
     }
   };
 
+  // One hint slot, so validation and save failures can't stack two error rows
+  // under the field. Validation wins: it blocks the save that would report the other.
+  const patternError = !isLoading && !validation.valid ? validation.error : undefined;
+
   const handleReset = () => {
     setPattern(DEFAULT_WORKTREE_PATH_PATTERN);
     setError(null);
@@ -183,56 +188,58 @@ export function WorktreeSettingsTab() {
         description="Configure the default path pattern for new worktrees. Use variables to build dynamic paths based on your repository and branch names."
       >
         <div className="contents">
-          <div className="space-y-2">
-            <label htmlFor="path-pattern" className="block text-sm font-medium text-daintree-text">
-              Pattern
-            </label>
-            <div className="flex gap-2">
-              <input
-                id="path-pattern"
-                type="text"
-                value={pattern}
-                onChange={(e) => {
-                  setPattern(e.target.value);
-                  setError(null);
-                }}
-                disabled={isLoading}
-                className={cn(
-                  "flex-1 px-3 py-1.5 bg-daintree-bg border rounded-[var(--radius-md)] text-daintree-text font-mono text-sm",
-                  "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30",
-                  !validation.valid ? "border-status-error/50" : "border-daintree-border"
-                )}
-                placeholder="{parent-dir}/{base-folder}-worktrees/{branch-slug}"
-              />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={handleReset}
-                    disabled={isLoading}
-                    className="px-3 py-1.5 border border-daintree-border rounded-[var(--radius-md)] text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors disabled:opacity-50"
-                    aria-label="Reset to default"
+          <FormGrid>
+            <FormRow
+              label="Pattern"
+              htmlFor="path-pattern"
+              hint={
+                (patternError || error) && (
+                  <div
+                    id="path-pattern-error"
+                    className="flex items-start gap-2 text-xs text-status-error"
+                    role="alert"
                   >
-                    <RotateCcw className="w-4 h-4" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Reset to default</TooltipContent>
-              </Tooltip>
-            </div>
-
-            {!isLoading && !validation.valid && validation.error && (
-              <div className="flex items-start gap-2 text-xs text-status-error">
-                <AlertCircle className="w-3 h-3 mt-0.5 flex-shrink-0" />
-                <span>{validation.error}</span>
+                    <AlertCircle className="w-3 h-3 mt-0.5 flex-shrink-0" aria-hidden="true" />
+                    <span>{patternError ?? error}</span>
+                  </div>
+                )
+              }
+            >
+              <div className="flex gap-2">
+                <input
+                  id="path-pattern"
+                  type="text"
+                  value={pattern}
+                  onChange={(e) => {
+                    setPattern(e.target.value);
+                    setError(null);
+                  }}
+                  disabled={isLoading}
+                  aria-invalid={!!patternError}
+                  aria-describedby={patternError || error ? "path-pattern-error" : undefined}
+                  className={cn(
+                    FIELD_INPUT,
+                    "flex-1 min-w-0 font-mono",
+                    !validation.valid && "border-status-error/50"
+                  )}
+                  placeholder="{parent-dir}/{base-folder}-worktrees/{branch-slug}"
+                />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={handleReset}
+                      disabled={isLoading}
+                      className="px-3 py-1.5 border border-daintree-border rounded-[var(--radius-md)] text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors disabled:opacity-50"
+                      aria-label="Reset to default"
+                    >
+                      <RotateCcw className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Reset to default</TooltipContent>
+                </Tooltip>
               </div>
-            )}
-
-            {error && (
-              <div className="flex items-start gap-2 text-xs text-status-error">
-                <AlertCircle className="w-3 h-3 mt-0.5 flex-shrink-0" />
-                <span>{error}</span>
-              </div>
-            )}
-          </div>
+            </FormRow>
+          </FormGrid>
 
           <div className="space-y-2">
             <span className="block text-xs font-medium text-daintree-text/70">

--- a/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
+++ b/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
@@ -112,7 +112,9 @@ describe("ResourceEnvironmentsSection", () => {
       />
     );
 
-    const selector = screen.getByLabelText("Select environment");
+    // The rail's visible label is "Environment", so the select's own name has to
+    // match it rather than read "Select environment" (WCAG 2.5.3).
+    const selector = screen.getByLabelText("Environment");
     expect(selector).toBeTruthy();
 
     const options = selector.querySelectorAll("option");

--- a/src/components/Terminal/UpdateCwdDialog.tsx
+++ b/src/components/Terminal/UpdateCwdDialog.tsx
@@ -2,6 +2,8 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import type { KeyboardEvent } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
+import { FIELD_INPUT, FormGrid, FormRow } from "@/components/Worktree/views";
+import { cn } from "@/lib/utils";
 import { FolderOpen, AlertCircle } from "lucide-react";
 import { logError } from "@/utils/logger";
 import { systemClient } from "@/clients/systemClient";
@@ -89,23 +91,29 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
           terminal.
         </AppDialog.Description>
 
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-daintree-text/70 mb-1">
-              Current directory
-            </label>
+        <FormGrid>
+          <FormRow label="Current directory">
             <code className="block p-2 bg-[color-mix(in_oklab,var(--color-status-error)_10%,transparent)] border border-status-error/30 rounded text-sm text-status-error font-mono truncate">
               {currentCwd}
             </code>
-          </div>
+          </FormRow>
 
-          <div>
-            <label
-              htmlFor="new-cwd-input"
-              className="block text-sm font-medium text-daintree-text/70 mb-1"
-            >
-              New directory
-            </label>
+          <FormRow
+            label="New directory"
+            htmlFor="new-cwd-input"
+            hint={
+              validationError && (
+                <div
+                  id="cwd-error"
+                  className="flex items-center gap-1 text-xs text-status-error"
+                  role="alert"
+                >
+                  <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                  {validationError}
+                </div>
+              )
+            }
+          >
             <input
               ref={inputRef}
               id="new-cwd-input"
@@ -116,23 +124,13 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
                 setValidationError(undefined);
               }}
               onKeyDown={handleKeyDown}
-              className="w-full p-2 bg-daintree-bg border border-daintree-border rounded font-mono text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent/40"
+              className={cn(FIELD_INPUT, "font-mono")}
               placeholder="/path/to/directory"
               aria-invalid={!!validationError}
               aria-describedby={validationError ? "cwd-error" : undefined}
             />
-            {validationError && (
-              <div
-                id="cwd-error"
-                className="flex items-center gap-1 mt-1.5 text-sm text-status-error"
-                role="alert"
-              >
-                <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
-                {validationError}
-              </div>
-            )}
-          </div>
-        </div>
+          </FormRow>
+        </FormGrid>
       </AppDialog.Body>
 
       <AppDialog.Footer>

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -281,12 +281,12 @@ export function RecipeEditor({
               />
             </FormRow>
 
-            <FormRow label="Scope" htmlFor="recipe-scope">
+            {/* No `for` when editing: scope is then a read-only display with no
+                control to name, and `output` — the one labelable element that
+                fits — is a live region, which would announce static text. */}
+            <FormRow label="Scope" htmlFor={recipe ? undefined : "recipe-scope"}>
               {recipe ? (
-                // `output` rather than a div: a label can only name a labelable
-                // element, and the rail's label is a real `for`.
-                <output
-                  id="recipe-scope"
+                <div
                   className={cn(
                     FIELD_SURFACE,
                     "flex h-8 items-center px-2.5 text-sm text-daintree-text opacity-75"
@@ -295,7 +295,7 @@ export function RecipeEditor({
                   {isInRepoRecipeId(recipe) || recipe.projectId !== undefined
                     ? "Project"
                     : "Global (all projects)"}
-                </output>
+                </div>
               ) : (
                 <select
                   id="recipe-scope"
@@ -661,7 +661,7 @@ export function RecipeEditor({
           </FormGrid>
 
           {error && (
-            <div className="mb-4 p-3 bg-status-error/10 border border-status-error/30 rounded-[var(--radius-md)] text-status-error text-sm">
+            <div className="mt-4 mb-4 p-3 bg-status-error/10 border border-status-error/30 rounded-[var(--radius-md)] text-status-error text-sm">
               {error}
             </div>
           )}

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -8,7 +8,15 @@ import { useProjectStore } from "@/store/projectStore";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import {
+  FIELD_INPUT,
+  FIELD_SURFACE,
+  FormGrid,
+  FormRow,
+  FormSection,
+} from "@/components/Worktree/views";
 import { RecipeVariablePreview } from "@/components/TerminalRecipe/RecipeVariablePreview";
+import { cn } from "@/lib/utils";
 
 function cloneTerminal(t: RecipeTerminal): RecipeTerminal {
   return { ...t, env: t.env ? { ...t.env } : {} };
@@ -261,51 +269,56 @@ export function RecipeEditor({
         </AppDialog.Header>
 
         <AppDialog.Body>
-          <div className="mb-4">
-            <label
-              htmlFor="recipe-name"
-              className="block text-sm font-medium text-daintree-text mb-1"
-            >
-              Recipe Name
-            </label>
-            <input
-              id="recipe-name"
-              type="text"
-              value={recipeName}
-              onChange={(e) => setRecipeName(e.target.value)}
-              placeholder="e.g., Full Stack Dev"
-              className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
-            />
-          </div>
+          <FormGrid>
+            <FormRow label="Recipe Name" htmlFor="recipe-name">
+              <input
+                id="recipe-name"
+                type="text"
+                value={recipeName}
+                onChange={(e) => setRecipeName(e.target.value)}
+                placeholder="e.g., Full Stack Dev"
+                className={FIELD_INPUT}
+              />
+            </FormRow>
 
-          <div className="mb-4">
-            <label
-              htmlFor="recipe-scope"
-              className="block text-sm font-medium text-daintree-text mb-1"
-            >
-              Scope
-            </label>
-            {recipe ? (
-              <div className="px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text text-sm opacity-75">
-                {isInRepoRecipeId(recipe) || recipe.projectId !== undefined
-                  ? "Project"
-                  : "Global (all projects)"}
-              </div>
-            ) : (
-              <select
-                id="recipe-scope"
-                value={scope}
-                onChange={(e) => setScope(e.target.value as "global" | "project")}
-                className="w-full px-3 pr-8 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
-              >
-                <option value="project">Project (current project only)</option>
-                <option value="global">Global (all projects)</option>
-              </select>
-            )}
-          </div>
+            <FormRow label="Scope" htmlFor="recipe-scope">
+              {recipe ? (
+                // `output` rather than a div: a label can only name a labelable
+                // element, and the rail's label is a real `for`.
+                <output
+                  id="recipe-scope"
+                  className={cn(
+                    FIELD_SURFACE,
+                    "flex h-8 items-center px-2.5 text-sm text-daintree-text opacity-75"
+                  )}
+                >
+                  {isInRepoRecipeId(recipe) || recipe.projectId !== undefined
+                    ? "Project"
+                    : "Global (all projects)"}
+                </output>
+              ) : (
+                <select
+                  id="recipe-scope"
+                  value={scope}
+                  onChange={(e) => setScope(e.target.value as "global" | "project")}
+                  className={cn(FIELD_INPUT, "pr-8")}
+                >
+                  <option value="project">Project (current project only)</option>
+                  <option value="global">Global (all projects)</option>
+                </select>
+              )}
+            </FormRow>
 
-          <div className="mb-4">
-            <label className="flex items-center gap-2 cursor-pointer">
+            <FormRow
+              label="Show in Empty State"
+              htmlFor="show-in-empty-state"
+              hint={
+                <p id="show-in-empty-state-help" className="text-xs text-text-muted select-text">
+                  Display this recipe as a primary launcher when the worktree has no active
+                  terminals
+                </p>
+              }
+            >
               <input
                 id="show-in-empty-state"
                 type="checkbox"
@@ -314,346 +327,338 @@ export function RecipeEditor({
                 aria-describedby="show-in-empty-state-help"
                 className="w-4 h-4 rounded border-daintree-border bg-daintree-bg checked:bg-daintree-accent checked:border-daintree-accent focus:ring-2 focus:ring-daintree-accent/30"
               />
-              <span className="text-sm font-medium text-daintree-text">Show in Empty State</span>
-            </label>
-            <p
-              id="show-in-empty-state-help"
-              className="text-xs text-text-muted mt-1 ml-6 select-text"
-            >
-              Display this recipe as a primary launcher when the worktree has no active terminals
-            </p>
-          </div>
+            </FormRow>
 
-          <div className="mb-4">
-            <label
+            <FormRow
+              label="Auto-assign Issue"
               htmlFor="auto-assign"
-              className="block text-sm font-medium text-daintree-text mb-1"
+              hint={
+                <p id="auto-assign-help" className="text-xs text-text-muted select-text">
+                  Controls whether the linked GitHub issue is automatically assigned to you during
+                  quick worktree creation
+                </p>
+              }
             >
-              Auto-assign Issue
-            </label>
-            <select
-              id="auto-assign"
-              value={autoAssign}
-              onChange={(e) => setAutoAssign(e.target.value as "always" | "never" | "prompt")}
-              aria-describedby="auto-assign-help"
-              className="w-full px-3 pr-8 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
-            >
-              <option value="always">Always assign to me</option>
-              <option value="prompt">Ask before assigning</option>
-              <option value="never">Never assign</option>
-            </select>
-            <p id="auto-assign-help" className="text-xs text-text-muted mt-1 select-text">
-              Controls whether the linked GitHub issue is automatically assigned to you during quick
-              worktree creation
-            </p>
-          </div>
-
-          <div className="mb-4">
-            <div className="flex items-center justify-between mb-2">
-              <label className="block text-sm font-medium text-daintree-text">
-                Terminals ({terminals.length}/{MAX_TERMINALS_PER_RECIPE})
-              </label>
-              <Button
-                size="sm"
-                onClick={handleAddTerminal}
-                disabled={terminals.length >= MAX_TERMINALS_PER_RECIPE}
+              <select
+                id="auto-assign"
+                value={autoAssign}
+                onChange={(e) => setAutoAssign(e.target.value as "always" | "never" | "prompt")}
+                aria-describedby="auto-assign-help"
+                className={cn(FIELD_INPUT, "pr-8")}
               >
-                + Add Terminal
-              </Button>
-            </div>
+                <option value="always">Always assign to me</option>
+                <option value="prompt">Ask before assigning</option>
+                <option value="never">Never assign</option>
+              </select>
+            </FormRow>
 
-            <div className="space-y-3">
-              {terminals.map((terminal, index) => (
-                <div
-                  key={index}
-                  className="bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] p-3"
+            <FormSection
+              title={`Terminals (${terminals.length}/${MAX_TERMINALS_PER_RECIPE})`}
+              action={
+                <Button
+                  size="sm"
+                  onClick={handleAddTerminal}
+                  disabled={terminals.length >= MAX_TERMINALS_PER_RECIPE}
                 >
-                  <div className="flex items-start gap-3">
-                    <div className="flex-1">
-                      <label
-                        htmlFor={`terminal-type-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        Type
-                      </label>
-                      <select
-                        id={`terminal-type-${index}`}
-                        value={terminal.type}
-                        onChange={(e) => {
-                          const newType = e.target.value as RecipeTerminalType;
-                          setTerminals((prev) => {
-                            const updated = [...prev];
-                            const current = updated[index];
-                            if (!current) return prev;
-                            const prevType = current.type;
-                            updated[index] = {
-                              ...current,
-                              type: newType,
-                              // Clear command when switching between types so the new type uses its default
-                              command: newType === prevType ? current.command : "",
-                              // Clear initialPrompt and args when switching to terminal or dev-preview
-                              initialPrompt:
-                                newType === "terminal" || newType === "dev-preview"
-                                  ? ""
-                                  : current.initialPrompt,
-                              args:
-                                newType === "terminal" || newType === "dev-preview"
-                                  ? ""
-                                  : current.args,
-                              // Clear devCommand when switching away from dev-preview
-                              devCommand: newType !== "dev-preview" ? "" : current.devCommand,
-                            };
-                            return updated;
-                          });
-                        }}
-                        className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                      >
-                        {TERMINAL_TYPES.map((type) => (
-                          <option key={type} value={type}>
-                            {TYPE_LABELS[type]}
-                          </option>
-                        ))}
-                      </select>
+                  + Add Terminal
+                </Button>
+              }
+            >
+              {/* Repeated cards, each with its own internal fields — they are not
+                  rows on this form's rail, so they span it rather than join it. */}
+              <div className="col-span-2 space-y-3">
+                {terminals.map((terminal, index) => (
+                  <div
+                    key={index}
+                    className="bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] p-3"
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="flex-1">
+                        <label
+                          htmlFor={`terminal-type-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          Type
+                        </label>
+                        <select
+                          id={`terminal-type-${index}`}
+                          value={terminal.type}
+                          onChange={(e) => {
+                            const newType = e.target.value as RecipeTerminalType;
+                            setTerminals((prev) => {
+                              const updated = [...prev];
+                              const current = updated[index];
+                              if (!current) return prev;
+                              const prevType = current.type;
+                              updated[index] = {
+                                ...current,
+                                type: newType,
+                                // Clear command when switching between types so the new type uses its default
+                                command: newType === prevType ? current.command : "",
+                                // Clear initialPrompt and args when switching to terminal or dev-preview
+                                initialPrompt:
+                                  newType === "terminal" || newType === "dev-preview"
+                                    ? ""
+                                    : current.initialPrompt,
+                                args:
+                                  newType === "terminal" || newType === "dev-preview"
+                                    ? ""
+                                    : current.args,
+                                // Clear devCommand when switching away from dev-preview
+                                devCommand: newType !== "dev-preview" ? "" : current.devCommand,
+                              };
+                              return updated;
+                            });
+                          }}
+                          className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                        >
+                          {TERMINAL_TYPES.map((type) => (
+                            <option key={type} value={type}>
+                              {TYPE_LABELS[type]}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="flex-1">
+                        <label
+                          htmlFor={`terminal-title-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          Title (optional)
+                        </label>
+                        <input
+                          id={`terminal-title-${index}`}
+                          type="text"
+                          value={terminal.title || ""}
+                          onChange={(e) => handleTerminalChange(index, "title", e.target.value)}
+                          placeholder="Default"
+                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                        />
+                      </div>
+
+                      <div className="pt-5">
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => handleRemoveTerminal(index)}
+                          disabled={terminals.length === 1}
+                        >
+                          Remove
+                        </Button>
+                      </div>
                     </div>
 
-                    <div className="flex-1">
-                      <label
-                        htmlFor={`terminal-title-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        Title (optional)
-                      </label>
-                      <input
-                        id={`terminal-title-${index}`}
-                        type="text"
-                        value={terminal.title || ""}
-                        onChange={(e) => handleTerminalChange(index, "title", e.target.value)}
-                        placeholder="Default"
-                        className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                      />
-                    </div>
+                    {terminal.type === "terminal" && (
+                      <>
+                        <div className="mt-2">
+                          <label
+                            htmlFor={`terminal-command-${index}`}
+                            className="block text-xs font-medium text-daintree-text mb-1"
+                          >
+                            Command (optional)
+                          </label>
+                          <input
+                            id={`terminal-command-${index}`}
+                            type="text"
+                            value={terminal.command || ""}
+                            onChange={(e) => handleTerminalChange(index, "command", e.target.value)}
+                            placeholder="e.g., npm run dev"
+                            className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                          />
+                        </div>
+                        <div className="mt-2">
+                          <label
+                            htmlFor={`terminal-exit-behavior-${index}`}
+                            className="block text-xs font-medium text-daintree-text mb-1"
+                          >
+                            After Exit
+                          </label>
+                          <select
+                            id={`terminal-exit-behavior-${index}`}
+                            value={terminal.exitBehavior || "trash"}
+                            onChange={(e) =>
+                              handleTerminalChange(
+                                index,
+                                "exitBehavior",
+                                e.target.value === "trash" ? "" : e.target.value
+                              )
+                            }
+                            aria-describedby={`terminal-exit-behavior-help-${index}`}
+                            className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                          >
+                            <option value="trash">Send to Trash (default)</option>
+                            <option value="keep">Keep for Review</option>
+                            <option value="remove">Remove Completely</option>
+                          </select>
+                          <p
+                            id={`terminal-exit-behavior-help-${index}`}
+                            className="text-xs text-text-muted mt-1 select-text"
+                          >
+                            {FAILURE_PRESERVE_CAPTION}
+                          </p>
+                        </div>
+                      </>
+                    )}
 
-                    <div className="pt-5">
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        onClick={() => handleRemoveTerminal(index)}
-                        disabled={terminals.length === 1}
-                      >
-                        Remove
-                      </Button>
-                    </div>
+                    {terminal.type !== "terminal" && terminal.type !== "dev-preview" && (
+                      <>
+                        <div className="mt-2">
+                          <label
+                            htmlFor={`terminal-args-${index}`}
+                            className="block text-xs font-medium text-daintree-text mb-1"
+                          >
+                            Arguments (optional)
+                          </label>
+                          <input
+                            id={`terminal-args-${index}`}
+                            type="text"
+                            value={terminal.args || ""}
+                            onChange={(e) => handleTerminalChange(index, "args", e.target.value)}
+                            placeholder="e.g., --model claude-opus-4-5"
+                            aria-describedby={`terminal-args-help-${index}`}
+                            className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                          />
+                          <p
+                            id={`terminal-args-help-${index}`}
+                            className="text-xs text-text-muted mt-1 select-text"
+                          >
+                            Additional CLI arguments passed to the agent at launch
+                          </p>
+                        </div>
+                        <div className="mt-2">
+                          <label
+                            htmlFor={`terminal-initial-prompt-${index}`}
+                            className="block text-xs font-medium text-daintree-text mb-1"
+                          >
+                            Initial Prompt (optional)
+                          </label>
+                          <textarea
+                            id={`terminal-initial-prompt-${index}`}
+                            value={terminal.initialPrompt || ""}
+                            onChange={(e) =>
+                              handleTerminalChange(index, "initialPrompt", e.target.value)
+                            }
+                            placeholder="e.g., Review the latest changes and suggest improvements"
+                            rows={2}
+                            aria-describedby={`terminal-initial-prompt-help-${index}`}
+                            className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text resize-y min-h-[60px]"
+                          />
+                          <RecipeVariablePreview
+                            initialPrompt={terminal.initialPrompt || ""}
+                            worktreeId={worktreeId ?? recipe?.worktreeId}
+                          />
+                          <p
+                            id={`terminal-initial-prompt-help-${index}`}
+                            className="text-xs text-text-muted mt-1 select-text"
+                          >
+                            Variables:{" "}
+                            <code className="text-daintree-text/70">{"{{issue_number}}"}</code>,{" "}
+                            <code className="text-daintree-text/70">{"{{pr_number}}"}</code>,{" "}
+                            <code className="text-daintree-text/70">{"{{number}}"}</code>,{" "}
+                            <code className="text-daintree-text/70">{"{{worktree_path}}"}</code>,{" "}
+                            <code className="text-daintree-text/70">{"{{branch_name}}"}</code>
+                          </p>
+                        </div>
+                        <div className="mt-2">
+                          <label
+                            htmlFor={`terminal-agent-exit-behavior-${index}`}
+                            className="block text-xs font-medium text-daintree-text mb-1"
+                          >
+                            After Exit
+                          </label>
+                          <select
+                            id={`terminal-agent-exit-behavior-${index}`}
+                            value={terminal.exitBehavior || "keep"}
+                            onChange={(e) =>
+                              handleTerminalChange(
+                                index,
+                                "exitBehavior",
+                                e.target.value === "keep" ? "" : e.target.value
+                              )
+                            }
+                            aria-describedby={`terminal-agent-exit-behavior-help-${index}`}
+                            className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                          >
+                            <option value="keep">Keep for Review (default)</option>
+                            <option value="trash">Send to Trash</option>
+                            <option value="remove">Remove Completely</option>
+                          </select>
+                          <p
+                            id={`terminal-agent-exit-behavior-help-${index}`}
+                            className="text-xs text-text-muted mt-1 select-text"
+                          >
+                            {FAILURE_PRESERVE_CAPTION}
+                          </p>
+                        </div>
+                      </>
+                    )}
+
+                    {terminal.type === "dev-preview" && (
+                      <>
+                        <div className="mt-2">
+                          <label
+                            htmlFor={`terminal-dev-command-${index}`}
+                            className="block text-xs font-medium text-daintree-text mb-1"
+                          >
+                            Dev Command (optional)
+                          </label>
+                          <input
+                            id={`terminal-dev-command-${index}`}
+                            type="text"
+                            value={terminal.devCommand || ""}
+                            onChange={(e) =>
+                              handleTerminalChange(index, "devCommand", e.target.value)
+                            }
+                            placeholder="e.g., npm run dev"
+                            aria-describedby={`terminal-dev-command-help-${index}`}
+                            className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                          />
+                          <p
+                            id={`terminal-dev-command-help-${index}`}
+                            className="text-xs text-text-muted mt-1 select-text"
+                          >
+                            Leave empty to use project default or auto-detect from package.json
+                          </p>
+                        </div>
+                        <div className="mt-2">
+                          <label
+                            htmlFor={`terminal-dev-exit-behavior-${index}`}
+                            className="block text-xs font-medium text-daintree-text mb-1"
+                          >
+                            After Exit
+                          </label>
+                          <select
+                            id={`terminal-dev-exit-behavior-${index}`}
+                            value={terminal.exitBehavior || "trash"}
+                            onChange={(e) =>
+                              handleTerminalChange(
+                                index,
+                                "exitBehavior",
+                                e.target.value === "trash" ? "" : e.target.value
+                              )
+                            }
+                            aria-describedby={`terminal-dev-exit-behavior-help-${index}`}
+                            className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                          >
+                            <option value="trash">Send to Trash (default)</option>
+                            <option value="keep">Keep for Review</option>
+                            <option value="remove">Remove Completely</option>
+                          </select>
+                          <p
+                            id={`terminal-dev-exit-behavior-help-${index}`}
+                            className="text-xs text-text-muted mt-1 select-text"
+                          >
+                            {FAILURE_PRESERVE_CAPTION}
+                          </p>
+                        </div>
+                      </>
+                    )}
                   </div>
-
-                  {terminal.type === "terminal" && (
-                    <>
-                      <div className="mt-2">
-                        <label
-                          htmlFor={`terminal-command-${index}`}
-                          className="block text-xs font-medium text-daintree-text mb-1"
-                        >
-                          Command (optional)
-                        </label>
-                        <input
-                          id={`terminal-command-${index}`}
-                          type="text"
-                          value={terminal.command || ""}
-                          onChange={(e) => handleTerminalChange(index, "command", e.target.value)}
-                          placeholder="e.g., npm run dev"
-                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                        />
-                      </div>
-                      <div className="mt-2">
-                        <label
-                          htmlFor={`terminal-exit-behavior-${index}`}
-                          className="block text-xs font-medium text-daintree-text mb-1"
-                        >
-                          After Exit
-                        </label>
-                        <select
-                          id={`terminal-exit-behavior-${index}`}
-                          value={terminal.exitBehavior || "trash"}
-                          onChange={(e) =>
-                            handleTerminalChange(
-                              index,
-                              "exitBehavior",
-                              e.target.value === "trash" ? "" : e.target.value
-                            )
-                          }
-                          aria-describedby={`terminal-exit-behavior-help-${index}`}
-                          className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                        >
-                          <option value="trash">Send to Trash (default)</option>
-                          <option value="keep">Keep for Review</option>
-                          <option value="remove">Remove Completely</option>
-                        </select>
-                        <p
-                          id={`terminal-exit-behavior-help-${index}`}
-                          className="text-xs text-text-muted mt-1 select-text"
-                        >
-                          {FAILURE_PRESERVE_CAPTION}
-                        </p>
-                      </div>
-                    </>
-                  )}
-
-                  {terminal.type !== "terminal" && terminal.type !== "dev-preview" && (
-                    <>
-                      <div className="mt-2">
-                        <label
-                          htmlFor={`terminal-args-${index}`}
-                          className="block text-xs font-medium text-daintree-text mb-1"
-                        >
-                          Arguments (optional)
-                        </label>
-                        <input
-                          id={`terminal-args-${index}`}
-                          type="text"
-                          value={terminal.args || ""}
-                          onChange={(e) => handleTerminalChange(index, "args", e.target.value)}
-                          placeholder="e.g., --model claude-opus-4-5"
-                          aria-describedby={`terminal-args-help-${index}`}
-                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                        />
-                        <p
-                          id={`terminal-args-help-${index}`}
-                          className="text-xs text-text-muted mt-1 select-text"
-                        >
-                          Additional CLI arguments passed to the agent at launch
-                        </p>
-                      </div>
-                      <div className="mt-2">
-                        <label
-                          htmlFor={`terminal-initial-prompt-${index}`}
-                          className="block text-xs font-medium text-daintree-text mb-1"
-                        >
-                          Initial Prompt (optional)
-                        </label>
-                        <textarea
-                          id={`terminal-initial-prompt-${index}`}
-                          value={terminal.initialPrompt || ""}
-                          onChange={(e) =>
-                            handleTerminalChange(index, "initialPrompt", e.target.value)
-                          }
-                          placeholder="e.g., Review the latest changes and suggest improvements"
-                          rows={2}
-                          aria-describedby={`terminal-initial-prompt-help-${index}`}
-                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text resize-y min-h-[60px]"
-                        />
-                        <RecipeVariablePreview
-                          initialPrompt={terminal.initialPrompt || ""}
-                          worktreeId={worktreeId ?? recipe?.worktreeId}
-                        />
-                        <p
-                          id={`terminal-initial-prompt-help-${index}`}
-                          className="text-xs text-text-muted mt-1 select-text"
-                        >
-                          Variables:{" "}
-                          <code className="text-daintree-text/70">{"{{issue_number}}"}</code>,{" "}
-                          <code className="text-daintree-text/70">{"{{pr_number}}"}</code>,{" "}
-                          <code className="text-daintree-text/70">{"{{number}}"}</code>,{" "}
-                          <code className="text-daintree-text/70">{"{{worktree_path}}"}</code>,{" "}
-                          <code className="text-daintree-text/70">{"{{branch_name}}"}</code>
-                        </p>
-                      </div>
-                      <div className="mt-2">
-                        <label
-                          htmlFor={`terminal-agent-exit-behavior-${index}`}
-                          className="block text-xs font-medium text-daintree-text mb-1"
-                        >
-                          After Exit
-                        </label>
-                        <select
-                          id={`terminal-agent-exit-behavior-${index}`}
-                          value={terminal.exitBehavior || "keep"}
-                          onChange={(e) =>
-                            handleTerminalChange(
-                              index,
-                              "exitBehavior",
-                              e.target.value === "keep" ? "" : e.target.value
-                            )
-                          }
-                          aria-describedby={`terminal-agent-exit-behavior-help-${index}`}
-                          className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                        >
-                          <option value="keep">Keep for Review (default)</option>
-                          <option value="trash">Send to Trash</option>
-                          <option value="remove">Remove Completely</option>
-                        </select>
-                        <p
-                          id={`terminal-agent-exit-behavior-help-${index}`}
-                          className="text-xs text-text-muted mt-1 select-text"
-                        >
-                          {FAILURE_PRESERVE_CAPTION}
-                        </p>
-                      </div>
-                    </>
-                  )}
-
-                  {terminal.type === "dev-preview" && (
-                    <>
-                      <div className="mt-2">
-                        <label
-                          htmlFor={`terminal-dev-command-${index}`}
-                          className="block text-xs font-medium text-daintree-text mb-1"
-                        >
-                          Dev Command (optional)
-                        </label>
-                        <input
-                          id={`terminal-dev-command-${index}`}
-                          type="text"
-                          value={terminal.devCommand || ""}
-                          onChange={(e) =>
-                            handleTerminalChange(index, "devCommand", e.target.value)
-                          }
-                          placeholder="e.g., npm run dev"
-                          aria-describedby={`terminal-dev-command-help-${index}`}
-                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                        />
-                        <p
-                          id={`terminal-dev-command-help-${index}`}
-                          className="text-xs text-text-muted mt-1 select-text"
-                        >
-                          Leave empty to use project default or auto-detect from package.json
-                        </p>
-                      </div>
-                      <div className="mt-2">
-                        <label
-                          htmlFor={`terminal-dev-exit-behavior-${index}`}
-                          className="block text-xs font-medium text-daintree-text mb-1"
-                        >
-                          After Exit
-                        </label>
-                        <select
-                          id={`terminal-dev-exit-behavior-${index}`}
-                          value={terminal.exitBehavior || "trash"}
-                          onChange={(e) =>
-                            handleTerminalChange(
-                              index,
-                              "exitBehavior",
-                              e.target.value === "trash" ? "" : e.target.value
-                            )
-                          }
-                          aria-describedby={`terminal-dev-exit-behavior-help-${index}`}
-                          className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                        >
-                          <option value="trash">Send to Trash (default)</option>
-                          <option value="keep">Keep for Review</option>
-                          <option value="remove">Remove Completely</option>
-                        </select>
-                        <p
-                          id={`terminal-dev-exit-behavior-help-${index}`}
-                          className="text-xs text-text-muted mt-1 select-text"
-                        >
-                          {FAILURE_PRESERVE_CAPTION}
-                        </p>
-                      </div>
-                    </>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
+                ))}
+              </div>
+            </FormSection>
+          </FormGrid>
 
           {error && (
             <div className="mb-4 p-3 bg-status-error/10 border border-status-error/30 rounded-[var(--radius-md)] text-status-error text-sm">

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -24,6 +24,14 @@ import { useProjectStore } from "@/store/projectStore";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
+import {
+  FIELD_FOCUS,
+  FIELD_INPUT,
+  FIELD_SURFACE,
+  FormGrid,
+  FormRow,
+} from "@/components/Worktree/views";
+import { cn } from "@/lib/utils";
 import type { TerminalRecipe } from "@/types";
 import { useRef } from "react";
 import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
@@ -541,27 +549,42 @@ export function RecipeManager({
         </AppDialog.Header>
 
         <AppDialog.Body>
-          <div className="mb-4">
-            <label className="block text-sm font-medium text-daintree-text mb-1">Import as</label>
-            <select
-              value={importScope}
-              onChange={(e) => setImportScope(e.target.value as "global" | "project")}
-              className="w-full px-3 pr-8 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text text-sm"
-            >
-              <option value="project">Project Recipe</option>
-              <option value="global">Global Recipe</option>
-            </select>
-          </div>
+          <FormGrid>
+            <FormRow label="Import as" htmlFor="recipe-import-scope">
+              <select
+                id="recipe-import-scope"
+                value={importScope}
+                onChange={(e) => setImportScope(e.target.value as "global" | "project")}
+                className={cn(FIELD_INPUT, "pr-8")}
+              >
+                <option value="project">Project Recipe</option>
+                <option value="global">Global Recipe</option>
+              </select>
+            </FormRow>
+          </FormGrid>
+
+          {/* Off the rail deliberately: pasted recipe JSON needs the dialog's
+              full width more than it needs a label column. */}
           <textarea
             value={importJson}
             onChange={(e) => setImportJson(e.target.value)}
             data-testid="recipe-import-textarea"
+            aria-label="Recipe JSON"
+            aria-describedby={importError ? "recipe-import-error" : undefined}
             placeholder='{"name": "My Recipe", "terminals": [...]}'
-            className="w-full h-48 px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text font-mono focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30 resize-none"
+            className={cn(
+              FIELD_SURFACE,
+              FIELD_FOCUS,
+              "mt-3 w-full h-48 px-2.5 py-2 text-sm text-daintree-text font-mono resize-none",
+              "placeholder:text-text-placeholder"
+            )}
             spellCheck={false}
           />
           {importError && (
-            <div className="mt-3 text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3">
+            <div
+              id="recipe-import-error"
+              className="mt-3 text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3"
+            >
               {importError}
             </div>
           )}

--- a/src/components/Worktree/views/WorktreeFormLayout.tsx
+++ b/src/components/Worktree/views/WorktreeFormLayout.tsx
@@ -92,6 +92,13 @@ interface FormRowProps {
    * group". Keep the control's name matching the visible label (WCAG 2.5.3).
    */
   selfLabelled?: boolean;
+  /**
+   * Escape hatch on the label cell, for rows the grid's defaults don't suit —
+   * `self-start` for a control taller than one line, a `max-w-*` cap for a
+   * label the app doesn't author (a plugin manifest's, say) and so can't keep
+   * short enough to leave the rail a sane width.
+   */
+  labelClassName?: string;
   children: React.ReactNode;
 }
 
@@ -105,19 +112,27 @@ interface FormRowProps {
  * cannot be, so it labels the control region as a `role="group"` instead —
  * visually aligned is not the same as programmatically named.
  */
-export function FormRow({ label, htmlFor, hint, selfLabelled, children }: FormRowProps) {
+export function FormRow({
+  label,
+  htmlFor,
+  hint,
+  selfLabelled,
+  labelClassName,
+  children,
+}: FormRowProps) {
   const labelId = useId();
   const needsGroupLabel = !!label && !htmlFor && !selfLabelled;
+  const labelClasses = cn(LABEL_CLASSES, labelClassName);
 
   return (
     <>
       {label ? (
         htmlFor ? (
-          <label htmlFor={htmlFor} className={LABEL_CLASSES}>
+          <label htmlFor={htmlFor} className={labelClasses}>
             {label}
           </label>
         ) : (
-          <span id={labelId} className={LABEL_CLASSES}>
+          <span id={labelId} className={labelClasses}>
             {label}
           </span>
         )

--- a/src/components/Worktree/views/__tests__/WorktreeFormLayout.test.tsx
+++ b/src/components/Worktree/views/__tests__/WorktreeFormLayout.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FormGrid, FormRow } from "../WorktreeFormLayout";
+
+describe("FormRow label semantics", () => {
+  it("names a single control with a real label association", () => {
+    render(
+      <FormGrid>
+        <FormRow label="Base" htmlFor="base-branch">
+          <input id="base-branch" />
+        </FormRow>
+      </FormGrid>
+    );
+
+    expect(screen.getByLabelText("Base")).toBe(screen.getByRole("textbox"));
+    expect(screen.queryByRole("group")).toBeNull();
+  });
+
+  it("names a composite control region as a group when there is no single control to point at", () => {
+    render(
+      <FormGrid>
+        <FormRow label="Mode">
+          <input type="radio" name="mode" aria-label="Local" />
+          <input type="radio" name="mode" aria-label="Remote" />
+        </FormRow>
+      </FormGrid>
+    );
+
+    const group = screen.getByRole("group", { name: "Mode" });
+    expect(group.querySelectorAll("input")).toHaveLength(2);
+  });
+
+  it("skips the group wrapper when the control already names itself", () => {
+    render(
+      <FormGrid>
+        <FormRow label="Environment" selfLabelled>
+          <div role="radiogroup" aria-label="Environment" />
+        </FormRow>
+      </FormGrid>
+    );
+
+    // Without the skip, the name would be announced twice — once for the
+    // wrapper group, once for the radiogroup inside it.
+    expect(screen.queryByRole("group")).toBeNull();
+    expect(screen.getByRole("radiogroup", { name: "Environment" })).toBeTruthy();
+  });
+
+  it("renders no hint cell at all when the hint is absent", () => {
+    const withoutHint = render(
+      <FormGrid>
+        <FormRow label="Path" htmlFor="p" hint={null}>
+          <input id="p" />
+        </FormRow>
+      </FormGrid>
+    );
+    const gridWithout = withoutHint.container.firstElementChild!;
+
+    const withHint = render(
+      <FormGrid>
+        <FormRow label="Path" htmlFor="q" hint={<span>relative to the repo</span>}>
+          <input id="q" />
+        </FormRow>
+      </FormGrid>
+    );
+    const gridWith = withHint.container.firstElementChild!;
+
+    // An always-rendered hint cell would eat a grid row and space every field apart.
+    expect(gridWithout.children).toHaveLength(2);
+    expect(gridWith.children).toHaveLength(3);
+  });
+
+  it("still occupies the label column when a row has no label", () => {
+    const { container } = render(
+      <FormGrid>
+        <FormRow>
+          <input />
+        </FormRow>
+      </FormGrid>
+    );
+
+    // Skipping the cell would slide the control into the label column.
+    expect(container.firstElementChild!.children).toHaveLength(2);
+  });
+});

--- a/src/components/Worktree/views/__tests__/WorktreeFormLayout.test.tsx
+++ b/src/components/Worktree/views/__tests__/WorktreeFormLayout.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { FormGrid, FormRow } from "../WorktreeFormLayout";
+import { FormGrid, FormRow, FormSection } from "../WorktreeFormLayout";
 
 describe("FormRow label semantics", () => {
   it("names a single control with a real label association", () => {
@@ -68,6 +68,24 @@ describe("FormRow label semantics", () => {
     // An always-rendered hint cell would eat a grid row and space every field apart.
     expect(gridWithout.children).toHaveLength(2);
     expect(gridWith.children).toHaveLength(3);
+  });
+
+  it("spans a section header across both columns instead of taking a rail cell", () => {
+    const { container } = render(
+      <FormGrid>
+        <FormSection title="Branch">
+          <FormRow label="Name" htmlFor="n">
+            <input id="n" />
+          </FormRow>
+        </FormSection>
+      </FormGrid>
+    );
+
+    // Header, then the row's two cells — a wrapper element around the section
+    // would give its rows their own columns and break the shared rail.
+    const cells = container.firstElementChild!.children;
+    expect(cells).toHaveLength(3);
+    expect(cells[0]?.textContent).toContain("Branch");
   });
 
   it("still occupies the label column when a row has no label", () => {

--- a/src/components/Worktree/views/index.ts
+++ b/src/components/Worktree/views/index.ts
@@ -8,4 +8,12 @@ export { NewBranchInput } from "./NewBranchInput";
 export { WorktreePathPicker } from "./WorktreePathPicker";
 export { EnvironmentRadioGroup } from "./EnvironmentRadioGroup";
 export { RecipePickerPopover } from "./RecipePickerPopover";
-export { FormGrid, FormSection, FormRow } from "./WorktreeFormLayout";
+export {
+  FormGrid,
+  FormSection,
+  FormRow,
+  FIELD_SURFACE,
+  FIELD_FOCUS,
+  FIELD_INPUT,
+  FIELD_TRIGGER,
+} from "./WorktreeFormLayout";


### PR DESCRIPTION
## Summary

Seven forms still put each field's label on its own row above the control. They now use the shared label rail, `FormGrid`/`FormSection`/`FormRow` from `src/components/Worktree/views/WorktreeFormLayout.tsx`, which was previously only used by `NewWorktreeDialog`: `UpdateCwdDialog`, `CodeForgeTab`, `RecipeManager`'s import dialog, `WorktreeSettingsTab`'s pattern field, `RecipeEditor`, `CommandBuilder`, and `ResourceEnvironmentsSection`.

Resolves #11965

## Changes

- Migrated all seven forms onto the shared rail. Several fields had no label association at all before and now have one: both `CodeForgeTab` selects, `ResourceEnvironments`' status and connect commands, and the default worktree mode radios, which get a named group via `FormRow`'s `role="group"` path.
- Repeated-row editors stay off the rail and span it instead. `RecipeEditor`'s terminal cards and `ResourceEnvironments`' command lists don't move onto the rail, since a card that repeats N times isn't a rail row.
- `FormRow` gained one optional `labelClassName` escape hatch, used by `CommandBuilder` to cap manifest-supplied labels (the app doesn't author these, so they can't be kept short) and to top-align a textarea's label.
- Two deliberate deferrals, left as follow-ups: the primitives were not relocated to `src/components/ui/` as the issue suggested, since that would triple the diff with rename churn and #11964 is still open and will adopt the same rail; and existing label text was preserved verbatim rather than sentence-cased, since three release-gating e2e specs pin the exact string "Default Worktree Mode".

## Testing

- 902 tests passing across every suite touching the branch: the label rail and `CommandBuilder` (10), `src/config/__tests__` contract suites (411), `CodeForgeTab`/`ResourceEnvironments`/`NewWorktreeDialog`/`RecipesTab` (75), recipe stores and settings primitives (357), sidebar empty-state (49). New tests cover `FormRow`'s three label strategies and `CommandBuilder`'s manifest field rendering, neither of which had coverage before.
- `npm run typecheck` clean
- `prettier --check` clean on all 12 changed files
- `eslint` 0 errors, no lint-ratchet regression
