### PR TITLE
fix(ui): demote ambient health chrome from green to neutral (1/3)

### DIFF
--- a/e2e/full/platform/core-voice-input.spec.ts
+++ b/e2e/full/platform/core-voice-input.spec.ts
@@ -321,10 +321,10 @@ test.describe.serial("E2E: Voice Input — Settings UI", () => {
     await openSettings(window);
     await window.locator(`${SEL.settings.navSidebar} button`, { hasText: "Voice Input" }).click();
 
-    // Configured-state indicators: "Enter new key to replace" placeholder + "Configured" badge + Clear button.
+    // Configured-state indicators: "Enter new key to replace" placeholder + Clear
+    // button. The green "Configured" badge was ambient chrome and is gone (#12002).
     const keyInput = window.locator('input[placeholder="Enter new key to replace"]');
     await expect(keyInput).toBeVisible({ timeout: T_SHORT });
-    await expect(window.getByText("Configured", { exact: true })).toBeVisible();
     const clearButton = window.getByRole("button", { name: "Clear", exact: true });
     await expect(clearButton).toBeVisible();
 
@@ -334,14 +334,12 @@ test.describe.serial("E2E: Voice Input — Settings UI", () => {
     await window.locator(`${SEL.settings.navSidebar} button`, { hasText: "Voice Input" }).click();
 
     await expect(keyInput).toBeVisible({ timeout: T_SHORT });
-    await expect(window.getByText("Configured", { exact: true })).toBeVisible();
+    await expect(clearButton).toBeVisible();
 
     // Clear reverts to unconfigured (placeholder returns to "sk-...").
     await clearButton.click();
     await expect(window.locator('input[placeholder="sk-..."]')).toBeVisible({ timeout: T_SHORT });
-    await expect(window.getByText("Configured", { exact: true })).not.toBeVisible({
-      timeout: T_SHORT,
-    });
+    await expect(clearButton).not.toBeVisible({ timeout: T_SHORT });
 
     // And the underlying store now reflects the empty key.
     const settings = await ipcGetSettings(window);

--- a/src/components/Diagnostics/PerfContent.tsx
+++ b/src/components/Diagnostics/PerfContent.tsx
@@ -125,11 +125,11 @@ function BudgetRow({ row }: { row: PerfSummaryRow }) {
       </td>
       <td className="px-3 py-1.5 text-xs">
         {row.failedBudget ? (
-          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide bg-status-error/15 text-status-error">
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide border border-status-error/30 bg-status-error/15 text-status-error">
             Over budget
           </span>
         ) : (
-          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide bg-overlay-subtle text-daintree-text/60">
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide border border-daintree-border bg-overlay-subtle text-daintree-text/60">
             Within budget
           </span>
         )}

--- a/src/components/Diagnostics/PerfContent.tsx
+++ b/src/components/Diagnostics/PerfContent.tsx
@@ -129,7 +129,7 @@ function BudgetRow({ row }: { row: PerfSummaryRow }) {
             Over budget
           </span>
         ) : (
-          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide bg-status-success/15 text-status-success">
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide bg-overlay-subtle text-daintree-text/60">
             Within budget
           </span>
         )}

--- a/src/components/Project/EnvironmentVariablesEditor.tsx
+++ b/src/components/Project/EnvironmentVariablesEditor.tsx
@@ -253,7 +253,7 @@ export function EnvironmentVariablesEditor({
                 >
                   {isSecured && (
                     <Lock
-                      className="h-3.5 w-3.5 text-status-success/60 flex-shrink-0"
+                      className="h-3.5 w-3.5 text-daintree-text/60 flex-shrink-0"
                       aria-label="Kept out of shared settings"
                     />
                   )}

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -697,7 +697,7 @@ export function GeneralTab({
 
         {currentProject?.daintreeConfigPresent && (
           <div className="flex items-center gap-2 mb-3 text-xs text-daintree-text/60">
-            <FolderOpen className="h-3.5 w-3.5 text-status-success shrink-0" />
+            <FolderOpen className="h-3.5 w-3.5 text-daintree-text/60 shrink-0" />
             <span>
               Settings loaded from{" "}
               <code className="font-mono text-daintree-text/80">.daintree/</code>

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -63,7 +63,7 @@ function HeapBar({ heapStats }: { heapStats: HeapStats }) {
       ? "bg-status-error/80"
       : heapStats.percent > 70
         ? "bg-status-warning/80"
-        : "bg-status-success/80";
+        : "bg-daintree-text/40";
 
   return (
     <div className="space-y-1">

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -556,7 +556,7 @@ function GenericCredentialForm({ providerId, providerName, fields }: GenericCred
       </div>
 
       {hasCredential && (
-        <div className="flex items-center gap-1 text-xs text-status-success">
+        <div className="flex items-center gap-1 text-xs text-daintree-text/60">
           <Check className="w-3 h-3" />
           {providerName} connected
         </div>

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -395,7 +395,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                             "p-1.5 rounded transition-colors",
                             isDisabled
                               ? "text-status-error hover:bg-status-error/10"
-                              : "text-status-success hover:bg-status-success/10"
+                              : "text-daintree-text/60 hover:bg-overlay-hover"
                           )}
                           aria-label={
                             isDisabled ? "Command disabled for this project" : "Command enabled"

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -205,7 +205,7 @@ export function EditorIntegrationTab() {
                 {discoveredEditors.map((d) => (
                   <div key={d.id} className="flex items-center gap-2 text-xs text-daintree-text/60">
                     {d.available ? (
-                      <CheckCircle className="w-3.5 h-3.5 text-status-success shrink-0" />
+                      <CheckCircle className="w-3.5 h-3.5 text-daintree-text/60 shrink-0" />
                     ) : (
                       <AlertCircle className="w-3.5 h-3.5 text-daintree-text/30 shrink-0" />
                     )}

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -822,7 +822,7 @@ export function GeneralTab({
                           type="button"
                           key={id}
                           className="settings-list-item border-daintree-border hover:bg-[var(--settings-nav-hover-bg,var(--theme-overlay-hover))] flex items-center justify-between text-sm px-3 py-2 rounded-[var(--radius-md)] border w-full text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                          aria-label={`Go to ${name} agent settings`}
+                          aria-label={`Go to ${name} agent settings${status ? ` — ${status.label}` : ""}`}
                           onClick={() => onNavigateToAgents?.(id)}
                         >
                           <span className="text-text-secondary">{name}</span>

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from "react";
 import {
   ChevronRight,
   Moon,
-  CheckCircle,
+  ShieldBan,
+  KeyRound,
   Wrench,
   LayoutGrid,
   PanelBottom,
@@ -799,24 +800,20 @@ export function GeneralTab({
                       const ready = isAgentReady(cliAvailability[id]);
                       const unauthenticated = isAgentUnauthenticated(cliAvailability[id]);
                       const blocked = isAgentBlocked(cliAvailability[id]);
-                      // A blocked agent is installed but can't run — show it
-                      // distinctly from the authentication-needed case so the
-                      // user doesn't waste time re-authenticating a binary
-                      // that an endpoint security tool is blocking.
-                      const statusLabel = blocked
-                        ? "Blocked"
-                        : unauthenticated
-                          ? "Login required"
-                          : ready
-                            ? "Ready"
-                            : "Needs setup";
-                      const statusClass = blocked
-                        ? "text-status-warning"
-                        : unauthenticated
-                          ? "text-status-warning"
-                          : ready
-                            ? "text-status-success"
-                            : "text-status-warning";
+                      // Ready is the expected state, so it gets no chrome at
+                      // all — only states needing the user's attention are
+                      // labelled. Each carries its own glyph: a blocked agent
+                      // is installed but can't run, and reads distinctly from
+                      // the authentication-needed case so the user doesn't
+                      // waste time re-authenticating a binary that an endpoint
+                      // security tool is blocking.
+                      const status = ready
+                        ? null
+                        : blocked
+                          ? { label: "Blocked", Icon: ShieldBan }
+                          : unauthenticated
+                            ? { label: "Login required", Icon: KeyRound }
+                            : { label: "Needs setup", Icon: Wrench };
 
                       return (
                         <button
@@ -827,10 +824,12 @@ export function GeneralTab({
                           onClick={() => onNavigateToAgents?.(id)}
                         >
                           <span className="text-text-secondary">{name}</span>
-                          <span className="flex items-center gap-2">
-                            <CheckCircle className={cn("w-3.5 h-3.5", statusClass)} />
-                            <span className={cn("text-xs", statusClass)}>{statusLabel}</span>
-                          </span>
+                          {status && (
+                            <span className="flex items-center gap-2 text-status-warning">
+                              <status.Icon className="w-3.5 h-3.5" aria-hidden="true" />
+                              <span className="text-xs">{status.label}</span>
+                            </span>
+                          )}
                         </button>
                       );
                     })}

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -806,13 +806,15 @@ export function GeneralTab({
                       // is installed but can't run, and reads distinctly from
                       // the authentication-needed case so the user doesn't
                       // waste time re-authenticating a binary that an endpoint
-                      // security tool is blocking.
-                      const status = ready
-                        ? null
-                        : blocked
-                          ? { label: "Blocked", Icon: ShieldBan }
-                          : unauthenticated
-                            ? { label: "Login required", Icon: KeyRound }
+                      // security tool is blocking. Attention states are tested
+                      // before `ready` so a probe that ever reports both still
+                      // surfaces the problem rather than falling silent.
+                      const status = blocked
+                        ? { label: "Blocked", Icon: ShieldBan }
+                        : unauthenticated
+                          ? { label: "Login required", Icon: KeyRound }
+                          : ready
+                            ? null
                             : { label: "Needs setup", Icon: Wrench };
 
                       return (

--- a/src/components/Settings/McpAuditLatencyTable.tsx
+++ b/src/components/Settings/McpAuditLatencyTable.tsx
@@ -55,8 +55,8 @@ function computeBlock(durations: number[]): ToolLatencyBlock {
 
 function sloBand(p95: number): SloBand {
   if (p95 <= 0) return { label: "", className: "" };
-  if (p95 < 200) return { label: "Instant", className: "text-status-success" };
-  if (p95 < 1000) return { label: "Fast", className: "text-status-success" };
+  if (p95 < 200) return { label: "Instant", className: "text-daintree-text/60" };
+  if (p95 < 1000) return { label: "Fast", className: "text-daintree-text/60" };
   if (p95 <= 5000) return { label: "Standard", className: "text-status-warning" };
   return { label: "Slow", className: "text-status-danger" };
 }

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -3,7 +3,6 @@ import {
   Copy,
   Check,
   AlertCircle,
-  Key,
   Hash,
   Shield,
   Eye,
@@ -882,11 +881,6 @@ export function McpServerSettingsTab() {
           >
             {status.apiKey ? (
               <div className="contents">
-                <div className="flex items-center gap-1.5 text-xs text-status-success">
-                  <Key className="w-3 h-3" />
-                  API key active — clients must send an Authorization header
-                </div>
-
                 <div className="flex items-center gap-2">
                   <div className="flex-1 flex items-center gap-2 rounded-[var(--radius-md)] bg-surface-disabled border border-daintree-border px-3 py-2 font-mono text-xs text-daintree-text/80 select-all">
                     <span className="flex-1 truncate">

--- a/src/components/Settings/TurnOutcomeDiagnostics.tsx
+++ b/src/components/Settings/TurnOutcomeDiagnostics.tsx
@@ -42,7 +42,7 @@ const OUTCOME_ORDER: TurnOutcomeClass[] = [
 const RATE_THRESHOLD = { low: 5, medium: 20 } as const;
 
 function rateColor(rate: number): string {
-  if (rate <= RATE_THRESHOLD.low) return "text-status-success";
+  if (rate <= RATE_THRESHOLD.low) return "text-daintree-text/60";
   if (rate <= RATE_THRESHOLD.medium) return "text-status-warning";
   return "text-status-danger";
 }

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -561,12 +561,7 @@ function ApiKeyRow({
           {label}
         </label>
         <div className="flex items-center gap-2">
-          {value ? (
-            <span className="flex items-center gap-1 text-xs text-status-success">
-              <Check className="w-3 h-3" />
-              Configured
-            </span>
-          ) : (
+          {!value && (
             <button
               onClick={() => window.electron?.system?.openExternal(helpUrl)}
               className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline flex items-center gap-1"

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -560,17 +560,15 @@ function ApiKeyRow({
           <Key className="w-3.5 h-3.5 text-daintree-text/50" aria-hidden="true" />
           {label}
         </label>
-        <div className="flex items-center gap-2">
-          {!value && (
-            <button
-              onClick={() => window.electron?.system?.openExternal(helpUrl)}
-              className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline flex items-center gap-1"
-            >
-              {helpLabel}
-              <ExternalLink className="w-3 h-3" />
-            </button>
-          )}
-        </div>
+        {!value && (
+          <button
+            onClick={() => window.electron?.system?.openExternal(helpUrl)}
+            className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline flex items-center gap-1"
+          >
+            {helpLabel}
+            <ExternalLink className="w-3 h-3" />
+          </button>
+        )}
       </div>
 
       <div className="flex gap-2">

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -133,8 +133,9 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     expect(screen.queryByText("Codex")).toBeNull();
     expect(screen.queryByText("Opencode")).toBeNull();
     expect(screen.queryByText("Cursor")).toBeNull();
-    // Both visible rows render the "Ready" badge
-    expect(screen.getAllByText("Ready")).toHaveLength(2);
+    // Ready is the expected state, so neither row is labelled at all
+    expect(screen.queryByText("Ready")).toBeNull();
+    expect(screen.queryByText("Needs setup")).toBeNull();
   });
 
   it("shows installed agents regardless of pin state (issue #5117)", async () => {
@@ -291,7 +292,50 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     });
 
     expect(screen.getByText("Needs setup")).toBeTruthy();
-    expect(screen.getByText("Ready")).toBeTruthy();
+    // Only the agent needing attention is labelled; the ready one stays quiet.
+    expect(screen.queryByText("Ready")).toBeNull();
+  });
+
+  // Green ambient chrome is gone (issue #12002), so colour can no longer be
+  // what separates these rows — each attention state has to carry its own
+  // glyph, and the expected state has to carry nothing at all.
+  it("gives every attention state its own glyph and leaves ready rows bare", async () => {
+    setupDispatchMock(
+      {
+        claude: "blocked",
+        gemini: "unauthenticated",
+        codex: "installed",
+        opencode: "ready",
+        cursor: "missing",
+      },
+      {
+        agents: {
+          claude: { pinned: true },
+          gemini: { pinned: true },
+          codex: { pinned: true },
+          opencode: { pinned: true },
+        },
+      } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Blocked")).toBeTruthy();
+    });
+    expect(screen.getByText("Login required")).toBeTruthy();
+    expect(screen.getByText("Needs setup")).toBeTruthy();
+
+    const glyphs = ["Claude", "Gemini", "Codex"].map((name) => {
+      const svg = screen.getByLabelText(`Go to ${name} agent settings`).querySelector("svg");
+      expect(svg).toBeTruthy();
+      return svg!.innerHTML;
+    });
+    expect(new Set(glyphs).size).toBe(3);
+
+    const readyRow = screen.getByLabelText("Go to Opencode agent settings");
+    expect(readyRow.querySelector("svg")).toBeNull();
+    expect(readyRow.textContent).toBe("Opencode");
   });
 
   it("renders empty-state CTA when no agents installed", async () => {

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -320,22 +320,33 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
     await renderGeneralTab();
 
-    await waitFor(() => {
-      expect(screen.getByText("Blocked")).toBeTruthy();
-    });
-    expect(screen.getByText("Login required")).toBeTruthy();
-    expect(screen.getByText("Needs setup")).toBeTruthy();
+    const rowFor = (name: string) => screen.getByLabelText(`Go to ${name} agent settings`);
+    const attention = [
+      { name: "Claude", label: "Blocked" },
+      { name: "Gemini", label: "Login required" },
+      { name: "Codex", label: "Needs setup" },
+    ];
 
-    const glyphs = ["Claude", "Gemini", "Codex"].map((name) => {
-      const svg = screen.getByLabelText(`Go to ${name} agent settings`).querySelector("svg");
+    await waitFor(() => {
+      expect(rowFor("Claude").textContent).toContain("Blocked");
+    });
+
+    // Each attention state must own both its label and a glyph nothing else uses.
+    const glyphs = attention.map(({ name, label }) => {
+      const row = rowFor(name);
+      expect(row.textContent).toContain(label);
+      const svg = row.querySelector("svg");
       expect(svg).toBeTruthy();
       return svg!.innerHTML;
     });
     expect(new Set(glyphs).size).toBe(3);
 
-    const readyRow = screen.getByLabelText("Go to Opencode agent settings");
+    const readyRow = rowFor("Opencode");
     expect(readyRow.querySelector("svg")).toBeNull();
-    expect(readyRow.textContent).toBe("Opencode");
+    for (const { label } of attention) {
+      expect(readyRow.textContent).not.toContain(label);
+    }
+    expect(readyRow.textContent).not.toContain("Ready");
   });
 
   it("renders empty-state CTA when no agents installed", async () => {

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -320,7 +320,8 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
     await renderGeneralTab();
 
-    const rowFor = (name: string) => screen.getByLabelText(`Go to ${name} agent settings`);
+    const rowFor = (name: string) =>
+      screen.getByLabelText(new RegExp(`^Go to ${name} agent settings\\b`));
     const attention = [
       { name: "Claude", label: "Blocked" },
       { name: "Gemini", label: "Login required" },
@@ -335,6 +336,9 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     const glyphs = attention.map(({ name, label }) => {
       const row = rowFor(name);
       expect(row.textContent).toContain(label);
+      // The row's aria-label overrides its inner text for assistive tech, so
+      // the state has to be repeated there or it is announced as nothing.
+      expect(row.getAttribute("aria-label")).toContain(label);
       const svg = row.querySelector("svg");
       expect(svg).toBeTruthy();
       return svg!.innerHTML;
@@ -345,6 +349,7 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     expect(readyRow.querySelector("svg")).toBeNull();
     for (const { label } of attention) {
       expect(readyRow.textContent).not.toContain(label);
+      expect(readyRow.getAttribute("aria-label")).not.toContain(label);
     }
     expect(readyRow.textContent).not.toContain("Ready");
   });

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -155,12 +155,13 @@ describe("McpServerSettingsTab", () => {
     );
 
   // The key section used to announce itself with an ambient "API key active"
-  // line; issue #12002 removed it, so gate on the controls that only exist
-  // once a key has loaded.
+  // line; issue #12002 removed it, so gate on a control that only exists once
+  // a key has loaded. Copy is the right anchor — the reveal button's label
+  // flips to "Hide API key" the moment a test reveals the key.
   const waitForApiKeyControls = (container: HTMLElement) =>
     waitFor(
       () => {
-        expect(container.querySelector('button[aria-label="Show API key"]')).toBeTruthy();
+        expect(container.querySelector('button[aria-label="Copy API key"]')).toBeTruthy();
       },
       { timeout: 5000 }
     );

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -154,13 +154,24 @@ describe("McpServerSettingsTab", () => {
       { timeout: 5000 }
     );
 
+  // The key section used to announce itself with an ambient "API key active"
+  // line; issue #12002 removed it, so gate on the controls that only exist
+  // once a key has loaded.
+  const waitForApiKeyControls = (container: HTMLElement) =>
+    waitFor(
+      () => {
+        expect(container.querySelector('button[aria-label="Show API key"]')).toBeTruthy();
+      },
+      { timeout: 5000 }
+    );
+
   it("renders API key in a non-input display element", async () => {
     const { container } = render(
       <SettingsValidationProvider>
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     const displayArea = container.querySelector(".bg-surface-disabled");
     expect(displayArea).toBeTruthy();
@@ -176,7 +187,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     const displayArea = container.querySelector(".bg-surface-disabled")!;
     expect(displayArea.textContent).not.toContain("dnt-key-abc123");
@@ -199,7 +210,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByLabelText("Copy API key"));
     await waitFor(() => {
@@ -213,7 +224,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByLabelText("Copy API key"));
 
@@ -229,7 +240,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByTitle("Rotate API key"));
 
@@ -264,7 +275,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByTitle("Rotate API key"));
     await waitFor(() => {
@@ -285,7 +296,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByLabelText("Show API key"));
     const displayArea = container.querySelector(".bg-surface-disabled")!;
@@ -320,7 +331,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByTitle("Rotate API key"));
     await waitFor(() => {
@@ -341,7 +352,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByLabelText("Show API key"));
     const displayArea = container.querySelector(".bg-surface-disabled")!;
@@ -377,7 +388,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     const displayArea = container.querySelector(".bg-surface-disabled")!;
     const maskSpan = displayArea.querySelector("span")!;
@@ -399,7 +410,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByLabelText("Copy API key"));
 
@@ -414,7 +425,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     expect(screen.queryByRole("button", { name: /^remove$/i })).toBeNull();
   });
@@ -507,7 +518,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     expect(screen.queryByText("MCP server is off")).toBeNull();
   });
@@ -709,7 +720,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     const maxRecordsInput = container.querySelector("#mcp-audit-max-records") as HTMLInputElement;
     fireEvent.change(maxRecordsInput, { target: { value: "99999" } });
@@ -731,7 +742,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByRole("switch", { name: /capture audit log/i }));
 
@@ -1014,7 +1025,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     const portInput = screen.getByLabelText("MCP server port") as HTMLInputElement;
     fireEvent.change(portInput, { target: { value: "9020 " } });
@@ -1050,7 +1061,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     const select = screen.getByLabelText("Filter audit by result") as HTMLSelectElement;
     expect(select).toBeTruthy();
@@ -1124,7 +1135,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
     expect(container.textContent).not.toContain("anomaly signal");
   });
 
@@ -1195,7 +1206,7 @@ describe("McpServerSettingsTab", () => {
         <McpServerSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "API key active");
+    await waitForApiKeyControls(container);
 
     fireEvent.click(screen.getByRole("button", { name: /copy mcp config/i }));
     await waitFor(() => {
@@ -1225,7 +1236,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).not.toContain("External clients");
     });
 
@@ -1274,7 +1285,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).not.toContain("External clients");
 
       runtimeCb?.({ enabled: true, state: "ready", port: 9020, lastError: null });
@@ -1298,7 +1309,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).not.toContain("Kept alive by Daintree Assistant");
     });
   });
@@ -1317,7 +1328,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).not.toContain("Internal connections");
     });
 
@@ -1393,7 +1404,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).not.toContain("Internal connections");
 
       runtimeCb?.({ enabled: true, state: "ready", port: 9020, lastError: null });
@@ -1408,7 +1419,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).toContain("Running on port 9020");
       // Regression (#11535): the box advertised the legacy /sse transport.
       expect(readDisplayedUrl(container)).toBe("http://127.0.0.1:9020/mcp");
@@ -1422,7 +1433,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
 
       const shownUrl = readDisplayedUrl(container);
       expect(shownUrl).toBeTruthy();
@@ -1443,7 +1454,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
 
       const group = screen.getByRole("radiogroup", { name: /client/i });
       const choices = Array.from(group.querySelectorAll('[role="radio"]'));
@@ -1466,7 +1477,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
 
       const text = container.textContent ?? "";
       for (const entry of MCP_CLIENT_CONFIGS) {
@@ -1481,7 +1492,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
 
       fireEvent.click(screen.getByRole("radio", { name: /other client/i }));
       fireEvent.click(screen.getByRole("button", { name: /copy mcp config/i }));
@@ -1505,7 +1516,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
 
       vi.mocked(window.electron.mcpServer.getStatus).mockResolvedValue({
         enabled: true,
@@ -1527,7 +1538,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
 
       fireEvent.click(screen.getByRole("radio", { name: /codex/i }));
       fireEvent.click(screen.getByRole("button", { name: /copy mcp config/i }));
@@ -1552,7 +1563,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
 
       fireEvent.click(screen.getByRole("button", { name: /copy mcp config/i }));
       await waitFor(() => {
@@ -1587,7 +1598,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).toContain("Running on port 9020");
       expect(container.textContent).toContain("http://127.0.0.1:9020/mcp");
     });
@@ -1607,7 +1618,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).toContain("Server is starting…");
       expect(container.textContent).not.toContain("http://127.0.0.1");
       expect(container.textContent).not.toContain("Copy MCP config");
@@ -1681,7 +1692,7 @@ describe("McpServerSettingsTab", () => {
           <McpServerSettingsTab />
         </SettingsValidationProvider>
       );
-      await waitForContent(container, "API key active");
+      await waitForApiKeyControls(container);
       expect(container.textContent).toContain("Running on port");
 
       runtimeCb?.({

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -249,11 +249,9 @@ export function AgentCliStep({
                 className={`flex items-center gap-3 w-full px-3 py-2 rounded-[var(--radius-md)] border transition-colors ${
                   isInstalling
                     ? "bg-overlay-soft border-border-strong"
-                    : isInstalled
-                      ? "bg-status-success/5 border-status-success/20"
-                      : isError
-                        ? "bg-status-error/5 border-status-error/20"
-                        : "bg-daintree-bg/30 border-daintree-border"
+                    : isError
+                      ? "bg-status-error/5 border-status-error/20"
+                      : "bg-daintree-bg/30 border-daintree-border"
                 }`}
               >
                 {/* The box only aligns the row; the mark carries its own colour and

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -44,8 +44,8 @@ function StateBanner({ state, detail }: { state: AgentAvailabilityState; detail:
   // sends the user hunting through endpoint security for a sign-in prompt.
   if (state === "unauthenticated") {
     return (
-      <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-status-success/20 bg-status-success/5">
-        <KeyRound className="w-5 h-5 text-status-success shrink-0 mt-px" />
+      <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-daintree-border bg-overlay-subtle">
+        <KeyRound className="w-5 h-5 text-daintree-text/60 shrink-0 mt-px" />
         <div>
           <p className="text-sm font-medium">Sign-in not detected</p>
           <p className="text-xs text-daintree-text/60 mt-1">


### PR DESCRIPTION
## Summary

This is 1 of 3 PRs for #12002, "Persistent green 'everything is fine' chrome in 55 places." It covers the ambient and default health bucket named in the ruling on that issue: Settings, Diagnostics, Project, Pulse, `MissingCliGate`, and the `AgentCliStep` row wash. PR 2 covers membership and settled-state work; PR 3 covers `state-working` retokenisation plus the policy doc and a guard test.

The policy from the ruling: green persists only for transient confirmations, finite checklist items, enumerated operation outcomes, or live-operation state. Threshold baselines, ambient health, membership, and settled completion get demoted to neutral or removed outright.

## Removed outright

- `Settings/GeneralTab.tsx`: the `CheckCircle` icon and "Ready" label on agent rows. Ready is the expected default state and doesn't need chrome. Blocked, Login required, and Needs setup keep their labels, each with its own icon (`ShieldBan`, `KeyRound`, `Wrench`) so hue isn't the only thing telling them apart.
- `VoiceInputSettingsTab.tsx`: the green "Configured" badge. The "Enter new key to replace" placeholder and Clear button already say the same thing.
- `McpServerSettingsTab.tsx`: the ambient "API key active" line. The masked key plus its reveal, copy, and rotate controls already establish that a key exists.

## Demoted to neutral

Eleven other surfaces move from green to `text-daintree-text/60`, `bg-overlay-subtle`, or `border-daintree-border`:

- `MissingCliGate` unauthenticated banner (flagged separately as a standalone bug: launchable by design isn't the same as success)
- `AgentCliStep` installed-row wash (inline "Installed" mark stays)
- Detected editors
- Forge connection line
- Enabled-command toggle
- Instant and Fast latency bands
- Low outcome-rate baseline
- "Within budget" pill
- Normal-heap bar
- `.daintree` config-source icon
- Secured env-var lock

## Left alone

`SystemRequirementsSection` checklist marks, every transient confirmation ("Copied!", "Credentials saved", "API key is valid", "Editor opened", "CLI is now available"), the inline "Installed" mark, and anything assigned to PR 2 or PR 3. `--color-status-success` isn't touched globally, just these specific surfaces.

## Non-colour channel

Every changed surface still says what state it's in through visible text, a distinct icon, geometry, or a real border, not colour alone, per the rule from #12000. Both the "Within budget" and "Over budget" pills got a real border so the neutral one keeps visible geometry and still reads correctly under `forced-colors`.

## Testing

318 targeted tests pass across every touched module.

- `GeneralTab.systemStatus.test.tsx`: Ready-label assertions replaced with absence assertions, plus a new test confirming each attention state owns a distinct icon, scoped per row.
- `McpServerSettingsTab.test.tsx`: 35 readiness waits re-anchored from the removed status text onto the stable "Copy API key" control.
- `e2e/full/platform/core-voice-input.spec.ts`: now gates on the Clear button instead of the removed "Configured" badge.

eslint and prettier are clean on all 17 changed files. No new tests were added for the five style-only files with no existing coverage since a class-literal assertion would violate the repo's no-tautological-assertions rule.

14 production files, 2 unit test files, 1 e2e spec. 17 files total.

Part of #12002.
