### PR TITLE
Refine the launcher row's metadata hierarchy

### DIFF
--- a/e2e/full/panels/core-dock-launcher-search.spec.ts
+++ b/e2e/full/panels/core-dock-launcher-search.spec.ts
@@ -227,8 +227,8 @@ test.describe.serial("Core: Dock launcher search", () => {
 
     // By the option's own accessible name, anchored at the start — `hasText`
     // is a substring match and "browser" also ranks File Browser.
-    const pin = window.locator(`${OPTION}[aria-label^="Browser,"] button[aria-pressed]`);
-    await expect(pin).toHaveAttribute("aria-pressed", "false", { timeout: T_MEDIUM });
+    const pin = window.locator(`${OPTION}[aria-label^="Browser,"] [data-launcher-pin]`);
+    await expect(pin).toHaveAttribute("data-pinned", "false", { timeout: T_MEDIUM });
 
     await pin.click();
 
@@ -237,7 +237,7 @@ test.describe.serial("Core: Dock launcher search", () => {
     await expect(searchBox(window)).toBeVisible();
     await expect(searchBox(window)).toHaveValue("browser");
     expect(await searchBoxHasFocus(window)).toBe(true);
-    await expect(pin).toHaveAttribute("aria-pressed", "true", { timeout: T_MEDIUM });
+    await expect(pin).toHaveAttribute("data-pinned", "true", { timeout: T_MEDIUM });
 
     // The point of the affordance: the toolbar button beside the launcher is
     // how a pin becomes visible. The write is optimistic through an async IPC,
@@ -262,10 +262,10 @@ test.describe.serial("Core: Dock launcher search", () => {
     // and later specs share this window.
     await openLauncher(window);
     await searchBox(window).fill("browser");
-    const pinAgain = window.locator(`${OPTION}[aria-label^="Browser,"] button[aria-pressed]`);
-    await expect(pinAgain).toHaveAttribute("aria-pressed", "true", { timeout: T_MEDIUM });
+    const pinAgain = window.locator(`${OPTION}[aria-label^="Browser,"] [data-launcher-pin]`);
+    await expect(pinAgain).toHaveAttribute("data-pinned", "true", { timeout: T_MEDIUM });
     await pinAgain.click();
-    await expect(pinAgain).toHaveAttribute("aria-pressed", "false", { timeout: T_MEDIUM });
+    await expect(pinAgain).toHaveAttribute("data-pinned", "false", { timeout: T_MEDIUM });
     // Two presses: the first clears the populated query, the second closes.
     await window.keyboard.press("Escape");
     await window.keyboard.press("Escape");

--- a/e2e/full/panels/core-toolbar-launcher-shared.spec.ts
+++ b/e2e/full/panels/core-toolbar-launcher-shared.spec.ts
@@ -142,7 +142,7 @@ test.describe.serial("Core: Toolbar launcher (shared component)", () => {
     // Whether it is gated depends on the fixture's project state; what must hold
     // either way is that the row is an option carrying its own pin control, so
     // the affordance stays reachable when it IS gated.
-    await expect(row.locator("button[aria-pressed]")).toHaveCount(1);
+    await expect(row.locator("[data-launcher-pin]")).toHaveCount(1);
   });
 
   test("Escape clears a query before it closes the launcher", async () => {

--- a/e2e/screenshots/launcher-review.spec.ts
+++ b/e2e/screenshots/launcher-review.spec.ts
@@ -1,0 +1,515 @@
+/**
+ * Launcher visual-review harness.
+ *
+ * Drives the `+` launcher palette (`DockLaunchButton`) through every state that
+ * carries design weight and writes a tightly-cropped PNG of each, so the row's
+ * metadata hierarchy can be judged against rendered pixels rather than against
+ * the class strings that produce them.
+ *
+ * Sibling of `palette-review.spec.ts`, which captures one shot of this surface
+ * as part of a family sweep. This one goes deep on the single surface: both
+ * placements, grouped browse against mixed search, the preset expansion, the
+ * hover and selection states that reveal the trailing controls, the pinned and
+ * shortcut-bearing rows, and the two accessibility media modes that redraw the
+ * row from something other than the theme's own tokens.
+ *
+ * Opt-in only: skips itself unless DAINTREE_SHOT_THEME is set, so neither the
+ * marketing screenshots workflow nor a bare `--project=screenshots` runs it.
+ *
+ *   DAINTREE_SHOT_THEME=daintree npx playwright test --project=screenshots launcher-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_THEME  required — theme id to render (e.g. daintree, bondi)
+ *   DAINTREE_SHOT_TAG    optional suffix to keep before/after rounds side by side
+ *   DAINTREE_SHOT_ONLY   comma-separated step filter (see STEPS below)
+ *   DAINTREE_SCREENSHOT_SCALE  device scale factor (default 2)
+ *
+ * Output: artifacts/launcher-shots/<theme>/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "launcher-shots", THEME || "unset");
+
+const DOCK_TRIGGER = '[aria-label="Open launcher"]';
+const TOOLBAR_TRIGGER = '[data-toolbar-button-id="launcher"] button';
+const SURFACE = '[role="dialog"][aria-label="Launch"]';
+const SEARCH_BOX = '[aria-label="Search agents, panels, and recipes"]';
+const LISTBOX = '[role="listbox"][aria-label="Launcher results"]';
+const OPTION = '[role="option"]';
+
+/**
+ * Every shot this harness owes, in capture order. Kept as data rather than
+ * spelled only inside the steps so the run can count what actually landed on
+ * disk against what was promised — an exit code alone has never been evidence
+ * that a capture harness produced anything.
+ */
+const STEPS = [
+  { name: "browse-top", slug: "01-browse-top" },
+  { name: "browse-mid", slug: "02-browse-mid" },
+  { name: "browse-bottom", slug: "03-browse-bottom" },
+  { name: "search-mixed", slug: "04-search-mixed" },
+  { name: "search-narrow", slug: "05-search-narrow" },
+  { name: "presets", slug: "06-presets-expanded" },
+  { name: "hover", slug: "07-row-hover" },
+  { name: "pinned", slug: "08-row-pinned" },
+  { name: "capture", slug: "09-shortcut-capture" },
+  { name: "empty", slug: "10-empty" },
+  { name: "toolbar", slug: "11-toolbar-placement" },
+  { name: "narrow", slug: "12-narrow-window" },
+  { name: "forced-colors", slug: "13-forced-colors" },
+  { name: "contrast-more", slug: "14-contrast-more" },
+] as const;
+
+// Freeze animations and hide carets so captures are deterministic. The palette
+// zooms and fades on entry; a mid-transition frame reads as a design flaw that
+// isn't there.
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/**
+ * A repo carrying the on-disk state the launcher reads: `.daintree/recipes/`
+ * for the recipe band and `.daintree/presets/<agentId>/` for the project preset
+ * group. Both are the real seams the app loads from — a store-level stub would
+ * skip the scope resolution that decides half the qualifiers under review.
+ *
+ * Recipe names are deliberately uneven in length. A row whose name always fits
+ * hides exactly the truncation behaviour this review is about.
+ */
+function createRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-launcher-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  writeFileSync(path.join(dir, "src", "index.ts"), "export const main = () => 0;\n");
+
+  const recipesDir = path.join(dir, ".daintree", "recipes");
+  mkdirSync(recipesDir, { recursive: true });
+  const recipes = [
+    { id: "inrepo-review", name: "Review", prompt: "/review" },
+    { id: "inrepo-work", name: "Work", prompt: "/work {{number}}" },
+    {
+      id: "inrepo-migrate",
+      name: "Migrate remaining JavaScript modules to TypeScript",
+      prompt: "/migrate",
+    },
+  ];
+  for (const recipe of recipes) {
+    writeFileSync(
+      path.join(recipesDir, `${recipe.id}.json`),
+      JSON.stringify(
+        {
+          id: recipe.id,
+          name: recipe.name,
+          terminals: [
+            { type: "claude", title: recipe.name, env: {}, initialPrompt: recipe.prompt },
+          ],
+          createdAt: 1775381905486,
+          showInEmptyState: false,
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  }
+
+  // Two named project presets on one agent, so the expansion renders its
+  // provenance heading and a non-current choice beside the current one.
+  const presetsDir = path.join(dir, ".daintree", "presets", "claude");
+  mkdirSync(presetsDir, { recursive: true });
+  for (const preset of [
+    { id: "team-plan", name: "Plan first" },
+    { id: "team-sonnet", name: "Sonnet" },
+  ]) {
+    writeFileSync(path.join(presetsDir, `${preset.id}.json`), JSON.stringify(preset, null, 2) + "\n");
+  }
+
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+
+  for (const branch of ["feature/oauth-device-flow", "fix/retry-backoff-jitter"]) {
+    const wtDir = path.join(wtRoot, branch.replace(/[/]/g, "-"));
+    git(`branch ${branch}`, dir);
+    git(`worktree add ${JSON.stringify(wtDir)} ${branch}`, dir);
+  }
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Clip to the palette plus a margin, so the capture carries the surface edge,
+ * its shadow and what sits immediately behind it — the three things that make a
+ * floating surface read as elevated. An element screenshot crops exactly at the
+ * border and hides all of it.
+ *
+ * Throws when the file did not land. A harness that writes a success artifact it
+ * has not verified is worse than one that fails.
+ */
+async function snapSurface(page: Page, slug: string, selector = SURFACE, pad = 40): Promise<void> {
+  await settle(page);
+  const box = await page.locator(selector).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${selector}`);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  const viewport = page.viewportSize() ?? { width: 1680, height: 1050 };
+  const x = Math.max(0, box.x - pad);
+  const y = Math.max(0, box.y - pad);
+  await page.screenshot({
+    path: file,
+    type: "png",
+    animations: "disabled",
+    caret: "hide",
+    clip: {
+      x,
+      y,
+      width: Math.min(box.width + pad * 2, viewport.width - x),
+      height: Math.min(box.height + pad * 2, viewport.height - y),
+    },
+  });
+  if (!existsSync(file)) throw new Error(`screenshot did not land at ${file}`);
+}
+
+/**
+ * Run a capture step. A failure never stops the remaining shots — one missing
+ * state should not cost the whole sweep — but it IS recorded, and the test fails
+ * at the end. The launcher is always closed afterwards, so a step that dies
+ * mid-flight cannot leave a palette open on top of the next one.
+ */
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+const stepFailures: string[] = [];
+async function step(page: Page, name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).split("\n")[0];
+    console.warn(`[launcher-shots] step "${name}" FAILED:`, detail);
+    stepFailures.push(`${name}: ${detail}`);
+  }
+  await closeLauncher(page).catch(() => {});
+}
+
+/** Opens a terminal and minimises it so the dock — and its launcher — renders. */
+let dockReady = false;
+async function ensureDock(page: Page): Promise<void> {
+  if (dockReady) return;
+  await page.locator(SEL.toolbar.openTerminal).click();
+  await page.locator(SEL.panel.gridPanel).first().waitFor({ state: "visible", timeout: T_LONG });
+  await settle(page, 1500);
+  const minimize = page.locator(SEL.panel.minimize).first();
+  await minimize.waitFor({ state: "visible", timeout: 5000 });
+  await minimize.click();
+  await settle(page, 1000);
+  dockReady = true;
+}
+
+async function openLauncher(page: Page, trigger = DOCK_TRIGGER): Promise<void> {
+  // A step that failed mid-flight can leave the popover open, and it is modal —
+  // Radix parks a dismissable layer over everything behind it, so the trigger
+  // click for the NEXT step times out on an element it can see but cannot
+  // reach. Close first, always.
+  await closeLauncher(page);
+  await page.locator(trigger).first().click({ timeout: 10_000 });
+  await page.locator(SEARCH_BOX).waitFor({ state: "visible", timeout: 8000 });
+  // The agent inventory resolves asynchronously; capturing before it lands
+  // photographs "Checking agents…" instead of the bands under review.
+  await expect
+    .poll(() => page.locator(OPTION).count(), { timeout: 10_000 })
+    .toBeGreaterThan(3);
+  await settle(page, 350);
+}
+
+async function closeLauncher(page: Page): Promise<void> {
+  // Up to four presses, checked between each. The launcher spends the first
+  // Escape clearing the query and the second closing, and a row that is
+  // recording a shortcut vetoes one before either of those — so a fixed count
+  // is not enough to guarantee the surface is gone.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (!(await page.locator(SEARCH_BOX).isVisible().catch(() => false))) return;
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+  }
+  if (await page.locator(SEARCH_BOX).isVisible().catch(() => false)) {
+    throw new Error("launcher would not close");
+  }
+}
+
+/**
+ * Scrolls the results list to a fraction of its height and settles.
+ *
+ * Walks up to the first genuinely scrollable ancestor rather than naming one:
+ * the palette body is a `ScrollShadow`, whose overflow element is an internal
+ * detail, and a selector aimed at it would silently scroll nothing the day that
+ * wrapper changes shape.
+ */
+async function scrollList(page: Page, fraction: number): Promise<void> {
+  const scrolled = await page.locator(LISTBOX).evaluate((el, f) => {
+    let node: HTMLElement | null = el as HTMLElement;
+    while (node) {
+      if (node.scrollHeight - node.clientHeight > 4) {
+        node.scrollTop = (node.scrollHeight - node.clientHeight) * f;
+        return true;
+      }
+      node = node.parentElement;
+    }
+    return false;
+  }, fraction);
+  if (!scrolled) throw new Error("results list has no scrollable ancestor");
+  await settle(page, 250);
+}
+
+test("launcher review — every state of the row", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_THEME is required for the launcher-review capture",
+  });
+  test.skip(!THEME, "Set DAINTREE_SHOT_THEME to run the launcher-review capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createRepo();
+  // Prefix deliberately avoids "daintree-e2e" — launchApp's pre-launch hygiene
+  // pkills that pattern, and parallel theme captures would SIGKILL each other.
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-launchershot-"));
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    await page.evaluate(async () => {
+      const cur = await window.electron.project.getCurrent();
+      if (cur?.id)
+        await window.electron.project.update(cur.id, { emoji: "☀️", name: "Helios Dashboard" });
+    });
+    await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 2000);
+    await dismissBlockingPalette(page);
+    await ensureDock(page);
+
+    // 1-3. Grouped browse, top to bottom. The bands are the whole point of the
+    // browse mode and they do not fit in one frame: the launchable agents sit
+    // at the top, panels and recipes in the middle, and the setup/available
+    // bands — the ones nobody scrolls to and therefore nobody has looked at —
+    // at the bottom.
+    await step(page, "browse-top", async () => {
+      await openLauncher(page);
+      await snapSurface(page, "01-browse-top");
+    });
+
+    await step(page, "browse-mid", async () => {
+      await openLauncher(page);
+      await scrollList(page, 0.45);
+      await snapSurface(page, "02-browse-mid");
+    });
+
+    await step(page, "browse-bottom", async () => {
+      await openLauncher(page);
+      await scrollList(page, 1);
+      await snapSurface(page, "03-browse-bottom");
+    });
+
+    // 4. Mixed search — the mode where a type qualifier genuinely earns its
+    // width, because one flat "Search results" band holds agents, panels and
+    // recipes together. "re" matches across all three.
+    await step(page, "search-mixed", async () => {
+      await openLauncher(page);
+      await page.locator(SEARCH_BOX).fill("re");
+      await expect.poll(() => page.locator(OPTION).count(), { timeout: 5000 }).toBeGreaterThan(2);
+      await snapSurface(page, "04-search-mixed");
+    });
+
+    // 5. A narrow result set, so the rows can be read individually rather than
+    // as a block of texture.
+    await step(page, "search-narrow", async () => {
+      await openLauncher(page);
+      await page.locator(SEARCH_BOX).fill("claude");
+      await expect.poll(() => page.locator(OPTION).count(), { timeout: 5000 }).toBeGreaterThan(0);
+      await snapSurface(page, "05-search-narrow");
+    });
+
+    // 6. Preset expansion. ArrowRight on a row that has presets splices its
+    // choices in as indented sibling rows; the parent/child relationship is
+    // carried by indentation alone, which is exactly the kind of thing that
+    // only shows up in pixels.
+    await step(page, "presets", async () => {
+      await openLauncher(page);
+      const parent = page.locator('[role="option"][data-row-kind="item"]').first();
+      await parent.hover();
+      await settle(page, 200);
+      await page.keyboard.press("ArrowRight");
+      await expect
+        .poll(() => page.locator('[role="option"][data-row-kind="preset"]').count(), {
+          timeout: 5000,
+        })
+        .toBeGreaterThan(1);
+      await snapSurface(page, "06-presets-expanded");
+    });
+
+    // 7. Hover — the state that reveals the shortcut-edit and pin controls in
+    // their reserved slots. Half the launcher's trailing rail is invisible
+    // until this happens, so a review that never hovers reviews half a row.
+    await step(page, "hover", async () => {
+      await openLauncher(page);
+      // `page.mouse.move` to the row's centre rather than `locator.hover()`:
+      // the popover is modal and Radix's dismissable layer fails Playwright's
+      // "receives pointer events" actionability check on the rows beneath it,
+      // even though a real pointer reaches them. The app listens on
+      // `onPointerEnter`, which a raw mouse move fires just the same.
+      const box = await page.locator(OPTION).nth(1).boundingBox();
+      if (!box) throw new Error("no bounding box for the row to hover");
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await settle(page, 400);
+      await snapSurface(page, "07-row-hover");
+    });
+
+    // 8. A pinned row. The pin is the one trailing control that stays visible
+    // at rest, so it is the one that competes with the row's name for the
+    // whole time the launcher is open.
+    await step(page, "pinned", async () => {
+      await openLauncher(page);
+      const pinnable = page.locator(`${OPTION} button[aria-pressed="false"]`).first();
+      await pinnable.waitFor({ state: "attached", timeout: 5000 });
+      await pinnable.click({ force: true });
+      await settle(page, 500);
+      await page.mouse.move(10, 10);
+      await settle(page, 300);
+      await snapSurface(page, "08-row-pinned");
+    });
+
+    // 9. The in-place shortcut recorder, which replaces the row rather than
+    // rendering inside it.
+    await step(page, "capture", async () => {
+      await openLauncher(page);
+      const edit = page.locator('[data-testid^="launcher-shortcut-edit-"]').first();
+      await edit.waitFor({ state: "attached", timeout: 5000 });
+      await edit.click({ force: true });
+      await settle(page, 400);
+      await snapSurface(page, "09-shortcut-capture");
+      await page.keyboard.press("Escape");
+      await settle(page, 200);
+    });
+
+    // 10. Empty state.
+    await step(page, "empty", async () => {
+      await openLauncher(page);
+      await page.locator(SEARCH_BOX).fill("zzzzqqqq");
+      await settle(page, 400);
+      await snapSurface(page, "10-empty");
+    });
+
+    // 11. Toolbar placement. Same content, opposite anchor — the rows must read
+    // the same opening downward from the toolbar as they do opening upward from
+    // the dock.
+    await step(page, "toolbar", async () => {
+      await openLauncher(page, TOOLBAR_TRIGGER);
+      await snapSurface(page, "11-toolbar-placement");
+    });
+
+    // 12. Narrow window. The surface is a fixed 484px until the viewport drops
+    // below it, at which point `max-w-[calc(100vw-2rem)]` takes over and every
+    // trailing element competes with the name for real. This is the state that
+    // decides whether the truncation priority is right.
+    await step(page, "narrow", async () => {
+      await page.setViewportSize({ width: 440, height: 900 });
+      await settle(page, 800);
+      // The DOCK trigger, not the toolbar one: below about 520px the toolbar
+      // collapses its buttons into an overflow menu and the launcher is no
+      // longer a clickable element on it. The dock's `+` survives the squeeze.
+      await openLauncher(page);
+      await snapSurface(page, "12-narrow-window", SURFACE, 8);
+      await closeLauncher(page);
+      await page.setViewportSize({ width: 1680, height: 1050 });
+      await settle(page, 600);
+    });
+
+    // 13-14. The two accessibility media modes. `forced-colors: active` throws
+    // the theme's tokens away and redraws from system keywords, and
+    // `prefers-contrast: more` swaps in the high-contrast block — a row whose
+    // hierarchy is carried purely by opacity collapses in both.
+    await step(page, "forced-colors", async () => {
+      await page.emulateMedia({ forcedColors: "active" });
+      await settle(page, 400);
+      await openLauncher(page);
+      await snapSurface(page, "13-forced-colors");
+      await closeLauncher(page);
+      await page.emulateMedia({ forcedColors: "none" });
+      await settle(page, 300);
+    });
+
+    await step(page, "contrast-more", async () => {
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 400);
+      await openLauncher(page);
+      await snapSurface(page, "14-contrast-more");
+      await closeLauncher(page);
+      await page.emulateMedia({ contrast: "no-preference" });
+      await settle(page, 300);
+    });
+
+    // Count what landed against what was promised. The exit code says only that
+    // no step threw; this says the sweep actually produced its artifacts.
+    const expected = STEPS.filter((s) => ONLY.length === 0 || ONLY.includes(s.name)).map(
+      (s) => `${s.slug}${TAG}.png`
+    );
+    const present = new Set(readdirSync(OUTPUT_DIR));
+    const missing = expected.filter((f) => !present.has(f));
+
+    expect(stepFailures, `launcher capture steps failed in "${THEME}"`).toEqual([]);
+    expect(missing, `launcher captures missing from ${OUTPUT_DIR}`).toEqual([]);
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/e2e/screenshots/launcher-review.spec.ts
+++ b/e2e/screenshots/launcher-review.spec.ts
@@ -151,7 +151,10 @@ function createRepo(): { dir: string; cleanup: () => void } {
     { id: "team-plan", name: "Plan first" },
     { id: "team-sonnet", name: "Sonnet" },
   ]) {
-    writeFileSync(path.join(presetsDir, `${preset.id}.json`), JSON.stringify(preset, null, 2) + "\n");
+    writeFileSync(
+      path.join(presetsDir, `${preset.id}.json`),
+      JSON.stringify(preset, null, 2) + "\n"
+    );
   }
 
   git("add -A", dir);
@@ -255,9 +258,7 @@ async function openLauncher(page: Page, trigger = DOCK_TRIGGER): Promise<void> {
   await page.locator(SEARCH_BOX).waitFor({ state: "visible", timeout: 8000 });
   // The agent inventory resolves asynchronously; capturing before it lands
   // photographs "Checking agents…" instead of the bands under review.
-  await expect
-    .poll(() => page.locator(OPTION).count(), { timeout: 10_000 })
-    .toBeGreaterThan(3);
+  await expect.poll(() => page.locator(OPTION).count(), { timeout: 10_000 }).toBeGreaterThan(3);
   await settle(page, 350);
 }
 
@@ -267,11 +268,22 @@ async function closeLauncher(page: Page): Promise<void> {
   // recording a shortcut vetoes one before either of those — so a fixed count
   // is not enough to guarantee the surface is gone.
   for (let attempt = 0; attempt < 4; attempt++) {
-    if (!(await page.locator(SEARCH_BOX).isVisible().catch(() => false))) return;
+    if (
+      !(await page
+        .locator(SEARCH_BOX)
+        .isVisible()
+        .catch(() => false))
+    )
+      return;
     await page.keyboard.press("Escape").catch(() => {});
     await settle(page, 200);
   }
-  if (await page.locator(SEARCH_BOX).isVisible().catch(() => false)) {
+  if (
+    await page
+      .locator(SEARCH_BOX)
+      .isVisible()
+      .catch(() => false)
+  ) {
     throw new Error("launcher would not close");
   }
 }

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -167,6 +167,11 @@ export function DockLaunchButton({
   const [expandedPresetParentKey, setExpandedPresetParentKey] = useState<string | null>(null);
   const [capturingRowKey, setCapturingRowKey] = useState<string | null>(null);
 
+  /** Pointer half of the Right/Left Arrow expansion. */
+  const toggleExpanded = useCallback((rowKey: string) => {
+    setExpandedPresetParentKey((current) => (current === rowKey ? null : rowKey));
+  }, []);
+
   // Subscribed here rather than threaded down from a host: the launcher already
   // owns its own model's store reads, and it serves both the dock and the
   // toolbar — neither of which is positioned to compute rows for it.
@@ -931,6 +936,7 @@ export function DockLaunchButton({
                       onActivate={activateRow}
                       onTogglePin={togglePin}
                       onStartCapture={setCapturingRowKey}
+                      onToggleExpanded={toggleExpanded}
                     />
                   )}
                 </Fragment>
@@ -1059,6 +1065,7 @@ interface DockLaunchOptionProps {
   onActivate: (row: DockLaunchRow) => void;
   onTogglePin: (target: DockLaunchPinTarget) => void;
   onStartCapture: (rowKey: string) => void;
+  onToggleExpanded: (rowKey: string) => void;
 }
 
 function DockLaunchOption({
@@ -1072,6 +1079,7 @@ function DockLaunchOption({
   onActivate,
   onTogglePin,
   onStartCapture,
+  onToggleExpanded,
 }: DockLaunchOptionProps) {
   const item = row.kind === "cue" ? undefined : row.item;
   const agent = item?.category === "agent" ? item.agent : undefined;
@@ -1115,6 +1123,12 @@ function DockLaunchOption({
       : row.kind === "preset"
         ? row.preset.label
         : item!.name;
+
+  // Whether this row reserves the two trailing control slots. See the comment at
+  // the slots themselves for why it is decided by category rather than per row.
+  const reservesControlSlots =
+    row.band === "results" ||
+    (row.kind === "item" && (item!.category === "agent" || item!.category === "panel"));
 
   // The one flag that separates the two modes. Browse keeps its per-band rows;
   // search collapses everything into a single `results` band.
@@ -1290,14 +1304,34 @@ function DockLaunchOption({
             would work right now. */}
         <span className="mr-0.5 w-3 shrink-0" data-launcher-slot="disclosure">
           {row.kind === "item" && rowHasPresets(row) && (
-            <ChevronRight
-              aria-hidden
-              className={cn(
-                "h-3 w-3 text-text-secondary transition-transform duration-150 ease-out",
-                "motion-reduce:transition-none",
-                isExpanded && "rotate-90"
-              )}
-            />
+            <span
+              // A chevron that launches the agent is worse than no chevron: it
+              // advertises the one thing it does not do, and the row it sits on
+              // starts a terminal. Presentational rather than a button — an
+              // option's descendants are presentational anyway, so a real button
+              // here would claim semantics the listbox flattens.
+              role="presentation"
+              data-launcher-disclosure=""
+              // The pointer target is bigger than the 12px column it draws in:
+              // negative margins let it cover a comfortable 20px without moving
+              // the icon that follows it.
+              className="-m-1 inline-flex size-5 items-center justify-center p-1"
+              onPointerDown={(event) => event.preventDefault()}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onToggleExpanded(row.rowKey);
+              }}
+            >
+              <ChevronRight
+                aria-hidden
+                className={cn(
+                  "h-3 w-3 text-text-secondary transition-transform duration-150 ease-out",
+                  "motion-reduce:transition-none",
+                  isExpanded && "rotate-90"
+                )}
+              />
+            </span>
           )}
         </span>
         <DockLaunchOptionIcon row={row} />
@@ -1323,7 +1357,29 @@ function DockLaunchOption({
             />
           )}
         </span>
-        {/* `shrink` with a cap, not `shrink-0`. Copied from `PilotView`'s park
+        {/* The shared keycap, not bare text. Rendered flat it was the same size,
+            colour and weight as the qualifier beside it, so "Agent  Cmd+Alt+C"
+            read as one run of trailing text — and the dock button for the very
+            same agent, three inches away, already draws it as chips. */}
+        {effectiveCombo && (
+          <KbdChord
+            shortcut={effectiveCombo}
+            density="compact"
+            className="ml-2 shrink-0"
+            aria-label={displayCombo}
+          />
+        )}
+
+        {/* Last, immediately before the fixed rail, so its right edge is the same
+            on every row. The general pattern pins the shortcut to the trailing
+            edge and puts metadata before it, and that is right where a shortcut
+            is on every row — here it is on about a third of them, so ordering it
+            last made the category column a mixed search is scanned by jump left
+            on any row that happened to have one. The qualifier is the higher
+            priority signal in the mode where it appears, so it takes the stable
+            column and the shortcut floats.
+
+            `shrink` with a cap, not `shrink-0`. Copied from `PilotView`'s park
             note, which shares the row with a truncating title the same way: the
             qualifier gives ground before the name does, and the cap stops a long
             scope label from starving it in the first place.
@@ -1344,86 +1400,99 @@ function DockLaunchOption({
             {visualQualifier}
           </span>
         )}
-        {/* The shared keycap, not bare text. Rendered flat it was the same size,
-            colour and weight as the qualifier beside it, so "Agent  Cmd+Alt+C"
-            read as one run of trailing text — and the dock button for the very
-            same agent, three inches away, already draws it as chips. */}
-        {effectiveCombo && (
-          <KbdChord shortcut={effectiveCombo} className="ml-2 shrink-0" aria-label={displayCombo} />
-        )}
+        {/* Reserved wherever a control can ever appear, so revealing one on hover
+            never shifts the row under the pointer.
 
-        {/* Reserved on every row, not just the ones that use it. Opacity hides
-            the controls without releasing their box, so a recipe and an agent
-            end their trailing labels on the same edge. */}
-        <span className="ml-1 w-5 shrink-0" data-launcher-slot="shortcut">
-          {shortcutAgentId && (
-            <button
-              type="button"
-              tabIndex={-1}
-              aria-hidden="true"
-              data-testid={`launcher-shortcut-edit-${shortcutAgentId}`}
-              title={displayCombo ? "Change keyboard shortcut" : "Assign keyboard shortcut"}
-              onPointerDown={(event) => event.preventDefault()}
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                onStartCapture(row.rowKey);
-              }}
-              className={cn(
-                "inline-flex h-5 w-5 items-center justify-center rounded-[var(--radius-sm)] bg-transparent border-0",
-                "text-daintree-text/40 opacity-0 transition-[opacity,color,background-color]",
-                "hover:bg-overlay-soft hover:text-daintree-text",
-                "group-hover:opacity-100 group-aria-selected:opacity-100"
+            Not on every row any more. Recipes, presets and cues can hold neither
+            control in any state, so on them the 48px was buying alignment with a
+            band they are not in — while the recipe band carries the longest names
+            in the palette. Bands are type-homogeneous, so deciding this by
+            category keeps every row within a band on the same edge; search mixes
+            the types under one heading, so there it always reserves. */}
+        {reservesControlSlots && (
+          <>
+            <span className="ml-1 w-5 shrink-0" data-launcher-slot="shortcut">
+              {shortcutAgentId && (
+                <span
+                  // `role="presentation"`, not a `<button>`. These sit inside
+                  // `role="option"`, where ARIA treats children as presentational
+                  // and a real button trips `nested-interactive`. They were
+                  // already `tabIndex={-1}`, so no keyboard path is lost — focus
+                  // stays on the search box and rows are driven by
+                  // `aria-activedescendant`. Mirrors `ActionPaletteItem`, which
+                  // fixed the same thing on the sibling palette.
+                  role="presentation"
+                  data-testid={`launcher-shortcut-edit-${shortcutAgentId}`}
+                  title={displayCombo ? "Change keyboard shortcut" : "Assign keyboard shortcut"}
+                  onPointerDown={(event) => event.preventDefault()}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onStartCapture(row.rowKey);
+                  }}
+                  className={cn(
+                    "inline-flex h-5 w-5 items-center justify-center rounded-[var(--radius-sm)] bg-transparent border-0",
+                    "text-daintree-text/40 opacity-0 transition-[opacity,color,background-color]",
+                    "hover:bg-overlay-soft hover:text-daintree-text",
+                    "group-hover:opacity-100 group-aria-selected:opacity-100"
+                  )}
+                >
+                  <Keyboard className="h-3 w-3" aria-hidden />
+                </span>
               )}
-            >
-              <Keyboard className="h-3 w-3" aria-hidden />
-            </button>
-          )}
-        </span>
+            </span>
 
-        <span className="ml-1 w-5 shrink-0" data-launcher-slot="pin">
-          {pinTarget && (
-            <button
-              type="button"
-              tabIndex={-1}
-              aria-label={`${pinTarget.onToolbar ? TOOLBAR_UNPIN_LABEL : TOOLBAR_PIN_LABEL}: ${pinTarget.name}`}
-              aria-pressed={pinTarget.onToolbar}
-              aria-keyshortcuts="Alt+P"
-              title={`${pinTarget.onToolbar ? TOOLBAR_UNPIN_LABEL : TOOLBAR_PIN_LABEL} (Alt+P)`}
-              // preventDefault keeps focus on the search box. stopPropagation
-              // belongs on the click below and nowhere else: the row's own
-              // onClick is an ancestor of this one, so the pin must stop the
-              // click — but stopping the POINTERDOWN would hide it from Radix's
-              // DismissableLayer, which needs to see it to classify the next
-              // outside click as a dismissal.
-              onPointerDown={(event) => event.preventDefault()}
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                onTogglePin(pinTarget);
-              }}
-              className={cn(
-                "inline-flex h-5 w-5 items-center justify-center rounded-[var(--radius-sm)] bg-transparent border-0",
-                "transition-[opacity,color,background-color] hover:bg-overlay-soft hover:text-daintree-text",
-                // Pinned rows read as state markers and stay visible; unpinned
-                // ones are controls that only appear once the row is under the
-                // pointer or the selection.
-                pinTarget.onToolbar
-                  ? "text-daintree-text/70 opacity-100"
-                  : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-aria-selected:opacity-100"
-              )}
-            >
-              {/* `Pin`, filled, for the pinned state — never `PinOff`. A pin
+            <span className="ml-1 w-5 shrink-0" data-launcher-slot="pin">
+              {pinTarget && (
+                <span
+                  role="presentation"
+                  data-launcher-pin=""
+                  // The state rides a data attribute because `aria-pressed` on a
+                  // presentational element is ignored — and it was never what
+                  // announced the pin anyway. The option's own `aria-label`
+                  // carries "Press Alt+P to pin/unpin to toolbar" and its
+                  // `aria-keyshortcuts` carries the chord.
+                  data-pinned={pinTarget.onToolbar}
+                  title={`${pinTarget.onToolbar ? TOOLBAR_UNPIN_LABEL : TOOLBAR_PIN_LABEL} (Alt+P)`}
+                  // preventDefault keeps focus on the search box. stopPropagation
+                  // belongs on the click below and nowhere else: the row's own
+                  // onClick is an ancestor of this one, so the pin must stop the
+                  // click — but stopping the POINTERDOWN would hide it from Radix's
+                  // DismissableLayer, which needs to see it to classify the next
+                  // outside click as a dismissal.
+                  onPointerDown={(event) => event.preventDefault()}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onTogglePin(pinTarget);
+                  }}
+                  className={cn(
+                    "inline-flex h-5 w-5 items-center justify-center rounded-[var(--radius-sm)] bg-transparent border-0",
+                    "transition-[opacity,color,background-color] hover:bg-overlay-soft hover:text-daintree-text",
+                    // Pinned rows read as state markers and stay visible; unpinned
+                    // ones are controls that only appear once the row is under the
+                    // pointer or the selection.
+                    pinTarget.onToolbar
+                      ? "text-daintree-text/70 opacity-100"
+                      : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-aria-selected:opacity-100"
+                  )}
+                >
+                  {/* `Pin`, filled, for the pinned state — never `PinOff`. A pin
                   with a slash through it is the "off/muted/unavailable" glyph
                   in every system that defines one, so wearing it at rest made a
                   pinned row advertise that it was not pinned. Paired with
                   `aria-pressed="true"` it read as a double negative to a screen
                   reader too. Filled-for-selected, outline-for-unselected is the
                   convention the rest of the app's toggles follow. */}
-              <Pin className={cn("h-3 w-3", pinTarget.onToolbar && "fill-current")} aria-hidden />
-            </button>
-          )}
-        </span>
+                  <Pin
+                    className={cn("h-3 w-3", pinTarget.onToolbar && "fill-current")}
+                    aria-hidden
+                  />
+                </span>
+              )}
+            </span>
+          </>
+        )}
       </div>
     </>
   );

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import Fuse, { type IFuseOptions } from "fuse.js";
-import { Keyboard, Pin, PinOff, Plug, Plus, Settings2, SquareTerminal } from "lucide-react";
+import { ChevronRight, Keyboard, Pin, Plug, Plus, Settings2, SquareTerminal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
@@ -9,6 +9,7 @@ import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { useDockLaunchHoverSelection } from "./useDockLaunchHoverSelection";
 import { AppPalettePopover } from "@/components/ui/AppPalettePopover";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
+import { KbdChord } from "@/components/ui/Kbd";
 import { PALETTE_ROW_CLASS, PALETTE_SECTION_LABEL_CLASS } from "@/components/ui/paletteRowStyles";
 import { BrandMark, Workflow } from "@/components/icons";
 import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
@@ -36,7 +37,7 @@ import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { dispatchToolbarVisibility } from "@/lib/toolbarVisibilityDispatch";
 import { normalizeKeyForBinding } from "@/services/keybindingUtils";
-import { useKeybindingDisplay } from "@/hooks";
+import { useEffectiveCombo, useKeybindingDisplay } from "@/hooks";
 import { TOOLBAR_PIN_LABEL, TOOLBAR_UNPIN_LABEL } from "./toolbarMenuStrings";
 import { LAUNCHER_PANEL_ITEMS } from "./launcherPanelItems";
 import { useSearchablePalette } from "@/hooks/useSearchablePalette";
@@ -49,6 +50,7 @@ import {
   rowHasPresets,
   useDockLaunchModel,
   DOCK_LAUNCH_BAND_LABELS,
+  DOCK_LAUNCH_CATEGORY_LABELS,
   DOCK_LAUNCH_CUE_LABELS,
   type DockLaunchAgent,
   type DockLaunchInventoryState,
@@ -896,36 +898,70 @@ export function DockLaunchButton({
             <AppPaletteDialog.Empty query={query} emptyMessage="Nothing to launch" />
           ) : (
             <div ref={listboxRef} id={listboxId} role="listbox" aria-label="Launcher results">
-              {results.map((row, index) =>
-                capturingRowKey === row.rowKey ? (
-                  <DockLaunchCaptureRow
-                    key={row.rowKey}
-                    row={row}
-                    onDone={() => setCapturingRowKey(null)}
-                  />
-                ) : (
-                  <DockLaunchOption
-                    key={row.rowKey}
-                    row={row}
-                    index={index}
-                    isSelected={index === activeIndex}
-                    showBandLabel={row.band !== results[index - 1]?.band}
-                    optionId={getOptionId(row.rowKey)}
-                    pinTarget={resolvePinTarget(row)}
-                    isExpanded={expandedPresetParentKey === row.rowKey}
-                    onHover={handleRowHover}
-                    onActivate={activateRow}
-                    onTogglePin={togglePin}
-                    onStartCapture={setCapturingRowKey}
-                  />
-                )
-              )}
+              {results.map((row, index) => (
+                // The band heading is a sibling of the row, not a child of it.
+                // It used to live inside `DockLaunchOption`, which meant the
+                // capture row — a different component that replaces the option
+                // outright — rendered no heading, and recording a shortcut on
+                // the first agent silently deleted "Launch agent" from the list.
+                <Fragment key={row.rowKey}>
+                  {shouldShowBandLabel(results, index) && (
+                    <div
+                      // Decorative inside the listbox — the band is conveyed by
+                      // the row's own accessible name, and an extra child would
+                      // break option counting.
+                      aria-hidden="true"
+                      data-testid="dock-launcher-band"
+                      className={cn(PALETTE_SECTION_LABEL_CLASS, "px-2 pt-2 pb-1 first:pt-0")}
+                    >
+                      {DOCK_LAUNCH_BAND_LABELS[row.band]}
+                    </div>
+                  )}
+                  {capturingRowKey === row.rowKey ? (
+                    <DockLaunchCaptureRow row={row} onDone={() => setCapturingRowKey(null)} />
+                  ) : (
+                    <DockLaunchOption
+                      row={row}
+                      index={index}
+                      isSelected={index === activeIndex}
+                      optionId={getOptionId(row.rowKey)}
+                      pinTarget={resolvePinTarget(row)}
+                      isExpanded={expandedPresetParentKey === row.rowKey}
+                      onHover={handleRowHover}
+                      onActivate={activateRow}
+                      onTogglePin={togglePin}
+                      onStartCapture={setCapturingRowKey}
+                    />
+                  )}
+                </Fragment>
+              ))}
             </div>
           )}
         </AppPaletteDialog.Body>
       </AppPalettePopover.Content>
     </AppPalettePopover>
   );
+}
+
+/**
+ * Whether this row opens a new band, and therefore owes a heading.
+ *
+ * Not simply "the band changed". An expanded agent's presets are spliced into
+ * the flat list as `band: "presets"` rows sitting INSIDE their parent's band,
+ * so the first agent after them looked like the start of a new group and
+ * re-rendered "Launch agent" — splitting one list of three agents into two
+ * apparent lists of one and two. Walking back past the preset block asks the
+ * question the heading is actually answering: is this row in the same group as
+ * the last row that was not part of an expansion?
+ */
+function shouldShowBandLabel(rows: ReadonlyArray<DockLaunchRow>, index: number): boolean {
+  const row = rows[index];
+  if (!row) return false;
+  // The presets block gets exactly one heading, on its first row.
+  if (row.kind === "preset") return rows[index - 1]?.kind !== "preset";
+  let previous = index - 1;
+  while (previous >= 0 && rows[previous]?.kind === "preset") previous -= 1;
+  return previous < 0 || rows[previous]?.band !== row.band;
 }
 
 /**
@@ -1015,7 +1051,6 @@ interface DockLaunchOptionProps {
   row: DockLaunchRow;
   index: number;
   isSelected: boolean;
-  showBandLabel: boolean;
   optionId: string;
   /** Null for rows with no toolbar button to pin — the slot is still reserved. */
   pinTarget: DockLaunchPinTarget | null;
@@ -1030,7 +1065,6 @@ function DockLaunchOption({
   row,
   index,
   isSelected,
-  showBandLabel,
   optionId,
   pinTarget,
   isExpanded,
@@ -1054,9 +1088,12 @@ function DockLaunchOption({
       ? (LAUNCHER_PANEL_ITEMS.find((p) => p.id === getLauncherPanelButtonIdForKind(item.kindId))
           ?.actionId ?? "")
       : "";
-  const displayCombo = useKeybindingDisplay(
-    shortcutAgentId ? `agent.${shortcutAgentId}` : panelActionId
-  );
+  const comboActionId = shortcutAgentId ? `agent.${shortcutAgentId}` : panelActionId;
+  const displayCombo = useKeybindingDisplay(comboActionId);
+  // The canonical chord ("Cmd+Alt+C"), which is what `KbdChord` parses into
+  // per-key chips. `displayCombo` is already formatted for the platform and
+  // stays the human-readable string for the tooltip and the spoken label.
+  const effectiveCombo = useEffectiveCombo(comboActionId);
 
   // A filtered row must carry the same warnings as its unfiltered twin: an
   // agent that lands on the recovery panel instead of a session, or a shadowed
@@ -1079,9 +1116,18 @@ function DockLaunchOption({
         ? row.preset.label
         : item!.name;
 
-  // Where the row lands, or which recipe wins — rendered as the trailing label
-  // and reused as the option's accessible name below.
-  const qualifier =
+  // The one flag that separates the two modes. Browse keeps its per-band rows;
+  // search collapses everything into a single `results` band.
+  const isSearchResult = row.band === "results";
+
+  // Two qualifiers, deliberately different.
+  //
+  // `spokenQualifier` is what the screen reader hears, and it is the one this
+  // row has always produced. It stays exhaustive — category, destination and
+  // all — because the accessible name is a contract: `e2e/helpers/panels.ts`
+  // matches rows by the `[aria-label^="Name,"]` prefix, and a listener who
+  // cannot see the band heading has nothing else to place the row with.
+  const spokenQualifier =
     row.kind === "cue"
       ? undefined
       : row.kind === "preset"
@@ -1102,6 +1148,53 @@ function DockLaunchOption({
                 ? "Setup"
                 : "Agent";
 
+  // `visualQualifier` is what the eye sees, and the eye has the band heading
+  // that the ear does not. Every browse band is type-homogeneous — "Launch
+  // agent" holds only agents, "Open in dock" only dock panels — so restating
+  // the type on each row underneath spends the row's scarcest resource on a
+  // word the heading already said, three or six times in a column.
+  //
+  // Search is the opposite case. One flat "Search results" band mixes agents,
+  // panels and recipes, and nothing else places a row: a query for "re" returns
+  // a recipe named Review and a panel named Review, and the old labels told them
+  // apart with "Team" and "Grid" — a scope and a destination, neither of which
+  // says what the row IS. There the category is the whole point.
+  //
+  // State outranks category in both modes. A disabled reason, an agent that
+  // needs setting up, or a recipe a team override has shadowed all change what
+  // Enter does, which is the second question this palette exists to answer.
+  const visualQualifier =
+    row.kind === "cue"
+      ? undefined
+      : row.kind === "preset"
+        ? // The provenance heading is rendered directly above this row, so the
+          // group name here is the same word twice. "Current" is not.
+          row.preset.isSelected
+          ? "Current"
+          : undefined
+        : // State first, in both modes: these change what Enter does.
+          disabledReason !== undefined
+          ? disabledReason
+          : item!.category === "recipe" && item!.isShadowed
+            ? `${item!.scopeLabel} · Overridden by Team`
+            : item!.category === "agent" && item!.agentBand !== "launch"
+              ? // In browse, "Needs setup" and "Available agents" already say it.
+                isSearchResult
+                ? "Setup"
+                : undefined
+              : isSearchResult
+                ? // One axis for the whole result list. Giving the recipe its
+                  // scope and the panel its category put two different kinds of
+                  // answer in one column, so the two rows a query for "re"
+                  // returns — a recipe named Review and a panel named Review —
+                  // still had to be compared across "Team" and "Panel". Scope is
+                  // a browsing nicety; which of the two things this IS is the
+                  // question search has to answer.
+                  DOCK_LAUNCH_CATEGORY_LABELS[item!.category]
+                : item!.category === "recipe"
+                  ? item!.scopeLabel
+                  : undefined;
+
   // What the row conveys visually, in one string — the option is what
   // `aria-activedescendant` points at, and its children (the trailing qualifier,
   // the pin's own state, the New cue) stop being announced with it once the name
@@ -1113,7 +1206,7 @@ function DockLaunchOption({
   // NOT folded in: `title` alongside an `aria-label` computes as the
   // description, so repeating it here would announce it twice.
   const optionLabel = [
-    qualifier ? `${displayName}, ${qualifier}` : displayName,
+    spokenQualifier ? `${displayName}, ${spokenQualifier}` : displayName,
     agent?.isNew ? "New" : undefined,
     // Stated only where it applies, so the phrase never advertises a key that
     // would do nothing on this row.
@@ -1129,17 +1222,6 @@ function DockLaunchOption({
 
   return (
     <>
-      {showBandLabel && (
-        <div
-          // Decorative inside the listbox — the band is conveyed by the row's
-          // own trailing label, and an extra child would break option counting.
-          aria-hidden="true"
-          data-testid="dock-launcher-band"
-          className={cn(PALETTE_SECTION_LABEL_CLASS, "px-2 pt-2 pb-1 first:pt-0")}
-        >
-          {DOCK_LAUNCH_BAND_LABELS[row.band]}
-        </div>
-      )}
       {row.kind === "preset" && row.groupLabel && (
         <div
           // Same rule as the band heading above: decorative, because the row's
@@ -1191,27 +1273,83 @@ function DockLaunchOption({
           // Preset children are indented so the expansion reads as belonging to
           // the agent above it rather than as another top-level row.
           row.kind === "preset" && "pl-7",
-          isDimmed && "opacity-70"
+          // Deliberately NOT a whole-row `opacity-70`. Dimming the row dimmed
+          // the qualifier with it, so "Needs a project" — the reason Enter will
+          // not do the ordinary thing — ended up the faintest text on the row,
+          // which is exactly backwards. The name and icon recede instead; the
+          // reason keeps the metadata token every other row uses.
+          isDimmed && "text-daintree-text/60"
         )}
       >
+        {/* Leading disclosure, reserved on every row so the icon column holds
+            still. Leading rather than trailing on purpose: a trailing chevron
+            reads as "this navigates somewhere else", and these presets splice
+            into the list in place. Visible at rest rather than on hover — the
+            palette is driven from the keyboard, and an affordance that only a
+            pointer can discover tells a keyboard user nothing about a key that
+            would work right now. */}
+        <span className="mr-0.5 w-3 shrink-0" data-launcher-slot="disclosure">
+          {row.kind === "item" && rowHasPresets(row) && (
+            <ChevronRight
+              aria-hidden
+              className={cn(
+                "h-3 w-3 text-text-secondary transition-transform duration-150 ease-out",
+                "motion-reduce:transition-none",
+                isExpanded && "rotate-90"
+              )}
+            />
+          )}
+        </span>
         <DockLaunchOptionIcon row={row} />
-        <span className="truncate">{displayName}</span>
-        {agent?.isNew && (
-          <>
+        {/* `min-w-0 flex-1`: the name is the query the user came here with, and
+            it takes the width the row can spare rather than yielding to whatever
+            metadata sits beside it.
+
+            The "new" dot rides inside this group rather than after it. Left as a
+            sibling of a growing name it was pushed out to the metadata rail,
+            where a mark that means "this agent just appeared" sat among the
+            marks that mean state — and stopped reading as attached to the name
+            it qualifies. */}
+        <span className="flex min-w-0 flex-1 items-center">
+          <span className="truncate">{displayName}</span>
+          {/* Only on the agent's own row. The dot marks the AGENT as newly
+              detected, and repeating it on each of its preset children said the
+              same thing four times about one thing. */}
+          {agent?.isNew && row.kind !== "preset" && (
             <span
               data-testid={`launcher-new-pill-${agent.id}`}
               aria-hidden="true"
               className="ml-2 shrink-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
             />
-          </>
-        )}
-        {qualifier && (
-          <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">{qualifier}</span>
-        )}
-        {displayCombo && (
-          <span className="ml-2 shrink-0 text-[11px] text-text-muted tabular-nums">
-            {displayCombo}
+          )}
+        </span>
+        {/* `shrink` with a cap, not `shrink-0`. Copied from `PilotView`'s park
+            note, which shares the row with a truncating title the same way: the
+            qualifier gives ground before the name does, and the cap stops a long
+            scope label from starving it in the first place.
+
+            `text-secondary`, not `text-muted`. The visual guide files `muted`
+            under "Timestamps, disabled text, helper text (may fall below WCAG
+            AA)" and `secondary` under "metadata", and this row was one of only
+            two in the app on the wrong one. The one-step lift on selection is
+            what five sibling palettes already do. */}
+        {visualQualifier && (
+          <span
+            data-launcher-qualifier=""
+            className={cn(
+              "ml-2 min-w-0 max-w-[40%] shrink truncate text-[11px] text-text-secondary",
+              "transition-colors group-aria-selected:text-daintree-text/80"
+            )}
+          >
+            {visualQualifier}
           </span>
+        )}
+        {/* The shared keycap, not bare text. Rendered flat it was the same size,
+            colour and weight as the qualifier beside it, so "Agent  Cmd+Alt+C"
+            read as one run of trailing text — and the dock button for the very
+            same agent, three inches away, already draws it as chips. */}
+        {effectiveCombo && (
+          <KbdChord shortcut={effectiveCombo} className="ml-2 shrink-0" aria-label={displayCombo} />
         )}
 
         {/* Reserved on every row, not just the ones that use it. Opacity hides
@@ -1275,11 +1413,14 @@ function DockLaunchOption({
                   : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-aria-selected:opacity-100"
               )}
             >
-              {pinTarget.onToolbar ? (
-                <PinOff className="h-3 w-3" aria-hidden />
-              ) : (
-                <Pin className="h-3 w-3" aria-hidden />
-              )}
+              {/* `Pin`, filled, for the pinned state — never `PinOff`. A pin
+                  with a slash through it is the "off/muted/unavailable" glyph
+                  in every system that defines one, so wearing it at rest made a
+                  pinned row advertise that it was not pinned. Paired with
+                  `aria-pressed="true"` it read as a double negative to a screen
+                  reader too. Filled-for-selected, outline-for-unselected is the
+                  convention the rest of the app's toggles follow. */}
+              <Pin className={cn("h-3 w-3", pinTarget.onToolbar && "fill-current")} aria-hidden />
             </button>
           )}
         </span>

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1846,8 +1846,8 @@ describe("DockLaunchButton", () => {
     }
 
     /** Structural, not by label: the pin is the row's toggle-state control. */
-    function pinControl(row: HTMLElement): HTMLButtonElement | null {
-      return row.querySelector<HTMLButtonElement>("button[aria-pressed]");
+    function pinControl(row: HTMLElement): HTMLElement | null {
+      return row.querySelector<HTMLElement>("[data-launcher-pin]");
     }
 
     it("renders each option as a container with sibling buttons, never a nested button", () => {
@@ -1910,13 +1910,13 @@ describe("DockLaunchButton", () => {
       // pin has to read the position too or it describes a button that is not
       // rendered anywhere.
       const { container } = renderButton();
-      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("aria-pressed")).toBe("false");
+      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("data-pinned")).toBe("false");
     });
 
     it("reports an agent positioned on either side as pinned", () => {
       mockToolbarLayout = { pinnedButtons: {}, leftButtons: [], rightButtons: ["claude"] };
       const { container } = renderButton();
-      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("aria-pressed")).toBe("true");
+      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("data-pinned")).toBe("true");
     });
 
     it("lets an explicit pin outrank a missing position, and an explicit hide outrank one", () => {
@@ -1924,14 +1924,14 @@ describe("DockLaunchButton", () => {
       mockToolbarLayout = { pinnedButtons: {}, leftButtons: ["gemini"], rightButtons: [] };
       const { container } = renderButton();
 
-      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("aria-pressed")).toBe("true");
-      expect(pinControl(rowFor(container, "Gemini"))?.getAttribute("aria-pressed")).toBe("false");
+      expect(pinControl(rowFor(container, "Claude"))?.getAttribute("data-pinned")).toBe("true");
+      expect(pinControl(rowFor(container, "Gemini"))?.getAttribute("data-pinned")).toBe("false");
     });
 
     it("writes an agent pin through the dispatcher that also gives it a position", () => {
       const { container } = renderButton();
       const pin = pinControl(rowFor(container, "Claude"))!;
-      expect(pin.getAttribute("aria-pressed")).toBe("false");
+      expect(pin.getAttribute("data-pinned")).toBe("false");
 
       fireEvent.click(pin);
 
@@ -1944,7 +1944,7 @@ describe("DockLaunchButton", () => {
       mockToolbarLayout = { pinnedButtons: {}, leftButtons: ["claude"], rightButtons: [] };
       const { container } = renderButton();
       const pin = pinControl(rowFor(container, "Claude"))!;
-      expect(pin.getAttribute("aria-pressed")).toBe("true");
+      expect(pin.getAttribute("data-pinned")).toBe("true");
 
       fireEvent.click(pin);
 
@@ -1964,7 +1964,7 @@ describe("DockLaunchButton", () => {
       mockToolbarLayout = { pinnedButtons: { browser: true }, leftButtons: [], rightButtons: [] };
       const { container } = renderButton();
       const pin = pinControl(rowFor(container, "Browser"))!;
-      expect(pin.getAttribute("aria-pressed")).toBe("true");
+      expect(pin.getAttribute("data-pinned")).toBe("true");
 
       fireEvent.click(pin);
 
@@ -2018,18 +2018,22 @@ describe("DockLaunchButton", () => {
       expect(setAgentPinnedMock).toHaveBeenCalledTimes(2);
     });
 
-    it("labels the pin control and keeps it out of the tab order", () => {
+    it("announces the pin on the option and keeps the control out of the tab order", () => {
       const { container } = renderButton();
-      const pin = pinControl(rowFor(container, "Claude"))!;
+      const row = rowFor(container, "Claude");
+      const pin = pinControl(row)!;
 
-      // Named for itself — the option's own label deliberately excludes it, so
-      // this is the only place the control says what it does.
-      expect(pin.getAttribute("aria-label")).toContain("Claude");
-      expect(pin.getAttribute("aria-keyshortcuts")).toBe("Alt+P");
+      // The control is presentational — children of `role="option"` are, and a
+      // real button there trips `nested-interactive` — so the chord and the verb
+      // have to be announced by the option that owns it. The control keeps only
+      // the mouse tooltip, which is not an accessibility surface.
+      expect(row.getAttribute("aria-keyshortcuts")).toBe("Alt+P");
+      expect(row.getAttribute("aria-label")).toContain("Alt+P");
       expect(pin.getAttribute("title")).toContain("Alt+P");
-      // A second tab stop inside every row would break the palette's keyboard
-      // model, which moves selection rather than focus.
+      // No second tab stop inside a row: the palette moves selection, not focus,
+      // and a focusable control here would break that model.
       expect(pin.tabIndex).toBe(-1);
+      expect(pin.getAttribute("role")).toBe("presentation");
     });
 
     it("names the pin shortcut's effect in the option's own name, flipped by state", () => {
@@ -2138,10 +2142,10 @@ describe("DockLaunchButton", () => {
       };
 
       const pressed = options(container).filter(
-        (row) => pinControl(row)?.getAttribute("aria-pressed") === "true"
+        (row) => pinControl(row)?.getAttribute("data-pinned") === "true"
       );
       const unpressed = options(container).filter(
-        (row) => pinControl(row)?.getAttribute("aria-pressed") === "false"
+        (row) => pinControl(row)?.getAttribute("data-pinned") === "false"
       );
       expect(pressed.length).toBeGreaterThan(0);
       expect(unpressed.length).toBeGreaterThan(0);
@@ -2165,32 +2169,50 @@ describe("DockLaunchButton", () => {
       expect(getAllByTestId("dock-launcher-band").map((el) => el.textContent)).toEqual(before);
     });
 
-    it("keeps the trailing slot on rows that cannot be pinned", () => {
-      // jsdom has no layout, so this checks the structure the alignment rests
-      // on rather than the width: an unpinnable row still ends with the same
-      // slot element, so its qualifier stops where a pinnable row's does.
-      // Dropping the slot for unpinnable rows changes the child count.
+    it("reserves the same trailing slots for every row under one heading", () => {
+      // jsdom has no layout, so this checks the structure the alignment rests on
+      // rather than the width. The rule is per BAND, not per row: revealing a
+      // control on hover must not shift the row under the pointer, and two rows
+      // under one heading must end their labels on one edge. It is no longer
+      // "every row in the list" — a recipe can hold neither control in any
+      // state, and reserving 48px on the band with the longest names in the
+      // palette bought alignment with a band it is not in.
       mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
       const { container } = renderButton();
 
-      const pinnable = rowFor(container, "Claude");
-      const notPinnable = rowFor(container, "My recipe");
-      expect(pinControl(notPinnable)).toBeNull();
-      // Both reserved slots are present on both rows even when empty — that is
-      // what keeps the two qualifiers ending on the same edge. Asserted on the
-      // slots themselves rather than a child count, because an agent row also
-      // carries a keyboard-shortcut hint that a recipe row never can.
       const slotsOf = (row: HTMLElement) =>
-        Array.from(row.querySelectorAll("[data-launcher-slot]")).map((el) =>
-          el.getAttribute("data-launcher-slot")
-        );
-      expect(slotsOf(notPinnable)).toEqual(slotsOf(pinnable));
-      // Leading disclosure, then the two trailing controls. The disclosure
-      // column is reserved for the same reason as the other two: only agents
-      // can expand, and letting the column collapse on every other row would
-      // step the icons in and out as the list is scrolled.
-      expect(slotsOf(notPinnable)).toEqual(["disclosure", "shortcut", "pin"]);
-      expect(notPinnable.lastElementChild?.tagName).toBe(pinnable.lastElementChild?.tagName);
+        Array.from(row.querySelectorAll("[data-launcher-slot]"))
+          .map((el) => el.getAttribute("data-launcher-slot"))
+          .join(",");
+
+      // Walk the listbox in DOM order, grouping rows under the heading above
+      // them, and require one slot signature per group.
+      const groups = new Map<string, Set<string>>();
+      let heading = "";
+      for (const node of listbox(container).querySelectorAll<HTMLElement>(
+        '[data-testid="dock-launcher-band"], [role="option"]'
+      )) {
+        if (node.getAttribute("data-testid") === "dock-launcher-band") {
+          heading = node.textContent ?? "";
+          continue;
+        }
+        // Cue rows carry no trailing label, so they have no edge to align.
+        if (node.getAttribute("data-row-kind") === "cue") continue;
+        const set = groups.get(heading) ?? new Set<string>();
+        set.add(slotsOf(node));
+        groups.set(heading, set);
+      }
+
+      expect(groups.size).toBeGreaterThan(1);
+      for (const [band, signatures] of groups) {
+        expect([band, signatures.size]).toEqual([band, 1]);
+      }
+
+      // The rows that can hold a control still reserve both, so revealing one on
+      // hover moves nothing; the recipe band keeps only its disclosure column.
+      expect(slotsOf(rowFor(container, "Claude"))).toBe("disclosure,shortcut,pin");
+      expect(slotsOf(rowFor(container, "My recipe"))).toBe("disclosure");
+      expect(pinControl(rowFor(container, "My recipe"))).toBeNull();
     });
 
     it("activates from the row itself, not only from an inner control", () => {
@@ -2210,7 +2232,7 @@ describe("DockLaunchButton", () => {
       const { container } = renderButton();
 
       const pin = pinControl(rowFor(container, "Claude"));
-      expect(pin?.getAttribute("aria-pressed")).toBe("false");
+      expect(pin?.getAttribute("data-pinned")).toBe("false");
       fireEvent.click(pin!);
       expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", true);
     });
@@ -2578,7 +2600,7 @@ describe("DockLaunchButton — migrated toolbar affordances (#11691)", () => {
       // Reachable: it is still an option, so arrow keys land on it...
       expect(options(container)).toContain(row);
       // ...and its pin is still there, which is the whole reason it stays.
-      expect(row.querySelector("button[aria-pressed]")).toBeTruthy();
+      expect(row.querySelector("[data-launcher-pin]")).toBeTruthy();
     });
 
     it("opens nothing and stays open when a gated row is activated", () => {
@@ -2595,8 +2617,8 @@ describe("DockLaunchButton — migrated toolbar affordances (#11691)", () => {
 
     it("still pins a gated row", () => {
       const { container } = renderButton({ agents: READY, hasWorkspace: false });
-      const pin = rowByName(container, "File Browser").querySelector<HTMLButtonElement>(
-        "button[aria-pressed]"
+      const pin = rowByName(container, "File Browser").querySelector<HTMLElement>(
+        "[data-launcher-pin]"
       )!;
       fireEvent.click(pin);
       expect(setPanelButtonOnToolbarMock).toHaveBeenCalledWith("file-browser", true);

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -404,6 +404,17 @@ function searchInput(container: HTMLElement): HTMLInputElement {
   return input;
 }
 
+/**
+ * The row's visible trailing qualifier, or "" when it renders none.
+ *
+ * Read off `data-launcher-qualifier` rather than a class string or a position:
+ * the point of these tests is which INFORMATION reaches the row, and that has
+ * to keep holding when the treatment changes again.
+ */
+function qualifierTextOf(row: HTMLElement): string {
+  return row.querySelector("[data-launcher-qualifier]")?.textContent?.trim() ?? "";
+}
+
 function listbox(container: HTMLElement): HTMLElement {
   const node = container.querySelector<HTMLElement>('[role="listbox"]');
   if (!node) throw new Error("listbox not found");
@@ -2059,6 +2070,101 @@ describe("DockLaunchButton", () => {
       expect(row.getAttribute("aria-label")).not.toContain("blocked by endpoint security");
     });
 
+    it("never restates on a row the word its band heading already said", () => {
+      // The rule, not the wording. Every browse band is type-homogeneous, so a
+      // qualifier that repeats its own heading is spending the row's scarcest
+      // width on nothing. Restating the check against a literal list of banned
+      // words would need editing every time a band is renamed; comparing the two
+      // rendered strings keeps holding whatever they are called.
+      const { container, getAllByTestId } = renderButton({ pinnedCount: 0 });
+
+      const nodes = Array.from(
+        listbox(container).querySelectorAll<HTMLElement>(
+          '[data-testid="dock-launcher-band"], [role="option"]'
+        )
+      );
+      let heading = "";
+      const offenders: string[] = [];
+      for (const node of nodes) {
+        if (node.getAttribute("data-testid") === "dock-launcher-band") {
+          heading = (node.textContent ?? "").trim().toLowerCase();
+          continue;
+        }
+        const qualifier = qualifierTextOf(node);
+        if (!qualifier || !heading) continue;
+        // "Open in dock" states "dock"; "Launch agent" states "agent".
+        const headingWords = new Set(heading.split(/\s+/));
+        for (const word of qualifier.toLowerCase().split(/[\s·]+/)) {
+          if (headingWords.has(word)) offenders.push(`${heading} → ${qualifier}`);
+        }
+      }
+
+      expect(getAllByTestId("dock-launcher-band").length).toBeGreaterThan(1);
+      expect(offenders).toEqual([]);
+    });
+
+    it("gives every mixed search result a category, since no heading places it", () => {
+      // The complement of the rule above, and the reason it is safe: browse can
+      // drop the category because a heading carries it, and search cannot,
+      // because one flat "Search results" band mixes all three kinds. Asserted
+      // as "every row has one" rather than "this row says Panel" so it survives
+      // the category words being renamed.
+      mockRecipes = [{ id: "r-1", name: "Review", worktreeId: undefined }];
+      const { container } = renderButton();
+      fireEvent.change(searchInput(container), { target: { value: "review" } });
+
+      const rows = options(container);
+      expect(rows.length).toBeGreaterThan(1);
+      for (const row of rows) {
+        expect(qualifierTextOf(row)).toBeTruthy();
+      }
+    });
+
+    it("marks a pinned row with the same glyph as an unpinned one, not a negated one", () => {
+      // A pin with a slash through it is the "off/muted/unavailable" mark
+      // everywhere that defines one, so wearing it at rest made a pinned row
+      // advertise the opposite of its state — and paired with `aria-pressed`
+      // it read as a double negative. The rule is that the two states differ by
+      // treatment, not by swapping in a contradictory glyph.
+      // A toolbar position is what makes a row pinned; `pinnedCount` only
+      // decides where the Pinned/Other band line falls.
+      mockToolbarLayout = { pinnedButtons: {}, leftButtons: [], rightButtons: ["claude"] };
+      const { container } = renderButton();
+
+      const glyphNameOf = (row: HTMLElement): string | undefined => {
+        const control = pinControl(row);
+        const svg = control?.querySelector("svg");
+        return Array.from(svg?.classList ?? []).find((c) => c.startsWith("lucide-"));
+      };
+
+      const pressed = options(container).filter(
+        (row) => pinControl(row)?.getAttribute("aria-pressed") === "true"
+      );
+      const unpressed = options(container).filter(
+        (row) => pinControl(row)?.getAttribute("aria-pressed") === "false"
+      );
+      expect(pressed.length).toBeGreaterThan(0);
+      expect(unpressed.length).toBeGreaterThan(0);
+      expect(glyphNameOf(pressed[0]!)).toBe(glyphNameOf(unpressed[0]!));
+      for (const row of pressed) {
+        expect(glyphNameOf(row)).not.toContain("off");
+      }
+    });
+
+    it("keeps a band's heading while its first row is recording a shortcut", () => {
+      // The recorder replaces the whole option, and the heading used to be a
+      // child of it — so recording on the first agent deleted "Launch agent"
+      // and left the rows beneath it under no heading at all.
+      const { container, getAllByTestId } = renderButton();
+      const before = getAllByTestId("dock-launcher-band").map((el) => el.textContent);
+
+      const edit = container.querySelector<HTMLElement>('[data-testid^="launcher-shortcut-edit-"]');
+      expect(edit).not.toBeNull();
+      fireEvent.click(edit!);
+
+      expect(getAllByTestId("dock-launcher-band").map((el) => el.textContent)).toEqual(before);
+    });
+
     it("keeps the trailing slot on rows that cannot be pinned", () => {
       // jsdom has no layout, so this checks the structure the alignment rests
       // on rather than the width: an unpinnable row still ends with the same
@@ -2079,7 +2185,11 @@ describe("DockLaunchButton", () => {
           el.getAttribute("data-launcher-slot")
         );
       expect(slotsOf(notPinnable)).toEqual(slotsOf(pinnable));
-      expect(slotsOf(notPinnable)).toEqual(["shortcut", "pin"]);
+      // Leading disclosure, then the two trailing controls. The disclosure
+      // column is reserved for the same reason as the other two: only agents
+      // can expand, and letting the column collapse on every other row would
+      // step the icons in and out as the list is scrolled.
+      expect(slotsOf(notPinnable)).toEqual(["disclosure", "shortcut", "pin"]);
       expect(notPinnable.lastElementChild?.tagName).toBe(pinnable.lastElementChild?.tagName);
     });
 
@@ -2243,6 +2353,29 @@ describe("DockLaunchButton — migrated toolbar affordances (#11691)", () => {
 
       fireEvent.keyDown(input, { key: "ArrowLeft" });
       expect(presetRows(container)).toHaveLength(0);
+    });
+
+    it("keeps one heading per band when an agent's presets are spliced in", () => {
+      // Two agents, expanding the first: the bug only shows when a row of the
+      // parent's band FOLLOWS the preset block. Preset rows are siblings in the
+      // same flat list spliced inside their parent's band, so comparing each
+      // row's band with the row immediately before it made Gemini look like the
+      // start of a second "Launch agent" group.
+      const two = [
+        { id: "claude", name: "Claude", availability: "ready" as const },
+        { id: "gemini", name: "Gemini", availability: "ready" as const },
+      ];
+      const { container, getAllByTestId } = renderButton({ agents: two });
+      const bandsOf = () => getAllByTestId("dock-launcher-band").map((el) => el.textContent);
+      const before = bandsOf();
+
+      fireEvent.keyDown(searchInput(container), { key: "ArrowRight" });
+      expect(presetRows(container).length).toBeGreaterThan(0);
+
+      const after = bandsOf();
+      expect(after.filter((label, i) => after.indexOf(label) !== i)).toEqual([]);
+      // The expansion contributes its own heading and disturbs no other.
+      expect(after).toEqual(expect.arrayContaining(before));
     });
 
     it("selects the first preset once the expansion has rendered", () => {

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -391,14 +391,23 @@ describe("buildDockLaunchModel — browse rows", () => {
     expect(bands.map((row) => row.band)).toEqual(["pinned", "other"]);
   });
 
-  it("collapses the panel bands when every panel shares one destination", () => {
-    const model = build({ surface: "grid" });
-    const panelBands = new Set(
-      model.browseRows
-        .filter((row) => getDockLaunchRowItem(row)?.category === "panel")
-        .map((row) => row.band)
-    );
-    expect([...panelBands]).toEqual(["panels"]);
+  it("bands panels by destination even when every panel shares one", () => {
+    // The generic "Launch panel" band used to be the single-destination
+    // fallback, which left every row to say where it lands — six rows ending in
+    // the word "Grid" under a heading that could have said it once. The heading
+    // is now always the one that names the destination, so no row has to.
+    const gridOnly = build({ surface: "grid" });
+    const bandsOf = (model: ReturnType<typeof build>) => [
+      ...new Set(
+        model.browseRows
+          .filter((row) => getDockLaunchRowItem(row)?.category === "panel")
+          .map((row) => row.band)
+      ),
+    ];
+
+    expect(bandsOf(gridOnly)).toEqual(["grid-panels"]);
+    // And the split case is unchanged: two destinations, two bands.
+    expect(bandsOf(build({ surface: "dock" }))).toEqual(["dock-panels", "grid-panels"]);
   });
 
   it("carries the create-recipe cue as an item-less row when there are none", () => {

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -138,7 +138,6 @@ export type DockLaunchBandId =
   | "agents"
   | "dock-panels"
   | "grid-panels"
-  | "panels"
   | "recipes"
   | "needs-setup"
   | "available-agents"
@@ -153,13 +152,27 @@ export const DOCK_LAUNCH_BAND_LABELS: Record<DockLaunchBandId, string> = {
   agents: "Launch agent",
   "dock-panels": "Open in dock",
   "grid-panels": "Open in grid",
-  panels: "Launch panel",
   recipes: "Launch recipe",
   "needs-setup": "Needs setup",
   "available-agents": "Available agents",
   presets: "Presets",
   actions: "More",
   results: "Search results",
+};
+
+/**
+ * What kind of thing a row is, in one word.
+ *
+ * Only ever rendered in the flat `results` band. Every browse band is
+ * type-homogeneous and its heading already says this, so a row that carries it
+ * under a heading is saying the same word twice; a row that carries it in mixed
+ * search results is the only thing telling a recipe named Review apart from a
+ * panel named Review.
+ */
+export const DOCK_LAUNCH_CATEGORY_LABELS: Record<DockLaunchItem["category"], string> = {
+  agent: "Agent",
+  panel: "Panel",
+  recipe: "Recipe",
 };
 
 /** A row that runs something other than a launchable item. */
@@ -575,7 +588,6 @@ export function buildDockLaunchModel({
   // it against every agent would put setup rows on the wrong side of the line.
   const showAgentGroups =
     pinnedCount !== undefined && pinnedCount > 0 && pinnedCount < launchAgents.length;
-  const isSplitByDestination = dockPanels.length > 0 && gridPanels.length > 0;
 
   const browseRows: DockLaunchRow[] = [];
   const pushRows = (band: DockLaunchBandId, items: ReadonlyArray<DockLaunchItem>) => {
@@ -600,12 +612,14 @@ export function buildDockLaunchModel({
     }
   }
 
-  if (isSplitByDestination) {
-    pushRows("dock-panels", dockPanels);
-    pushRows("grid-panels", gridPanels);
-  } else {
-    pushRows("panels", [...dockPanels, ...gridPanels]);
-  }
+  // Always banded by destination, even when only one destination is present.
+  // The generic "Launch panel" heading used to be the fallback, and it left the
+  // row to say where it lands — which in the toolbar meant six consecutive rows
+  // ending in the word "Grid", a column with no information in it. A heading
+  // that states the destination once says the same thing for free, and lets the
+  // row spend that width on its name instead.
+  if (dockPanels.length > 0) pushRows("dock-panels", dockPanels);
+  if (gridPanels.length > 0) pushRows("grid-panels", gridPanels);
 
   if (recipeItems.length > 0) {
     pushRows("recipes", recipeItems);

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -430,19 +430,22 @@ function agentRows(container: HTMLElement): string[] {
     .filter(Boolean);
 }
 
-// The verb in the label states the current state, so the pin's own accessible
-// name is the assertion target — no data attribute needed.
+// The control is presentational now — children of `role="option"` are, and a
+// real button there trips `nested-interactive` — so it has no accessible name of
+// its own to query by. The option carries the pin verb in ITS label; the control
+// is located through the row it belongs to and reports state on `data-pinned`.
 function pinFor(view: ReturnType<typeof render>, id: string): HTMLElement {
   const name = AGENT_NAMES[id] ?? id;
-  const pin = view.queryByLabelText(`Pin to toolbar: ${name}`);
-  const unpin = view.queryByLabelText(`Unpin from toolbar: ${name}`);
-  const found = pin ?? unpin;
+  const row = Array.from(view.container.querySelectorAll<HTMLElement>('[role="option"]')).find(
+    (option) => option.getAttribute("aria-label")?.startsWith(`${name},`)
+  );
+  const found = row?.querySelector<HTMLElement>("[data-launcher-pin]");
   if (!found) throw new Error(`no pin control for ${id}`);
   return found;
 }
 
 function isPinned(view: ReturnType<typeof render>, id: string): boolean {
-  return pinFor(view, id).getAttribute("aria-pressed") === "true";
+  return pinFor(view, id).getAttribute("data-pinned") === "true";
 }
 
 describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#5112)", () => {

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -98,7 +98,13 @@ vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
 }));
 
-vi.mock("@/hooks", () => ({ useKeybindingDisplay: () => null }));
+// Both combo hooks, or the launcher row throws on the missing export: the
+// display string feeds the shortcut-edit tooltip and the canonical combo feeds
+// the `KbdChord` keycaps.
+vi.mock("@/hooks", () => ({
+  useKeybindingDisplay: () => null,
+  useEffectiveCombo: () => undefined,
+}));
 
 vi.mock("@shared/config/agentIds", () => {
   const BUILT_IN_AGENT_IDS = ["claude", "gemini", "codex"] as const;

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -6,6 +6,19 @@ import { parseChord } from "@/lib/kbdShortcut";
 export const KBD_CLASS =
   "px-1.5 py-0.5 rounded-sm text-xs font-mono tabular-nums leading-none bg-overlay-subtle text-daintree-text/70 border border-border-subtle";
 
+/**
+ * The same chip, tightened for a dense one-line list row.
+ *
+ * Only the box changes — glyph size, padding and the gap between keys. The
+ * border, fill and font stay, because what the chip is for is telling a key
+ * apart from the words beside it, and that is carried by the border and the
+ * monospace face rather than by its size. At the full size a three-key chord
+ * repeated down a list of rows draws a second grid over the surface, which is
+ * loudest on the light themes.
+ */
+export const KBD_COMPACT_CLASS =
+  "px-1 py-px rounded-sm text-[10px] font-mono tabular-nums leading-none bg-overlay-subtle text-daintree-text/70 border border-border-subtle";
+
 export interface KbdProps {
   children: React.ReactNode;
   className?: string;
@@ -21,6 +34,11 @@ export interface KbdChordProps {
   isMac?: boolean;
   className?: string;
   "aria-label"?: string;
+  /**
+   * Tighten the chips for a dense list row. Same grammar, smaller box — see
+   * {@link KBD_COMPACT_CLASS}.
+   */
+  density?: "default" | "compact";
 }
 
 /**
@@ -34,13 +52,16 @@ export function KbdChord({
   isMac: isMacProp,
   className,
   "aria-label": ariaLabel,
+  density = "default",
 }: KbdChordProps) {
   const mac = isMacProp ?? isMac();
   const steps = parseChord(shortcut, mac);
   if (steps.length === 0) return null;
+  const compact = density === "compact";
+  const keyClass = compact ? KBD_COMPACT_CLASS : KBD_CLASS;
 
   return (
-    <span className={cn("inline-flex items-center gap-1", className)}>
+    <span className={cn("inline-flex items-center", compact ? "gap-0.5" : "gap-1", className)}>
       <span className="sr-only">{ariaLabel ?? shortcut}</span>
       {steps.map((tokens, stepIndex) => (
         <Fragment key={stepIndex}>
@@ -49,7 +70,7 @@ export function KbdChord({
               ,
             </span>
           )}
-          <span className="inline-flex items-center gap-0.5">
+          <span className={cn("inline-flex items-center", compact ? "gap-px" : "gap-0.5")}>
             {tokens.map((token, tokenIndex) => (
               <Fragment key={tokenIndex}>
                 {tokenIndex > 0 && !mac && (
@@ -57,7 +78,7 @@ export function KbdChord({
                     +
                   </span>
                 )}
-                <kbd aria-hidden="true" className={KBD_CLASS}>
+                <kbd aria-hidden="true" className={keyClass}>
                   {token}
                 </kbd>
               </Fragment>

--- a/src/index.css
+++ b/src/index.css
@@ -2755,6 +2755,18 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
      row. Scoped to the `.palette-row` marker rather than [role="option"], which
      the file pane, the settings selectors and the agent/forge dropdowns use
      too. */
+  /* The row's `border border-transparent` is a layout reservation — it holds
+     every row's content box on one column — but forced colors remaps border
+     colours from the system palette, so a border that paints nothing in every
+     theme painted a `CanvasText` box round every row here. A list of twenty rows
+     read as a stack of input fields, with the doubled rules between adjacent
+     borders competing with the band headings that actually organise it.
+     `Canvas` keeps the reservation and gives back the invisibility; the selected
+     row's own outline below is unaffected, and is what marks the row. */
+  .palette-row {
+    border-color: Canvas;
+  }
+
   .palette-row[aria-selected="true"] {
     outline: 2px solid SelectedItem;
     outline-offset: -2px;


### PR DESCRIPTION
Resolves #11990.

Every browse band in the launcher is single-type, so the trailing label on each row was repeating the heading directly above it. A `Launch agent` heading over three rows each labelled `Agent`. An `Open in dock` heading over four rows each labelled `Dock`.

Mixed search is the opposite case. One flat band holds all three kinds, and there the label gave scope or destination rather than type, so a query for `re` returning a recipe named Review and a panel named Review told them apart with `Team` and `Grid`. Neither of those says what the row is.

The label is now two values. `spokenQualifier` is the exhaustive string it always was and still drives `aria-label`, because a listener has no heading to place the row with and `e2e/helpers/panels.ts` matches rows on that prefix. `visualQualifier` follows the mode: browse drops what the heading already said and keeps only what changes the outcome (recipe scope, a disabled reason, a team override), search names the category on every row. State outranks category in both.

Panels are also always banded by destination now rather than falling back to a generic `Launch panel` when only one destination exists, which is what put the word `Grid` on six consecutive toolbar rows.

## Also in the row

- The name takes the free width and the label yields first, capped so a long scope label cannot starve it. It used to be the only shrinkable element on the row.
- Shortcuts render through the shared `KbdChord` instead of bare text that matched the label beside it in size, colour and weight. The dock button for the same agent already drew them as chips.
- A pinned row shows a filled `Pin`. It was showing `PinOff`, a pin with a slash through it, which is the off/muted mark everywhere that defines one, and with `aria-pressed` it read as a double negative.
- Preset-capable agents get a leading disclosure chevron that toggles instead of launching. Right Arrow already worked; nothing said so, and the chevron itself used to start a terminal.
- The two reserved trailing slots are released on recipes, presets and cues, which can hold neither control in any state. Search keeps them, and so do agents and panels, so nothing shifts under the pointer.
- Both row controls are `role="presentation"` spans now, matching `ActionPaletteItem`. This was the last palette row nesting real `<button>` elements inside `role="option"`.
- Metadata moved to `text-text-secondary` with a selected-state lift, and an unavailable row dims its name rather than the whole row, so the reason it cannot launch is no longer the faintest thing on it.

## Two changes reach past this surface

- `KbdChord` gains `density="compact"`. A three-key chord repeated down a dense list drew a second grid over the surface, loudest in the light themes. Same component, same per-key grammar, smaller box. Only the launcher opts in.
- `.palette-row` pins its `border-color` to `Canvas` under `forced-colors: active`. The transparent border is a layout reservation, but forced colours remap border colours, so it painted a box round every row and the list read as a stack of input fields. Fifteen palettes share that class and all of them improve.

## How it was driven

`e2e/screenshots/launcher-review.spec.ts` is new in this branch, a sibling of `palette-review.spec.ts`. Fourteen states per theme: both placements, grouped browse against mixed search, presets expanded, hover, selection, pinned, recording, empty, a narrow viewport, and the two accessibility media modes. It counts its own output against a declared step list and fails when a shot is missing, because an exit code has never been evidence that a capture harness produced anything.

Scored against those pixels twice: 7.1, then 8.8. Round three landed the remaining priced items but is unscored, since the reviewer went offline before it could re-run.

## Testing

`npm run check` and the full `npm run test -- --run`: 51,464 tests across 2,341 files, 0 failures, lint ratchet at baseline.

Nine invariants pinned, all mutation-checked. Reintroducing each bug fails exactly the test that covers it and nothing else:

- no row's visible label repeats a word from the band heading above it
- every row in a mixed search result carries a category
- a pinned row's glyph is the same icon as an unpinned row's, never a negated one
- one heading per band when presets are spliced in
- a band keeps its heading while its first row is recording a shortcut
- every row under one heading reserves the same trailing slots

Two of those passed against deliberately broken source on the first mutation run and had to be rewritten, which is the only reason they are worth anything now.

## Follow-ups this surfaced, not fixed here

A survey of 27 row renderers to check none of this made the launcher an outlier. It did not: every pattern touched either joined the dominant convention or is the only instance of its kind. It did turn up pre-existing debt elsewhere, worth their own issues:

- `ActionPaletteItem.tsx` renders a category chip on rows already under a heading naming that category, across ~383 actions in 26 categories. Same defect this PR just fixed.
- `ActionPaletteItem.tsx` still shows `PinOff` at rest on a pinned row, and renders its shortcut as a bare span.
- `ActionPalette.tsx` hand-rolls `SECTION_HEADER_CLASS` with `text-daintree-text/40` instead of the shared `PALETTE_SECTION_LABEL_CLASS`, which is the ~3.3:1 contrast failure that constant was created to fix. It is the only palette section header not on it.