### PR TITLE
fix(recipes): drop the ProjectFileStore mirror when deleting an in-repo recipe

### DIFF
--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -2695,11 +2695,13 @@ describe("recipeStore", () => {
         terminals: [{ type: "terminal" as const, title: "Shell", env: { TOKEN: "" } }],
         createdAt: 500,
       };
+      // The blanked env is the one thing `loadRecipes` does not hydrate onto the
+      // canonical copy, so it identifies which of the two restored rows the
+      // rollback re-merge actually rendered.
       const mirror = {
         ...inRepoRecipe,
         projectId: "project-1",
-        lastUsedAt: 900,
-        usageHistory: [800, 900],
+        terminals: [{ type: "terminal" as const, title: "Shell", env: { TOKEN: "secret" } }],
       };
       globalGetRecipesMock.mockResolvedValueOnce([]);
       getRecipesMock.mockResolvedValueOnce({ recipes: [mirror], collisions: [] });
@@ -2708,60 +2710,32 @@ describe("recipeStore", () => {
 
       // Hold the IPC open so the optimistic slice can be inspected before the
       // rollback runs — a post-rejection assertion alone passes either way.
-      let rejectDelete: (error: Error) => void = () => {};
-      deleteInRepoRecipeMock.mockImplementationOnce(
-        () =>
-          new Promise<void>((_resolve, reject) => {
-            rejectDelete = reject;
-          })
-      );
+      let rejectDelete!: (error: Error) => void;
+      const deleteInFlight = new Promise<void>((_resolve, reject) => {
+        rejectDelete = reject;
+      });
+      deleteInRepoRecipeMock.mockReturnValueOnce(deleteInFlight);
 
       const pending = useRecipeStore.getState().deleteRecipe("recipe-opaque-abc");
+      // Proves the IPC was reached synchronously, so the assertions below read
+      // the optimistic slice rather than hanging if that sequencing changes.
+      expect(deleteInRepoRecipeMock).toHaveBeenCalledWith("project-1", "Team Recipe");
       const optimistic = useRecipeStore.getState();
       expect(optimistic.inRepoRecipes).toHaveLength(0);
       expect(optimistic.projectRecipes).toHaveLength(0);
       expect(optimistic.recipes).toHaveLength(0);
 
+      const settled = expect(pending).rejects.toThrow("disk error");
       rejectDelete(new Error("disk error"));
-      await expect(pending).rejects.toThrow("disk error");
+      await settled;
 
       const state = useRecipeStore.getState();
       expect(state.inRepoRecipes.map((r) => r.id)).toEqual(["recipe-opaque-abc"]);
       expect(state.projectRecipes.map((r) => r.id)).toEqual(["recipe-opaque-abc"]);
-      // Restoring both copies must re-collapse into one row, not a duplicate,
-      // and the surviving row keeps the mirror-only frecency.
+      // Restoring both copies must re-collapse into the single mirror-backed
+      // row, not a duplicate and not the redacted canonical copy.
       expect(state.recipes).toHaveLength(1);
-      expect(state.recipes[0]).toMatchObject({
-        id: "recipe-opaque-abc",
-        lastUsedAt: 900,
-        usageHistory: [800, 900],
-      });
-    });
-
-    it("deleteRecipe drops the mirror of a renamed in-repo recipe (#11993)", async () => {
-      const inRepoRecipe = {
-        id: "recipe-opaque-abc",
-        name: "Before",
-        scope: "inrepo" as const,
-        terminals: [{ type: "terminal" as const, title: "Shell" }],
-        createdAt: 500,
-      };
-      globalGetRecipesMock.mockResolvedValueOnce([]);
-      getRecipesMock.mockResolvedValueOnce({
-        recipes: [{ ...inRepoRecipe, projectId: "project-1", lastUsedAt: 900 }],
-        collisions: [],
-      });
-      getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
-      await useRecipeStore.getState().loadRecipes("project-1");
-
-      await useRecipeStore.getState().updateRecipe("recipe-opaque-abc", { name: "After" });
-      await useRecipeStore.getState().deleteRecipe("recipe-opaque-abc");
-
-      expect(deleteInRepoRecipeMock).toHaveBeenCalledWith("project-1", "After");
-      const state = useRecipeStore.getState();
-      expect(state.inRepoRecipes).toHaveLength(0);
-      expect(state.projectRecipes).toHaveLength(0);
-      expect(state.recipes).toHaveLength(0);
+      expect(state.recipes[0]?.terminals[0]?.env).toEqual({ TOKEN: "secret" });
     });
 
     describe("RECIPE_STALE_CONFLICT handling (#9186)", () => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -2638,6 +2638,132 @@ describe("recipeStore", () => {
       expect(state.recipes).toHaveLength(1);
     });
 
+    it("deleteRecipe drops the ProjectFileStore mirror so no ghost row survives (#11993)", async () => {
+      // The mirror shares the canonical recipe's id and carries the frecency the
+      // git-tracked file deliberately omits. `mergeRecipes` only hides it while
+      // the canonical row exists, so a delete that spares it renders it as an
+      // ordinary project-local recipe until the next load.
+      const inRepoRecipe = {
+        id: "recipe-opaque-abc",
+        name: "Team Recipe",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, title: "Shell", env: { TOKEN: "" } }],
+        createdAt: 500,
+      };
+      const mirror = {
+        ...inRepoRecipe,
+        projectId: "project-1",
+        lastUsedAt: 900,
+        usageHistory: [800, 900],
+        terminals: [{ type: "terminal" as const, title: "Shell", env: { TOKEN: "secret" } }],
+      };
+      const sameNameLocal = {
+        id: "recipe-local",
+        name: "Team Recipe",
+        projectId: "project-1",
+        terminals: [{ type: "terminal" as const, title: "Local" }],
+        createdAt: 100,
+      };
+      globalGetRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [mirror, sameNameLocal], collisions: [] });
+      getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      await useRecipeStore.getState().deleteRecipe("recipe-opaque-abc");
+
+      expect(deleteInRepoRecipeMock).toHaveBeenCalledWith("project-1", "Team Recipe");
+      const state = useRecipeStore.getState();
+      expect(state.inRepoRecipes.map((r) => r.id)).not.toContain("recipe-opaque-abc");
+      expect(state.projectRecipes.map((r) => r.id)).not.toContain("recipe-opaque-abc");
+      expect(state.recipes.map((r) => r.id)).not.toContain("recipe-opaque-abc");
+      // The same-named local recipe is a different recipe, not the mirror: it
+      // survives and stops being shadowed now that the team recipe is gone.
+      const survivor = state.recipes.find((r) => r.id === "recipe-local");
+      expect(survivor).toBeDefined();
+      expect(survivor?.shadowedBy).toBeUndefined();
+      // The ghost also made a repeat delete a silent no-op; now the id is gone.
+      await expect(useRecipeStore.getState().deleteRecipe("recipe-opaque-abc")).rejects.toThrow(
+        /not found/
+      );
+    });
+
+    it("deleteRecipe prunes the mirror optimistically and restores it on failure (#11993)", async () => {
+      const inRepoRecipe = {
+        id: "recipe-opaque-abc",
+        name: "Team Recipe",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, title: "Shell", env: { TOKEN: "" } }],
+        createdAt: 500,
+      };
+      const mirror = {
+        ...inRepoRecipe,
+        projectId: "project-1",
+        lastUsedAt: 900,
+        usageHistory: [800, 900],
+      };
+      globalGetRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [mirror], collisions: [] });
+      getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      // Hold the IPC open so the optimistic slice can be inspected before the
+      // rollback runs — a post-rejection assertion alone passes either way.
+      let rejectDelete: (error: Error) => void = () => {};
+      deleteInRepoRecipeMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectDelete = reject;
+          })
+      );
+
+      const pending = useRecipeStore.getState().deleteRecipe("recipe-opaque-abc");
+      const optimistic = useRecipeStore.getState();
+      expect(optimistic.inRepoRecipes).toHaveLength(0);
+      expect(optimistic.projectRecipes).toHaveLength(0);
+      expect(optimistic.recipes).toHaveLength(0);
+
+      rejectDelete(new Error("disk error"));
+      await expect(pending).rejects.toThrow("disk error");
+
+      const state = useRecipeStore.getState();
+      expect(state.inRepoRecipes.map((r) => r.id)).toEqual(["recipe-opaque-abc"]);
+      expect(state.projectRecipes.map((r) => r.id)).toEqual(["recipe-opaque-abc"]);
+      // Restoring both copies must re-collapse into one row, not a duplicate,
+      // and the surviving row keeps the mirror-only frecency.
+      expect(state.recipes).toHaveLength(1);
+      expect(state.recipes[0]).toMatchObject({
+        id: "recipe-opaque-abc",
+        lastUsedAt: 900,
+        usageHistory: [800, 900],
+      });
+    });
+
+    it("deleteRecipe drops the mirror of a renamed in-repo recipe (#11993)", async () => {
+      const inRepoRecipe = {
+        id: "recipe-opaque-abc",
+        name: "Before",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, title: "Shell" }],
+        createdAt: 500,
+      };
+      globalGetRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({
+        recipes: [{ ...inRepoRecipe, projectId: "project-1", lastUsedAt: 900 }],
+        collisions: [],
+      });
+      getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      await useRecipeStore.getState().updateRecipe("recipe-opaque-abc", { name: "After" });
+      await useRecipeStore.getState().deleteRecipe("recipe-opaque-abc");
+
+      expect(deleteInRepoRecipeMock).toHaveBeenCalledWith("project-1", "After");
+      const state = useRecipeStore.getState();
+      expect(state.inRepoRecipes).toHaveLength(0);
+      expect(state.projectRecipes).toHaveLength(0);
+      expect(state.recipes).toHaveLength(0);
+    });
+
     describe("RECIPE_STALE_CONFLICT handling (#9186)", () => {
       function makeConflictError(name: string) {
         // Mirror the `[AppError|<code>|<urlencoded userMessage>] <message>`

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -703,8 +703,10 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     const prevProject = get().projectRecipes;
     const prevInRepo = get().inRepoRecipes;
     const nextGlobal = isGlobal ? prevGlobal.filter((r) => r.id !== id) : prevGlobal;
-    const nextProject =
-      !isGlobal && !isInRepo ? prevProject.filter((r) => r.id !== id) : prevProject;
+    // In-repo recipes also have a same-id ProjectFileStore mirror holding their
+    // machine-local frecency; leaving it behind makes `mergeRecipes` render it as
+    // a project-local ghost once the canonical row is gone (#11993).
+    const nextProject = !isGlobal ? prevProject.filter((r) => r.id !== id) : prevProject;
     const nextInRepo = isInRepo ? prevInRepo.filter((r) => r.id !== id) : prevInRepo;
     set({
       globalRecipes: nextGlobal,


### PR DESCRIPTION
Summary: Deleting an in-repo recipe removed the `.daintree/recipes/*.json` file but left the row in the list until the store reloaded on window focus or a project switch. A second delete on the same row did nothing.

Root cause: an in-repo recipe has two copies in renderer state — the canonical entry in `inRepoRecipes`, and a same-id ProjectFileStore mirror in `projectRecipes` that carries machine-local frecency the git-tracked file deliberately omits. `deleteRecipe` only pruned the canonical one. `mergeRecipes` hides a mirror only while its id is still present in `inRepoIds`, so once the canonical row went away the orphaned mirror fell through into the project-local tier and rendered as a ghost. Because that ghost still carries `scope: "inrepo"`, the retry classified it as in-repo again and repeated the same half-delete.

Fix: `deleteRecipe` now filters `projectRecipes` for every non-global recipe (`!isGlobal`) instead of only project-local ones. This matches what `updateRecipe` already does one function up, and what the main process already does on disk — `PROJECT_DELETE_INREPO_RECIPE` deletes the canonical file and then the mirror. The rollback path needed no change: its snapshots are taken before the optimistic mutation, so `prevProject` still holds the mirror and restores it.

Tests: two regression tests in `recipeStore.test.ts`. Both were verified to fail against the unfixed code.
- the ghost row: a canonical in-repo recipe, its mirror, and a same-name/different-id project-local recipe. After delete the id is gone from all three slices, the different-id local recipe survives and loses its `shadowedBy` marker, and a repeat delete now rejects instead of silently no-opping.
- optimistic prune + rollback: holds the delete IPC open to assert the slices are actually empty mid-flight, then rejects and asserts both copies come back and re-collapse into one rendered row — identified by the mirror's env values, since `loadRecipes` hydrates frecency onto the canonical copy and so frecency wouldn't prove which row was rendered.

Follow-ups found while reviewing, not fixed here (each is pre-existing and independent of this change):
- `saveToRepo` strands an existing target mirror when a repeat promotion reuses `existingInRepoId` — same bug class, different site.
- `PROJECT_DELETE_INREPO_RECIPE` resolves the canonical file by name while the store keys by id, so a hand-edited JSON `name` can leave the file behind and resurrect the row on next load.
- The optimistic rollback restores whole pre-request arrays, so a concurrent edit or project switch during a pending mutation can be clobbered. Applies to every mutator in the store, not just delete.
- The underlying cause of this recurring bug class (#4928, #11860, now this) is that `recipes` is a materialized field recomputed by hand at every mutation site. A memoized selector would eliminate it structurally.

Local verification: 306 tests pass across the recipe store and its consumers (`recipeStore.test.ts`, `recipeActions.adversarial.test.ts`, `useRecipeRunner.test.tsx`, `RecipesTab.pin.test.tsx`, `worktreeStore.test.ts`, `usePluginRecipes.test.tsx`); prettier and eslint clean on both changed files.

Resolves #11993