### PR TITLE
Refine the sidebar WorktreeCard hierarchy and internal chrome

### DIFF
--- a/e2e/screenshots/worktree-card-review.spec.ts
+++ b/e2e/screenshots/worktree-card-review.spec.ts
@@ -1,0 +1,630 @@
+/**
+ * Sidebar `WorktreeCard` visual-review harness.
+ *
+ * Boots a fixture repo whose worktrees are shaped to exercise the card's real
+ * variation — an issue-derived headline, a very long one, a plain branch label,
+ * a dirty tree with a live AI note, a clean tree with nothing to say — then
+ * writes PNGs of every state that carries design weight so the card can be
+ * judged against rendered pixels rather than JSX.
+ *
+ * Everything is driven through the app's real seams:
+ *   - Issue number + headline come from the branch name (`issue-<n>-<slug>`),
+ *     which is what `extractIssueNumberSync` / `deriveBranchTitle` read offline.
+ *   - The AI note is a real `<gitdir>/daintree/note` file, read by NoteFileReader.
+ *   - Changed files, diff stats, last commit, author and ahead/behind are real git.
+ *   - Sessions are real PTYs; agent rows use the shared fake-claude CLI.
+ * Nothing is faked at the component level, so a capture shows a state the app
+ * can actually produce.
+ *
+ * Opt-in only, like the sibling review harnesses: skips itself unless
+ * DAINTREE_SHOT_CARD is set, so the marketing screenshots workflow never runs it.
+ *
+ *   DAINTREE_SHOT_CARD=1 npx playwright test --project=screenshots worktree-card-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_CARD    required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME   optional theme id for the single-theme states
+ *   DAINTREE_SHOT_TAG     optional suffix so review rounds sit side by side
+ *   DAINTREE_SHOT_ONLY    comma-separated step filter (step names below)
+ *   DAINTREE_SHOT_THEMES  comma-separated theme sweep (default: every built-in)
+ *   DAINTREE_SHOT_SESSIONS  set to "0" to skip the (slow) session launches
+ *
+ * Output: artifacts/card-shots/<NN-slug>[-tag].png (gitignored).
+ *
+ * Hard rule, inherited from the other review harnesses and then some: this spec
+ * never writes a PNG it has not verified. `snap()` asserts the target is on
+ * screen and has a real box before it writes, and throws otherwise — a missing
+ * file is a loud, correct failure, where a plausible-looking wrong file sends a
+ * whole design review off reasoning about a screen that does not exist.
+ */
+
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { getGridPanelIds } from "../helpers/panels";
+import { getTerminalText, waitForTerminalText, writeTerminalInput } from "../helpers/terminal";
+import { installFakeAgent, fakeAgentEnv, FAKE_AGENT_READY } from "../helpers/fakeAgent";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_CARD;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const WITH_SESSIONS = process.env.DAINTREE_SHOT_SESSIONS !== "0";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "card-shots");
+
+/** Every built-in theme. The sweep reloads in place; no re-boot needed. */
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+const SWEEP_THEMES = (process.env.DAINTREE_SHOT_THEMES ?? "")
+  .split(",")
+  .map((t) => t.trim())
+  .filter(Boolean);
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+const SIDEBAR_RESIZE = '[role="separator"][aria-label^="Resize sidebar"]';
+
+/**
+ * The cards, in sidebar order. Each one exists to make a different part of the
+ * card's variation visible — see `why`.
+ */
+const WORKTREES = {
+  /**
+   * The flagship. Issue-derived headline, dirty tree with a realistic diff
+   * stat, a live AI note, a multi-line last commit, and (when sessions are on)
+   * the Active Sessions list. Nearly every review finding lands on this card.
+   */
+  flagship: {
+    branch: "feature/issue-4821-stream-upload-retry-with-backoff",
+    slug: "stream-upload-retry",
+    note: "Reworked the retry ladder so a 429 backs off on the server's Retry-After instead of the fixed 2s step. Still need to decide whether the jitter is per-attempt or per-request — see https://github.com/daintreehq/daintree/issues/4821",
+  },
+  /** Long headline + long branch: the truncation and overflow case. */
+  long: {
+    branch:
+      "feature/issue-9310-collapse-the-inspector-panel-when-the-window-narrows-below-the-medium-breakpoint",
+    slug: "collapse-inspector",
+    note: undefined,
+  },
+  /** No issue number → the BranchLabel path rather than IssueBadge. */
+  plain: {
+    branch: "fix/retry-backoff-jitter",
+    slug: "retry-jitter",
+    note: undefined,
+  },
+  /** Clean tree, no note: the narrative slot falls through to the last commit. */
+  quiet: {
+    branch: "feature/issue-7702-dark-mode-token-audit",
+    slug: "dark-mode-tokens",
+    note: undefined,
+  },
+} as const;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/** Realistic file bodies — sparse fixtures hide the defects worth finding. */
+const SEED_FILES: Record<string, string> = {
+  "README.md": "# Helios Dashboard\n\nOperator console for the ingest fleet.\n",
+  "src/index.ts": "export { startCheckout } from './checkout';\nexport { retry } from './retry';\n",
+  "src/checkout.ts":
+    "export async function startCheckout(cartId: string): Promise<string> {\n  return `charge_${cartId}`;\n}\n",
+  "src/retry.ts":
+    "export interface RetryOptions {\n  attempts: number;\n  baseDelayMs: number;\n}\n\nexport async function retry<T>(fn: () => Promise<T>, opts: RetryOptions): Promise<T> {\n  let lastError: unknown;\n  for (let i = 0; i < opts.attempts; i++) {\n    try {\n      return await fn();\n    } catch (error) {\n      lastError = error;\n    }\n  }\n  throw lastError;\n}\n",
+  "src/upload/stream.ts":
+    "export async function streamUpload(body: ReadableStream): Promise<void> {\n  void body;\n}\n",
+  "src/upload/parts.ts": "export const PART_SIZE = 8 * 1024 * 1024;\n",
+  "src/api/client.ts": "export const BASE_URL = 'https://api.helios.dev';\n",
+  "docs/architecture.md": "# Architecture\n\nIngest -> queue -> worker -> store.\n",
+};
+
+interface FixtureRepo {
+  dir: string;
+  worktreeRoot: string;
+  cleanup: () => void;
+}
+
+function writeFiles(root: string, files: Record<string, string>): void {
+  for (const [rel, body] of Object.entries(files)) {
+    const target = path.join(root, rel);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, body);
+  }
+}
+
+/**
+ * Repo + linked worktrees, each shaped for the card state it has to produce.
+ * The AI note goes to `<gitdir>/daintree/note`, which is the file NoteFileReader
+ * actually reads — not a store patch.
+ */
+function createFixtureRepo(): FixtureRepo {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-cardshots-"));
+  const worktreeRoot = path.join(path.dirname(dir), `${path.basename(dir)}-worktrees`);
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "avery@helios.dev"', dir);
+  git('config user.name "Avery Lindqvist"', dir);
+  writeFiles(dir, SEED_FILES);
+  git("add -A", dir);
+  git('commit -m "Set up the ingest console skeleton"', dir);
+
+  for (const wt of Object.values(WORKTREES)) {
+    const wtDir = path.join(worktreeRoot, wt.slug);
+    git(`worktree add -b ${wt.branch} "${wtDir}" main`, dir);
+    git('config user.email "avery@helios.dev"', wtDir);
+    git('config user.name "Avery Lindqvist"', wtDir);
+
+    if (wt.note) {
+      // The note lives in the worktree's own git dir, which for a linked
+      // worktree is `<main>/.git/worktrees/<name>`.
+      const gitDir = path.join(dir, ".git", "worktrees", wt.slug, "daintree");
+      mkdirSync(gitDir, { recursive: true });
+      writeFileSync(path.join(gitDir, "note"), wt.note);
+    }
+  }
+
+  // Flagship: a real commit with a real multi-line message, then a dirty tree
+  // across several folders so the diff stat and the grouped file list both fill.
+  const flagshipDir = path.join(worktreeRoot, WORKTREES.flagship.slug);
+  writeFiles(flagshipDir, {
+    "src/retry.ts":
+      "export interface RetryOptions {\n  attempts: number;\n  baseDelayMs: number;\n  respectRetryAfter?: boolean;\n}\n",
+  });
+  git("add -A", flagshipDir);
+  git(
+    'commit -m "Honour Retry-After on 429 responses" -m "The fixed 2s ladder hammered the ingest API during a partial outage. Read the header when the server sends one and fall back to the exponential step otherwise."',
+    flagshipDir
+  );
+  writeFiles(flagshipDir, {
+    "src/retry.ts":
+      "export interface RetryOptions {\n  attempts: number;\n  baseDelayMs: number;\n  respectRetryAfter?: boolean;\n  jitter?: 'per-attempt' | 'per-request';\n}\n\nexport function backoffDelay(attempt: number, opts: RetryOptions): number {\n  return opts.baseDelayMs * 2 ** attempt;\n}\n",
+    "src/upload/stream.ts":
+      "import { retry } from '../retry';\n\nexport async function streamUpload(body: ReadableStream): Promise<void> {\n  await retry(async () => {\n    void body;\n  }, { attempts: 5, baseDelayMs: 250, respectRetryAfter: true });\n}\n",
+    "src/upload/parts.ts": "export const PART_SIZE = 16 * 1024 * 1024;\n",
+    "src/api/client.ts":
+      "export const BASE_URL = 'https://api.helios.dev';\nexport const RETRY_AFTER_CAP_MS = 30_000;\n",
+    "src/upload/checksum.ts":
+      "export function checksum(chunk: Uint8Array): string {\n  return String(chunk.byteLength);\n}\n",
+    "docs/retry-policy.md": "# Retry policy\n\nRespect Retry-After. Cap at 30s.\n",
+  });
+
+  // Long-title card: one modified file, so it is dirty but not busy.
+  const longDir = path.join(worktreeRoot, WORKTREES.long.slug);
+  writeFiles(longDir, {
+    "src/index.ts":
+      "export { startCheckout } from './checkout';\nexport { retry } from './retry';\nexport { useBreakpoint } from './breakpoint';\n",
+  });
+
+  // Plain branch: committed and ahead of main, clean tree.
+  const plainDir = path.join(worktreeRoot, WORKTREES.plain.slug);
+  writeFiles(plainDir, {
+    "src/retry.ts": SEED_FILES["src/retry.ts"] + "\nexport const JITTER = 0.2;\n",
+  });
+  git("add -A", plainDir);
+  git('commit -m "Add a jitter constant"', plainDir);
+
+  // Quiet card stays exactly as branched: clean, no note, nothing to report.
+
+  return {
+    dir,
+    worktreeRoot,
+    cleanup: () => {
+      if (existsSync(worktreeRoot)) rmSync(worktreeRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 500): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+const written = new Set<string>();
+
+/**
+ * Capture, but only after proving there is something real to capture.
+ *
+ * A harness that swallows a failed step reports success while producing no
+ * files, and one that shoots too early writes a plausible empty-state PNG over
+ * a good one. So: settle, assert the target is visible with a non-degenerate
+ * box, optionally assert the content that makes this state *this* state, and
+ * only then write. Anything else throws.
+ */
+async function snap(
+  page: Page,
+  slug: string,
+  target?: Locator,
+  expectText?: string | RegExp
+): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+
+  if (target) {
+    await expect(target, `"${slug}": target never became visible — refusing to write`).toBeVisible({
+      timeout: T_LONG,
+    });
+    const box = await target.boundingBox();
+    if (!box || box.width < 40 || box.height < 16) {
+      throw new Error(`"${slug}": target box is ${JSON.stringify(box)} — refusing to write`);
+    }
+    if (expectText !== undefined) {
+      await expect(target, `"${slug}": expected content missing — refusing to write`).toContainText(
+        expectText,
+        { timeout: T_LONG }
+      );
+    }
+    await target.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+
+  written.add(`${slug}${TAG}.png`);
+}
+
+/** Every capture step is named so `DAINTREE_SHOT_ONLY` can select it. */
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+const stepFailures: string[] = [];
+
+/**
+ * Steps do not silently swallow: a failure is recorded and re-reported at the
+ * end so the run fails loudly, while later steps still get to produce their
+ * shots (one broken state should not cost the whole round).
+ */
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).slice(0, 400);
+    stepFailures.push(`${name}: ${detail}`);
+    console.warn(`[card-shots] step "${name}" FAILED:`, detail);
+  }
+}
+
+const row = (page: Page, branch: string): Locator => page.locator(SEL.worktree.row(branch)).first();
+
+const sectionButton = (rowLocator: Locator, kind: "details" | "terminals"): Locator =>
+  rowLocator.locator(`[id$="-${kind}-button"]`).first();
+
+/** Toggle a disclosure only when it is not already in the wanted state. */
+async function setSection(
+  rowLocator: Locator,
+  kind: "details" | "terminals",
+  expanded: boolean
+): Promise<void> {
+  const button = sectionButton(rowLocator, kind);
+  if (!(await button.isVisible().catch(() => false))) return;
+  const current = (await button.getAttribute("aria-expanded")) === "true";
+  if (current !== expanded) {
+    await button.click();
+    await rowLocator.page().waitForTimeout(350);
+  }
+}
+
+/**
+ * Card-level collapse lives on the header toolbar, not the section buttons.
+ * The toolbar also holds the "More actions" trigger, which carries its own
+ * `aria-expanded` — so target the collapse control by its label, and verify the
+ * card actually reached the wanted state. A silently-failed restore leaves the
+ * card collapsed, which makes every later step shoot the wrong component.
+ */
+async function setCardCollapsed(rowLocator: Locator, collapsed: boolean): Promise<void> {
+  const toggle = rowLocator
+    .locator(
+      '[data-worktree-row-toolbar] [aria-label="Expand card"], [data-worktree-row-toolbar] [aria-label="Collapse card"]'
+    )
+    .first();
+  await expect(toggle, "card collapse toggle is missing").toBeVisible({ timeout: T_LONG });
+  const expanded = (await toggle.getAttribute("aria-expanded")) === "true";
+  if (expanded === collapsed) {
+    await toggle.click();
+    await rowLocator.page().waitForTimeout(400);
+  }
+  await expect(toggle, `card did not reach collapsed=${collapsed}`).toHaveAttribute(
+    "aria-expanded",
+    collapsed ? "false" : "true",
+    { timeout: T_LONG }
+  );
+}
+
+/** Nudge the sidebar to a target width through its real keyboard resize path. */
+async function setSidebarWidth(page: Page, target: number): Promise<void> {
+  const handle = page.locator(SIDEBAR_RESIZE).first();
+  if (!(await handle.isVisible().catch(() => false))) return;
+  await handle.focus();
+  const current = Number((await handle.getAttribute("aria-valuenow")) ?? "0");
+  const key = target < current ? "ArrowLeft" : "ArrowRight";
+  for (let i = 0; i < 60; i++) {
+    const now = Number((await handle.getAttribute("aria-valuenow")) ?? "0");
+    if (Math.abs(now - target) <= 12) break;
+    if (target < current && now <= target) break;
+    if (target > current && now >= target) break;
+    await page.keyboard.press(key);
+  }
+  await page.waitForTimeout(250);
+}
+
+/**
+ * Launch one fake-claude session in the active worktree and drive it past the
+ * trust prompt so the row renders a real agent state rather than a cold shell.
+ */
+async function launchAgentSession(page: Page): Promise<string | null> {
+  const before = new Set(await getGridPanelIds(page));
+  await dismissBlockingPalette(page).catch(() => {});
+  await page
+    .locator(SEL.agent.trayButton)
+    .click()
+    .catch(() => {});
+  await page
+    .locator(SEL.agent.launcherRow("Claude"))
+    .first()
+    .click()
+    .catch(() => {});
+
+  let panelId: string | null = null;
+  for (let i = 0; i < 60 && !panelId; i++) {
+    const ids = await getGridPanelIds(page).catch(() => [] as string[]);
+    panelId = ids.find((id) => !before.has(id)) ?? null;
+    if (!panelId) await page.waitForTimeout(250);
+  }
+  if (!panelId) return null;
+
+  const panel = page.locator(`[data-panel-id="${panelId}"]`);
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const text = (await getTerminalText(panel).catch(() => "")).toLowerCase();
+    if (text.includes(FAKE_AGENT_READY.toLowerCase())) break;
+    if (text.includes("enter to confirm") || text.includes("trust this folder")) {
+      await writeTerminalInput(page, panel, "\r").catch(() => {});
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  await waitForTerminalText(panel, FAKE_AGENT_READY, T_LONG).catch(() => {});
+  return panelId;
+}
+
+test("sidebar worktree card review — states and themes", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_CARD is required for the worktree-card capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_CARD to run the worktree-card capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const fakeBinDir = installFakeAgent(repo.dir);
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-cardshot-"));
+  let ctx: AppContext | undefined;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      env: fakeAgentEnv(fakeBinDir),
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+
+    const sidebar = page.locator(SEL.sidebar.aside).first();
+    const flagship = row(page, WORKTREES.flagship.branch);
+    const long = row(page, WORKTREES.long.branch);
+    const plain = row(page, WORKTREES.plain.branch);
+    const quiet = row(page, WORKTREES.quiet.branch);
+
+    // Every card must exist before any capture, or the whole run is judging a
+    // sidebar that never finished loading.
+    for (const [name, locator] of Object.entries({ flagship, long, plain, quiet })) {
+      await expect(locator, `worktree card "${name}" never rendered`).toBeVisible({
+        timeout: T_LONG,
+      });
+    }
+    // Git status is polled, so wait for the flagship's diff stat to arrive
+    // rather than shooting the pre-status card.
+    await expect(flagship, "flagship card never reported its changed files").toContainText(
+      /\d+ files/,
+      { timeout: T_LONG }
+    );
+    await settle(page, 1500);
+    await dismissBlockingPalette(page);
+
+    // 1. The sidebar as a whole — the only shot that shows what repetition does.
+    await step("sidebar", async () => {
+      await snap(page, "10-sidebar-rest", sidebar);
+      await snap(page, "11-window-rest");
+    });
+
+    // 2. The flagship card with Details collapsed: the resting card, and the
+    //    single most repeated shape in the app.
+    await step("resting", async () => {
+      await setSection(flagship, "details", false);
+      await snap(page, "20-card-resting", flagship, /\d+ files/);
+    });
+
+    // 3. Details expanded — the nested-card stack the issue is about.
+    await step("expanded", async () => {
+      await setSection(flagship, "details", true);
+      await snap(page, "30-card-details-expanded", flagship, "Changed Files");
+    });
+
+    // 4. The quiet card expanded: clean tree, no note, so the narrative slot
+    //    falls through to the last commit message. (The "No AI summary yet"
+    //    placeholder is not reachable here — a real worktree always has a last
+    //    commit, which wins the slot before the placeholder is considered.)
+    await step("quiet", async () => {
+      await setSection(quiet, "details", true);
+      await snap(page, "40-card-clean-expanded", quiet, "Set up the ingest console skeleton");
+      await setSection(quiet, "details", false);
+    });
+
+    // 5. Long headline and long branch — truncation and overflow.
+    await step("long", async () => {
+      await setSection(long, "details", true);
+      await snap(page, "50-card-long-title", long);
+      await setSection(long, "details", false);
+    });
+
+    // 6. Plain branch label rather than an issue headline.
+    await step("plain", async () => {
+      await snap(page, "55-card-plain-branch", plain);
+    });
+
+    // 7. Selected. The right-edge accent, the background lift, and how the
+    //    expanded chrome reads on the elevated surface.
+    await step("selected", async () => {
+      await flagship.click({ position: { x: 120, y: 12 } });
+      await page.waitForTimeout(600);
+      await snap(page, "60-card-selected", flagship);
+      await snap(page, "61-sidebar-selected", sidebar);
+    });
+
+    // 8. Card fully collapsed — disclosure as a pair with the expanded state.
+    await step("collapsed", async () => {
+      await setCardCollapsed(flagship, true);
+      await snap(page, "70-card-collapsed", flagship);
+      await snap(page, "71-sidebar-collapsed", sidebar);
+      await setCardCollapsed(flagship, false);
+    });
+
+    // 9. Keyboard focus. The row draws no ring by design (#8094); the toolbar
+    //    and drag handle revealing IS the affordance, so it has to be legible.
+    await step("focus", async () => {
+      await sectionButton(flagship, "details").focus();
+      await snap(page, "80-card-keyboard-focus", flagship);
+    });
+
+    // 10. Sessions. Real PTYs in the flagship worktree so Active Sessions has
+    //     agent identity, state and location to render — the densest row in
+    //     the card and the one that shares a shell with Details.
+    if (WITH_SESSIONS) {
+      await step("sessions", async () => {
+        // Sessions land in the ACTIVE worktree, so the flagship has to be it.
+        // The `selected` step already selected it; re-clicking by coordinate is
+        // unreliable once the row is taller than the sidebar viewport, so
+        // assert rather than click, and only click if the assertion would fail.
+        const card = flagship.locator(".sidebar-worktree-card").first();
+        if ((await card.getAttribute("data-active")) !== "true") {
+          await card.click();
+        }
+        await expect(card, "flagship is not the active worktree").toHaveAttribute(
+          "data-active",
+          "true",
+          { timeout: T_LONG }
+        );
+        await page.waitForTimeout(800);
+        await launchAgentSession(page);
+        await launchAgentSession(page);
+        await page.waitForTimeout(1500);
+        await dismissBlockingPalette(page);
+
+        await setSection(flagship, "terminals", true);
+        await snap(page, "100-card-sessions-expanded", flagship, "Active Sessions");
+        await setSection(flagship, "details", true);
+        await snap(page, "101-card-details-and-sessions", flagship, "Active Sessions");
+        await snap(page, "102-sidebar-loaded", sidebar);
+        await setSection(flagship, "terminals", false);
+        await snap(page, "103-card-sessions-collapsed", flagship, "active");
+        await setSection(flagship, "terminals", true);
+      });
+    }
+
+    // 11. Narrow sidebar — where truncation and the trailing cluster compete.
+    await step("narrow", async () => {
+      await setSidebarWidth(page, 240);
+      await snap(page, "90-sidebar-narrow", sidebar);
+      await snap(page, "91-card-narrow", flagship);
+      await setSidebarWidth(page, 320);
+    });
+
+    // 12. High contrast. macOS fires prefers-contrast; forced-colors is the
+    //     Windows half. Both are emulated so the pair can be compared.
+    await step("contrast", async () => {
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 400);
+      await snap(page, "110-card-prefers-contrast", flagship);
+      await page.emulateMedia({ contrast: "no-preference" });
+      await page.emulateMedia({ forcedColors: "active" });
+      await settle(page, 400);
+      await snap(page, "111-card-forced-colors", flagship);
+      await page.emulateMedia({ forcedColors: "none" });
+      await settle(page, 400);
+    });
+
+    // 13. Theme sweep of the state everything else is judged against. Theme
+    //     collapse is real and only a sweep across all of them finds it.
+    await step("themes", async () => {
+      const themes = SWEEP_THEMES.length > 0 ? SWEEP_THEMES : ALL_THEMES;
+      for (const theme of themes) {
+        await setAppTheme(page, theme);
+        await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+        await dismissBlockingPalette(page);
+        const themedRow = row(page, WORKTREES.flagship.branch);
+        await expect(themedRow, `card missing after switching to ${theme}`).toBeVisible({
+          timeout: T_LONG,
+        });
+        await setSection(themedRow, "details", true);
+        await settle(page, 800);
+        await snap(page, `200-theme-${theme}`, themedRow);
+      }
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+
+  // Count the outputs ourselves. A passing exit code says nothing about
+  // whether the harness actually produced anything.
+  const onDisk = readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`));
+  console.log(`[card-shots] wrote ${written.size} shots; ${onDisk.length} PNGs on disk`);
+  if (written.size === 0) {
+    throw new Error("[card-shots] produced no screenshots at all");
+  }
+  if (stepFailures.length > 0) {
+    throw new Error(
+      `[card-shots] ${stepFailures.length} step(s) failed:\n${stepFailures.join("\n")}`
+    );
+  }
+});

--- a/e2e/screenshots/worktree-card-review.spec.ts
+++ b/e2e/screenshots/worktree-card-review.spec.ts
@@ -511,12 +511,27 @@ test("sidebar worktree card review — states and themes", async () => {
       await snap(page, "55-card-plain-branch", plain);
     });
 
-    // 7. Selected. The right-edge accent, the background lift, and how the
-    //    expanded chrome reads on the elevated surface.
+    // 7. Selected vs inactive. The right-edge accent and the background lift
+    //    only mean anything as a comparison, so shoot the selected card and an
+    //    unselected sibling from the same frame, and assert which is which —
+    //    otherwise a card that was incidentally selected by an earlier step
+    //    reads as "selection is invisible".
     await step("selected", async () => {
-      await flagship.click({ position: { x: 120, y: 12 } });
+      const flagshipCard = flagship.locator(".sidebar-worktree-card").first();
+      const quietCard = quiet.locator(".sidebar-worktree-card").first();
+      await flagshipCard.click();
+      await expect(flagshipCard, "flagship did not become active").toHaveAttribute(
+        "data-active",
+        "true",
+        { timeout: T_LONG }
+      );
+      await expect(quietCard, "sibling card should not be active").not.toHaveAttribute(
+        "data-active",
+        "true"
+      );
       await page.waitForTimeout(600);
       await snap(page, "60-card-selected", flagship);
+      await snap(page, "62-card-inactive", quiet);
       await snap(page, "61-sidebar-selected", sidebar);
     });
 
@@ -528,11 +543,32 @@ test("sidebar worktree card review — states and themes", async () => {
       await setCardCollapsed(flagship, false);
     });
 
-    // 9. Keyboard focus. The row draws no ring by design (#8094); the toolbar
-    //    and drag handle revealing IS the affordance, so it has to be legible.
+    // 9. Keyboard focus. The row draws no ring by design (#8094); the toolbar,
+    //    drag handle and the disclosure's own outline are the affordance, so
+    //    they have to be legible.
+    //
+    //    This must be driven by real Tab presses. A scripted `.focus()` on a
+    //    <button> does not satisfy Chromium's `:focus-visible` heuristic, so a
+    //    shot taken that way shows the surface with NO focus styling and looks
+    //    exactly like a missing focus ring — a capture that lies about the very
+    //    state it is named for. Tab until the target matches `:focus-visible`,
+    //    and refuse to shoot if it never does.
     await step("focus", async () => {
-      await sectionButton(flagship, "details").focus();
+      const target = sectionButton(flagship, "details");
+      await expect(target, "details disclosure is missing").toBeVisible({ timeout: T_LONG });
+      await page.locator(SEL.worktree.searchInput).first().click();
+      let reached = false;
+      for (let i = 0; i < 60 && !reached; i++) {
+        await page.keyboard.press("Tab");
+        reached = await target
+          .evaluate((el) => el === document.activeElement && el.matches(":focus-visible"))
+          .catch(() => false);
+      }
+      if (!reached) {
+        throw new Error("never reached :focus-visible on the details disclosure by Tab");
+      }
       await snap(page, "80-card-keyboard-focus", flagship);
+      await snap(page, "81-sidebar-keyboard-focus", sidebar);
     });
 
     // 10. Sessions. Real PTYs in the flagship worktree so Active Sessions has
@@ -559,14 +595,21 @@ test("sidebar worktree card review — states and themes", async () => {
         await page.waitForTimeout(1500);
         await dismissBlockingPalette(page);
 
+        // Details stays collapsed for the session shots. A card with both
+        // sections open is taller than the sidebar viewport, and an element
+        // screenshot of that stitches the list's sticky overlays across the
+        // very rows being reviewed — 101 keeps that combined shot for the
+        // nesting evidence, but the session rows have to be legible somewhere.
+        await setSection(flagship, "details", false);
         await setSection(flagship, "terminals", true);
         await snap(page, "100-card-sessions-expanded", flagship, "Active Sessions");
-        await setSection(flagship, "details", true);
-        await snap(page, "101-card-details-and-sessions", flagship, "Active Sessions");
         await snap(page, "102-sidebar-loaded", sidebar);
         await setSection(flagship, "terminals", false);
         await snap(page, "103-card-sessions-collapsed", flagship, "active");
         await setSection(flagship, "terminals", true);
+        await setSection(flagship, "details", true);
+        await snap(page, "101-card-details-and-sessions", flagship, "Active Sessions");
+        await setSection(flagship, "details", false);
       });
     }
 

--- a/e2e/screenshots/worktree-card-review.spec.ts
+++ b/e2e/screenshots/worktree-card-review.spec.ts
@@ -486,7 +486,7 @@ test("sidebar worktree card review — states and themes", async () => {
     // 3. Details expanded — the nested-card stack the issue is about.
     await step("expanded", async () => {
       await setSection(flagship, "details", true);
-      await snap(page, "30-card-details-expanded", flagship, "Changed Files");
+      await snap(page, "30-card-details-expanded", flagship, "Changed files");
     });
 
     // 4. The quiet card expanded: clean tree, no note, so the narrative slot
@@ -602,13 +602,13 @@ test("sidebar worktree card review — states and themes", async () => {
         // nesting evidence, but the session rows have to be legible somewhere.
         await setSection(flagship, "details", false);
         await setSection(flagship, "terminals", true);
-        await snap(page, "100-card-sessions-expanded", flagship, "Active Sessions");
+        await snap(page, "100-card-sessions-expanded", flagship, "Active sessions");
         await snap(page, "102-sidebar-loaded", sidebar);
         await setSection(flagship, "terminals", false);
         await snap(page, "103-card-sessions-collapsed", flagship, "active");
         await setSection(flagship, "terminals", true);
         await setSection(flagship, "details", true);
-        await snap(page, "101-card-details-and-sessions", flagship, "Active Sessions");
+        await snap(page, "101-card-details-and-sessions", flagship, "Active sessions");
         await setSection(flagship, "details", false);
       });
     }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -1094,6 +1094,7 @@ export function WorktreeCard({
                   {isMainWorktree && <MainWorktreeSummaryRows health={projectHealth ?? null} />}
 
                   <WorktreeDetailsSection
+                    variant={variant}
                     worktree={worktree}
                     homeDir={homeDir}
                     isExpanded={isExpanded}
@@ -1127,6 +1128,7 @@ export function WorktreeCard({
                   />
 
                   <WorktreeTerminalSection
+                    variant={variant}
                     worktreeId={worktree.id}
                     isExpanded={isTerminalsExpanded}
                     counts={terminalCounts}

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -124,8 +124,11 @@ export function NonMainSecondaryRow({
           underlineOnHover={underlineOnHover}
         />
       )}
-      {upstreamFirst ? upstreamBadge : prBadge}
-      {upstreamFirst ? prBadge : upstreamBadge}
+      {/* Branch before upstream delta: the branch is identity, the delta is
+          state, and the card answers "which worktree is this?" before "how far
+          has it drifted?". The upstream/PR pair still swaps between itself by
+          alarm tier — that ordering is about which alarm outranks which, not
+          about outranking the branch name. */}
       {hasDisplayTitle && (
         <BranchLabel
           label={branchLabel}
@@ -134,6 +137,8 @@ export function NonMainSecondaryRow({
           isMainWorktree={false}
         />
       )}
+      {upstreamFirst ? upstreamBadge : prBadge}
+      {upstreamFirst ? prBadge : upstreamBadge}
       {hasPlanFile && badges.onOpenPlan && (
         <button
           type="button"

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { actionService } from "@/services/ActionService";
 import type { ComputedSubtitle, WorktreeReviewState } from "./hooks/useWorktreeStatus";
+import { SECTION_LABEL, SECTION_TRIGGER_SURFACE } from "./sectionChrome";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   ContextMenu,
@@ -36,6 +37,15 @@ import {
 export interface WorktreeDetailsSectionProps {
   worktree: WorktreeState;
   homeDir?: string;
+  /**
+   * Sidebar cards flatten this section into the card surface; grid cards keep
+   * the bordered, filled well. The sidebar row is already a container, and a
+   * second bordered plane inside it (with a third for the note and a fourth
+   * for the file list) reads as a stack of nested cards and eats ~34px of a
+   * 240-360px column per level. The grid card sits on a wider, standalone
+   * surface where the well still earns its keep.
+   */
+  variant?: "sidebar" | "grid";
   isExpanded: boolean;
   hasChanges: boolean;
   computedSubtitle: ComputedSubtitle;
@@ -70,6 +80,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
   const {
     worktree,
     homeDir,
+    variant = "sidebar",
     isExpanded,
     hasChanges,
     computedSubtitle,
@@ -144,7 +155,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
   // push — so the opener stays visible; only the label shifts to match.
   const isUnpushedClean = reviewState === "unpushed-clean" && !hasChanges;
   const showReviewHubButton = !!onOpenReviewHub && (hasChanges || isUnpushedClean);
-  const reviewHubButtonLabel = isUnpushedClean ? "Review & Push" : "Review & Commit";
+  const reviewHubButtonLabel = isUnpushedClean ? "Review & push" : "Review & commit";
   const rightButtonGroupShown = showReviewHubButton;
 
   const lifecycleState = worktree.lifecycleStatus?.state;
@@ -182,24 +193,43 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
   const showResourcePause = hasResourceConfig && (rsLower === "running" || rsLower === "starting");
   const showResourceConnect = hasResourceConfig && !!onResourceConnect && rsLower === "running";
 
+  const isSidebar = variant === "sidebar";
+
   return (
     <>
       <div
         id={detailsId}
-        className="mt-2 rounded-[var(--radius-lg)] border border-border-default bg-surface-inset p-3"
+        className={cn(
+          isSidebar
+            ? "mt-3"
+            : "mt-2 rounded-[var(--radius-lg)] border border-border-default bg-surface-inset p-3"
+        )}
       >
         {isExpanded ? (
-          <div className="-m-3">
+          <div className={cn(!isSidebar && "-m-3")}>
             <button
               onClick={onToggleExpand}
               aria-expanded={true}
               aria-controls={detailsPanelId}
-              className="worktree-section-button flex w-full items-center justify-between rounded-t-[var(--radius-lg)] border-b border-border-default bg-surface-inset px-3 py-2.5 text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+              className={cn(
+                "worktree-section-button flex w-full items-center text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+                isSidebar
+                  ? // Leading chevron, no fill, no rule under it: the trigger has
+                    // to stay attached to the body it just revealed. A divider
+                    // there cuts the two apart and they read as separate
+                    // components.
+                    cn(SECTION_TRIGGER_SURFACE, "gap-1.5 py-1")
+                  : "justify-between rounded-t-[var(--radius-lg)] border-b border-border-default bg-surface-inset px-3 py-2.5"
+              )}
               id={`${detailsId}-button`}
             >
+              {isSidebar && <ChevronRight className="h-3 w-3 shrink-0 rotate-90 text-text-muted" />}
               {isBeingDeleted && !deleteError ? (
                 <span
-                  className="flex items-center gap-1.5 text-xs font-medium text-text-secondary"
+                  className={cn(
+                    "flex items-center gap-1.5 text-xs font-medium text-text-secondary",
+                    isSidebar && SECTION_LABEL
+                  )}
                   role="status"
                   aria-live="polite"
                 >
@@ -207,17 +237,22 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                   <span>Deleting…</span>
                 </span>
               ) : (
-                <span className="text-xs font-medium text-text-muted">Details</span>
+                <span
+                  className={cn(isSidebar ? SECTION_LABEL : "text-xs font-medium text-text-muted")}
+                >
+                  Details
+                </span>
               )}
-              <ChevronRight className="h-3 w-3 rotate-90 text-text-muted" />
+              {!isSidebar && <ChevronRight className="h-3 w-3 rotate-90 text-text-muted" />}
             </button>
             <div
               id={detailsPanelId}
               role="region"
               aria-labelledby={`${detailsId}-button`}
-              className="p-3"
+              className={cn(isSidebar ? "mt-2" : "p-3")}
             >
               <WorktreeDetails
+                variant={variant}
                 worktree={worktree}
                 homeDir={homeDir}
                 effectiveNote={effectiveNote}
@@ -237,15 +272,23 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
             </div>
           </div>
         ) : (
-          <div className="-m-3 flex flex-col">
+          <div className={cn("flex flex-col", !isSidebar && "-m-3")}>
             <div className="flex items-stretch">
               <div
                 onClick={onToggleExpand}
                 className={cn(
-                  "worktree-section-button relative flex min-w-0 flex-1 items-center justify-between px-3 py-2.5 text-left transition-colors",
-                  rightButtonGroupShown
-                    ? "rounded-l-[var(--radius-lg)]"
-                    : "rounded-[var(--radius-lg)]"
+                  "worktree-section-button relative flex min-w-0 flex-1 items-center justify-between text-left transition-colors",
+                  // Sidebar: a flat row on the card surface with a hover
+                  // backplate, not a permanent bordered well. Same hit area,
+                  // same content, one less container.
+                  isSidebar
+                    ? "-ml-1.5 rounded-[var(--radius-md)] py-1.5 pl-1.5 pr-1"
+                    : cn(
+                        "px-3 py-2.5",
+                        rightButtonGroupShown
+                          ? "rounded-l-[var(--radius-lg)]"
+                          : "rounded-[var(--radius-lg)]"
+                      )
                 )}
               >
                 <button
@@ -256,9 +299,11 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                   aria-label="Show details"
                   className={cn(
                     "absolute inset-0",
-                    rightButtonGroupShown
-                      ? "rounded-l-[var(--radius-lg)]"
-                      : "rounded-[var(--radius-lg)]",
+                    isSidebar
+                      ? "rounded-[var(--radius-md)]"
+                      : rightButtonGroupShown
+                        ? "rounded-l-[var(--radius-lg)]"
+                        : "rounded-[var(--radius-lg)]",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
                   )}
                 />
@@ -357,7 +402,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                       {onResourceStatus && (
                         <ContextMenuItem onClick={onResourceStatus}>
                           <Activity className="w-3.5 h-3.5 mr-2" />
-                          Check Status
+                          Check status
                         </ContextMenuItem>
                       )}
                       {onResourceTeardown && (
@@ -368,7 +413,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                             className="text-status-error"
                           >
                             <Trash2 className="w-3.5 h-3.5 mr-2" />
-                            Teardown
+                            Tear down resource
                           </ContextMenuItem>
                         </>
                       )}
@@ -388,12 +433,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                                 onResourceResume();
                               }}
                               className="shrink-0 p-1 rounded transition-colors text-status-success/70 hover:text-status-success hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                              aria-label="Resume Resource"
+                              aria-label="Resume resource"
                             >
                               <Play className="w-3 h-3" />
                             </button>
                           </TooltipTrigger>
-                          <TooltipContent side="bottom">Resume Resource</TooltipContent>
+                          <TooltipContent side="bottom">Resume resource</TooltipContent>
                         </Tooltip>
                       )}
                       {showResourcePause && onResourcePause && (
@@ -405,12 +450,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                                 onResourcePause();
                               }}
                               className="shrink-0 p-1 rounded transition-colors text-status-error/70 hover:text-status-error hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                              aria-label="Pause Resource"
+                              aria-label="Pause resource"
                             >
                               <Square className="w-3 h-3" />
                             </button>
                           </TooltipTrigger>
-                          <TooltipContent side="bottom">Pause Resource</TooltipContent>
+                          <TooltipContent side="bottom">Pause resource</TooltipContent>
                         </Tooltip>
                       )}
                       {showResourceConnect && (
@@ -422,12 +467,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                                 onResourceConnect!();
                               }}
                               className="shrink-0 p-1 rounded transition-colors text-status-info/70 hover:text-status-info hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                              aria-label="Connect to Resource"
+                              aria-label="Connect to resource"
                             >
                               <Plug className="w-3 h-3" />
                             </button>
                           </TooltipTrigger>
-                          <TooltipContent side="bottom">Connect to Resource</TooltipContent>
+                          <TooltipContent side="bottom">Connect to resource</TooltipContent>
                         </Tooltip>
                       )}
                     </span>
@@ -448,9 +493,14 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                     <button
                       onClick={onOpenReviewHub}
                       className={cn(
-                        "shrink-0 border-l border-border-default px-2 py-1 transition-colors",
+                        "shrink-0 transition-colors",
                         "text-[var(--color-state-active)]/70 hover:bg-[var(--color-state-active)]/10 hover:text-[var(--color-state-active)]",
-                        "rounded-r-[var(--radius-lg)]",
+                        // Sidebar: a trailing icon button in the same row. The
+                        // fenced right segment made one summary read as a split
+                        // pill with an unlabelled second half.
+                        isSidebar
+                          ? "ml-0.5 rounded-[var(--radius-md)] px-1.5 py-1"
+                          : "rounded-r-[var(--radius-lg)] border-l border-border-default px-2 py-1",
                         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
                       )}
                       aria-label={`Open ${reviewHubButtonLabel}`}
@@ -464,7 +514,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
             </div>
 
             {lifecycleFailed && (
-              <div className="flex flex-col gap-2 border-t border-border-default px-3 py-2">
+              <div
+                className={cn(
+                  "flex flex-col gap-2",
+                  isSidebar ? "mt-1 py-1" : "border-t border-border-default px-3 py-2"
+                )}
+              >
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-xs text-text-muted truncate">
                     Setup didn't finish. Re-run when you're ready.

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -201,7 +201,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
         id={detailsId}
         className={cn(
           isSidebar
-            ? "mt-3"
+            ? "mt-2"
             : "mt-2 rounded-[var(--radius-lg)] border border-border-default bg-surface-inset p-3"
         )}
       >
@@ -307,6 +307,16 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
                   )}
                 />
+                {isSidebar && (
+                  // The closed half of the same disclosure vocabulary the
+                  // expanded state uses. Flattening removed the well that used
+                  // to say "this is a thing you open", so without a chevron the
+                  // resting row is just a line of metadata.
+                  <ChevronRight
+                    className="pointer-events-none relative z-10 mr-1.5 h-3 w-3 shrink-0 text-text-muted"
+                    aria-hidden="true"
+                  />
+                )}
                 <span className="relative z-10 text-xs truncate min-w-0 flex-1 pointer-events-none">
                   {isBeingDeleted && !deleteError ? (
                     <span
@@ -382,19 +392,19 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                       {showResourceResume && onResourceResume && (
                         <ContextMenuItem onClick={onResourceResume}>
                           <Play className="w-3.5 h-3.5 mr-2" />
-                          Resume
+                          Resume resource
                         </ContextMenuItem>
                       )}
                       {showResourcePause && onResourcePause && (
                         <ContextMenuItem onClick={onResourcePause}>
                           <Square className="w-3.5 h-3.5 mr-2" />
-                          Pause
+                          Pause resource
                         </ContextMenuItem>
                       )}
                       {showResourceConnect && (
                         <ContextMenuItem onClick={onResourceConnect}>
                           <Plug className="w-3.5 h-3.5 mr-2" />
-                          Connect
+                          Connect to resource
                         </ContextMenuItem>
                       )}
                       {(showResourceResume || showResourcePause || showResourceConnect) &&

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -78,7 +78,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
         isArmed && !isPrimary && "outline-dashed outline-border-strong"
       )}
     >
-      <div className="worktree-section-button group/termrow flex items-center justify-between gap-2.5 px-3 py-2 transition-colors">
+      <div className="worktree-section-button group/termrow flex items-center justify-between gap-2.5 py-2 pl-[18px] pr-1 transition-colors">
         <TruncatedTooltip content={term.title} isTruncated={isTruncated}>
           <button
             type="button"
@@ -387,7 +387,7 @@ export function WorktreeTerminalSection({
         isSidebar
           ? // Flat on the card surface, and separated from Details by a peer
             // divider rather than by each section carrying its own well.
-            "mt-3 border-t border-border-subtle pt-3"
+            "mt-2 border-t border-border-subtle pt-2"
           : "mt-3 rounded-[var(--radius-lg)] border border-border-default bg-surface-inset"
       )}
     >
@@ -504,6 +504,9 @@ export function WorktreeTerminalSection({
           id={`${terminalsId}-button`}
         >
           <div className="flex items-center gap-1.5 text-[11px] text-text-secondary">
+            {isSidebar && (
+              <ChevronRight className="h-3 w-3 shrink-0 text-text-muted" aria-hidden="true" />
+            )}
             {SummaryIcon ? (
               <SummaryIcon className="w-3 h-3" />
             ) : (

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -24,6 +24,7 @@ import {
   PanelBottom,
   PanelTopClose,
   SquareTerminal,
+  X,
 } from "lucide-react";
 import {
   SortableWorktreeTerminal,
@@ -32,6 +33,7 @@ import {
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useKeybindingScope } from "@/hooks/useKeybinding";
+import { SECTION_LABEL, SECTION_TRIGGER_SURFACE } from "./sectionChrome";
 
 interface MarqueeBox {
   x: number;
@@ -148,7 +150,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
               </div>
             </TooltipTrigger>
             <TooltipContent side="bottom">
-              {term.location === "dock" ? "Docked" : "On Grid"}
+              {term.location === "dock" ? "Docked" : "On grid"}
             </TooltipContent>
           </Tooltip>
 
@@ -170,6 +172,8 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
 
 export interface WorktreeTerminalSectionProps {
   worktreeId: string;
+  /** See {@link WorktreeDetailsSectionProps.variant} — same reasoning. */
+  variant?: "sidebar" | "grid";
   isExpanded: boolean;
   counts: WorktreeTerminalCounts;
   terminals: PtyPanelData[];
@@ -181,6 +185,7 @@ const FLEET_HINT_DISMISSED_KEY = "daintree:fleet-selection-hint-dismissed";
 
 export function WorktreeTerminalSection({
   worktreeId,
+  variant = "sidebar",
   isExpanded,
   counts,
   terminals,
@@ -189,6 +194,7 @@ export function WorktreeTerminalSection({
 }: WorktreeTerminalSectionProps) {
   useKeybindingScope("worktreeGrid", isExpanded);
 
+  const isSidebar = variant === "sidebar";
   const showMetaFooter = counts.total > 0;
 
   const terminalsId = `worktree-${worktreeId}-terminals`;
@@ -377,7 +383,13 @@ export function WorktreeTerminalSection({
   return (
     <div
       id={terminalsId}
-      className="mt-3 rounded-[var(--radius-lg)] border border-border-default bg-surface-inset"
+      className={cn(
+        isSidebar
+          ? // Flat on the card surface, and separated from Details by a peer
+            // divider rather than by each section carrying its own well.
+            "mt-3 border-t border-border-subtle pt-3"
+          : "mt-3 rounded-[var(--radius-lg)] border border-border-default bg-surface-inset"
+      )}
     >
       {isExpanded ? (
         <>
@@ -385,18 +397,29 @@ export function WorktreeTerminalSection({
             onClick={onToggle}
             aria-expanded={true}
             aria-controls={terminalsPanelId}
-            className="worktree-section-button flex w-full items-center justify-between rounded-t-[var(--radius-lg)] border-b border-border-default bg-surface-inset px-3 py-1.5 text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+            className={cn(
+              "worktree-section-button flex w-full items-center text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+              isSidebar
+                ? cn(SECTION_TRIGGER_SURFACE, "gap-1.5 py-1")
+                : "justify-between rounded-t-[var(--radius-lg)] border-b border-border-default bg-surface-inset px-3 py-1.5"
+            )}
             id={`${terminalsId}-button`}
           >
-            <span className="flex items-center gap-1.5 text-[11px] font-medium text-text-muted">
+            {isSidebar && <ChevronRight className="h-3 w-3 shrink-0 rotate-90 text-text-muted" />}
+            <span
+              className={cn(
+                "flex items-center gap-1.5",
+                isSidebar ? SECTION_LABEL : "text-[11px] font-medium text-text-muted"
+              )}
+            >
               {SummaryIcon ? (
                 <SummaryIcon className="w-3 h-3" />
               ) : (
                 <SquareTerminal className="w-3 h-3" />
               )}
-              <span>Active Sessions ({counts.total})</span>
+              <span>Active sessions ({counts.total})</span>
             </span>
-            <ChevronRight className="h-3 w-3 rotate-90 text-text-muted" />
+            {!isSidebar && <ChevronRight className="h-3 w-3 rotate-90 text-text-muted" />}
           </button>
           <SortableContext
             id={`worktree-${worktreeId}-accordion`}
@@ -404,7 +427,12 @@ export function WorktreeTerminalSection({
             strategy={verticalListSortingStrategy}
           >
             {eligibleTerminals.length >= 2 && armedIdsSize === 0 && !hintDismissed && (
-              <div className="flex items-center justify-between px-3 py-1.5 text-[11px] text-text-muted bg-surface-inset border-b border-border-default">
+              <div
+                className={cn(
+                  "flex items-center justify-between py-1.5 text-[11px] text-text-muted",
+                  isSidebar ? "" : "border-b border-border-default bg-surface-inset px-3"
+                )}
+              >
                 <span>Drag to select multiple, ⇧-click to add</span>
                 <button
                   type="button"
@@ -418,7 +446,7 @@ export function WorktreeTerminalSection({
                     setHintDismissed(true);
                   }}
                 >
-                  ✕
+                  <X className="h-3 w-3" aria-hidden="true" />
                 </button>
               </div>
             )}
@@ -432,7 +460,10 @@ export function WorktreeTerminalSection({
               onPointerMove={handlePointerMove}
               onPointerUp={handlePointerUp}
               onPointerCancel={handlePointerCancel}
-              className="relative max-h-[300px] overflow-y-auto bg-surface-inset cursor-crosshair"
+              className={cn(
+                "relative max-h-[300px] cursor-crosshair overflow-y-auto",
+                isSidebar ? "mt-1" : "bg-surface-inset"
+              )}
             >
               {orderedWorktreeTerminals.map((term, index) => (
                 <SortableWorktreeTerminal
@@ -464,7 +495,12 @@ export function WorktreeTerminalSection({
           onClick={onToggle}
           aria-expanded={false}
           aria-controls={terminalsPanelId}
-          className="worktree-section-button flex w-full items-center justify-between rounded-[var(--radius-lg)] px-3 py-1.5 text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+          className={cn(
+            "worktree-section-button flex w-full items-center justify-between text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+            isSidebar
+              ? cn(SECTION_TRIGGER_SURFACE, "py-1.5")
+              : "rounded-[var(--radius-lg)] px-3 py-1.5"
+          )}
           id={`${terminalsId}-button`}
         >
           <div className="flex items-center gap-1.5 text-[11px] text-text-secondary">

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -310,7 +310,7 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
       reviewState: "has-changes",
       onOpenReviewHub,
     });
-    const button = screen.getByLabelText("Open Review & Commit");
+    const button = screen.getByLabelText("Open Review & commit");
     expect(button).toBeDefined();
     fireEvent.click(button);
     expect(onOpenReviewHub).toHaveBeenCalledTimes(1);
@@ -332,10 +332,10 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
         } as WorktreeChanges,
       },
     });
-    expect(screen.queryByLabelText("Open Review & Commit")).toBeNull();
+    expect(screen.queryByLabelText("Open Review & commit")).toBeNull();
     expect(screen.queryByText("Conflicts need review")).toBeNull();
     expect(screen.getByText("fix: stuff")).toBeDefined();
-    const button = screen.getByLabelText("Open Review & Push");
+    const button = screen.getByLabelText("Open Review & push");
     fireEvent.click(button);
     expect(onOpenReviewHub).toHaveBeenCalledTimes(1);
   });
@@ -354,8 +354,8 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
         } as WorktreeChanges,
       },
     });
-    expect(screen.queryByLabelText("Open Review & Commit")).toBeNull();
-    expect(screen.queryByLabelText("Open Review & Push")).toBeNull();
+    expect(screen.queryByLabelText("Open Review & commit")).toBeNull();
+    expect(screen.queryByLabelText("Open Review & push")).toBeNull();
   });
 });
 

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -414,9 +414,14 @@ describe("WorktreeDetailsSection activity chip (collapsed row)", () => {
     const worktree = withCommit({
       lastCommitAuthor: { name: "Codex", email: "noreply@codex.openai.com" },
     });
-    const { container } = renderSection({ worktree, hasChanges: false });
-    expect(container.querySelector("svg")).toBeNull();
-    expect(container.querySelector("img")).toBeNull();
+    renderSection({ worktree, hasChanges: false });
+    // Scoped to the chip itself. The row legitimately carries other icons —
+    // the disclosure chevron, the Review Hub control — so asserting "no svg
+    // anywhere in the row" tested the surrounding chrome rather than the rule,
+    // which is that the activity chip never paints committer identity.
+    const chip = screen.getByRole("group", { name: "Last activity" });
+    expect(chip.querySelector("svg")).toBeNull();
+    expect(chip.querySelector("img")).toBeNull();
   });
 
   it("renders activity for a worktree with no commit", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/sidebarCardContainment.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/sidebarCardContainment.test.tsx
@@ -225,4 +225,23 @@ describe("sidebar card containment", () => {
       "the chevron should precede the section label"
     ).toBeTruthy();
   });
+
+  it("marks a sidebar section as a disclosure while it is CLOSED, not only while open", () => {
+    // Flattening took away the well that used to say "this opens". Without a
+    // closed-state chevron the resting Details row is a line of metadata with
+    // no affordance, which is the one thing the boxes were still earning.
+    const details = renderDetails({ variant: "sidebar", isExpanded: false });
+    const detailsRow = details.container.querySelector('[aria-expanded="false"]')!.closest("div")!;
+    expect(
+      detailsRow.querySelector("svg"),
+      "collapsed sidebar Details should carry a disclosure chevron"
+    ).toBeTruthy();
+    details.unmount();
+
+    const terminals = renderTerminals({ variant: "sidebar", isExpanded: false });
+    expect(
+      terminals.container.querySelector('[aria-expanded="false"]')!.querySelectorAll("svg").length,
+      "collapsed sidebar Active sessions should carry a disclosure chevron beside its own icon"
+    ).toBeGreaterThan(1);
+  });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/sidebarCardContainment.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/sidebarCardContainment.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Containment rules for the sidebar worktree card (#11992).
+ *
+ * These assert the RULE, not the classes that currently satisfy it. The card's
+ * material will keep changing; what must not come back is a second bordered,
+ * filled plane inside a row that is already a container, a divider cutting a
+ * disclosure trigger off from the body it just revealed, or the two sibling
+ * sections drifting into different shells. Each test states the rule it is
+ * defending so a future change can argue with it rather than guess at it.
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { WorktreeState } from "@/types";
+import type { PtyPanelData } from "@shared/types/panel";
+import type { ComputedSubtitle } from "../hooks/useWorktreeStatus";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  WorktreeDetailsSection,
+  type WorktreeDetailsSectionProps,
+} from "../WorktreeDetailsSection";
+import { WorktreeTerminalSection } from "../WorktreeTerminalSection";
+
+const mockAnimate = vi.fn();
+
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ children, ...props }, ref) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    )
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+    useAnimate: () => [{ current: null } as unknown as React.RefObject<HTMLElement>, mockAnimate],
+    useReducedMotion: () => false,
+  };
+});
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+const noop = () => {};
+const noopAsync = async () => {};
+
+const worktree: WorktreeState = {
+  id: "wt-1",
+  worktreeId: "wt-1",
+  path: "/tmp/wt-1",
+  name: "stream-upload",
+  branch: "feature/issue-1-stream-upload",
+  isCurrent: false,
+  isMainWorktree: false,
+  worktreeChanges: {
+    worktreeId: "wt-1",
+    changedFileCount: 3,
+    insertions: 5,
+    deletions: 2,
+    changes: [],
+    rootPath: "",
+  },
+  lastActivityTimestamp: null,
+};
+
+const subtitle: ComputedSubtitle = { text: "3 files changed", tone: "muted" };
+
+const detailsProps: WorktreeDetailsSectionProps = {
+  worktree,
+  isExpanded: false,
+  hasChanges: true,
+  computedSubtitle: subtitle,
+  worktreeErrors: [],
+  isFocused: false,
+  onToggleExpand: noop,
+  onPathClick: noop,
+  onDismissError: noop,
+  onRetryError: noopAsync,
+};
+
+const terminal = {
+  id: "term-1",
+  kind: "pty",
+  title: "Claude",
+  worktreeId: "wt-1",
+  location: "grid",
+} as unknown as PtyPanelData;
+
+function renderDetails(overrides: Partial<WorktreeDetailsSectionProps> = {}) {
+  return render(
+    <TooltipProvider>
+      <WorktreeDetailsSection {...detailsProps} {...overrides} />
+    </TooltipProvider>
+  );
+}
+
+function renderTerminals(overrides: { variant?: "sidebar" | "grid"; isExpanded?: boolean } = {}) {
+  return render(
+    <TooltipProvider>
+      <WorktreeTerminalSection
+        worktreeId="wt-1"
+        variant={overrides.variant}
+        isExpanded={overrides.isExpanded ?? false}
+        counts={{ total: 1, byState: {} } as never}
+        terminals={[terminal]}
+        onToggle={noop}
+        onTerminalSelect={noop}
+      />
+    </TooltipProvider>
+  );
+}
+
+/**
+ * A "well" is the combination that makes an element read as a card: a visible
+ * border AND a surface fill of its own. Either alone is a legitimate tool;
+ * together, inside a row that is already a card, they add a containment level.
+ */
+function isWell(el: Element): boolean {
+  const cls = el.className.toString();
+  const hasBorder = /(^|\s|:)border(\s|$|-[trbl]\b)/.test(cls) || /\sborder\s/.test(` ${cls} `);
+  const hasFill = /\bbg-surface-inset\b/.test(cls);
+  return hasBorder && hasFill;
+}
+
+function wellCount(container: HTMLElement): number {
+  return Array.from(container.querySelectorAll("*")).filter(isWell).length;
+}
+
+describe("sidebar card containment", () => {
+  it("adds no bordered-and-filled plane of its own in the sidebar, in either disclosure state", () => {
+    for (const isExpanded of [false, true]) {
+      const { container, unmount } = renderDetails({ variant: "sidebar", isExpanded });
+      expect(
+        wellCount(container),
+        `sidebar Details (expanded=${isExpanded}) introduced a nested card-like well`
+      ).toBe(0);
+      unmount();
+    }
+
+    for (const isExpanded of [false, true]) {
+      const { container, unmount } = renderTerminals({ variant: "sidebar", isExpanded });
+      expect(
+        wellCount(container),
+        `sidebar Active sessions (expanded=${isExpanded}) introduced a nested card-like well`
+      ).toBe(0);
+      unmount();
+    }
+  });
+
+  it("keeps the well in the grid variant, where the card is a standalone surface", () => {
+    const details = renderDetails({ variant: "grid", isExpanded: false });
+    expect(wellCount(details.container)).toBeGreaterThan(0);
+    details.unmount();
+
+    const terminals = renderTerminals({ variant: "grid", isExpanded: false });
+    expect(wellCount(terminals.container)).toBeGreaterThan(0);
+  });
+
+  it("does not separate a sidebar disclosure trigger from the body it reveals", () => {
+    // A rule between a trigger and its own content cuts the two apart and they
+    // read as separate components. Dividers belong BETWEEN sibling sections.
+    for (const render_ of [
+      () => renderDetails({ variant: "sidebar", isExpanded: true }),
+      () => renderTerminals({ variant: "sidebar", isExpanded: true }),
+    ]) {
+      const { container, unmount } = render_();
+      const trigger = container.querySelector('[aria-expanded="true"]');
+      expect(trigger, "expanded section should expose an aria-expanded trigger").toBeTruthy();
+      expect(
+        /\bborder-b\b/.test(trigger!.className.toString()),
+        "a sidebar disclosure trigger must not carry a bottom rule above its own body"
+      ).toBe(false);
+      unmount();
+    }
+  });
+
+  it("gives both sidebar sections the same trigger label treatment", () => {
+    // They are siblings. Two equal sections wearing different label type read
+    // as two different components, which is what this replaced.
+    const details = renderDetails({ variant: "sidebar", isExpanded: true });
+    const detailsLabel = details.container
+      .querySelector('[aria-expanded="true"]')!
+      .querySelector("span")!;
+    const detailsClasses = new Set(detailsLabel.className.toString().split(/\s+/));
+    details.unmount();
+
+    const terminals = renderTerminals({ variant: "sidebar", isExpanded: true });
+    const terminalsLabel = terminals.container
+      .querySelector('[aria-expanded="true"]')!
+      .querySelector("span")!;
+    const terminalsClasses = new Set(terminalsLabel.className.toString().split(/\s+/));
+
+    // Every typographic token on one label must appear on the other. Layout
+    // utilities may differ (one carries an icon); the type ramp may not.
+    const typeTokens = (set: Set<string>) =>
+      [...set].filter((c) => /^(text-|font-|uppercase|tracking-)/.test(c)).sort();
+    expect(typeTokens(detailsClasses)).toEqual(typeTokens(terminalsClasses));
+  });
+
+  it("puts the sidebar disclosure chevron before its label, not after", () => {
+    // Leading chevrons are the tree/outline convention these sections belong
+    // to, and a consistent side is what makes a column of them scannable.
+    const { container } = renderDetails({ variant: "sidebar", isExpanded: true });
+    const trigger = container.querySelector('[aria-expanded="true"]')!;
+    const svg = trigger.querySelector("svg");
+    const label = trigger.querySelector("span");
+    expect(svg).toBeTruthy();
+    expect(label).toBeTruthy();
+    expect(
+      svg!.compareDocumentPosition(label!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      "the chevron should precede the section label"
+    ).toBeTruthy();
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/sidebarSelectionAccent.test.ts
+++ b/src/components/Worktree/WorktreeCard/__tests__/sidebarSelectionAccent.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Accent restraint in the sidebar's selection vocabulary (#11992).
+ *
+ * `sidebar.css` is unlayered, so these rules are decided by source order and a
+ * later full-strength rule silently wins over an earlier dimmed one. That makes
+ * the cascade itself the thing worth pinning: this reads the stylesheet as text
+ * and asserts the ORDER and SHAPE of the accent rules, not their exact values.
+ *
+ * The rule being defended: an active row shows a full-strength accent edge, but
+ * while a control inside it is drawing its own accent focus ring, that edge must
+ * recede — two full-strength accent shapes in one frame leave neither reading as
+ * the anchor.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+
+const CSS = readFileSync(
+  path.resolve(__dirname, "../../../../styles/components/sidebar.css"),
+  "utf8"
+);
+
+/** Source offsets of every rule whose selector matches `pattern`. */
+function ruleOffsets(pattern: RegExp): number[] {
+  const offsets: number[] = [];
+  const re = new RegExp(
+    pattern.source,
+    pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g"
+  );
+  for (const match of CSS.matchAll(re)) {
+    if (match.index !== undefined) offsets.push(match.index);
+  }
+  return offsets;
+}
+
+/** The declaration block that starts at `offset`. */
+function blockAt(offset: number): string {
+  const open = CSS.indexOf("{", offset);
+  const close = CSS.indexOf("}", open);
+  return CSS.slice(open + 1, close);
+}
+
+describe("sidebar selection accent", () => {
+  it("dims the active row's accent edge while a control inside it owns the focus ring", () => {
+    const offsets = ruleOffsets(
+      /\.sidebar-worktree-card\[data-active="true"\]:has\(:focus-visible\)/
+    );
+    expect(
+      offsets.length,
+      "expected a rule scoping the active card's edge to the case where a descendant is focus-visible"
+    ).toBeGreaterThan(0);
+
+    for (const offset of offsets) {
+      const block = blockAt(offset);
+      expect(
+        /color-mix\([^)]*--theme-accent-primary/.test(block),
+        "the focused-descendant rule must use a dimmed (color-mixed) accent, not the full-strength token"
+      ).toBe(true);
+    }
+  });
+
+  it("orders the dimmed rule after the full-strength one so it actually wins", () => {
+    // Same specificity would be a coin toss decided by source order, and this
+    // file is unlayered — so order is the whole mechanism.
+    const base = ruleOffsets(/\.sidebar-worktree-card\[data-active="true"\]\s*\{/);
+    const focused = ruleOffsets(
+      /\.sidebar-worktree-card\[data-active="true"\]:has\(:focus-visible\)/
+    );
+    expect(base.length).toBeGreaterThan(0);
+    expect(focused.length).toBeGreaterThan(0);
+    expect(
+      Math.min(...focused),
+      "the focused-descendant rule must come after the base active-row rule"
+    ).toBeGreaterThan(Math.min(...base));
+  });
+
+  it("keeps the selection marker on the right edge in every mode, including forced colors", () => {
+    // #9711 round 3, all themes. A left-edge fallback put the marker on the
+    // opposite side for exactly the high-contrast users least able to absorb a
+    // second, different selection signal.
+    const activeRules = ruleOffsets(/\.sidebar-worktree-card\[data-active="true"\]/).map(blockAt);
+    expect(activeRules.length).toBeGreaterThan(0);
+    for (const block of activeRules) {
+      expect(
+        /border-left\s*:/.test(block),
+        "no active-row rule may mark selection on the left edge"
+      ).toBe(false);
+      // The inset box-shadow form is a negative x-offset (right edge).
+      const inset = block.match(/inset\s+(-?\d+)px\s+0\s+0/);
+      if (inset) {
+        expect(
+          Number(inset[1]),
+          "the inset selection marker must sit on the right edge"
+        ).toBeLessThan(0);
+      }
+    }
+  });
+});

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -231,10 +231,10 @@ export function useWorktreeActions({
     );
     setConfirmDialog({
       isOpen: true,
-      title: `Teardown resource for '${label}'?`,
+      title: `Tear down resource for '${label}'?`,
       description:
         "This runs the project's resource-teardown commands for this worktree. Tearing down a remote or shared environment may require manual steps to recreate.",
-      confirmLabel: "Teardown resource",
+      confirmLabel: "Tear down resource",
       variant: "destructive",
       children: preview,
       onConfirm: () => {

--- a/src/components/Worktree/WorktreeCard/sectionChrome.ts
+++ b/src/components/Worktree/WorktreeCard/sectionChrome.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared chrome for the sidebar card's two disclosure sections (Details and
+ * Active sessions).
+ *
+ * They are siblings and must read as siblings. Before this they used the same
+ * bordered, filled well but different label type (12px sans vs 11px medium
+ * muted), so two equal sections looked like two different components. One
+ * label token here is what keeps them in step.
+ *
+ * The sidebar deliberately drops the well: the card row is already a
+ * container, and nesting a second bordered plane inside it — with a third for
+ * the note and a fourth for the file list — reads as a stack of cards and
+ * costs roughly 34px of a 240-360px column per level. The grid card keeps the
+ * well, because it sits on a wider standalone surface where containment still
+ * earns its keep.
+ */
+
+/**
+ * The section trigger's label. A quiet micro-label rather than a heading:
+ * these name a region, they are not content, and at this size tracking is what
+ * keeps uppercase legible.
+ *
+ * `text-secondary`, not `text-muted`: this labels an interactive disclosure,
+ * and on the darkest palettes the muted tone dropped it to the weight of
+ * passive metadata. The 10px uppercase size does the de-emphasis; the tone
+ * does not have to as well.
+ */
+export const SECTION_LABEL =
+  "text-[10px] font-medium uppercase tracking-[0.06em] text-text-secondary";
+
+/**
+ * Hover/press target for a flattened section trigger. Bleeds slightly past the
+ * card's text column so the backplate reads as a row rather than a chip, the
+ * way a sidebar list row's hover does.
+ */
+export const SECTION_TRIGGER_SURFACE =
+  "worktree-section-button -mx-1.5 w-[calc(100%+0.75rem)] rounded-[var(--radius-md)] px-1.5";

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -230,10 +230,13 @@ export function WorktreeDetails({
             <div className="text-xs text-text-muted">No AI summary yet</div>
           )}
 
-          {/* Block 3: Artifacts (grouped file changes + system path). The list
-              sits in a well painted the selected-worktree-card color
-              (`.sidebar-active-well`, sidebar.css) — a hairline carries the
-              shape on themes where that fill lands close to the panel's. */}
+          {/* Block 3: Artifacts (grouped file changes + system path). In the
+              GRID variant the list sits in a well painted the
+              selected-worktree-card color (`.sidebar-active-well`,
+              sidebar.css), with a hairline to carry the shape on themes where
+              that fill lands close to the panel's. The sidebar drops both: the
+              row is already inside a card and a Details region, and the rows'
+              own hover backplates give it all the shape it needs. */}
           {hasChanges && worktree.worktreeChanges && (
             <div className="space-y-2.5">
               <div className="flex items-center justify-between gap-2 px-2">

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -8,7 +8,7 @@ import { LiveTimeAgo } from "./LiveTimeAgo";
 import { CommitAuthorAvatar } from "./WorktreeCard/CommitAuthorAvatar";
 import { CommitInfoTooltip } from "./WorktreeCard/CommitInfoTooltip";
 import { cn } from "../../lib/utils";
-import { GitCommit, Copy, Check, ExternalLink, FileDiff } from "lucide-react";
+import { GitCommit, Copy, Check, ExternalLink, FileDiff, Sparkles } from "lucide-react";
 import { parseNoteWithLinks, formatPath, type TextSegment } from "../../utils/textParsing";
 import { actionService } from "@/services/ActionService";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
@@ -17,9 +17,19 @@ import { isValidPastTimestamp } from "@/utils/timestamps";
 
 const MAX_VISIBLE_FILES = 100;
 
+/**
+ * The narrative slot's shared shell. A quiet left rail marks derived
+ * commentary as a distinct content role without adding another container.
+ */
+const NARRATIVE_RAIL = "border-l-2 border-border-default pl-2.5";
+const NARRATIVE_LABEL =
+  "flex items-center gap-1 text-[10px] font-medium uppercase tracking-[0.06em] text-text-muted";
+
 export interface WorktreeDetailsProps {
   worktree: WorktreeState;
   homeDir?: string;
+  /** See {@link WorktreeDetailsSectionProps.variant} — same reasoning. */
+  variant?: "sidebar" | "grid";
   effectiveNote?: string;
   effectiveSummary?: string | null;
   worktreeErrors: ErrorRecord[];
@@ -41,6 +51,7 @@ export interface WorktreeDetailsProps {
 export function WorktreeDetails({
   worktree,
   homeDir,
+  variant = "sidebar",
   effectiveNote,
   effectiveSummary,
   worktreeErrors,
@@ -56,6 +67,7 @@ export function WorktreeDetails({
   showTime = false,
   forgeAvatarUrl,
 }: WorktreeDetailsProps) {
+  const isSidebar = variant === "sidebar";
   const displayPath = formatPath(worktree.path, homeDir);
   const rawLastCommitMsg = worktree.worktreeChanges?.lastCommitMessage;
   const { copied: pathCopied, copy: copyPath } = useCopyWithFeedback();
@@ -146,10 +158,27 @@ export function WorktreeDetails({
             </div>
           )}
 
-          {/* Block 2: Narrative (AI note, summary, or commit message) */}
+          {/* Block 2: Narrative — the AI note, the AI summary, or the last
+              commit message, whichever is current. Exactly one of these ever
+              renders, so they are one slot wearing four costumes. They used to
+              wear four: a bordered amber well in monospace, a filled sans
+              well, a filled italic well, and a filled italic placeholder — so
+              the card changed material and typeface depending on which backend
+              field happened to resolve. One rail, one type ramp, and a
+              micro-label to say which it is.
+
+              The rail is `border-l`, not a fill plus a border: a filled well
+              with an outline draws the same boundary twice, and this content
+              is derived commentary, not a warning. Prose stays sans — the
+              monospace note cost ~15% more measure in a 240-360px column for
+              text that is not a machine artefact. */}
           {effectiveNote && (
-            <div className="p-3 rounded-[var(--radius-lg)] bg-status-warning/5 border border-status-warning/20">
-              <div className="text-xs text-status-warning/90 whitespace-pre-wrap font-mono">
+            <div className={NARRATIVE_RAIL}>
+              <div className={NARRATIVE_LABEL}>
+                <Sparkles className="h-3 w-3 shrink-0" aria-hidden="true" />
+                <span>AI note</span>
+              </div>
+              <div className="mt-1 whitespace-pre-wrap break-words text-xs leading-relaxed text-text-secondary">
                 {parsedNoteSegments.map((segment) =>
                   segment.type === "link" ? (
                     <a
@@ -157,7 +186,10 @@ export function WorktreeDetails({
                       href={segment.content}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-text-link underline hover:brightness-110 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                      // `break-all` rather than the inherited word wrap: a bare
+                      // GitHub URL has no break opportunity and used to run
+                      // straight out of the card and off the sidebar.
+                      className="rounded break-all text-text-link underline hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                       onClick={(e) => handleLinkClick(e, segment.content)}
                     >
                       {segment.content}
@@ -170,22 +202,32 @@ export function WorktreeDetails({
             </div>
           )}
           {!effectiveNote && effectiveSummary && (
-            <div className="rounded bg-overlay-subtle p-2 text-xs leading-relaxed whitespace-pre-wrap text-text-secondary">
-              {effectiveSummary}
+            <div className={NARRATIVE_RAIL}>
+              <div className={NARRATIVE_LABEL}>
+                <Sparkles className="h-3 w-3 shrink-0" aria-hidden="true" />
+                <span>Summary</span>
+              </div>
+              <div className="mt-1 whitespace-pre-wrap break-words text-xs leading-relaxed text-text-secondary">
+                {effectiveSummary}
+              </div>
             </div>
           )}
           {!effectiveNote && !effectiveSummary && showLastCommit && rawLastCommitMsg && (
-            <div className="flex gap-2 rounded bg-overlay-subtle p-2 text-xs italic text-text-secondary">
-              <GitCommit className="w-3.5 h-3.5 mt-0.5 shrink-0 text-text-muted" />
-              <div className="whitespace-pre-wrap leading-relaxed min-w-0">{rawLastCommitMsg}</div>
+            <div className={NARRATIVE_RAIL}>
+              <div className={NARRATIVE_LABEL}>
+                <GitCommit className="h-3 w-3 shrink-0" aria-hidden="true" />
+                <span>Last commit</span>
+              </div>
+              <div className="mt-1 min-w-0 whitespace-pre-wrap break-words text-xs leading-relaxed text-text-secondary">
+                {rawLastCommitMsg}
+              </div>
             </div>
           )}
 
-          {/* Placeholder when no AI summary or note exists */}
+          {/* Nothing to say yet. A filled box here occupied the footprint of
+              real content and read as data; a single muted line does not. */}
           {!effectiveNote && !effectiveSummary && !rawLastCommitMsg && (
-            <div className="rounded bg-overlay-subtle px-2 py-2 text-xs italic text-text-muted">
-              No AI summary yet
-            </div>
+            <div className="text-xs text-text-muted">No AI summary yet</div>
           )}
 
           {/* Block 3: Artifacts (grouped file changes + system path). The list
@@ -195,7 +237,7 @@ export function WorktreeDetails({
           {hasChanges && worktree.worktreeChanges && (
             <div className="space-y-2.5">
               <div className="flex items-center justify-between gap-2 px-2">
-                <span className="text-xs font-medium text-text-secondary">Changed Files</span>
+                <span className="text-xs font-medium text-text-secondary">Changed files</span>
                 {worktree.worktreeChanges.changes.length > 0 && (
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -225,15 +267,27 @@ export function WorktreeDetails({
                 maxVisible={MAX_VISIBLE_FILES}
                 groupByFolder={worktree.worktreeChanges.changedFileCount > 5}
                 isStale={isStale}
-                className="sidebar-active-well rounded-[var(--radius-md)] border border-border-subtle p-2"
+                className={cn(
+                  "rounded-[var(--radius-md)] p-2",
+                  // Sidebar: the list is already inside the card and the
+                  // Details region; a filled, hairlined well here is the
+                  // third containment level in a 240-360px column. The rows
+                  // carry their own hover backplate, which is enough shape.
+                  !isSidebar && "sidebar-active-well border border-border-subtle"
+                )}
               />
             </div>
           )}
         </>
       )}
 
-      {/* Footer: system path, then the last-active line */}
-      <div className="space-y-2.5 border-t border-border-subtle pt-3">
+      {/* Footer: system path, then the last-active line. Separated by an
+          asymmetric gap rather than a rule — a full-width hairline in a
+          300px column reads as another section boundary, and the tertiary
+          tone already terminates the block. */}
+      <div
+        className={cn("space-y-2.5", isSidebar ? "pt-1.5" : "border-t border-border-subtle pt-3")}
+      >
         <div className="flex items-center gap-2">
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -80,8 +80,9 @@ html[data-dragging="true"]
     var(--sidebar-card-shadow, 0 0 #0000);
 }
 
-/* No focus/cursor ring on the rows: the only visual signal in this list is the
-   active-worktree left marker. Suppress the default browser outline so clicking
+/* No focus/cursor ring on the rows: the only visual signals in this list are
+   the active row's neutral lift and its right-edge marker. Suppress the default
+   browser outline so clicking
    or tabbing through rows doesn't paint an outline. The per-row toolbar/drag
    handle still reveal on keyboard focus (below) so keyboard users keep a usable
    affordance, and forced-colors mode still gets a system outline (it can't be

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -42,6 +42,24 @@
     var(--sidebar-card-shadow, 0 0 #0000);
 }
 
+/* Accent restraint: exactly one accent anchor per focus region. While a
+   control inside the active row is drawing its own accent focus ring, the
+   full-strength selection edge and that ring are two load-bearing accent
+   shapes in one frame and neither reads as the anchor. Focus wins for as long
+   as it lasts — it is the transient thing the user is steering — so the
+   selection edge recedes to the same dimmed accent it already uses when the
+   sidebar loses focus entirely, rather than the ring changing colour depending
+   on which row it lands on.
+
+   `:has(:focus-visible)` and not `:focus-within`: the keyboard-cursor row
+   draws no ring at all (#8094), so on that path there is no second accent to
+   yield to and the edge must stay at full strength. */
+.sidebar-root .sidebar-worktree-card[data-active="true"]:has(:focus-visible) {
+  box-shadow:
+    inset -2px 0 0 color-mix(in srgb, var(--theme-accent-primary) 45%, transparent),
+    var(--sidebar-card-shadow, 0 0 #0000);
+}
+
 .sidebar-worktree-card[data-hoverable="true"]:hover,
 .sidebar-worktree-card[data-hovered="true"] {
   background: var(--sidebar-hover-bg, rgba(255, 255, 255, 0.03));

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -165,11 +165,15 @@ html[data-dragging="true"]
     outline-offset: -2px;
   }
 
-  /* The active row's left-edge indicator is an inset box-shadow, which is
-     stripped here. Fall back to a system-color left border so the selected
-     worktree stays distinguishable from idle rows. */
+  /* The active row's right-edge indicator is an inset box-shadow, which is
+     stripped here. Fall back to a system-color border on the SAME edge so the
+     selected worktree stays distinguishable from idle rows without moving the
+     marker across the card — a left fallback contradicted the all-theme
+     right-edge vocabulary (#9711 round 3) and read as a second, different
+     selection signal for exactly the high-contrast users least able to
+     absorb one. */
   .sidebar-worktree-card[data-active="true"] {
-    border-left: 2px solid SelectedItem;
+    border-right: 2px solid SelectedItem;
   }
 
   /* The panel drag-over ring is also an inset box-shadow; restore it as a


### PR DESCRIPTION
## Summary

The sidebar worktree card was three levels of bordered, filled boxes deep, inside a sidebar row that is already a container. Those are now flat in the sidebar, and the grid variant in the overview modal keeps them.

The narrative area had four different visual treatments for what is really one slot, including monospace amber text in a bordered box that read as a warning. It is now one left rail with a small label saying which of the four it is.

Resolves #11992

## What changed

**Containment.** The Details and Active sessions sections drop their border, fill and radius in the sidebar. Each nesting level costs roughly 34px of a 240-360px column, so a quarter of the sidebar went on box model before any branch name, path or commit text. Repeated down a twenty-card list the boxes, not the worktree identities, were the visual rhythm. Both sections take a new `variant` prop, so the grid card is untouched.

**Disclosure.** The rule under each trigger is gone. It cut the trigger off from the body it had just revealed, so the two read as separate components. Sections are separated from each other by one peer divider instead. Both triggers share one label token and a leading chevron, in the open state and the closed one, so the resting row still says it opens.

**Narrative.** One left rail for all four states, with a sparkle or commit micro-label naming which it is, sans-serif body, and the empty state as a plain muted line rather than a filled box. The note link carries `break-all`, so a bare GitHub URL wraps instead of running out of the card and off the sidebar.

**Identity order.** The branch label now sits above the upstream delta in `NonMainSecondaryRow.tsx`. The branch is identity, the delta is state. The upstream and PR badges still swap between themselves by alarm tier.

**Selection.** The `forced-colors` fallback drew the selection border on the left edge while every other mode draws it on the right (#9711 round 3), so high-contrast users got the marker on the opposite side. And while a control inside the active row owns the focus ring, the row's accent edge now recedes to the dimmed accent it already uses when the sidebar loses focus. Two full-strength accent shapes in one frame left neither reading as the anchor.

**Copy and icons.** Sentence case across `Changed files`, `Active sessions`, `On grid`, `Review & push`, `Review & commit`, the three resource controls and `Check status`. The destructive `Teardown` becomes `Tear down resource`. The Fleet hint's literal `✕` is now the Lucide `X`.

## Design review

Score 6.3 to 9.6 over three rounds, against rendered pixels rather than JSX, across all 15 themes plus `prefers-contrast: more` and `forced-colors: active`.

| Round | Score | Δ | What it bought |
|---|---|---|---|
| 1 | 6.3 | | Flattened the containment, unified the narrative slot, fixed the forced-colors edge, microcopy and icon rules |
| 2 | 8.9 | +2.6 | Restored the disclosure vocabulary the flattening removed, tightened spacing to the 8px tier, finished the resource copy |
| 3 | 9.6 | +0.7 | Selection edge yields to a focus ring inside it |

Three claims were pushed back on and conceded by the reviewer. The activity chip was called a repeated operational status; `ActivityLight` is a decay signal that holds green for five minutes and fades to a hollow idle ring by ten, and every worktree in the fixture was seconds old. Two more were the harness lying: a scripted `.focus()` does not satisfy Chromium's `:focus-visible` heuristic, so the keyboard-focus shot rendered with no focus styling at all, and a card an earlier step had already selected made selection look invisible. The harness now Tabs to the target, asserts `matches(':focus-visible')` before it writes, and shoots an asserted-unselected sibling for comparison.

The consistency survey counted the patterns across `src/`. The removed one (a bordered, filled section well nested inside a bounded row) was a local one-off: 11 occurrences, 6 of them this card's own grid branch, and none of the rest a nested section in a list row. The introduced ones match what the app already does: 125 uppercase micro-labels across 70 files, 16 other left-rail callouts, and 30 leading disclosure chevrons against 3 trailing, so the leading chevron moved this card into the dominant convention rather than out of it. No rollout needed, nothing to revert.

One defect found during the review is filed separately as #12010: the sidebar's scroll pill floats over card content. It lives in `ScrollIndicator.tsx` and the ghosting is in the shared `ScrollPill` primitive with 14 call sites, so it is not a card fix and no card file should compensate for it.

## Testing

`npm run check` and the full `vitest run` are green: 2,343 files, 51,468 passed.

Nine invariants pinned across `sidebarCardContainment.test.tsx` and `sidebarSelectionAccent.test.ts`, each mutation-checked by reintroducing the bug and confirming the test fails. They assert the rules, not the classes: no bordered-and-filled plane in the sidebar, the grid keeps its well, no divider between a trigger and its body, one shared label ramp across the two sections, a leading chevron in both disclosure states, and for the accent, that the dimmed rule is ordered after the base rule so it actually wins in an unlayered stylesheet.

A screenshot harness went in at `e2e/screenshots/worktree-card-review.spec.ts`, gated behind `DAINTREE_SHOT_CARD`. 37 states across 15 themes in about 90 seconds, driven through real seams: the issue headline comes from the branch name, the AI note is a real `<gitdir>/daintree/note` file, changed files and commits are real git, and the sessions are real PTYs. Every shot is verified before it is written, and the spec counts its own output rather than trusting the exit code. It caught my own microcopy change on the next run.