### PR TITLE
Preview the commits a push would actually publish

### DIFF
--- a/e2e/screenshots/git-push-confirm-review.spec.ts
+++ b/e2e/screenshots/git-push-confirm-review.spec.ts
@@ -1,0 +1,485 @@
+/**
+ * `GitPushConfirmDialog` visual-review harness (#11979).
+ *
+ * The D2 push confirm is judged on rendered pixels: half of what is wrong with a
+ * preview surface — a truncating message column, a hash rail that reads as noise, a
+ * spinner in an empty box — is invisible in the JSX and obvious in a PNG.
+ *
+ * Every state here is driven through the REAL seams, never a renderer mock:
+ *
+ *   - the loaded states come from a real fixture repo with a real bare remote, so
+ *     `resolveGitPushDestination` resolves a real destination and `git log` returns
+ *     real commits. Switching state means `git checkout` in the fixture, exactly as a
+ *     user would arrive at it.
+ *   - loading and load-failure come from the main-process fault registry
+ *     (`DAINTREE_E2E_FAULT_MODE=1` + `e2e/helpers/ipcFaults`), so the app takes its
+ *     genuine error path rather than a stubbed one.
+ *   - the dialog is opened by dispatching `git.push` itself. It is NEVER confirmed —
+ *     every step leaves by Escape, which resolves the deferred promise `false`.
+ *
+ *   DAINTREE_SHOT_GITPUSH=1 npx playwright test --project=screenshots git-push-confirm-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_GITPUSH  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME    optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG      optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY     comma-separated step filter (see step names below)
+ *   DAINTREE_SHOT_OUT      optional absolute output dir (default artifacts/git-push-confirm-shots)
+ *
+ * Output: <out>/<NN-slug>[-tag].png (artifacts/ is gitignored).
+ */
+
+import { test, type Page } from "@playwright/test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { injectDelay, injectFault, clearAllFaults } from "../helpers/ipcFaults";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_GITPUSH;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ??
+  path.resolve(process.cwd(), "artifacts", "git-push-confirm-shots");
+
+/**
+ * The dialog CARD, not the surface element.
+ *
+ * `AppDialog` puts `role="dialog"` on the `fixed inset-0` scrim, so screenshotting
+ * the role selector silently returns the whole window — a full-window PNG that looks
+ * like a successful crop until you compare its dimensions.
+ */
+const DIALOG = "[data-app-dialog-surface] > div";
+
+/**
+ * The stable testid contract this harness asserts against. The redesign may move,
+ * restyle, or re-shape any of these — it must not delete them, or the harness stops
+ * being able to prove the state it captured is the state it meant to capture.
+ */
+const TID = {
+  noDestination: '[data-testid="git-push-no-destination"]',
+  loading: '[data-testid="git-push-commits-loading"]',
+  retry: '[data-testid="git-push-commits-retry"]',
+  commitRow: '[data-testid="git-push-commit-row"]',
+} as const;
+
+const CH = {
+  listCommits: "git:list-commits",
+  stagingStatus: "git:get-staging-status",
+  listPushCommits: "git:list-push-commits",
+} as const;
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+/**
+ * execFile, not execSync with an interpolated string: commit messages and branch
+ * names here deliberately contain the punctuation a shell would eat.
+ */
+function git(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function commit(dir: string, file: string, body: string, message: string, author: string): void {
+  const target = path.join(dir, file);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, body);
+  git(["add", "-A"], dir);
+  git(["-c", `user.name=${author}`, "-c", "user.email=dev@daintree.dev", "commit", "-m", message], dir);
+}
+
+/** Realistic subjects: a mix of lengths, conventional-commit prefixes, and one that clips. */
+const SUBJECTS: Array<[string, string]> = [
+  ["fix(pty): stop the resize observer firing during a parser drain", "Ada Lovelace"],
+  ["refactor(store): collapse the two worktree selectors into one", "Grace Hopper"],
+  ["feat(review): show the CI status pill inline on each pull-request row", "Katherine Johnson"],
+  ["chore: bump electron to 42.0.3", "Ada Lovelace"],
+  ["fix(theme): raise the working-state contrast in namib and svalbard", "Radia Perlman"],
+  [
+    "fix(worktree): resolve the push destination through git rather than assuming origin, so a branch configured to push to a fork stops writing to the wrong repository",
+    "Barbara Liskov",
+  ],
+  ["test(e2e): unflake the terminal-identity transition spec", "Grace Hopper"],
+  ["docs: describe the destructive-action tiers", "Ada Lovelace"],
+  ["perf(grid): memoise the panel layout measurement", "Margaret Hamilton"],
+  ["fix(mcp): reject an output schema that is not an object", "Radia Perlman"],
+  ["feat(pilot): land focus in the search box on open", "Katherine Johnson"],
+  ["fix(registry): retry a failed chunk load once before falling back", "Barbara Liskov"],
+  ["chore(deps): drop the unused diff-view shim", "Margaret Hamilton"],
+  ["feat(git): add the push-range preview", "Ada Lovelace"],
+];
+
+/**
+ * A repo whose branches each sit in one of the states the dialog has to render, plus
+ * a real bare remote so the destination resolves the way it does in production.
+ *
+ * A SECOND remote exists on purpose: with one remote, an unconfigured branch resolves
+ * to it (`resolveUnconfigured`), so the "no unambiguous destination" state is only
+ * reachable when there is a genuine ambiguity to be had.
+ */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const root = mkdtempSync(path.join(tmpdir(), "daintree-gitpush-shots-"));
+  const dir = path.join(root, "helios-dashboard");
+  const originDir = path.join(root, "origin.git");
+  const mirrorDir = path.join(root, "mirror.git");
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(dir, { recursive: true });
+  mkdirSync(wtRoot, { recursive: true });
+
+  git(["init", "--bare", "-b", "main", originDir], root);
+  git(["init", "--bare", "-b", "main", mirrorDir], root);
+
+  git(["init", "-b", "main", dir], root);
+  git(["config", "user.email", "dev@daintree.dev"], dir);
+  git(["config", "user.name", "Daintree Test"], dir);
+  git(["config", "commit.gpgsign", "false"], dir);
+
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  git(["add", "-A"], dir);
+  git(["commit", "-m", "initial commit"], dir);
+
+  git(["remote", "add", "origin", originDir], dir);
+  git(["remote", "add", "upstream-mirror-eu-west-1", mirrorDir], dir);
+
+  // main: pushed, then run well past the 12-row preview limit so the tail is exercised.
+  git(["push", "-u", "origin", "main"], dir);
+  SUBJECTS.forEach(([message, author], i) => {
+    commit(dir, `src/module-${i}.ts`, `export const m${i} = ${i};\n`, message, author);
+  });
+
+  // one-ahead: the single-commit preview.
+  git(["checkout", "-b", "fix/retry-backoff-jitter", "main~14"], dir);
+  git(["push", "-u", "origin", "fix/retry-backoff-jitter"], dir);
+  commit(
+    dir,
+    "src/backoff.ts",
+    "export const jitter = 0.3;\n",
+    "fix(net): jitter the retry backoff so a fleet doesn't resynchronise",
+    "Grace Hopper"
+  );
+
+  // in-sync: pushed with nothing ahead. The dialog must not imply this pushes anything.
+  git(["checkout", "-b", "chore/bump-electron", "main~14"], dir);
+  git(["push", "-u", "origin", "chore/bump-electron"], dir);
+
+  // long values: a long branch name pushing to the long-named remote, with a long author.
+  const longBranch =
+    "feature/11979-refine-git-push-confirm-dialog-preview-states-and-destination-summary";
+  git(["checkout", "-b", longBranch, "main~14"], dir);
+  git(["push", "-u", "upstream-mirror-eu-west-1", longBranch], dir);
+  commit(
+    dir,
+    "src/preview.ts",
+    "export const preview = true;\n",
+    "feat(git): render the resolved destination, the branch it comes from, and the exact commits the push would publish in one preview region instead of four",
+    "Wilhelmina Fitzgerald-Mackintosh"
+  );
+  commit(
+    dir,
+    "src/preview2.ts",
+    "export const two = 2;\n",
+    "fix: short one",
+    "Jean Bartik"
+  );
+
+  // no destination: never pushed, no push config, two remotes -> genuinely ambiguous.
+  git(["checkout", "-b", "spike/unconfigured-remote", "main~14"], dir);
+  commit(dir, "src/spike.ts", "export const spike = 1;\n", "spike: try the new layout", "Ada Lovelace");
+
+  git(["checkout", "main"], dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Screenshot, but only after the state it claims to be has been proven on screen.
+ *
+ * This is the hard rule of the whole harness: a capture run that quietly writes a
+ * plausible-looking wrong artifact is worse than one that fails, because the review
+ * then reasons about a screen that never existed.
+ */
+async function snap(
+  page: Page,
+  slug: string,
+  opts: { marker: string; locator?: string; markerTimeout?: number }
+): Promise<void> {
+  await page
+    .locator(opts.marker)
+    .first()
+    .waitFor({ state: "visible", timeout: opts.markerTimeout ?? 8000 });
+  await settle(page);
+  // Re-checked AFTER the settle, not only before it: the app's own later render can
+  // replace the state between the assertion and the shutter.
+  if (!(await page.locator(opts.marker).first().isVisible())) {
+    throw new Error(`[git-push-shots] "${slug}": marker ${opts.marker} vanished before the shot`);
+  }
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (opts.locator) {
+    await page.locator(opts.locator).last().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+}
+
+/**
+ * Open the push confirm by dispatching the real action, fire-and-forget.
+ *
+ * NOT awaited: `git.push`'s `run()` blocks on the deferred confirm promise, so
+ * awaiting it here would hang until the dialog resolves. Every caller closes with
+ * Escape, which resolves it `false` — this harness never confirms a push.
+ */
+async function openPushConfirm(page: Page, cwd: string): Promise<void> {
+  await page.evaluate((worktreePath) => {
+    const dispatch = (
+      window as unknown as {
+        __daintreeDispatchAction?: (
+          id: string,
+          args: unknown,
+          opts: unknown
+        ) => Promise<unknown>;
+      }
+    ).__daintreeDispatchAction;
+    if (typeof dispatch !== "function") throw new Error("Action dispatch hook not available");
+    void dispatch("git.push", { worktreePath }, { source: "test" });
+  }, cwd);
+}
+
+async function closeDialog(page: Page): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    if (!(await page.locator(DIALOG).first().isVisible().catch(() => false))) return;
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+  }
+}
+
+/**
+ * Every built-in theme. Switching themes in place crashes the project view under this
+ * harness (the same constraint worktree-dialog-review and confirm-dialog-review hit),
+ * so a cross-theme sweep boots once per theme:
+ *
+ *   for t in <these ids>; do
+ *     DAINTREE_SHOT_GITPUSH=1 DAINTREE_SHOT_THEME=$t DAINTREE_SHOT_TAG=$t \
+ *     DAINTREE_SHOT_ONLY=many npx playwright test --project=screenshots git-push-confirm-review
+ *   done
+ */
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — the remaining shots are still worth having,
+// and a per-theme sweep should not lose fourteen themes to one bad selector. But the
+// run must still FAIL: a silent exit 0 over an empty output directory reads as success.
+const failures: string[] = [];
+
+test("git push confirm review — preview states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_GITPUSH is required for the push-confirm capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_GITPUSH to run the push-confirm capture");
+
+  failures.length = 0;
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-gitpushshot-"));
+  let ctx: AppContext | undefined;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      env: { DAINTREE_E2E_FAULT_MODE: "1" },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const app = ctx.app;
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 2000);
+    await dismissBlockingPalette(page);
+
+    /**
+     * Runs one state, then unconditionally returns to rest. Unconditionally, not on
+     * the success path only: a step that dies holding the dialog open would otherwise
+     * wedge every step after it behind a modal.
+     */
+    const step = async (
+      name: string,
+      branch: string | null,
+      fn: () => Promise<void>
+    ): Promise<void> => {
+      if (ONLY.length > 0 && !ONLY.includes(name)) return;
+      try {
+        if (branch) git(["checkout", branch], repo.dir);
+        await fn();
+      } catch (error) {
+        const detail = String(error).slice(0, 300);
+        console.warn(`[git-push-shots] step "${name}" failed:`, detail);
+        failures.push(`${name}: ${detail}`);
+      } finally {
+        await clearAllFaults(app).catch(() => {});
+        await closeDialog(page).catch((error) => {
+          failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+        });
+        await page.emulateMedia({ forcedColors: null, contrast: null }).catch(() => {});
+      }
+    };
+
+    // 1. The headline state: a real destination and more commits than the preview shows.
+    await step("many", "main", async () => {
+      await openPushConfirm(page, repo.dir);
+      await snap(page, "10-loaded-many", { marker: TID.commitRow, locator: DIALOG });
+      await snap(page, "11-loaded-many-in-window", { marker: TID.commitRow });
+    });
+
+    // 2. One commit — the row treatment with nothing to compare itself against.
+    await step("one", "fix/retry-backoff-jitter", async () => {
+      await openPushConfirm(page, repo.dir);
+      await snap(page, "15-loaded-one", { marker: TID.commitRow, locator: DIALOG });
+    });
+
+    // 3. Nothing ahead of the remote. The state that shows whether the preview
+    //    describes the push range or merely the branch's recent history.
+    await step("in-sync", "chore/bump-electron", async () => {
+      await openPushConfirm(page, repo.dir);
+      await snap(page, "20-in-sync", { marker: SEL.confirmDialog.confirm, locator: DIALOG });
+    });
+
+    // 4. Long everything: branch, remote, subject, author. Where truncation shows up.
+    await step(
+      "long",
+      "feature/11979-refine-git-push-confirm-dialog-preview-states-and-destination-summary",
+      async () => {
+        await openPushConfirm(page, repo.dir);
+        await snap(page, "25-long-values", { marker: TID.commitRow, locator: DIALOG });
+      }
+    );
+
+    // 5. No unambiguous destination — the block that must never degrade into "origin".
+    await step("no-destination", "spike/unconfigured-remote", async () => {
+      await openPushConfirm(page, repo.dir);
+      await snap(page, "30-no-destination", { marker: TID.noDestination, locator: DIALOG });
+    });
+
+    // 6. Preview load failure and its retry, through the real error path.
+    await step("error", "main", async () => {
+      await injectFault(app, CH.stagingStatus, "fatal: not a git repository (or any parent up to mount point /)");
+      await injectFault(app, CH.listPushCommits, "fatal: not a git repository (or any parent up to mount point /)");
+      await openPushConfirm(page, repo.dir);
+      await snap(page, "40-load-error", { marker: TID.retry, locator: DIALOG });
+    });
+
+    // 7. Loading held open by a main-process delay, so the shot is the real in-flight
+    //    render rather than a paused animation frame.
+    await step("loading", "main", async () => {
+      await injectDelay(app, CH.listCommits, 9000);
+      await injectDelay(app, CH.listPushCommits, 9000);
+      await injectDelay(app, CH.stagingStatus, 9000);
+      await openPushConfirm(page, repo.dir);
+      // Past the 400ms Doherty gate, so a gated skeleton has committed to rendering.
+      await page.waitForTimeout(1200);
+      await snap(page, "50-loading", { marker: TID.loading, locator: DIALOG });
+    });
+
+    // 8. Keyboard focus on the primary control — an affordance, not a detail, on a
+    //    surface reached from the palette and a keybinding.
+    await step("focus", "main", async () => {
+      await openPushConfirm(page, repo.dir);
+      await page.locator(TID.commitRow).first().waitFor({ state: "visible", timeout: 8000 });
+      await page.locator(SEL.confirmDialog.confirm).focus();
+      await snap(page, "60-focus-primary", { marker: SEL.confirmDialog.confirm, locator: DIALOG });
+    });
+
+    // 9. prefers-contrast: more — macOS "Increase contrast".
+    await step("contrast", "main", async () => {
+      await page.emulateMedia({ contrast: "more" });
+      await openPushConfirm(page, repo.dir);
+      await snap(page, "70-contrast-more", { marker: TID.commitRow, locator: DIALOG });
+    });
+
+    // 10. forced-colors: active — Windows high contrast swaps in system colours, and
+    //     anything carrying meaning in a tint alone collapses here.
+    await step("forced", "main", async () => {
+      await page.emulateMedia({ forcedColors: "active" });
+      await openPushConfirm(page, repo.dir);
+      await snap(page, "75-forced-colors", { marker: TID.commitRow, locator: DIALOG });
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    try {
+      repo.cleanup();
+    } catch {
+      /* best effort */
+    }
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+
+  // Counted here rather than trusted from the exit code: swallowed per-step errors are
+  // exactly how a harness reports PASS over an empty directory.
+  const written = existsSync(OUTPUT_DIR)
+    ? readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`)).length
+    : 0;
+  console.log(`[git-push-shots] wrote ${written} png(s) to ${OUTPUT_DIR}`);
+
+  if (failures.length > 0) {
+    throw new Error(`[git-push-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`);
+  }
+  if (written === 0) {
+    throw new Error(`[git-push-shots] no PNGs written to ${OUTPUT_DIR}`);
+  }
+});

--- a/e2e/screenshots/git-push-confirm-review.spec.ts
+++ b/e2e/screenshots/git-push-confirm-review.spec.ts
@@ -86,6 +86,13 @@ const POLISH_CSS = `
     transition-delay: 0s !important;
     caret-color: transparent !important;
   }
+  /*
+   * Skeleton bones start at opacity 0 and are faded in by the pulse keyframes
+   * after the 400ms Doherty delay, so the animation freeze above leaves them
+   * INVISIBLE — a loading shot that looks like an empty panel and sends the
+   * whole review off reviewing a screen that does not exist. Pin them visible.
+   */
+  [class*="animate-pulse-"] { opacity: 1 !important; }
 `;
 
 /**

--- a/e2e/screenshots/git-push-confirm-review.spec.ts
+++ b/e2e/screenshots/git-push-confirm-review.spec.ts
@@ -108,7 +108,10 @@ function commit(dir: string, file: string, body: string, message: string, author
   mkdirSync(path.dirname(target), { recursive: true });
   writeFileSync(target, body);
   git(["add", "-A"], dir);
-  git(["-c", `user.name=${author}`, "-c", "user.email=dev@daintree.dev", "commit", "-m", message], dir);
+  git(
+    ["-c", `user.name=${author}`, "-c", "user.email=dev@daintree.dev", "commit", "-m", message],
+    dir
+  );
 }
 
 /** Realistic subjects: a mix of lengths, conventional-commit prefixes, and one that clips. */
@@ -197,17 +200,17 @@ function createFixtureRepo(): { dir: string; cleanup: () => void } {
     "feat(git): render the resolved destination, the branch it comes from, and the exact commits the push would publish in one preview region instead of four",
     "Wilhelmina Fitzgerald-Mackintosh"
   );
-  commit(
-    dir,
-    "src/preview2.ts",
-    "export const two = 2;\n",
-    "fix: short one",
-    "Jean Bartik"
-  );
+  commit(dir, "src/preview2.ts", "export const two = 2;\n", "fix: short one", "Jean Bartik");
 
   // no destination: never pushed, no push config, two remotes -> genuinely ambiguous.
   git(["checkout", "-b", "spike/unconfigured-remote", "main~14"], dir);
-  commit(dir, "src/spike.ts", "export const spike = 1;\n", "spike: try the new layout", "Ada Lovelace");
+  commit(
+    dir,
+    "src/spike.ts",
+    "export const spike = 1;\n",
+    "spike: try the new layout",
+    "Ada Lovelace"
+  );
 
   git(["checkout", "main"], dir);
 
@@ -268,11 +271,7 @@ async function openPushConfirm(page: Page, cwd: string): Promise<void> {
   await page.evaluate((worktreePath) => {
     const dispatch = (
       window as unknown as {
-        __daintreeDispatchAction?: (
-          id: string,
-          args: unknown,
-          opts: unknown
-        ) => Promise<unknown>;
+        __daintreeDispatchAction?: (id: string, args: unknown, opts: unknown) => Promise<unknown>;
       }
     ).__daintreeDispatchAction;
     if (typeof dispatch !== "function") throw new Error("Action dispatch hook not available");
@@ -282,7 +281,14 @@ async function openPushConfirm(page: Page, cwd: string): Promise<void> {
 
 async function closeDialog(page: Page): Promise<void> {
   for (let i = 0; i < 3; i++) {
-    if (!(await page.locator(DIALOG).first().isVisible().catch(() => false))) return;
+    if (
+      !(await page
+        .locator(DIALOG)
+        .first()
+        .isVisible()
+        .catch(() => false))
+    )
+      return;
     await page.keyboard.press("Escape").catch(() => {});
     await settle(page, 200);
   }
@@ -421,8 +427,16 @@ test("git push confirm review — preview states", async () => {
 
     // 6. Preview load failure and its retry, through the real error path.
     await step("error", "main", async () => {
-      await injectFault(app, CH.stagingStatus, "fatal: not a git repository (or any parent up to mount point /)");
-      await injectFault(app, CH.listPushCommits, "fatal: not a git repository (or any parent up to mount point /)");
+      await injectFault(
+        app,
+        CH.stagingStatus,
+        "fatal: not a git repository (or any parent up to mount point /)"
+      );
+      await injectFault(
+        app,
+        CH.listPushCommits,
+        "fatal: not a git repository (or any parent up to mount point /)"
+      );
       await openPushConfirm(page, repo.dir);
       await snap(page, "40-load-error", { marker: TID.retry, locator: DIALOG });
     });

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -348,6 +348,7 @@ export const CHANNELS = {
   GIT_PULL_REBASE: "git:pull-rebase",
   GIT_FORCE_PUSH_WITH_LEASE: "git:force-push-with-lease",
   GIT_LIST_REMOTE_COMMITS: "git:list-remote-commits",
+  GIT_LIST_PUSH_COMMITS: "git:list-push-commits",
   GIT_PUSH_PROGRESS: "git:push-progress",
   GIT_GET_STAGING_STATUS: "git:get-staging-status",
   GIT_COMPARE_WORKTREES: "git:compare-worktrees",

--- a/electron/ipc/handlers/__tests__/git-write.pushDestination.test.ts
+++ b/electron/ipc/handlers/__tests__/git-write.pushDestination.test.ts
@@ -67,24 +67,36 @@ const UPSTREAM_REMOTE = "origin";
 const UPSTREAM_BRANCH = "release/topic";
 const UPSTREAM_REF = `refs/remotes/${UPSTREAM_REMOTE}/${UPSTREAM_BRANCH}`;
 
+const FOR_EACH_REF = `refs/heads/${LOCAL_BRANCH}\u0000${REMOTE}\u0000${PUSH_REF}`;
+const FOR_EACH_REF_UPSTREAM = `refs/heads/${LOCAL_BRANCH}\u0000${UPSTREAM_REMOTE}\u0000${UPSTREAM_REF}`;
+
+/**
+ * The shared `git.raw` behaviour, callable on its own so a double that
+ * intercepts part of the argv can delegate the rest here rather than restating
+ * the ref-resolution config a second time.
+ */
+function rawResponder(forEachRef: string, forEachRefUpstream: string) {
+  return async (args: string[]): Promise<string> => {
+    if (args[0] === "for-each-ref") {
+      const format = args[1] ?? "";
+      return `${format.includes("upstream") ? forEachRefUpstream : forEachRef}\n`;
+    }
+    if (args[0] === "rev-list") return "7\n";
+    return "";
+  };
+}
+
 function makeGit(
   overrides: FakeGit = {},
-  forEachRef = `refs/heads/${LOCAL_BRANCH}\u0000${REMOTE}\u0000${PUSH_REF}`,
-  forEachRefUpstream = `refs/heads/${LOCAL_BRANCH}\u0000${UPSTREAM_REMOTE}\u0000${UPSTREAM_REF}`
+  forEachRef = FOR_EACH_REF,
+  forEachRefUpstream = FOR_EACH_REF_UPSTREAM
 ): FakeGit {
   return {
     revparse: vi.fn(async (args: string[]) => {
       if (args[0] === "--abbrev-ref" && args[1] === "HEAD") return `${LOCAL_BRANCH}\n`;
       return "aaaaaaaabbbbbbbbccccccccdddddddd\n";
     }),
-    raw: vi.fn(async (args: string[]) => {
-      if (args[0] === "for-each-ref") {
-        const format = args[1] ?? "";
-        return `${format.includes("upstream") ? forEachRefUpstream : forEachRef}\n`;
-      }
-      if (args[0] === "rev-list") return "7\n";
-      return "";
-    }),
+    raw: vi.fn(rawResponder(forEachRef, forEachRefUpstream)),
     getRemotes: vi.fn(async () => [
       { name: "origin", refs: { fetch: "", push: "" } },
       { name: REMOTE, refs: { fetch: "", push: "" } },
@@ -253,6 +265,142 @@ describe("list-remote-commits — resolved destination", () => {
       "--count",
       `refs/heads/${LOCAL_BRANCH}..${PUSH_REF}`,
     ]);
+  });
+});
+
+describe("list-push-commits — publish range", () => {
+  const LOCAL_REF = `refs/heads/${LOCAL_BRANCH}`;
+  /** A 40-hex sha, so `readRemoteBranchTip` accepts the ls-remote line. */
+  const REMOTE_TIP = "0123456789abcdef0123456789abcdef01234567";
+
+  /**
+   * A git double for the preview's two probes. `knownRefs` decides what
+   * `rev-parse --verify` resolves — which is how the handler learns whether a
+   * remote-tracking ref exists — and `lsRemote` is the remote's own answer,
+   * kept independent of it so every branch of the basis choice is reachable.
+   */
+  function makePreviewGit(opts: {
+    knownRefs?: string[];
+    lsRemote?: () => Promise<string>;
+  }): FakeGit {
+    const knownRefs = new Set(opts.knownRefs ?? []);
+    const git = makeGit({
+      log: vi.fn(async () => ({
+        all: [{ hash: "h1", date: "d", message: "m", author_name: "a" }],
+      })),
+    });
+    const fallback = rawResponder(FOR_EACH_REF, FOR_EACH_REF_UPSTREAM);
+    git.raw = vi.fn(async (args: string[]) => {
+      if (args[0] === "rev-parse") {
+        const ref = (args[3] ?? "").replace(/\^\{commit\}$/, "");
+        if (!knownRefs.has(ref)) throw new Error("fatal: bad revision");
+        return `${REMOTE_TIP}\n`;
+      }
+      if (args[0] === "ls-remote") {
+        if (!opts.lsRemote) throw new Error("ls-remote was not expected here");
+        return opts.lsRemote();
+      }
+      return fallback(args);
+    });
+    return git;
+  }
+
+  /** Every argv a git double was called with, for the negative assertions. */
+  function argvOf(fn: ReturnType<typeof vi.fn>): string[][] {
+    return fn.mock.calls.map((call: unknown[]) => (call[0] ?? []) as string[]);
+  }
+
+  function listPushCommits(git: FakeGit) {
+    createHardenedGitMock.mockResolvedValue(git);
+    return getHandler("git:list-push-commits")(FAKE_EVENT, {
+      cwd: CWD,
+      branchName: LOCAL_BRANCH,
+      limit: 5,
+    }) as Promise<{ rangeBasis: string; total: number; destination: unknown }>;
+  }
+
+  it("ranges from the destination's tracking ref up to the named branch", async () => {
+    const git = makePreviewGit({ knownRefs: [PUSH_REF] });
+
+    const result = await listPushCommits(git);
+
+    // The range runs remote..local, the opposite direction from the discard
+    // preview above: these are the commits the push would ADD.
+    expect(git.log).toHaveBeenCalledWith(["--max-count=5", `${PUSH_REF}..${LOCAL_REF}`]);
+    expect(git.raw).toHaveBeenCalledWith(["rev-list", "--count", `${PUSH_REF}..${LOCAL_REF}`]);
+    expect(result.rangeBasis).toBe("tracked");
+    expect(result.destination).toEqual({ remote: REMOTE, branch: REMOTE_BRANCH });
+    // A tracking ref we hold is a settled answer; nothing justifies the network.
+    expect(argvOf(git.raw).some((args) => args[0] === "ls-remote")).toBe(false);
+    // Never HEAD: it resolves to whatever is checked out when the range is
+    // measured, not to the branch the approver was shown.
+    expect(argvOf(git.log).some((args) => args.some((a) => a.includes("HEAD")))).toBe(false);
+  });
+
+  it("claims a creation only after the remote reports no such branch", async () => {
+    const git = makePreviewGit({ knownRefs: [], lsRemote: async () => "" });
+
+    const result = await listPushCommits(git);
+
+    expect(git.raw).toHaveBeenCalledWith([
+      "ls-remote",
+      "--heads",
+      "--",
+      REMOTE,
+      `refs/heads/${REMOTE_BRANCH}`,
+    ]);
+    expect(git.log).toHaveBeenCalledWith(["--max-count=5", LOCAL_REF]);
+    expect(result.rangeBasis).toBe("creates");
+  });
+
+  it("ranges from a remote-named tip this repository already holds", async () => {
+    const git = makePreviewGit({
+      knownRefs: [REMOTE_TIP],
+      lsRemote: async () => `${REMOTE_TIP}\trefs/heads/${REMOTE_BRANCH}\n`,
+    });
+
+    const result = await listPushCommits(git);
+
+    expect(git.log).toHaveBeenCalledWith(["--max-count=5", `${REMOTE_TIP}..${LOCAL_REF}`]);
+    expect(result.rangeBasis).toBe("tracked");
+  });
+
+  it("marks the range unverified rather than claiming a creation when the remote is unreachable", async () => {
+    const git = makePreviewGit({
+      knownRefs: [],
+      lsRemote: () => Promise.reject(new Error("Could not read from remote repository")),
+    });
+
+    const result = await listPushCommits(git);
+
+    // The local approximation excludes everything already on ANY ref of that
+    // remote — an over-count would read as commits this push publishes.
+    expect(git.log).toHaveBeenCalledWith([
+      "--max-count=5",
+      LOCAL_REF,
+      "--not",
+      `--remotes=${REMOTE}`,
+    ]);
+    expect(result.rangeBasis).toBe("unverified");
+    expect(result.rangeBasis).not.toBe("creates");
+  });
+
+  it("counts the tail over the same range the rows came from", async () => {
+    const git = makePreviewGit({
+      knownRefs: [],
+      lsRemote: () => Promise.reject(new Error("offline")),
+    });
+
+    const result = await listPushCommits(git);
+
+    expect(git.raw).toHaveBeenCalledWith([
+      "rev-list",
+      "--count",
+      LOCAL_REF,
+      "--not",
+      `--remotes=${REMOTE}`,
+    ]);
+    expect(result.total).toBe(7);
   });
 });
 

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -208,11 +208,14 @@ const gitPushPreviewNamespace = defineIpcNamespace({
           const localRef = `refs/heads/${branchName}`;
           const hasRemoteRef = await refExists(git, destination.remoteTrackingRef);
 
-          // A branch that has never been pushed has no remote-tracking ref to
-          // subtract, and `<missing>..<branch>` is a fatal argument rather than
-          // "everything". What such a push publishes is whatever is not already
-          // reachable from some other ref on that remote, which is what git
-          // itself would transfer — so ask for exactly that.
+          // With no remote-tracking ref there is nothing to subtract, and
+          // `<missing>..<branch>` is a fatal argument rather than "everything".
+          // Fall back to whatever is not already reachable from any ref held for
+          // that remote. That over-reports when the branch exists remotely and
+          // simply has not been fetched — the safe direction for a destructive
+          // preview, and the reason `rangeBasis` travels with the rows so the
+          // surface can say the list is an upper bound instead of asserting a
+          // branch creation only the remote can confirm.
           const revArgs = hasRemoteRef
             ? [`${destination.remoteTrackingRef}..${localRef}`]
             : [localRef, "--not", `--remotes=${destination.remote}`];
@@ -224,7 +227,7 @@ const gitPushPreviewNamespace = defineIpcNamespace({
 
           return {
             destination: { remote: destination.remote, branch: destination.branch },
-            createsRemoteBranch: !hasRemoteRef,
+            rangeBasis: hasRemoteRef ? "tracked" : "untracked",
             total,
             commits: log.all.map((commit) => ({
               hash: commit.hash,

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -156,6 +156,51 @@ async function refExists(
   }
 }
 
+/** Upper bound on the one network read the push preview is allowed to make. */
+const PUSH_PREVIEW_LS_REMOTE_TIMEOUT_MS = 4000;
+
+/**
+ * The destination branch's tip according to the REMOTE, or `undefined` when the
+ * remote could not be asked.
+ *
+ * `null` is a real answer — the remote replied and has no such branch — and is
+ * what lets the preview say a push creates a branch instead of guessing from the
+ * absence of a local ref. `undefined` is "no answer", which the caller must
+ * treat as unverified rather than as absence.
+ *
+ * Bounded and swallowed on purpose. This runs while a confirm dialog is waiting,
+ * so a slow or unreachable remote must degrade the preview's precision, never
+ * hold the dialog open — the local approximation is still shown, labelled.
+ */
+async function readRemoteBranchTip(
+  git: Pick<Awaited<ReturnType<typeof createHardenedGit>>, "raw">,
+  remote: string,
+  branch: string
+): Promise<string | null | undefined> {
+  try {
+    const out = await Promise.race([
+      // `--` before the remote so a remote whose name survived the argv guard
+      // still cannot be read as an option, and the ref given in full.
+      git.raw(["ls-remote", "--heads", "--", remote, `refs/heads/${branch}`]),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("ls-remote timed out")),
+          PUSH_PREVIEW_LS_REMOTE_TIMEOUT_MS
+        )
+      ),
+    ]);
+    const line = out
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.length > 0);
+    if (!line) return null;
+    const sha = line.split(/\s+/)[0] ?? "";
+    return /^[0-9a-f]{40,64}$/i.test(sha) ? sha : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * The commits a push would actually publish (#11979).
  *
@@ -208,17 +253,44 @@ const gitPushPreviewNamespace = defineIpcNamespace({
           const localRef = `refs/heads/${branchName}`;
           const hasRemoteRef = await refExists(git, destination.remoteTrackingRef);
 
-          // With no remote-tracking ref there is nothing to subtract, and
+          // With no remote-tracking ref there is nothing to subtract locally, and
           // `<missing>..<branch>` is a fatal argument rather than "everything".
-          // Fall back to whatever is not already reachable from any ref held for
-          // that remote. That over-reports when the branch exists remotely and
-          // simply has not been fetched — the safe direction for a destructive
-          // preview, and the reason `rangeBasis` travels with the rows so the
-          // surface can say the list is an upper bound instead of asserting a
-          // branch creation only the remote can confirm.
-          const revArgs = hasRemoteRef
-            ? [`${destination.remoteTrackingRef}..${localRef}`]
-            : [localRef, "--not", `--remotes=${destination.remote}`];
+          //
+          // Ask the remote before guessing. A missing tracking ref does not mean
+          // a missing branch — it also happens when the branch was never
+          // fetched, was pruned, or is excluded by the fetch refspec — and the
+          // purely local fallback is wrong in BOTH directions: it overstates when
+          // the destination exists but is unfetched, and understates a commit
+          // that sits on another ref of the same remote yet not on the
+          // destination branch, which this push would add.
+          let rangeBasis: GitPushCommitPreview["rangeBasis"];
+          let revArgs: string[];
+          if (hasRemoteRef) {
+            rangeBasis = "tracked";
+            revArgs = [`${destination.remoteTrackingRef}..${localRef}`];
+          } else {
+            const remoteTip = await readRemoteBranchTip(
+              git,
+              destination.remote,
+              destination.branch
+            );
+            if (remoteTip === null) {
+              // The remote answered and has no such branch: the push creates it,
+              // and what it publishes is the branch's own history.
+              rangeBasis = "creates";
+              revArgs = [localRef];
+            } else if (remoteTip && (await refExists(git, remoteTip))) {
+              // The remote named a tip this repository already holds, so the
+              // delta is exact even without a tracking ref.
+              rangeBasis = "tracked";
+              revArgs = [`${remoteTip}..${localRef}`];
+            } else {
+              // No answer, or a tip we cannot resolve. Fall back to the local
+              // approximation and mark it as what it is.
+              rangeBasis = "unverified";
+              revArgs = [localRef, "--not", `--remotes=${destination.remote}`];
+            }
+          }
 
           // No `--no-merges`: the "N more" tail is only honest while the listed
           // rows and `total` describe the same set the push would write.
@@ -227,7 +299,7 @@ const gitPushPreviewNamespace = defineIpcNamespace({
 
           return {
             destination: { remote: destination.remote, branch: destination.branch },
-            rangeBasis: hasRemoteRef ? "tracked" : "untracked",
+            rangeBasis,
             total,
             commits: log.all.map((commit) => ({
               hash: commit.hash,

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -5,11 +5,13 @@ import { realpath } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { CHANNELS } from "../channels.js";
+import { defineIpcNamespace, op } from "../define.js";
 import { checkRateLimit, typedHandle, typedHandleWithContext, sendToRenderer } from "../utils.js";
 import type { HandlerDependencies, IpcContext } from "../types.js";
 import type { PushProgressEvent } from "../../../shared/types/ipc/gitPush.js";
 import type {
   ConflictedFileEntry,
+  GitPushCommitPreview,
   GitRemoteCommitPreview,
   GitStatus,
   RebaseSequence,
@@ -82,15 +84,20 @@ interface StagingFileEntry {
 }
 
 /**
- * `git rev-list --count <range>`. Falls back to 0 on unparseable output, which
+ * `git rev-list --count <rev spec>`. Falls back to 0 on unparseable output, which
  * renders as "no hidden tail" rather than a wrong count — the rows themselves
  * are still shown, so the preview degrades quietly instead of overstating.
+ *
+ * Takes the rev spec as an argument LIST rather than one range string: a push
+ * that creates a remote branch has no `a..b` range to measure and is expressed
+ * as `<branch> --not --remotes=<remote>` instead. Both forms have to reach
+ * `rev-list` unsplit, or a two-word spec would arrive as one bogus revision.
  */
 async function countCommitsInRange(
   git: Pick<Awaited<ReturnType<typeof createHardenedGit>>, "raw">,
-  range: string
+  revArgs: readonly string[]
 ): Promise<number> {
-  const out = await git.raw(["rev-list", "--count", range]);
+  const out = await git.raw(["rev-list", "--count", ...revArgs]);
   const parsed = Number.parseInt(out.trim(), 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
@@ -128,6 +135,124 @@ async function requireRemoteTarget(
     { cwd, op, rawMessage: message, branchName }
   );
 }
+
+/**
+ * Does `ref` name a commit that exists in this repository right now?
+ *
+ * `rev-parse --verify --quiet` exits non-zero without writing to stderr when it
+ * does not, which simple-git surfaces as a rejection — so absence arrives here
+ * as a throw, not as an empty string. `^{commit}` peels an annotated tag rather
+ * than reporting the tag object as a usable range endpoint.
+ */
+async function refExists(
+  git: Pick<Awaited<ReturnType<typeof createHardenedGit>>, "raw">,
+  ref: string
+): Promise<boolean> {
+  try {
+    const out = await git.raw(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]);
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The commits a push would actually publish (#11979).
+ *
+ * The push confirm used to preview `git log HEAD` — the branch's recent history,
+ * which is only the same set when nothing on the branch has ever been pushed. A
+ * branch level with its remote previewed commits that were already published, and
+ * a branch 2 ahead of 14 previewed 12 that mostly were. For a D2 safeguard whose
+ * whole job is "a preview of the ACTUAL content", that is the wrong set.
+ *
+ * Ranged the same way the force-push discard preview is, and reversed: from the
+ * destination's remote-tracking ref up to the named local branch. The branch is
+ * named explicitly rather than read as `HEAD`, because the two diverge the moment
+ * anything checks out another branch between opening the dialog and confirming it.
+ *
+ * Fails CLOSED on an unresolvable destination, via the same `requireRemoteTarget`
+ * every remote-mutating path uses: returning an empty list would read as "nothing
+ * to publish", which is the reassuring answer and the wrong one (#11746).
+ */
+const gitPushPreviewNamespace = defineIpcNamespace({
+  name: "gitPushPreview",
+  ops: {
+    listPushCommits: op(
+      CHANNELS.GIT_LIST_PUSH_COMMITS,
+      async (payload: {
+        cwd: string;
+        branchName: string;
+        limit?: number;
+      }): Promise<GitPushCommitPreview> => {
+        checkRateLimit(CHANNELS.GIT_LIST_PUSH_COMMITS, 10, 10_000);
+        validateCwd(payload?.cwd);
+        if (typeof payload.branchName !== "string" || !payload.branchName.trim()) {
+          throw new Error("Invalid branch name");
+        }
+        const branchName = payload.branchName.trim();
+        const limit = Math.max(1, Math.min(100, payload.limit ?? 20));
+
+        const git = await createHardenedGit(payload.cwd);
+        try {
+          const destination = await requireRemoteTarget(
+            git,
+            branchName,
+            payload.cwd,
+            "list-push-commits"
+          );
+
+          // Every ref is written out in full so a branch named like a flag cannot
+          // reach argv as one: `refs/heads/` and `refs/remotes/` prefixes make a
+          // leading `-` impossible. The remote name is already argv-guarded by
+          // `isSafeRemoteName` inside the resolver.
+          const localRef = `refs/heads/${branchName}`;
+          const hasRemoteRef = await refExists(git, destination.remoteTrackingRef);
+
+          // A branch that has never been pushed has no remote-tracking ref to
+          // subtract, and `<missing>..<branch>` is a fatal argument rather than
+          // "everything". What such a push publishes is whatever is not already
+          // reachable from some other ref on that remote, which is what git
+          // itself would transfer — so ask for exactly that.
+          const revArgs = hasRemoteRef
+            ? [`${destination.remoteTrackingRef}..${localRef}`]
+            : [localRef, "--not", `--remotes=${destination.remote}`];
+
+          // No `--no-merges`: the "N more" tail is only honest while the listed
+          // rows and `total` describe the same set the push would write.
+          const log = await git.log([`--max-count=${limit}`, ...revArgs]);
+          const total = await countCommitsInRange(git, revArgs);
+
+          return {
+            destination: { remote: destination.remote, branch: destination.branch },
+            createsRemoteBranch: !hasRemoteRef,
+            total,
+            commits: log.all.map((commit) => ({
+              hash: commit.hash,
+              date: commit.date,
+              message: commit.message,
+              author: commit.author_name,
+            })),
+          };
+        } catch (error) {
+          if (error instanceof GitOperationError) throw error;
+          const errorMessage = formatErrorMessage(error, "git log failed");
+          const gitReason = classifyGitFailure(error, errorMessage);
+          throw new GitOperationError(
+            gitReason,
+            encodeGitOperationErrorMessage(gitReason, errorMessage, { branchName }),
+            {
+              cwd: payload.cwd,
+              op: "list-push-commits",
+              cause: error instanceof Error ? error : undefined,
+              rawMessage: errorMessage,
+              branchName,
+            }
+          );
+        }
+      }
+    ),
+  },
+});
 
 export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -546,7 +671,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       // against a different repository's ref: `behindCount` comes from upstream
       // status, which in a triangular workflow tracks the fetch remote while the
       // force-push targets the push remote.
-      const total = await countCommitsInRange(git, range);
+      const total = await countCommitsInRange(git, [range]);
 
       return {
         destination: { remote: destination.remote, branch: destination.branch },
@@ -576,6 +701,8 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     }
   };
   handlers.push(typedHandle(CHANNELS.GIT_LIST_REMOTE_COMMITS, handleListRemoteCommits));
+
+  handlers.push(gitPushPreviewNamespace.register());
 
   const handleGetUsername = async (cwd: string): Promise<string | null> => {
     checkRateLimit(CHANNELS.GIT_GET_USERNAME, 20, 10_000);

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2119,6 +2119,8 @@ function buildElectronApi(): ElectronAPI {
 
       listRemoteCommits: (cwd: string, branchName: string, limit?: number) =>
         _unwrappingInvoke(CHANNELS.GIT_LIST_REMOTE_COMMITS, { cwd, branchName, limit }),
+      listPushCommits: (cwd: string, branchName: string, limit?: number) =>
+        _unwrappingInvoke(CHANNELS.GIT_LIST_PUSH_COMMITS, { cwd, branchName, limit }),
 
       onPushProgress: (callback: (event: PushProgressEvent) => void) =>
         _typedOn(CHANNELS.GIT_PUSH_PROGRESS, callback),

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -179,12 +179,22 @@ export interface GitRemoteCommitPreview {
 export interface GitPushCommitPreview {
   destination: GitPushDestination;
   /**
-   * The destination's remote-tracking ref does not exist locally, so this push
-   * CREATES the remote branch rather than fast-forwarding one. The range is then
-   * measured against every other ref on that remote, which is what git would
-   * actually transfer.
+   * How the range was measured, which decides how much the rows can be trusted.
+   *
+   * - `tracked` — the destination has a remote-tracking ref here, and the range
+   *   is exactly `<that ref>..<branch>`.
+   * - `untracked` — it does not, so the range is everything on the branch not
+   *   reachable from any ref this machine holds for that remote.
+   *
+   * `untracked` deliberately does NOT claim the push creates the branch. Only
+   * the remote can settle that, and a tracking ref can be missing because the
+   * branch is new, because it has never been fetched, because it was pruned, or
+   * because the fetch refspec excludes it. Where the branch does exist remotely
+   * and has simply not been fetched, this over-reports — the safe direction for
+   * a destructive preview, and the reason the renderer says so out loud rather
+   * than asserting a creation it cannot verify without a network round trip.
    */
-  createsRemoteBranch: boolean;
+  rangeBasis: "tracked" | "untracked";
   commits: GitRemoteCommit[];
   /** Total commits in the range, which may exceed the returned `commits`. */
   total: number;

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -179,22 +179,20 @@ export interface GitRemoteCommitPreview {
 export interface GitPushCommitPreview {
   destination: GitPushDestination;
   /**
-   * How the range was measured, which decides how much the rows can be trusted.
+   * How the range was established, which decides what the rows may be called.
    *
-   * - `tracked` — the destination has a remote-tracking ref here, and the range
-   *   is exactly `<that ref>..<branch>`.
-   * - `untracked` — it does not, so the range is everything on the branch not
-   *   reachable from any ref this machine holds for that remote.
-   *
-   * `untracked` deliberately does NOT claim the push creates the branch. Only
-   * the remote can settle that, and a tracking ref can be missing because the
-   * branch is new, because it has never been fetched, because it was pruned, or
-   * because the fetch refspec excludes it. Where the branch does exist remotely
-   * and has simply not been fetched, this over-reports — the safe direction for
-   * a destructive preview, and the reason the renderer says so out loud rather
-   * than asserting a creation it cannot verify without a network round trip.
+   * - `tracked` — the delta against the destination tip is exact, either from a
+   *   local remote-tracking ref or from a tip the remote named that this
+   *   repository already has.
+   * - `creates` — the remote confirmed the destination branch does not exist, so
+   *   the push creates it and the rows are the branch's own history.
+   * - `unverified` — neither could be established (no tracking ref, and the
+   *   remote could not be reached or named a tip this repository does not hold).
+   *   The rows are a local approximation that can BOTH overstate and understate,
+   *   so callers must present them as unverified — and an empty one means
+   *   "nothing found locally", never "the destination is up to date".
    */
-  rangeBasis: "tracked" | "untracked";
+  rangeBasis: "tracked" | "creates" | "unverified";
   commits: GitRemoteCommit[];
   /** Total commits in the range, which may exceed the returned `commits`. */
   total: number;

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -168,6 +168,28 @@ export interface GitRemoteCommitPreview {
   total: number;
 }
 
+/**
+ * What a push would actually publish, over the range git itself resolved.
+ *
+ * Distinct from a branch's recent history, which is what a plain `git log HEAD`
+ * returns: the two diverge for every branch that is not entirely unpushed, and a
+ * D2 confirm that shows the second while claiming the first is showing commits
+ * the push will not write (#11979).
+ */
+export interface GitPushCommitPreview {
+  destination: GitPushDestination;
+  /**
+   * The destination's remote-tracking ref does not exist locally, so this push
+   * CREATES the remote branch rather than fast-forwarding one. The range is then
+   * measured against every other ref on that remote, which is what git would
+   * actually transfer.
+   */
+  createsRemoteBranch: boolean;
+  commits: GitRemoteCommit[];
+  /** Total commits in the range, which may exceed the returned `commits`. */
+  total: number;
+}
+
 export interface StagingStatus {
   staged: StagingFileEntry[];
   unstaged: StagingFileEntry[];

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -934,6 +934,11 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       branchName: string,
       limit?: number
     ): Promise<import("../git.js").GitRemoteCommitPreview>;
+    listPushCommits(
+      cwd: string,
+      branchName: string,
+      limit?: number
+    ): Promise<import("../git.js").GitPushCommitPreview>;
     onPushProgress(callback: (event: PushProgressEvent) => void): () => void;
     getStagingStatus(cwd: string): Promise<StagingStatus>;
     abortRepositoryOperation(cwd: string): Promise<void>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -648,6 +648,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: { exists: boolean; alternateBufferEnabled: boolean; error?: string | undefined };
   };
+  "git:list-push-commits": {
+    args: [payload: { cwd: string; branchName: string; limit?: number | undefined }];
+    result: import("../git.js").GitPushCommitPreview;
+  };
   "global-env:get": {
     args: [];
     result: Record<string, string>;

--- a/src/components/Git/GitPullRebaseConfirmDialog.tsx
+++ b/src/components/Git/GitPullRebaseConfirmDialog.tsx
@@ -48,7 +48,7 @@ function GitPullRebaseConfirmDialogInner() {
     safeFireAndForget(
       // Shared with the MCP confirm surface so agent and human approvers see
       // the identical fresh branch/commit content (#11538).
-      buildGitRemoteOperationPreview(cwd)
+      buildGitRemoteOperationPreview(cwd, "pull-rebase")
         .then((preview) => {
           if (requestIdRef.current !== requestId) return;
           setBranch(preview.branch);

--- a/src/components/Git/GitPushConfirmDialog.tsx
+++ b/src/components/Git/GitPushConfirmDialog.tsx
@@ -10,6 +10,7 @@ import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { isClientGitError } from "@/utils/clientGitError";
 import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
 import {
   buildGitRemoteOperationPreview,
@@ -93,7 +94,13 @@ function GitPushConfirmDialogInner() {
         })
         .catch((err: unknown) => {
           if (requestIdRef.current !== requestId) return;
-          setLoadError(formatErrorMessage(err, "Failed to load push preview"));
+          // `git:list-push-commits` fails as a `GitOperationError`, and the
+          // preload carries its discriminant across the realm boundary encoded
+          // INTO the message (`[GitError|<reason>||<branch>] fatal: …`). The
+          // guard strips that prefix in place and is idempotent, so format
+          // after calling it or the dialog shows the user the encoding.
+          isClientGitError(err);
+          setLoadError(formatErrorMessage(err, "Git ended the read without saying why."));
         })
         .finally(() => {
           if (requestIdRef.current !== requestId) return;

--- a/src/components/Git/GitPushConfirmDialog.tsx
+++ b/src/components/Git/GitPushConfirmDialog.tsx
@@ -6,6 +6,8 @@ import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
@@ -53,6 +55,17 @@ function GitPushConfirmDialogInner() {
   const [pushRange, setPushRange] = useState<GitPushRangeFacts | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  /**
+   * The cwd the currently-held preview actually describes.
+   *
+   * Approval is gated on this matching the pending request, not merely on
+   * "something loaded". The dialog keeps its state across close/open — the host
+   * stays mounted and only returns null — so without this a second confirm for a
+   * DIFFERENT worktree renders the previous worktree's branch, destination and
+   * commits for the frames between render and effect, with Push enabled against
+   * them.
+   */
+  const [loadedFor, setLoadedFor] = useState<string | null>(null);
   const requestIdRef = useRef(0);
 
   const loadPreview = useCallback(() => {
@@ -64,6 +77,7 @@ function GitPushConfirmDialogInner() {
     setDestination(null);
     setCommits(null);
     setPushRange(null);
+    setLoadedFor(null);
 
     safeFireAndForget(
       // Shared with the MCP confirm surface so agent and human approvers see
@@ -75,6 +89,7 @@ function GitPushConfirmDialogInner() {
           setDestination(preview.destination);
           setCommits(preview.commits);
           setPushRange(preview.pushRange);
+          setLoadedFor(cwd);
         })
         .catch((err: unknown) => {
           if (requestIdRef.current !== requestId) return;
@@ -90,16 +105,27 @@ function GitPushConfirmDialogInner() {
 
   useEffect(() => {
     if (!cwd) {
+      // Bumped, not just cleared: a request already in flight when the dialog
+      // closes would otherwise land its `.then` and repopulate state while
+      // hidden, ready to be shown to whatever asks next.
+      requestIdRef.current++;
       setBranch(null);
       setDestination(null);
       setCommits(null);
       setPushRange(null);
+      setLoadedFor(null);
       setLoadError(null);
       setIsLoading(false);
       return;
     }
     loadPreview();
   }, [cwd, loadPreview]);
+
+  // The skeleton's 400ms gate lives in `animate-pulse-delayed`'s own
+  // animation-delay, so it is free. The footer hint is plain text and had no
+  // gate at all, which put a "checking…" line on screen for fetches that
+  // resolved before the bones ever became visible.
+  const showPendingHint = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
 
   // Resolve false on unmount to prevent a leaked awaited Promise.
   useEffect(() => {
@@ -113,27 +139,33 @@ function GitPushConfirmDialogInner() {
   if (!pendingConfirm) return null;
 
   const destinationLabel = destination ? formatGitPushDestination(destination) : null;
-  const isLoaded_ = !isLoading && !loadError;
+  // Settled means "this request's own fresh answer is on screen". `isLoading`
+  // starts false and the fetch only begins in an effect, so a check that asked
+  // merely whether loading had finished classified the first painted frame as
+  // "no destination" and flashed that error before anything had been read.
+  const isSettled = !isLoading && !loadError && loadedFor === cwd;
   // Checked BEFORE the missing-destination branch. A detached HEAD also resolves
   // no destination, but telling someone with no branch checked out to configure
   // a push remote for it is both the wrong diagnosis and an unfollowable fix.
-  const isDetached = isLoaded_ && commits !== null && branch === null;
-  const isDestinationMissing = isLoaded_ && !isDetached && destination === null;
-  const isLoaded = isLoaded_ && commits !== null;
-  const isInSync = isLoaded && commits.length === 0 && destination !== null;
+  const isDetached = isSettled && commits !== null && branch === null;
+  const isDestinationMissing = isSettled && !isDetached && destination === null;
+  const isLoaded = isSettled && commits !== null;
+  const isCreatingBranch = pushRange?.rangeBasis === "creates";
+  const isUnverified = pushRange?.rangeBasis === "unverified";
+  // "Already has everything" is a categorical claim, so it needs a range that was
+  // actually settled against the destination. An unverified one was not, and an
+  // empty one there means "nothing found locally", not "nothing to send".
+  const isInSync = isLoaded && commits.length === 0 && destination !== null && !isUnverified;
+  const isEmptyUnverified =
+    isLoaded && commits.length === 0 && destination !== null && isUnverified;
   const total = pushRange?.total ?? commits?.length ?? 0;
-  // No remote-tracking ref means the range was measured against everything this
-  // machine holds for that remote, so it can only over-report. Saying so is the
-  // honest version of the "creates this branch" claim that cannot be verified
-  // without a network round trip.
-  const isUpperBound = pushRange?.rangeBasis === "untracked";
   const hiddenCount = commits ? Math.max(0, total - commits.length) : 0;
 
   // A destination nobody can name can't be approved — the handler would refuse
   // the write anyway, and guessing `origin` is the bug (#11746). `commits === null`
   // is "not loaded", which is a different thing from a loaded empty range: an
   // in-sync branch is approvable and pushes nothing (#9575).
-  const confirmDisabled = commits === null || !destination || !!loadError;
+  const confirmDisabled = !isSettled || commits === null || !destination || !!loadError;
 
   // Names the one unmet prerequisite rather than leaving a dead button to be
   // read as arbitrary. Ordered by which the user can act on first.
@@ -143,7 +175,7 @@ function GitPushConfirmDialogInner() {
       ? "Push stays blocked until a branch is checked out"
       : isDestinationMissing
         ? "Push stays blocked until a destination is set"
-        : isLoading
+        : showPendingHint
           ? "Checking what this would publish…"
           : null;
 
@@ -180,9 +212,9 @@ function GitPushConfirmDialogInner() {
       <div className="rounded border border-tint/[0.08] bg-tint/[0.04] text-xs">
         <dl className="px-3 py-2 space-y-1.5" data-testid="git-push-destination-summary">
           <SummaryRow label="From">
-            {branch ? (
+            {branch && isSettled ? (
               <RefChip value={branch} />
-            ) : isLoading ? (
+            ) : !isSettled && !loadError ? (
               <Bone className="w-40" />
             ) : loadError ? (
               <Unknown />
@@ -191,14 +223,15 @@ function GitPushConfirmDialogInner() {
             )}
           </SummaryRow>
           <SummaryRow label="To">
-            {destinationLabel ? (
+            {destinationLabel && isSettled ? (
               <span className="flex flex-wrap items-baseline gap-1.5">
                 <RefChip value={destinationLabel} emphasis />
-                {isUpperBound && (
-                  <span className="text-[10px] text-daintree-text/55">no local copy</span>
+                {isCreatingBranch && (
+                  <span className="text-[10px] text-daintree-text/55">creates this branch</span>
                 )}
+                {isUnverified && <span className="text-[10px] text-status-error">unverified</span>}
               </span>
-            ) : isLoading ? (
+            ) : !isSettled && !loadError ? (
               <Bone className="w-48" />
             ) : loadError ? (
               <Unknown />
@@ -215,7 +248,7 @@ function GitPushConfirmDialogInner() {
             className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
           >
             Commits to push
-            {isLoaded && total > 0 && (
+            {isSettled && total > 0 && (
               <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
                 {total}
               </span>
@@ -223,7 +256,7 @@ function GitPushConfirmDialogInner() {
           </span>
         </div>
 
-        {isLoading && (
+        {!isSettled && !loadError && (
           // `Skeleton` is what makes this reach a screen reader: the bones alone
           // are decorative, so a blocked Push with no announced busy state left
           // an AT user with a dead button and no explanation.
@@ -279,12 +312,14 @@ function GitPushConfirmDialogInner() {
             <div className="flex-1 min-w-0" data-testid="git-push-no-destination">
               <div className="font-medium">No destination git can name</div>
               <div className="mt-0.5 text-daintree-text/70">
-                This branch has no push destination, or more than one remote could be meant. Set an
-                upstream, or name the remote yourself:
-                {/* Its own line, and unbroken: wrapped inline it split as
-                    "with g / it config", which is not a command anyone can run. */}
+                This branch has no push destination, or more than one remote could be meant. Setting
+                an upstream resolves both:
+                {/* `git config branch.<n>.pushRemote <remote>` alone is NOT
+                    reliable here: under the default push.default it leaves the
+                    push ref empty, the resolver still refuses, and the user
+                    lands back on this screen having followed the instruction. */}
                 <span className="mt-1 block font-mono text-daintree-text/80 whitespace-nowrap overflow-x-auto">
-                  git config branch.&lt;name&gt;.pushRemote &lt;remote&gt;
+                  git push -u &lt;remote&gt; {branch ?? "<branch>"}
                 </span>
               </div>
             </div>
@@ -294,6 +329,13 @@ function GitPushConfirmDialogInner() {
         {isInSync && (
           <div className="px-3 py-3 text-daintree-text/60" data-testid="git-push-in-sync">
             Nothing to publish &mdash; {destinationLabel} already has everything on this branch.
+          </div>
+        )}
+
+        {isEmptyUnverified && (
+          <div className="px-3 py-3 text-daintree-text/60" data-testid="git-push-empty-unverified">
+            Nothing found to publish, but {destination?.remote} couldn&apos;t be reached to check{" "}
+            {destinationLabel} &mdash; so this isn&apos;t confirmed.
           </div>
         )}
 
@@ -331,10 +373,10 @@ function GitPushConfirmDialogInner() {
                   </span>
                 </li>
               ))}
-              {isUpperBound && (
-                <li className="text-[11px] text-daintree-text/55 pt-0.5">
-                  No local copy of {destinationLabel} &mdash; this list is an upper bound and may
-                  include commits it already has.
+              {isUnverified && (
+                <li className="text-[11px] text-status-error pt-0.5">
+                  Couldn&apos;t reach {destination?.remote} to check {destinationLabel}, so this
+                  list is unverified.
                 </li>
               )}
               {hiddenCount > 0 && (
@@ -346,6 +388,12 @@ function GitPushConfirmDialogInner() {
           </ScrollShadow>
         )}
       </div>
+      {/* The quietest tier on the surface, and last: this is the least specific
+          thing the dialog has to say, but it is the one question a push raises
+          that nothing else here answers. */}
+      <p className="text-[11px] text-daintree-text/55">
+        If the remote has moved on, Git refuses the push rather than overwriting it.
+      </p>
     </ConfirmDialog>
   );
 }

--- a/src/components/Git/GitPushConfirmDialog.tsx
+++ b/src/components/Git/GitPushConfirmDialog.tsx
@@ -3,6 +3,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Button } from "@/components/ui/button";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -112,10 +113,20 @@ function GitPushConfirmDialogInner() {
   if (!pendingConfirm) return null;
 
   const destinationLabel = destination ? formatGitPushDestination(destination) : null;
-  const isDestinationMissing = !isLoading && !loadError && destination === null;
-  const isLoaded = !isLoading && !loadError && commits !== null;
+  const isLoaded_ = !isLoading && !loadError;
+  // Checked BEFORE the missing-destination branch. A detached HEAD also resolves
+  // no destination, but telling someone with no branch checked out to configure
+  // a push remote for it is both the wrong diagnosis and an unfollowable fix.
+  const isDetached = isLoaded_ && commits !== null && branch === null;
+  const isDestinationMissing = isLoaded_ && !isDetached && destination === null;
+  const isLoaded = isLoaded_ && commits !== null;
   const isInSync = isLoaded && commits.length === 0 && destination !== null;
   const total = pushRange?.total ?? commits?.length ?? 0;
+  // No remote-tracking ref means the range was measured against everything this
+  // machine holds for that remote, so it can only over-report. Saying so is the
+  // honest version of the "creates this branch" claim that cannot be verified
+  // without a network round trip.
+  const isUpperBound = pushRange?.rangeBasis === "untracked";
   const hiddenCount = commits ? Math.max(0, total - commits.length) : 0;
 
   // A destination nobody can name can't be approved — the handler would refuse
@@ -128,24 +139,30 @@ function GitPushConfirmDialogInner() {
   // read as arbitrary. Ordered by which the user can act on first.
   const blockedReason = loadError
     ? "Push stays blocked until the preview loads"
-    : isDestinationMissing
-      ? "Push stays blocked until a destination is set"
-      : isLoading
-        ? "Checking what this would publish…"
-        : null;
+    : isDetached
+      ? "Push stays blocked until a branch is checked out"
+      : isDestinationMissing
+        ? "Push stays blocked until a destination is set"
+        : isLoading
+          ? "Checking what this would publish…"
+          : null;
 
   return (
     <ConfirmDialog
       isOpen={true}
       onClose={() => resolveConfirmation(false)}
       title="Push commits?"
+      // Deliberately says "commits", not "these commits": the same sentence has
+      // to be true in the states where there is nothing to point at — in sync,
+      // no destination, preview failed — and a description that asserts the push
+      // will happen sat directly above an error saying it cannot.
       description={
         <span>
-          Publishing puts these commits on the remote, where everyone working from it sees them.
-          Taking them back afterwards needs a force-push.
+          Publishing puts commits on the remote, where everyone working from it sees them. Taking
+          them back afterwards needs a force-push.
         </span>
       }
-      confirmLabel="Push"
+      confirmLabel="Push commits"
       cancelLabel="Cancel"
       variant="destructive"
       hasPreview={true}
@@ -167,6 +184,8 @@ function GitPushConfirmDialogInner() {
               <RefChip value={branch} />
             ) : isLoading ? (
               <Bone className="w-40" />
+            ) : loadError ? (
+              <Unknown />
             ) : (
               <Unresolved />
             )}
@@ -175,12 +194,14 @@ function GitPushConfirmDialogInner() {
             {destinationLabel ? (
               <span className="flex flex-wrap items-baseline gap-1.5">
                 <RefChip value={destinationLabel} emphasis />
-                {pushRange?.createsRemoteBranch && (
-                  <span className="text-[10px] text-daintree-text/55">creates this branch</span>
+                {isUpperBound && (
+                  <span className="text-[10px] text-daintree-text/55">no local copy</span>
                 )}
               </span>
             ) : isLoading ? (
               <Bone className="w-48" />
+            ) : loadError ? (
+              <Unknown />
             ) : (
               <Unresolved />
             )}
@@ -203,19 +224,20 @@ function GitPushConfirmDialogInner() {
         </div>
 
         {isLoading && (
-          <ul
-            className="px-3 py-2 space-y-1.5"
-            data-testid="git-push-commits-loading"
-            aria-hidden="true"
-          >
-            {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
-              <li key={i} className="flex items-baseline gap-2">
-                <Bone className="w-[3.5rem]" />
-                <Bone className={i === 1 ? "w-40" : "w-52"} />
-                <Bone className="w-16 ml-auto" />
-              </li>
-            ))}
-          </ul>
+          // `Skeleton` is what makes this reach a screen reader: the bones alone
+          // are decorative, so a blocked Push with no announced busy state left
+          // an AT user with a dead button and no explanation.
+          <Skeleton label="Checking what this would publish" data-testid="git-push-commits-loading">
+            <ul className="px-3 py-2 space-y-1.5">
+              {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+                <li key={i} className="flex items-baseline gap-2">
+                  <Bone className="w-[3.5rem]" />
+                  <Bone className={i === 1 ? "w-40" : "w-52"} />
+                  <Bone className="w-16 ml-auto" />
+                </li>
+              ))}
+            </ul>
+          </Skeleton>
         )}
 
         {!isLoading && loadError && (
@@ -238,6 +260,19 @@ function GitPushConfirmDialogInner() {
           </div>
         )}
 
+        {isDetached && (
+          <div className="px-3 py-3 text-status-error flex items-start gap-2" role="alert">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0" data-testid="git-push-detached-head">
+              <div className="font-medium">No branch checked out</div>
+              <div className="mt-0.5 text-daintree-text/70">
+                This worktree is on a detached HEAD, so there is no branch to publish. Check one out
+                and try again.
+              </div>
+            </div>
+          </div>
+        )}
+
         {isDestinationMissing && (
           <div className="px-3 py-3 text-status-error flex items-start gap-2" role="alert">
             <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
@@ -245,11 +280,12 @@ function GitPushConfirmDialogInner() {
               <div className="font-medium">No destination git can name</div>
               <div className="mt-0.5 text-daintree-text/70">
                 This branch has no push destination, or more than one remote could be meant. Set an
-                upstream, or name one with{" "}
-                <span className="font-mono break-all">
-                  git config branch.&lt;name&gt;.pushRemote
+                upstream, or name the remote yourself:
+                {/* Its own line, and unbroken: wrapped inline it split as
+                    "with g / it config", which is not a command anyone can run. */}
+                <span className="mt-1 block font-mono text-daintree-text/80 whitespace-nowrap overflow-x-auto">
+                  git config branch.&lt;name&gt;.pushRemote &lt;remote&gt;
                 </span>
-                .
               </div>
             </div>
           </div>
@@ -295,6 +331,12 @@ function GitPushConfirmDialogInner() {
                   </span>
                 </li>
               ))}
+              {isUpperBound && (
+                <li className="text-[11px] text-daintree-text/55 pt-0.5">
+                  No local copy of {destinationLabel} &mdash; this list is an upper bound and may
+                  include commits it already has.
+                </li>
+              )}
               {hiddenCount > 0 && (
                 <li className="text-[11px] text-daintree-text/55 italic pt-0.5">
                   &hellip;and {hiddenCount} more
@@ -331,7 +373,7 @@ function RefChip({ value, emphasis }: { value: string; emphasis?: boolean }) {
   return (
     <span
       className={cn(
-        "inline-flex items-baseline px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] font-mono break-all",
+        "inline-flex items-baseline px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] font-mono break-words",
         emphasis ? "text-daintree-text" : "text-daintree-text/70"
       )}
     >
@@ -340,8 +382,14 @@ function RefChip({ value, emphasis }: { value: string; emphasis?: boolean }) {
   );
 }
 
+/** Git answered, and the answer was "no destination anyone can name". */
 function Unresolved() {
   return <span className="text-status-error text-[11px]">Not resolved</span>;
+}
+
+/** Git did not answer at all. The failure is stated once, below, not per row. */
+function Unknown() {
+  return <span className="text-daintree-text/55 text-[11px]">&mdash;</span>;
 }
 
 /**
@@ -351,6 +399,7 @@ function Unresolved() {
 function Bone({ className }: { className?: string }) {
   return (
     <span
+      aria-hidden="true"
       className={cn("inline-block h-3.5 rounded bg-tint/[0.08] animate-pulse-delayed", className)}
     />
   );

--- a/src/components/Git/GitPushConfirmDialog.tsx
+++ b/src/components/Git/GitPushConfirmDialog.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { Spinner } from "@/components/ui/Spinner";
-import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { AlertTriangle, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -11,16 +12,33 @@ import {
   buildGitRemoteOperationPreview,
   formatGitPushDestination,
   type GitPreviewCommit,
+  type GitPushRangeFacts,
 } from "@/components/Git/gitRemoteOperationPreview";
 import type { GitPushDestination } from "@shared/types/git";
 
 const SHORT_HASH_LEN = 7;
 
+/** Rows the skeleton draws. Enough to hold the panel's height without claiming a count. */
+const SKELETON_ROWS = 3;
+
 /**
  * D2 confirm for `git.push` dispatched from the action palette or a keybinding
  * (#8242). Reads the pending request from `gitPushConfirmStore`, previews the
- * target branch and the recent local commits, and resolves the deferred
- * Promise the action `run()` is awaiting.
+ * resolved destination and the commits the push would actually publish, and
+ * resolves the deferred Promise the action `run()` is awaiting.
+ *
+ * The three things that decide the layout (#11979):
+ *
+ * 1. The title is fixed. It used to interpolate whatever had loaded, so it read
+ *    `Push 'current branch'?` mid-flight, then `Push 'origin/main'?` — and the
+ *    quoted string silently changed from naming the LOCAL branch to naming the
+ *    REMOTE ref between states. The refs now live in the summary, which is a
+ *    place that can hold a pending state honestly.
+ * 2. Everything that decides whether the push may proceed — destination, range,
+ *    load failure, retry — is inside one preview region, so a blocked push and
+ *    the reason for it are never in different parts of the dialog.
+ * 3. The commits shown are the publish range, not recent history. See
+ *    `buildGitRemoteOperationPreview`.
  */
 function GitPushConfirmDialogInner() {
   const pendingConfirm = useGitPushConfirmStore((s) => s.pendingConfirm);
@@ -31,6 +49,7 @@ function GitPushConfirmDialogInner() {
   const [branch, setBranch] = useState<string | null>(null);
   const [destination, setDestination] = useState<GitPushDestination | null>(null);
   const [commits, setCommits] = useState<GitPreviewCommit[] | null>(null);
+  const [pushRange, setPushRange] = useState<GitPushRangeFacts | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const requestIdRef = useRef(0);
@@ -43,16 +62,18 @@ function GitPushConfirmDialogInner() {
     setBranch(null);
     setDestination(null);
     setCommits(null);
+    setPushRange(null);
 
     safeFireAndForget(
       // Shared with the MCP confirm surface so agent and human approvers see
-      // the identical fresh branch/commit content (#11538).
-      buildGitRemoteOperationPreview(cwd)
+      // the identical fresh destination and publish range (#11538).
+      buildGitRemoteOperationPreview(cwd, "push")
         .then((preview) => {
           if (requestIdRef.current !== requestId) return;
           setBranch(preview.branch);
           setDestination(preview.destination);
           setCommits(preview.commits);
+          setPushRange(preview.pushRange);
         })
         .catch((err: unknown) => {
           if (requestIdRef.current !== requestId) return;
@@ -71,6 +92,7 @@ function GitPushConfirmDialogInner() {
       setBranch(null);
       setDestination(null);
       setCommits(null);
+      setPushRange(null);
       setLoadError(null);
       setIsLoading(false);
       return;
@@ -89,116 +111,248 @@ function GitPushConfirmDialogInner() {
 
   if (!pendingConfirm) return null;
 
-  const branchLabel = branch ?? "current branch";
   const destinationLabel = destination ? formatGitPushDestination(destination) : null;
   const isDestinationMissing = !isLoading && !loadError && destination === null;
+  const isLoaded = !isLoading && !loadError && commits !== null;
+  const isInSync = isLoaded && commits.length === 0 && destination !== null;
+  const total = pushRange?.total ?? commits?.length ?? 0;
+  const hiddenCount = commits ? Math.max(0, total - commits.length) : 0;
+
+  // A destination nobody can name can't be approved — the handler would refuse
+  // the write anyway, and guessing `origin` is the bug (#11746). `commits === null`
+  // is "not loaded", which is a different thing from a loaded empty range: an
+  // in-sync branch is approvable and pushes nothing (#9575).
+  const confirmDisabled = commits === null || !destination || !!loadError;
+
+  // Names the one unmet prerequisite rather than leaving a dead button to be
+  // read as arbitrary. Ordered by which the user can act on first.
+  const blockedReason = loadError
+    ? "Push stays blocked until the preview loads"
+    : isDestinationMissing
+      ? "Push stays blocked until a destination is set"
+      : isLoading
+        ? "Checking what this would publish…"
+        : null;
 
   return (
     <ConfirmDialog
       isOpen={true}
       onClose={() => resolveConfirmation(false)}
-      title={destinationLabel ? `Push to '${destinationLabel}'?` : `Push '${branchLabel}'?`}
+      title="Push commits?"
       description={
-        destinationLabel ? (
-          <span>
-            Pushes local commits on <span className="font-mono">{branchLabel}</span> to{" "}
-            <span className="font-mono">{destinationLabel}</span>. If the remote has moved forward,
-            the push is rejected until you pull and rebase.
-          </span>
-        ) : (
-          <span>
-            Pushes local commits on <span className="font-mono">{branchLabel}</span> to its remote
-            branch. If the remote has moved forward, the push is rejected until you pull and rebase.
-          </span>
-        )
+        <span>
+          Publishing puts these commits on the remote, where everyone working from it sees them.
+          Taking them back afterwards needs a force-push.
+        </span>
       }
       confirmLabel="Push"
       cancelLabel="Cancel"
       variant="destructive"
       hasPreview={true}
-      isConfirmLoading={isLoading}
-      // A destination nobody can name can't be approved — the handler would
-      // refuse the write anyway, and guessing `origin` is the bug (#11746).
-      confirmDisabled={commits === null || !destination || !!loadError}
+      // Deliberately NOT `isConfirmLoading={isLoading}`. That prop means "the
+      // confirmed action is running": it overlays a spinner on the primary,
+      // dims its label to 30%, and disables Cancel. Wiring the PREVIEW fetch to
+      // it drew a spinner across the word "Push", and — because AppDialog's
+      // initial-focus pass finds the Cancel button by selector and calls
+      // `.focus()` on it without checking it is enabled — left focus outside
+      // the dialog entirely for the whole fetch.
+      confirmDisabled={confirmDisabled}
+      hint={blockedReason}
       onConfirm={() => resolveConfirmation(true)}
     >
-      {isDestinationMissing && (
-        <div
-          className="mb-3 rounded border border-status-error/30 bg-status-error/10 px-3 py-2 text-xs text-status-error flex items-start gap-2"
-          data-testid="git-push-no-destination"
-        >
-          <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
-          <span>
-            This branch has no push destination, or more than one remote could be meant. Set an
-            upstream, or name one with{" "}
-            <span className="font-mono">git config branch.&lt;name&gt;.pushRemote</span>.
-          </span>
-        </div>
-      )}
-      <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
-        <div className="px-3 py-2 border-b border-tint/[0.08]">
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-            Recent local commits
+      <div className="rounded border border-tint/[0.08] bg-tint/[0.04] text-xs">
+        <dl className="px-3 py-2 space-y-1.5" data-testid="git-push-destination-summary">
+          <SummaryRow label="From">
+            {branch ? (
+              <RefChip value={branch} />
+            ) : isLoading ? (
+              <Bone className="w-40" />
+            ) : (
+              <Unresolved />
+            )}
+          </SummaryRow>
+          <SummaryRow label="To">
+            {destinationLabel ? (
+              <span className="flex flex-wrap items-baseline gap-1.5">
+                <RefChip value={destinationLabel} emphasis />
+                {pushRange?.createsRemoteBranch && (
+                  <span className="text-[10px] text-daintree-text/55">creates this branch</span>
+                )}
+              </span>
+            ) : isLoading ? (
+              <Bone className="w-48" />
+            ) : (
+              <Unresolved />
+            )}
+          </SummaryRow>
+        </dl>
+
+        <div className="px-3 py-2 border-y border-tint/[0.08] flex items-center justify-between gap-2">
+          <span
+            role="heading"
+            aria-level={3}
+            className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
+          >
+            Commits to push
+            {isLoaded && total > 0 && (
+              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+                {total}
+              </span>
+            )}
           </span>
         </div>
 
         {isLoading && (
-          <div
-            className="flex items-center justify-center py-6"
+          <ul
+            className="px-3 py-2 space-y-1.5"
             data-testid="git-push-commits-loading"
+            aria-hidden="true"
           >
-            <Spinner size="sm" className="text-daintree-text/40" />
-          </div>
-        )}
-
-        {!isLoading && loadError && (
-          <div className="px-3 py-3 text-status-error flex items-start gap-2">
-            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
-            <div className="flex-1 min-w-0">
-              <div>{loadError}</div>
-              <button
-                type="button"
-                onClick={loadPreview}
-                data-testid="git-push-commits-retry"
-                className={cn(
-                  "mt-1 inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
-                  "bg-status-error/15 hover:bg-status-error/25 text-status-error",
-                  "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-error"
-                )}
-              >
-                Retry
-              </button>
-            </div>
-          </div>
-        )}
-
-        {!isLoading && !loadError && commits && commits.length === 0 && (
-          <div className="px-3 py-3 text-daintree-text/50">
-            No local commits found on this branch.
-          </div>
-        )}
-
-        {!isLoading && !loadError && commits && commits.length > 0 && (
-          <ul className="px-3 py-2 space-y-1.5 max-h-[180px] overflow-y-auto">
-            {commits.map((commit) => (
-              <li
-                key={commit.hash}
-                className="flex items-baseline gap-2"
-                data-testid="git-push-commit-row"
-              >
-                <span className="font-mono text-[10px] text-daintree-text/40 shrink-0 tabular-nums">
-                  {commit.hash.slice(0, SHORT_HASH_LEN)}
-                </span>
-                <span className="text-daintree-text/80 truncate min-w-0">{commit.message}</span>
-                <span className="text-[10px] text-daintree-text/40 shrink-0 ml-auto">
-                  {commit.author}
-                </span>
+            {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+              <li key={i} className="flex items-baseline gap-2">
+                <Bone className="w-[3.5rem]" />
+                <Bone className={i === 1 ? "w-40" : "w-52"} />
+                <Bone className="w-16 ml-auto" />
               </li>
             ))}
           </ul>
         )}
+
+        {!isLoading && loadError && (
+          <div className="px-3 py-3 text-status-error flex items-start gap-2" role="alert">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="font-medium">Couldn&apos;t read what this would publish</div>
+              <div className="mt-0.5 text-daintree-text/70 break-words">{loadError}</div>
+              <Button
+                variant="ghost-danger"
+                size="sm"
+                onClick={loadPreview}
+                data-testid="git-push-commits-retry"
+                className="mt-1.5 h-6 px-2 text-[11px]"
+              >
+                <RefreshCw className="w-3 h-3" />
+                Retry
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {isDestinationMissing && (
+          <div className="px-3 py-3 text-status-error flex items-start gap-2" role="alert">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0" data-testid="git-push-no-destination">
+              <div className="font-medium">No destination git can name</div>
+              <div className="mt-0.5 text-daintree-text/70">
+                This branch has no push destination, or more than one remote could be meant. Set an
+                upstream, or name one with{" "}
+                <span className="font-mono break-all">
+                  git config branch.&lt;name&gt;.pushRemote
+                </span>
+                .
+              </div>
+            </div>
+          </div>
+        )}
+
+        {isInSync && (
+          <div className="px-3 py-3 text-daintree-text/60" data-testid="git-push-in-sync">
+            Nothing to publish &mdash; {destinationLabel} already has everything on this branch.
+          </div>
+        )}
+
+        {isLoaded && commits.length > 0 && (
+          // A scrollable region with no focusable children of its own has to be
+          // reachable by keyboard in its own right (WCAG 2.1.1), and the fades
+          // are what say "there is more" — a row clipped by the panel edge was
+          // the only previous cue, and a clip that happens to land on a row
+          // boundary says the opposite.
+          <ScrollShadow
+            className="max-h-[180px]"
+            scrollClassName="scroll-py-8"
+            tabIndex={0}
+            role="region"
+            aria-label={`Commits to push${destinationLabel ? ` to ${destinationLabel}` : ""}`}
+          >
+            <ul className="px-3 py-2 space-y-1.5">
+              {commits.map((commit) => (
+                <li
+                  key={commit.hash}
+                  className="flex items-baseline gap-2"
+                  data-testid="git-push-commit-row"
+                >
+                  <span className="font-mono text-[11px] text-daintree-text/55 shrink-0 tabular-nums">
+                    {commit.hash.slice(0, SHORT_HASH_LEN)}
+                  </span>
+                  <span className="flex-1 min-w-0 truncate text-daintree-text/90">
+                    {commit.message}
+                  </span>
+                  {/* Bounded, unlike the rest of the row: an author is the least
+                    important column here, and left unbounded a long name took
+                    40% of the width and truncated the subject to nothing. */}
+                  <span className="text-[11px] text-daintree-text/55 shrink-0 max-w-[7rem] truncate">
+                    {commit.author}
+                  </span>
+                </li>
+              ))}
+              {hiddenCount > 0 && (
+                <li className="text-[11px] text-daintree-text/55 italic pt-0.5">
+                  &hellip;and {hiddenCount} more
+                </li>
+              )}
+            </ul>
+          </ScrollShadow>
+        )}
       </div>
     </ConfirmDialog>
+  );
+}
+
+function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <dt className="text-[10px] uppercase tracking-wider text-daintree-text/55 shrink-0 w-10">
+        {label}
+      </dt>
+      <dd className="flex-1 min-w-0">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * A ref as a value rather than a word in a sentence.
+ *
+ * `break-all` rather than truncation: a push destination is the one fact on this
+ * surface that must never be shortened, and a 90-character fork ref wrapping
+ * across three lines is a better outcome than an ellipsis in the middle of the
+ * repository name being written to.
+ */
+function RefChip({ value, emphasis }: { value: string; emphasis?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-baseline px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] font-mono break-all",
+        emphasis ? "text-daintree-text" : "text-daintree-text/70"
+      )}
+    >
+      {value}
+    </span>
+  );
+}
+
+function Unresolved() {
+  return <span className="text-status-error text-[11px]">Not resolved</span>;
+}
+
+/**
+ * Skeleton bone. `animate-pulse-delayed` carries the 400ms Doherty gate in its
+ * own `animation-delay`, so a fetch that returns quickly paints nothing at all.
+ */
+function Bone({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn("inline-block h-3.5 rounded bg-tint/[0.08] animate-pulse-delayed", className)}
+    />
   );
 }
 

--- a/src/components/Git/__tests__/GitPullRebaseConfirmDialog.test.tsx
+++ b/src/components/Git/__tests__/GitPullRebaseConfirmDialog.test.tsx
@@ -74,6 +74,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       destination: { remote: "origin", branch: "feature/y" },
       pullSource: { remote: "origin", branch: "feature/y" },
       commits: [],
+      pushRange: null,
     });
     render(<GitPullRebaseConfirmDialog />);
 
@@ -81,7 +82,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       void useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(mocks.buildPreview).toHaveBeenCalledWith("/repo");
+    expect(mocks.buildPreview).toHaveBeenCalledWith("/repo", "pull-rebase");
   });
 
   it("blocks approval while the preview is still loading", async () => {
@@ -90,6 +91,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       destination: { remote: string; branch: string };
       pullSource: { remote: string; branch: string };
       commits: never[];
+      pushRange: null;
     }>();
     mocks.buildPreview.mockReturnValue(gate.promise);
     render(<GitPullRebaseConfirmDialog />);
@@ -106,6 +108,7 @@ describe("GitPullRebaseConfirmDialog", () => {
         destination: { remote: "origin", branch: "main" },
         pullSource: { remote: "origin", branch: "main" },
         commits: [],
+        pushRange: null,
       });
       await gate.promise;
     });
@@ -130,6 +133,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       destination: { remote: "origin", branch: "main" },
       pullSource: { remote: "origin", branch: "main" },
       commits: [],
+      pushRange: null,
     });
     render(<GitPullRebaseConfirmDialog />);
 

--- a/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
+++ b/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
@@ -341,32 +341,47 @@ describe("GitPushConfirmDialog", () => {
     expect(unverified.textContent).toMatch(/n't confirmed|unverified/);
   });
 
-  // The host stays mounted across close/open, so state survives. Approval must
-  // be gated on the preview belonging to THIS request, or a second confirm for a
-  // different worktree is approvable against the previous one's commits.
-  it("will not approve a preview belonging to a previous request", async () => {
-    mocks.buildPreview.mockResolvedValue({
-      branch: "main",
-      destination: { remote: "origin", branch: "main" },
-      pullSource: null,
-      commits: [{ hash: "abcdef12", message: "One", author: "Ada" }],
-      pushRange: { total: 1, rangeBasis: "tracked" as const },
-    });
+  // The host stays mounted across close/open, so preview state survives a
+  // request. A superseded request's response must not land and re-enable
+  // approval against the worktree the user has already moved away from.
+  it("drops a superseded response instead of approving against it", async () => {
+    const first = deferred<{
+      branch: string;
+      destination: { remote: string; branch: string };
+      pullSource: null;
+      commits: Array<{ hash: string; message: string; author: string }>;
+      pushRange: { total: number; rangeBasis: "tracked" };
+    }>();
+    mocks.buildPreview.mockReturnValue(first.promise);
     render(<GitPushConfirmDialog />);
 
     await act(async () => {
       void useGitPushConfirmStore.getState().requestConfirmation("/repo-a");
     });
-    expect(pushButton().hasAttribute("disabled")).toBe(false);
 
-    // A second request for a DIFFERENT worktree, held mid-flight.
-    const gate = deferred<never>();
-    mocks.buildPreview.mockReturnValue(gate.promise);
+    // A second request for a DIFFERENT worktree supersedes the first.
+    const second = deferred<never>();
+    mocks.buildPreview.mockReturnValue(second.promise);
     await act(async () => {
       void useGitPushConfirmStore.getState().requestConfirmation("/repo-b");
     });
 
+    // The FIRST worktree's answer arrives late.
+    await act(async () => {
+      first.resolve({
+        branch: "main",
+        destination: { remote: "origin", branch: "main" },
+        pullSource: null,
+        commits: [{ hash: "abcdef12", message: "One", author: "Ada" }],
+        pushRange: { total: 1, rangeBasis: "tracked" },
+      });
+      await first.promise;
+    });
+
+    // It must neither render nor enable approval: it describes /repo-a, and the
+    // dialog on screen is asking about /repo-b.
     expect(pushButton().hasAttribute("disabled")).toBe(true);
+    expect(screen.queryAllByTestId("git-push-commit-row")).toHaveLength(0);
   });
 
   // The creation marker is the one claim that requires the remote to have spoken.

--- a/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
+++ b/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
@@ -43,7 +43,7 @@ vi.stubGlobal(
 );
 
 function pushButton(): HTMLElement {
-  return screen.getByRole("button", { name: "Push" });
+  return screen.getByRole("button", { name: "Push commits" });
 }
 
 /** A promise plus its resolvers, so a test can hold the fetch mid-flight. */
@@ -78,7 +78,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: "origin", branch: "feature/x" },
       pullSource: { remote: "origin", branch: "feature/x" },
       commits: [],
-      pushRange: { total: 0, createsRemoteBranch: false },
+      pushRange: { total: 0, rangeBasis: "tracked" as const },
     });
     render(<GitPushConfirmDialog />);
 
@@ -95,7 +95,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: string; branch: string };
       pullSource: { remote: string; branch: string };
       commits: never[];
-      pushRange: { total: number; createsRemoteBranch: boolean } | null;
+      pushRange: { total: number; rangeBasis: "tracked" | "untracked" } | null;
     }>();
     mocks.buildPreview.mockReturnValue(gate.promise);
     render(<GitPushConfirmDialog />);
@@ -112,7 +112,7 @@ describe("GitPushConfirmDialog", () => {
         destination: { remote: "origin", branch: "main" },
         pullSource: { remote: "origin", branch: "main" },
         commits: [],
-        pushRange: { total: 0, createsRemoteBranch: false },
+        pushRange: { total: 0, rangeBasis: "tracked" as const },
       });
       await gate.promise;
     });
@@ -128,7 +128,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: "origin", branch: "main" },
       pullSource: { remote: "origin", branch: "main" },
       commits: [],
-      pushRange: { total: 0, createsRemoteBranch: false },
+      pushRange: { total: 0, rangeBasis: "tracked" as const },
     });
     render(<GitPushConfirmDialog />);
 
@@ -156,7 +156,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: "origin", branch: "main" },
       pullSource: { remote: "origin", branch: "main" },
       commits: [{ hash: "abcdef1234", message: "Fix it", author: "Ada" }],
-      pushRange: { total: 1, createsRemoteBranch: false },
+      pushRange: { total: 1, rangeBasis: "tracked" as const },
     });
     await act(async () => {
       retry.click();
@@ -196,7 +196,7 @@ describe("GitPushConfirmDialog", () => {
         { hash: "aaaaaaa1", message: "One", author: "Ada" },
         { hash: "bbbbbbb2", message: "Two", author: "Bob" },
       ],
-      pushRange: { total: 7, createsRemoteBranch: false },
+      pushRange: { total: 7, rangeBasis: "tracked" as const },
     });
     render(<GitPushConfirmDialog />);
 
@@ -216,7 +216,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: "fork", branch: "release/topic" },
       pullSource: null,
       commits: [],
-      pushRange: { total: 0, createsRemoteBranch: false },
+      pushRange: { total: 0, rangeBasis: "tracked" as const },
     });
     render(<GitPushConfirmDialog />);
 
@@ -246,7 +246,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: "origin", branch: "main" },
       pullSource: null,
       commits: [{ hash: "abcdef12", message: "One", author: "Ada" }],
-      pushRange: { total: 1, createsRemoteBranch: false },
+      pushRange: { total: 1, rangeBasis: "tracked" as const },
     });
     await act(async () => {
       useGitPushConfirmStore.getState().resolveConfirmation(false);
@@ -275,13 +275,55 @@ describe("GitPushConfirmDialog", () => {
     expect(screen.getByTestId("git-push-no-destination")).toBeTruthy();
   });
 
+  // A detached HEAD also resolves no destination. Diagnosing it as a missing
+  // push remote gives the wrong reason and a fix that cannot be followed.
+  it("names a detached HEAD rather than blaming a missing push remote", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      branch: null,
+      destination: null,
+      pullSource: null,
+      commits: [],
+      pushRange: null,
+    });
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    expect(screen.getByTestId("git-push-detached-head")).toBeTruthy();
+    expect(screen.queryByTestId("git-push-no-destination")).toBeNull();
+    expect(pushButton().hasAttribute("disabled")).toBe(true);
+  });
+
+  // An untracked range can only over-report, so the surface must say the list is
+  // an upper bound rather than assert a branch creation it cannot verify.
+  it("calls an untracked range an upper bound, never a branch creation", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      branch: "spike",
+      destination: { remote: "origin", branch: "spike" },
+      pullSource: null,
+      commits: [{ hash: "abcdef12", message: "One", author: "Ada" }],
+      pushRange: { total: 1, rangeBasis: "untracked" as const },
+    });
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    const region = screen.getByTestId("git-push-destination-summary").parentElement!;
+    expect(region.textContent).toContain("upper bound");
+    expect(region.textContent).not.toContain("creates this branch");
+  });
+
   it("resolves the awaited confirm promise with the user's decision", async () => {
     mocks.buildPreview.mockResolvedValue({
       branch: "main",
       destination: { remote: "origin", branch: "main" },
       pullSource: { remote: "origin", branch: "main" },
       commits: [],
-      pushRange: { total: 0, createsRemoteBranch: false },
+      pushRange: { total: 0, rangeBasis: "tracked" as const },
     });
     render(<GitPushConfirmDialog />);
 

--- a/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
+++ b/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
@@ -78,6 +78,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: "origin", branch: "feature/x" },
       pullSource: { remote: "origin", branch: "feature/x" },
       commits: [],
+      pushRange: { total: 0, createsRemoteBranch: false },
     });
     render(<GitPushConfirmDialog />);
 
@@ -85,7 +86,7 @@ describe("GitPushConfirmDialog", () => {
       void useGitPushConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(mocks.buildPreview).toHaveBeenCalledWith("/repo");
+    expect(mocks.buildPreview).toHaveBeenCalledWith("/repo", "push");
   });
 
   it("blocks approval while the preview is still loading", async () => {
@@ -94,6 +95,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: string; branch: string };
       pullSource: { remote: string; branch: string };
       commits: never[];
+      pushRange: { total: number; createsRemoteBranch: boolean } | null;
     }>();
     mocks.buildPreview.mockReturnValue(gate.promise);
     render(<GitPushConfirmDialog />);
@@ -110,6 +112,7 @@ describe("GitPushConfirmDialog", () => {
         destination: { remote: "origin", branch: "main" },
         pullSource: { remote: "origin", branch: "main" },
         commits: [],
+        pushRange: { total: 0, createsRemoteBranch: false },
       });
       await gate.promise;
     });
@@ -125,6 +128,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: "origin", branch: "main" },
       pullSource: { remote: "origin", branch: "main" },
       commits: [],
+      pushRange: { total: 0, createsRemoteBranch: false },
     });
     render(<GitPushConfirmDialog />);
 
@@ -133,7 +137,7 @@ describe("GitPushConfirmDialog", () => {
     });
 
     expect(pushButton().hasAttribute("disabled")).toBe(false);
-    expect(screen.getByText(/No local commits found/)).toBeTruthy();
+    expect(screen.getByTestId("git-push-in-sync").textContent).toContain("Nothing to publish");
   });
 
   it("keeps approval blocked when the preview fetch fails, and offers a retry", async () => {
@@ -152,6 +156,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: "origin", branch: "main" },
       pullSource: { remote: "origin", branch: "main" },
       commits: [{ hash: "abcdef1234", message: "Fix it", author: "Ada" }],
+      pushRange: { total: 1, createsRemoteBranch: false },
     });
     await act(async () => {
       retry.click();
@@ -162,12 +167,121 @@ describe("GitPushConfirmDialog", () => {
     expect(screen.getByText("Fix it")).toBeTruthy();
   });
 
+  // A preview fetch is not the action running. Wiring it to `isConfirmLoading`
+  // disabled Cancel, and AppDialog's initial-focus pass calls `.focus()` on the
+  // Cancel button it finds by selector without checking it is enabled — so a
+  // disabled Cancel left focus outside the dialog for the whole fetch.
+  it("keeps Cancel usable while the preview is still loading", async () => {
+    const gate = deferred<never>();
+    mocks.buildPreview.mockReturnValue(gate.promise);
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(cancel.hasAttribute("disabled")).toBe(false);
+    expect(pushButton().hasAttribute("disabled")).toBe(true);
+  });
+
+  // The rows and the count have to describe the same range, or the tail states
+  // a number that was measured over a different set of commits.
+  it("counts and tails from the measured range, not from the rows on screen", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      branch: "main",
+      destination: { remote: "origin", branch: "main" },
+      pullSource: { remote: "origin", branch: "main" },
+      commits: [
+        { hash: "aaaaaaa1", message: "One", author: "Ada" },
+        { hash: "bbbbbbb2", message: "Two", author: "Bob" },
+      ],
+      pushRange: { total: 7, createsRemoteBranch: false },
+    });
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    expect(screen.getAllByTestId("git-push-commit-row")).toHaveLength(2);
+    const region = screen.getByTestId("git-push-destination-summary").parentElement!;
+    expect(region.textContent).toContain("7");
+    expect(region.textContent).toContain("and 5 more");
+  });
+
+  it("names the resolved destination rather than leaving it to the title", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      branch: "topic",
+      destination: { remote: "fork", branch: "release/topic" },
+      pullSource: null,
+      commits: [],
+      pushRange: { total: 0, createsRemoteBranch: false },
+    });
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    const summary = screen.getByTestId("git-push-destination-summary");
+    expect(summary.textContent).toContain("fork/release/topic");
+    expect(summary.textContent).toContain("topic");
+  });
+
+  // The title used to interpolate whatever had loaded, so the quoted string
+  // silently changed from naming the local branch to naming the remote ref.
+  it("keeps one title across loading, blocked and loaded states", async () => {
+    const gate = deferred<never>();
+    mocks.buildPreview.mockReturnValue(gate.promise);
+    const { rerender } = render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+    const whileLoading = screen.getByRole("heading", { level: 2 }).textContent;
+
+    mocks.buildPreview.mockResolvedValue({
+      branch: "main",
+      destination: { remote: "origin", branch: "main" },
+      pullSource: null,
+      commits: [{ hash: "abcdef12", message: "One", author: "Ada" }],
+      pushRange: { total: 1, createsRemoteBranch: false },
+    });
+    await act(async () => {
+      useGitPushConfirmStore.getState().resolveConfirmation(false);
+      rerender(<GitPushConfirmDialog />);
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    expect(screen.getByRole("heading", { level: 2 }).textContent).toBe(whileLoading);
+  });
+
+  it("blocks approval and says so when no destination resolves", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      branch: "spike",
+      destination: null,
+      pullSource: null,
+      commits: [],
+      pushRange: null,
+    });
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    expect(pushButton().hasAttribute("disabled")).toBe(true);
+    expect(screen.getByTestId("git-push-no-destination")).toBeTruthy();
+  });
+
   it("resolves the awaited confirm promise with the user's decision", async () => {
     mocks.buildPreview.mockResolvedValue({
       branch: "main",
       destination: { remote: "origin", branch: "main" },
       pullSource: { remote: "origin", branch: "main" },
       commits: [],
+      pushRange: { total: 0, createsRemoteBranch: false },
     });
     render(<GitPushConfirmDialog />);
 

--- a/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
+++ b/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
@@ -167,6 +167,25 @@ describe("GitPushConfirmDialog", () => {
     expect(screen.getByText("Fix it")).toBeTruthy();
   });
 
+  // The preview handler fails as a `GitOperationError`, whose discriminant the
+  // preload encodes into `.message` because contextBridge strips own Error
+  // properties. Rendered raw, that encoding is what the approver reads.
+  it("shows the git message without the encoded error prefix", async () => {
+    mocks.buildPreview.mockRejectedValue(
+      new Error("[GitError|not-a-repo||feature%2Fx] fatal: not a git repository")
+    );
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    const alert = screen.getByTestId("git-push-commits-retry").closest("[role='alert']");
+    expect(alert?.textContent).toContain("fatal: not a git repository");
+    expect(alert?.textContent).not.toContain("GitError");
+    expect(alert?.textContent).not.toContain("feature%2Fx");
+  });
+
   // A preview fetch is not the action running. Wiring it to `isConfirmLoading`
   // disabled Cancel, and AppDialog's initial-focus pass calls `.focus()` on the
   // Cancel button it finds by selector without checking it is enabled — so a

--- a/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
+++ b/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
@@ -95,7 +95,7 @@ describe("GitPushConfirmDialog", () => {
       destination: { remote: string; branch: string };
       pullSource: { remote: string; branch: string };
       commits: never[];
-      pushRange: { total: number; rangeBasis: "tracked" | "untracked" } | null;
+      pushRange: { total: number; rangeBasis: "tracked" | "creates" | "unverified" } | null;
     }>();
     mocks.buildPreview.mockReturnValue(gate.promise);
     render(<GitPushConfirmDialog />);
@@ -298,13 +298,13 @@ describe("GitPushConfirmDialog", () => {
 
   // An untracked range can only over-report, so the surface must say the list is
   // an upper bound rather than assert a branch creation it cannot verify.
-  it("calls an untracked range an upper bound, never a branch creation", async () => {
+  it("labels an unreachable remote as unverified, never as a branch creation", async () => {
     mocks.buildPreview.mockResolvedValue({
       branch: "spike",
       destination: { remote: "origin", branch: "spike" },
       pullSource: null,
       commits: [{ hash: "abcdef12", message: "One", author: "Ada" }],
-      pushRange: { total: 1, rangeBasis: "untracked" as const },
+      pushRange: { total: 1, rangeBasis: "unverified" as const },
     });
     render(<GitPushConfirmDialog />);
 
@@ -313,8 +313,80 @@ describe("GitPushConfirmDialog", () => {
     });
 
     const region = screen.getByTestId("git-push-destination-summary").parentElement!;
-    expect(region.textContent).toContain("upper bound");
+    expect(region.textContent).toContain("unverified");
     expect(region.textContent).not.toContain("creates this branch");
+  });
+
+  // An untracked range was never compared against the destination, so an empty
+  // one means "nothing found locally" — not "the destination is up to date".
+  it("never claims a destination is in sync from an unverified range", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      branch: "spike",
+      destination: { remote: "origin", branch: "spike" },
+      pullSource: null,
+      commits: [],
+      pushRange: { total: 0, rangeBasis: "unverified" as const },
+    });
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    // The rule, not the wording: an unverified empty range gets its own state and
+    // must never produce the categorical "already has everything" claim.
+    expect(screen.queryByTestId("git-push-in-sync")).toBeNull();
+    const unverified = screen.getByTestId("git-push-empty-unverified");
+    expect(unverified.textContent).not.toContain("already has everything");
+    expect(unverified.textContent).toMatch(/n't confirmed|unverified/);
+  });
+
+  // The host stays mounted across close/open, so state survives. Approval must
+  // be gated on the preview belonging to THIS request, or a second confirm for a
+  // different worktree is approvable against the previous one's commits.
+  it("will not approve a preview belonging to a previous request", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      branch: "main",
+      destination: { remote: "origin", branch: "main" },
+      pullSource: null,
+      commits: [{ hash: "abcdef12", message: "One", author: "Ada" }],
+      pushRange: { total: 1, rangeBasis: "tracked" as const },
+    });
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo-a");
+    });
+    expect(pushButton().hasAttribute("disabled")).toBe(false);
+
+    // A second request for a DIFFERENT worktree, held mid-flight.
+    const gate = deferred<never>();
+    mocks.buildPreview.mockReturnValue(gate.promise);
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo-b");
+    });
+
+    expect(pushButton().hasAttribute("disabled")).toBe(true);
+  });
+
+  // The creation marker is the one claim that requires the remote to have spoken.
+  it("marks a branch creation only from a remote-confirmed range", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      branch: "spike",
+      destination: { remote: "origin", branch: "spike" },
+      pullSource: null,
+      commits: [{ hash: "abcdef12", message: "One", author: "Ada" }],
+      pushRange: { total: 1, rangeBasis: "creates" as const },
+    });
+    render(<GitPushConfirmDialog />);
+
+    await act(async () => {
+      void useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    });
+
+    const region = screen.getByTestId("git-push-destination-summary").parentElement!;
+    expect(region.textContent).toContain("creates this branch");
+    expect(region.textContent).not.toContain("unverified");
   });
 
   it("resolves the awaited confirm promise with the user's decision", async () => {

--- a/src/components/Git/__tests__/gitRemoteOperationPreview.test.ts
+++ b/src/components/Git/__tests__/gitRemoteOperationPreview.test.ts
@@ -265,11 +265,14 @@ describe("formatGitRemoteOperationPreviewLines", () => {
   it("warns explicitly when no push destination is configured", () => {
     const lines = formatGitRemoteOperationPreviewLines(
       { branch: "topic", destination: null, pullSource: null, commits: [], pushRange: null },
-      "none",
+      "Nothing to publish — the destination already has everything on this branch.",
       "push"
     );
     expect(lines[0]).toContain("No push destination");
     expect(lines[1]).toBe("Branch: topic");
+    // Nothing was compared, so the in-sync note would contradict the warning
+    // one line above it — the line that says the push will be refused.
+    expect(lines.join(" ")).not.toContain("already has everything");
   });
 
   it("warns about a missing upstream for a pull-rebase, even when a push target resolves", () => {
@@ -419,6 +422,55 @@ describe("formatGitRemoteOperationPreviewLines", () => {
     );
     expect(lines[0]).toContain("unverified");
     expect(lines[0]).not.toContain("creates");
+  });
+
+  // An empty `unverified` range means "nothing found locally", never "the
+  // destination is up to date" — the caller's note asserts the second, so it
+  // must not reach an approver who was told the remote was unreachable.
+  it("refuses the in-sync note for an empty range the remote never confirmed", () => {
+    const lines = formatGitRemoteOperationPreviewLines(
+      {
+        branch: "spike",
+        destination: { remote: "fork", branch: "release/spike" },
+        pullSource: null,
+        commits: [],
+        pushRange: { total: 0, rangeBasis: "unverified" as const },
+      },
+      "Nothing to publish — the destination already has everything on this branch.",
+      "push"
+    );
+    const body = lines.join(" ");
+    expect(body).not.toContain("already has everything");
+    expect(body).toContain("fork");
+    expect(body).toContain("isn't confirmed");
+  });
+
+  // The same range basis with a settled `tracked` answer IS the in-sync case,
+  // so the guard above must not be swallowing the note in every empty state.
+  it("still states in sync when the range settled against the destination", () => {
+    const lines = formatGitRemoteOperationPreviewLines(
+      {
+        branch: "main",
+        destination: { remote: "origin", branch: "main" },
+        pullSource: null,
+        commits: [],
+        pushRange: { total: 0, rangeBasis: "tracked" as const },
+      },
+      "Nothing to publish — the destination already has everything on this branch.",
+      "push"
+    );
+    expect(lines[2]).toContain("already has everything");
+  });
+
+  // The pull-rebase note claims nothing about a remote, so it survives states
+  // that silence the push one.
+  it("keeps the pull-rebase note when there is no upstream to rebase onto", () => {
+    const lines = formatGitRemoteOperationPreviewLines(
+      { branch: "topic", destination: null, pullSource: null, commits: [], pushRange: null },
+      "No local commits to replay.",
+      "pull-rebase"
+    );
+    expect(lines[2]).toBe("No local commits to replay.");
   });
 
   it("surfaces an explicit couldn't-verify warning for a failed fetch", () => {

--- a/src/components/Git/__tests__/gitRemoteOperationPreview.test.ts
+++ b/src/components/Git/__tests__/gitRemoteOperationPreview.test.ts
@@ -12,7 +12,7 @@ function stubGit(overrides: {
   items?: Array<{ hash: string; message: string; author: { name: string } }>;
   pushCommits?: Array<{ hash: string; message: string; author: string }>;
   pushTotal?: number;
-  rangeBasis?: "tracked" | "untracked";
+  rangeBasis?: "tracked" | "creates" | "unverified";
   reject?: boolean;
   rejectCommits?: boolean;
   rejectPushCommits?: boolean;
@@ -94,11 +94,11 @@ describe("buildGitRemoteOperationPreview", () => {
     stubGit({
       pushCommits: [{ hash: "abcdef1234", message: "First", author: "Ada" }],
       pushTotal: 9,
-      rangeBasis: "untracked" as const,
+      rangeBasis: "unverified" as const,
     });
     await expect(buildGitRemoteOperationPreview("/repo", "push")).resolves.toMatchObject({
       commits: [{ hash: "abcdef1234", message: "First", author: "Ada" }],
-      pushRange: { total: 9, rangeBasis: "untracked" as const },
+      pushRange: { total: 9, rangeBasis: "unverified" as const },
     });
   });
 
@@ -388,23 +388,36 @@ describe("formatGitRemoteOperationPreviewLines", () => {
     expect(lines.join(" ")).not.toContain("more");
   });
 
-  // Deliberately NOT "creates this branch": a missing local remote-tracking ref
-  // does not prove the remote branch is absent, so the line states what was
-  // measured rather than asserting a creation only the remote can confirm.
-  it("marks an untracked range as an upper bound instead of claiming a creation", () => {
+  // A creation claim is only made from a `creates` basis, which main sets only
+  // after the REMOTE said it has no such branch — never from a missing local ref.
+  it("says a push creates the branch only when the remote confirmed it", () => {
     const lines = formatGitRemoteOperationPreviewLines(
       {
         branch: "spike",
         destination: { remote: "origin", branch: "spike" },
         pullSource: null,
         commits: [],
-        pushRange: { total: 0, rangeBasis: "untracked" as const },
+        pushRange: { total: 0, rangeBasis: "creates" as const },
       },
       "none",
       "push"
     );
-    expect(lines[0]).toContain("Destination: origin/spike");
-    expect(lines[0]).toContain("upper bound");
+    expect(lines[0]).toBe("Destination: origin/spike (this push creates the branch)");
+  });
+
+  it("says unverified, not creates, when the remote could not be reached", () => {
+    const lines = formatGitRemoteOperationPreviewLines(
+      {
+        branch: "spike",
+        destination: { remote: "origin", branch: "spike" },
+        pullSource: null,
+        commits: [],
+        pushRange: { total: 0, rangeBasis: "unverified" as const },
+      },
+      "none",
+      "push"
+    );
+    expect(lines[0]).toContain("unverified");
     expect(lines[0]).not.toContain("creates");
   });
 

--- a/src/components/Git/__tests__/gitRemoteOperationPreview.test.ts
+++ b/src/components/Git/__tests__/gitRemoteOperationPreview.test.ts
@@ -12,7 +12,7 @@ function stubGit(overrides: {
   items?: Array<{ hash: string; message: string; author: { name: string } }>;
   pushCommits?: Array<{ hash: string; message: string; author: string }>;
   pushTotal?: number;
-  createsRemoteBranch?: boolean;
+  rangeBasis?: "tracked" | "untracked";
   reject?: boolean;
   rejectCommits?: boolean;
   rejectPushCommits?: boolean;
@@ -44,7 +44,7 @@ function stubGit(overrides: {
       ? Promise.reject(new Error("git log range failed"))
       : Promise.resolve({
           destination: pushDestination,
-          createsRemoteBranch: overrides.createsRemoteBranch ?? false,
+          rangeBasis: overrides.rangeBasis ?? "tracked",
           commits: pushCommits,
           total: overrides.pushTotal ?? pushCommits.length,
         })
@@ -94,11 +94,11 @@ describe("buildGitRemoteOperationPreview", () => {
     stubGit({
       pushCommits: [{ hash: "abcdef1234", message: "First", author: "Ada" }],
       pushTotal: 9,
-      createsRemoteBranch: true,
+      rangeBasis: "untracked" as const,
     });
     await expect(buildGitRemoteOperationPreview("/repo", "push")).resolves.toMatchObject({
       commits: [{ hash: "abcdef1234", message: "First", author: "Ada" }],
-      pushRange: { total: 9, createsRemoteBranch: true },
+      pushRange: { total: 9, rangeBasis: "untracked" as const },
     });
   });
 
@@ -139,7 +139,7 @@ describe("buildGitRemoteOperationPreview", () => {
     const { listPushCommits } = stubGit({ pushDestination: { remote: "fork", branch: "topic" } });
     listPushCommits.mockResolvedValueOnce({
       destination: { remote: "fork", branch: "renamed-topic" },
-      createsRemoteBranch: false,
+      rangeBasis: "tracked" as const,
       commits: [],
       total: 0,
     });
@@ -348,7 +348,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
         destination: { remote: "origin", branch: "main" },
         pullSource: { remote: "origin", branch: "main" },
         commits: [{ hash: "abcdef1234567", message: "First", author: "Ada" }],
-        pushRange: { total: 4, createsRemoteBranch: false },
+        pushRange: { total: 4, rangeBasis: "tracked" as const },
       },
       "none",
       "push"
@@ -363,7 +363,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
         destination: { remote: "origin", branch: "main" },
         pullSource: { remote: "origin", branch: "main" },
         commits: [{ hash: "abcdef1234567", message: "First", author: "Ada" }],
-        pushRange: { total: 1, createsRemoteBranch: false },
+        pushRange: { total: 1, rangeBasis: "tracked" as const },
       },
       "none",
       "push"
@@ -388,19 +388,24 @@ describe("formatGitRemoteOperationPreviewLines", () => {
     expect(lines.join(" ")).not.toContain("more");
   });
 
-  it("says a push creates the remote branch when there is nothing there yet", () => {
+  // Deliberately NOT "creates this branch": a missing local remote-tracking ref
+  // does not prove the remote branch is absent, so the line states what was
+  // measured rather than asserting a creation only the remote can confirm.
+  it("marks an untracked range as an upper bound instead of claiming a creation", () => {
     const lines = formatGitRemoteOperationPreviewLines(
       {
         branch: "spike",
         destination: { remote: "origin", branch: "spike" },
         pullSource: null,
         commits: [],
-        pushRange: { total: 0, createsRemoteBranch: true },
+        pushRange: { total: 0, rangeBasis: "untracked" as const },
       },
       "none",
       "push"
     );
-    expect(lines[0]).toBe("Destination: origin/spike (creates this branch)");
+    expect(lines[0]).toContain("Destination: origin/spike");
+    expect(lines[0]).toContain("upper bound");
+    expect(lines[0]).not.toContain("creates");
   });
 
   it("surfaces an explicit couldn't-verify warning for a failed fetch", () => {

--- a/src/components/Git/__tests__/gitRemoteOperationPreview.test.ts
+++ b/src/components/Git/__tests__/gitRemoteOperationPreview.test.ts
@@ -10,8 +10,12 @@ function stubGit(overrides: {
   pushDestination?: { remote: string; branch: string } | null;
   pullSource?: { remote: string; branch: string } | null;
   items?: Array<{ hash: string; message: string; author: { name: string } }>;
+  pushCommits?: Array<{ hash: string; message: string; author: string }>;
+  pushTotal?: number;
+  createsRemoteBranch?: boolean;
   reject?: boolean;
   rejectCommits?: boolean;
+  rejectPushCommits?: boolean;
 }) {
   // `??` would swallow an explicit null, which is exactly the detached-HEAD
   // case under test — key off presence instead.
@@ -34,12 +38,23 @@ function stubGit(overrides: {
       ? Promise.reject(new Error("git log failed"))
       : Promise.resolve({ items: overrides.items ?? [] })
   );
+  const pushCommits = overrides.pushCommits ?? [];
+  const listPushCommits = vi.fn(() =>
+    overrides.rejectPushCommits
+      ? Promise.reject(new Error("git log range failed"))
+      : Promise.resolve({
+          destination: pushDestination,
+          createsRemoteBranch: overrides.createsRemoteBranch ?? false,
+          commits: pushCommits,
+          total: overrides.pushTotal ?? pushCommits.length,
+        })
+  );
   Object.defineProperty(globalThis, "window", {
-    value: { electron: { git: { getStagingStatus, listCommits } } },
+    value: { electron: { git: { getStagingStatus, listCommits, listPushCommits } } },
     configurable: true,
     writable: true,
   });
-  return { getStagingStatus, listCommits };
+  return { getStagingStatus, listCommits, listPushCommits };
 }
 
 afterEach(() => {
@@ -47,39 +62,114 @@ afterEach(() => {
 });
 
 describe("buildGitRemoteOperationPreview", () => {
-  it("reads branch and commits fresh from the same cwd on every call", async () => {
-    const { getStagingStatus, listCommits } = stubGit({ currentBranch: "feature/x" });
-    await buildGitRemoteOperationPreview("/repo");
-    await buildGitRemoteOperationPreview("/repo");
+  it("reads fresh from the same cwd on every call", async () => {
+    const { getStagingStatus, listPushCommits } = stubGit({ currentBranch: "feature/x" });
+    await buildGitRemoteOperationPreview("/repo", "push");
+    await buildGitRemoteOperationPreview("/repo", "push");
     expect(getStagingStatus).toHaveBeenCalledTimes(2);
     expect(getStagingStatus).toHaveBeenCalledWith("/repo");
-    expect(listCommits).toHaveBeenCalledTimes(2);
-    expect(listCommits).toHaveBeenCalledWith({ cwd: "/repo", limit: PREVIEW_COMMIT_LIMIT });
+    expect(listPushCommits).toHaveBeenCalledTimes(2);
   });
 
-  it("flattens the commit author to a display name", async () => {
+  // The #11979 invariant. A push preview must describe the range the push would
+  // publish; the generic recent-history read describes the branch instead, and
+  // the two diverge for every branch that is not entirely unpushed.
+  it("measures a push against the resolved destination, never as recent history", async () => {
+    const { listCommits, listPushCommits } = stubGit({ currentBranch: "feature/x" });
+    await buildGitRemoteOperationPreview("/repo", "push");
+    expect(listPushCommits).toHaveBeenCalledWith("/repo", "feature/x", PREVIEW_COMMIT_LIMIT);
+    expect(listCommits).not.toHaveBeenCalled();
+  });
+
+  // Named explicitly rather than left to main to re-resolve: anything that
+  // checks out another branch between the two reads would otherwise move the
+  // range onto a branch the approver never saw.
+  it("names the branch the status just reported when it asks for the range", async () => {
+    const { listPushCommits } = stubGit({ currentBranch: "release/topic" });
+    await buildGitRemoteOperationPreview("/repo", "push");
+    expect(listPushCommits).toHaveBeenCalledWith("/repo", "release/topic", PREVIEW_COMMIT_LIMIT);
+  });
+
+  it("carries the range total and the creates-branch flag through for the push tail", async () => {
     stubGit({
+      pushCommits: [{ hash: "abcdef1234", message: "First", author: "Ada" }],
+      pushTotal: 9,
+      createsRemoteBranch: true,
+    });
+    await expect(buildGitRemoteOperationPreview("/repo", "push")).resolves.toMatchObject({
+      commits: [{ hash: "abcdef1234", message: "First", author: "Ada" }],
+      pushRange: { total: 9, createsRemoteBranch: true },
+    });
+  });
+
+  // A destination nobody can name has no range to measure, and asking for one
+  // anyway would surface the resolver's refusal as a load error rather than as
+  // the actionable "set an upstream" state.
+  it("skips the range read and reports no range when the destination is unresolved", async () => {
+    const { listPushCommits } = stubGit({ pushDestination: null });
+    await expect(buildGitRemoteOperationPreview("/repo", "push")).resolves.toMatchObject({
+      destination: null,
+      commits: [],
+      pushRange: null,
+    });
+    expect(listPushCommits).not.toHaveBeenCalled();
+  });
+
+  it("skips the range read for a detached HEAD", async () => {
+    const { listPushCommits } = stubGit({ currentBranch: null });
+    await expect(buildGitRemoteOperationPreview("/repo", "push")).resolves.toMatchObject({
+      branch: null,
+      pushRange: null,
+    });
+    expect(listPushCommits).not.toHaveBeenCalled();
+  });
+
+  // Fail closed. "The read broke" must never arrive looking like "there is
+  // nothing to publish", which is the reassuring answer and the wrong one.
+  it("propagates a push-range rejection instead of substituting an empty range", async () => {
+    stubGit({ rejectPushCommits: true });
+    await expect(buildGitRemoteOperationPreview("/repo", "push")).rejects.toThrow(
+      "git log range failed"
+    );
+  });
+
+  it("prefers the destination the range was actually measured against", async () => {
+    // Main resolves independently for the ranged read. If the two ever disagree,
+    // the rows on screen belong to main's answer, so that is the one to render.
+    const { listPushCommits } = stubGit({ pushDestination: { remote: "fork", branch: "topic" } });
+    listPushCommits.mockResolvedValueOnce({
+      destination: { remote: "fork", branch: "renamed-topic" },
+      createsRemoteBranch: false,
+      commits: [],
+      total: 0,
+    });
+    await expect(buildGitRemoteOperationPreview("/repo", "push")).resolves.toMatchObject({
+      destination: { remote: "fork", branch: "renamed-topic" },
+    });
+  });
+
+  it("keeps reading recent local history for a pull-rebase", async () => {
+    const { listCommits, listPushCommits } = stubGit({
       items: [{ hash: "abcdef1234", message: "Fix the thing", author: { name: "Ada" } }],
     });
-    const preview = await buildGitRemoteOperationPreview("/repo");
-    expect(preview).toEqual({
-      branch: "main",
-      destination: { remote: "origin", branch: "main" },
-      pullSource: { remote: "origin", branch: "main" },
+    await expect(buildGitRemoteOperationPreview("/repo", "pull-rebase")).resolves.toMatchObject({
       commits: [{ hash: "abcdef1234", message: "Fix the thing", author: "Ada" }],
+      pushRange: null,
     });
+    expect(listCommits).toHaveBeenCalledWith({ cwd: "/repo", limit: PREVIEW_COMMIT_LIMIT });
+    expect(listPushCommits).not.toHaveBeenCalled();
   });
 
   it("carries the resolved push destination through from the staging status", async () => {
     stubGit({ pushDestination: { remote: "fork", branch: "release/topic" } });
-    await expect(buildGitRemoteOperationPreview("/repo")).resolves.toMatchObject({
+    await expect(buildGitRemoteOperationPreview("/repo", "push")).resolves.toMatchObject({
       destination: { remote: "fork", branch: "release/topic" },
     });
   });
 
   it("preserves a null destination rather than inventing origin", async () => {
     stubGit({ pushDestination: null });
-    await expect(buildGitRemoteOperationPreview("/repo")).resolves.toMatchObject({
+    await expect(buildGitRemoteOperationPreview("/repo", "push")).resolves.toMatchObject({
       destination: null,
     });
   });
@@ -91,28 +181,24 @@ describe("buildGitRemoteOperationPreview", () => {
       pushDestination: { remote: "fork", branch: "topic" },
       pullSource: { remote: "origin", branch: "release/topic" },
     });
-    await expect(buildGitRemoteOperationPreview("/repo")).resolves.toMatchObject({
+    await expect(buildGitRemoteOperationPreview("/repo", "pull-rebase")).resolves.toMatchObject({
       destination: { remote: "fork", branch: "topic" },
       pullSource: { remote: "origin", branch: "release/topic" },
     });
   });
 
-  it("preserves a null branch rather than inventing one for detached HEAD", async () => {
-    stubGit({ currentBranch: null });
-    await expect(buildGitRemoteOperationPreview("/repo")).resolves.toMatchObject({ branch: null });
-  });
-
   it("rejects when the status read fails so callers can distinguish it from an empty repo", async () => {
     stubGit({ reject: true });
-    await expect(buildGitRemoteOperationPreview("/repo")).rejects.toThrow("git status failed");
+    await expect(buildGitRemoteOperationPreview("/repo", "push")).rejects.toThrow(
+      "git status failed"
+    );
   });
 
-  // A commit-read failure must NOT be laundered into an empty commit list —
-  // that would render as "no local commits" and enable approval on a preview
-  // that never loaded.
   it("propagates a commit-read rejection instead of substituting an empty list", async () => {
     stubGit({ rejectCommits: true });
-    await expect(buildGitRemoteOperationPreview("/repo")).rejects.toThrow("git log failed");
+    await expect(buildGitRemoteOperationPreview("/repo", "pull-rebase")).rejects.toThrow(
+      "git log failed"
+    );
   });
 });
 
@@ -127,6 +213,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
           { hash: "abcdef1234567", message: "First", author: "Ada" },
           { hash: "9876543210fed", message: "Second", author: "Bob" },
         ],
+        pushRange: null,
       },
       "none",
       "push"
@@ -149,6 +236,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
         destination: { remote: "fork", branch: "release/topic" },
         pullSource: { remote: "fork", branch: "release/topic" },
         commits: [],
+        pushRange: null,
       },
       "none",
       "push"
@@ -165,6 +253,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
         destination: { remote: "fork", branch: "topic" },
         pullSource: { remote: "origin", branch: "release/topic" },
         commits: [],
+        pushRange: null,
       },
       "none",
       "pull-rebase"
@@ -175,7 +264,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
 
   it("warns explicitly when no push destination is configured", () => {
     const lines = formatGitRemoteOperationPreviewLines(
-      { branch: "topic", destination: null, pullSource: null, commits: [] },
+      { branch: "topic", destination: null, pullSource: null, commits: [], pushRange: null },
       "none",
       "push"
     );
@@ -190,6 +279,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
         destination: { remote: "fork", branch: "topic" },
         pullSource: null,
         commits: [],
+        pushRange: null,
       },
       "none",
       "pull-rebase"
@@ -206,6 +296,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
         destination: null,
         pullSource: { remote: "origin", branch: "topic" },
         commits: [],
+        pushRange: null,
       },
       "none",
       "pull-rebase"
@@ -220,6 +311,7 @@ describe("formatGitRemoteOperationPreviewLines", () => {
         destination: { remote: "origin", branch: "main" },
         pullSource: { remote: "origin", branch: "main" },
         commits: [],
+        pushRange: null,
       },
       "No local commits found on this branch.",
       "push"
@@ -239,11 +331,76 @@ describe("formatGitRemoteOperationPreviewLines", () => {
         destination: { remote: "origin", branch: "main" },
         pullSource: { remote: "origin", branch: "main" },
         commits: [],
+        pushRange: null,
       },
       "none",
       "push"
     );
     expect(lines[1]).toBe("Branch: (detached HEAD)");
+  });
+
+  // The tail is only honest while it is measured over the SAME range the rows
+  // came from — a count from anywhere else describes a different set of commits.
+  it("states the hidden tail from the measured push range", () => {
+    const lines = formatGitRemoteOperationPreviewLines(
+      {
+        branch: "main",
+        destination: { remote: "origin", branch: "main" },
+        pullSource: { remote: "origin", branch: "main" },
+        commits: [{ hash: "abcdef1234567", message: "First", author: "Ada" }],
+        pushRange: { total: 4, createsRemoteBranch: false },
+      },
+      "none",
+      "push"
+    );
+    expect(lines[lines.length - 1]).toBe("  \u2026and 3 more");
+  });
+
+  it("omits a tail when the rows are the whole measured range", () => {
+    const lines = formatGitRemoteOperationPreviewLines(
+      {
+        branch: "main",
+        destination: { remote: "origin", branch: "main" },
+        pullSource: { remote: "origin", branch: "main" },
+        commits: [{ hash: "abcdef1234567", message: "First", author: "Ada" }],
+        pushRange: { total: 1, createsRemoteBranch: false },
+      },
+      "none",
+      "push"
+    );
+    expect(lines.join(" ")).not.toContain("more");
+  });
+
+  // No range was measured, so no tail may be claimed — deriving one from the
+  // row count would assert a total nothing counted.
+  it("claims no tail when no range was measured", () => {
+    const lines = formatGitRemoteOperationPreviewLines(
+      {
+        branch: "main",
+        destination: { remote: "origin", branch: "main" },
+        pullSource: { remote: "origin", branch: "main" },
+        commits: [{ hash: "abcdef1234567", message: "First", author: "Ada" }],
+        pushRange: null,
+      },
+      "none",
+      "pull-rebase"
+    );
+    expect(lines.join(" ")).not.toContain("more");
+  });
+
+  it("says a push creates the remote branch when there is nothing there yet", () => {
+    const lines = formatGitRemoteOperationPreviewLines(
+      {
+        branch: "spike",
+        destination: { remote: "origin", branch: "spike" },
+        pullSource: null,
+        commits: [],
+        pushRange: { total: 0, createsRemoteBranch: true },
+      },
+      "none",
+      "push"
+    );
+    expect(lines[0]).toBe("Destination: origin/spike (creates this branch)");
   });
 
   it("surfaces an explicit couldn't-verify warning for a failed fetch", () => {

--- a/src/components/Git/gitRemoteOperationPreview.ts
+++ b/src/components/Git/gitRemoteOperationPreview.ts
@@ -159,7 +159,8 @@ export async function buildGitRemoteOperationPreview(
  *
  * `null` means the fresh fetch could not be verified: surface that explicitly
  * rather than an empty list, which would imply "nothing to push". An empty
- * `commits` array IS a valid loaded state and gets `emptyNote`, never a warning.
+ * `commits` array IS a valid loaded state and never gets a warning — what it is
+ * allowed to say about the remote is decided by {@link emptyLines}.
  */
 export function formatGitRemoteOperationPreviewLines(
   preview: GitRemoteOperationPreview | null,
@@ -190,7 +191,7 @@ export function formatGitRemoteOperationPreviewLines(
       ? `${MCP_PREVIEW_CAUTION_PREFIX}This branch has no upstream to rebase onto — this operation will be refused.`
       : `${MCP_PREVIEW_CAUTION_PREFIX}No push destination is configured for this branch — this operation will be refused.`;
   if (preview.commits.length === 0) {
-    return [destinationLine, branchLine, emptyNote];
+    return [destinationLine, branchLine, ...emptyLines(preview, emptyNote, operation)];
   }
   // The tail is only stated when a total was actually measured over the same
   // range the rows came from. Deriving it from anything else would let the
@@ -206,6 +207,38 @@ export function formatGitRemoteOperationPreviewLines(
     ),
     ...(hidden > 0 ? [`  …and ${hidden} more`] : []),
   ];
+}
+
+/**
+ * What an empty commit list is allowed to claim.
+ *
+ * A push caller's `emptyNote` is the categorical "the destination already has
+ * everything" claim, and that is only true when the range settled against a
+ * destination git could name:
+ *
+ * - With no destination, the line above already says the push will be refused,
+ *   so an in-sync note would contradict it — nothing was compared at all.
+ * - With an `unverified` range, empty means "nothing found locally", never "the
+ *   destination is up to date" (see {@link GitPushRangeFacts.rangeBasis}). The
+ *   human dialog guards this with its `git-push-empty-unverified` state; the
+ *   MCP surface says the same thing here so the two approvers read one story.
+ *
+ * A pull-rebase keeps its own note in every state: it names no publish range,
+ * and its note claims nothing about the remote.
+ */
+function emptyLines(
+  preview: GitRemoteOperationPreview,
+  emptyNote: string,
+  operation: GitRemoteOperationKind
+): string[] {
+  if (operation !== "push") return [emptyNote];
+  if (preview.destination === null) return [];
+  if (preview.pushRange?.rangeBasis === "unverified") {
+    return [
+      `Nothing found to publish, but ${preview.destination.remote} couldn't be reached to check ${formatGitPushDestination(preview.destination)} — so this isn't confirmed.`,
+    ];
+  }
+  return [emptyNote];
 }
 
 /** Human-facing `remote/branch`. */

--- a/src/components/Git/gitRemoteOperationPreview.ts
+++ b/src/components/Git/gitRemoteOperationPreview.ts
@@ -39,12 +39,11 @@ export interface GitPushRangeFacts {
   /** Commits in the whole range, which may exceed the rows in `commits`. */
   total: number;
   /**
-   * `untracked` means there is no local remote-tracking ref for the
-   * destination, so the range is an upper bound rather than an exact answer —
-   * see `GitPushCommitPreview.rangeBasis`. It is NOT a claim that the push
-   * creates the branch; only the remote can settle that.
+   * How the rows were established — see `GitPushCommitPreview.rangeBasis`.
+   * `creates` and `tracked` are both settled answers; `unverified` is not, and
+   * an empty `unverified` range is NOT evidence the destination is up to date.
    */
-  rangeBasis: "tracked" | "untracked";
+  rangeBasis: "tracked" | "creates" | "unverified";
 }
 
 export interface GitRemoteOperationPreview {
@@ -181,9 +180,11 @@ export function formatGitRemoteOperationPreviewLines(
   const remoteRef = isPullRebase ? preview.pullSource : preview.destination;
   const destinationLine = remoteRef
     ? `${isPullRebase ? "Rebases onto" : "Destination"}: ${formatGitPushDestination(remoteRef)}${
-        preview.pushRange?.rangeBasis === "untracked"
-          ? " (no local copy of this branch — the commits below are an upper bound)"
-          : ""
+        preview.pushRange?.rangeBasis === "creates"
+          ? " (this push creates the branch)"
+          : preview.pushRange?.rangeBasis === "unverified"
+            ? " (could not reach the remote — the commits below are unverified)"
+            : ""
       }`
     : isPullRebase
       ? `${MCP_PREVIEW_CAUTION_PREFIX}This branch has no upstream to rebase onto — this operation will be refused.`

--- a/src/components/Git/gitRemoteOperationPreview.ts
+++ b/src/components/Git/gitRemoteOperationPreview.ts
@@ -38,8 +38,13 @@ export interface GitPreviewCommit {
 export interface GitPushRangeFacts {
   /** Commits in the whole range, which may exceed the rows in `commits`. */
   total: number;
-  /** The push would CREATE the remote branch rather than fast-forward it. */
-  createsRemoteBranch: boolean;
+  /**
+   * `untracked` means there is no local remote-tracking ref for the
+   * destination, so the range is an upper bound rather than an exact answer —
+   * see `GitPushCommitPreview.rangeBasis`. It is NOT a claim that the push
+   * creates the branch; only the remote can settle that.
+   */
+  rangeBasis: "tracked" | "untracked";
 }
 
 export interface GitRemoteOperationPreview {
@@ -131,7 +136,7 @@ export async function buildGitRemoteOperationPreview(
       })),
       pushRange: {
         total: preview.total,
-        createsRemoteBranch: preview.createsRemoteBranch,
+        rangeBasis: preview.rangeBasis,
       },
     };
   }
@@ -176,7 +181,9 @@ export function formatGitRemoteOperationPreviewLines(
   const remoteRef = isPullRebase ? preview.pullSource : preview.destination;
   const destinationLine = remoteRef
     ? `${isPullRebase ? "Rebases onto" : "Destination"}: ${formatGitPushDestination(remoteRef)}${
-        preview.pushRange?.createsRemoteBranch ? " (creates this branch)" : ""
+        preview.pushRange?.rangeBasis === "untracked"
+          ? " (no local copy of this branch — the commits below are an upper bound)"
+          : ""
       }`
     : isPullRebase
       ? `${MCP_PREVIEW_CAUTION_PREFIX}This branch has no upstream to rebase onto — this operation will be refused.`

--- a/src/components/Git/gitRemoteOperationPreview.ts
+++ b/src/components/Git/gitRemoteOperationPreview.ts
@@ -27,9 +27,31 @@ export interface GitPreviewCommit {
   author: string;
 }
 
+/**
+ * Push-only facts about the range `commits` was drawn from.
+ *
+ * Kept in its own object rather than flattened onto the preview so a
+ * pull-rebase preview cannot accidentally read a count that was never measured
+ * for it: `null` means "no range was measured", which is a different statement
+ * from "the range is empty".
+ */
+export interface GitPushRangeFacts {
+  /** Commits in the whole range, which may exceed the rows in `commits`. */
+  total: number;
+  /** The push would CREATE the remote branch rather than fast-forward it. */
+  createsRemoteBranch: boolean;
+}
+
 export interface GitRemoteOperationPreview {
   /** `null` for a detached HEAD — `getStagingStatus` reports no current branch. */
   branch: string | null;
+  /**
+   * The commits the operation would act on.
+   *
+   * For `"push"` this is the actual publish range (`<destination>..<branch>`),
+   * not the branch's recent history — see {@link buildGitRemoteOperationPreview}.
+   * For `"pull-rebase"` it stays the branch's recent local commits.
+   */
   commits: GitPreviewCommit[];
   /**
    * Where the operation would actually write, as git resolved it, or `null`
@@ -40,10 +62,15 @@ export interface GitRemoteOperationPreview {
   destination: GitPushDestination | null;
   /** Where a pull-and-rebase would integrate FROM — the upstream, not the push target. */
   pullSource: GitPushDestination | null;
+  /**
+   * Set only for `"push"`, and only once the destination resolved and the range
+   * was measured. `null` everywhere else.
+   */
+  pushRange: GitPushRangeFacts | null;
 }
 
 /**
- * Fetch the branch and recent local commits for `cwd`, fresh at call time.
+ * Fetch what `operation` would actually act on in `cwd`, fresh at call time.
  *
  * Deliberately un-cached: the preview must describe the repository state at the
  * moment the human is asked to approve, not a snapshot taken earlier (#8725).
@@ -51,28 +78,73 @@ export interface GitRemoteOperationPreview {
  * dialogs show a retryable error and keep confirm disabled; the MCP surface
  * shows a "couldn't verify" note).
  *
- * Caveat inherited from the IPC layer: `listCommits` swallows git failures in
- * main and resolves `{items: []}`, so a broken commit read is indistinguishable
- * here from a branch with no commits. Pre-existing behaviour — both dialogs read
- * the same IPC before this module existed — and not something this layer can
- * fix without changing that handler's contract for every caller.
+ * `operation` decides which commits are fetched, and the difference is the whole
+ * point of #11979:
+ *
+ * - **push** reads the real publish range through `git.listPushCommits`, which
+ *   ranges from the resolved destination's remote-tracking ref up to the named
+ *   branch. It also fails CLOSED: any git failure rejects, so "the read broke"
+ *   can never arrive looking like "there is nothing to publish".
+ * - **pull-rebase** keeps reading recent local history through `git.listCommits`.
+ *   That read swallows git failures into an empty list, so it cannot distinguish
+ *   a broken repository from an empty branch — a known weakness of that IPC's
+ *   contract, unchanged here because every other caller depends on it.
+ *
+ * The branch is read first and then named explicitly in the range read, rather
+ * than letting main resolve `HEAD` a second time: the two diverge the moment
+ * anything checks out another branch between the two calls, and a range measured
+ * against the wrong local branch can report "nothing to publish" for a push that
+ * publishes plenty.
  */
 export async function buildGitRemoteOperationPreview(
-  cwd: string
+  cwd: string,
+  operation: GitRemoteOperationKind
 ): Promise<GitRemoteOperationPreview> {
-  const [status, commitList] = await Promise.all([
-    window.electron.git.getStagingStatus(cwd),
-    window.electron.git.listCommits({ cwd, limit: PREVIEW_COMMIT_LIMIT }),
-  ]);
-  return {
+  const status = await window.electron.git.getStagingStatus(cwd);
+  const base = {
     branch: status.currentBranch,
     destination: status.pushDestination,
     pullSource: status.pullSource,
+  };
+
+  if (operation === "push") {
+    // No branch or no nameable destination means there is no range to measure.
+    // Both states already block confirm on their own terms, and the dialog says
+    // which one it is rather than showing an empty list that reads as "safe".
+    if (!status.currentBranch || !status.pushDestination) {
+      return { ...base, commits: [], pushRange: null };
+    }
+    const preview = await window.electron.git.listPushCommits(
+      cwd,
+      status.currentBranch,
+      PREVIEW_COMMIT_LIMIT
+    );
+    return {
+      ...base,
+      // Main resolves the destination independently for the range read. Prefer
+      // its answer: it is the one the rows were actually measured against.
+      destination: preview.destination,
+      commits: preview.commits.map((c) => ({
+        hash: c.hash,
+        message: c.message,
+        author: c.author,
+      })),
+      pushRange: {
+        total: preview.total,
+        createsRemoteBranch: preview.createsRemoteBranch,
+      },
+    };
+  }
+
+  const commitList = await window.electron.git.listCommits({ cwd, limit: PREVIEW_COMMIT_LIMIT });
+  return {
+    ...base,
     commits: commitList.items.map((c) => ({
       hash: c.hash,
       message: c.message,
       author: c.author.name,
     })),
+    pushRange: null,
   };
 }
 
@@ -103,19 +175,28 @@ export function formatGitRemoteOperationPreviewLines(
   const isPullRebase = operation === "pull-rebase";
   const remoteRef = isPullRebase ? preview.pullSource : preview.destination;
   const destinationLine = remoteRef
-    ? `${isPullRebase ? "Rebases onto" : "Destination"}: ${formatGitPushDestination(remoteRef)}`
+    ? `${isPullRebase ? "Rebases onto" : "Destination"}: ${formatGitPushDestination(remoteRef)}${
+        preview.pushRange?.createsRemoteBranch ? " (creates this branch)" : ""
+      }`
     : isPullRebase
       ? `${MCP_PREVIEW_CAUTION_PREFIX}This branch has no upstream to rebase onto — this operation will be refused.`
       : `${MCP_PREVIEW_CAUTION_PREFIX}No push destination is configured for this branch — this operation will be refused.`;
   if (preview.commits.length === 0) {
     return [destinationLine, branchLine, emptyNote];
   }
+  // The tail is only stated when a total was actually measured over the same
+  // range the rows came from. Deriving it from anything else would let the
+  // approver read a count that describes a different set of commits.
+  const hidden = preview.pushRange
+    ? Math.max(0, preview.pushRange.total - preview.commits.length)
+    : 0;
   return [
     destinationLine,
     branchLine,
     ...preview.commits.map(
       (c) => `  ${c.hash.slice(0, SHORT_HASH_LEN)} ${c.message} — ${c.author}`
     ),
+    ...(hidden > 0 ? [`  …and ${hidden} more`] : []),
   ];
 }
 

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -886,7 +886,7 @@ describe("useMcpBridge", () => {
 
     useMcpConfirmStore.getState().resolveCurrent("approved");
     await dispatched;
-    expect(mocks.buildGitPreview).toHaveBeenCalledWith("/repo");
+    expect(mocks.buildGitPreview).toHaveBeenCalledWith("/repo", "push");
   });
 
   // The preview resolves cwd when the modal opens; ActionService would otherwise
@@ -996,7 +996,7 @@ describe("useMcpBridge", () => {
     useMcpConfirmStore.getState().resolveCurrent("approved");
     await dispatched;
 
-    expect(mocks.buildGitPreview).toHaveBeenCalledWith("/previewed");
+    expect(mocks.buildGitPreview).toHaveBeenCalledWith("/previewed", "pull-rebase");
     expect(mocks.dispatch).toHaveBeenCalledWith(
       "git.pullRebase",
       { cwd: "/previewed" },
@@ -1463,7 +1463,7 @@ describe("buildMcpConfirmPreview (#11343, #11538)", () => {
       commits: [{ hash: "abcdef1234", message: "Fix the thing", author: "Ada" }],
     });
     const lines = await buildMcpConfirmPreview({ kind: "gitPush", cwd: "/repo" });
-    expect(mocks.buildGitPreview).toHaveBeenCalledWith("/repo");
+    expect(mocks.buildGitPreview).toHaveBeenCalledWith("/repo", "push");
     expect(lines[0]).toBe("Destination: origin/feature/x");
     expect(lines[1]).toBe("Branch: feature/x");
     expect(lines[2]).toContain("Fix the thing");

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -284,11 +284,11 @@ export async function buildMcpConfirmPreview(target: McpConfirmPreviewTarget): P
   }
   const operation = target.kind === "gitPush" ? "push" : "pull-rebase";
   try {
-    const preview = await buildGitRemoteOperationPreview(target.cwd);
+    const preview = await buildGitRemoteOperationPreview(target.cwd, operation);
     return formatGitRemoteOperationPreviewLines(
       preview,
       target.kind === "gitPush"
-        ? "No local commits found on this branch."
+        ? "Nothing to publish — the destination already has everything on this branch."
         : "No local commits to replay.",
       operation
     );


### PR DESCRIPTION
## Summary

The push confirm was previewing the wrong commits. It read `git log HEAD`, which returns a branch's recent history, not the commits a push would publish. A branch already level with its remote listed commits that were already on it, and a branch 2 ahead of 14 listed 12 that mostly were. For a D2 safeguard whose whole job is a preview of the actual content, that is the wrong set.

The fix is a ranged read scoped to the resolved destination, plus a rebuild of the surface around it.

Resolves #11979

## The preview

`git:list-push-commits` ranges from the destination's remote-tracking ref up to the named branch, mirroring the force-push discard preview in reverse. It lands as a `defineIpcNamespace` block so the channel goes into the generated half of the map (`check:ipc-handwritten` stays at 237). The branch is named explicitly rather than left as `HEAD`, so a checkout between opening the dialog and confirming it cannot move the range.

It fails closed. `listCommits` swallows every git failure into `{items: []}`, so a broken read used to arrive looking like "nothing to publish" with Push enabled. The ranged read throws instead, and the shared builder propagates it.

When there is no local tracking ref, it asks the remote. A missing ref does not mean a missing branch: it also happens when the branch was never fetched, was pruned, or is excluded by the fetch refspec. One bounded `ls-remote` (4s, untracked path only, swallowed into an unverified state on failure) settles it, so the range now reports how it was established:

| basis | how | what the dialog may say |
| --- | --- | --- |
| `tracked` | a local tracking ref, or a tip the remote named that we already hold | exact delta, "already has everything" allowed |
| `creates` | the remote answered and has no such branch | "creates this branch" |
| `unverified` | remote unreachable, or it named a tip we lack | rows shown but labelled, in-sync claim forbidden |

The shared builder (`buildGitRemoteOperationPreview`) now takes the operation, so the MCP confirm surface gets the identical range and the two cannot drift (#11538).

## The surface

One fixed title. It used to interpolate whatever had loaded, reading `Push 'current branch'?` mid-flight and `Push to 'origin/main'?` after, with the quoted string silently changing from naming the local branch to naming the remote ref. A title that fills in after the fetch is also never re-announced: the accessible name is computed once as focus enters, so a screen reader only ever heard the placeholder. The refs moved into a From/To summary, which can hold a pending state honestly and can wrap a 90 character fork ref without pushing the close button into the middle of the header.

Destination, range, load failure and retry now share one preview region, so a blocked push and its reason are never in different parts of the dialog. The count and the "and N more" tail are both measured over the same range as the rows.

Preview loading no longer rides `isConfirmLoading`. That prop means the confirmed action is running: it drew a spinner across the word Push, dimmed the label to 30%, and disabled Cancel. Because `AppDialog` finds the Cancel button by selector and calls `.focus()` on it without checking it is enabled, that also left keyboard focus outside the dialog for the whole fetch. It is a gated skeleton now, wrapped in `Skeleton` so the busy state is announced, and Cancel stays usable.

Also in here: a detached HEAD gets its own diagnosis rather than being told to configure a push remote for a branch that does not exist; approval is bound to the request that produced the preview, so a second confirm for another worktree cannot be approved against the first one's commits; the recovery command is `git push -u <remote> <branch>`, because `git config branch.<name>.pushRemote` with no value reads the setting rather than setting it, and under the default `push.default` it leaves the push ref empty and lands you back on the same screen; the commit list is a keyboard reachable region with scroll shadows instead of a row clipped by the panel edge; the author column is bounded so a long name cannot gut the subject; and hashes and authors moved from `text-daintree-text/40` (3.23:1) to `/55`, matching `ConflictPanel`.

## Design review

Scored 4.9 to 9.0 over three rounds against real captures, on information hierarchy, scannability, visual language consistency, typography, density, affordance, states, accessibility, microcopy, truthfulness of the preview, and craft. The harness is committed at `e2e/screenshots/git-push-confirm-review.spec.ts`: 11 states (loaded, single commit, in sync, long values, no destination, load failure, in flight, keyboard focus, `prefers-contrast: more`, `forced-colors: active`, full window), driven through real seams. Fixture repo with two real bare remotes for the loaded states, the main process fault registry for loading and failure. It opens the dialog by dispatching `git.push` and only ever leaves by Escape, so it never pushes.

```
DAINTREE_SHOT_GITPUSH=1 npx playwright test --project=screenshots git-push-confirm-review
```

Consistency survey before shipping: of 12 patterns this touches, 9 move the dialog toward what the rest of the app already does, and in 6 of those the entire remaining old way is `GitPullRebaseConfirmDialog` and `ForcePushConfirmDialog`, which were near clones of this file. Both are left alone here. Two are conscious minority choices (`role="heading"` on the section label, 3 of 23; `footerHint`, which had no callers). One is new: the labelled From/To rail.

## Testing

`npm run check` and the full `npx vitest run` suite, both green. Eight invariants pinned and every one mutation checked (reintroduce the bug, confirm the test fails): the push path reads the range and never recent history, the ranged read fails closed, a preview fetch is not action loading, detached HEAD is not a missing remote, the count and tail come from the measured range, a creation is claimed only from a remote confirmed range, an unverified range never yields an in-sync claim, and a preview from a previous request is not approvable.

## Follow-ups, not in here

- No destructive specific `forced-colors` rule exists anywhere in the app (0 across 7 blocks in 4 files), so Push and Cancel are still one white pill apart under forced colors. Adding one would be the first, and would change every dialog.
- `ConfirmDialog` uses a real `disabled` on the primary across 50 call sites. Current guidance prefers `aria-disabled` with `aria-describedby`. `footerHint` is the adjacent explanation in the meantime, and 7 of the 8 `confirmDisabled` callers still have none.
- `text-daintree-text/40` is 3.23:1 and appears 437 times across 169 files. Worth a decision, not a unilateral change.
- `AppDialog`'s initial focus pass does not verify that the element it focused actually took focus. `src/lib/accessibility.ts` already has the verify and continue pattern.
- Threading the resolver's unresolved reason through `StagingStatus` would let the no destination state distinguish "pick a remote" from "configure an upstream".
