### PR TITLE
Refine AddPresetDialog's start-from choices

### DIFF
--- a/e2e/full/platform/core-resource-settings-persistence.spec.ts
+++ b/e2e/full/platform/core-resource-settings-persistence.spec.ts
@@ -333,7 +333,7 @@ test.describe.serial("Full: Resource Settings Persistence", () => {
 
     // Set default worktree mode to "e2e-docker"
     const panel = window.locator("#settings-panel-project\\:automation");
-    await expect(panel.locator("text=Default Worktree Mode")).toBeVisible({ timeout: T_SHORT });
+    await expect(panel.locator("text=Default worktree mode")).toBeVisible({ timeout: T_SHORT });
     const dockerRadio = panel.locator('input[type="radio"][value="e2e-docker"]');
     await dockerRadio.click();
     await expect(dockerRadio).toBeChecked({ timeout: T_SHORT });

--- a/e2e/full/platform/core-settings-load.spec.ts
+++ b/e2e/full/platform/core-settings-load.spec.ts
@@ -385,8 +385,8 @@ test.describe.serial("Core: Settings Pages Load", () => {
         }
       );
 
-      // Default Worktree Mode section should be visible (scoped to automation panel)
-      await expect(automationPanel.locator("text=Default Worktree Mode")).toBeVisible({
+      // Default worktree mode section should be visible (scoped to automation panel)
+      await expect(automationPanel.locator("text=Default worktree mode")).toBeVisible({
         timeout: T_SHORT,
       });
     });

--- a/e2e/full/platform/core-settings-tabs.spec.ts
+++ b/e2e/full/platform/core-settings-tabs.spec.ts
@@ -578,7 +578,7 @@ test.describe.serial("Core: Settings Tabs Coverage", () => {
     await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });
   });
 
-  // ── Project Resources Tab: Default Worktree Mode ──────────
+  // ── Project Resources Tab: Default worktree mode ──────────
 
   test("Project Resources tab: toggle default worktree mode", async () => {
     const { window } = ctx;
@@ -615,8 +615,8 @@ test.describe.serial("Core: Settings Tabs Coverage", () => {
     // rest of the test — gate on it rather than continuing against a broken state.
     await expect(selectorBar).toBeVisible({ timeout: T_MEDIUM });
 
-    // Default Worktree Mode should be visible
-    await expect(panel.locator("text=Default Worktree Mode")).toBeVisible({ timeout: T_SHORT });
+    // Default worktree mode should be visible
+    await expect(panel.locator("text=Default worktree mode")).toBeVisible({ timeout: T_SHORT });
 
     // Scope radios to the worktreeMode group — AutomationTab also renders a
     // branchPrefixMode radio group in this panel, so an unscoped lookup would

--- a/e2e/screenshots/add-preset-dialog-review.spec.ts
+++ b/e2e/screenshots/add-preset-dialog-review.spec.ts
@@ -1,0 +1,414 @@
+/**
+ * Add-preset dialog visual-review harness.
+ *
+ * Boots a minimal fixture repo, walks to Settings → CLI Agents, and writes PNGs
+ * of every state the "Start from" chooser carries design weight in — blank,
+ * clone with and without a current preset, template with the provider selector,
+ * the two-option shape agents without provider templates get, plus hover,
+ * keyboard focus, an overlong preset name, high contrast and forced colors — so
+ * the dialog can be judged against real rendered pixels (#11972).
+ *
+ * Opt-in only, like theme-review and worktree-dialog-review: skips itself unless
+ * DAINTREE_SHOT_PRESET is set, so the marketing screenshots workflow never
+ * executes it.
+ *
+ *   DAINTREE_SHOT_PRESET=1 npx playwright test --project=screenshots add-preset-dialog-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_PRESET  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME   optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG     optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY    comma-separated step filter (see step names below)
+ *   DAINTREE_SHOT_SWEEP   set to run the all-themes sweep instead of the state matrix
+ *   DAINTREE_SHOT_OUT     optional absolute output dir (default artifacts/preset-shots)
+ *
+ * Output: artifacts/preset-shots/<NN-slug>[-tag].png (gitignored).
+ *
+ * Steps never swallow their own failures. A state that cannot be reached throws
+ * rather than leaving a stale or plausible-but-wrong PNG behind, and the run
+ * writes MANIFEST.txt so the caller can count captures without trusting the
+ * exit code.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, appendFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { navigateToAgentSettings } from "../helpers/presets";
+import { SEL } from "../helpers/selectors";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_PRESET;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const SWEEP = !!process.env.DAINTREE_SHOT_SWEEP;
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ?? path.resolve(process.cwd(), "artifacts", "preset-shots");
+
+/** The testid sits on the backdrop; the dialog panel is its first child. */
+const DIALOG = '[data-testid="add-preset-dialog"]';
+const PANEL = `${DIALOG} > div`;
+
+/** Freeze animations and hide carets so captures are deterministic. */
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+/**
+ * Every built-in theme. Switching themes reloads the renderer, so the sweep
+ * re-walks to the dialog after each switch rather than booting once per theme.
+ */
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/** Minimal repo — the dialog lives in Settings, so no worktree topology is needed. */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-preset-shots-"));
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Seed an agent's custom presets through the real settings seam, then reload so
+ * the renderer rebuilds from persisted state rather than a live patch.
+ */
+async function seedPresets(
+  page: Page,
+  agentId: string,
+  presets: { id: string; name: string; env?: Record<string, string>; args?: string[] }[],
+  selectedId: string | null
+): Promise<void> {
+  await page.evaluate(
+    async ({ targetAgentId, nextPresets, presetId }) => {
+      type AgentEntry = Record<string, unknown>;
+      type AgentSettings = { agents?: Record<string, AgentEntry | undefined> };
+      const settings = (await window.electron.agentSettings.get()) as AgentSettings;
+      const entry = settings.agents?.[targetAgentId] ?? {};
+      await window.electron.agentSettings.set(targetAgentId, {
+        ...entry,
+        customPresets: nextPresets,
+        presetId: presetId ?? undefined,
+      } as never);
+    },
+    { targetAgentId: agentId, nextPresets: presets, presetId: selectedId }
+  );
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.addStyleTag({ content: POLISH_CSS });
+  await dismissBlockingPalette(page).catch(() => undefined);
+}
+
+/** Walk to an agent's settings and open the Add preset dialog. */
+async function openDialog(page: Page, agentId: string): Promise<void> {
+  await navigateToAgentSettings(page, agentId);
+  const section = page.locator(SEL.preset.section);
+  await expect(section).toBeVisible({ timeout: 15_000 });
+  await section.locator(SEL.preset.addButton).click({ force: true, noWaitAfter: true });
+  await expect(page.locator(DIALOG)).toBeVisible({ timeout: 10_000 });
+  await settle(page, 500);
+}
+
+/**
+ * Walk focus into the choice group with real Tab presses so `:focus-visible`
+ * actually applies, and fail loudly if it never lands there.
+ */
+async function tabToRadioGroup(page: Page): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await page.keyboard.press("Tab");
+    await settle(page, 150);
+    const onRadio = await page.evaluate(() => {
+      const el = document.activeElement as HTMLInputElement | null;
+      return el?.tagName === "INPUT" && el.type === "radio" && el.matches(":focus-visible");
+    });
+    if (onRadio) return;
+  }
+  throw new Error("Tab never reached a keyboard-focused radio in the choice group");
+}
+
+async function closeDialog(page: Page): Promise<void> {
+  const dialog = page.locator(DIALOG);
+  if (!(await dialog.isVisible().catch(() => false))) return;
+  await dialog.getByRole("button", { name: "Cancel" }).click({ force: true });
+  await expect(dialog).not.toBeVisible({ timeout: 5000 });
+}
+
+const written: string[] = [];
+
+/**
+ * Capture one state.
+ *
+ * `requiredText` is asserted AFTER the settle and immediately before the
+ * screenshot: it is what stops the harness writing a plausible-looking PNG of a
+ * dialog that never reached the state the filename claims.
+ */
+async function snap(
+  page: Page,
+  slug: string,
+  requiredText: string[],
+  locator: string = PANEL
+): Promise<void> {
+  await settle(page);
+  const target = page.locator(locator).first();
+  await expect(target, `"${slug}": capture target is not visible — refusing to write`).toBeVisible({
+    timeout: 5000,
+  });
+  for (const text of requiredText) {
+    await expect(
+      target,
+      `"${slug}": expected ${JSON.stringify(text)} on screen — refusing to write`
+    ).toContainText(text, { timeout: 5000 });
+  }
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  await target.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  written.push(path.basename(file));
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+/**
+ * Run a named capture step. Unlike the older dialog harness this does NOT
+ * swallow errors — a step that cannot reach its state fails the run, because a
+ * silently missing capture sends the whole review off reviewing a screen that
+ * does not exist.
+ */
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  await test.step(name, fn);
+}
+
+async function boot(): Promise<{
+  ctx: AppContext;
+  page: Page;
+  cleanup: () => Promise<void>;
+}> {
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-presetshot-"));
+  const ctx = await launchApp({
+    userDataDir,
+    screenshotScale: SCALE,
+    windowSize: { width: 1680, height: 1050 },
+    extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+  });
+  const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+  if (THEME) await setAppTheme(page, THEME);
+  await page.addStyleTag({ content: POLISH_CSS });
+  await dismissBlockingPalette(page).catch(() => undefined);
+  await settle(page, 1500);
+  return {
+    ctx,
+    page,
+    cleanup: async () => {
+      if (ctx.app) await closeApp(ctx.app);
+      repo.cleanup();
+      rmSync(userDataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function writeManifest(): void {
+  const manifest = path.join(OUTPUT_DIR, `MANIFEST${TAG}.txt`);
+  appendFileSync(manifest, written.map((f) => f).join("\n") + "\n");
+}
+
+test("add-preset dialog review — start-from states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_PRESET is required for the add-preset capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_PRESET to run the add-preset capture");
+  test.skip(SWEEP, "Sweep mode runs the theme test instead");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const { page, cleanup } = await boot();
+  try {
+    // ---- Shape A: claude, no custom presets. The rest state, and the shape a
+    // first-time user actually meets.
+    await seedPresets(page, "claude", [], null);
+
+    await step("blank", async () => {
+      await openDialog(page, "claude");
+      await snap(page, "10-blank-no-current", ["Start from", "Blank", "Clone current"]);
+      await snap(page, "11-blank-no-current-window", ["Blank"], "body");
+      await closeDialog(page);
+    });
+
+    // The provider selector's dependency on "From template" — the state the
+    // issue calls visually dishonest.
+    await step("template", async () => {
+      await openDialog(page, "claude");
+      await page.getByText("From template", { exact: true }).click();
+      await settle(page, 400);
+      await snap(page, "20-template-selected", ["From template", "Provider"]);
+      await closeDialog(page);
+    });
+
+    // Keyboard focus on the choice group — the affordance a pointer-only
+    // review never sees.
+    //
+    // Tab, never `.focus()`: Chromium only sets `:focus-visible` when focus
+    // arrives by keyboard, so a programmatic focus captures a frame that looks
+    // exactly like rest and reads as "there is no focus ring" when there is.
+    await step("focus", async () => {
+      await openDialog(page, "claude");
+      await tabToRadioGroup(page);
+      await snap(page, "30-focus-visible-blank", ["Blank"]);
+      await page.keyboard.press("ArrowDown");
+      await settle(page, 300);
+      await snap(page, "31-focus-visible-arrowed", ["Clone current"]);
+      await closeDialog(page);
+    });
+
+    // Hover on a row that is not the selected one — the click-target question.
+    await step("hover", async () => {
+      await openDialog(page, "claude");
+      await page.getByText("Clone current", { exact: true }).hover();
+      await settle(page, 300);
+      await snap(page, "35-hover-clone", ["Clone current"]);
+      await closeDialog(page);
+    });
+
+    // High contrast and forced colors, on the state that carries the most
+    // custom styling.
+    await step("contrast", async () => {
+      await openDialog(page, "claude");
+      await page.getByText("From template", { exact: true }).click();
+      await settle(page, 300);
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 400);
+      await snap(page, "40-high-contrast", ["From template", "Provider"]);
+      await page.emulateMedia({ contrast: null, forcedColors: "active" });
+      await settle(page, 400);
+      await snap(page, "41-forced-colors", ["From template", "Provider"]);
+      await page.emulateMedia({ forcedColors: null });
+      await settle(page, 300);
+      await closeDialog(page);
+    });
+
+    // ---- Shape B: an agent with no provider templates. Two options, not
+    // three — a shape the code path makes easy to forget.
+    await step("no-templates", async () => {
+      await openDialog(page, "codex");
+      await snap(page, "50-no-templates", ["Start from", "Blank", "Clone current"]);
+      await closeDialog(page);
+    });
+
+    // ---- Shape C: a current preset exists and is selected, so "Clone current"
+    // is genuinely available and names its source.
+    await step("clone", async () => {
+      await seedPresets(
+        page,
+        "claude",
+        [{ id: "shot-preset-1", name: "Z.AI (GLM-5.2)", env: {}, args: [] }],
+        "shot-preset-1"
+      );
+      await openDialog(page, "claude");
+      await page.getByText("Clone current", { exact: true }).click();
+      await settle(page, 400);
+      await snap(page, "60-clone-with-current", ["Clone current", "Z.AI"]);
+      await closeDialog(page);
+    });
+
+    // ---- Shape D: extreme density. The longest name a user can actually
+    // produce, to expose truncation and wrapping.
+    await step("long-name", async () => {
+      await seedPresets(
+        page,
+        "claude",
+        [
+          {
+            id: "shot-preset-long",
+            name: "OpenRouter — Claude Opus 4.6 with extended thinking and a 1M context window",
+            env: {},
+            args: [],
+          },
+        ],
+        "shot-preset-long"
+      );
+      await openDialog(page, "claude");
+      await page.getByText("Clone current", { exact: true }).click();
+      await settle(page, 400);
+      await snap(page, "70-clone-long-name", ["Clone current"]);
+      await closeDialog(page);
+    });
+  } finally {
+    writeManifest();
+    await cleanup();
+  }
+});
+
+test("add-preset dialog review — every theme", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_PRESET and DAINTREE_SHOT_SWEEP are required for the theme sweep",
+  });
+  test.skip(!ENABLED || !SWEEP, "Set DAINTREE_SHOT_PRESET and DAINTREE_SHOT_SWEEP for the sweep");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const { page, cleanup } = await boot();
+  try {
+    await seedPresets(
+      page,
+      "claude",
+      [{ id: "shot-preset-1", name: "Z.AI (GLM-5.2)", env: {}, args: [] }],
+      "shot-preset-1"
+    );
+
+    for (const theme of ALL_THEMES) {
+      await test.step(theme, async () => {
+        await setAppTheme(page, theme);
+        await page.addStyleTag({ content: POLISH_CSS });
+        await dismissBlockingPalette(page).catch(() => undefined);
+        await openDialog(page, "claude");
+        await page.getByText("From template", { exact: true }).click();
+        await settle(page, 400);
+        await snap(page, `80-theme-${theme}`, ["From template", "Provider"]);
+        await closeDialog(page);
+      });
+    }
+  } finally {
+    writeManifest();
+    await cleanup();
+  }
+});

