### PR TITLE
feat(ui): make the high-contrast neutral button the standard dialog primary action

### DIFF
--- a/e2e/screenshots/confirm-dialog-review.spec.ts
+++ b/e2e/screenshots/confirm-dialog-review.spec.ts
@@ -1,0 +1,303 @@
+/**
+ * Dialog primary-action visual-review harness.
+ *
+ * #11963 made the high-contrast neutral button (`variant="contrast"` — the theme's own
+ * body-text colour as the fill) the standard dialog primary action, replacing the accent
+ * fill. That reads differently in every theme, and the failure mode is a fill that
+ * disappears into the panel behind it, so the change is judged on rendered pixels.
+ *
+ * Captures one state per code path the change touches:
+ *
+ *   preset      `AppDialog.Footer primaryAction` — the central `getPrimaryVariant()`
+ *               resolver. Every non-destructive `ConfirmDialog` in the app renders its
+ *               primary through this same function, so this shot is what all 70-odd of
+ *               them look like.
+ *   editor      a footer that hand-writes its buttons, converted by hand.
+ *   import      a second hand-written footer, on a smaller dialog.
+ *   destructive `ConfirmDialog variant="destructive"` — must still be destructive-red,
+ *               not the contrast fill. This is the shot that proves the precedence.
+ *   discard     a nested destructive confirm stacked over an open dialog.
+ *
+ * Opt-in only, like worktree-dialog-review: skips itself unless DAINTREE_SHOT_CONFIRM is
+ * set, so the marketing screenshots workflow never executes it.
+ *
+ *   DAINTREE_SHOT_CONFIRM=1 npx playwright test --project=screenshots confirm-dialog-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_CONFIRM  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME    optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG      optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY     comma-separated step filter (see step names above)
+ *
+ * Output: artifacts/confirm-dialog-shots/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { navigateToAgentSettings } from "../helpers/presets";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_CONFIRM;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "confirm-dialog-shots");
+
+/** The dialog card, so the shot is the surface plus its footer rather than the app. */
+const DIALOG = '[role="dialog"], [role="alertdialog"]';
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+const SEEDED_RECIPE = {
+  id: "recipe-review",
+  name: "Claude + Codex pair",
+  terminals: [
+    { type: "claude", title: "Claude", env: {}, initialPrompt: "" },
+    { type: "codex", title: "Codex", env: {}, initialPrompt: "" },
+  ],
+  createdAt: 1775381905486,
+  showInEmptyState: true,
+};
+
+/** Minimal repo carrying one saved recipe, so the delete/edit paths have a target. */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-confirm-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+
+  mkdirSync(path.join(dir, ".daintree", "recipes"), { recursive: true });
+  writeFileSync(
+    path.join(dir, ".daintree", "recipes", `${SEEDED_RECIPE.id}.json`),
+    JSON.stringify(SEEDED_RECIPE, null, 2)
+  );
+
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  git("branch develop", dir);
+  git("checkout develop", dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+async function snap(page: Page, slug: string, locator?: string): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).last().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+}
+
+/**
+ * Every built-in theme. Switching themes in place crashes the project view under this
+ * harness (same constraint as worktree-dialog-review), so the sweep boots once per theme:
+ *
+ *   for t in <these ids>; do
+ *     DAINTREE_SHOT_CONFIRM=1 DAINTREE_SHOT_THEME=$t DAINTREE_SHOT_TAG=$t \
+ *     npx playwright test --project=screenshots confirm-dialog-review
+ *   done
+ */
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    console.warn(`[confirm-shots] step "${name}" skipped:`, String(error).slice(0, 300));
+  }
+}
+
+async function escapeAll(page: Page, times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 150);
+  }
+}
+
+/** Project settings -> Recipes, where the recipe dialogs live. */
+async function openRecipesTab(page: Page): Promise<void> {
+  await dismissBlockingPalette(page);
+  await page.locator(SEL.toolbar.projectSwitcherTrigger).click();
+  await page
+    .locator(SEL.projectSwitcher.palette)
+    .waitFor({ state: "visible", timeout: 6000 })
+    .catch(() => {});
+  await page.locator(SEL.projectSwitcher.projectSettings).click();
+  await page
+    .locator(SEL.projectSettings.heading)
+    .waitFor({ state: "visible", timeout: 8000 })
+    .catch(() => {});
+  await page.locator(SEL.projectSettings.recipesTab).click();
+  await settle(page, 500);
+}
+
+async function closeProjectSettings(page: Page): Promise<void> {
+  await page
+    .locator(SEL.projectSettings.closeButton)
+    .click()
+    .catch(() => {});
+  await settle(page, 300);
+}
+
+test("dialog primary-action review — contrast CTA and destructive precedence", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_CONFIRM is required for the dialog capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_CONFIRM to run the dialog capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-confirmshot-"));
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 2000);
+    await dismissBlockingPalette(page);
+
+    // 1. The central resolver. Whatever this footer paints is what every
+    //    non-destructive ConfirmDialog in the app paints.
+    await step("preset", async () => {
+      await navigateToAgentSettings(page, "claude");
+      await page
+        .locator(SEL.preset.section)
+        .locator(SEL.preset.addButton)
+        .click({ force: true, noWaitAfter: true });
+      await page
+        .locator('[data-testid="add-preset-dialog"]')
+        .waitFor({ state: "visible", timeout: 6000 });
+      await snap(page, "10-primary-action-resolver", '[data-testid="add-preset-dialog"]');
+      await snap(page, "11-primary-action-in-window");
+      await escapeAll(page);
+      await page
+        .locator(SEL.settings.closeButton)
+        .click()
+        .catch(() => {});
+      await settle(page, 400);
+    });
+
+    await step("editor", async () => {
+      await openRecipesTab(page);
+      await page.locator(SEL.projectSettings.addRecipeButton).click();
+      await settle(page, 600);
+      await snap(page, "20-handwritten-footer-editor", DIALOG);
+    });
+
+    // 2. Nested destructive confirm stacked over the editor: two dialog surfaces,
+    //    and the confirm must still read as destructive.
+    await step("discard", async () => {
+      await page
+        .locator(SEL.recipeEditor.nameInput)
+        .fill("Review sweep")
+        .catch(() => {});
+      await settle(page, 250);
+      await page.locator(SEL.recipeEditor.cancelButton).first().click();
+      await page
+        .getByRole("alertdialog")
+        .waitFor({ state: "visible", timeout: 5000 })
+        .catch(() => {});
+      await snap(page, "30-nested-destructive-confirm");
+      await escapeAll(page);
+    });
+
+    await step("import", async () => {
+      await escapeAll(page);
+      await openRecipesTab(page);
+      await page.getByRole("button", { name: "Import recipe" }).click();
+      await settle(page, 500);
+      await snap(page, "40-handwritten-footer-import", DIALOG);
+      await escapeAll(page);
+    });
+
+    // 3. The precedence check the issue calls out: destructive must not become contrast.
+    await step("destructive", async () => {
+      await openRecipesTab(page);
+      await page
+        .locator(SEL.projectSettings.deleteRecipeButton(SEEDED_RECIPE.name))
+        .click({ force: true });
+      await page
+        .getByRole("alertdialog")
+        .waitFor({ state: "visible", timeout: 5000 })
+        .catch(() => {});
+      await snap(page, "50-destructive-confirm", DIALOG);
+      await snap(page, "51-destructive-in-window");
+      await escapeAll(page);
+      await closeProjectSettings(page);
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/e2e/screenshots/confirm-dialog-review.spec.ts
+++ b/e2e/screenshots/confirm-dialog-review.spec.ts
@@ -156,12 +156,19 @@ export const ALL_THEMES = [
 ];
 
 const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — the other shots are still worth having, and a
+// per-theme sweep shouldn't lose fourteen themes to one bad selector. But the run must
+// still FAIL, or a silent exit 0 with an empty output directory reads as success.
+const failures: string[] = [];
 async function step(name: string, fn: () => Promise<void>): Promise<void> {
   if (ONLY.length > 0 && !ONLY.includes(name)) return;
   try {
     await fn();
   } catch (error) {
-    console.warn(`[confirm-shots] step "${name}" skipped:`, String(error).slice(0, 300));
+    const detail = String(error).slice(0, 300);
+    console.warn(`[confirm-shots] step "${name}" failed:`, detail);
+    failures.push(`${name}: ${detail}`);
   }
 }
 
@@ -240,10 +247,7 @@ test("dialog primary-action review — contrast CTA and destructive precedence",
       await snap(page, "10-primary-action-resolver", '[data-testid="add-preset-dialog"]');
       await snap(page, "11-primary-action-in-window");
       await escapeAll(page);
-      await page
-        .locator(SEL.settings.closeButton)
-        .click()
-        .catch(() => {});
+      await page.locator(SEL.settings.closeButton).click();
       await settle(page, 400);
     });
 
@@ -252,32 +256,39 @@ test("dialog primary-action review — contrast CTA and destructive precedence",
       await page.locator(SEL.projectSettings.addRecipeButton).click();
       await settle(page, 600);
       await snap(page, "20-handwritten-footer-editor", DIALOG);
+      await escapeAll(page);
+      await closeProjectSettings(page);
     });
 
