### PR TITLE
fix(review-hub): refine the readiness rail's ready and attention states

### DIFF
--- a/e2e/screenshots/readiness-rail-review.spec.ts
+++ b/e2e/screenshots/readiness-rail-review.spec.ts
@@ -299,11 +299,40 @@ const STATES: RailState[] = [
     arrange: async (page) => {
       // `:focus-visible` does not match a programmatic `.focus()` — the browser only
       // treats focus as keyboard-driven after a real key event. Land on the CTA, step
-      // off it, then Tab back so the ring the shot is meant to show actually paints.
+      // off it, then Tab forward until a real key event puts focus back on it.
       const cta = page.locator('[data-testid^="readiness-cta-"]').first();
       await cta.focus();
       await page.keyboard.press("Shift+Tab");
-      await page.keyboard.press("Tab");
+      for (let i = 0; i < 8; i++) {
+        await page.keyboard.press("Tab");
+        const state = await page.evaluate(() => {
+          const el = document.activeElement as HTMLElement | null;
+          return {
+            testid: el?.getAttribute("data-testid") ?? el?.tagName ?? "none",
+            visible: !!el?.matches(":focus-visible"),
+          };
+        });
+        if (state.testid.startsWith("readiness-cta-")) {
+          const computed = await page.evaluate(() => {
+            const el = document.activeElement as HTMLElement;
+            const cs = getComputedStyle(el);
+            return [cs.outlineStyle, cs.outlineWidth, cs.outlineColor, cs.outlineOffset].join("|");
+          });
+          console.log(
+            `[readiness-shots] focus landed on ${state.testid}, :focus-visible=${state.visible}, outline=${computed}`
+          );
+          if (!state.visible) throw new Error("CTA focused but :focus-visible did not match");
+          // A ring that resolves to `outline-style: none` is invisible however correct
+          // its colour and width look — that is exactly how Tailwind v4's
+          // `outline-hidden` silently cancels `focus-visible:outline-2`. Refuse to
+          // write a "focused" shot that shows no focus.
+          if (computed.startsWith("none")) {
+            throw new Error(`focus ring resolves to no outline: ${computed}`);
+          }
+          return;
+        }
+      }
+      throw new Error("could not Tab onto the rail CTA");
     },
   },
   {
@@ -317,9 +346,12 @@ const STATES: RailState[] = [
     capture: "page",
     arrange: async (page) => {
       await page.locator(OVERFLOW).click();
+      // The hub itself is a `role="dialog"` containing the leading condition, so wait
+      // on the trigger's own expanded state plus an item only the popover can hold.
       await page
-        .locator('[role="dialog"]:has([data-testid^="readiness-item-"])')
+        .locator(`${OVERFLOW}[aria-expanded="true"]`)
         .waitFor({ state: "visible", timeout: 5000 });
+      await page.locator(item("no-remote")).waitFor({ state: "visible", timeout: 5000 });
     },
     restore: async (page) => {
       await page.keyboard.press("Escape").catch(() => {});
@@ -391,14 +423,18 @@ async function stubStagingStatus(
   );
 }
 
+/* Generous, because this harness is routinely run on a machine with a dozen other
+   worktrees building at once; at load average 20+ the worktree card takes seconds to
+   paint and a tight timeout reports a layout regression that isn't one. */
 async function openHub(page: Page): Promise<void> {
   await dismissBlockingPalette(page);
+  await page.locator(SEL.worktree.mainCard).first().waitFor({ state: "visible", timeout: 30_000 });
   await page.locator(SEL.worktree.mainCard).first().hover();
   await settle(page, 250);
   const btn = page.locator(SEL.worktree.reviewHubButton).first();
-  await btn.waitFor({ state: "visible", timeout: 8000 });
+  await btn.waitFor({ state: "visible", timeout: 30_000 });
   await btn.click();
-  await page.locator(SEL.reviewHub.container).waitFor({ state: "visible", timeout: 15_000 });
+  await page.locator(SEL.reviewHub.container).waitFor({ state: "visible", timeout: 30_000 });
 }
 
 async function closeHub(page: Page): Promise<void> {

--- a/e2e/screenshots/readiness-rail-review.spec.ts
+++ b/e2e/screenshots/readiness-rail-review.spec.ts
@@ -1,0 +1,556 @@
+/**
+ * ReadinessRail visual-review harness (#11983).
+ *
+ * The rail is the compact merge-readiness strip between the Review Hub header and its
+ * review body. Its design question — is the *ready* state louder than it deserves, and
+ * does the *attention* state stay legible instead of becoming a status wall — can only be
+ * judged on rendered pixels, in situ, against the dense hub it sits inside.
+ *
+ * Every state is driven through the real data seam: `git:get-staging-status`, the same
+ * IPC handler `ReviewHubContent` already invokes. The stub returns a fabricated
+ * `StagingStatus`, `deriveReviewReadiness` runs for real on top of it, and the rail
+ * renders whatever that derivation produces. Nothing about the component or the
+ * derivation is mocked, so a shot is evidence about the shipping code path.
+ *
+ * The hub re-fetches on open, so each state closes and reopens the dialog rather than
+ * trying to poke a live one.
+ *
+ *   DAINTREE_SHOT_READINESS=1 npx playwright test --project=screenshots readiness-rail-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_READINESS  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME      optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG        optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY       comma-separated state filter (see STATES below)
+ *   DAINTREE_SHOT_DIR        output directory override
+ *   DAINTREE_SHOT_SWEEP      only capture the states marked `sweep` (theme sweep)
+ *
+ * Switching themes in place crashes the project view under this harness (same constraint
+ * as confirm-dialog-review), so a theme sweep boots once per theme:
+ *
+ *   for t in arashiyama atacama bali bondi daintree fiordland galapagos highlands \
+ *            hokkaido movile namib redwoods serengeti svalbard table-mountain; do
+ *     DAINTREE_SHOT_READINESS=1 DAINTREE_SHOT_SWEEP=1 DAINTREE_SHOT_THEME=$t \
+ *     npx playwright test --project=screenshots readiness-rail-review
+ *   done
+ *
+ * Output: artifacts/readiness-rail-shots/<slug>--<theme>[-tag].png (gitignored).
+ */
+
+import { test, expect, type Page, type ElectronApplication } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import type {
+  GitStatus,
+  StagingFileEntry,
+  StagingStatus,
+  ConflictedFileEntry,
+} from "../../shared/types/git";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_READINESS;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const THEME_SLUG = THEME || "default";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const SWEEP_ONLY = !!process.env.DAINTREE_SHOT_SWEEP;
+const OUTPUT_DIR = process.env.DAINTREE_SHOT_DIR
+  ? path.resolve(process.env.DAINTREE_SHOT_DIR)
+  : path.resolve(process.cwd(), "artifacts", "readiness-rail-shots");
+
+const STAGING_CHANNEL = "git:get-staging-status";
+const RAIL = '[data-testid="review-readiness-rail"]';
+const LEVEL = '[data-testid="review-readiness-level"]';
+const OVERFLOW = '[data-testid="review-readiness-overflow"]';
+const item = (id: string) => `[data-testid="readiness-item-${id}"]`;
+
+const WIDE = { width: 1680, height: 1050 };
+const NARROW = { width: 900, height: 900 };
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/** A repo with real uncommitted work, so the hub has a body under the rail. */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-readiness-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  writeFileSync(path.join(dir, "src", "index.ts"), "export const version = 1;\n");
+  writeFileSync(path.join(dir, "src", "checkout.ts"), "export function checkout() {}\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+
+  // Real dirt so the file sections below the rail are populated.
+  writeFileSync(
+    path.join(dir, "src", "index.ts"),
+    "export const version = 2;\nexport const b = 1;\n"
+  );
+  writeFileSync(
+    path.join(dir, "src", "checkout.ts"),
+    "export function checkout() {\n  return 1;\n}\n"
+  );
+  writeFileSync(path.join(dir, "src", "cart.ts"), "export function cart() {}\n");
+  git("add src/index.ts", dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function file(p: string, status: GitStatus = "modified"): StagingFileEntry {
+  return { path: p, status, insertions: 14, deletions: 3 };
+}
+
+function conflict(p: string): ConflictedFileEntry {
+  return { path: p, xy: "UU", label: "both modified" };
+}
+
+function status(over: Partial<StagingStatus> = {}): StagingStatus {
+  const branch = over.currentBranch === undefined ? "feature/checkout-retry" : over.currentBranch;
+  return {
+    staged: [],
+    unstaged: [],
+    conflicted: [],
+    conflictedFiles: [],
+    isDetachedHead: false,
+    currentBranch: branch,
+    hasRemote: true,
+    pushDestination: branch ? { remote: "origin", branch } : null,
+    pullSource: branch ? { remote: "origin", branch } : null,
+    repoState: "CLEAN",
+    rebaseStep: null,
+    rebaseTotalSteps: null,
+    rebaseSequence: null,
+    ...over,
+  };
+}
+
+const SRC = [file("src/checkout.ts"), file("src/cart.ts"), file("src/index.ts")];
+const GENERATED = [
+  file("package-lock.json"),
+  file("dist/bundle.min.js"),
+  file("src/api.generated.ts"),
+];
+
+interface RailState {
+  slug: string;
+  /** `"pending"` never resolves, which is how the hub's real "status unknown" looks. */
+  status: StagingStatus | "pending";
+  /** `null` asserts the rail is absent. */
+  level: "ready" | "needs-review" | "blocked" | null;
+  items?: string[];
+  overflow?: boolean;
+  /** Included in the per-theme sweep. */
+  sweep?: boolean;
+  /**
+   * `"page"` shoots the whole window and skips the rail crop — the disclosure
+   * popover is portalled outside the dialog, so a container-scoped shot would
+   * frame it out entirely.
+   */
+  capture?: "hub" | "page";
+  /** Runs after the state renders and before the shot. */
+  arrange?: (page: Page, app: ElectronApplication) => Promise<void>;
+  /** Runs after the shot, whether or not it succeeded. */
+  restore?: (page: Page, app: ElectronApplication) => Promise<void>;
+}
+
+async function setWindowSize(
+  app: ElectronApplication,
+  size: { width: number; height: number }
+): Promise<void> {
+  await app.evaluate(({ BrowserWindow }, s) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    win?.setSize(s.width, s.height);
+  }, size);
+}
+
+const STATES: RailState[] = [
+  {
+    // Staging status has not resolved. The rail must render nothing at all rather
+    // than a placeholder — this shot is the proof.
+    slug: "01-unknown",
+    status: "pending",
+    level: null,
+  },
+  {
+    // The state the issue is about: a clean worktree, nothing to do, and a full-width
+    // green band saying so.
+    slug: "02-ready-clean",
+    status: status(),
+    // Nothing to report: the strip must not render at all.
+    level: null,
+    sweep: true,
+  },
+  {
+    slug: "03-ready-info",
+    status: status({ staged: SRC }),
+    level: "ready",
+    items: ["pr-missing"],
+    // The lone info IS the leading condition, so there is nothing to disclose.
+  },
+  {
+    slug: "04-attention-single",
+    status: status({ unstaged: SRC }),
+    level: "needs-review",
+    items: ["nothing-staged"],
+    overflow: true,
+  },
+  {
+    slug: "05-attention-multi",
+    status: status({ unstaged: GENERATED }),
+    level: "needs-review",
+    items: ["generated-only"],
+    overflow: true,
+    sweep: true,
+  },
+  {
+    slug: "06-blocked-conflicts",
+    status: status({
+      repoState: "DIRTY",
+      staged: [file("src/index.ts")],
+      unstaged: [file("src/cart.ts")],
+      conflicted: ["src/checkout.ts", "src/api.ts", "src/router.ts"],
+      conflictedFiles: [
+        conflict("src/checkout.ts"),
+        conflict("src/api.ts"),
+        conflict("src/router.ts"),
+      ],
+    }),
+    level: "blocked",
+    items: ["conflicts"],
+    overflow: true,
+    sweep: true,
+  },
+  {
+    // A blocker with no safe action — the rail has to read well without a CTA.
+    slug: "07-blocked-rebase",
+    status: status({
+      repoState: "REBASING",
+      rebaseStep: 2,
+      rebaseTotalSteps: 5,
+      staged: [file("src/index.ts")],
+      conflicted: ["src/checkout.ts", "src/api.ts"],
+      conflictedFiles: [conflict("src/checkout.ts"), conflict("src/api.ts")],
+    }),
+    level: "blocked",
+    items: ["operation-in-progress"],
+    overflow: true,
+  },
+  {
+    slug: "08-blocked-detached",
+    status: status({ currentBranch: null, isDetachedHead: true, staged: SRC.slice(0, 2) }),
+    level: "blocked",
+    items: ["detached-head"],
+    overflow: true,
+  },
+  {
+    // Four items: past MAX_VISIBLE_ITEMS, so the "+N more" affordance is on screen.
+    slug: "09-overflow",
+    status: status({ currentBranch: "main", unstaged: GENERATED }),
+    level: "needs-review",
+    items: ["generated-only"],
+    overflow: true,
+  },
+  {
+    // Four conditions, every one carrying a detail — the case that used to wrap the
+    // strip onto a second line at full width.
+    slug: "10-dense",
+    status: status({ currentBranch: "main", hasRemote: false, unstaged: GENERATED }),
+    level: "needs-review",
+    items: ["generated-only"],
+    overflow: true,
+  },
+  {
+    // Keyboard affordance: the CTA's focus ring, which is the only way a keyboard
+    // user can tell the rail is interactive at all.
+    slug: "11-cta-focus",
+    status: status({ unstaged: SRC }),
+    level: "needs-review",
+    items: ["nothing-staged"],
+    overflow: true,
+    arrange: async (page) => {
+      // `:focus-visible` does not match a programmatic `.focus()` — the browser only
+      // treats focus as keyboard-driven after a real key event. Land on the CTA, step
+      // off it, then Tab back so the ring the shot is meant to show actually paints.
+      const cta = page.locator('[data-testid^="readiness-cta-"]').first();
+      await cta.focus();
+      await page.keyboard.press("Shift+Tab");
+      await page.keyboard.press("Tab");
+    },
+  },
+  {
+    // The disclosure open: every remaining condition, its detail, and its action —
+    // the surface that replaced a `title` attribute nobody could open.
+    slug: "15-disclosure-open",
+    status: status({ currentBranch: "main", hasRemote: false, unstaged: GENERATED }),
+    level: "needs-review",
+    items: ["generated-only"],
+    overflow: true,
+    capture: "page",
+    arrange: async (page) => {
+      await page.locator(OVERFLOW).click();
+      await page
+        .locator('[role="dialog"]:has([data-testid^="readiness-item-"])')
+        .waitFor({ state: "visible", timeout: 5000 });
+    },
+    restore: async (page) => {
+      await page.keyboard.press("Escape").catch(() => {});
+    },
+  },
+  {
+    slug: "12-forced-colors",
+    status: status({ currentBranch: "main", hasRemote: false, unstaged: GENERATED }),
+    level: "needs-review",
+    items: ["generated-only"],
+    overflow: true,
+    arrange: async (page) => {
+      await page.emulateMedia({ forcedColors: "active" });
+    },
+    restore: async (page) => {
+      await page.emulateMedia({ forcedColors: "none" });
+    },
+  },
+  {
+    slug: "13-contrast-more",
+    status: status({ currentBranch: "main", hasRemote: false, unstaged: GENERATED }),
+    level: "needs-review",
+    items: ["generated-only"],
+    overflow: true,
+    arrange: async (page) => {
+      await page.emulateMedia({ contrast: "more" });
+    },
+    restore: async (page) => {
+      await page.emulateMedia({ contrast: "no-preference" });
+    },
+  },
+  {
+    // Narrow pane: does the rail wrap into a multi-line wall and shove the review
+    // body down the screen?
+    slug: "14-narrow",
+    status: status({ currentBranch: "main", hasRemote: false, unstaged: GENERATED }),
+    level: "needs-review",
+    items: ["generated-only"],
+    overflow: true,
+    arrange: async (_page, app) => setWindowSize(app, NARROW),
+    restore: async (_page, app) => setWindowSize(app, WIDE),
+  },
+];
+
+async function settle(page: Page, ms = 350): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Replace the staging-status handler. `"pending"` installs one that never settles,
+ * which is the only honest way to render the hub's pre-resolution state.
+ */
+async function stubStagingStatus(
+  app: ElectronApplication,
+  next: StagingStatus | "pending"
+): Promise<void> {
+  await app.evaluate(
+    ({ ipcMain }, { channel, response }) => {
+      ipcMain.removeHandler(channel);
+      ipcMain.handle(channel, async () => {
+        if (response === "pending") return new Promise(() => {});
+        return response;
+      });
+    },
+    { channel: STAGING_CHANNEL, response: next }
+  );
+}
+
+async function openHub(page: Page): Promise<void> {
+  await dismissBlockingPalette(page);
+  await page.locator(SEL.worktree.mainCard).first().hover();
+  await settle(page, 250);
+  const btn = page.locator(SEL.worktree.reviewHubButton).first();
+  await btn.waitFor({ state: "visible", timeout: 8000 });
+  await btn.click();
+  await page.locator(SEL.reviewHub.container).waitFor({ state: "visible", timeout: 15_000 });
+}
+
+async function closeHub(page: Page): Promise<void> {
+  await page
+    .locator(SEL.reviewHub.close)
+    .click()
+    .catch(() => {});
+  await page
+    .locator(SEL.reviewHub.container)
+    .waitFor({ state: "hidden", timeout: 8000 })
+    .catch(() => {});
+  await settle(page, 200);
+}
+
+/**
+ * Verify AFTER the settle and BEFORE the shot. A state that did not render must throw
+ * rather than write a plausible-looking PNG of the wrong screen — a wrong artifact sends
+ * the whole review off reasoning about a surface that does not exist.
+ */
+async function verify(page: Page, state: RailState): Promise<void> {
+  await expect(
+    page.locator(SEL.reviewHub.container),
+    `${state.slug}: review hub did not open`
+  ).toBeVisible({ timeout: 10_000 });
+
+  if (state.level === null) {
+    await expect(
+      page.locator(RAIL),
+      `${state.slug}: expected no rail, but one rendered`
+    ).toHaveCount(0, { timeout: 8000 });
+    return;
+  }
+
+  await expect(page.locator(LEVEL), `${state.slug}: readiness level chip missing`).toHaveAttribute(
+    "data-level",
+    state.level,
+    { timeout: 10_000 }
+  );
+
+  for (const id of state.items ?? []) {
+    await expect(
+      page.locator(item(id)),
+      `${state.slug}: expected readiness item "${id}" to render`
+    ).toBeVisible({ timeout: 8000 });
+  }
+
+  if (state.overflow) {
+    await expect(
+      page.locator(OVERFLOW),
+      `${state.slug}: expected the "+N more" overflow affordance`
+    ).toBeVisible({ timeout: 8000 });
+  }
+}
+
+async function snap(page: Page, slug: string, locator: string | null): Promise<void> {
+  const target = locator === null ? page : page.locator(locator).first();
+  await target.screenshot({
+    path: path.join(OUTPUT_DIR, `${slug}--${THEME_SLUG}${TAG}.png`),
+    type: "png",
+    animations: "disabled",
+    caret: "hide",
+  });
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+/* A failed state must not abort the run — the rest are still worth having, and a
+   fifteen-theme sweep shouldn't lose fourteen themes to one bad selector. But the run
+   must still FAIL: a silent exit 0 over an empty output directory reads as success. */
+const failures: string[] = [];
+let captured = 0;
+
+test("readiness rail review — ready, attention and blocked states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_READINESS is required for the readiness-rail capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_READINESS to run the readiness-rail capture");
+
+  failures.length = 0;
+  captured = 0;
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-readinessshot-"));
+  let ctx: AppContext | undefined;
+
+  const planned = STATES.filter(
+    (s) => (ONLY.length === 0 || ONLY.includes(s.slug)) && (!SWEEP_ONLY || s.sweep)
+  );
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: WIDE,
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS });
+    await settle(page, 600);
+
+    for (const state of planned) {
+      const app = ctx.app;
+      try {
+        await closeHub(page);
+        await stubStagingStatus(app, state.status);
+        await openHub(page);
+        await settle(page, 700);
+        if (state.arrange) await state.arrange(page, app);
+        await settle(page, 450);
+
+        await verify(page, state);
+
+        if (state.capture === "page") {
+          await snap(page, `${state.slug}--page`, null);
+          captured++;
+        } else {
+          await snap(page, `${state.slug}--hub`, SEL.reviewHub.container);
+          captured++;
+          if (state.level !== null) {
+            await snap(page, `${state.slug}--rail`, RAIL);
+            captured++;
+          }
+        }
+      } catch (error) {
+        const detail = String(error).slice(0, 400);
+        console.warn(`[readiness-shots] state "${state.slug}" failed:`, detail);
+        failures.push(`${state.slug}: ${detail}`);
+      } finally {
+        if (state.restore) {
+          await state.restore(page, app).catch((error) => {
+            failures.push(`${state.slug} (restore): ${String(error).slice(0, 200)}`);
+          });
+        }
+      }
+    }
+  } finally {
+    if (ctx) await closeApp(ctx).catch(() => {});
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+
+  // The exit code is only meaningful if it accounts for what actually landed on disk.
+  const expected = planned.reduce(
+    (n, s) => n + (s.capture === "page" || s.level === null ? 1 : 2),
+    0
+  );
+  console.log(`[readiness-shots] ${captured}/${expected} PNGs → ${OUTPUT_DIR}`);
+  if (failures.length > 0) {
+    throw new Error(`readiness-rail capture failed:\n  ${failures.join("\n  ")}`);
+  }
+  expect(captured, `expected ${expected} PNGs, wrote ${captured}`).toBe(expected);
+});

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -905,7 +905,7 @@ export function BrowserToolbar({
                 "w-full pl-7 pr-2 py-1 text-xs rounded",
                 "bg-daintree-bg border border-overlay",
                 "focus:outline-hidden focus:border-border-strong",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+                "focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                 "text-daintree-text placeholder:text-text-placeholder",
                 error && "border-status-error/50"
               )}

--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -389,7 +389,7 @@ function TerminalRow({
         className={cn(
           "flex flex-1 items-start gap-2 pl-5 pr-2 py-1.5 rounded text-[13px] text-daintree-text cursor-pointer outline-hidden",
           "hover:bg-tint/[0.06]",
-          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+          "focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
         )}
         onClick={handleClick}
         data-testid={`${testIdPrefix}-row-${terminal.id}`}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1932,7 +1932,7 @@ export function Toolbar({
       <TooltipTrigger asChild>
         <button
           data-toolbar-item=""
-          className="toolbar-project-pill app-no-drag pointer-events-auto flex h-9 min-w-0 max-w-full items-center justify-center gap-2 overflow-hidden border px-3 outline-hidden focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          className="toolbar-project-pill app-no-drag pointer-events-auto flex h-9 min-w-0 max-w-full items-center justify-center gap-2 overflow-hidden border px-3 outline-hidden focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
           data-testid="project-switcher-trigger"
           aria-label={workspaceIdentity.ariaLabel}
           role={workspaceIdentity.kind !== "none" ? "combobox" : undefined}

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -345,7 +345,7 @@ function WaitingSingleItem({
         }
       }}
       className={cn(
-        "flex items-center gap-2 px-3 py-2.5 hover:bg-muted/50 focus:bg-muted/50 focus-visible:outline-2 focus-visible:outline-daintree-accent outline-hidden transition-colors group/row cursor-pointer w-full select-none",
+        "flex items-center gap-2 px-3 py-2.5 hover:bg-muted/50 focus:bg-muted/50 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent outline-hidden transition-colors group/row cursor-pointer w-full select-none",
         compact && "py-1.5 pl-1.5"
       )}
       aria-label={

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1553,7 +1553,7 @@ function ScratchNameEditor({
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
         onBlur={onCancel}
-        className="flex-1 min-w-0 bg-overlay-soft border border-[var(--border-overlay)] rounded-[var(--radius-md)] px-2 py-1 text-sm text-daintree-text outline-hidden focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+        className="flex-1 min-w-0 bg-overlay-soft border border-[var(--border-overlay)] rounded-[var(--radius-md)] px-2 py-1 text-sm text-daintree-text outline-hidden focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
       />
     </div>
   );

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -87,7 +87,7 @@ export function HostCrashBanner() {
       className={cn(
         "flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded transition-colors",
         "text-daintree-text/70 hover:text-daintree-text hover:bg-daintree-border/50",
-        "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
+        "outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
         isCollectingDiagnostics && "cursor-not-allowed opacity-60 hover:bg-transparent"
       )}
     >

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -233,7 +233,7 @@ export function DeletedWorktreeCard({
         // contract), this card has no focusable parent row owning keyboard
         // nav — the overlay button IS the keyboard path, so it carries its
         // own inset focus ring.
-        className="absolute inset-0 z-0 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+        className="absolute inset-0 z-0 outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
         aria-label={`Select deleted worktree: ${worktree.title}`}
       />
       <div

--- a/src/components/Sidebar/DeletedWorktreeGroup.tsx
+++ b/src/components/Sidebar/DeletedWorktreeGroup.tsx
@@ -168,7 +168,7 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
           type="button"
           onClick={toggleExpanded}
           aria-expanded={isExpanded}
-          className="flex min-w-0 flex-1 items-center gap-1.5 rounded text-left outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded text-left outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
         >
           <ChevronRight
             data-animated-chevron

--- a/src/components/Terminal/BannerOverflowMenu.tsx
+++ b/src/components/Terminal/BannerOverflowMenu.tsx
@@ -32,7 +32,7 @@ export function BannerOverflowMenu({
         type="button"
         aria-label={ariaLabel}
         title="More options"
-        className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
+        className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
       >
         <MoreHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
       </PopoverTrigger>
@@ -54,7 +54,7 @@ export function BannerOverflowMenu({
               }}
               className={cn(
                 "flex items-center gap-2 w-full px-2 py-1.5 rounded text-left transition-colors",
-                "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-daintree-accent",
+                "outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-daintree-accent",
                 isDanger
                   ? "text-status-error hover:bg-status-error/10"
                   : "text-daintree-text hover:bg-daintree-border/50",

--- a/src/components/Terminal/DiagnosticCopyButton.tsx
+++ b/src/components/Terminal/DiagnosticCopyButton.tsx
@@ -88,7 +88,7 @@ export function DiagnosticCopyButton({ diagnostics, className }: DiagnosticCopyB
         type="button"
         onClick={handleClick}
         aria-label={copied ? "Diagnostics copied" : "Copy diagnostics"}
-        className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/40 rounded transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
+        className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/40 rounded transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
       >
         <Copy className="w-3 h-3" aria-hidden="true" />
         {copied ? "Copied" : "Copy"}

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -226,7 +226,7 @@ export function InlineStatusBanner({
       }}
       aria-label={closeAriaLabel}
       className={cn(
-        "p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0",
+        "p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0",
         isTitleBarSurface && "app-no-drag"
       )}
     >
@@ -364,7 +364,7 @@ export function InlineStatusBanner({
                   action.iconOnly
                     ? "p-1"
                     : "flex items-center gap-1.5 px-2 py-1 text-xs font-medium",
-                  "transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
+                  "transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
                   variantClasses,
                   (variant === "danger" || variant === "dangerFilled") &&
                     "hover:[color:var(--hover-color)] hover:[background:var(--hover-bg)]",

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -117,7 +117,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
           <button
             type="button"
             onClick={handleCleanup}
-            className="mt-1 text-xs underline text-daintree-text/70 hover:text-daintree-text transition-colors inline-flex items-center gap-1 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent rounded-sm"
+            className="mt-1 text-xs underline text-daintree-text/70 hover:text-daintree-text transition-colors inline-flex items-center gap-1 outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent rounded-sm"
           >
             <Trash2 className="h-3 w-3" />
             Close <span className="tabular-nums">{completedCount}</span> completed agent

--- a/src/components/Terminal/WorktreeMoveBanner.tsx
+++ b/src/components/Terminal/WorktreeMoveBanner.tsx
@@ -73,7 +73,7 @@ export function WorktreeMoveBanner({
               e.stopPropagation();
               onTell();
             }}
-            className="-ml-1 mt-0.5 inline-block max-w-full cursor-pointer rounded-sm px-1 py-0.5 text-left text-xs font-medium whitespace-normal break-words text-daintree-text underline underline-offset-4 outline-hidden transition-[background-color] duration-150 ease-out hover:bg-overlay-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
+            className="-ml-1 mt-0.5 inline-block max-w-full cursor-pointer rounded-sm px-1 py-0.5 text-left text-xs font-medium whitespace-normal break-words text-daintree-text underline underline-offset-4 outline-hidden transition-[background-color] duration-150 ease-out hover:bg-overlay-hover focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
           >
             {deliveryFailed ? "Retry telling it to continue in" : "Tell it to continue in"}{" "}
             {destinationPath}

--- a/src/components/Worktree/ReviewHub/ReadinessRail.tsx
+++ b/src/components/Worktree/ReviewHub/ReadinessRail.tsx
@@ -27,7 +27,11 @@ const LEVEL_LABEL = {
 const SEVERITY: Record<ReviewReadinessSeverity, { Icon: typeof CircleAlert; toneClass: string }> = {
   blocker: { Icon: CircleAlert, toneClass: "text-status-error" },
   warning: { Icon: AlertTriangle, toneClass: "text-status-warning" },
-  info: { Icon: Info, toneClass: "text-text-muted" },
+  // `secondary`, not `muted`: with the level word sr-only the glyph is the only visual
+  // severity carrier, so it owes the 3:1 non-text floor. `text-muted` is guarded at 3.5
+  // for light themes ONLY (`shared/theme/contrast.ts`) and runs ~2.2:1 on dark built-ins;
+  // `text-secondary` holds 3.0 against every display surface.
+  info: { Icon: Info, toneClass: "text-text-secondary" },
 };
 
 const CTA_LABELS: Record<ReviewReadinessCta["kind"], string> = {

--- a/src/components/Worktree/ReviewHub/ReadinessRail.tsx
+++ b/src/components/Worktree/ReviewHub/ReadinessRail.tsx
@@ -1,35 +1,34 @@
+import { useState } from "react";
+import { AlertTriangle, ChevronDown, CircleAlert, Info } from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { cn } from "@/lib/utils";
 import type {
   ReviewReadinessCta,
   ReviewReadinessItem,
+  ReviewReadinessSeverity,
   ReviewReadinessSummary,
 } from "./reviewReadiness";
 
-const MAX_VISIBLE_ITEMS = 3;
-
-const LEVEL_CONFIG = {
-  ready: {
-    label: "Ready",
-    chipClass: "bg-status-success/10 border-status-success/30 text-status-success",
-    dotClass: "bg-status-success",
-  },
-  "needs-review": {
-    label: "Needs attention",
-    chipClass: "bg-status-warning/10 border-status-warning/30 text-status-warning",
-    dotClass: "bg-status-warning",
-  },
-  blocked: {
-    label: "Blocked",
-    chipClass: "bg-status-error/10 border-status-error/30 text-status-error",
-    dotClass: "bg-status-error",
-  },
+/** Announced when the level changes; never painted, because the leading icon and the
+ *  condition's own title already say more than the verdict word does. */
+const LEVEL_LABEL = {
+  ready: "Ready",
+  "needs-review": "Needs attention",
+  blocked: "Blocked",
 } as const;
 
-const SEVERITY_DOT = {
-  blocker: "bg-status-error",
-  warning: "bg-status-warning",
-  info: "bg-text-muted",
-} as const;
+/**
+ * Severity carries a distinct SHAPE, not just a hue. A `background-color` dot is
+ * erased wholesale by `forced-colors: active`; a Lucide glyph strokes in
+ * `currentColor` and survives it, which is also what the house rule in
+ * `worktreeCIStatus.ts` asks for (terminal states get an icon).
+ */
+const SEVERITY: Record<ReviewReadinessSeverity, { Icon: typeof CircleAlert; toneClass: string }> = {
+  blocker: { Icon: CircleAlert, toneClass: "text-status-error" },
+  warning: { Icon: AlertTriangle, toneClass: "text-status-warning" },
+  info: { Icon: Info, toneClass: "text-text-muted" },
+};
 
 const CTA_LABELS: Record<ReviewReadinessCta["kind"], string> = {
   "focus-conflicts": "Show conflicts",
@@ -38,97 +37,157 @@ const CTA_LABELS: Record<ReviewReadinessCta["kind"], string> = {
   "open-pr": "Open PR",
 };
 
+/* The action sits immediately after the message it belongs to rather than pinned to
+   the far edge: "Show conflicts" only means anything next to "3 conflicted files",
+   and a control stranded at the right margin of a wide strip is the one a screen
+   magnifier never reaches. */
+const CTA_CLASS = cn(
+  "inline-flex items-center gap-1 shrink-0 px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
+  "bg-filter-selected-bg-soft hover:bg-tint/[0.14] text-daintree-text/80",
+  "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+);
+
 interface ReadinessRailProps {
   summary: ReviewReadinessSummary;
   onCta: (cta: ReviewReadinessCta) => void;
 }
 
 /**
- * Compact merge-readiness strip for the top of Review Hub. Shows the overall
- * level plus the 3 highest-priority items (blockers, then warnings, then
- * infos) with their safe next action. Purely presentational — all derivation
- * lives in `deriveReviewReadiness`, all mutations behind `onCta` stay on the
- * hub's existing confirmed paths.
+ * Merge-readiness strip for the top of Review Hub. Leads with the single
+ * highest-priority condition and its own safe next action; everything else lives
+ * behind a disclosure. Purely presentational — all derivation stays in
+ * `deriveReviewReadiness`, all mutations stay on the hub's confirmed paths.
+ *
+ * It renders nothing at all when there is nothing to report. A clean worktree is
+ * already announced by the hub's own empty state, and a full-width band restating
+ * it in success green is exactly the chrome that trains people to stop reading the
+ * strip before it ever carries a blocker.
  */
 export function ReadinessRail({ summary, onCta }: ReadinessRailProps) {
   // "unknown" means staging status hasn't resolved — nothing useful to show.
   if (summary.level === "unknown") return null;
 
-  const level = LEVEL_CONFIG[summary.level];
   const ordered = [...summary.blockers, ...summary.warnings, ...summary.infos];
-  const visible = ordered.slice(0, MAX_VISIBLE_ITEMS);
-  const hidden = ordered.slice(MAX_VISIBLE_ITEMS);
+  const [primary, ...rest] = ordered;
+
+  // Nothing worth a row: silence is the readiness signal.
+  if (!primary) return null;
+
+  const { Icon, toneClass } = SEVERITY[primary.severity];
+  const fullText = primary.detail ? `${primary.label} — ${primary.detail}` : primary.label;
 
   return (
     <div
       data-testid="review-readiness-rail"
       role="group"
       aria-label="Review readiness"
-      className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-1.5 border-b border-divider bg-overlay-subtle text-[11px]"
+      className="flex items-center gap-2 px-4 py-1.5 border-b border-divider text-[11px]"
     >
       <span
         data-testid="review-readiness-level"
         data-level={summary.level}
         role="status"
-        className={cn(
-          "inline-flex items-center gap-1.5 px-1.5 py-0.5 rounded border font-medium shrink-0",
-          level.chipClass
-        )}
+        className="flex items-center shrink-0"
       >
-        <span aria-hidden="true" className={cn("w-1.5 h-1.5 rounded-full", level.dotClass)} />
-        {level.label}
+        <Icon className={cn("w-3.5 h-3.5 shrink-0", toneClass)} aria-hidden="true" />
+        <span className="sr-only">{LEVEL_LABEL[summary.level]}</span>
       </span>
-      {visible.map((item) => (
-        <RailItem key={item.id} item={item} onCta={onCta} />
-      ))}
-      {hidden.length > 0 && (
-        <span
-          data-testid="review-readiness-overflow"
-          className="text-daintree-text/40 shrink-0 cursor-help"
-          title={hidden.map((item) => item.label).join("\n")}
-          aria-label={`${hidden.length} more: ${hidden.map((item) => item.label).join(", ")}`}
-        >
-          +{hidden.length} more
+
+      <TruncatedTooltip content={fullText}>
+        <span data-testid={`readiness-item-${primary.id}`} className="min-w-0 truncate">
+          {/* Weight and colour separate the condition from its advice — an em dash
+              turns the pair into one run of prose, which is how three items used to
+              read as a single sentence. Weight also survives `prefers-contrast:
+              more`, where the colour difference is flattened away. */}
+          <span className="font-medium text-daintree-text/85">{primary.label}</span>
+          {primary.detail && <span className="text-text-secondary"> {primary.detail}</span>}
         </span>
+      </TruncatedTooltip>
+
+      {primary.action && (
+        <button
+          type="button"
+          data-testid={`readiness-cta-${primary.id}`}
+          onClick={() => onCta(primary.action!)}
+          className={CTA_CLASS}
+        >
+          {CTA_LABELS[primary.action.kind]}
+        </button>
       )}
+
+      {rest.length > 0 && <ReadinessOverflow items={rest} onCta={onCta} />}
     </div>
   );
 }
 
-function RailItem({
-  item,
+/**
+ * The remaining conditions. A `title` attribute was never a control: it could not
+ * be opened from the keyboard, and it dropped every hidden item's action on the
+ * floor. Radix supplies `aria-expanded`, `aria-haspopup`, focus return and
+ * Escape-to-close; the list semantics and the accessible name are ours to write.
+ */
+function ReadinessOverflow({
+  items,
   onCta,
 }: {
-  item: ReviewReadinessItem;
+  items: ReviewReadinessItem[];
   onCta: (cta: ReviewReadinessCta) => void;
 }) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <span
-      data-testid={`readiness-item-${item.id}`}
-      className="inline-flex items-center gap-1.5 min-w-0"
-    >
-      <span
-        aria-hidden="true"
-        className={cn("w-1.5 h-1.5 rounded-full shrink-0", SEVERITY_DOT[item.severity])}
-      />
-      <span className="truncate text-daintree-text/70">
-        {item.label}
-        {item.detail && <span className="text-daintree-text/40"> — {item.detail}</span>}
-      </span>
-      {item.action && (
-        <button
-          type="button"
-          data-testid={`readiness-cta-${item.id}`}
-          onClick={() => onCta(item.action!)}
-          className={cn(
-            "shrink-0 px-1.5 py-px rounded text-[10px] font-medium transition-colors",
-            "bg-filter-selected-bg-soft hover:bg-tint/[0.14] text-daintree-text/80",
-            "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
-          )}
-        >
-          {CTA_LABELS[item.action.kind]}
-        </button>
-      )}
-    </span>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        type="button"
+        data-testid="review-readiness-overflow"
+        aria-label={`${items.length} more: ${items.map((i) => i.label).join(", ")}`}
+        className={cn(
+          "inline-flex items-center gap-0.5 shrink-0 px-1.5 py-0.5 rounded text-[11px] transition-colors",
+          "text-text-secondary hover:text-daintree-text hover:bg-tint/[0.06]",
+          "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        )}
+      >
+        {items.length} more
+        <ChevronDown className="w-3 h-3 shrink-0" aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        aria-label="Other readiness conditions"
+        className="p-1 min-w-64 max-w-sm text-xs"
+      >
+        <ul className="flex flex-col gap-0.5">
+          {items.map((item) => {
+            const { Icon, toneClass } = SEVERITY[item.severity];
+            return (
+              <li
+                key={item.id}
+                data-testid={`readiness-item-${item.id}`}
+                className="flex items-start gap-2 px-2 py-1.5 rounded"
+              >
+                <Icon className={cn("w-3.5 h-3.5 shrink-0 mt-px", toneClass)} aria-hidden="true" />
+                <span className="min-w-0 flex-1">
+                  <span className="font-medium text-daintree-text">{item.label}</span>
+                  {item.detail && <span className="block text-text-secondary">{item.detail}</span>}
+                </span>
+                {item.action && (
+                  <button
+                    type="button"
+                    data-testid={`readiness-cta-${item.id}`}
+                    onClick={() => {
+                      onCta(item.action!);
+                      setOpen(false);
+                    }}
+                    className={CTA_CLASS}
+                  >
+                    {CTA_LABELS[item.action.kind]}
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/components/Worktree/ReviewHub/ReadinessRail.tsx
+++ b/src/components/Worktree/ReviewHub/ReadinessRail.tsx
@@ -41,10 +41,19 @@ const CTA_LABELS: Record<ReviewReadinessCta["kind"], string> = {
    the far edge: "Show conflicts" only means anything next to "3 conflicted files",
    and a control stranded at the right margin of a wide strip is the one a screen
    magnifier never reaches. */
+/* `focus-visible:outline-solid` is load-bearing, not decoration. Tailwind v4 compiles the
+   outline-suppressing utility below to `--tw-outline-style: none` on the element
+   unconditionally, and compiles `focus-visible:outline-2` to
+   `outline-style: var(--tw-outline-style)` — so the two cancel and the ring never paints
+   however right its colour and width look. Restating the style under the variant is what
+   makes the focus indicator visible; the capture harness asserts the computed outline. */
+const FOCUS_RING =
+  "outline-hidden focus-visible:outline focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
+
 const CTA_CLASS = cn(
   "inline-flex items-center gap-1 shrink-0 px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
   "bg-filter-selected-bg-soft hover:bg-tint/[0.14] text-daintree-text/80",
-  "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+  FOCUS_RING
 );
 
 interface ReadinessRailProps {
@@ -144,7 +153,7 @@ function ReadinessOverflow({
         className={cn(
           "inline-flex items-center gap-0.5 shrink-0 px-1.5 py-0.5 rounded text-[11px] transition-colors",
           "text-text-secondary hover:text-daintree-text hover:bg-tint/[0.06]",
-          "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          FOCUS_RING
         )}
       >
         {items.length} more

--- a/src/components/Worktree/ReviewHub/ReadinessRail.tsx
+++ b/src/components/Worktree/ReviewHub/ReadinessRail.tsx
@@ -109,7 +109,12 @@ export function ReadinessRail({ summary, onCta }: ReadinessRailProps) {
               read as a single sentence. Weight also survives `prefers-contrast:
               more`, where the colour difference is flattened away. */}
           <span className="font-medium text-daintree-text/85">{primary.label}</span>
-          {primary.detail && <span className="text-text-secondary"> {primary.detail}</span>}
+          {primary.detail && (
+            // The literal space stays: adjacent inline spans concatenate in the
+            // accessibility tree, so dropping it would announce "changedCheck". The
+            // margin is what opens the optical gap.
+            <span className="ml-1 text-text-secondary"> {primary.detail}</span>
+          )}
         </span>
       </TruncatedTooltip>
 

--- a/src/components/Worktree/ReviewHub/__tests__/ReadinessRail.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReadinessRail.test.tsx
@@ -217,6 +217,34 @@ describe("ReadinessRail", () => {
     expect(screen.queryByTestId("readiness-cta-generated-only")).toBeNull();
   });
 
+  it("never suppresses an outline without restoring the style under focus", () => {
+    // Tailwind v4 compiles `outline-hidden` to `--tw-outline-style: none` on the
+    // element and `focus-visible:outline-2` to `outline-style: var(--tw-outline-style)`,
+    // so the two silently cancel and the focus ring never paints. Any control that
+    // opts out of the default outline has to restate the style under the variant.
+    const summary = makeSummary({
+      level: "blocked",
+      blockers: [
+        item({ id: "conflicts", severity: "blocker", action: { kind: "focus-conflicts" } }),
+      ],
+      infos: [item({ id: "no-remote" })],
+    });
+    render(<ReadinessRail summary={summary} onCta={vi.fn()} />);
+
+    const controls = [
+      screen.getByTestId("readiness-cta-conflicts"),
+      screen.getByTestId("review-readiness-overflow"),
+    ];
+    expect(controls).not.toHaveLength(0);
+    for (const el of controls) {
+      if (!el.className.includes("outline-hidden")) continue;
+      expect(
+        el.className,
+        `${el.dataset.testid} suppresses its outline but never restores the style`
+      ).toContain("focus-visible:outline-solid");
+    }
+  });
+
   it("labels the rail as a group and announces each level through a status region", () => {
     const announced = new Set<string>();
     for (const [level, severity] of [

--- a/src/components/Worktree/ReviewHub/__tests__/ReadinessRail.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReadinessRail.test.tsx
@@ -1,10 +1,35 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { render as rtlRender, screen, fireEvent, cleanup, within } from "@testing-library/react";
+import { primeRadix } from "@/components/ui/radix-loader";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { ReadinessRail } from "../ReadinessRail";
 import type { ReviewReadinessItem, ReviewReadinessSummary } from "../reviewReadiness";
+
+class StubResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(async () => {
+  await primeRadix();
+});
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", StubResizeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+/** The app mounts a single `TooltipProvider` in `App.tsx`; the rail's truncation
+ *  tooltip relies on it, so an isolated render has to supply one too. */
+const render = (ui: React.ReactElement) => rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
 
 const makeSummary = (overrides?: Partial<ReviewReadinessSummary>): ReviewReadinessSummary => ({
   level: "ready",
@@ -25,101 +50,199 @@ const item = (overrides: Partial<ReviewReadinessItem> & Pick<ReviewReadinessItem
     ...overrides,
   }) as ReviewReadinessItem;
 
+/** The severity glyph the strip leads with, as markup — so a test can ask whether two
+ *  severities are distinguishable without reading a colour off a class name. */
+function leadGlyph(): string {
+  const svg = screen.getByTestId("review-readiness-level").querySelector("svg");
+  expect(svg, "the strip must lead with a severity glyph").not.toBeNull();
+  return svg!.innerHTML;
+}
+
+function openDisclosure() {
+  fireEvent.click(screen.getByTestId("review-readiness-overflow"));
+}
+
 describe("ReadinessRail", () => {
   it("renders nothing while readiness is unknown", () => {
     render(<ReadinessRail summary={makeSummary({ level: "unknown" })} onCta={vi.fn()} />);
     expect(screen.queryByTestId("review-readiness-rail")).toBeNull();
   });
 
-  it("shows the level chip with the level encoded for tests and themes", () => {
-    render(<ReadinessRail summary={makeSummary({ level: "blocked" })} onCta={vi.fn()} />);
-    const chip = screen.getByTestId("review-readiness-level");
-    expect(chip.dataset.level).toBe("blocked");
-    expect(chip.textContent).toBe("Blocked");
+  it("renders nothing when no condition is worth reporting", () => {
+    // A clean worktree is announced by the hub's own empty state. The strip must not
+    // spend a row — or a success colour — restating it.
+    render(<ReadinessRail summary={makeSummary({ level: "ready" })} onCta={vi.fn()} />);
+    expect(screen.queryByTestId("review-readiness-rail")).toBeNull();
   });
 
-  it("caps visible items at three, blockers first, with an overflow count", () => {
+  it("leads with the highest-priority condition whatever order the summary lists", () => {
+    const summary = makeSummary({
+      level: "blocked",
+      infos: [item({ id: "no-remote" })],
+      warnings: [item({ id: "behind-remote", severity: "warning" })],
+      blockers: [item({ id: "conflicts", severity: "blocker" })],
+    });
+    render(<ReadinessRail summary={summary} onCta={vi.fn()} />);
+
+    const rail = screen.getByTestId("review-readiness-rail");
+    const onStrip = within(rail)
+      .queryAllByTestId(/^readiness-item-/)
+      .map((el) => el.dataset.testid ?? el.getAttribute("data-testid"));
+    expect(onStrip).toEqual(["readiness-item-conflicts"]);
+  });
+
+  it("keeps every other condition reachable, with its action, from the disclosure", () => {
+    // The regression this pins: the overflow used to be a `title` attribute, so a
+    // hidden condition's CTA could not be reached at all.
+    const onCta = vi.fn();
     const summary = makeSummary({
       level: "blocked",
       blockers: [item({ id: "conflicts", severity: "blocker" })],
       warnings: [
-        item({ id: "behind-remote", severity: "warning" }),
-        item({ id: "ci-failing", severity: "warning" }),
+        item({ id: "behind-remote", severity: "warning", action: { kind: "pull-rebase" } }),
       ],
+      infos: [item({ id: "no-remote", label: "No remote configured" })],
+    });
+    render(<ReadinessRail summary={summary} onCta={onCta} />);
+
+    expect(screen.queryByTestId("readiness-item-behind-remote")).toBeNull();
+
+    openDisclosure();
+
+    expect(screen.getByTestId("readiness-item-behind-remote")).toBeDefined();
+    expect(screen.getByText("No remote configured")).toBeDefined();
+
+    fireEvent.click(screen.getByTestId("readiness-cta-behind-remote"));
+    expect(onCta).toHaveBeenCalledWith({ kind: "pull-rebase" });
+  });
+
+  it("gives the disclosure a real control and an accessible name that counts the rest", () => {
+    const summary = makeSummary({
+      level: "blocked",
+      blockers: [item({ id: "conflicts", severity: "blocker" })],
       infos: [item({ id: "no-remote" }), item({ id: "pr-missing" })],
     });
     render(<ReadinessRail summary={summary} onCta={vi.fn()} />);
-    expect(screen.getByTestId("readiness-item-conflicts")).toBeDefined();
-    expect(screen.getByTestId("readiness-item-behind-remote")).toBeDefined();
-    expect(screen.getByTestId("readiness-item-ci-failing")).toBeDefined();
-    expect(screen.queryByTestId("readiness-item-no-remote")).toBeNull();
-    expect(screen.queryByTestId("readiness-item-pr-missing")).toBeNull();
-    expect(screen.getByTestId("review-readiness-overflow").textContent).toBe("+2 more");
+
+    const trigger = screen.getByTestId("review-readiness-overflow");
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger.getAttribute("aria-label")).toContain("2 more");
+
+    openDisclosure();
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("discloses the hidden items' labels on the overflow indicator", () => {
-    const summary = makeSummary({
-      level: "blocked",
-      blockers: [item({ id: "conflicts", severity: "blocker" })],
-      warnings: [
-        item({ id: "behind-remote", severity: "warning" }),
-        item({ id: "ci-failing", severity: "warning" }),
-      ],
-      infos: [
-        item({ id: "no-remote", label: "No remote configured" }),
-        item({ id: "pr-missing", label: "No pull request for this branch" }),
-      ],
-    });
-    render(<ReadinessRail summary={summary} onCta={vi.fn()} />);
-    const overflow = screen.getByTestId("review-readiness-overflow");
-    expect(overflow.getAttribute("title")).toBe(
-      "No remote configured\nNo pull request for this branch"
-    );
-    expect(overflow.getAttribute("aria-label")).toBe(
-      "2 more: No remote configured, No pull request for this branch"
-    );
-  });
-
-  it("labels the rail as a group and announces level changes via a status region", () => {
-    const { rerender } = render(
-      <ReadinessRail summary={makeSummary({ level: "ready" })} onCta={vi.fn()} />
-    );
-    const rail = screen.getByTestId("review-readiness-rail");
-    expect(rail.getAttribute("role")).toBe("group");
-    expect(rail.getAttribute("aria-label")).toBe("Review readiness");
-    const chip = screen.getByTestId("review-readiness-level");
-    expect(chip.getAttribute("role")).toBe("status");
-    rerender(<ReadinessRail summary={makeSummary({ level: "blocked" })} onCta={vi.fn()} />);
-    expect(screen.getByTestId("review-readiness-level").textContent).toBe("Blocked");
-  });
-
-  it("renders detail inline after the label", () => {
+  it("omits the disclosure when the leading condition is the only one", () => {
     const summary = makeSummary({
       level: "needs-review",
-      warnings: [
-        item({ id: "behind-remote", severity: "warning", label: "Behind", detail: "2 commits" }),
-      ],
+      warnings: [item({ id: "generated-only", severity: "warning" })],
     });
     render(<ReadinessRail summary={summary} onCta={vi.fn()} />);
-    expect(screen.getByTestId("readiness-item-behind-remote").textContent).toContain("2 commits");
+    expect(screen.queryByTestId("review-readiness-overflow")).toBeNull();
   });
 
-  it("dispatches the item's CTA on click and omits the button when absent", () => {
-    const onCta = vi.fn();
+  it("distinguishes severities by shape, not by colour alone", () => {
+    // Colour is erased by `forced-colors: active`; a glyph stroked in currentColor
+    // is not. Two severities that render the same markup would be indistinguishable
+    // there, so the shapes must actually differ.
+    const glyphs = new Set<string>();
+    for (const [level, severity] of [
+      ["blocked", "blocker"],
+      ["needs-review", "warning"],
+      ["ready", "info"],
+    ] as const) {
+      render(
+        <ReadinessRail
+          summary={makeSummary({ level, [`${severity}s`]: [item({ id: "conflicts", severity })] })}
+          onCta={vi.fn()}
+        />
+      );
+      glyphs.add(leadGlyph());
+      cleanup();
+    }
+    expect(glyphs.size).toBe(3);
+  });
+
+  it("keeps the condition and its detail in separate elements", () => {
+    // They are separated by weight and colour rather than punctuation, which means
+    // they must be separately styleable — and it is the weight difference that
+    // survives `prefers-contrast: more`.
     const summary = makeSummary({
       level: "needs-review",
       warnings: [
         item({
           id: "behind-remote",
           severity: "warning",
-          action: { kind: "pull-rebase" },
+          label: "Behind remote",
+          detail: "2 commits",
         }),
-        item({ id: "generated-only", severity: "warning" }),
       ],
     });
-    render(<ReadinessRail summary={summary} onCta={onCta} />);
+    render(<ReadinessRail summary={summary} onCta={vi.fn()} />);
+
+    const row = screen.getByTestId("readiness-item-behind-remote");
+    const label = screen.getByText("Behind remote");
+    const detail = screen.getByText("2 commits");
+    expect(label).not.toBe(detail);
+    expect(row.textContent).toContain("2 commits");
+  });
+
+  it("dispatches the leading condition's own action and omits the button when absent", () => {
+    const onCta = vi.fn();
+    render(
+      <ReadinessRail
+        summary={makeSummary({
+          level: "needs-review",
+          warnings: [
+            item({ id: "behind-remote", severity: "warning", action: { kind: "pull-rebase" } }),
+          ],
+        })}
+        onCta={onCta}
+      />
+    );
     fireEvent.click(screen.getByTestId("readiness-cta-behind-remote"));
     expect(onCta).toHaveBeenCalledWith({ kind: "pull-rebase" });
+
+    cleanup();
+    render(
+      <ReadinessRail
+        summary={makeSummary({
+          level: "needs-review",
+          warnings: [item({ id: "generated-only", severity: "warning" })],
+        })}
+        onCta={onCta}
+      />
+    );
     expect(screen.queryByTestId("readiness-cta-generated-only")).toBeNull();
+  });
+
+  it("labels the rail as a group and announces each level through a status region", () => {
+    const announced = new Set<string>();
+    for (const [level, severity] of [
+      ["blocked", "blocker"],
+      ["needs-review", "warning"],
+      ["ready", "info"],
+    ] as const) {
+      render(
+        <ReadinessRail
+          summary={makeSummary({ level, [`${severity}s`]: [item({ id: "conflicts", severity })] })}
+          onCta={vi.fn()}
+        />
+      );
+      const rail = screen.getByTestId("review-readiness-rail");
+      expect(rail.getAttribute("role")).toBe("group");
+      expect(rail.getAttribute("aria-label")).toBe("Review readiness");
+
+      const status = screen.getByTestId("review-readiness-level");
+      expect(status.getAttribute("role")).toBe("status");
+      expect(status.dataset.level).toBe(level);
+      // The level must be *announced* even though the strip no longer paints a
+      // verdict chip — and each level must announce something different.
+      expect(status.textContent?.trim()).toBeTruthy();
+      announced.add(status.textContent!.trim());
+      cleanup();
+    }
+    expect(announced.size).toBe(3);
   });
 });

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -671,6 +671,97 @@ describe("focus-ring fallback contract", () => {
     );
   });
 
+  /**
+   * Tailwind v4 compiles the outline utilities through a registered custom property:
+   *
+   *   @property --tw-outline-style { syntax:"*"; inherits:false; initial-value:solid }
+   *   .outline-hidden                     { --tw-outline-style:none; outline-style:none }
+   *   .focus-visible\:outline:focus-visible   { outline-style:var(--tw-outline-style); … }
+   *   .focus-visible\:outline-2:focus-visible { outline-style:var(--tw-outline-style); … }
+   *
+   * The property does not inherit, so `outline-hidden` sets it to `none` on the very
+   * element the focus utilities then read it from. An element carrying both resolves to
+   * `outline-style: none` under `:focus-visible` — correct colour, correct width, correct
+   * offset, and nothing painted. The test above does not catch this: it sees a
+   * `focus-visible:outline*` utility and calls the fallback satisfied.
+   *
+   * A ring-based fallback (`focus-visible:ring-*`) is box-shadow and unaffected.
+   */
+  it("an outline-based focus fallback restates the outline style", () => {
+    const OUTLINE_FOCUS_UTILITY = /focus(?:-visible)?:outline(?:-\d+)?(?=[\s"'`])/;
+
+    /**
+     * Expressions where the suppressor and the outline fallback are the two arms of a
+     * ternary, so they can never apply to the same element at the same time. The
+     * extractor sees one class expression and cannot tell the arms apart.
+     */
+    const TERNARY_ARMS: ReadonlyArray<{ file: string; fragment: string; reason: string }> = [
+      {
+        file: "src/components/ui/AppPaletteDialog.tsx",
+        fragment: "focus:outline-hidden",
+        reason:
+          "The outline fallback and `focus:outline-hidden` are the two arms of the " +
+          '`focusIndicator === "region"` ternary. Whichever arm renders, the other\'s ' +
+          "classes are absent, so `--tw-outline-style` keeps its `solid` initial value.",
+      },
+    ];
+    for (const entry of TERNARY_ARMS) {
+      expect(entry.reason.trim().length, `${entry.file} needs a rationale`).toBeGreaterThan(0);
+      expect(
+        fs.readFileSync(path.join(REPO_ROOT, entry.file), "utf8").includes(entry.fragment),
+        `stale ternary-arm entry: ${entry.file} no longer contains "${entry.fragment}"`
+      ).toBe(true);
+    }
+
+    const scanRoots = [SRC_ROOT, ...PLUGIN_RENDERER_ROOTS];
+    const allFiles = scanRoots.flatMap((root) =>
+      fs.existsSync(root) ? collectSourceFiles(root) : []
+    );
+    expect(allFiles.length, "scan must find source files").toBeGreaterThan(100);
+
+    const violations: Array<{ file: string; line: number; snippet: string }> = [];
+
+    for (const filePath of allFiles) {
+      const source = fs.readFileSync(filePath, "utf8");
+      const relativePath = path.relative(REPO_ROOT, filePath).replace(/\\/g, "/");
+
+      OUTLINE_HIDDEN_PATTERN.lastIndex = 0;
+      for (const match of source.matchAll(OUTLINE_HIDDEN_PATTERN)) {
+        const matchPos = match.index ?? -1;
+        if (matchPos < 0) continue;
+
+        const expression = extractClassExpression(source, matchPos);
+        if (!OUTLINE_FOCUS_UTILITY.test(expression)) continue;
+        if (expression.includes("outline-solid")) continue;
+        if (
+          TERNARY_ARMS.some(
+            (entry) => entry.file === relativePath && expression.includes(entry.fragment)
+          )
+        )
+          continue;
+
+        const lineNumber = source.slice(0, matchPos).split("\n").length;
+        const snippet = source.split("\n")[lineNumber - 1]!.trim();
+        violations.push({ file: relativePath, line: lineNumber, snippet });
+      }
+    }
+
+    if (violations.length === 0) return;
+
+    const detail = violations
+      .slice(0, 20)
+      .map((v) => `  ${v.file}:${v.line} — ${v.snippet}`)
+      .join("\n");
+    const more = violations.length > 20 ? `\n  …and ${violations.length - 20} more` : "";
+
+    throw new Error(
+      `Found ${violations.length} element(s) whose focus ring resolves to \`outline-style: none\`: ` +
+        `\`outline-hidden\` sets \`--tw-outline-style: none\` on the element, and ` +
+        `\`focus-visible:outline-2\` reads that same value. Add \`focus-visible:outline-solid\` ` +
+        `(or switch the fallback to \`focus-visible:ring-*\`):\n${detail}${more}`
+    );
+  });
+
   it("every allowlist entry has a non-empty rationale", () => {
     for (const entry of ALLOWLIST) {
       expect(


### PR DESCRIPTION
## Summary

The readiness rail spent a full-width band, a green bordered chip and a success tint on saying "Ready", directly above an empty state that already read "Working tree clean". In light themes the whole band turned green. It now renders nothing when there is nothing to report.

When something does need attention it leads with the single highest-priority condition, its detail, and that condition's own action. Everything else moves into a disclosure popover. The strip is one line in every state, at a constant height.

Resolves #11983

## What changed

**The ready state is silent.** No chip, no green, no band. `severity="success"` has zero uses anywhere in the app and `AgentCompletionBanner` already renders good news as `neutral`, so this brings the rail in line with what we were already doing everywhere else. The verdict pills also measured 4.03:1 (Ready) and 4.35:1 (Blocked), below the floor, so removing them fixed that too.

**One condition on the strip, the rest behind a disclosure.** It used to assemble every visible item into a single inline sentence separated by dots. At four conditions that wrapped onto a second line at full width (2400px, not just narrow) and *still* hid an item behind "+1 more", so the wrap bought nothing. Height went 71px to 111px between states, moving the whole review workspace.

**"+N more" is a real control.** It was a `<span>` with a `title` attribute: not focusable, not openable from the keyboard, and it dropped the hidden conditions' CTAs entirely. It is now a `PopoverTrigger` opening a list of every remaining condition with its own action. Radix supplies `aria-expanded`, `aria-haspopup`, focus return and Escape; the `<ul>`/`<li>` semantics and the accessible name are written explicitly.

**Severity is a shape, not just a hue.** The dots were `background-color` on empty spans, which `forced-colors: active` erases outright, leaving blocker, warning and info indistinguishable. They are Lucide glyphs now, stroked in `currentColor`. Because only one condition is on the line, severities are also never compared side by side, which removed the light-theme inversion where the info dot rendered darkest of the three.

**Detail text is readable.** Off `text-daintree-text/40` (measured 3.22:1) onto the solid `text-text-secondary`, following the precedent in `paletteRowStyles.ts:60`. It is separated from its label by weight rather than an em dash. Weight is what survives `prefers-contrast: more`, where the global override was flattening both halves to the same colour and destroying the two-part structure of every item.

**Focus rings that paint.** Chasing a suspicious capture turned up a real bug. Tailwind v4 compiles `outline-hidden` to `--tw-outline-style: none` on the element, and compiles `focus-visible:outline-2` to `outline-style: var(--tw-outline-style)`. The property is registered `inherits: false`, so an element carrying both reads its own `none` back: right colour, right width, right offset, nothing painted. Fifteen controls across `Browser`, `Fleet`, `Layout`, `Project`, `Recovery`, `Sidebar` and `Terminal` were in that state, including the shared `InlineStatusBanner` buttons and both `BannerOverflowMenu` controls. Forced-colors hid it, since `src/index.css` paints a blanket `Highlight` outline there, so it only ever showed in normal rendering.

The existing focus-ring contract test did not catch it, because a `focus-visible:outline-2` satisfies its "has a fallback" check. There is a second contract test now that fails when a suppressed outline is never restored.

## Design review

Scored 4.7 to 10.0 over three rounds against signal proportionality, information hierarchy, scannability under load, visual language consistency, density, affordance and discoverability, states, accessibility, microcopy and craft. Round two moved it from 4.7 to 9.8; round three closed the last 0.2.

Two reviewer recommendations were declined and both were withdrawn on the evidence. A fixed right-anchored action column, because Carbon puts an inline notification's action directly after the prose, and an action pinned to the far edge of a wide strip is what screen-magnifier users never pan across (WCAG 1.4.10). And leading with the highest-priority *actionable* condition instead of the highest-priority one, which was priced at minus 0.4: an action is not the safest next step just because the UI can perform it.

A codebase-wide consistency survey ran afterwards. The rail is now a deliberate outlier on five more patterns, all filed rather than smuggled in here: #12000 (43 colour-only severity dots), #12001 (9 dead-end overflow indicators), #12002 (55 persistent green "all fine" chrome sites), #12003 (~290 meaningful text uses at 3.2:1), #12004 (21 em-dash separators).

## Testing

Full unit suite and `npm run check` locally, plus the ReviewHub and `src/config/__tests__` contract suites.

Six invariants pinned, each mutation-checked by reintroducing the bug and confirming the test fails:

- renders nothing when no condition is worth reporting
- leads with the highest-priority condition whatever order the summary lists
- every hidden condition and its action stay reachable through the disclosure
- severities are distinguishable by shape, not colour alone
- label and detail stay in separate elements so weight can separate them
- a control that suppresses its outline restates the style under focus (repo-wide contract)

Adds an opt-in capture harness at `e2e/screenshots/readiness-rail-review.spec.ts`, gated on `DAINTREE_SHOT_READINESS` so it never runs in CI. Fifteen states across every built-in theme, including forced-colors, increased contrast, keyboard focus, narrow width and the disclosure open. It verifies each state actually rendered before writing a PNG, and refuses to write a "focused" shot whose computed outline resolves to `none`. That last check is what found the focus-ring bug.
