### PR TITLE
fix(settings): weight the global skip-permissions toggle to match its consequence

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -421,7 +421,7 @@ export function AgentSettings({
             <div id="agents-skip-permissions">
               <SettingsSwitchCard
                 title="Skip permission prompts for agents"
-                subtitle="Agents run commands and edit files without asking — faster, but you won't get a chance to review first. Sets the default for every agent; override per agent below. Assistant sessions aren't affected"
+                subtitle="Agents run commands and edit files without asking — faster, but you won't get a chance to review first. Sets the default for every agent that supports it; override per agent below. Assistant sessions aren't affected"
                 ariaLabel="Skip permission prompts for agents"
                 isEnabled={settings?.globalSkipPermissions ?? false}
                 onChange={() => {

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -420,9 +420,8 @@ export function AgentSettings({
             </div>
             <div id="agents-skip-permissions">
               <SettingsSwitchCard
-                variant="compact"
                 title="Skip permission prompts for agents"
-                subtitle="Agents run commands and edit files without asking — faster, but they act without confirmation. Sets the default for every agent; override per agent below. Applies to agent terminals, not Assistant sessions"
+                subtitle="Agents run commands and edit files without asking — faster, but you won't get a chance to review first. Sets the default for every agent; override per agent below. Assistant sessions aren't affected"
                 ariaLabel="Skip permission prompts for agents"
                 isEnabled={settings?.globalSkipPermissions ?? false}
                 onChange={() => {

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import type { ComponentType } from "react";
 import { RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -44,6 +45,7 @@ export function SettingsSwitchCard({
   lifecycleBadge,
   scope,
 }: SettingsSwitchCardProps) {
+  const descriptionId = useId();
   const scheme = COLOR_SCHEMES[colorScheme] ?? COLOR_SCHEMES.accent;
   const isCard = variant === "card";
   const showReset = isModified && onReset && !disabled;
@@ -97,7 +99,9 @@ export function SettingsSwitchCard({
               </span>
             )}
           </div>
-          <div className="text-xs opacity-70">{subtitle}</div>
+          <div id={descriptionId} className="text-xs opacity-70">
+            {subtitle}
+          </div>
         </div>
       </div>
       <SettingsSwitch
@@ -105,6 +109,7 @@ export function SettingsSwitchCard({
         onCheckedChange={onChange}
         disabled={disabled}
         aria-label={ariaLabel}
+        aria-describedby={descriptionId}
         colorScheme={colorScheme}
       />
     </div>

--- a/src/components/Settings/__tests__/SettingsSwitchCard.test.tsx
+++ b/src/components/Settings/__tests__/SettingsSwitchCard.test.tsx
@@ -3,6 +3,12 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { SettingsSwitchCard } from "../SettingsSwitchCard";
 
+// Resolve within the render container rather than `document`, so the assertion
+// survives a custom/detached container and doesn't pin the useId format.
+function describedElement(container: HTMLElement, id: string | null | undefined) {
+  return id ? Array.from(container.querySelectorAll("[id]")).find((el) => el.id === id) : undefined;
+}
+
 const defaultProps = {
   title: "Test Setting",
   subtitle: "A test subtitle",
@@ -71,7 +77,7 @@ describe("SettingsSwitchCard", () => {
     const switchEl = container.querySelector('[role="switch"]');
     const describedBy = switchEl?.getAttribute("aria-describedby");
     expect(describedBy, "switch must describe itself with the subtitle").toBeTruthy();
-    expect(document.getElementById(describedBy!)).toBe(screen.getByText(defaultProps.subtitle));
+    expect(describedElement(container, describedBy)?.textContent).toBe(defaultProps.subtitle);
   });
 
   it("gives each card its own description id", () => {
@@ -86,7 +92,7 @@ describe("SettingsSwitchCard", () => {
     );
     expect(ids).toHaveLength(2);
     expect(new Set(ids).size).toBe(2);
-    expect(document.getElementById(ids[0]!)?.textContent).toBe("First subtitle");
-    expect(document.getElementById(ids[1]!)?.textContent).toBe("Second subtitle");
+    expect(describedElement(container, ids[0])?.textContent).toBe("First subtitle");
+    expect(describedElement(container, ids[1])?.textContent).toBe("Second subtitle");
   });
 });

--- a/src/components/Settings/__tests__/SettingsSwitchCard.test.tsx
+++ b/src/components/Settings/__tests__/SettingsSwitchCard.test.tsx
@@ -65,4 +65,28 @@ describe("SettingsSwitchCard", () => {
     const switchEl = container.querySelector('[role="switch"]');
     expect(switchEl?.className).toContain("data-[state=checked]:bg-daintree-text");
   });
+
+  it("points the switch at the subtitle via aria-describedby", () => {
+    const { container } = render(<SettingsSwitchCard {...defaultProps} />);
+    const switchEl = container.querySelector('[role="switch"]');
+    const describedBy = switchEl?.getAttribute("aria-describedby");
+    expect(describedBy, "switch must describe itself with the subtitle").toBeTruthy();
+    expect(document.getElementById(describedBy!)).toBe(screen.getByText(defaultProps.subtitle));
+  });
+
+  it("gives each card its own description id", () => {
+    const { container } = render(
+      <>
+        <SettingsSwitchCard {...defaultProps} title="First" subtitle="First subtitle" />
+        <SettingsSwitchCard {...defaultProps} title="Second" subtitle="Second subtitle" />
+      </>
+    );
+    const ids = Array.from(container.querySelectorAll('[role="switch"]')).map((el) =>
+      el.getAttribute("aria-describedby")
+    );
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+    expect(document.getElementById(ids[0]!)?.textContent).toBe("First subtitle");
+    expect(document.getElementById(ids[1]!)?.textContent).toBe("Second subtitle");
+  });
 });

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1037,6 +1037,7 @@ export const SETTINGS_REGISTRY = [
           "dangerous",
           "allow",
           "bypass",
+          "review",
         ],
       },
       {


### PR DESCRIPTION
## Summary

The global "Skip permission prompts for agents" toggle in Settings (`src/components/Settings/AgentSettings.tsx`) was a `SettingsSwitchCard` with `variant="compact"`: a bare `py-2` row with no border, visually identical to the far lower-stakes "Use alt-screen mode by default" toggle directly beneath it. It's the one switch that turns off every agent confirmation prompt in the app, and it read the same as a cosmetic terminal setting.

Resolves #11999

## Changes

1. **Bordered card.** Dropped `variant="compact"` from that one card so it falls back to the component's existing default, `variant="card"`, which is bordered. No new styling, no new classes. The alt-screen toggle stays compact on purpose. The two being visually equal was the bug, so restoring the contrast is the fix. Per the issue, no alarm styling either: `colorScheme` stays default, not `amber` or `danger`. Color escalation on a setting people deliberately opt into just creates habituation.

2. **`aria-describedby`, always on.** `SettingsSwitchCard` now generates a description id with `useId()`, attaches it to the subtitle element, and forwards it as `aria-describedby` to the underlying switch. `subtitle` was already a required prop, and `SettingsSwitch` already accepted and forwarded `aria-describedby`, it just was never passed. Every sibling Settings primitive (`SettingsCheckbox`, `SettingsChoicebox`, `SettingsInput`, `SettingsSelect`, `SettingsTextarea`) already wires this up; `SettingsSwitchCard` was the one outlier. This is also the one thing the setup wizard genuinely does that Settings didn't.

3. **Copy accuracy.** The subtitle claimed the toggle "sets the default for every agent." Not true: `resolveEffectiveBypass` gates it on `isAgentBypassSupported`, and only `claude.ts` and `codex.ts` declare `supports.permissionBypass: true` out of 18 built-in agents. Now it says "every agent that supports it." Also cut a clause that said the same thing twice ("without asking," then "act without confirmation") and replaced it with information the first clause didn't already carry. Indexed "review" in the settings-search registry (`settingsTabRegistry.tsx`) since the subtitle now uses that word.

One correction to the issue's premise, worth stating plainly: the setup wizard's toggle row has no border of its own. That "first-class consent step" feel comes from the enclosing `AppDialog` chrome, not from any markup in `PermissionsStep`. What the wizard genuinely has that Settings didn't is the `aria-describedby` wiring in point 2. The wizard itself is untouched here; #11976 owns its presentation separately.

## Notes for reviewers

- The promoted card now sits inside the already-bordered `agents-general` shell (`AgentSettings.tsx:388`), separated from it only by that parent's `p-4`, with no background of its own. Reads as section shell next to item-level consent boundary rather than two clearly distinct ones. This is the one visual call worth a second look.
- Always-on `aria-describedby` changes screen-reader output at all ~48 production `SettingsSwitchCard` call sites. Audited: every subtitle resolves to a plain string (no JSX or fragments), every explicit `id` prop lands on the outer wrapper so it can't collide with the generated one, and Radix's `Switch.Root` forwards the attribute through correctly. A handful of unrelated call sites have subtitles that partly restate their `ariaLabel`, mild repetition, left alone as out of scope here.

## Testing

- 755 tests across 17 targeted Vitest suites pass: every settings tab that renders a `SettingsSwitchCard`, the settings-search registry, the `accentGuard` source-scanning contract test, and `shared/types/__tests__/agentSettings.test.ts`.
- Two new tests in `SettingsSwitchCard.test.tsx`: the switch's `aria-describedby` resolves to the element carrying its subtitle, and two cards on one page get distinct generated ids. Both pin the relationship rather than literal id strings or Tailwind classes, per the project's rule against tautological tests.
- eslint clean on all changed files (4 pre-existing warnings untouched); prettier clean.
- No automated test pins the `AgentSettings.tsx` half. A Tailwind class assertion would be tautological under the project's testing rules, so that half was verified manually. Flagging deliberately.