-    // 2. Nested destructive confirm stacked over the editor: two dialog surfaces,
-    //    and the confirm must still read as destructive.
+    // 2. Nested destructive confirm stacked over the editor: two dialog surfaces, and
+    //    the confirm must still read as destructive. Opens its own editor so the step
+    //    runs standalone under DAINTREE_SHOT_ONLY.
     await step("discard", async () => {
-      await page
-        .locator(SEL.recipeEditor.nameInput)
-        .fill("Review sweep")
-        .catch(() => {});
+      await openRecipesTab(page);
+      await page.locator(SEL.projectSettings.addRecipeButton).click();
+      await settle(page, 600);
+      await page.locator(SEL.recipeEditor.nameInput).fill("Review sweep");
       await settle(page, 250);
       await page.locator(SEL.recipeEditor.cancelButton).first().click();
-      await page
-        .getByRole("alertdialog")
-        .waitFor({ state: "visible", timeout: 5000 })
-        .catch(() => {});
+      await page.getByRole("alertdialog").waitFor({ state: "visible", timeout: 5000 });
       await snap(page, "30-nested-destructive-confirm");
-      await escapeAll(page);
+      // Actually discard. Escaping only dismisses the confirm — the editor stays dirty
+      // and re-raises it on the next close, which would wedge every later step.
+      await page.locator(SEL.confirmDialog.confirm).last().click();
+      await page
+        .locator(SEL.recipeEditor.nameInput)
+        .waitFor({ state: "hidden", timeout: 5000 })
+        .catch(() => {});
+      await closeProjectSettings(page);
     });
 
     await step("import", async () => {
-      await escapeAll(page);
       await openRecipesTab(page);
       await page.getByRole("button", { name: "Import recipe" }).click();
       await settle(page, 500);
       await snap(page, "40-handwritten-footer-import", DIALOG);
       await escapeAll(page);
+      await closeProjectSettings(page);
     });
 
     // 3. The precedence check the issue calls out: destructive must not become contrast.
@@ -286,18 +297,29 @@ test("dialog primary-action review — contrast CTA and destructive precedence",
       await page
         .locator(SEL.projectSettings.deleteRecipeButton(SEEDED_RECIPE.name))
         .click({ force: true });
-      await page
-        .getByRole("alertdialog")
-        .waitFor({ state: "visible", timeout: 5000 })
-        .catch(() => {});
+      await page.getByRole("alertdialog").waitFor({ state: "visible", timeout: 5000 });
       await snap(page, "50-destructive-confirm", DIALOG);
       await snap(page, "51-destructive-in-window");
       await escapeAll(page);
       await closeProjectSettings(page);
     });
   } finally {
-    if (ctx?.app) await closeApp(ctx.app);
-    repo.cleanup();
-    rmSync(userDataDir, { recursive: true, force: true });
+    // Each cleanup runs even if an earlier one throws — a rejected closeApp used to
+    // strand the fixture repo and the user-data dir on disk.
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    try {
+      repo.cleanup();
+    } catch {
+      /* best effort */
+    }
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`[confirm-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`);
   }
 });

--- a/e2e/screenshots/confirm-dialog-review.spec.ts
+++ b/e2e/screenshots/confirm-dialog-review.spec.ts
@@ -161,7 +161,7 @@ const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
 // per-theme sweep shouldn't lose fourteen themes to one bad selector. But the run must
 // still FAIL, or a silent exit 0 with an empty output directory reads as success.
 const failures: string[] = [];
