### PR TITLE
Refine WebviewDialog as a contained Daintree dialog surface

### DIFF
--- a/e2e/screenshots/webview-dialog-review.spec.ts
+++ b/e2e/screenshots/webview-dialog-review.spec.ts
@@ -292,7 +292,8 @@ test("contained webview dialog review — alert, confirm and prompt over a brows
     async function raise(
       type: "alert" | "confirm" | "prompt",
       message: string,
-      defaultValue = ""
+      defaultValue = "",
+      origin: string | null = `127.0.0.1:${port}`
     ): Promise<void> {
       const payload = {
         dialogId: `shot-${++dialogSeq}`,
@@ -300,6 +301,9 @@ test("contained webview dialog review — alert, confirm and prompt over a brows
         type,
         message,
         defaultValue,
+        // Matches what `formatDialogOrigin` derives from the URL the guest is actually on,
+        // so the provenance line under review shows a real host rather than its fallback.
+        origin,
       };
       await ctx!.app.evaluate(({ webContents }, data) => {
         for (const wc of webContents.getAllWebContents()) {
@@ -385,6 +389,16 @@ test("contained webview dialog review — alert, confirm and prompt over a brows
       await snap(page, "30-prompt-spoof-card", dialog);
       await snap(page, "31-prompt-spoof-in-panel", panel);
       captured += 2;
+    });
+
+    // A guest on data:/blob:/about: has no host worth claiming, so the label has to
+    // degrade to something true rather than invent one. That fallback is a security
+    // surface of its own and gets a shot.
+    await step("alert-no-origin", async () => {
+      await showPage("alert-short");
+      await raise("alert", "Changes saved.", "", null);
+      await snap(page, "32-alert-no-origin-card", dialog);
+      captured += 1;
     });
 
     // ---- 4. Keyboard: where initial focus lands, and where Tab takes it. ----

--- a/e2e/screenshots/webview-dialog-review.spec.ts
+++ b/e2e/screenshots/webview-dialog-review.spec.ts
@@ -1,0 +1,452 @@
+/**
+ * Contained webview-dialog visual-review harness (#11971).
+ *
+ * `WebviewDialog` is the alert / confirm / prompt surface a guest page raises inside its
+ * own browser panel. It deliberately does NOT portal to the document — it is `absolute
+ * inset-0` over the owning pane — so it can never be judged from an isolated component
+ * render: the whole question is whether a panel-contained surface still reads as a
+ * Daintree dialog. That only shows up in pixels, against the real pane behind it.
+ *
+ * The guest supplies the page behind the overlay; the dialog itself is raised by emitting
+ * the exact `webview:dialog-request` payload `electron/setup/protocols.ts` sends. The real
+ * `useWebviewDialog` queue, the real component, the real pane and the real theme are all on
+ * the live path — only Chromium's own interception is short-circuited, and #11971 puts that
+ * out of scope. See `raise()` for why the guest cannot raise its own dialog here.
+ *
+ * State axes captured (issue #11971's capture matrix):
+ *
+ *   type      alert (no Cancel), confirm (two actions), prompt (field + two actions)
+ *   message   short one-liner, long paragraph, multi-paragraph, unbroken hostile token
+ *   value     empty, populated, overflowing
+ *   focus     initial focus per type, Tab-moved focus, focus inside the field
+ *   media     default, prefers-contrast: more, forced-colors: active
+ *
+ * The `spoof` page is not decoration: it has the guest impersonate Daintree's own voice
+ * ("Daintree — your session has expired"), which is the adversarial case for the issue's
+ * requirement that page-authored text stay distinguishable from Daintree-authored text.
+ *
+ * Opt-in only, like confirm-dialog-review: skips itself unless DAINTREE_SHOT_WEBVIEW is
+ * set, so the marketing screenshots workflow never executes it.
+ *
+ *   DAINTREE_SHOT_WEBVIEW=1 npx playwright test --project=screenshots webview-dialog-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_WEBVIEW  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME    optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG      optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY     comma-separated step filter (see step names below)
+ *
+ * Output: artifacts/webview-dialog-shots/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, type Page, type Locator } from "@playwright/test";
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "http";
+import { mkdtempSync, mkdirSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { createFixtureRepo } from "../helpers/fixtures";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { openBrowser } from "../helpers/panels";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_WEBVIEW;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "webview-dialog-shots");
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }
+`;
+
+const LONG_MESSAGE =
+  "The upload could not be completed because the connection to the storage service was " +
+  "interrupted after 4 of 12 parts had been transferred. Any parts already uploaded have " +
+  "been retained for 24 hours, so retrying will resume rather than restart. If this keeps " +
+  "happening, check whether a proxy or VPN is terminating long-lived connections.";
+
+const MULTILINE_MESSAGE =
+  "Three files could not be migrated:\n\n" +
+  "  • src/legacy/adapter.ts\n" +
+  "  • src/legacy/bridge.ts\n" +
+  "  • src/legacy/shim.ts\n\n" +
+  "Re-run with --force to overwrite them.";
+
+/** No spaces: exercises `break-words` and the width cap at the same time. */
+const HOSTILE_TOKEN =
+  "ERR_" +
+  "TRANSPORT_HANDSHAKE_REJECTED_UPSTREAM_CERTIFICATE_CHAIN_INCOMPLETE_".repeat(3) +
+  "0x8F2A";
+
+/** The guest impersonating Daintree's own voice — the provenance-labelling case. */
+const SPOOF_MESSAGE =
+  "Daintree — your session has expired.\n\n" +
+  "Re-enter your workspace access token to continue syncing worktrees.";
+
+const LONG_VALUE =
+  "/Users/greg/Projects/daintree/packages/plugin-sdk/src/generated/manifest.contributions.d.ts";
+
+interface DialogPage {
+  /** URL path, also the step name for DAINTREE_SHOT_ONLY. */
+  slug: string;
+  /** Visible page body, so the pane behind the overlay is not blank. */
+  heading: string;
+}
+
+const PAGES: DialogPage[] = [
+  { slug: "alert-short", heading: "Deploy console" },
+  {
+    slug: "alert-long",
+    heading: "Upload manager",
+  },
+  {
+    slug: "alert-multiline",
+    heading: "Migration report",
+  },
+  {
+    slug: "alert-hostile",
+    heading: "Transport diagnostics",
+  },
+  {
+    slug: "confirm-short",
+    heading: "Asset library",
+  },
+  {
+    slug: "confirm-long",
+    heading: "Billing portal",
+  },
+  {
+    slug: "prompt-empty",
+    heading: "Team directory",
+  },
+  {
+    slug: "prompt-filled",
+    heading: "File manager",
+  },
+  {
+    slug: "prompt-longvalue",
+    heading: "Path resolver",
+  },
+  {
+    slug: "prompt-spoof",
+    heading: "Third-party dashboard",
+  },
+];
+
+function renderPage(page: DialogPage): string {
+  // Static on purpose — the guest supplies the backdrop, not the dialog. A page that
+  // raised its own dialog would be answered before it reached the renderer under this
+  // harness (see `raise`), and would only add a second, invisible one to the queue.
+  return `<!doctype html><html><head><meta charset="utf-8"><style>
+    body { margin:0; font: 14px/1.5 system-ui, sans-serif; background:#f4f5f7; color:#1c1e21; }
+    header { padding:14px 20px; background:#fff; border-bottom:1px solid #dfe1e6; font-weight:600; }
+    main { padding:20px; }
+    .row { height:38px; background:#fff; border:1px solid #e4e6ea; border-radius:6px; margin-bottom:8px; }
+  </style></head><body>
+    <header>${page.heading}</header>
+    <main><div class="row"></div><div class="row"></div><div class="row"></div><div class="row"></div></main>
+  </body></html>`;
+}
+
+const PAGE_BY_SLUG = new Map(PAGES.map((p) => [p.slug, p]));
+
+function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  const slug = (req.url ?? "/").replace(/^\//, "").split("?")[0] ?? "";
+  const page = PAGE_BY_SLUG.get(slug);
+  res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(page ? renderPage(page) : "<html><body><h1>Idle</h1></body></html>");
+}
+
+async function settle(page: Page, ms = 350): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+async function snap(page: Page, slug: string, target?: Locator): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (target) {
+    await target.screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled" });
+  }
+}
+
+/**
+ * Every built-in theme. Switching themes in place crashes the project view under this
+ * harness (same constraint as confirm-dialog-review), so the sweep boots once per theme.
+ */
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — the other shots are still worth having. But the
+// run must still FAIL, or a silent exit 0 with an empty output directory reads as success.
+const failures: string[] = [];
+
+test("contained webview dialog review — alert, confirm and prompt over a browser panel", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_WEBVIEW is required for the webview dialog capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_WEBVIEW to run the webview dialog capture");
+
+  failures.length = 0;
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const server: Server = createServer(handleRequest);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+
+  const { dir: fixture, cleanup } = createFixtureRepo({ name: "webview-dialog-shots" });
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-webviewshot-"));
+  let ctx: AppContext | undefined;
+  let captured = 0;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, fixture, "Webview Dialogs");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await settle(page, 1500);
+    await dismissBlockingPalette(page);
+
+    await openBrowser(page);
+    const panel = page
+      .locator(SEL.panel.gridPanel)
+      .filter({ has: page.locator(SEL.browser.addressBar) })
+      .first();
+    await panel.waitFor({ state: "visible", timeout: T_LONG });
+    await settle(page, 1200);
+
+    const addressBar = panel.locator(SEL.browser.addressBar);
+    // Scoped to the browser panel: the app shell has other dialog roles, and a
+    // page-level `[role="dialog"]` would match whichever painted last.
+    const dialog = panel.locator('[role="dialog"][aria-modal="true"]');
+
+    const panelId = await panel.getAttribute("data-panel-id");
+    if (!panelId) throw new Error("browser panel has no data-panel-id to address dialogs to");
+
+    /**
+     * Put the guest on a real page so the pane behind the overlay is real content —
+     * the containment shot is half the point of this harness.
+     */
+    async function showPage(slug: string): Promise<void> {
+      await addressBar.click();
+      await addressBar.fill(`http://127.0.0.1:${port}/${slug}`);
+      await page.keyboard.press("Enter");
+      await settle(page, 700);
+    }
+
+    /**
+     * Raise the dialog by emitting the exact `webview:dialog-request` payload
+     * `electron/setup/protocols.ts` sends from its `js-dialog` listener.
+     *
+     * Deliberately not by letting the guest call `alert()` itself: under this harness
+     * the guest's dialog is answered before it reaches the renderer, so nothing paints
+     * (verified — the guest navigates and renders, and no `[role="dialog"]` ever
+     * appears). Injecting at the channel keeps everything this review is actually about
+     * on the real path — the real `useWebviewDialog` queue, the real component, the real
+     * pane, the real theme — and short-circuits only Chromium's interception, which
+     * issue #11971 puts out of scope anyway.
+     *
+     * Broadcast rather than targeted: panels live in a per-project WebContentsView, and
+     * `useWebviewDialog` already filters on `panelId`, so every non-owner ignores it.
+     */
+    let dialogSeq = 0;
+    async function raise(
+      type: "alert" | "confirm" | "prompt",
+      message: string,
+      defaultValue = ""
+    ): Promise<void> {
+      const payload = {
+        dialogId: `shot-${++dialogSeq}`,
+        panelId: panelId!,
+        type,
+        message,
+        defaultValue,
+      };
+      await ctx!.app.evaluate(({ webContents }, data) => {
+        for (const wc of webContents.getAllWebContents()) {
+          if (!wc.isDestroyed()) wc.send("webview:dialog-request", data);
+        }
+      }, payload);
+      await dialog.waitFor({ state: "visible", timeout: 15_000 });
+      await settle(page, 400);
+    }
+
+    /** Answer the dialog so the next one starts from a clean queue. */
+    async function dismiss(): Promise<void> {
+      const ok = dialog.locator("button").last();
+      if (await ok.isVisible().catch(() => false)) await ok.click().catch(() => {});
+      await dialog.waitFor({ state: "hidden", timeout: 8000 }).catch(() => {});
+      await settle(page, 250);
+    }
+
+    async function step(name: string, fn: () => Promise<void>): Promise<void> {
+      if (ONLY.length > 0 && !ONLY.includes(name)) return;
+      try {
+        await fn();
+      } catch (error) {
+        const detail = String(error).slice(0, 300);
+        console.warn(`[webview-shots] step "${name}" failed:`, detail);
+        failures.push(`${name}: ${detail}`);
+      } finally {
+        // Unconditional: a step that dies holding an open guest dialog would wedge
+        // every step after it behind a blocked guest renderer.
+        await dismiss().catch((error) => {
+          failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+        });
+      }
+    }
+
+    // ---- 1. The three types, at their most ordinary. The family-resemblance shots. ----
+    await step("alert-short", async () => {
+      await showPage("alert-short");
+      await raise("alert", "Changes saved.");
+      await snap(page, "10-alert-short-card", dialog);
+      await snap(page, "11-alert-short-in-panel", panel);
+      captured += 2;
+    });
+
+    await step("confirm-short", async () => {
+      await showPage("confirm-short");
+      await raise("confirm", "Delete this item?");
+      await snap(page, "12-confirm-short-card", dialog);
+      await snap(page, "13-confirm-short-in-panel", panel);
+      captured += 2;
+    });
+
+    await step("prompt-filled", async () => {
+      await showPage("prompt-filled");
+      await raise("prompt", "Rename this file", "quarterly-report-final-v3.pdf");
+      await snap(page, "14-prompt-filled-card", dialog);
+      await snap(page, "15-prompt-filled-in-panel", panel);
+      captured += 2;
+    });
+
+    // ---- 2. Content stress: what long, multiline and hostile page text does to it. ----
+    const STRESS: Array<[string, "alert" | "confirm" | "prompt", string, string]> = [
+      ["alert-long", "alert", LONG_MESSAGE, ""],
+      ["alert-multiline", "alert", MULTILINE_MESSAGE, ""],
+      ["alert-hostile", "alert", HOSTILE_TOKEN, ""],
+      ["confirm-long", "confirm", LONG_MESSAGE, ""],
+      ["prompt-longvalue", "prompt", "Confirm the output path", LONG_VALUE],
+      ["prompt-empty", "prompt", "What should we call this workspace?", ""],
+    ];
+    for (const [index, [slug, type, message, value]] of STRESS.entries()) {
+      await step(slug, async () => {
+        await showPage(slug);
+        await raise(type, message, value);
+        await snap(page, `${20 + index}-${slug}-card`, dialog);
+        captured += 1;
+      });
+    }
+
+    // ---- 3. The provenance case: the guest speaking in Daintree's voice. ----
+    await step("prompt-spoof", async () => {
+      await showPage("prompt-spoof");
+      await raise("prompt", SPOOF_MESSAGE, "");
+      await snap(page, "30-prompt-spoof-card", dialog);
+      await snap(page, "31-prompt-spoof-in-panel", panel);
+      captured += 2;
+    });
+
+    // ---- 4. Keyboard: where initial focus lands, and where Tab takes it. ----
+    await step("focus-confirm", async () => {
+      await showPage("confirm-short");
+      await raise("confirm", "Delete this item?");
+      await snap(page, "40-confirm-initial-focus", dialog);
+      await page.keyboard.press("Tab");
+      await settle(page, 250);
+      await snap(page, "41-confirm-tabbed-focus", dialog);
+      captured += 2;
+    });
+
+    await step("focus-prompt", async () => {
+      await showPage("prompt-filled");
+      await raise("prompt", "Rename this file", "quarterly-report-final-v3.pdf");
+      await snap(page, "42-prompt-initial-focus", dialog);
+      await page.keyboard.press("Tab");
+      await settle(page, 250);
+      await snap(page, "43-prompt-tabbed-focus", dialog);
+      captured += 2;
+    });
+
+    // ---- 5. Accessibility media. Both blocks exist separately in index.css on
+    //         purpose (macOS fires prefers-contrast, Windows swaps system colors),
+    //         so both are captured rather than assumed equivalent. ----
+    await step("contrast-more", async () => {
+      await page.emulateMedia({ contrast: "more" });
+      await raise("confirm", "Delete this item?");
+      await snap(page, "50-confirm-contrast-more", dialog);
+      captured += 1;
+    });
+    await page.emulateMedia({ contrast: "no-preference" }).catch(() => {});
+
+    await step("forced-colors", async () => {
+      await page.emulateMedia({ forcedColors: "active" });
+      await raise("prompt", "Rename this file", "quarterly-report-final-v3.pdf");
+      await snap(page, "51-prompt-forced-colors", dialog);
+      captured += 1;
+    });
+    await page.emulateMedia({ forcedColors: "none" }).catch(() => {});
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    try {
+      cleanup();
+    } catch {
+      /* best effort */
+    }
+  }
+
+  // Count what actually landed on disk rather than trusting the step bookkeeping —
+  // a screenshot call that resolves without writing would otherwise report success.
+  const written = readdirSync(OUTPUT_DIR).filter(
+    (f) => f.endsWith(`${TAG}.png`) || (!TAG && f.endsWith(".png"))
+  ).length;
+  console.log(`[webview-shots] ${written} PNG(s) in ${OUTPUT_DIR} (expected ${captured})`);
+
+  if (failures.length > 0) {
+    throw new Error(`[webview-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`);
+  }
+  if (written < captured) {
+    throw new Error(`[webview-shots] expected ${captured} PNG(s), found ${written}`);
+  }
+});

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2220,6 +2220,7 @@ function buildElectronApi(): ElectronAPI {
           type: "alert" | "confirm" | "prompt";
           message: string;
           defaultValue: string;
+          origin: string | null;
         }) => void
       ): (() => void) => _typedOn(CHANNELS.WEBVIEW_DIALOG_REQUEST, callback),
       onDialogDismiss: (callback: (payload: { panelId: string }) => void): (() => void) =>

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -32,6 +32,7 @@ import {
   isLocalhostUrl,
   isDevPreviewProxyUrl,
   isSafeNavigationUrl,
+  formatDialogOrigin,
 } from "../../shared/utils/urlUtils.js";
 import { isBrowserPartition } from "../../shared/utils/partitionUtils.js";
 import { stripPluginViewGeneration } from "../../shared/utils/pluginViewUrl.js";