--- a/e2e/screenshots/add-preset-dialog-review.spec.ts
+++ b/e2e/screenshots/add-preset-dialog-review.spec.ts
@@ -205,6 +205,61 @@ async function snap(
   written.push(path.basename(file));
 }
 
+/**
+ * Measure what the option descriptions actually resolve to against the surface
+ * behind them. The descriptions answer the dialog's primary question, so their
+ * contrast is a design decision rather than a detail — and an alpha-modified
+ * utility resolves to a number no token guard measures. Reported, not asserted:
+ * the tier this text sits in is a judgement call, and the number is the input
+ * to it.
+ */
+async function measureDescriptionContrast(page: Page): Promise<string> {
+  return page.evaluate((panelSel) => {
+    const parse = (input: string): [number, number, number] => {
+      const el = document.createElement("div");
+      el.style.color = input;
+      document.body.appendChild(el);
+      const resolved = getComputedStyle(el).color;
+      el.remove();
+      const m = resolved.match(/(\d+(?:\.\d+)?)/g) ?? [];
+      return [Number(m[0] ?? 0), Number(m[1] ?? 0), Number(m[2] ?? 0)];
+    };
+    const lum = ([r, g, b]: [number, number, number]) => {
+      const f = (c: number) => {
+        const s = c / 255;
+        return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+      };
+      return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+    };
+    const ratio = (a: [number, number, number], b: [number, number, number]) => {
+      const [l1, l2] = [lum(a), lum(b)].sort((x, y) => y - x);
+      return ((l1 as number) + 0.05) / ((l2 as number) + 0.05);
+    };
+
+    const panel = document.querySelector(panelSel);
+    if (!panel) return "no panel";
+    // The description is the second line inside an option's text column.
+    const label = Array.from(panel.querySelectorAll("label")).find((l) =>
+      l.querySelector('input[type="radio"]')
+    );
+    const desc = label?.querySelectorAll("span span")[1];
+    if (!desc) return "no description node";
+
+    let bgEl: Element | null = desc;
+    let bg = "rgba(0, 0, 0, 0)";
+    while (bgEl) {
+      const c = getComputedStyle(bgEl).backgroundColor;
+      if (c && !c.endsWith(", 0)") && c !== "transparent") {
+        bg = c;
+        break;
+      }
+      bgEl = bgEl.parentElement;
+    }
+    const fg = getComputedStyle(desc).color;
+    return `${getComputedStyle(document.documentElement).getPropertyValue("--theme-name") || document.documentElement.getAttribute("data-theme")}: fg=${fg} bg=${bg} ratio=${ratio(parse(fg), parse(bg)).toFixed(2)}:1`;
+  }, PANEL);
+}
+
 const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
 
 /**
@@ -257,19 +312,19 @@ test("add-preset dialog review — start-from states", async () => {
     type: "conditional-skip",
     description: "DAINTREE_SHOT_PRESET is required for the add-preset capture",
   });
-  test.skip(!ENABLED, "Set DAINTREE_SHOT_PRESET to run the add-preset capture");
-  test.skip(SWEEP, "Sweep mode runs the theme test instead");
+  test.skip(!ENABLED || SWEEP, "Set DAINTREE_SHOT_PRESET, and unset SWEEP, for the state matrix");
 
   mkdirSync(OUTPUT_DIR, { recursive: true });
   const { page, cleanup } = await boot();
   try {
     // ---- Shape A: claude, no custom presets. The rest state, and the shape a
-    // first-time user actually meets.
+    // first-time user actually meets. Nothing can be cloned, so the clone
+    // option is absent and the decision is Blank vs template.
     await seedPresets(page, "claude", [], null);
 
     await step("blank", async () => {
       await openDialog(page, "claude");
-      await snap(page, "10-blank-no-current", ["Start from", "Blank", "Clone current"]);
+      await snap(page, "10-blank-no-current", ["Start from", "Blank", "From template"]);
       await snap(page, "11-blank-no-current-window", ["Blank"], "body");
       await closeDialog(page);
     });
@@ -294,18 +349,20 @@ test("add-preset dialog review — start-from states", async () => {
       await openDialog(page, "claude");
       await tabToRadioGroup(page);
       await snap(page, "30-focus-visible-blank", ["Blank"]);
+      // Arrow must move selection with focus — native radio behaviour, and the
+      // reason this group is not built on the app's roving-tabindex primitive.
       await page.keyboard.press("ArrowDown");
       await settle(page, 300);
-      await snap(page, "31-focus-visible-arrowed", ["Clone current"]);
+      await snap(page, "31-focus-visible-arrowed", ["From template"]);
       await closeDialog(page);
     });
 
     // Hover on a row that is not the selected one — the click-target question.
     await step("hover", async () => {
       await openDialog(page, "claude");
-      await page.getByText("Clone current", { exact: true }).hover();
+      await page.getByText("From template", { exact: true }).hover();
       await settle(page, 300);
-      await snap(page, "35-hover-clone", ["Clone current"]);
+      await snap(page, "35-hover-unselected", ["From template"]);
       await closeDialog(page);
     });
 
@@ -326,11 +383,27 @@ test("add-preset dialog review — start-from states", async () => {
       await closeDialog(page);
     });
 
-    // ---- Shape B: an agent with no provider templates. Two options, not
-    // three — a shape the code path makes easy to forget.
+    // ---- Shape B: an agent with no provider templates and nothing to clone.
+    // Every branch but Blank is unavailable, so there is no decision left to
+    // present — the state most easily forgotten, and the one the old dialog
+    // rendered as two options that did exactly the same thing.
     await step("no-templates", async () => {
       await openDialog(page, "codex");
-      await snap(page, "50-no-templates", ["Start from", "Blank", "Clone current"]);
+      await snap(page, "50-single-path", ["The new preset starts empty"]);
+      await closeDialog(page);
+    });
+
+    // ---- Shape B2: the same agent once a preset exists — a real two-option
+    // decision, with no template branch.
+    await step("clone-no-templates", async () => {
+      await seedPresets(
+        page,
+        "codex",
+        [{ id: "shot-codex-1", name: "Sandboxed", env: {}, args: [] }],
+        "shot-codex-1"
+      );
+      await openDialog(page, "codex");
+      await snap(page, "55-clone-no-templates", ["Start from", "Blank", "Clone current"]);
       await closeDialog(page);
     });
 
@@ -404,6 +477,7 @@ test("add-preset dialog review — every theme", async () => {
         await page.getByText("From template", { exact: true }).click();
         await settle(page, 400);
         await snap(page, `80-theme-${theme}`, ["From template", "Provider"]);
+        console.log(`[preset-shots] contrast ${await measureDescriptionContrast(page)}`);
         await closeDialog(page);
       });
     }

--- a/e2e/screenshots/add-preset-dialog-review.spec.ts
+++ b/e2e/screenshots/add-preset-dialog-review.spec.ts
@@ -480,6 +480,73 @@ test("add-preset dialog review — start-from states", async () => {
   }
 });
 
+/**
+ * The choice-row treatment is shared, so the surfaces it was rolled out to need
+ * eyes on them too — particularly this one, where the group sits in the narrow
+ * right column of a two-column label rail rather than across a dialog.
+ */
+test("choice-row rollout review — settings surfaces", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_PRESET and DAINTREE_SHOT_ROLLOUT are required",
+  });
+  test.skip(!ENABLED || !process.env.DAINTREE_SHOT_ROLLOUT, "Set DAINTREE_SHOT_ROLLOUT");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const { page, cleanup } = await boot();
+  try {
+    const { openSettings } = await import("../helpers/panels");
+    await openSettings(page);
+    await expect(page.locator(SEL.settings.heading)).toBeVisible({ timeout: 15_000 });
+
+    await page.locator('[aria-label="Settings scope"]').click();
+    await page.locator('[role="option"]', { hasText: "Project" }).click();
+    await settle(page, 800);
+    await page.locator(`${SEL.settings.navSidebar} button`, { hasText: "Worktree Setup" }).click();
+
+    const panel = page.locator("#settings-panel-project\\:automation");
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+
+    // Seed one resource environment so the worktree-mode group has a second option.
+    const selectorBar = panel.locator('[data-testid="environment-selector-bar"]');
+    if (!(await selectorBar.isVisible().catch(() => false))) {
+      await panel.locator('[aria-label="Add environment"]').click();
+      const nameInput = panel.locator("#new-environment-name");
+      await expect(nameInput).toBeVisible({ timeout: 10_000 });
+      await nameInput.fill("docker-local");
+      await panel
+        .locator('[data-testid="add-environment-form"]')
+        .locator("button", { hasText: "Add" })
+        .click();
+    }
+    await expect(selectorBar).toBeVisible({ timeout: 15_000 });
+
+    await page
+      .locator("#project-branch-prefix")
+      .scrollIntoViewIfNeeded()
+      .catch(() => undefined);
+    await settle(page, 600);
+    await snap(page, "90-branch-prefix", ["Branch Prefix", "Username"], "#project-branch-prefix");
+
+    // The custom option's dependent field, nested in its own card.
+    await panel
+      .locator('input[type="radio"][name="branchPrefixMode"][value="custom"]')
+      .click({ force: true });
+    await settle(page, 500);
+    await snap(page, "91-branch-prefix-custom", ["Custom", "Prefix"], "#project-branch-prefix");
+
+    await panel
+      .locator('input[type="radio"][name="worktreeMode"]')
+      .first()
+      .scrollIntoViewIfNeeded();
+    await settle(page, 600);
+    await snap(page, "92-worktree-mode", ["Default worktree mode", "Local"], "body");
+  } finally {
+    writeManifest();
+    await cleanup();
+  }
+});
+
 test("add-preset dialog review — every theme", async () => {
   test.info().annotations.push({
     type: "conditional-skip",

--- a/e2e/screenshots/add-preset-dialog-review.spec.ts
+++ b/e2e/screenshots/add-preset-dialog-review.spec.ts
@@ -215,48 +215,77 @@ async function snap(
  */
 async function measureDescriptionContrast(page: Page): Promise<string> {
   return page.evaluate((panelSel) => {
-    const parse = (input: string): [number, number, number] => {
-      const el = document.createElement("div");
-      el.style.color = input;
-      document.body.appendChild(el);
-      const resolved = getComputedStyle(el).color;
-      el.remove();
-      const m = resolved.match(/(\d+(?:\.\d+)?)/g) ?? [];
-      return [Number(m[0] ?? 0), Number(m[1] ?? 0), Number(m[2] ?? 0)];
-    };
-    const lum = ([r, g, b]: [number, number, number]) => {
-      const f = (c: number) => {
-        const s = c / 255;
-        return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    type Rgba = { r: number; g: number; b: number; a: number };
+
+    const parse = (input: string): Rgba => {
+      const probe = document.createElement("div");
+      probe.style.color = input;
+      document.body.appendChild(probe);
+      const resolved = getComputedStyle(probe).color;
+      probe.remove();
+      const m = resolved.match(/[\d.]+/g) ?? [];
+      return {
+        r: Number(m[0] ?? 0),
+        g: Number(m[1] ?? 0),
+        b: Number(m[2] ?? 0),
+        a: m[3] === undefined ? 1 : Number(m[3]),
       };
-      return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
     };
-    const ratio = (a: [number, number, number], b: [number, number, number]) => {
-      const [l1, l2] = [lum(a), lum(b)].sort((x, y) => y - x);
-      return ((l1 as number) + 0.05) / ((l2 as number) + 0.05);
+
+    /** Composite `fg` over `bg` — the card fills are alpha washes, not opaque. */
+    const over = (fg: Rgba, bg: Rgba): Rgba => {
+      const a = fg.a + bg.a * (1 - fg.a);
+      if (a <= 0) return { r: 0, g: 0, b: 0, a: 0 };
+      return {
+        r: (fg.r * fg.a + bg.r * bg.a * (1 - fg.a)) / a,
+        g: (fg.g * fg.a + bg.g * bg.a * (1 - fg.a)) / a,
+        b: (fg.b * fg.a + bg.b * bg.a * (1 - fg.a)) / a,
+        a,
+      };
+    };
+
+    const lum = (c: Rgba) => {
+      const f = (v: number) => {
+        const x = v / 255;
+        return x <= 0.04045 ? x / 12.92 : ((x + 0.055) / 1.055) ** 2.4;
+      };
+      return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b);
+    };
+
+    const ratio = (fg: Rgba, bg: Rgba) => {
+      const composited = over(fg, bg);
+      const [hi, lo] = [lum(composited), lum(bg)].sort((x, y) => y - x);
+      return ((hi as number) + 0.05) / ((lo as number) + 0.05);
+    };
+
+    /** Every wash between the text and the first opaque surface, flattened. */
+    const effectiveBackground = (el: Element | null): Rgba => {
+      let acc: Rgba = { r: 255, g: 255, b: 255, a: 1 };
+      const chain: Rgba[] = [];
+      for (let node: Element | null = el; node; node = node.parentElement) {
+        chain.push(parse(getComputedStyle(node).backgroundColor));
+      }
+      for (let i = chain.length - 1; i >= 0; i--) acc = over(chain[i]!, acc);
+      return acc;
     };
 
     const panel = document.querySelector(panelSel);
     if (!panel) return "no panel";
-    // The description is the second line inside an option's text column.
+
+    const which = (globalThis as { __shotContrastTarget?: string }).__shotContrastTarget;
     const label = Array.from(panel.querySelectorAll("label")).find((l) =>
       l.querySelector('input[type="radio"]')
     );
-    const desc = label?.querySelectorAll("span span")[1];
+    const desc =
+      which === "provider"
+        ? panel.querySelector('[data-testid="template-choice-row"] p')
+        : label?.querySelectorAll("span span")[1];
     if (!desc) return "no description node";
 
-    let bgEl: Element | null = desc;
-    let bg = "rgba(0, 0, 0, 0)";
-    while (bgEl) {
-      const c = getComputedStyle(bgEl).backgroundColor;
-      if (c && !c.endsWith(", 0)") && c !== "transparent") {
-        bg = c;
-        break;
-      }
-      bgEl = bgEl.parentElement;
-    }
-    const fg = getComputedStyle(desc).color;
-    return `${getComputedStyle(document.documentElement).getPropertyValue("--theme-name") || document.documentElement.getAttribute("data-theme")}: fg=${fg} bg=${bg} ratio=${ratio(parse(fg), parse(bg)).toFixed(2)}:1`;
+    const fg = parse(getComputedStyle(desc).color);
+    const bg = effectiveBackground(desc.parentElement);
+    const theme = document.documentElement.getAttribute("data-theme");
+    return `${theme}: fg=${getComputedStyle(desc).color} bg=rgb(${Math.round(bg.r)}, ${Math.round(bg.g)}, ${Math.round(bg.b)}) ratio=${ratio(fg, bg).toFixed(2)}:1`;
   }, PANEL);
 }
 
@@ -477,7 +506,14 @@ test("add-preset dialog review — every theme", async () => {
         await page.getByText("From template", { exact: true }).click();
         await settle(page, 400);
         await snap(page, `80-theme-${theme}`, ["From template", "Provider"]);
-        console.log(`[preset-shots] contrast ${await measureDescriptionContrast(page)}`);
+        console.log(`[preset-shots] option ${await measureDescriptionContrast(page)}`);
+        await page.evaluate(() => {
+          (globalThis as { __shotContrastTarget?: string }).__shotContrastTarget = "provider";
+        });
+        console.log(`[preset-shots] provider ${await measureDescriptionContrast(page)}`);
+        await page.evaluate(() => {
+          (globalThis as { __shotContrastTarget?: string }).__shotContrastTarget = undefined;
+        });
         await closeDialog(page);
       });
     }

--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -10,7 +10,17 @@ import {
   LayoutGrid,
   RefreshCw,
 } from "lucide-react";
+import { useId } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  RadioChoiceGroup,
+  RadioChoiceRow,
+  CHOICE_SHELL,
+  CHOICE_PAD,
+  CHOICE_SELECTED,
+  CHOICE_UNSELECTED,
+  CHOICE_LABEL_INSET,
+} from "@/components/ui/RadioChoice";
 import { cn } from "@/lib/utils";
 import { SCROLLBACK_MIN, SCROLLBACK_MAX } from "@shared/config/scrollback";
 import { validatePathPattern, previewPathPattern } from "@shared/utils/pathPattern";
@@ -83,6 +93,7 @@ export function AutomationTab({
   onDefaultWorktreeModeChange,
   isOpen,
 }: AutomationTabProps) {
+  const branchPrefixFieldId = useId();
   const trimmedWorktreePathPattern = worktreePathPattern.trim();
   const hasPathPatternError =
     trimmedWorktreePathPattern.length > 0 && !validatePathPattern(trimmedWorktreePathPattern).valid;
@@ -271,7 +282,7 @@ export function AutomationTab({
           Automatically prefix new branch names when creating worktrees.
         </p>
 
-        <div className="space-y-2">
+        <RadioChoiceGroup legend="Branch prefix" legendHidden>
           {(
             [
               { value: "none", label: "None", description: "No prefix added" },
@@ -286,38 +297,59 @@ export function AutomationTab({
                 description: "Use a custom prefix string",
               },
             ] as const
-          ).map(({ value, label, description }) => (
-            <label
-              key={value}
-              className="flex items-start gap-3 p-2.5 rounded-[var(--radius-md)] border border-daintree-border cursor-pointer hover:bg-daintree-border/30 transition-colors"
-            >
-              <input
-                type="radio"
+          ).map(({ value, label, description }) =>
+            value === "custom" ? (
+              // The custom prefix field belongs to this option, so it renders
+              // inside the card and outside the label — nesting is what carries
+              // the dependency once forced-colors has flattened fills.
+              <div
+                key={value}
+                className={cn(
+                  CHOICE_SHELL,
+                  branchPrefixMode === value ? CHOICE_SELECTED : CHOICE_UNSELECTED
+                )}
+              >
+                <RadioChoiceRow
+                  name="branchPrefixMode"
+                  value={value}
+                  checked={branchPrefixMode === value}
+                  onChange={() => onBranchPrefixModeChange(value)}
+                  label={label}
+                  description={description}
+                  bare
+                />
+                {branchPrefixMode === "custom" && (
+                  <div className={cn(CHOICE_PAD, "pt-0 space-y-1.5", CHOICE_LABEL_INSET)}>
+                    <label
+                      htmlFor={branchPrefixFieldId}
+                      className="block text-xs font-medium text-text-secondary"
+                    >
+                      Prefix
+                    </label>
+                    <input
+                      id={branchPrefixFieldId}
+                      type="text"
+                      value={branchPrefixCustom}
+                      onChange={(e) => onBranchPrefixCustomChange(e.target.value)}
+                      placeholder="e.g. feature/ or myteam/"
+                      className="w-full px-3 py-1.5 bg-surface-input border border-border-strong rounded-[var(--radius-md)] text-sm text-daintree-text font-mono transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                    />
+                  </div>
+                )}
+              </div>
+            ) : (
+              <RadioChoiceRow
+                key={value}
                 name="branchPrefixMode"
                 value={value}
                 checked={branchPrefixMode === value}
                 onChange={() => onBranchPrefixModeChange(value)}
-                className="mt-0.5 accent-daintree-accent"
+                label={label}
+                description={description}
               />
-              <div>
-                <span className="text-sm font-medium text-daintree-text">{label}</span>
-                <p className="text-xs text-daintree-text/50">{description}</p>
-              </div>
-            </label>
-          ))}
-        </div>
-
-        {branchPrefixMode === "custom" && (
-          <div className="mt-3">
-            <input
-              type="text"
-              value={branchPrefixCustom}
-              onChange={(e) => onBranchPrefixCustomChange(e.target.value)}
-              placeholder="e.g. feature/ or myteam/"
-              className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text font-mono focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
-            />
-          </div>
-        )}
+            )
+          )}
+        </RadioChoiceGroup>
 
         {branchPrefixMode !== "none" && (
           <div className="mt-3 p-3 rounded-[var(--radius-md)] bg-daintree-bg/50 border border-daintree-border">

--- a/src/components/Settings/AddPresetDialog.tsx
+++ b/src/components/Settings/AddPresetDialog.tsx
@@ -1,38 +1,18 @@
 import { useState, useEffect, useMemo, useId } from "react";
 import { getAgentConfig, type AgentPreset } from "@/config/agents";
 import { AppDialog } from "@/components/ui/AppDialog";
+import {
+  RadioChoiceGroup,
+  RadioChoiceRow,
+  CHOICE_SHELL,
+  CHOICE_PAD,
+  CHOICE_SELECTED,
+  CHOICE_UNSELECTED,
+  CHOICE_LABEL_INSET,
+} from "@/components/ui/RadioChoice";
 import { cn } from "@/lib/utils";
 
 type CreationChoice = "blank" | "clone" | "template";
-
-/**
- * Full-row choice surfaces, so the click target matches the visual target and
- * the three starting points read as one decision set.
- *
- * Selection is carried by the neutral border + fill pair the rest of the app
- * uses for a chosen option, never by accent: the dialog's single accent spend
- * is the focus ring. Under forced-colors both the fill and the border colour
- * are overridden, which is why the native radio stays — the UA paints its
- * checked state itself and remains the indicator of last resort.
- */
-// No display utility here: the shell is composed onto a `flex` label, and
-// tailwind-merge resolves same-property utilities by order, so a `block` in
-// this string silently wins and drops the radio onto its own line.
-const ROW_SHELL = "rounded-[var(--radius-md)] border transition-colors duration-150";
-const ROW_PAD = "px-3 py-2.5";
-/**
- * The transparent outline is not decoration. Under `forced-colors: active` the
- * UA overrides `outline-color` — including `transparent` — to a system colour,
- * so this is what keeps the chosen card distinguishable when the fill and the
- * border have both been repainted to the same value. It costs nothing in normal
- * rendering. (MDN/Microsoft forced-colors guidance; the same reason the app
- * prefers `outline` over `ring` for focus.)
- */
-const ROW_SELECTED =
-  "border-border-strong bg-overlay-selected outline outline-2 outline-transparent";
-const ROW_UNSELECTED = "border-daintree-border hover:bg-overlay-soft hover:border-daintree-text/30";
-/** Radio (~13px) + `gap-3`, so a nested control lines up with the label column. */
-const LABEL_COLUMN_INSET = "ml-[25px]";
 
 interface AddPresetDialogProps {
   isOpen: boolean;
@@ -119,10 +99,8 @@ export function AddPresetDialog({
 
       <AppDialog.Body>
         {hasChoice ? (
-          <fieldset className="space-y-2">
-            <legend className="text-sm font-medium text-daintree-text mb-2">Start from</legend>
-
-            <RadioOption
+          <RadioChoiceGroup legend="Start from">
+            <RadioChoiceRow
               name="creation-choice"
               value="blank"
               checked={choice === "blank"}
@@ -132,7 +110,7 @@ export function AddPresetDialog({
             />
 
             {currentPreset && (
-              <RadioOption
+              <RadioChoiceRow
                 name="creation-choice"
                 value="clone"
                 checked={choice === "clone"}
@@ -144,10 +122,13 @@ export function AddPresetDialog({
 
             {canUseTemplate && (
               <div
-                className={cn(ROW_SHELL, choice === "template" ? ROW_SELECTED : ROW_UNSELECTED)}
+                className={cn(
+                  CHOICE_SHELL,
+                  choice === "template" ? CHOICE_SELECTED : CHOICE_UNSELECTED
+                )}
                 data-testid="template-choice-row"
               >
-                <RadioOption
+                <RadioChoiceRow
                   name="creation-choice"
                   value="template"
                   checked={choice === "template"}
@@ -162,7 +143,7 @@ export function AddPresetDialog({
                     carries the dependency: fills and borders are stripped under
                     forced-colors, structure is not. */}
                 {choice === "template" && (
-                  <div className={cn(ROW_PAD, "pt-0 space-y-1.5", LABEL_COLUMN_INSET)}>
+                  <div className={cn(CHOICE_PAD, "pt-0 space-y-1.5", CHOICE_LABEL_INSET)}>
                     <label
                       htmlFor={providerId}
                       className="block text-xs font-medium text-text-secondary"
@@ -195,7 +176,7 @@ export function AddPresetDialog({
                 )}
               </div>
             )}
-          </fieldset>
+          </RadioChoiceGroup>
         ) : (
           // One path left is not a decision. Say what will happen and why the
           // other two are absent, rather than rendering a single-option group.
@@ -211,69 +192,5 @@ export function AddPresetDialog({
         primaryAction={{ label: "Create preset", onClick: handleCreate, disabled: !canCreate }}
       />
     </AppDialog>
-  );
-}
-
-function RadioOption({
-  name,
-  value,
-  checked,
-  onChange,
-  label,
-  description,
-  bare,
-}: {
-  name: string;
-  value: string;
-  checked: boolean;
-  onChange: () => void;
-  label: string;
-  description: string;
-  /** Rendered inside a row that already paints the choice surface. */
-  bare?: boolean;
-}) {
-  const labelId = useId();
-  const descriptionId = useId();
-
-  return (
-    <label
-      className={cn(
-        "flex items-start gap-3 cursor-pointer",
-        ROW_PAD,
-        // A bare option is padded by the same rule but leaves the border and
-        // fill to the row that wraps it, so the whole card stays one target.
-        !bare && [ROW_SHELL, checked ? ROW_SELECTED : ROW_UNSELECTED]
-      )}
-    >
-      <input
-        type="radio"
-        name={name}
-        value={value}
-        checked={checked}
-        onChange={onChange}
-        // Wrapping the whole card in the <label> is what makes the row one
-        // click target, but it also folds the description into the accessible
-        // name, so every option announces as one long run-on string. Naming the
-        // title explicitly wins over the label subtree (AccName precedence),
-        // and the consequence line comes back as a description instead.
-        aria-labelledby={labelId}
-        aria-describedby={descriptionId}
-        // The theme accent tint comes from the global `accent-color` base rule;
-        // the outline is here because the global `*:focus-visible` rule only
-        // wires the transition, so a bare radio would fall through to
-        // Chromium's cobalt — the one hue the app otherwise never renders.
-        // mt-1 centres the ~13px control in the label's 20px line box; at
-        // mt-0.5 it rode level with the top of the capital letter.
-        className="mt-1 shrink-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-      />
-      <span className="min-w-0">
-        <span id={labelId} className="block text-sm font-medium text-daintree-text">
-          {label}
-        </span>
-        <span id={descriptionId} className="block text-xs text-text-secondary select-text">
-          {description}
-        </span>
-      </span>
-    </label>
   );
 }

--- a/src/components/Settings/AddPresetDialog.tsx
+++ b/src/components/Settings/AddPresetDialog.tsx
@@ -1,8 +1,38 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useId } from "react";
 import { getAgentConfig, type AgentPreset } from "@/config/agents";
 import { AppDialog } from "@/components/ui/AppDialog";
+import { cn } from "@/lib/utils";
 
 type CreationChoice = "blank" | "clone" | "template";
+
+/**
+ * Full-row choice surfaces, so the click target matches the visual target and
+ * the three starting points read as one decision set.
+ *
+ * Selection is carried by the neutral border + fill pair the rest of the app
+ * uses for a chosen option, never by accent: the dialog's single accent spend
+ * is the focus ring. Under forced-colors both the fill and the border colour
+ * are overridden, which is why the native radio stays — the UA paints its
+ * checked state itself and remains the indicator of last resort.
+ */
+// No display utility here: the shell is composed onto a `flex` label, and
+// tailwind-merge resolves same-property utilities by order, so a `block` in
+// this string silently wins and drops the radio onto its own line.
+const ROW_SHELL = "rounded-[var(--radius-md)] border transition-colors duration-150";
+const ROW_PAD = "px-3 py-2.5";
+/**
+ * The transparent outline is not decoration. Under `forced-colors: active` the
+ * UA overrides `outline-color` — including `transparent` — to a system colour,
+ * so this is what keeps the chosen card distinguishable when the fill and the
+ * border have both been repainted to the same value. It costs nothing in normal
+ * rendering. (MDN/Microsoft forced-colors guidance; the same reason the app
+ * prefers `outline` over `ring` for focus.)
+ */
+const ROW_SELECTED =
+  "border-border-strong bg-overlay-selected outline outline-2 outline-transparent";
+const ROW_UNSELECTED = "border-daintree-border hover:bg-overlay-soft";
+/** Radio (~13px) + `gap-3`, so a nested control lines up with the label column. */
+const LABEL_COLUMN_INSET = "ml-[25px]";
 
 interface AddPresetDialogProps {
   isOpen: boolean;
@@ -21,9 +51,17 @@ export function AddPresetDialog({
 }: AddPresetDialogProps) {
   const [choice, setChoice] = useState<CreationChoice>("blank");
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>("");
+  const providerId = useId();
 
   const templates = useMemo(() => getAgentConfig(agentId)?.providerTemplates ?? [], [agentId]);
   const selectedTemplate = templates.find((t) => t.id === selectedTemplateId);
+
+  // Both are offers the dialog can only honour when it has something to honour
+  // them with, so neither is rendered otherwise — an option that silently
+  // falls back to Blank asks the user to interpret a choice that isn't real.
+  const canClone = !!currentPreset;
+  const canUseTemplate = templates.length > 0;
+  const hasChoice = canClone || canUseTemplate;
 
   useEffect(() => {
     if (isOpen) {
@@ -33,48 +71,44 @@ export function AddPresetDialog({
   }, [isOpen, templates]);
 
   const handleCreate = () => {
-    const name =
-      choice === "clone" && currentPreset ? `${currentPreset.name} (copy)` : "New preset";
-
     switch (choice) {
       case "blank":
-        onCreate({ name, env: {} });
+        onCreate({ name: "New preset", env: {} });
         break;
       case "clone":
-        if (currentPreset) {
-          onCreate({
-            name,
-            env: currentPreset.env ? { ...currentPreset.env } : {},
-            args: currentPreset.args ? [...currentPreset.args] : undefined,
-            dangerousEnabled: currentPreset.dangerousEnabled,
-            dangerousMode: currentPreset.dangerousMode,
-            customFlags: currentPreset.customFlags,
-            inlineMode: currentPreset.inlineMode,
-            color: currentPreset.color,
-            fallbacks: undefined,
-          });
-        } else {
-          onCreate({ name, env: {} });
-        }
+        // Guarded rather than defaulted: `canCreate` keeps the button disabled
+        // instead of quietly creating something other than what was asked for.
+        if (!currentPreset) return;
+        onCreate({
+          name: `${currentPreset.name} (copy)`,
+          env: currentPreset.env ? { ...currentPreset.env } : {},
+          args: currentPreset.args ? [...currentPreset.args] : undefined,
+          dangerousEnabled: currentPreset.dangerousEnabled,
+          dangerousMode: currentPreset.dangerousMode,
+          customFlags: currentPreset.customFlags,
+          inlineMode: currentPreset.inlineMode,
+          color: currentPreset.color,
+          fallbacks: undefined,
+        });
         break;
       case "template":
-        if (selectedTemplate) {
-          onCreate({
-            name: selectedTemplate.name,
-            description: selectedTemplate.description,
-            env: selectedTemplate.env ? { ...selectedTemplate.env } : {},
-            args: selectedTemplate.args ? [...selectedTemplate.args] : undefined,
-            dangerousEnabled: selectedTemplate.dangerousEnabled,
-            dangerousMode: selectedTemplate.dangerousMode,
-            customFlags: selectedTemplate.customFlags,
-            inlineMode: selectedTemplate.inlineMode,
-          });
-        }
+        if (!selectedTemplate) return;
+        onCreate({
+          name: selectedTemplate.name,
+          description: selectedTemplate.description,
+          env: selectedTemplate.env ? { ...selectedTemplate.env } : {},
+          args: selectedTemplate.args ? [...selectedTemplate.args] : undefined,
+          dangerousEnabled: selectedTemplate.dangerousEnabled,
+          dangerousMode: selectedTemplate.dangerousMode,
+          customFlags: selectedTemplate.customFlags,
+          inlineMode: selectedTemplate.inlineMode,
+        });
         break;
     }
   };
 
-  const canCreate = choice !== "template" || !!selectedTemplate;
+  const canCreate =
+    (choice !== "template" || !!selectedTemplate) && (choice !== "clone" || !!currentPreset);
 
   return (
     <AppDialog isOpen={isOpen} onClose={onClose} size="sm" data-testid="add-preset-dialog">
@@ -83,65 +117,88 @@ export function AddPresetDialog({
         <AppDialog.CloseButton />
       </AppDialog.Header>
 
-      <AppDialog.Body className="space-y-4">
-        <fieldset className="space-y-3">
-          <legend className="text-sm font-medium text-daintree-text mb-2">Start from</legend>
+      <AppDialog.Body>
+        {hasChoice ? (
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium text-daintree-text mb-2">Start from</legend>
 
-          <RadioOption
-            name="creation-choice"
-            value="blank"
-            checked={choice === "blank"}
-            onChange={() => setChoice("blank")}
-            label="Blank"
-            description="Empty env, fill in from scratch"
-          />
-
-          <RadioOption
-            name="creation-choice"
-            value="clone"
-            checked={choice === "clone"}
-            onChange={() => setChoice("clone")}
-            label="Clone current"
-            description={
-              currentPreset
-                ? `Duplicate "${currentPreset.name}"`
-                : "No preset selected — will create blank"
-            }
-          />
-
-          {templates.length > 0 && (
             <RadioOption
               name="creation-choice"
-              value="template"
-              checked={choice === "template"}
-              onChange={() => setChoice("template")}
-              label="From template"
-              description="Pre-fill provider settings, API key left blank"
+              value="blank"
+              checked={choice === "blank"}
+              onChange={() => setChoice("blank")}
+              label="Blank"
+              description="An empty preset, with no runtime overrides"
             />
-          )}
-        </fieldset>
 
-        {choice === "template" && templates.length > 0 && (
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium text-daintree-text block">Provider</label>
-            <select
-              value={selectedTemplateId}
-              onChange={(e) => setSelectedTemplateId(e.target.value)}
-              className="w-full rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg px-3 py-1.5 text-sm focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50"
-              data-testid="template-select"
-            >
-              {templates.map((t) => (
-                <option key={t.id} value={t.id}>
-                  {t.name}
-                </option>
-              ))}
-            </select>
-            {selectedTemplate?.description && (
-              <p className="text-xs text-daintree-text/40 select-text">
-                {selectedTemplate.description}
-              </p>
+            {currentPreset && (
+              <RadioOption
+                name="creation-choice"
+                value="clone"
+                checked={choice === "clone"}
+                onChange={() => setChoice("clone")}
+                label="Clone current"
+                description={`A copy of "${currentPreset.name}", ready to edit`}
+              />
             )}
-          </div>
+
+            {canUseTemplate && (
+              <div
+                className={cn(ROW_SHELL, choice === "template" ? ROW_SELECTED : ROW_UNSELECTED)}
+                data-testid="template-choice-row"
+              >
+                <RadioOption
+                  name="creation-choice"
+                  value="template"
+                  checked={choice === "template"}
+                  onChange={() => setChoice("template")}
+                  label="From template"
+                  description="A provider's connection settings, filled in"
+                  bare
+                />
+
+                {/* Inside the option it belongs to, and outside its <label> so
+                    the select does not toggle the radio. The nesting is what
+                    carries the dependency: fills and borders are stripped under
+                    forced-colors, structure is not. */}
+                {choice === "template" && (
+                  <div className={cn(ROW_PAD, "pt-0 space-y-1.5", LABEL_COLUMN_INSET)}>
+                    <label
+                      htmlFor={providerId}
+                      className="block text-xs font-medium text-text-secondary"
+                    >
+                      Provider
+                    </label>
+                    <select
+                      id={providerId}
+                      value={selectedTemplateId}
+                      onChange={(e) => setSelectedTemplateId(e.target.value)}
+                      className="w-full rounded-[var(--radius-md)] border border-border-strong bg-surface-input px-3 py-1.5 text-sm text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                      data-testid="template-select"
+                    >
+                      {templates.map((t) => (
+                        <option key={t.id} value={t.id}>
+                          {t.name}
+                        </option>
+                      ))}
+                    </select>
+                    {selectedTemplate?.description && (
+                      <p className="text-xs text-text-muted select-text">
+                        {selectedTemplate.description}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </fieldset>
+        ) : (
+          // One path left is not a decision. Say what will happen and why the
+          // other two are absent, rather than rendering a single-option group.
+          <p className="text-sm text-text-secondary select-text">
+            The new preset starts empty — there's no preset selected to clone, and this agent has no
+            provider templates.
+          </p>
         )}
       </AppDialog.Body>
 
@@ -160,6 +217,7 @@ function RadioOption({
   onChange,
   label,
   description,
+  bare,
 }: {
   name: string;
   value: string;
@@ -167,23 +225,51 @@ function RadioOption({
   onChange: () => void;
   label: string;
   description: string;
+  /** Rendered inside a row that already paints the choice surface. */
+  bare?: boolean;
 }) {
+  const labelId = useId();
+  const descriptionId = useId();
+
   return (
-    <label className="flex items-start gap-3 cursor-pointer group">
+    <label
+      className={cn(
+        "flex items-start gap-3 cursor-pointer",
+        ROW_PAD,
+        // A bare option is padded by the same rule but leaves the border and
+        // fill to the row that wraps it, so the whole card stays one target.
+        !bare && [ROW_SHELL, checked ? ROW_SELECTED : ROW_UNSELECTED]
+      )}
+    >
       <input
         type="radio"
         name={name}
         value={value}
         checked={checked}
         onChange={onChange}
-        className="mt-0.5 shrink-0 accent-daintree-accent"
+        // Wrapping the whole card in the <label> is what makes the row one
+        // click target, but it also folds the description into the accessible
+        // name, so every option announces as one long run-on string. Naming the
+        // title explicitly wins over the label subtree (AccName precedence),
+        // and the consequence line comes back as a description instead.
+        aria-labelledby={labelId}
+        aria-describedby={descriptionId}
+        // The theme accent tint comes from the global `accent-color` base rule;
+        // the outline is here because the global `*:focus-visible` rule only
+        // wires the transition, so a bare radio would fall through to
+        // Chromium's cobalt — the one hue the app otherwise never renders.
+        // mt-1 centres the ~13px control in the label's 20px line box; at
+        // mt-0.5 it rode level with the top of the capital letter.
+        className="mt-1 shrink-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
       />
-      <div>
-        <span className="text-sm font-medium text-daintree-text group-hover:text-daintree-text transition-colors">
+      <span className="min-w-0">
+        <span id={labelId} className="block text-sm font-medium text-daintree-text">
           {label}
         </span>
-        <p className="text-xs text-daintree-text/40 select-text">{description}</p>
-      </div>
+        <span id={descriptionId} className="block text-xs text-text-secondary select-text">
+          {description}
+        </span>
+      </span>
     </label>
   );
 }

--- a/src/components/Settings/AddPresetDialog.tsx
+++ b/src/components/Settings/AddPresetDialog.tsx
@@ -30,7 +30,7 @@ const ROW_PAD = "px-3 py-2.5";
  */
 const ROW_SELECTED =
   "border-border-strong bg-overlay-selected outline outline-2 outline-transparent";
-const ROW_UNSELECTED = "border-daintree-border hover:bg-overlay-soft";
+const ROW_UNSELECTED = "border-daintree-border hover:bg-overlay-soft hover:border-daintree-text/30";
 /** Radio (~13px) + `gap-3`, so a nested control lines up with the label column. */
 const LABEL_COLUMN_INSET = "ml-[25px]";
 
@@ -183,8 +183,12 @@ export function AddPresetDialog({
                       ))}
                     </select>
                     {selectedTemplate?.description && (
-                      <p className="text-xs text-text-muted select-text">
-                        {selectedTemplate.description}
+                      <p className="text-xs text-text-secondary select-text">
+                        {/* Trimmed at render, not at the source: these strings
+                            are agent-facing through the MCP preset schema and
+                            pinned by the registry contract test, but as a
+                            single-clause subtitle here the period is wrong. */}
+                        {selectedTemplate.description.replace(/\.$/, "")}
                       </p>
                     )}
                   </div>

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -1,4 +1,14 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useId } from "react";
+import {
+  RadioChoiceGroup,
+  RadioChoiceRow,
+  CHOICE_SHELL,
+  CHOICE_PAD,
+  CHOICE_SELECTED,
+  CHOICE_UNSELECTED,
+  CHOICE_LABEL_INSET,
+} from "@/components/ui/RadioChoice";
+import { cn } from "@/lib/utils";
 import { Image } from "lucide-react";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { useProjectStore } from "@/store";
@@ -9,6 +19,7 @@ import { logError } from "@/utils/logger";
 type ImageViewerMode = "os" | "custom";
 
 export function ImageViewerTab() {
+  const commandFieldId = useId();
   const [mode, setMode] = useState<ImageViewerMode>("os");
   const [customCommand, setCustomCommand] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -20,6 +31,8 @@ export function ImageViewerTab() {
 
   const activeProject = useProjectStore((s) => s.currentProject);
   const activeProjectId = activeProject?.id;
+
+  const controlsDisabled = isLoading || Boolean(loadError);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -127,53 +140,61 @@ export function ImageViewerTab() {
         description="Choose the application that opens when you click 'Open in Image Viewer' in the file viewer."
       >
         <div className="space-y-4">
-          <div className="space-y-2">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="radio"
-                name="imageViewerMode"
-                value="os"
-                checked={mode === "os"}
-                onChange={() => handleModeChange("os")}
-                disabled={isLoading || Boolean(loadError)}
-                className="accent-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-              <span className="text-sm text-daintree-text">Use OS default</span>
-            </label>
-            <p className="text-xs text-daintree-text/40 ml-6">
-              Opens images with your system default viewer (Preview on macOS, Photos on Windows).
-            </p>
+          <RadioChoiceGroup legend="Image viewer mode" legendHidden>
+            <RadioChoiceRow
+              name="imageViewerMode"
+              value="os"
+              checked={mode === "os"}
+              onChange={() => handleModeChange("os")}
+              disabled={controlsDisabled}
+              label="Use OS default"
+              description="Opens images with your system default viewer — Preview on macOS, Photos on Windows"
+            />
 
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="radio"
+            {/* The command field belongs to this option, so it renders inside
+                the card and outside the label: nesting is what carries the
+                dependency once forced-colors has flattened every fill. */}
+            <div
+              className={cn(
+                CHOICE_SHELL,
+                mode === "custom" ? CHOICE_SELECTED : CHOICE_UNSELECTED,
+                controlsDisabled && "opacity-50"
+              )}
+            >
+              <RadioChoiceRow
                 name="imageViewerMode"
                 value="custom"
                 checked={mode === "custom"}
                 onChange={() => handleModeChange("custom")}
-                disabled={isLoading || Boolean(loadError)}
-                className="accent-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={controlsDisabled}
+                label="Custom command"
+                description="Opens images with a command you provide"
+                bare
               />
-              <span className="text-sm text-daintree-text">Custom command</span>
-            </label>
-          </div>
-
-          {mode === "custom" && (
-            <div className="space-y-1 ml-6">
-              <label className="text-xs text-daintree-text/60">Command</label>
-              <input
-                type="text"
-                value={customCommand}
-                onChange={(e) => handleCommandChange(e.target.value)}
-                disabled={isLoading || Boolean(loadError)}
-                placeholder="e.g. open -a Photoshop, gimp"
-                className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent/40 transition-colors font-mono disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-              <p className="text-xs text-daintree-text/40">
-                The file path will be appended as the last argument.
-              </p>
+              {mode === "custom" && (
+                <div className={cn(CHOICE_PAD, "pt-0 space-y-1.5", CHOICE_LABEL_INSET)}>
+                  <label
+                    htmlFor={commandFieldId}
+                    className="block text-xs font-medium text-text-secondary"
+                  >
+                    Command
+                  </label>
+                  <input
+                    id={commandFieldId}
+                    type="text"
+                    value={customCommand}
+                    onChange={(e) => handleCommandChange(e.target.value)}
+                    disabled={controlsDisabled}
+                    placeholder="e.g. open -a Photoshop, gimp"
+                    className="w-full bg-surface-input border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text font-mono transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                  />
+                  <p className="text-xs text-text-secondary select-text">
+                    The file path is appended as the last argument
+                  </p>
+                </div>
+              )}
             </div>
-          )}
+          </RadioChoiceGroup>
 
           <div className="flex items-center gap-2">
             <button

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { RadioChoiceGroup, RadioChoiceRow } from "@/components/ui/RadioChoice";
 import { AlertTriangle } from "lucide-react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { parseEnvPaste, type ParseEnvResult } from "@/utils/parseEnvPaste";
@@ -188,23 +189,26 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
               {conflicts.length} key{conflicts.length === 1 ? "" : "s"} already exist
               {conflicts.length === 1 ? "s" : ""}. Choose how to merge.
             </AppDialog.Description>
-            <fieldset className="space-y-2">
-              <legend className="sr-only">Conflict resolution</legend>
-              <ConflictOption
+            <RadioChoiceGroup legend="Conflict resolution" legendHidden>
+              <RadioChoiceRow
+                name="import-env-conflict-mode"
+                value="keep"
                 checked={conflictResolution === "keep"}
                 onChange={() => setConflictResolution("keep")}
                 label="Keep existing"
-                description="Only add new keys — leave colliding values untouched."
+                description="Only add new keys — leave colliding values untouched"
                 testId="import-env-mode-keep"
               />
-              <ConflictOption
+              <RadioChoiceRow
+                name="import-env-conflict-mode"
+                value="overwrite"
                 checked={conflictResolution === "overwrite"}
                 onChange={() => setConflictResolution("overwrite")}
                 label="Overwrite conflicts"
-                description="Replace colliding values with the pasted ones."
+                description="Replace colliding values with the pasted ones"
                 testId="import-env-mode-overwrite"
               />
-            </fieldset>
+            </RadioChoiceGroup>
             <div
               className="rounded-[var(--radius-md)] border border-daintree-border overflow-hidden"
               data-testid="import-env-conflict-list"
@@ -238,38 +242,5 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
         }}
       />
     </AppDialog>
-  );
-}
-
-function ConflictOption({
-  checked,
-  onChange,
-  label,
-  description,
-  testId,
-}: {
-  checked: boolean;
-  onChange: () => void;
-  label: string;
-  description: string;
-  testId: string;
-}) {
-  return (
-    <label className="flex items-start gap-3 cursor-pointer group">
-      <input
-        type="radio"
-        name="import-env-conflict-mode"
-        checked={checked}
-        onChange={onChange}
-        className="mt-0.5 shrink-0 accent-daintree-accent"
-        data-testid={testId}
-      />
-      <div>
-        <span className="text-sm font-medium text-daintree-text group-hover:text-daintree-text transition-colors">
-          {label}
-        </span>
-        <p className="text-xs text-daintree-text/40">{description}</p>
-      </div>
-    </label>
   );
 }

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -20,6 +20,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import type { ResourceEnvironment } from "@shared/types/project";
 import { FIELD_INPUT, FormGrid, FormRow, FormSection } from "@/components/Worktree/views";
+import { RadioChoiceRow } from "@/components/ui/RadioChoice";
 
 interface EnvironmentSettingsTabProps {
   resourceEnvironments?: Record<string, ResourceEnvironment>;
@@ -551,35 +552,34 @@ export function ResourceEnvironmentsSection({
           {/* No htmlFor: a set of radios has no single control to name, so the
               rail's label names the group instead. */}
           <FormRow
-            label="Default Worktree Mode"
+            label="Default worktree mode"
+            labelClassName="self-start pt-2.5"
             hint={
               <p className="text-xs text-text-muted">Default mode when creating new worktrees</p>
             }
           >
-            <div className="flex items-center gap-4 flex-wrap">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="radio"
-                  name="worktreeMode"
-                  value="local"
-                  checked={(defaultWorktreeMode ?? "local") === "local"}
-                  onChange={() => onDefaultWorktreeModeChange("local")}
-                  className="accent-daintree-accent"
-                />
-                <span className="text-sm text-daintree-text">Local</span>
-              </label>
+            {/* No RadioChoiceGroup here: FormRow already renders the rail label
+                and wires `role="group"`/`aria-labelledby` to it, so a second
+                legend would name the group twice. */}
+            <div className="space-y-2">
+              <RadioChoiceRow
+                name="worktreeMode"
+                value="local"
+                checked={(defaultWorktreeMode ?? "local") === "local"}
+                onChange={() => onDefaultWorktreeModeChange("local")}
+                label="Local"
+                description="Run worktrees directly on this machine"
+              />
               {envKeys.map((key) => (
-                <label key={key} className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="worktreeMode"
-                    value={key}
-                    checked={defaultWorktreeMode === key}
-                    onChange={() => onDefaultWorktreeModeChange(key)}
-                    className="accent-daintree-accent"
-                  />
-                  <span className="text-sm text-daintree-text">{key}</span>
-                </label>
+                <RadioChoiceRow
+                  key={key}
+                  name="worktreeMode"
+                  value={key}
+                  checked={defaultWorktreeMode === key}
+                  onChange={() => onDefaultWorktreeModeChange(key)}
+                  label={key}
+                  description="Run worktrees in this resource environment"
+                />
               ))}
             </div>
           </FormRow>

--- a/src/components/Settings/__tests__/AddPresetDialog.test.tsx
+++ b/src/components/Settings/__tests__/AddPresetDialog.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { AddPresetDialog } from "../AddPresetDialog";
+import type { AgentPreset } from "@/config/agents";
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+/**
+ * `claude` is the only agent in the roster that ships provider templates, so it
+ * and any other id are the two structural shapes this dialog has to render.
+ */
+const AGENT_WITH_TEMPLATES = "claude";
+const AGENT_WITHOUT_TEMPLATES = "codex";
+
+const CURRENT: AgentPreset = {
+  id: "preset-1",
+  name: "Z.AI (GLM-5.2)",
+  env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" },
+  args: ["--verbose"],
+};
+
+type CreatePayload = Omit<AgentPreset, "id">;
+
+function renderDialog(overrides: Partial<Parameters<typeof AddPresetDialog>[0]> = {}) {
+  const onCreate = vi.fn<(preset: CreatePayload) => void>();
+  const onClose = vi.fn();
+  render(
+    <AddPresetDialog
+      isOpen
+      onClose={onClose}
+      agentId={AGENT_WITH_TEMPLATES}
+      currentPreset={null}
+      onCreate={onCreate}
+      {...overrides}
+    />
+  );
+  return { onCreate, onClose };
+}
+
+function optionRadios(): HTMLInputElement[] {
+  return screen.queryAllByRole("radio") as HTMLInputElement[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AddPresetDialog — every offered option is one the dialog can honour", () => {
+  it("offers no option whose outcome it cannot actually produce", () => {
+    // The rule, not the roster: whatever the dialog renders as a choice must
+    // correspond to a starting point that exists in this context. Cloning
+    // requires something to clone; a template requires a template.
+    const cases: { currentPreset: AgentPreset | null; agentId: string }[] = [
+      { currentPreset: null, agentId: AGENT_WITH_TEMPLATES },
+      { currentPreset: CURRENT, agentId: AGENT_WITH_TEMPLATES },
+      { currentPreset: null, agentId: AGENT_WITHOUT_TEMPLATES },
+      { currentPreset: CURRENT, agentId: AGENT_WITHOUT_TEMPLATES },
+    ];
+
+    for (const { currentPreset, agentId } of cases) {
+      const { unmount } = render(
+        <AddPresetDialog
+          isOpen
+          onClose={vi.fn()}
+          agentId={agentId}
+          currentPreset={currentPreset}
+          onCreate={vi.fn()}
+        />
+      );
+
+      const values = optionRadios().map((r) => r.value);
+      expect(values.includes("clone"), `clone offered with currentPreset=${!!currentPreset}`).toBe(
+        !!currentPreset
+      );
+      expect(values.includes("template"), `template offered for agent=${agentId}`).toBe(
+        agentId === AGENT_WITH_TEMPLATES
+      );
+
+      unmount();
+    }
+  });
+
+  it("drops the choice group entirely rather than presenting a single option", () => {
+    // A one-option radio group is a decision the user cannot make: nothing to
+    // compare, and no way to deselect. When only Blank survives, the dialog
+    // must say what will happen instead of rendering a lone control.
+    renderDialog({ agentId: AGENT_WITHOUT_TEMPLATES, currentPreset: null });
+
+    expect(optionRadios()).toHaveLength(0);
+    expect(screen.queryByRole("group")).toBeNull();
+    expect(screen.queryByText(/starts empty/i)).not.toBeNull();
+  });
+
+  it("never renders a choice group with fewer than two options", () => {
+    for (const agentId of [AGENT_WITH_TEMPLATES, AGENT_WITHOUT_TEMPLATES]) {
+      for (const currentPreset of [null, CURRENT]) {
+        const { unmount } = render(
+          <AddPresetDialog
+            isOpen
+            onClose={vi.fn()}
+            agentId={agentId}
+            currentPreset={currentPreset}
+            onCreate={vi.fn()}
+          />
+        );
+        const count = optionRadios().length;
+        expect(count === 0 || count >= 2, `rendered ${count} option(s)`).toBe(true);
+        unmount();
+      }
+    }
+  });
+});
+
+describe("AddPresetDialog — single-choice semantics", () => {
+  it("keeps the options in one native radio group", () => {
+    // Native grouping is what supplies arrow-key selection, the single tab
+    // stop, and the checked state the UA repaints under forced colors. A
+    // roving-tabindex reimplementation would satisfy none of those for free.
+    renderDialog({ currentPreset: CURRENT });
+
+    const radios = optionRadios();
+    expect(radios.length).toBeGreaterThan(1);
+    for (const radio of radios) {
+      expect(radio.type).toBe("radio");
+    }
+    expect(new Set(radios.map((r) => r.name)).size).toBe(1);
+  });
+
+  it("keeps exactly one option checked as the choice moves", () => {
+    renderDialog({ currentPreset: CURRENT });
+
+    const checkedCount = () => optionRadios().filter((r) => r.checked).length;
+    expect(checkedCount()).toBe(1);
+
+    for (const name of ["Clone current", "From template", "Blank"]) {
+      fireEvent.click(screen.getByRole("radio", { name }));
+      expect(checkedCount(), `after choosing ${name}`).toBe(1);
+    }
+  });
+
+  it("names each option by its title alone and carries the consequence as a description", () => {
+    // The whole card is the label so the row is one click target, which would
+    // otherwise fold the consequence line into the accessible name and
+    // announce every option as one run-on string.
+    renderDialog({ currentPreset: CURRENT });
+
+    const clone = screen.getByRole("radio", { name: "Clone current" });
+    const describedBy = clone.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)?.textContent).toMatch(/Z\.AI/);
+  });
+
+  it("makes the whole option row the click target, not just the control", () => {
+    // The consequence line has to sit inside the option's own <label> for the
+    // row to be one target; if it drifts outside, the visual card and the
+    // clickable area stop agreeing.
+    renderDialog({ currentPreset: CURRENT });
+
+    for (const radio of optionRadios()) {
+      const label = radio.closest("label");
+      expect(label, `option ${radio.value} has no wrapping label`).not.toBeNull();
+      const describedBy = radio.getAttribute("aria-describedby")!;
+      expect(label!.contains(document.getElementById(describedBy))).toBe(true);
+    }
+  });
+});
+
+describe("AddPresetDialog — the dependent control belongs to the option that owns it", () => {
+  it("renders the provider selector only while its option is chosen", () => {
+    renderDialog();
+
+    expect(screen.queryByTestId("template-select")).toBeNull();
+    fireEvent.click(screen.getByRole("radio", { name: "From template" }));
+    expect(screen.queryByTestId("template-select")).not.toBeNull();
+    fireEvent.click(screen.getByRole("radio", { name: "Blank" }));
+    expect(screen.queryByTestId("template-select")).toBeNull();
+  });
+
+  it("nests the provider selector inside its own option's row, not beside the group", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("radio", { name: "From template" }));
+
+    const row = screen.getByTestId("template-choice-row");
+    expect(within(row).queryByRole("radio", { name: "From template" })).not.toBeNull();
+    expect(row.contains(screen.getByTestId("template-select"))).toBe(true);
+  });
+
+  it("keeps the provider selector out of the label so choosing a provider cannot retoggle the option", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("radio", { name: "From template" }));
+
+    expect(screen.getByTestId("template-select").closest("label")).toBeNull();
+  });
+});
+
+describe("AddPresetDialog — what gets created matches what was chosen", () => {
+  it("creates from the current preset when cloning, never a silent blank", () => {
+    const { onCreate } = renderDialog({ currentPreset: CURRENT });
+
+    fireEvent.click(screen.getByRole("radio", { name: "Clone current" }));
+    fireEvent.click(screen.getByRole("button", { name: /create preset/i }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    const payload = onCreate.mock.calls[0]![0];
+    expect(payload.name).toContain(CURRENT.name);
+    expect(payload.env).toEqual(CURRENT.env);
+    expect(payload.env).not.toBe(CURRENT.env);
+  });
+
+  it("creates from the chosen template, carrying its settings", () => {
+    const { onCreate } = renderDialog();
+
+    fireEvent.click(screen.getByRole("radio", { name: "From template" }));
+    const select = screen.getByTestId("template-select") as HTMLSelectElement;
+    const target = Array.from(select.options).find((o) => o.value !== select.value)!;
+    fireEvent.change(select, { target: { value: target.value } });
+    fireEvent.click(screen.getByRole("button", { name: /create preset/i }));
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    const payload = onCreate.mock.calls[0]![0];
+    expect(payload.name).toBe(target.textContent);
+    expect(Object.keys(payload.env ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it("starts on the blank option every time it opens", () => {
+    // Downstream specs depend on the untouched path producing a blank preset,
+    // and reopening must not inherit the previous visit's choice.
+    const { onCreate } = renderDialog({ currentPreset: CURRENT });
+    const checked = optionRadios().find((r) => r.checked);
+    expect(checked?.value).toBe("blank");
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
+++ b/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
@@ -171,7 +171,7 @@ describe("ResourceEnvironmentsSection", () => {
       />
     );
 
-    expect(screen.getByText("Default Worktree Mode")).toBeTruthy();
+    expect(screen.getByText("Default worktree mode")).toBeTruthy();
     expect(screen.getByText("Default mode when creating new worktrees")).toBeTruthy();
 
     const localRadio = screen.getByRole("radio", { name: "Local" });

--- a/src/components/ui/RadioChoice.tsx
+++ b/src/components/ui/RadioChoice.tsx
@@ -1,0 +1,165 @@
+import { useId } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * A labelled single-choice group built on native radios.
+ *
+ * Deliberately not `SettingsChoicebox`: that one is `role="radio"` buttons with
+ * a roving tabindex, so its arrow keys move focus without moving the selection.
+ * A native radio group moves both together, is one tab stop, and has its checked
+ * state painted by the user agent — which is the only thing that still reads as
+ * "chosen" once `forced-colors: active` has flattened every author fill and
+ * border. Anything mutually exclusive and keyboard-driven should use this;
+ * `SettingsChoicebox` remains for the settings-form grid it is built into.
+ *
+ * The row is the click target, so the whole card is the `<label>`. That would
+ * normally fold the description into the accessible name and announce each
+ * option as one run-on string, which is why the title is named explicitly and
+ * the description is attached as a description instead.
+ */
+
+/**
+ * No display utility here: the shell composes onto a `flex` label, and
+ * tailwind-merge resolves same-property utilities by order, so a `block` in this
+ * string silently wins and drops the control onto its own line.
+ *
+ * The focus ring sits on the row rather than the ~13px control — the row is what
+ * the pointer targets and it encloses the control. Scoped to `input` so focusing
+ * a nested dependent control does not also light up the card.
+ */
+export const CHOICE_SHELL =
+  "rounded-[var(--radius-md)] border transition-colors duration-150 " +
+  "has-[input:focus-visible]:outline has-[input:focus-visible]:outline-2 " +
+  "has-[input:focus-visible]:outline-daintree-accent has-[input:focus-visible]:outline-offset-2";
+
+export const CHOICE_PAD = "px-3 py-2.5";
+
+/**
+ * The transparent outline is not decoration. Under `forced-colors: active` the
+ * UA overrides `outline-color` — including `transparent` — to a system colour,
+ * so this is what keeps the chosen card distinguishable once the fill and the
+ * border have both been repainted to the same value. It costs nothing in normal
+ * rendering.
+ */
+export const CHOICE_SELECTED =
+  "border-border-strong bg-overlay-selected outline outline-2 outline-transparent";
+
+export const CHOICE_UNSELECTED =
+  "border-daintree-border hover:bg-overlay-soft hover:border-daintree-text/30";
+
+/** Control (~13px) + `gap-3`, so a nested control lines up with the label column. */
+export const CHOICE_LABEL_INSET = "ml-[25px]";
+
+interface RadioChoiceGroupProps {
+  /** Names the group. Visible unless `legendHidden`. */
+  legend: string;
+  legendHidden?: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function RadioChoiceGroup({
+  legend,
+  legendHidden,
+  children,
+  className,
+}: RadioChoiceGroupProps) {
+  return (
+    <fieldset className={cn("space-y-2", className)}>
+      <legend
+        className={cn(legendHidden ? "sr-only" : "text-sm font-medium text-daintree-text mb-2")}
+      >
+        {legend}
+      </legend>
+      {children}
+    </fieldset>
+  );
+}
+
+interface RadioChoiceRowProps {
+  /**
+   * The group name. Always passed in, never derived from `useId` — end-to-end
+   * specs select these groups by name.
+   */
+  name: string;
+  /** Always emitted as the `value` attribute; specs select on it. */
+  value: string;
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  /** What the user ends up with. Announced as a description, not part of the name. */
+  description?: string;
+  disabled?: boolean;
+  /** Lands on the `<input>`, never on the shell — clicking a wrapper misses the control. */
+  testId?: string;
+  /**
+   * Rendered inside a row that already paints the choice surface, for options
+   * that host a dependent control. The caller owns the shell and must keep the
+   * dependent control outside this label so it cannot retoggle the option.
+   */
+  bare?: boolean;
+  className?: string;
+}
+
+export function RadioChoiceRow({
+  name,
+  value,
+  checked,
+  onChange,
+  label,
+  description,
+  disabled,
+  testId,
+  bare,
+  className,
+}: RadioChoiceRowProps) {
+  const labelId = useId();
+  const descriptionId = useId();
+
+  return (
+    <label
+      className={cn(
+        "flex items-start gap-3",
+        disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+        CHOICE_PAD,
+        // A bare row is padded by the same rule but leaves the border and fill
+        // to the shell that wraps it, so the whole card stays one target.
+        !bare && [CHOICE_SHELL, checked ? CHOICE_SELECTED : CHOICE_UNSELECTED],
+        className
+      )}
+    >
+      <input
+        type="radio"
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+        data-testid={testId}
+        aria-labelledby={labelId}
+        aria-describedby={description ? descriptionId : undefined}
+        // The accent tint comes from the global `accent-color` base rule. The
+        // visible focus indicator is the row's, so the control's own ring is
+        // neutralised with a transparent outline rather than one of the
+        // outline-suppressing utilities, which the repo's focus-ring contract
+        // treats as removing the indicator outright. Left bare it would fall
+        // through to Chromium's cobalt, the one hue the app never renders.
+        // Under forced-colors the UA repaints this outline, so the control
+        // keeps a system ring there as well.
+        //
+        // mt-1 centres the ~13px control in the label's 20px line box.
+        className="mt-1 shrink-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-transparent"
+      />
+      <span className="min-w-0">
+        <span id={labelId} className="block text-sm font-medium text-daintree-text">
+          {label}
+        </span>
+        {description && (
+          <span id={descriptionId} className="block text-xs text-text-secondary select-text">
+            {description}
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}


### PR DESCRIPTION
## Summary

The three start-from options in `AddPresetDialog` were bare radios with loosely attached text, and the selected one was carried almost entirely by a 13px dot. Each option is now a full-width choice surface with a neutral selected treatment, so the set reads as one decision.

Two of the options were also lying. "Clone current" rendered whether or not there was anything to clone, and for an agent with no provider templates that left a two-option group where both options produced exactly the same blank preset. Unavailable options are now absent, and when nothing is left to choose the group is replaced by a plain statement of what will happen.

Resolves #11972

## What changed

**The decision itself**

- Every option is a full-width choice surface. Selected is `border-border-strong bg-overlay-selected`, which is already the app's most common selected treatment (13 other files use it). Nothing here spends accent.
- "Clone current" only renders when there is a preset to clone. "From template" already only rendered when the agent had templates. When both are unavailable, the group is dropped for a sentence, because a one-option radio group cannot be compared or deselected.
- The `Provider` selector moved inside the "From template" card, aligned to its label column and outside its `<label>` so picking a provider cannot retoggle the option. The nesting is structural on purpose: fills and borders get flattened under `forced-colors`, DOM structure does not.
- Descriptions are consequence-first and parallel, so the three options differ only in the part that matters.

**Things the pixels caught that the code review did not**

- The keyboard focus ring was Chromium's cobalt `#99c8ff`, the only blue rendered anywhere in the app, and the exact hue `src/index.css` goes out of its way to strip from the radio fill one rule above. The global `*:focus-visible` rule only wires a transition, it sets no outline colour, so a bare radio fell straight through to the browser default. The focus ring now sits on the row (it matches the click target and encloses the control) in the theme accent.
- Option descriptions were `text-daintree-text/40`, an alpha spelling no token guard measures. Measured in the running app across all fifteen themes: **3.19:1 before, 5.45:1 to 9.61:1 after**. The provider description was a tier lower still at about 4.3:1 and now measures 4.93:1 to 8.29:1. Every theme clears 4.5:1 on both.
- The selected card carries `outline outline-2 outline-transparent`. Invisible normally, but `forced-colors` repaints `outline-color`, so the chosen option stays distinguishable once fill and border have been flattened to the same value.
- Hover changed 213 pixels out of 623,616 (0.034%), all inside the radio itself, because `group-hover:text-daintree-text` set the colour to the colour it already was. Hover now answers on both the fill and the border.

**Accessibility**

Wrapping the whole card in a `<label>` is what makes the row one click target, but it also folds the description into the accessible name and announces each option as one run-on string. Titles are now named explicitly with `aria-labelledby` and the consequence line comes back as `aria-describedby`.

## Consistency

The treatment was extracted to `src/components/ui/RadioChoice.tsx` and rolled out rather than left as a local exception. Four other surfaces used the same bare-radio pattern:

| Surface | What it gains |
|---|---|
| `ImportEnvDialog` | Byte-identical helper to the old one. Straight swap. |
| `ImageViewerTab` | A group name it never had, and the `Command` field nested into its own option. |
| `AutomationTab` | A selected state, which the branch-prefix group had no version of at all. |
| `ResourceEnvironmentsSection` | Descriptions, and a top-aligned rail label. |

Deliberately not built on `SettingsChoicebox`. Its arrows move focus without moving the selection, where a native radio group moves both together. That is the WAI-ARIA APG standard for radios, it is what issue requirements R4 and R5 protect, and the UA-painted checked state is the only thing that still reads as "chosen" under Windows High Contrast.

Not in scope: 164 files still use `text-daintree-text/40` for descriptions. That is a repo-wide change, not this one. `#11973` overlaps on `ImportEnvDialog` and now narrows to its paste and conflict-review states.

## Design review

Scored 7.2, then 9.0, then 9.8 over three rounds against ten dimensions, using real rendered pixels rather than a reading of the source. The last item (a square focus outline around a circular radio) is closed by moving the ring to the row.

Two reviewer findings were rejected and the rejection was accepted. Stripping the terminal periods from the six provider template descriptions at source is out of scope per the issue, and those strings are agent-facing through the `agent.listPresets` MCP schema and pinned by `agentRegistry.test.ts`. The period is trimmed at render instead. The "Add preset" / "Create preset" wording stays, since `e2e/helpers/presets.ts` matches the button by `has-text("Create")` across several suites.

## Testing

`npm run check` passes and `npx vitest run` is green across the full suite. All 20 repo-wide contract suites pass, including the accent guard, the focus-ring fallback contract and the dialog-footer CTA contract.

13 new tests in `src/components/Settings/__tests__/AddPresetDialog.test.tsx`, which had no unit test before. They assert rules rather than values: that no option is offered the dialog cannot honour, that the group is never rendered with fewer than two options, that the options stay in one native radio group, that the provider selector is nested inside its own option and outside its label, and that cloning never silently produces a blank. Each was mutation-checked by reintroducing the bug.

`e2e/screenshots/add-preset-dialog-review.spec.ts` is a new opt-in capture harness covering twelve states plus an all-themes sweep. It asserts the expected text is on screen before writing each PNG, so a state it cannot reach fails loudly instead of leaving a plausible-looking wrong screenshot behind. It also reports the measured contrast of both description roles per theme, which is where the numbers above come from.

```
DAINTREE_SHOT_PRESET=1 npx playwright test --project=screenshots add-preset-dialog-review
```
