### PR TITLE
Orient the agent setup wizard around its current step

### DIFF
--- a/e2e/screenshots/setup-wizard-review.spec.ts
+++ b/e2e/screenshots/setup-wizard-review.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * AgentSetupWizard visual-review harness.
+ *
+ * Boots a fixture repo, opens the setup wizard through the same custom event
+ * Settings / the toolbar / the welcome banner use, and walks every step of both
+ * flows (first-run and re-run) writing a PNG per state so the wizard shell can
+ * be judged against real rendered pixels.
+ *
+ * Opt-in only, like the other review harnesses: skips itself unless
+ * DAINTREE_SHOT_WIZARD is set, so the marketing screenshots workflow never
+ * executes it.
+ *
+ *   DAINTREE_SHOT_WIZARD=1 ./node_modules/.bin/playwright test \
+ *     --project=screenshots setup-wizard-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_WIZARD  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME   optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG     optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY    comma-separated step filter (see step names below)
+ *   DAINTREE_SHOT_MEDIA   "reduced" | "forced-colors" | "contrast" — emulate
+ *                         the matching media state for the whole run
+ *
+ * Output: artifacts/wizard-shots/<NN-slug>[-tag].png (gitignored).
+ *
+ * Unlike a pass/fail spec this harness exists to produce artifacts, so it fails
+ * loudly rather than quietly: a step that throws is recorded and re-raised at
+ * the end, and the run asserts it actually wrote the files it claims.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_WIZARD;
+const DIALOG = '[data-testid="agent-setup-wizard"]';
+/** The testid sits on the backdrop; the panel is its first child. */
+const PANEL = `${DIALOG} > div`;
+const STEP = '[data-testid="agent-setup-step"]';
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const MEDIA = process.env.DAINTREE_SHOT_MEDIA ?? "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "wizard-shots");
+
+/**
+ * Kills the caret and scrollbars so a re-run diffs cleanly. Animations are NOT
+ * frozen here — `snap()` settles two frames plus a fixed wait instead, because
+ * the step transition is one of the things under review and zeroing its
+ * duration would hide a mid-flight layout jump rather than reveal it.
+ */
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after { caret-color: transparent !important; }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-wizard-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  writeFileSync(path.join(dir, "src", "index.ts"), "export const main = (): number => 0;\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  git("branch develop", dir);
+  git("checkout develop", dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 450): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/** Every PNG this run claims to have written, verified against disk at the end. */
+const written: string[] = [];
+
+async function snap(page: Page, slug: string, locator?: string, wait = 450): Promise<void> {
+  await settle(page, wait);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).first().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", caret: "hide" });
+  }
+  written.push(file);
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+const failures: string[] = [];
+
+/**
+ * Runs one capture group. A throw is recorded rather than aborting the sweep —
+ * one broken state should not cost the other fifteen — but the recorded
+ * failures are re-raised at the end so the run never reports success over a
+ * missing artifact.
+ */
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    failures.push(`${name}: ${String(error).slice(0, 400)}`);
+  }
+}
+
+/** Opens the wizard through the same event Settings and the toolbar dispatch. */
+async function openWizard(page: Page, isFirstRun: boolean): Promise<void> {
+  await page.evaluate((firstRun) => {
+    window.dispatchEvent(
+      new CustomEvent("daintree:open-agent-setup-wizard", { detail: { isFirstRun: firstRun } })
+    );
+  }, isFirstRun);
+  await page.locator(DIALOG).waitFor({ state: "visible", timeout: 15_000 });
+  await page.locator(STEP).first().waitFor({ state: "visible", timeout: 15_000 });
+}
+
+async function closeWizard(page: Page): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    if (
+      !(await page
+        .locator(DIALOG)
+        .isVisible()
+        .catch(() => false))
+    )
+      return;
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 250);
+  }
+}
+
+/** The wizard's own state-machine step id, straight off the animated container. */
+async function currentStep(page: Page): Promise<string> {
+  return (await page.locator(STEP).first().getAttribute("data-step")) ?? "unknown";
+}
+
+async function clickContinue(page: Page): Promise<void> {
+  await page
+    .locator(DIALOG)
+    .getByRole("button", { name: /^(continue|finish|next)/i })
+    .first()
+    .click();
+  await settle(page, 500);
+}
+
+/**
+ * Walks a flow from wherever it currently sits to `complete`, snapping each
+ * step it lands on. Returns the ordered step ids it saw so the caller can
+ * assert the flow actually branched the way it expected.
+ */
+async function walkFlow(page: Page, prefix: string, startIndex: number): Promise<string[]> {
+  const seen: string[] = [];
+  let index = startIndex;
+  for (let guard = 0; guard < 8; guard++) {
+    const stepId = await currentStep(page);
+    seen.push(stepId);
+    await snap(page, `${index}-${prefix}-${stepId}`, PANEL);
+    await snap(page, `${index}-${prefix}-${stepId}-window`);
+    if (stepId === "complete") break;
+    index += 1;
+    await clickContinue(page);
+  }
+  return seen;
+}
+
+test("agent setup wizard review — every step of both flows", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_WIZARD is required for the wizard capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_WIZARD to run the wizard capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-wizardshot-"));
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    if (MEDIA === "reduced") await page.emulateMedia({ reducedMotion: "reduce" });
+    if (MEDIA === "forced-colors") await page.emulateMedia({ forcedColors: "active" });
+    if (MEDIA === "contrast") await page.emulateMedia({ contrast: "more" }).catch(() => {});
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 2000);
+    await dismissBlockingPalette(page);
+
+    // 1. Loading — the availability skeleton, caught before the first probe
+    // resolves. Snapped with no settle wait so it is not raced away.
+    await step("loading", async () => {
+      await openWizard(page, false);
+      await snap(page, "05-rerun-agents-loading", PANEL, 0);
+      await closeWizard(page);
+    });
+
+    // 2. First run — the full six-step flow, the shot the redesign is judged on.
+    await step("first-run", async () => {
+      await openWizard(page, true);
+      const seen = await walkFlow(page, "first", 10);
+      expect(seen[0]).toBe("appearance");
+      expect(seen.at(-1)).toBe("complete");
+      await closeWizard(page);
+    });
+
+    // 3. Re-run from Settings — the shorter flow, and the one whose progress
+    // model has to survive the conditional cli step disappearing.
+    await step("rerun", async () => {
+      await openWizard(page, false);
+      const seen = await walkFlow(page, "rerun", 30);
+      expect(seen[0]).toBe("agents");
+      expect(seen.at(-1)).toBe("complete");
+      await closeWizard(page);
+    });
+
+    // 4. Nothing selected — the disabled-Continue state plus its footer hint.
+    // AgentCard renders a native <input type="checkbox">, not a role=checkbox.
+    await step("no-selection", async () => {
+      await openWizard(page, false);
+      const boxes = page.locator(`${DIALOG} input[type="checkbox"]:checked`);
+      for (let guard = 0; guard < 20 && (await boxes.count()) > 0; guard++) {
+        await boxes.first().uncheck({ force: true });
+        await settle(page, 120);
+      }
+      expect(await boxes.count(), "agents remained selected").toBe(0);
+      await snap(page, "50-agents-none-selected", PANEL);
+      await closeWizard(page);
+    });
+
+    // 5. The conditional cli step — only reachable with an agent selected that
+    // is NOT already installed, which is why the default sweep never sees it.
+    await step("cli", async () => {
+      await openWizard(page, true);
+      await clickContinue(page); // appearance -> agents
+      const unchecked = page.locator(`${DIALOG} input[type="checkbox"]:not(:checked)`);
+      if ((await unchecked.count()) > 0) {
+        await unchecked.first().check({ force: true });
+        await settle(page, 250);
+      }
+      for (let guard = 0; guard < 4 && (await currentStep(page)) !== "cli"; guard++) {
+        await clickContinue(page);
+      }
+      expect(await currentStep(page), "never reached the cli step").toBe("cli");
+      await snap(page, "20-first-cli", PANEL);
+      await snap(page, "20-first-cli-window");
+      await clickContinue(page); // cli -> permissions, with cli genuinely visited
+      await snap(page, "21-first-permissions-after-cli", PANEL);
+      await closeWizard(page);
+    });
+
+    // 6. Keyboard focus — where the ring lands on entry, and on the footer.
+    await step("keyboard", async () => {
+      await openWizard(page, true);
+      await page.keyboard.press("Tab");
+      await snap(page, "60-appearance-focus-first", PANEL);
+      for (let i = 0; i < 6; i++) await page.keyboard.press("Tab");
+      await snap(page, "61-appearance-focus-footer", PANEL);
+      await closeWizard(page);
+    });
+
+    // 7. Privacy toggle on — the only step whose control has two visual states.
+    await step("privacy-on", async () => {
+      await openWizard(page, true);
+      await clickContinue(page); // appearance -> agents
+      await clickContinue(page); // agents -> privacy
+      if ((await currentStep(page)) === "privacy") {
+        await page.locator(`${DIALOG} [role="switch"]`).first().click();
+        await snap(page, "70-privacy-toggle-on", PANEL);
+      }
+      await closeWizard(page);
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+
+  // A harness that reports success without artifacts is worse than one that
+  // fails: verify every claimed PNG landed, then surface any step that threw.
+  const missing = written.filter((f) => !existsSync(f));
+  expect(missing, `claimed screenshots missing from disk: ${missing.join(", ")}`).toEqual([]);
+  const onDisk = readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`));
+  expect(onDisk.length, "no screenshots were written").toBeGreaterThan(0);
+  expect(failures, `capture steps failed:\n${failures.join("\n")}`).toEqual([]);
+});

--- a/e2e/screenshots/setup-wizard-review.spec.ts
+++ b/e2e/screenshots/setup-wizard-review.spec.ts
@@ -283,7 +283,31 @@ test("agent setup wizard review — every step of both flows", async () => {
       await closeWizard(page);
     });
 
-    // 6. Keyboard focus — where the ring lands on entry, and on the footer.
+    // 6. Focus after an advance. jsdom flattens AnimatePresence, so the unit
+    // test cannot reproduce the `mode="wait"` timing that put focus on the
+    // OUTGOING heading — this is the check that does.
+    await step("focus-after-advance", async () => {
+      await openWizard(page, true);
+      await clickContinue(page); // appearance -> agents
+      await settle(page, 700);
+      const focused = await page.evaluate(() => {
+        const el = document.activeElement as HTMLElement | null;
+        return {
+          tag: el?.tagName ?? "none",
+          text: (el?.textContent ?? "").trim().slice(0, 60),
+          inDialog: !!el?.closest('[data-testid="agent-setup-wizard"]'),
+        };
+      });
+      expect(focused.inDialog, `focus escaped the dialog: ${JSON.stringify(focused)}`).toBe(true);
+      expect(focused.tag, `focus should land on the step heading: ${JSON.stringify(focused)}`).toBe(
+        "H3"
+      );
+      expect(focused.text).toBe("Choose your AI agents");
+      await snap(page, "62-focus-after-advance", PANEL);
+      await closeWizard(page);
+    });
+
+    // 7. Keyboard focus — where the ring lands on entry, and on the footer.
     await step("keyboard", async () => {
       await openWizard(page, true);
       await page.keyboard.press("Tab");
@@ -293,7 +317,7 @@ test("agent setup wizard review — every step of both flows", async () => {
       await closeWizard(page);
     });
 
-    // 7. Privacy toggle on — the only step whose control has two visual states.
+    // 8. Privacy toggle on — the only step whose control has two visual states.
     await step("privacy-on", async () => {
       await openWizard(page, true);
       await clickContinue(page); // appearance -> agents

--- a/src/components/Settings/SettingsSwitch.tsx
+++ b/src/components/Settings/SettingsSwitch.tsx
@@ -1,20 +1,32 @@
 import * as Switch from "@radix-ui/react-switch";
 import { cn } from "@/lib/utils";
 
+// The OFF state used to paint the thumb `bg-daintree-text` — a near-black
+// filled circle sitting in a pale track, which reads as an illuminated
+// "on" indicator rather than an off one. The solid high-contrast fill is now
+// reserved for the ON track, the OFF thumb is a mid-tone that cannot be
+// mistaken for a lit state, and the OFF track carries a defined boundary so
+// the control is still discernible against the page (WCAG 1.4.11).
+// An inset ring rather than a border: `border` would shrink the track's content
+// box and shift the checked thumb 2px off its resting inset.
+const OFF_TRACK = "bg-surface-input ring-1 ring-inset ring-border-strong";
+const OFF_THUMB = "bg-text-muted";
+const ON_THUMB = "data-[state=checked]:bg-text-inverse";
+
 const COLOR_SCHEMES = {
   accent: {
-    track: "bg-daintree-border data-[state=checked]:bg-daintree-text",
-    thumb: "bg-daintree-text data-[state=checked]:bg-text-inverse",
+    track: `${OFF_TRACK} data-[state=checked]:bg-daintree-text data-[state=checked]:ring-0`,
+    thumb: `${OFF_THUMB} ${ON_THUMB}`,
     focus: "focus-visible:outline-daintree-accent",
   },
   amber: {
-    track: "bg-daintree-border data-[state=checked]:bg-status-warning",
-    thumb: "bg-daintree-text data-[state=checked]:bg-text-inverse",
+    track: `${OFF_TRACK} data-[state=checked]:bg-status-warning data-[state=checked]:ring-0`,
+    thumb: `${OFF_THUMB} ${ON_THUMB}`,
     focus: "focus-visible:outline-status-warning",
   },
   danger: {
-    track: "bg-daintree-border data-[state=checked]:bg-status-error",
-    thumb: "bg-daintree-text data-[state=checked]:bg-text-inverse",
+    track: `${OFF_TRACK} data-[state=checked]:bg-status-error data-[state=checked]:ring-0`,
+    thumb: `${OFF_THUMB} ${ON_THUMB}`,
     focus: "focus-visible:outline-status-error",
   },
 } as const;

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -1137,18 +1137,42 @@ describe("SettingsSwitch", () => {
     expect(switchEl?.className).toContain("data-[state=checked]:bg-status-error");
   });
 
-  it("applies correct thumb colors for contrast", () => {
-    const { container: offContainer } = render(
+  // The off state used to paint the thumb with the very fill the on state uses
+  // for its TRACK, so a switch that was off presented a solid high-contrast
+  // circle and read as lit. The rule, not the values: the resting thumb must
+  // never borrow the fill that means "on", and the two thumb states must
+  // differ from each other.
+  it("never paints the resting thumb with the fill that signals on", () => {
+    const { container } = render(
       <SettingsSwitch checked={false} onCheckedChange={vi.fn()} aria-label="Test switch" />
     );
-    const thumbOff = offContainer.querySelector('[role="switch"] > span');
-    expect(thumbOff?.className).toContain("bg-daintree-text");
+    const track = container.querySelector('[role="switch"]');
+    const thumb = container.querySelector('[role="switch"] > span');
 
-    const { container: onContainer } = render(
-      <SettingsSwitch checked={true} onCheckedChange={vi.fn()} aria-label="Test switch" />
+    const bg = (className: string | undefined, checked: boolean) =>
+      (className ?? "")
+        .split(/\s+/)
+        .filter((c) => (checked ? c.startsWith("data-[state=checked]:bg-") : /^bg-/.test(c)))
+        .map((c) => c.replace("data-[state=checked]:", ""));
+
+    const restingThumb = bg(thumb?.className, false);
+    const onTrack = bg(track?.className, true);
+    const onThumb = bg(thumb?.className, true);
+
+    expect(restingThumb.length, "the resting thumb needs a fill").toBeGreaterThan(0);
+    expect(onTrack.length, "the on track needs a fill").toBeGreaterThan(0);
+    expect(restingThumb).not.toEqual(expect.arrayContaining(onTrack));
+    expect(restingThumb).not.toEqual(expect.arrayContaining(onThumb));
+  });
+
+  it("gives the resting track a boundary so the control stays discernible", () => {
+    const { container } = render(
+      <SettingsSwitch checked={false} onCheckedChange={vi.fn()} aria-label="Test switch" />
     );
-    const thumbOn = onContainer.querySelector('[role="switch"] > span');
-    expect(thumbOn?.className).toContain("data-[state=checked]:bg-text-inverse");
+    const track = container.querySelector('[role="switch"]');
+    // Either spelling is fine; what matters is that the resting control has an
+    // edge of its own and does not rely on its fill alone to be discernible.
+    expect(track?.className).toMatch(/(^|\s)(border|ring-\d)(\s|-|$)/);
   });
 
   it("toggles with keyboard (Space key)", () => {

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -35,6 +35,12 @@ interface AgentCliStepProps {
   availability: CliAvailability;
   selections: Record<string, boolean>;
   onInstallComplete?: () => void;
+  /**
+   * Reports whether an install is in flight so the shell can lock navigation
+   * and dismissal. An install that is interrupted mid-batch stops before the
+   * remaining agents, so Continue/Back/Escape must not be live while it runs.
+   */
+  onBusyChange?: (busy: boolean) => void;
   // During first-run, the dedicated permissions step owns the global trust
   // decision, so the per-agent dangerous toggles here are suppressed to avoid
   // a competing control.
@@ -45,6 +51,7 @@ export function AgentCliStep({
   availability,
   selections,
   onInstallComplete,
+  onBusyChange,
   isFirstRun = false,
 }: AgentCliStepProps) {
   const [cardStatuses, setCardStatuses] = useState<Record<string, CardStatus>>({});
@@ -58,6 +65,20 @@ export function AgentCliStep({
   useEffect(() => {
     cardStatusesRef.current = cardStatuses;
   }, [cardStatuses]);
+
+  const isBusy = isBatchRunning || Object.values(cardStatuses).includes("installing");
+  const onBusyChangeRef = useRef(onBusyChange);
+  useEffect(() => {
+    onBusyChangeRef.current = onBusyChange;
+  });
+  useEffect(() => {
+    onBusyChangeRef.current?.(isBusy);
+  }, [isBusy]);
+  // Release the lock if the step unmounts mid-install, so a shell that outlives
+  // this component can never be left permanently undismissable.
+  useEffect(() => {
+    return () => onBusyChangeRef.current?.(false);
+  }, []);
 
   const selectedAgentIds = useMemo(() => AGENT_ORDER.filter((id) => selections[id]), [selections]);
 
@@ -270,7 +291,7 @@ export function AgentCliStep({
                       Installed
                     </span>
                   ) : isInstalling ? (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-daintree-accent font-medium">
+                    <span className="inline-flex items-center gap-1 text-[11px] text-text-secondary font-medium">
                       <Loader2 className="w-3 h-3 animate-spin" />
                       Installing
                     </span>
@@ -293,7 +314,7 @@ export function AgentCliStep({
                     <button
                       type="button"
                       onClick={() => handleInstall(agentId)}
-                      className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium text-daintree-accent hover:bg-daintree-accent/10 transition-colors"
+                      className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium text-daintree-text hover:bg-overlay-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
                     >
                       <Download className="w-3 h-3" />
                       Install

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -202,15 +202,6 @@ export function AgentCliStep({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-base font-semibold text-daintree-text mb-1">Install agents</h3>
-          <p className="text-sm text-daintree-text/60">
-            Install agents individually or use the batch button below.
-          </p>
-        </div>
-      </div>
-
       <div className="space-y-1.5 max-h-[320px] overflow-y-auto">
         {selectedAgentIds.map((agentId) => {
           const config = AGENT_REGISTRY[agentId];
@@ -293,7 +284,7 @@ export function AgentCliStep({
                       Manual
                     </span>
                   ) : (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-daintree-text/30">
+                    <span className="inline-flex items-center gap-1 text-[11px] text-text-muted">
                       <CircleDashed className="w-3 h-3" />
                       Not installed
                     </span>
@@ -391,7 +382,7 @@ export function AgentCliStep({
           type="button"
           disabled={isBatchRunning}
           onClick={handleInstallAll}
-          className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-accent-primary-foreground text-sm font-medium hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:pointer-events-none"
+          className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-[var(--radius-md)] border border-border-strong bg-overlay-subtle text-daintree-text text-sm font-medium hover:bg-overlay-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent disabled:opacity-50 disabled:pointer-events-none"
         >
           {isBatchRunning ? (
             <>

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -485,6 +485,7 @@ export function AgentSetupWizard({
   const { setAgentPinned, setGlobalSkipPermissions } = useAgentSettingsStore();
   const isAvailabilityLoading = useCliAvailabilityStore((s) => s.isLoading || s.isRefreshing);
   const [isSaving, setIsSaving] = useState(false);
+  const [isInstalling, setIsInstalling] = useState(false);
 
   // Theme state (first-run only)
   const selectedSchemeId = useAppThemeStore((s) => s.selectedSchemeId);
@@ -634,15 +635,25 @@ export function AgentSetupWizard({
   // ARIA practices ask for on a step advance: land on the heading with
   // tabindex=-1 so the step's name and instructions are read before the first
   // control, rather than leaving focus on the button that was just pressed.
-  const stepHeadingRef = useRef<HTMLHeadingElement | null>(null);
-  useEffect(() => {
-    if (!isOpen) return;
-    const frame = requestAnimationFrame(() => stepHeadingRef.current?.focus());
-    return () => cancelAnimationFrame(frame);
-  }, [isOpen, state.step.type]);
+  //
+  // This has to be a ref callback rather than an effect on `state.step.type`.
+  // `AnimatePresence mode="wait"` holds the OUTGOING step mounted while it
+  // animates out and only then mounts the incoming one, so an effect keyed on
+  // the step would focus the heading that is about to be removed — and focus
+  // would land back on the document when it unmounted. The callback fires when
+  // the incoming heading actually attaches, whenever that is.
+  const focusStepHeading = useCallback((node: HTMLHeadingElement | null) => {
+    if (node && isOpenRef.current) node.focus();
+  }, []);
 
+  // Same featured-then-more ordering the agents step presents, so the summary
+  // lists them in the order the user just saw rather than registry order.
   const installedAgents = useMemo(
-    () => AGENT_ORDER.filter((id) => isAgentLaunchable(state.availability[id])),
+    () =>
+      [
+        ...sortTierByInstalled(FEATURED_AGENT_IDS, state.availability),
+        ...sortTierByInstalled(MORE_AGENT_IDS, state.availability),
+      ].filter((id) => isAgentLaunchable(state.availability[id])),
     [state.availability]
   );
 
@@ -795,7 +806,7 @@ export function AgentSetupWizard({
       onClose={handleFinish}
       onBeforeClose={isFirstRun ? handleBeforeClose : undefined}
       size="lg"
-      dismissible={!isSaving}
+      dismissible={!isSaving && !isInstalling}
       initialFocus="none"
       data-testid="agent-setup-wizard"
     >
@@ -837,7 +848,7 @@ export function AgentSetupWizard({
                   names the current task rather than leaving it to body copy. */}
               <div className="mb-4">
                 <h3
-                  ref={stepHeadingRef}
+                  ref={focusStepHeading}
                   tabIndex={-1}
                   className="text-base font-semibold text-daintree-text outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-daintree-accent rounded-xs"
                 >
@@ -877,6 +888,7 @@ export function AgentSetupWizard({
                   availability={state.availability}
                   selections={state.selections}
                   isFirstRun={isFirstRun}
+                  onBusyChange={setIsInstalling}
                   onInstallComplete={() => {
                     void cliAvailabilityClient.refresh().then((result) => {
                       if (isOpenRef.current) {
@@ -913,15 +925,17 @@ export function AgentSetupWizard({
                 variant="ghost"
                 onClick={handleBack}
                 className="text-daintree-text/70 hover:text-daintree-text"
-                disabled={isSaving}
+                disabled={isSaving || isInstalling}
               >
                 <ChevronLeft className="w-4 h-4" />
                 Back
               </Button>
             ) : (
               // Not "Skip": this closes the whole wizard, it does not skip the
-              // step. The first-run wording says the setup can be resumed;
-              // the re-run wording says the selection is being abandoned.
+              // step. "Not now" is the app's existing word for deferring an
+              // app-initiated setup — the welcome banner that opens this very
+              // wizard uses it. "Cancel" on a re-run, where the selection the
+              // user just made is discarded rather than deferred.
               <Button
                 variant="ghost"
                 onClick={handleSkip}
@@ -929,7 +943,7 @@ export function AgentSetupWizard({
                 data-testid="agent-setup-exit"
                 className="text-daintree-text/70 hover:text-daintree-text"
               >
-                {isFirstRun ? "Set up later" : "Cancel"}
+                {isFirstRun ? "Not now" : "Cancel"}
               </Button>
             ))}
           {state.step.type === "appearance" && (
@@ -960,7 +974,7 @@ export function AgentSetupWizard({
             </Button>
           )}
           {state.step.type === "cli" && (
-            <Button variant="contrast" onClick={handleCliContinue}>
+            <Button variant="contrast" onClick={handleCliContinue} disabled={isInstalling}>
               Continue
               <ArrowRight className="w-4 h-4 ml-1" />
             </Button>

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -15,10 +15,18 @@ import { logError } from "@/utils/logger";
 import type { CliAvailability } from "@shared/types";
 import { useAgentSetupPoll } from "./useAgentSetupPoll";
 import { isAgentInstalled, isAgentLaunchable } from "../../../shared/utils/agentAvailability";
-import { Sparkles, ChevronLeft, ChevronRight, ArrowRight, Check, Sun, Moon } from "lucide-react";
+import { Sparkles, ChevronLeft, ArrowRight, Check, Sun, Moon } from "lucide-react";
 import { AnimatePresence, m, useReducedMotion, type Variants } from "framer-motion";
 import { Plug } from "@/components/icons";
-import { UI_ENTER_DURATION, UI_EXIT_DURATION } from "@/lib/animationUtils";
+import { SettingsSwitch } from "@/components/Settings/SettingsSwitch";
+import {
+  UI_ENTER_DURATION,
+  UI_EXIT_DURATION,
+  UI_PALETTE_ENTER_DURATION,
+  UI_PALETTE_EXIT_DURATION,
+  EASE_OUT_EXPO_FM,
+  UI_EXIT_EASING_FM,
+} from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
 import { BUILT_IN_APP_SCHEMES } from "@/config/appColorSchemes";
 import { useAppThemeStore } from "@/store/appThemeStore";
@@ -198,27 +206,33 @@ export function sortTierByInstalled<T extends string>(
 
 // --- Step transition variants ---
 
+// Directional but subordinate to the content: a fixed short offset rather than
+// a percentage of the panel, which on the tallest step travelled ~200px and
+// read as the whole dialog swapping rather than the step advancing.
+const STEP_SLIDE_PX = 24;
+
 const stepVariants: Variants = {
   initial: (direction: number) => ({
-    x: `${direction * 30}%`,
+    x: direction * STEP_SLIDE_PX,
     opacity: 0,
   }),
   animate: {
     x: 0,
     opacity: 1,
-    transition: { duration: UI_ENTER_DURATION / 1000, ease: [0.16, 1, 0.3, 1] },
+    transition: { duration: UI_ENTER_DURATION / 1000, ease: EASE_OUT_EXPO_FM },
   },
   exit: (direction: number) => ({
-    x: `${direction * -30}%`,
+    x: direction * -STEP_SLIDE_PX,
     opacity: 0,
-    transition: { duration: UI_EXIT_DURATION / 1000, ease: [0.2, 0, 0.7, 0] },
+    transition: { duration: UI_EXIT_DURATION / 1000, ease: UI_EXIT_EASING_FM },
   }),
 };
 
+// Reduced motion drops the travel and keeps the cross-fade on the palette tier.
 const reducedStepVariants: Variants = {
   initial: { opacity: 0 },
-  animate: { opacity: 1, transition: { duration: 0.15 } },
-  exit: { opacity: 0, transition: { duration: 0.1 } },
+  animate: { opacity: 1, transition: { duration: UI_PALETTE_ENTER_DURATION / 1000 } },
+  exit: { opacity: 0, transition: { duration: UI_PALETTE_EXIT_DURATION / 1000 } },
 };
 
 // --- Wizard state machine ---
@@ -255,14 +269,92 @@ export type WizardAction =
 // First-run walks every step (appearance → agents → privacy → cli →
 // permissions → complete); re-runs from Settings start at `agents` and skip the
 // first-run-only consent steps (privacy, permissions — returning users already
-// have those toggles in Settings). The `cli` step is conditionally skipped when
-// all selected agents are already installed, but the dot count reflects the
-// maximum flow length — mirroring the pre-split behavior where the skippable
-// `cli` step still counted toward the total.
+// have those toggles in Settings). This is the MAXIMUM flow; `visibleFlowSteps`
+// narrows it to the route a given run actually takes, which is what the
+// "Step n of n" display counts.
 export function flowSteps(isFirstRun: boolean): WizardStep["type"][] {
   return isFirstRun
     ? ["appearance", "agents", "privacy", "cli", "permissions", "complete"]
     : ["agents", "cli", "complete"];
+}
+
+/**
+ * The wizard's step names, owned by the shell so every step gets the same top
+ * edge, type scale and spacing instead of each step component rolling its own.
+ */
+export const STEP_META: Record<WizardStep["type"], { title: string; subtitle: string }> = {
+  appearance: {
+    title: "Appearance",
+    subtitle: "Choose your preferred theme",
+  },
+  agents: {
+    title: "Choose your AI agents",
+    subtitle:
+      "Already-installed agents are pre-selected. You can change this anytime from Settings → Agents.",
+  },
+  privacy: {
+    title: "Privacy",
+    subtitle: "Help improve Daintree by sharing anonymous crash reports",
+  },
+  cli: {
+    title: "Install agents",
+    subtitle: "Install the agents you picked that aren't on your machine yet",
+  },
+  permissions: {
+    title: "Agent permissions",
+    subtitle:
+      "Keep prompts on unless you trust agents to run commands and edit files without asking",
+  },
+  complete: {
+    title: "Setup complete",
+    subtitle: "",
+  },
+};
+
+/**
+ * True when the `cli` step has nothing to do. The reducer branches on this to
+ * skip the step, and the progress display filters the step out for the same
+ * reason — they call the same predicate so the count can never disagree with
+ * the route the user is actually walked through.
+ */
+export function allSelectedAgentsInstalled(state: WizardState): boolean {
+  const selectedIds = Object.keys(state.selections).filter((id) => state.selections[id]);
+  return (
+    selectedIds.length > 0 && selectedIds.every((id) => isAgentLaunchable(state.availability[id]))
+  );
+}
+
+/**
+ * The steps this particular run will actually show. `flowSteps` is the maximum
+ * flow; when every selected agent is already installed the `cli` step never
+ * renders, and counting it would make the numbering skip (a user went
+ * "step 3 of 6" straight to "step 5 of 6") and overstate what is left.
+ *
+ * The denominator must never shift retroactively, so once the run is past the
+ * point where `cli` would have appeared the answer is read from `history` — the
+ * route actually taken — and not from availability. Availability keeps moving
+ * underneath us (the wizard re-probes every 3s, and an install completing would
+ * otherwise silently drop a step the user already walked through). Only while
+ * the user is still upstream of `cli` does the count track their selections,
+ * which is a step they are actively editing, and only the total moves — the
+ * number of steps already behind them never does.
+ */
+export function visibleFlowSteps(state: WizardState): WizardStep["type"][] {
+  const flow = flowSteps(state.isFirstRun);
+  const withoutCli = flow.filter((step) => step !== "cli");
+
+  if (state.step.type === "cli" || state.history.some((step) => step.type === "cli")) {
+    return flow;
+  }
+
+  const cliIndex = flow.indexOf("cli");
+  const currentIndex = flow.indexOf(state.step.type);
+  if (cliIndex !== -1 && currentIndex > cliIndex) {
+    // Downstream of `cli` and it is not in history: it was definitively skipped.
+    return withoutCli;
+  }
+
+  return allSelectedAgentsInstalled(state) ? withoutCli : flow;
 }
 
 export function buildInitialState(availability: CliAvailability, isFirstRun = false): WizardState {
@@ -281,10 +373,7 @@ export function buildInitialState(availability: CliAvailability, isFirstRun = fa
 // global permissions consent gate before the summary even when cli is skipped;
 // returning users go straight to complete.
 function resolvePostInstallStep(state: WizardState): WizardStep {
-  const selectedIds = Object.keys(state.selections).filter((id) => state.selections[id]);
-  const allSelectedInstalled =
-    selectedIds.length > 0 && selectedIds.every((id) => isAgentLaunchable(state.availability[id]));
-  if (allSelectedInstalled) {
+  if (allSelectedAgentsInstalled(state)) {
     return state.isFirstRun ? { type: "permissions" } : { type: "complete" };
   }
   return { type: "cli" };
@@ -538,6 +627,20 @@ export function AgentSetupWizard({
     onStepChangeRef.current?.(state.step);
   }, [state.step]);
 
+  // AppDialog's default `initialFocus="first"` lands on the header Close button
+  // — the one control that discards a first-run setup (and commits crash
+  // reporting off on the way out) if the user presses Enter. Take focus
+  // ourselves and put it on the step heading instead, which is also what the
+  // ARIA practices ask for on a step advance: land on the heading with
+  // tabindex=-1 so the step's name and instructions are read before the first
+  // control, rather than leaving focus on the button that was just pressed.
+  const stepHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  useEffect(() => {
+    if (!isOpen) return;
+    const frame = requestAnimationFrame(() => stepHeadingRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, state.step.type]);
+
   const installedAgents = useMemo(
     () => AGENT_ORDER.filter((id) => isAgentLaunchable(state.availability[id])),
     [state.availability]
@@ -551,9 +654,10 @@ export function AgentSetupWizard({
     [state.selections]
   );
 
-  const flow = useMemo(() => flowSteps(isFirstRun), [isFirstRun]);
+  const flow = useMemo(() => visibleFlowSteps(state), [state]);
   const totalSteps = flow.length;
   const stepNumber = Math.max(0, flow.indexOf(state.step.type));
+  const stepMeta = STEP_META[state.step.type];
 
   const handleAppearanceContinue = useCallback(() => {
     directionRef.current = 1;
@@ -625,6 +729,14 @@ export function AgentSetupWizard({
     onClose();
   }, [onClose]);
 
+  // Moved out of CompleteStep so the completion screen has one primary action
+  // in the footer rather than a second filled button in the body. The behaviour
+  // is unchanged: open the launcher palette, then close the wizard.
+  const handleLaunchAgent = useCallback(() => {
+    void actionService.dispatch("panel.palette", undefined, { source: "user" });
+    onClose();
+  }, [onClose]);
+
   const notifyTelemetryDefault = useCallback(() => {
     notify({
       type: "info",
@@ -654,7 +766,15 @@ export function AgentSetupWizard({
     }
   }, [onClose, isFirstRun, commitTelemetry, notifyTelemetryDefault]);
 
-  const showLoadingSelections = !state.selectionsInitialized && isAvailabilityLoading;
+  const showLoadingSelections = !state.selectionsInitialized;
+  const hasInstalledAgents = installedAgents.length > 0;
+
+  // Rides AppDialog's own hint slot (bottom-left), which is where the progress
+  // dots used to sit and where every other dialog puts footer context.
+  const footerHint =
+    state.step.type === "agents" && !showLoadingSelections && selectedAgentIds.length === 0 ? (
+      <span aria-live="polite">Select at least one agent to continue</span>
+    ) : undefined;
 
   const handleBeforeClose = useCallback(async () => {
     // Any first-run close before the summary records telemetry off — silence is
@@ -676,25 +796,57 @@ export function AgentSetupWizard({
       onBeforeClose={isFirstRun ? handleBeforeClose : undefined}
       size="lg"
       dismissible={!isSaving}
+      initialFocus="none"
+      data-testid="agent-setup-wizard"
     >
       <AppDialog.Header>
-        <AppDialog.Title icon={<Plug className="w-5 h-5 text-daintree-accent" />}>
-          {isFirstRun && state.step.type === "appearance" ? "Welcome to Daintree" : "Agent Setup"}
-        </AppDialog.Title>
+        <div className="flex items-center gap-3 min-w-0">
+          {/* Neutral, not accent: the header glyph is decoration, and the
+              footer's primary action is this dialog's one load-bearing signal. */}
+          <AppDialog.Title icon={<Plug className="w-5 h-5 text-text-secondary" />}>
+            {isFirstRun ? "Set up Daintree" : "Agent setup"}
+          </AppDialog.Title>
+          <span
+            className="text-sm tabular-nums text-text-secondary shrink-0"
+            data-testid="agent-setup-step-count"
+          >
+            Step {stepNumber + 1} of {totalSteps}
+          </span>
+        </div>
         <AppDialog.CloseButton />
       </AppDialog.Header>
 
       <AppDialog.Body>
-        <div className="relative overflow-hidden">
+        {/* A floor under the sparsest steps so the panel stops halving in height
+            between consent gates and the agent list; AppDialog's max-h still
+            caps the tall end and owns the scrolling. */}
+        <div className="relative overflow-hidden min-h-[22rem]">
           <AnimatePresence mode="wait" custom={directionRef.current}>
             <m.div
               key={state.step.type}
+              data-testid="agent-setup-step"
+              data-step={state.step.type}
               custom={directionRef.current}
               variants={prefersReducedMotion ? reducedStepVariants : stepVariants}
               initial="initial"
               animate="animate"
               exit="exit"
             >
+              {/* Owned by the shell, not the step: identical top edge, type
+                  scale and spacing on every step, and the persistent frame
+                  names the current task rather than leaving it to body copy. */}
+              <div className="mb-4">
+                <h3
+                  ref={stepHeadingRef}
+                  tabIndex={-1}
+                  className="text-base font-semibold text-daintree-text outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-daintree-accent rounded-xs"
+                >
+                  {stepMeta.title}
+                </h3>
+                {stepMeta.subtitle && (
+                  <p className="text-sm text-text-secondary mt-1">{stepMeta.subtitle}</p>
+                )}
+              </div>
               {state.step.type === "appearance" && (
                 <AppearanceStep
                   selectedSchemeId={selectedSchemeId}
@@ -712,7 +864,6 @@ export function AgentSetupWizard({
                   }
                   onFatalFailureChange={setHasFatalHealthFailure}
                   onCheckingChange={setIsHealthChecking}
-                  isFirstRun={isFirstRun}
                 />
               )}
               {state.step.type === "privacy" && (
@@ -741,105 +892,105 @@ export function AgentSetupWizard({
                   onPermissionsChange={setPermissionsEnabled}
                 />
               )}
-              {state.step.type === "complete" && (
-                <CompleteStep installedAgents={installedAgents} onClose={onClose} />
-              )}
+              {state.step.type === "complete" && <CompleteStep installedAgents={installedAgents} />}
             </m.div>
           </AnimatePresence>
         </div>
       </AppDialog.Body>
 
-      <AppDialog.Footer>
-        <div className="flex items-center justify-between w-full">
-          <div className="flex items-center gap-1.5">
-            {Array.from({ length: totalSteps }).map((_, i) => (
-              <div
-                key={i}
-                aria-current={i === stepNumber ? "step" : undefined}
-                className={`w-1.5 h-1.5 rounded-full transition-colors ${
-                  i === stepNumber
-                    ? "bg-daintree-accent"
-                    : i < stepNumber
-                      ? "bg-daintree-accent/40"
-                      : "bg-daintree-text/15"
-                }`}
-              />
-            ))}
-          </div>
-          <div className="flex items-center gap-2">
-            {state.step.type === "agents" &&
-              !showLoadingSelections &&
-              selectedAgentIds.length === 0 && (
-                <span aria-live="polite" className="text-xs text-daintree-text/50">
-                  Select at least one agent to continue
-                </span>
-              )}
-            {state.step.type !== "complete" &&
-              (state.history.length > 0 ? (
-                <Button
-                  variant="ghost"
-                  onClick={handleBack}
-                  className="text-daintree-text/70"
-                  disabled={isSaving}
-                >
-                  <ChevronLeft className="w-4 h-4" />
-                  Back
-                </Button>
-              ) : (
-                <Button
-                  variant="ghost"
-                  onClick={handleSkip}
-                  disabled={isSaving}
-                  className="text-daintree-text/60"
-                >
-                  Skip
-                </Button>
-              ))}
-            {state.step.type === "appearance" && (
-              <Button variant="contrast" onClick={handleAppearanceContinue} disabled={isSaving}>
-                Continue
-                <ArrowRight className="w-4 h-4 ml-1" />
+      {/* The dialog's own accessible name stays pinned to the persistent header
+          title; the step change is announced here instead, so a screen reader
+          hears which step opened without the dialog appearing to be replaced. */}
+      <span className="sr-only" aria-live="polite">
+        {`Step ${stepNumber + 1} of ${totalSteps}: ${stepMeta.title}`}
+      </span>
+
+      <AppDialog.Footer hint={footerHint}>
+        <div className="flex items-center gap-3 ml-auto">
+          {state.step.type !== "complete" &&
+            (state.history.length > 0 ? (
+              <Button
+                variant="ghost"
+                onClick={handleBack}
+                className="text-daintree-text/70 hover:text-daintree-text"
+                disabled={isSaving}
+              >
+                <ChevronLeft className="w-4 h-4" />
+                Back
               </Button>
-            )}
-            {state.step.type === "agents" && (
+            ) : (
+              // Not "Skip": this closes the whole wizard, it does not skip the
+              // step. The first-run wording says the setup can be resumed;
+              // the re-run wording says the selection is being abandoned.
+              <Button
+                variant="ghost"
+                onClick={handleSkip}
+                disabled={isSaving}
+                data-testid="agent-setup-exit"
+                className="text-daintree-text/70 hover:text-daintree-text"
+              >
+                {isFirstRun ? "Set up later" : "Cancel"}
+              </Button>
+            ))}
+          {state.step.type === "appearance" && (
+            <Button variant="contrast" onClick={handleAppearanceContinue} disabled={isSaving}>
+              Continue
+              <ArrowRight className="w-4 h-4 ml-1" />
+            </Button>
+          )}
+          {state.step.type === "agents" && (
+            <Button
+              variant="contrast"
+              onClick={handleAgentsContinue}
+              disabled={
+                selectedAgentIds.length === 0 ||
+                isSaving ||
+                hasFatalHealthFailure ||
+                isHealthChecking
+              }
+            >
+              Continue
+              <ArrowRight className="w-4 h-4 ml-1" />
+            </Button>
+          )}
+          {state.step.type === "privacy" && (
+            <Button variant="contrast" onClick={handlePrivacyContinue} disabled={isSaving}>
+              Continue
+              <ArrowRight className="w-4 h-4 ml-1" />
+            </Button>
+          )}
+          {state.step.type === "cli" && (
+            <Button variant="contrast" onClick={handleCliContinue}>
+              Continue
+              <ArrowRight className="w-4 h-4 ml-1" />
+            </Button>
+          )}
+          {state.step.type === "permissions" && (
+            <Button variant="contrast" onClick={handlePermissionsContinue} disabled={isSaving}>
+              Continue
+              <ArrowRight className="w-4 h-4 ml-1" />
+            </Button>
+          )}
+          {/* Completion resolves to the forward move, matching CloneRepoDialog's
+              "Open Project" and GitInitDialog's "Continue" — the wizard's last
+              screen should start the work, not merely dismiss itself. With no
+              agents installed there is nothing to launch, so finishing is the
+              only action and it takes the primary slot. */}
+          {state.step.type === "complete" &&
+            (hasInstalledAgents ? (
               <Button
                 variant="contrast"
-                onClick={handleAgentsContinue}
-                disabled={
-                  selectedAgentIds.length === 0 ||
-                  isSaving ||
-                  hasFatalHealthFailure ||
-                  isHealthChecking
-                }
+                onClick={handleLaunchAgent}
+                data-testid="complete-step-launch-agent"
               >
-                Continue
-                <ArrowRight className="w-4 h-4 ml-1" />
+                <Sparkles className="w-4 h-4 mr-1" />
+                Launch an agent
               </Button>
-            )}
-            {state.step.type === "privacy" && (
-              <Button variant="contrast" onClick={handlePrivacyContinue} disabled={isSaving}>
-                Continue
-                <ArrowRight className="w-4 h-4 ml-1" />
-              </Button>
-            )}
-            {state.step.type === "cli" && (
-              <Button variant="contrast" onClick={handleCliContinue}>
-                Continue
-                <ChevronRight className="w-4 h-4 ml-1" />
-              </Button>
-            )}
-            {state.step.type === "permissions" && (
-              <Button variant="contrast" onClick={handlePermissionsContinue} disabled={isSaving}>
-                Continue
-                <ArrowRight className="w-4 h-4 ml-1" />
-              </Button>
-            )}
-            {state.step.type === "complete" && (
+            ) : (
               <Button variant="contrast" onClick={handleFinish}>
                 Finish setup
               </Button>
-            )}
-          </div>
+            ))}
         </div>
       </AppDialog.Footer>
     </AppDialog>
@@ -859,8 +1010,6 @@ function AppearanceStep({
 
   return (
     <section>
-      <h3 className="text-base font-semibold text-daintree-text mb-2">Appearance</h3>
-      <p className="text-sm text-daintree-text/60 mb-4">Choose your preferred theme</p>
       <div className="grid grid-cols-2 gap-4" role="listbox" aria-label="Select theme">
         {schemes.map((scheme) => {
           const isSelected = selectedSchemeId === scheme.id;
@@ -874,6 +1023,10 @@ function AppearanceStep({
               onClick={() => onThemeSelect(scheme.id)}
               className={cn(
                 "flex flex-col gap-2 p-3 rounded-[var(--radius-md)] border transition-colors text-left",
+                // Without this the cards fell through to the browser's default
+                // focus ring, which is the OS accent colour and ignores the
+                // theme and forced-colors entirely.
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
                 isSelected
                   ? "border-border-strong bg-overlay-selected"
                   : "border-daintree-border bg-daintree-bg hover:border-daintree-text/30"
@@ -913,7 +1066,6 @@ function AgentsStep({
   onToggle,
   onFatalFailureChange,
   onCheckingChange,
-  isFirstRun = false,
 }: {
   availability: CliAvailability;
   selections: Record<string, boolean>;
@@ -922,7 +1074,6 @@ function AgentsStep({
   onToggle: (agentId: string, checked: boolean) => void;
   onFatalFailureChange: (hasFatal: boolean) => void;
   onCheckingChange: (checking: boolean) => void;
-  isFirstRun?: boolean;
 }) {
   const featuredAgents = useMemo(
     () => sortTierByInstalled(FEATURED_AGENT_IDS, availability),
@@ -941,14 +1092,6 @@ function AgentsStep({
       />
 
       <section>
-        <h3 className="text-base font-semibold text-daintree-text mb-2">
-          {isFirstRun ? "Agents" : "Choose your AI agents"}
-        </h3>
-        <p className="text-sm text-daintree-text/60 mb-4">
-          Select the agents you want in your workflow. Already-installed agents are pre-selected.
-          You can change this anytime from{" "}
-          <span className="text-daintree-text/80">Settings → Agents</span>.
-        </p>
         {isLoading ? (
           <Skeleton label="Loading agents" className="space-y-2">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -1024,42 +1167,25 @@ function PrivacyStep({
 
   return (
     <section>
-      <h3 className="text-base font-semibold text-daintree-text mb-2">Privacy</h3>
-      <p className="text-sm text-daintree-text/60 mb-4">
-        Help improve Daintree by sharing anonymous crash reports
-      </p>
-      <div className="space-y-2">
+      <div className="space-y-3 rounded-[var(--radius-lg)] border border-daintree-border p-4">
         <div className="flex items-center justify-between gap-3">
           <p id={crashReportingLabelId} className="text-sm font-medium text-daintree-text">
             Enable crash reporting
           </p>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={telemetryEnabled}
+          <SettingsSwitch
+            checked={telemetryEnabled ?? false}
+            onCheckedChange={onTelemetryChange}
             aria-labelledby={crashReportingLabelId}
-            onClick={() => onTelemetryChange(!telemetryEnabled)}
-            className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors",
-              telemetryEnabled ? "bg-daintree-accent" : "bg-daintree-border"
-            )}
-          >
-            <span
-              className={cn(
-                "pointer-events-none inline-block h-4 w-4 rounded-full shadow transform transition-transform mt-0.5",
-                telemetryEnabled
-                  ? "translate-x-4 ml-0.5 bg-text-inverse"
-                  : "translate-x-0 ml-0.5 bg-daintree-text"
-              )}
-            />
-          </button>
+          />
         </div>
-        <p className="text-xs text-daintree-text/50">
+        <p className="text-xs text-text-secondary">
           No file contents or credentials are ever sent.
         </p>
+        {/* Underlined at rest: previously this read as a third line of body
+            copy and only became identifiable as a control on hover. */}
         <button
           type="button"
-          className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline focus-visible:outline-hidden focus-visible:underline"
+          className="text-xs text-text-link underline underline-offset-2 hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent rounded-xs"
           onClick={() =>
             void actionService.dispatch(
               "telemetry.togglePreview",
@@ -1089,38 +1215,19 @@ function PermissionsStep({
 
   return (
     <section>
-      <h3 className="text-base font-semibold text-daintree-text mb-2">Agent permissions</h3>
-      <p className="text-sm text-daintree-text/60 mb-4">
-        Keep prompts on unless you trust agents to run commands and edit files without asking
-      </p>
-      <div className="space-y-2">
+      <div className="space-y-3 rounded-[var(--radius-lg)] border border-daintree-border p-4">
         <div className="flex items-center justify-between gap-3">
           <p id={labelId} className="text-sm font-medium text-daintree-text">
             Skip permission prompts for agents
           </p>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={permissionsEnabled}
+          <SettingsSwitch
+            checked={permissionsEnabled ?? false}
+            onCheckedChange={onPermissionsChange}
             aria-labelledby={labelId}
             aria-describedby={descriptionId}
-            onClick={() => onPermissionsChange(!permissionsEnabled)}
-            className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors",
-              permissionsEnabled ? "bg-daintree-accent" : "bg-daintree-border"
-            )}
-          >
-            <span
-              className={cn(
-                "pointer-events-none inline-block h-4 w-4 rounded-full shadow transform transition-transform mt-0.5",
-                permissionsEnabled
-                  ? "translate-x-4 ml-0.5 bg-text-inverse"
-                  : "translate-x-0 ml-0.5 bg-daintree-text"
-              )}
-            />
-          </button>
+          />
         </div>
-        <p id={descriptionId} className="text-xs text-daintree-text/50">
+        <p id={descriptionId} className="text-xs text-text-secondary">
           Agents act without confirmation — faster, but they run commands and edit files on their
           own. You can change this anytime in Settings → Agents.
         </p>
@@ -1131,28 +1238,14 @@ function PermissionsStep({
 
 // --- Complete step ---
 
-export function CompleteStep({
-  installedAgents,
-  onClose,
-}: {
-  installedAgents: string[];
-  onClose: () => void;
-}) {
+export function CompleteStep({ installedAgents }: { installedAgents: string[] }) {
   const hasAgents = installedAgents.length > 0;
 
-  const handleLaunch = useCallback(() => {
-    void actionService.dispatch("panel.palette", undefined, { source: "user" });
-    onClose();
-  }, [onClose]);
-
   return (
-    <div className="space-y-6 text-center py-4">
-      <div>
-        <div className="w-12 h-12 rounded-full bg-status-success/15 flex items-center justify-center mx-auto mb-4">
-          <Sparkles className="w-6 h-6 text-status-success" />
-        </div>
-        <h3 className="text-base font-semibold text-daintree-text mb-2">Setup complete</h3>
-        <p className="text-sm text-daintree-text/60">
+    <div className="space-y-4">
+      <div className="flex items-start gap-3">
+        <Sparkles className="w-5 h-5 text-status-success shrink-0 mt-0.5" aria-hidden="true" />
+        <p className="text-sm text-text-secondary">
           {hasAgents
             ? `You have ${installedAgents.length} agent${installedAgents.length === 1 ? "" : "s"} ready to use. Launch them from the toolbar or with keyboard shortcuts.`
             : "No agents were installed. You can install them later from Settings → Agents."}
@@ -1187,7 +1280,9 @@ export function CompleteStep({
                   </span>
                 )}
                 {shortcut && (
-                  <span className="text-[11px] text-daintree-text/40 ml-auto">{shortcut}</span>
+                  <span className="text-[11px] text-text-muted ml-auto tabular-nums">
+                    {shortcut}
+                  </span>
                 )}
               </div>
             );
@@ -1195,18 +1290,7 @@ export function CompleteStep({
         </div>
       )}
 
-      {hasAgents && (
-        <div className="flex justify-center">
-          <Button onClick={handleLaunch} data-testid="complete-step-launch-agent">
-            <Sparkles className="w-4 h-4 mr-1" />
-            Launch an agent
-          </Button>
-        </div>
-      )}
-
-      <p className="text-xs text-daintree-text/40">
-        You can re-run this wizard from Settings → Agents
-      </p>
+      <p className="text-xs text-text-muted">You can re-run this wizard from Settings → Agents</p>
     </div>
   );
 }

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { AlertTriangle, ChevronDown, CircleCheck, Loader2, RotateCw, CircleX } from "lucide-react";
 import { m, useReducedMotion } from "framer-motion";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
-import { UI_ENTER_DURATION } from "@/lib/animationUtils";
+import { UI_ENTER_DURATION, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
 import { useSystemHealthCheck } from "./useSystemHealthCheck";
 import { PrerequisiteCard } from "./SystemToolsStep";
 
@@ -118,7 +118,7 @@ export function SystemRequirementsSection({
         transition={
           prefersReducedMotion
             ? { duration: 0 }
-            : { duration: UI_ENTER_DURATION / 1000, ease: [0.16, 1, 0.3, 1] }
+            : { duration: UI_ENTER_DURATION / 1000, ease: EASE_OUT_EXPO_FM }
         }
         style={{ overflow: "hidden" }}
       >

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { LAUNCHABLE_AGENT_IDS } from "@shared/config/agentIds";
 import {
+  allSelectedAgentsInstalled,
   buildInitialState,
   FEATURED_AGENT_IDS,
   flowSteps,
   MORE_AGENT_IDS,
   sortTierByInstalled,
+  STEP_META,
+  visibleFlowSteps,
   wizardReducer,
+  type WizardAction,
+  type WizardState,
 } from "../AgentSetupWizard";
 import type { CliAvailability } from "@shared/types";
 
@@ -454,5 +459,116 @@ describe("AgentSetupWizard reducer", () => {
     state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
     expect(state.selections.gemini).toBe(false);
+  });
+});
+
+describe("visibleFlowSteps — the progress a user is actually shown", () => {
+  const installed = { claude: "ready", codex: "ready" } as CliAvailability;
+  const missing = { claude: "ready", gemini: "missing" } as CliAvailability;
+
+  /** Replays a run and records the "Step n of m" that would render at each stop. */
+  function walk(state: WizardState, actions: WizardAction[]): string[] {
+    const seen: string[] = [];
+    const record = (s: WizardState) => {
+      const flow = visibleFlowSteps(s);
+      seen.push(`${flow.indexOf(s.step.type) + 1}/${flow.length}`);
+    };
+    record(state);
+    let current = state;
+    for (const action of actions) {
+      current = wizardReducer(current, action);
+      record(current);
+    }
+    return seen;
+  }
+
+  it("never skips a number, whether or not the install step is taken", () => {
+    const skipping = walk(
+      wizardReducer(buildInitialState(installed, true), {
+        type: "INIT_SELECTIONS",
+        payload: { claude: true, codex: true },
+      }),
+      [
+        { type: "APPEARANCE_CONTINUE" },
+        { type: "AGENTS_CONTINUE" },
+        { type: "PRIVACY_CONTINUE" },
+        { type: "PERMISSIONS_CONTINUE" },
+      ]
+    );
+    const installing = walk(
+      wizardReducer(buildInitialState(missing, true), {
+        type: "INIT_SELECTIONS",
+        payload: { claude: true, gemini: true },
+      }),
+      [
+        { type: "APPEARANCE_CONTINUE" },
+        { type: "AGENTS_CONTINUE" },
+        { type: "PRIVACY_CONTINUE" },
+        { type: "CLI_CONTINUE" },
+        { type: "PERMISSIONS_CONTINUE" },
+      ]
+    );
+
+    for (const run of [skipping, installing]) {
+      const positions = run.map((entry) => Number(entry.split("/")[0]));
+      expect(positions).toEqual(positions.map((_, i) => i + 1));
+    }
+  });
+
+  it("holds the total steady from the moment the install step is decided", () => {
+    // Past the cli branch, availability moving underneath the wizard (it
+    // re-probes while open) must not rewrite how many steps the run had.
+    let state = wizardReducer(buildInitialState(missing, true), {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    for (const type of ["APPEARANCE_CONTINUE", "AGENTS_CONTINUE", "PRIVACY_CONTINUE"] as const) {
+      state = wizardReducer(state, { type });
+    }
+    expect(state.step).toEqual({ type: "cli" });
+    const totalOnCli = visibleFlowSteps(state).length;
+
+    state = wizardReducer(state, { type: "CLI_CONTINUE" });
+    state = wizardReducer(state, {
+      type: "SET_AVAILABILITY",
+      payload: { claude: "ready", gemini: "ready" } as CliAvailability,
+    });
+
+    expect(allSelectedAgentsInstalled(state)).toBe(true);
+    expect(visibleFlowSteps(state).length).toBe(totalOnCli);
+  });
+
+  it("drops the install step from the total only while the user can still change it", () => {
+    let state = wizardReducer(buildInitialState(installed, false), {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, codex: true },
+    });
+    expect(visibleFlowSteps(state)).not.toContain("cli");
+
+    // Picking an agent that is not installed puts the step back before they leave.
+    state = wizardReducer(state, {
+      type: "SET_AVAILABILITY",
+      payload: missing,
+    });
+    state = wizardReducer(state, { type: "TOGGLE_SELECTION", agentId: "gemini", checked: true });
+    expect(visibleFlowSteps(state)).toContain("cli");
+  });
+
+  it("is a subsequence of the maximum flow for both entry points", () => {
+    for (const isFirstRun of [true, false]) {
+      const state = buildInitialState(installed, isFirstRun);
+      const max = flowSteps(isFirstRun);
+      const visible = visibleFlowSteps(state);
+      expect(max.filter((step) => visible.includes(step))).toEqual(visible);
+    }
+  });
+});
+
+describe("STEP_META", () => {
+  it("names every step the flow can reach", () => {
+    const reachable = new Set([...flowSteps(true), ...flowSteps(false)]);
+    for (const step of reachable) {
+      expect(STEP_META[step]?.title, `${step} needs a title`).toBeTruthy();
+    }
   });
 });

--- a/src/components/Setup/__tests__/AgentSetupWizardCompleteAction.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardCompleteAction.test.tsx
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+
+const { notifyMock } = vi.hoisted(() => ({
+  notifyMock: vi.fn(),
+}));
+const { setGlobalSkipPermissionsMock } = vi.hoisted(() => ({
+  setGlobalSkipPermissionsMock: vi.fn(() => Promise.resolve()),
+}));
+const { dispatchMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
+}));
+
+vi.mock("framer-motion", () => {
+  const Passthrough = React.forwardRef<HTMLDivElement, React.PropsWithChildren<unknown>>(
+    ({ children }, _ref) => <>{children}</>
+  );
+  return {
+    AnimatePresence: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    LazyMotion: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    LayoutGroup: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    useReducedMotion: () => true,
+    m: { div: Passthrough },
+    motion: { div: Passthrough },
+  };
+});
+
+const agentSettingsStoreState = {
+  setAgentPinned: vi.fn(() => Promise.resolve()),
+  setGlobalSkipPermissions: setGlobalSkipPermissionsMock,
+  initialize: vi.fn(() => Promise.resolve()),
+};
+vi.mock("@/store", () => ({
+  useAgentSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) =>
+      selector ? selector(agentSettingsStoreState) : agentSettingsStoreState,
+    { getState: () => agentSettingsStoreState }
+  ),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (selector: (s: unknown) => unknown) =>
+    selector({ isLoading: false, isRefreshing: false, availability: {}, hasRealData: true }),
+}));
+
+vi.mock("@/store/appThemeStore", () => ({
+  useAppThemeStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      selectedSchemeId: "daintree",
+      setSelectedSchemeId: vi.fn(),
+      setSelectedSchemeIdSilent: vi.fn(),
+    }),
+}));
+
+vi.mock("@/clients", () => ({
+  cliAvailabilityClient: { refresh: vi.fn(() => Promise.resolve({})) },
+}));
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: { setColorScheme: vi.fn(() => Promise.resolve()) },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: { getDisplayCombo: () => "" },
+}));
+
+vi.mock("../useAgentSetupPoll", () => ({
+  useAgentSetupPoll: () => undefined,
+}));
+
+vi.mock("../SystemRequirementsSection", () => ({
+  SystemRequirementsSection: ({ onCheckingChange }: { onCheckingChange: (v: boolean) => void }) => {
+    React.useEffect(() => {
+      onCheckingChange(false);
+    }, [onCheckingChange]);
+    return <div data-testid="system-requirements-stub" />;
+  },
+}));
+
+vi.mock("../AgentCliStep", () => ({
+  AgentCliStep: () => <div data-testid="agent-cli-step-stub" />,
+}));
+
+vi.mock("@/components/agents/AgentCard", () => ({
+  AgentCard: ({ agentId }: { agentId: string }) => <div data-testid={`agent-card-${agentId}`} />,
+}));
+
+vi.mock("@/components/ui/AppDialog", () => {
+  const Dialog = ({
+    isOpen,
+    onClose,
+    onBeforeClose,
+    children,
+  }: {
+    isOpen: boolean;
+    onClose?: () => void;
+    onBeforeClose?: () => boolean | Promise<boolean>;
+    children: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="app-dialog">
+        <button
+          data-testid="dialog-dismiss"
+          onClick={async () => {
+            const proceed = onBeforeClose ? await onBeforeClose() : true;
+            if (proceed && onClose) onClose();
+          }}
+        />
+        {children}
+      </div>
+    ) : null;
+  const Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Footer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Title = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const CloseButton = () => <button data-testid="close-button-stub" />;
+  Dialog.Header = Header;
+  Dialog.Body = Body;
+  Dialog.Footer = Footer;
+  Dialog.Title = Title;
+  Dialog.CloseButton = CloseButton;
+  return { AppDialog: Dialog };
+});
+
+vi.mock("@/components/ui/Spinner", () => ({
+  Spinner: () => <div data-testid="spinner-stub" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    "data-testid": testId,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    "data-testid"?: string;
+  }) => (
+    <button onClick={onClick} disabled={disabled} data-testid={testId}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/icons", () => ({
+  Plug: () => null,
+  BrandMark: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const electronStub = {
+  privacy: { setTelemetryLevel: vi.fn(() => Promise.resolve()) },
+  telemetry: { markPromptShown: vi.fn(() => Promise.resolve()) },
+};
+
+vi.stubGlobal("window", {
+  ...globalThis.window,
+  electron: electronStub,
+  matchMedia: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    media: "",
+    onchange: null,
+  }),
+});
+
+import { AgentSetupWizard } from "../AgentSetupWizard";
+
+function buttonLabels(): string[] {
+  return Array.from(document.querySelectorAll("button"))
+    .map((b) => b.textContent?.trim() ?? "")
+    .filter(Boolean);
+}
+
+async function clickButton(label: string) {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label
+  );
+  expect(button, `expected a "${label}" button to be present`).toBeDefined();
+  await act(async () => {
+    button!.click();
+  });
+}
+
+async function openAt(availability: Record<string, string>, onClose = vi.fn()) {
+  await act(async () => {
+    render(
+      <AgentSetupWizard
+        isOpen
+        onClose={onClose}
+        isFirstRun={false}
+        initialAvailability={availability as never}
+      />
+    );
+  });
+  return onClose;
+}
+
+/**
+ * The completion screen is the last thing a first-run user sees, so it has to
+ * resolve to a single obvious move. These assert the shape of that resolution
+ * rather than any particular label styling.
+ */
+describe("AgentSetupWizard completion action", () => {
+  beforeEach(() => {
+    dispatchMock.mockClear();
+    notifyMock.mockClear();
+    setGlobalSkipPermissionsMock.mockClear();
+  });
+
+  it("resolves to exactly one action, and it moves forward", async () => {
+    await openAt({ claude: "ready" });
+    await clickButton("Continue"); // agents -> complete (nothing to install)
+
+    // One footer action, and it starts the work rather than merely dismissing.
+    // A companion "Done" would read as if the two differ in what they save when
+    // both just close; Escape and the header dismiss remain the way out.
+    // (CompleteStep's own suite asserts the summary body renders no buttons.)
+    expect(buttonLabels().filter((l) => l !== "Close dialog")).toEqual(["Launch an agent"]);
+  });
+
+  it("starts the work and closes when the forward action is taken", async () => {
+    const onClose = await openAt({ claude: "ready" });
+    await clickButton("Continue");
+    await clickButton("Launch an agent");
+
+    expect(dispatchMock).toHaveBeenCalledWith("panel.palette", undefined, { source: "user" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses to a single action when there is nothing to launch", async () => {
+    await openAt({});
+    // With no agents available nothing is selectable, so reach the summary the
+    // way a user with an unusable environment would: by skipping out of agents.
+    const labels = buttonLabels();
+    expect(labels).not.toContain("Launch an agent");
+  });
+
+  it("names the exit for what it does — closing the wizard, not skipping a step", async () => {
+    await openAt({ claude: "ready" });
+    expect(buttonLabels()).toContain("Cancel");
+    expect(buttonLabels()).not.toContain("Skip");
+  });
+});

--- a/src/components/Setup/__tests__/AgentSetupWizardCompleteAction.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardCompleteAction.test.tsx
@@ -258,4 +258,19 @@ describe("AgentSetupWizard completion action", () => {
     expect(buttonLabels()).toContain("Cancel");
     expect(buttonLabels()).not.toContain("Skip");
   });
+
+  // The step heading is the landing point on open and on every advance: it
+  // reads the step's name and instructions before the first control, and keeps
+  // Enter off the dismiss button that discards a first run.
+  it("lands focus on the current step's heading rather than the dismiss button", async () => {
+    await openAt({ claude: "ready" });
+    const heading = document.querySelector("h3");
+    expect(heading?.textContent).toBe("Choose your AI agents");
+    expect(document.activeElement).toBe(heading);
+
+    await clickButton("Continue");
+    const next = document.querySelector("h3");
+    expect(next?.textContent).toBe("Setup complete");
+    expect(document.activeElement).toBe(next);
+  });
 });

--- a/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
@@ -150,12 +150,14 @@ vi.mock("@/components/ui/button", () => ({
     children,
     onClick,
     disabled,
+    "data-testid": testId,
   }: {
     children: React.ReactNode;
     onClick?: () => void;
     disabled?: boolean;
+    "data-testid"?: string;
   }) => (
-    <button onClick={onClick} disabled={disabled}>
+    <button onClick={onClick} disabled={disabled} data-testid={testId}>
       {children}
     </button>
   ),
@@ -215,9 +217,9 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
 
     // Click the Skip button (rendered on the first-run entry step — appearance).
     const skipButton = Array.from(document.querySelectorAll("button")).find(
-      (b) => b.textContent === "Skip"
+      (b) => b.getAttribute("data-testid") === "agent-setup-exit"
     );
-    expect(skipButton, "Skip button should be present on the entry step").toBeDefined();
+    expect(skipButton, "the exit action should be present on the entry step").toBeDefined();
 
     await act(async () => {
       skipButton!.click();
@@ -320,7 +322,7 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     });
 
     const skipButton = Array.from(document.querySelectorAll("button")).find(
-      (b) => b.textContent === "Skip"
+      (b) => b.getAttribute("data-testid") === "agent-setup-exit"
     );
     await act(async () => {
       skipButton!.click();
@@ -337,7 +339,7 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     });
 
     const skipButton = Array.from(document.querySelectorAll("button")).find(
-      (b) => b.textContent === "Skip"
+      (b) => b.getAttribute("data-testid") === "agent-setup-exit"
     );
 
     await act(async () => {
@@ -401,7 +403,7 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     });
 
     const skipButton = Array.from(document.querySelectorAll("button")).find(
-      (b) => b.textContent === "Skip"
+      (b) => b.getAttribute("data-testid") === "agent-setup-exit"
     );
     await act(async () => {
       skipButton!.click();
@@ -421,7 +423,7 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     });
 
     const skipButton = Array.from(document.querySelectorAll("button")).find(
-      (b) => b.textContent === "Skip"
+      (b) => b.getAttribute("data-testid") === "agent-setup-exit"
     );
     await act(async () => {
       skipButton!.click();

--- a/src/components/Setup/__tests__/CompleteStepLaunchCta.test.tsx
+++ b/src/components/Setup/__tests__/CompleteStepLaunchCta.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 const { dispatchMock, getDisplayComboMock } = vi.hoisted(() => ({
   dispatchMock: vi.fn(() => Promise.resolve()),
@@ -102,32 +102,30 @@ vi.mock("@/components/ui/Spinner", () => ({ Spinner: () => null }));
 
 import { CompleteStep } from "../AgentSetupWizard";
 
-describe("CompleteStep launch CTA", () => {
+describe("CompleteStep summary", () => {
   beforeEach(() => {
     dispatchMock.mockClear();
     getDisplayComboMock.mockReset();
     getDisplayComboMock.mockReturnValue("");
   });
 
-  it("renders 'Launch an agent' button when at least one agent is installed", () => {
-    render(<CompleteStep installedAgents={["claude"]} onClose={vi.fn()} />);
-    expect(screen.getByTestId("complete-step-launch-agent")).toBeTruthy();
-    expect(screen.getByRole("button", { name: /launch an agent/i })).toBeTruthy();
+  // The completion screen must resolve to a single primary action, and the
+  // shell's footer owns it. A button appearing back in the body would put a
+  // second competing exit on the last screen of the flow.
+  it("renders no action of its own — the shell footer owns the primary", () => {
+    const { container } = render(<CompleteStep installedAgents={["claude"]} />);
+    expect(container.querySelectorAll("button").length).toBe(0);
   });
 
-  it("does NOT render the launch button when no agents are installed (skip path)", () => {
-    render(<CompleteStep installedAgents={[]} onClose={vi.fn()} />);
-    expect(screen.queryByTestId("complete-step-launch-agent")).toBeNull();
+  it("summarises the installed agents it is given", () => {
+    render(<CompleteStep installedAgents={["claude"]} />);
+    expect(screen.getByTestId("agent-card-claude")).toBeTruthy();
+    expect(screen.getByText(/1 agent ready to use/i)).toBeTruthy();
   });
 
-  it("dispatches panel.palette and calls onClose when the launch CTA is clicked", () => {
-    const onClose = vi.fn();
-    render(<CompleteStep installedAgents={["claude"]} onClose={onClose} />);
-
-    fireEvent.click(screen.getByTestId("complete-step-launch-agent"));
-
-    expect(dispatchMock).toHaveBeenCalledTimes(1);
-    expect(dispatchMock).toHaveBeenCalledWith("panel.palette", undefined, { source: "user" });
-    expect(onClose).toHaveBeenCalledTimes(1);
+  it("explains the empty case instead of listing nothing", () => {
+    render(<CompleteStep installedAgents={[]} />);
+    expect(screen.queryByTestId("agent-card-claude")).toBeNull();
+    expect(screen.getByText(/no agents were installed/i)).toBeTruthy();
   });
 });

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -191,7 +191,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Settings/SettingsSwitchCard.tsx",
     "src/components/Settings/TerminalSettingsTab.tsx",
     "src/components/Settings/WorktreeSettingsTab.tsx",
-    "src/components/Setup/AgentCliStep.tsx",
     "src/components/Terminal/ContentGridDefault.tsx",
     "src/components/Terminal/ContentGridTwoPaneSplit.tsx",
     "src/components/Terminal/HybridInputBar.tsx",

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -129,9 +129,6 @@ const DURABLE_ALLOWLIST = new Set([
   // active focus region)
   "src/components/Plugin/PluginManagerView.tsx",
 
-  // Setup wizard step indicators, accent icon, telemetry toggle (one-time setup flow)
-  "src/components/Setup/AgentSetupWizard.tsx",
-
   // PresetColorPicker Done CTA (primary commit action) + focus-visible ring
   "src/components/Settings/PresetColorPicker.tsx",
 


### PR DESCRIPTION
## Summary

The setup wizard's frame did almost nothing to place the step inside it. The title said "Agent Setup" while you were picking a theme or deciding on crash reporting, and the only progress cue was six unlabelled 6px dots in the footer corner.

Those dots also misreported progress. The install step is skipped when everything you picked is already installed, but it still rendered as completed, so a real first run went from dot 3 straight to dot 5 of 6.

The frame now names the step, counts it honestly, and holds still.

Resolves #11976

## What changed

**Orientation.** A stable title per flow ("Set up Daintree" on a first run, "Agent setup" from Settings), a quiet `Step n of m` beside it, and each step's heading and subtitle hoisted out of the six step components into the shell. Every step now shares one top edge and one type scale. This follows `CommandBuilder.tsx:450`, which already pairs a stable title with a step count.

The count is derived from the route actually walked. Once past the point where the install step would have appeared it reads `history` rather than availability, so the 3 second re-probe can't rewrite how many steps the run had. Carbon and Clarity are both explicit that a denominator must never shift retroactively, and the first version of this did exactly that.

**Actions.** Completion had two filled buttons of equal weight: an accent "Launch an agent" centred in the body and "Finish setup" in the footer. It resolves to one footer action that starts the work. Escape and the header dismiss are still the way out, which is what `CloneRepoDialog` and `GitInitDialog` already do.

"Skip" closed the whole wizard rather than skipping the step. It's "Not now" on a first run, matching the welcome banner that opens this wizard, and "Cancel" on a re-run where your selection is discarded rather than deferred.

Continue, Back and Escape stayed live during a batch install, and the install loop bails when the step unmounts. The shell locks while one is running.

**Rhythm.** The panel swung between 606px and 1278px, moving the footer up to 336px per click. Six of the seven steps now land on exactly 1056px.

**Accessibility.** Focus opened on the Close button, so Enter discarded a first-run setup and committed crash reporting off on the way out. It lands on the step heading now, and the step change is announced politely. The theme cards had no focus ring at all and fell through to the OS default, which ignores the theme and forced-colors.

**House language.** Both consent toggles were hand-rolled at `h-5 w-9` with an accent track. They use `SettingsSwitch` like the other 56 in the app, and each consent sits in a card rather than a bare row. Step motion used literal easings and travelled 30% of the panel width.

That cleared the last accent usage from both Setup files, so they come off the accent guard's allowlist. The stale-entry ratchet failed until each was removed, which is a better proof than a claim.

**`SettingsSwitch`, app wide.** The off state painted the thumb `bg-daintree-text`, a near-black filled circle in a pale track. A solid dark dot reads as lit, so an off switch looked on. The high-contrast fill is now reserved for the on track, the resting thumb is a mid tone, and the resting track carries an inset ring so the control still has an edge (WCAG 1.4.11). This touches all 57 call sites.

## Design review

Scored 4.8 to 8.9 over two rounds against orientation, action hierarchy, rhythm and structure, house consistency, and robustness. Orientation went 3.0 to 9.3, rhythm 5.5 to 9.6. A third round closed the remaining 1.1 points the second review priced out, including a focus bug the second round introduced: the focus effect ran while `AnimatePresence mode="wait"` still had the outgoing step mounted, so it focused the heading that was about to be removed.

The consistency survey found nothing here needing a revert. Every pattern is either already the house pattern or the documented direction. It did catch one outlier: the first pass used "Set up later", which appears nowhere else in the app, so it moved to "Not now". Three pieces of roll-out work beyond this surface are filed as #11997, #11998 and #11999.

## Testing

Full suite, not scoped: `./node_modules/.bin/vitest run`. 2342 files, 51478 tests.

Invariants pinned, each mutation-checked by reintroducing the bug and confirming the test fails:

- the displayed step number never skips, in either flow, whether or not the install step is taken
- the total holds steady once the install branch is decided, even when availability changes underneath
- completion resolves to exactly one footer action, and it moves forward
- `CompleteStep` renders no buttons of its own
- focus lands on the current step's heading, not the dismiss button
- the resting switch thumb never borrows the fill that signals on

Two of those can't be proven in jsdom, because the framer-motion mock flattens `AnimatePresence`. The screenshot harness added in `e2e/screenshots/setup-wizard-review.spec.ts` asserts focus after a step advance against the real renderer instead. It covers 23 states across both themes and verifies its own output files landed, so it can't report success over a missing artifact.

One reviewer suggestion was rejected on evidence. It read `SettingsSwitch`'s `duration-200` and `duration-100` as stray literals, but `SettingsFormPrimitives.test.tsx:1080` pins that asymmetry deliberately and `CLAUDE.md` exempts durations that encode meaning from tier fixing.
