### PR TITLE
Rebuild the clone dialog as four modes of one surface

### DIFF
--- a/e2e/screenshots/clone-dialog-review.spec.ts
+++ b/e2e/screenshots/clone-dialog-review.spec.ts
@@ -41,7 +41,7 @@ import { openAndOnboardProject } from "../helpers/project";
 import { dismissBlockingPalette } from "../helpers/overlays";
 import { setAppTheme } from "../helpers/theme";
 import { SEL } from "../helpers/selectors";
-import { T_LONG, T_MEDIUM } from "../helpers/timeouts";
+import { T_MEDIUM } from "../helpers/timeouts";
 
 const ENABLED = !!process.env.DAINTREE_SHOT_CLONE;
 const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
@@ -305,7 +305,12 @@ async function openDialog(page: Page): Promise<void> {
  */
 async function closeDialog(page: Page): Promise<void> {
   for (let i = 0; i < 4; i++) {
-    if (!(await dialog(page).isVisible().catch(() => false))) return;
+    if (
+      !(await dialog(page)
+        .isVisible()
+        .catch(() => false))
+    )
+      return;
     await page.keyboard.press("Escape").catch(() => {});
     await settle(page, 200);
   }
@@ -466,8 +471,7 @@ test("clone dialog review — configuration, progress, failure and success state
         mode: "error",
         stages: LONG_STAGES.slice(0, 2),
         stageDelayMs: 120,
-        errorMessage:
-          "repository 'https://github.com/helios-labs/helios-dashboard.git/' not found",
+        errorMessage: "repository 'https://github.com/helios-labs/helios-dashboard.git/' not found",
       });
       await startClone(page);
       await settle(page, 1200);
@@ -483,7 +487,8 @@ test("clone dialog review — configuration, progress, failure and success state
         mode: "auth",
         stages: LONG_STAGES.slice(0, 1),
         stageDelayMs: 120,
-        errorMessage: "Authentication failed for 'https://github.com/helios-labs/helios-dashboard.git/'",
+        errorMessage:
+          "Authentication failed for 'https://github.com/helios-labs/helios-dashboard.git/'",
       });
       await startClone(page);
       await settle(page, 1200);

