### PR TITLE
Refine the Worktrees sidebar header and search/filter rail

### DIFF
--- a/e2e/screenshots/worktree-sidebar-rail-review.spec.ts
+++ b/e2e/screenshots/worktree-sidebar-rail-review.spec.ts
@@ -704,6 +704,7 @@ test("worktrees sidebar rail — state matrix", async () => {
 
     // 14. Narrow + hover — the header cluster's worst case for crowding.
     await cap.step("width-min-hover", async () => {
+      await blurAll(page);
       await page.locator(SIDEBAR).getByRole("heading", { name: "Worktrees" }).hover();
       await settle(page, 400);
       await expect(page.locator(SEL.worktree.openOverviewButton)).toBeVisible();

--- a/e2e/screenshots/worktree-sidebar-rail-review.spec.ts
+++ b/e2e/screenshots/worktree-sidebar-rail-review.spec.ts
@@ -1,0 +1,858 @@
+/**
+ * Worktrees sidebar control-zone visual-review harness.
+ *
+ * Boots a repo with a main worktree plus several feature worktrees, then writes
+ * PNGs of every state the fixed control zone at the top of the sidebar carries
+ * design weight in — header at rest / hover / keyboard focus, the search field
+ * empty / typed / long / no-match, one and several active filter axes, the
+ * filter popover collapsed / expanded / active, the loading and only-main
+ * variants, and the zone at minimum, default and generous sidebar widths — so
+ * a redesign can be judged against real rendered pixels.
+ *
+ * Opt-in only, like theme-review: skips itself unless DAINTREE_SHOT_SIDEBAR is
+ * set, so the marketing screenshots workflow never executes it.
+ *
+ *   DAINTREE_SHOT_SIDEBAR=1 npx playwright test --project=screenshots worktree-sidebar-rail
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_SIDEBAR    required — any truthy value runs the state capture
+ *   DAINTREE_SHOT_THEME      theme id for the state capture (default: daintree)
+ *   DAINTREE_SHOT_THEMES     comma-separated ids for the cross-theme sweep
+ *                            (default: every built-in theme)
+ *   DAINTREE_SHOT_TAG        optional suffix so review rounds sit side by side
+ *   DAINTREE_SHOT_ONLY       comma-separated step filter (see step names below)
+ *
+ * Output: artifacts/sidebar-shots/<theme>/<NN-slug>[-tag].png (gitignored).
+ *
+ * Verification contract: every step asserts the state it drove actually
+ * rendered BEFORE writing a file, and a step that throws records a failure
+ * instead of writing one. The test fails at the end with the list of states it
+ * could not capture, so a green run means every PNG on disk is real.
+ */
+
+import { test, expect, type Page, type Locator } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { addAndSwitchToProject } from "../helpers/workflows";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_SIDEBAR;
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const STATE_THEME = process.env.DAINTREE_SHOT_THEME ?? "daintree";
+
+/** Every built-in theme, light and dark, in id order. */
+const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+const SWEEP_THEMES = (process.env.DAINTREE_SHOT_THEMES ?? ALL_THEMES.join(","))
+  .split(",")
+  .map((id) => id.trim())
+  .filter(Boolean);
+
+const SIDEBAR = SEL.sidebar.aside;
+/** SEL.sidebar.resizeHandle matches the label exactly; the real one is
+ *  "Resize sidebar (double-click to reset)". */
+const RESIZE_HANDLE = '[aria-label^="Resize sidebar"]';
+/**
+ * Radix keeps a closing popover mounted through its exit animation, and it
+ * precedes the new one in DOM order — so a bare testid + `.first()` can
+ * resolve to the stale copy, which still renders the state it closed with.
+ * Every popover assertion here addresses the one that is actually open.
+ */
+const OPEN_POPOVER = `${SEL.worktree.filterPopover}[data-state="open"]`;
+/** Tall enough to hold the header, the rail, the status line and the first card. */
+const ZONE_HEIGHT = 420;
+/** Comfortably past WorktreeSidebarSearchBar's 500ms query-persist debounce. */
+const QUERY_PERSIST_SETTLE_MS = 900;
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+interface Fixture {
+  dir: string;
+  cleanup: () => void;
+}
+
+/**
+ * Feature branches chosen so the rail has something to do: several match
+ * "auth", one is long enough to test truncation at 200px, and the prefixes
+ * spread across the popover's Branch Type taxonomy.
+ */
+const FEATURES = [
+  { branch: "feature/oauth-device-flow", dirty: true, commits: 2 },
+  { branch: "feature/streaming-token-budget", dirty: false, commits: 1 },
+  { branch: "fix/auth-refresh-retry-backoff-jitter", dirty: true, commits: 3 },
+  { branch: "chore/bump-electron-42-and-chromium-148", dirty: false, commits: 1 },
+  { branch: "refactor/worktree-port-broker", dirty: true, commits: 1 },
+  { branch: "docs/plugin-authoring-guide", dirty: false, commits: 1 },
+];
+
+/** Repo with a main worktree plus the feature worktrees above. */
+function createRailRepo(prefix: string, features: typeof FEATURES): Fixture {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  writeFileSync(path.join(dir, "src", "index.ts"), "export const main = (): number => 0;\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  writeFileSync(path.join(dir, "notes.md"), "# Notes\n\n- sidebar rail pass\n");
+
+  for (const f of features) {
+    const slug = f.branch.replace(/[/]/g, "-");
+    const wtDir = path.join(wtRoot, slug);
+    git(`branch ${f.branch}`, dir);
+    git(`worktree add ${JSON.stringify(wtDir)} ${f.branch}`, dir);
+    for (let i = 0; i < f.commits; i++) {
+      writeFileSync(path.join(wtDir, `change-${i}.md`), `change ${i} on ${f.branch}\n`);
+      git("add -A", wtDir);
+      git(`commit -m "work ${i} on ${slug}"`, wtDir);
+    }
+    if (f.dirty) {
+      writeFileSync(path.join(wtDir, "wip.txt"), "in progress\n");
+      writeFileSync(path.join(wtDir, "src", "index.ts"), `// ${slug}\nexport const x = 1;\n`);
+    }
+  }
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 450): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/** Current rendered width of the sidebar column. */
+async function sidebarWidth(page: Page): Promise<number> {
+  return Math.round((await page.locator(SIDEBAR).first().boundingBox())?.width ?? -1);
+}
+
+/**
+ * Resize the sidebar to an absolute logical width using the separator's own
+ * keyboard affordance — ArrowLeft/ArrowRight move in fixed 10px steps, so the
+ * end width is exact. A synthetic pointer drag depends on hit geometry that
+ * did not hold here, and silently landed back on the default width.
+ */
+async function setSidebarWidth(page: Page, width: number): Promise<void> {
+  const handle = page.locator(RESIZE_HANDLE).first();
+  await handle.focus();
+  for (let i = 0; i < 60; i++) {
+    const current = await sidebarWidth(page);
+    if (Math.abs(current - width) < 5) break;
+    await page.keyboard.press(current > width ? "ArrowLeft" : "ArrowRight");
+    await page.waitForTimeout(30);
+  }
+  // Blur the separator: it paints its own focus indicator, which would sit in
+  // every width capture as a stray coloured rule down the sidebar edge.
+  await handle.evaluate((el: HTMLElement) => el.blur());
+  await settle(page, 350);
+  await expect
+    .poll(async () => sidebarWidth(page), {
+      timeout: 5000,
+      message: `sidebar should resize to ${width}px`,
+    })
+    .toBe(width);
+}
+
+/** Park the pointer well away from the sidebar so no hover state leaks in. */
+async function parkPointer(page: Page): Promise<void> {
+  await page.mouse.move(1200, 700);
+  await settle(page, 250);
+}
+
+/** Drop focus so a "rest" capture does not inherit the previous step's ring. */
+async function blurAll(page: Page): Promise<void> {
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+  await settle(page, 200);
+}
+
+/**
+ * Measured geometry of the control zone, written beside the PNGs.
+ *
+ * A review argued from CSS arithmetic gets the nesting wrong; these are the
+ * boxes the browser actually laid out, in CSS pixels relative to the sidebar's
+ * own left edge, so claims about insets, control heights and the zone's total
+ * cost are checkable rather than estimated.
+ */
+async function collectMetrics(page: Page): Promise<unknown> {
+  return page.evaluate(() => {
+    const aside = document.querySelector('aside[aria-label="Sidebar"]');
+    if (!aside) return { error: "no sidebar" };
+    const origin = aside.getBoundingClientRect();
+    const box = (el: Element | null) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return {
+        left: +(r.left - origin.left).toFixed(1),
+        right: +(origin.right - r.right).toFixed(1),
+        top: +(r.top - origin.top).toFixed(1),
+        width: +r.width.toFixed(1),
+        height: +r.height.toFixed(1),
+      };
+    };
+    const heading = aside.querySelector("h2");
+    const header = heading?.closest("div.group\\/header") ?? heading?.parentElement?.parentElement;
+    const input = aside.querySelector('[aria-label="Search worktrees"]');
+    const field = input?.closest('[role="search"]') ?? null;
+    const glyph = field?.querySelector("svg") ?? null;
+    const trigger = aside.querySelector('[aria-label="Filter and sort worktrees"]');
+    const rail = trigger?.closest("div.shrink-0") ?? null;
+    const firstCard = aside.querySelector("[data-worktree-is-main]");
+    return {
+      sidebarWidth: +origin.width.toFixed(1),
+      header: box(header ?? null),
+      heading: box(heading ?? null),
+      rail: box(rail),
+      field: box(field),
+      searchGlyph: box(glyph),
+      filterTrigger: box(trigger),
+      firstCard: box(firstCard),
+      zoneHeightToFirstCard: firstCard
+        ? +(firstCard.getBoundingClientRect().top - origin.top).toFixed(1)
+        : null,
+      dividers: Array.from(aside.querySelectorAll("div"))
+        .filter((el) => {
+          const cs = getComputedStyle(el);
+          return (
+            cs.borderBottomWidth !== "0px" &&
+            cs.borderBottomStyle !== "none" &&
+            el.getBoundingClientRect().top - origin.top < 260
+          );
+        })
+        .map((el) => ({
+          y: +(el.getBoundingClientRect().bottom - origin.top).toFixed(1),
+          color: getComputedStyle(el).borderBottomColor,
+          cls: el.className.toString().slice(0, 60),
+        })),
+    };
+  });
+}
+
+class Capture {
+  readonly failures: string[] = [];
+  readonly missing: string[] = [];
+  readonly notes: string[] = [];
+
+  note(text: string): void {
+    this.notes.push(text);
+  }
+  private written = 0;
+  private readonly only: string[];
+
+  constructor(
+    private readonly page: Page,
+    private outputDir: string
+  ) {
+    this.only = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+  }
+
+  setOutputDir(dir: string): void {
+    this.outputDir = dir;
+    mkdirSync(dir, { recursive: true });
+  }
+
+  get count(): number {
+    return this.written;
+  }
+
+  /**
+   * Drive a state, assert it rendered, then write the PNG. A step that throws
+   * records a failure and writes nothing — never a plausible-looking artifact
+   * for a state that did not happen.
+   */
+  async step(name: string, fn: () => Promise<void>): Promise<void> {
+    if (this.only.length > 0 && !this.only.includes(name)) return;
+    try {
+      await fn();
+    } catch (error) {
+      this.failures.push(`${name}: ${String(error).slice(0, 1200)}`);
+    }
+  }
+
+  /**
+   * A state the harness cannot drive deterministically (a transient the app
+   * owns, like the loading skeleton). A miss is recorded in MISSING.txt beside
+   * the PNGs so the review is told the state is absent, rather than failing the
+   * whole run or — worse — writing a stand-in.
+   */
+  async optionalStep(name: string, fn: () => Promise<void>): Promise<void> {
+    if (this.only.length > 0 && !this.only.includes(name)) return;
+    try {
+      await fn();
+    } catch (error) {
+      this.missing.push(`${name}: ${String(error).slice(0, 300)}`);
+    }
+  }
+
+  /** Full-height sidebar column. */
+  async snapSidebar(slug: string): Promise<void> {
+    await settle(this.page);
+    await this.page
+      .locator(SIDEBAR)
+      .first()
+      .screenshot({ path: this.file(slug), type: "png", animations: "disabled", caret: "hide" });
+    this.written++;
+  }
+
+  /** Just the control zone plus the top of the first card. */
+  async snapZone(slug: string): Promise<void> {
+    await settle(this.page);
+    const box = await this.page.locator(SIDEBAR).first().boundingBox();
+    if (!box) throw new Error("sidebar has no bounding box");
+    await this.page.screenshot({
+      path: this.file(slug),
+      type: "png",
+      animations: "disabled",
+      caret: "hide",
+      clip: { x: box.x, y: box.y, width: box.width, height: Math.min(ZONE_HEIGHT, box.height) },
+    });
+    this.written++;
+  }
+
+  /** An overlay that escapes the sidebar's bounds — the filter popover. */
+  async snapLocator(slug: string, locator: Locator): Promise<void> {
+    await settle(this.page);
+    await locator.screenshot({ path: this.file(slug), type: "png" });
+    this.written++;
+  }
+
+  /** The sidebar and the popover together, so their relationship is visible. */
+  async snapRegion(slug: string, width: number, height: number): Promise<void> {
+    await settle(this.page);
+    const box = await this.page.locator(SIDEBAR).first().boundingBox();
+    if (!box) throw new Error("sidebar has no bounding box");
+    await this.page.screenshot({
+      path: this.file(slug),
+      type: "png",
+      animations: "disabled",
+      caret: "hide",
+      clip: { x: box.x, y: box.y, width, height },
+    });
+    this.written++;
+  }
+
+  private file(slug: string): string {
+    return path.join(this.outputDir, `${slug}${TAG}.png`);
+  }
+}
+
+/** Type into the search field and wait for the visible list to react. */
+async function typeQuery(page: Page, query: string): Promise<void> {
+  const input = page.locator(SEL.worktree.searchInput).first();
+  await input.click();
+  await input.fill(query);
+  await settle(page, 500);
+}
+
+/**
+ * Clear the query AND wait out its persistence debounce.
+ *
+ * The visible filter clears instantly but the localStorage write is debounced
+ * 500ms, so a theme switch (which reloads the renderer) inside that window
+ * rehydrates the old query — which is how fourteen "rest" frames in the first
+ * theme sweep came back with `auth` still typed.
+ */
+async function clearQuery(page: Page): Promise<void> {
+  const input = page.locator(SEL.worktree.searchInput).first();
+  await input.fill("");
+  await expect(page.locator(SIDEBAR).getByLabel("Clear search")).toHaveCount(0, { timeout: 5000 });
+  await page.waitForTimeout(QUERY_PERSIST_SETTLE_MS);
+  await settle(page, 200);
+}
+
+/**
+ * Open the filter popover and wait for its content. Idempotent: the trigger is
+ * a toggle, so a popover left open by a failed step would be CLOSED by a naive
+ * click, cascading one failure into every later popover step.
+ */
+async function openFilterPopover(page: Page): Promise<Locator> {
+  const popover = page.locator(OPEN_POPOVER).first();
+  if (!(await popover.isVisible().catch(() => false))) {
+    await page.locator(SEL.worktree.filterButton).first().click();
+  }
+  await expect(popover).toBeVisible({ timeout: 6000 });
+  await settle(page, 400);
+  return popover;
+}
+
+async function closeFilterPopover(page: Page): Promise<void> {
+  if ((await page.locator(OPEN_POPOVER).count()) === 0) return;
+  await page.keyboard.press("Escape");
+  await expect(page.locator(OPEN_POPOVER)).toHaveCount(0, { timeout: 5000 });
+  await settle(page, 250);
+}
+
+/**
+ * A button inside the popover, addressed by its rendered text.
+ *
+ * NOT `getByText` / `getByRole`: `Button` wraps its label in a
+ * `display: contents` span, which has no box, so Playwright reads the label
+ * element as invisible and a click on it never becomes actionable. `:has-text`
+ * on the `<button>` itself matches the element that does have a box.
+ */
+function popoverButton(popover: Locator, label: string): Locator {
+  return popover.locator(`button:has-text(${JSON.stringify(label)})`).first();
+}
+
+/**
+ * Assert a string is really in the open popover, quoting what IS there when it
+ * is not — a bare "element not found" says nothing about which state rendered.
+ */
+async function expectInPopover(popover: Locator, text: string): Promise<void> {
+  // textContent, not innerText: the popover clips and scrolls, and innerText's
+  // "rendered text" approximation is exactly the wrong oracle for asking
+  // whether something is in the DOM at all.
+  const body = (await popover.textContent().catch(() => "")) ?? "";
+  if (!body.replace(/\s+/g, " ").toLowerCase().includes(text.toLowerCase())) {
+    throw new Error(
+      `popover missing "${text}". Popover buttons were: ` +
+        (await popover
+          .evaluate((el) =>
+            Array.from(el.querySelectorAll("button"))
+              .map((b) => (b.textContent ?? "").trim())
+              .join(" | ")
+          )
+          .catch(() => "<unreadable>"))
+    );
+  }
+}
+
+/** Scroll an overflowing popover to its end so the footer is in frame. */
+async function scrollPopoverToEnd(popover: Locator): Promise<void> {
+  await popover.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+}
+
+async function openProjectFixture(ctx: AppContext, repoDir: string, theme: string): Promise<Page> {
+  const page = await openAndOnboardProject(ctx.app, ctx.window, repoDir, "Helios Dashboard");
+  if (theme) await setAppTheme(page, theme);
+  await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+  await dismissBlockingPalette(page);
+  await page.locator(SEL.worktree.mainCard).waitFor({ state: "visible", timeout: T_LONG });
+  await page.locator(SEL.worktree.searchInput).waitFor({ state: "visible", timeout: T_LONG });
+  await settle(page, 2000);
+  await dismissBlockingPalette(page);
+  return page;
+}
+
+test("worktrees sidebar rail — state matrix", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_SIDEBAR is required for the sidebar rail capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_SIDEBAR to run the sidebar rail capture");
+
+  const outputDir = path.resolve(process.cwd(), "artifacts", "sidebar-shots", STATE_THEME);
+  mkdirSync(outputDir, { recursive: true });
+  const repo = createRailRepo("daintree-railshots-", FEATURES);
+  const soloRepo = createRailRepo("daintree-railsolo-", []);
+  // Prefix deliberately avoids "daintree-e2e": launchApp's pre-launch hygiene
+  // pkills that pattern, and a concurrent capture session would otherwise
+  // SIGKILL this one mid-launch. launchApp skips auto-cleanup for
+  // caller-provided dirs, so remove it in the finally.
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-railshot-"));
+  let ctx: AppContext | undefined;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openProjectFixture(ctx, repo.dir, STATE_THEME);
+    const cap = new Capture(page, outputDir);
+
+    // 0. Measured geometry, so the review argues from laid-out boxes rather
+    //    than from CSS arithmetic over nested padding.
+    await cap.step("metrics", async () => {
+      await parkPointer(page);
+      const metrics = await collectMetrics(page);
+      writeFileSync(path.join(outputDir, "METRICS.json"), JSON.stringify(metrics, null, 2) + "\n");
+    });
+
+    // 1. Rest — the shot the whole refinement is judged on.
+    await cap.step("rest", async () => {
+      await parkPointer(page);
+      await expect(page.locator(SIDEBAR).getByRole("heading", { name: "Worktrees" })).toBeVisible();
+      await expect(page.locator(SEL.worktree.searchInput)).toBeVisible();
+      await cap.snapSidebar("10-rest-sidebar");
+      await cap.snapZone("11-rest-zone");
+    });
+
+    // 2. Header hover — the reveal the three secondary actions live behind.
+    await cap.step("header-hover", async () => {
+      await page.locator(SIDEBAR).getByRole("heading", { name: "Worktrees" }).hover();
+      await settle(page, 400);
+      await expect(page.locator(SEL.worktree.openOverviewButton)).toBeVisible();
+      await cap.snapZone("12-header-hover");
+      await parkPointer(page);
+    });
+
+    // 3. Keyboard focus walking backwards out of the search field into the
+    //    header cluster — the reveal path a keyboard user actually takes.
+    await cap.step("header-focus", async () => {
+      await page.locator(SEL.worktree.searchInput).first().click();
+      await page.keyboard.press("Shift+Tab"); // create-worktree "+"
+      await settle(page, 250);
+      await expect(page.locator(SEL.worktree.newWorktreeButton)).toBeFocused();
+      await cap.snapZone("13-focus-create");
+      await page.keyboard.press("Shift+Tab"); // refresh
+      await page.keyboard.press("Shift+Tab"); // fleet arm
+      await page.keyboard.press("Shift+Tab"); // overview
+      await settle(page, 250);
+      await expect(page.locator(SEL.worktree.openOverviewButton)).toBeFocused();
+      await cap.snapZone("14-focus-overview");
+      await page.locator(SEL.worktree.searchInput).first().click();
+      await page.keyboard.press("Escape");
+      await parkPointer(page);
+    });
+
+    // 4. Search field focused and empty.
+    await cap.step("search-focus", async () => {
+      await page.locator(SEL.worktree.searchInput).first().click();
+      await page.keyboard.press("Shift+Tab");
+      await page.keyboard.press("Tab");
+      await settle(page, 300);
+      await expect(page.locator(SEL.worktree.searchInput)).toBeFocused();
+      await cap.snapZone("20-search-focus");
+    });
+
+    // 5. Typed query — clear button, status line, filtered list.
+    await cap.step("search-typed", async () => {
+      await typeQuery(page, "auth");
+      await expect(page.locator(SIDEBAR).getByLabel("Clear search")).toBeVisible();
+      await cap.snapSidebar("21-search-typed-sidebar");
+      await cap.snapZone("22-search-typed-zone");
+    });
+
+    // 6. Long query — the field's truncation behaviour and the status line's.
+    await cap.step("search-long", async () => {
+      await typeQuery(page, "feature/streaming-token-budget-with-a-very-long-tail");
+      await expect(page.locator(SIDEBAR).getByLabel("Clear search")).toBeVisible();
+      await cap.snapZone("23-search-long");
+    });
+
+    // 7. No match — the zero-result branch under the rail.
+    await cap.step("search-nomatch", async () => {
+      await typeQuery(page, "zzzqqq");
+      await expect(page.locator(SIDEBAR).getByLabel("Clear search")).toBeVisible();
+      await cap.snapSidebar("24-search-nomatch");
+      await clearQuery(page);
+    });
+
+    // 8. One facet filter — the neutral count on the trigger, and the status line.
+    await cap.step("filters-one", async () => {
+      const popover = await openFilterPopover(page);
+      await popover.getByRole("button", { name: "Status" }).first().click();
+      await settle(page, 300);
+      await popover
+        .getByRole("button", { name: /^Dirty/ })
+        .first()
+        .click();
+      await settle(page, 400);
+      await closeFilterPopover(page);
+      await parkPointer(page);
+      await expect(page.locator(SEL.worktree.filterButton)).toContainText("1");
+      await cap.snapSidebar("30-filter-one-sidebar");
+      await cap.snapZone("31-filter-one-zone");
+    });
+
+    // 9. Several axes — count, status line and "Clear all" all present at once.
+    await cap.step("filters-many", async () => {
+      const popover = await openFilterPopover(page);
+      await popover.getByRole("button", { name: "Branch Type" }).first().click();
+      await settle(page, 300);
+      await popover
+        .getByRole("button", { name: /^Feature/ })
+        .first()
+        .click();
+      await popover
+        .getByRole("button", { name: /^Fix|^Bugfix/ })
+        .first()
+        .click();
+      await settle(page, 400);
+      await closeFilterPopover(page);
+      await typeQuery(page, "auth");
+      await parkPointer(page);
+      await expect(page.locator(SIDEBAR).getByRole("button", { name: "Clear all" })).toBeVisible();
+      await cap.snapSidebar("32-filters-many-sidebar");
+      await cap.snapZone("33-filters-many-zone");
+    });
+
+    // 10. Popover with active filters — section counts, per-section Clear, footer.
+    //     Asserted on the sections it must contain end to end, NOT on the footer
+    //     button: whether the footer renders here is one of the things the
+    //     review is looking at, so the harness must not presuppose it.
+    await cap.step("popover-active", async () => {
+      await expect(page.locator(SEL.worktree.filterButton)).toContainText("3");
+      const popover = await openFilterPopover(page);
+      await expectInPopover(popover, "Sort by");
+      await expectInPopover(popover, "Dev server");
+      await cap.snapLocator("40-popover-active", popover);
+      await cap.snapRegion("41-popover-active-in-context", 760, 900);
+      await scrollPopoverToEnd(popover);
+      await cap.snapLocator("45-popover-active-footer", popover);
+      // The footer is one of the things under review, so it is observed and
+      // reported rather than asserted — a missing footer must show up as a
+      // finding about the popover, not as a harness failure that writes nothing.
+      cap.note(
+        `popover footer with 3 active filters: ` +
+          ((await popoverButton(popover, "Clear all filters").count()) > 0 ? "present" : "ABSENT")
+      );
+      await closeFilterPopover(page);
+    });
+
+    // 11. Popover at rest — nothing active. Cleared by toggling the same chips
+    //     back off rather than through the footer, so this step does not depend
+    //     on the footer the step above is investigating.
+    await cap.step("popover-rest", async () => {
+      await clearQuery(page);
+      const popover = await openFilterPopover(page);
+      for (const chip of [/^Dirty/, /^Feature/, /^Bugfix/]) {
+        await popover
+          .getByRole("button", { name: chip })
+          .first()
+          .click()
+          .catch(() => {});
+        await settle(page, 250);
+      }
+      await expect(page.locator(SEL.worktree.filterButton)).not.toContainText(/\d/);
+      await cap.snapLocator("42-popover-rest", popover);
+      await cap.snapRegion("43-popover-rest-in-context", 760, 900);
+    });
+
+    // 12. Popover expanded — chips, counts, and the zero-count dimming.
+    await cap.step("popover-expanded", async () => {
+      const popover = await openFilterPopover(page);
+      for (const section of ["Status", "Branch Type", "Sessions"]) {
+        const toggle = popover.getByRole("button", { name: section }).first();
+        // Click only when collapsed: these sections keep their own open state
+        // across a filter clear, so an unconditional click closes them instead.
+        if ((await toggle.getAttribute("aria-expanded")) !== "true") {
+          await toggle.click();
+          await settle(page, 250);
+        }
+      }
+      await expect(popover.getByRole("button", { name: /^Feature/ })).toBeVisible();
+      await cap.snapLocator("44-popover-expanded", popover);
+      await closeFilterPopover(page);
+      await parkPointer(page);
+    });
+
+    // 13. Narrow sidebar — the width everything has to survive.
+    await cap.step("width-min", async () => {
+      await setSidebarWidth(page, 200);
+      await blurAll(page);
+      await parkPointer(page);
+      await expect(page.locator(SIDEBAR).getByRole("heading", { name: "Worktrees" })).toBeVisible();
+      await cap.snapSidebar("50-width-200-rest");
+      await typeQuery(page, "auth");
+      await parkPointer(page);
+      await cap.snapZone("51-width-200-typed");
+      await clearQuery(page);
+    });
+
+    // 14. Narrow + hover — the header cluster's worst case for crowding.
+    await cap.step("width-min-hover", async () => {
+      await page.locator(SIDEBAR).getByRole("heading", { name: "Worktrees" }).hover();
+      await settle(page, 400);
+      await expect(page.locator(SEL.worktree.openOverviewButton)).toBeVisible();
+      await cap.snapZone("52-width-200-hover");
+      await parkPointer(page);
+    });
+
+    // 15. Generous sidebar — how the rail reads with room to spare.
+    await cap.step("width-wide", async () => {
+      await setSidebarWidth(page, 480);
+      await blurAll(page);
+      await parkPointer(page);
+      await cap.snapSidebar("53-width-480-rest");
+      await cap.snapZone("54-width-480-zone");
+      await setSidebarWidth(page, 350);
+    });
+
+    // 16. Loading skeleton — caught on reload. The window is short and belongs
+    //     to the app, not the harness, so CPU throttling widens it and a miss is
+    //     recorded rather than faked.
+    await cap.optionalStep("loading", async () => {
+      const cdp = await page.context().newCDPSession(page);
+      await cdp.send("Emulation.setCPUThrottlingRate", { rate: 12 });
+      try {
+        const reload = page.reload({ waitUntil: "domcontentloaded" });
+        const skeleton = page.getByLabel("Loading worktrees").first();
+        await skeleton.waitFor({ state: "visible", timeout: 20_000 });
+        await cap.snapSidebar("60-loading");
+        await reload;
+      } finally {
+        await cdp.send("Emulation.setCPUThrottlingRate", { rate: 1 }).catch(() => {});
+        await cdp.detach().catch(() => {});
+      }
+      await page.locator(SEL.worktree.searchInput).waitFor({ state: "visible", timeout: T_LONG });
+      await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+      await settle(page, 1500);
+    });
+
+    // 17. Only the main worktree — the branch where the rail does not render.
+    await cap.step("only-main", async () => {
+      const solo = await addAndSwitchToProject(ctx!.app, page, soloRepo.dir, "Solo");
+      await solo.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+      await dismissBlockingPalette(solo);
+      await solo.locator(SEL.worktree.mainCard).waitFor({ state: "visible", timeout: T_LONG });
+      await settle(solo, 2000);
+      await dismissBlockingPalette(solo);
+      await parkPointer(solo);
+      await expect(solo.locator(SIDEBAR).getByRole("heading", { name: "Worktrees" })).toBeVisible();
+      await expect(solo.locator(SEL.worktree.searchInput)).toHaveCount(0);
+      const soloCap = new Capture(solo, outputDir);
+      await soloCap.snapSidebar("61-only-main");
+      await soloCap.snapZone("62-only-main-zone");
+    });
+
+    const notesFile = path.join(outputDir, "NOTES.txt");
+    if (cap.notes.length > 0) {
+      writeFileSync(notesFile, cap.notes.map((n) => `- ${n}`).join("\n") + "\n");
+    } else if (existsSync(notesFile)) {
+      rmSync(notesFile);
+    }
+
+    const missingFile = path.join(outputDir, "MISSING.txt");
+    if (cap.missing.length > 0) {
+      writeFileSync(missingFile, cap.missing.map((m) => `- ${m}`).join("\n") + "\n");
+    } else if (existsSync(missingFile)) {
+      rmSync(missingFile);
+    }
+
+    if (cap.failures.length > 0) {
+      throw new Error(
+        `sidebar rail capture: ${cap.failures.length} state(s) failed and were not written:\n` +
+          cap.failures.map((f) => `  - ${f}`).join("\n")
+      );
+    }
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    soloRepo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+
+  const written = readdirSync(outputDir).filter((f) => f.endsWith(".png"));
+  expect(written.length, `expected sidebar-rail PNGs in ${outputDir}`).toBeGreaterThanOrEqual(20);
+});
+
+test("worktrees sidebar rail — theme sweep", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_SIDEBAR is required for the sidebar rail theme sweep",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_SIDEBAR to run the sidebar rail theme sweep");
+
+  const outputRoot = path.resolve(process.cwd(), "artifacts", "sidebar-shots", "themes");
+  mkdirSync(outputRoot, { recursive: true });
+  const repo = createRailRepo("daintree-railtheme-", FEATURES);
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-railtheme-ud-"));
+  let ctx: AppContext | undefined;
+  const failures: string[] = [];
+  let written = 0;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openProjectFixture(ctx, repo.dir, "");
+    const cap = new Capture(page, outputRoot);
+
+    for (const theme of SWEEP_THEMES) {
+      try {
+        await setAppTheme(page, theme);
+        await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+        await dismissBlockingPalette(page);
+        await page.locator(SEL.worktree.searchInput).waitFor({ state: "visible", timeout: T_LONG });
+        await settle(page, 1200);
+        await parkPointer(page);
+        cap.setOutputDir(outputRoot);
+        await expect(
+          page.locator(SIDEBAR).getByRole("heading", { name: "Worktrees" })
+        ).toBeVisible();
+        // A rest frame must actually be at rest: the clear button only exists
+        // when a query is live, so its absence is the proof.
+        await expect(page.locator(SIDEBAR).getByLabel("Clear search")).toHaveCount(0);
+        await cap.snapZone(`${theme}-rest`);
+        await typeQuery(page, "auth");
+        await parkPointer(page);
+        await expect(page.locator(SIDEBAR).getByLabel("Clear search")).toBeVisible();
+        await cap.snapZone(`${theme}-typed`);
+        await clearQuery(page);
+        written += 2;
+      } catch (error) {
+        failures.push(`${theme}: ${String(error).slice(0, 300)}`);
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `sidebar rail theme sweep: ${failures.length} theme(s) failed:\n` +
+          failures.map((f) => `  - ${f}`).join("\n")
+      );
+    }
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+
+  const files = readdirSync(outputRoot).filter((f) => f.endsWith(".png"));
+  expect(files.length, `expected ${written} theme-sweep PNGs in ${outputRoot}`).toBe(written);
+});

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/components/DragDrop/SortableWorktreeCard";
 import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { cn } from "@/lib/utils";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
 import type { PendingCreation, DeletedWorktree } from "@/store/worktreeStore";
@@ -1524,8 +1525,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     return (
       <div className="flex flex-col h-full">
         {worktreeLoadErrorBanner}
-        <div className="flex items-center px-4 py-2 border-b border-divider shrink-0">
-          <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
+        <div className="flex h-8 items-center px-3 border-b border-divider shrink-0">
+          <h2 className="truncate text-daintree-text font-semibold text-sm tracking-wide">
+            Worktrees
+          </h2>
         </div>
         <div className="flex-1 min-h-0 relative overflow-hidden pb-8">
           <Skeleton label="Loading worktrees">
@@ -1558,8 +1561,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       <>
         <div className="flex flex-col h-full">
           {worktreeLoadErrorBanner}
-          <div className="flex items-center px-4 py-2 border-b border-divider shrink-0">
-            <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
+          <div className="flex h-8 items-center px-3 border-b border-divider shrink-0">
+            <h2 className="truncate text-daintree-text font-semibold text-sm tracking-wide">
+              Worktrees
+            </h2>
           </div>
           {errorBanner}
 
@@ -1652,9 +1657,21 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     <div className="flex flex-col h-full">
       {worktreeLoadErrorBanner}
       {/* Header Section */}
-      <div className="group/header flex items-center justify-between px-4 py-2 border-b border-divider bg-transparent shrink-0">
-        <div className="flex items-baseline gap-1.5">
-          <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
+      {/* The control zone carries ONE horizontal rule, at its bottom edge. When
+          the search rail renders it owns that rule, so the header goes without;
+          with no rail the header IS the bottom of the zone and keeps it.
+          Stacking a header rule on a rail rule put two hairlines in the first
+          90px of the sidebar and neither was carrying hierarchy (#11991). */}
+      <div
+        className={cn(
+          "group/header @container/header flex h-8 items-center justify-between gap-1 px-3 bg-transparent shrink-0",
+          !hasNonMainWorktrees && "border-b border-divider"
+        )}
+      >
+        <div className="flex min-w-0 items-baseline gap-1.5">
+          <h2 className="truncate text-daintree-text font-semibold text-sm tracking-wide">
+            Worktrees
+          </h2>
           {showReconnecting && (
             <span
               aria-hidden="true"
@@ -1665,8 +1682,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 <Tooltip autoDismiss={false}>
                   <TooltipTrigger asChild>
                     <span className="inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-status-warning text-xs">
-                      <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
-                      Reconnecting…
+                      <RefreshCw
+                        className="w-3 h-3 animate-spin motion-reduce:animate-none"
+                        aria-hidden="true"
+                      />
+                      <span className="hidden @[16rem]/header:inline">Reconnecting…</span>
                     </span>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
@@ -1674,16 +1694,22 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   </TooltipContent>
                 </Tooltip>
               ) : (
-                <span className="inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-daintree-text/60 text-xs">
-                  <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
-                  Reconnecting…
+                <span className="inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-text-secondary text-xs">
+                  <RefreshCw
+                    className="w-3 h-3 animate-spin motion-reduce:animate-none"
+                    aria-hidden="true"
+                  />
+                  <span className="hidden @[16rem]/header:inline">Reconnecting…</span>
                 </span>
               )}
             </span>
           )}
         </div>