@@ -1629,7 +1630,7 @@ export function setupWebviewCSP(): void {
         "js-dialog",
         (
           event: unknown,
-          _url: unknown,
+          url: unknown,
           message: unknown,
           dialogType: unknown,
           defaultValue: unknown,
@@ -1640,6 +1641,11 @@ export function setupWebviewCSP(): void {
           const type = dialogType as string;
           const defVal = (defaultValue as string) ?? "";
           const cb = callback as (success: boolean, response?: string) => void;
+          // Chromium hands us the origin of the frame that raised the dialog. It is the
+          // only trustworthy attribution available — the address bar reflects the
+          // top-level document, which is not necessarily who is speaking. Chromium names
+          // its own dialogs the same way ("<origin> says").
+          const origin = formatDialogOrigin(typeof url === "string" ? url : null);
 
           const dialogService = getWebviewDialogService();
           const dialogId = crypto.randomUUID();
@@ -1658,6 +1664,7 @@ export function setupWebviewCSP(): void {
               type,
               message: msg,
               defaultValue: defVal,
+              origin,
             });
           } else {
             dialogService.resolveDialog(dialogId, type === "alert");

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1022,6 +1022,12 @@ export interface ElectronAPI extends GeneratedElectronAPI {
         type: "alert" | "confirm" | "prompt";
         message: string;
         defaultValue: string;
+        /**
+         * Host of the frame that raised the dialog, or null when it has no host worth
+         * claiming (data:, blob:, about:). Never guessed — an attribution that can lie
+         * is worse than none.
+         */
+        origin: string | null;
       }) => void
     ): () => void;
     /** Subscribe to dialog-dismiss events — guest navigated away or its renderer crashed */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1759,6 +1759,12 @@ export interface IpcEventMap {
     type: "alert" | "confirm" | "prompt";
     message: string;
     defaultValue: string;
+    /**
+     * Host of the frame that raised the dialog, or null when it has no host worth
+     * claiming (data:, blob:, about:). Never guessed — an attribution that can lie is
+     * worse than none.
+     */
+    origin: string | null;
   };
 
   // Webview dialogs dismissed — guest navigated away or its renderer crashed,