--- a/e2e/screenshots/clone-dialog-review.spec.ts
+++ b/e2e/screenshots/clone-dialog-review.spec.ts
@@ -1,0 +1,532 @@
+/**
+ * Clone-repository dialog visual-review harness.
+ *
+ * Drives `CloneRepoDialog` through every state that carries design weight —
+ * empty and valid configuration, validation error, the pre-Doherty busy phase,
+ * "Connecting…", a multi-stage clone, cancellation, generic failure,
+ * authentication failure with provider recovery, failure plus partial-cleanup
+ * failure, and success — and writes a PNG of each so the redesign can be judged
+ * against real rendered pixels.
+ *
+ * States are produced by replacing the `project:clone-repo` /
+ * `project:clone-cancel` / `forge:get-providers` handlers in the MAIN process,
+ * so everything downstream of `ipcMain` is the real path: the real envelope,
+ * the real `GitOperationError` reconstruction in the preload, the real
+ * contextBridge property stripping, the real `onCloneProgress` subscription.
+ * Nothing in the renderer is stubbed. A real network clone can't produce
+ * auth-failure or cleanup-failure on demand, and can't hold the busy phase
+ * still long enough to photograph it.
+ *
+ * Opt-in only, like the other review harnesses: skips itself unless
+ * DAINTREE_SHOT_CLONE is set, so the marketing screenshots workflow never runs it.
+ *
+ *   DAINTREE_SHOT_CLONE=1 npx playwright test --project=screenshots clone-dialog-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_CLONE   required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME   optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG     optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY    comma-separated step filter (see step names below)
+ *
+ * Output: artifacts/clone-shots/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, expect, type Page, type ElectronApplication } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, statSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, mockOpenDialog, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG, T_MEDIUM } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_CLONE;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "clone-shots");
+
+/** The dialog backdrop carries `aria-modal`; the panel is its first child. */
+const BACKDROP = 'div[aria-modal="true"]';
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+const CLONE_URL = "https://github.com/helios-labs/helios-dashboard.git";
+
+/** Git's own stage labels, sentence-cased by the handler before they're sent. */
+const LONG_STAGES = [
+  { stage: "counting objects", progress: 100, message: "Counting objects: 100%" },
+  { stage: "compressing objects", progress: 100, message: "Compressing objects: 100%" },
+  { stage: "receiving objects", progress: 64, message: "Receiving objects: 64%" },
+];
+
+interface ScriptStage {
+  stage: string;
+  progress: number;
+  message: string;
+}
+
+interface CloneScript {
+  mode: "success" | "error" | "auth" | "cleanup" | "hang";
+  stages: ScriptStage[];
+  stageDelayMs: number;
+  clonedPath: string;
+  errorMessage: string;
+  cleanupMessage: string;
+}
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/** A minimal repo just so the app has a project to sit behind the dialog. */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-clone-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Swap the three main-process handlers the dialog talks to for scripted ones.
+ * `forge:get-providers` is pinned to a single GitHub provider so both the
+ * `owner/repo` shorthand host and the auth-failure sign-in route are
+ * deterministic — with the real registry the recovery banner silently
+ * degrades to the generic block and the capture would be of the wrong state.
+ */
+async function installCloneStub(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ ipcMain, webContents }) => {
+    const scope = globalThis as unknown as {
+      __cloneShotScript?: CloneScript;
+      __cloneShotCancelled?: boolean;
+    };
+    scope.__cloneShotScript ??= {
+      mode: "success",
+      stages: [],
+      stageDelayMs: 150,
+      clonedPath: "/Users/you/Code/helios-dashboard",
+      errorMessage: "Clone failed",
+      cleanupMessage: "Cleanup failed",
+    };
+
+    // `electron/setup/security.ts` monkey-patches `ipcMain.handle` to wrap every
+    // return in the success envelope and every throw in the error envelope. A
+    // handler that builds its own envelope gets double-wrapped and the renderer
+    // reads the failure as a success — so return raw payloads and throw real
+    // Errors, exactly as the production handlers do. `serializeError` promotes
+    // own `name` / `code` / `gitReason` onto the wire.
+    const gitError = (message: string, gitReason: string) => {
+      const error = new Error(message);
+      error.name = "GitOperationError";
+      (error as Error & { gitReason: string }).gitReason = gitReason;
+      return error;
+    };
+    const cancelledError = () => {
+      const error = new Error("Clone cancelled");
+      error.name = "AppError";
+      (error as Error & { code: string }).code = "CANCELLED";
+      return error;
+    };
+
+    const emit = (payload: unknown) => {
+      for (const contents of webContents.getAllWebContents()) {
+        if (contents.isDestroyed()) continue;
+        try {
+          contents.send("project:clone-progress", payload);
+        } catch {
+          // A view torn down mid-send is not this harness's problem.
+        }
+      }
+    };
+
+    // Fixed timestamps — a wall-clock value would make otherwise-identical
+    // rounds differ and defeat side-by-side comparison.
+    let tick = 1_700_000_000_000;
+    const progress = (stage: string, value: number, message: string) =>
+      emit({ stage, progress: value, message, timestamp: (tick += 1000) });
+
+    ipcMain.removeHandler("project:clone-repo");
+    ipcMain.handle("project:clone-repo", async () => {
+      const script = scope.__cloneShotScript!;
+      scope.__cloneShotCancelled = false;
+
+      for (const stage of script.stages) {
+        await new Promise((resolve) => setTimeout(resolve, script.stageDelayMs));
+        if (scope.__cloneShotCancelled) break;
+        progress(stage.stage, stage.progress, stage.message);
+      }
+
+      if (script.mode === "hang") {
+        // Held open so the busy phases can be photographed; "Stop clone"
+        // releases it through the cancel handler below.
+        await new Promise<void>((resolve) => {
+          const poll = setInterval(() => {
+            if (scope.__cloneShotCancelled) {
+              clearInterval(poll);
+              resolve();
+            }
+          }, 50);
+        });
+      }
+
+      if (scope.__cloneShotCancelled) {
+        progress("cancelled", 0, "Clone cancelled");
+        throw cancelledError();
+      }
+
+      if (script.mode === "success") {
+        progress("complete", 100, "Clone complete");
+        return { clonedPath: script.clonedPath };
+      }
+
+      if (script.mode === "cleanup") {
+        progress("cleanup-failed", 0, script.cleanupMessage);
+      }
+
+      progress("error", 0, `Clone failed: ${script.errorMessage}`);
+      throw gitError(script.errorMessage, script.mode === "auth" ? "auth-failed" : "unknown");
+    });
+
+    ipcMain.removeHandler("project:clone-cancel");
+    ipcMain.handle("project:clone-cancel", () => {
+      scope.__cloneShotCancelled = true;
+    });
+
+    ipcMain.removeHandler("forge:get-providers");
+    ipcMain.handle("forge:get-providers", () => [
+      {
+        pluginId: "daintree.github",
+        contribution: { id: "github", name: "GitHub", matches: ["github.com"] },
+      },
+    ]);
+  });
+}
+
+async function setScript(app: ElectronApplication, script: Partial<CloneScript>): Promise<void> {
+  await app.evaluate((_electron, patch) => {
+    const scope = globalThis as unknown as { __cloneShotScript?: CloneScript };
+    scope.__cloneShotScript = { ...scope.__cloneShotScript!, ...patch };
+  }, script);
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+const written: string[] = [];
+
+/**
+ * Screenshot, then confirm a non-empty file actually landed. A harness that
+ * trusts its own exit code reports success while writing nothing.
+ */
+async function snap(page: Page, slug: string, locator?: string): Promise<void> {
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).first().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+  if (!existsSync(file) || statSync(file).size === 0) {
+    throw new Error(`[clone-shots] snap "${slug}" produced no file at ${file}`);
+  }
+  written.push(path.basename(file));
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+const failures: string[] = [];
+
+/**
+ * Steps are isolated so one broken state doesn't cost the whole sweep, but
+ * every failure is collected and rethrown at the end — a swallowed step is how
+ * a harness reports PASS over a missing capture.
+ */
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = `${name}: ${String(error).slice(0, 400)}`;
+    console.warn(`[clone-shots] step failed — ${detail}`);
+    failures.push(detail);
+  }
+}
+
+/**
+ * Sibling project dialogs stay mounted, so `Browse` and `Cancel` are ambiguous
+ * page-wide. Every interaction scopes through this.
+ */
+const dialog = (page: Page) => page.locator(BACKDROP).filter({ hasText: "Clone repository" });
+const panel = () => `${BACKDROP}:has-text("Clone repository") > div`;
+
+async function openDialog(page: Page): Promise<void> {
+  const mod = process.platform === "darwin" ? "Meta" : "Control";
+  await page.keyboard.press(`${mod}+Shift+P`);
+  await page.locator(SEL.actionPalette.dialog).waitFor({ state: "visible", timeout: T_MEDIUM });
+  await page.locator(SEL.actionPalette.searchInput).fill("Clone Repository");
+  await settle(page, 400);
+  await page.locator(SEL.actionPalette.options).first().click();
+  await dialog(page).waitFor({ state: "visible", timeout: T_MEDIUM });
+  await settle(page, 500);
+}
+
+/**
+ * Throws rather than giving up quietly. A dialog stuck open turns every later
+ * step into a 30s timeout on a disabled input, which reads as ten unrelated
+ * failures instead of the one that actually happened.
+ */
+async function closeDialog(page: Page): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    if (!(await dialog(page).isVisible().catch(() => false))) return;
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+  }
+  throw new Error("dialog did not close — later steps would cascade");
+}
+
+/** Fill the form to a clonable state. `parentPath` is picker-only by design. */
+async function fillForm(page: Page, url = CLONE_URL): Promise<void> {
+  await dialog(page).locator("#clone-repo-url").fill(url);
+  await dialog(page).getByRole("button", { name: "Browse" }).click();
+  await settle(page, 400);
+}
+
+async function startClone(page: Page): Promise<void> {
+  await dialog(page).getByRole("button", { name: "Clone", exact: true }).click();
+}
+
+async function stopClone(page: Page): Promise<void> {
+  await dialog(page).getByRole("button", { name: "Stop clone" }).click();
+}
+
+/** Every built-in theme — see the worktree harness for the per-theme sweep. */
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+test("clone dialog review — configuration, progress, failure and success states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_CLONE is required for the clone-dialog capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_CLONE to run the clone-dialog capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const destination = mkdtempSync(path.join(tmpdir(), "daintree-clone-dest-"));
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-cloneshot-"));
+  let ctx: AppContext | undefined;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await settle(page, 2000);
+    await dismissBlockingPalette(page);
+
+    await installCloneStub(ctx.app);
+    // The Browse button resolves through the real open-dialog channel.
+    await mockOpenDialog(ctx.app, destination);
+    await setScript(ctx.app, { clonedPath: path.join(destination, "helios-dashboard") });
+
+    // 1. Empty configuration — the dialog as it first appears.
+    await step("empty", async () => {
+      await openDialog(page);
+      await snap(page, "10-config-empty", panel());
+      await snap(page, "11-config-empty-in-window");
+      await closeDialog(page);
+    });
+
+    // 2. Valid configuration — every field satisfied, Clone enabled.
+    await step("valid", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await snap(page, "15-config-valid", panel());
+      await closeDialog(page);
+    });
+
+    // 3. Folder-name validation error.
+    await step("validation", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await dialog(page).locator("#clone-folder-name").fill("helios:dashboard");
+      await settle(page, 300);
+      await snap(page, "20-config-validation-error", panel());
+      await closeDialog(page);
+    });
+
+    // 4. Shorthand `owner/repo` — the single-provider expansion path.
+    await step("shorthand", async () => {
+      await openDialog(page);
+      await fillForm(page, "helios-labs/helios-dashboard");
+      await snap(page, "25-config-shorthand", panel());
+      await closeDialog(page);
+    });
+
+    // 5. Busy before the Doherty gate elapses — a clone fast enough that the
+    // progress box never appears. Only ~400ms wide, so this is snapped
+    // immediately after the click with no settle.
+    await step("busy", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await setScript(ctx!.app, { mode: "hang", stages: [] });
+      await startClone(page);
+      await snap(page, "30-busy-pre-gate", panel());
+      await stopClone(page);
+      await settle(page, 500);
+      await closeDialog(page);
+    });
+
+    // 6. Past the gate with no git progress yet — the "Connecting…" row.
+    await step("connecting", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await setScript(ctx!.app, { mode: "hang", stages: [] });
+      await startClone(page);
+      await settle(page, 900);
+      await snap(page, "35-connecting", panel());
+      await stopClone(page);
+      await settle(page, 500);
+      await closeDialog(page);
+    });
+
+    // 7. Long clone, several stages live at once — the crowded state the
+    // redesign exists to fix.
+    await step("progress", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await setScript(ctx!.app, { mode: "hang", stages: LONG_STAGES, stageDelayMs: 250 });
+      await startClone(page);
+      await settle(page, 1600);
+      await snap(page, "40-progress-multi-stage", panel());
+      await snap(page, "41-progress-multi-stage-in-window");
+      await stopClone(page);
+      await settle(page, 600);
+
+      // 8. Cancellation — the same clone after the user stops it.
+      await snap(page, "45-cancelled", panel());
+      await closeDialog(page);
+    });
+
+    // 9. Generic failure — no matching provider, so the locally-styled block.
+    await step("error", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await setScript(ctx!.app, {
+        mode: "error",
+        stages: LONG_STAGES.slice(0, 2),
+        stageDelayMs: 120,
+        errorMessage:
+          "repository 'https://github.com/helios-labs/helios-dashboard.git/' not found",
+      });
+      await startClone(page);
+      await settle(page, 1200);
+      await snap(page, "50-failure-generic", panel());
+      await closeDialog(page);
+    });
+
+    // 10. Authentication failure — the provider sign-in recovery banner.
+    await step("auth", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await setScript(ctx!.app, {
+        mode: "auth",
+        stages: LONG_STAGES.slice(0, 1),
+        stageDelayMs: 120,
+        errorMessage: "Authentication failed for 'https://github.com/helios-labs/helios-dashboard.git/'",
+      });
+      await startClone(page);
+      await settle(page, 1200);
+      await snap(page, "55-failure-auth", panel());
+      await closeDialog(page);
+    });
+
+    // 11. Failure plus partial-cleanup failure — two error surfaces at once.
+    await step("cleanup", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await setScript(ctx!.app, {
+        mode: "cleanup",
+        stages: LONG_STAGES.slice(0, 2),
+        stageDelayMs: 120,
+        errorMessage: "early EOF",
+        cleanupMessage: `Couldn't remove the partial clone at ${path.join(destination, "helios-dashboard")}. Close any Git processes using it and delete the folder manually.`,
+      });
+      await startClone(page);
+      await settle(page, 1200);
+      await snap(page, "60-failure-with-cleanup", panel());
+      await closeDialog(page);
+    });
+
+    // 12. Success — the two-second window before the dialog hands off.
+    await step("success", async () => {
+      await openDialog(page);
+      await fillForm(page);
+      await setScript(ctx!.app, { mode: "success", stages: LONG_STAGES, stageDelayMs: 120 });
+      await startClone(page);
+      await settle(page, 700);
+      await snap(page, "70-success", panel());
+      await snap(page, "71-success-in-window");
+      await closeDialog(page);
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    rmSync(destination, { recursive: true, force: true });
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+
+  console.log(`[clone-shots] wrote ${written.length} file(s): ${written.join(", ")}`);
+  expect(failures, `capture steps failed:\n${failures.join("\n")}`).toEqual([]);
+  expect(written.length, "no screenshots were written").toBeGreaterThan(0);
+});

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -50,6 +50,14 @@ interface CloneRepoDialogProps {
 
 const AUTO_CLOSE_DELAY_MS = 2000;
 
+/**
+ * House rule for a wait with nothing to show is reassurance past five seconds;
+ * `SkeletonHint`'s own default is eight, which suits a skeleton that at least
+ * has shape. Only the first threshold moves — the later escalations keep the
+ * shared cadence.
+ */
+const STILL_WORKING_AFTER_MS = 5000;
+
 /** Stages that end the operation. They are reported by the promise, not as a row. */
 const TERMINAL_STAGES = new Set(["complete", "error", "cancelled"]);
 
@@ -142,6 +150,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const [forgeProviders, setForgeProviders] = useState<CloneForgeProvider[]>([]);
   const urlInputRef = useRef<HTMLInputElement>(null);
   const footerActionRef = useRef<HTMLButtonElement>(null);
+  const previousModeRef = useRef<"configure" | "running" | "failed" | "complete">("configure");
   const hasFinalizedRef = useRef(false);
 
   const suggestedEmoji = useMemo(() => {
@@ -348,8 +357,10 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const currentStage = currentIndex === -1 ? null : (stages[currentIndex] ?? null);
   const completedStages = currentIndex === -1 ? [] : stages.slice(0, currentIndex);
 
-  const showConnecting = useDohertyGate(isCloning && currentStage === null);
-  const isRunning = showConnecting || currentStage !== null;
+  // The gate belongs on the clone itself, not on the absence of events. Gating
+  // "no event yet" let a fast clone that reports progress inside 400ms switch
+  // modes immediately — the flash the threshold exists to prevent.
+  const isRunning = useDohertyGate(isCloning);
 
   // Four modes of one surface. Configuration stays on screen through the
   // sub-gate window and after a stop, so a fast clone never flashes a mode
@@ -369,8 +380,19 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   // already put focus in the URL field, and re-running this on every keystroke
   // would fight it.
   useEffect(() => {
-    if (!isOpen || mode === "configure") return;
-    const frame = requestAnimationFrame(() => footerActionRef.current?.focus());
+    const previousMode = previousModeRef.current;
+    previousModeRef.current = mode;
+    if (!isOpen) return;
+    // Returning to the form after a stop unmounts the Stop button that had
+    // focus, so without this the focus falls to the document body.
+    const target =
+      mode === "configure"
+        ? previousMode === "running"
+          ? urlInputRef.current
+          : null
+        : footerActionRef.current;
+    if (!target) return;
+    const frame = requestAnimationFrame(() => target.focus());
     return () => cancelAnimationFrame(frame);
   }, [isOpen, mode]);
 
@@ -484,7 +506,12 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
 
       <AppDialog.Body className="space-y-5">
         {mode === "complete" ? (
-          <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <div
+            className="flex flex-col items-center gap-4 py-6 text-center"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-status-success/15">
               <Check className="h-6 w-6 text-status-success" />
             </div>
@@ -492,41 +519,24 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
               <h3 className="text-base font-semibold text-daintree-text">Repository cloned</h3>
               <p className="text-sm text-daintree-text/60">
                 <span aria-hidden="true">{effectiveEmoji} </span>
-                {trimmedFolderName} is ready to open.
+                {trimmedFolderName} is ready to open
               </p>
             </div>
             {clonedPath !== null && <PathCaption path={clonedPath} className="max-w-full" />}
           </div>
         ) : mode === "running" ? (
           <>
-            {summary}
-
             {/* One current phase, the way every other running-operation surface
-                in the app reports itself. The percentage rides the payload's
-                `progress`, which the transcript this replaced threw away. */}
+                in the app reports itself, and first — "what is happening now"
+                is the question this mode exists to answer. The percentage rides
+                the payload's `progress`, which the transcript this replaced
+                threw away. */}
             <div className="space-y-2" aria-busy="true">
               {/* Carries the phase and nothing else, so stage changes are
                   announced and percentage ticks are not. */}
               <span className="sr-only" role="status" aria-live="polite">
                 {currentStage ? stageLabel(currentStage) : "Connecting"}
               </span>
-              {/* Phases already finished, quieted to a static check. They are
-                  what makes the current phase's bar resetting to 0% read as
-                  "next step" instead of "went backwards". */}
-              {completedStages.length > 0 && (
-                <ul className="space-y-1">
-                  {completedStages.map((event) => (
-                    <li
-                      key={event.stage}
-                      className="flex items-center gap-2 text-xs text-daintree-text/45"
-                    >
-                      <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                      <span>{stageLabel(event)}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-
               <div className="flex items-center gap-2">
                 <Spinner size="sm" className="shrink-0 text-text-secondary" />
                 <span aria-hidden="true" className="text-sm text-daintree-text">
@@ -564,9 +574,33 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
               </div>
               {/* Only while the phase is indeterminate — once a percentage is
                   moving, "Still working…" would be telling the user something
-                  the number already says. */}
-              {!currentStage && <SkeletonHint message="Still connecting…" />}
+                  the number already says. Five seconds, per the house rule for
+                  a wait with nothing to show. */}
+              {!currentStage && (
+                <SkeletonHint message="Still working…" firstThreshold={STILL_WORKING_AFTER_MS} />
+              )}
             </div>
+
+            {/* Phases already finished, quieted to a static check. They are what
+                makes the live phase's bar resetting to 0% read as "next step"
+                instead of "went backwards". */}
+            {completedStages.length > 0 && (
+              <ul className="space-y-1">
+                {completedStages.map((event) => (
+                  <li
+                    key={event.stage}
+                    className="flex items-center gap-2 text-xs text-daintree-text/45"
+                  >
+                    <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    <span>{stageLabel(event)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {/* Subordinate to the live phase: what is being cloned and where,
+                kept legible now that the form is gone. */}
+            {summary}
 
             {cleanupBanner}
           </>

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -144,6 +144,13 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const [cleanupError, setCleanupError] = useState<string | null>(null);
   const [isComplete, setIsComplete] = useState(false);
   const [clonedPath, setClonedPath] = useState<string | null>(null);
+  // Where the partial clone was left, pinned when the clone was launched. A
+  // failure or a stop hands the form back editable with the cleanup banner
+  // still up, so deriving this from the live fields would silently repoint the
+  // banner — and its "Show in folder" action — at a folder that was never
+  // cloned into. This mirrors the `path.join(parentPath, trimmedFolder)` the
+  // main process composes and names in its `cleanup-failed` message.
+  const [strandedPath, setStrandedPath] = useState<string | null>(null);
   // Registered forge providers — gate the auth-failed recovery banner on the
   // clone URL belonging to a registered provider, and derive that banner's
   // sign-in label/route plus the owner/repo shorthand host.
@@ -184,6 +191,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       setCleanupError(null);
       setIsComplete(false);
       setClonedPath(null);
+      setStrandedPath(null);
       hasFinalizedRef.current = false;
       return;
     }
@@ -271,6 +279,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   };
 
   const startClone = async () => {
+    const targetFolder = folderName.trim();
     setIsCloning(true);
     setError(null);
     setWasCancelled(false);
@@ -279,13 +288,16 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     setIsComplete(false);
     setStages([]);
     setCurrentStageKey(null);
+    // Pin the destination this run is launched against, from the very values
+    // handed to the main process, before the form becomes editable again.
+    setStrandedPath(joinPath(parentPath, targetFolder));
     hasFinalizedRef.current = false;
 
     try {
       const { clonedPath: resultPath } = await projectClient.cloneRepo({
         url: normalizeCloneUrl(url, shorthandHost),
         parentPath,
-        folderName: folderName.trim(),
+        folderName: targetFolder,
         shallowClone,
       });
 
@@ -402,9 +414,6 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       ? joinPath(parentPath, trimmedFolderName)
       : null;
   const normalizedUrl = normalizeCloneUrl(url, shorthandHost);
-  // The partial clone the main process failed to remove sits at the same target
-  // path it was asked to clone into, composed from the same two inputs.
-  const strandedPath = destinationPath;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     // Enter acts as Retry too — startClone resets `error` internally, so this
@@ -531,7 +540,14 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
                 is the question this mode exists to answer. The percentage rides
                 the payload's `progress`, which the transcript this replaced
                 threw away. */}
-            <div className="space-y-2" aria-busy="true">
+            {/* No `aria-busy` on this wrapper: it would silence mutations
+                within its own subtree on modern screen readers (see the note on
+                `SkeletonHint` in `@/components/ui/Skeleton`), and the two live
+                regions below are exactly the mutations this mode exists to
+                announce. Unlike a skeleton — meaningless placeholder shape that
+                aria-busy rightly mutes — the progress readout is the content,
+                and the `progressbar` already carries the busy semantics. */}
+            <div className="space-y-2">
               {/* Carries the phase and nothing else, so stage changes are
                   announced and percentage ticks are not. */}
               <span className="sr-only" role="status" aria-live="polite">

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef, useCallback, useMemo, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { Check, AlertCircle, FolderOpen, LogIn, X } from "lucide-react";
+import { Check, AlertCircle, CircleSlash, FolderOpen, LogIn } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
+import { SkeletonHint } from "@/components/ui/Skeleton";
 import { FolderGit2 } from "@/components/icons";
 import { InlineStatusBanner, type BannerAction } from "@/components/Terminal/InlineStatusBanner";
-import { projectClient } from "@/clients";
+import { projectClient, systemClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
 import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -19,13 +20,16 @@ import {
   FIELD_CHECKBOX_CLASS,
   FIELD_BROWSE_BUTTON_CLASS,
   FIELD_EMOJI_ROW_INDENT,
+  PathCaption,
 } from "./projectDialogFields";
+import { join as joinPath } from "@shared/utils/path";
 import { matchProviderForRemoteUrl } from "@shared/utils/forgeHostnames";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
 import type { CloneRepoProgressEvent } from "@shared/types/ipc/gitClone";
 import type { ProjectCreationIdentity } from "@shared/types";
 import type { GitOperationReason } from "@shared/types/ipc/errors";
 import { isClientGitError } from "@/utils/clientGitError";
+import { isClientAppError } from "@/utils/clientAppError";
 
 interface CloneError {
   message: string;
@@ -45,6 +49,27 @@ interface CloneRepoDialogProps {
 }
 
 const AUTO_CLOSE_DELAY_MS = 2000;
+
+/** Stages that end the operation. They are reported by the promise, not as a row. */
+const TERMINAL_STAGES = new Set(["complete", "error", "cancelled"]);
+
+/**
+ * Git's own stage labels arrive pre-formatted as `"Receiving objects: 64%"`, and
+ * the percentage gets its own tabular slot here, so strip it off the label. The
+ * trailing-colon trim catches simple-git's `"remote:"` stage key, which the main
+ * process capitalises into the doubled `"Remote:: 100%"`.
+ */
+function stageLabel(event: CloneRepoProgressEvent): string {
+  const label = event.message
+    .replace(/\s*:\s*\d+%\s*$/, "")
+    .replace(/:+$/, "")
+    .trim();
+  return label || "Working";
+}
+
+function stagePercent(event: CloneRepoProgressEvent): number {
+  return Math.min(100, Math.max(0, Math.round(event.progress)));
+}
 
 function extractFolderName(url: string): string {
   const trimmed = url
@@ -90,9 +115,22 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   // typed) until the user picks explicitly; after that the pick sticks.
   const [pickedEmoji, setPickedEmoji] = useState<string | null>(null);
   const [shallowClone, setShallowClone] = useState(false);
-  const [progressEvents, setProgressEvents] = useState<CloneRepoProgressEvent[]>([]);
+  // Stages in first-seen order, plus which one is live. Git's clone phases run
+  // strictly in sequence and each one counts 0→100% of *itself*, so a lone bar
+  // would fill and reset four times and read as the operation going backwards.
+  // Quiet checkmarks for the phases already done explain each reset, and are
+  // the same done/current treatment `RebaseSequenceRail` uses.
+  const [stages, setStages] = useState<CloneRepoProgressEvent[]>([]);
+  const [currentStageKey, setCurrentStageKey] = useState<string | null>(null);
   const [isCloning, setIsCloning] = useState(false);
   const [error, setError] = useState<CloneError | null>(null);
+  // A user-initiated stop is an outcome, not a failure — it gets a neutral
+  // banner over the re-enabled form instead of the error surface.
+  const [wasCancelled, setWasCancelled] = useState(false);
+  // Git's teardown (killing the child, removing the partial clone) is not
+  // instant, so the stop button acknowledges the click instead of sitting
+  // there looking unpressed.
+  const [isStopping, setIsStopping] = useState(false);
   // Kept separate from `progressEvents` (which dedups by stage) so the
   // cleanup-failure banner isn't swallowed by, or lost among, progress rows.
   const [cleanupError, setCleanupError] = useState<string | null>(null);
@@ -102,7 +140,8 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   // clone URL belonging to a registered provider, and derive that banner's
   // sign-in label/route plus the owner/repo shorthand host.
   const [forgeProviders, setForgeProviders] = useState<CloneForgeProvider[]>([]);
-  const logEndRef = useRef<HTMLDivElement>(null);
+  const urlInputRef = useRef<HTMLInputElement>(null);
+  const footerActionRef = useRef<HTMLButtonElement>(null);
   const hasFinalizedRef = useRef(false);
 
   const suggestedEmoji = useMemo(() => {
@@ -127,9 +166,12 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       setFolderNameEdited(false);
       setPickedEmoji(null);
       setShallowClone(false);
-      setProgressEvents([]);
+      setStages([]);
+      setCurrentStageKey(null);
       setIsCloning(false);
       setError(null);
+      setWasCancelled(false);
+      setIsStopping(false);
       setCleanupError(null);
       setIsComplete(false);
       setClonedPath(null);
@@ -142,14 +184,16 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
         setCleanupError(event.message);
         return;
       }
-      setProgressEvents((prev) => {
-        // Dedup by stage so a long clone (hundreds of byte-count updates per
-        // stage) shows one live-updating row per stage instead of an unbounded
-        // log. Final `complete`/`error`/`cancelled` events also dedup.
+      // The terminal stages duplicate what the `cloneRepo` promise already
+      // reports. Rendering them as well is what put the same failure on screen
+      // twice, once as a row and once as a banner.
+      if (TERMINAL_STAGES.has(event.stage)) return;
+      setStages((prev) => {
         const merged = new Map(prev.map((e) => [e.stage, e]));
         merged.set(event.stage, event);
         return [...merged.values()];
       });
+      setCurrentStageKey(event.stage);
     });
 
     return cleanup;
@@ -183,11 +227,6 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const shorthandHost =
     forgeProviders.length === 1 ? (forgeProviders[0]?.hostnames[0] ?? null) : null;
 
-  // Auto-scroll progress log
-  useEffect(() => {
-    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [progressEvents]);
-
   // Auto-derive folder name from URL
   useEffect(() => {
     if (!folderNameEdited) {
@@ -206,6 +245,15 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     return () => window.clearTimeout(timeoutId);
   }, [isOpen, isComplete, finalizeSuccess]);
 
+  // AppDialog's default `initialFocus="first"` lands on the header close
+  // button, which puts the focus ring — this region's one accent — on "get out
+  // of here". A form dialog's first stop is its first field.
+  useEffect(() => {
+    if (!isOpen) return;
+    const frame = requestAnimationFrame(() => urlInputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen]);
+
   const pickDirectory = async () => {
     const selected = await projectClient.openDialog();
     if (selected) {
@@ -216,9 +264,12 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const startClone = async () => {
     setIsCloning(true);
     setError(null);
+    setWasCancelled(false);
+    setIsStopping(false);
     setCleanupError(null);
     setIsComplete(false);
-    setProgressEvents([]);
+    setStages([]);
+    setCurrentStageKey(null);
     hasFinalizedRef.current = false;
 
     try {
@@ -233,8 +284,16 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       setIsComplete(true);
     } catch (err) {
       // CANCELLED is the user aborting via the cancel button — not a failure.
-      const code = (err as { code?: string })?.code;
-      if (code !== "CANCELLED") {
+      // It has to be decoded, not read off the error: contextBridge strips own
+      // properties (including `code`) when the preload's reconstructed error
+      // crosses into the renderer, so `err.code` is always undefined here and
+      // every stop used to surface as "Clone failed" with the raw
+      // `[AppError|CANCELLED]` prefix showing. `isClientAppError` decodes the
+      // message prefix the preload injects, exactly as `isClientGitError` does
+      // for the git branch below.
+      if (isClientAppError(err) && err.code === "CANCELLED") {
+        setWasCancelled(true);
+      } else {
         // Decode the preload-injected `[GitError|...]` message prefix so we
         // can branch on `gitReason`. contextBridge strips own Error properties
         // when the preload's reconstructed error crosses to the renderer, so
@@ -248,7 +307,13 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       }
     } finally {
       setIsCloning(false);
+      setIsStopping(false);
     }
+  };
+
+  const stopClone = () => {
+    setIsStopping(true);
+    void projectClient.cancelClone();
   };
 
   const handleClose = () => {
@@ -270,11 +335,48 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     parentPath.trim() !== "" &&
     folderName.trim() !== "" &&
     folderNameError === null;
-  // Doherty gate: don't flash the progress box / spinner for a sub-400ms gap
-  // before the first git progress event — only reveal it if the wait exceeds
-  // the threshold. Once real progress arrives the box stays up regardless.
-  const showConnecting = useDohertyGate(isCloning && progressEvents.length === 0);
-  const showProgress = showConnecting || progressEvents.length > 0;
+  // Doherty gate: don't flash the running mode for a sub-400ms gap before the
+  // first git progress event — only switch once the wait exceeds the threshold.
+  // Once real progress arrives the running mode stays up regardless.
+  const currentIndex = stages.findIndex((e) => e.stage === currentStageKey);
+  const currentStage = currentIndex === -1 ? null : (stages[currentIndex] ?? null);
+  const completedStages = currentIndex === -1 ? [] : stages.slice(0, currentIndex);
+
+  const showConnecting = useDohertyGate(isCloning && currentStage === null);
+  const isRunning = showConnecting || currentStage !== null;
+
+  // Four modes of one surface. Configuration stays on screen through the
+  // sub-gate window and after a stop, so a fast clone never flashes a mode
+  // change and a stopped clone lands back on an editable form.
+  const mode: "configure" | "running" | "failed" | "complete" = isComplete
+    ? "complete"
+    : error
+      ? "failed"
+      : isRunning
+        ? "running"
+        : "configure";
+
+  // Each mode replaces the controls the previous one owned, so keyboard focus
+  // has to follow or it lands on a node that no longer exists. Running hands it
+  // to Stop clone, failure to Retry, success to Open project — the one action
+  // each mode is actually about. Configuration is excluded: the open effect
+  // already put focus in the URL field, and re-running this on every keystroke
+  // would fight it.
+  useEffect(() => {
+    if (!isOpen || mode === "configure") return;
+    const frame = requestAnimationFrame(() => footerActionRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, mode]);
+
+  const trimmedFolderName = folderName.trim();
+  const destinationPath =
+    parentPath.trim() !== "" && trimmedFolderName !== ""
+      ? joinPath(parentPath, trimmedFolderName)
+      : null;
+  const normalizedUrl = normalizeCloneUrl(url, shorthandHost);
+  // The partial clone the main process failed to remove sits at the same target
+  // path it was asked to clone into, composed from the same two inputs.
+  const strandedPath = destinationPath;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     // Enter acts as Retry too — startClone resets `error` internally, so this
@@ -285,235 +387,355 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     }
   };
 
+  // The provider sign-in is the banner's action only when the URL actually
+  // belongs to a registered forge; otherwise the footer's Retry is the sole
+  // recovery, so the two never offer competing answers to the same failure.
+  const signInAction: BannerAction | null = useMemo(() => {
+    if (error?.gitReason !== "auth-failed") return null;
+    const matchedProviderId = matchProviderForRemoteUrl(
+      normalizeCloneUrl(url, shorthandHost),
+      forgeProviders
+    );
+    if (matchedProviderId === null) return null;
+    const matchedProvider = forgeProviders.find((p) => p.providerId === matchedProviderId);
+    if (!matchedProvider) return null;
+    return {
+      id: "signin-forge-provider",
+      label: `Sign in to ${matchedProvider.name}`,
+      icon: LogIn,
+      // Neutral chip, not the info-tinted `accent`: inside a red banner that
+      // variant rendered dimmer than the prose it was meant to resolve.
+      variant: "primary",
+      onClick: () => {
+        void actionService.dispatch(
+          "app.settings.openTab",
+          { tab: "code-forge", subtab: matchedProvider.providerId },
+          { source: "user" }
+        );
+      },
+      title: `Open ${matchedProvider.name} sign-in`,
+      ariaLabel: `Sign in to ${matchedProvider.name}`,
+    };
+  }, [error?.gitReason, url, shorthandHost, forgeProviders]);
+
+  const summary =
+    destinationPath !== null ? (
+      <div className="space-y-2.5 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg px-3 py-3">
+        <div className="space-y-1">
+          <span className="text-xs font-medium text-daintree-text/60">Source</span>
+          <p className="truncate text-xs font-mono text-daintree-text/80" title={normalizedUrl}>
+            {normalizedUrl}
+          </p>
+        </div>
+        <div className="space-y-1">
+          <span className="text-xs font-medium text-daintree-text/60">Destination</span>
+          <PathCaption path={destinationPath} className="text-daintree-text/80" />
+        </div>
+      </div>
+    ) : null;
+
+  const cleanupBanner = cleanupError ? (
+    <InlineStatusBanner
+      icon={AlertCircle}
+      severity="error"
+      title="Partial clone not removed"
+      description="Close any Git processes using it, then delete the folder manually."
+      {...(strandedPath !== null ? { contextLine: strandedPath } : {})}
+      {...(strandedPath !== null
+        ? {
+            action: {
+              id: "reveal-partial-clone",
+              label: "Show in folder",
+              icon: FolderOpen,
+              variant: "primary",
+              onClick: () => void systemClient.showItemInFolderUnconfined(strandedPath),
+              ariaLabel: "Show the partial clone in the file manager",
+            } satisfies BannerAction,
+          }
+        : {})}
+      onClose={() => setCleanupError(null)}
+      closeAriaLabel="Dismiss partial-clone warning"
+      className="rounded-[var(--radius-md)]"
+    />
+  ) : null;
+
   return (
-    <AppDialog isOpen={isOpen} onClose={handleClose} size="md" dismissible={!isCloning}>
+    <AppDialog
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="md"
+      dismissible={!isCloning}
+      initialFocus="none"
+    >
       <AppDialog.Header>
-        <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-daintree-accent" />}>
+        {/* Neutral, not accent: the header glyph is decoration, and this focus
+            region's one load-bearing accent is the keyboard focus ring. */}
+        <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-text-secondary" />}>
           Clone repository
         </AppDialog.Title>
         {!isCloning && <AppDialog.CloseButton />}
       </AppDialog.Header>
 
       <AppDialog.Body className="space-y-5">
-        {/* URL Input */}
-        <div className="space-y-1.5">
-          <label className={FIELD_LABEL_CLASS} htmlFor="clone-repo-url">
-            Repository URL
-          </label>
-          <input
-            id="clone-repo-url"
-            type="text"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="owner/repo or repository URL"
-            disabled={isCloning || isComplete}
-            className={FIELD_INPUT_CLASS}
-          />
-        </div>
-
-        {/* Parent Directory */}
-        <div className="space-y-1.5">
-          <label className={FIELD_LABEL_CLASS} htmlFor="clone-parent-dir">
-            Parent directory
-          </label>
-          <div className="flex gap-2">
-            <input
-              id="clone-parent-dir"
-              type="text"
-              value={parentPath}
-              readOnly
-              aria-readonly="true"
-              placeholder="Select a directory…"
-              className={`${FIELD_READONLY_INPUT_CLASS} select-all`}
-            />
-            <Button
-              variant="outline"
-              onClick={() => void pickDirectory()}
-              disabled={isCloning || isComplete}
-              className={FIELD_BROWSE_BUTTON_CLASS}
-            >
-              <FolderOpen className="h-4 w-4" />
-              Browse
-            </Button>
+        {mode === "complete" ? (
+          <div className="flex flex-col items-center gap-4 py-6 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-status-success/15">
+              <Check className="h-6 w-6 text-status-success" />
+            </div>
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold text-daintree-text">Repository cloned</h3>
+              <p className="text-sm text-daintree-text/60">
+                <span aria-hidden="true">{effectiveEmoji} </span>
+                {trimmedFolderName} is ready to open.
+              </p>
+            </div>
+            {clonedPath !== null && <PathCaption path={clonedPath} className="max-w-full" />}
           </div>
-        </div>
+        ) : mode === "running" ? (
+          <>
+            {summary}
 
-        {/* Folder Name */}
-        <div className="space-y-1.5">
-          <label className={FIELD_LABEL_CLASS} htmlFor="clone-folder-name">
-            Folder name
-          </label>
-          <div className="flex items-center gap-2">
-            <ProjectEmojiButton
-              emoji={effectiveEmoji}
-              onEmojiChange={setPickedEmoji}
-              disabled={isCloning || isComplete}
-              ariaLabel="Choose project emoji"
-            />
-            <input
-              id="clone-folder-name"
-              type="text"
-              value={folderName}
-              onChange={(e) => {
-                const next = e.target.value;
-                setFolderName(next);
-                // Clearing the field re-enables URL-derived auto-suggest so the
-                // user can recover after a manual edit they no longer want.
-                setFolderNameEdited(next !== "");
-              }}
-              onKeyDown={handleKeyDown}
-              disabled={isCloning || isComplete}
-              aria-invalid={folderNameError != null}
-              aria-describedby={folderNameError ? folderNameErrorId : undefined}
-              className={FIELD_INPUT_CLASS}
-              placeholder="my-project"
-            />
-          </div>
-          {folderNameError && (
-            <p
-              id={folderNameErrorId}
-              role="alert"
-              className={`${FIELD_EMOJI_ROW_INDENT} text-xs text-status-error`}
-            >
-              {folderNameError}
-            </p>
-          )}
-        </div>
+            {/* One current phase, the way every other running-operation surface
+                in the app reports itself. The percentage rides the payload's
+                `progress`, which the transcript this replaced threw away. */}
+            <div className="space-y-2" aria-busy="true">
+              {/* Carries the phase and nothing else, so stage changes are
+                  announced and percentage ticks are not. */}
+              <span className="sr-only" role="status" aria-live="polite">
+                {currentStage ? stageLabel(currentStage) : "Connecting"}
+              </span>
+              {/* Phases already finished, quieted to a static check. They are
+                  what makes the current phase's bar resetting to 0% read as
+                  "next step" instead of "went backwards". */}
+              {completedStages.length > 0 && (
+                <ul className="space-y-1">
+                  {completedStages.map((event) => (
+                    <li
+                      key={event.stage}
+                      className="flex items-center gap-2 text-xs text-daintree-text/45"
+                    >
+                      <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      <span>{stageLabel(event)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
 
-        {/* Shallow Clone */}
-        <div className="space-y-1">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={shallowClone}
-              onChange={(e) => setShallowClone(e.target.checked)}
-              disabled={isCloning || isComplete}
-              className={FIELD_CHECKBOX_CLASS}
-            />
-            <span className="text-sm text-daintree-text/80">Shallow clone (--depth 1)</span>
-          </label>
-          <p className="ml-6 text-xs text-daintree-text/50">
-            Only fetches the latest commit — faster for large repos, but limits history and some
-            push paths.
-          </p>
-        </div>
-
-        {/* Progress Log */}
-        {showProgress && (
-          <div className="rounded-lg bg-muted/50 p-4 min-h-[120px] max-h-[250px] overflow-y-auto font-mono text-sm">
-            {showConnecting && <div className="text-muted-foreground">Connecting…</div>}
-
-            {progressEvents.map((event, index) => (
-              <div key={index} className="flex items-start gap-2 mb-1">
-                {event.stage === "complete" ? (
-                  <Check className="h-4 w-4 text-status-success shrink-0 mt-0.5" />
-                ) : event.stage === "error" ? (
-                  <AlertCircle className="h-4 w-4 text-status-error shrink-0 mt-0.5" />
-                ) : event.stage === "cancelled" ? (
-                  <X className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
-                ) : (
-                  <Spinner size="md" className="text-status-info shrink-0" />
-                )}
-                <span
-                  className={
-                    event.stage === "error"
-                      ? "text-status-error"
-                      : event.stage === "complete"
-                        ? "text-status-success"
-                        : event.stage === "cancelled"
-                          ? "text-muted-foreground"
-                          : "text-foreground"
-                  }
-                >
-                  {event.message}
+              <div className="flex items-center gap-2">
+                <Spinner size="sm" className="shrink-0 text-text-secondary" />
+                <span aria-hidden="true" className="text-sm text-daintree-text">
+                  {currentStage ? stageLabel(currentStage) : "Connecting…"}
                 </span>
+                {currentStage && (
+                  <span
+                    aria-hidden="true"
+                    className="ml-auto text-xs tabular-nums text-daintree-text/60"
+                  >
+                    {stagePercent(currentStage)}%
+                  </span>
+                )}
               </div>
-            ))}
+              {/* The track is rendered in both phases on purpose: a clone starts
+                  with no measurable progress and gains it the moment git speaks,
+                  and swapping the indicator in would shift everything under it.
+                  Indeterminate omits `aria-valuenow` and pulses the empty track. */}
+              <div
+                role="progressbar"
+                aria-label={currentStage ? stageLabel(currentStage) : "Connecting"}
+                {...(currentStage ? { "aria-valuenow": stagePercent(currentStage) } : {})}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                className={`h-1 w-full overflow-hidden rounded-full bg-daintree-border/50 ${
+                  currentStage ? "" : "animate-pulse-immediate"
+                }`}
+              >
+                {currentStage && (
+                  <div
+                    className="h-full rounded-full bg-daintree-text/60 transition-[width] duration-150 ease-out"
+                    style={{ width: `${stagePercent(currentStage)}%` }}
+                  />
+                )}
+              </div>
+              {/* Only while the phase is indeterminate — once a percentage is
+                  moving, "Still working…" would be telling the user something
+                  the number already says. */}
+              {!currentStage && <SkeletonHint message="Still connecting…" />}
+            </div>
 
-            <div ref={logEndRef} />
-          </div>
-        )}
+            {cleanupBanner}
+          </>
+        ) : (
+          <>
+            {/* Outcome first. A failure or a stop returns the user to the form
+                with the fields they typed intact, so the explanation belongs
+                above the inputs it is about — not below them, where the body
+                scrolls it out of sight entirely. */}
+            {error && (
+              <InlineStatusBanner
+                icon={AlertCircle}
+                severity="error"
+                title="Clone failed"
+                description={error.message}
+                {...(signInAction ? { action: signInAction } : {})}
+                className="rounded-[var(--radius-md)]"
+              />
+            )}
 
-        {/* Cleanup failure — the partial clone couldn't be removed and needs
-            manual deletion, so it gets its own persistent Tier 3 banner.
-            Kept separate from the recovery error block below because the two
-            failures are orthogonal (cleanup can fail whether or not the clone
-            itself recovered) and the user may need to act on both. */}
-        {cleanupError && (
-          <InlineStatusBanner
-            icon={AlertCircle}
-            severity="error"
-            title="Partial clone not removed"
-            description={cleanupError}
-            onClose={() => setCleanupError(null)}
-            className="rounded-lg"
-          />
-        )}
+            {/* A stop is an outcome, not a failure: neutral severity, and the
+                form underneath is editable again so Clone can just be pressed. */}
+            {wasCancelled && (
+              <InlineStatusBanner
+                icon={CircleSlash}
+                severity="neutral"
+                title="Clone stopped"
+                description="You stopped the clone before it finished."
+                onClose={() => setWasCancelled(false)}
+                closeAriaLabel="Dismiss stopped-clone notice"
+                role="status"
+                className="rounded-[var(--radius-md)]"
+              />
+            )}
 
-        {/* Error block — rendered alongside the progress log so the recovery
-            banner is reachable even when emitProgress("error") has already
-            queued an "error" row in the log. */}
-        {error &&
-          (() => {
-            const matchedProviderId =
-              error.gitReason === "auth-failed"
-                ? matchProviderForRemoteUrl(normalizeCloneUrl(url, shorthandHost), forgeProviders)
-                : null;
-            const matchedProvider =
-              matchedProviderId !== null
-                ? forgeProviders.find((p) => p.providerId === matchedProviderId)
-                : undefined;
-            if (matchedProvider) {
-              const signInAction: BannerAction = {
-                id: "signin-forge-provider",
-                label: `Sign in to ${matchedProvider.name}`,
-                icon: LogIn,
-                variant: "accent",
-                onClick: () => {
-                  void actionService.dispatch(
-                    "app.settings.openTab",
-                    { tab: "code-forge", subtab: matchedProvider.providerId },
-                    { source: "user" }
-                  );
-                },
-                title: `Open ${matchedProvider.name} sign-in`,
-                ariaLabel: `Sign in to ${matchedProvider.name}`,
-              };
-              return (
-                <InlineStatusBanner
-                  icon={AlertCircle}
-                  title="Clone Failed"
-                  description={error.message}
-                  severity="error"
-                  action={signInAction}
+            {/* Orthogonal to the failure above and ordered after it: the clone
+                can fail with the partial copy cleanly removed, or be stopped
+                with it stranded, and only this one needs action outside the app. */}
+            {cleanupBanner}
+
+            {/* URL Input */}
+            <div className="space-y-1.5">
+              <label className={FIELD_LABEL_CLASS} htmlFor="clone-repo-url">
+                Repository URL
+              </label>
+              <input
+                id="clone-repo-url"
+                ref={urlInputRef}
+                type="text"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="owner/repo or repository URL"
+                disabled={isCloning}
+                className={FIELD_INPUT_CLASS}
+              />
+            </div>
+
+            {/* Parent Directory */}
+            <div className="space-y-1.5">
+              <label className={FIELD_LABEL_CLASS} htmlFor="clone-parent-dir">
+                Parent directory
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="clone-parent-dir"
+                  type="text"
+                  value={parentPath}
+                  readOnly
+                  aria-readonly="true"
+                  placeholder="Select a directory…"
+                  className={`${FIELD_READONLY_INPUT_CLASS} select-all`}
                 />
-              );
-            }
-            return (
-              <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive flex items-start gap-2">
-                <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                <div>
-                  <div className="font-medium">Clone Failed</div>
-                  <div className="text-xs mt-1">{error.message}</div>
-                </div>
+                <Button
+                  variant="outline"
+                  onClick={() => void pickDirectory()}
+                  disabled={isCloning}
+                  className={FIELD_BROWSE_BUTTON_CLASS}
+                >
+                  <FolderOpen className="h-4 w-4" />
+                  Browse
+                </Button>
               </div>
-            );
-          })()}
+            </div>
+
+            {/* Folder Name */}
+            <div className="space-y-1.5">
+              <label className={FIELD_LABEL_CLASS} htmlFor="clone-folder-name">
+                Folder name
+              </label>
+              <div className="flex items-center gap-2">
+                <ProjectEmojiButton
+                  emoji={effectiveEmoji}
+                  onEmojiChange={setPickedEmoji}
+                  disabled={isCloning}
+                  ariaLabel="Choose project emoji"
+                />
+                <input
+                  id="clone-folder-name"
+                  type="text"
+                  value={folderName}
+                  onChange={(e) => {
+                    const next = e.target.value;
+                    setFolderName(next);
+                    // Clearing the field re-enables URL-derived auto-suggest so the
+                    // user can recover after a manual edit they no longer want.
+                    setFolderNameEdited(next !== "");
+                  }}
+                  onKeyDown={handleKeyDown}
+                  disabled={isCloning}
+                  aria-invalid={folderNameError != null}
+                  aria-describedby={folderNameError ? folderNameErrorId : undefined}
+                  className={FIELD_INPUT_CLASS}
+                  placeholder="my-project"
+                />
+              </div>
+              {folderNameError ? (
+                <p
+                  id={folderNameErrorId}
+                  role="alert"
+                  className={`${FIELD_EMOJI_ROW_INDENT} text-xs text-status-error`}
+                >
+                  {folderNameError}
+                </p>
+              ) : (
+                // Says where the clone will actually land, keeping the leaf
+                // folder that the parent-directory field's own truncation eats.
+                destinationPath !== null && (
+                  <PathCaption path={destinationPath} className={FIELD_EMOJI_ROW_INDENT} />
+                )
+              )}
+            </div>
+
+            {/* Shallow Clone */}
+            <div className="space-y-1">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={shallowClone}
+                  onChange={(e) => setShallowClone(e.target.checked)}
+                  disabled={isCloning}
+                  className={FIELD_CHECKBOX_CLASS}
+                />
+                <span className="text-sm text-daintree-text/80">Shallow clone</span>
+              </label>
+              <p className="ml-6 text-xs text-daintree-text/50">
+                Fetches only the latest commit (<code>--depth 1</code>) — faster for large repos,
+                but limits history and some push paths.
+              </p>
+            </div>
+          </>
+        )}
       </AppDialog.Body>
 
       <AppDialog.Footer>
-        {isComplete ? (
-          <Button variant="contrast" onClick={handleClose} className="gap-2">
+        {mode === "complete" ? (
+          <Button ref={footerActionRef} variant="contrast" onClick={handleClose} className="gap-2">
             <Check className="h-4 w-4" />
-            Open Project
+            Open project
+          </Button>
+        ) : mode === "running" ? (
+          <Button ref={footerActionRef} variant="outline" onClick={stopClone} loading={isStopping}>
+            {isStopping ? "Stopping…" : "Stop clone"}
           </Button>
         ) : error ? (
           <>
             <Button variant="outline" onClick={onCancel}>
               Close
             </Button>
-            <Button variant="contrast" onClick={() => void startClone()} disabled={isCloning}>
+            <Button
+              ref={footerActionRef}
+              variant="contrast"
+              onClick={() => void startClone()}
+              disabled={isCloning}
+            >
               Retry
             </Button>
           </>
@@ -521,9 +743,10 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
           <>
             <Button
               variant="outline"
-              onClick={isCloning ? () => void projectClient.cancelClone() : onCancel}
+              onClick={isCloning ? stopClone : onCancel}
+              loading={isStopping}
             >
-              {isCloning ? "Stop clone" : "Cancel"}
+              {isCloning ? (isStopping ? "Stopping…" : "Stop clone") : "Cancel"}
             </Button>
             <Button
               variant="contrast"

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -308,6 +308,12 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     } finally {
       setIsCloning(false);
       setIsStopping(false);
+      // Drop the live phase whatever the outcome. Success and failure have
+      // modes of their own that don't render it, but a stop returns to the
+      // form — and a leftover phase would keep `isRunning` true, leaving the
+      // dialog looking like it were still cloning.
+      setStages([]);
+      setCurrentStageKey(null);
     }
   };
 

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -30,14 +30,21 @@ beforeAll(() => {
   });
 });
 
-const { cloneRepoMock, onCloneProgressMock, openDialogMock, cancelCloneMock, dispatchMock } =
-  vi.hoisted(() => ({
-    cloneRepoMock: vi.fn(),
-    onCloneProgressMock: vi.fn(),
-    openDialogMock: vi.fn(),
-    cancelCloneMock: vi.fn(),
-    dispatchMock: vi.fn(),
-  }));
+const {
+  cloneRepoMock,
+  onCloneProgressMock,
+  openDialogMock,
+  cancelCloneMock,
+  dispatchMock,
+  showItemInFolderMock,
+} = vi.hoisted(() => ({
+  cloneRepoMock: vi.fn(),
+  onCloneProgressMock: vi.fn(),
+  openDialogMock: vi.fn(),
+  cancelCloneMock: vi.fn(),
+  dispatchMock: vi.fn(),
+  showItemInFolderMock: vi.fn(),
+}));
 
 vi.mock("@/clients", () => ({
   projectClient: {
@@ -45,6 +52,9 @@ vi.mock("@/clients", () => ({
     onCloneProgress: onCloneProgressMock,
     openDialog: openDialogMock,
     cancelClone: cancelCloneMock,
+  },
+  systemClient: {
+    showItemInFolderUnconfined: showItemInFolderMock,
   },
 }));
 
@@ -57,9 +67,14 @@ vi.mock("@/services/ActionService", () => ({
 vi.mock("@/components/ui/button", () => ({
   Button: ({
     children,
+    loading,
     ...props
-  }: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: string; size?: string }) => (
-    <button type="button" {...props}>
+  }: ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: string;
+    size?: string;
+    loading?: boolean;
+  }) => (
+    <button type="button" aria-busy={loading || undefined} {...props}>
       {children}
     </button>
   ),
@@ -112,12 +127,14 @@ vi.mock("@/components/Terminal/InlineStatusBanner", () => ({
   InlineStatusBanner: ({
     title,
     description,
+    contextLine,
     action,
     actions,
     onClose,
   }: {
     title: ReactNode;
     description?: ReactNode;
+    contextLine?: string;
     action?: MockBannerAction;
     actions?: MockBannerAction[];
     onClose?: () => void;
@@ -127,6 +144,7 @@ vi.mock("@/components/Terminal/InlineStatusBanner", () => ({
       <div data-testid="cleanup-banner">
         <span>{title}</span>
         <span>{description}</span>
+        {contextLine !== undefined && <span data-testid="banner-context">{contextLine}</span>}
         {actionList.map((a) => (
           <button key={a.id} type="button" aria-label={a.ariaLabel} onClick={a.onClick}>
             {a.label}
@@ -267,7 +285,7 @@ describe("CloneRepoDialog", () => {
       });
     });
 
-    expect(screen.getByText("receiving: 50%")).toBeTruthy();
+    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("receiving");
   });
 
   it("calls onSuccess with clonedPath after successful clone", async () => {
@@ -289,7 +307,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Open Project")).toBeTruthy();
+      expect(screen.getByText("Open project")).toBeTruthy();
     });
 
     // Auto-close runs after AUTO_CLOSE_DELAY_MS (2s) — extend the waitFor
@@ -327,7 +345,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Clone Failed")).toBeTruthy();
+      expect(screen.getByText("Clone failed")).toBeTruthy();
       expect(screen.getByText("Auth failed")).toBeTruthy();
       expect(screen.getByText("Retry")).toBeTruthy();
     });
@@ -416,7 +434,7 @@ describe("CloneRepoDialog", () => {
 
     const signInBtn = await waitFor(() => screen.getByText("Sign in to GitHub"));
     expect(signInBtn).toBeTruthy();
-    expect(screen.getByText("Clone Failed")).toBeTruthy();
+    expect(screen.getByText("Clone failed")).toBeTruthy();
 
     await act(async () => {
       fireEvent.click(signInBtn);
@@ -483,7 +501,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Clone Failed")).toBeTruthy();
+      expect(screen.getByText("Clone failed")).toBeTruthy();
     });
     expect(screen.queryByText("Sign in to GitHub")).toBeNull();
   });
@@ -514,7 +532,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Clone Failed")).toBeTruthy();
+      expect(screen.getByText("Clone failed")).toBeTruthy();
     });
     expect(screen.queryByText("Sign in to GitHub")).toBeNull();
   });
@@ -699,8 +717,81 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText("Clone Failed")).toBeNull();
+      expect(screen.queryByText("Clone failed")).toBeNull();
     });
+  });
+
+  it("treats a bridge-shaped CANCELLED rejection as a stop, not a failure", async () => {
+    // The shape that actually reaches the renderer. `contextBridge` strips own
+    // Error properties, so the preload encodes the code into the message and
+    // `code` is undefined by the time the dialog sees it. Reading `err.code`
+    // here used to classify every user stop as a failure and print the raw
+    // `[AppError|CANCELLED]` prefix into the error surface.
+    cloneRepoMock.mockRejectedValue(new Error("[AppError|CANCELLED] Clone cancelled"));
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or repository URL");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Clone stopped")).toBeTruthy();
+    });
+    expect(screen.queryByText("Clone failed")).toBeNull();
+    // No internal encoding may reach the user, in any surface.
+    expect(document.body.textContent).not.toContain("[AppError");
+    // A stop leaves the form editable so Clone can simply be pressed again.
+    expect(screen.getByRole("button", { name: "Clone" }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("states a failure once, never as both a stage row and a banner", async () => {
+    const gitError = Object.assign(new Error("early EOF"), {
+      name: "GitOperationError",
+      gitReason: "unknown",
+    });
+    cloneRepoMock.mockRejectedValue(gitError);
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or repository URL");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+
+    // The handler emits an `error` progress event before it throws. Rendering
+    // that as a stage as well is what put the same sentence on screen twice.
+    act(() => {
+      progressHandler?.({
+        stage: "error",
+        progress: 0,
+        message: "Clone failed: early EOF",
+        timestamp: Date.now(),
+      });
+    });
+
+    await waitFor(() => expect(screen.getByText("Clone failed")).toBeTruthy());
+    expect(screen.getAllByText("early EOF")).toHaveLength(1);
+    expect(screen.queryByText("Clone failed: early EOF")).toBeNull();
   });
 
   it("preserves Unicode characters in derived folder name", () => {
@@ -819,13 +910,22 @@ describe("CloneRepoDialog", () => {
       });
     });
 
-    // counting and checkout (one each) survive; receiving collapses to its
-    // latest value. A broken implementation that simply replaced the entire
-    // list with each new event would lose counting/checkout.
-    expect(screen.getByText("counting: 100%")).toBeTruthy();
-    expect(screen.getByText("checkout: 0%")).toBeTruthy();
-    expect(screen.queryByText("receiving: 10%")).toBeNull();
-    expect(screen.getByText("receiving: 80%")).toBeTruthy();
+    // The invariant: however many stages have been seen, exactly one is live.
+    // Multiple concurrent spinners were the defect — finished git stages never
+    // emit a terminal event, so every row used to keep spinning forever.
+    expect(screen.getAllByTestId("spinner")).toHaveLength(1);
+
+    // Earlier stages are still accounted for, quieted rather than dropped:
+    // they are what makes the live stage's bar restarting at 0% legible.
+    // `receiving` appears twice on purpose — the visible label plus the
+    // sr-only status node that announces phase changes.
+    expect(screen.getByText("counting")).toBeTruthy();
+    expect(screen.getAllByText("receiving").length).toBeGreaterThan(0);
+
+    // The live stage is the most recent event's stage, and its percentage is
+    // read off the payload rather than scraped out of the message string.
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("80");
+    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("receiving");
   });
 
   it("Enter retries after a failed clone (matches Retry button behavior)", async () => {
@@ -852,7 +952,7 @@ describe("CloneRepoDialog", () => {
       fireEvent.click(cloneBtn);
     });
 
-    await waitFor(() => expect(screen.getByText("Clone Failed")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Clone failed")).toBeTruthy());
 
     // Press Enter — should fire a second clone attempt without requiring the
     // user to click Retry, since the form fields are still valid.
@@ -898,11 +998,12 @@ describe("CloneRepoDialog", () => {
       });
     });
 
-    // The cancelled message is visible alongside its specific (non-spinner)
-    // icon — confirms it doesn't fall through to the in-progress Spinner.
-    const cancelledRow = screen.getByText("Clone cancelled").closest("div");
-    expect(cancelledRow).toBeTruthy();
-    expect(cancelledRow!.querySelector('[data-testid="spinner"]')).toBeNull();
+    // A terminal `cancelled` event is reported by the promise, not rendered as
+    // a stage, so it must never become a row of its own — and it must not
+    // displace the live stage either.
+    expect(screen.queryByText("Clone cancelled")).toBeNull();
+    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("receiving");
+    expect(screen.getAllByTestId("spinner")).toHaveLength(1);
   });
 
   it("dedups progress events by stage so a single stage shows one row", async () => {
@@ -936,11 +1037,43 @@ describe("CloneRepoDialog", () => {
       }
     });
 
-    // Only the latest message for the `receiving` stage should remain — the
-    // earlier 10–90% rows are deduped out, leaving a single live row.
-    expect(screen.queryByText("receiving: 0%")).toBeNull();
-    expect(screen.queryByText("receiving: 50%")).toBeNull();
-    expect(screen.getByText("receiving: 100%")).toBeTruthy();
+    // One stage updating repeatedly stays one row — an unbounded log was the
+    // old failure mode — and the reported value tracks the latest payload.
+    expect(screen.getAllByTestId("spinner")).toHaveLength(1);
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("reads the percentage from the payload, not from the message text", async () => {
+    cloneRepoMock.mockImplementation(() => new Promise(() => {}));
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or repository URL");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+
+    // Message and payload deliberately disagree. The bar must follow `progress`.
+    act(() => {
+      progressHandler?.({
+        stage: "receiving",
+        progress: 37,
+        message: "receiving: 99%",
+        timestamp: Date.now(),
+      });
+    });
+
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("37");
   });
 
   it("does not treat full URLs as owner/repo shorthand", async () => {
@@ -1034,7 +1167,7 @@ describe("CloneRepoDialog", () => {
       });
 
       expect(screen.queryByText("Connecting…")).toBeNull();
-      expect(screen.getByText("Receiving: 5%")).toBeTruthy();
+      expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("Receiving");
     });
 
     it("replaces the placeholder with the live log when the first event arrives", async () => {
@@ -1056,7 +1189,7 @@ describe("CloneRepoDialog", () => {
       });
 
       expect(screen.queryByText("Connecting…")).toBeNull();
-      expect(screen.getByText("Receiving: 12%")).toBeTruthy();
+      expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("Receiving");
     });
   });
 
@@ -1085,14 +1218,14 @@ describe("CloneRepoDialog", () => {
 
       const banner = screen.getByTestId("cleanup-banner");
       expect(banner).toBeTruthy();
-      expect(banner.textContent).toContain("Couldn't remove the partial clone at /tmp/repo.");
-      // The cleanup message must appear exactly once — only in the banner,
-      // never also as a deduped row in the progress log.
-      expect(screen.getAllByText("Couldn't remove the partial clone at /tmp/repo.")).toHaveLength(
-        1
-      );
-      // The real progress row is still there, unaffected.
-      expect(screen.getByText("Receiving: 40%")).toBeTruthy();
+      expect(banner.textContent).toContain("Partial clone not removed");
+      // The stranded path is carried as the banner's context line rather than
+      // buried in prose, and it names the composed destination.
+      expect(screen.getByTestId("banner-context").textContent).toBe("/tmp/repo");
+      // Exactly one cleanup surface — never also a row in the progress region.
+      expect(screen.getAllByTestId("cleanup-banner")).toHaveLength(1);
+      // The live stage is unaffected: cleanup failure is orthogonal to it.
+      expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("Receiving");
     });
 
     it("dismisses the cleanup banner via its close control", async () => {

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -727,7 +727,15 @@ describe("CloneRepoDialog", () => {
     // `code` is undefined by the time the dialog sees it. Reading `err.code`
     // here used to classify every user stop as a failure and print the raw
     // `[AppError|CANCELLED]` prefix into the error surface.
-    cloneRepoMock.mockRejectedValue(new Error("[AppError|CANCELLED] Clone cancelled"));
+    // Resolve only once a stage has been emitted, so the stop happens with a
+    // live phase on screen — the case the unit suite previously never hit.
+    let rejectClone: ((reason: Error) => void) | null = null;
+    cloneRepoMock.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectClone = reject;
+        })
+    );
 
     render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
 
@@ -744,6 +752,21 @@ describe("CloneRepoDialog", () => {
       fireEvent.click(cloneBtn);
     });
 
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+    act(() => {
+      progressHandler?.({
+        stage: "receiving",
+        progress: 42,
+        message: "receiving: 42%",
+        timestamp: Date.now(),
+      });
+    });
+    expect(screen.getByRole("progressbar")).toBeTruthy();
+
+    await act(async () => {
+      rejectClone?.(new Error("[AppError|CANCELLED] Clone cancelled"));
+    });
+
     await waitFor(() => {
       expect(screen.getByText("Clone stopped")).toBeTruthy();
     });
@@ -752,6 +775,10 @@ describe("CloneRepoDialog", () => {
     expect(document.body.textContent).not.toContain("[AppError");
     // A stop leaves the form editable so Clone can simply be pressed again.
     expect(screen.getByRole("button", { name: "Clone" }).hasAttribute("disabled")).toBe(false);
+    // And the live phase is gone. A leftover stage would keep the running mode
+    // on screen, so the dialog would still look like it were cloning.
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.queryAllByTestId("spinner")).toHaveLength(0);
   });
 
   it("states a failure once, never as both a stage row and a banner", async () => {

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -1272,6 +1272,26 @@ describe("CloneRepoDialog", () => {
     });
   });
 
+  it("keeps the running mode's live regions out of any aria-busy subtree", async () => {
+    // An `aria-busy="true"` ancestor silences mutations within its subtree on
+    // modern screen readers (the hazard `SkeletonHint` documents), so nesting
+    // the phase announcer or the "Still working…" hint under one would mute
+    // exactly the updates this mode exists to speak.
+    cloneRepoMock.mockImplementation(() => new Promise(() => {}));
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+    await startActiveClone();
+
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+    await waitForRunningMode();
+
+    // The phase announcer plus SkeletonHint's always-present live region.
+    const liveRegions = Array.from(document.querySelectorAll("[aria-live]"));
+    expect(liveRegions.length).toBeGreaterThanOrEqual(2);
+    for (const region of liveRegions) {
+      expect(region.closest('[aria-busy="true"]')).toBeNull();
+    }
+  });
+
   describe("cleanup-failure banner", () => {
     it("renders the cleanup-failed event as a separate banner, not a log row", async () => {
       cloneRepoMock.mockImplementation(() => new Promise(() => {}));
@@ -1306,6 +1326,50 @@ describe("CloneRepoDialog", () => {
       expect(screen.getAllByTestId("cleanup-banner")).toHaveLength(1);
       // The live stage is unaffected: cleanup failure is orthogonal to it.
       expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("Receiving");
+    });
+
+    it("keeps the failed run's path after the returned form is edited", async () => {
+      // A failure hands the form back editable with the banner still up. The
+      // stranded folder is wherever the clone that failed was pointed, so
+      // retyping the folder name must not repoint the banner — or its reveal
+      // action — at a directory nothing was ever cloned into.
+      let rejectClone: ((reason: Error) => void) | null = null;
+      cloneRepoMock.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectClone = reject;
+          })
+      );
+      render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+      await startActiveClone();
+
+      await waitFor(() => expect(progressHandler).not.toBeNull());
+
+      act(() => {
+        progressHandler?.({
+          stage: "cleanup-failed",
+          progress: 0,
+          message: "Couldn't remove the partial clone at /tmp/repo.",
+          timestamp: Date.now(),
+        });
+      });
+
+      await act(async () => {
+        rejectClone?.(new Error("Failed to clone repository"));
+      });
+
+      await waitFor(() => expect(screen.getByText("Clone failed")).toBeTruthy());
+
+      fireEvent.change(screen.getByLabelText(/folder name/i), {
+        target: { value: "somewhere-else" },
+      });
+
+      expect(screen.getByTestId("banner-context").textContent).toBe("/tmp/repo");
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Show the partial clone in the file manager"));
+      });
+      expect(showItemInFolderMock).toHaveBeenCalledWith("/tmp/repo");
     });
 
     it("dismisses the cleanup banner via its close control", async () => {

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -203,6 +203,24 @@ describe("CloneRepoDialog", () => {
     });
   });
 
+  /**
+   * The mode swap is gated on the Doherty threshold, so the running view does
+   * not exist for the first 400ms of a clone however fast the first progress
+   * event arrives. Tests that assert on the live phase have to cross it first.
+   */
+  async function waitForRunningMode() {
+    await screen.findByText("Connecting…", {}, { timeout: 3000 });
+  }
+
+  /**
+   * The live phase is gated behind a real 400ms timer AND arrives through an
+   * IPC callback, so querying for it synchronously races the gate — which
+   * passed in isolation and flaked under full-suite load.
+   */
+  async function findProgressBar(): Promise<HTMLElement> {
+    return screen.findByRole("progressbar", {}, { timeout: 3000 });
+  }
+
   it("renders input fields when opened", () => {
     render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
 
@@ -275,6 +293,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => expect(progressHandler).not.toBeNull());
+    await waitForRunningMode();
 
     act(() => {
       progressHandler?.({
@@ -285,7 +304,7 @@ describe("CloneRepoDialog", () => {
       });
     });
 
-    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("receiving");
+    expect((await findProgressBar()).getAttribute("aria-label")).toBe("receiving");
   });
 
   it("calls onSuccess with clonedPath after successful clone", async () => {
@@ -753,6 +772,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => expect(progressHandler).not.toBeNull());
+    await waitForRunningMode();
     act(() => {
       progressHandler?.({
         stage: "receiving",
@@ -761,7 +781,7 @@ describe("CloneRepoDialog", () => {
         timestamp: Date.now(),
       });
     });
-    expect(screen.getByRole("progressbar")).toBeTruthy();
+    expect(await findProgressBar()).toBeTruthy();
 
     await act(async () => {
       rejectClone?.(new Error("[AppError|CANCELLED] Clone cancelled"));
@@ -909,6 +929,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => expect(progressHandler).not.toBeNull());
+    await waitForRunningMode();
 
     act(() => {
       progressHandler?.({
@@ -951,8 +972,8 @@ describe("CloneRepoDialog", () => {
 
     // The live stage is the most recent event's stage, and its percentage is
     // read off the payload rather than scraped out of the message string.
-    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("80");
-    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("receiving");
+    expect((await findProgressBar()).getAttribute("aria-valuenow")).toBe("80");
+    expect((await findProgressBar()).getAttribute("aria-label")).toBe("receiving");
   });
 
   it("Enter retries after a failed clone (matches Retry button behavior)", async () => {
@@ -1009,6 +1030,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => expect(progressHandler).not.toBeNull());
+    await waitForRunningMode();
 
     act(() => {
       progressHandler?.({
@@ -1029,7 +1051,7 @@ describe("CloneRepoDialog", () => {
     // a stage, so it must never become a row of its own — and it must not
     // displace the live stage either.
     expect(screen.queryByText("Clone cancelled")).toBeNull();
-    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("receiving");
+    expect((await findProgressBar()).getAttribute("aria-label")).toBe("receiving");
     expect(screen.getAllByTestId("spinner")).toHaveLength(1);
   });
 
@@ -1052,6 +1074,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => expect(progressHandler).not.toBeNull());
+    await waitForRunningMode();
 
     act(() => {
       for (let pct = 0; pct <= 100; pct += 10) {
@@ -1067,7 +1090,7 @@ describe("CloneRepoDialog", () => {
     // One stage updating repeatedly stays one row — an unbounded log was the
     // old failure mode — and the reported value tracks the latest payload.
     expect(screen.getAllByTestId("spinner")).toHaveLength(1);
-    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("100");
+    expect((await findProgressBar()).getAttribute("aria-valuenow")).toBe("100");
   });
 
   it("reads the percentage from the payload, not from the message text", async () => {
@@ -1089,6 +1112,7 @@ describe("CloneRepoDialog", () => {
     });
 
     await waitFor(() => expect(progressHandler).not.toBeNull());
+    await waitForRunningMode();
 
     // Message and payload deliberately disagree. The bar must follow `progress`.
     act(() => {
@@ -1100,7 +1124,7 @@ describe("CloneRepoDialog", () => {
       });
     });
 
-    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("37");
+    expect((await findProgressBar()).getAttribute("aria-valuenow")).toBe("37");
   });
 
   it("does not treat full URLs as owner/repo shorthand", async () => {
@@ -1197,6 +1221,34 @@ describe("CloneRepoDialog", () => {
       expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("Receiving");
     });
 
+    it("does not switch to the running view when progress arrives before the threshold", async () => {
+      render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+      await startActiveClone();
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+        progressHandler?.({
+          stage: "receiving",
+          progress: 5,
+          message: "Receiving: 5%",
+          timestamp: Date.now(),
+        });
+      });
+
+      // A clone fast enough to report progress inside the threshold must not
+      // flash the monitor. Gating on "no event yet" rather than on the clone
+      // itself let a quick first event bypass the gate entirely.
+      expect(screen.queryByRole("progressbar")).toBeNull();
+      expect(screen.queryByTestId("spinner")).toBeNull();
+      // Still the configuration form, untouched.
+      expect(screen.getByPlaceholderText("owner/repo or repository URL")).toBeTruthy();
+
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("5");
+    });
+
     it("replaces the placeholder with the live log when the first event arrives", async () => {
       render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
       await startActiveClone();
@@ -1227,6 +1279,7 @@ describe("CloneRepoDialog", () => {
       await startActiveClone();
 
       await waitFor(() => expect(progressHandler).not.toBeNull());
+      await waitForRunningMode();
 
       act(() => {
         progressHandler?.({
@@ -1261,6 +1314,7 @@ describe("CloneRepoDialog", () => {
       await startActiveClone();
 
       await waitFor(() => expect(progressHandler).not.toBeNull());
+      await waitForRunningMode();
 
       act(() => {
         progressHandler?.({

--- a/src/components/Project/__tests__/projectDialogFields.test.tsx
+++ b/src/components/Project/__tests__/projectDialogFields.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
-import { PathCaption } from "../projectDialogFields";
+import { PathCaption, FIELD_INPUT_CLASS } from "../projectDialogFields";
 
 afterEach(cleanup);
 
@@ -65,5 +65,27 @@ describe("PathCaption", () => {
 
     // Whatever the ellipsis hides visually stays reachable.
     expect(screen.getByTitle(path)).toBeTruthy();
+  });
+});
+
+describe("FIELD_INPUT_CLASS", () => {
+  it("pairs the accent focus ring with an error focus ring for the invalid case", () => {
+    // Not an assertion about which colours are used — those can change. The rule
+    // is that a field cannot advertise an accent focus ring without also saying
+    // what the ring becomes when the field is invalid, or an invalid focused
+    // field draws the accent ring concentric with its red error border and the
+    // louder of the two signals says nothing is wrong.
+    const declaresAccentFocusRing = /(?:^|\s)focus:ring-\S*accent/.test(FIELD_INPUT_CLASS);
+    const declaresInvalidFocusRing = /aria-invalid:focus:ring-\S*status-error/.test(
+      FIELD_INPUT_CLASS
+    );
+
+    expect(declaresAccentFocusRing && !declaresInvalidFocusRing).toBe(false);
+  });
+
+  it("marks the invalid border so the error state is not carried by the ring alone", () => {
+    // Colour is never the only carrier: the border changes too, which survives
+    // forced-colors and does not depend on the field being focused.
+    expect(/aria-invalid:border-\S*status-error/.test(FIELD_INPUT_CLASS)).toBe(true);
   });
 });

--- a/src/components/Project/__tests__/projectDialogFields.test.tsx
+++ b/src/components/Project/__tests__/projectDialogFields.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { PathCaption } from "../projectDialogFields";
+
+afterEach(cleanup);
+
+/**
+ * `PathCaption` exists so a filesystem path elides its ancestors rather than
+ * its leaf — the leaf is what identifies the project, and a plain `truncate`
+ * eats exactly that. These assert the rule, not any particular rendered width:
+ * the split point is a layout decision that can change, the invariants can't.
+ */
+describe("PathCaption", () => {
+  it("puts the whole leaf in the span that never truncates away", () => {
+    render(<PathCaption path="/Users/dev/code/helios-dashboard" />);
+
+    const caption = screen.getByTitle("/Users/dev/code/helios-dashboard");
+    const spans = caption.querySelectorAll("span");
+    expect(spans).toHaveLength(2);
+
+    // The leaf sits in the shrink-0 span, so the ellipsis can never reach it.
+    expect(spans[1]?.textContent).toContain("helios-dashboard");
+    expect(spans[0]?.textContent).not.toContain("helios-dashboard");
+  });
+
+  it("keeps the separator attached to the leaf, not to the elided ancestors", () => {
+    render(<PathCaption path="/Users/dev/code/helios-dashboard" />);
+
+    const spans = screen.getByTitle("/Users/dev/code/helios-dashboard").querySelectorAll("span");
+
+    // The separator is the first character the ellipsis would consume if it
+    // lived with the ancestors, and losing it makes the caption read as two
+    // unrelated strings instead of one elided path.
+    expect(spans[1]?.textContent).toBe("/helios-dashboard");
+    expect(spans[0]?.textContent?.endsWith("/")).toBe(false);
+  });
+
+  it("reassembles to the normalized path across the split", () => {
+    const path = "/Users/dev/code/helios-dashboard";
+    render(<PathCaption path={path} />);
+
+    const spans = screen.getByTitle(path).querySelectorAll("span");
+    const rejoined = Array.from(spans)
+      .map((span) => span.textContent ?? "")
+      .join("");
+
+    // No character is dropped or duplicated at the seam.
+    expect(rejoined).toBe(path);
+  });
+
+  it("renders a bare leaf with no separator and no empty ancestor text", () => {
+    render(<PathCaption path="helios-dashboard" />);
+
+    const spans = screen.getByTitle("helios-dashboard").querySelectorAll("span");
+    expect(spans[0]?.textContent).toBe("");
+    expect(spans[1]?.textContent).toBe("helios-dashboard");
+  });
+
+  it("carries the untruncated path as the accessible title", () => {
+    const path = "/Users/dev/a/very/deeply/nested/place/helios-dashboard";
+    render(<PathCaption path={path} />);
+
+    // Whatever the ellipsis hides visually stays reachable.
+    expect(screen.getByTitle(path)).toBeTruthy();
+  });
+});

--- a/src/components/Project/projectDialogFields.tsx
+++ b/src/components/Project/projectDialogFields.tsx
@@ -42,7 +42,17 @@ export const FIELD_EMOJI_ROW_INDENT = "ml-11";
 export function PathCaption({ path, className }: { path: string; className?: string }) {
   const displayPath = normalize(path);
   const leaf = basename(displayPath);
-  const ancestors = displayPath.slice(0, displayPath.length - leaf.length);
+  // The separator rides with the leaf, not with the ancestors. Left inside the
+  // truncating span it is the first thing the ellipsis eats, and the caption
+  // then reads as two unrelated strings ("…/some/pre  leaf") rather than as one
+  // elided path ("…/leaf").
+  const separatorIndex = displayPath.length - leaf.length - 1;
+  const separator =
+    separatorIndex >= 0 &&
+    (displayPath[separatorIndex] === "/" || displayPath[separatorIndex] === "\\")
+      ? displayPath[separatorIndex]
+      : "";
+  const ancestors = displayPath.slice(0, displayPath.length - leaf.length - separator.length);
 
   return (
     <p
@@ -52,7 +62,10 @@ export function PathCaption({ path, className }: { path: string; className?: str
       <span className="min-w-0 truncate">{ancestors}</span>
       {/* Pinned against the ancestors, but still capped: a leaf wider than the
           dialog would otherwise overflow into a horizontal scroll. */}
-      <span className="max-w-full shrink-0 truncate">{leaf}</span>
+      <span className="max-w-full shrink-0 truncate">
+        {separator}
+        {leaf}
+      </span>
     </p>
   );
 }

--- a/src/components/Project/projectDialogFields.tsx
+++ b/src/components/Project/projectDialogFields.tsx
@@ -15,8 +15,14 @@ import { cn } from "@/lib/utils";
 
 export const FIELD_LABEL_CLASS = "text-sm font-medium text-daintree-text/80";
 
+/**
+ * The invalid-focused case needs the error ring, not the accent one. Left to the
+ * plain `focus:` rule, an invalid field drew a green accent ring concentric with
+ * its red error border: two colour signals disagreeing inside 2px, with the
+ * louder of the two saying nothing is wrong.
+ */
 export const FIELD_INPUT_CLASS =
-  "min-h-9 w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error";
+  "min-h-9 w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error aria-invalid:focus:ring-status-error/50";
 
 /** Picker-backed fields: muted fill signals "typing here does nothing". */
 export const FIELD_READONLY_INPUT_CLASS =

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -173,7 +173,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Panel/TabButton.tsx",
     "src/components/Portal/PortalDock.tsx",
     "src/components/Portal/PortalToolbar.tsx",
-    "src/components/Project/CloneRepoDialog.tsx",
     "src/components/Project/CreateProjectFolderDialog.tsx",
     "src/components/Project/GeneralTab.tsx",
     "src/components/Project/GitInitDialog.tsx",


### PR DESCRIPTION
## Summary

The clone dialog kept every form field mounted and disabled while a monospaced transcript grew underneath it, so configuration, progress, failure and completion all rendered as one crowded state.

It now switches between four modes of the same surface: configuration, running, failure, completion. Progress shows one live phase with a determinate bar instead of a transcript where several rows spun at once.

Resolves #11974

## What changed

**The dialog changes mode instead of disabling itself.** Running replaces the form with a compact source and destination recap plus the current phase. Completion recomposes around the cloned project and where it landed. Failure returns to an editable form with the explanation above the inputs it is about, rather than below them where the body scrolled it out of sight.

**Progress reports one live phase.** Git never marks an intermediate stage finished, so every row used to keep spinning. A long clone ended with three or four spinners racing, two of them on stages already at 100%. Finished phases are quiet checkmarks now and only the live one spins, which also makes its bar restarting at zero read as the next step rather than as the operation going backwards. The bar uses the `progress` number `CloneRepoProgressEvent` has always carried and the renderer always threw away.

**Stopping a clone was reported as a failure.** The renderer branched on `err.code`, which `contextBridge` strips, so `code` was always `undefined` and every stop rendered a red "Clone Failed" box with the raw `[AppError|CANCELLED]` prefix showing. It decodes the message prefix through `isClientAppError` now, the same way the git branch three lines below already did. A stop gets a neutral notice over a form that is editable again.

**Failures share one hierarchy.** One `InlineStatusBanner`, no longer duplicated as a progress row, with the provider sign-in as its single action when the URL matches a registered forge. Stranded-cleanup reporting stays its own banner, ordered after the failure it followed from, carrying the path as a context line and a "Show in folder" action instead of three wrapped lines of prose.

Also in here: the header glyph is neutral, so the focus ring is the region's only accent and the file comes off the accent-guard allowlist. Focus opens in the URL field and follows each mode change. `PathCaption` composes the destination so the leaf folder survives truncation, and its separator now rides with the leaf rather than being the first character the ellipsis eats (that one fixes the caption in all four dialogs that use it). `--depth 1` moves out of the checkbox label into its caption. "Stop clone" acknowledges the click while git tears down.

## Design review

Scored 4.2 to 8.2 over three rounds against real rendered pixels, on mode legibility, information hierarchy, progress legibility, error and recovery coherence, visual language consistency, typography, density, affordance, states, accessibility, microcopy and craft.

`e2e/screenshots/clone-dialog-review.spec.ts` drives all fifteen states that carry design weight by replacing the clone, cancel and forge-provider handlers in the main process, so everything downstream of `ipcMain` stays real: the envelope, the preload's `GitOperationError` reconstruction, `contextBridge` stripping, the live `onCloneProgress` subscription. A real clone cannot produce auth failure or stranded cleanup on demand, or hold the busy phase still long enough to photograph. It is opt-in behind `DAINTREE_SHOT_CLONE` and verifies every PNG it claims to write rather than trusting its own exit code.

Two rounds of external design research (NN/g, Apple HIG, Material 3, Fluent, GNOME HIG, WAI-ARIA APG) changed the design rather than just confirming it. Completed checkpoints came back after NN/g's point that a lone bar resetting each phase reads as regression. The progress track renders in both the indeterminate and determinate phases because Apple HIG warns that swapping the indicator shifts the frame under it.

**Consistency survey.** Nothing this introduced makes the dialog an outlier. Two patterns where it *was* the outlier are gone: it held the only `rounded-lg` banner override in the app, and one of only two accumulating mono progress transcripts. Three pre-existing debts surfaced and are deliberately not in this diff: `GitInitDialog` is now the last holder of the mono transcript, the hand-rolled `bg-destructive/10` block and an accent title icon, all three at once; `FIELD_CHECKBOX_CLASS` still tints with `accent-daintree-accent`; and `FIELD_READONLY_INPUT_CLASS` end-truncates a filesystem path, hiding the leaf.

**One open decision.** The success state still hands off automatically after two seconds. Both the reviewer and the external guidance flag that as a WCAG 2.2.1 Timing Adjustable breach, and note a screen reader cannot finish announcing a modal state change in that window. Auto-advancing into the freshly cloned project is a product-flow choice rather than a styling one, so it is left as it was. Dropping the timer and requiring the "Open project" click is a one-line change if we want it.

## Testing

Full unit suite green, run twice (the second run is what caught two assertions of mine that raced the Doherty gate under load and passed in isolation). Typecheck, lint and format clean, with lint warnings back at their pre-existing baseline.

Nine invariants pinned across `CloneRepoDialog.test.tsx` and a new `projectDialogFields.test.tsx`, each one mutation-checked by reintroducing the bug and confirming the test fails. They assert rules rather than values (exactly one live phase however many stages arrive; the bar follows the payload and not the message string; a bridge-shaped `CANCELLED` rejection never reaches an error surface), so they survive the design changing again.

The accent fix is proved by the guard rather than by assertion: removing the file from the `#5978-5986-pre-existing` bucket passes the stale-entry ratchet, which only holds if no non-focus-ring accent remains.