-        <div className="flex items-center gap-1">
-          <div className="invisible opacity-0 pointer-events-none transition-[opacity,visibility] duration-150 delay-75 group-hover/header:visible group-hover/header:opacity-100 group-hover/header:pointer-events-auto group-hover/header:delay-75 group-focus-within/header:visible group-focus-within/header:opacity-100 group-focus-within/header:pointer-events-auto group-focus-within/header:delay-75 motion-reduce:transition-none flex items-center gap-1">
+        {/* gap-0.5, not gap-1: the four buttons already carry p-1, so a 4px gap
+            on top of that spent ~12px the 200px minimum width does not have —
+            the cluster crowded the "Worktrees" landmark it sits beside. */}
+        <div className="flex shrink-0 items-center gap-0.5">
+          <div className="invisible opacity-0 pointer-events-none transition-[opacity,visibility] duration-150 delay-75 group-hover/header:visible group-hover/header:opacity-100 group-hover/header:pointer-events-auto group-hover/header:delay-75 group-focus-within/header:visible group-focus-within/header:opacity-100 group-focus-within/header:pointer-events-auto group-focus-within/header:delay-75 motion-reduce:transition-none flex items-center gap-0.5">
             <button
               type="button"
               onClick={onOpenOverview}

--- a/src/components/Sidebar/WorkspaceRootSidebar.tsx
+++ b/src/components/Sidebar/WorkspaceRootSidebar.tsx
@@ -29,11 +29,13 @@ export function WorkspaceRootSidebar({
 }) {
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center px-4 py-2 border-b border-divider shrink-0">
+      <div className="flex h-8 items-center px-3 border-b border-divider shrink-0">
         {/* Not "Worktrees": this workspace has none, and naming the slot after
             a concept it can't hold is what made the header wrong for two of the
             three workspace kinds. */}
-        <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Workspace</h2>
+        <h2 className="truncate text-daintree-text font-semibold text-sm tracking-wide">
+          Workspace
+        </h2>
       </div>
 
       {/* Plain container, not a `role="grid"`: the worktree list is a grid

--- a/src/components/Sidebar/__tests__/SidebarContent.controlZone.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.controlZone.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+/**
+ * The fixed control zone at the top of the Worktrees sidebar — the title row,
+ * the search/filter rail, and the status line under them (#11991).
+ *
+ * These assert rules about how the zone is composed, not the particular
+ * spacing values it is composed from, so a later density pass restates the
+ * numbers in one place instead of here as well.
+ */
+const SIDEBAR_CONTENT = path.resolve(__dirname, "../SidebarContent.tsx");
+const SEARCH_BAR = path.resolve(__dirname, "../../Worktree/WorktreeSidebarSearchBar.tsx");
+/** Unique to the rail's own element — the bare class name also appears in prose. */
+const RAIL_MARKER = 'variant === "sidebar" && "worktree-filter-bar"';
+
+/**
+ * The class string of the row element that carries `marker`.
+ *
+ * Comments are stripped first: both rows explain themselves in a comment
+ * between `cn(` and its first argument, and one of the markers also appears in
+ * the file's own doc block.
+ */
+function rowClasses(chunk: string, marker: string): string {
+  const stripped = chunk.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+  const at = stripped.indexOf(marker);
+  expect(at).toBeGreaterThan(-1);
+  const from = stripped.lastIndexOf("<div", at);
+  expect(from).toBeGreaterThan(-1);
+  // Window past the marker: the class string it identifies continues beyond it.
+  const slice = stripped.slice(from, from + 600);
+  return slice.match(/className=(?:"|\{cn\(\s*")([^"]*)"/)?.[1] ?? "";
+}
+
+function inset(classes: string): string | null {
+  return classes.match(/\bpx-[\d.]+\b/)?.[0] ?? null;
+}
+
+describe("Worktrees sidebar control zone — issue #11991", () => {
+  let sidebar: string;
+  let searchBar: string;
+
+  beforeAll(async () => {
+    sidebar = await fs.readFile(SIDEBAR_CONTENT, "utf-8");
+    searchBar = await fs.readFile(SEARCH_BAR, "utf-8");
+  });
+
+  it("carries exactly one horizontal rule, at the bottom of the whole zone", () => {
+    // The header used to draw a rule and the rail drew another, putting two
+    // hairlines inside the first 90px of the sidebar with the list's own
+    // dividers immediately below. Whichever row is last owns the rule: the
+    // rail when it renders, the header when it does not.
+    const header = rowClasses(sidebar, "group/header");
+    expect(header).not.toMatch(/(?:^|\s)border-b(?:\s|$)/);
+    expect(sidebar).toMatch(/!hasNonMainWorktrees && "border-b border-divider"/);
+
+    const rail = rowClasses(searchBar, RAIL_MARKER);
+    expect(rail).toMatch(/\bborder-b\b/);
+  });
+
+  it("keeps the header and the rail on one horizontal inset", () => {
+    // Three competing left margins in 90px of height — the title at one inset,
+    // the field container at another — is what made the zone read as two
+    // separately framed bands rather than one control zone.
+    const headerInset = inset(rowClasses(sidebar, "group/header"));
+    const railInset = inset(rowClasses(searchBar, RAIL_MARKER));
+    expect(headerInset).not.toBeNull();
+    expect(railInset).not.toBeNull();
+    expect(headerInset).toBe(railInset);
+  });
+
+  it("gives every header branch the same row height so the zone never resizes", () => {
+    // Loading, empty and loaded all render the same landmark row; if their
+    // heights diverge the sidebar's contents jump as a project resolves.
+    const heights = [
+      ...sidebar.matchAll(/className=(?:"|\{cn\(\s*")([^"]*\bitems-center\b[^"]*)"/g),
+    ]
+      .map((m) => m[1] ?? "")
+      .filter((cls) => cls.includes("border-divider") || cls.includes("group/header"))
+      .map((cls) => cls.match(/\bh-\d+\b/)?.[0] ?? cls.match(/\bpy-[\d.]+\b/)?.[0] ?? null);
+
+    expect(heights.length).toBeGreaterThanOrEqual(3);
+    expect(new Set(heights).size).toBe(1);
+    expect(heights[0]).not.toBeNull();
+  });
+
+  it("reveals the secondary header actions on keyboard focus, not hover alone", () => {
+    // The cluster is hidden at rest; if it only came back on hover it would be
+    // unreachable by keyboard, since visibility:hidden also removes it from the
+    // tab order.
+    expect(sidebar).toMatch(/group-hover\/header:visible/);
+    expect(sidebar).toMatch(/group-focus-within\/header:visible/);
+  });
+
+  it("honours reduced motion on the reconnecting spinner", () => {
+    const spinners = [...sidebar.matchAll(/className="[^"]*\banimate-spin\b[^"]*"/g)].map(
+      (m) => m[0]
+    );
+    expect(spinners.length).toBeGreaterThan(0);
+    for (const cls of spinners) {
+      expect(cls).toContain("motion-reduce:animate-none");
+    }
+  });
+});

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -392,21 +392,25 @@ describe("SidebarContent initial loading skeleton — issues #7215, #8804", () =
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
     const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
-    expect(branch).toMatch(/<h2[^>]*>Worktrees<\/h2>/);
-    // The loading header's vertical padding must match the loaded header's, or
-    // the bar shrinks and the list jumps up when worktrees finish loading
-    // (#10318). Compare the two against each other rather than pinning a literal.
-    const loadingHeaderDiv = branch.match(
-      /<div className="flex items-center [^"]*border-b[^"]*"/
-    )?.[0];
-    const loadedHeaderDiv = source.match(
-      /<div className="group\/header flex items-center [^"]*border-b[^"]*"/
-    )?.[0];
-    const loadingPy = loadingHeaderDiv?.match(/\bpy-\d+\b/)?.[0];
-    const loadedPy = loadedHeaderDiv?.match(/\bpy-\d+\b/)?.[0];
-    expect(loadingPy).toBeDefined();
-    expect(loadedPy).toBeDefined();
-    expect(loadingPy).toBe(loadedPy);
+    expect(branch).toMatch(/<h2[^>]*>\s*Worktrees\s*<\/h2>/);
+    // The loading header must be the same height as the loaded one, or the bar
+    // changes size when worktrees finish loading and the list jumps (#10318).
+    // Compare the two branches against each other, and read whichever utility
+    // is setting the height, so switching between a fixed height and vertical
+    // padding does not force an edit here.
+    function headerBox(chunk: string): { h: string | null; py: string | null } {
+      const cls = chunk.match(/className=(?:"|\{cn\(\s*")([^"]*\bitems-center\b[^"]*)"/)?.[1] ?? "";
+      return {
+        h: cls.match(/\bh-\d+\b/)?.[0] ?? null,
+        py: cls.match(/\bpy-[\d.]+\b/)?.[0] ?? null,
+      };
+    }
+    const loading = headerBox(branch);
+    const groupIdx = source.indexOf("group/header");
+    const loaded = headerBox(source.slice(source.lastIndexOf("<div", groupIdx)));
+    expect(loading.h ?? loading.py).not.toBeNull();
+    expect(loaded.h ?? loaded.py).not.toBeNull();
+    expect(loading).toEqual(loaded);
   });
 
   it("uses SkeletonBone with shimmer and no immediate prop (400ms Doherty gate) — #8804", () => {

--- a/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
@@ -26,7 +26,11 @@ describe("SidebarContent header reveal — issue #6964", () => {
   });
 
   it("keeps the named group/header parent so focus-within and hover variants resolve", () => {
-    expect(source).toMatch(/className="[^"]*\bgroup\/header\b/);
+    // Matched on the class name itself, not on `className="…` — the header
+    // composes its classes through cn() now that the bottom border is
+    // conditional, and the rule being protected is "the named group exists",
+    // not which attribute syntax declares it.
+    expect(source).toMatch(/["'\s]group\/header\b/);
   });
 
   it("uses a scoped transition covering opacity and visibility at Tier 1 duration-150", () => {

--- a/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
@@ -47,12 +47,15 @@ describe("SidebarContent reconnecting indicator — issue #8074", () => {
     // Both badge branches must now stay single-line (whitespace-nowrap) and the
     // text size must match across them (text-xs parity), scoped to the badge so
     // an unrelated element keeping these classes can't mask a regression.
-    expect(source).toMatch(
-      /inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-status-warning text-xs/
-    );
-    expect(source).toMatch(
-      /inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-daintree-text\/60 text-xs/
-    );
+    // Asserted as a rule over both matched badges rather than as two literal
+    // class strings: the muted branch's colour token is free to change, the
+    // single-line + shared-text-size contract is not.
+    const badges = [
+      ...source.matchAll(/inline-flex items-center gap-1 whitespace-nowrap shrink-0 ([^"]*)"/g),
+    ].map((m) => m[1] ?? "");
+    expect(badges).toHaveLength(2);
+    for (const cls of badges) expect(cls).toContain("text-xs");
+    expect(badges.filter((cls) => cls.includes("text-status-warning"))).toHaveLength(1);
     // The relative-time detail moved off the visible badge into hover tooltip
     // content; the old inline combined template literal must be gone (the
     // explanatory comment at the tick may still mention the phrasing).

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -45,7 +45,7 @@ function FilterSection({
           onClick={() => setIsOpen(!isOpen)}
           aria-expanded={isOpen}
           aria-controls={contentId}
-          className="flex flex-1 items-center justify-between px-3 py-2 text-xs font-medium text-daintree-text/70 transition-colors hover:bg-overlay-soft"
+          className="flex flex-1 items-center justify-between px-3 py-1.5 text-xs font-medium text-daintree-text/70 transition-colors hover:bg-overlay-soft"
         >
           <span className="flex items-center gap-1.5">
             {title}
@@ -71,7 +71,7 @@ function FilterSection({
               onClear();
             }}
             aria-label={`Clear ${title} filters`}
-            className="shrink-0 px-2 py-2 text-[11px] text-daintree-text/50 transition-colors hover:text-daintree-text"
+            className="shrink-0 px-2 py-1.5 text-[11px] text-text-secondary transition-colors hover:text-daintree-text"
           >
             Clear
           </button>
@@ -90,7 +90,7 @@ function FilterSection({
         )}
       >
         <div className="overflow-hidden">
-          <div id={contentId} className="px-3 pb-3 pt-1">
+          <div id={contentId} className="px-3 pb-2.5 pt-0.5">
             {children}
           </div>
         </div>
@@ -119,8 +119,8 @@ function FilterChip({ label, isActive, onClick, count }: FilterChipProps) {
         isActive
           ? "bg-filter-selected-bg-soft border-daintree-border text-daintree-text"
           : isDimmed
-            ? "bg-daintree-bg border-daintree-border text-daintree-text/30 hover:bg-overlay-soft hover:text-daintree-text/50"
-            : "bg-daintree-bg border-daintree-border text-daintree-text/60 hover:bg-overlay-medium hover:text-daintree-text/80"
+            ? "bg-daintree-bg border-daintree-border text-daintree-text/45 hover:bg-overlay-soft hover:text-daintree-text/70"
+            : "bg-daintree-bg border-daintree-border text-daintree-text/75 hover:bg-overlay-medium hover:text-daintree-text"
       )}
     >
       {showCount ? `${label} (${count})` : label}
@@ -154,15 +154,15 @@ const TYPE_OPTIONS: { value: TypeFilter; label: string }[] = [
 ];
 
 const PR_ISSUE_OPTIONS: { value: PrIssueFilter; label: string }[] = [
-  { value: "hasIssue", label: "Has Issue" },
+  { value: "hasIssue", label: "Has issue" },
   { value: "hasPR", label: "Has PR" },
-  { value: "prOpen", label: "PR Open" },
-  { value: "prMerged", label: "PR Merged" },
-  { value: "prClosed", label: "PR Closed" },
+  { value: "prOpen", label: "PR open" },
+  { value: "prMerged", label: "PR merged" },
+  { value: "prClosed", label: "PR closed" },
 ];
 
 const SESSION_OPTIONS: { value: SessionFilter; label: string }[] = [
-  { value: "hasTerminals", label: "Has Terminals" },
+  { value: "hasTerminals", label: "Has terminals" },
   { value: "working", label: "Working" },
   { value: "waiting", label: "Waiting" },
   { value: "completed", label: "Completed" },
@@ -228,6 +228,7 @@ export function WorktreeFilterPopover({
     sessionFilters,
     activityFilters,
     devServerFilters,
+    quickStateFilter,
     setQuery,
     setOrderBy,
     setGroupByType,
@@ -244,8 +245,6 @@ export function WorktreeFilterPopover({
     clearActivityFilters,
     clearDevServerFilters,
     clearAll,
-    getActiveFilterCount,
-    hasActiveFilters,
   } = useWorktreeFilterStore(
     useShallow((state) => ({
       query: state.query,
@@ -257,6 +256,7 @@ export function WorktreeFilterPopover({
       sessionFilters: state.sessionFilters,
       activityFilters: state.activityFilters,
       devServerFilters: state.devServerFilters,
+      quickStateFilter: state.quickStateFilter,
       setQuery: state.setQuery,
       setOrderBy: state.setOrderBy,
       setGroupByType: state.setGroupByType,
@@ -273,15 +273,26 @@ export function WorktreeFilterPopover({
       clearActivityFilters: state.clearActivityFilters,
       clearDevServerFilters: state.clearDevServerFilters,
       clearAll: state.clearAll,
-      getActiveFilterCount: state.getActiveFilterCount,
-      hasActiveFilters: state.hasActiveFilters,
     }))
   );
 
-  const fullFilterCount = getActiveFilterCount();
-  const filterCount = hideSearchInput
-    ? fullFilterCount - (query.trim().length > 0 ? 1 : 0)
-    : fullFilterCount;
+  // Derived from the SUBSCRIBED snapshot, not from the store's imperative
+  // `getActiveFilterCount()` / `hasActiveFilters()` helpers. Those reread
+  // `_projectStore` live at call time, so the badge and the footer were reading
+  // the store at two different instants within one render and could disagree —
+  // which is how the "Clear all filters" footer went missing while the trigger
+  // was showing a count of 3. One snapshot, one number, three consumers.
+  const hasQuery = query.trim().length > 0;
+  const facetFilterCount =
+    statusFilters.size +
+    typeFilters.size +
+    prIssueFilters.size +
+    sessionFilters.size +
+    activityFilters.size +
+    devServerFilters.size +
+    (quickStateFilter !== "all" ? 1 : 0);
+  const fullFilterCount = facetFilterCount + (hasQuery ? 1 : 0);
+  const filterCount = hideSearchInput ? facetFilterCount : fullFilterCount;
   const showBadge = filterCount > 0;
 
   useEffect(() => {
@@ -313,8 +324,8 @@ export function WorktreeFilterPopover({
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
     }
-    // The footer (and this button) unmount the moment hasActiveFilters() goes
-    // false, so move focus onto the still-mounted popover content first — else
+    // The footer (and this button) unmount the moment the last filter clears,
+    // so move focus onto the still-mounted popover content first — else
     // it drops to document.body inside the open popover (issue #10315).
     contentRef.current?.focus();
     setLocalQuery("");
@@ -322,7 +333,8 @@ export function WorktreeFilterPopover({
   }, [clearAll]);
 
   const isField = appearance === "field";
-  const filtersActive = hasActiveFilters();
+  const filtersActive = showBadge;
+  const hasAnyFilter = fullFilterCount > 0;
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
@@ -330,6 +342,9 @@ export function WorktreeFilterPopover({
         <button
           className={cn(
             "flex shrink-0 items-center justify-center gap-1 rounded-[var(--radius-md)] transition-colors",
+            // Every other control in this rail carries the accent focus ring;
+            // without one here the browser painted its own blue outline.
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
             isField ? "self-stretch border border-daintree-border px-2" : "h-6 min-w-6 px-1.5",
             // Active state is a neutral fill + count, never a saturated colour or a
             // floating notification dot. A dot reads as "something new"; what matters
@@ -397,11 +412,18 @@ export function WorktreeFilterPopover({
           )}
 
           {/* Sort Order */}
-          <div className="p-3 border-b border-daintree-border">
-            <div className="text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide mb-2">
+          <div className="px-3 pt-2.5 pb-2 border-b border-daintree-border">
+            <div
+              id="worktree-sort-by-label"
+              className="text-[10px] font-medium text-text-secondary uppercase tracking-wide mb-1.5"
+            >
               Sort by
             </div>
-            <div className="flex flex-col gap-1">
+            <div
+              role="radiogroup"
+              aria-labelledby="worktree-sort-by-label"
+              className="flex flex-col"
+            >
               {ORDER_OPTIONS.filter((option) => !(option.value === "manual" && groupByType)).map(
                 (option) => (
                   <button
@@ -412,6 +434,7 @@ export function WorktreeFilterPopover({
                     aria-checked={orderBy === option.value}
                     className={cn(
                       "flex items-center gap-2 px-2 py-1 text-xs rounded",
+                      "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent",
                       orderBy === option.value
                         ? "bg-overlay-raised text-daintree-text"
                         : "text-daintree-text/70 hover:bg-overlay-medium"
@@ -472,7 +495,7 @@ export function WorktreeFilterPopover({
           </FilterSection>
 
           <FilterSection
-            title="Branch Type"
+            title="Branch type"
             defaultOpen={typeFilters.size > 0}
             activeCount={typeFilters.size}
             onClear={clearTypeFilters}
@@ -567,7 +590,7 @@ export function WorktreeFilterPopover({
           </FilterSection>
 
           {/* Clear All */}
-          {hasActiveFilters() && (
+          {hasAnyFilter && (
             <div className="p-3 border-t border-daintree-border">
               <Button variant="subtle" size="xs" onClick={handleClearAll} className="w-full">
                 Clear all filters

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -359,10 +359,18 @@ export function WorktreeFilterPopover({
 
   const handleSortKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
-      const step = SORT_ARROW_STEPS[event.key];
-      if (step === undefined) return;
+      // Home/End as well as the arrows, matching SegmentedRadioGroup — the
+      // app's other radio-group keyboard model.
+      const next =
+        event.key === "Home"
+          ? 0
+          : event.key === "End"
+            ? sortOptions.length - 1
+            : SORT_ARROW_STEPS[event.key] !== undefined
+              ? (index + SORT_ARROW_STEPS[event.key]! + sortOptions.length) % sortOptions.length
+              : -1;
+      if (next < 0) return;
       event.preventDefault();
-      const next = (index + step + sortOptions.length) % sortOptions.length;
       const option = sortOptions[next];
       if (!option) return;
       setOrderBy(option.value);

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { Filter, X, ChevronDown } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
@@ -190,6 +190,14 @@ const ORDER_OPTIONS: { value: OrderBy; label: string }[] = [
   { value: "manual", label: "Custom order" },
 ];
 
+/** Both orientations, because the group reads as a vertical list of choices. */
+const SORT_ARROW_STEPS: Record<string, number | undefined> = {
+  ArrowDown: 1,
+  ArrowRight: 1,
+  ArrowUp: -1,
+  ArrowLeft: -1,
+};
+
 interface WorktreeFilterPopoverProps {
   hideSearchInput?: boolean;
   chipCounts?: ChipCounts;
@@ -332,6 +340,37 @@ export function WorktreeFilterPopover({
     clearAll();
   }, [clearAll]);
 
+  // Sort options are a real radio group, so they take one tab stop and the
+  // arrows move (and select) within it — ARIA APG. Exposing `role="radio"`
+  // without this promised keyboard behaviour the component did not have.
+  // "Custom order" drops out while grouping is on, so the roving index has to
+  // track the VISIBLE list, not ORDER_OPTIONS.
+  const sortOptions = useMemo(
+    () => ORDER_OPTIONS.filter((option) => !(option.value === "manual" && groupByType)),
+    [groupByType]
+  );
+  const sortRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const checkedSortIndex = sortOptions.findIndex((option) => option.value === orderBy);
+  // Defence, not a live path: `setGroupByType` already moves the selection off
+  // "manual" when grouping turns on, so nothing reachable through the store
+  // leaves the group with no checked option. If that guard ever slips, this
+  // keeps the group tabbable instead of stranding it.
+  const tabbableSortIndex = checkedSortIndex >= 0 ? checkedSortIndex : 0;
+
+  const handleSortKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const step = SORT_ARROW_STEPS[event.key];
+      if (step === undefined) return;
+      event.preventDefault();
+      const next = (index + step + sortOptions.length) % sortOptions.length;
+      const option = sortOptions[next];
+      if (!option) return;
+      setOrderBy(option.value);
+      sortRefs.current[next]?.focus();
+    },
+    [sortOptions, setOrderBy]
+  );
+
   const isField = appearance === "field";
   const filtersActive = showBadge;
   const hasAnyFilter = fullFilterCount > 0;
@@ -424,40 +463,44 @@ export function WorktreeFilterPopover({
               aria-labelledby="worktree-sort-by-label"
               className="flex flex-col"
             >
-              {ORDER_OPTIONS.filter((option) => !(option.value === "manual" && groupByType)).map(
-                (option) => (
-                  <button
-                    key={option.value}
-                    type="button"
-                    onClick={() => setOrderBy(option.value)}
-                    role="radio"
-                    aria-checked={orderBy === option.value}
+              {sortOptions.map((option, index) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  ref={(el) => {
+                    sortRefs.current[index] = el;
+                  }}
+                  onClick={() => setOrderBy(option.value)}
+                  onKeyDown={(event) => handleSortKeyDown(event, index)}
+                  role="radio"
+                  aria-checked={orderBy === option.value}
+                  // One tab stop for the whole group, arrows move within it.
+                  tabIndex={index === tabbableSortIndex ? 0 : -1}
+                  className={cn(
+                    "flex items-center gap-2 px-2 py-1 text-xs rounded",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent",
+                    orderBy === option.value
+                      ? "bg-overlay-raised text-daintree-text"
+                      : "text-daintree-text/70 hover:bg-overlay-medium"
+                  )}
+                >
+                  <div
                     className={cn(
-                      "flex items-center gap-2 px-2 py-1 text-xs rounded",
-                      "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent",
+                      "w-3 h-3 rounded-full border",
                       orderBy === option.value
-                        ? "bg-overlay-raised text-daintree-text"
-                        : "text-daintree-text/70 hover:bg-overlay-medium"
+                        ? "border-daintree-text bg-daintree-text"
+                        : "border-daintree-border"
                     )}
                   >
-                    <div
-                      className={cn(
-                        "w-3 h-3 rounded-full border",
-                        orderBy === option.value
-                          ? "border-daintree-text bg-daintree-text"
-                          : "border-daintree-border"
-                      )}
-                    >
-                      {orderBy === option.value && (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <div className="w-1.5 h-1.5 bg-text-inverse rounded-full" />
-                        </div>
-                      )}
-                    </div>
-                    {option.label}
-                  </button>
-                )
-              )}
+                    {orderBy === option.value && (
+                      <div className="w-full h-full flex items-center justify-center">
+                        <div className="w-1.5 h-1.5 bg-text-inverse rounded-full" />
+                      </div>
+                    )}
+                  </div>
+                  {option.label}
+                </button>
+              ))}
             </div>
           </div>
 

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -175,7 +175,9 @@ export function WorktreeSidebarSearchBar({
   return (
     <div
       className={cn(
-        "px-3 py-2 border-b border-divider shrink-0",
+        // px-3 matches the header above and the status line below, so the whole
+        // control zone sits on one 12px inset instead of three (#11991).
+        "px-3 py-1.5 border-b border-divider shrink-0",
         variant === "sidebar" && "worktree-filter-bar"
       )}
     >
@@ -183,7 +185,10 @@ export function WorktreeSidebarSearchBar({
         <div
           role="search"
           className={cn(
-            "flex flex-1 min-w-0 items-center gap-1.5 px-2.5 py-2 rounded-[var(--radius-md)]",
+            // h-7: 28px is the app's compact control height and the desktop-IDE
+            // norm; the field used to be 34px, which gave the rail more visual
+            // mass than the title above it.
+            "flex h-7 flex-1 min-w-0 items-center gap-1.5 px-2 rounded-[var(--radius-md)]",
             // Fallback keeps themes without --worktree-search-input-bg byte-identical.
             "bg-[var(--worktree-search-input-bg,var(--color-daintree-bg))] border border-daintree-border",
             "focus-within:border-daintree-accent/40 focus-within:ring-1 focus-within:ring-daintree-accent/20"
@@ -199,7 +204,11 @@ export function WorktreeSidebarSearchBar({
             value={liveQuery}
             onChange={(e) => handleQueryChange(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Search worktrees..."
+            // Short on purpose: at the 200px minimum "Search worktrees..." clips
+            // to "Search worktree", which reads as a typo rather than as
+            // truncation. The noun is already the heading directly above, and
+            // the full phrase stays the accessible name.
+            placeholder="Search…"
             aria-label="Search worktrees"
             className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder-daintree-text/40 focus:outline-hidden"
           />
@@ -207,7 +216,7 @@ export function WorktreeSidebarSearchBar({
             <button
               type="button"
               onClick={handleClearSearch}
-              className="flex shrink-0 items-center justify-center w-5 h-5 rounded text-daintree-text/40 hover:text-daintree-text"
+              className="flex shrink-0 items-center justify-center w-5 h-5 rounded text-daintree-text/40 transition-colors hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-daintree-accent"
               aria-label="Clear search"
             >
               <X className="w-3 h-3" />
@@ -228,7 +237,7 @@ export function WorktreeSidebarSearchBar({
       {(statusText || showClearAll) && (
         <div className="flex items-center gap-2 pt-1">
           {statusText && (
-            <span className="min-w-0 flex-1 truncate text-[11px] text-daintree-text/50">
+            <span className="min-w-0 flex-1 truncate text-[11px] text-text-secondary">
               {statusText}
             </span>
           )}
@@ -236,7 +245,7 @@ export function WorktreeSidebarSearchBar({
             <button
               type="button"
               onClick={handleClearAll}
-              className="ml-auto shrink-0 text-[11px] text-daintree-text/50 hover:text-daintree-text transition-colors"
+              className="ml-auto shrink-0 rounded text-[11px] text-text-secondary hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-daintree-accent"
             >
               Clear all
             </button>

--- a/src/components/Worktree/__tests__/WorktreeFilterPopover.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeFilterPopover.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import { render, screen, cleanup } from "@testing-library/react";
+import { WorktreeFilterPopover } from "../WorktreeFilterPopover";
+import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
+
+const SOURCE = fs.readFileSync(path.resolve(__dirname, "../WorktreeFilterPopover.tsx"), "utf-8");
+
+function openPopover() {
+  return render(
+    <WorktreeFilterPopover appearance="field" hideSearchInput open onOpenChange={() => {}} />
+  );
+}
+
+describe("WorktreeFilterPopover derives its filter state from one snapshot", () => {
+  beforeEach(() => {
+    useWorktreeFilterStore.getState().clearAll();
+  });
+  afterEach(cleanup);
+
+  // The defect this guards: the trigger's count came from
+  // `getActiveFilterCount()` and the footer from `hasActiveFilters()`, two
+  // helpers that reread the project store imperatively at call time. They are
+  // logically equivalent, so they can only disagree by observing the store at
+  // two different instants — which is exactly what happened: the trigger
+  // showed "3" while the bulk-clear footer was absent from the DOM, leaving no
+  // way out of three active filters except clearing each axis by hand.
+  it("does not call the store's derived predicates during render", () => {
+    const body = SOURCE.slice(SOURCE.indexOf("export function WorktreeFilterPopover"))
+      // Strip comments: this file explains the defect by naming the helpers,
+      // and the rule is about calls, not prose.
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/[^\n]*/g, "");
+    expect(body).not.toMatch(/\bhasActiveFilters\(\)/);
+    expect(body).not.toMatch(/\bgetActiveFilterCount\(\)/);
+  });
+
+  it("shows a count and a bulk clear together whenever a facet filter is on", () => {
+    useWorktreeFilterStore.getState().toggleStatusFilter("dirty");
+    openPopover();
+    const trigger = screen.getByLabelText("Filter and sort worktrees");
+    expect(trigger.textContent).toContain("1");
+    expect(screen.queryByText("Clear all filters")).not.toBeNull();
+  });
+
+  it("offers a bulk clear for a query-only filter, and no count beside it", () => {
+    // The query is a filter — it belongs in the bulk clear. It is NOT one of
+    // the filters the trigger counts, because it is already visible in the
+    // field next to the trigger; counting it lit the control up with no number
+    // beside it, which read as "a filter is on" pointing at nothing.
+    useWorktreeFilterStore.getState().setQuery("auth");
+    openPopover();
+    const trigger = screen.getByLabelText("Filter and sort worktrees");
+    expect(trigger.textContent?.trim()).toBe("");
+    // Boundary-matched: the resting trigger legitimately carries
+    // `hover:bg-overlay-soft`, so a substring check would always pass.
+    expect(trigger.className).not.toMatch(/(?:^|\s)bg-overlay-soft(?:\s|$)/);
+    expect(screen.queryByText("Clear all filters")).not.toBeNull();
+  });
+
+  it("offers no bulk clear when nothing is filtered", () => {
+    openPopover();
+    expect(screen.queryByText("Clear all filters")).toBeNull();
+  });
+
+  it("keeps the trigger's count and its active styling in agreement", () => {
+    // One derived number drives both, so the control can never look switched
+    // on while showing nothing, or show a number while looking switched off.
+    useWorktreeFilterStore.getState().toggleTypeFilter("feature");
+    useWorktreeFilterStore.getState().toggleTypeFilter("bugfix");
+    openPopover();
+    const trigger = screen.getByLabelText("Filter and sort worktrees");
+    expect(trigger.textContent).toContain("2");
+    expect(trigger.className).toMatch(/(?:^|\s)bg-overlay-soft(?:\s|$)/);
+  });
+});
+
+describe("WorktreeFilterPopover keyboard and focus surfaces", () => {
+  beforeEach(() => {
+    useWorktreeFilterStore.getState().clearAll();
+  });
+  afterEach(cleanup);
+
+  it("gives the trigger the app's accent focus ring rather than the browser's", () => {
+    // Every other control in the sidebar rail carries this; without it the
+    // trigger fell back to the UA's own outline, which is a different colour
+    // from the rest of the surface.
+    openPopover();
+    const trigger = screen.getByLabelText("Filter and sort worktrees");
+    expect(trigger.className).toMatch(/focus-visible:outline\b/);
+    expect(trigger.className).toContain("outline-daintree-accent");
+  });
+
+  it("owns its sort radios with a labelled radiogroup", () => {
+    // `role="radio"` outside a radiogroup is invalid ARIA — the options were
+    // announced as four unrelated radios with no group name.
+    openPopover();
+    const group = screen.getByRole("radiogroup");
+    expect(group).not.toBeNull();
+    expect(group.getAttribute("aria-labelledby")).toBeTruthy();
+    const radios = screen.getAllByRole("radio");
+    expect(radios.length).toBeGreaterThan(1);
+    for (const radio of radios) {
+      expect(group.contains(radio)).toBe(true);
+    }
+  });
+
+  it("names every radio group option and marks exactly one checked", () => {
+    openPopover();
+    const radios = screen.getAllByRole("radio");
+    expect(radios.filter((r) => r.getAttribute("aria-checked") === "true")).toHaveLength(1);
+  });
+});

--- a/src/components/Worktree/__tests__/WorktreeFilterPopover.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeFilterPopover.test.tsx
@@ -144,6 +144,18 @@ describe("WorktreeFilterPopover keyboard and focus surfaces", () => {
     expect(document.activeElement).toBe(radios()[count - 1]);
   });
 
+  it("jumps to the ends with Home and End, like the app's other radio group", () => {
+    openPopover();
+    const radios = () => screen.getAllByRole("radio");
+    const checkedIndex = () => radios().findIndex((r) => r.getAttribute("aria-checked") === "true");
+
+    fireEvent.keyDown(radios()[0]!, { key: "End" });
+    expect(checkedIndex()).toBe(radios().length - 1);
+
+    fireEvent.keyDown(radios()[radios().length - 1]!, { key: "Home" });
+    expect(checkedIndex()).toBe(0);
+  });
+
   it("keeps exactly one tabbable option when grouping removes an option", () => {
     // "Custom order" leaves the list while grouping is on. Whatever the store
     // does with the selection, the group must never end up with no tab stop.

--- a/src/components/Worktree/__tests__/WorktreeFilterPopover.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeFilterPopover.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { WorktreeFilterPopover } from "../WorktreeFilterPopover";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 
@@ -79,7 +79,11 @@ describe("WorktreeFilterPopover derives its filter state from one snapshot", () 
 
 describe("WorktreeFilterPopover keyboard and focus surfaces", () => {
   beforeEach(() => {
+    // clearAll() resets the project-scoped filters; sort order and grouping are
+    // global preferences and would otherwise leak between tests.
     useWorktreeFilterStore.getState().clearAll();
+    useWorktreeFilterStore.getState().setGroupByType(false);
+    useWorktreeFilterStore.getState().setOrderBy("created");
   });
   afterEach(cleanup);
 
@@ -111,5 +115,43 @@ describe("WorktreeFilterPopover keyboard and focus surfaces", () => {
     openPopover();
     const radios = screen.getAllByRole("radio");
     expect(radios.filter((r) => r.getAttribute("aria-checked") === "true")).toHaveLength(1);
+  });
+
+  it("is one tab stop, with the checked option holding it", () => {
+    // A radio group is a single stop; without a roving index every option was
+    // its own stop, so Tab walked four times through one choice.
+    openPopover();
+    const radios = screen.getAllByRole("radio");
+    const tabbable = radios.filter((r) => r.getAttribute("tabindex") === "0");
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0]?.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("moves selection and focus with the arrows, and wraps at the ends", () => {
+    // Selection follows focus, which is the APG default for a radio group.
+    openPopover();
+    const radios = () => screen.getAllByRole("radio");
+    const checkedIndex = () => radios().findIndex((r) => r.getAttribute("aria-checked") === "true");
+    const count = radios().length;
+    const start = checkedIndex();
+
+    fireEvent.keyDown(radios()[start]!, { key: "ArrowDown" });
+    expect(checkedIndex()).toBe((start + 1) % count);
+    expect(document.activeElement).toBe(radios()[(start + 1) % count]);
+
+    fireEvent.keyDown(radios()[0]!, { key: "ArrowLeft" });
+    expect(checkedIndex()).toBe(count - 1);
+    expect(document.activeElement).toBe(radios()[count - 1]);
+  });
+
+  it("keeps exactly one tabbable option when grouping removes an option", () => {
+    // "Custom order" leaves the list while grouping is on. Whatever the store
+    // does with the selection, the group must never end up with no tab stop.
+    useWorktreeFilterStore.getState().setOrderBy("manual");
+    useWorktreeFilterStore.getState().setGroupByType(true);
+    openPopover();
+    const radios = screen.getAllByRole("radio");
+    expect(radios.map((r) => r.textContent)).not.toContain("Custom order");
+    expect(radios.filter((r) => r.getAttribute("tabindex") === "0")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

The fixed control zone at the top of the Worktrees sidebar read as two separately framed bands rather than one set of controls. It now reads as one, and costs 73px before the first worktree instead of 90px.

Resolves #11991

## What changed

**The zone's composition.** Two horizontal rules were stacked in the first 90px, one under the header and one under the search rail, with the list's own dividers immediately below. Whichever row is last now owns the rule: the rail when it renders, the header when there is no rail. There were also three competing left margins in that 90px (16px for the title, 12px for the field container, 23px for the magnifier). The header and the rail now share one 12px inset, and the magnifier stays where it is as nested control padding, which is what Material 3, Fluent 2, Carbon, Primer and Apple HIG all specify for a bordered field.

**Density.** The header row goes 39px to 32px and the controls 34px to 28px, which puts both inside the range VS Code, JetBrains and Linear use for a sidebar of this width. The controls were previously taller than the heading above them.

**A real defect in the filter popover.** With three filters active the trigger showed `3` and the "Clear all filters" footer was absent from the DOM, so the only way out was clearing each axis by hand. The count came from `getActiveFilterCount()` and the footer from `hasActiveFilters()`, two helpers that reread the project store imperatively at call time. They are logically equivalent, so they could only disagree by observing the store at two different instants. Both now derive from one subscribed snapshot, along with the trigger's active fill.

**Smaller items:**

* The filter trigger had no `focus-visible` rule, so keyboard focus fell back to the browser's own blue outline while every other control in the rail used the accent ring. It has the accent ring now.
* The sort options exposed `role="radio"` with no owning `radiogroup` and no radio keyboard model: four separate tab stops and dead arrow keys. They are now a labelled group with one tab stop, wrapping arrows, and Home/End, matching `SegmentedRadioGroup`.
* The status line and "Clear all" move from `text-daintree-text/50`, which has no contrast floor, to `text-text-secondary`, which the theme suite guards at 4.5:1 against `surface-sidebar`.
* The reconnect spinners honour `prefers-reduced-motion`, and the "Reconnecting…" word collapses to its spinner below a 16rem header.
* `"Search worktrees..."` clipped to "Search worktree" at the 200px minimum, which reads as a typo rather than truncation. The placeholder is `"Search…"`; the full phrase stays the accessible name.
* Sentence case on `Branch type`, `Has issue`, `Has terminals`, `PR open`, `PR merged`, `PR closed`. Zero-count filter chips move from 30% to 45% opacity, since they are still clickable and were reading as disabled.

## Design review

Three rounds of scored adversarial review against real rendered pixels: **6.9, then 9.8, then 10.0**. Round 2 bought the most, which matches the usual shape.

Two of the reviewer's asks were pushed back on and conceded in writing. It wanted a rail silhouette in the loading skeleton, but that branch renders precisely because the worktree list has not resolved, so it cannot know whether the repo has non-main worktrees, and reserving the height trades one jump for a different one. It also wanted the seven light themes that set `--worktree-filter-bar-bg` given a recessed value, which is the one thing those palettes state they never do.

The consistency survey found no new outliers. Six of the eight patterns introduced here move this surface into an existing convention (`px-3` headers are 10 of 17, `Search…` already exists in two other fields, the accent focus ring in 64 places, and every other `role="radio"` in the app already has a `radiogroup`). Nothing needs rolling out, so no follow-up issues are filed.

One thing worth knowing and deliberately not acted on: `--worktree-filter-bar-bg` is a verified no-op. All seven themes that set it set it to exactly their own `surfaces.sidebar` value, and the other eight fall through to `transparent`. The reviewer priced deleting it at 0.0 design points. Happy to file a cleanup issue if it is wanted.

## Testing

`npm run check`, the full unit suite (2343 files, 51476 tests), and the three affected E2E specs (`worktree-dashboard-cards`, `core-project-management-advanced`, `core-v030-features`, 24 tests) all pass locally.

Thirteen new invariants are pinned across `WorktreeFilterPopover.test.tsx` and `SidebarContent.controlZone.test.ts`, each mutation-checked by reintroducing the defect and confirming the test fails. Three existing tests were rewritten from pinning literal class values to asserting the rule, so a later density pass restates the numbers in one place rather than two.

`e2e/screenshots/worktree-sidebar-rail-review.spec.ts` is a new opt-in capture harness (`DAINTREE_SHOT_SIDEBAR=1`) covering 27 states plus a 15-theme sweep, 57 captures in total, with a `METRICS.json` of the laid-out geometry so a review argues from measured boxes rather than CSS arithmetic. It refuses to write a PNG for a state it could not verify.
