### PR TITLE
fix(worktree): keep the sidebar scroll pill clear of card content

### DIFF
--- a/src/components/Worktree/ScrollIndicator.tsx
+++ b/src/components/Worktree/ScrollIndicator.tsx
@@ -25,7 +25,7 @@ export function ScrollIndicator({
   // while it fades out. Without this, a drop to 0 (scrolled to an edge, or a
   // filter/sort/group change that resets the offscreen counts) flips `isOpen`
   // false but holds `shouldRender` true for the exit animation, and the live
-  // `count` prop — now 0 — would render "0 more above/below" mid-fade (#10316).
+  // `count` prop — now 0 — would render a bare "0" mid-fade (#10316).
   // The latch is state adjusted during render, not a ref: React discards an
   // abandoned concurrent render's state update, so a stale count can't leak in.
   const [lastPositiveCount, setLastPositiveCount] = useState(count);
@@ -37,10 +37,16 @@ export function ScrollIndicator({
   const Icon = direction === "above" ? ChevronUp : ChevronDown;
 
   return (
+    // Trailing edge, not centred: sidebar rows put identity text in a leading
+    // `min-w-0 flex-1` block and icons in a trailing `shrink-0` one, so a
+    // centred pill lands on the worktree title or the "Changed files" heading —
+    // the text you're scanning while you scroll (#12010). `pr-4` matches the
+    // card content column's own right gutter, which also keeps the pill off the
+    // active row's 2px inset accent edge at `right-0` (`sidebar.css`).
     <div
       aria-hidden={ariaHidden || undefined}
       className={cn(
-        "absolute left-0 right-0 z-20 pointer-events-none flex justify-center",
+        "absolute left-0 right-0 z-20 pointer-events-none flex justify-end pr-4",
         direction === "above" ? "top-0 pt-2" : "bottom-0 pb-2"
       )}
     >
@@ -59,7 +65,6 @@ export function ScrollIndicator({
       >
         <Icon className="h-3 w-3" />
         <span className="font-medium tabular-nums">{displayCount}</span>
-        <span>more {direction}</span>
       </ScrollPill>
     </div>
   );

--- a/src/components/Worktree/__tests__/ScrollIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/ScrollIndicator.test.tsx
@@ -52,16 +52,15 @@ describe("ScrollIndicator", () => {
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders pill when count > 0 with direction below", () => {
-    render(<ScrollIndicator direction="below" count={3} onClick={onClick} />);
-    expect(screen.getByText("3")).toBeTruthy();
-    expect(screen.getByText("more below")).toBeTruthy();
-  });
-
-  it("renders pill when count > 0 with direction above", () => {
-    render(<ScrollIndicator direction="above" count={5} onClick={onClick} />);
-    expect(screen.getByText("5")).toBeTruthy();
-    expect(screen.getByText("more above")).toBeTruthy();
+  // The visible pill is chevron + count only, so it stays narrow enough to sit
+  // in the trailing gutter without reaching the row's identity text (#12010).
+  // Direction is carried by the icon, the edge it sits on, and the aria-label.
+  it.each([
+    ["below", 3],
+    ["above", 5],
+  ] as const)("renders only the count for direction %s", (direction, count) => {
+    render(<ScrollIndicator direction={direction} count={count} onClick={onClick} />);
+    expect(screen.getByRole("button").textContent?.trim()).toBe(String(count));
   });
 
   it("calls onClick when clicked", () => {
@@ -78,20 +77,6 @@ describe("ScrollIndicator", () => {
   it("has correct aria-label for above direction", () => {
     render(<ScrollIndicator direction="above" count={5} onClick={onClick} />);
     expect(screen.getByLabelText("Scroll up, 5 more above")).toBeTruthy();
-  });
-
-  it("applies bottom-0 positioning for below direction", () => {
-    render(<ScrollIndicator direction="below" count={1} onClick={onClick} />);
-    const button = screen.getByRole("button");
-    const container = button.parentElement!;
-    expect(container.className).toContain("bottom-0");
-  });
-
-  it("applies top-0 positioning for above direction", () => {
-    render(<ScrollIndicator direction="above" count={1} onClick={onClick} />);
-    const button = screen.getByRole("button");
-    const container = button.parentElement!;
-    expect(container.className).toContain("top-0");
   });
 
   it("uses translate-y-0 when visible (below)", () => {

--- a/src/components/Worktree/__tests__/ScrollIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/ScrollIndicator.test.tsx
@@ -113,7 +113,7 @@ describe("ScrollIndicator", () => {
   it("keeps showing the last positive count while fading out at count 0 (issue #10316)", () => {
     // Exit state: shouldRender stays true through the close animation while the
     // live count has already dropped to 0. The pill must render the latched
-    // count, not "0 more below".
+    // count, not a bare "0" — and its aria-label must latch with it.
     mockUseAnimatedPresence.mockReturnValue({ isVisible: false, shouldRender: true });
     const { rerender } = render(<ScrollIndicator direction="below" count={4} onClick={onClick} />);
     expect(screen.getByText("4")).toBeTruthy();


### PR DESCRIPTION
## Summary

- The worktree sidebar's scroll indicator pill was centered and pinned to the top/bottom edge of the list, so it landed on top of whatever card sat at that edge, usually the worktree title or the `Changed files` heading, exactly the text you're scanning while you scroll.
- Fixed with two changes scoped entirely to the sidebar call site in `ScrollIndicator.tsx`. The shared `ScrollPill` component and every card file stay untouched, per the issue's own constraint.
- Right-anchored the pill and dropped it to chevron + count, matching the corner anchoring the terminal's scroll indicator already uses without this problem.

Resolves #12010

## Changes

- Re-anchored the pill's wrapper from `justify-center` to `justify-end pr-4`. That matches the 16px right gutter used elsewhere in the card content column and keeps the pill clear of the 2px inset accent edge on active rows.
- Dropped the visible "more above" / "more below" text so the pill is just a chevron and a count. Right-anchoring alone wasn't enough: the sidebar is resizable down to 200px, and at that width the full-text pill was about 61% of the row, still reaching into the title. Chevron + count is about 52px. Direction is still carried by the chevron and by which edge the pill sits on, and the full phrasing stays in the `aria-label` for screen readers.
- Didn't take the issue's other suggested approach (reserving a sticky lane in the scroll container). The sidebar uses `react-virtuoso`, whose `Header`/`Footer` render inside scrollable space rather than as persistent chrome, and padding on the scroll container would desync virtuoso's own `ResizeObserver`/`scrollTop` measurements. `scroll-padding`/`scroll-margin` don't help either, since virtuoso doesn't use native scroll-snap.
- Removed the two test assertions checking for literal `top-0`/`bottom-0` Tailwind classes, since they just mirrored source literals (the project's rule against tautological assertions). Replaced with a parameterized test asserting the pill's visible content is exactly the count. Existing tests for count latching, slide direction, `aria-label`, `tabIndex`, `aria-hidden`, and scoped transitions are untouched and still pass.

## Testing

- `npx vitest run src/components/Sidebar/__tests__ src/components/Worktree/__tests__/ScrollIndicator.test.tsx src/components/ui/__tests__/ScrollPill.test.tsx src/config/__tests__/focusRingFallback.contract.test.ts` — 371 tests, 21 files, all passing
- `eslint` and `prettier --check` on both changed files, no issues
- Codex adversarial review: no blocking or should-fix findings, one documentation nit fixed in a follow-up commit
