### PR TITLE
Refine the MCP approval dialog's trust hierarchy

### DIFF
--- a/e2e/screenshots/mcp-confirm-review.spec.ts
+++ b/e2e/screenshots/mcp-confirm-review.spec.ts
@@ -1,0 +1,653 @@
+/**
+ * MCP approval-dialog visual-review harness (#11981).
+ *
+ * `McpConfirmDialog` is the singleton approval surface for every action an MCP
+ * client asks Daintree to run. It has to answer several trust questions at once
+ * — what will run, who asked, why it is gated, what content it affects, what
+ * arguments it carries — and the shape of that answer changes with the caller,
+ * the danger tier, and whether the fresh preview has landed yet. Those axes
+ * cross into far more states than anyone reads the JSX for, so the surface is
+ * judged on rendered pixels.
+ *
+ * States are parked directly in the confirmation queue through the E2E store
+ * backdoor (`window.__DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__`, installed by
+ * `useE2EBridges` under DAINTREE_E2E_MODE) rather than by standing up a real
+ * MCP client and a real destructive dispatch — the store IS the seam the
+ * production bridge writes through, so the dialog renders exactly what it
+ * renders in the app.
+ *
+ *   assistant-*   pinned help-session dispatch: no callerInfo, so the
+ *                 "Requested by" block is absent. The skeleton must not lurch
+ *                 between this and the external shape.
+ *   external-*    unpinned external/api-key dispatch carrying the requesting
+ *                 bearer's identity (#9157).
+ *   preview-*     the off-critical-path preview fetch: pending (approval
+ *                 disabled), populated, and empty/unavailable.
+ *   overflow      hostile lengths — an 8 KB-class user agent, a long redacted
+ *                 args blob, a 40-line preview. Proves the action row survives.
+ *   queued        three concurrent dispatches; only the head is visible.
+ *   cooldown      captured inside the destructive read-time gate, so the
+ *                 primary button is disabled for reasons the user must be able
+ *                 to tell apart from a broken action.
+ *   focus         keyboard focus ring on the primary action.
+ *   contrast      prefers-contrast: more.
+ *   forced        forced-colors: active.
+ *
+ * Opt-in only, like confirm-dialog-review: skips itself unless
+ * DAINTREE_SHOT_MCP is set, so the marketing screenshots workflow never runs it.
+ *
+ *   DAINTREE_SHOT_MCP=1 npx playwright test --project=screenshots mcp-confirm-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_MCP      required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME    optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG      optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY     comma-separated step filter (see step names above)
+ *   DAINTREE_SHOT_OUT      optional absolute output dir (default: artifacts/…)
+ *
+ * Output: artifacts/mcp-confirm-shots/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_MCP;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ?? path.resolve(process.cwd(), "artifacts", "mcp-confirm-shots");
+
+/**
+ * The dialog CARD, so the shot is the approval surface rather than the whole app.
+ * Not `[role="dialog"]` — `AppDialog` puts the role on the full-viewport backdrop
+ * (AppDialog.tsx:414), so a role-based locator silently screenshots the entire
+ * window and every "crop" comes back identical to the in-window shot.
+ */
+const DIALOG_BACKDROP = "[data-app-dialog-surface]";
+const DIALOG = `${DIALOG_BACKDROP} > div`;
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/** Minimal repo so the app has a project view to mount the singleton dialog in. */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-mcp-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  git("branch develop", dir);
+  git("checkout develop", dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture payloads. Deliberately realistic: `argsSummary` is what
+// `summarizeMcpArgs` actually produces (redacted, JSON-ish), preview lines are
+// what `buildMcpConfirmPreview` actually emits, and the rationale strings are
+// copied from real action definitions.
+// ---------------------------------------------------------------------------
+
+const RATIONALE_DELETE =
+  "Permanently removes the worktree directory and every uncommitted change inside it. The branch is left in place; the working copy is not recoverable.";
+
+const PREVIEW_DIRTY = [
+  "3 files with uncommitted changes:",
+  "  M  src/components/Terminal/HybridInputBar.tsx",
+  "  M  src/store/panelStore.ts",
+  "  ?? src/components/Terminal/InputHistory.tsx",
+];
+
+const PREVIEW_PUSH = [
+  "Branch: feature/agent-fanout → origin/feature/agent-fanout",
+  "2 local commits ahead:",
+  "  a41c9de  Widen the fanout budget to the worktree count",
+  "  7bd0f12  Drop the per-agent sleep now the queue is bounded",
+];
+
+const ARGS_SHORT = '{\n  "worktreeId": "wt-agent-fanout"\n}';
+
+const ARGS_LONG = [
+  "{",
+  '  "worktreeId": "wt-agent-fanout",',
+  '  "branch": "feature/agent-fanout",',
+  '  "force": true,',
+  '  "removeDirectory": true,',
+  '  "apiKey": "[redacted]",',
+  '  "token": "[redacted]",',
+  '  "context": {',
+  '    "projectId": "proj-helios-dashboard",',
+  '    "requestedBy": "assistant",',
+  '    "correlationId": "0f1c3b6a-9d4e-4b2a-8c71-5e3f9a0d2b14"',
+  "  },",
+  '  "reason": "Cleaning up the fanout worktrees after the batch merged"',
+  "}",
+].join("\n");
+
+const LONG_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) SomeVeryChattyMcpClient/4.19.2-nightly.20260814+build.7719 Chrome/148.0.0.0 Safari/537.36 mcp-sdk/1.24.0";
+
+const PREVIEW_HUGE = [
+  "41 files with uncommitted changes:",
+  ...Array.from({ length: 40 }, (_, i) => `  M  src/components/generated/Module${i + 1}.tsx`),
+];
+
+type ShotPayload = {
+  requestId: string;
+  actionId: string;
+  actionTitle: string;
+  actionDescription: string;
+  argsSummary: string;
+  danger: "safe" | "confirm" | "restricted";
+  dangerRationale?: string;
+  callerInfo?: { token4LastChars: string; userAgent: string };
+  preview?: string[];
+  previewTitle?: string;
+  previewPending?: boolean;
+};
+
+const EXTERNAL_CALLER = { token4LastChars: "8f3a", userAgent: "Claude Code 2.4.1 (darwin)" };
+
+/** Mirrors CONFIRM_COOLDOWN_MS in src/components/McpConfirmDialog.tsx. */
+const CONFIRM_COOLDOWN_MS = 1_200;
+
+function deleteWorktree(over: Partial<ShotPayload> = {}): ShotPayload {
+  return {
+    requestId: `shot-${Math.abs(hash(JSON.stringify(over)))}`,
+    actionId: "worktree.delete",
+    actionTitle: "Delete worktree",
+    actionDescription: "Permanently delete a git worktree and its directory.",
+    argsSummary: ARGS_SHORT,
+    danger: "confirm",
+    dangerRationale: RATIONALE_DELETE,
+    ...over,
+  };
+}
+
+/** Stable id per payload so a re-run of one step reuses its cooldown key. */
+function hash(value: string): number {
+  let h = 0;
+  for (let i = 0; i < value.length; i++) h = (Math.imul(31, h) + value.charCodeAt(i)) | 0;
+  return h;
+}
+
+// ---------------------------------------------------------------------------
+
+async function settle(page: Page, ms = 350): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Screenshot a state. `snap` is the only thing that writes a PNG, and it waits
+ * for the dialog to actually be on screen first — a shot taken of an empty
+ * workbench because a state failed to park is a plausible-looking artifact that
+ * would poison the review.
+ */
+async function snap(page: Page, slug: string, locator?: string): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    const target = page.locator(locator).last();
+    await target.waitFor({ state: "visible", timeout: 5000 });
+    await target.screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+}
+
+/** Clear the queue, then park exactly these items (FIFO — index 0 becomes visible). */
+async function park(page: Page, items: ShotPayload[]): Promise<void> {
+  await page.evaluate((payloads) => {
+    window.__DAINTREE_E2E_RESET_MCP_CONFIRM__?.();
+    for (const payload of payloads) {
+      window.__DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__?.(payload);
+    }
+  }, items);
+  await page.locator(DIALOG).last().waitFor({ state: "visible", timeout: 8000 });
+  // Past the destructive read-time gate, so a state captured through park() shows
+  // the primary button ENABLED. Without this every shot silently captures the
+  // 1.2s cooldown and the review scores a disabled button as the resting state.
+  await page.waitForTimeout(CONFIRM_COOLDOWN_MS + 300);
+}
+
+async function clearQueue(page: Page): Promise<void> {
+  await page.evaluate(() => window.__DAINTREE_E2E_RESET_MCP_CONFIRM__?.());
+  await page
+    .locator(DIALOG)
+    .last()
+    .waitFor({ state: "hidden", timeout: 5000 })
+    .catch(() => {});
+}
+
+/**
+ * Every built-in theme. Switching themes in place crashes the project view
+ * under this harness (same constraint as confirm-dialog-review), so the sweep
+ * boots once per theme:
+ *
+ *   for t in <these ids>; do
+ *     DAINTREE_SHOT_MCP=1 DAINTREE_SHOT_THEME=$t DAINTREE_SHOT_TAG=$t \
+ *     npx playwright test --project=screenshots mcp-confirm-review
+ *   done
+ */
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — the other shots are still worth
+// having. But the run must still FAIL, or a silent exit 0 with a half-empty
+// output directory reads as success.
+const failures: string[] = [];
+async function step(page: Page, name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).slice(0, 300);
+    console.warn(`[mcp-shots] step "${name}" failed:`, detail);
+    failures.push(`${name}: ${detail}`);
+  } finally {
+    // Unconditionally: a step that dies holding an open modal would wedge every
+    // step after it.
+    await clearQueue(page).catch((error) => {
+      failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+    });
+  }
+}
+
+test("MCP approval dialog review — trust hierarchy across caller, danger, and preview states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_MCP is required for the approval-dialog capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_MCP to run the approval-dialog capture");
+
+  // Module-scoped so `step()` can reach it; cleared here so a Playwright retry
+  // starts from a clean slate rather than inheriting the previous attempt's.
+  failures.length = 0;
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-mcpshot-"));
+  let ctx: AppContext | undefined;
+  let expectedShots = 0;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 1500);
+    await dismissBlockingPalette(page);
+
+    // The backdoor is the whole harness. If it never attached, every later step
+    // would "succeed" against an empty workbench, so fail loudly here instead.
+    const hasBackdoor = await page.evaluate(
+      () => typeof window.__DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__ === "function"
+    );
+    expect(hasBackdoor, "MCP confirm E2E backdoor is not installed (DAINTREE_E2E_MODE?)").toBe(
+      true
+    );
+
+    // ---- Assistant-owned dispatch: no provenance block ----------------------
+    await step(page, "assistant", async () => {
+      await park(page, [
+        {
+          requestId: "shot-assist-safe",
+          actionId: "worktree.list",
+          actionTitle: "List worktrees",
+          actionDescription: "List every git worktree in the current project.",
+          argsSummary: "(none)",
+          danger: "safe",
+        },
+      ]);
+      await snap(page, "10-assistant-safe-no-preview", DIALOG);
+      expectedShots++;
+
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-assist-destructive",
+          preview: PREVIEW_DIRTY,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "11-assistant-destructive-with-preview", DIALOG);
+      await snap(page, "12-assistant-destructive-in-window");
+      expectedShots += 2;
+    });
+
+    // ---- External client: the "Requested by" identity ----------------------
+    await step(page, "external", async () => {
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-ext-destructive",
+          callerInfo: EXTERNAL_CALLER,
+          preview: PREVIEW_DIRTY,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "20-external-destructive", DIALOG);
+      expectedShots++;
+
+      // Same action, non-destructive tier — the consequence hierarchy must
+      // differ from 20 by more than the button colour.
+      await park(page, [
+        {
+          requestId: "shot-ext-safe",
+          actionId: "git.status",
+          actionTitle: "Show git status",
+          actionDescription: "Report the working-tree status for a worktree.",
+          argsSummary: ARGS_SHORT,
+          danger: "safe",
+          callerInfo: EXTERNAL_CALLER,
+        },
+      ]);
+      await snap(page, "21-external-safe", DIALOG);
+      expectedShots++;
+
+      // A different preview shape: git.push previews commits, not files.
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-ext-push",
+          actionId: "git.push",
+          actionTitle: "Push branch",
+          actionDescription: "Push the current branch to its remote.",
+          dangerRationale:
+            "Publishes local commits to the shared remote, where other people and CI will act on them. Pushed history cannot be quietly withdrawn.",
+          callerInfo: EXTERNAL_CALLER,
+          preview: PREVIEW_PUSH,
+          previewTitle: "Branch and local commits",
+        }),
+      ]);
+      await snap(page, "22-external-push-commit-preview", DIALOG);
+      expectedShots++;
+    });
+
+    // ---- Preview lifecycle -------------------------------------------------
+    await step(page, "preview", async () => {
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-preview-pending",
+          callerInfo: EXTERNAL_CALLER,
+          previewPending: true,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "30-preview-pending", DIALOG);
+      expectedShots++;
+
+      // The same item after the fetch lands — the transition a real approver
+      // watches happen in place.
+      await page.evaluate(() =>
+        window.__DAINTREE_E2E_SET_MCP_PREVIEW__?.("shot-preview-pending", [
+          "3 files with uncommitted changes:",
+          "  M  src/components/Terminal/HybridInputBar.tsx",
+          "  M  src/store/panelStore.ts",
+          "  ?? src/components/Terminal/InputHistory.tsx",
+        ])
+      );
+      await snap(page, "31-preview-landed", DIALOG);
+      expectedShots++;
+
+      // Empty preview: the fetch succeeded and found nothing, or failed soft.
+      // Today this drops the whole block.
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-preview-empty",
+          callerInfo: EXTERNAL_CALLER,
+          preview: [],
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "32-preview-empty", DIALOG);
+      expectedShots++;
+
+      // No preview target at all (most actions), and no arguments either.
+      await park(page, [
+        {
+          requestId: "shot-no-args",
+          actionId: "app.reloadWindow",
+          actionTitle: "Reload window",
+          actionDescription: "Reload the Daintree window.",
+          argsSummary: "",
+          danger: "confirm",
+          dangerRationale: "Discards unsaved renderer state in every open panel.",
+          callerInfo: EXTERNAL_CALLER,
+        },
+      ]);
+      await snap(page, "33-no-preview-no-args", DIALOG);
+      expectedShots++;
+    });
+
+    // ---- Hostile lengths ---------------------------------------------------
+    await step(page, "overflow", async () => {
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-overflow",
+          callerInfo: { token4LastChars: "c19d", userAgent: LONG_USER_AGENT },
+          argsSummary: ARGS_LONG,
+          preview: PREVIEW_HUGE,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "40-overflow-dialog", DIALOG);
+      // The in-window shot is the one that proves the action row is reachable.
+      await snap(page, "41-overflow-in-window");
+      expectedShots += 2;
+    });
+
+    // ---- Queue depth -------------------------------------------------------
+    await step(page, "queued", async () => {
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-queue-1",
+          callerInfo: EXTERNAL_CALLER,
+          preview: PREVIEW_DIRTY,
+          previewTitle: "Working tree changes",
+        }),
+        deleteWorktree({
+          requestId: "shot-queue-2",
+          actionTitle: "Push branch",
+          callerInfo: { token4LastChars: "2b71", userAgent: "codex-cli/0.42.0" },
+        }),
+        {
+          requestId: "shot-queue-3",
+          actionId: "terminal.kill",
+          actionTitle: "Kill terminal",
+          actionDescription: "Terminate a running terminal process.",
+          argsSummary: '{\n  "terminalId": "pty-7"\n}',
+          danger: "confirm",
+          callerInfo: EXTERNAL_CALLER,
+        },
+      ]);
+      await snap(page, "50-three-queued-head-visible", DIALOG);
+      expectedShots++;
+
+      // The control: the SAME head payload with nothing queued behind it. If 50
+      // and 51 come back byte-identical, the surface tells the approver nothing
+      // about how many more requests are stacked behind the one they are reading.
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-queue-1",
+          callerInfo: EXTERNAL_CALLER,
+          preview: PREVIEW_DIRTY,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "51-single-not-queued-control", DIALOG);
+      expectedShots++;
+    });
+
+    // ---- Cooldown: disabled for a reason ------------------------------------
+    await step(page, "cooldown", async () => {
+      // No settle before the shot — the destructive read-time gate is only
+      // 1200ms, so this has to be captured immediately after parking.
+      await page.evaluate(() => {
+        window.__DAINTREE_E2E_RESET_MCP_CONFIRM__?.();
+        window.__DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__?.({
+          requestId: "shot-cooldown",
+          actionId: "worktree.delete",
+          actionTitle: "Delete worktree",
+          actionDescription: "Permanently delete a git worktree and its directory.",
+          argsSummary: '{\n  "worktreeId": "wt-agent-fanout"\n}',
+          danger: "confirm",
+          dangerRationale:
+            "Permanently removes the worktree directory and every uncommitted change inside it. The branch is left in place; the working copy is not recoverable.",
+          callerInfo: { token4LastChars: "8f3a", userAgent: "Claude Code 2.4.1 (darwin)" },
+          preview: [
+            "3 files with uncommitted changes:",
+            "  M  src/components/Terminal/HybridInputBar.tsx",
+            "  M  src/store/panelStore.ts",
+            "  ?? src/components/Terminal/InputHistory.tsx",
+          ],
+          previewTitle: "Working tree changes",
+        });
+      });
+      await page.locator(DIALOG).last().waitFor({ state: "visible", timeout: 8000 });
+      const file = path.join(OUTPUT_DIR, `60-cooldown-active${TAG}.png`);
+      await page.locator(DIALOG).last().screenshot({ path: file, type: "png" });
+      expectedShots++;
+
+      // And the same dialog once the gate clears, so the two are comparable.
+      await page.waitForTimeout(1600);
+      await snap(page, "61-cooldown-cleared", DIALOG);
+      expectedShots++;
+    });
+
+    // ---- Keyboard focus ----------------------------------------------------
+    await step(page, "focus", async () => {
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-focus",
+          callerInfo: EXTERNAL_CALLER,
+          preview: PREVIEW_DIRTY,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await page.keyboard.press("Tab");
+      await snap(page, "70-keyboard-focus-first", DIALOG);
+      await page.keyboard.press("Tab");
+      await snap(page, "71-keyboard-focus-second", DIALOG);
+      expectedShots += 2;
+    });
+
+    // ---- Accessibility media modes -----------------------------------------
+    await step(page, "contrast", async () => {
+      await page.emulateMedia({ contrast: "more" }).catch(() => {});
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-contrast",
+          callerInfo: EXTERNAL_CALLER,
+          preview: PREVIEW_DIRTY,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "80-prefers-contrast-more", DIALOG);
+      expectedShots++;
+      await page.emulateMedia({ contrast: "no-preference" }).catch(() => {});
+    });
+
+    await step(page, "forced", async () => {
+      await page.emulateMedia({ forcedColors: "active" }).catch(() => {});
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-forced",
+          callerInfo: EXTERNAL_CALLER,
+          preview: PREVIEW_DIRTY,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "81-forced-colors-active", DIALOG);
+      expectedShots++;
+      await page.emulateMedia({ forcedColors: "none" }).catch(() => {});
+    });
+  } finally {
+    // Each cleanup runs even if an earlier one throws.
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    try {
+      repo.cleanup();
+    } catch {
+      /* best effort */
+    }
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`[mcp-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`);
+  }
+
+  // Count the files rather than trusting the exit code: a harness that reports
+  // success while writing nothing is worse than one that fails.
+  const written = readdirSync(OUTPUT_DIR).filter(
+    (f) => f.endsWith(`${TAG}.png`) || (TAG === "" && f.endsWith(".png"))
+  );
+  expect(
+    written.length,
+    `[mcp-shots] expected ${expectedShots} PNGs in ${OUTPUT_DIR}, found ${written.length}`
+  ).toBeGreaterThanOrEqual(expectedShots);
+});