-async function step(name: string, fn: () => Promise<void>): Promise<void> {
+async function step(page: Page, name: string, fn: () => Promise<void>): Promise<void> {
   if (ONLY.length > 0 && !ONLY.includes(name)) return;
   try {
     await fn();
@@ -169,6 +169,12 @@ async function step(name: string, fn: () => Promise<void>): Promise<void> {
     const detail = String(error).slice(0, 300);
     console.warn(`[confirm-shots] step "${name}" failed:`, detail);
     failures.push(`${name}: ${detail}`);
+  } finally {
+    // Unconditionally, not on the success path only: a step that dies holding an open
+    // editor would otherwise wedge every step after it behind a modal.
+    await returnToRest(page).catch((error) => {
+      failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+    });
   }
 }
 
@@ -196,12 +202,36 @@ async function openRecipesTab(page: Page): Promise<void> {
   await settle(page, 500);
 }
 
-async function closeProjectSettings(page: Page): Promise<void> {
-  await page
-    .locator(SEL.projectSettings.closeButton)
-    .click()
-    .catch(() => {});
-  await settle(page, 300);
+/**
+ * Dismiss whatever is open and get back to the workbench. Escape closes the topmost
+ * surface, so this presses once per possible layer and then closes any settings dialog by
+ * its own button, waiting for the heading to actually go rather than assuming it did.
+ */
+async function returnToRest(page: Page): Promise<void> {
+  for (const heading of [SEL.projectSettings.heading, SEL.settings.heading]) {
+    for (let layer = 0; layer < 3; layer++) {
+      if (
+        !(await page
+          .locator(heading)
+          .isVisible()
+          .catch(() => false))
+      )
+        break;
+      const closeButton = page.locator(SEL.settings.closeButton).first();
+      if (await closeButton.isVisible().catch(() => false)) {
+        await closeButton.click().catch(() => {});
+      } else {
+        await page.keyboard.press("Escape").catch(() => {});
+      }
+      await settle(page, 200);
+    }
+    await page
+      .locator(heading)
+      .waitFor({ state: "hidden", timeout: 5000 })
+      .catch(() => {});
+  }
+  await escapeAll(page, 1);
+  await dismissBlockingPalette(page);
 }
 
 test("dialog primary-action review — contrast CTA and destructive precedence", async () => {
@@ -210,6 +240,10 @@ test("dialog primary-action review — contrast CTA and destructive precedence",
     description: "DAINTREE_SHOT_CONFIRM is required for the dialog capture",
   });
   test.skip(!ENABLED, "Set DAINTREE_SHOT_CONFIRM to run the dialog capture");
+
+  // Module-scoped so `step()` can reach it; cleared here so a Playwright retry starts
+  // from a clean slate rather than inheriting the previous attempt's failures.
+  failures.length = 0;
 
   mkdirSync(OUTPUT_DIR, { recursive: true });
   const repo = createFixtureRepo();
@@ -235,7 +269,7 @@ test("dialog primary-action review — contrast CTA and destructive precedence",
 
     // 1. The central resolver. Whatever this footer paints is what every
     //    non-destructive ConfirmDialog in the app paints.
-    await step("preset", async () => {
+    await step(page, "preset", async () => {
       await navigateToAgentSettings(page, "claude");
       await page
         .locator(SEL.preset.section)
@@ -246,24 +280,19 @@ test("dialog primary-action review — contrast CTA and destructive precedence",
         .waitFor({ state: "visible", timeout: 6000 });
       await snap(page, "10-primary-action-resolver", '[data-testid="add-preset-dialog"]');
       await snap(page, "11-primary-action-in-window");
-      await escapeAll(page);
-      await page.locator(SEL.settings.closeButton).click();
-      await settle(page, 400);
     });
 
-    await step("editor", async () => {
+    await step(page, "editor", async () => {
       await openRecipesTab(page);
       await page.locator(SEL.projectSettings.addRecipeButton).click();
       await settle(page, 600);
       await snap(page, "20-handwritten-footer-editor", DIALOG);
-      await escapeAll(page);
-      await closeProjectSettings(page);
     });
 
     // 2. Nested destructive confirm stacked over the editor: two dialog surfaces, and
     //    the confirm must still read as destructive. Opens its own editor so the step
     //    runs standalone under DAINTREE_SHOT_ONLY.
-    await step("discard", async () => {
+    await step(page, "discard", async () => {
       await openRecipesTab(page);
       await page.locator(SEL.projectSettings.addRecipeButton).click();
       await settle(page, 600);
@@ -274,25 +303,22 @@ test("dialog primary-action review — contrast CTA and destructive precedence",
       await snap(page, "30-nested-destructive-confirm");
       // Actually discard. Escaping only dismisses the confirm — the editor stays dirty
       // and re-raises it on the next close, which would wedge every later step.
-      await page.locator(SEL.confirmDialog.confirm).last().click();
+      await page.getByRole("alertdialog").locator(SEL.confirmDialog.confirm).click();
       await page
         .locator(SEL.recipeEditor.nameInput)
         .waitFor({ state: "hidden", timeout: 5000 })
         .catch(() => {});
-      await closeProjectSettings(page);
     });
 
-    await step("import", async () => {
+    await step(page, "import", async () => {
       await openRecipesTab(page);
       await page.getByRole("button", { name: "Import recipe" }).click();
       await settle(page, 500);
       await snap(page, "40-handwritten-footer-import", DIALOG);
-      await escapeAll(page);
-      await closeProjectSettings(page);
     });
 
     // 3. The precedence check the issue calls out: destructive must not become contrast.
-    await step("destructive", async () => {
+    await step(page, "destructive", async () => {
       await openRecipesTab(page);
       await page
         .locator(SEL.projectSettings.deleteRecipeButton(SEEDED_RECIPE.name))
@@ -300,8 +326,6 @@ test("dialog primary-action review — contrast CTA and destructive precedence",
       await page.getByRole("alertdialog").waitFor({ state: "visible", timeout: 5000 });
       await snap(page, "50-destructive-confirm", DIALOG);
       await snap(page, "51-destructive-in-window");
-      await escapeAll(page);
-      await closeProjectSettings(page);
     });
   } finally {
     // Each cleanup runs even if an earlier one throws — a rejected closeApp used to

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -1317,7 +1317,7 @@ export function BulkCreateWorktreeDialog({
                 Retry failed
               </Button>
             )}
-            <Button onClick={handleDone} data-testid="bulk-create-done-button">
+            <Button variant="contrast" onClick={handleDone} data-testid="bulk-create-done-button">
               <Check />
               Done
             </Button>
@@ -1331,6 +1331,7 @@ export function BulkCreateWorktreeDialog({
               Cancel
             </Button>
             <Button
+              variant="contrast"
               onClick={handleCreate}
               disabled={isExecuting || creatableCount === 0}
               className="min-w-[100px]"

--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -940,3 +940,48 @@ describe("terminal/syntax validation", () => {
     expect(unevaluable).toHaveLength(0);
   });
 });
+
+// The high-contrast neutral CTA (`variant="contrast"`) is the standard dialog primary
+// action: it fills itself with the theme's body-text colour and paints its label in the
+// inverse. Every other text-primary pair puts that token on a *surface*, so nothing else
+// in the matrix notices when a theme collapses the fill against its own label.
+describe("contrast-CTA pair (text-inverse on text-primary)", () => {
+  const findWarning = (scheme: AppColorScheme) =>
+    getThemeContrastWarnings(scheme).find(
+      (w) => w.kind === "low-contrast" && w.message.startsWith("text-inverse on text-primary")
+    );
+
+  it("flags a theme whose inverse label collapses against the fill", () => {
+    const scheme = makeScheme({
+      "text-primary": "#767676" as AppColorSchemeTokens["text-primary"],
+      "text-inverse": "#8a8a8a" as AppColorSchemeTokens["text-inverse"],
+    });
+    const warning = findWarning(scheme);
+    expect(warning).toBeDefined();
+    // The message carries the measured ratio, so a regression says how far off it is.
+    expect(warning!.message).toMatch(/is \d+\.\d\d:1; target is 4\.5:1/);
+  });
+
+  it("flags a near-miss that still reads as two distinct colours", () => {
+    // ~4.3:1 — visibly different, but under the AA floor for a normal-sized label.
+    const scheme = makeScheme({
+      "text-primary": "#7a7a7a" as AppColorSchemeTokens["text-primary"],
+      "text-inverse": "#ffffff" as AppColorSchemeTokens["text-inverse"],
+    });
+    expect(contrastRatio("#ffffff", "#7a7a7a")).toBeLessThan(4.5);
+    expect(findWarning(scheme)).toBeDefined();
+  });
+
+  it("stays quiet for a legible inverse pair in either polarity", () => {
+    const dark = makeScheme({
+      "text-primary": "#e8e8e8" as AppColorSchemeTokens["text-primary"],
+      "text-inverse": "#141414" as AppColorSchemeTokens["text-inverse"],
+    });
+    const light = makeScheme({
+      "text-primary": "#141414" as AppColorSchemeTokens["text-primary"],
+      "text-inverse": "#e8e8e8" as AppColorSchemeTokens["text-inverse"],
+    });
+    expect(findWarning(dark)).toBeUndefined();
+    expect(findWarning(light)).toBeUndefined();
+  });
+});

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -116,10 +116,12 @@ const CONTRAST_PAIRS: Array<{
   //
   // LIMIT: this checks the resting fill only. The variant's hover and active states mix
   // the fill 90%/82% toward the label (`color-mix(in oklab, ...)` in button.tsx), so a
-  // theme sitting just over this floor at rest can dip under it while pressed. Modelling
-  // that would need an OKLab->sRGB round-trip this module doesn't have, and the built-ins
-  // are ~3x clear of the floor, so their interaction states have ample room. A custom
-  // theme near the floor gets a warning here for the resting state either way.
+  // theme sitting just over this floor at rest can dip under it while pressed — e.g.
+  // #767676/#ffffff is 4.54:1 at rest, ~3.8:1 hovered, ~3.3:1 pressed. Modelling that
+  // exactly needs an OKLab round-trip, which means either hand-rolling one here or
+  // pulling culori (a devDependency) into code the main process loads. Not worth it yet:
+  // every built-in is ~3x clear of the floor (weakest interaction state ~8:1), and the
+  // consequence for a custom theme is an advisory warning, never a rejected import.
   { foreground: "text-inverse", background: "text-primary", minimum: 4.5 },
   { foreground: "search-highlight-text", background: "search-highlight-background", minimum: 3.0 },
 ];

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -106,6 +106,14 @@ const CONTRAST_PAIRS: Array<{
   { foreground: "status-info", background: "surface-canvas", minimum: 3.0 },
   { foreground: "status-info", background: "surface-panel-elevated", minimum: 3.0 },
   ACCENT_CONTRAST_PAIR,
+  // The high-contrast neutral CTA — the standard dialog primary action (#11963) — fills
+  // itself with the theme's own body-text colour and paints its label in the inverse.
+  // That is the one pair where those two roles meet as foreground and background, and no
+  // other entry covers it: every other text-primary pair puts it on a surface. Both
+  // polarities, because the button renders in both and its label is normal-sized text,
+  // so AA 4.5:1 is the right floor. The built-ins clear it by a wide margin (weakest
+  // ~12:1); a theme that fails here cannot carry a legible primary button.
+  { foreground: "text-inverse", background: "text-primary", minimum: 4.5 },
   { foreground: "search-highlight-text", background: "search-highlight-background", minimum: 3.0 },
 ];
 

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -113,6 +113,13 @@ const CONTRAST_PAIRS: Array<{
   // polarities, because the button renders in both and its label is normal-sized text,
   // so AA 4.5:1 is the right floor. The built-ins clear it by a wide margin (weakest
   // ~12:1); a theme that fails here cannot carry a legible primary button.
+  //
+  // LIMIT: this checks the resting fill only. The variant's hover and active states mix
+  // the fill 90%/82% toward the label (`color-mix(in oklab, ...)` in button.tsx), so a
+  // theme sitting just over this floor at rest can dip under it while pressed. Modelling
+  // that would need an OKLab->sRGB round-trip this module doesn't have, and the built-ins
+  // are ~3x clear of the floor, so their interaction states have ample room. A custom
+  // theme near the floor gets a warning here for the resting state either way.
   { foreground: "text-inverse", background: "text-primary", minimum: 4.5 },
   { foreground: "search-highlight-text", background: "search-highlight-background", minimum: 3.0 },
 ];

--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -170,7 +170,7 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
             ref={okRef}
             type="button"
             onClick={handleOk}
-            className="px-3 py-1.5 text-xs font-medium text-accent-primary-foreground bg-daintree-accent hover:bg-daintree-accent/90 rounded-md transition-colors focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50"
+            className="px-3 py-1.5 text-xs font-medium text-text-inverse bg-daintree-text hover:bg-[color-mix(in_oklab,var(--color-daintree-text)_90%,var(--color-text-inverse))] rounded-md transition-colors focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50"
           >
             OK
           </button>

--- a/src/components/Commands/CommandBuilder.tsx
+++ b/src/components/Commands/CommandBuilder.tsx
@@ -506,9 +506,13 @@ export function CommandBuilder({
 
       <AppDialog.Footer>
         {showSuccessState ? (
-          <Button onClick={onCancel}>Close</Button>
+          <Button variant="contrast" onClick={onCancel}>
+            Close
+          </Button>
         ) : hasEmptySteps ? (
-          <Button onClick={onCancel}>Close</Button>
+          <Button variant="contrast" onClick={onCancel}>
+            Close
+          </Button>
         ) : (
           <>
             <div className="flex-1 flex items-center gap-2">
@@ -534,7 +538,7 @@ export function CommandBuilder({
                 Cancel
               </Button>
               {isLastStep ? (
-                <Button onClick={handleExecute} disabled={isExecuting}>
+                <Button variant="contrast" onClick={handleExecute} disabled={isExecuting}>
                   {isExecuting ? (
                     <>
                       <Spinner size="md" />
@@ -545,7 +549,7 @@ export function CommandBuilder({
                   )}
                 </Button>
               ) : (
-                <Button onClick={handleNext} disabled={isExecuting}>
+                <Button variant="contrast" onClick={handleNext} disabled={isExecuting}>
                   Next
                   <ChevronRight className="h-4 w-4" />
                 </Button>

--- a/src/components/Commands/CommandPickerHost.tsx
+++ b/src/components/Commands/CommandPickerHost.tsx
@@ -138,7 +138,9 @@ export function CommandPickerHost({ context, onCommandExecuted }: CommandPickerH
             </div>
           </AppDialog.Body>
           <AppDialog.Footer>
-            <Button onClick={handleBuilderCancel}>Close</Button>
+            <Button variant="contrast" onClick={handleBuilderCancel}>
+              Close
+            </Button>
           </AppDialog.Footer>
         </AppDialog>
       )}

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -504,7 +504,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
 
       <AppDialog.Footer>
         {isComplete ? (
-          <Button onClick={handleClose} className="gap-2">
+          <Button variant="contrast" onClick={handleClose} className="gap-2">
             <Check className="h-4 w-4" />
             Open Project
           </Button>
@@ -513,7 +513,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             <Button variant="outline" onClick={onCancel}>
               Close
             </Button>
-            <Button onClick={() => void startClone()} disabled={isCloning}>
+            <Button variant="contrast" onClick={() => void startClone()} disabled={isCloning}>
               Retry
             </Button>
           </>
@@ -525,7 +525,12 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             >
               {isCloning ? "Stop clone" : "Cancel"}
             </Button>
-            <Button onClick={() => void startClone()} disabled={!canClone} loading={isCloning}>
+            <Button
+              variant="contrast"
+              onClick={() => void startClone()}
+              disabled={!canClone}
+              loading={isCloning}
+            >
               Clone
             </Button>
           </>

--- a/src/components/Project/CreateProjectFolderDialog.tsx
+++ b/src/components/Project/CreateProjectFolderDialog.tsx
@@ -214,7 +214,11 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
         <Button variant="outline" onClick={onClose} disabled={isCreating}>
           Cancel
         </Button>
-        <Button onClick={handleCreate} disabled={isCreating || !parentPath || !folderName.trim()}>
+        <Button
+          variant="contrast"
+          onClick={handleCreate}
+          disabled={isCreating || !parentPath || !folderName.trim()}
+        >
           {isCreating ? "Creating…" : "Create folder"}
         </Button>
       </AppDialog.Footer>

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -368,7 +368,7 @@ export function GitInitDialog({
 
       <AppDialog.Footer>
         {isComplete ? (
-          <Button onClick={handleClose} className="gap-2">
+          <Button variant="contrast" onClick={handleClose} className="gap-2">
             <Check className="h-4 w-4" />
             Continue
           </Button>
@@ -378,6 +378,7 @@ export function GitInitDialog({
               Cancel
             </Button>
             <Button
+              variant="contrast"
               onClick={() => void startInitialization()}
               disabled={isInitializing || !canStart}
             >
@@ -390,6 +391,7 @@ export function GitInitDialog({
               Cancel
             </Button>
             <Button
+              variant="contrast"
               onClick={() => void startInitialization()}
               disabled={isInitializing || !canStart}
               loading={isInitializing}

--- a/src/components/Project/NonGitFolderDialog.tsx
+++ b/src/components/Project/NonGitFolderDialog.tsx
@@ -85,7 +85,9 @@ export function NonGitFolderDialog({
         <Button variant="outline" onClick={() => setStep("initialize")}>
           Initialize repository
         </Button>
-        <Button onClick={onOpenWithoutGit}>Open without git</Button>
+        <Button variant="contrast" onClick={onOpenWithoutGit}>
+          Open without git
+        </Button>
       </AppDialog.Footer>
     </AppDialog>
   );

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -511,7 +511,7 @@ export function RecipesTab({
           >
             Cancel
           </Button>
-          <Button onClick={handleImportRecipe} disabled={!importJson.trim()}>
+          <Button variant="contrast" onClick={handleImportRecipe} disabled={!importJson.trim()}>
             Import
           </Button>
         </AppDialog.Footer>

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -320,6 +320,7 @@ export function CrashRecoveryDialog({
 
               <div className="flex gap-2">
                 <Button
+                  variant="contrast"
                   onClick={handleRestoreSelected}
                   disabled={resolving || selectedCount === 0}
                   className="flex-1"
@@ -567,6 +568,7 @@ export function CrashRecoveryDialog({
                     )}
                     <div className="flex gap-2">
                       <Button
+                        variant="contrast"
                         size="sm"
                         className="text-xs h-7"
                         onClick={() => void handleSubmitReport()}

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -796,13 +796,14 @@ export function AgentSetupWizard({
                 </Button>
               ))}
             {state.step.type === "appearance" && (
-              <Button onClick={handleAppearanceContinue} disabled={isSaving}>
+              <Button variant="contrast" onClick={handleAppearanceContinue} disabled={isSaving}>
                 Continue
                 <ArrowRight className="w-4 h-4 ml-1" />
               </Button>
             )}
             {state.step.type === "agents" && (
               <Button
+                variant="contrast"
                 onClick={handleAgentsContinue}
                 disabled={
                   selectedAgentIds.length === 0 ||
@@ -816,24 +817,28 @@ export function AgentSetupWizard({
               </Button>
             )}
             {state.step.type === "privacy" && (
-              <Button onClick={handlePrivacyContinue} disabled={isSaving}>
+              <Button variant="contrast" onClick={handlePrivacyContinue} disabled={isSaving}>
                 Continue
                 <ArrowRight className="w-4 h-4 ml-1" />
               </Button>
             )}
             {state.step.type === "cli" && (
-              <Button onClick={handleCliContinue}>
+              <Button variant="contrast" onClick={handleCliContinue}>
                 Continue
                 <ChevronRight className="w-4 h-4 ml-1" />
               </Button>
             )}
             {state.step.type === "permissions" && (
-              <Button onClick={handlePermissionsContinue} disabled={isSaving}>
+              <Button variant="contrast" onClick={handlePermissionsContinue} disabled={isSaving}>
                 Continue
                 <ArrowRight className="w-4 h-4 ml-1" />
               </Button>
             )}
-            {state.step.type === "complete" && <Button onClick={handleFinish}>Finish setup</Button>}
+            {state.step.type === "complete" && (
+              <Button variant="contrast" onClick={handleFinish}>
+                Finish setup
+              </Button>
+            )}
           </div>
         </div>
       </AppDialog.Footer>

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -464,7 +464,9 @@ Performance & Diagnostics:
           <Button variant="ghost" onClick={onClose}>
             Close
           </Button>
-          <Button onClick={copyToClipboard}>Copy to Clipboard</Button>
+          <Button variant="contrast" onClick={copyToClipboard}>
+            Copy to Clipboard
+          </Button>
         </AppDialog.Footer>
       )}
     </AppDialog>

--- a/src/components/Terminal/UpdateCwdDialog.tsx
+++ b/src/components/Terminal/UpdateCwdDialog.tsx
@@ -139,7 +139,7 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={handleUpdate} disabled={validating}>
+        <Button variant="contrast" onClick={handleUpdate} disabled={validating}>
           {validating ? "Updating…" : "Update and restart"}
         </Button>
       </AppDialog.Footer>

--- a/src/components/TerminalRecipe/RecipeConflictDialog.tsx
+++ b/src/components/TerminalRecipe/RecipeConflictDialog.tsx
@@ -57,7 +57,7 @@ function RecipeConflictDialogInner() {
             Overwrite recipe
           </Button>
           <Button
-            variant="default"
+            variant="contrast"
             onClick={() => resolveConflict("reload")}
             data-testid="recipe-conflict-reload"
           >

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -666,7 +666,7 @@ export function RecipeEditor({
           <Button variant="outline" onClick={handleCancel} disabled={isSaving}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={isSaving}>
+          <Button variant="contrast" onClick={handleSave} disabled={isSaving}>
             {isSaving ? "Saving…" : recipe ? "Update Recipe" : "Create Recipe"}
           </Button>
         </AppDialog.Footer>

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -578,7 +578,7 @@ export function RecipeManager({
           >
             Cancel
           </Button>
-          <Button onClick={handleImportRecipe} disabled={!importJson.trim()}>
+          <Button variant="contrast" onClick={handleImportRecipe} disabled={!importJson.trim()}>
             Import
           </Button>
         </AppDialog.Footer>

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -559,11 +559,16 @@ AppDialog.Footer = function AppDialogFooter({
   const context = useContext(AppDialogContext);
   const dialogVariant = context?.variant ?? "default";
 
+  // The standard dialog primary action is the high-contrast neutral button, not the
+  // accent fill: its fill is the theme's own body-text colour, so it resolves near-white
+  // on dark themes and near-black on light ones and stays legible whatever the accent is
+  // (a bright accent made the old CTA label hard to read). `intent` stays a semantic
+  // danger flag — destructive wins first and is unaffected.
   const getPrimaryVariant = () => {
     if (primaryAction?.intent === "destructive" || dialogVariant === "destructive") {
       return "destructive";
     }
-    return "default";
+    return "contrast";
   };
 
   return (

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { AppDialog } from "../AppDialog";
+import { buttonVariants } from "../button";
 import { _resetForTests } from "@/lib/escapeStack";
 import { _resetForTests as _resetBackstopForTests } from "@/lib/dialogEscapeBackstop";
 import { handleDockEscapeKeyDown } from "@/components/Layout/dockPopoverGuard";
@@ -1364,5 +1365,90 @@ describe("AppDialog.Body className placement", () => {
     const wrapper = screen.getByTestId("field-a").parentElement?.parentElement;
     expect(wrapper).not.toBeNull();
     expect(wrapper?.classList.contains("dialog-body-spacing")).toBe(false);
+  });
+});
+
+// The footer resolves the primary button's visual variant from dialog/action
+// semantics. Expectations are derived from `buttonVariants` itself rather than
+// restating utility strings, so a change to what `contrast` or `destructive`
+// paints doesn't need editing here — only a change to the *mapping* does.
+describe("AppDialog.Footer primary variant resolution", () => {
+  beforeEach(() => {
+    mockPrevOpen = false;
+    _resetForTests();
+    vi.useRealTimers();
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  const CANDIDATES = ["default", "destructive", "contrast"] as const;
+  type Candidate = (typeof CANDIDATES)[number];
+
+  const classesOf = (variant: Candidate) =>
+    new Set(buttonVariants({ variant }).split(/\s+/).filter(Boolean));
+
+  /** The classes that belong to this variant and to none of the others. */
+  const fingerprint = (variant: Candidate): string[] => {
+    const own = classesOf(variant);
+    for (const other of CANDIDATES) {
+      if (other === variant) continue;
+      for (const shared of classesOf(other)) own.delete(shared);
+    }
+    return [...own];
+  };
+
+  function renderFooter(props: {
+    dialogVariant?: "default" | "destructive" | "info";
+    intent?: "default" | "destructive";
+  }) {
+    render(
+      <AppDialog isOpen={true} onClose={() => {}} variant={props.dialogVariant}>
+        <AppDialog.Body>
+          <p>Content</p>
+        </AppDialog.Body>
+        <AppDialog.Footer
+          primaryAction={{ label: "Proceed", onClick: () => {}, intent: props.intent }}
+        />
+      </AppDialog>
+    );
+    return screen.getByRole("button", { name: "Proceed" });
+  }
+
+  function expectVariant(button: HTMLElement, expected: Candidate) {
+    const own = fingerprint(expected);
+    // Guard against the assertion going vacuous if the variants ever converge.
+    expect(own.length).toBeGreaterThan(0);
+    for (const className of own) {
+      expect(button.classList.contains(className)).toBe(true);
+    }
+    for (const other of CANDIDATES) {
+      if (other === expected) continue;
+      for (const className of fingerprint(other)) {
+        expect(button.classList.contains(className)).toBe(false);
+      }
+    }
+  }
+
+  it("paints a plain confirmation with the high-contrast neutral CTA, not the accent fill", () => {
+    expectVariant(renderFooter({}), "contrast");
+  });
+
+  it("keeps the contrast CTA for an info dialog", () => {
+    expectVariant(renderFooter({ dialogVariant: "info" }), "contrast");
+  });
+
+  it("lets a destructive action outrank the contrast CTA", () => {
+    expectVariant(renderFooter({ intent: "destructive" }), "destructive");
+  });
+
+  it("lets a destructive dialog outrank the contrast CTA even with a default action", () => {
+    expectVariant(renderFooter({ dialogVariant: "destructive", intent: "default" }), "destructive");
+  });
+
+  it("resolves destructive from dialog context when the action states no intent", () => {
+    expectVariant(renderFooter({ dialogVariant: "destructive" }), "destructive");
   });
 });

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -156,7 +156,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
   "#5978-5986-pre-existing": [
     "plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx",
     "plugins/builtin/github/renderer/components/CommitList.tsx",
-    "src/components/Browser/WebviewDialog.tsx",
     "src/components/Commands/CommandBuilder.tsx",
     "src/components/Commands/CommandPicker.tsx",
     "src/components/DevPreview/DevPreviewEmptyStates.tsx",

--- a/src/config/__tests__/dialogFooterPrimary.contract.test.ts
+++ b/src/config/__tests__/dialogFooterPrimary.contract.test.ts
@@ -36,19 +36,23 @@ const SCAN_ROOTS = [
   path.join(REPO_ROOT, "plugins/builtin/github/renderer"),
 ];
 
-const APP_DIALOG_MODULE = "components/ui/AppDialog";
+const APP_DIALOG_MODULE = "/AppDialog";
 const DEFAULT_DIALOG_BINDING = "AppDialog";
 const FOOTER_MEMBER = "Footer";
 const BUTTON_TAG = "Button";
-// cva's own fallback. Naming it explicitly is the same accent fill as omitting the prop,
-// so both are rejected — the point is that no dialog footer paints the accent CTA.
-const REJECTED_VARIANT = "default";
+// Every Button variant that paints the accent fill (`bg-primary`, per button.tsx).
+// `default` is cva's own fallback, so naming it explicitly and omitting the prop are the
+// same thing; `glow` and `vibrant` are the same fill with a shadow or a gradient. The
+// point is that no dialog footer paints the accent CTA, however it's spelled.
+const ACCENT_FILL_VARIANTS = new Set(["default", "glow", "vibrant"]);
 
-// Ratchets. These are floors, not exact counts: they exist so a rename or refactor that
-// stopped matching can't leave the contract green by inspecting nothing. Raise them only
-// alongside a deliberate change in how many footers exist.
-const MIN_FOOTERS_INSPECTED = 20;
-const MIN_BUTTONS_INSPECTED = 40;
+// Coverage ratchets, set to the current actuals rather than a loose floor: this is a
+// static repo scan, so the numbers only move when someone adds or removes a dialog
+// footer. Growth passes freely; a DROP fails, which is the point — it means a rename or
+// refactor stopped matching and the contract went blind. Lower them deliberately, in the
+// same commit that removes the footers.
+const MIN_FOOTERS_INSPECTED = 24;
+const MIN_BUTTONS_INSPECTED = 53;
 
 function tsxFiles(dir: string, found: string[] = []): string[] {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -71,7 +75,7 @@ function dialogBinding(source: ts.SourceFile): string {
   for (const statement of source.statements) {
     if (!ts.isImportDeclaration(statement)) continue;
     const specifier = statement.moduleSpecifier;
-    if (!ts.isStringLiteral(specifier) || !specifier.text.includes(APP_DIALOG_MODULE)) continue;
+    if (!ts.isStringLiteral(specifier) || !specifier.text.endsWith(APP_DIALOG_MODULE)) continue;
     const bindings = statement.importClause?.namedBindings;
     if (!bindings || !ts.isNamedImports(bindings)) continue;
     for (const element of bindings.elements) {
@@ -83,44 +87,53 @@ function dialogBinding(source: ts.SourceFile): string {
 }
 
 /**
- * Every string literal an expression can evaluate to, or null when that can't be
- * determined statically. Covers the shapes a variant realistically takes.
+ * Every string literal an expression can evaluate to, plus whether some branch of it was
+ * opaque. The two are kept separate on purpose: `variant={candidate ?? "default"}` has one
+ * branch we can't read and one we can, and dropping the readable half because of the
+ * other would let an explicit accent branch through.
  */
-function literalValues(node: ts.Expression): string[] | null {
-  if (ts.isStringLiteralLike(node)) return [node.text];
+type Resolution = { literals: string[]; unknown: boolean };
+
+const OPAQUE: Resolution = { literals: [], unknown: true };
+
+function merge(...parts: Resolution[]): Resolution {
+  return {
+    literals: parts.flatMap((part) => part.literals),
+    unknown: parts.some((part) => part.unknown),
+  };
+}
+
+function literalValues(node: ts.Expression): Resolution {
+  if (ts.isStringLiteralLike(node)) return { literals: [node.text], unknown: false };
   if (ts.isParenthesizedExpression(node)) return literalValues(node.expression);
   if (ts.isConditionalExpression(node)) {
-    const whenTrue = literalValues(node.whenTrue);
-    const whenFalse = literalValues(node.whenFalse);
-    return whenTrue && whenFalse ? [...whenTrue, ...whenFalse] : null;
+    return merge(literalValues(node.whenTrue), literalValues(node.whenFalse));
   }
   if (
     ts.isBinaryExpression(node) &&
     (node.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
       node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken)
   ) {
-    const left = literalValues(node.left);
-    const right = literalValues(node.right);
-    return left && right ? [...left, ...right] : null;
+    return merge(literalValues(node.left), literalValues(node.right));
   }
-  return null;
+  return OPAQUE;
 }
 
-type VariantInfo =
-  { kind: "absent" } | { kind: "literals"; values: string[] } | { kind: "unresolvable" };
+type VariantInfo = { kind: "absent" } | ({ kind: "expression" } & Resolution);
 
 function variantOf(element: ts.JsxOpeningLikeElement): VariantInfo {
   for (const attribute of element.attributes.properties) {
     if (!ts.isJsxAttribute(attribute)) continue;
     if (attribute.name.getText() !== "variant") continue;
     const initializer = attribute.initializer;
-    if (!initializer) return { kind: "unresolvable" };
-    if (ts.isStringLiteral(initializer)) return { kind: "literals", values: [initializer.text] };
-    if (ts.isJsxExpression(initializer) && initializer.expression) {
-      const values = literalValues(initializer.expression);
-      return values ? { kind: "literals", values } : { kind: "unresolvable" };
+    if (!initializer) return { kind: "expression", ...OPAQUE };
+    if (ts.isStringLiteral(initializer)) {
+      return { kind: "expression", literals: [initializer.text], unknown: false };
     }
-    return { kind: "unresolvable" };
+    if (ts.isJsxExpression(initializer) && initializer.expression) {
+      return { kind: "expression", ...literalValues(initializer.expression) };
+    }
+    return { kind: "expression", ...OPAQUE };
   }
   return { kind: "absent" };
 }
@@ -155,8 +168,13 @@ function scan(filePath: string): ScanResult {
           line,
           reason: "no variant (inherits the accent CTA)",
         });
-      } else if (variant.kind === "literals" && variant.values.includes(REJECTED_VARIANT)) {
-        result.violations.push({ file: relative, line, reason: `variant="${REJECTED_VARIANT}"` });
+      } else {
+        // Any branch we CAN see that paints the accent is a violation, even when a
+        // sibling branch is opaque.
+        for (const value of new Set(variant.literals)) {
+          if (!ACCENT_FILL_VARIANTS.has(value)) continue;
+          result.violations.push({ file: relative, line, reason: `variant="${value}"` });
+        }
       }
     }
     ts.forEachChild(node, inspectButtons);
@@ -248,7 +266,7 @@ describe("dialog footers never inherit the accent CTA (#11963)", () => {
   it("follows an aliased AppDialog import", () => {
     withFixture(
       [
-        'import { AppDialog as Modal } from "@/components/ui/AppDialog";',
+        'import { AppDialog as Modal } from "../ui/AppDialog";',
         "export const D = () => (",
         "  <Modal.Footer>",
         "    <Button onClick={go}>Go</Button>",
@@ -277,10 +295,55 @@ describe("dialog footers never inherit the accent CTA (#11963)", () => {
         ");",
       ],
       (result) => {
-        // Only the branch that can resolve to the accent CTA is rejected; an
-        // unresolvable expression is a documented known limit, not a violation.
+        // Only the branch that can resolve to the accent CTA is rejected; a wholly
+        // unreadable expression is a documented known limit, not a violation.
         expect(result.violations.map((v) => v.reason)).toEqual(['variant="default"']);
         expect(result.buttons).toBe(3);
+      }
+    );
+  });
+
+  // The half-readable case: one opaque branch must not buy amnesty for a sibling branch
+  // that plainly names the accent fill.
+  it("still rejects a readable accent branch when a sibling branch is opaque", () => {
+    withFixture(
+      [
+        'import { AppDialog } from "@/components/ui/AppDialog";',
+        "export const D = () => (",
+        "  <AppDialog.Footer>",
+        '    <Button variant={candidate ?? "default"}>A</Button>',
+        '    <Button variant={flag ? candidate : "default"}>B</Button>',
+        "  </AppDialog.Footer>",
+        ");",
+      ],
+      (result) => {
+        expect(result.violations.map((v) => v.reason)).toEqual([
+          'variant="default"',
+          'variant="default"',
+        ]);
+      }
+    );
+  });
+
+  // `glow` and `vibrant` are the same `bg-primary` accent fill wearing a shadow or a
+  // gradient — spelling it differently must not slip the CTA past the contract.
+  it("rejects the other variants that paint the accent fill", () => {
+    withFixture(
+      [
+        'import { AppDialog } from "@/components/ui/AppDialog";',
+        "export const D = () => (",
+        "  <AppDialog.Footer>",
+        '    <Button variant="glow">A</Button>',
+        '    <Button variant="vibrant">B</Button>',
+        '    <Button variant="subtle">C</Button>',
+        "  </AppDialog.Footer>",
+        ");",
+      ],
+      (result) => {
+        expect(result.violations.map((v) => v.reason)).toEqual([
+          'variant="glow"',
+          'variant="vibrant"',
+        ]);
       }
     );
   });

--- a/src/config/__tests__/dialogFooterPrimary.contract.test.ts
+++ b/src/config/__tests__/dialogFooterPrimary.contract.test.ts
@@ -9,7 +9,7 @@ import ts from "typescript";
 // every dialog that uses it followed #11963 for free. A footer that hand-writes its
 // buttons instead bypasses that resolver entirely: `<Button>` with no variant falls
 // through to cva's `default`, the accent fill, and looks correct in review because the
-// omission is invisible. Thirteen files had drifted that way by the time the standard
+// omission is invisible. Fourteen files had drifted that way by the time the standard
 // changed.
 //
 // This guard closes that hatch. Inside a dialog footer a `Button` must name its variant,
@@ -17,11 +17,17 @@ import ts from "typescript";
 // ghost/outline/subtle, and a dangerous action is `destructive`.
 //
 // KNOWN LIMITS (deliberate — a regression guard, not a sound checker):
-//   - A computed variant (`variant={x}`) is not analyzed; only literals are.
-//   - A spread (`{...props}`) is not treated as supplying the variant, for the same
-//     reason the grid-panel guard rejects one: its contents aren't visible here.
-//   - A `Button` reached through a wrapper component rendered inside the footer is
-//     outside this file's view.
+//   - A variant expression that isn't statically resolvable to string literals (a call, an
+//     imported constant) is reported as unresolvable and counted, not rejected. Ternaries
+//     and `||`/`??` chains over literals ARE resolved, so `variant={x ? "default" : "ghost"}`
+//     is caught.
+//   - A spread (`{...props}`) is not treated as supplying the variant, for the same reason
+//     the grid-panel guard rejects one: its contents aren't visible here.
+//   - A `Button` reached through a wrapper component rendered inside the footer, or a
+//     locally aliased `Button`, is outside this file's view.
+//   - Dialogs that don't use `AppDialog.Footer` at all (a hand-rolled footer row in the
+//     body) are not in scope; this guards the footer contract, not every button in every
+//     dialog.
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
@@ -30,11 +36,19 @@ const SCAN_ROOTS = [
   path.join(REPO_ROOT, "plugins/builtin/github/renderer"),
 ];
 
-const FOOTER_TAG = "AppDialog.Footer";
+const APP_DIALOG_MODULE = "components/ui/AppDialog";
+const DEFAULT_DIALOG_BINDING = "AppDialog";
+const FOOTER_MEMBER = "Footer";
 const BUTTON_TAG = "Button";
 // cva's own fallback. Naming it explicitly is the same accent fill as omitting the prop,
 // so both are rejected — the point is that no dialog footer paints the accent CTA.
 const REJECTED_VARIANT = "default";
+
+// Ratchets. These are floors, not exact counts: they exist so a rename or refactor that
+// stopped matching can't leave the contract green by inspecting nothing. Raise them only
+// alongside a deliberate change in how many footers exist.
+const MIN_FOOTERS_INSPECTED = 20;
+const MIN_BUTTONS_INSPECTED = 40;
 
 function tsxFiles(dir: string, found: string[] = []): string[] {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -49,41 +63,73 @@ function tsxFiles(dir: string, found: string[] = []): string[] {
   return found;
 }
 
-function tagNameOf(node: ts.JsxOpeningLikeElement, source: ts.SourceFile): string {
-  return node.tagName.getText(source);
+/**
+ * The local name `AppDialog` is bound to in this file. Almost always "AppDialog", but an
+ * alias would otherwise slip every footer in the file past the tag-name match.
+ */
+function dialogBinding(source: ts.SourceFile): string {
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const specifier = statement.moduleSpecifier;
+    if (!ts.isStringLiteral(specifier) || !specifier.text.includes(APP_DIALOG_MODULE)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (imported === DEFAULT_DIALOG_BINDING) return element.name.text;
+    }
+  }
+  return DEFAULT_DIALOG_BINDING;
 }
 
-/** Literal variant, or null when absent/computed. */
-function variantOf(
-  element: ts.JsxOpeningLikeElement,
-  source: ts.SourceFile
-): { present: boolean; literal: string | null } {
+/**
+ * Every string literal an expression can evaluate to, or null when that can't be
+ * determined statically. Covers the shapes a variant realistically takes.
+ */
+function literalValues(node: ts.Expression): string[] | null {
+  if (ts.isStringLiteralLike(node)) return [node.text];
+  if (ts.isParenthesizedExpression(node)) return literalValues(node.expression);
+  if (ts.isConditionalExpression(node)) {
+    const whenTrue = literalValues(node.whenTrue);
+    const whenFalse = literalValues(node.whenFalse);
+    return whenTrue && whenFalse ? [...whenTrue, ...whenFalse] : null;
+  }
+  if (
+    ts.isBinaryExpression(node) &&
+    (node.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
+      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken)
+  ) {
+    const left = literalValues(node.left);
+    const right = literalValues(node.right);
+    return left && right ? [...left, ...right] : null;
+  }
+  return null;
+}
+
+type VariantInfo =
+  { kind: "absent" } | { kind: "literals"; values: string[] } | { kind: "unresolvable" };
+
+function variantOf(element: ts.JsxOpeningLikeElement): VariantInfo {
   for (const attribute of element.attributes.properties) {
     if (!ts.isJsxAttribute(attribute)) continue;
-    if (attribute.name.getText(source) !== "variant") continue;
+    if (attribute.name.getText() !== "variant") continue;
     const initializer = attribute.initializer;
-    if (initializer && ts.isStringLiteral(initializer)) {
-      return { present: true, literal: initializer.text };
+    if (!initializer) return { kind: "unresolvable" };
+    if (ts.isStringLiteral(initializer)) return { kind: "literals", values: [initializer.text] };
+    if (ts.isJsxExpression(initializer) && initializer.expression) {
+      const values = literalValues(initializer.expression);
+      return values ? { kind: "literals", values } : { kind: "unresolvable" };
     }
-    if (
-      initializer &&
-      ts.isJsxExpression(initializer) &&
-      initializer.expression &&
-      ts.isStringLiteralLike(initializer.expression)
-    ) {
-      return { present: true, literal: initializer.expression.text };
-    }
-    return { present: true, literal: null };
+    return { kind: "unresolvable" };
   }
-  return { present: false, literal: null };
+  return { kind: "absent" };
 }
 
 type Violation = { file: string; line: number; reason: string };
+type ScanResult = { violations: Violation[]; footers: number; buttons: number };
 
-function scan(filePath: string): Violation[] {
+function scan(filePath: string): ScanResult {
   const text = fs.readFileSync(filePath, "utf8");
-  if (!text.includes(FOOTER_TAG)) return [];
-
   const source = ts.createSourceFile(
     filePath,
     text,
@@ -91,54 +137,94 @@ function scan(filePath: string): Violation[] {
     true,
     ts.ScriptKind.TSX
   );
-  const violations: Violation[] = [];
+  const footerTag = `${dialogBinding(source)}.${FOOTER_MEMBER}`;
+  const result: ScanResult = { violations: [], footers: 0, buttons: 0 };
   const relative = path.relative(REPO_ROOT, filePath);
 
   const inspectButtons = (node: ts.Node) => {
     if (
       (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
-      tagNameOf(node, source) === BUTTON_TAG
+      node.tagName.getText() === BUTTON_TAG
     ) {
-      const { present, literal } = variantOf(node, source);
+      result.buttons += 1;
+      const variant = variantOf(node);
       const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
-      if (!present) {
-        violations.push({ file: relative, line, reason: "no variant (inherits the accent CTA)" });
-      } else if (literal === REJECTED_VARIANT) {
-        violations.push({ file: relative, line, reason: `variant="${REJECTED_VARIANT}"` });
+      if (variant.kind === "absent") {
+        result.violations.push({
+          file: relative,
+          line,
+          reason: "no variant (inherits the accent CTA)",
+        });
+      } else if (variant.kind === "literals" && variant.values.includes(REJECTED_VARIANT)) {
+        result.violations.push({ file: relative, line, reason: `variant="${REJECTED_VARIANT}"` });
       }
     }
     ts.forEachChild(node, inspectButtons);
   };
 
   const visit = (node: ts.Node) => {
-    if (ts.isJsxElement(node) && tagNameOf(node.openingElement, source) === FOOTER_TAG) {
+    if (ts.isJsxElement(node) && node.openingElement.tagName.getText() === footerTag) {
+      result.footers += 1;
       for (const child of node.children) inspectButtons(child);
+      // Buttons handed in as props (`children={<Button/>}`, `hint={...}`) render inside
+      // the footer just the same.
+      inspectButtons(node.openingElement.attributes);
+    } else if (ts.isJsxSelfClosingElement(node) && node.tagName.getText() === footerTag) {
+      result.footers += 1;
+      inspectButtons(node.attributes);
     }
     ts.forEachChild(node, visit);
   };
   visit(source);
 
-  return violations;
+  return result;
 }
 
 describe("dialog footers never inherit the accent CTA (#11963)", () => {
-  const files = SCAN_ROOTS.flatMap((root) => tsxFiles(root));
-  const footerFiles = files.filter((file) => fs.readFileSync(file, "utf8").includes(FOOTER_TAG));
+  const results = SCAN_ROOTS.flatMap((root) => tsxFiles(root))
+    .filter((file) => fs.readFileSync(file, "utf8").includes(`.${FOOTER_MEMBER}`))
+    .map((file) => scan(file));
 
-  it("finds the dialog footers it is meant to guard", () => {
-    // Guards the guard: a rename that stopped matching would otherwise make the
-    // contract pass by scanning nothing.
-    expect(footerFiles.length).toBeGreaterThan(5);
+  const footers = results.reduce((total, r) => total + r.footers, 0);
+  const buttons = results.reduce((total, r) => total + r.buttons, 0);
+
+  // Guards the guard. A rename, an alias, or a refactor that stopped matching would
+  // otherwise leave this contract green because it walked nothing — and it counts AST
+  // nodes actually inspected, not files whose text happens to mention the tag.
+  it("inspects the dialog footers it is meant to guard", () => {
+    expect(footers, "footer elements matched by the AST walk").toBeGreaterThanOrEqual(
+      MIN_FOOTERS_INSPECTED
+    );
+    expect(buttons, "buttons inspected inside those footers").toBeGreaterThanOrEqual(
+      MIN_BUTTONS_INSPECTED
+    );
   });
 
-  // Proves the scanner actually fires. Written outside the repo so a crashed run
-  // can't leave a stray .tsx behind for the other repo-wide contract suites.
-  it("recognises hand-written footer buttons that inherit or name the accent CTA", () => {
+  it("has no footer button inheriting or naming the accent CTA", () => {
+    const violations = results.flatMap((r) => r.violations);
+    expect(
+      violations.map((v) => `${v.file}:${v.line} — ${v.reason}`),
+      'dialog footer buttons must name a variant; the primary action is "contrast"'
+    ).toEqual([]);
+  });
+
+  // Fixtures live outside the repo so a crashed run can't leave a stray .tsx behind for
+  // the other repo-wide contract suites.
+  function withFixture(lines: string[], assert: (result: ScanResult) => void) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dialog-footer-contract-"));
     const fixture = path.join(dir, "Fixture.tsx");
-    fs.writeFileSync(
-      fixture,
+    fs.writeFileSync(fixture, lines.join("\n"));
+    try {
+      assert(scan(fixture));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("catches a footer button that inherits or names the accent CTA", () => {
+    withFixture(
       [
+        'import { AppDialog } from "@/components/ui/AppDialog";',
         "export const D = () => (",
         "  <AppDialog.Footer>",
         '    <Button variant="ghost" onClick={cancel}>Cancel</Button>',
@@ -147,25 +233,79 @@ describe("dialog footers never inherit the accent CTA (#11963)", () => {
         '    <Button variant="contrast" onClick={ok}>OK</Button>',
         "  </AppDialog.Footer>",
         ");",
-      ].join("\n")
+      ],
+      (result) => {
+        expect(result.violations.map((v) => v.reason)).toEqual([
+          "no variant (inherits the accent CTA)",
+          'variant="default"',
+        ]);
+        expect(result.buttons).toBe(4);
+        expect(result.footers).toBe(1);
+      }
     );
-    try {
-      expect(scan(fixture).map((v) => v.reason)).toEqual([
-        "no variant (inherits the accent CTA)",
-        'variant="default"',
-      ]);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
   });
 
-  // A Button outside a footer is none of this contract's business.
-  it("ignores buttons that are not inside a dialog footer", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dialog-footer-contract-"));
-    const fixture = path.join(dir, "Fixture.tsx");
-    fs.writeFileSync(
-      fixture,
+  it("follows an aliased AppDialog import", () => {
+    withFixture(
       [
+        'import { AppDialog as Modal } from "@/components/ui/AppDialog";',
+        "export const D = () => (",
+        "  <Modal.Footer>",
+        "    <Button onClick={go}>Go</Button>",
+        "  </Modal.Footer>",
+        ");",
+      ],
+      (result) => {
+        expect(result.footers).toBe(1);
+        expect(result.violations.map((v) => v.reason)).toEqual([
+          "no variant (inherits the accent CTA)",
+        ]);
+      }
+    );
+  });
+
+  it("resolves a conditional variant and rejects the branch that paints accent", () => {
+    withFixture(
+      [
+        'import { AppDialog } from "@/components/ui/AppDialog";',
+        "export const D = () => (",
+        "  <AppDialog.Footer>",
+        '    <Button variant={danger ? "destructive" : "default"}>A</Button>',
+        '    <Button variant={danger ? "destructive" : "contrast"}>B</Button>',
+        "    <Button variant={computeVariant()}>C</Button>",
+        "  </AppDialog.Footer>",
+        ");",
+      ],
+      (result) => {
+        // Only the branch that can resolve to the accent CTA is rejected; an
+        // unresolvable expression is a documented known limit, not a violation.
+        expect(result.violations.map((v) => v.reason)).toEqual(['variant="default"']);
+        expect(result.buttons).toBe(3);
+      }
+    );
+  });
+
+  it("sees a button handed to a self-closing footer as a prop", () => {
+    withFixture(
+      [
+        'import { AppDialog } from "@/components/ui/AppDialog";',
+        "export const D = () => (",
+        "  <AppDialog.Footer hint={<Button onClick={go}>Go</Button>} />",
+        ");",
+      ],
+      (result) => {
+        expect(result.footers).toBe(1);
+        expect(result.violations.map((v) => v.reason)).toEqual([
+          "no variant (inherits the accent CTA)",
+        ]);
+      }
+    );
+  });
+
+  it("ignores buttons that are not inside a dialog footer", () => {
+    withFixture(
+      [
+        'import { AppDialog } from "@/components/ui/AppDialog";',
         "export const D = () => (",
         "  <AppDialog>",
         "    <AppDialog.Body><Button onClick={go}>Go</Button></AppDialog.Body>",
@@ -174,20 +314,11 @@ describe("dialog footers never inherit the accent CTA (#11963)", () => {
         "    </AppDialog.Footer>",
         "  </AppDialog>",
         ");",
-      ].join("\n")
+      ],
+      (result) => {
+        expect(result.violations).toEqual([]);
+        expect(result.buttons).toBe(1);
+      }
     );
-    try {
-      expect(scan(fixture)).toEqual([]);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("has no footer button inheriting or naming the accent CTA", () => {
-    const violations = footerFiles.flatMap((file) => scan(file));
-    expect(
-      violations.map((v) => `${v.file}:${v.line} — ${v.reason}`),
-      'dialog footer buttons must name a variant; the primary action is "contrast"'
-    ).toEqual([]);
   });
 });

--- a/src/config/__tests__/dialogFooterPrimary.contract.test.ts
+++ b/src/config/__tests__/dialogFooterPrimary.contract.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+// `AppDialog.Footer`'s `primaryAction` prop resolves the CTA's variant centrally, so
+// every dialog that uses it followed #11963 for free. A footer that hand-writes its
+// buttons instead bypasses that resolver entirely: `<Button>` with no variant falls
+// through to cva's `default`, the accent fill, and looks correct in review because the
+// omission is invisible. Thirteen files had drifted that way by the time the standard
+// changed.
+//
+// This guard closes that hatch. Inside a dialog footer a `Button` must name its variant,
+// and it must not name the accent CTA — the primary action is `contrast`, secondaries are
+// ghost/outline/subtle, and a dangerous action is `destructive`.
+//
+// KNOWN LIMITS (deliberate — a regression guard, not a sound checker):
+//   - A computed variant (`variant={x}`) is not analyzed; only literals are.
+//   - A spread (`{...props}`) is not treated as supplying the variant, for the same
+//     reason the grid-panel guard rejects one: its contents aren't visible here.
+//   - A `Button` reached through a wrapper component rendered inside the footer is
+//     outside this file's view.
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const SCAN_ROOTS = [
+  path.join(REPO_ROOT, "src"),
+  path.join(REPO_ROOT, "plugins/builtin/github/renderer"),
+];
+
+const FOOTER_TAG = "AppDialog.Footer";
+const BUTTON_TAG = "Button";
+// cva's own fallback. Naming it explicitly is the same accent fill as omitting the prop,
+// so both are rejected — the point is that no dialog footer paints the accent CTA.
+const REJECTED_VARIANT = "default";
+
+function tsxFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "__tests__") continue;
+      tsxFiles(full, found);
+    } else if (entry.name.endsWith(".tsx")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function tagNameOf(node: ts.JsxOpeningLikeElement, source: ts.SourceFile): string {
+  return node.tagName.getText(source);
+}
+
+/** Literal variant, or null when absent/computed. */
+function variantOf(
+  element: ts.JsxOpeningLikeElement,
+  source: ts.SourceFile
+): { present: boolean; literal: string | null } {
+  for (const attribute of element.attributes.properties) {
+    if (!ts.isJsxAttribute(attribute)) continue;
+    if (attribute.name.getText(source) !== "variant") continue;
+    const initializer = attribute.initializer;
+    if (initializer && ts.isStringLiteral(initializer)) {
+      return { present: true, literal: initializer.text };
+    }
+    if (
+      initializer &&
+      ts.isJsxExpression(initializer) &&
+      initializer.expression &&
+      ts.isStringLiteralLike(initializer.expression)
+    ) {
+      return { present: true, literal: initializer.expression.text };
+    }
+    return { present: true, literal: null };
+  }
+  return { present: false, literal: null };
+}
+
+type Violation = { file: string; line: number; reason: string };
+
+function scan(filePath: string): Violation[] {
+  const text = fs.readFileSync(filePath, "utf8");
+  if (!text.includes(FOOTER_TAG)) return [];
+
+  const source = ts.createSourceFile(
+    filePath,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const violations: Violation[] = [];
+  const relative = path.relative(REPO_ROOT, filePath);
+
+  const inspectButtons = (node: ts.Node) => {
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      tagNameOf(node, source) === BUTTON_TAG
+    ) {
+      const { present, literal } = variantOf(node, source);
+      const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+      if (!present) {
+        violations.push({ file: relative, line, reason: "no variant (inherits the accent CTA)" });
+      } else if (literal === REJECTED_VARIANT) {
+        violations.push({ file: relative, line, reason: `variant="${REJECTED_VARIANT}"` });
+      }
+    }
+    ts.forEachChild(node, inspectButtons);
+  };
+
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxElement(node) && tagNameOf(node.openingElement, source) === FOOTER_TAG) {
+      for (const child of node.children) inspectButtons(child);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return violations;
+}
+
+describe("dialog footers never inherit the accent CTA (#11963)", () => {
+  const files = SCAN_ROOTS.flatMap((root) => tsxFiles(root));
+  const footerFiles = files.filter((file) => fs.readFileSync(file, "utf8").includes(FOOTER_TAG));
+
+  it("finds the dialog footers it is meant to guard", () => {
+    // Guards the guard: a rename that stopped matching would otherwise make the
+    // contract pass by scanning nothing.
+    expect(footerFiles.length).toBeGreaterThan(5);
+  });
+
+  // Proves the scanner actually fires. Written outside the repo so a crashed run
+  // can't leave a stray .tsx behind for the other repo-wide contract suites.
+  it("recognises hand-written footer buttons that inherit or name the accent CTA", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dialog-footer-contract-"));
+    const fixture = path.join(dir, "Fixture.tsx");
+    fs.writeFileSync(
+      fixture,
+      [
+        "export const D = () => (",
+        "  <AppDialog.Footer>",
+        '    <Button variant="ghost" onClick={cancel}>Cancel</Button>',
+        "    <Button onClick={go}>Go</Button>",
+        '    <Button variant="default" onClick={other}>Other</Button>',
+        '    <Button variant="contrast" onClick={ok}>OK</Button>',
+        "  </AppDialog.Footer>",
+        ");",
+      ].join("\n")
+    );
+    try {
+      expect(scan(fixture).map((v) => v.reason)).toEqual([
+        "no variant (inherits the accent CTA)",
+        'variant="default"',
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // A Button outside a footer is none of this contract's business.
+  it("ignores buttons that are not inside a dialog footer", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dialog-footer-contract-"));
+    const fixture = path.join(dir, "Fixture.tsx");
+    fs.writeFileSync(
+      fixture,
+      [
+        "export const D = () => (",
+        "  <AppDialog>",
+        "    <AppDialog.Body><Button onClick={go}>Go</Button></AppDialog.Body>",
+        "    <AppDialog.Footer>",
+        '      <Button variant="contrast" onClick={ok}>OK</Button>',
+        "    </AppDialog.Footer>",
+        "  </AppDialog>",
+        ");",
+      ].join("\n")
+    );
+    try {
+      expect(scan(fixture)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("has no footer button inheriting or naming the accent CTA", () => {
+    const violations = footerFiles.flatMap((file) => scan(file));
+    expect(
+      violations.map((v) => `${v.file}:${v.line} — ${v.reason}`),
+      'dialog footer buttons must name a variant; the primary action is "contrast"'
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Makes the `contrast` button variant (`bg-daintree-text text-text-inverse`, the theme's own body-text colour as the fill) the standard primary action button across every dialog in the app, replacing the accent fill.
- The variant shipped in one place first (the create-worktree dialog, #11960). This PR takes it app-wide: the central `AppDialog.Footer` resolver, 27 hand-written footer buttons across 14 files, and 3 dialog primaries that live outside `AppDialog.Footer` entirely.
- Adds contrast validation for the new fill/label pair across all 15 built-in themes, and a new AST-based contract test that stops any dialog footer button from silently reverting to the accent fill.

Resolves #11963

## Changes

**Primary variant resolver.** `AppDialog.Footer`'s `getPrimaryVariant()` returned a default accent variant for the non-destructive case. Now it returns `contrast` instead. This one change covers every `ConfirmDialog` render plus the 6 dialogs that pass a `primaryAction` prop. The destructive-precedence check is untouched and still runs first, so a destructive action or destructive dialog context still resolves to `destructive`.

**Hand-written footers.** 27 footer buttons across 14 files bypass `primaryAction`, so they got `variant="contrast"` applied explicitly.

**Outside `AppDialog.Footer`.** Three more dialog primaries needed the same treatment by hand: crash recovery's `Restore selected` and `Submit on GitHub` buttons, and the webview dialog's plain OK button. That last one was a hardcoded raw `<button>`, so it's now on the theme-aware contrast token pair instead of a hardcoded colour.

**Corrections to the issue's numbers**, worth stating plainly since they shaped the scope:
- The issue described two `getPrimaryVariant()` functions, one in `ConfirmDialog.tsx` and one in `AppDialog.tsx`. There's only one, in `AppDialog.tsx`. `ConfirmDialog.tsx` just sets a semantic `intent` value and routes through `AppDialog.Footer`'s single resolver.
- The issue said 6 hand-written footer buttons. It's 27, across 14 files.
- The issue said 7 `primaryAction` callers. It's 6.

**Contrast validation.** Added one entry to `CONTRAST_PAIRS` in `shared/theme/contrast.ts`: foreground `text-inverse`, background `text-primary`, minimum 4.5. That single entry covers all 15 built-in themes in both polarities (8 dark, 7 light) through the existing `getThemeContrastWarnings` machinery. All 15 clear the floor comfortably, weakest is arashiyama at 12.14:1 against the 4.5 minimum.

Known limitation, documented inline: this only checks the resting fill. Hover mixes the fill 90% toward the label colour, active/pressed mixes it 82%, so a theme sitting just above the floor at rest could in theory dip below it while hovered or pressed. As an illustration, `#767676` on `#ffffff` is 4.54:1 resting, roughly 3.8:1 hovered, roughly 3.3:1 pressed. Modelling that properly means doing the mix in OKLab space, which means either hand-rolling that math or promoting `culori` out of devDependencies into code the main process loads. Not worth it yet: every built-in theme's weakest interaction state still sits around 8:1. For a custom theme that fails the check, the consequence is an advisory warning badge in the theme editor, never a rejected import.

**Accent-guard allowlist.** The issue predicted a few entries would go stale once the accent fill left dialog buttons. Only one did: `src/components/Browser/WebviewDialog.tsx`, whose sole non-focus-ring accent match was the OK button's `bg-daintree-accent`. Removed. The other dialog files stay allowlisted because their remaining accent usage is icons, rings, and borders, not the primary action itself. The button component's `default` variant paints via `bg-primary`, which the guard's regex doesn't match anyway.

**New guard test**, `src/config/__tests__/dialogFooterPrimary.contract.test.ts`: a TypeScript-AST source contract that rejects any `<Button>` inside an `AppDialog.Footer` that states no `variant` or names one that still paints the accent fill (`default`, `glow`, `vibrant`). It resolves the local `AppDialog` import binding so an aliased import can't slip past, reads conditional and `??` variant expressions down to their literal values (keeping the readable branch when a sibling is opaque to static analysis), inspects self-closing footers' props too, and ratchets on the actual number of AST nodes inspected (24 footers, 53 buttons) rather than on which files merely mention the tag as text. Known limitations are documented inline.

**Other tests.** A resolver matrix in `AppDialog.test.tsx` covering all four semantic combinations, with expectations computed from `buttonVariants` rather than hardcoded utility strings. New negative and positive fixtures in `shared/theme/__tests__/contrast.test.ts` proving the new pair is actually enforced.

**Screenshots.** New opt-in harness at `e2e/screenshots/confirm-dialog-review.spec.ts`, modelled on `worktree-dialog-review.spec.ts` from #11960. Gated on `DAINTREE_SHOT_CONFIRM`, one theme per boot via `DAINTREE_SHOT_THEME`, never runs in CI. Captures five states: the central `primaryAction` resolver, two hand-written footers, a nested destructive confirm, and the delete-recipe destructive confirm, the one that proves destructive still wins over the new contrast default.

## Testing

226 test files, 4,483 tests, all green: `shared/theme/__tests__`, `src/components/ui/__tests__`, `src/config/__tests__`, and `src/components/{Project,Terminal,Setup,Recovery,Browser,Commands,TerminalRecipe}/__tests__`, plus the GitHub plugin's renderer tests. `tsc --noEmit` clean. `eslint` and `prettier` clean on every changed file. The opt-in e2e screenshot spec is gated off by design and wasn't run in CI.