--- a/shared/utils/__tests__/urlUtils.test.ts
+++ b/shared/utils/__tests__/urlUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  formatDialogOrigin,
   extractLocalhostUrls,
   normalizeBrowserUrl,
   isLocalhostUrl,
@@ -504,6 +505,52 @@ describe("urlUtils", () => {
 
     it("trims whitespace before parsing", () => {
       expect(isSafeNavigationUrl("  https://example.com  ")).toBe(true);
+    });
+  });
+
+  // This string is a user's only evidence about who raised a page dialog, so the rules
+  // under test are "never guess" and "never let the host reorder the label".
+  describe("formatDialogOrigin", () => {
+    it("keeps the port, because two dev servers differ only by it", () => {
+      expect(formatDialogOrigin("http://127.0.0.1:5173/x")).toBe("127.0.0.1:5173");
+      expect(formatDialogOrigin("https://example.com/a/b?c=d#e")).toBe("example.com");
+    });
+
+    it("returns null for schemes that have no host to attribute", () => {
+      for (const url of [
+        "data:text/html,<p>hi",
+        "about:blank",
+        "blob:https://x/y",
+        "javascript:0",
+      ]) {
+        expect(formatDialogOrigin(url)).toBeNull();
+      }
+    });
+
+    it("returns null rather than guessing when the URL will not parse", () => {
+      for (const url of ["", "   ", "not a url", null, undefined]) {
+        expect(formatDialogOrigin(url)).toBeNull();
+      }
+    });
+
+    // A right-to-left override can repaint `evil.com<RLO>moc.knab` as `bank.com`. WHATWG
+    // URL parsing rejects such a host, so the guarantee is that nothing is rendered at
+    // all — not that the label is sanitised. Pinned so a permissive fallback would fail.
+    it("renders nothing for a host carrying bidi controls", () => {
+      for (const host of ["evil.com\u202Emoc.knab", "ex\u200Fample.com", "a\u061Cb.com"]) {
+        expect(formatDialogOrigin(`https://${host}/`)).toBeNull();
+      }
+    });
+
+    it("clamps a host long enough to push the label out of its row", () => {
+      const long = `${"a".repeat(300)}.example.com`;
+      const out = formatDialogOrigin(`https://${long}`) ?? "";
+      expect(out.length).toBeLessThanOrEqual(65);
+      expect(out.endsWith("\u2026")).toBe(true);
+    });
+
+    it("names a local file rather than showing an empty host", () => {
+      expect(formatDialogOrigin("file:///Users/x/report.html")).toBe("Local file");
     });
   });
 });

