### PR TITLE
Refine the notification inbox row's trailing metadata and actions

### DIFF
--- a/e2e/helpers/notifications.ts
+++ b/e2e/helpers/notifications.ts
@@ -250,3 +250,56 @@ export async function getGridBarDwellFloorMs(page: Page): Promise<number> {
     return a.GRID_BAR_DWELL_FLOOR_MS;
   });
 }
+
+export interface SeedHistoryEntry {
+  id: string;
+  type: NotificationType;
+  message: string;
+  timestamp: number;
+  title?: string;
+  correlationId?: string;
+  seenAsToast?: boolean;
+  countable?: boolean;
+  archivedAt?: number | null;
+  context?: {
+    projectId?: string;
+    worktreeId?: string;
+    panelId?: string;
+    eventKind?: string;
+  };
+  actions?: { label: string; actionId: string; variant?: "primary" | "secondary" }[];
+}
+
+/**
+ * Replaces the entire notification history in one write, with full control over
+ * timestamps, actions, context, and archived/snoozed state — the axes
+ * `injectHistoryEntry` can't reach because `addEntry` derives them.
+ */
+export async function seedNotificationHistory(
+  page: Page,
+  entries: SeedHistoryEntry[],
+  snoozedThreads: Record<string, number> = {}
+): Promise<void> {
+  await waitForNotificationsBackdoor(page);
+  await page.evaluate(
+    ({ entries, snoozedThreads }) => {
+      const a = (
+        window as unknown as {
+          __daintreeNotificationsE2E?: { seedHistory: (input: unknown) => void };
+        }
+      ).__daintreeNotificationsE2E;
+      if (!a) throw new Error("__daintreeNotificationsE2E backdoor not attached");
+      a.seedHistory({
+        entries: entries.map((e) => ({
+          summarized: false,
+          seenAsToast: false,
+          countable: true,
+          archivedAt: null,
+          ...e,
+        })),
+        snoozedThreads,
+      });
+    },
+    { entries, snoozedThreads }
+  );
+}

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -343,6 +343,7 @@ export const SEL = {
     gridBar: '[data-testid="grid-notification-bar"]',
     gridBarStatus: '[data-testid="grid-notification-bar"] [role="status"]',
     // Notification center (NotificationCenter.tsx)
+    center: '[data-testid="notification-center"]',
     centerList: '[role="list"][aria-label="Notifications"]',
     centerRow: '[role="listitem"]',
     centerFilter: (label: string) => `button[aria-pressed]:has-text("${label}")`,

--- a/e2e/screenshots/notification-entry-review.spec.ts
+++ b/e2e/screenshots/notification-entry-review.spec.ts
@@ -1,0 +1,579 @@
+/**
+ * NotificationCenterEntry visual-review harness (#11988).
+ *
+ * One inbox row carries severity, unread state, title, message, thread count,
+ * contextual actions, timestamp, snooze state, an overflow menu and dismissal —
+ * inside a 360px popover. The trailing rail is the contested space: at rest it
+ * shows snooze state and time, and on hover/focus/open-menu an absolutely
+ * positioned action layer fades in *over* it. Whether that reads as a stable
+ * row or a temporary patch is a pixel question, so it gets captured.
+ *
+ * Seeds the full history through `seedHistory` on the E2E notification backdoor
+ * (`src/lib/e2eNotificationBackdoor.ts`) — the store's own setState, with real
+ * timestamps, real action manifests, and real context — then drives every state
+ * axis the issue names.
+ *
+ * Steps (each also the DAINTREE_SHOT_ONLY filter name):
+ *
+ *   rest        the seeded list at rest, list + popover. Doubles as the
+ *               coarse-pointer state — see the note at the `contrast` step.
+ *   hover       pointer hover on a metadata-rich row
+ *   focus       keyboard focus (roving tabindex) on the same row
+ *   menu        the row overflow menu open
+ *   contrast    `prefers-contrast: more`
+ *   forced      `forced-colors: active`
+ *   dense       long titles / long relative times / big thread counts
+ *   archived    the Archived tab (dismiss unavailable)
+ *   snoozed     the Snoozed tab
+ *
+ * Opt-in only, like confirm-dialog-review: skips itself unless
+ * DAINTREE_SHOT_NOTIF is set, so the marketing screenshots workflow never runs it.
+ *
+ *   DAINTREE_SHOT_NOTIF=1 npx playwright test --project=screenshots notification-entry-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_NOTIF   required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME   optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG     optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY    comma-separated step filter (see step names above)
+ *
+ * Output: artifacts/notification-entry-shots/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, type CDPSession, type Locator, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { seedNotificationHistory, type SeedHistoryEntry } from "../helpers/notifications";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_NOTIF;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "notification-entry-shots");
+
+/** The popover card, so a shot is the inbox rather than the whole app window. */
+const POPOVER = SEL.notifications.center;
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-notif-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  git("branch develop", dir);
+  git("checkout develop", dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * The review fixture. Every axis the issue's capture matrix names is present in
+ * one list so a single shot is comparable across rounds: read/unread, titled/
+ * untitled, threaded/solo, actions/no actions, snoozed/active, dismissible/not,
+ * and the four relative-time shapes (`just now`, `Nm ago`, `Yesterday HH:MM`,
+ * `Mar 4`, `Mar 4 2024`).
+ *
+ * `project.silenceNotificationKind` and `project.muteNotifications` are what the
+ * overflow menu keys off, so `context.eventKind` / `context.projectId` decide
+ * whether a row even has a menu — rows deliberately vary on both.
+ */
+function buildFixture(now: number): SeedHistoryEntry[] {
+  const PROJECT = "helios-dashboard";
+  return [
+    // Unread error, threaded (3), contextual actions, full menu, dismissible.
+    ...[0, 1, 2].map((i) => ({
+      id: `err-${i}`,
+      type: "error" as const,
+      title: "Push rejected",
+      message: "The remote has commits your branch doesn't. Pull with rebase, then push again.",
+      timestamp: now - 45_000 - i * MINUTE,
+      correlationId: "thread-push-rejected",
+      seenAsToast: false,
+      context: { projectId: PROJECT, eventKind: "git", panelId: "panel-git-1" },
+      actions: [
+        { label: "Pull and rebase", actionId: "git.push" },
+        { label: "Open review", actionId: "app.settings.openTab", variant: "secondary" as const },
+      ],
+    })),
+    // Unread warning, no title, short relative time, one action.
+    {
+      id: "warn-untitled",
+      type: "warning",
+      message: "Claude has been waiting for input for 4 minutes in feature/refine-inbox.",
+      timestamp: now - 4 * MINUTE,
+      correlationId: "thread-waiting-claude",
+      seenAsToast: false,
+      context: { projectId: PROJECT, eventKind: "waiting", panelId: "panel-term-2" },
+      actions: [{ label: "Go to terminal", actionId: "panel.focus" }],
+    },
+    // Read success, titled, no actions, hours-old.
+    {
+      id: "ok-worktree",
+      type: "success",
+      title: "Worktree created",
+      message: "feature/issue-11988-refine-notificationcenterentry is ready.",
+      timestamp: now - 3 * HOUR,
+      correlationId: "thread-worktree-created",
+      seenAsToast: true,
+      context: { projectId: PROJECT, eventKind: "git" },
+    },
+    // Read info, yesterday, snoozed thread (see SNOOZED_ID below).
+    {
+      id: "info-snoozed",
+      type: "info",
+      title: "Update available",
+      message: "Daintree 1.4.2 is ready to install. It'll apply on the next restart.",
+      timestamp: now - 26 * HOUR,
+      correlationId: "thread-update-available",
+      seenAsToast: true,
+      context: { projectId: PROJECT, eventKind: "settings" },
+      actions: [{ label: "Restart and install", actionId: "app.settings.openTab" }],
+    },
+    // Read info, no correlationId at all → no snooze, no thread, minimal menu.
+    {
+      id: "info-bare",
+      type: "info",
+      title: "Theme changed",
+      message: "Switched to Fiordland.",
+      timestamp: now - 5 * DAY,
+      seenAsToast: true,
+    },
+    // The density case: long title, long message, prior-year timestamp, a big
+    // thread count, and three actions all at once.
+    ...[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map((i) => ({
+      id: `dense-${i}`,
+      type: "warning" as const,
+      title: "Watchdog restarted the terminal host after repeated unresponsive checks",
+      message:
+        "The pty host stopped answering health checks three times in a row and was restarted. Open panels were reattached; scrollback older than the restart is gone.",
+      timestamp: now - 400 * DAY - i * MINUTE,
+      correlationId: "thread-watchdog",
+      seenAsToast: true,
+      context: { projectId: PROJECT, eventKind: "recovery", panelId: "panel-term-9" },
+      actions: [
+        { label: "Show host logs", actionId: "app.settings.openTab" },
+        { label: "Restart terminal", actionId: "terminal.restart", variant: "secondary" as const },
+        { label: "Report", actionId: "system.openExternal", variant: "secondary" as const },
+      ],
+    })),
+    // Archived — the Archived tab, where dismissal is unavailable.
+    {
+      id: "archived-1",
+      type: "success",
+      title: "Merged pull request #11967",
+      message: "feature/issue-11965-move-remaining-stacked-label merged into develop.",
+      timestamp: now - 2 * DAY,
+      archivedAt: now - DAY,
+      seenAsToast: true,
+      correlationId: "thread-merged-pr",
+      context: { projectId: PROJECT, eventKind: "git" },
+    },
+  ];
+}
+
+const SNOOZED_THREAD = "thread-update-available";
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+async function snap(page: Page, slug: string, locator?: string): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).last().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+}
+
+/**
+ * Assert the seeded content is actually painted before writing a PNG. Without
+ * this the harness happily captures an empty inbox — the exact silent-wrong-
+ * artifact failure that sends a whole review off reasoning about a screen that
+ * doesn't exist.
+ */
+async function assertSeeded(page: Page, minRows: number): Promise<void> {
+  const rows = page.locator(SEL.notifications.centerList).locator(SEL.notifications.centerRow);
+  const count = await rows.count();
+  if (count < minRows) {
+    throw new Error(`expected at least ${minRows} inbox rows on screen, saw ${count}`);
+  }
+}
+
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — but the run must still FAIL, or an
+// exit 0 over a half-empty output directory reads as success.
+const failures: string[] = [];
+async function step(page: Page, name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).slice(0, 300);
+    console.warn(`[notif-shots] step "${name}" failed:`, detail);
+    failures.push(`${name}: ${detail}`);
+  } finally {
+    await resetMedia(page).catch(() => {});
+    await reopenCenter(page).catch((error) => {
+      failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+    });
+  }
+}
+
+/**
+ * Playwright's `emulateMedia` covers forced-colors and reduced-motion but not
+ * `pointer` or `prefers-contrast`, so those go through CDP directly.
+ *
+ * The session is created once and held: `Emulation.setEmulatedMedia` overrides
+ * are scoped to their CDP session, so detaching right after the send silently
+ * reverts them — which produced three capture files byte-identical to the rest
+ * state on the first run.
+ */
+let mediaSession: CDPSession | null = null;
+
+async function setMediaFeatures(
+  page: Page,
+  features: { name: string; value: string }[]
+): Promise<void> {
+  mediaSession ??= await page.context().newCDPSession(page);
+  await mediaSession.send("Emulation.setEmulatedMedia", { features });
+  // Prove the override took. Without this a shot that is byte-identical to the
+  // rest state is ambiguous — "this media query changes nothing here" and
+  // "the emulation silently no-opped" look exactly the same on disk.
+  for (const f of features) {
+    const query = `(${f.name}: ${f.value})`;
+    const matches = await page.evaluate((q) => window.matchMedia(q).matches, query);
+    if (!matches) throw new Error(`media emulation did not apply: ${query}`);
+  }
+}
+
+async function resetMedia(page: Page): Promise<void> {
+  if (mediaSession) {
+    await mediaSession.send("Emulation.setEmulatedMedia", { features: [] }).catch(() => {});
+  }
+  await page.emulateMedia({ forcedColors: null }).catch(() => {});
+}
+
+async function closeCenter(page: Page): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    if (
+      !(await page
+        .locator(SEL.notifications.centerList)
+        .isVisible()
+        .catch(() => false))
+    )
+      return;
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+  }
+}
+
+/** Close and reopen the popover so each step starts from a known rest state. */
+async function reopenCenter(page: Page): Promise<void> {
+  await closeCenter(page);
+  await dismissBlockingPalette(page);
+  await page.locator(SEL.notifications.bellButton).click();
+  await page
+    .locator(SEL.notifications.centerList)
+    .waitFor({ state: "visible", timeout: 8000 })
+    .catch(() => {});
+  await settle(page, 500);
+}
+
+/**
+ * Put keyboard focus on a row the way the inbox's own roving tabindex does.
+ *
+ * A bare scripted `.focus()` is not enough — the reveal is `:focus-visible`
+ * gated, and Chromium only sets that for keyboard-initiated focus. Tab does not
+ * reach the rows either: the popover is portalled to the end of `document.body`
+ * while the bell that opened it sits in the toolbar, so Tab walks the whole app
+ * first. So: seed focus on row 0 programmatically, then press a real ArrowDown,
+ * which lands in the list's own keydown handler and re-focuses from inside a
+ * keyboard event — which is exactly the condition `:focus-visible` wants.
+ */
+async function focusFirstRowByKeyboard(page: Page): Promise<void> {
+  await page
+    .locator(SEL.notifications.centerList)
+    .locator(SEL.notifications.centerRow)
+    .first()
+    .evaluate((el) => (el as HTMLElement).focus());
+  await settle(page, 150);
+}
+
+/** The reveal is `:focus-visible`-gated — assert it actually matched. */
+async function assertRowFocusVisible(page: Page): Promise<void> {
+  const ok = await page.evaluate(() => {
+    const el = document.activeElement;
+    if (!el || el.getAttribute("role") !== "listitem") return false;
+    return el.matches(":focus-visible");
+  });
+  if (!ok) throw new Error("focused row did not match :focus-visible");
+}
+
+/** Throws unless the locator's box sits inside the popover's visible box. */
+async function assertInsidePopover(page: Page, target: Locator): Promise<void> {
+  const popover = await page.locator(POPOVER).last().boundingBox();
+  const box = await target.boundingBox();
+  if (!popover || !box) throw new Error("could not measure popover or target row");
+  if (box.y < popover.y || box.y + box.height > popover.y + popover.height) {
+    throw new Error(
+      `target row is outside the popover viewport (row y=${Math.round(box.y)}h=${Math.round(
+        box.height
+      )}, popover y=${Math.round(popover.y)}h=${Math.round(popover.height)})`
+    );
+  }
+}
+
+/** Selects a filter tab by its visible label ("All" / "Archived" / "Snoozed"). */
+async function selectFilter(page: Page, label: string): Promise<void> {
+  await page.locator(SEL.notifications.centerFilter(label)).first().click();
+  await settle(page, 400);
+}
+
+test("notification entry review — trailing rail, actions, and time", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_NOTIF is required for the inbox row capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_NOTIF to run the inbox row capture");
+
+  failures.length = 0;
+  mediaSession = null;
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-notifshot-"));
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 1500);
+    await dismissBlockingPalette(page);
+
+    const now = Date.now();
+    await seedNotificationHistory(page, buildFixture(now), {
+      [SNOOZED_THREAD]: now + 8 * HOUR,
+    });
+    await reopenCenter(page);
+    await assertSeeded(page, 4);
+
+    // 1. Rest — what the row looks like when nobody is touching it. This is the
+    //    only state that shows the timestamp today.
+    await step(page, "rest", async () => {
+      await assertSeeded(page, 4);
+      await snap(page, "10-rest-popover", POPOVER);
+      await snap(page, "11-rest-window");
+    });
+
+    // 2. Hover — the action layer fades in over the timestamp. The whole issue.
+    await step(page, "hover", async () => {
+      const row = page.locator(SEL.notifications.centerList).locator(SEL.notifications.centerRow);
+      await row.first().hover();
+      await settle(page, 300);
+      await snap(page, "20-hover-popover", POPOVER);
+      await snap(page, "21-hover-row", `${SEL.notifications.centerRow} >> nth=0`);
+    });
+
+    // 3. Keyboard focus — same reveal, reached without a pointer.
+    await step(page, "focus", async () => {
+      await focusFirstRowByKeyboard(page);
+      await page.keyboard.press("ArrowDown");
+      await settle(page, 300);
+      await assertRowFocusVisible(page);
+      await snap(page, "30-focus-popover", POPOVER);
+    });
+
+    // 4. Open overflow menu — the row's management actions, and the state that
+    //    pins the reveal open.
+    await step(page, "menu", async () => {
+      const row = page.locator(SEL.notifications.centerList).locator(SEL.notifications.centerRow);
+      await row.first().hover();
+      await settle(page, 250);
+      await page.locator('button[aria-label="Notification options"]').first().click();
+      await settle(page, 500);
+      await snap(page, "40-menu-open-window");
+    });
+
+    // 5. Coarse pointer has no capture of its own, deliberately. Chromium's
+    //    `Emulation.setEmulatedMedia` has no `pointer` feature (only
+    //    prefers-*/forced-colors/color-gamut), and a survey of the repo found
+    //    zero `(pointer: coarse)` / `(hover: hover)` rules anywhere — so a touch
+    //    session renders exactly `10-rest-popover`, byte for byte. That shot IS
+    //    the coarse-pointer state: whatever is missing from it is missing for a
+    //    touch user permanently. Writing a separate identical file would only
+    //    dress that fact up as evidence it isn't.
+
+    // 6. prefers-contrast: more (macOS "Increase contrast").
+    await step(page, "contrast", async () => {
+      await setMediaFeatures(page, [{ name: "prefers-contrast", value: "more" }]);
+      await settle(page, 400);
+      await snap(page, "60-high-contrast-popover", POPOVER);
+    });
+
+    // 7. forced-colors: active (Windows high-contrast). The overlay's own
+    //    background is the thing most likely to collapse here.
+    await step(page, "forced", async () => {
+      await page.emulateMedia({ forcedColors: "active" });
+      await settle(page, 500);
+      if (!(await page.evaluate(() => matchMedia("(forced-colors: active)").matches))) {
+        throw new Error("forced-colors emulation did not apply");
+      }
+      await snap(page, "70-forced-colors-popover", POPOVER);
+      const row = page.locator(SEL.notifications.centerList).locator(SEL.notifications.centerRow);
+      await row.first().hover();
+      await settle(page, 300);
+      await snap(page, "71-forced-colors-hover", POPOVER);
+    });
+
+    // 8. Density — the longest title, the biggest thread count, a prior-year
+    //    timestamp and three action buttons in a 360px popover.
+    await step(page, "dense", async () => {
+      // Re-seed rather than scroll. The dense row sits ~20 rows down the full
+      // fixture and nothing moved the inbox's scrollport to it — `scrollTop`,
+      // `scrollIntoView` and 40 `mouse.wheel` ticks all left the row's box at
+      // the same y. Seeding the dense entries on their own puts the case at the
+      // top of the list: deterministic, and it isolates density from whatever
+      // happens to be above it. The full fixture is restored before the next
+      // step so Archived and Snoozed still have their rows.
+      await seedNotificationHistory(
+        page,
+        buildFixture(now).filter((e) => e.id.startsWith("dense"))
+      );
+      await reopenCenter(page);
+      const denseRow = page
+        .locator(SEL.notifications.centerList)
+        .locator(SEL.notifications.centerRow)
+        .filter({ hasText: "Watchdog restarted" })
+        .first();
+      await assertInsidePopover(page, denseRow);
+      await snap(page, "80-dense-popover", POPOVER);
+      await denseRow.hover();
+      await settle(page, 300);
+      await snap(page, "81-dense-hover-popover", POPOVER);
+      await seedNotificationHistory(page, buildFixture(now), {
+        [SNOOZED_THREAD]: now + 8 * HOUR,
+      });
+      await reopenCenter(page);
+    });
+
+    // 9. Archived tab — dismissal unavailable, so the rail loses a control.
+    await step(page, "archived", async () => {
+      await selectFilter(page, "Archived");
+      await snap(page, "90-archived-popover", POPOVER);
+      await page
+        .locator(SEL.notifications.centerList)
+        .locator(SEL.notifications.centerRow)
+        .first()
+        .hover();
+      await settle(page, 300);
+      await snap(page, "91-archived-hover-popover", POPOVER);
+    });
+
+    // 10. Snoozed tab — the snooze clock and the timestamp share the rail.
+    await step(page, "snoozed", async () => {
+      await selectFilter(page, "Snoozed");
+      await snap(page, "95-snoozed-popover", POPOVER);
+      await page
+        .locator(SEL.notifications.centerList)
+        .locator(SEL.notifications.centerRow)
+        .first()
+        .hover();
+      await settle(page, 300);
+      await snap(page, "96-snoozed-hover-popover", POPOVER);
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    try {
+      repo.cleanup();
+    } catch {
+      /* best effort */
+    }
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+
+  const written = existsSync(OUTPUT_DIR)
+    ? readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`)).length
+    : 0;
+  console.warn(`[notif-shots] wrote ${written} png(s) to ${OUTPUT_DIR}`);
+
+  if (failures.length > 0) {
+    throw new Error(`[notif-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`);
+  }
+});

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -15,6 +15,7 @@ import {
   useNotificationHistoryStore,
   type NotificationHistoryEntry,
 } from "@/store/slices/notificationHistorySlice";
+import { PALETTE_ROW_FOCUS_CLASS } from "@/components/ui/paletteRowStyles";
 import { NotificationCenterEntry } from "./NotificationCenterEntry";
 import { useSnoozeExpiryTimer } from "./useSnoozeExpiryTimer";
 import { resolveSnoozeDuration, type SnoozeDurationOption } from "@shared/utils/snoozeTimestamps";
@@ -855,156 +856,167 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   return (
     <div data-testid="notification-center" className="w-[360px] max-h-[420px] flex flex-col">
-      {/* pr-2, not px-3: the right-side icon buttons carry 4px of internal p-1
-          touch padding, so an 8px container edge lands their glyphs at the same
-          12px optical inset as the title text on the left. */}
-      <div className="flex items-start justify-between pl-3 pr-2 py-2 border-b border-divider gap-2">
-        <div className="flex flex-1 flex-wrap items-center gap-1.5 min-w-0">
-          <span className="text-xs font-medium text-daintree-text/80">Notifications</span>
-          {entries.length > 0 && (
-            <>
+      {/* Two rows, not one. Sharing a line with the toolbar squeezed the filter
+          group down to about 120px, so all four chips wrapped onto three lines
+          and the header ate a quarter of a 420px popover while roughly 230px
+          sat empty to the right of them. It also stranded "All" up beside the
+          heading, where it read as part of the title rather than as a peer of
+          the other three.
+
+          pr-2, not px-3, on both rows: the right-side icon buttons carry 4px of
+          internal p-1 touch padding, so an 8px container edge lands their
+          glyphs at the same 12px optical inset as the title text on the left. */}
+      <div className="flex flex-col border-b border-divider">
+        <div className="flex items-center justify-between pl-3 pr-2 py-2 gap-2">
+          <span className="min-w-0 truncate text-xs font-medium text-daintree-text/80">
+            Notifications
+          </span>
+          <div className="flex items-center gap-1 shrink-0">
+            {showGroupToggle && (
               <button
                 type="button"
-                aria-pressed={filter === "all"}
-                onClick={() => {
-                  setFilter("all");
-                  setFrozenUnreadIds(null);
-                }}
-                className={cn(
-                  "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
-                  filter === "all"
-                    ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
-                    : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
-                )}
-              >
-                All
-              </button>
-              <button
-                type="button"
-                aria-pressed={filter === "unread"}
-                onClick={() => setFilter("unread")}
-                className={cn(
-                  "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
-                  filter === "unread"
-                    ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
-                    : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
-                )}
-              >
-                Unread
-              </button>
-              <button
-                type="button"
-                aria-pressed={filter === "archived"}
-                onClick={() => {
-                  setFilter("archived");
-                  setFrozenUnreadIds(null);
-                }}
-                className={cn(
-                  "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
-                  filter === "archived"
-                    ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
-                    : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
-                )}
-              >
-                Archived
-              </button>
-              {hasSnoozedThreads && (
-                <button
-                  type="button"
-                  aria-pressed={filter === "snoozed"}
-                  onClick={() => {
-                    setFilter("snoozed");
-                    setFrozenUnreadIds(null);
-                  }}
-                  className={cn(
-                    "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
-                    filter === "snoozed"
-                      ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
-                      : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
-                  )}
-                >
-                  Snoozed
-                </button>
-              )}
-            </>
-          )}
-        </div>
-        <div className="flex items-center gap-1 shrink-0">
-          {showGroupToggle && (
-            <button
-              type="button"
-              aria-label="Group by project or worktree"
-              aria-pressed={groupByContext}
-              title="Group by project or worktree"
-              onClick={() => setGroupByContext(!groupByContext)}
-              className="toolbar-icon-button p-1 rounded-[var(--radius-sm)] text-daintree-text/50"
-            >
-              <Layers className="w-3 h-3" aria-hidden="true" />
-            </button>
-          )}
-          {unreadCount > 0 && (
-            <button
-              type="button"
-              onClick={handleMarkAllRead}
-              className="toolbar-icon-button inline-flex items-center gap-1 px-1.5 py-1 rounded-[var(--radius-sm)] text-[11px] text-daintree-text/50 whitespace-nowrap"
-            >
-              <CheckCheck className="w-3 h-3" aria-hidden="true" />
-              Mark all read
-            </button>
-          )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                aria-label="Pause notifications"
-                title="Pause notifications"
+                aria-label="Group by project or worktree"
+                aria-pressed={groupByContext}
+                title="Group by project or worktree"
+                onClick={() => setGroupByContext(!groupByContext)}
                 className="toolbar-icon-button p-1 rounded-[var(--radius-sm)] text-daintree-text/50"
               >
-                <Moon className="w-3 h-3" aria-hidden="true" />
+                <Layers className="w-3 h-3" aria-hidden="true" />
               </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-[180px]">
-              <DropdownMenuItem onSelect={() => handleMuteFor(60 * 60 * 1000)}>
-                For 1 hour
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={handleMuteUntilMorning}>{morningLabel}</DropdownMenuItem>
-              <DropdownMenuItem onSelect={openNotificationSettings}>Custom…</DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                aria-label="Notification settings"
-                onSelect={openNotificationSettings}
+            )}
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                onClick={handleMarkAllRead}
+                className="toolbar-icon-button inline-flex items-center gap-1 px-1.5 py-1 rounded-[var(--radius-sm)] text-[11px] text-daintree-text/50 whitespace-nowrap"
               >
-                Notification settings…
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {entries.length > 0 && (
+                <CheckCheck className="w-3 h-3" aria-hidden="true" />
+                Mark all read
+              </button>
+            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
+                  aria-label="Pause notifications"
+                  title="Pause notifications"
                   className="toolbar-icon-button p-1 rounded-[var(--radius-sm)] text-daintree-text/50"
-                  aria-label="More notification actions"
-                  title="More notification actions"
                 >
-                  <Ellipsis className="w-3 h-3" aria-hidden="true" />
+                  <Moon className="w-3 h-3" aria-hidden="true" />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-[160px]">
+              <DropdownMenuContent align="end" className="min-w-[180px]">
+                <DropdownMenuItem onSelect={() => handleMuteFor(60 * 60 * 1000)}>
+                  For 1 hour
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={handleMuteUntilMorning}>
+                  {morningLabel}
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={openNotificationSettings}>Custom…</DropdownMenuItem>
+                <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  destructive
-                  onSelect={() => {
-                    clearAll();
-                    onClose();
-                  }}
+                  aria-label="Notification settings"
+                  onSelect={openNotificationSettings}
                 >
-                  <Trash2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
-                  Clear all
+                  Notification settings…
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-          )}
+            {entries.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="toolbar-icon-button p-1 rounded-[var(--radius-sm)] text-daintree-text/50"
+                    aria-label="More notification actions"
+                    title="More notification actions"
+                  >
+                    <Ellipsis className="w-3 h-3" aria-hidden="true" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[160px]">
+                  <DropdownMenuItem
+                    destructive
+                    onSelect={() => {
+                      clearAll();
+                      onClose();
+                    }}
+                  >
+                    <Trash2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+                    Clear all
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
         </div>
+        {entries.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5 pl-3 pr-2 pb-2">
+            <button
+              type="button"
+              aria-pressed={filter === "all"}
+              onClick={() => {
+                setFilter("all");
+                setFrozenUnreadIds(null);
+              }}
+              className={cn(
+                "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                filter === "all"
+                  ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
+                  : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
+              )}
+            >
+              All
+            </button>
+            <button
+              type="button"
+              aria-pressed={filter === "unread"}
+              onClick={() => setFilter("unread")}
+              className={cn(
+                "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                filter === "unread"
+                  ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
+                  : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
+              )}
+            >
+              Unread
+            </button>
+            <button
+              type="button"
+              aria-pressed={filter === "archived"}
+              onClick={() => {
+                setFilter("archived");
+                setFrozenUnreadIds(null);
+              }}
+              className={cn(
+                "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                filter === "archived"
+                  ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
+                  : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
+              )}
+            >
+              Archived
+            </button>
+            {hasSnoozedThreads && (
+              <button
+                type="button"
+                aria-pressed={filter === "snoozed"}
+                onClick={() => {
+                  setFilter("snoozed");
+                  setFrozenUnreadIds(null);
+                }}
+                className={cn(
+                  "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                  filter === "snoozed"
+                    ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
+                    : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
+                )}
+              >
+                Snoozed
+              </button>
+            )}
+          </div>
+        )}
       </div>
       {showMutedPill && (
         <div
@@ -1590,8 +1602,11 @@ function NotificationThread({
       data-testid="notification-thread"
       className={cn(
         "group relative border-l-2 border-tint/15",
-        tabIndex !== undefined &&
-          "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-daintree-accent/50"
+        // Same treatment as a solo row (NotificationCenterEntry). Both are
+        // stops on the same roving-tabindex ring, so they must not focus
+        // differently — one outline, one box-shadow ring would read as two
+        // kinds of row.
+        tabIndex !== undefined && PALETTE_ROW_FOCUS_CLASS
       )}
     >
       <NotificationCenterEntry

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -854,7 +854,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   }, [filter, hasSnoozedThreads]);
 
   return (
-    <div className="w-[360px] max-h-[420px] flex flex-col">
+    <div data-testid="notification-center" className="w-[360px] max-h-[420px] flex flex-col">
       {/* pr-2, not px-3: the right-side icon buttons carry 4px of internal p-1
           touch padding, so an 8px container edge lands their glyphs at the same
           12px optical inset as the title text on the left. */}

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -223,32 +223,139 @@ export function NotificationCenterEntry({
         )}
         <Icon className="h-4 w-4" />
       </div>
-      <div className="flex-1 min-w-0">
-        {/* One stable rail, floated rather than a flex sibling.
+      <div className="grid flex-1 min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-x-2">
+        {entry.title && (
+          <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-1.5">
+            <p
+              className={cn(
+                "text-xs text-daintree-text truncate",
+                isNew ? "font-semibold" : "font-normal"
+              )}
+            >
+              {entry.title}
+            </p>
+            {showChip && (
+              <span
+                key={bumpKey}
+                aria-label={formatNotificationCountAriaLabel(safeCount)}
+                // Handle for the forced-colors repaint — the tint fill is forced
+                // to Canvas there, leaving a bare numeral that reads as part of
+                // the title.
+                data-notification-count="true"
+                style={{ animationDuration: "150ms" }}
+                className={cn(
+                  "shrink-0 rounded-full bg-tint/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
+                  bumpKey > 0 && "animate-badge-bump"
+                )}
+              >
+                {formatNotificationCountGlyph(safeCount)}
+              </span>
+            )}
+          </div>
+        )}
+        {/* A titled row's message spans both columns on row 2, under the rail,
+            so it gets the full width. An untitled row has nothing else to put
+            on row 1, so the message takes that cell instead — otherwise the
+            rail sits alone against an empty gutter and the row wastes a line.
+            It wraps inside column 1 there, which costs nothing at the widths
+            this popover actually uses: the rail is about 100px for a relative
+            stamp, and a message long enough to wrap at 210px was already
+            wrapping at 312px. */}
+        <p
+          className={cn(
+            "text-xs text-daintree-text/70 leading-snug break-words",
+            entry.title ? "col-span-2 row-start-2" : "col-start-1 row-start-1 min-w-0"
+          )}
+        >
+          {entry.message}
+        </p>
+        {showChip && !entry.title && (
+          <span
+            key={bumpKey}
+            aria-label={formatNotificationCountAriaLabel(safeCount)}
+            data-notification-count="true"
+            style={{ animationDuration: "150ms" }}
+            className={cn(
+              "col-span-2 row-start-2 mt-0.5 justify-self-start rounded-full bg-tint/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
+              bumpKey > 0 && "animate-badge-bump"
+            )}
+          >
+            {formatNotificationCountGlyph(safeCount)}
+          </span>
+        )}
+        {entry.actions && entry.actions.length > 0 && (
+          <div className="col-span-2 row-start-4 mt-1.5 flex flex-wrap gap-1.5">
+            {entry.actions.map((action, index) => {
+              const manifest = actionService.get(action.actionId as ActionId);
+              const isAvailable = manifest !== null && manifest.enabled;
+              return (
+                <button
+                  key={`${action.actionId}-${index}`}
+                  type="button"
+                  aria-disabled={!isAvailable || undefined}
+                  title={
+                    !isAvailable ? (manifest?.disabledReason ?? "Action unavailable") : undefined
+                  }
+                  onClick={
+                    isAvailable
+                      ? () =>
+                          void actionService.dispatch(
+                            action.actionId as ActionId,
+                            action.actionArgs
+                          )
+                      : undefined
+                  }
+                  className={cn(
+                    "h-6 rounded-[var(--radius-sm)] px-2 text-[11px] font-medium transition-colors",
+                    isAvailable
+                      ? action.variant === "secondary"
+                        ? "border border-daintree-text/20 text-text-secondary hover:bg-overlay-medium"
+                        : // The primary used to ink its label from `status-info`,
+                          // which `shared/theme/contrast.ts` only gates at 3:1 —
+                          // no body-text guarantee. It measured 4.46:1 against
+                          // its own fill while the secondary beside it measured
+                          // 7.6:1, so the button with primary chrome read as the
+                          // weaker, near-disabled one, and `prefers-contrast:
+                          // more` lifted the secondary and left it behind. Keep
+                          // status-info as the fill and border (that is what
+                          // marks it primary) and take the label from the gated
+                          // text ramp.
+                          "border border-status-info/30 bg-status-info/15 text-daintree-text hover:bg-status-info/20"
+                      : "border border-daintree-text/10 text-text-muted cursor-not-allowed"
+                  )}
+                >
+                  {action.label}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        {/* One stable rail — the row's trailing metadata and management
+            controls, held in a grid cell rather than an overlay or a float.
 
             The old build cross-faded the metadata out and covered it with an
             absolutely positioned layer carrying its own `bg-overlay-raised`
             fill, so time — the orientation cue the inbox exists to provide —
             vanished at exactly the moment the user was inspecting the row, and
             on the Snoozed tab took the snooze state with it. It was also the
-            only metadata-covering action layer in the app; every other row here
-            reserves a stable box instead. So now nothing moves and nothing is
-            covered: the controls hold their place at every state, quiet at rest
-            and stronger under the pointer, which is the "quiet at rest,
-            stronger on hover" treatment the worktree card's action toolbar
-            already uses here. Keeping them in flow is also what makes them
-            reachable on a touch screen, where there is no hover to reveal
-            anything.
+            only metadata-covering action layer in the app. Now nothing moves
+            and nothing is covered: the controls hold their place at every
+            state, quiet at rest and stronger under the pointer, which is the
+            treatment the worktree card's action toolbar already uses here.
+            Keeping them in flow is what makes them reachable on a touch screen,
+            where there is no hover to reveal anything.
 
-            Float, not a flex sibling, because a sibling subtracts its width
-            from *every* line of the row rather than the one it sits on. At its
-            widest the rail is about 138px of a 360px popover, so as a sibling
-            it pushed the default message from two lines to three and the dense
-            one from four to six. Floated, the title shrinks beside it (the
-            title's `truncate` gives it its own formatting context, so it clears
-            the float rather than running under), the first message line wraps
-            around it, and every line below reclaims the full width. */}
-        <div className="float-right ml-2 mt-0.5 flex items-center gap-1.5">
+            Grid, not a flex sibling and not a float. A flex sibling subtracts
+            its width from every line of the row rather than the one it sits on,
+            which cost the default message a line and the dense one two. A float
+            fixes that but has to precede the content it shifts, which put the
+            management controls ahead of the title, message and recovery actions
+            in DOM order — so tabbing reached Dismiss before "Pull and rebase",
+            and a screen reader read the metadata before the event. Explicit
+            grid placement gets both: this rail is last in the DOM and reads
+            last, but paints in row 1's trailing column, and the message and
+            actions below it span the full width. */}
+        <div className="col-start-2 row-start-1 flex items-center gap-1.5">
           {isSnoozed && snoozedUntil !== undefined && (
             <>
               <span
@@ -308,97 +415,6 @@ export function NotificationCenterEntry({
             </button>
           )}
         </div>
-        {entry.title && (
-          <div className="flex items-center gap-1.5">
-            <p
-              className={cn(
-                "text-xs text-daintree-text truncate",
-                isNew ? "font-semibold" : "font-normal"
-              )}
-            >
-              {entry.title}
-            </p>
-            {showChip && (
-              <span
-                key={bumpKey}
-                aria-label={formatNotificationCountAriaLabel(safeCount)}
-                // Handle for the forced-colors repaint — the tint fill is forced
-                // to Canvas there, leaving a bare numeral that reads as part of
-                // the title.
-                data-notification-count="true"
-                style={{ animationDuration: "150ms" }}
-                className={cn(
-                  "shrink-0 rounded-full bg-tint/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
-                  bumpKey > 0 && "animate-badge-bump"
-                )}
-              >
-                {formatNotificationCountGlyph(safeCount)}
-              </span>
-            )}
-          </div>
-        )}
-        <p className="text-xs text-daintree-text/70 leading-snug break-words">{entry.message}</p>
-        {showChip && !entry.title && (
-          <span
-            key={bumpKey}
-            aria-label={formatNotificationCountAriaLabel(safeCount)}
-            data-notification-count="true"
-            style={{ animationDuration: "150ms" }}
-            className={cn(
-              "mt-0.5 inline-block rounded-full bg-tint/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
-              bumpKey > 0 && "animate-badge-bump"
-            )}
-          >
-            {formatNotificationCountGlyph(safeCount)}
-          </span>
-        )}
-        {entry.actions && entry.actions.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mt-1.5">
-            {entry.actions.map((action, index) => {
-              const manifest = actionService.get(action.actionId as ActionId);
-              const isAvailable = manifest !== null && manifest.enabled;
-              return (
-                <button
-                  key={`${action.actionId}-${index}`}
-                  type="button"
-                  aria-disabled={!isAvailable || undefined}
-                  title={
-                    !isAvailable ? (manifest?.disabledReason ?? "Action unavailable") : undefined
-                  }
-                  onClick={
-                    isAvailable
-                      ? () =>
-                          void actionService.dispatch(
-                            action.actionId as ActionId,
-                            action.actionArgs
-                          )
-                      : undefined
-                  }
-                  className={cn(
-                    "h-6 rounded-[var(--radius-sm)] px-2 text-[11px] font-medium transition-colors",
-                    isAvailable
-                      ? action.variant === "secondary"
-                        ? "border border-daintree-text/20 text-text-secondary hover:bg-overlay-medium"
-                        : // The primary used to ink its label from `status-info`,
-                          // which `shared/theme/contrast.ts` only gates at 3:1 —
-                          // no body-text guarantee. It measured 4.46:1 against
-                          // its own fill while the secondary beside it measured
-                          // 7.6:1, so the button with primary chrome read as the
-                          // weaker, near-disabled one, and `prefers-contrast:
-                          // more` lifted the secondary and left it behind. Keep
-                          // status-info as the fill and border (that is what
-                          // marks it primary) and take the label from the gated
-                          // text ramp.
-                          "border border-status-info/30 bg-status-info/15 text-daintree-text hover:bg-status-info/20"
-                      : "border border-daintree-text/10 text-text-muted cursor-not-allowed"
-                  )}
-                >
-                  {action.label}
-                </button>
-              );
-            })}
-          </div>
-        )}
       </div>
     </div>
   );