--- a/e2e/screenshots/mcp-confirm-review.spec.ts
+++ b/e2e/screenshots/mcp-confirm-review.spec.ts
@@ -173,6 +173,7 @@ type ShotPayload = {
   actionDescription: string;
   argsSummary: string;
   danger: "safe" | "confirm" | "restricted";
+  sessionOrigin?: "help" | "assistant-pane" | "external";
   dangerRationale?: string;
   callerInfo?: { token4LastChars: string; userAgent: string };
   preview?: string[];
@@ -181,6 +182,7 @@ type ShotPayload = {
 };
 
 const EXTERNAL_CALLER = { token4LastChars: "8f3a", userAgent: "Claude Code 2.4.1 (darwin)" };
+const EXTERNAL_ORIGIN = "external" as const;
 
 /** Mirrors CONFIRM_COOLDOWN_MS in src/components/McpConfirmDialog.tsx. */
 const CONFIRM_COOLDOWN_MS = 1_200;
@@ -360,6 +362,9 @@ test("MCP approval dialog review — trust hierarchy across caller, danger, and 
           actionDescription: "List every git worktree in the current project.",
           argsSummary: "(none)",
           danger: "safe",
+          // Without an origin these render the "Unidentified client" fallback,
+          // so the shot named "assistant" would prove the wrong branch.
+          sessionOrigin: "help",
         },
       ]);
       await snap(page, "10-assistant-safe-no-preview", DIALOG);
