### PR TITLE
Refine the Review Hub file section header

### DIFF
--- a/e2e/screenshots/review-hub-filesection-review.spec.ts
+++ b/e2e/screenshots/review-hub-filesection-review.spec.ts
@@ -1,0 +1,636 @@
+/**
+ * Review Hub `FileSection` visual-review harness (#11984).
+ *
+ * `FileSection` renders the Staged and Changes section headers — title, file count,
+ * churn, filter field, view menu, and a bulk action whose label changes with selection
+ * and filtering — plus the rows and the three local empty states. Every one of those
+ * decisions is a pixel decision at a real panel width, so the refinement is judged on
+ * rendered output rather than on the JSX.
+ *
+ * The fixture repo is deliberately unpleasant: eighteen unstaged files against six
+ * staged, deep nested paths, four-digit churn, and a generated-file population big
+ * enough that hiding it empties a whole section. Sparse fixtures hide exactly the
+ * defects worth finding here (label truncation, trailing-rail shove, count wrap).
+ *
+ * Steps, and what each is evidence for:
+ *
+ *   rest        both sections at rest — the shot the whole issue is about.
+ *   filter      an active query, and a query that matches nothing.
+ *   selection   multi-select in each section — the widest bulk label the UI can reach.
+ *   viewmenu    the view dropdown, at defaults and with every setting non-default.
+ *   density     compact rows against the same header chrome.
+ *   generated   the "only generated files" empty state, reached by hiding them.
+ *   emptystaged "Nothing staged" — the section header with a zero count and no bulk action.
+ *   narrow      the window squeezed to where the header has to give something up.
+ *   keyboard    focus rings on the filter field and on a row.
+ *   contrast    forced-colors and prefers-contrast: more.
+ *
+ * Opt-in only, like confirm-dialog-review: skips itself unless DAINTREE_SHOT_FILESECTION
+ * is set, so the marketing screenshots workflow never executes it.
+ *
+ *   DAINTREE_SHOT_FILESECTION=1 npx playwright test --project=screenshots review-hub-filesection
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_FILESECTION  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME        optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG          optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY         comma-separated step filter (see step names above)
+ *   DAINTREE_SHOT_OUT          optional absolute output dir (default: artifacts/filesection-shots)
+ *
+ * Output: <out>/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, type Page, type ElectronApplication } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG, T_MEDIUM } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_FILESECTION;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ?? path.resolve(process.cwd(), "artifacts", "filesection-shots");
+
+const WIDE = { width: 1680, height: 1050 };
+const NARROW = { width: 900, height: 1050 };
+
+/** The two sections, and the file list that holds both. */
+const STAGED = '[data-testid="review-hub-file-section-staged"]';
+const UNSTAGED = '[data-testid="review-hub-file-section-unstaged"]';
+const FILE_LIST = '[role="listbox"][aria-label="Changed files"]';
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/** Deterministic filler so churn numbers are large and stable across runs. */
+function lines(prefix: string, n: number): string {
+  return Array.from({ length: n }, (_, i) => `${prefix} line ${i + 1};`).join("\n") + "\n";
+}
+
+/**
+ * Baseline committed tree, then a working state with SIX staged files against
+ * EIGHTEEN unstaged ones.
+ *
+ * The split has to be built with `git add` before the hub opens: the hub
+ * auto-stages everything on open, but only when nothing is staged yet
+ * (`ReviewHubContent` skips the effect on `status.staged.length > 0`), so
+ * pre-staging is what keeps a mixed state mixed.
+ */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-filesection-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+
+  const write = (rel: string, body: string): void => {
+    const abs = path.join(dir, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  };
+
+  // ---- committed baseline -------------------------------------------------
+  write("README.md", "# Helios Dashboard\n");
+  write("package.json", JSON.stringify({ name: "helios", version: "1.0.0" }, null, 2) + "\n");
+  write("package-lock.json", lines("  //lock", 900));
+  write("src/renderer/orchestration/OrchestrationPreferencesPanel.tsx", lines("panel", 220));
+  write("src/renderer/orchestration/useOrchestrationScheduler.ts", lines("sched", 140));
+  write("src/main/services/workspace/WorkspaceReconciliationService.ts", lines("recon", 260));
+  write("src/main/services/workspace/reconciliationTelemetry.ts", lines("telem", 90));
+  write("src/shared/config/agents/anthropic/claudeCodeAgentDefinition.ts", lines("agent", 180));
+  write("src/legacy/deprecatedStagingBridge.ts", lines("legacy", 60));
+  write("docs/architecture/notification-system.md", lines("- doc", 120));
+  write("dist/assets/vendor.bundle.js", lines("/*v*/", 700));
+  write("dist/assets/app.bundle.js", lines("/*a*/", 500));
+  write("coverage/lcov.info", lines("DA:", 400));
+  write("src/api/__generated__/schemaTypes.ts", lines("gen", 300));
+  write("src/api/__generated__/operationHooks.ts", lines("hook", 240));
+  write("src/renderer/components/CommandPalette/CommandPaletteResultRow.tsx", lines("row", 160));
+  write("src/renderer/components/CommandPalette/commandPaletteScoring.ts", lines("score", 130));
+  write("src/renderer/hooks/useDeferredWorkspaceSnapshot.ts", lines("snap", 110));
+  write("src/renderer/store/worktreeTopologyStore.ts", lines("topo", 200));
+  write("src/test/fixtures/worktreeTopology.fixture.ts", lines("fix", 95));
+  write("e2e/full/worktree/core-worktree-topology-reconciliation.spec.ts", lines("spec", 170));
+  write("scripts/perf/scenarios/worktreeSidebarScroll.ts", lines("perf", 85));
+  write(".github/workflows/stabilize.yml", lines("#  ", 70));
+
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  git("branch develop", dir);
+  git("checkout develop", dir);
+  git("checkout -b feature/orchestration-preferences", dir);
+  git('commit --allow-empty -m "start feature"', dir);
+
+  // ---- staged: 6 files, four-digit churn, one deletion, one deep add ------
+  write("src/renderer/orchestration/OrchestrationPreferencesPanel.tsx", lines("panel-v2", 640));
+  write("src/renderer/orchestration/useOrchestrationScheduler.ts", lines("sched-v2", 310));
+  write("docs/architecture/notification-system.md", lines("- doc v2", 260));
+  write("package-lock.json", lines("  //lock-v2", 1480));
+  write(
+    "src/renderer/orchestration/preferences/sections/advanced/OrchestrationConcurrencyLimitsSection.tsx",
+    lines("limits", 190)
+  );
+  rmSync(path.join(dir, "src/legacy/deprecatedStagingBridge.ts"));
+  git("add -A", dir);
+
+  // ---- unstaged: 18 files, six of them generated -------------------------
+  write("src/main/services/workspace/WorkspaceReconciliationService.ts", lines("recon-v2", 520));
+  write("src/main/services/workspace/reconciliationTelemetry.ts", lines("telem-v2", 210));
+  write("src/shared/config/agents/anthropic/claudeCodeAgentDefinition.ts", lines("agent-v2", 340));
+  write("src/renderer/components/CommandPalette/CommandPaletteResultRow.tsx", lines("row-v2", 300));
+  write("src/renderer/components/CommandPalette/commandPaletteScoring.ts", lines("score-v2", 250));
+  write("src/renderer/hooks/useDeferredWorkspaceSnapshot.ts", lines("snap-v2", 190));
+  write("src/renderer/store/worktreeTopologyStore.ts", lines("topo-v2", 430));
+  write("src/test/fixtures/worktreeTopology.fixture.ts", lines("fix-v2", 175));
+  write("e2e/full/worktree/core-worktree-topology-reconciliation.spec.ts", lines("spec-v2", 330));
+  write("scripts/perf/scenarios/worktreeSidebarScroll.ts", lines("perf-v2", 145));
+  write(".github/workflows/stabilize.yml", lines("#  v2", 130));
+  write("src/renderer/components/Worktree/ReviewHub/sectionHeaderDensity.ts", lines("new", 120));
+  // generated population — hiding these empties the section entirely below.
+  write("dist/assets/vendor.bundle.js", lines("/*v2*/", 1230));
+  write("dist/assets/app.bundle.js", lines("/*a2*/", 880));
+  write("coverage/lcov.info", lines("DA:v2", 610));
+  write("src/api/__generated__/schemaTypes.ts", lines("gen-v2", 470));
+  write("src/api/__generated__/operationHooks.ts", lines("hook-v2", 390));
+  write("src/renderer/store/__generated__/topologySelectors.generated.ts", lines("sel", 260));
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 350): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+const written: string[] = [];
+
+async function snap(page: Page, slug: string, locator?: string): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).last().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+  written.push(path.basename(file));
+}
+
+/** Both sections in one frame — the comparison the issue is actually about. */
+async function snapList(page: Page, slug: string): Promise<void> {
+  await snap(page, slug, FILE_LIST);
+}
+
+async function setWindowSize(
+  app: ElectronApplication,
+  size: { width: number; height: number }
+): Promise<void> {
+  await app.evaluate(({ BrowserWindow }, target) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    win?.setSize(target.width, target.height);
+  }, size);
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — the other shots are still worth having. But the
+// run must still FAIL, or a silent exit 0 with an empty output directory reads as success.
+const failures: string[] = [];
+async function step(name: string, fn: () => Promise<void>, reset: () => Promise<void>) {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).slice(0, 300);
+    console.warn(`[filesection-shots] step "${name}" failed:`, detail);
+    failures.push(`${name}: ${detail}`);
+  } finally {
+    await reset().catch((error) => {
+      failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+    });
+  }
+}
+
+/** Scoped handles for one section's controls. */
+function controls(page: Page, root: string) {
+  return {
+    filter: page.locator(`${root} input[type="text"]`),
+    viewButton: page.locator(`${root} [aria-label="View options"]`),
+    bulk: page.locator(
+      `${root} [data-testid="review-hub-stage-section-button"], ${root} [data-testid="review-hub-unstage-section-button"]`
+    ),
+  };
+}
+
+async function openViewMenu(page: Page, root: string): Promise<void> {
+  await controls(page, root).viewButton.click();
+  await page.locator('[role="menu"]').waitFor({ state: "visible", timeout: 5000 });
+  await settle(page, 250);
+}
+
+async function closeMenus(page: Page): Promise<void> {
+  for (let i = 0; i < 2; i++) {
+    if (
+      !(await page
+        .locator('[role="menu"]')
+        .first()
+        .isVisible()
+        .catch(() => false))
+    )
+      break;
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 150);
+  }
+}
+
+async function clearFilters(page: Page): Promise<void> {
+  for (const root of [STAGED, UNSTAGED]) {
+    const input = controls(page, root).filter;
+    if (await input.isVisible().catch(() => false)) {
+      await input.fill("").catch(() => {});
+    }
+  }
+  // `fill` leaves focus in the last field, which paints a focus ring on every
+  // later "rest" shot and makes rest look like an interaction. Hand focus back
+  // to the list so rest actually is rest.
+  await page
+    .locator(FILE_LIST)
+    .focus()
+    .catch(() => {});
+  await settle(page, 250);
+}
+
+/**
+ * Add one row to the multi-select.
+ *
+ * Always modifier-clicks. A PLAIN click on a row is not "select" — `handleRowClick`
+ * treats it as "open this file's diff", which layers a second dialog over the hub.
+ */
+async function selectRow(page: Page, filePath: string, modifier: "Meta" | "Shift" = "Meta") {
+  const row = page.locator(`[data-testid="file-stage-row-${filePath}"]`).first();
+  await row.scrollIntoViewIfNeeded().catch(() => {});
+  await row.click({ modifiers: [modifier] });
+  await settle(page, 150);
+}
+
+/**
+ * Drop the selection — and ONLY then.
+ *
+ * The hub's Escape handler is a precedence ladder: open diff → base-branch diff →
+ * selection → close the dialog. An unconditional Escape therefore closes the hub the
+ * moment nothing is selected, which silently ends the capture. So: press it only while
+ * a selected row is actually on screen, and re-check afterwards.
+ */
+async function clearSelection(page: Page): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    const selected = await page
+      .locator("[data-selected]")
+      .count()
+      .catch(() => 0);
+    if (selected === 0) break;
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+  }
+}
+
+/** Re-open the hub if a stray Escape or a failed step closed it. */
+async function ensureHubOpen(page: Page): Promise<void> {
+  const hub = page.locator(SEL.reviewHub.container);
+  if (await hub.isVisible().catch(() => false)) {
+    // A per-file diff can sit above the hub; close it without touching the hub.
+    const diff = page.locator(SEL.reviewHub.diffDialog);
+    if (await diff.isVisible().catch(() => false)) {
+      await page.keyboard.press("Escape").catch(() => {});
+      await settle(page, 250);
+    }
+    if (
+      await page
+        .locator(FILE_LIST)
+        .isVisible()
+        .catch(() => false)
+    )
+      return;
+  } else {
+    await dismissBlockingPalette(page);
+    await page.locator(SEL.worktree.reviewHubButton).first().click();
+    await hub.waitFor({ state: "visible", timeout: T_MEDIUM });
+  }
+  const toggle = hub.locator(SEL.reviewHub.fileListToggle);
+  await toggle.waitFor({ state: "visible", timeout: T_MEDIUM });
+  if ((await toggle.getAttribute("aria-expanded")) !== "true") await toggle.click();
+  await page.locator(FILE_LIST).waitFor({ state: "visible", timeout: T_MEDIUM });
+  await settle(page, 400);
+}
+
+test("review hub file-section review — header density across states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_FILESECTION is required for the file-section capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_FILESECTION to run the file-section capture");
+
+  failures.length = 0;
+  written.length = 0;
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-filesectionshot-"));
+  let ctx: AppContext | undefined;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: WIDE,
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 1500);
+    await dismissBlockingPalette(page);
+
+    // Open Review & Commit and expand the file list (#7890 collapses it on open).
+    const reviewBtn = page.locator(SEL.worktree.reviewHubButton).first();
+    await reviewBtn.waitFor({ state: "visible", timeout: T_LONG });
+    await reviewBtn.click();
+    const hub = page.locator(SEL.reviewHub.container);
+    await hub.waitFor({ state: "visible", timeout: T_MEDIUM });
+
+    const toggle = hub.locator(SEL.reviewHub.fileListToggle);
+    await toggle.waitFor({ state: "visible", timeout: T_MEDIUM });
+    if ((await toggle.getAttribute("aria-expanded")) !== "true") await toggle.click();
+    await page.locator(FILE_LIST).waitFor({ state: "visible", timeout: T_MEDIUM });
+    await settle(page, 800);
+
+    // A reset that returns to the documented rest state rather than assuming it.
+    const rest = async (): Promise<void> => {
+      await closeMenus(page);
+      await clearFilters(page);
+      await clearSelection(page);
+      await setWindowSize(ctx!.app, WIDE);
+      await page.emulateMedia({ forcedColors: "none", contrast: "no-preference" }).catch(() => {});
+      await settle(page, 300);
+      await ensureHubOpen(page);
+    };
+
+    await step(
+      "rest",
+      async () => {
+        await snapList(page, "10-rest-both-sections");
+        await snap(page, "11-rest-staged-header", STAGED);
+        await snap(page, "12-rest-changes-header", UNSTAGED);
+        await snap(page, "13-rest-window");
+      },
+      rest
+    );
+
+    await step(
+      "filter",
+      async () => {
+        await controls(page, UNSTAGED).filter.fill("renderer");
+        await settle(page, 400);
+        await snapList(page, "20-filter-active");
+        await snap(page, "21-filter-active-changes", UNSTAGED);
+        await controls(page, UNSTAGED).filter.fill("zzzznomatch");
+        await settle(page, 400);
+        await snapList(page, "22-filter-no-match");
+        // Both sections filtered at once — two active queries stacked.
+        await controls(page, STAGED).filter.fill("orchestration");
+        await controls(page, UNSTAGED).filter.fill("store");
+        await settle(page, 400);
+        await snapList(page, "23-filter-both-sections");
+      },
+      rest
+    );
+
+    await step(
+      "selection",
+      async () => {
+        await selectRow(page, "src/renderer/store/worktreeTopologyStore.ts");
+        await selectRow(page, "src/renderer/hooks/useDeferredWorkspaceSnapshot.ts");
+        await selectRow(page, "src/main/services/workspace/reconciliationTelemetry.ts");
+        await snapList(page, "30-selection-changes");
+        await snap(page, "31-selection-changes-header", UNSTAGED);
+        await clearSelection(page);
+        await selectRow(page, "docs/architecture/notification-system.md");
+        await selectRow(page, "package-lock.json");
+        await snapList(page, "32-selection-staged");
+        await snap(page, "33-selection-staged-header", STAGED);
+        // Selection AND an active filter — the two label drivers at once.
+        await clearSelection(page);
+        await controls(page, UNSTAGED).filter.fill("src");
+        await settle(page, 400);
+        await selectRow(page, "src/renderer/store/worktreeTopologyStore.ts");
+        await snap(page, "34-selection-plus-filter", UNSTAGED);
+      },
+      rest
+    );
+
+    await step(
+      "viewmenu",
+      async () => {
+        await openViewMenu(page, UNSTAGED);
+        await snap(page, "40-view-menu-defaults");
+        await closeMenus(page);
+        // Drive every setting away from its default, then show the trigger at rest —
+        // the question is whether the collapsed control admits it holds state.
+        await openViewMenu(page, UNSTAGED);
+        await page.getByRole("menuitemradio", { name: "Churn" }).click();
+        await openViewMenu(page, UNSTAGED);
+        await page.getByRole("menuitemradio", { name: "Compact" }).click();
+        await openViewMenu(page, UNSTAGED);
+        await page.getByRole("menuitemcheckbox", { name: "Show generated files" }).click();
+        await openViewMenu(page, UNSTAGED);
+        await snap(page, "41-view-menu-all-non-default");
+        await closeMenus(page);
+        await snapList(page, "42-non-default-view-at-rest");
+        await snap(page, "43-non-default-changes-header", UNSTAGED);
+      },
+      rest
+    );
+
+    await step(
+      "density",
+      async () => {
+        for (const root of [STAGED, UNSTAGED]) {
+          await openViewMenu(page, root);
+          await page.getByRole("menuitemradio", { name: "Compact" }).click();
+          await settle(page, 200);
+        }
+        await snapList(page, "50-compact-both-sections");
+      },
+      async () => {
+        for (const root of [STAGED, UNSTAGED]) {
+          await openViewMenu(page, root).catch(() => {});
+          await page
+            .getByRole("menuitemradio", { name: "Comfortable" })
+            .click()
+            .catch(() => {});
+        }
+        await rest();
+      }
+    );
+
+    // Hide generated files in a section whose visible population is entirely
+    // generated — the "Only generated files changed" empty state.
+    await step(
+      "generated",
+      async () => {
+        await controls(page, UNSTAGED).filter.fill("dist/");
+        await settle(page, 400);
+        await snapList(page, "60-generated-shown");
+        await openViewMenu(page, UNSTAGED);
+        const checkbox = page.getByRole("menuitemcheckbox", { name: "Show generated files" });
+        if ((await checkbox.getAttribute("aria-checked")) === "true") await checkbox.click();
+        else await closeMenus(page);
+        await settle(page, 400);
+        await snapList(page, "61-generated-hidden-empty");
+        await snap(page, "62-generated-hidden-changes", UNSTAGED);
+      },
+      rest
+    );
+
+    await step(
+      "emptystaged",
+      async () => {
+        await controls(page, STAGED).bulk.click();
+        await page
+          .locator(SEL.reviewHub.noStagedFiles)
+          .waitFor({ state: "visible", timeout: T_MEDIUM });
+        await settle(page, 500);
+        await snapList(page, "70-nothing-staged");
+        await snap(page, "71-nothing-staged-header", STAGED);
+        // One file back, so the header renders a singular count next to a live bulk action.
+        // Uses the row's own stage control — a row click would open its diff instead.
+        await page
+          .locator(SEL.reviewHub.stageButton("src/renderer/store/worktreeTopologyStore.ts"))
+          .click();
+        await settle(page, 900);
+        await snap(page, "72-one-file-staged", STAGED);
+      },
+      rest
+    );
+
+    await step(
+      "narrow",
+      async () => {
+        await setWindowSize(ctx!.app, NARROW);
+        await settle(page, 800);
+        await snapList(page, "80-narrow-both-sections");
+        await snap(page, "81-narrow-changes-header", UNSTAGED);
+        await snap(page, "82-narrow-window");
+        await selectRow(page, "src/renderer/store/worktreeTopologyStore.ts");
+        await selectRow(page, "src/renderer/hooks/useDeferredWorkspaceSnapshot.ts");
+        await snap(page, "83-narrow-selection-header", UNSTAGED);
+        await clearSelection(page);
+        await controls(page, UNSTAGED).filter.fill("renderer");
+        await settle(page, 400);
+        await snap(page, "84-narrow-filter-header", UNSTAGED);
+      },
+      rest
+    );
+
+    await step(
+      "keyboard",
+      async () => {
+        await controls(page, UNSTAGED).filter.focus();
+        await settle(page, 250);
+        await snap(page, "90-focus-filter-field", UNSTAGED);
+        await page.keyboard.press("Tab");
+        await settle(page, 250);
+        await snap(page, "91-focus-view-button", UNSTAGED);
+        await page.keyboard.press("Tab");
+        await settle(page, 250);
+        await snap(page, "92-focus-bulk-action", UNSTAGED);
+        // Roving row focus inside the listbox.
+        await page.locator(FILE_LIST).focus();
+        for (let i = 0; i < 3; i++) await page.keyboard.press("ArrowDown");
+        await settle(page, 300);
+        await snapList(page, "93-keyboard-row-focus");
+      },
+      rest
+    );
+
+    await step(
+      "contrast",
+      async () => {
+        await page.emulateMedia({ contrast: "more" });
+        await settle(page, 500);
+        await snapList(page, "94-prefers-contrast-more");
+        await page.emulateMedia({ contrast: "no-preference", forcedColors: "active" });
+        await settle(page, 500);
+        await snapList(page, "95-forced-colors-active");
+        await snap(page, "96-forced-colors-changes", UNSTAGED);
+      },
+      rest
+    );
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    try {
+      repo.cleanup();
+    } catch {
+      /* best effort */
+    }
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+
+  // Count the artifacts rather than trusting the step loop: a harness that exits 0 with
+  // an empty output directory is worse than one that fails.
+  const onDisk = existsSync(OUTPUT_DIR)
+    ? readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`))
+    : [];
+  console.log(`[filesection-shots] wrote ${written.length} shot(s), ${onDisk.length} on disk`);
+
+  if (failures.length > 0) {
+    throw new Error(
+      `[filesection-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`
+    );
+  }
+  if (written.length === 0) {
+    throw new Error("[filesection-shots] no screenshots were written");
+  }
+  if (onDisk.length < written.length) {
+    throw new Error(
+      `[filesection-shots] wrote ${written.length} shot(s) but only ${onDisk.length} landed on disk`
+    );
+  }
+});

--- a/e2e/screenshots/review-hub-filesection-review.spec.ts
+++ b/e2e/screenshots/review-hub-filesection-review.spec.ts
@@ -22,6 +22,7 @@
  *   generated   the "only generated files" empty state, reached by hiding them.
  *   emptystaged "Nothing staged" — the section header with a zero count and no bulk action.
  *   narrow      the window squeezed to where the header has to give something up.
+ *   sticky      the list scrolled, shot as a viewport, so the pinned header is visible.
  *   keyboard    focus rings on the filter field and on a row.
  *   contrast    forced-colors and prefers-contrast: more.
  *
@@ -66,6 +67,7 @@ const NARROW = { width: 900, height: 1050 };
 const STAGED = '[data-testid="review-hub-file-section-staged"]';
 const UNSTAGED = '[data-testid="review-hub-file-section-unstaged"]';
 const FILE_LIST = '[role="listbox"][aria-label="Changed files"]';
+const SCROLLER = '[data-testid="review-hub-scroll-container"]';
 
 const POLISH_CSS = `
   ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
@@ -244,7 +246,10 @@ async function step(name: string, fn: () => Promise<void>, reset: () => Promise<
 function controls(page: Page, root: string) {
   return {
     filter: page.locator(`${root} input[type="text"]`),
-    viewButton: page.locator(`${root} [aria-label="View options"]`),
+    // NOT [aria-label="View options"] — the label gains a "(N changed from
+    // default)" suffix as soon as a setting diverges, so it stops matching
+    // exactly when the later steps need it.
+    viewButton: page.locator(`${root} [data-testid$="-section-view-trigger"]`),
     bulk: page.locator(
       `${root} [data-testid="review-hub-stage-section-button"], ${root} [data-testid="review-hub-unstage-section-button"]`
     ),
@@ -254,6 +259,27 @@ function controls(page: Page, root: string) {
 async function openViewMenu(page: Page, root: string): Promise<void> {
   await controls(page, root).viewButton.click();
   await page.locator('[role="menu"]').waitFor({ state: "visible", timeout: 5000 });
+  await settle(page, 250);
+}
+
+/**
+ * Put one section's view settings back to the defaults.
+ *
+ * Sort needs two clicks on `Path`: switching key away from `churn` keeps the
+ * current direction (`applySortChange`), so the first click restores the key
+ * with `desc` still set and the second flips it back to `asc`.
+ */
+async function restoreDefaultView(page: Page, root: string): Promise<void> {
+  for (let i = 0; i < 2; i++) {
+    await openViewMenu(page, root);
+    await page.getByRole("menuitemradio", { name: "Path" }).click();
+  }
+  await openViewMenu(page, root);
+  await page.getByRole("menuitemradio", { name: "Comfortable" }).click();
+  await openViewMenu(page, root);
+  const generated = page.getByRole("menuitemcheckbox", { name: "Show generated files" });
+  if ((await generated.getAttribute("aria-checked")) !== "true") await generated.click();
+  else await closeMenus(page);
   await settle(page, 250);
 }
 
@@ -481,7 +507,11 @@ test("review hub file-section review — header density across states", async ()
         await snapList(page, "42-non-default-view-at-rest");
         await snap(page, "43-non-default-changes-header", UNSTAGED);
       },
-      rest
+      async () => {
+        await closeMenus(page);
+        await restoreDefaultView(page, UNSTAGED).catch(() => {});
+        await rest();
+      }
     );
 
     await step(
@@ -522,7 +552,12 @@ test("review hub file-section review — header density across states", async ()
         await snapList(page, "61-generated-hidden-empty");
         await snap(page, "62-generated-hidden-changes", UNSTAGED);
       },
-      rest
+      async () => {
+        await closeMenus(page);
+        await clearFilters(page);
+        await restoreDefaultView(page, UNSTAGED).catch(() => {});
+        await rest();
+      }
     );
 
     await step(
@@ -563,6 +598,35 @@ test("review hub file-section review — header density across states", async ()
         await snap(page, "84-narrow-filter-header", UNSTAGED);
       },
       rest
+    );
+
+    // The header is sticky; the only way to see that is to scroll the list and
+    // shoot the VIEWPORT, not the section element (an element screenshot always
+    // contains its own header and would show a pass either way).
+    await step(
+      "sticky",
+      async () => {
+        await page
+          .locator(SCROLLER)
+          .evaluate((el) => {
+            el.scrollTop = el.scrollHeight;
+          })
+          .catch(async () => {
+            await page.mouse.move(700, 500);
+            for (let i = 0; i < 12; i++) await page.mouse.wheel(0, 300);
+          });
+        await settle(page, 600);
+        await snap(page, "85-scrolled-header-pinned");
+      },
+      async () => {
+        await page
+          .locator(SCROLLER)
+          .evaluate((el) => {
+            el.scrollTop = 0;
+          })
+          .catch(() => {});
+        await rest();
+      }
     );
 
     await step(

--- a/src/components/Worktree/ReviewHub/ConflictPanel.tsx
+++ b/src/components/Worktree/ReviewHub/ConflictPanel.tsx
@@ -19,6 +19,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Spinner } from "@/components/ui/Spinner";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
+import { REVIEW_HUB_STICKY_BAND } from "./reviewHubUtils";
 
 type ConflictOperationState = Exclude<RepoState, "CLEAN" | "DIRTY">;
 
@@ -92,13 +93,15 @@ function RebaseSequenceRail({ entries }: { entries: RebaseEntry[] }) {
 
   return (
     <div className="border-b border-divider" data-testid="conflict-rebase-sequence">
-      <div className="px-4 py-2 bg-overlay-subtle flex items-center">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-          Rebase sequence
-          <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
-            {display.length}
+      <div className={REVIEW_HUB_STICKY_BAND}>
+        <div className="px-4 py-2 bg-overlay-subtle flex items-center">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+            Rebase sequence
+            <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+              {display.length}
+            </span>
           </span>
-        </span>
+        </div>
       </div>
       <ul
         className="px-2 py-1 flex flex-col gap-0.5 max-h-48 overflow-y-auto"
@@ -479,13 +482,15 @@ export function ConflictPanel({
 
       {/* Region 2: Conflict worklist */}
       <div className="border-b border-divider">
-        <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle">
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-            Conflicted
-            <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
-              {conflictCount}
+        <div className={REVIEW_HUB_STICKY_BAND}>
+          <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+              Conflicted
+              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+                {conflictCount}
+              </span>
             </span>
-          </span>
+          </div>
         </div>
         {conflictCount > 0 ? (
           <ul className="px-2 py-1 flex flex-col gap-0.5" role="list">

--- a/src/components/Worktree/ReviewHub/FileSection.tsx
+++ b/src/components/Worktree/ReviewHub/FileSection.tsx
@@ -18,6 +18,7 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { FileStageRow, type FileStageRowSection } from "./FileStageRow";
 import { isGeneratedFile } from "../generatedFileClassifier";
 import {
+  REVIEW_HUB_STICKY_BAND,
   type SectionViewState,
   applySortChange,
   countNonDefaultView,
@@ -156,16 +157,8 @@ export function FileSection({
       className={cn(isStaged && "border-b border-divider")}
     >
       {/* Sticky so identity, count and the scoped bulk action stay reachable
-          while a long changeset scrolls. `bg-daintree-bg` is the hub's own
-          surface (ReviewHubContent's root) and only exists to make the band
-          opaque over passing rows — the visible tint is still the
-          `bg-overlay-subtle` below, so the header looks unchanged at rest. */}
-      <div
-        className={cn(
-          "@container/file-section sticky top-0 z-10 bg-daintree-bg",
-          isStaged ? "" : "border-t border-divider/0"
-        )}
-      >
+          while a long changeset scrolls. */}
+      <div className={cn("@container/file-section", REVIEW_HUB_STICKY_BAND)}>
         <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle gap-2">
           <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 shrink-0 flex items-center">
             {title}
@@ -210,6 +203,12 @@ export function FileSection({
                 "bg-tint/[0.04] border border-border-strong",
                 "hover:bg-tint/[0.06] transition-colors",
                 "focus-within:border-daintree-accent",
+                // The strip IS the field, so it owns the forced-colors focus
+                // boundary. Without this the inner input painted its own
+                // rectangle inside the wrapper and the pair read as two
+                // separate controls.
+                "forced-colors:focus-within:outline forced-colors:focus-within:outline-2",
+                "forced-colors:focus-within:outline-[Highlight]",
                 filterDropClass
               )}
             >
@@ -227,7 +226,12 @@ export function FileSection({
                 className={cn(
                   "w-[104px] min-w-0 bg-transparent text-[11px]",
                   "text-daintree-text placeholder:text-text-placeholder",
-                  "outline-hidden"
+                  // The transparent-outline utility below is what forced
+                  // colors would normally turn into a visible box. That is
+                  // right for a standalone control and wrong inside a strip
+                  // whose wrapper already draws the boundary, so its width is
+                  // zeroed there and the wrapper paints the focus ring.
+                  "outline-hidden forced-colors:outline-0"
                 )}
               />
             </div>
@@ -236,7 +240,10 @@ export function FileSection({
                 <button
                   type="button"
                   className={cn(
-                    "toolbar-icon-button inline-flex items-center gap-1 p-1 rounded",
+                    // Fixed width, not min-width: the count appears and
+                    // disappears as settings change, and an intrinsically-sized
+                    // trigger drags the filter field with it every time.
+                    "toolbar-icon-button inline-flex w-8 shrink-0 items-center justify-center gap-1 rounded p-1",
                     nonDefaultViewCount > 0 && "text-daintree-text"
                   )}
                   data-testid={`${section}-section-view-trigger`}
@@ -333,9 +340,13 @@ export function FileSection({
                 // min-w holds the trailing rail still. The label legitimately
                 // changes width as its scope changes, and without a floor every
                 // such change dragged the filter field and the view trigger
-                // sideways with it — 33px between "all" and "selection", and a
-                // visible jitter from nothing more than a digit.
-                className="h-5 px-1.5 text-[10px] shrink-0 min-w-[7.25rem] justify-center"
+                // sideways with it. Sized for the longest label the component
+                // can produce — "Unstage selection (NNN)" — because a floor that
+                // merely narrows the travel still leaves the rail moving.
+                // justify-start so the glyph keeps the same x in both stacked
+                // sections; the ghost button has no chrome at rest, so the
+                // reserved trailing space is invisible.
+                className="h-5 px-1.5 text-[10px] shrink-0 min-w-[9rem] justify-start"
                 data-testid={bulkActionTestId}
               >
                 <BulkActionIcon className="w-3 h-3 mr-1" />

--- a/src/components/Worktree/ReviewHub/FileSection.tsx
+++ b/src/components/Worktree/ReviewHub/FileSection.tsx
@@ -112,7 +112,11 @@ export function FileSection({
   const emptyFilteredNoun = isStaged ? "staged files" : "changed files";
 
   return (
-    <div ref={sectionRef} className={cn(isStaged && "border-b border-divider")}>
+    <div
+      ref={sectionRef}
+      data-testid={`review-hub-file-section-${section}`}
+      className={cn(isStaged && "border-b border-divider")}
+    >
       <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle gap-2">
         <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 shrink-0">
           {title}

--- a/src/components/Worktree/ReviewHub/FileSection.tsx
+++ b/src/components/Worktree/ReviewHub/FileSection.tsx
@@ -1,14 +1,7 @@
 import type React from "react";
 import type { Dispatch, Ref, RefObject, SetStateAction } from "react";
 import type { GitStatus, StagingFileEntry } from "@shared/types";
-import {
-  CheckSquare,
-  ChevronDown,
-  ChevronUp,
-  Search,
-  Square,
-  SlidersHorizontal,
-} from "lucide-react";
+import { ChevronDown, ChevronUp, Minus, Plus, Search, SlidersHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -25,10 +18,13 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { FileStageRow, type FileStageRowSection } from "./FileStageRow";
 import { isGeneratedFile } from "../generatedFileClassifier";
 import {
-  type ChurnTotals,
   type SectionViewState,
   applySortChange,
+  countNonDefaultView,
   isDensity,
+  matchesFilter,
+  resolveBulkScope,
+  sumChurn,
   truncateFilterQuery,
 } from "./reviewHubUtils";
 
@@ -36,9 +32,13 @@ interface FileSectionProps {
   /** Drives every staged/unstaged copy, testid, and toggle-verb choice below. */
   isStaged: boolean;
   files: StagingFileEntry[];
-  /** Unfiltered section source — only used for the "only generated files" empty-state check. */
+  /**
+   * The section's TRUE population, before the filter query and the
+   * generated-file toggle narrow it. The header counts this rather than
+   * `files`, so a narrowed section can never report its visible subset as the
+   * group total.
+   */
   allFiles: StagingFileEntry[];
-  churn: ChurnTotals;
   /** Row index offset into the shared staged+unstaged flat keyboard-nav list; 0 for staged. */
   indexOffset: number;
   focusedIndex: number;
@@ -78,7 +78,6 @@ export function FileSection({
   isStaged,
   files,
   allFiles,
-  churn,
   indexOffset,
   focusedIndex,
   selectionSection,
@@ -104,12 +103,51 @@ export function FileSection({
     ? "review-hub-unstage-section-button"
     : "review-hub-stage-section-button";
   const bulkActionVerb = isStaged ? "Unstage" : "Stage";
-  const BulkActionIcon = isStaged ? Square : CheckSquare;
+  // The rows spell this operation `+` / `-`; the header spelled it with
+  // check-box glyphs, which read as the section's state rather than as the
+  // action about to run. One vocabulary per operation.
+  const BulkActionIcon = isStaged ? Minus : Plus;
   const emptyNothingTitle = isStaged ? "Nothing staged" : "All changes staged";
   const emptyGeneratedTitle = isStaged
     ? "Only generated files staged"
     : "Only generated files changed";
   const emptyFilteredNoun = isStaged ? "staged files" : "changed files";
+  const filterLabel = isStaged ? "Filter staged files" : "Filter changed files";
+
+  // Counts and churn come from the unnarrowed population. `files` is what is
+  // currently on screen; the difference between the two is disclosed, never
+  // silently absorbed into the headline number.
+  const totalCount = allFiles.length;
+  const shownCount = files.length;
+  const isNarrowed = shownCount !== totalCount;
+  const churn = sumChurn(allFiles);
+
+  const bulkScope = resolveBulkScope(view, hasSelection);
+  const bulkCount = bulkScope === "selection" ? selectedPaths.size : shownCount;
+  const bulkLabel =
+    bulkScope === "selection"
+      ? `${bulkActionVerb} selection (${bulkCount})`
+      : bulkScope === "shown"
+        ? `${bulkActionVerb} shown (${bulkCount})`
+        : `${bulkActionVerb} all (${bulkCount})`;
+
+  const nonDefaultViewCount = countNonDefaultView(view);
+
+  // Generated files that the query WOULD have matched, were they not hidden.
+  // Without this the filter branch below claims nothing matches, which is a
+  // false diagnosis and offers a recovery ("Clear filter") that cannot work.
+  const hiddenGeneratedMatches =
+    !view.showGenerated && view.filterQuery
+      ? allFiles.filter((f) => isGeneratedFile(f.path) && matchesFilter(f.path, view.filterQuery))
+          .length
+      : 0;
+
+  // Static drop table, ordered by ascending importance — the last entry hides
+  // first as the header narrows. Title, count, the shown/total disclosure and
+  // the bulk action are never in it. An active query keeps its field on screen
+  // at any width; a user cannot clear what they cannot see.
+  const churnDropClass = "@max-[560px]/file-section:hidden";
+  const filterDropClass = view.filterQuery ? "" : "@max-[460px]/file-section:hidden";
 
   return (
     <div
@@ -117,140 +155,194 @@ export function FileSection({
       data-testid={`review-hub-file-section-${section}`}
       className={cn(isStaged && "border-b border-divider")}
     >
-      <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle gap-2">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 shrink-0">
-          {title}
-          <span
-            data-testid={countTestId}
-            className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal inline-flex items-center gap-1"
-          >
-            <span>
-              {files.length} file{files.length !== 1 ? "s" : ""}
-            </span>
-            {(churn.ins > 0 || churn.del > 0) && (
-              <>
-                <span aria-hidden="true" className="text-daintree-text/30">
-                  ·
+      {/* Sticky so identity, count and the scoped bulk action stay reachable
+          while a long changeset scrolls. `bg-daintree-bg` is the hub's own
+          surface (ReviewHubContent's root) and only exists to make the band
+          opaque over passing rows — the visible tint is still the
+          `bg-overlay-subtle` below, so the header looks unchanged at rest. */}
+      <div
+        className={cn(
+          "@container/file-section sticky top-0 z-10 bg-daintree-bg",
+          isStaged ? "" : "border-t border-divider/0"
+        )}
+      >
+        <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle gap-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 shrink-0 flex items-center">
+            {title}
+            <span
+              data-testid={countTestId}
+              className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal inline-flex items-center gap-1"
+            >
+              <span>
+                {totalCount} file{totalCount !== 1 ? "s" : ""}
+              </span>
+              {(churn.ins > 0 || churn.del > 0) && (
+                <span className={cn("inline-flex items-center gap-1", churnDropClass)}>
+                  <span aria-hidden="true" className="text-daintree-text/30">
+                    ·
+                  </span>
+                  {churn.ins > 0 && (
+                    <span className="text-status-success/80">{`+${churn.ins}`}</span>
+                  )}
+                  {churn.del > 0 && <span className="text-status-error/80">{`-${churn.del}`}</span>}
                 </span>
-                {churn.ins > 0 && <span className="text-status-success/80">{`+${churn.ins}`}</span>}
-                {churn.del > 0 && <span className="text-status-error/80">{`-${churn.del}`}</span>}
-              </>
+              )}
+            </span>
+            {/* The disclosure that the count above is not what is on screen.
+                Independent of the bulk label on purpose: that label loses its
+                "shown" wording the moment rows are selected, which used to
+                leave a filtered section with no filter signal at all. */}
+            {isNarrowed && (
+              <span
+                role="status"
+                data-testid={`${section}-section-shown-chip`}
+                aria-label={`${shownCount} of ${totalCount} files shown`}
+                className="ml-1 tabular-nums rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal text-daintree-text/50 bg-overlay-medium"
+              >
+                {shownCount} shown
+              </span>
             )}
           </span>
-        </span>
-        <div className="flex items-center gap-1.5 min-w-0">
-          <div className="relative flex items-center">
-            <Search className="absolute left-1.5 w-3 h-3 text-daintree-text/30 pointer-events-none" />
-            <input
-              ref={inputRef}
-              type="text"
-              placeholder="Filter…"
-              defaultValue={view.filterQuery}
-              onChange={(e) => setFilterQuery(e.target.value)}
+          <div className="flex items-center gap-1.5 min-w-0">
+            <div
               className={cn(
-                "w-[120px] h-5 pl-6 pr-1.5 rounded text-[11px]",
-                "bg-tint/[0.04] border border-tint/[0.08]",
-                "text-daintree-text placeholder:text-text-placeholder",
-                "focus:outline-hidden focus:border-daintree-accent/40",
-                "hover:bg-tint/[0.06] transition-colors"
+                "flex items-center gap-1 h-5 pl-1.5 pr-1.5 rounded min-w-0",
+                "bg-tint/[0.04] border border-border-strong",
+                "hover:bg-tint/[0.06] transition-colors",
+                "focus-within:border-daintree-accent",
+                filterDropClass
               )}
-            />
-          </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  "p-1 rounded transition-colors",
-                  "text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06]",
-                  "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
-                )}
-                aria-label="View options"
-              >
-                <SlidersHorizontal className="w-3.5 h-3.5" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-[180px]">
-              <DropdownMenuLabel>Sort by</DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={view.sortKey}
-                onValueChange={(v) => setView((prev) => applySortChange(prev, v))}
-              >
-                <DropdownMenuRadioItem value="path">
-                  <span className="flex items-center gap-2 flex-1">
-                    Path
-                    {view.sortKey === "path" &&
-                      (view.sortDir === "asc" ? (
-                        <ChevronUp className="w-3 h-3 ml-auto text-daintree-text/40" />
-                      ) : (
-                        <ChevronDown className="w-3 h-3 ml-auto text-daintree-text/40" />
-                      ))}
-                  </span>
-                </DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="status">
-                  <span className="flex items-center gap-2 flex-1">
-                    Status
-                    {view.sortKey === "status" &&
-                      (view.sortDir === "asc" ? (
-                        <ChevronUp className="w-3 h-3 ml-auto text-daintree-text/40" />
-                      ) : (
-                        <ChevronDown className="w-3 h-3 ml-auto text-daintree-text/40" />
-                      ))}
-                  </span>
-                </DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="churn">
-                  <span className="flex items-center gap-2 flex-1">
-                    Churn
-                    {view.sortKey === "churn" &&
-                      (view.sortDir === "asc" ? (
-                        <ChevronUp className="w-3 h-3 ml-auto text-daintree-text/40" />
-                      ) : (
-                        <ChevronDown className="w-3 h-3 ml-auto text-daintree-text/40" />
-                      ))}
-                  </span>
-                </DropdownMenuRadioItem>
-              </DropdownMenuRadioGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>View</DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={view.density}
-                onValueChange={(v) =>
-                  setView((prev) => ({
-                    ...prev,
-                    density: isDensity(v) ? v : prev.density,
-                  }))
-                }
-              >
-                <DropdownMenuRadioItem value="comfortable">Comfortable</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="compact">Compact</DropdownMenuRadioItem>
-              </DropdownMenuRadioGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuCheckboxItem
-                checked={view.showGenerated}
-                onCheckedChange={(checked) =>
-                  setView((prev) => ({ ...prev, showGenerated: !!checked }))
-                }
-              >
-                Show generated files
-              </DropdownMenuCheckboxItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {files.length > 0 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onBulkAction}
-              className="h-5 px-1.5 text-[10px] shrink-0"
-              data-testid={bulkActionTestId}
             >
-              <BulkActionIcon className="w-3 h-3 mr-1" />
-              {hasSelection
-                ? `${bulkActionVerb} selection (${selectedPaths.size})`
-                : view.filterQuery
-                  ? `${bulkActionVerb} shown (${files.length})`
-                  : `${bulkActionVerb} all (${files.length})`}
-            </Button>
-          )}
+              <Search
+                aria-hidden="true"
+                className="w-3 h-3 shrink-0 text-daintree-text/40 forced-colors:text-[CanvasText]"
+              />
+              <input
+                ref={inputRef}
+                type="text"
+                aria-label={filterLabel}
+                placeholder="Filter…"
+                defaultValue={view.filterQuery}
+                onChange={(e) => setFilterQuery(e.target.value)}
+                className={cn(
+                  "w-[104px] min-w-0 bg-transparent text-[11px]",
+                  "text-daintree-text placeholder:text-text-placeholder",
+                  "outline-hidden"
+                )}
+              />
+            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    "toolbar-icon-button inline-flex items-center gap-1 p-1 rounded",
+                    nonDefaultViewCount > 0 && "text-daintree-text"
+                  )}
+                  data-testid={`${section}-section-view-trigger`}
+                  aria-label={
+                    nonDefaultViewCount > 0
+                      ? `View options (${nonDefaultViewCount} changed from default)`
+                      : "View options"
+                  }
+                >
+                  <SlidersHorizontal className="w-3.5 h-3.5" />
+                  {/* A count, not a dot: a dot reads as "something new", and
+                      what matters here is how many settings are non-default.
+                      Same ruling as WorktreeFilterPopover. Neutral, never accent. */}
+                  {nonDefaultViewCount > 0 && (
+                    <span
+                      aria-hidden="true"
+                      className="text-[10px] font-medium leading-none tabular-nums"
+                    >
+                      {nonDefaultViewCount}
+                    </span>
+                  )}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[180px]">
+                <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={view.sortKey}
+                  onValueChange={(v) => setView((prev) => applySortChange(prev, v))}
+                >
+                  <DropdownMenuRadioItem value="path">
+                    <span className="flex items-center gap-2 flex-1">
+                      Path
+                      {view.sortKey === "path" &&
+                        (view.sortDir === "asc" ? (
+                          <ChevronUp className="w-3 h-3 ml-auto text-daintree-text/40" />
+                        ) : (
+                          <ChevronDown className="w-3 h-3 ml-auto text-daintree-text/40" />
+                        ))}
+                    </span>
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="status">
+                    <span className="flex items-center gap-2 flex-1">
+                      Status
+                      {view.sortKey === "status" &&
+                        (view.sortDir === "asc" ? (
+                          <ChevronUp className="w-3 h-3 ml-auto text-daintree-text/40" />
+                        ) : (
+                          <ChevronDown className="w-3 h-3 ml-auto text-daintree-text/40" />
+                        ))}
+                    </span>
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="churn">
+                    <span className="flex items-center gap-2 flex-1">
+                      Churn
+                      {view.sortKey === "churn" &&
+                        (view.sortDir === "asc" ? (
+                          <ChevronUp className="w-3 h-3 ml-auto text-daintree-text/40" />
+                        ) : (
+                          <ChevronDown className="w-3 h-3 ml-auto text-daintree-text/40" />
+                        ))}
+                    </span>
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>View</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={view.density}
+                  onValueChange={(v) =>
+                    setView((prev) => ({
+                      ...prev,
+                      density: isDensity(v) ? v : prev.density,
+                    }))
+                  }
+                >
+                  <DropdownMenuRadioItem value="comfortable">Comfortable</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="compact">Compact</DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuCheckboxItem
+                  checked={view.showGenerated}
+                  onCheckedChange={(checked) =>
+                    setView((prev) => ({ ...prev, showGenerated: !!checked }))
+                  }
+                >
+                  Show generated files
+                </DropdownMenuCheckboxItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {shownCount > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onBulkAction}
+                // min-w holds the trailing rail still. The label legitimately
+                // changes width as its scope changes, and without a floor every
+                // such change dragged the filter field and the view trigger
+                // sideways with it — 33px between "all" and "selection", and a
+                // visible jitter from nothing more than a digit.
+                className="h-5 px-1.5 text-[10px] shrink-0 min-w-[7.25rem] justify-center"
+                data-testid={bulkActionTestId}
+              >
+                <BulkActionIcon className="w-3 h-3 mr-1" />
+                {bulkLabel}
+              </Button>
+            )}
+          </div>
         </div>
       </div>
       {files.length > 0 ? (
@@ -283,6 +375,26 @@ export function FileSection({
             );
           })}
         </div>
+      ) : hiddenGeneratedMatches > 0 ? (
+        /* The query DOES match — those matches are just hidden as generated.
+           Reaching the plain filter branch here would name the wrong cause and
+           offer "Clear filter", which cannot bring them back. */
+        <EmptyState
+          variant="filtered-empty"
+          scale="sidebar"
+          title={`${hiddenGeneratedMatches} matching generated file${
+            hiddenGeneratedMatches !== 1 ? "s" : ""
+          } hidden`}
+          action={
+            <button
+              type="button"
+              onClick={() => setView((prev) => ({ ...prev, showGenerated: true }))}
+              className="text-xs text-daintree-text/60 hover:text-daintree-text transition-colors underline underline-offset-2"
+            >
+              Show generated files
+            </button>
+          }
+        />
       ) : view.filterQuery ? (
         <EmptyState
           variant="filtered-empty"

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -75,6 +75,7 @@ import {
   DEFAULT_SECTION_STATE,
   matchesFilter,
   readGitErrorFields,
+  resolveBulkScope,
   sortFiles,
   sumChurn,
 } from "./reviewHubUtils";
@@ -363,10 +364,6 @@ export function ReviewHubContent({
     );
     row?.scrollIntoView({ behavior: "instant", block: "nearest" });
   }, [focusedIndex]);
-
-  const stagedChurn = useMemo(() => sumChurn(derivedStaged), [derivedStaged]);
-
-  const unstagedChurn = useMemo(() => sumChurn(derivedUnstaged), [derivedUnstaged]);
 
   const sortedBaseBranchFiles = useMemo(
     () =>
@@ -1870,7 +1867,6 @@ export function ReviewHubContent({
                         isStaged={true}
                         files={derivedStaged}
                         allFiles={status.staged}
-                        churn={stagedChurn}
                         indexOffset={0}
                         focusedIndex={focusedIndex}
                         selectionSection={selectionSection}
@@ -1883,13 +1879,14 @@ export function ReviewHubContent({
                         clearFilter={clearStagedFilter}
                         onToggle={handleToggleStaged}
                         onRowClick={handleRowClick}
-                        onBulkAction={() =>
-                          void (hasStagedSelection
+                        onBulkAction={() => {
+                          const scope = resolveBulkScope(stagedView, hasStagedSelection);
+                          void (scope === "selection"
                             ? handleUnstageSelection()
-                            : stagedView.filterQuery || !stagedView.showGenerated
+                            : scope === "shown"
                               ? handleUnstageFiltered()
-                              : handleUnstageAll())
-                        }
+                              : handleUnstageAll());
+                        }}
                         viewedFiles={viewedFiles}
                         onViewedChange={handleViewedChange}
                         renderRowMenu={renderRowMenu}
@@ -1901,7 +1898,6 @@ export function ReviewHubContent({
                         isStaged={false}
                         files={derivedUnstaged}
                         allFiles={status.unstaged}
-                        churn={unstagedChurn}
                         indexOffset={derivedStaged.length}
                         focusedIndex={focusedIndex}
                         selectionSection={selectionSection}
@@ -1914,13 +1910,14 @@ export function ReviewHubContent({
                         clearFilter={clearChangesFilter}
                         onToggle={handleToggleUnstaged}
                         onRowClick={handleRowClick}
-                        onBulkAction={() =>
-                          void (hasUnstagedSelection
+                        onBulkAction={() => {
+                          const scope = resolveBulkScope(changesView, hasUnstagedSelection);
+                          void (scope === "selection"
                             ? handleStageSelection()
-                            : changesView.filterQuery || !changesView.showGenerated
+                            : scope === "shown"
                               ? handleStageFiltered()
-                              : handleStageAll())
-                        }
+                              : handleStageAll());
+                        }}
                         viewedFiles={viewedFiles}
                         onViewedChange={handleViewedChange}
                         renderRowMenu={renderRowMenu}

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -74,6 +74,7 @@ import {
   type SectionViewState,
   DEFAULT_SECTION_STATE,
   matchesFilter,
+  REVIEW_HUB_STICKY_BAND,
   readGitErrorFields,
   resolveBulkScope,
   sortFiles,
@@ -1692,23 +1693,25 @@ export function ReviewHubContent({
               </div>
             ) : sortedBaseBranchFiles !== null ? (
               <div>
-                <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle border-b border-divider">
-                  <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-                    Changed vs {mainBranch}
-                    <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
-                      {sortedBaseBranchFiles.length} file
-                      {sortedBaseBranchFiles.length !== 1 ? "s" : ""}
-                      {(baseBranchChurn.ins > 0 || baseBranchChurn.del > 0) && (
-                        <>
-                          {" "}
-                          <span className="text-status-success/80">
-                            +{baseBranchChurn.ins}
-                          </span>{" "}
-                          <span className="text-status-error/80">-{baseBranchChurn.del}</span>
-                        </>
-                      )}
+                <div className={REVIEW_HUB_STICKY_BAND}>
+                  <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle border-b border-divider">
+                    <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+                      Changed vs {mainBranch}
+                      <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+                        {sortedBaseBranchFiles.length} file
+                        {sortedBaseBranchFiles.length !== 1 ? "s" : ""}
+                        {(baseBranchChurn.ins > 0 || baseBranchChurn.del > 0) && (
+                          <>
+                            {" "}
+                            <span className="text-status-success/80">
+                              +{baseBranchChurn.ins}
+                            </span>{" "}
+                            <span className="text-status-error/80">-{baseBranchChurn.del}</span>
+                          </>
+                        )}
+                      </span>
                     </span>
-                  </span>
+                  </div>
                 </div>
                 <div className="px-2 py-1 flex flex-col gap-0.5">
                   {sortedBaseBranchFiles.map((file) => {

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.sectionToolbar.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.sectionToolbar.test.tsx
@@ -747,6 +747,134 @@ describe("ReviewHub", () => {
       });
     });
 
+    /**
+     * A fixture whose Changes section contains a generated file, so hiding
+     * generated output actually narrows that section.
+     */
+    const generatedInChangesStatus = (): StagingStatus =>
+      makeStatus({
+        staged: [{ path: "src/index.ts", status: "modified", insertions: null, deletions: null }],
+        unstaged: [
+          { path: "src/app.ts", status: "modified", insertions: null, deletions: null },
+          { path: "dist/bundle.js", status: "modified", insertions: null, deletions: null },
+        ],
+      });
+
+    /**
+     * The invariant behind #11984's worst defect: the word in the bulk label and
+     * the IPC the same button dispatches are two readings of one decision, and
+     * they must never disagree. Previously the label branched on the filter
+     * query alone while the handler also branched on generated visibility, so
+     * hiding generated files produced "Stage all (N)" over a stage-shown call.
+     *
+     * Asserted as an equivalence rather than a fixed pair, so it keeps holding
+     * when new ways to narrow a section are added.
+     */
+    it("bulk label's scope word agrees with the IPC the button dispatches", async () => {
+      const narrowings: { name: string; narrow: () => void }[] = [
+        {
+          name: "no narrowing at all",
+          narrow: () => {},
+        },
+        {
+          name: "an active filter query",
+          narrow: () => {
+            const filters = screen.getAllByPlaceholderText("Filter…");
+            fireEvent.change(filters[1]!, { target: { value: "app" } });
+          },
+        },
+        {
+          name: "generated files hidden",
+          narrow: () => {
+            // [0] is Staged's toggle, [1] is Changes'.
+            const checkboxes = screen.getAllByRole("menuitemcheckbox");
+            fireEvent.click(checkboxes[1]!);
+          },
+        },
+      ];
+
+      for (const { name, narrow } of narrowings) {
+        stageFilesMock.mockClear();
+        stageAllMock.mockClear();
+        getStagingStatusMock.mockResolvedValue(generatedInChangesStatus());
+
+        const { unmount } = render(
+          <ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />
+        );
+        await waitFor(() => screen.getByText("app.ts"));
+
+        narrow();
+
+        const button = await screen.findByTestId("review-hub-stage-section-button");
+        const claimsWholeSection = /\ball\b/.test(button.textContent ?? "");
+        fireEvent.click(button);
+
+        await waitFor(() => {
+          expect(stageAllMock.mock.calls.length + stageFilesMock.mock.calls.length).toBe(1);
+        });
+
+        // The equivalence. `stageAll` acts on the section; `stageFiles` acts on
+        // an explicit path list. Saying "all" and calling the second is the bug.
+        expect(
+          stageAllMock.mock.calls.length === 1,
+          `with ${name}, label was "${button.textContent ?? ""}"`
+        ).toBe(claimsWholeSection);
+
+        unmount();
+      }
+    });
+
+    it("keeps reporting the section's full population when rows are hidden", async () => {
+      const status = generatedInChangesStatus();
+      getStagingStatusMock.mockResolvedValue(status);
+
+      render(<ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("app.ts"));
+
+      const total = status.unstaged.length;
+      const chip = screen.getByTestId("changes-section-count-chip");
+      expect(chip.textContent).toContain(`${total} files`);
+      // Nothing hidden yet, so nothing to disclose.
+      expect(screen.queryByTestId("unstaged-section-shown-chip")).toBeNull();
+
+      const checkboxes = screen.getAllByRole("menuitemcheckbox");
+      fireEvent.click(checkboxes[1]!);
+
+      await waitFor(() => {
+        expect(screen.queryByText("bundle.js")).toBeNull();
+      });
+
+      // The headline count must NOT have followed the visible rows down.
+      expect(screen.getByTestId("changes-section-count-chip").textContent).toContain(
+        `${total} files`
+      );
+      const shown = screen.getByTestId("unstaged-section-shown-chip");
+      expect(shown.textContent).toBe(`${total - 1} shown`);
+    });
+
+    it("offers a recovery that can actually reveal the matches when a query only matches hidden generated files", async () => {
+      getStagingStatusMock.mockResolvedValue(generatedInChangesStatus());
+
+      render(<ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("app.ts"));
+
+      const checkboxes = screen.getAllByRole("menuitemcheckbox");
+      fireEvent.click(checkboxes[1]!);
+
+      const filters = screen.getAllByPlaceholderText("Filter…");
+      fireEvent.change(filters[1]!, { target: { value: "dist" } });
+
+      // "dist/bundle.js" matches the query and exists; it is hidden as
+      // generated. Blaming the filter here names the wrong cause and offers a
+      // recovery that cannot bring it back.
+      const reveal = await screen.findByText("Show generated files", { selector: "button" });
+      expect(reveal).toBeTruthy();
+      expect(screen.queryByText("Clear filter")).toBeNull();
+
+      fireEvent.click(reveal);
+      await waitFor(() => screen.getByText("bundle.js"));
+    });
+
     it("shows bulk button hidden when no files in section", async () => {
       getStagingStatusMock.mockResolvedValue(
         makeStatus({

--- a/src/components/Worktree/ReviewHub/__tests__/reviewHubUtils.test.ts
+++ b/src/components/Worktree/ReviewHub/__tests__/reviewHubUtils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { StagingFileEntry } from "@shared/types";
-import { isSortKey, readGitErrorFields, sortFiles } from "../reviewHubUtils";
+import {
+  DEFAULT_SECTION_STATE,
+  countNonDefaultView,
+  isSortKey,
+  readGitErrorFields,
+  resolveBulkScope,
+  sortFiles,
+} from "../reviewHubUtils";
 
 function file(
   path: string,
@@ -263,5 +270,71 @@ describe("sortFiles", () => {
     const before = files.map((f) => f.path);
     sortFiles(files, "path", "asc");
     expect(files.map((f) => f.path)).toEqual(before);
+  });
+});
+
+describe("resolveBulkScope", () => {
+  const view = (overrides: Partial<typeof DEFAULT_SECTION_STATE> = {}) => ({
+    ...DEFAULT_SECTION_STATE,
+    ...overrides,
+  });
+
+  it("reports 'shown' for every way a section can be narrowed, not just a query", () => {
+    // The rule: if ANYTHING is hiding rows, the scope is 'shown'. The bug this
+    // pins is a scope that considered only `filterQuery`, so hiding generated
+    // files produced an "all" label over a shown-only action.
+    const narrowed = [view({ filterQuery: "src" }), view({ showGenerated: false })];
+    for (const v of narrowed) {
+      expect(resolveBulkScope(v, false)).toBe("shown");
+    }
+  });
+
+  it("only reports 'all' when nothing is narrowing the section", () => {
+    expect(resolveBulkScope(view(), false)).toBe("all");
+  });
+
+  it("lets selection win over every narrowing cause", () => {
+    const combos = [
+      view(),
+      view({ filterQuery: "src" }),
+      view({ showGenerated: false }),
+      view({ filterQuery: "src", showGenerated: false }),
+    ];
+    for (const v of combos) {
+      expect(resolveBulkScope(v, true)).toBe("selection");
+    }
+  });
+
+  it("never reports 'all' while any narrowing flag is set, across the whole state space", () => {
+    for (const filterQuery of ["", "src"]) {
+      for (const showGenerated of [true, false]) {
+        const v = view({ filterQuery, showGenerated });
+        const isNarrowed = filterQuery !== "" || !showGenerated;
+        expect(resolveBulkScope(v, false) === "all").toBe(!isNarrowed);
+      }
+    }
+  });
+});
+
+describe("countNonDefaultView", () => {
+  it("returns zero for the defaults", () => {
+    expect(countNonDefaultView(DEFAULT_SECTION_STATE)).toBe(0);
+  });
+
+  it("counts each diverging setting once, and sort key+direction as one", () => {
+    const bump = (overrides: Partial<typeof DEFAULT_SECTION_STATE>) =>
+      countNonDefaultView({ ...DEFAULT_SECTION_STATE, ...overrides });
+
+    expect(bump({ sortKey: "churn" })).toBe(1);
+    expect(bump({ sortDir: "desc" })).toBe(1);
+    // Both halves of the same decision still count once.
+    expect(bump({ sortKey: "churn", sortDir: "desc" })).toBe(1);
+    expect(bump({ density: "compact" })).toBe(1);
+    expect(bump({ showGenerated: false })).toBe(1);
+    expect(bump({ sortKey: "churn", density: "compact", showGenerated: false })).toBe(3);
+  });
+
+  it("ignores the filter query, which has its own always-visible field", () => {
+    expect(countNonDefaultView({ ...DEFAULT_SECTION_STATE, filterQuery: "src" })).toBe(0);
   });
 });

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -355,6 +355,43 @@ export function sortFiles(
   return sorted;
 }
 
+export type BulkScope = "selection" | "shown" | "all";
+
+/**
+ * The single source of truth for what a section's bulk action targets.
+ *
+ * Both the button's label and the handler the hub dispatches read this, because
+ * they used to decide independently: the label branched on `filterQuery` alone
+ * while the handler branched on `filterQuery || !showGenerated`. With generated
+ * files hidden and no query, the button therefore read "Stage all (12)" and then
+ * staged only the twelve shown, leaving the hidden ones behind. Any new thing
+ * that narrows a section has to be added here, once, or that divergence returns.
+ */
+export function resolveBulkScope(view: SectionViewState, hasSelection: boolean): BulkScope {
+  if (hasSelection) return "selection";
+  return view.filterQuery || !view.showGenerated ? "shown" : "all";
+}
+
+/**
+ * How many of a section's view settings differ from the defaults, so a collapsed
+ * trigger can admit it is holding state. Sort key and direction count as one
+ * setting — flipping direction is not a second decision the user made.
+ *
+ * `filterQuery` is deliberately excluded: it has its own always-visible field.
+ */
+export function countNonDefaultView(view: SectionViewState): number {
+  let n = 0;
+  if (
+    view.sortKey !== DEFAULT_SECTION_STATE.sortKey ||
+    view.sortDir !== DEFAULT_SECTION_STATE.sortDir
+  ) {
+    n += 1;
+  }
+  if (view.density !== DEFAULT_SECTION_STATE.density) n += 1;
+  if (view.showGenerated !== DEFAULT_SECTION_STATE.showGenerated) n += 1;
+  return n;
+}
+
 export function isSortKey(v: string): v is SortKey {
   return v === "path" || v === "status" || v === "churn";
 }

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -355,6 +355,21 @@ export function sortFiles(
   return sorted;
 }
 
+/**
+ * The pin for a Review Hub band header inside `review-hub-scroll-container`.
+ *
+ * Four band headers share this: both `FileSection` instances, the base-branch
+ * "Changed vs <main>" header, and the conflict panel's two rails. They all sit
+ * in the same scroll container, so one of them sticking while the others scroll
+ * away is visible the moment a user switches diff mode.
+ *
+ * `bg-daintree-bg` is the hub root's own surface (`ReviewHubContent`) and is
+ * here only to make the band opaque over rows passing underneath — the visible
+ * tint is still the `bg-overlay-subtle` on the band itself, so a pinned header
+ * looks exactly like an unpinned one.
+ */
+export const REVIEW_HUB_STICKY_BAND = "sticky top-0 z-10 bg-daintree-bg";
+
 export type BulkScope = "selection" | "shown" | "all";
 
 /**

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -240,6 +240,12 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
       "The field is the popover's whole top strip, so its indicator is painted once on the wrapping label via focus-within — it has to span the panel's full width and take its rounded top corners, which a ring on the bare input cannot do (that ring is precisely what this component replaced)",
   },
   {
+    file: "src/components/Worktree/ReviewHub/FileSection.tsx",
+    fragment: "w-[104px] min-w-0 bg-transparent text-[11px]",
+    reason:
+      "Section filter is a strip: the wrapper carries the border, focus-within and the forced-colors outline, so the bare input must not paint a second box inside it (that nested rectangle is exactly what #11984 removed)",
+  },
+  {
     file: "src/components/HelpPanel/HelpPanel.tsx",
     fragment: "relative shrink-0 flex flex-col h-full overflow-hidden outline-hidden",
     reason:


### PR DESCRIPTION
## Summary

The file section header carried a bug that mattered more than the density problem the issue was about. The bulk stage button decided its scope in one place and the handler decided it in another, so with generated files hidden the button read `Stage all (12)` and then staged only the twelve on screen.

The count had the same shape of problem. It reported the visible rows as if they were the group total, so hiding six files quietly turned `18 files` into `12 files`.

Resolves #11984

## What changed

**The header tells the truth about what it hides**

- `resolveBulkScope()` in `reviewHubUtils.ts` is now the single source of truth for scope. The label and the handler both read it, so they cannot drift apart again.
- The count chip counts the real population. A separate `N shown` chip appears when rows are hidden, carrying `role="status"`. It is deliberately independent of the bulk label, which loses its "shown" wording the moment you select rows. That used to leave a filtered section with no filter signal at all.
- An empty state that blamed the filter now offers `Show generated files` when the query did match files that are hidden as generated. The old `Clear filter` could never have revealed them.

**The header stopped sliding around**

- The bulk button has a width floor sized for the longest label it can produce. The control rail used to travel 26px sideways every time the scope changed.
- The view options trigger reserves a slot for its count, worth another 10px.
- Both measure 0px now, off the captures.

**Progressive disclosure**

- The view options trigger carries a count of non-default settings, so a transformed list admits it. Neutral fill and a number, not a dot, following the ruling already written into `WorktreeFilterPopover.tsx`. It also picks up `toolbar-icon-button`, which brings the armed state and an outline focus ring instead of the old `ring`.
- Churn and an inactive filter field drop by container query at narrow widths. An active query never drops.
- The header is sticky, so identity, count and the scoped action survive scrolling a long changeset.
- The bulk buttons use `Plus` and `Minus`, matching what the rows already use for the same operation.
- The filter field is a strip now: the wrapper owns the border and `focus-within`, and each section's input gets its own accessible name. Both used to compute the same placeholder-derived name.

## Design review

Scored 6.7, then 9.8, then 10.0 across three rounds against hierarchy, action clarity, progressive disclosure, responsive behaviour, consistency and states/accessibility. Real pixels drove it: 37 captures a round covering rest, filter, selection, view menu, density, generated hidden, empty, 900px, keyboard focus, `prefers-contrast: more` and `forced-colors: active`. The harness is `e2e/screenshots/review-hub-filesection-review.spec.ts`, opt-in behind `DAINTREE_SHOT_FILESECTION`, so it never runs in the marketing screenshot workflow.

Consistency survey: sticky group headers are 4 of 23 across the app, so this is a precedented minority rather than a new pattern. But three sibling band headers sat in the same scroll container and still scrolled away, which shows the moment you switch diff mode. The base-branch header and the conflict panel's two rails now share the treatment through one `REVIEW_HUB_STICKY_BAND` constant, so all four move together if it ever changes.

Worth flagging: those three siblings have no screenshot coverage. Base-branch mode is not reachable in the capture fixture and conflict mode needs a real conflict. Their structure is covered by the existing base-branch and conflict-mode suites, but I have not seen them pinned in pixels.

The survey also turned up four other places where a count still reports a filtered subset as the total (`NotificationCenter.tsx:1504`, `FleetPickerContent.tsx:333`, `NewTerminalPalette.tsx:129`, `SidebarContent.tsx:318`). Out of scope here, worth a follow-up.

## Testing

Three invariants pinned, each mutation-checked by reintroducing the bug and confirming the test fails:

- the bulk label's scope word and the IPC the button dispatches agree, across every way a section can be narrowed
- the headline count keeps reporting the full population when rows are hidden
- a query matching only hidden generated files offers a recovery that can actually reveal them

Green locally: 301 Review Hub tests, 420 repo-wide contract and guard suites (accent guard, `outline-hidden` guard, colour system, focus-ring fallback), typecheck, lint, format.

The full suite is a different story locally, and I want to be straight about it. I ran it three times and got a different failure set each time: once in `electron/lifecycle/__tests__/shutdown.test.ts`, once in `electron/utils/__tests__/logger.test.ts` plus a settings test, once across logger, shutdown and a `scripts/` shell harness that timed out at 18.2s against a 15s cap. Every one of them passes in isolation. They are all timing and file-IO sensitive, and other agents were running vitest concurrently from sibling worktrees on the same box throughout, which is exactly the failure shape load produces.

This branch touches no files under `electron/` or `scripts/`, so none of it is attributable here. CI on a clean runner is the real check.
