### PR TITLE
fix(worktree): stop the removal tombstone swallowing a recreated worktree

### DIFF
--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -13,6 +13,7 @@ import type { PluginWorktreeLinked } from "../../shared/types/plugin.js";
 
 export interface SnapshotBuilderHost {
   readonly id: string;
+  readonly generation: number;
   readonly path: string;
   readonly name: string;
   readonly branch: string | undefined;
@@ -112,6 +113,7 @@ export class SnapshotBuilder {
 
     const snapshot: WorktreeSnapshot = {
       id: this.host.id,
+      generation: this.host.generation,
       path: this.host.path,
       name: this.host.name,
       branch: this.host.branch,

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -369,6 +369,19 @@ export class WorkspaceService {
   private seq = 0;
 
   /**
+   * Monotonic monitor-incarnation counter within `epoch`. Deliberately separate
+   * from `seq`: a generation is an identity for one monitor, not a position in
+   * the event stream, and minting one must not advance the stamp the renderer
+   * orders events by. A worktree id is its path, so a delete-then-create at the
+   * same location reuses the id — the incarnation is the only thing that tells
+   * the renderer's tombstone a real recreation apart from a buffered update
+   * belonging to the monitor that was just torn down (#11994). Reset on host
+   * restart, which is safe because that also mints a new `epoch` and the
+   * renderer drops every tombstone on an epoch transition.
+   */
+  private worktreeGeneration = 0;
+
+  /**
    * Epoch-scoped set of mutation IDs that have been successfully acknowledged
    * by this host run. The renderer mints a stable mutationId per delete intent
    * (#8405) and the host records each successful delete here so a replay of
@@ -1201,6 +1214,7 @@ export class WorkspaceService {
       worktreeId: monitor.id,
       epoch: this.epoch,
       seq: this.nextSeq(),
+      generation: monitor.generation,
     });
     events.emit("sys:worktree:remove", { worktreeId: monitor.id, timestamp: Date.now() });
   }
@@ -1396,10 +1410,10 @@ export class WorkspaceService {
           this.handleMonitorUpdate(monitor, snapshot);
         },
         onRemoved: (worktreeId) => {
-          this.handleExternalWorktreeRemoval(worktreeId);
+          this.handleExternalWorktreeRemoval(worktreeId, monitor);
         },
         onExternalRemoval: (worktreeId) => {
-          this.handleExternalWorktreeRemoval(worktreeId);
+          this.handleExternalWorktreeRemoval(worktreeId, monitor);
         },
         onResourceStatusPoll: (worktreeId) => {
           return this.runResourceAction(
@@ -1446,7 +1460,8 @@ export class WorkspaceService {
         },
       },
       this.mainBranch,
-      this.pollQueue
+      this.pollQueue,
+      ++this.worktreeGeneration
     );
 
     monitor.setIssueNumber(issueNumber ?? undefined);
@@ -2131,9 +2146,19 @@ export class WorkspaceService {
     }
   }
 
-  private handleExternalWorktreeRemoval(worktreeId: string): void {
+  /**
+   * `origin` is the monitor whose callback fired. A watcher/poll continuation
+   * belonging to a torn-down monitor can resume after a same-path worktree was
+   * recreated, and the id alone would then resolve to the *new* monitor and
+   * delete a live worktree the user just created (#11994). Identity, not id,
+   * is what makes the two incarnations distinguishable here.
+   */
+  private handleExternalWorktreeRemoval(worktreeId: string, origin?: WorktreeMonitor): void {
     const monitor = this.monitors.get(worktreeId);
     if (!monitor) {
+      return;
+    }
+    if (origin && origin !== monitor) {
       return;
     }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -382,6 +382,17 @@ export class WorkspaceService {
   private worktreeGeneration = 0;
 
   /**
+   * Worktree ids with an `addNewWorktreeMonitor` call in flight. The entry
+   * guard reads `monitors` before several awaits, so without this a second
+   * caller for the same id (a `syncMonitors` pass racing `performCreateWorktree`
+   * or a topology reconcile) sails past it and installs a second live monitor
+   * for one path — double-polling it, and breaking the invariant the removal
+   * tombstone leans on: the registered monitor holds the highest incarnation
+   * minted for its id (#11994).
+   */
+  private readonly pendingMonitorInstalls = new Set<string>();
+
+  /**
    * Epoch-scoped set of mutation IDs that have been successfully acknowledged
    * by this host run. The renderer mints a stable mutationId per delete intent
    * (#8405) and the host records each successful delete here so a replay of
@@ -1374,10 +1385,23 @@ export class WorkspaceService {
     skipInitialGitStatus: boolean,
     deferWatcherBudget: boolean = false
   ): Promise<void> {
-    if (this.monitors.has(wt.id)) {
+    if (this.monitors.has(wt.id) || this.pendingMonitorInstalls.has(wt.id)) {
       return;
     }
+    this.pendingMonitorInstalls.add(wt.id);
+    try {
+      await this.installWorktreeMonitor(wt, isActive, skipInitialGitStatus, deferWatcherBudget);
+    } finally {
+      this.pendingMonitorInstalls.delete(wt.id);
+    }
+  }
 
+  private async installWorktreeMonitor(
+    wt: Worktree,
+    isActive: boolean,
+    skipInitialGitStatus: boolean,
+    deferWatcherBudget: boolean
+  ): Promise<void> {
     const enrichedWt = await this.enrichWorktreeWithWsl(wt);
     wt = enrichedWt;
 
@@ -1391,6 +1415,14 @@ export class WorkspaceService {
       createdAt = stats.birthtimeMs > 0 ? stats.birthtimeMs : stats.ctimeMs;
     } catch {
       // If stat fails, leave undefined
+    }
+
+    // The single-flight guard in the caller covers concurrent installs; this
+    // catches any other path that registered this id across the awaits above.
+    // Minting the incarnation only once we know we will register keeps the
+    // counter aligned with the monitors that actually exist.
+    if (this.monitors.has(wt.id)) {
+      return;
     }
 
     const monitor = new WorktreeMonitor(

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -382,15 +382,18 @@ export class WorkspaceService {
   private worktreeGeneration = 0;
 
   /**
-   * Worktree ids with an `addNewWorktreeMonitor` call in flight. The entry
-   * guard reads `monitors` before several awaits, so without this a second
+   * In-flight `installWorktreeMonitor` promise per worktree id. The entry guard
+   * reads `monitors` before several awaits, so without single-flighting a second
    * caller for the same id (a `syncMonitors` pass racing `performCreateWorktree`
    * or a topology reconcile) sails past it and installs a second live monitor
    * for one path — double-polling it, and breaking the invariant the removal
    * tombstone leans on: the registered monitor holds the highest incarnation
-   * minted for its id (#11994).
+   * minted for its id (#11994). The promise, rather than a bare id set, is what
+   * lets the losing caller wait for the winner instead of returning while the
+   * monitor is still absent — `performCreateWorktree` documents that the
+   * monitor IS registered once its await resolves.
    */
-  private readonly pendingMonitorInstalls = new Set<string>();
+  private readonly pendingMonitorInstalls = new Map<string, Promise<void>>();
 
   /**
    * Epoch-scoped set of mutation IDs that have been successfully acknowledged
@@ -1385,12 +1388,27 @@ export class WorkspaceService {
     skipInitialGitStatus: boolean,
     deferWatcherBudget: boolean = false
   ): Promise<void> {
-    if (this.monitors.has(wt.id) || this.pendingMonitorInstalls.has(wt.id)) {
+    if (this.monitors.has(wt.id)) {
       return;
     }
-    this.pendingMonitorInstalls.add(wt.id);
+    const inFlight = this.pendingMonitorInstalls.get(wt.id);
+    if (inFlight) {
+      // Swallow the winner's failure rather than re-throwing it into a caller
+      // that only asked for the monitor to exist: a duplicate call stays the
+      // no-op it always was, and the shared await is purely so this returns
+      // once the install has actually settled.
+      await inFlight.catch(() => {});
+      return;
+    }
+    const install = this.installWorktreeMonitor(
+      wt,
+      isActive,
+      skipInitialGitStatus,
+      deferWatcherBudget
+    );
+    this.pendingMonitorInstalls.set(wt.id, install);
     try {
-      await this.installWorktreeMonitor(wt, isActive, skipInitialGitStatus, deferWatcherBudget);
+      await install;
     } finally {
       this.pendingMonitorInstalls.delete(wt.id);
     }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -102,6 +102,13 @@ export interface WorktreeMonitorCallbacks {
 
 export class WorktreeMonitor {
   readonly id: string;
+  /**
+   * Incarnation stamp for {@link id}, minted by `WorkspaceService` from a
+   * process-wide monotonic counter. Stamped onto every snapshot this monitor
+   * builds so the renderer can tell a recreated worktree apart from a buffered
+   * update belonging to the previous monitor for the same path (#11994).
+   */
+  readonly generation: number;
   readonly path: string;
 
   private _name: string;
@@ -284,9 +291,11 @@ export class WorktreeMonitor {
     private config: WorktreeMonitorConfig,
     private callbacks: WorktreeMonitorCallbacks,
     private mainBranch: string,
-    pollQueue?: PQueue
+    pollQueue?: PQueue,
+    generation: number = 0
   ) {
     this.id = worktree.id;
+    this.generation = generation;
     this.path = worktree.path;
     this._name = worktree.name;
     this._branch = worktree.branch;
@@ -416,6 +425,9 @@ export class WorktreeMonitor {
     const snapshotHost: SnapshotBuilderHost = {
       get id() {
         return monitor.id;
+      },
+      get generation() {
+        return monitor.generation;
       },
       get path() {
         return monitor.path;

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -4,6 +4,7 @@ import { SnapshotBuilder, type SnapshotBuilderHost } from "../SnapshotBuilder.js
 function makeHost(overrides: Partial<SnapshotBuilderHost> = {}): SnapshotBuilderHost {
   return {
     id: "/test/worktree",
+    generation: 1,
     path: "/test/worktree",
     name: "worktree",
     branch: "feature/x",
@@ -213,6 +214,14 @@ describe("SnapshotBuilder", () => {
 
     const stamped = makeHost({ workingTreeChangedAt: 1_725_000_000_000 });
     expect(new SnapshotBuilder(stamped).build().workingTreeChangedAt).toBe(1_725_000_000_000);
+  });
+
+  it("carries the monitor's incarnation stamp onto the snapshot", () => {
+    // The renderer's removal tombstone compares this to tell a re-created
+    // worktree apart from a buffered update for the path's previous monitor
+    // (#11994), so it has to survive snapshot construction.
+    const host = makeHost({ generation: 7 });
+    expect(new SnapshotBuilder(host).build().generation).toBe(host.generation);
   });
 
   it("passes isExternal through without collapsing false into undefined", () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -188,6 +188,11 @@ describe("WorkspaceService external worktree removal", () => {
   });
 
   afterEach(() => {
+    // Both the re-creation tests install real monitors, which arm polling and
+    // fetch timers; leaving them running lets a torn-down monitor fire against
+    // a later test's mocks.
+    service.dispose();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -365,9 +370,24 @@ describe("WorkspaceService external worktree removal", () => {
     // reuses it. The monitor incarnation is the only thing that distinguishes
     // the two, both for the renderer's tombstone and for fencing continuations
     // still running against the torn-down monitor.
+    const OTHER_WORKTREE_PATH = pathResolve("/test/other-worktree");
+
     it("mints a higher incarnation for the replacement and stamps the removal with the old one", async () => {
       await service["addNewWorktreeMonitor"](createTestWorktree(), false, true);
       const first = service["monitors"].get(TEST_WORKTREE_PATH);
+      expect(first).toBeDefined();
+
+      // Advance the service counter between creation and removal, so a removal
+      // that stamped the counter's current value instead of the torn-down
+      // monitor's own would carry a different number.
+      await service["addNewWorktreeMonitor"](
+        createTestWorktree({ id: OTHER_WORKTREE_PATH, path: OTHER_WORKTREE_PATH }),
+        false,
+        true
+      );
+      expect(service["monitors"].get(OTHER_WORKTREE_PATH)!.generation).toBeGreaterThan(
+        first!.generation
+      );
 
       service["removeMonitor"](TEST_WORKTREE_PATH);
 
@@ -375,12 +395,13 @@ describe("WorkspaceService external worktree removal", () => {
         expect.objectContaining({
           type: "worktree-removed",
           worktreeId: TEST_WORKTREE_PATH,
-          generation: first?.generation,
+          generation: first!.generation,
         })
       );
 
       await service["addNewWorktreeMonitor"](createTestWorktree(), false, true);
       const second = service["monitors"].get(TEST_WORKTREE_PATH);
+      expect(second).toBeDefined();
 
       expect(second).not.toBe(first);
       expect(second!.generation).toBeGreaterThan(first!.generation);
@@ -389,20 +410,40 @@ describe("WorkspaceService external worktree removal", () => {
 
     it("ignores a torn-down monitor's removal callback for the worktree that replaced it", async () => {
       await service["addNewWorktreeMonitor"](createTestWorktree(), false, true);
-      const first = service["monitors"].get(TEST_WORKTREE_PATH)!;
+      const first = service["monitors"].get(TEST_WORKTREE_PATH);
       service["removeMonitor"](TEST_WORKTREE_PATH);
       await service["addNewWorktreeMonitor"](createTestWorktree(), false, true);
-      const second = service["monitors"].get(TEST_WORKTREE_PATH)!;
+      const second = service["monitors"].get(TEST_WORKTREE_PATH);
+      expect(first).toBeDefined();
+      expect(second).toBeDefined();
+      expect(second).not.toBe(first);
       mockSendEvent.mockClear();
 
-      // The old monitor's watcher finally fires. Resolving by id alone would
-      // find — and delete — the live worktree the user just created.
-      service["handleExternalWorktreeRemoval"](TEST_WORKTREE_PATH, first);
+      // Drive the production callbacks the old monitor actually holds, so this
+      // also fails if `addNewWorktreeMonitor` stops passing the origin along.
+      // Resolving by id alone would find — and delete — the live worktree the
+      // user just created.
+      first!["callbacks"].onRemoved!(TEST_WORKTREE_PATH);
+      first!["callbacks"].onExternalRemoval!(TEST_WORKTREE_PATH);
 
       expect(service["monitors"].get(TEST_WORKTREE_PATH)).toBe(second);
       expect(mockSendEvent).not.toHaveBeenCalledWith(
         expect.objectContaining({ type: "worktree-removed" })
       );
+    });
+
+    it("installs one monitor when two adds for the same path overlap", async () => {
+      // The entry guard reads `monitors` before several awaits, so without
+      // single-flighting both callers install a monitor and the registered one
+      // is no longer guaranteed to hold the highest incarnation.
+      await Promise.all([
+        service["addNewWorktreeMonitor"](createTestWorktree(), false, true),
+        service["addNewWorktreeMonitor"](createTestWorktree(), false, true),
+      ]);
+
+      const registered = service["monitors"].get(TEST_WORKTREE_PATH);
+      expect(registered).toBeDefined();
+      expect(registered!.generation).toBe(service["worktreeGeneration"]);
     });
   });
 

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -360,6 +360,52 @@ describe("WorkspaceService external worktree removal", () => {
     });
   });
 
+  describe("same-path re-creation (#11994)", () => {
+    // A worktree id is its path, so a delete-then-create at the same location
+    // reuses it. The monitor incarnation is the only thing that distinguishes
+    // the two, both for the renderer's tombstone and for fencing continuations
+    // still running against the torn-down monitor.
+    it("mints a higher incarnation for the replacement and stamps the removal with the old one", async () => {
+      await service["addNewWorktreeMonitor"](createTestWorktree(), false, true);
+      const first = service["monitors"].get(TEST_WORKTREE_PATH);
+
+      service["removeMonitor"](TEST_WORKTREE_PATH);
+
+      expect(mockSendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "worktree-removed",
+          worktreeId: TEST_WORKTREE_PATH,
+          generation: first?.generation,
+        })
+      );
+
+      await service["addNewWorktreeMonitor"](createTestWorktree(), false, true);
+      const second = service["monitors"].get(TEST_WORKTREE_PATH);
+
+      expect(second).not.toBe(first);
+      expect(second!.generation).toBeGreaterThan(first!.generation);
+      expect(second!.getSnapshot().generation).toBe(second!.generation);
+    });
+
+    it("ignores a torn-down monitor's removal callback for the worktree that replaced it", async () => {
+      await service["addNewWorktreeMonitor"](createTestWorktree(), false, true);
+      const first = service["monitors"].get(TEST_WORKTREE_PATH)!;
+      service["removeMonitor"](TEST_WORKTREE_PATH);
+      await service["addNewWorktreeMonitor"](createTestWorktree(), false, true);
+      const second = service["monitors"].get(TEST_WORKTREE_PATH)!;
+      mockSendEvent.mockClear();
+
+      // The old monitor's watcher finally fires. Resolving by id alone would
+      // find — and delete — the live worktree the user just created.
+      service["handleExternalWorktreeRemoval"](TEST_WORKTREE_PATH, first);
+
+      expect(service["monitors"].get(TEST_WORKTREE_PATH)).toBe(second);
+      expect(mockSendEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "worktree-removed" })
+      );
+    });
+  });
+
   describe("periodic safety-net timer (#8510)", () => {
     it("clears a phantom monitor end-to-end when the interval fires", async () => {
       createAndRegisterMonitor();

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -85,6 +85,16 @@ export interface PRServiceStatus {
  */
 export interface WorktreeSnapshot {
   id: string;
+  /**
+   * Monotonic incarnation stamp for this id, minted when the host creates the
+   * worktree's monitor. An id is its path, so a delete-then-create at the same
+   * location reuses it — the generation is what tells the renderer's removal
+   * tombstone a genuine recreation apart from a buffered pre-delete update,
+   * which is closure-bound to the old monitor and so carries the old stamp
+   * (#11994). Optional only so snapshot fixtures stay light; every snapshot the
+   * host builds carries it (`SnapshotBuilder` is the sole construction point).
+   */
+  generation?: number;
   path: string;
   name: string;
   branch?: string;
@@ -666,7 +676,16 @@ export type WorkspaceHostEvent =
     }
   // Spontaneous updates (no requestId - these are pushed events)
   | { type: "worktree-update"; worktree: WorktreeSnapshot; epoch: string; seq: number }
-  | { type: "worktree-removed"; worktreeId: string; epoch: string; seq: number }
+  // `generation` is the removed monitor's incarnation stamp — the renderer
+  // records it on the tombstone so a later update can be compared against it
+  // (#11994). See `WorktreeSnapshot.generation`.
+  | {
+      type: "worktree-removed";
+      worktreeId: string;
+      epoch: string;
+      seq: number;
+      generation?: number;
+    }
   // Host-originated active-worktree change. Emitted from the host's authoritative
   // `setActiveWorktree` writer so the per-view renderer's WorktreeStoreContext
   // learns the new active id in the same tick as any accompanying

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -100,7 +100,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     watcherDegraded: false,
     topologyWatcherDark: false,
     applySnapshot: () => {},
-    applyUpdate: () => {},
+    applyUpdate: () => true,
     applyRemove: () => {},
     setManualAssociation: () => {},
     clearManualAssociation: () => {},

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -61,6 +61,7 @@ interface WorktreeRemovedEvent {
   worktreeId: string;
   epoch: string;
   seq: number;
+  generation?: number;
 }
 
 interface PRDetectedEvent {
@@ -357,8 +358,17 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // anything the restart's seq reset would otherwise have hidden.
         // prevEpoch === "" is the pre-hydration baseline, not a restart.
         const epochChanged = event.epoch !== prevEpoch && prevEpoch !== "";
-        store.getState().applyUpdate(event.worktree, { epoch: event.epoch, seq: event.seq });
+        const applied = store
+          .getState()
+          .applyUpdate(event.worktree, { epoch: event.epoch, seq: event.seq });
         if (epochChanged) fetchInitialState();
+
+        // A rejected event describes a worktree that is NOT in the map — a
+        // stale stamp, a superseded monitor incarnation, or an active removal
+        // tombstone. Resolving the placeholder and running the pending
+        // selection policy anyway is what made the swallowed create silent:
+        // the "Creating…" row vanished with no worktree and no error (#11994).
+        if (!applied) return;
 
         // Side effect: sync pending worktree selection
         const selectionStore = useWorktreeSelectionStore.getState();
@@ -392,7 +402,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           return;
         }
 
-        store.getState().applyRemove(event.worktreeId, { epoch: event.epoch, seq: event.seq });
+        store
+          .getState()
+          .applyRemove(event.worktreeId, { epoch: event.epoch, seq: event.seq }, event.generation);
         if (epochChanged) fetchInitialState();
 
         // applyRemove version-gates internally but returns void: a stale

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -132,8 +132,12 @@ async function renderProvider() {
   return { store: rendered.result.current, unmount: rendered.unmount };
 }
 
-function removeEvent(worktreeId: string) {
-  return { type: "worktree-removed", worktreeId, ...nextV() };
+function removeEvent(worktreeId: string, generation?: number) {
+  return { type: "worktree-removed", worktreeId, generation, ...nextV() };
+}
+
+function updateEvent(worktree: WorktreeSnapshot) {
+  return { type: "worktree-update", worktree, ...nextV() };
 }
 
 describe("WorktreeStoreProvider — surviving terminals on worktree removal", () => {
@@ -764,5 +768,55 @@ describe("WorktreeStoreProvider — worktrees dropped without a removal event (#
     // A deleted id resolves to nothing after a restart, so it must not persist
     // as the restore point even while its ghost row is still on screen.
     expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBeNull();
+  });
+});
+
+describe("WorktreeStoreProvider — same-path re-creation (#11994)", () => {
+  // Re-creating a worktree at a deleted one's path reuses its id and lands
+  // inside the removal tombstone's window. The monitor incarnation is what
+  // separates the real creation from a buffered update for the dead monitor.
+  it("retires the ghost row and resolves the placeholder for the re-created worktree", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1", { generation: 4 })], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1", 4));
+    });
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
+
+    act(() => {
+      useWorktreeSelectionStore.getState().addPendingCreation("wt-1", { branch: "branch-wt-1" });
+      emit("worktree-update", updateEvent(makeWorktree("wt-1", { generation: 5 })));
+    });
+
+    expect(store.getState().worktrees.has("wt-1")).toBe(true);
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+    expect(useWorktreeSelectionStore.getState().pendingCreations.has("wt-1")).toBe(false);
+    expect(usePanelStore.getState().panelsById["agent-a"]).toBeDefined();
+  });
+
+  it("leaves the placeholder standing when the update is rejected as stale", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1", { generation: 4 })], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1", 4));
+    });
+
+    act(() => {
+      useWorktreeSelectionStore.getState().addPendingCreation("wt-1", { branch: "branch-wt-1" });
+      // The dead monitor's buffered poll — same incarnation, so the tombstone
+      // still suppresses it. Clearing the placeholder here is what made the
+      // swallowed creation silent: no row, no skeleton, no error.
+      emit("worktree-update", updateEvent(makeWorktree("wt-1", { generation: 4 })));
+    });
+
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+    expect(useWorktreeSelectionStore.getState().pendingCreations.has("wt-1")).toBe(true);
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
   });
 });

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -788,13 +788,42 @@ describe("WorktreeStoreProvider — same-path re-creation (#11994)", () => {
 
     act(() => {
       useWorktreeSelectionStore.getState().addPendingCreation("wt-1", { branch: "branch-wt-1" });
+      useWorktreeSelectionStore.getState().setPendingWorktree("wt-1");
+    });
+    expect(useWorktreeSelectionStore.getState().pendingCreations.has("wt-1")).toBe(true);
+
+    act(() => {
       emit("worktree-update", updateEvent(makeWorktree("wt-1", { generation: 5 })));
     });
 
     expect(store.getState().worktrees.has("wt-1")).toBe(true);
     expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
     expect(useWorktreeSelectionStore.getState().pendingCreations.has("wt-1")).toBe(false);
+    expect(useWorktreeSelectionStore.getState().pendingWorktreeId).toBeNull();
     expect(usePanelStore.getState().panelsById["agent-a"]).toBeDefined();
+  });
+
+  it("forwards the removal event's own generation to the tombstone", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-other")], nextV());
+    });
+
+    // No row for this id, so the outgoing-row fallback has nothing to read —
+    // only the event's stamp can seed the fence.
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1", 4));
+    });
+
+    act(() => {
+      emit("worktree-update", updateEvent(makeWorktree("wt-1", { generation: 4 })));
+    });
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+
+    act(() => {
+      emit("worktree-update", updateEvent(makeWorktree("wt-1", { generation: 5 })));
+    });
+    expect(store.getState().worktrees.has("wt-1")).toBe(true);
   });
 
   it("leaves the placeholder standing when the update is rejected as stale", async () => {
@@ -809,6 +838,10 @@ describe("WorktreeStoreProvider — same-path re-creation (#11994)", () => {
 
     act(() => {
       useWorktreeSelectionStore.getState().addPendingCreation("wt-1", { branch: "branch-wt-1" });
+      useWorktreeSelectionStore.getState().setPendingWorktree("wt-1");
+    });
+
+    act(() => {
       // The dead monitor's buffered poll — same incarnation, so the tombstone
       // still suppresses it. Clearing the placeholder here is what made the
       // swallowed creation silent: no row, no skeleton, no error.
@@ -817,6 +850,7 @@ describe("WorktreeStoreProvider — same-path re-creation (#11994)", () => {
 
     expect(store.getState().worktrees.has("wt-1")).toBe(false);
     expect(useWorktreeSelectionStore.getState().pendingCreations.has("wt-1")).toBe(true);
+    expect(useWorktreeSelectionStore.getState().pendingWorktreeId).toBe("wt-1");
     expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
   });
 });

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -902,7 +902,7 @@ describe("destructive-action danger metadata", () => {
       watcherDegraded: false,
       topologyWatcherDark: false,
       applySnapshot: () => {},
-      applyUpdate: () => {},
+      applyUpdate: () => true,
       applyRemove: () => {},
       setManualAssociation: () => {},
       clearManualAssociation: () => {},

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -518,3 +518,121 @@ describe("createWorktreeStore — removal tombstones (#8403)", () => {
     expect(store.getState().tombstones.size).toBe(0);
   });
 });
+
+describe("createWorktreeStore — same-path re-creation (#11994)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // A worktree id is its path, so deleting and re-creating at the same location
+  // reuses the id and lands inside the removal tombstone's suppression window.
+  // The monitor incarnation is what separates the two cases: the host builds a
+  // new monitor for the new worktree, while the buffered update the tombstone
+  // exists to suppress is closure-bound to the torn-down one.
+  it("accepts a higher-generation update inside the suppression window", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 4 })], { epoch: "e", seq: 1 });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, 4);
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+
+    vi.advanceTimersByTime(10_000);
+    const applied = store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: 5 }), { epoch: "e", seq: 3 });
+
+    expect(applied).toBe(true);
+    expect(store.getState().worktrees.has("wt-1")).toBe(true);
+    expect(store.getState().tombstones.has("wt-1")).toBe(false);
+  });
+
+  it("still suppresses a same-generation update inside the window", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 4 })], { epoch: "e", seq: 1 });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, 4);
+
+    // The buffered pre-delete poll: same monitor, so same stamp, even though
+    // the host minted it a higher seq than the removal.
+    const applied = store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: 4 }), { epoch: "e", seq: 3 });
+
+    expect(applied).toBe(false);
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+  });
+
+  it("takes the removed row's generation when the event omits one", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 4 })], { epoch: "e", seq: 1 });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 });
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { generation: 5 }), { epoch: "e", seq: 3 });
+
+    expect(store.getState().worktrees.has("wt-1")).toBe(true);
+  });
+
+  it("rejects a stale-incarnation update after the re-created row is live", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { generation: 4, branch: "old" })], {
+      epoch: "e",
+      seq: 1,
+    });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, 4);
+    store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: 5, branch: "new" }), { epoch: "e", seq: 3 });
+
+    // The torn-down monitor's in-flight poll finally resolves and emits.
+    const applied = store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: 4, branch: "old" }), { epoch: "e", seq: 4 });
+
+    expect(applied).toBe(false);
+    expect(store.getState().worktrees.get("wt-1")?.branch).toBe("new");
+  });
+
+  it("keeps accepting same-generation updates for a live row", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 5 })], { epoch: "e", seq: 1 });
+
+    const applied = store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: 5, branch: "renamed" }), {
+        epoch: "e",
+        seq: 2,
+      });
+
+    expect(applied).toBe(true);
+    expect(store.getState().worktrees.get("wt-1")?.branch).toBe("renamed");
+  });
+
+  it("accepts a lower generation from a restarted host", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 9 })], { epoch: "e1", seq: 5 });
+    store.getState().applyRemove("wt-1", { epoch: "e1", seq: 6 }, 9);
+
+    // A restart resets the host's counter, so the new run's first monitor can
+    // carry a lower stamp than the tombstone. The epoch transition clears the
+    // tombstones before any incarnation comparison, so it must still land.
+    const applied = store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: 1 }), { epoch: "e2", seq: 1 });
+
+    expect(applied).toBe(true);
+    expect(store.getState().worktrees.has("wt-1")).toBe(true);
+  });
+});

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -521,7 +521,11 @@ describe("createWorktreeStore — removal tombstones (#8403)", () => {
 
 // Comfortably past any plausible suppression window without restating its
 // length — the point is that a stamped comparison ignores the clock entirely.
-const TOMBSTONE_WINDOW_OVERSHOOT_MS = 10 * 60_000;
+const TOMBSTONE_WINDOW_OVERSHOOT_MS = 60_000;
+
+// Past any plausible fence lifetime. A stamped fence is deliberately kept far
+// longer than the suppression window, so this has to clear a much bigger gap.
+const FENCE_LIFETIME_OVERSHOOT_MS = 24 * 60 * 60_000;
 
 describe("createWorktreeStore — same-path re-creation (#11994)", () => {
   beforeEach(() => {
@@ -741,6 +745,23 @@ describe("createWorktreeStore — same-path re-creation (#11994)", () => {
         seq: 2,
       });
     expect(store.getState().worktrees.has("wt-2")).toBe(true);
+  });
+
+  it("retires a stamped fence only once it is far older than any in-flight poll", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 4 })], { epoch: "e", seq: 1 });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, 4);
+
+    // Reaping happens on write, so a later unrelated removal is what sweeps it.
+    vi.advanceTimersByTime(TOMBSTONE_WINDOW_OVERSHOOT_MS);
+    store.getState().applyRemove("wt-2", { epoch: "e", seq: 3 }, 9);
+    expect(store.getState().tombstones.has("wt-1")).toBe(true);
+
+    vi.advanceTimersByTime(FENCE_LIFETIME_OVERSHOOT_MS);
+    store.getState().applyRemove("wt-3", { epoch: "e", seq: 4 }, 9);
+    expect(store.getState().tombstones.has("wt-1")).toBe(false);
   });
 
   it("accepts a lower generation from a restarted host", () => {

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -519,6 +519,10 @@ describe("createWorktreeStore — removal tombstones (#8403)", () => {
   });
 });
 