@@ -368,6 +373,7 @@ test("MCP approval dialog review — trust hierarchy across caller, danger, and 
       await park(page, [
         deleteWorktree({
           requestId: "shot-assist-destructive",
+          sessionOrigin: "help",
           preview: PREVIEW_DIRTY,
           previewTitle: "Working tree changes",
         }),
@@ -375,6 +381,19 @@ test("MCP approval dialog review — trust hierarchy across caller, danger, and 
       await snap(page, "11-assistant-destructive-with-preview", DIALOG);
       await snap(page, "12-assistant-destructive-in-window");
       expectedShots += 2;
+
+      // Neither an external client nor the assistant: a session whose token
+      // hash was never registered. It must not borrow the assistant's standing.
+      await park(page, [
+        deleteWorktree({
+          requestId: "shot-unidentified",
+          sessionOrigin: "external",
+          preview: PREVIEW_DIRTY,
+          previewTitle: "Working tree changes",
+        }),
+      ]);
+      await snap(page, "13-unidentified-caller", DIALOG);
+      expectedShots++;
     });
 
     // ---- External client: the "Requested by" identity ----------------------

--- a/src/components/Git/gitRemoteOperationPreview.ts
+++ b/src/components/Git/gitRemoteOperationPreview.ts
@@ -11,6 +11,7 @@
  */
 
 import type { GitPushDestination } from "@shared/types/git";
+import { MCP_PREVIEW_CAUTION_PREFIX } from "@/lib/mcpPreviewLines";
 
 /** Max commits fetched and shown before the tail is collapsed. */
 export const PREVIEW_COMMIT_LIMIT = 12;
@@ -90,7 +91,9 @@ export function formatGitRemoteOperationPreviewLines(
   operation: GitRemoteOperationKind
 ): string[] {
   if (preview === null) {
-    return ["⚠ Could not verify the branch and local commits — proceed with caution."];
+    return [
+      `${MCP_PREVIEW_CAUTION_PREFIX}Could not verify the branch and local commits — proceed with caution.`,
+    ];
   }
   const branchLine = `Branch: ${preview.branch ?? "(detached HEAD)"}`;
   // Named before the commits: which repository this writes to is the fact an
@@ -102,8 +105,8 @@ export function formatGitRemoteOperationPreviewLines(
   const destinationLine = remoteRef
     ? `${isPullRebase ? "Rebases onto" : "Destination"}: ${formatGitPushDestination(remoteRef)}`
     : isPullRebase
-      ? "⚠ This branch has no upstream to rebase onto — this operation will be refused."
-      : "⚠ No push destination is configured for this branch — this operation will be refused.";
+      ? `${MCP_PREVIEW_CAUTION_PREFIX}This branch has no upstream to rebase onto — this operation will be refused.`
+      : `${MCP_PREVIEW_CAUTION_PREFIX}No push destination is configured for this branch — this operation will be refused.`;
   if (preview.commits.length === 0) {
     return [destinationLine, branchLine, emptyNote];
   }

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertTriangle, ChevronRight, Plug, ShieldAlert, Sparkles } from "lucide-react";
 import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
+import { cn } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { Spinner } from "@/components/ui/Spinner";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { useMcpConfirmStore } from "@/store/mcpConfirmStore";
+import { isCautionPreviewLine, stripCautionPrefix } from "@/lib/mcpPreviewLines";
+import { useMcpConfirmStore, type PendingMcpConfirm } from "@/store/mcpConfirmStore";
 
 /**
  * Renderer-side timer that beats main's 30s `pendingDispatches` deadline by
@@ -18,6 +22,10 @@ const CONFIRMATION_TIMEOUT_MS = 28_000;
  * the second click; this disables the primary button briefly after each item
  * is promoted so a click meant for the previous modal can't silently approve a
  * freshly-promoted destructive write before the user has read it.
+ *
+ * This is a click-carry-over guard, not an attention device — passive delays
+ * are known not to make anyone read. Chromium applies 500-1000ms to its own
+ * security prompts for the same hazard; 1200ms sits just above that floor.
  */
 const CONFIRM_COOLDOWN_MS = 1_200;
 
@@ -25,9 +33,22 @@ const CONFIRM_COOLDOWN_MS = 1_200;
  * Upper bound for the user-agent shown in the "Requested by" row. An external
  * client controls its own `User-Agent` header (capped at Node's ~8 KB header
  * limit, not at a sane length), so clamp the display value here so an oversized
- * string can't push the Arguments block and confirm button below the fold.
+ * string can't push the rest of the request out of view. The row is also
+ * clamped to a single line in CSS — 120 characters is still three wrapped lines
+ * in a `max-w-md` dialog, which is three lines of incidental client text
+ * sitting above the evidence that actually decides the approval.
  */
 const MAX_USER_AGENT_DISPLAY = 120;
+
+/**
+ * Height reserved for the preview body before its content lands. Sized to the
+ * common case (a heading plus ~3 rows) so the card does not grow when the fetch
+ * resolves: the dialog is centre-anchored, so a body that grows moves the
+ * confirm button — and it moves at the exact moment the button also stops being
+ * disabled. A relocating, newly-live destructive target is a misclick hazard,
+ * so the loading state reserves the space the content will occupy.
+ */
+const PREVIEW_MIN_BODY_HEIGHT = "min-h-[5.5rem]";
 
 function truncateUserAgent(userAgent: string): string {
   return userAgent.length > MAX_USER_AGENT_DISPLAY
@@ -36,13 +57,44 @@ function truncateUserAgent(userAgent: string): string {
 }
 
 /**
+ * What the fresh-preview fetch has to say, derived from the payload rather than
+ * stored as a separate field — `preview` and `previewPending` already encode
+ * all four cases and the store contract does not need to widen:
+ *
+ *   none        no preview target for this action; nothing was ever attempted.
+ *   pending     a target exists and the fetch is in flight.
+ *   ready       lines came back.
+ *   unavailable a target existed and produced nothing — the monitor was gone,
+ *               or a rejection escaped the builder and the bridge cleared the
+ *               pending flag with an empty array. Distinct from `none`, and the
+ *               distinction matters: it is the difference between "this action
+ *               has no content to show" and "we could not find out what this
+ *               affects", and a D2 approval must never read the second as the
+ *               first.
+ */
+type PreviewState = "none" | "pending" | "ready" | "unavailable";
+
+export function derivePreviewState(current: PendingMcpConfirm): PreviewState {
+  if (current.previewPending === true) return "pending";
+  if (current.preview === undefined) return "none";
+  return current.preview.length > 0 ? "ready" : "unavailable";
+}
+
+/**
  * Singleton dialog driven by the MCP confirmation queue. Mounted once near
  * the top of `App.tsx`. Reads `current` from `useMcpConfirmStore` and
  * surfaces one `ConfirmDialog` at a time — concurrent agent calls queue
  * FIFO behind the visible modal rather than stacking overlapping dialogs.
+ *
+ * Body order follows the ordering every permission surface converges on —
+ * identity, then consequence, then evidence, then technical detail. People
+ * anchor their trust judgement on who is asking before they weigh what is
+ * being asked, so provenance leads; but it leads as one compact line, because
+ * its cost in vertical space is what pushed the evidence down before.
  */
 export function McpConfirmDialog() {
   const current = useMcpConfirmStore((state) => state.current);
+  const queueDepth = useMcpConfirmStore((state) => state.queue.length);
   const resolveCurrent = useMcpConfirmStore((state) => state.resolveCurrent);
   const resetKey = current?.requestId ?? "null";
 
@@ -100,14 +152,18 @@ export function McpConfirmDialog() {
 
   // Severity follows the action's registry classification, not the fact that
   // an MCP client dispatched it; only genuinely destructive dispatches earn
-  // red. Provenance differs by dispatch origin: pinned help-session dispatch
-  // is the assistant's own panel, so `callerInfo` is absent and the dialog
-  // stays provenance-free. Unpinned external/api-key dispatch carries the
-  // requesting bearer's identity (#9157), surfaced in a "Requested by" row so
-  // the user can see which client is asking before approving.
+  // red. Daintree classifies its own actions, so unlike a remote server's
+  // self-reported tool annotations this value is trusted.
   const isDestructive = current.danger === "confirm";
   const variant = isDestructive ? "destructive" : "default";
-  const callerInfo = current.callerInfo;
+  const previewState = derivePreviewState(current);
+  const hasArgs = current.argsSummary.trim().length > 0;
+
+  // `alertdialog` is for a brief, important message; APG reserves it for text
+  // the screen reader should read out whole on open. This body carries a
+  // scrollable file list and a redacted payload, so it is a `dialog` whenever
+  // either is present — matching every sibling confirm that shows a preview.
+  const hasScrollableContent = previewState !== "none" || hasArgs;
 
   return (
     <ErrorBoundary variant="component" componentName="McpConfirmDialog" resetKeys={[resetKey]}>
@@ -120,55 +176,279 @@ export function McpConfirmDialog() {
         cancelLabel="Cancel"
         onConfirm={() => resolveOnce(current.requestId, "approved")}
         variant={variant}
-        confirmDisabled={Boolean(current.previewPending)}
+        hasPreview={hasScrollableContent}
+        confirmDisabled={previewState === "pending"}
         confirmCooldownMs={isDestructive ? CONFIRM_COOLDOWN_MS : undefined}
         cooldownKey={current.requestId}
+        hint={<GateHint previewState={previewState} queueDepth={queueDepth} />}
       >
         <div className="space-y-3">
-          {callerInfo && (
-            <div className="space-y-2">
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-                Requested by
-              </div>
-              <div className="text-xs text-daintree-text/80 break-words">
-                …{callerInfo.token4LastChars} · {truncateUserAgent(callerInfo.userAgent)}
-              </div>
-            </div>
-          )}
+          <RequesterRow current={current} />
+
           {current.dangerRationale && (
-            <div className="space-y-2">
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-                Why this is gated
-              </div>
-              <div className="text-xs text-daintree-text/80 break-words">
-                {current.dangerRationale}
-              </div>
-            </div>
+            <ConsequenceNote isDestructive={isDestructive}>
+              {current.dangerRationale}
+            </ConsequenceNote>
           )}
-          {(current.previewPending || (current.preview && current.preview.length > 0)) && (
-            <div className="space-y-2">
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-                {current.previewTitle ?? "Working tree changes"}
-              </div>
-              {current.previewPending ? (
-                <div className="text-xs text-daintree-text/60">Checking current changes…</div>
-              ) : (
-                <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
-                  {current.preview?.join("\n")}
-                </pre>
-              )}
-            </div>
+
+          {previewState !== "none" && (
+            <PreviewCard
+              title={current.previewTitle ?? "Working tree changes"}
+              state={previewState}
+              lines={current.preview ?? []}
+            />
           )}
-          <div className="space-y-2">
-            <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-              Arguments
-            </div>
-            <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
-              {current.argsSummary || "(none)"}
-            </pre>
-          </div>
+
+          {hasArgs && <ArgumentsDisclosure argsSummary={current.argsSummary} />}
         </div>
       </ConfirmDialog>
     </ErrorBoundary>
+  );
+}
+
+/** Shared micro-label, matching the section-heading grammar used app-wide. */
+const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
+
+/**
+ * Who is asking, in one line.
+ *
+ * Provenance differs by dispatch origin, and an absent `callerInfo` has two
+ * causes, not one: the pinned help-session route never carries an identity
+ * (the assistant's own panel is its own context), and `getBearerInfoForSession`
+ * also returns null for a session whose token hash was never registered. So the
+ * row reads `sessionOrigin` — the field that actually records which class of
+ * surface dispatched — and names an unidentified caller as unidentified rather
+ * than letting it inherit the assistant's standing.
+ *
+ * The row is always present. It was previously dropped entirely for
+ * assistant-owned requests, which moved everything below it by ~52px whenever a
+ * queued item promoted across origins, and left the most trusted case looking
+ * like a missing section.
+ */
+function RequesterRow({ current }: { current: PendingMcpConfirm }) {
+  const { callerInfo, sessionOrigin } = current;
+  const isAssistant = sessionOrigin === "help" || sessionOrigin === "assistant-pane";
+
+  let Icon = ShieldAlert;
+  let name = "Unidentified client";
+  let detail: string | null = null;
+
+  if (callerInfo) {
+    Icon = Plug;
+    name = truncateUserAgent(callerInfo.userAgent);
+    detail = `…${callerInfo.token4LastChars}`;
+  } else if (isAssistant) {
+    Icon = Sparkles;
+    name = "Daintree Assistant";
+  }
+
+  return (
+    <div className="flex items-baseline gap-2 text-xs">
+      <span className={cn(MICRO_LABEL, "shrink-0")}>Requested by</span>
+      <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+        <Icon
+          aria-hidden="true"
+          className="w-3 h-3 shrink-0 translate-y-0.5 text-daintree-text/45"
+        />
+        <span className="truncate text-daintree-text/80" title={callerInfo?.userAgent}>
+          {name}
+        </span>
+        {detail && (
+          <span className="shrink-0 font-mono text-[11px] text-daintree-text/45">{detail}</span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Why the action is gated.
+ *
+ * For a destructive dispatch this is the consequence statement, so it gets a
+ * toned callout with a real icon rather than another paragraph at body weight:
+ * an icon keeps its shape under `forced-colors: active`, where the destructive
+ * button's fill is replaced by a system colour and stops distinguishing itself
+ * from Cancel. One toned block also keeps the severity signal singular — the
+ * point is a consequence hierarchy, not red spread across every section.
+ */
+function ConsequenceNote({
+  isDestructive,
+  children,
+}: {
+  isDestructive: boolean;
+  children: React.ReactNode;
+}) {
+  if (!isDestructive) {
+    return (
+      <div className="space-y-1">
+        <div className={MICRO_LABEL}>Why this is gated</div>
+        <div className="text-xs text-daintree-text/70 break-words">{children}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-2 rounded-[var(--radius-md)] border border-status-danger/20 bg-status-danger/10 p-3">
+      <AlertTriangle aria-hidden="true" className="w-4 h-4 shrink-0 mt-px text-status-danger" />
+      <div className="min-w-0 space-y-1">
+        <div className={cn(MICRO_LABEL, "text-status-danger/80")}>What this does</div>
+        <div className="text-xs text-daintree-text/80 break-words">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The actual content the dispatch would affect — the decisive evidence for a
+ * D2 approval, so it gets the framed, headed, bounded card every sibling
+ * destructive confirm already uses, rather than the same bare `<pre>` well the
+ * redacted arguments sit in.
+ *
+ * Rows are rendered individually rather than joined into one wrapped block:
+ * soft-wrapping a monospace listing with no hanging indent puts continuation
+ * text at the same left edge as a new entry, so a two-commit list reads as
+ * however many visual rows it happens to wrap to.
+ */
+function PreviewCard({
+  title,
+  state,
+  lines,
+}: {
+  title: string;
+  state: Exclude<PreviewState, "none">;
+  lines: string[];
+}) {
+  const contentRows = lines.filter((line) => !isCautionPreviewLine(line));
+
+  return (
+    <div className="rounded-[var(--radius-md)] border border-tint/[0.08] bg-tint/[0.04]">
+      <div className="flex items-center justify-between gap-2 border-b border-tint/[0.08] px-3 py-2">
+        <span className={MICRO_LABEL}>{title}</span>
+        {state === "ready" && contentRows.length > 0 && (
+          <span className="shrink-0 rounded bg-tint/10 px-1 py-0.5 text-[10px] font-medium tabular-nums leading-none text-daintree-text/60">
+            {contentRows.length}
+          </span>
+        )}
+      </div>
+
+      <div className={cn("px-3 py-2", PREVIEW_MIN_BODY_HEIGHT)}>
+        {state === "pending" ? (
+          <div
+            className="flex h-full items-center justify-center py-4"
+            role="status"
+            aria-label="Checking what this affects"
+          >
+            <Spinner size="sm" className="text-daintree-text/40" />
+          </div>
+        ) : state === "unavailable" ? (
+          <CautionRow>
+            Couldn't check what this affects. Approve only if you already know what it will change.
+          </CautionRow>
+        ) : (
+          <div className="space-y-1">
+            {lines.map((line, index) =>
+              isCautionPreviewLine(line) ? (
+                <CautionRow key={index}>{stripCautionPrefix(line)}</CautionRow>
+              ) : (
+                <div
+                  key={index}
+                  className="pl-4 -indent-4 font-mono text-xs break-words text-daintree-text/80"
+                >
+                  {line}
+                </div>
+              )
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A preview line the formatters marked as a caution — "could not verify",
+ * "this operation will be refused". It is the most safety-relevant thing the
+ * preview can say and previously rendered as an inline "⚠" character at the
+ * same weight as a filename.
+ */
+function CautionRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-1.5 text-xs text-status-warning">
+      <AlertTriangle aria-hidden="true" className="w-3.5 h-3.5 shrink-0 mt-px" />
+      <span className="min-w-0 break-words">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * The redacted argument summary, behind a disclosure.
+ *
+ * Raw payloads shown inline are the classic driver of consent-dialog
+ * click-through: they read as noise, and the noise trains people to skip the
+ * whole surface. Collapsed, they stay one keystroke away for anyone who wants
+ * them without competing with the evidence for attention. The preview above is
+ * never collapsed — a D2 approval has to show actual content, not offer it.
+ */
+function ArgumentsDisclosure({ argsSummary }: { argsSummary: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded-[var(--radius-sm)] py-1 text-left",
+          "transition-colors duration-150 ease-out hover:bg-overlay-subtle",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2"
+        )}
+      >
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            "w-3 h-3 shrink-0 text-daintree-text/40 transition-transform duration-150 ease-out",
+            expanded && "rotate-90"
+          )}
+        />
+        <span className={MICRO_LABEL}>Arguments</span>
+      </button>
+      {expanded && (
+        <pre className="mt-1 max-h-40 overflow-y-auto rounded-[var(--radius-md)] bg-overlay-subtle px-2 py-1.5 font-mono text-xs break-words whitespace-pre-wrap text-daintree-text/80">
+          {argsSummary}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The subdued line beside the action row, answering "can I act right now, and
+ * what happens when I do".
+ *
+ * Deliberately not a countdown. The request does expire, but a ticking clock on
+ * a security decision pushes the reader toward impulsive rather than
+ * deliberative processing, so the expiry stays silent and only the conditions
+ * the user can act on are named. Nothing here is colour-coded either — it has
+ * to survive forced-colors, where a tone would be flattened away.
+ */
+function GateHint({
+  previewState,
+  queueDepth,
+}: {
+  previewState: PreviewState;
+  queueDepth: number;
+}) {
+  const parts: string[] = [];
+  if (previewState === "pending") parts.push("Checking what this affects…");
+  if (queueDepth > 0) {
+    parts.push(`${queueDepth} more request${queueDepth === 1 ? "" : "s"} waiting`);
+  }
+  if (parts.length === 0) return null;
+
+  return (
+    <span aria-live="polite" className="min-w-0 truncate">
+      {parts.join(" · ")}
+    </span>
   );
 }

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -18,6 +18,16 @@ import { useMcpConfirmStore, type PendingMcpConfirm } from "@/store/mcpConfirmSt
 const CONFIRMATION_TIMEOUT_MS = 28_000;
 
 /**
+ * Main's own hard deadline, mirrored from `MCP_DISPATCH_TIMEOUT_MS` in
+ * `electron/services/mcp-server/shared.ts` (main-process only, so it cannot be
+ * imported here). Nothing this modal does may outlive it: past this point main
+ * has already failed the dispatch and told the agent it timed out, so an
+ * approval landing afterwards would run the action anyway — the destructive
+ * write happens while the caller was told it did not.
+ */
+const MAIN_DISPATCH_DEADLINE_MS = 30_000;
+
+/**
  * Lower-bound read-time gate for destructive dispatches. `resolveOnce` guards
  * the second click; this disables the primary button briefly after each item
  * is promoted so a click meant for the previous modal can't silently approve a
@@ -49,6 +59,15 @@ const MAX_USER_AGENT_DISPLAY = 120;
  * so the loading state reserves the space the content will occupy.
  */
 const PREVIEW_MIN_BODY_HEIGHT = "min-h-[5.5rem]";
+
+/**
+ * Ceiling for the same body. A worktree with forty changed files is exactly the
+ * case the preview exists for, but an unbounded listing pushes the argument
+ * summary and the rest of the card back below the fold — the containment
+ * problem the framed card was meant to solve. Bound it and scroll in place, as
+ * every sibling preview does; the content is all still there.
+ */
+const PREVIEW_MAX_BODY_HEIGHT = "max-h-[13rem]";
 
 function truncateUserAgent(userAgent: string): string {
   return userAgent.length > MAX_USER_AGENT_DISPLAY
@@ -129,7 +148,18 @@ export function McpConfirmDialog() {
     // under main's 30s deadline (28s budget + ~1.5s), preserving the clean
     // CONFIRMATION_TIMEOUT outcome.
     const floor = current.danger === "confirm" ? CONFIRM_COOLDOWN_MS + 300 : 500;
-    const remaining = Math.max(floor, CONFIRMATION_TIMEOUT_MS - elapsed);
+    // The floor keeps a deeply-queued destructive item approvable for at least
+    // as long as its own cooldown. But the floor must never push the modal past
+    // main's deadline: an item promoted at ~29s would otherwise sit open until
+    // 30.5s and re-enable its confirm button at 30.2s — after main had already
+    // failed the dispatch — so a click would run the destructive action while
+    // the agent had been told it timed out. Clamp to whatever budget is
+    // genuinely left; a non-positive clamp fires the timeout immediately, which
+    // is the honest outcome for a request that can no longer be approved.
+    const remaining = Math.min(
+      Math.max(floor, CONFIRMATION_TIMEOUT_MS - elapsed),
+      MAIN_DISPATCH_DEADLINE_MS - elapsed
+    );
     const timer = setTimeout(() => {
       resolveOnce(requestId, "timeout");
     }, remaining);
@@ -170,7 +200,7 @@ export function McpConfirmDialog() {
       <ConfirmDialog
         isOpen={true}
         onClose={() => resolveOnce(current.requestId, "rejected")}
-        title={`Run '${current.actionTitle}'?`}
+        title={confirmTitle(current)}
         description={current.actionDescription}
         confirmLabel={current.actionTitle}
         cancelLabel="Cancel"
@@ -204,6 +234,21 @@ export function McpConfirmDialog() {
       </ConfirmDialog>
     </ErrorBoundary>
   );
+}
+
+/**
+ * The dialog title, naming the affected entity when one is known.
+ *
+ * `Run 'Delete worktree'?` says which registry action will execute but not
+ * which worktree — and under multi-agent interruption the target is the thing
+ * the approver most needs and can least infer. Where a subject resolved, the
+ * title names it; where none did, it stays the stable generic form rather than
+ * changing after open.
+ */
+export function confirmTitle(current: PendingMcpConfirm): string {
+  return current.subject
+    ? `${current.actionTitle} '${current.subject}'?`
+    : `Run '${current.actionTitle}'?`;
 }
 
 /** Shared micro-label, matching the section-heading grammar used app-wide. */
@@ -304,6 +349,11 @@ function ConsequenceNote({
  * destructive confirm already uses, rather than the same bare `<pre>` well the
  * redacted arguments sit in.
  *
+ * The card carries no row-count badge: these lines are freeform, and the first
+ * one is usually the formatter's own summary ("3 files with uncommitted
+ * changes:"), so a count of rendered rows sits next to a sentence stating a
+ * different number.
+ *
  * Rows are rendered individually rather than joined into one wrapped block:
  * soft-wrapping a monospace listing with no hanging indent puts continuation
  * text at the same left edge as a new entry, so a two-commit list reads as
@@ -318,20 +368,19 @@ function PreviewCard({
   state: Exclude<PreviewState, "none">;
   lines: string[];
 }) {
-  const contentRows = lines.filter((line) => !isCautionPreviewLine(line));
-
   return (
     <div className="rounded-[var(--radius-md)] border border-tint/[0.08] bg-tint/[0.04]">
-      <div className="flex items-center justify-between gap-2 border-b border-tint/[0.08] px-3 py-2">
+      <div className="border-b border-tint/[0.08] px-3 py-2">
         <span className={MICRO_LABEL}>{title}</span>
-        {state === "ready" && contentRows.length > 0 && (
-          <span className="shrink-0 rounded bg-tint/10 px-1 py-0.5 text-[10px] font-medium tabular-nums leading-none text-daintree-text/60">
-            {contentRows.length}
-          </span>
-        )}
       </div>
 
-      <div className={cn("px-3 py-2", PREVIEW_MIN_BODY_HEIGHT)}>
+      <div
+        className={cn(
+          "overflow-y-auto px-3 py-2",
+          PREVIEW_MIN_BODY_HEIGHT,
+          PREVIEW_MAX_BODY_HEIGHT
+        )}
+      >
         {state === "pending" ? (
           <div
             className="flex h-full items-center justify-center py-4"
@@ -352,7 +401,7 @@ function PreviewCard({
               ) : (
                 <div
                   key={index}
-                  className="pl-4 -indent-4 font-mono text-xs break-words text-daintree-text/80"
+                  className="pl-4 -indent-4 font-mono text-xs break-words whitespace-pre-wrap text-daintree-text/80"
                 >
                   {line}
                 </div>

--- a/src/components/Worktree/worktreeDeletePreview.ts
+++ b/src/components/Worktree/worktreeDeletePreview.ts
@@ -1,5 +1,6 @@
 import { worktreeClient } from "@/clients";
 import type { FileChangeDetail, WorktreeChanges } from "@shared/types/git";
+import { MCP_PREVIEW_CAUTION_PREFIX } from "@/lib/mcpPreviewLines";
 
 /**
  * Canonical fresh preview for the worktree-delete confirm surfaces (#11343).
@@ -109,7 +110,7 @@ export function formatWorktreeChangeRows(
  */
 export function formatWorktreeDeletePreviewLines(preview: WorktreeDeletePreview | null): string[] {
   if (preview === null) {
-    return ["⚠ Could not verify current changes — proceed with caution."];
+    return [`${MCP_PREVIEW_CAUTION_PREFIX}Could not verify current changes — proceed with caution.`];
   }
   const { trackedChangeCount, untrackedFileCount, changes } = preview;
   if (changes.length === 0) {

--- a/src/components/Worktree/worktreeDeletePreview.ts
+++ b/src/components/Worktree/worktreeDeletePreview.ts
@@ -110,7 +110,9 @@ export function formatWorktreeChangeRows(
  */
 export function formatWorktreeDeletePreviewLines(preview: WorktreeDeletePreview | null): string[] {
   if (preview === null) {
-    return [`${MCP_PREVIEW_CAUTION_PREFIX}Could not verify current changes — proceed with caution.`];
+    return [
+      `${MCP_PREVIEW_CAUTION_PREFIX}Could not verify current changes — proceed with caution.`,
+    ];
   }
   const { trackedChangeCount, untrackedFileCount, changes } = preview;
   if (changes.length === 0) {

--- a/src/components/__tests__/McpConfirmDialog.test.tsx
+++ b/src/components/__tests__/McpConfirmDialog.test.tsx
@@ -51,6 +51,7 @@ function enqueue(
     previewPending?: boolean;
     sessionOrigin?: "help" | "assistant-pane" | "external";
     argsSummary?: string;
+    subject?: string;
   } = {}
 ) {
   return requestMcpConfirmation({
@@ -62,6 +63,7 @@ function enqueue(
     danger: overrides.danger ?? "confirm",
     callerInfo: overrides.callerInfo,
     ...(overrides.sessionOrigin ? { sessionOrigin: overrides.sessionOrigin } : {}),
+    ...(overrides.subject ? { subject: overrides.subject } : {}),
     ...(overrides.dangerRationale ? { dangerRationale: overrides.dangerRationale } : {}),
     ...(overrides.preview ? { preview: overrides.preview } : {}),
     ...(overrides.previewTitle ? { previewTitle: overrides.previewTitle } : {}),
@@ -556,6 +558,53 @@ describe("McpConfirmDialog", () => {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
     }
+  });
+
+  // #11981 — the cooldown floor must not push the modal past main's own 30s
+  // deadline. An item promoted at ~29s used to stay open to 30.5s and re-enable
+  // its confirm button at 30.2s, after main had already failed the dispatch and
+  // told the agent it timed out — so a click ran the destructive action anyway.
+  it("never leaves approval possible after main's dispatch deadline has passed", async () => {
+    vi.useFakeTimers();
+    try {
+      const p = enqueue({ actionTitle: "Delete worktree", danger: "confirm" });
+
+      // ~29s spent queued behind earlier modals before promotion.
+      act(() => {
+        vi.advanceTimersByTime(29_000);
+      });
+      render(<McpConfirmDialog />);
+
+      // Run out the remaining budget to main's deadline and no further.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+
+      await expect(p).resolves.toBe("timeout");
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  // #11981 — "Run 'Delete worktree'?" names the registry action but not which
+  // worktree, and under multi-agent interruption the target is what the
+  // approver most needs and can least infer.
+  it("names the affected entity in the title when one resolved", () => {
+    void enqueue({ actionTitle: "Delete worktree", subject: "feature/agent-fanout" });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByText("Delete worktree 'feature/agent-fanout'?")).toBeTruthy();
+  });
+
+  // A title that changes after open is worse than a stable generic one: the
+  // dialog's accessible name is not re-announced. Actions whose subject only
+  // exists on the async preview keep the generic form.
+  it("keeps the stable generic title when no subject resolved", () => {
+    void enqueue({ actionTitle: "Push branch" });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByText("Run 'Push branch'?")).toBeTruthy();
   });
 
   it("keeps the auto-timeout window above the cooldown for a long-queued destructive item", async () => {

--- a/src/components/__tests__/McpConfirmDialog.test.tsx
+++ b/src/components/__tests__/McpConfirmDialog.test.tsx
@@ -49,6 +49,8 @@ function enqueue(
     preview?: string[];
     previewTitle?: string;
     previewPending?: boolean;
+    sessionOrigin?: "help" | "assistant-pane" | "external";
+    argsSummary?: string;
   } = {}
 ) {
   return requestMcpConfirmation({
@@ -56,9 +58,10 @@ function enqueue(
     actionId: "worktree.delete",
     actionTitle: overrides.actionTitle ?? "Delete worktree",
     actionDescription: "Permanently delete a worktree.",
-    argsSummary: '{"worktreeId":"wt-1"}',
+    argsSummary: overrides.argsSummary ?? '{"worktreeId":"wt-1"}',
     danger: overrides.danger ?? "confirm",
     callerInfo: overrides.callerInfo,
+    ...(overrides.sessionOrigin ? { sessionOrigin: overrides.sessionOrigin } : {}),
     ...(overrides.dangerRationale ? { dangerRationale: overrides.dangerRationale } : {}),
     ...(overrides.preview ? { preview: overrides.preview } : {}),
     ...(overrides.previewTitle ? { previewTitle: overrides.previewTitle } : {}),
@@ -140,7 +143,7 @@ describe("McpConfirmDialog", () => {
 
       const confirm = screen.getByRole("button", { name: "Delete worktree" });
       expect(confirm.hasAttribute("disabled")).toBe(true);
-      expect(screen.getByText(/Checking current changes/)).toBeTruthy();
+      expect(screen.getByRole("status", { name: /checking what this affects/i })).toBeTruthy();
 
       // Only the preview landing unblocks it.
       act(() => {
@@ -182,15 +185,56 @@ describe("McpConfirmDialog", () => {
     render(<McpConfirmDialog />);
 
     expect(screen.getByText("Requested by")).toBeTruthy();
-    expect(screen.getByText(/…1234 · Claude Code/)).toBeTruthy();
+    expect(screen.getByText("Claude Code")).toBeTruthy();
+    expect(screen.getByText("…1234")).toBeTruthy();
   });
 
-  it("omits the requesting-bearer row when callerInfo is absent (pinned help-session)", () => {
-    void enqueue({ actionTitle: "Delete worktree" });
+  // The client-supplied name leads and the token trails: the user agent is what
+  // a human recognises, the token suffix is the corroborating detail.
+  it("orders the caller's own name before the token suffix", () => {
+    void enqueue({
+      actionTitle: "Delete worktree",
+      callerInfo: { token4LastChars: "1234", userAgent: "Claude Code" },
+    });
     render(<McpConfirmDialog />);
 
-    expect(screen.queryByText("Requested by")).toBeNull();
+    // AppDialog portals to document.body, so render()'s container is empty.
+    const text = document.body.textContent ?? "";
+    expect(text.indexOf("Claude Code")).toBeGreaterThan(-1);
+    expect(text.indexOf("Claude Code")).toBeLessThan(text.indexOf("…1234"));
   });
+
+  // The row is never dropped: its absence used to shift everything below it
+  // whenever a queued item promoted across origins, and left the most trusted
+  // caller looking like a missing section.
+  it("names the assistant instead of dropping the row when callerInfo is absent", () => {
+    void enqueue({ actionTitle: "Delete worktree", sessionOrigin: "help" });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByText("Requested by")).toBeTruthy();
+    expect(screen.getByText("Daintree Assistant")).toBeTruthy();
+  });
+
+  // The security-relevant leg. `callerInfo` is also absent for a session whose
+  // token hash was never registered, which dispatches with an "external"
+  // origin — that caller must never inherit the assistant's standing.
+  it.each([
+    ["external", "external"],
+    ["missing", undefined],
+  ] as const)(
+    "does not claim an unidentified caller (%s origin) is the assistant",
+    (_label, sessionOrigin) => {
+      void enqueue({
+        actionTitle: "Delete worktree",
+        ...(sessionOrigin ? { sessionOrigin } : {}),
+      });
+      render(<McpConfirmDialog />);
+
+      expect(screen.getByText("Requested by")).toBeTruthy();
+      expect(screen.queryByText("Daintree Assistant")).toBeNull();
+      expect(screen.getByText("Unidentified client")).toBeTruthy();
+    }
+  );
 
   it("surfaces the action's dangerRationale so the human sees why it's gated (#11342)", () => {
     void enqueue({
@@ -199,17 +243,17 @@ describe("McpConfirmDialog", () => {
     });
     render(<McpConfirmDialog />);
 
-    expect(screen.getByText("Why this is gated")).toBeTruthy();
     expect(
       screen.getByText(/Permanently removes the worktree directory and any uncommitted changes\./)
     ).toBeTruthy();
   });
 
-  it("omits the rationale row when the action carries no dangerRationale", () => {
+  it("omits the rationale block entirely when the action carries no dangerRationale", () => {
     void enqueue({ actionTitle: "Delete worktree" });
     render(<McpConfirmDialog />);
 
     expect(screen.queryByText("Why this is gated")).toBeNull();
+    expect(screen.queryByText("What this does")).toBeNull();
   });
 
   it("renders destructive styling only for danger:confirm dispatches", () => {
@@ -385,6 +429,129 @@ describe("McpConfirmDialog", () => {
       });
 
       await expectStillPending(pB);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  // #11981 — the decisive evidence and the incidental payload must not be
+  // interchangeable. The rule is that the preview is shown and the arguments
+  // are not, until asked for; not which classes either one carries.
+  it("shows the preview outright but keeps the arguments behind a disclosure", () => {
+    void enqueue({ preview: ["3 files with uncommitted changes:", "  M  src/App.tsx"] });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByText(/src\/App\.tsx/)).toBeTruthy();
+
+    const disclosure = screen.getByRole("button", { name: /arguments/i });
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText(/wt-1/)).toBeNull();
+
+    act(() => {
+      disclosure.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText(/wt-1/)).toBeTruthy();
+  });
+
+  // #11981 — an empty array means the fetch ran and produced nothing, which is
+  // NOT the same as an action that never had a preview target. Dropping the
+  // section for both made a D2 approval with no content evidence look identical
+  // to one that needed none.
+  it("keeps the preview section present and explicit when the fetch returns nothing", () => {
+    void enqueue({ requestId: "req-empty", previewPending: true });
+    render(<McpConfirmDialog />);
+
+    act(() => {
+      useMcpConfirmStore.getState().setPreview("req-empty", []);
+    });
+
+    expect(screen.getByText("Working tree changes")).toBeTruthy();
+    expect(screen.getByText(/Couldn't check what this affects/)).toBeTruthy();
+  });
+
+  it("renders no preview section at all when the action never had a preview target", () => {
+    void enqueue({ actionTitle: "Reload window" });
+    render(<McpConfirmDialog />);
+
+    expect(screen.queryByText("Working tree changes")).toBeNull();
+    expect(screen.queryByText(/Couldn't check what this affects/)).toBeNull();
+  });
+
+  // #11981 — APG reserves alertdialog for a brief, important message. A body
+  // carrying a scrollable file list is a dialog. Every sibling confirm that
+  // shows a preview already passes hasPreview.
+  it("is a dialog rather than an alertdialog once it carries preview or argument content", () => {
+    void enqueue({ preview: ["No uncommitted changes."] });
+    const { unmount } = render(<McpConfirmDialog />);
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    unmount();
+    __resetMcpConfirmStoreForTesting();
+
+    // Nothing scrollable in the body — the brief-message case alertdialog is for.
+    void enqueue({ actionTitle: "Reload window", argsSummary: "" });
+    render(<McpConfirmDialog />);
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+  });
+
+  // #11981 — the caution marker is a rendering instruction, not content. It
+  // used to reach the user as a bare glyph inside a monospace block, at the
+  // same weight as a filename.
+  it("renders a caution preview line as a warning rather than emitting its marker as text", () => {
+    void enqueue({
+      preview: ["\u26A0 Could not verify current changes — proceed with caution."],
+    });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByText(/Could not verify current changes/)).toBeTruthy();
+    // document.body, not render()'s container: AppDialog portals, so asserting
+    // on the container would pass whether or not the glyph was emitted.
+    expect(document.body.textContent).not.toContain("\u26A0");
+  });
+
+  // #11981 — resolving this dialog immediately promotes the next request into
+  // the same modal at the same coordinates. The user has to be able to see that
+  // is about to happen.
+  it("names how many requests are waiting, and says nothing when none are", () => {
+    void enqueue({ requestId: "A" });
+    const { unmount } = render(<McpConfirmDialog />);
+    expect(screen.queryByText(/waiting/)).toBeNull();
+
+    unmount();
+    __resetMcpConfirmStoreForTesting();
+
+    void enqueue({ requestId: "A" });
+    void enqueue({ requestId: "B" });
+    void enqueue({ requestId: "C" });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByText(/2 more requests waiting/)).toBeTruthy();
+  });
+
+  // #11981 — a ticking countdown on a security decision pushes the reader into
+  // impulsive rather than deliberative processing, so the 28s expiry stays
+  // silent. Guard against a well-meaning countdown being added later.
+  it("does not display a running countdown of the approval deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      void enqueue({ requestId: "req-timer" });
+      render(<McpConfirmDialog />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+      });
+
+      // document.body, not render()'s container: AppDialog portals, so a
+      // container assertion here would hold no matter what was rendered.
+      const text = document.body.textContent ?? "";
+      expect(text).toContain("Delete worktree");
+      // No "Ns"/"N seconds"/"N:NN" remaining-time readout anywhere on the surface.
+      expect(text).not.toMatch(/\d+\s*(s\b|sec|second)/i);
+      expect(text).not.toMatch(/\d+:\d{2}/);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -77,6 +77,18 @@ type ConfirmDialogBaseProps = {
    */
   restoreFocusTo?: RestoreFocusTarget;
   /**
+   * Forwarded to {@link AppDialog.Footer.hint}: a subdued status line rendered
+   * beside the action row. Use it to say why the primary action is currently
+   * unavailable, or what resolving this dialog will do next — the action row is
+   * where the user is looking when they ask that question, and a body-level
+   * note is not.
+   *
+   * Deliberately not a countdown. Ticking timers on a security decision push
+   * the reader into impulsive rather than deliberative processing and raise
+   * erroneous-approval rates, so state the condition, not the seconds.
+   */
+  hint?: React.ReactNode;
+  /**
    * Forwarded to {@link AppDialog.hasPreview}: set to true when the dialog
    * body contains scrollable preview content (commit lists, directory tables).
    * Switches the ARIA role from `alertdialog` to `dialog` for destructive
@@ -114,6 +126,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     initialFocus,
     restoreFocusTo,
     hasPreview = false,
+    hint,
   } = props;
   const rawTypedNameTarget = (props as { typedNameTarget?: string }).typedNameTarget;
   const typedNameTarget = variant === "destructive" ? rawTypedNameTarget : undefined;
@@ -229,6 +242,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
       </AppDialog.Body>
 
       <AppDialog.Footer
+        hint={hint}
         secondaryAction={{
           label: cancelLabel,
           onClick: handleClose,

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         default:
           "bg-primary text-primary-foreground ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none",
         destructive:
-          "bg-destructive text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none focus-visible:outline-destructive",
+          "bg-destructive text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none",
         outline:
           "ring-1 ring-border-strong bg-surface-panel-elevated/95 backdrop-blur-md text-daintree-text shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_var(--color-overlay-soft)] hover:bg-surface-panel-elevated hover:ring-border-default hover:text-daintree-text active:bg-overlay-soft active:shadow-none",
         // High-contrast INVERSE CTA: a near-white fill + off-black text on dark
@@ -164,6 +164,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         aria-busy={loading || undefined}
         aria-disabled={resolvedAriaDisabled}
         data-loading={loading || undefined}
+        // A durable hook for the forced-colors rule in index.css. In
+        // forced-colors the UA replaces every button's background with a system
+        // colour, so `bg-destructive` stops distinguishing this button from
+        // Cancel — an attribute survives where a fill does not, and unlike
+        // keying the CSS off the fill utility it cannot silently stop matching
+        // if the variant's classes are restyled.
+        data-variant={variant ?? "default"}
       >
         {spinner}
         {/* asChild + loading: overlay renders alongside the slotted child;

--- a/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
+++ b/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
@@ -94,3 +94,39 @@ describe("forced-colors status-indicator contract (#8936)", () => {
     );
   });
 });
+
+// #11981: a destructive button is distinguished from Cancel only by its fill,
+// and forced-colors replaces every fill with a system colour — so the two
+// render as identical pills and nothing marks which one destroys. The fallback
+// is a heavier border (stroke weight is one of the few things the UA leaves
+// alone) keyed off `data-variant`, which `Button` emits. Both halves are
+// guarded: a rule with no emitter, or an emitter with no rule, is a silent
+// regression for High Contrast users.
+describe("forced-colors destructive button distinction (#11981)", () => {
+  it("keeps a heavier border on the destructive variant inside the forced-colors block", () => {
+    const blocks = readForcedColorsBlocks(INDEX_CSS);
+    const rule =
+      /button\[data-variant=["']destructive["']\]\s*\{[^}]*border:\s*2px\s+solid\s+ButtonText/;
+    expect(blocks).toMatch(rule);
+  });
+
+  it("does not use outline for that distinction — the focus ring owns outline and would win", () => {
+    const blocks = readForcedColorsBlocks(INDEX_CSS);
+    const match = blocks.match(/button\[data-variant=["']destructive["']\]\s*\{([^}]*)\}/);
+    expect(match).not.toBeNull();
+    expect(match?.[1]).not.toMatch(/outline\s*:/);
+  });
+
+  it("is actually emitted: Button renders the data-variant attribute the rule targets", () => {
+    const button = fs.readFileSync(path.join(REPO_ROOT, "src/components/ui/button.tsx"), "utf8");
+    expect(button).toMatch(/data-variant=\{/);
+  });
+
+  // The destructive focus ring used to be `focus-visible:outline-destructive`,
+  // which resolves through the same variable chain as `bg-destructive` — a
+  // focus indicator in exactly the colour of the thing it indicates.
+  it("does not paint the destructive focus ring in the button's own fill colour", () => {
+    const button = fs.readFileSync(path.join(REPO_ROOT, "src/components/ui/button.tsx"), "utf8");
+    expect(button).not.toMatch(/focus-visible:outline-destructive/);
+  });
+});

--- a/src/hooks/app/__tests__/useE2EBridges.test.tsx
+++ b/src/hooks/app/__tests__/useE2EBridges.test.tsx
@@ -37,6 +37,8 @@ const errorStoreState = vi.hoisted(() => ({
   reset: vi.fn(),
 }));
 const requestConflictMock = vi.hoisted(() => vi.fn());
+const requestMcpConfirmationMock = vi.hoisted(() => vi.fn(() => Promise.resolve("rejected")));
+const mcpConfirmState = vi.hoisted(() => ({ setPreview: vi.fn(), reset: vi.fn() }));
 const diagnosticsState = vi.hoisted(() => ({ isOpen: false, openDock: vi.fn() }));
 const perfMetricsState = vi.hoisted(() => ({
   fps: 60,
@@ -69,6 +71,10 @@ vi.mock("@/store", () => ({
 vi.mock("@/store/recipeConflictStore", () => ({
   useRecipeConflictStore: { getState: () => ({ requestConflict: requestConflictMock }) },
 }));
+vi.mock("@/store/mcpConfirmStore", () => ({
+  requestMcpConfirmation: requestMcpConfirmationMock,
+  useMcpConfirmStore: { getState: () => mcpConfirmState },
+}));
 vi.mock("@/store/perfMetricsStore", () => ({
   usePerfMetricsStore: { getState: () => perfMetricsState },
 }));
@@ -90,6 +96,9 @@ const E2E_GLOBAL_KEYS = [
   "__DAINTREE_E2E_CLEAR_ERRORS__",
   "__DAINTREE_E2E_WORKTREES__",
   "__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__",
+  "__DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__",
+  "__DAINTREE_E2E_SET_MCP_PREVIEW__",
+  "__DAINTREE_E2E_RESET_MCP_CONFIRM__",
   "__DAINTREE_E2E_DIAGNOSTICS_STATE__",
   "__DAINTREE_E2E_OPEN_DIAGNOSTICS__",
   "__DAINTREE_E2E_PERF_METRICS_STATE__",
@@ -168,6 +177,29 @@ describe("useE2EBridges", () => {
       recipeName: "my-recipe",
       updates: { name: "my-recipe" },
     });
+  });
+
+  it("routes the MCP confirm backdoors to the confirmation queue", () => {
+    window.__DAINTREE_E2E_MODE__ = true;
+    renderHook(() => useE2EBridges());
+
+    window.__DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__?.({
+      requestId: "shot-1",
+      actionId: "worktree.delete",
+      actionTitle: "Delete worktree",
+      actionDescription: "Permanently delete a worktree.",
+      argsSummary: "{}",
+      danger: "confirm",
+    });
+    expect(requestMcpConfirmationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: "shot-1", danger: "confirm" })
+    );
+
+    window.__DAINTREE_E2E_SET_MCP_PREVIEW__?.("shot-1", ["M src/App.tsx"]);
+    expect(mcpConfirmState.setPreview).toHaveBeenCalledWith("shot-1", ["M src/App.tsx"]);
+
+    window.__DAINTREE_E2E_RESET_MCP_CONFIRM__?.();
+    expect(mcpConfirmState.reset).toHaveBeenCalledTimes(1);
   });
 
   it("deletes every E2E global on unmount", async () => {

--- a/src/hooks/app/useE2EBridges.ts
+++ b/src/hooks/app/useE2EBridges.ts
@@ -2,6 +2,11 @@ import { useEffect } from "react";
 import { useErrorStore, useDiagnosticsStore, usePerformanceModeStore } from "@/store";
 import { useRecipeConflictStore } from "@/store/recipeConflictStore";
 import { usePerfMetricsStore } from "@/store/perfMetricsStore";
+import {
+  requestMcpConfirmation,
+  useMcpConfirmStore,
+  type PendingMcpConfirm,
+} from "@/store/mcpConfirmStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { installE2EActionDispatchBridge } from "@/services/ActionService";
 import { loadE2ENotificationBackdoor } from "@/lazyPanels";
@@ -59,6 +64,23 @@ export function useE2EBridges(): void {
         });
       };
 
+      // Parks a synthetic MCP confirmation in the queue so the design-review
+      // screenshot harness can capture every approval state (provenance present
+      // or absent, destructive or safe, preview pending/populated/empty, queued
+      // depth) without standing up a real MCP client and a real destructive
+      // dispatch. Mirrors __DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__: the returned
+      // promise is deliberately not awaited — the harness screenshots the modal
+      // and moves on, and reset() clears the resolver map between states.
+      window.__DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__ = (item) => {
+        void requestMcpConfirmation(item as Omit<PendingMcpConfirm, "enqueuedAt">);
+      };
+      window.__DAINTREE_E2E_SET_MCP_PREVIEW__ = (requestId, preview) => {
+        useMcpConfirmStore.getState().setPreview(requestId, preview);
+      };
+      window.__DAINTREE_E2E_RESET_MCP_CONFIRM__ = () => {
+        useMcpConfirmStore.getState().reset();
+      };
+
       // Per-window store accessors for the multi-window isolation spec (#9599).
       // Each project view is its own V8 context, so these Zustand singletons are
       // per-window — mutating one window's store must not leak into another's.
@@ -95,6 +117,9 @@ export function useE2EBridges(): void {
       delete window.__DAINTREE_E2E_CLEAR_ERRORS__;
       delete window.__DAINTREE_E2E_WORKTREES__;
       delete window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__;
+      delete window.__DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__;
+      delete window.__DAINTREE_E2E_SET_MCP_PREVIEW__;
+      delete window.__DAINTREE_E2E_RESET_MCP_CONFIRM__;
       delete window.__DAINTREE_E2E_DIAGNOSTICS_STATE__;
       delete window.__DAINTREE_E2E_OPEN_DIAGNOSTICS__;
       delete window.__DAINTREE_E2E_PERF_METRICS_STATE__;

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -23,6 +23,7 @@ import type { McpConfirmationDecision, McpSessionOrigin } from "@shared/types/ip
 import type { TerminalSpawnSource } from "@shared/types/panel";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { summarizeMcpArgs } from "@shared/utils/mcpArgsSummary";
+import { getCurrentViewStore } from "@/store/createWorktreeStore";
 
 const REJECTION_RESULT: ActionDispatchResult = {
   ok: false,
@@ -207,6 +208,46 @@ export function resolveMcpConfirmPreviewTarget(
       resolvedRecipeId: resolved?.id ?? recipeId,
       spawns: RECIPE_SPAWNING_ACTIONS.has(actionId),
     };
+  }
+  return undefined;
+}
+
+/**
+ * A display-safe name for what a confirm target acts on, for the dialog title.
+ *
+ * Read from the renderer's own stores, never from the dispatch arguments: the
+ * `argsSummary` the modal shows is already redacted, and deriving a title by
+ * reparsing it would widen what main chose to expose.
+ *
+ * Deliberately synchronous and deliberately partial. `git.push` /
+ * `git.pullRebase` resolve their branch and destination only on the async
+ * preview, so they get no subject and keep a stable generic title — the preview
+ * card names the branch and destination as its first two lines anyway, and
+ * approval is gated until those land. A title that mutated after open would be
+ * worse than a generic one: the dialog's accessible name would change without
+ * being re-announced.
+ */
+export function resolveMcpConfirmSubject(
+  target: McpConfirmPreviewTarget | undefined
+): string | undefined {
+  if (target === undefined) return undefined;
+  // Fails soft, and that is load-bearing. This only sharpens a title;
+  // `getCurrentViewStore()` throws when no worktree view store is mounted, and
+  // letting that escape would turn a destructive confirmation into an
+  // EXECUTION_ERROR — the dispatch would fail instead of asking the user. A
+  // missing subject costs the generic title and nothing else.
+  try {
+    if (target.kind === "worktreeDelete") {
+      const worktree = getCurrentViewStore().getState().worktrees.get(target.worktreeId);
+      const name = worktree?.branch ?? worktree?.name;
+      return name !== undefined && name.length > 0 ? name : undefined;
+    }
+    if (target.kind === "recipe") {
+      const recipe = useRecipeStore.getState().getRecipeById(target.resolvedRecipeId);
+      return recipe?.name !== undefined && recipe.name.length > 0 ? recipe.name : undefined;
+    }
+  } catch {
+    return undefined;
   }
   return undefined;
 }
@@ -424,6 +465,14 @@ export function useMcpBridge(): void {
                     ? { dangerRationale: definition.dangerRationale }
                     : {}),
                   argsSummary: summarizeMcpArgs(args),
+                  // Names WHICH worktree/recipe in the title. Resolved from the
+                  // renderer's stores, not from the redacted args summary.
+                  ...(previewTarget
+                    ? (() => {
+                        const subject = resolveMcpConfirmSubject(previewTarget);
+                        return subject ? { subject } : {};
+                      })()
+                    : {}),
                   danger: definition.danger,
                   // Display-only requesting-bearer identity (#9157). Present
                   // only for unpinned external dispatch; the dialog renders a

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -429,6 +429,10 @@ export function useMcpBridge(): void {
                   // only for unpinned external dispatch; the dialog renders a
                   // "Requested by" row when set, stays provenance-free when not.
                   callerInfo,
+                  // Origin travels with the identity so the dialog can name the
+                  // requester positively instead of inferring one from an
+                  // absence that has two very different causes.
+                  sessionOrigin,
                   previewPending,
                   ...(previewTarget ? { previewTitle: mcpConfirmPreviewTitle(previewTarget) } : {}),
                 });

--- a/src/index.css
+++ b/src/index.css
@@ -2839,6 +2839,17 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border: 1px solid ButtonText;
   }
 
+  /* A destructive button is distinguished only by its fill, and the UA replaces
+   * every fill with a system colour — so "Delete worktree" and "Cancel" render
+   * as the same white pill with the same border, and nothing marks which one
+   * destroys. Stroke WEIGHT is one of the few things the UA leaves alone, so
+   * the destructive action takes a heavier border. Deliberately not an outline:
+   * the focus ring above already owns `outline` and the later rule would win,
+   * erasing the distinction on the button the user is most likely focused on. */
+  button[data-variant="destructive"] {
+    border: 2px solid ButtonText;
+  }
+
   input,
   select,
   textarea {

--- a/src/lib/mcpPreviewLines.ts
+++ b/src/lib/mcpPreviewLines.ts
@@ -1,0 +1,32 @@
+/**
+ * The caution-line convention shared by every MCP confirm preview formatter.
+ *
+ * `buildMcpConfirmPreview` flattens each preview kind to `string[]`, so a line
+ * that means "we could not verify this" or "this operation will be refused" has
+ * no way to carry severity except in its own text. Four formatter sites already
+ * prefixed those lines with a bare "⚠ " (#11343, #11538, #11746). Naming the
+ * marker here lets the dialog render them as real warnings — a Lucide icon and
+ * a status tone — instead of leaving a bespoke glyph to do the work inside a
+ * monospace block, where the most safety-critical line the preview can emit
+ * renders at exactly the same weight as "No uncommitted changes."
+ *
+ * The line array is consumed only by `McpConfirmDialog`; the human-initiated
+ * dialogs render structured data instead, so this stays a private contract
+ * between the formatters and that one surface.
+ */
+export const MCP_PREVIEW_CAUTION_PREFIX = "⚠ ";
+
+/** True when a preview line is a caution rather than ordinary content. */
+export function isCautionPreviewLine(line: string): boolean {
+  return line.startsWith(MCP_PREVIEW_CAUTION_PREFIX);
+}
+
+/** The line's text with the caution marker removed, for rendering beside an icon. */
+export function stripCautionPrefix(line: string): string {
+  return isCautionPreviewLine(line) ? line.slice(MCP_PREVIEW_CAUTION_PREFIX.length) : line;
+}
+
+/** True when any line in a preview is a caution. Drives the card's tone. */
+export function hasCautionLine(lines: readonly string[]): boolean {
+  return lines.some(isCautionPreviewLine);
+}

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -23,6 +23,19 @@ export interface PendingMcpConfirm {
    * `danger !== "safe"` actions carry a rationale.
    */
   dangerRationale?: string;
+  /**
+   * Human-readable name of the thing this dispatch acts on — the worktree's
+   * branch or folder name, the recipe's name. Resolved from the renderer's own
+   * stores at request time, NEVER by reparsing {@link argsSummary}: that value
+   * is already redacted for display and widening it here would leak past the
+   * boundary main drew.
+   *
+   * Absent when no subject can be resolved synchronously. The git actions are
+   * the notable case — their branch and destination only exist on the async
+   * preview, and a title that changes after the dialog opens is worse than a
+   * stable generic one, because a dialog's accessible name is not re-announced.
+   */
+  subject?: string;
   argsSummary: string;
   /**
    * The dispatched action's registry `danger` classification. Drives the

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -1,6 +1,10 @@
 import { create } from "zustand";
 import type { ActionDanger } from "@shared/types/actions";
-import type { McpBearerIdentity, McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
+import type {
+  McpBearerIdentity,
+  McpConfirmationDecision,
+  McpSessionOrigin,
+} from "@shared/types/ipc/mcpServer";
 
 /**
  * One pending confirmation surfaced for a `danger: "confirm"` MCP dispatch.
@@ -33,6 +37,21 @@ export interface PendingMcpConfirm {
    * the dialog shows a "Requested by" row only for genuine external clients.
    */
   callerInfo?: McpBearerIdentity;
+  /**
+   * Which class of surface the dispatching session is (#9157 companion).
+   * Distinct from {@link callerInfo}, which names *which external client* is
+   * asking: an assistant session has no meaningful `callerInfo` and still has
+   * an origin.
+   *
+   * Load-bearing for the requester row. Absent `callerInfo` does NOT imply the
+   * in-app assistant — `getBearerInfoForSession` also returns null for a
+   * session whose token hash was never registered, so a generic pane token
+   * dispatches unpinned with no `callerInfo` and `sessionOrigin: "external"`.
+   * Without this field the dialog cannot tell the trusted assistant apart from
+   * a caller it failed to identify, and must never label the second as the
+   * first.
+   */
+  sessionOrigin?: McpSessionOrigin;
   /**
    * Fresh, human-readable preview lines describing the ACTUAL content this
    * dispatch would affect — e.g. the changed-file list a `worktree.delete`

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -9,6 +9,7 @@ import type {
   TerminalInfoPayload,
 } from "@shared/types";
 import type { NotificationsE2EApi } from "@/lib/e2eNotificationBackdoor";
+import type { PendingMcpConfirm } from "@/store/mcpConfirmStore";
 
 declare global {
   interface Window {
@@ -29,6 +30,10 @@ declare global {
     }>;
     __DAINTREE_E2E_REFRESH_GITHUB_CONFIG__?: () => Promise<void>;
     __DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__?: (recipeName: string) => void;
+    /** Parks a synthetic MCP confirmation for the approval-dialog screenshot harness (#11981). */
+    __DAINTREE_E2E_ENQUEUE_MCP_CONFIRM__?: (item: Omit<PendingMcpConfirm, "enqueuedAt">) => void;
+    __DAINTREE_E2E_SET_MCP_PREVIEW__?: (requestId: string, preview: string[]) => void;
+    __DAINTREE_E2E_RESET_MCP_CONFIRM__?: () => void;
     /** Per-window store accessors for the multi-window isolation spec (#9599). */
     __DAINTREE_E2E_DIAGNOSTICS_STATE__?: () => { isOpen: boolean };
     __DAINTREE_E2E_OPEN_DIAGNOSTICS__?: () => void;


### PR DESCRIPTION
## Summary

`McpConfirmDialog` is the modal that stops everything when an agent asks to run something dangerous, like deleting a worktree or force pushing. It showed four identically styled sections in source order, so the order the eye found them in was source order rather than importance. The two blocks that did have a container, the changed-file preview and the redacted arguments, were pixel identical.

The new order is requester, consequence, evidence, arguments. Arguments sit behind a disclosure. Resolves #11981.

## What changed

**Hierarchy.** The changed-file preview moves into the framed, headed, bounded card that `GitPushConfirmDialog` and the other evidence-bearing confirms already use. The redacted `argsSummary` moves behind a `ChevronRight` disclosure, collapsed by default. The preview is never collapsed: a D2 approval has to show actual content, not offer it.

**Provenance.** The requester row is now always present and always a positive statement. An absent `callerInfo` had two very different causes, and I got this wrong on the first pass. `getBearerInfoForSession()` returns null for the pinned assistant route AND for a session whose token hash was never registered, and that second case dispatches with `sessionOrigin: "external"`. So the row now reads `sessionOrigin` and names an unidentified caller as unidentified rather than letting it inherit the assistant's standing.

**Preview states.** Four instead of two: no target, pending, ready, unavailable. An empty array means the fetch ran and found nothing, which is not the same as an action that never had a preview target. Collapsing both to absence let a destructive approval proceed with no content evidence and no sign that any was expected. No new store field was needed, `preview === undefined` versus `preview === []` already encodes it.

**Layout stability.** The loading state reserves the height its content will occupy. The dialog is centre anchored, so a body that grew when the fetch landed moved the confirm button about 30px at the same moment it stopped being disabled. Measured: that shift was 120 device px, it is now 8.

**Timing bug.** `Math.max(floor, CONFIRMATION_TIMEOUT_MS - elapsed)` granted a queued destructive item another 1.5s regardless of how late it was promoted. An item promoted around 29s sat open past main's 30s deadline and re-enabled its confirm button at 30.2s, after `MCP_DISPATCH_TIMEOUT_MS` had already failed the dispatch. A click then ran the action while the agent had been told it timed out. The window is clamped to the budget that actually remains.

**Caution lines.** The preview formatters emit `⚠ Could not verify current changes` as a bare glyph inside a monospace block, at the same weight as a filename. That prefix is now a named constant with a predicate, and the dialog renders those lines with a Lucide icon and a status tone.

**ARIA role.** `hasPreview` is passed once the body carries a file list or a payload, so the surface stops being an `alertdialog`, a role the APG reserves for brief text-only messages. Twelve sibling dialogs already pass it.

## Two shared button fixes, outside the original scope

Both were found while reviewing this dialog's pixels, and neither could be fixed from inside it.

The destructive focus ring was `focus-visible:outline-destructive`, which resolves through the same variable chain as `bg-destructive`. A focus indicator painted in exactly the colour of the thing it indicates, at 1:1 against it, and widened to 3px under `prefers-contrast: more`. It now uses the shared accent ring like every other button.

Under `forced-colors: active` the destructive button was indistinguishable from Cancel. The UA replaces every fill with a system colour, so both painted as the same bordered pill and nothing marked which one destroys. The destructive variant now takes a heavier border, keyed off a `data-variant` attribute rather than a fill utility that could be restyled out from under the rule. Not an outline, because the focus ring already owns outline in that block and would win.

## Design review

Scored 6.2 to 9.5 over two review rounds against trust hierarchy, consequence legibility, state honesty, skeletal stability, containment, and native craft. Three of the reviewer's recommendations were rejected with evidence rather than applied:

- It wanted provenance moved below the evidence. Platform permission surfaces converge on identity first (macOS TCC, Android, OAuth, W3C Permissions), and people settle who is asking before weighing what is asked. The real complaint was the cost of a 120 character user agent taking three lines, so provenance still leads but takes one.
- It wanted a `27s remaining` countdown in the action row. Ticking countdowns on a security decision drive impulsive rather than deliberative processing and raise erroneous approval rates. The queue depth and the gate reason landed, the clock did not.
- It flagged `duration-150` as a hardcoded motion literal. `--duration-150` is declared in the motion `@theme` block, which generates that utility, so the utility is the token.

The consistency survey found the framed evidence card is already used by 7 of 7 comparable confirms, so this joins the dominant pattern rather than inventing one. The one genuine outlier is the arguments disclosure, 1 of 1. Filed as follow-up rather than rolled out here, because `PluginCapabilityConfirmDialog` must be excluded from any rollout: its capability list is the consent subject, not incidental detail.

## Testing

`npm run check` passes. `npx vitest run` is green apart from 12 timeouts in 7 files that this branch does not touch. Load average was 74 to 81 during that run, every failure is a 15s import timeout on the first test in its file, they pass in isolation and with a raised timeout, and the same set fails on the baseline commit.

30 tests on `McpConfirmDialog`, up from 15. Every new one was mutation checked by reintroducing the bug and confirming the test fails. That process caught a real problem: `AppDialog` portals to `document.body`, so four tests asserting on `render()`'s container were empty and two were passing vacuously.

New screenshot harness at `e2e/screenshots/mcp-confirm-review.spec.ts`, opt in behind `DAINTREE_SHOT_MCP`, covering 20 states across 4 themes plus `prefers-contrast: more` and `forced-colors: active`.