### PR TITLE
fix(ui): theme the focus ring on card-style option buttons

### DIFF
--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -241,6 +241,7 @@ export function ColorSchemePicker() {
                     onBlur={handlePreviewLeave}
                     className={cn(
                       "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
+                      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                       "[&>*]:pointer-events-none",
                       isSelected
                         ? "border-border-strong bg-overlay-selected"

--- a/src/components/Settings/PresetSelector.tsx
+++ b/src/components/Settings/PresetSelector.tsx
@@ -253,7 +253,7 @@ function PresetOption({
       className={cn(
         "flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] cursor-pointer text-sm",
         "hover:bg-overlay-soft focus:bg-overlay-soft focus:outline-hidden",
-        "focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+        "focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
         isSelected && "text-daintree-text font-medium bg-overlay-selected"
       )}
     >

--- a/src/components/Settings/PresetSelector.tsx
+++ b/src/components/Settings/PresetSelector.tsx
@@ -253,6 +253,7 @@ function PresetOption({
       className={cn(
         "flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] cursor-pointer text-sm",
         "hover:bg-overlay-soft focus:bg-overlay-soft focus:outline-hidden",
+        "focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
         isSelected && "text-daintree-text font-medium bg-overlay-selected"
       )}
     >

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -702,6 +702,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   onClick={() => handleStrategyChange(id)}
                   className={cn(
                     "flex flex-col items-center justify-center p-4 rounded-[var(--radius-md)] border transition-colors",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                     layoutConfig.strategy === id
                       ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
                       : "border-daintree-border hover:bg-tint/5 text-daintree-text/70"

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -547,6 +547,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 aria-label={`${label} - ${description}`}
                 className={cn(
                   "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                   cachedProjectViews === value
                     ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
                     : "border-daintree-border hover:bg-tint/5 text-daintree-text/70"
@@ -761,6 +762,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 aria-label={`${label} - ${description}`}
                 className={cn(
                   "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                   performanceMode && "opacity-50 cursor-not-allowed",
                   scrollbackLines === value
                     ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
@@ -853,6 +855,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 aria-label={`${label} - ${description}`}
                 className={cn(
                   "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                   screenReaderMode === value
                     ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
                     : "border-daintree-border hover:bg-tint/5 text-daintree-text/70"

--- a/src/components/Settings/ThemeSelector.tsx
+++ b/src/components/Settings/ThemeSelector.tsx
@@ -124,6 +124,7 @@ export function ThemeSelector<T extends { id: string }>({
       onBlur={handlePreviewLeave}
       className={cn(
         "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
         "[&>*]:pointer-events-none",
         item.id === selectedId
           ? "border-border-strong bg-overlay-selected"

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -42,7 +42,7 @@ function IssueOptionRow({ issue, isSelected, isCurrentlyAttached, onClick }: Iss
         onClick={onClick}
         className={cn(
           "w-full text-left px-3 py-2.5 rounded-[var(--radius-md)] transition-colors flex items-start gap-3",
-          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
           isSelected
             ? "bg-overlay-soft border border-border-strong"
             : "hover:bg-tint/5 border border-transparent",

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -42,6 +42,7 @@ function IssueOptionRow({ issue, isSelected, isCurrentlyAttached, onClick }: Iss
         onClick={onClick}
         className={cn(
           "w-full text-left px-3 py-2.5 rounded-[var(--radius-md)] transition-colors flex items-start gap-3",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
           isSelected
             ? "bg-overlay-soft border border-border-strong"
             : "hover:bg-tint/5 border border-transparent",


### PR DESCRIPTION
## Summary

Eight card-style option buttons across Settings and the worktree issue picker had no `focus-visible` ring, so keyboard focus fell through to Chromium's default outline, the OS accent colour, which ignores the theme and the forced-colors treatment entirely.
The rest of the app already uses one consistent themed ring on roughly 90 other controls, so this just brings these eight in line.

Resolves #11997

## Changes

Six card-shaped sites get the standard outward ring, `focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2`: the scheme card in `ColorSchemePicker.tsx`, the theme card in `ThemeSelector.tsx`, and all four card grids in `TerminalSettingsTab.tsx`.

Two row-shaped sites get the inset ring instead (same treatment, `outline-offset-[-2px]`): the option row in `PresetSelector.tsx` and the issue row in `IssuePickerDialog.tsx`.

Both are documented recipes in `docs/themes/interaction-state-recipes.md` ("Default focus ring" and "Inset focus ring"). The split is by element shape, matching `FleetPickerContent` and the docked item rows, which are full-width rows in a scrollport and already use the inset form. An outward ring on those two would clip against the scrollport edge: `PresetSelector`'s listbox has no padding at all, so every row would lose its ring on the left and right, and `IssuePickerDialog`'s container has no top padding, so the first row would lose its top stroke.

## A subtlety in the preset selector

That row already carries `focus:outline-hidden`. In Tailwind v4, `outline-hidden` compiles to `--tw-outline-style: none`, and `focus-visible:outline-2` compiles to `outline-style: var(--tw-outline-style)`. The property is registered `inherits: false`, so an element carrying both reads its own `none` back and paints nothing, with the right colour, width, and offset all sitting there unused.

Same root cause as the fifteen controls fixed in #12009. The row leads with `focus-visible:outline-solid`, which restores the style. Verified by compiling the exact class list against the installed Tailwind 4.3.3: `focus:outline-hidden` is emitted first and `focus-visible:outline-solid` last, so the solid style wins.

## Scope notes

The issue listed seven sites. `TerminalSettingsTab.tsx` turned out to have a fourth card grid of the same shape, the "Grid layout strategy" cards, with the same gap, so it's included rather than left as the only untreated grid in the file.

`ThemeSelector` has no production consumer. It's only re-exported from `src/components/Settings/index.ts` and imported by its own test. Fixed it in place here because the issue names it as a file to fix, and removing it touches a public re-export, which is a separate call. It isn't a duplicate of `ColorSchemePicker` either: `ColorSchemePicker` is terminal-store-bound and fixed to two columns, while `ThemeSelector` is generic over grouped or flat items with arbitrary preview and meta renderers, a three-column mode, and a click-origin callback. Worth deciding separately whether to delete it or wire it up.

## Follow-up (not fixed here)

`docs/themes/interaction-state-recipes.md:128` says the bare `focus-visible:outline` class is required to enable outline rendering. That's not true in Tailwind 4.3.3 once `outline-2` is present, and `cn()` strips the bare class anyway via `tailwind-merge`, including in the canonical `SettingsChoicebox`. Docs are out of scope for this PR.

## Testing

198 targeted tests pass: the four component test files plus the `accentGuard`, `focusRingFallback`, `outlineHidden`, `colorSystem`, and `accentForeground` contract tests. ESLint and prettier clean on all five files.

No new test added. The project bans tautological className assertions, and the correct invariant test, a repo-wide scan requiring `outline-solid` wherever a suppressed outline meets an outline-based focus fallback, is already landing on #12009 in the same shared test file. Adding it here would conflict with that PR and fail against the thirteen other components #12009 fixes.

## Reviewer note

Worth keyboard-tabbing the preset dropdown and the issue picker to confirm the inset ring reads correctly against those rows' borders.