+// Comfortably past any plausible suppression window without restating its
+// length — the point is that a stamped comparison ignores the clock entirely.
+const TOMBSTONE_WINDOW_OVERSHOOT_MS = 10 * 60_000;
+
 describe("createWorktreeStore — same-path re-creation (#11994)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -616,6 +620,127 @@ describe("createWorktreeStore — same-path re-creation (#11994)", () => {
 
     expect(applied).toBe(true);
     expect(store.getState().worktrees.get("wt-1")?.branch).toBe("renamed");
+  });
+
+  it.each([
+    ["the update is unstamped", undefined, 4],
+    ["the tombstone is unstamped", 5, undefined],
+  ])("falls back to the suppression window when %s", (_label, updateGen, tombstoneGen) => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: tombstoneGen })], { epoch: "e", seq: 1 });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, tombstoneGen);
+
+    const applied = store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: updateGen }), { epoch: "e", seq: 3 });
+
+    expect(applied).toBe(false);
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+  });
+
+  it("keeps suppressing a stale incarnation once the suppression window lapses", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 4 })], { epoch: "e", seq: 1 });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, 4);
+
+    // A poll can outlive the window — its watchdog does not cancel the
+    // underlying git call — so the wall clock must not decide a case both
+    // sides carry an incarnation for.
+    vi.advanceTimersByTime(TOMBSTONE_WINDOW_OVERSHOOT_MS);
+    const applied = store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: 4 }), { epoch: "e", seq: 3 });
+
+    expect(applied).toBe(false);
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+  });
+
+  it("keeps a stamped fence across a snapshot that still omits the worktree", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 4 })], { epoch: "e", seq: 1 });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, 4);
+
+    // The host re-hydrates and agrees the worktree is gone. Dropping the fence
+    // here would leave the dead monitor's next poll free to resurrect it.
+    store.getState().applySnapshot([makeSnapshot("wt-2")], { epoch: "e", seq: 3 });
+    const applied = store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { generation: 4 }), { epoch: "e", seq: 4 });
+
+    expect(applied).toBe(false);
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+  });
+
+  it("retires the fence once a snapshot reports the id alive again", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 4 })], { epoch: "e", seq: 1 });
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, 4);
+
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 5 })], { epoch: "e", seq: 3 });
+
+    expect(store.getState().tombstones.has("wt-1")).toBe(false);
+    expect(store.getState().worktrees.has("wt-1")).toBe(true);
+  });
+
+  it("records the event's generation for an id the store never held", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-other")], { epoch: "e", seq: 1 });
+
+    // No outgoing row to fall back to, so the event's own stamp is the only
+    // thing that can seed the fence.
+    store.getState().applyRemove("wt-1", { epoch: "e", seq: 2 }, 4);
+
+    expect(
+      store.getState().applyUpdate(makeSnapshot("wt-1", { generation: 4 }), { epoch: "e", seq: 3 })
+    ).toBe(false);
+    expect(
+      store.getState().applyUpdate(makeSnapshot("wt-1", { generation: 5 }), { epoch: "e", seq: 4 })
+    ).toBe(true);
+  });
+
+  it("adopts a newer incarnation even when nothing else about the row changed", () => {
+    const store = createWorktreeStore();
+    const snapshot = makeSnapshot("wt-1", { generation: 4 });
+    store.getState().applySnapshot([snapshot], { epoch: "e", seq: 1 });
+
+    // Value-equal apart from the stamp. Collapsing this as "no change" would
+    // leave the row judging later events against the dead monitor's fence.
+    store.getState().applyUpdate({ ...snapshot, generation: 5 }, { epoch: "e", seq: 2 });
+
+    expect(store.getState().worktrees.get("wt-1")?.generation).toBe(5);
+    expect(
+      store.getState().applyUpdate({ ...snapshot, generation: 4 }, { epoch: "e", seq: 3 })
+    ).toBe(false);
+  });
+
+  it("does not spend the event counter rejecting a stale incarnation", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 5 })], { epoch: "e", seq: 1 });
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { generation: 4 }), { epoch: "e", seq: 9 });
+
+    // Burning the counter on a rejection would make an in-flight snapshot
+    // minted at a lower seq look stale, stranding the row it carries.
+    expect(store.getState().version.seq).toBe(1);
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { generation: 5 }), makeSnapshot("wt-2")], {
+        epoch: "e",
+        seq: 2,
+      });
+    expect(store.getState().worktrees.has("wt-2")).toBe(true);
   });
 
   it("accepts a lower generation from a restarted host", () => {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -23,6 +23,18 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 const TOMBSTONE_TTL_MS = 30_000;
 
 /**
+ * A removed worktree's suppression record. `generation` is the torn-down
+ * monitor's incarnation stamp; an update carrying a strictly higher one is a
+ * genuine re-creation at the same path and must be let through, while a late
+ * buffered update from the removed monitor carries the same stamp and stays
+ * suppressed (#11994). `removedAt` remains the fallback for unstamped events.
+ */
+interface WorktreeTombstone {
+  removedAt: number;
+  generation?: number;
+}
+
+/**
  * Order two host-minted version stamps. A differing epoch means the events
  * came from different host runs — UUIDv4 epochs carry no ordering, so a new
  * epoch always wins (the renderer re-hydrates from the fresh host). Within an
@@ -241,11 +253,12 @@ export interface WorktreeViewState {
    */
   version: WorktreeEventVersion;
   /**
-   * `worktreeId → removedAt` (epoch ms) for recently removed worktrees, so a
-   * late same-epoch `worktree-update` can't resurrect a deleted row. Cleared
-   * on epoch transition; entries expire after {@link TOMBSTONE_TTL_MS}.
+   * `worktreeId → tombstone` for recently removed worktrees, so a late
+   * same-epoch `worktree-update` can't resurrect a deleted row. Cleared on
+   * epoch transition; entries expire after {@link TOMBSTONE_TTL_MS} or when a
+   * newer monitor incarnation claims the id.
    */
-  tombstones: Map<string, number>;
+  tombstones: Map<string, WorktreeTombstone>;
   /**
    * Worktrees with a delete currently in flight (renderer-local — no backend
    * lifecycle phase exists for delete). Drives the card's reduced-opacity
@@ -308,7 +321,14 @@ export interface WorktreeViewActions {
     version: WorktreeEventVersion,
     associations?: Record<string, ManualIssueAssociation>
   ): void;
-  applyUpdate(state: WorktreeSnapshot, version: WorktreeEventVersion): void;
+  /**
+   * Merge one host `worktree-update` into the map. Returns whether the event
+   * was accepted — a stale version, a superseded monitor incarnation or an
+   * active tombstone all reject it. Callers must gate any side effect that
+   * assumes the worktree is now present (clearing the "Creating…" placeholder,
+   * applying a pending selection) on a `true` return (#11994).
+   */
+  applyUpdate(state: WorktreeSnapshot, version: WorktreeEventVersion): boolean;
   /**
    * Clear forge-issue overlay without going through `mergeIssueState`, which
    * would restore the previous `issueTitle` whenever `issueNumber` is
@@ -318,7 +338,12 @@ export interface WorktreeViewActions {
    * fallback intact (#8851).
    */
   applyIssueNotFound(worktreeId: string, issueNumber: number): void;
-  applyRemove(worktreeId: string, version: WorktreeEventVersion): void;
+  /**
+   * `generation` is the removed monitor's incarnation stamp, recorded on the
+   * tombstone so a later update can be told apart from a re-creation at the
+   * same path (#11994).
+   */
+  applyRemove(worktreeId: string, version: WorktreeEventVersion, generation?: number): void;
   setManualAssociation(worktreeId: string, assoc: ManualIssueAssociation): void;
   clearManualAssociation(worktreeId: string): void;
   startDelete(worktreeId: string, options: WorktreeDeleteOptions): void;
@@ -505,7 +530,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
 
     applyUpdate(state: WorktreeSnapshot, version: WorktreeEventVersion) {
       const prevState = get();
-      if (compareVersion(version, prevState.version) < 0) return;
+      if (compareVersion(version, prevState.version) < 0) return false;
       const prev = prevState.worktrees;
       const existing = prev.get(state.id);
 
@@ -517,14 +542,38 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const epochChanged = version.epoch !== prevState.version.epoch;
       if (epochChanged) {
         if (tombstones.size > 0) tombstones = new Map();
-      } else if (!existing) {
-        const removedAt = tombstones.get(state.id);
-        if (removedAt !== undefined) {
-          if (Date.now() - removedAt < TOMBSTONE_TTL_MS) {
+      } else if (existing) {
+        // Incarnation fence for a row that is already live: once a re-created
+        // worktree has landed, a continuation still running against the
+        // torn-down monitor for the same path would otherwise clobber the new
+        // row with pre-delete data. Only a strictly older stamp is rejected, so
+        // the renderer's own overlay updates (which reuse the row's stamp) and
+        // unstamped events are unaffected.
+        if (
+          state.generation !== undefined &&
+          existing.generation !== undefined &&
+          state.generation < existing.generation
+        ) {
+          set({ version });
+          return false;
+        }
+      } else {
+        const tombstone = tombstones.get(state.id);
+        if (tombstone !== undefined) {
+          // A strictly higher incarnation means the host built a new monitor
+          // for this path, so this is a genuine re-creation rather than the
+          // buffered update the tombstone exists to suppress (#11994). The
+          // suppression window says nothing about it — accept regardless of
+          // how much of the TTL is left.
+          const recreated =
+            state.generation !== undefined &&
+            tombstone.generation !== undefined &&
+            state.generation > tombstone.generation;
+          if (!recreated && Date.now() - tombstone.removedAt < TOMBSTONE_TTL_MS) {
             // Still within the suppression window — drop the late update but
             // advance the version so a subsequent stale event stays rejected.
             set({ version });
-            return;
+            return false;
           }
           tombstones = new Map(tombstones);
           tombstones.delete(state.id);
@@ -569,7 +618,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
           ...(tombstonesChanged ? { tombstones } : {}),
         });
-        return;
+        return true;
       }
       const next = new Map(prev);
       next.set(state.id, merged);
@@ -580,6 +629,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
         ...(tombstonesChanged ? { tombstones } : {}),
       });
+      return true;
     },
 
     applyIssueNotFound(worktreeId: string, issueNumber: number) {
@@ -627,7 +677,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       set({ manualAssociations: nextAssoc });
     },
 
-    applyRemove(worktreeId: string, version: WorktreeEventVersion) {
+    applyRemove(worktreeId: string, version: WorktreeEventVersion, generation?: number) {
       const prevState = get();
       if (compareVersion(version, prevState.version) < 0) return;
 
@@ -636,13 +686,21 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       // set fresh — the prior run's removals don't apply to the new host.
       const now = Date.now();
       const epochChanged = version.epoch !== prevState.version.epoch;
-      const tombstones = epochChanged ? new Map<string, number>() : new Map(prevState.tombstones);
+      const tombstones = epochChanged
+        ? new Map<string, WorktreeTombstone>()
+        : new Map(prevState.tombstones);
       // Reap expired tombstones on write so ids that never receive a follow-up
       // update can't accumulate unbounded over a long high-churn session.
-      for (const [id, removedAt] of tombstones) {
-        if (now - removedAt >= TOMBSTONE_TTL_MS) tombstones.delete(id);
+      for (const [id, tombstone] of tombstones) {
+        if (now - tombstone.removedAt >= TOMBSTONE_TTL_MS) tombstones.delete(id);
       }
-      tombstones.set(worktreeId, now);
+      // Fall back to the outgoing row's stamp when the event didn't carry one,
+      // so the incarnation comparison still works for any path that removes a
+      // worktree the store had already hydrated from a snapshot.
+      tombstones.set(worktreeId, {
+        removedAt: now,
+        generation: generation ?? prevState.worktrees.get(worktreeId)?.generation,
+      });
 
       const hadWorktree = prevState.worktrees.has(worktreeId);
       const hadStatusCheckedAt = prevState.statusCheckedAt.has(worktreeId);
@@ -1738,6 +1796,10 @@ function mergeIssueState(
 
 function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
   return (
+    // Compared so a new incarnation of the same path is never collapsed as
+    // value-equal — the row must adopt the newer stamp or the fence in
+    // `applyUpdate` would keep judging against the dead monitor's (#11994).
+    a.generation === b.generation &&
     a.branch === b.branch &&
     a.path === b.path &&
     a.name === b.name &&

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -35,12 +35,16 @@ interface WorktreeTombstone {
 }
 
 /**
- * Ceiling on retained tombstones. A stamped one outlives {@link TOMBSTONE_TTL_MS}
- * (only a newer incarnation retires it), so age-based eviction is what keeps a
- * long session that churns hundreds of worktrees from growing the map without
- * bound. Insertion order tracks recency — `applyRemove` re-inserts on rewrite.
+ * How long a *stamped* tombstone is kept. Unlike {@link TOMBSTONE_TTL_MS} this
+ * is not a correctness window — the incarnation comparison decides those cases
+ * algebraically — it only stops fences accumulating for the life of an epoch.
+ * The bound worth clearing is the longest a torn-down monitor can still emit:
+ * a queued git-status pass is capped at 60s by the host's own poll-queue
+ * timeout, so ten minutes is two orders of magnitude of headroom over the
+ * thing it has to outlive. Counting entries instead would be wrong — evicting
+ * by volume can drop a fence whose monitor has not gone quiet yet.
  */
-const MAX_TOMBSTONES = 256;
+const FENCE_TTL_MS = 10 * 60_000;
 
 /**
  * Drop the tombstones a host snapshot has settled. An id the host still reports
@@ -726,23 +730,14 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         ? new Map<string, WorktreeTombstone>()
         : new Map(prevState.tombstones);
       // Reap on write so ids that never receive a follow-up update can't
-      // accumulate over a long high-churn session. Only unstamped tombstones
-      // expire by age — a stamped one is a durable fence and is retired by a
-      // newer incarnation, an epoch change, or the size cap below.
+      // accumulate over a long high-churn session. A stamped fence is durable —
+      // retired by a newer incarnation, an epoch change, or a snapshot that
+      // reports the id alive — so it expires on the far longer FENCE_TTL_MS
+      // rather than the suppression window.
       for (const [id, tombstone] of tombstones) {
-        if (tombstone.generation === undefined && now - tombstone.removedAt >= TOMBSTONE_TTL_MS) {
-          tombstones.delete(id);
-        }
+        const ttl = tombstone.generation === undefined ? TOMBSTONE_TTL_MS : FENCE_TTL_MS;
+        if (now - tombstone.removedAt >= ttl) tombstones.delete(id);
       }
-      while (tombstones.size >= MAX_TOMBSTONES) {
-        const oldest = tombstones.keys().next().value;
-        if (oldest === undefined) break;
-        tombstones.delete(oldest);
-      }
-      // Delete before re-inserting so insertion order tracks recency: `set` on
-      // an existing key would leave the entry at its original position and the
-      // eviction above would then evict by first-seen rather than by age.
-      tombstones.delete(worktreeId);
       // Fall back to the outgoing row's stamp when the event didn't carry one,
       // so the incarnation comparison still works for any path that removes a
       // worktree the store had already hydrated from a snapshot.

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -35,6 +35,33 @@ interface WorktreeTombstone {
 }
 
 /**
+ * Ceiling on retained tombstones. A stamped one outlives {@link TOMBSTONE_TTL_MS}
+ * (only a newer incarnation retires it), so age-based eviction is what keeps a
+ * long session that churns hundreds of worktrees from growing the map without
+ * bound. Insertion order tracks recency — `applyRemove` re-inserts on rewrite.
+ */
+const MAX_TOMBSTONES = 256;
+
+/**
+ * Drop the tombstones a host snapshot has settled. An id the host still reports
+ * is alive by definition, and an unstamped tombstone has no incarnation to
+ * compare against so the snapshot is the last word on it. A stamped one for an
+ * id the host does NOT report stays: the removal it records is still in force,
+ * and dropping it would let a poll that outlived the removal resurrect the row
+ * (the pre-existing #8403 hole the incarnation stamp finally closes).
+ */
+function retainTombstoneFences(
+  tombstones: ReadonlyMap<string, WorktreeTombstone>,
+  liveIds: ReadonlySet<string>
+): Map<string, WorktreeTombstone> {
+  const next = new Map<string, WorktreeTombstone>();
+  for (const [id, tombstone] of tombstones) {
+    if (tombstone.generation !== undefined && !liveIds.has(id)) next.set(id, tombstone);
+  }
+  return next;
+}
+
+/**
  * Order two host-minted version stamps. A differing epoch means the events
  * came from different host runs — UUIDv4 epochs carry no ordering, so a new
  * epoch always wins (the renderer re-hydrates from the fresh host). Within an
@@ -428,10 +455,16 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     ) {
       const prev = get();
       if (compareVersion(version, prev.version) < 0) return;
-      // A snapshot is the host's authoritative state. Drop every tombstone:
-      // an epoch transition means the host rebuilt from scratch, and within
-      // the same epoch any id the host still reports is alive by definition.
-      const tombstonesChanged = prev.tombstones.size > 0;
+      // A snapshot is the host's authoritative state. An epoch transition means
+      // the host rebuilt from scratch, so nothing from the prior run survives;
+      // within the same epoch the snapshot settles every id it reports, but a
+      // stamped fence for an id it does NOT report still stands (see
+      // `retainTombstoneFences`).
+      const epochChanged = version.epoch !== prev.version.epoch;
+      const nextTombstones = epochChanged
+        ? new Map<string, WorktreeTombstone>()
+        : retainTombstoneFences(prev.tombstones, new Set(states.map((s) => s.id)));
+      const tombstonesChanged = nextTombstones.size !== prev.tombstones.size;
       // Atomically adopt the freshly-hydrated manual associations alongside
       // the snapshot (lesson #4958 — no separate slice update that could
       // render a half-merged state). When the caller doesn't pass them
@@ -505,7 +538,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           ...(workingTreeChangedAtChanged
             ? { workingTreeChangedAtById: nextWorkingTreeChangedAt }
             : {}),
-          ...(tombstonesChanged ? { tombstones: new Map() } : {}),
+          ...(tombstonesChanged ? { tombstones: nextTombstones } : {}),
           ...(associationsChanged ? { manualAssociations: manual } : {}),
         });
         return;
@@ -523,7 +556,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         ...(workingTreeChangedAtChanged
           ? { workingTreeChangedAtById: nextWorkingTreeChangedAt }
           : {}),
-        ...(tombstonesChanged ? { tombstones: new Map() } : {}),
+        ...(tombstonesChanged ? { tombstones: nextTombstones } : {}),
         ...(associationsChanged ? { manualAssociations: manual } : {}),
       });
     },
@@ -548,30 +581,33 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         // torn-down monitor for the same path would otherwise clobber the new
         // row with pre-delete data. Only a strictly older stamp is rejected, so
         // the renderer's own overlay updates (which reuse the row's stamp) and
-        // unstamped events are unaffected.
+        // unstamped events are unaffected. The version is deliberately NOT
+        // advanced: the fence lives on the row itself, so it keeps rejecting
+        // later stale events without borrowing the event counter to do it —
+        // and advancing here would make an in-flight snapshot look stale and
+        // strand the row (the snapshot is version-gated too).
         if (
           state.generation !== undefined &&
           existing.generation !== undefined &&
           state.generation < existing.generation
         ) {
-          set({ version });
           return false;
         }
       } else {
         const tombstone = tombstones.get(state.id);
         if (tombstone !== undefined) {
-          // A strictly higher incarnation means the host built a new monitor
-          // for this path, so this is a genuine re-creation rather than the
-          // buffered update the tombstone exists to suppress (#11994). The
-          // suppression window says nothing about it — accept regardless of
-          // how much of the TTL is left.
-          const recreated =
-            state.generation !== undefined &&
-            tombstone.generation !== undefined &&
-            state.generation > tombstone.generation;
-          if (!recreated && Date.now() - tombstone.removedAt < TOMBSTONE_TTL_MS) {
-            // Still within the suppression window — drop the late update but
-            // advance the version so a subsequent stale event stays rejected.
+          if (state.generation !== undefined && tombstone.generation !== undefined) {
+            // Both stamped, so the decision is algebraic and the wall clock
+            // plays no part: only a newer monitor incarnation may claim the id
+            // back. A strictly higher stamp is the host having built a new
+            // monitor for this path — a genuine re-creation (#11994) — while
+            // anything at or below it is the buffered update the tombstone
+            // exists to suppress, however long it took to arrive.
+            if (state.generation <= tombstone.generation) return false;
+          } else if (Date.now() - tombstone.removedAt < TOMBSTONE_TTL_MS) {
+            // One side is unstamped, so fall back to the suppression window:
+            // drop the late update but advance the version so a subsequent
+            // stale event stays rejected (#8403).
             set({ version });
             return false;
           }
@@ -689,11 +725,24 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const tombstones = epochChanged
         ? new Map<string, WorktreeTombstone>()
         : new Map(prevState.tombstones);
-      // Reap expired tombstones on write so ids that never receive a follow-up
-      // update can't accumulate unbounded over a long high-churn session.
+      // Reap on write so ids that never receive a follow-up update can't
+      // accumulate over a long high-churn session. Only unstamped tombstones
+      // expire by age — a stamped one is a durable fence and is retired by a
+      // newer incarnation, an epoch change, or the size cap below.
       for (const [id, tombstone] of tombstones) {
-        if (now - tombstone.removedAt >= TOMBSTONE_TTL_MS) tombstones.delete(id);
+        if (tombstone.generation === undefined && now - tombstone.removedAt >= TOMBSTONE_TTL_MS) {
+          tombstones.delete(id);
+        }
       }
+      while (tombstones.size >= MAX_TOMBSTONES) {
+        const oldest = tombstones.keys().next().value;
+        if (oldest === undefined) break;
+        tombstones.delete(oldest);
+      }
+      // Delete before re-inserting so insertion order tracks recency: `set` on
+      // an existing key would leave the entry at its original position and the
+      // eviction above would then evict by first-seen rather than by age.
+      tombstones.delete(worktreeId);
       // Fall back to the outgoing row's stamp when the event didn't carry one,
       // so the incarnation comparison still works for any path that removes a
       // worktree the store had already hydrated from a snapshot.


### PR DESCRIPTION
## Summary

A worktree id is its normalized path, so deleting a worktree and creating a new one at the same location mints the same id. `applyRemove` writes a 30 second tombstone keyed by that id, and `applyUpdate` drops any update for a tombstoned id, including the creation event, which is the only thing that puts a new worktree into the renderer's list. The new worktree stays invisible for 30 to 60 seconds, renders inside the "deleted worktrees" ghost group counting its fresh agents as survivors of the dead one, and if the ghost's cleanup countdown fires first, `bulkTrashByWorktree` trashes the brand new terminals.

The tombstone can't just go away. It guards #8403, where an in-flight `git status` poll that started before a delete resolves after the `worktree-removed` send and emits stale pre-delete data with a higher seq. The existing regression test proves that stale event is bit-for-bit identical on the wire to a genuine recreate, so `(epoch, seq)` alone can't tell them apart.

Resolves #11994

## The fix

A per-monitor incarnation stamp. The host mints a `generation` for each `WorktreeMonitor` from a process-wide monotonic counter and stamps it onto every snapshot via `SnapshotBuilder` (the sole construction point) and onto `worktree-removed` from `removeMonitor` (the sole emission point). A buffered update is closure-bound to the torn-down monitor, so it carries the old stamp. A genuine recreate carries a new one. The renderer's tombstone records the stamp and admits only a strictly higher one.

## Changes

- When both sides carry a stamp, the comparison is algebraic, so the wall clock plays no part: a poll that outlives the suppression window can no longer resurrect a removed worktree. The 30 second window remains only for unstamped events.
- A stamped fence survives a snapshot that still omits the id, and is retired once the host reports the id alive again.
- A live row is fenced against an older incarnation, so a dead monitor's late poll can't clobber the worktree that replaced it.
- An external-removal callback from a superseded monitor is ignored. Resolving by id alone would have found and deleted the worktree that just took its path.
- Monitor installs are single-flighted per id. The entry guard read `monitors` before three awaits, so two overlapping adds could both register. The losing caller now awaits the winner, preserving `performCreateWorktree`'s documented "monitor is registered once this resolves" invariant.
- The `worktree-update` handler now gates `applyPendingWorktreeSelection` and `resolvePendingCreation` on `applyUpdate` actually accepting the event. Running them on a dropped event is what made the swallowed creation silent: the "Creating..." placeholder cleared with no row and no error.

## Testing

688 tests pass across the store, context, and workspace-host suites, including the untouched #8403 tombstone regressions. New coverage: same-path recreate accepted inside the window, same-incarnation stale update still suppressed, one-sided-stamp fallback matrix, fence surviving a snapshot, fence lifetime, version not spent on a fenced rejection, host incarnation minting and removal stamping, the superseded-callback guard, and overlapping installs registering one monitor.