@@ -605,9 +621,11 @@ function RowOptionsMenu({
           <MoreHorizontal className="h-3.5 w-3.5" />
         </button>
       </DropdownMenuTrigger>
-      {/* Capped and inset so the menu cannot end up wider than the 360px popover
-          it belongs to — it was overlaying three rows of the inbox behind it. */}
-      <DropdownMenuContent align="end" sideOffset={4} className="max-w-[280px]">
+      {/* Bounded on both sides, matching the panel-header and docked-tab menus:
+          a floor so short items do not collapse it, and a ceiling so it cannot
+          end up wider than the 360px popover it belongs to — it was overlaying
+          three rows of the inbox behind it. */}
+      <DropdownMenuContent align="end" sideOffset={4} className="min-w-[200px] max-w-[280px]">
         {supportsSnooze &&
           (isSnoozed ? (
             <DropdownMenuItem

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -12,6 +12,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PALETTE_ROW_FOCUS_CLASS } from "@/components/ui/paletteRowStyles";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { actionService } from "@/services/ActionService";
 import { EVENT_KIND_LABEL, isNotificationEventKind, notify } from "@/lib/notify";
@@ -49,6 +50,20 @@ function formatSnoozedUntil(snoozedUntil: number): string {
   const target = new Date(snoozedUntil);
   return snoozedUntilFormatter.format(target);
 }
+
+/**
+ * The row's two management controls. 24x24 rather than the previous 16x16:
+ * WCAG 2.2 SC 2.5.8 wants 24 CSS px, and the old pair sat 22px apart, so it
+ * cleared neither the size rule nor the spacing exemption. It is also the size
+ * the toast uses for this same notification content, and the dominant size for
+ * row controls across the app. They had no focus ring at all before.
+ */
+const ROW_CONTROL_CLASS = cn(
+  "h-6 w-6 shrink-0 flex items-center justify-center rounded-[var(--radius-sm)]",
+  "text-text-muted transition-colors hover:bg-overlay-soft hover:text-daintree-text",
+  "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2",
+  "focus-visible:outline-daintree-accent focus-visible:text-daintree-text"
+);
 
 const TYPE_CONFIG = {
   success: { icon: CheckCircle2, className: "text-status-success" },
@@ -180,9 +195,13 @@ export function NotificationCenterEntry({
       role={role}
       onFocus={onFocus}
       className={cn(
-        "group flex items-start gap-2 px-3 py-2.5 hover:bg-overlay-raised transition-colors",
-        tabIndex !== undefined &&
-          "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-daintree-accent/50"
+        "group flex items-start gap-2 px-3 py-2.5 hover:bg-overlay-subtle transition-colors",
+        // The shared palette-row focus treatment, not a bespoke ring: `outline`
+        // survives Windows High Contrast where a box-shadow ring does not, and
+        // the offset is negative because this row is full-bleed inside three
+        // nested clipping ancestors (ScrollShadow's scrollport and wrapper, and
+        // the popover itself), so an outset outline loses all four sides.
+        tabIndex !== undefined && PALETTE_ROW_FOCUS_CLASS
       )}
     >
       <div className={cn("relative shrink-0", config.className)}>
@@ -192,6 +211,13 @@ export function NotificationCenterEntry({
         {isNew && (
           <span
             aria-hidden="true"
+            // The attribute is not styling — it is the handle the
+            // `forced-colors: active` block in index.css repaints, the same way
+            // ActivityLight's dot is handled. Without it the UA forces this
+            // background to Canvas and the dot disappears, and an unread row
+            // carries no border or tint by design, so an untitled one was left
+            // with no unread signal at all.
+            data-notification-unread="true"
             className="absolute right-full mr-[3px] top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full bg-status-info"
           />
         )}
@@ -212,6 +238,10 @@ export function NotificationCenterEntry({
               <span
                 key={bumpKey}
                 aria-label={formatNotificationCountAriaLabel(safeCount)}
+                // Handle for the forced-colors repaint — the tint fill is forced
+                // to Canvas there, leaving a bare numeral that reads as part of
+                // the title.
+                data-notification-count="true"
                 style={{ animationDuration: "150ms" }}
                 className={cn(
                   "shrink-0 rounded-full bg-tint/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
@@ -228,6 +258,7 @@ export function NotificationCenterEntry({
           <span
             key={bumpKey}
             aria-label={formatNotificationCountAriaLabel(safeCount)}
+            data-notification-count="true"
             style={{ animationDuration: "150ms" }}
             className={cn(
               "mt-0.5 inline-block rounded-full bg-tint/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
@@ -263,9 +294,19 @@ export function NotificationCenterEntry({
                     "h-6 rounded-[var(--radius-sm)] px-2 text-[11px] font-medium transition-colors",
                     isAvailable
                       ? action.variant === "secondary"
-                        ? "border border-daintree-text/20 text-daintree-text/70 hover:bg-overlay-medium"
-                        : "border border-status-info/30 bg-status-info/15 text-status-info hover:bg-status-info/20"
-                      : "border border-daintree-text/10 text-daintree-text/30 cursor-not-allowed"
+                        ? "border border-daintree-text/20 text-text-secondary hover:bg-overlay-medium"
+                        : // The primary used to ink its label from `status-info`,
+                          // which `shared/theme/contrast.ts` only gates at 3:1 —
+                          // no body-text guarantee. It measured 4.46:1 against
+                          // its own fill while the secondary beside it measured
+                          // 7.6:1, so the button with primary chrome read as the
+                          // weaker, near-disabled one, and `prefers-contrast:
+                          // more` lifted the secondary and left it behind. Keep
+                          // status-info as the fill and border (that is what
+                          // marks it primary) and take the label from the gated
+                          // text ramp.
+                          "border border-status-info/30 bg-status-info/15 text-daintree-text hover:bg-status-info/20"
+                      : "border border-daintree-text/10 text-text-muted cursor-not-allowed"
                   )}
                 >
                   {action.label}
@@ -275,57 +316,79 @@ export function NotificationCenterEntry({
           </div>
         )}
       </div>
-      <div className="relative shrink-0 self-start mt-0.5 flex items-center justify-end">
-        <div className="flex items-center gap-1.5 transition-opacity duration-150 group-hover:opacity-0 group-focus-visible:opacity-0 group-has-[:focus-visible]:opacity-0 group-has-[[data-state=open]]:opacity-0">
-          {isSnoozed && snoozedUntil !== undefined && (
+      {/* One stable rail. The previous build cross-faded the metadata out and
+          covered it with an absolutely positioned layer carrying its own
+          `bg-overlay-raised` fill, which meant time — the orientation cue the
+          inbox exists to provide — vanished at exactly the moment the user was
+          inspecting the row, and on the Snoozed tab took the snooze state with
+          it. It was also the only metadata-covering action layer in the app;
+          every other row here reserves a stable box instead.
+
+          So: nothing moves and nothing is covered. The controls hold their
+          place in flow at every state, quiet at rest and stronger under the
+          pointer — the "quiet at rest, stronger on hover" treatment this repo
+          already uses on the worktree card's action toolbar. Keeping them
+          visible is also what makes them reachable at all on a touch screen,
+          where there is no hover to reveal anything. */}
+      <div className="shrink-0 self-start mt-0.5 flex items-center gap-1.5">
+        {isSnoozed && snoozedUntil !== undefined && (
+          <>
             <span
               data-testid="notification-snoozed-indicator"
               title={`Snoozed until ${formatSnoozedUntil(snoozedUntil)}`}
               aria-label={`Snoozed until ${formatSnoozedUntil(snoozedUntil)}`}
-              className="inline-flex h-4 w-4 items-center justify-center text-daintree-text/40"
+              className="inline-flex h-4 w-4 items-center justify-center text-text-secondary"
             >
               <Clock className="h-3 w-3" aria-hidden="true" />
             </span>
-          )}
-          {(() => {
-            const ts = formatNotificationTimestamp(entry.timestamp);
-            return (
-              <span
-                data-testid="notification-timestamp"
-                title={ts.absolute}
-                aria-label={ts.absolute}
-                className="text-[10px] text-daintree-text/40 tabular-nums"
-              >
-                {ts.label}
-              </span>
-            );
-          })()}
-        </div>
-        <div className="absolute inset-y-0 right-0 flex items-center gap-1.5 pl-3 bg-overlay-raised opacity-0 pointer-events-none transition-opacity duration-150 group-hover:opacity-100 group-hover:pointer-events-auto group-focus-visible:opacity-100 group-focus-visible:pointer-events-auto group-has-[:focus-visible]:opacity-100 group-has-[:focus-visible]:pointer-events-auto group-has-[[data-state=open]]:opacity-100 group-has-[[data-state=open]]:pointer-events-auto">
-          <RowOptionsMenu
-            entry={entry}
-            onDropdownOpenChange={onDropdownOpenChange}
-            isSnoozePending={isSnoozePending}
-            isSnoozed={isSnoozed}
-            snoozedUntil={snoozedUntil}
-            onConsumeSnoozePending={onConsumeSnoozePending}
-            onSnooze={onSnooze}
-            onUnsnooze={onUnsnooze}
-          />
-          {onDismiss && (
-            <button
-              type="button"
-              aria-label="Dismiss notification"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDismiss();
-              }}
-              className="h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
+            {/* The clock means "snoozed until later"; the stamp beside it means
+                "arrived at". Abutting they read as one fact, so they get a
+                separator. */}
+            <span aria-hidden="true" className="text-[10px] leading-none text-text-secondary">
+              ·
+            </span>
+          </>
+        )}
+        {(() => {
+          const ts = formatNotificationTimestamp(entry.timestamp);
+          return (
+            <span
+              data-testid="notification-timestamp"
+              title={ts.absolute}
+              aria-label={ts.absolute}
+              // A solid token, not `text-daintree-text/40`: slash-alpha
+              // composites against whatever is behind it and read at ~3.2:1
+              // here. `theme-tokens.md` gates `text-secondary` at >=3:1 across
+              // every theme and prefers a solid token for exactly this.
+              className="text-[10px] text-text-secondary tabular-nums"
             >
-              <X className="h-3 w-3" />
-            </button>
-          )}
-        </div>
+              {ts.label}
+            </span>
+          );
+        })()}
+        <RowOptionsMenu
+          entry={entry}
+          onDropdownOpenChange={onDropdownOpenChange}
+          isSnoozePending={isSnoozePending}
+          isSnoozed={isSnoozed}
+          snoozedUntil={snoozedUntil}
+          onConsumeSnoozePending={onConsumeSnoozePending}
+          onSnooze={onSnooze}
+          onUnsnooze={onUnsnooze}
+        />
+        {onDismiss && (
+          <button
+            type="button"
+            aria-label="Dismiss notification"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDismiss();
+            }}
+            className={ROW_CONTROL_CLASS}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
       </div>
     </div>
   );
@@ -524,12 +587,17 @@ function RowOptionsMenu({
           type="button"
           aria-label="Notification options"
           onClick={(e) => e.stopPropagation()}
-          className="h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
+          // `data-[state=open]` so the trigger reads as pressed while its menu
+          // is up — the repo's standard open-row cue. Without it nothing said
+          // which of the two controls opened the menu.
+          className={cn(ROW_CONTROL_CLASS, "data-[state=open]:bg-overlay-raised")}
         >
-          <MoreHorizontal className="h-3 w-3" />
+          <MoreHorizontal className="h-3.5 w-3.5" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" sideOffset={4}>
+      {/* Capped and inset so the menu cannot end up wider than the 360px popover
+          it belongs to — it was overlaying three rows of the inbox behind it. */}
+      <DropdownMenuContent align="end" sideOffset={4} className="max-w-[280px]">
         {supportsSnooze &&
           (isSnoozed ? (
             <DropdownMenuItem
@@ -599,8 +667,10 @@ function RowOptionsMenu({
               });
             }}
           >
-            Silence {EVENT_KIND_LABEL[eventKind]}
-            {entry.context?.projectId && eventKind !== "uiFeedback" ? " from this project" : ""}
+            <span className="ml-[1.375rem]">
+              Silence {EVENT_KIND_LABEL[eventKind]}
+              {entry.context?.projectId && eventKind !== "uiFeedback" ? " from this project" : ""}
+            </span>
           </DropdownMenuItem>
         )}
         {entry.context?.projectId && (
@@ -611,7 +681,7 @@ function RowOptionsMenu({
               void actionService.dispatch("project.muteNotifications", { projectId });
             }}
           >
-            Mute project notifications
+            <span className="ml-[1.375rem]">Mute project notifications</span>
           </DropdownMenuItem>
         )}
       </DropdownMenuContent>

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -224,6 +224,90 @@ export function NotificationCenterEntry({
         <Icon className="h-4 w-4" />
       </div>
       <div className="flex-1 min-w-0">
+        {/* One stable rail, floated rather than a flex sibling.
+
+            The old build cross-faded the metadata out and covered it with an
+            absolutely positioned layer carrying its own `bg-overlay-raised`
+            fill, so time — the orientation cue the inbox exists to provide —
+            vanished at exactly the moment the user was inspecting the row, and
+            on the Snoozed tab took the snooze state with it. It was also the
+            only metadata-covering action layer in the app; every other row here
+            reserves a stable box instead. So now nothing moves and nothing is
+            covered: the controls hold their place at every state, quiet at rest
+            and stronger under the pointer, which is the "quiet at rest,
+            stronger on hover" treatment the worktree card's action toolbar
+            already uses here. Keeping them in flow is also what makes them
+            reachable on a touch screen, where there is no hover to reveal
+            anything.
+
+            Float, not a flex sibling, because a sibling subtracts its width
+            from *every* line of the row rather than the one it sits on. At its
+            widest the rail is about 138px of a 360px popover, so as a sibling
+            it pushed the default message from two lines to three and the dense
+            one from four to six. Floated, the title shrinks beside it (the
+            title's `truncate` gives it its own formatting context, so it clears
+            the float rather than running under), the first message line wraps
+            around it, and every line below reclaims the full width. */}
+        <div className="float-right ml-2 mt-0.5 flex items-center gap-1.5">
+          {isSnoozed && snoozedUntil !== undefined && (
+            <>
+              <span
+                data-testid="notification-snoozed-indicator"
+                title={`Snoozed until ${formatSnoozedUntil(snoozedUntil)}`}
+                aria-label={`Snoozed until ${formatSnoozedUntil(snoozedUntil)}`}
+                className="inline-flex h-4 w-4 items-center justify-center text-text-secondary"
+              >
+                <Clock className="h-3 w-3" aria-hidden="true" />
+              </span>
+              {/* The clock means "snoozed until later"; the stamp beside it means
+                  "arrived at". Abutting they read as one fact, so they get a
+                  separator. */}
+              <span aria-hidden="true" className="text-[10px] leading-none text-text-secondary">
+                ·
+              </span>
+            </>
+          )}
+          {(() => {
+            const ts = formatNotificationTimestamp(entry.timestamp);
+            return (
+              <span
+                data-testid="notification-timestamp"
+                title={ts.absolute}
+                aria-label={ts.absolute}
+                // A solid token, not `text-daintree-text/40`: slash-alpha
+                // composites against whatever is behind it and read at ~3.2:1
+                // here. `theme-tokens.md` gates `text-secondary` at >=3:1 across
+                // every theme and prefers a solid token for exactly this.
+                className="text-[10px] text-text-secondary tabular-nums"
+              >
+                {ts.label}
+              </span>
+            );
+          })()}
+          <RowOptionsMenu
+            entry={entry}
+            onDropdownOpenChange={onDropdownOpenChange}
+            isSnoozePending={isSnoozePending}
+            isSnoozed={isSnoozed}
+            snoozedUntil={snoozedUntil}
+            onConsumeSnoozePending={onConsumeSnoozePending}
+            onSnooze={onSnooze}
+            onUnsnooze={onUnsnooze}
+          />
+          {onDismiss && (
+            <button
+              type="button"
+              aria-label="Dismiss notification"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDismiss();
+              }}
+              className={ROW_CONTROL_CLASS}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
         {entry.title && (
           <div className="flex items-center gap-1.5">
             <p
@@ -314,80 +398,6 @@ export function NotificationCenterEntry({
               );
             })}
           </div>
-        )}
-      </div>
-      {/* One stable rail. The previous build cross-faded the metadata out and
-          covered it with an absolutely positioned layer carrying its own
-          `bg-overlay-raised` fill, which meant time — the orientation cue the
-          inbox exists to provide — vanished at exactly the moment the user was
-          inspecting the row, and on the Snoozed tab took the snooze state with
-          it. It was also the only metadata-covering action layer in the app;
-          every other row here reserves a stable box instead.
-
-          So: nothing moves and nothing is covered. The controls hold their
-          place in flow at every state, quiet at rest and stronger under the
-          pointer — the "quiet at rest, stronger on hover" treatment this repo
-          already uses on the worktree card's action toolbar. Keeping them
-          visible is also what makes them reachable at all on a touch screen,
-          where there is no hover to reveal anything. */}
-      <div className="shrink-0 self-start mt-0.5 flex items-center gap-1.5">
-        {isSnoozed && snoozedUntil !== undefined && (
-          <>
-            <span
-              data-testid="notification-snoozed-indicator"
-              title={`Snoozed until ${formatSnoozedUntil(snoozedUntil)}`}
-              aria-label={`Snoozed until ${formatSnoozedUntil(snoozedUntil)}`}
-              className="inline-flex h-4 w-4 items-center justify-center text-text-secondary"
-            >
-              <Clock className="h-3 w-3" aria-hidden="true" />
-            </span>
-            {/* The clock means "snoozed until later"; the stamp beside it means
-                "arrived at". Abutting they read as one fact, so they get a
-                separator. */}
-            <span aria-hidden="true" className="text-[10px] leading-none text-text-secondary">
-              ·
-            </span>
-          </>
-        )}
-        {(() => {
-          const ts = formatNotificationTimestamp(entry.timestamp);
-          return (
-            <span
-              data-testid="notification-timestamp"
-              title={ts.absolute}
-              aria-label={ts.absolute}
-              // A solid token, not `text-daintree-text/40`: slash-alpha
-              // composites against whatever is behind it and read at ~3.2:1
-              // here. `theme-tokens.md` gates `text-secondary` at >=3:1 across
-              // every theme and prefers a solid token for exactly this.
-              className="text-[10px] text-text-secondary tabular-nums"
-            >
-              {ts.label}
-            </span>
-          );
-        })()}
-        <RowOptionsMenu
-          entry={entry}
-          onDropdownOpenChange={onDropdownOpenChange}
-          isSnoozePending={isSnoozePending}
-          isSnoozed={isSnoozed}
-          snoozedUntil={snoozedUntil}
-          onConsumeSnoozePending={onConsumeSnoozePending}
-          onSnooze={onSnooze}
-          onUnsnooze={onUnsnooze}
-        />
-        {onDismiss && (
-          <button
-            type="button"
-            aria-label="Dismiss notification"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDismiss();
-            }}
-            className={ROW_CONTROL_CLASS}
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
         )}
       </div>
     </div>

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
+import { PALETTE_ROW_FOCUS_CLASS } from "@/components/ui/paletteRowStyles";
 import { NotificationCenterEntry } from "../NotificationCenterEntry";
 
 const dispatchMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
@@ -518,35 +519,138 @@ describe("NotificationCenterEntry roving focus props", () => {
     expect(onFocus).toHaveBeenCalledTimes(1);
   });
 
-  it("adds focus-visible ring classes only when tabIndex is set", () => {
+  it("applies a keyboard-focus treatment only when tabIndex is set", () => {
     const { container, rerender } = render(<NotificationCenterEntry entry={makeEntry()} />);
-    expect((container.firstElementChild as HTMLElement).className).not.toMatch(
-      /focus-visible:ring/
-    );
+    const focusClasses = () => (container.firstElementChild as HTMLElement).className;
+    expect(focusClasses()).not.toMatch(/focus-visible:/);
 
     rerender(<NotificationCenterEntry entry={makeEntry()} tabIndex={0} />);
-    expect((container.firstElementChild as HTMLElement).className).toMatch(/focus-visible:ring/);
+    // Every focus utility the shared palette-row treatment contributes must
+    // survive onto the row. Checked token-by-token rather than as one string
+    // because `cn()` runs tailwind-merge, which folds the constant's bare
+    // `focus-visible:outline` into its `focus-visible:outline-2` sibling — the
+    // width utility carries `outline-style: var(--tw-outline-style)`, whose
+    // registered initial value is `solid`, so the ring still paints.
+    const survivors = PALETTE_ROW_FOCUS_CLASS.split(/\s+/).filter(
+      (token) => token !== "focus-visible:outline"
+    );
+    for (const token of survivors) {
+      expect(focusClasses()).toContain(token);
+    }
   });
 
-  it("reveals the action layer on keyboard focus of the row or a descendant", () => {
-    render(<NotificationCenterEntry entry={makeEntry()} onDismiss={vi.fn()} />);
-    // Visibility is owned by the action-layer wrapper (the dismiss button's parent),
-    // not the buttons themselves.
-    const actionLayer = screen.getByLabelText("Dismiss notification").parentElement as HTMLElement;
-    // Row-focus path: the row is the `group`, so `group-focus-visible` must be present.
-    expect(actionLayer.className).toMatch(/group-focus-visible:opacity-100/);
-    expect(actionLayer.className).toMatch(/group-focus-visible:pointer-events-auto/);
-    // Descendant-focus path (focus lands on a button inside the row).
-    expect(actionLayer.className).toMatch(/group-has-\[:focus-visible\]:opacity-100/);
-    expect(actionLayer.className).toMatch(/group-has-\[:focus-visible\]:pointer-events-auto/);
-    expect(actionLayer.className).not.toMatch(/group-focus-within:opacity-100/);
+  it("uses an outline rather than a box-shadow ring for keyboard focus", () => {
+    // The rule, not the value: `outline` is the only focus primitive that
+    // survives Windows High Contrast, where box-shadow is forced to `none`.
+    const { container } = render(<NotificationCenterEntry entry={makeEntry()} tabIndex={0} />);
+    const className = (container.firstElementChild as HTMLElement).className;
+    expect(className).toMatch(/focus-visible:outline/);
+    expect(className).not.toMatch(/focus-visible:ring-/);
   });
 
-  it("keeps the action layer revealed while the kebab dropdown is open", () => {
-    render(<NotificationCenterEntry entry={makeEntry({ context: { projectId: "p1" } })} />);
-    const actionLayer = screen.getByLabelText("Notification options").parentElement as HTMLElement;
-    expect(actionLayer.className).toMatch(/group-has-\[\[data-state=open\]\]:opacity-100/);
-    expect(actionLayer.className).toMatch(/group-has-\[\[data-state=open\]\]:pointer-events-auto/);
+  it("keeps the timestamp rendered in every interaction state", () => {
+    // The defect this replaced: the trailing region cross-faded the timestamp
+    // out and covered it with an absolutely positioned action layer, so time —
+    // the reason the inbox is the durable surface — disappeared exactly when a
+    // row was being inspected. The invariant is that no interaction state may
+    // remove or occlude it, so no class on the timestamp or any ancestor
+    // between it and the row may be conditional on hover, focus or menu state.
+    const { container } = render(
+      <NotificationCenterEntry
+        entry={makeEntry({ context: { projectId: "p1" } })}
+        onDismiss={vi.fn()}
+        tabIndex={0}
+      />
+    );
+    const row = container.firstElementChild as HTMLElement;
+    const timestamp = screen.getByTestId("notification-timestamp");
+    expect(row.contains(timestamp)).toBe(true);
+
+    const stateVariant = /(?:^|:)(?:group-)?(?:hover|focus-visible|has-\[)/;
+    for (let el: HTMLElement | null = timestamp; el && el !== row; el = el.parentElement) {
+      const conditional = el.className
+        .split(/\s+/)
+        .filter((c) => stateVariant.test(c) && /opacity|hidden|invisible/.test(c));
+      expect(conditional).toEqual([]);
+    }
+  });
+
+  it("keeps the snooze indicator rendered alongside the timestamp, not behind it", () => {
+    const { container } = render(
+      <NotificationCenterEntry
+        entry={makeEntry()}
+        isSnoozed
+        snoozedUntil={Date.now() + 3_600_000}
+        onDismiss={vi.fn()}
+      />
+    );
+    const row = container.firstElementChild as HTMLElement;
+    const indicator = screen.getByTestId("notification-snoozed-indicator");
+    const timestamp = screen.getByTestId("notification-timestamp");
+    expect(row.contains(indicator)).toBe(true);
+    // Siblings in one rail — if either ends up in a separately-revealed layer
+    // they stop sharing a parent, which is how the snooze state used to vanish
+    // on the one tab that exists to show it.
+    expect(indicator.parentElement).toBe(timestamp.parentElement);
+  });
+
+  it("keeps the management controls operable without hover", () => {
+    // There is no hover on a touch screen, and this repo has no
+    // `(pointer: coarse)` branch anywhere, so a control that is only reachable
+    // through a hover-gated layer is not reachable at all for those users.
+    // Nothing between a control and the row may gate pointer-events on hover.
+    const { container } = render(
+      <NotificationCenterEntry
+        entry={makeEntry({ context: { projectId: "p1" } })}
+        onDismiss={vi.fn()}
+      />
+    );
+    const row = container.firstElementChild as HTMLElement;
+    for (const label of ["Dismiss notification", "Notification options"]) {
+      const control = screen.getByLabelText(label);
+      for (let el: HTMLElement | null = control; el && el !== row; el = el.parentElement) {
+        expect(el.className).not.toMatch(/pointer-events-none/);
+        expect(el.className).not.toMatch(/(?:group-)?hover:pointer-events-auto/);
+      }
+    }
+  });
+
+  it("gives both management controls the same hit target", () => {
+    // WCAG 2.2 SC 2.5.8 wants 24 CSS px. The pair used to be 16px boxes 6px
+    // apart, clearing neither the size rule nor its spacing exemption. The rule
+    // being pinned is that they match each other and the row's other control —
+    // divergence is how one of them silently shrinks again.
+    render(
+      <NotificationCenterEntry
+        entry={makeEntry({ context: { projectId: "p1" } })}
+        onDismiss={vi.fn()}
+      />
+    );
+    const boxOf = (label: string) =>
+      screen
+        .getByLabelText(label)
+        .className.split(/\s+/)
+        .filter((c) => /^h-\d|^w-\d/.test(c))
+        .sort();
+    expect(boxOf("Dismiss notification")).toEqual(boxOf("Notification options"));
+    expect(boxOf("Dismiss notification")).toEqual(["h-6", "w-6"]);
+  });
+
+  it("carries the forced-colors repaint handle on the unread dot", () => {
+    // forced-colors forces `background-color` to Canvas, which erased the dot.
+    // An unread row carries no border or tint by design and an untitled one has
+    // no title to embolden, so the dot was the entire signal. The repaint rule
+    // itself lives in index.css and is pinned by the forced-colors contract
+    // suite; what this asserts is that the handle it targets is still here.
+    const { container } = render(<NotificationCenterEntry entry={makeEntry()} isNew />);
+    const dot = container.querySelector('[data-notification-unread="true"]');
+    expect(dot).not.toBeNull();
+    expect(container.querySelectorAll('[data-notification-unread="true"]')).toHaveLength(1);
+  });
+
+  it("carries the forced-colors repaint handle on the thread-count chip", () => {
+    render(<NotificationCenterEntry entry={makeEntry()} threadCount={3} />);
+    expect(screen.getByLabelText(/3/).getAttribute("data-notification-count")).toBe("true");
   });
 
   it("invokes onDropdownOpenChange when the kebab menu opens and closes", async () => {

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -650,7 +650,10 @@ describe("NotificationCenterEntry roving focus props", () => {
 
   it("carries the forced-colors repaint handle on the thread-count chip", () => {
     render(<NotificationCenterEntry entry={makeEntry()} threadCount={3} />);
-    expect(screen.getByLabelText(/3/).getAttribute("data-notification-count")).toBe("true");
+    // Exact label, not /3/: the timestamp's aria-label is an absolute datetime,
+    // so a loose match also hits it whenever the wall clock happens to contain
+    // the digit — a test that only fails for part of the day.
+    expect(screen.getByLabelText("3 events").getAttribute("data-notification-count")).toBe("true");
   });
 
   it("invokes onDropdownOpenChange when the kebab menu opens and closes", async () => {

--- a/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
+++ b/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
@@ -61,6 +61,30 @@ describe("forced-colors status-indicator contract (#8936)", () => {
     );
   });
 
+  // #11988: the notification inbox row's unread dot and thread-count chip are
+  // both solid backgrounds, so forced colors pushed them to Canvas. The dot is
+  // the more serious of the two — an unread row deliberately carries no border
+  // and no background tint, and an untitled one has no title to embolden, so
+  // losing the dot left that row with no unread indication at all.
+  it("index.css repaints the inbox unread dot with CanvasText !important", () => {
+    const block = readForcedColorsBlocks(INDEX_CSS);
+    expect(block).toContain('[data-notification-unread="true"]');
+    // !important for the same reason ActivityLight needs it: it has to beat the
+    // background-color the UA otherwise forces to Canvas.
+    expect(block).toMatch(
+      /\[data-notification-unread="true"\]\s*\{[^}]*background-color:\s*CanvasText[^}]*!important/
+    );
+  });
+
+  it("index.css gives the inbox thread-count chip a border in forced colors", () => {
+    const block = readForcedColorsBlocks(INDEX_CSS);
+    expect(block).toContain('[data-notification-count="true"]');
+    // A border, not a background: borders survive the override, backgrounds do
+    // not. Without it the count renders as a bare numeral running on from the
+    // title instead of as a chip.
+    expect(block).toMatch(/\[data-notification-count="true"\]\s*\{[^}]*border:[^}]*CanvasText/);
+  });
+
   it("index.css gives the checked SettingsSwitch track a Highlight fill", () => {
     const block = readForcedColorsBlocks(INDEX_CSS);
     expect(block).toContain('[role="switch"][data-state="checked"]');

--- a/src/index.css
+++ b/src/index.css
@@ -2854,6 +2854,26 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     background-color: CanvasText !important;
   }
 
+  /* Inbox unread dot. Same problem, same fix: the dot is a solid background, so
+     forced colors pushes it to Canvas and it vanishes. It is load-bearing here
+     in a way it is not elsewhere — an unread inbox row deliberately carries no
+     border and no background tint (weight on the title is the only companion
+     signal), and an untitled row has no title to embolden, so losing the dot
+     leaves that row with no unread indication at all. CanvasText, not
+     Highlight: this block already spends Highlight on `*:focus-visible`, and a
+     row can be both unread and focused. */
+  [data-notification-unread="true"] {
+    background-color: CanvasText !important;
+  }
+
+  /* Inbox thread-count chip. The tint fill is forced to Canvas, which strips the
+     pill and leaves a bare numeral running on from the title — "Push rejected 3"
+     reads as the title rather than as a count of three grouped events. Borders
+     survive the override, so give it one. */
+  [data-notification-count="true"] {
+    border: 1px solid CanvasText;
+  }
+
   /* Project-switcher row marks. The solid states are a CSS background, which
      forced colors pushes toward Canvas, so the whole 8px slot would read as
      empty. Repaint them as a CanvasText disc: hue is gone here either way, and

--- a/src/lib/e2eNotificationBackdoor.ts
+++ b/src/lib/e2eNotificationBackdoor.ts
@@ -13,7 +13,10 @@ import {
   type NotificationPriority,
   type NotificationPlacement,
 } from "@/store/notificationStore";
-import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import {
+  useNotificationHistoryStore,
+  type NotificationHistoryEntry,
+} from "@/store/slices/notificationHistorySlice";
 import {
   _setQuietUntil,
   _resetRateLimitBuckets,
@@ -55,6 +58,12 @@ export interface E2EHistoryInput {
   seenAsToast?: boolean;
 }
 
+export interface E2ESeedHistoryInput {
+  entries: NotificationHistoryEntry[];
+  /** `correlationId` → expiry epoch-ms. Defaults to no snoozed threads. */
+  snoozedThreads?: Record<string, number>;
+}
+
 export interface NotificationsE2EApi {
   readonly MAX_VISIBLE_TOASTS: number;
   readonly GRID_BAR_DWELL_FLOOR_MS: number;
@@ -63,6 +72,14 @@ export interface NotificationsE2EApi {
   backdateNotification: (id: string, firstShownAt: number) => void;
   resetToasts: () => void;
   addHistoryEntry: (input: E2EHistoryInput) => string;
+  /**
+   * Replaces the whole history store contents in one write. Unlike
+   * `addHistoryEntry` this accepts the full persisted entry shape —
+   * timestamps, actions, context, archived/snoozed state — so a capture or
+   * regression fixture can pin states that `addEntry` derives from the clock
+   * (relative-time labels) or never sets at all (row actions, panel context).
+   */
+  seedHistory: (input: E2ESeedHistoryInput) => void;
   archiveHistoryEntry: (id: string) => void;
   snoozeThread: (correlationId: string, snoozedUntil: number) => void;
   clearHistory: () => void;
@@ -114,6 +131,16 @@ function buildApi(): NotificationsE2EApi {
         correlationId: input.correlationId,
         seenAsToast: input.seenAsToast ?? false,
       }),
+    seedHistory: ({ entries, snoozedThreads = {} }) => {
+      const unreadCount = entries.filter(
+        (e) =>
+          !e.seenAsToast &&
+          e.countable !== false &&
+          !e.archivedAt &&
+          !(e.correlationId && (snoozedThreads[e.correlationId] ?? 0) > Date.now())
+      ).length;
+      useNotificationHistoryStore.setState({ entries, snoozedThreads, unreadCount });
+    },
     archiveHistoryEntry: (id) => useNotificationHistoryStore.getState().archiveEntry(id),
     snoozeThread: (correlationId, snoozedUntil) =>
       useNotificationHistoryStore.getState().snoozeThread(correlationId, snoozedUntil),


### PR DESCRIPTION
## Summary

The inbox row's trailing area swapped information for controls. At rest it showed the timestamp and snooze state; on hover, row focus, descendant focus or an open menu, an absolutely positioned layer with its own `bg-overlay-raised` fill faded in over the same area and hid both.

A survey of the renderer found it was the only metadata-covering action layer in the app. Roughly thirty other row components reveal trailing controls by keeping their layout box, and not one of them covers anything.

It is now a single stable rail placed by CSS grid. Nothing moves and nothing is covered.

Resolves #11988

## What changed

**The trailing rail.** The `relative` wrapper, the fading metadata layer and the `absolute inset-y-0 right-0` action layer are gone. Snooze indicator, timestamp and both management controls now sit in one rail that holds its place in every state. Because the controls no longer depend on hover, they exist on a touch screen, where there is nothing to hover.

Getting the rail there without taxing the row took two attempts, which is worth recording. As a flex sibling of the content column it subtracted its width from every line, not just the line it occupied, and cost the default message a line and the dense one two. A float fixed that but has to precede the content whose lines it shifts, which put the management controls ahead of the title, message and recovery actions in the DOM. Tabbing off the row reached Dismiss before "Pull and rebase". Explicit grid placement gets both: the rail is last in the DOM and reads last, but paints in row 1's trailing column.

**Target sizes.** Both controls go from 16px to 24px boxes with `h-3.5 w-3.5` glyphs, matching `toaster.tsx`, which renders this same notification content. Two 16px targets 6px apart cleared neither WCAG 2.2 SC 2.5.8 nor its spacing exemption. They also had no focus ring at all and now carry one.

**Forced colors.** The unread dot and the thread-count chip are both solid backgrounds, which the user agent forces to `Canvas`. The dot vanished completely, and since an unread row deliberately carries no border and no tint, an untitled one was left with no unread indication whatsoever. Both are repainted in the existing `@media (forced-colors: active)` block, the same way `ActivityLight` is handled.

**Contrast.** The primary contextual action inked its label from `status-info`, which `shared/theme/contrast.ts` gates at only 3:1. It measured 4.46:1 against its own fill while the secondary button beside it measured 7.6:1, so the button with primary chrome read as the weaker of the two, and `prefers-contrast: more` lifted the secondary and left it behind. Row metadata also moves off ad-hoc slash-alpha onto the contract-gated text tokens, which `docs/themes/theme-tokens.md` prefers for exactly this reason.

**Row treatments.** Hover is `hover:bg-overlay-subtle` and focus is the shared `PALETTE_ROW_FOCUS_CLASS`, applied to the grouped-thread wrapper as well since both are stops on the same roving-tabindex ring.

**The row menu** is bounded on both sides so it can no longer render wider than the 360px popover it belongs to, its two icon-less items line up with the rest, and the trigger shows a pressed state while the menu is open.

**Adjacent, outside the issue.** The header's filter chips move to their own row. Sharing a line with the toolbar squeezed them into about 120px, so all four wrapped onto three lines and ate a quarter of a 420px popover while roughly 230px sat empty beside them.

## Design review

Scored 6.4, then 8.5 over three rounds against a rubric covering hierarchy, scannability, consistency, typography, density, affordance, states, accessibility, microcopy and craft. Accessibility went 5.2 to 9.6, affordance 4.2 to 9.3, consistency 5.4 to 9.7.

Three of the reviewer's findings were rejected with evidence rather than applied. The needs-attention section duplicating rows into the chronological list is deliberate and asserted by `NotificationCenter.test.tsx`. What looked like an inconsistent severity rail is the thread rail working correctly. A missing scroll fade was my own capture harness zeroing transitions.

Two items are priced and left for you:

- **Per-row project and worktree identification, 0.5 points.** Two identical "Push rejected" rows are indistinguishable unless grouping happens to be on. Fixing it needs a display-ready context label on `NotificationHistoryEntry` and a value supplied at every `notify()` call site, which is a bigger change than this issue.
- **Dismiss semantics, 0.3 points.** The X calls `dismissEntry`, a hard delete, in all four tabs, while the `e` key archives in three of them. So the two agree only in Archived. The issue lists dismissal as unchanged, so spending that constraint is your call.

A consistency survey run against the changed code confirms every pattern this touches moved toward the app's conventions rather than away: the metadata-covering layer went from a population of one to zero, hover joined the 52-use `overlay-subtle` cluster, `PALETTE_ROW_FOCUS_CLASS` consumers went from one to three, and the control size joined the largest cluster. Nothing needs rolling out elsewhere.

## Separately

The archived-thread X routes through `dismissByCorrelationId` (`NotificationCenter.tsx:1407`), which destroys every entry sharing that `correlationId`, including live ones. That is the exact hazard the `e` handler's own comment warns about at `:667`. It is a data-loss bug rather than a design one, so it is not fixed here.

## Testing

`npm run check` and the full `vitest` suite, both green.

Seven new invariants, every one mutation-checked by reintroducing its bug and confirming the test failed. They assert rules rather than values: no element between the timestamp and the row may carry a hover-conditional opacity, no element between a control and the row may gate `pointer-events` on hover, the two controls must match each other's hit target, focus must use an outline rather than a box-shadow ring.

There is also a new opt-in capture harness at `e2e/screenshots/notification-entry-review.spec.ts`, covering rest, hover, keyboard focus, open menu, `prefers-contrast`, `forced-colors`, max density, archived and snoozed. It verifies every media override with `matchMedia` and measures the density row against the popover box before writing a PNG, because the first run produced three files byte-identical to the rest state while claiming to be focus, coarse-pointer and high-contrast, and nothing in the exit code said so.