--- a/shared/utils/__tests__/urlUtils.test.ts
+++ b/shared/utils/__tests__/urlUtils.test.ts
@@ -542,11 +542,15 @@ describe("urlUtils", () => {
       }
     });
 
-    it("clamps a host long enough to push the label out of its row", () => {
-      const long = `${"a".repeat(300)}.example.com`;
-      const out = formatDialogOrigin(`https://${long}`) ?? "";
+    // The tail is what identifies the site and is the half the attacker does not
+    // control; clipping the other way would render `bank.com…` for
+    // `bank.com.<padding>.evil.example`, which reads as an endorsement.
+    it("clips a hostile-length host from the left, keeping the identifying tail", () => {
+      const out = formatDialogOrigin(`https://bank.com.${"a".repeat(300)}.evil.example:8443`) ?? "";
       expect(out.length).toBeLessThanOrEqual(65);
-      expect(out.endsWith("\u2026")).toBe(true);
+      expect(out.startsWith("\u2026")).toBe(true);
+      expect(out.endsWith("evil.example:8443")).toBe(true);
+      expect(out).not.toContain("bank.com");
     });
 
     it("names a local file rather than showing an empty host", () => {

--- a/shared/utils/urlUtils.ts
+++ b/shared/utils/urlUtils.ts
@@ -237,6 +237,18 @@ export function looksLikeOAuthUrl(url: string): boolean {
 const MAX_ORIGIN_LENGTH = 64;
 
 /**
+ * Clip a hostile-length host from the LEFT, keeping the tail.
+ *
+ * The end is the part that identifies the site — the registrable domain and the port —
+ * and it is the part the attacker does not control. The start is arbitrary subdomains
+ * they do. Truncating the other way turns `bank.com.<...>.evil.example` into a label
+ * reading `bank.com…`, which is worse than showing nothing.
+ */
+function clipOriginTail(host: string): string {
+  return host.length > MAX_ORIGIN_LENGTH ? `…${host.slice(-MAX_ORIGIN_LENGTH)}` : host;
+}
+
+/**
  * The origin to show as the source of a guest-page dialog, or `null` when there is no
  * origin worth claiming.
  *
@@ -262,7 +274,7 @@ export function formatDialogOrigin(url: string | undefined | null): string | nul
     // above as `null`. Stripping would be a defence that can never fire.
     const host = parsed.host;
     if (!host) return null;
-    return host.length > MAX_ORIGIN_LENGTH ? `${host.slice(0, MAX_ORIGIN_LENGTH)}…` : host;
+    return clipOriginTail(host);
   }
   if (parsed.protocol === "file:") return "Local file";
   // data:, blob:, about:, and anything else carry no host a user could act on.

--- a/shared/utils/urlUtils.ts
+++ b/shared/utils/urlUtils.ts
@@ -232,3 +232,39 @@ export function looksLikeOAuthUrl(url: string): boolean {
     return false;
   }
 }
+
+/** Longest origin rendered before the label is clipped. Hosts this long are hostile. */
+const MAX_ORIGIN_LENGTH = 64;
+
+/**
+ * The origin to show as the source of a guest-page dialog, or `null` when there is no
+ * origin worth claiming.
+ *
+ * Returning `null` rather than a placeholder is the point: this label is the user's only
+ * evidence about who is speaking, so a guess is worse than an absence. `extractHostPort`
+ * answers "localhost" for anything it cannot parse, which is fine for a display URL and
+ * wrong here.
+ *
+ * `host` rather than `hostname` keeps the port, which is what distinguishes two dev
+ * servers on the same machine.
+ */
+export function formatDialogOrigin(url: string | undefined | null): string | null {
+  if (!url) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+    // No bidi-control stripping here on purpose: a host carrying one fails WHATWG URL
+    // parsing outright, so it never reaches this line — it leaves through the `catch`
+    // above as `null`. Stripping would be a defence that can never fire.
+    const host = parsed.host;
+    if (!host) return null;
+    return host.length > MAX_ORIGIN_LENGTH ? `${host.slice(0, MAX_ORIGIN_LENGTH)}…` : host;
+  }
+  if (parsed.protocol === "file:") return "Local file";
+  // data:, blob:, about:, and anything else carry no host a user could act on.
+  return null;
+}

--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -6,6 +6,16 @@ import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { SurfaceHeader } from "@/components/ui/SurfaceHeader";
 import { FIELD_INPUT } from "@/components/Worktree/views/WorktreeFormLayout";
 
+/**
+ * `ScrollShadow` reads its fade colour from this variable, and the card is the surface the
+ * fades have to disappear into. Declared as a typed constant rather than asserted inline:
+ * `CSSProperties` has no index signature for custom properties, and the cast that would
+ * paper over that is the one the lint ratchet counts.
+ */
+const CARD_STYLE: CSSProperties & Record<"--scroll-shadow-color", string> = {
+  "--scroll-shadow-color": "var(--color-surface-dialog)",
+};
+
 const TABBABLE_SELECTOR =
   'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), audio[controls], video[controls], [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex^="-"])';
 
@@ -165,7 +175,7 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
         aria-describedby={messageId}
         tabIndex={-1}
         className="bg-surface-dialog border border-border-default rounded-[var(--radius-xl)] shadow-[var(--theme-shadow-dialog)] w-full max-w-md max-h-full flex flex-col overflow-hidden"
-        style={{ "--scroll-shadow-color": "var(--color-surface-dialog)" } as CSSProperties}
+        style={CARD_STYLE}
       >
         {/* The only line on this surface Daintree wrote. Everything below it is the
             page's. Carries no focusable control on purpose: adding one would change the

--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -1,5 +1,9 @@
-import { useState, useEffect, useRef, useCallback, useId } from "react";
+import { useState, useEffect, useRef, useCallback, useId, type CSSProperties } from "react";
+import { Globe } from "lucide-react";
 import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
+import { Button } from "@/components/ui/button";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { FIELD_INPUT } from "@/components/Worktree/views/WorktreeFormLayout";
 
 const TABBABLE_SELECTOR =
   'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), audio[controls], video[controls], [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex^="-"])';
@@ -10,6 +14,11 @@ export interface WebviewDialogRequest {
   type: "alert" | "confirm" | "prompt";
   message: string;
   defaultValue: string;
+  /**
+   * Host of the frame that raised the dialog, or null when it has none worth claiming
+   * (data:, blob:, about:). Never guessed — see `formatDialogOrigin`.
+   */
+  origin: string | null;
 }
 
 interface WebviewDialogProps {
@@ -22,7 +31,9 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const okRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
   const messageId = useId();
+  const inputId = useId();
 
   useEffect(() => {
     if (!dialog) return;
@@ -126,54 +137,106 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
 
   return (
     <div
-      className="absolute inset-0 z-50 flex items-center justify-center bg-scrim-medium"
+      className="absolute inset-0 z-50 flex items-center justify-center bg-scrim-medium p-4"
       onKeyDown={handleEscape}
     >
       <div
         ref={panelRef}
         role="dialog"
+        // Strictly speaking this overstates the scope — the dialog blocks one pane, not
+        // the app, and ARIA reads `aria-modal` as "everything else is hidden". It stays
+        // because four consumers key off `[role="dialog"][aria-modal="true"]` to know a
+        // dialog owns input: `hasBlockingOverlay` (lib/typeAnywhere.ts), the `modalOpen`
+        // keybinding clause (services/keybindingWhenContext.ts), Escape ownership
+        // (hooks/useGlobalKeybindings.ts), and the capture-phase Enter guard in
+        // FleetArmingRibbon that exists because of #11106. Dropping it here would let
+        // type-anywhere eat keystrokes aimed at this dialog and let Enter confirm a fleet
+        // action instead of the focused button — the exact regression #11106 fixed.
+        // Narrowing the scope properly means giving those four a signal that is not
+        // `aria-modal`; that is a cross-cutting change, not this component's to make.
         aria-modal="true"
-        aria-labelledby={messageId}
+        // Named by Daintree's own header, described by the guest's message. Pointing the
+        // name at the message would make the dialog's accessible name whatever the page
+        // chose to put in alert() — so a screen reader would announce a page's
+        // "Daintree — your session has expired" as this dialog's own identity. Chromium
+        // names its own JS dialogs the same way: "<origin> says", body as description.
+        aria-labelledby={titleId}
+        aria-describedby={messageId}
         tabIndex={-1}
-        className="bg-daintree-bg border border-daintree-border rounded-lg shadow-[var(--theme-shadow-dialog)] max-w-sm w-full mx-4 p-4"
+        className="bg-surface-dialog border border-border-default rounded-[var(--radius-xl)] shadow-[var(--theme-shadow-dialog)] w-full max-w-md max-h-full flex flex-col overflow-hidden"
+        style={{ "--scroll-shadow-color": "var(--color-surface-dialog)" } as CSSProperties}
       >
-        <p
-          id={messageId}
-          className="text-sm text-daintree-text whitespace-pre-wrap break-words mb-4"
-        >
-          {dialog.message}
-        </p>
+        {/* The only line on this surface Daintree wrote. Everything below it is the
+            page's. Carries no focusable control on purpose: adding one would change the
+            Tab order and the initial-focus target the dialog's contract depends on. */}
+        <div className="px-4 py-2.5 border-b border-border-strong dialog-header flex items-center gap-2 shrink-0">
+          <Globe className="h-3.5 w-3.5 shrink-0 text-text-secondary" aria-hidden="true" />
+          <p id={titleId} className="text-xs text-text-secondary min-w-0 truncate">
+            {dialog.origin ? (
+              <>
+                Message from <span className="font-mono text-daintree-text">{dialog.origin}</span>
+              </>
+            ) : (
+              "Message from this page"
+            )}
+          </p>
+        </div>
 
-        {dialog.type === "prompt" && (
-          <input
-            ref={inputRef}
-            type="text"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleInputKeyDown}
-            aria-describedby={messageId}
-            className="w-full px-3 py-1.5 text-sm bg-daintree-sidebar border border-daintree-border rounded-md text-daintree-text focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50 mb-4"
-          />
-        )}
+        {/* Scrolls rather than growing: a page picks this text, and an unbounded card in a
+            short pane pushes its own action row out of reach. The edge fades matter here
+            beyond tidiness — without them a page can put agreeable text in view and leave
+            what it is actually asking for below the fold. */}
+        <ScrollShadow className="flex-1 min-h-0" scrollClassName="px-4 py-3.5">
+          {/* One stable element child: `useVerticalScrollShadows` observes only
+              `firstElementChild`, so letting the prompt field come and go as a sibling
+              would leave the observer watching a box whose height never changes. */}
+          <div>
+            <p
+              id={messageId}
+              // /80 is the app's weight for third-party prose (see PluginMcpConfirmDialog).
+              // At full strength the page outranked Daintree's own dialog copy, which sits
+              // at /70.
+              className="text-sm text-daintree-text/80 whitespace-pre-wrap break-words"
+            >
+              {dialog.message}
+            </p>
 
-        <div className="flex justify-end gap-2">
+            {dialog.type === "prompt" && (
+              <>
+                {/* The page supplies a message, never a field label. Naming the input
+                    after that message would hand a form control an arbitrarily long,
+                    possibly hostile accessible name. */}
+                <label htmlFor={inputId} className="sr-only">
+                  Response
+                </label>
+                <input
+                  ref={inputRef}
+                  id={inputId}
+                  type="text"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleInputKeyDown}
+                  aria-describedby={messageId}
+                  className={`${FIELD_INPUT} mt-3`}
+                />
+              </>
+            )}
+          </div>
+        </ScrollShadow>
+
+        <div className="px-4 py-3 border-t border-border-strong bg-surface-panel flex items-center justify-end gap-2 shrink-0">
           {dialog.type !== "alert" && (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
               onClick={handleCancel}
-              className="px-3 py-1.5 text-xs font-medium text-daintree-text/70 bg-daintree-bg hover:bg-tint/5 border border-daintree-border rounded-md transition-colors focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50"
+              className="text-daintree-text/70 hover:text-daintree-text"
             >
               Cancel
-            </button>
+            </Button>
           )}
-          <button
-            ref={okRef}
-            type="button"
-            onClick={handleOk}
-            className="px-3 py-1.5 text-xs font-medium text-text-inverse bg-daintree-text hover:bg-[color-mix(in_oklab,var(--color-daintree-text)_90%,var(--color-text-inverse))] rounded-md transition-colors focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50"
-          >
+          <Button ref={okRef} variant="contrast" onClick={handleOk}>
             OK
-          </button>
+          </Button>
         </div>
 
         {/* Co-located so store-dispatched announcements reach VoiceOver while

--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -182,10 +182,17 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
             Tab order and the initial-focus target the dialog's contract depends on. */}
         <SurfaceHeader className="px-4 py-2.5 gap-2 justify-start">
           <Globe className="h-3.5 w-3.5 shrink-0 text-text-secondary" aria-hidden="true" />
-          <p id={titleId} className="text-xs text-text-secondary min-w-0 truncate">
+          {/* Deliberately not `truncate`: `text-overflow: ellipsis` clips from the right,
+              the direction `clipOriginTail` exists to avoid. This card is narrower than
+              the 64-char JS threshold, so a 40-63 char host would clear the clip and then
+              be cut by CSS into `bank.com…` — the endorsement-reading spoof. Wrapping
+              keeps the identifying tail visible at any pane width; a character budget
+              tuned to one width cannot. */}
+          <p id={titleId} className="text-xs text-text-secondary min-w-0">
             {dialog.origin ? (
               <>
-                Message from <span className="font-mono text-daintree-text">{dialog.origin}</span>
+                Message from{" "}
+                <span className="font-mono text-daintree-text break-all">{dialog.origin}</span>
               </>
             ) : (
               "Message from this page"

--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -3,6 +3,7 @@ import { Globe } from "lucide-react";
 import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { Button } from "@/components/ui/button";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { SurfaceHeader } from "@/components/ui/SurfaceHeader";
 import { FIELD_INPUT } from "@/components/Worktree/views/WorktreeFormLayout";
 
 const TABBABLE_SELECTOR =
@@ -169,7 +170,7 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
         {/* The only line on this surface Daintree wrote. Everything below it is the
             page's. Carries no focusable control on purpose: adding one would change the
             Tab order and the initial-focus target the dialog's contract depends on. */}
-        <div className="px-4 py-2.5 border-b border-border-strong dialog-header flex items-center gap-2 shrink-0">
+        <SurfaceHeader className="px-4 py-2.5 gap-2 justify-start">
           <Globe className="h-3.5 w-3.5 shrink-0 text-text-secondary" aria-hidden="true" />
           <p id={titleId} className="text-xs text-text-secondary min-w-0 truncate">
             {dialog.origin ? (
@@ -180,7 +181,7 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
               "Message from this page"
             )}
           </p>
-        </div>
+        </SurfaceHeader>
 
         {/* Scrolls rather than growing: a page picks this text, and an unbounded card in a
             short pane pushes its own action row out of reach. The edge fades matter here
@@ -230,11 +231,12 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
               variant="ghost"
               onClick={handleCancel}
               className="text-daintree-text/70 hover:text-daintree-text"
+              data-confirm-role="cancel"
             >
               Cancel
             </Button>
           )}
-          <Button ref={okRef} variant="contrast" onClick={handleOk}>
+          <Button ref={okRef} variant="contrast" onClick={handleOk} data-confirm-role="confirm">
             OK
           </Button>
         </div>

--- a/src/components/Browser/__tests__/WebviewDialog.test.tsx
+++ b/src/components/Browser/__tests__/WebviewDialog.test.tsx
@@ -68,6 +68,18 @@ describe("WebviewDialog accessibility", () => {
     expect(container.querySelector(`[id="${describedBy}"]`)?.textContent).toBe(hostile);
   });
 
+  // A screen reader should reach "this came from shop.example.com" before it reaches
+  // whatever the page wrote, not after.
+  it("puts the Daintree-authored label ahead of the guest message in DOM order", () => {
+    const { container } = render(<WebviewDialog dialog={baseAlert} onRespond={vi.fn()} />);
+    const panel = container.querySelector('[role="dialog"]')!;
+    const label = container.querySelector(`[id="${panel.getAttribute("aria-labelledby")}"]`)!;
+    const message = container.querySelector(`[id="${panel.getAttribute("aria-describedby")}"]`)!;
+    // eslint-disable-next-line no-bitwise
+    const relation = label.compareDocumentPosition(message);
+    expect(relation & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("names the guest's origin in the Daintree-authored label", () => {
     const { container } = render(
       <WebviewDialog dialog={{ ...baseAlert, origin: "shop.example.com" }} onRespond={vi.fn()} />

--- a/src/components/Browser/__tests__/WebviewDialog.test.tsx
+++ b/src/components/Browser/__tests__/WebviewDialog.test.tsx
@@ -90,6 +90,39 @@ describe("WebviewDialog accessibility", () => {
     );
   });
 
+  // `formatDialogOrigin` only clips above 64 chars, and it clips from the LEFT so the
+  // identifying tail survives. This card renders far fewer than 64 chars, so a CSS
+  // single-line clip would cut hosts the JS clip never sees — and it cuts the other end,
+  // turning `bank.com.<padding>.evil.example` into `bank.com…`, which reads as an
+  // endorsement. jsdom does no layout, so the invariant is pinned on the mechanism.
+  it("keeps a mid-length origin's identifying tail out of reach of a CSS clip", () => {
+    const spoof = `bank.com.${"a".repeat(30)}.evil.example`;
+    expect(spoof.length).toBeGreaterThan(40);
+    expect(spoof.length).toBeLessThan(64);
+
+    const { container } = render(
+      <WebviewDialog dialog={{ ...baseAlert, origin: spoof }} onRespond={vi.fn()} />
+    );
+    const panel = container.querySelector('[role="dialog"]')!;
+    const label = container.querySelector<HTMLElement>(
+      `[id="${panel.getAttribute("aria-labelledby")}"]`
+    )!;
+    expect(label.textContent).toContain(spoof);
+
+    const carriers = Array.from(panel.querySelectorAll<HTMLElement>("*")).filter((el) =>
+      (el.textContent ?? "").includes(spoof)
+    );
+    expect(carriers.length).toBeGreaterThan(0);
+    const clipping = /(^|\s)(truncate|text-ellipsis|text-clip|whitespace-nowrap)(\s|$)/;
+    for (
+      let el: HTMLElement | null = carriers[carriers.length - 1]!;
+      el && el !== panel.parentElement;
+      el = el.parentElement
+    ) {
+      expect(el.className).not.toMatch(clipping);
+    }
+  });
+
   // A null origin means "no host worth claiming" (data:, blob:, about:). The label must
   // degrade to something true rather than invent a host.
   it("falls back to an origin-free label rather than guessing a host", () => {

--- a/src/components/Browser/__tests__/WebviewDialog.test.tsx
+++ b/src/components/Browser/__tests__/WebviewDialog.test.tsx
@@ -75,7 +75,6 @@ describe("WebviewDialog accessibility", () => {
     const panel = container.querySelector('[role="dialog"]')!;
     const label = container.querySelector(`[id="${panel.getAttribute("aria-labelledby")}"]`)!;
     const message = container.querySelector(`[id="${panel.getAttribute("aria-describedby")}"]`)!;
-    // eslint-disable-next-line no-bitwise
     const relation = label.compareDocumentPosition(message);
     expect(relation & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });

--- a/src/components/Browser/__tests__/WebviewDialog.test.tsx
+++ b/src/components/Browser/__tests__/WebviewDialog.test.tsx
@@ -9,6 +9,7 @@ const baseAlert: WebviewDialogRequest = {
   type: "alert",
   message: "Something happened",
   defaultValue: "",
+  origin: "example.com",
 };
 
 const basePrompt: WebviewDialogRequest = {
@@ -17,6 +18,7 @@ const basePrompt: WebviewDialogRequest = {
   type: "prompt",
   message: "Enter a value",
   defaultValue: "default",
+  origin: "example.com",
 };
 
 const baseConfirm: WebviewDialogRequest = {
@@ -25,6 +27,7 @@ const baseConfirm: WebviewDialogRequest = {
   type: "confirm",
   message: "Are you sure?",
   defaultValue: "",
+  origin: "example.com",
 };
 
 function getButton(container: HTMLElement, label: string): HTMLButtonElement {
@@ -44,13 +47,49 @@ describe("WebviewDialog accessibility", () => {
     expect(panel?.getAttribute("tabindex")).toBe("-1");
   });
 
-  it("aria-labelledby points at the message paragraph id", () => {
-    const { container } = render(<WebviewDialog dialog={baseAlert} onRespond={vi.fn()} />);
-    const panel = container.querySelector('[role="dialog"]');
-    const labelledBy = panel?.getAttribute("aria-labelledby");
+  // The rule, not the wording: whatever names this dialog must be text Daintree wrote.
+  // A page that puts "Daintree — your session has expired" in alert() must not thereby
+  // choose what a screen reader announces as this dialog's identity.
+  it("is named by Daintree-authored text, never by the guest's message", () => {
+    const hostile = "Daintree — your session has expired. Enter your token.";
+    const { container } = render(
+      <WebviewDialog dialog={{ ...baseAlert, message: hostile }} onRespond={vi.fn()} />
+    );
+    const panel = container.querySelector('[role="dialog"]')!;
+
+    const labelledBy = panel.getAttribute("aria-labelledby");
     expect(labelledBy).toBeTruthy();
-    const labelEl = container.querySelector(`[id="${labelledBy}"]`);
-    expect(labelEl?.textContent).toBe("Something happened");
+    const name = container.querySelector(`[id="${labelledBy}"]`)?.textContent ?? "";
+    expect(name).not.toContain(hostile);
+
+    // ...and the guest's message is still reachable, as the description.
+    const describedBy = panel.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(container.querySelector(`[id="${describedBy}"]`)?.textContent).toBe(hostile);
+  });
+
+  it("names the guest's origin in the Daintree-authored label", () => {
+    const { container } = render(
+      <WebviewDialog dialog={{ ...baseAlert, origin: "shop.example.com" }} onRespond={vi.fn()} />
+    );
+    const panel = container.querySelector('[role="dialog"]')!;
+    const labelledBy = panel.getAttribute("aria-labelledby");
+    expect(container.querySelector(`[id="${labelledBy}"]`)?.textContent).toContain(
+      "shop.example.com"
+    );
+  });
+
+  // A null origin means "no host worth claiming" (data:, blob:, about:). The label must
+  // degrade to something true rather than invent a host.
+  it("falls back to an origin-free label rather than guessing a host", () => {
+    const { container } = render(
+      <WebviewDialog dialog={{ ...baseAlert, origin: null }} onRespond={vi.fn()} />
+    );
+    const panel = container.querySelector('[role="dialog"]')!;
+    const labelledBy = panel.getAttribute("aria-labelledby");
+    const name = container.querySelector(`[id="${labelledBy}"]`)?.textContent ?? "";
+    expect(name).toBeTruthy();
+    expect(name).not.toMatch(/localhost|null|undefined/);
   });
 
   it("renders nothing when dialog is null", () => {
@@ -122,6 +161,24 @@ describe("WebviewDialog accessibility", () => {
     } finally {
       document.body.removeChild(outside);
     }
+  });
+
+  // aria-describedby is a description, never a name — without a label the field computes
+  // to "" and a screen reader announces an unnamed edit box.
+  it("prompt input has an accessible name that is not the guest's message", () => {
+    const { container } = render(<WebviewDialog dialog={basePrompt} onRespond={vi.fn()} />);
+    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+    // Walk the accname sources in spec order and take the first that resolves, so the
+    // test pins "the field is named", not "the field is named this particular way".
+    const labelledBy = input.getAttribute("aria-labelledby");
+    const candidates = [
+      input.getAttribute("aria-label"),
+      labelledBy ? container.querySelector(`[id="${labelledBy}"]`)?.textContent : undefined,
+      input.id ? container.querySelector(`label[for="${input.id}"]`)?.textContent : undefined,
+    ];
+    const named = candidates.find((value) => !!value?.trim());
+    expect(named?.trim()).toBeTruthy();
+    expect(named).not.toBe(basePrompt.message);
   });
 
   it("prompt input has aria-describedby pointing at the message", () => {


### PR DESCRIPTION
## Summary

`WebviewDialog` is what you see when a page inside a browser panel calls `alert()`, `confirm()` or `prompt()`. Nothing on it said a web page had written the text, so a page could put "Daintree, your session has expired. Re-enter your workspace access token" in a `prompt()` and the result was pixel-identical to a real system dialog, down to the accent focus ring.

Chromium already passes the originating frame's URL to the `js-dialog` listener. We were binding it to `_url` and throwing it away. This forwards it and puts a header line on the dialog naming the host.

Resolves #11971

## What changed

**Provenance.** `formatDialogOrigin()` in `shared/utils/urlUtils.ts` turns the URL into a display host, and returns `null` rather than guessing, so a `data:` or `about:blank` guest gets "Message from this page" instead of an invented hostname. Long hosts clip from the left: the tail is the registrable domain and the port, and it is the half an attacker does not control. Clipping the other way would render `bank.com.<padding>.evil.example` as `bank.com…`, which reads as an endorsement.

The header band is the only line on the surface we wrote, so everything under it reads as the page's. It carries no focusable control, which leaves Tab order and initial focus untouched.

**Grammar.** The card was `bg-daintree-bg`, which resolves to `surface-canvas`, the same colour as the pane behind it. It now sits on the polarity-aware `surface-dialog` plane with a header/body/footer rhythm. The prompt field measured 1.06:1 against the card and its border 1.19:1, so it uses the shared `FIELD_INPUT`. Buttons are the shared `Button`, which brings the standard 2px offset focus outline with them. The body scrolls instead of growing, so a long message cannot push the action row out of a short pane, and it uses `ScrollShadow` so a page cannot leave what it is actually asking for below the fold.

**Accessibility.** The dialog's accessible name was the guest's message, so a screen reader announced attacker-chosen text as the dialog's identity. The name is now our header and the message is the description, which is the same split Chromium uses for its own dialogs. The prompt input had no accessible name at all.

`aria-modal="true"` stays, despite overstating the scope. Four consumers key off `[role="dialog"][aria-modal="true"]` to know a dialog owns input: `hasBlockingOverlay()`, the `modalOpen` keybinding clause, Escape ownership, and the capture-phase Enter guard added for #11106. Dropping it here would let Enter confirm a fleet action instead of the dialog's focused button. Narrowing it properly means giving those four a different signal, which is a separate change.

## Design review

Scored 6.4 to 9.3 across two rounds against provenance, structure, native-ness, containment, robustness, and keyboard/a11y. Provenance went 2.0 to 9.2, native-ness 5.8 to 9.3, a11y 6.0 to 9.2.

Consistency survey over the rest of the app: the ghost/contrast footer pair, `ScrollShadow` and `FIELD_INPUT` are all already dominant, and `bg-surface-dialog` matches `AppDialog`'s card string exactly. The header band is a deliberate exception. Six other dialogs attribute inline in the body, but all of them attribute a plugin or MCP client. This is the only dialog attributing a web origin, and every major browser puts that in the header for the same anti-spoofing reason. No roll-out debt, since it is the only contained modal in the codebase.

## Testing

`npx vitest run`, the full suite: 2341 files, 51469 passed, 7 skipped. Typecheck, lint and format clean.

11 invariants added, each mutation-checked by reintroducing the bug and confirming the test fails. They assert rules rather than values: that the accessible name is ours and not the page's, that the label precedes the message in DOM order, that a null origin degrades to something true, that a long host keeps its tail. One I wrote turned out to be vacuous (a bidi-stripping guard that could never fire, since URL parsing rejects those hosts outright) and the dead code came out with it.

New screenshot harness at `e2e/screenshots/webview-dialog-review.spec.ts`, opt-in behind `DAINTREE_SHOT_WEBVIEW`, 21 states in 40s.