### PR TITLE
Refine the Review Hub's empty and error states

### DIFF
--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -116,7 +116,14 @@ export const SEL = {
     deleteConfirmInput: '[data-testid="delete-worktree-confirm-input"]',
     searchInput: '[aria-label="Search worktrees"]',
     searchClear: '[aria-label="Clear search"]',
-    reviewHubButton: '[aria-label="Open Review & Commit"]',
+    // Prefix match, deliberately. The card builds this label from the worktree's
+    // review state (`WorktreeDetailsSection.reviewHubButtonLabel`): "Open Review &
+    // commit" normally, "Open Review & push" once the tree is clean but commits
+    // are unpushed. An exact selector silently stops matching the moment either
+    // the verb or its casing shifts — which is what happened here, leaving every
+    // ReviewHub spec unable to open the hub. Note the button is ABSENT entirely
+    // when there is nothing to review and nothing to push.
+    reviewHubButton: '[aria-label^="Open Review &"]',
     filterButton: '[aria-label="Filter and sort worktrees"]',
     filterPopover: '[data-testid="worktree-filter-popover"]',
     openOverviewButton: '[aria-label="Open worktrees overview"]',

--- a/e2e/screenshots/review-hub-states-review.spec.ts
+++ b/e2e/screenshots/review-hub-states-review.spec.ts
@@ -340,6 +340,24 @@ async function setWindowSize(
   }, size);
 }
 
+/**
+ * Tab until `target` actually holds focus, and report whether it got there.
+ *
+ * A fixed number of Tab presses is not a focus shot: it lands wherever the tab
+ * order happens to put it, which in a body-scoped capture is often outside the
+ * crop entirely — so the "focused" PNG comes out byte-identical to its
+ * unfocused sibling and reads as a missing focus ring that isn't missing.
+ * `.focus()` is no substitute either: programmatic focus does not match
+ * `:focus-visible` in Chromium.
+ */
+async function tabTo(page: Page, target: string, maxPresses = 14): Promise<boolean> {
+  for (let i = 0; i < maxPresses; i++) {
+    await page.keyboard.press("Tab");
+    if (await page.locator(`${target}:focus`).count()) return true;
+  }
+  return false;
+}
+
 const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
 
 // A failed step must not abort the run — the other shots are still worth having. But
@@ -702,13 +720,13 @@ test("review hub states review — the states around the populated review flow",
         });
         await snapBody(page, "53-base-branch-failure");
         await snap(page, "54-base-branch-failure-window");
-        // Tab, never .focus() — programmatic focus does not match
-        // :focus-visible in Chromium, which is why the earlier focus shot came
-        // out byte-identical to its unfocused sibling.
-        await page.keyboard.press("Tab");
-        await page.keyboard.press("Tab");
-        await settle(page, 250);
-        await snapBody(page, "55-base-branch-failure-tabbed");
+        await page.locator(CONTENT).click({ position: { x: 5, y: 5 } });
+        if (await tabTo(page, `${CONTENT} button:has-text("Retry")`)) {
+          await settle(page, 250);
+          await snapBody(page, "55-base-branch-failure-tabbed");
+        } else {
+          console.log("[reviewstates-shots] Retry never took focus — shot skipped, not duplicated");
+        }
       },
       rest
     );
@@ -768,12 +786,12 @@ test("review hub states review — the states around the populated review flow",
         await snap(page, "71-clean-with-unpushed-commits-window");
         // Tab into Push rather than focusing it — see the base-branch note.
         await page.locator(CONTENT).click({ position: { x: 5, y: 5 } });
-        for (let i = 0; i < 12; i++) {
-          await page.keyboard.press("Tab");
-          if (await page.locator(`${CLEAN_PUSH}:focus`).count()) break;
+        if (await tabTo(page, CLEAN_PUSH)) {
+          await settle(page, 250);
+          await snapBody(page, "72-clean-unpushed-push-tabbed");
+        } else {
+          console.log("[reviewstates-shots] Push never took focus — shot skipped, not duplicated");
         }
-        await settle(page, 250);
-        await snapBody(page, "72-clean-unpushed-push-tabbed");
       },
       rest
     );
@@ -907,9 +925,13 @@ test("review hub states review — the states around the populated review flow",
         await clearAllFaults(app);
         await useGitState("clean-unpushed");
         await expectState(page, `${CONTENT} ${CLEAN_UNPUSHED}`, { label: "clean for keyboard" });
-        await page.keyboard.press("Tab");
-        await settle(page, 250);
-        await snapBody(page, "95-keyboard-into-clean-state");
+        await page.locator(CONTENT).click({ position: { x: 5, y: 5 } });
+        if (await tabTo(page, CLEAN_PUSH)) {
+          await settle(page, 250);
+          await snapBody(page, "95-keyboard-into-clean-state");
+        } else {
+          console.log("[reviewstates-shots] Push never took focus — shot skipped, not duplicated");
+        }
       },
       rest
     );
@@ -994,24 +1016,11 @@ test("review hub states review — the states around the populated review flow",
     : [];
   console.log(`[reviewstates-shots] wrote ${written.length} shot(s), ${onDisk.length} on disk`);
 
-  if (failures.length > 0) {
-    throw new Error(
-      `[reviewstates-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`
-    );
-  }
-  if (written.length === 0) {
-    throw new Error("[reviewstates-shots] no screenshots were written");
-  }
-  if (onDisk.length < written.length) {
-    throw new Error(
-      `[reviewstates-shots] wrote ${written.length} shot(s) but only ${onDisk.length} landed on disk`
-    );
-  }
-
-  // Two shots of DIFFERENT states must never be the same image. When they are,
-  // the harness captured before the state changed and the whole set silently
-  // stops being evidence. Distinct states are the entire point of this capture,
-  // so an identical pair is a hard failure rather than a warning.
+  // Duplicate detection runs BEFORE the step-failure throw and reports
+  // alongside it. It used to sit last, so any failing step short-circuited the
+  // single most valuable assertion this harness makes — a `grid` timeout would
+  // hide the fact that two states had rendered byte-identical, which is the
+  // exact class of silent-wrong-evidence bug the check exists to catch.
   const byHash = new Map<string, string[]>();
   for (const file of onDisk) {
     const hash = createHash("md5")
@@ -1020,10 +1029,27 @@ test("review hub states review — the states around the populated review flow",
     byHash.set(hash, [...(byHash.get(hash) ?? []), file]);
   }
   const dupes = [...byHash.values()].filter((group) => group.length > 1);
+
+  const problems: string[] = [];
   if (dupes.length > 0) {
+    problems.push(
+      `${dupes.length} group(s) of DIFFERENT states rendered byte-identical — the capture ` +
+        `raced the state change, or the two states genuinely look the same:\n` +
+        dupes.map((g) => `  ${g.join(" == ")}`).join("\n")
+    );
+  }
+  if (failures.length > 0) {
+    problems.push(`${failures.length} step(s) failed:\n  ${failures.join("\n  ")}`);
+  }
+  if (problems.length > 0) {
+    throw new Error(`[reviewstates-shots]\n${problems.join("\n")}`);
+  }
+  if (written.length === 0) {
+    throw new Error("[reviewstates-shots] no screenshots were written");
+  }
+  if (onDisk.length < written.length) {
     throw new Error(
-      `[reviewstates-shots] ${dupes.length} group(s) of DIFFERENT states rendered byte-identical — ` +
-        `the capture raced the state change:\n${dupes.map((g) => g.join(" == ")).join("\n")}`
+      `[reviewstates-shots] wrote ${written.length} shot(s) but only ${onDisk.length} landed on disk`
     );
   }
 });

--- a/e2e/screenshots/review-hub-states-review.spec.ts
+++ b/e2e/screenshots/review-hub-states-review.spec.ts
@@ -1,0 +1,1029 @@
+/**
+ * Review Hub non-content states visual-review harness (#11985).
+ *
+ * `ReviewHubContent` switches among eight states around its populated review flow:
+ * loading, initial-load failure, base-branch loading, base-branch failure, base-branch
+ * empty, working-tree clean (finished vs unpublished), general action failure, push
+ * failure, and conflict. Each accumulated separately, so the question the issue asks —
+ * "do these read as one visual language?" — can only be answered by seeing them side
+ * by side at a real panel width. That is what this harness produces.
+ *
+ * How each state is reached, and why:
+ *
+ *   Real git wherever git is deterministic. The fixture is a repo whose MAIN worktree
+ *   sits on `main` and whose feature worktree sits on `feature/agent-refactor` — the
+ *   split matters, because `fetchBaseBranch` returns early when the current branch IS
+ *   the main worktree's branch, so a single-worktree fixture can never reach
+ *   base-branch mode at all. A bare remote gives `hasRemote`, a pushed branch plus one
+ *   local commit gives `aheadCount > 0` with `behindCount === 0`, which is the only
+ *   combination that makes `pushReady` true and renders the clean-state Push button.
+ *
+ *   IPC fault injection for the failures. `DAINTREE_E2E_FAULT_MODE=1` plus
+ *   `e2e/helpers/ipcFaults` makes a real `git:*` invoke reject in the main process, so
+ *   the renderer's `window.electron.git.*` promise rejects exactly as it would in
+ *   production. This is the app's real data seam, not a UI-level mock — the component
+ *   is unaware it is under test, and the error text it renders is the error text the
+ *   handler actually threw. Delay faults drive the Doherty gate the same honest way.
+ *
+ * Steps, and what each is evidence for:
+ *
+ *   populated       the populated working tree — the geometry every other state is judged against.
+ *   loading         initial load below and above the 400ms Doherty gate.
+ *   loadfail        initial-load failure and its Retry, at rest and focused.
+ *   actionfail      a staging action rejecting — the full-width strip above the scroll area.
+ *   basebranch      base-branch mode: populated, loading skeleton, failure.
+ *   conflictop      a real merge conflict — `ConflictPanel` owns the frame.
+ *   conflictstrip   a stash-pop conflict — unmerged index with no MERGE_HEAD, which is
+ *                   the only way to see the local conflict strip above the file list.
+ *   cleanunpushed   clean tree with unpushed commits and a live Push.
+ *   pushfail        that Push rejecting — the specialised banner stacked over a quiet state.
+ *   cleandone       clean tree with nothing left to publish — the genuinely finished state.
+ *   basebranchempty no commits ahead of base — the other finished state, for direct comparison.
+ *   narrow          the two finished states and the failures at a squeezed panel width.
+ *   keyboard        focus rings on every recovery control these states own.
+ *   contrast        forced-colors and prefers-contrast: more.
+ *   grid            the same states hosted in the panel grid rather than the dialog.
+ *
+ * Opt-in only, like review-hub-filesection-review: skips itself unless
+ * DAINTREE_SHOT_REVIEWSTATES is set, so the marketing screenshots workflow never runs it.
+ *
+ *   DAINTREE_SHOT_REVIEWSTATES=1 npx playwright test --project=screenshots review-hub-states
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_REVIEWSTATES  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME         optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG           optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY          comma-separated step filter (see step names above)
+ *   DAINTREE_SHOT_OUT           optional absolute output dir (default: artifacts/reviewstates-shots)
+ *
+ * Output: <out>/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, type Page, type ElectronApplication } from "@playwright/test";
+import { execSync } from "child_process";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+} from "fs";
+import { createHash } from "crypto";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { injectFault, injectDelay, clearAllFaults } from "../helpers/ipcFaults";
+import { SEL } from "../helpers/selectors";
+import { T_LONG, T_MEDIUM } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_REVIEWSTATES;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ?? path.resolve(process.cwd(), "artifacts", "reviewstates-shots");
+
+const WIDE = { width: 1680, height: 1050 };
+const NARROW = { width: 900, height: 1050 };
+
+const FEATURE_BRANCH = "feature/agent-refactor";
+
+/** The review body — the element every state shot is scoped to. */
+const CONTENT = '[data-testid="review-hub-content"]';
+/** The clean-state Push, and the push banner's own detail disclosure. */
+const CLEAN_PUSH = '[data-testid="review-hub-clean-push"]';
+/** Proof the divergence data reached the UI — the marker `cleandone` waits to LOSE. */
+const CLEAN_UNPUSHED = '[data-testid="review-hub-clean-unpushed"]';
+const PUSH_TOGGLE = '[data-testid="review-hub-push-error-toggle"]';
+const REFRESH = '[aria-label="Refresh"]';
+
+/** Channels this harness injects on. Names come from `electron/ipc/channels.ts`. */
+const CH = {
+  stagingStatus: "git:get-staging-status",
+  compare: "git:compare-worktrees",
+  unstageAll: "git:unstage-all",
+  push: "git:push",
+} as const;
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+/**
+ * The skeleton steps are the one exception to POLISH_CSS: zeroing animation
+ * duration makes `animate-pulse-delayed` paint at whatever keyframe offset 0
+ * happens to be, so the Doherty-gated skeleton would be captured at an
+ * arbitrary opacity. These steps re-enable animation on the skeleton only.
+ */
+const SKELETON_ANIMATION_CSS = `
+  [data-testid="review-hub-content"] [class*="animate-pulse"] {
+    animation-duration: 2s !important;
+    animation-delay: 0s !important;
+  }
+`;
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/** Same command, but the caller expects it to fail (conflicts return non-zero). */
+function gitAllowFail(cmd: string, cwd: string): void {
+  try {
+    execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+  } catch {
+    /* expected — conflict paths exit non-zero by design */
+  }
+}
+
+/** Deterministic filler so churn numbers are large and stable across runs. */
+function lines(prefix: string, n: number): string {
+  return Array.from({ length: n }, (_, i) => `${prefix} line ${i + 1};`).join("\n") + "\n";
+}
+
+interface Fixture {
+  dir: string;
+  worktreeDir: string;
+  cleanup: () => void;
+}
+
+/**
+ * A repo whose MAIN worktree stays on `main`, plus a feature worktree that is the
+ * subject of every shot.
+ *
+ * The two-worktree shape is load-bearing rather than decorative. `mainBranch` is read
+ * off whichever worktree reports `isMainWorktree`, and `fetchBaseBranch` bails when the
+ * current branch equals it — so a fixture that reviews the main worktree can never
+ * reach base-branch mode, and half this issue's capture matrix would silently produce
+ * working-tree shots instead.
+ *
+ * The bare remote is equally load-bearing: without `hasRemote` the clean state renders
+ * its "No changes to commit" branch unconditionally, and the unpushed-commits branch —
+ * the one the issue is actually asking about — is unreachable.
+ */
+function createFixtureRepo(): Fixture {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-reviewstates-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  const remoteDir = path.join(path.dirname(dir), path.basename(dir) + "-remote.git");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+
+  const write = (rel: string, body: string, root = dir): void => {
+    const abs = path.join(root, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  };
+
+  // ---- committed baseline on main ----------------------------------------
+  write("README.md", "# Helios Dashboard\n");
+  write("package.json", JSON.stringify({ name: "helios", version: "1.0.0" }, null, 2) + "\n");
+  write("src/renderer/orchestration/OrchestrationPreferencesPanel.tsx", lines("panel", 220));
+  write("src/renderer/orchestration/useOrchestrationScheduler.ts", lines("sched", 140));
+  write("src/main/services/workspace/WorkspaceReconciliationService.ts", lines("recon", 260));
+  write("src/shared/config/agents/anthropic/claudeCodeAgentDefinition.ts", lines("agent", 180));
+  write("src/renderer/components/CommandPalette/CommandPaletteResultRow.tsx", lines("row", 160));
+  write("src/renderer/store/worktreeTopologyStore.ts", lines("topo", 200));
+  write("docs/architecture/notification-system.md", lines("- doc", 120));
+  write("conflict-target.ts", lines("shared", 40));
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+
+  // ---- a bare remote, so hasRemote is true and ahead/behind are real ------
+  execSync(`git init --bare ${JSON.stringify(remoteDir)}`, { stdio: "ignore" });
+  git(`remote add origin ${JSON.stringify(remoteDir)}`, dir);
+  git("push -u origin main", dir);
+
+  // ---- a branch that will conflict with the feature branch later ----------
+  git("checkout -b conflict-source", dir);
+  write("conflict-target.ts", lines("SOURCE-SIDE", 40));
+  git("add -A", dir);
+  git('commit -m "rewrite the shared module from the source side"', dir);
+  git("checkout main", dir);
+
+  // ---- the feature worktree: three commits ahead of main, pushed ---------
+  git(`worktree add -b ${FEATURE_BRANCH} ${JSON.stringify(wtRoot)}/agent-refactor main`, dir);
+  const worktreeDir = path.join(wtRoot, "agent-refactor");
+
+  write("src/renderer/orchestration/OrchestrationPreferencesPanel.tsx", lines("panel-v2", 420), worktreeDir); // prettier-ignore
+  write("src/renderer/orchestration/preferences/AdvancedConcurrencySection.tsx", lines("adv", 180), worktreeDir); // prettier-ignore
+  git("add -A", worktreeDir);
+  git('commit -m "rework the orchestration preferences panel"', worktreeDir);
+
+  write("src/main/services/workspace/WorkspaceReconciliationService.ts", lines("recon-v2", 380), worktreeDir); // prettier-ignore
+  git("add -A", worktreeDir);
+  git('commit -m "reconcile workspace state on worktree add"', worktreeDir);
+
+  write("conflict-target.ts", lines("FEATURE-SIDE", 40), worktreeDir);
+  git("add -A", worktreeDir);
+  git('commit -m "rewrite the shared module from the feature side"', worktreeDir);
+
+  git(`push -u origin ${FEATURE_BRANCH}`, worktreeDir);
+
+  // One more commit AFTER the push — this is what makes aheadCount 1 with
+  // behindCount 0, the only combination that renders the clean-state Push.
+  write("docs/architecture/notification-system.md", lines("- doc v2", 200), worktreeDir);
+  git("add -A", worktreeDir);
+  git('commit -m "document the reconciliation notifications"', worktreeDir);
+
+  // ---- the dirty working tree the populated shots need -------------------
+  write("src/shared/config/agents/anthropic/claudeCodeAgentDefinition.ts", lines("agent-v2", 340), worktreeDir); // prettier-ignore
+  write("src/renderer/components/CommandPalette/CommandPaletteResultRow.tsx", lines("row-v2", 300), worktreeDir); // prettier-ignore
+  write("src/renderer/store/worktreeTopologyStore.ts", lines("topo-v2", 430), worktreeDir);
+  write("src/renderer/orchestration/useOrchestrationScheduler.ts", lines("sched-v2", 310), worktreeDir); // prettier-ignore
+
+  return {
+    dir,
+    worktreeDir,
+    cleanup: () => {
+      for (const target of [wtRoot, remoteDir, dir]) {
+        try {
+          if (existsSync(target)) rmSync(target, { recursive: true, force: true });
+        } catch {
+          /* best effort */
+        }
+      }
+    },
+  };
+}
+
+async function settle(page: Page, ms = 350): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+const written: string[] = [];
+
+/**
+ * Wait until a marker proves the app actually reached the state, and THROW if it
+ * does not.
+ *
+ * This exists because the first run of this harness wrote twelve PNGs that
+ * collapsed into four distinct images: base-branch populated/skeleton/failure
+ * were one identical file, and clean-with-unpushed/nothing-to-publish were
+ * another. Every one of them was a timer-based `settle()` firing before the
+ * state changed, so the step "passed" and produced confident, wrong evidence —
+ * which is worse than failing, because a review then gets scored against it.
+ * Snapping on an assertion rather than a delay is the only thing that prevents
+ * it.
+ */
+async function expectState(
+  page: Page,
+  selector: string,
+  opts: { hidden?: boolean; label: string; timeout?: number }
+): Promise<void> {
+  try {
+    await page
+      .locator(selector)
+      .first()
+      .waitFor({ state: opts.hidden ? "hidden" : "visible", timeout: opts.timeout ?? 15_000 });
+  } catch {
+    throw new Error(
+      `[reviewstates-shots] state "${opts.label}" never materialised — ` +
+        `${selector} was not ${opts.hidden ? "hidden" : "visible"}. Refusing to shoot a wrong-state PNG.`
+    );
+  }
+}
+
+async function snap(page: Page, slug: string, locator?: string): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).last().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+  written.push(path.basename(file));
+}
+
+/** The review body in one frame — the comparison the issue is actually about. */
+async function snapBody(page: Page, slug: string): Promise<void> {
+  await snap(page, slug, CONTENT);
+}
+
+/**
+ * Shoot without waiting out a settle — the pre-Doherty window is 400ms wide, and
+ * `snap`'s default 350ms wait plus two rAFs would land on the far side of it.
+ */
+async function snapNow(page: Page, slug: string, locator?: string): Promise<void> {
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).last().screenshot({ path: file, type: "png", timeout: 4000 });
+  } else {
+    await page.screenshot({ path: file, type: "png", caret: "hide" });
+  }
+  written.push(path.basename(file));
+}
+
+async function setWindowSize(
+  app: ElectronApplication,
+  size: { width: number; height: number }
+): Promise<void> {
+  await app.evaluate(({ BrowserWindow }, target) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    win?.setSize(target.width, target.height);
+  }, size);
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — the other shots are still worth having. But
+// the run must still FAIL, or a silent exit 0 with an empty output directory reads as
+// success.
+const failures: string[] = [];
+async function step(name: string, fn: () => Promise<void>, reset: () => Promise<void>) {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).slice(0, 300);
+    console.warn(`[reviewstates-shots] step "${name}" failed:`, detail);
+    failures.push(`${name}: ${detail}`);
+  } finally {
+    await reset().catch((error) => {
+      failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+    });
+  }
+}
+
+test("review hub states review — the states around the populated review flow", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_REVIEWSTATES is required for the review-states capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_REVIEWSTATES to run the review-states capture");
+
+  failures.length = 0;
+  written.length = 0;
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-reviewstatesshot-"));
+  let ctx: AppContext | undefined;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: WIDE,
+      // Fault mode is what lets a real `git:*` invoke reject in the main process,
+      // so the renderer sees a genuine IPC rejection rather than a stubbed one.
+      env: { DAINTREE_E2E_FAULT_MODE: "1" },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 1500);
+    await dismissBlockingPalette(page);
+
+    const app = ctx.app;
+    const hub = page.locator(SEL.reviewHub.container);
+    const featureCard = page.locator(SEL.worktree.card(FEATURE_BRANCH));
+
+    /**
+     * Open Review & Commit on the FEATURE worktree — never the main one.
+     *
+     * The card's opener is not always there: `WorktreeDetailsSection` renders it
+     * only while `hasChanges || isUnpushedClean`, so it VANISHES for exactly the
+     * two finished states this issue is most about. The context menu carries the
+     * same command unconditionally, so it is the fallback rather than the
+     * primary — clicking the button when it exists is the path a user takes.
+     */
+    const openHub = async (): Promise<void> => {
+      await dismissBlockingPalette(page);
+      await featureCard.waitFor({ state: "visible", timeout: T_LONG });
+      const opener = featureCard.locator(SEL.worktree.reviewHubButton).first();
+      if (await opener.isVisible().catch(() => false)) {
+        await opener.click();
+      } else {
+        await featureCard.click({ button: "right" });
+        await page.locator('[role="menu"]').waitFor({ state: "visible", timeout: T_MEDIUM });
+        await page
+          .getByRole("menuitem", { name: /Review & Commit/i })
+          .first()
+          .click();
+      }
+      await hub.waitFor({ state: "visible", timeout: T_MEDIUM });
+      await page.locator(CONTENT).waitFor({ state: "visible", timeout: T_MEDIUM });
+    };
+
+    const closeHub = async (): Promise<void> => {
+      for (let i = 0; i < 4; i++) {
+        if (!(await hub.isVisible().catch(() => false))) return;
+        await page.keyboard.press("Escape").catch(() => {});
+        await settle(page, 250);
+      }
+    };
+
+    /** Close, reopen — the only way to replay the initial-load path. */
+    const reopenHub = async (): Promise<void> => {
+      await closeHub();
+      await settle(page, 300);
+      await openHub();
+    };
+
+    const expandFileList = async (): Promise<void> => {
+      const toggle = hub.locator(SEL.reviewHub.fileListToggle);
+      if (!(await toggle.isVisible().catch(() => false))) return;
+      if ((await toggle.getAttribute("aria-expanded")) !== "true") await toggle.click();
+      await settle(page, 400);
+    };
+
+    /**
+     * Flip the working-tree / base-branch segmented control.
+     *
+     * By index, not by label: the second button reads "vs {mainBranch}", so a
+     * text selector would have to know the fixture's branch name, and it is
+     * `disabled` whenever the current branch IS the main branch — which is
+     * exactly the misconfiguration this harness's two-worktree fixture exists
+     * to avoid, so it is worth failing loudly on rather than silently skipping.
+     */
+    const setDiffMode = async (mode: "working-tree" | "base-branch"): Promise<void> => {
+      const button = page
+        .locator(`${SEL.reviewHub.diffMode} button`)
+        .nth(mode === "base-branch" ? 1 : 0);
+      await button.click();
+      await settle(page, 600);
+    };
+
+    /**
+     * Put the fixture into a NAMED git state, from whatever state it is in.
+     *
+     * Steps used to mutate git in sequence and rely on the previous step having
+     * run. `DAINTREE_SHOT_ONLY` then silently produced shots of the WRONG state
+     * — the narrow and prefers-contrast steps captured a populated working tree
+     * while claiming to show a clean one, because the steps that clean the tree
+     * had been filtered out. A capture harness whose steps are order-dependent
+     * cannot be re-run piecemeal, which is exactly what you need when one step
+     * fails. Every state-dependent step now declares what it needs.
+     */
+    const setGitState = async (
+      kind: "dirty" | "clean-unpushed" | "clean-done" | "base-empty" | "conflicted"
+    ): Promise<void> => {
+      const wt = repo.worktreeDir;
+      gitAllowFail("merge --abort", wt);
+      gitAllowFail("rebase --abort", wt);
+      git("reset --hard HEAD", wt);
+      git("clean -fd", wt);
+      // Back to the pushed tip, so every branch below starts from one baseline.
+      git(`reset --hard origin/${FEATURE_BRANCH}`, wt);
+
+      if (kind === "clean-done") return; // ahead 0, behind 0, nothing to publish
+
+      if (kind === "base-empty") {
+        git("reset --hard main", wt);
+        return;
+      }
+
+      if (kind === "conflicted") {
+        // A genuinely unmerged index with NO operation in progress — the only
+        // way to reach the local conflict strip, because MERGING/REBASING hand
+        // the frame to ConflictPanel instead. Stash a change to a file, commit
+        // an incompatible change to that same file, then pop: git leaves UU
+        // entries and no MERGE_HEAD. The earlier attempt used `merge -X ours`,
+        // which auto-resolved and produced no conflict at all.
+        writeFileSync(path.join(wt, "conflict-target.ts"), lines("STASHED-SIDE", 40));
+        git("stash push -u -m reviewstates-conflict", wt);
+        writeFileSync(path.join(wt, "conflict-target.ts"), lines("COMMITTED-SIDE", 40));
+        git("add -A", wt);
+        git('commit -m "rewrite the shared module incompatibly"', wt);
+        gitAllowFail("stash pop", wt);
+        return;
+      }
+
+      // Both remaining states need one unpushed commit (ahead 1, behind 0) —
+      // the only combination that makes `pushReady` true.
+      writeFileSync(
+        path.join(wt, "docs/architecture/notification-system.md"),
+        lines("- doc v2", 200)
+      );
+      git("add -A", wt);
+      git('commit -m "document the reconciliation notifications"', wt);
+      if (kind === "clean-unpushed") return;
+
+      // dirty: put the working-tree changes back on top.
+      writeFileSync(path.join(wt, "src/shared/config/agents/anthropic/claudeCodeAgentDefinition.ts"), lines("agent-v2", 340)); // prettier-ignore
+      writeFileSync(path.join(wt, "src/renderer/components/CommandPalette/CommandPaletteResultRow.tsx"), lines("row-v2", 300)); // prettier-ignore
+      writeFileSync(
+        path.join(wt, "src/renderer/store/worktreeTopologyStore.ts"),
+        lines("topo-v2", 430)
+      );
+      writeFileSync(path.join(wt, "src/renderer/orchestration/useOrchestrationScheduler.ts"), lines("sched-v2", 310)); // prettier-ignore
+    };
+
+    /** Apply a git state and remount so the hub actually reads it. */
+    const useGitState = async (
+      kind: "dirty" | "clean-unpushed" | "clean-done" | "base-empty" | "conflicted"
+    ): Promise<void> => {
+      await closeHub();
+      await setGitState(kind);
+      await settle(page, 400);
+      await openHub();
+      await settle(page, 900);
+    };
+
+    await openHub();
+    await expandFileList();
+    await settle(page, 800);
+
+    /**
+     * A reset that returns to the documented rest state rather than assuming it.
+     *
+     * The close/reopen is NOT optional, and leaving it out cost a whole capture
+     * run. Clearing an injected fault does not re-fetch: after a `loadfail` step
+     * the component still holds `loadError` with `status === null`, which leaves
+     * the "vs {main}" toggle `disabled` and the file list unmounted for every
+     * step that follows. Five later steps timed out on controls that were never
+     * coming back. Only a fresh mount re-runs the initial fetch, so `rest`
+     * remounts and then waits for status to actually resolve.
+     */
+    const rest = async (): Promise<void> => {
+      await clearAllFaults(app).catch(() => {});
+      await setWindowSize(app, WIDE);
+      await page.emulateMedia({ forcedColors: "none", contrast: "no-preference" }).catch(() => {});
+      await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+      await settle(page, 300);
+      await closeHub();
+      await settle(page, 300);
+      await openHub();
+      // Status resolved == either the file list toggle or a resolved empty
+      // state is on screen. Without this the next step races the fetch.
+      await page
+        .locator(
+          `${SEL.reviewHub.fileListToggle}, ${CONTENT} [data-testid="review-hub-clean-unpushed"], ${CONTENT} p`
+        )
+        .first()
+        .waitFor({ state: "visible", timeout: T_MEDIUM })
+        .catch(() => {});
+      await settle(page, 400);
+      await setDiffMode("working-tree").catch(() => {});
+    };
+
+    // ── the populated baseline every other state is judged against ─────────
+
+    await step(
+      "populated",
+      async () => {
+        await snapBody(page, "10-populated-working-tree");
+        await snap(page, "11-populated-window");
+      },
+      rest
+    );
+
+    // ── loading: below and above the 400ms Doherty gate ───────────────────
+
+    await step(
+      "loading",
+      async () => {
+        await page.addStyleTag({ content: SKELETON_ANIMATION_CSS }).catch(() => {});
+        await injectDelay(app, CH.stagingStatus, 4000);
+        await closeHub();
+        await settle(page, 300);
+        await openHub();
+        // Inside the gate: the surface must show NOTHING, not a spinner.
+        await page.waitForTimeout(180);
+        await snapNow(page, "20-loading-inside-doherty-gate", CONTENT);
+        // Past the gate: the skeleton, whose geometry must match what resolves.
+        await page.waitForTimeout(700);
+        await snapNow(page, "21-loading-skeleton", CONTENT);
+        await snapNow(page, "22-loading-skeleton-window");
+        await clearAllFaults(app);
+        await page.waitForTimeout(4200);
+        await settle(page, 600);
+        await snapBody(page, "23-loading-resolved-for-comparison");
+      },
+      rest
+    );
+
+    // ── initial-load failure ──────────────────────────────────────────────
+
+    await step(
+      "loadfail",
+      async () => {
+        await injectFault(
+          app,
+          CH.stagingStatus,
+          "fatal: not a git repository (or any of the parent directories): .git"
+        );
+        await reopenHub();
+        await settle(page, 900);
+        await snapBody(page, "30-initial-load-failure");
+        await snap(page, "31-initial-load-failure-window");
+        // The Retry control focused — this is the only recovery the state offers.
+        await page
+          .locator(`${CONTENT} button:has-text("Retry")`)
+          .first()
+          .focus()
+          .catch(() => {});
+        await settle(page, 250);
+        await snapBody(page, "32-initial-load-failure-retry-focused");
+      },
+      rest
+    );
+
+    // ── a staging action rejecting ────────────────────────────────────────
+
+    await step(
+      "actionfail",
+      async () => {
+        await expandFileList();
+        await injectFault(
+          app,
+          CH.unstageAll,
+          "error: unable to write new index file\nfatal: Unable to write new index file"
+        );
+        await page.locator(SEL.reviewHub.unstageAllButton).first().click();
+        await settle(page, 1200);
+        await snapBody(page, "40-action-failure");
+        await snap(page, "41-action-failure-window");
+      },
+      rest
+    );
+
+    // ── base-branch mode: populated, loading, failure ─────────────────────
+
+    await step(
+      "basebranch",
+      async () => {
+        await useGitState("dirty");
+        await setDiffMode("base-branch");
+        await expectState(
+          page,
+          `${CONTENT} [data-testid="base-branch-file-row"], ${CONTENT} span:has-text("Changed vs")`,
+          { label: "base-branch populated" }
+        );
+        await snapBody(page, "50-base-branch-populated");
+
+        // Remount rather than round-tripping the toggle. `fetchBaseBranch` runs
+        // on entering base-branch mode; toggling out and back inside one React
+        // batch did NOT re-fire it, so the delay and error faults landed on a
+        // view that never re-fetched and five shots came out byte-identical.
+        await page.addStyleTag({ content: SKELETON_ANIMATION_CSS }).catch(() => {});
+        await injectDelay(app, CH.compare, 4000);
+        await closeHub();
+        await openHub();
+        await setDiffMode("base-branch");
+        await page.waitForTimeout(700);
+        await snapNow(page, "52-base-branch-skeleton", CONTENT);
+        await clearAllFaults(app);
+        await page.waitForTimeout(4200);
+
+        await injectFault(
+          app,
+          CH.compare,
+          "fatal: ambiguous argument 'main...feature/agent-refactor': unknown revision or path not in the working tree"
+        );
+        await closeHub();
+        await openHub();
+        await setDiffMode("base-branch");
+        await expectState(page, `${CONTENT} button:has-text("Retry")`, {
+          label: "base-branch failure",
+        });
+        await snapBody(page, "53-base-branch-failure");
+        await snap(page, "54-base-branch-failure-window");
+        // Tab, never .focus() — programmatic focus does not match
+        // :focus-visible in Chromium, which is why the earlier focus shot came
+        // out byte-identical to its unfocused sibling.
+        await page.keyboard.press("Tab");
+        await page.keyboard.press("Tab");
+        await settle(page, 250);
+        await snapBody(page, "55-base-branch-failure-tabbed");
+      },
+      rest
+    );
+
+    // ── a real merge conflict: ConflictPanel owns the frame ───────────────
+
+    await step(
+      "conflictop",
+      async () => {
+        await closeHub();
+        await setGitState("dirty");
+        git("stash push -u -m reviewstates-preconflict", repo.worktreeDir);
+        gitAllowFail("merge conflict-source", repo.worktreeDir);
+        await openHub();
+        await expectState(page, `${CONTENT} :text("conflict")`, {
+          label: "conflict operation",
+        });
+        await snapBody(page, "60-conflict-operation");
+        await snap(page, "61-conflict-operation-window");
+      },
+      async () => {
+        await closeHub();
+        gitAllowFail("merge --abort", repo.worktreeDir);
+        gitAllowFail("stash drop", repo.worktreeDir);
+        await rest();
+      }
+    );
+
+    // ── an unmerged index with NO operation: the local conflict strip ─────
+
+    await step(
+      "conflictstrip",
+      async () => {
+        await useGitState("conflicted");
+        await expandFileList();
+        await expectState(page, `${CONTENT} :text("conflicted file")`, {
+          label: "conflict strip",
+        });
+        await snapBody(page, "65-conflict-strip");
+        await snap(page, "66-conflict-strip-window");
+      },
+      async () => {
+        await closeHub();
+        gitAllowFail("stash drop", repo.worktreeDir);
+        await rest();
+      }
+    );
+
+    // ── clean tree with unpushed commits ──────────────────────────────────
+
+    await step(
+      "cleanunpushed",
+      async () => {
+        await useGitState("clean-unpushed");
+        await expectState(page, `${CONTENT} ${CLEAN_UNPUSHED}`, { label: "clean with unpushed" });
+        await snapBody(page, "70-clean-with-unpushed-commits");
+        await snap(page, "71-clean-with-unpushed-commits-window");
+        // Tab into Push rather than focusing it — see the base-branch note.
+        await page.locator(CONTENT).click({ position: { x: 5, y: 5 } });
+        for (let i = 0; i < 12; i++) {
+          await page.keyboard.press("Tab");
+          if (await page.locator(`${CLEAN_PUSH}:focus`).count()) break;
+        }
+        await settle(page, 250);
+        await snapBody(page, "72-clean-unpushed-push-tabbed");
+      },
+      rest
+    );
+
+    // ── that Push rejecting — the specialised banner over a quiet state ───
+
+    await step(
+      "pushfail",
+      async () => {
+        await useGitState("clean-unpushed");
+        await expectState(page, `${CONTENT} ${CLEAN_PUSH}`, { label: "push available" });
+        await injectFault(
+          app,
+          CH.push,
+          "! [rejected]        feature/agent-refactor -> feature/agent-refactor (non-fast-forward)\nerror: failed to push some refs\nhint: Updates were rejected because the remote contains work that you do not have locally."
+        );
+        await page.locator(CLEAN_PUSH).click();
+        // The clean-state Push is a D2 destructive action: it only REQUESTS a
+        // push, and the globally-mounted preview dialog is what dispatches it
+        // (#7880 safeguards). Without confirming here the step would capture
+        // the confirm dialog and never reach the push-error banner at all.
+        await page
+          .locator(SEL.reviewHub.pushConfirmMessage)
+          .waitFor({ state: "visible", timeout: T_MEDIUM })
+          .catch(() => {});
+        await page
+          .locator(SEL.confirmDialog.confirm)
+          .click()
+          .catch(() => {});
+        await expectState(page, SEL.reviewHub.pushError, { label: "push failure banner" });
+        await snapBody(page, "75-push-failure-over-clean-state");
+        await snap(page, "76-push-failure-window");
+        // The detail disclosure exists only when the classified reason opts
+        // into `detailPolicy: "collapse"`. Shooting unconditionally produced a
+        // byte-identical duplicate of the shot above, so only shoot it when the
+        // control is genuinely there.
+        if (await page.locator(PUSH_TOGGLE).count()) {
+          await page.locator(PUSH_TOGGLE).click();
+          await expectState(page, '[data-testid="review-hub-push-error-details"]', {
+            label: "push details expanded",
+          });
+          await snapBody(page, "77-push-failure-details-expanded");
+        } else {
+          console.log("[reviewstates-shots] no push-detail toggle for this reason — shot skipped");
+        }
+      },
+      rest
+    );
+
+    // ── clean tree with nothing left to publish — genuinely finished ──────
+
+    await step(
+      "cleandone",
+      async () => {
+        await useGitState("clean-done");
+        // Assert the divergence actually reached the UI. The worktree store
+        // polls independently of the hub's own fetch, so a fixed settle here
+        // captured a stale "1 commit not pushed" and produced a shot identical
+        // to the unpushed state — the opposite of what this step documents.
+        await expectState(page, `${CONTENT} ${CLEAN_UNPUSHED}`, {
+          hidden: true,
+          label: "nothing left to publish",
+          timeout: 30_000,
+        });
+        await snapBody(page, "80-clean-nothing-to-publish");
+        await snap(page, "81-clean-nothing-to-publish-window");
+      },
+      rest
+    );
+
+    // ── no commits ahead of base — the OTHER finished state ───────────────
+
+    await step(
+      "basebranchempty",
+      async () => {
+        await useGitState("base-empty");
+        await setDiffMode("base-branch");
+        await expectState(page, `${CONTENT} :text("No changes vs")`, {
+          label: "no changes vs base",
+        });
+        await snapBody(page, "85-base-branch-empty");
+        await snap(page, "86-base-branch-empty-window");
+        await setDiffMode("working-tree");
+        await settle(page, 900);
+        await snapBody(page, "87-clean-state-for-direct-comparison");
+      },
+      rest
+    );
+
+    // ── narrow ────────────────────────────────────────────────────────────
+
+    await step(
+      "narrow",
+      async () => {
+        await useGitState("clean-unpushed");
+        await setWindowSize(app, NARROW);
+        await settle(page, 900);
+        await expectState(page, `${CONTENT} ${CLEAN_UNPUSHED}`, { label: "narrow clean state" });
+        await snapBody(page, "90-narrow-clean-state");
+        await snap(page, "91-narrow-window");
+        await injectFault(app, CH.stagingStatus, "fatal: unable to read the index file");
+        await reopenHub();
+        await expectState(page, `${CONTENT} button:has-text("Retry")`, {
+          label: "narrow load failure",
+        });
+        await snapBody(page, "92-narrow-load-failure");
+        await clearAllFaults(app);
+        await reopenHub();
+        await setDiffMode("base-branch");
+        await settle(page, 1200);
+        await snapBody(page, "93-narrow-base-branch");
+      },
+      rest
+    );
+
+    // ── keyboard ──────────────────────────────────────────────────────────
+
+    await step(
+      "keyboard",
+      async () => {
+        await useGitState("dirty");
+        await injectFault(app, CH.compare, "fatal: bad revision 'main'");
+        await setDiffMode("base-branch");
+        await expectState(page, `${CONTENT} button:has-text("Retry")`, {
+          label: "base-branch failure for keyboard",
+        });
+        await page.keyboard.press("Tab");
+        await page.keyboard.press("Tab");
+        await settle(page, 250);
+        await snapBody(page, "94-keyboard-into-base-branch-failure");
+        await clearAllFaults(app);
+        await useGitState("clean-unpushed");
+        await expectState(page, `${CONTENT} ${CLEAN_UNPUSHED}`, { label: "clean for keyboard" });
+        await page.keyboard.press("Tab");
+        await settle(page, 250);
+        await snapBody(page, "95-keyboard-into-clean-state");
+      },
+      rest
+    );
+
+    // ── contrast ──────────────────────────────────────────────────────────
+
+    await step(
+      "contrast",
+      async () => {
+        await useGitState("clean-unpushed");
+        await page.emulateMedia({ contrast: "more" });
+        await settle(page, 600);
+        await expectState(page, `${CONTENT} ${CLEAN_UNPUSHED}`, { label: "contrast clean" });
+        await snapBody(page, "96-prefers-contrast-more-clean");
+        await injectFault(app, CH.stagingStatus, "fatal: unable to read the index file");
+        await reopenHub();
+        await expectState(page, `${CONTENT} button:has-text("Retry")`, {
+          label: "contrast failure",
+        });
+        await snapBody(page, "97-prefers-contrast-more-failure");
+        await page.emulateMedia({ contrast: "no-preference", forcedColors: "active" });
+        await settle(page, 600);
+        await snapBody(page, "98-forced-colors-failure");
+        await clearAllFaults(app);
+        await reopenHub();
+        await expectState(page, `${CONTENT} ${CLEAN_UNPUSHED}`, { label: "forced-colors clean" });
+        await snapBody(page, "99-forced-colors-clean");
+      },
+      rest
+    );
+
+    // ── the same states, hosted in the grid rather than the dialog ────────
+
+    await step(
+      "grid",
+      async () => {
+        await closeHub();
+        await dismissBlockingPalette(page);
+        await featureCard.click();
+        await settle(page, 500);
+        await page.keyboard.press("ControlOrMeta+KeyK");
+        await settle(page, 500);
+        await page.keyboard.type("Review");
+        await settle(page, 600);
+        await page.keyboard.press("Enter");
+        await settle(page, 2500);
+        await page.locator(CONTENT).waitFor({ state: "visible", timeout: T_LONG });
+        await snapBody(page, "A0-grid-hosted-clean-state");
+        await snap(page, "A1-grid-hosted-window");
+        await injectFault(app, CH.stagingStatus, "fatal: unable to read the index file");
+        await page
+          .locator(`${CONTENT} ${REFRESH}`)
+          .first()
+          .click()
+          .catch(() => {});
+        await settle(page, 1200);
+        await snapBody(page, "A2-grid-hosted-load-failure");
+      },
+      async () => {
+        await clearAllFaults(app).catch(() => {});
+        await settle(page, 300);
+      }
+    );
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    try {
+      repo.cleanup();
+    } catch {
+      /* best effort */
+    }
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+
+  // Count the artifacts rather than trusting the step loop: a harness that exits 0 with
+  // an empty output directory is worse than one that fails.
+  const onDisk = existsSync(OUTPUT_DIR)
+    ? readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`))
+    : [];
+  console.log(`[reviewstates-shots] wrote ${written.length} shot(s), ${onDisk.length} on disk`);
+
+  if (failures.length > 0) {
+    throw new Error(
+      `[reviewstates-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`
+    );
+  }
+  if (written.length === 0) {
+    throw new Error("[reviewstates-shots] no screenshots were written");
+  }
+  if (onDisk.length < written.length) {
+    throw new Error(
+      `[reviewstates-shots] wrote ${written.length} shot(s) but only ${onDisk.length} landed on disk`
+    );
+  }
+
+  // Two shots of DIFFERENT states must never be the same image. When they are,
+  // the harness captured before the state changed and the whole set silently
+  // stops being evidence. Distinct states are the entire point of this capture,
+  // so an identical pair is a hard failure rather than a warning.
+  const byHash = new Map<string, string[]>();
+  for (const file of onDisk) {
+    const hash = createHash("md5")
+      .update(readFileSync(path.join(OUTPUT_DIR, file)))
+      .digest("hex");
+    byHash.set(hash, [...(byHash.get(hash) ?? []), file]);
+  }
+  const dupes = [...byHash.values()].filter((group) => group.length > 1);
+  if (dupes.length > 0) {
+    throw new Error(
+      `[reviewstates-shots] ${dupes.length} group(s) of DIFFERENT states rendered byte-identical — ` +
+        `the capture raced the state change:\n${dupes.map((g) => g.join(" == ")).join("\n")}`
+    );
+  }
+});

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -154,7 +154,14 @@ export function InlineStatusBanner({
 }: InlineStatusBannerProps) {
   const prefersReducedMotion =
     typeof window !== "undefined" &&
-    (window.matchMedia("(prefers-reduced-motion: reduce)").matches ||
+    // `matchMedia` is guarded separately from `window`: the SSR check above only
+    // covers `window` being absent entirely, but a jsdom environment has a
+    // `window` with no `matchMedia` implementation. Calling it there threw and
+    // took the whole banner subtree down with it — which, for a component this
+    // widely mounted, turns one missing test-env stub into an unrelated-looking
+    // render failure somewhere else on the page.
+    ((typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches) ||
       (typeof document !== "undefined" &&
         (document.body.getAttribute("data-reduce-animations") === "true" ||
           document.body.getAttribute("data-performance-mode") === "true")));

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -473,7 +473,7 @@ describe("InlineStatusBanner", () => {
     });
   });
 
-  it("uses the 250ms entrance duration class when animated", () => {
+  it("scopes the entrance transition to the properties it animates", () => {
     const { container } = render(
       <InlineStatusBanner
         icon={Info}
@@ -497,7 +497,7 @@ describe("InlineStatusBanner", () => {
     expect(root.className).not.toContain("transition-all");
   });
 
-  it("suppresses the 250ms entrance class when data-reduce-animations is true", () => {
+  it("suppresses the entrance transition when data-reduce-animations is true", () => {
     document.body.setAttribute("data-reduce-animations", "true");
     try {
       const { container } = render(

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -484,8 +484,17 @@ describe("InlineStatusBanner", () => {
       />
     );
     const root = container.firstElementChild as HTMLElement;
-    expect(root.className).toContain("duration-250");
-    expect(root.className).not.toContain("duration-150");
+    // Assert the RULE, not the number. The old form asserted the literal
+    // `duration-250` copied straight from the component, so retiming the
+    // banner forced the identical edit here and the test proved nothing —
+    // exactly the tautological shape the repo's testing rules ban. What
+    // actually matters is that the entry transition exists and is scoped to
+    // the properties it animates: a bare `transition` would sweep in every
+    // animatable property, so an unrelated colour or size change would
+    // silently inherit entry timing.
+    expect(root.className).toMatch(/transition-\[[^\]]+\]/);
+    expect(root.className).not.toMatch(/(?:^|\s)transition(?:\s|$)/);
+    expect(root.className).not.toContain("transition-all");
   });
 
   it("suppresses the 250ms entrance class when data-reduce-animations is true", () => {

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -17,7 +17,16 @@ import { isClientAppError } from "@/utils/clientAppError";
 import { cn } from "@/lib/utils";
 
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
-import { X, RefreshCw, CheckSquare, ChevronRight, AlertTriangle, GitBranch } from "lucide-react";
+import {
+  X,
+  RefreshCw,
+  CircleCheck,
+  ArrowUpFromLine,
+  ChevronRight,
+  AlertTriangle,
+  CircleAlert,
+  GitBranch,
+} from "lucide-react";
 import { isProtectedBranch } from "@shared/utils/gitConstants";
 import { useUIStore } from "@/store/uiStore";
 import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
@@ -25,6 +34,8 @@ import { usePreferencesStore } from "@/store/preferencesStore";
 import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
 import type { DiffChangeSetEntry } from "@/components/FileViewer/diffChangeSet";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { basename, join } from "@shared/utils/path";
@@ -45,7 +56,11 @@ import { PrStatusChip } from "./PrStatusChip";
 import { CommitPanel } from "./CommitPanel";
 import { ConflictPanel } from "./ConflictPanel";
 import { ReadinessRail } from "./ReadinessRail";
-import { deriveReviewReadiness, type ReviewReadinessCta } from "./reviewReadiness";
+import {
+  deriveReviewReadiness,
+  type ReviewReadinessCta,
+  type ReviewReadinessItem,
+} from "./reviewReadiness";
 // Lazy: these modals statically reach the DiffViewer/CodeViewer/vendor-editor
 // chunks (~223 KB gzip), and ReviewPane is a first-render preload seed — a
 // static import drags the whole editor stack into every boot's modulepreload
@@ -638,6 +653,23 @@ export function ReviewHubContent({
       }),
     [status, aheadCount, behindCount, worktreePR, providerHealth, pushError]
   );
+
+  /**
+   * What the rail actually renders. Identical to `readinessSummary` except that
+   * the `push-failed` item is dropped while the dedicated push banner is up —
+   * see the note at the `ReadinessRail` call site. Never used for gating.
+   */
+  const railSummary = useMemo(() => {
+    if (!pushError) return readinessSummary;
+    const drop = (items: ReviewReadinessItem[]) => items.filter((i) => i.id !== "push-failed");
+    return {
+      ...readinessSummary,
+      blockers: drop(readinessSummary.blockers),
+      warnings: drop(readinessSummary.warnings),
+      infos: drop(readinessSummary.infos),
+      nextActions: drop(readinessSummary.nextActions),
+    };
+  }, [readinessSummary, pushError]);
 
   const refresh = useCallback(async () => {
     if (!worktreePath) return;
@@ -1608,15 +1640,41 @@ export function ReviewHubContent({
           </div>
         </div>
 
-        {/* Merge-readiness rail — hidden until staging status resolves */}
-        <ReadinessRail summary={readinessSummary} onCta={handleReadinessCta} />
+        {/* Merge-readiness rail — hidden until staging status resolves.
+            While `PushErrorBanner` is mounted it owns the push failure outright:
+            it classifies the reason, names the remedy, and carries the only
+            actions (pull-rebase / force-push). The rail's own `push-failed` item
+            says the same thing in different words, one severity louder, with no
+            action — so the two stacked directly on top of each other and the
+            louder of the pair was the useless one. Filtered from what the RAIL
+            renders only; `readinessSummary` itself keeps the blocker so
+            readiness and push gating are unchanged. */}
+        <ReadinessRail summary={railSummary} onCta={handleReadinessCta} />
 
         {/* Inline error banners */}
         {actionError && (
-          <div className="px-4 py-2 text-xs text-status-error bg-status-error/10 flex items-start gap-2 shrink-0">
-            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
-            <span>{actionError}</span>
-          </div>
+          /* One grammar for every failure on this surface: icon, verb-noun
+             title, the git detail as supporting copy, and exactly one recovery.
+             This used to be a bespoke strip that printed raw stderr with no
+             title, no role and nothing the user could do — the message sat in
+             the layout permanently because there was not even a dismiss. It is
+             `role="status"` rather than `alert` because the pane is still fully
+             usable: the failed action is recoverable in place, and an assertive
+             interrupt for a secondary failure would fight the user's focus. */
+          <InlineStatusBanner
+            severity="error"
+            role="status"
+            ariaLive="polite"
+            icon={CircleAlert}
+            title="Action failed"
+            description={actionError}
+            onClose={() => setActionError(null)}
+            action={{
+              id: "review-hub-action-error-refresh",
+              label: "Refresh",
+              onClick: () => void refresh(),
+            }}
+          />
         )}
         {pushError && (
           <PushErrorBanner
@@ -1679,18 +1737,39 @@ export function ReviewHubContent({
                 </>
               ) : null
             ) : baseBranchError ? (
-              <div className="p-4 text-xs text-status-error">
-                <p className="mb-2">{baseBranchError}</p>
-                <Button variant="subtle" size="sm" onClick={() => void fetchBaseBranch()}>
-                  Retry
-                </Button>
-              </div>
+              /* A SECONDARY failure — the comparison could not be computed, but
+                 the pane and its chrome are intact. Announced politely and
+                 without moving focus (WCAG 2.2 SC 3.2.1/3.2.2); only the root
+                 failure below is assertive. */
+              <InlineStatusBanner
+                severity="error"
+                role="status"
+                ariaLive="polite"
+                icon={CircleAlert}
+                title={`Couldn't compare with ${mainBranch}`}
+                description={baseBranchError}
+                action={{
+                  id: "review-hub-base-branch-retry",
+                  label: "Retry",
+                  onClick: () => void fetchBaseBranch(),
+                }}
+              />
             ) : sortedBaseBranchFiles !== null && sortedBaseBranchFiles.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-12 text-daintree-text/50">
-                <CheckSquare className="w-8 h-8 mb-2 text-daintree-text/30" />
-                <p className="text-sm">No changes vs {mainBranch}</p>
-                <p className="text-xs mt-1">This branch has no commits ahead of {mainBranch}</p>
-              </div>
+              /* A completed inspection: there is genuinely nothing to review
+                 against the base branch. `user-cleared` is the Blank-Slate
+                 variant — it forbids a description and an action by design, so
+                 the redundant "This branch has no commits ahead of {main}"
+                 subtitle goes with it. The headline alone carries the meaning,
+                 and it is deliberately a DIFFERENT headline and a different
+                 icon from the working-tree clean state, which used to look
+                 identical to this one. */
+              <EmptyState
+                variant="user-cleared"
+                scale="canvas"
+                className="py-12"
+                icon={<CircleCheck />}
+                title={`No changes vs ${mainBranch}`}
+              />
             ) : sortedBaseBranchFiles !== null ? (
               <div>
                 <div className={REVIEW_HUB_STICKY_BAND}>
@@ -1754,12 +1833,26 @@ export function ReviewHubContent({
                   </>
                 ) : null
               ) : loadError ? (
-                <div className="p-4 text-xs text-status-error">
-                  <p className="mb-2">{loadError}</p>
-                  <Button variant="subtle" size="sm" onClick={() => void refresh()}>
-                    Retry
-                  </Button>
-                </div>
+                /* The ROOT failure: nothing else in the body rendered, so this
+                   is the one presentation that is genuinely blocking and the
+                   one that takes `role="alert"`. It previously rendered raw git
+                   stderr as its entire user-facing message, with no icon at
+                   all — which meant that under `forced-colors: active`, where
+                   the UA strips the tint, it was typographically identical to
+                   ordinary body text and nothing marked it as an error
+                   (WCAG 2.2 SC 1.4.1). The icon is what survives that. */
+                <InlineStatusBanner
+                  severity="error"
+                  role="alert"
+                  icon={CircleAlert}
+                  title="Couldn't load changes"
+                  description={loadError}
+                  action={{
+                    id: "review-hub-load-retry",
+                    label: "Retry",
+                    onClick: () => void refresh(),
+                  }}
+                />
               ) : status && isOperationState ? (
                 <ConflictPanel
                   status={status}
@@ -1771,35 +1864,50 @@ export function ReviewHubContent({
                   onContinue={handleContinueOperation}
                 />
               ) : status && totalChanges === 0 ? (
-                <div className="flex flex-col items-center justify-center py-12 text-daintree-text/50">
-                  <CheckSquare className="w-8 h-8 mb-2 text-daintree-text/30" />
-                  <p className="text-sm">Working tree clean</p>
-                  {status.hasRemote && (aheadCount ?? 0) > 0 ? (
-                    <>
-                      <p className="text-xs mt-1" data-testid="review-hub-clean-unpushed">
-                        {aheadCount} commit{aheadCount !== 1 ? "s" : ""} not pushed
-                      </p>
-                      {readinessSummary.pushReady && (
-                        <button
-                          type="button"
-                          onClick={() => void handlePushClean()}
-                          disabled={isPushing}
-                          data-testid="review-hub-clean-push"
-                          className={cn(
-                            "mt-3 px-2.5 py-1 rounded text-xs font-medium transition-colors",
-                            "bg-filter-selected-bg-soft hover:bg-tint/[0.14] text-daintree-text/80",
-                            "disabled:opacity-50 disabled:cursor-not-allowed",
-                            "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
-                          )}
-                        >
-                          {isPushing ? "Pushing…" : "Push"}
-                        </button>
-                      )}
-                    </>
-                  ) : (
-                    <p className="text-xs mt-1">No changes to commit</p>
-                  )}
-                </div>
+                status.hasRemote && (aheadCount ?? 0) > 0 ? (
+                  /* NOT a completed state. The working tree being clean is the
+                     inert fact here; the unpushed commits are the live one, so
+                     they own the headline and the icon rather than sitting in a
+                     12px subtitle under a completion mark. Previously this and
+                     the genuinely-finished state below rendered the same glyph,
+                     the same layout and the same type scale, which meant "you
+                     still have work to publish" and "you are done" were
+                     distinguishable only by reading the small print. */
+                  <div data-testid="review-hub-clean-unpushed">
+                    <EmptyState
+                      variant="zero-data"
+                      scale="canvas"
+                      className="py-12"
+                      icon={<ArrowUpFromLine />}
+                      title={`${aheadCount} commit${aheadCount !== 1 ? "s" : ""} ready to push`}
+                      description="Nothing left to commit — these commits just aren't on the remote yet."
+                      action={
+                        readinessSummary.pushReady ? (
+                          <Button
+                            variant="subtle"
+                            size="sm"
+                            onClick={() => void handlePushClean()}
+                            disabled={isPushing}
+                            data-testid="review-hub-clean-push"
+                          >
+                            {isPushing ? "Pushing…" : "Push"}
+                          </Button>
+                        ) : undefined
+                      }
+                    />
+                  </div>
+                ) : (
+                  /* Genuinely finished. `user-cleared` nulls the action and
+                     forbids a description, which is what removes the redundant
+                     "No changes to commit" line: the headline already says it. */
+                  <EmptyState
+                    variant="user-cleared"
+                    scale="canvas"
+                    className="py-12"
+                    icon={<CircleCheck />}
+                    title="Working tree clean"
+                  />
+                )
               ) : status ? (
                 <div>
                   {/* File-list disclosure — default collapsed so the commit
@@ -1850,18 +1958,24 @@ export function ReviewHubContent({
                         <div
                           ref={conflictSectionRef}
                           tabIndex={-1}
-                          className="px-4 py-2.5 bg-status-error/10 border-b border-divider flex items-start gap-2 outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
+                          /* Focusable because `handleFocusBlocker` sends focus
+                             here from the readiness rail's "conflicts" CTA, so
+                             it keeps its own ring. The banner inside carries the
+                             shared failure grammar; this wrapper only owns
+                             focus. */
+                          className="outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
                         >
-                          <AlertTriangle className="w-3.5 h-3.5 text-status-error mt-0.5 shrink-0" />
-                          <div className="text-xs text-status-error">
-                            <span className="font-medium">
-                              {status.conflicted.length} conflicted file
-                              {status.conflicted.length !== 1 ? "s" : ""}
-                            </span>
-                            <span className="text-daintree-text/60 ml-1">
-                              — resolve conflicts before committing
-                            </span>
-                          </div>
+                          <InlineStatusBanner
+                            severity="warning"
+                            role="status"
+                            ariaLive="polite"
+                            icon={AlertTriangle}
+                            title={`${status.conflicted.length} conflicted file${
+                              status.conflicted.length !== 1 ? "s" : ""
+                            }`}
+                            description="Resolve these before committing."
+                            animated={false}
+                          />
                         </div>
                       )}
 

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -49,7 +49,10 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeIdForPath } from "@/panels/diff/useWorktreeIdForPath";
 import { type FileStageRowSection } from "./FileStageRow";
 import { FileSection } from "./FileSection";
-import { useReviewHubStagingActions } from "./useReviewHubStagingActions";
+import {
+  useReviewHubStagingActions,
+  type ReviewHubActionFailure,
+} from "./useReviewHubStagingActions";
 import { BaseBranchFileRow } from "./BaseBranchFileRow";
 import { PushErrorBanner } from "./PushErrorBanner";
 import { PrStatusChip } from "./PrStatusChip";
@@ -96,6 +99,14 @@ import {
   sumChurn,
 } from "./reviewHubUtils";
 import { isGeneratedFile } from "../generatedFileClassifier";
+
+/**
+ * Floor for the dialog-hosted body, so the pane stops resizing itself around
+ * its own content as it moves between loading, failure, empty and resolved.
+ * Named rather than inlined to match `McpConfirmDialog`'s
+ * `PREVIEW_MIN_BODY_HEIGHT`, which reserves a dialog body for the same reason.
+ */
+const DIALOG_MIN_BODY_HEIGHT = "min-h-[22rem]";
 
 export interface ReviewHubContentProps {
   /**
@@ -170,7 +181,7 @@ export function ReviewHubContent({
   const [loading, setLoading] = useState(false);
   const [isBackgroundRefreshing, setIsBackgroundRefreshing] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<ReviewHubActionFailure | null>(null);
   const [pushError, setPushError] = useState<PushErrorState | null>(null);
   // Provider-classified push-error state, resolved async via the active forge
   // provider (ForgeProviderImpl lives in main). `forgeErrorCode` is a stable,
@@ -855,7 +866,10 @@ export function ReviewHubContent({
         await refresh();
       } catch (err) {
         hasAutoStagedRef.current = false;
-        setActionError(formatErrorMessage(err, "Failed to stage all files"));
+        setActionError({
+          title: "Couldn't stage all files",
+          detail: formatErrorMessage(err, "Failed to stage all files"),
+        });
       }
     })();
   }, [isOpen, autoStageOnOpen, status, refresh, worktreePath]);
@@ -964,7 +978,10 @@ export function ReviewHubContent({
         useDiffViewedStore.getState().clearWorktree(worktreePath);
         await refresh();
       } catch (err) {
-        setActionError(formatErrorMessage(err, "Failed to commit changes"));
+        setActionError({
+          title: "Couldn't commit changes",
+          detail: formatErrorMessage(err, "Failed to commit changes"),
+        });
         throw err;
       }
     },
@@ -978,7 +995,10 @@ export function ReviewHubContent({
       await window.electron.git.abortRepositoryOperation(worktreePath);
       await refresh();
     } catch (err) {
-      setActionError(formatErrorMessage(err, "Failed to abort repository operation"));
+      setActionError({
+        title: "Couldn't abort repository operation",
+        detail: formatErrorMessage(err, "Failed to abort repository operation"),
+      });
       throw err;
     }
   }, [worktreePath, refresh]);
@@ -990,7 +1010,10 @@ export function ReviewHubContent({
       await window.electron.git.continueRepositoryOperation(worktreePath);
       await refresh();
     } catch (err) {
-      setActionError(formatErrorMessage(err, "Failed to continue repository operation"));
+      setActionError({
+        title: "Couldn't continue repository operation",
+        detail: formatErrorMessage(err, "Failed to continue repository operation"),
+      });
       throw err;
     }
   }, [worktreePath, refresh]);
@@ -1009,7 +1032,10 @@ export function ReviewHubContent({
         }
         await window.electron.system.openInEditor(payload);
       } catch (err) {
-        setActionError(formatErrorMessage(err, "Failed to open file in editor"));
+        setActionError({
+          title: "Couldn't open file in editor",
+          detail: formatErrorMessage(err, "Failed to open file in editor"),
+        });
       }
     },
     [worktreePath]
@@ -1023,9 +1049,13 @@ export function ReviewHubContent({
         await window.electron.git.checkoutOursTheirs(worktreePath, filePath, side);
         await refresh();
       } catch (err) {
-        setActionError(
-          formatErrorMessage(err, side === "ours" ? "Failed to take ours" : "Failed to take theirs")
-        );
+        setActionError({
+          title: side === "ours" ? "Couldn't take ours" : "Couldn't take theirs",
+          detail: formatErrorMessage(
+            err,
+            side === "ours" ? "Failed to take ours" : "Failed to take theirs"
+          ),
+        });
         throw err;
       }
     },
@@ -1044,7 +1074,10 @@ export function ReviewHubContent({
         await window.electron.git.stageFile(worktreePath, filePath);
         await refresh();
       } catch (err) {
-        setActionError(formatErrorMessage(err, "Failed to mark file resolved"));
+        setActionError({
+          title: "Couldn't mark file resolved",
+          detail: formatErrorMessage(err, "Failed to mark file resolved"),
+        });
         throw err;
       }
     },
@@ -1109,7 +1142,10 @@ export function ReviewHubContent({
       try {
         await window.electron.git.commit(worktreePath, message);
       } catch (err) {
-        setActionError(formatErrorMessage(err, "Failed to commit changes"));
+        setActionError({
+          title: "Couldn't commit changes",
+          detail: formatErrorMessage(err, "Failed to commit changes"),
+        });
         throw err;
       }
       // Same review reset as handleCommit — the changeset starts over.
@@ -1666,8 +1702,8 @@ export function ReviewHubContent({
             role="status"
             ariaLive="polite"
             icon={CircleAlert}
-            title="Action failed"
-            description={actionError}
+            title={actionError.title}
+            description={actionError.detail}
             onClose={() => setActionError(null)}
             action={{
               id: "review-hub-action-error-refresh",
@@ -1704,6 +1740,20 @@ export function ReviewHubContent({
           data-testid="review-hub-scroll-container"
           className={cn(
             "flex-1 overflow-y-auto min-h-0",
+            // Reserve the body in the DIALOG host so the pane stops resizing
+            // itself around its own content. Loading, failure, empty and
+            // resolved states used to produce wildly different dialog heights
+            // — the same "Working tree clean" composition measured 458px on one
+            // route and 522px on another — so a retry or a mode switch read as
+            // a major transition rather than as the same surface updating.
+            // Long content still scrolls inside this block, and the Doherty
+            // gate still paints nothing before 400ms: the space is reserved,
+            // not filled.
+            //
+            // Grid-hosted panes are deliberately excluded. There the tile owns
+            // its own height from the layout, so a floor here would fight the
+            // grid instead of stabilising anything.
+            isDialog && DIALOG_MIN_BODY_HEIGHT,
             isBackgroundRefreshing && "surface-stale"
           )}
           aria-busy={isBackgroundRefreshing || undefined}
@@ -1878,9 +1928,30 @@ export function ReviewHubContent({
                       variant="zero-data"
                       scale="canvas"
                       className="py-12"
+                      // The copy below is conditional on `pushError`, and
+                      // EmptyState's fade-through keeps the OUTGOING text
+                      // visually dominant for ~150ms. That is long enough to
+                      // show "ready to push" underneath a banner that has
+                      // already said the push failed, so this one transition
+                      // has to be atomic rather than animated.
+                      instant={pushError !== null}
                       icon={<ArrowUpFromLine />}
-                      title={`${aheadCount} commit${aheadCount !== 1 ? "s" : ""} ready to push`}
-                      description="Nothing left to commit — these commits just aren't on the remote yet."
+                      title={
+                        pushError
+                          ? `${aheadCount} commit${aheadCount !== 1 ? "s" : ""} not pushed`
+                          : `${aheadCount} commit${aheadCount !== 1 ? "s" : ""} ready to push`
+                      }
+                      // "Ready to push" is a readiness claim, so it must not
+                      // survive a rejection: after a push fails, `pushReady`
+                      // goes false and the remedy moves to the push banner's
+                      // pull-rebase / force-push. Claiming readiness while the
+                      // banner directly above explains why it is not ready is
+                      // the pane contradicting itself.
+                      description={
+                        pushError
+                          ? "Nothing left to commit — resolve the push above to publish them."
+                          : "Nothing left to commit — these commits just aren't on the remote yet."
+                      }
                       action={
                         readinessSummary.pushReady ? (
                           <Button

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -63,6 +63,7 @@ import {
   deriveReviewReadiness,
   type ReviewReadinessCta,
   type ReviewReadinessItem,
+  type ReviewReadinessSummary,
 } from "./reviewReadiness";
 // Lazy: these modals statically reach the DiffViewer/CodeViewer/vendor-editor
 // chunks (~223 KB gzip), and ReviewPane is a first-render preload seed — a
@@ -670,13 +671,29 @@ export function ReviewHubContent({
    * the `push-failed` item is dropped while the dedicated push banner is up —
    * see the note at the `ReadinessRail` call site. Never used for gating.
    */
-  const railSummary = useMemo(() => {
+  const railSummary = useMemo<ReviewReadinessSummary>(() => {
     if (!pushError) return readinessSummary;
     const drop = (items: ReviewReadinessItem[]) => items.filter((i) => i.id !== "push-failed");
+    const blockers = drop(readinessSummary.blockers);
+    const warnings = drop(readinessSummary.warnings);
     return {
       ...readinessSummary,
-      blockers: drop(readinessSummary.blockers),
-      warnings: drop(readinessSummary.warnings),
+      // Re-derived from what SURVIVES the filter, by the same rule
+      // `deriveReviewReadiness` uses. The rail takes its glyph and copy from
+      // the first remaining item but announces `level` sr-only, so carrying the
+      // unfiltered verdict here would say "Blocked" beside a warning row
+      // whenever push-failed was the only blocker. `unknown` is passed through:
+      // it means staging status hasn't resolved, and the rail renders nothing.
+      level:
+        readinessSummary.level === "unknown"
+          ? readinessSummary.level
+          : blockers.length > 0
+            ? "blocked"
+            : warnings.length > 0
+              ? "needs-review"
+              : "ready",
+      blockers,
+      warnings,
       infos: drop(readinessSummary.infos),
       nextActions: drop(readinessSummary.nextActions),
     };
@@ -1706,8 +1723,8 @@ export function ReviewHubContent({
             description={actionError.detail}
             onClose={() => setActionError(null)}
             action={{
-              id: "review-hub-action-error-refresh",
-              label: "Refresh",
+              id: "review-hub-action-error-retry",
+              label: "Retry",
               onClick: () => void refresh(),
             }}
           />
@@ -1739,73 +1756,87 @@ export function ReviewHubContent({
           ref={scrollContainerRef}
           data-testid="review-hub-scroll-container"
           className={cn(
+            // `min-h-0` is load-bearing and stays alone in its Tailwind group:
+            // it is what lets the scroller shrink inside a dialog body capped
+            // at 85vh. A `min-h-*` floor added here would not sit beside it —
+            // tailwind-merge collapses the group and keeps the last one — so
+            // the reservation below lives on the content wrapper instead.
             "flex-1 overflow-y-auto min-h-0",
-            // Reserve the body in the DIALOG host so the pane stops resizing
-            // itself around its own content. Loading, failure, empty and
-            // resolved states used to produce wildly different dialog heights
-            // — the same "Working tree clean" composition measured 458px on one
-            // route and 522px on another — so a retry or a mode switch read as
-            // a major transition rather than as the same surface updating.
-            // Long content still scrolls inside this block, and the Doherty
-            // gate still paints nothing before 400ms: the space is reserved,
-            // not filled.
-            //
-            // Grid-hosted panes are deliberately excluded. There the tile owns
-            // its own height from the layout, so a floor here would fight the
-            // grid instead of stabilising anything.
-            isDialog && DIALOG_MIN_BODY_HEIGHT,
             isBackgroundRefreshing && "surface-stale"
           )}
           aria-busy={isBackgroundRefreshing || undefined}
           onScroll={handleScrollContainer}
         >
-          {diffMode === "base-branch" ? (
-            /* Base-branch diff panel */
-            baseBranchLoading ? (
-              showBaseBranchSkeleton ? (
-                <>
-                  <Skeleton label={`Loading changes vs ${mainBranch}`}>
-                    <SkeletonBone immediate className="h-8 mx-4 my-2" />
-                    <div className="px-2 py-1 flex flex-col gap-0.5">
-                      {Array.from({ length: 8 }).map((_, i) => (
-                        <div key={i} className="flex items-center gap-2 px-1.5 py-1.5">
-                          <SkeletonBone immediate className="h-4 w-4 shrink-0 rounded-sm" />
-                          <SkeletonBone
-                            immediate
-                            className={cn(
-                              "h-2.5",
-                              ["w-48", "w-32", "w-56", "w-24", "w-40", "w-36", "w-52", "w-28"][
-                                i % 8
-                              ]
-                            )}
-                          />
-                        </div>
-                      ))}
-                    </div>
-                  </Skeleton>
-                  <SkeletonHint className="px-4 py-2" onRetry={() => void fetchBaseBranch()} />
-                </>
-              ) : null
-            ) : baseBranchError ? (
-              /* A SECONDARY failure — the comparison could not be computed, but
+          {/* Reserve the body in the DIALOG host so the pane stops resizing
+              itself around its own content. Loading, failure, empty and
+              resolved states used to produce wildly different dialog heights
+              — the same "Working tree clean" composition measured 458px on one
+              route and 522px on another — so a retry or a mode switch read as
+              a major transition rather than as the same surface updating.
+              Long content still scrolls inside this block, and the Doherty
+              gate still paints nothing before 400ms: the space is reserved,
+              not filled.
+
+              The floor is on the CONTENT, not on the scrollport: as scrollable
+              content it grows the dialog while there is room and scrolls once
+              there isn't, so a short window (the 600px minimum, 85vh = 510px)
+              still shrinks the scroller instead of pushing the commit button
+              out through the dialog body's `overflow-hidden`.
+
+              Grid-hosted panes are deliberately excluded. There the tile owns
+              its own height from the layout, so a floor here would fight the
+              grid instead of stabilising anything. */}
+          <div
+            data-testid="review-hub-body-reservation"
+            className={cn(isDialog && DIALOG_MIN_BODY_HEIGHT)}
+          >
+            {diffMode === "base-branch" ? (
+              /* Base-branch diff panel */
+              baseBranchLoading ? (
+                showBaseBranchSkeleton ? (
+                  <>
+                    <Skeleton label={`Loading changes vs ${mainBranch}`}>
+                      <SkeletonBone immediate className="h-8 mx-4 my-2" />
+                      <div className="px-2 py-1 flex flex-col gap-0.5">
+                        {Array.from({ length: 8 }).map((_, i) => (
+                          <div key={i} className="flex items-center gap-2 px-1.5 py-1.5">
+                            <SkeletonBone immediate className="h-4 w-4 shrink-0 rounded-sm" />
+                            <SkeletonBone
+                              immediate
+                              className={cn(
+                                "h-2.5",
+                                ["w-48", "w-32", "w-56", "w-24", "w-40", "w-36", "w-52", "w-28"][
+                                  i % 8
+                                ]
+                              )}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </Skeleton>
+                    <SkeletonHint className="px-4 py-2" onRetry={() => void fetchBaseBranch()} />
+                  </>
+                ) : null
+              ) : baseBranchError ? (
+                /* A SECONDARY failure — the comparison could not be computed, but
                  the pane and its chrome are intact. Announced politely and
                  without moving focus (WCAG 2.2 SC 3.2.1/3.2.2); only the root
                  failure below is assertive. */
-              <InlineStatusBanner
-                severity="error"
-                role="status"
-                ariaLive="polite"
-                icon={CircleAlert}
-                title={`Couldn't compare with ${mainBranch}`}
-                description={baseBranchError}
-                action={{
-                  id: "review-hub-base-branch-retry",
-                  label: "Retry",
-                  onClick: () => void fetchBaseBranch(),
-                }}
-              />
-            ) : sortedBaseBranchFiles !== null && sortedBaseBranchFiles.length === 0 ? (
-              /* A completed inspection: there is genuinely nothing to review
+                <InlineStatusBanner
+                  severity="error"
+                  role="status"
+                  ariaLive="polite"
+                  icon={CircleAlert}
+                  title={`Couldn't compare with ${mainBranch}`}
+                  description={baseBranchError}
+                  action={{
+                    id: "review-hub-base-branch-retry",
+                    label: "Retry",
+                    onClick: () => void fetchBaseBranch(),
+                  }}
+                />
+              ) : sortedBaseBranchFiles !== null && sortedBaseBranchFiles.length === 0 ? (
+                /* A completed inspection: there is genuinely nothing to review
                  against the base branch. `user-cleared` is the Blank-Slate
                  variant — it forbids a description and an action by design, so
                  the redundant "This branch has no commits ahead of {main}"
@@ -1813,77 +1844,77 @@ export function ReviewHubContent({
                  and it is deliberately a DIFFERENT headline and a different
                  icon from the working-tree clean state, which used to look
                  identical to this one. */
-              <EmptyState
-                variant="user-cleared"
-                scale="canvas"
-                className="py-12"
-                icon={<CircleCheck />}
-                title={`No changes vs ${mainBranch}`}
-              />
-            ) : sortedBaseBranchFiles !== null ? (
-              <div>
-                <div className={REVIEW_HUB_STICKY_BAND}>
-                  <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle border-b border-divider">
-                    <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-                      Changed vs {mainBranch}
-                      <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
-                        {sortedBaseBranchFiles.length} file
-                        {sortedBaseBranchFiles.length !== 1 ? "s" : ""}
-                        {(baseBranchChurn.ins > 0 || baseBranchChurn.del > 0) && (
-                          <>
-                            {" "}
-                            <span className="text-status-success/80">
-                              +{baseBranchChurn.ins}
-                            </span>{" "}
-                            <span className="text-status-error/80">-{baseBranchChurn.del}</span>
-                          </>
-                        )}
+                <EmptyState
+                  variant="user-cleared"
+                  scale="canvas"
+                  className="py-12"
+                  icon={<CircleCheck />}
+                  title={`No changes vs ${mainBranch}`}
+                />
+              ) : sortedBaseBranchFiles !== null ? (
+                <div>
+                  <div className={REVIEW_HUB_STICKY_BAND}>
+                    <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle border-b border-divider">
+                      <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+                        Changed vs {mainBranch}
+                        <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+                          {sortedBaseBranchFiles.length} file
+                          {sortedBaseBranchFiles.length !== 1 ? "s" : ""}
+                          {(baseBranchChurn.ins > 0 || baseBranchChurn.del > 0) && (
+                            <>
+                              {" "}
+                              <span className="text-status-success/80">
+                                +{baseBranchChurn.ins}
+                              </span>{" "}
+                              <span className="text-status-error/80">-{baseBranchChurn.del}</span>
+                            </>
+                          )}
+                        </span>
                       </span>
-                    </span>
+                    </div>
+                  </div>
+                  <div className="px-2 py-1 flex flex-col gap-0.5">
+                    {sortedBaseBranchFiles.map((file) => {
+                      const decoration = reviewDecorations[file.path];
+                      return (
+                        <BaseBranchFileRow
+                          key={`${file.status}:${file.path}`}
+                          file={file}
+                          onClick={(e) => {
+                            diffTriggerRef.current = e.currentTarget;
+                            setSelectedBaseBranchFile(file);
+                          }}
+                          unresolvedDecoration={decoration}
+                          onBadgeClick={
+                            decoration?.url
+                              ? () => void systemClient.openExternal(decoration.url as string)
+                              : undefined
+                          }
+                        />
+                      );
+                    })}
                   </div>
                 </div>
-                <div className="px-2 py-1 flex flex-col gap-0.5">
-                  {sortedBaseBranchFiles.map((file) => {
-                    const decoration = reviewDecorations[file.path];
-                    return (
-                      <BaseBranchFileRow
-                        key={`${file.status}:${file.path}`}
-                        file={file}
-                        onClick={(e) => {
-                          diffTriggerRef.current = e.currentTarget;
-                          setSelectedBaseBranchFile(file);
-                        }}
-                        unresolvedDecoration={decoration}
-                        onBadgeClick={
-                          decoration?.url
-                            ? () => void systemClient.openExternal(decoration.url as string)
-                            : undefined
-                        }
-                      />
-                    );
-                  })}
-                </div>
-              </div>
-            ) : null
-          ) : (
-            /* Working-tree panel */
-            <>
-              {loading && !status ? (
-                showWorkingTreeSkeleton ? (
-                  <>
-                    {/* File-list disclosure header — mirrors the collapsed-by-
+              ) : null
+            ) : (
+              /* Working-tree panel */
+              <>
+                {loading && !status ? (
+                  showWorkingTreeSkeleton ? (
+                    <>
+                      {/* File-list disclosure header — mirrors the collapsed-by-
                         default list bar. The commit-panel skeleton lives outside
                         this scroll container (below), matching the real layout. */}
-                    <Skeleton label="Loading review changes">
-                      <div className="px-4 py-2 bg-overlay-subtle border-b border-divider">
-                        <SkeletonBone immediate className="h-3.5 w-28" />
-                      </div>
-                    </Skeleton>
-                    <SkeletonHint className="px-4 py-2" onRetry={() => void refresh()} />
-                  </>
-                ) : null
-              ) : loadError ? (
-                /* The ROOT failure: nothing else in the body rendered, so this
+                      <Skeleton label="Loading review changes">
+                        <div className="px-4 py-2 bg-overlay-subtle border-b border-divider">
+                          <SkeletonBone immediate className="h-3.5 w-28" />
+                        </div>
+                      </Skeleton>
+                      <SkeletonHint className="px-4 py-2" onRetry={() => void refresh()} />
+                    </>
+                  ) : null
+                ) : loadError ? (
+                  /* The ROOT failure: nothing else in the body rendered, so this
                    is the one presentation that is genuinely blocking and the
                    one that takes `role="alert"`. It previously rendered raw git
                    stderr as its entire user-facing message, with no icon at
@@ -1891,31 +1922,31 @@ export function ReviewHubContent({
                    the UA strips the tint, it was typographically identical to
                    ordinary body text and nothing marked it as an error
                    (WCAG 2.2 SC 1.4.1). The icon is what survives that. */
-                <InlineStatusBanner
-                  severity="error"
-                  role="alert"
-                  icon={CircleAlert}
-                  title="Couldn't load changes"
-                  description={loadError}
-                  action={{
-                    id: "review-hub-load-retry",
-                    label: "Retry",
-                    onClick: () => void refresh(),
-                  }}
-                />
-              ) : status && isOperationState ? (
-                <ConflictPanel
-                  status={status}
-                  worktreePath={worktreePath}
-                  onMarkResolved={handleMarkResolved}
-                  onOpenInEditor={handleOpenInEditor}
-                  onCheckoutOursTheirs={handleCheckoutOursTheirs}
-                  onAbort={handleAbortOperation}
-                  onContinue={handleContinueOperation}
-                />
-              ) : status && totalChanges === 0 ? (
-                status.hasRemote && (aheadCount ?? 0) > 0 ? (
-                  /* NOT a completed state. The working tree being clean is the
+                  <InlineStatusBanner
+                    severity="error"
+                    role="alert"
+                    icon={CircleAlert}
+                    title="Couldn't load changes"
+                    description={loadError}
+                    action={{
+                      id: "review-hub-load-retry",
+                      label: "Retry",
+                      onClick: () => void refresh(),
+                    }}
+                  />
+                ) : status && isOperationState ? (
+                  <ConflictPanel
+                    status={status}
+                    worktreePath={worktreePath}
+                    onMarkResolved={handleMarkResolved}
+                    onOpenInEditor={handleOpenInEditor}
+                    onCheckoutOursTheirs={handleCheckoutOursTheirs}
+                    onAbort={handleAbortOperation}
+                    onContinue={handleContinueOperation}
+                  />
+                ) : status && totalChanges === 0 ? (
+                  status.hasRemote && (aheadCount ?? 0) > 0 ? (
+                    /* NOT a completed state. The working tree being clean is the
                      inert fact here; the unpushed commits are the live one, so
                      they own the headline and the icon rather than sitting in a
                      12px subtitle under a completion mark. Previously this and
@@ -1923,199 +1954,200 @@ export function ReviewHubContent({
                      the same layout and the same type scale, which meant "you
                      still have work to publish" and "you are done" were
                      distinguishable only by reading the small print. */
-                  <div data-testid="review-hub-clean-unpushed">
-                    <EmptyState
-                      variant="zero-data"
-                      scale="canvas"
-                      className="py-12"
-                      // The copy below is conditional on `pushError`, and
-                      // EmptyState's fade-through keeps the OUTGOING text
-                      // visually dominant for ~150ms. That is long enough to
-                      // show "ready to push" underneath a banner that has
-                      // already said the push failed, so this one transition
-                      // has to be atomic rather than animated.
-                      instant={pushError !== null}
-                      icon={<ArrowUpFromLine />}
-                      title={
-                        pushError
-                          ? `${aheadCount} commit${aheadCount !== 1 ? "s" : ""} not pushed`
-                          : `${aheadCount} commit${aheadCount !== 1 ? "s" : ""} ready to push`
-                      }
-                      // "Ready to push" is a readiness claim, so it must not
-                      // survive a rejection: after a push fails, `pushReady`
-                      // goes false and the remedy moves to the push banner's
-                      // pull-rebase / force-push. Claiming readiness while the
-                      // banner directly above explains why it is not ready is
-                      // the pane contradicting itself.
-                      description={
-                        pushError
-                          ? "Nothing left to commit — resolve the push above to publish them."
-                          : "Nothing left to commit — these commits just aren't on the remote yet."
-                      }
-                      action={
-                        readinessSummary.pushReady ? (
-                          <Button
-                            variant="subtle"
-                            size="sm"
-                            onClick={() => void handlePushClean()}
-                            disabled={isPushing}
-                            data-testid="review-hub-clean-push"
-                          >
-                            {isPushing ? "Pushing…" : "Push"}
-                          </Button>
-                        ) : undefined
-                      }
-                    />
-                  </div>
-                ) : (
-                  /* Genuinely finished. `user-cleared` nulls the action and
+                    <div data-testid="review-hub-clean-unpushed">
+                      <EmptyState
+                        variant="zero-data"
+                        scale="canvas"
+                        className="py-12"
+                        // The copy below is conditional on `pushError`, and
+                        // EmptyState's fade-through keeps the OUTGOING text
+                        // visually dominant for ~150ms. That is long enough to
+                        // show "ready to push" underneath a banner that has
+                        // already said the push failed, so this one transition
+                        // has to be atomic rather than animated.
+                        instant={pushError !== null}
+                        icon={<ArrowUpFromLine />}
+                        title={
+                          pushError
+                            ? `${aheadCount} commit${aheadCount !== 1 ? "s" : ""} not pushed`
+                            : `${aheadCount} commit${aheadCount !== 1 ? "s" : ""} ready to push`
+                        }
+                        // "Ready to push" is a readiness claim, so it must not
+                        // survive a rejection: after a push fails, `pushReady`
+                        // goes false and the remedy moves to the push banner's
+                        // pull-rebase / force-push. Claiming readiness while the
+                        // banner directly above explains why it is not ready is
+                        // the pane contradicting itself.
+                        description={
+                          pushError
+                            ? "Nothing left to commit — resolve the push above to publish them."
+                            : "Nothing left to commit — these commits just aren't on the remote yet."
+                        }
+                        action={
+                          readinessSummary.pushReady ? (
+                            <Button
+                              variant="subtle"
+                              size="sm"
+                              onClick={() => void handlePushClean()}
+                              disabled={isPushing}
+                              data-testid="review-hub-clean-push"
+                            >
+                              {isPushing ? "Pushing…" : "Push"}
+                            </Button>
+                          ) : undefined
+                        }
+                      />
+                    </div>
+                  ) : (
+                    /* Genuinely finished. `user-cleared` nulls the action and
                      forbids a description, which is what removes the redundant
                      "No changes to commit" line: the headline already says it. */
-                  <EmptyState
-                    variant="user-cleared"
-                    scale="canvas"
-                    className="py-12"
-                    icon={<CircleCheck />}
-                    title="Working tree clean"
-                  />
-                )
-              ) : status ? (
-                <div>
-                  {/* File-list disclosure — default collapsed so the commit
+                    <EmptyState
+                      variant="user-cleared"
+                      scale="canvas"
+                      className="py-12"
+                      icon={<CircleCheck />}
+                      title="Working tree clean"
+                    />
+                  )
+                ) : status ? (
+                  <div>
+                    {/* File-list disclosure — default collapsed so the commit
                       textarea is the focal point on open. State lives per
                       worktree in uiStore (session-scoped, in-memory only). */}
-                  <div className="px-4 py-2 bg-overlay-subtle border-b border-divider flex items-center justify-between">
-                    <button
-                      type="button"
-                      onClick={() => setFileListExpanded(worktreePath, !fileListExpanded)}
-                      aria-expanded={fileListExpanded}
-                      aria-controls={`review-hub-files-${worktreePath}`}
-                      data-testid="review-hub-file-list-toggle"
-                      className={cn(
-                        "inline-flex items-center gap-1 text-[11px] font-medium text-daintree-text/70 hover:text-daintree-text transition-colors",
-                        "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent rounded"
-                      )}
-                    >
-                      <ChevronRight
+                    <div className="px-4 py-2 bg-overlay-subtle border-b border-divider flex items-center justify-between">
+                      <button
+                        type="button"
+                        onClick={() => setFileListExpanded(worktreePath, !fileListExpanded)}
+                        aria-expanded={fileListExpanded}
+                        aria-controls={`review-hub-files-${worktreePath}`}
+                        data-testid="review-hub-file-list-toggle"
                         className={cn(
-                          "w-3 h-3 transition-transform duration-150",
-                          fileListExpanded && "rotate-90"
+                          "inline-flex items-center gap-1 text-[11px] font-medium text-daintree-text/70 hover:text-daintree-text transition-colors",
+                          "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent rounded"
                         )}
-                        aria-hidden="true"
-                      />
-                      <span>
-                        {fileListExpanded ? "Hide" : "Show"} files ({totalChanges})
-                      </span>
-                    </button>
-                  </div>
-                  {fileListExpanded && (
-                    <div
-                      id={`review-hub-files-${worktreePath}`}
-                      ref={fileListRef}
-                      role="listbox"
-                      aria-label="Changed files"
-                      tabIndex={-1}
-                      // Stands the global Shift+F10 / Menu-key handler down so
-                      // the focused row's own menu opens instead of the focused
-                      // panel's (`useGlobalKeybindings`).
-                      data-row-menu=""
-                      aria-activedescendant={
-                        focusedIndex >= 0 ? `review-hub-row-${focusedIndex}` : undefined
-                      }
-                      className="outline-hidden"
-                    >
-                      {/* Conflict warning */}
-                      {hasConflicts && (
-                        <div
-                          ref={conflictSectionRef}
-                          tabIndex={-1}
-                          /* Focusable because `handleFocusBlocker` sends focus
+                      >
+                        <ChevronRight
+                          className={cn(
+                            "w-3 h-3 transition-transform duration-150",
+                            fileListExpanded && "rotate-90"
+                          )}
+                          aria-hidden="true"
+                        />
+                        <span>
+                          {fileListExpanded ? "Hide" : "Show"} files ({totalChanges})
+                        </span>
+                      </button>
+                    </div>
+                    {fileListExpanded && (
+                      <div
+                        id={`review-hub-files-${worktreePath}`}
+                        ref={fileListRef}
+                        role="listbox"
+                        aria-label="Changed files"
+                        tabIndex={-1}
+                        // Stands the global Shift+F10 / Menu-key handler down so
+                        // the focused row's own menu opens instead of the focused
+                        // panel's (`useGlobalKeybindings`).
+                        data-row-menu=""
+                        aria-activedescendant={
+                          focusedIndex >= 0 ? `review-hub-row-${focusedIndex}` : undefined
+                        }
+                        className="outline-hidden"
+                      >
+                        {/* Conflict warning */}
+                        {hasConflicts && (
+                          <div
+                            ref={conflictSectionRef}
+                            tabIndex={-1}
+                            /* Focusable because `handleFocusBlocker` sends focus
                              here from the readiness rail's "conflicts" CTA, so
                              it keeps its own ring. The banner inside carries the
                              shared failure grammar; this wrapper only owns
                              focus. */
-                          className="outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
-                        >
-                          <InlineStatusBanner
-                            severity="warning"
-                            role="status"
-                            ariaLive="polite"
-                            icon={AlertTriangle}
-                            title={`${status.conflicted.length} conflicted file${
-                              status.conflicted.length !== 1 ? "s" : ""
-                            }`}
-                            description="Resolve these before committing."
-                            animated={false}
-                          />
-                        </div>
-                      )}
+                            className="outline-hidden focus:ring-2 focus:ring-daintree-accent/30"
+                          >
+                            <InlineStatusBanner
+                              severity="warning"
+                              role="status"
+                              ariaLive="polite"
+                              icon={AlertTriangle}
+                              title={`${status.conflicted.length} conflicted file${
+                                status.conflicted.length !== 1 ? "s" : ""
+                              }`}
+                              description="Resolve these before committing."
+                              animated={false}
+                            />
+                          </div>
+                        )}
 
-                      {/* Staged section */}
-                      <FileSection
-                        isStaged={true}
-                        files={derivedStaged}
-                        allFiles={status.staged}
-                        indexOffset={0}
-                        focusedIndex={focusedIndex}
-                        selectionSection={selectionSection}
-                        selectedPaths={selectedPaths}
-                        hasSelection={hasStagedSelection}
-                        view={stagedView}
-                        setView={setStagedView}
-                        inputRef={stagedInputRef}
-                        setFilterQuery={setStagedFilterQuery}
-                        clearFilter={clearStagedFilter}
-                        onToggle={handleToggleStaged}
-                        onRowClick={handleRowClick}
-                        onBulkAction={() => {
-                          const scope = resolveBulkScope(stagedView, hasStagedSelection);
-                          void (scope === "selection"
-                            ? handleUnstageSelection()
-                            : scope === "shown"
-                              ? handleUnstageFiltered()
-                              : handleUnstageAll());
-                        }}
-                        viewedFiles={viewedFiles}
-                        onViewedChange={handleViewedChange}
-                        renderRowMenu={renderRowMenu}
-                      />
+                        {/* Staged section */}
+                        <FileSection
+                          isStaged={true}
+                          files={derivedStaged}
+                          allFiles={status.staged}
+                          indexOffset={0}
+                          focusedIndex={focusedIndex}
+                          selectionSection={selectionSection}
+                          selectedPaths={selectedPaths}
+                          hasSelection={hasStagedSelection}
+                          view={stagedView}
+                          setView={setStagedView}
+                          inputRef={stagedInputRef}
+                          setFilterQuery={setStagedFilterQuery}
+                          clearFilter={clearStagedFilter}
+                          onToggle={handleToggleStaged}
+                          onRowClick={handleRowClick}
+                          onBulkAction={() => {
+                            const scope = resolveBulkScope(stagedView, hasStagedSelection);
+                            void (scope === "selection"
+                              ? handleUnstageSelection()
+                              : scope === "shown"
+                                ? handleUnstageFiltered()
+                                : handleUnstageAll());
+                          }}
+                          viewedFiles={viewedFiles}
+                          onViewedChange={handleViewedChange}
+                          renderRowMenu={renderRowMenu}
+                        />
 
-                      {/* Unstaged section */}
-                      <FileSection
-                        sectionRef={unstagedSectionRef}
-                        isStaged={false}
-                        files={derivedUnstaged}
-                        allFiles={status.unstaged}
-                        indexOffset={derivedStaged.length}
-                        focusedIndex={focusedIndex}
-                        selectionSection={selectionSection}
-                        selectedPaths={selectedPaths}
-                        hasSelection={hasUnstagedSelection}
-                        view={changesView}
-                        setView={setChangesView}
-                        inputRef={changesInputRef}
-                        setFilterQuery={setChangesFilterQuery}
-                        clearFilter={clearChangesFilter}
-                        onToggle={handleToggleUnstaged}
-                        onRowClick={handleRowClick}
-                        onBulkAction={() => {
-                          const scope = resolveBulkScope(changesView, hasUnstagedSelection);
-                          void (scope === "selection"
-                            ? handleStageSelection()
-                            : scope === "shown"
-                              ? handleStageFiltered()
-                              : handleStageAll());
-                        }}
-                        viewedFiles={viewedFiles}
-                        onViewedChange={handleViewedChange}
-                        renderRowMenu={renderRowMenu}
-                      />
-                    </div>
-                  )}
-                </div>
-              ) : null}
-            </>
-          )}
+                        {/* Unstaged section */}
+                        <FileSection
+                          sectionRef={unstagedSectionRef}
+                          isStaged={false}
+                          files={derivedUnstaged}
+                          allFiles={status.unstaged}
+                          indexOffset={derivedStaged.length}
+                          focusedIndex={focusedIndex}
+                          selectionSection={selectionSection}
+                          selectedPaths={selectedPaths}
+                          hasSelection={hasUnstagedSelection}
+                          view={changesView}
+                          setView={setChangesView}
+                          inputRef={changesInputRef}
+                          setFilterQuery={setChangesFilterQuery}
+                          clearFilter={clearChangesFilter}
+                          onToggle={handleToggleUnstaged}
+                          onRowClick={handleRowClick}
+                          onBulkAction={() => {
+                            const scope = resolveBulkScope(changesView, hasUnstagedSelection);
+                            void (scope === "selection"
+                              ? handleStageSelection()
+                              : scope === "shown"
+                                ? handleStageFiltered()
+                                : handleStageAll());
+                          }}
+                          viewedFiles={viewedFiles}
+                          onViewedChange={handleViewedChange}
+                          renderRowMenu={renderRowMenu}
+                        />
+                      </div>
+                    )}
+                  </div>
+                ) : null}
+              </>
+            )}
+          </div>
         </div>
 
         {/* Commit-panel skeleton — sibling of the scroll container so it occupies

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.lifecycleAndReadiness.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.lifecycleAndReadiness.test.tsx
@@ -902,13 +902,23 @@ describe("ReviewHub", () => {
       render(<ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
     }
 
+    /**
+     * These assert the RULE — an unfinished state must not present itself as a
+     * finished one — rather than the exact words, so a later copy change does
+     * not force an identical edit here. The pair that matters is: the unpushed
+     * state never shows the completion headline, and the completed state never
+     * shows an action.
+     */
+    const COMPLETION_HEADLINE = "Working tree clean";
+
     it("names the unpushed commits and gates Push behind the D2 preview dialog", async () => {
       renderCleanHub({ aheadCount: 2, behindCount: 0 });
-      await waitFor(() => screen.getByText("Working tree clean"));
+      const unpushed = await screen.findByTestId("review-hub-clean-unpushed");
 
-      expect(screen.getByTestId("review-hub-clean-unpushed").textContent).toBe(
-        "2 commits not pushed"
-      );
+      // The count is what the user acts on, so it leads.
+      expect(unpushed.textContent).toContain("2 commits");
+      // ...and this state must NOT read as finished.
+      expect(screen.queryByText(COMPLETION_HEADLINE)).toBeNull();
 
       act(() => void fireEvent.click(screen.getByTestId("review-hub-clean-push")));
       // The click only requests the push confirmation — nothing reaches the
@@ -924,7 +934,7 @@ describe("ReviewHub", () => {
 
     it("does not push when the preview dialog is declined", async () => {
       renderCleanHub({ aheadCount: 1, behindCount: 0 });
-      await waitFor(() => screen.getByText("Working tree clean"));
+      await screen.findByTestId("review-hub-clean-unpushed");
 
       act(() => void fireEvent.click(screen.getByTestId("review-hub-clean-push")));
       await act(async () => {
@@ -937,40 +947,45 @@ describe("ReviewHub", () => {
       // behindCount undefined — an unknown divergence state must never read
       // as pushable (mirrors deriveReviewReadiness.pushReady).
       renderCleanHub({ aheadCount: 3, behindCount: undefined });
-      await waitFor(() => screen.getByText("Working tree clean"));
+      const unpushed = await screen.findByTestId("review-hub-clean-unpushed");
 
-      expect(screen.getByTestId("review-hub-clean-unpushed").textContent).toBe(
-        "3 commits not pushed"
-      );
+      expect(unpushed.textContent).toContain("3 commits");
       expect(screen.queryByTestId("review-hub-clean-push")).toBeNull();
+      expect(screen.queryByText(COMPLETION_HEADLINE)).toBeNull();
     });
 
     it("offers no Push while behind the remote", async () => {
       renderCleanHub({ aheadCount: 2, behindCount: 1 });
-      await waitFor(() => screen.getByText("Working tree clean"));
+      const unpushed = await screen.findByTestId("review-hub-clean-unpushed");
       // The unpushed copy proves the divergence fixture reached the component
       // — without it the missing button would pass vacuously.
-      expect(screen.getByTestId("review-hub-clean-unpushed").textContent).toBe(
-        "2 commits not pushed"
-      );
+      expect(unpushed.textContent).toContain("2 commits");
       expect(screen.queryByTestId("review-hub-clean-push")).toBeNull();
     });
 
-    it("keeps the quiet no-changes copy when there is nothing to push", async () => {
+    it("renders the completed state quietly when there is nothing to push", async () => {
       renderCleanHub({ aheadCount: 0, behindCount: 0 });
-      await waitFor(() => screen.getByText("Working tree clean"));
+      await waitFor(() => screen.getByText(COMPLETION_HEADLINE));
 
-      expect(screen.getByText("No changes to commit")).toBeDefined();
+      // A completed-work state carries no next action and no restatement of
+      // its own headline — the EmptyState `user-cleared` contract.
       expect(screen.queryByTestId("review-hub-clean-unpushed")).toBeNull();
       expect(screen.queryByTestId("review-hub-clean-push")).toBeNull();
     });
 
-    it("keeps the quiet copy when unpushed commits exist but there is no remote", async () => {
+    it("stays quiet when unpushed commits exist but there is no remote", async () => {
       renderCleanHub({ aheadCount: 2, behindCount: 0 }, false);
-      await waitFor(() => screen.getByText("Working tree clean"));
-
-      expect(screen.getByText("No changes to commit")).toBeDefined();
+      await waitFor(() => screen.getByText(COMPLETION_HEADLINE));
       expect(screen.queryByTestId("review-hub-clean-push")).toBeNull();
+    });
+
+    it("never renders the unpushed state and the completed state together", async () => {
+      // The defect this closes: both states shared one composition, so the
+      // only thing distinguishing "you still have work to publish" from "you
+      // are done" was a 12px subtitle. They must now be mutually exclusive.
+      renderCleanHub({ aheadCount: 2, behindCount: 0 });
+      await screen.findByTestId("review-hub-clean-unpushed");
+      expect(screen.queryByText(COMPLETION_HEADLINE)).toBeNull();
     });
   });
 });

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.stale.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.stale.test.tsx
@@ -305,4 +305,38 @@ describe("ReviewHub stale visual", () => {
       expect(scroll.getAttribute("aria-busy")).toBeNull();
     });
   });
+
+  it("keeps the scroller shrinkable in the dialog host and puts the height floor on the content", async () => {
+    render(
+      <ReviewHubContent
+        isOpen={true}
+        location="dialog"
+        worktreePath={WORKTREE_PATH}
+        onClose={vi.fn()}
+      />
+    );
+    await waitFor(() => screen.getByText("index.ts"));
+
+    // A `min-h-*` floor on the scrollport is not additive: tailwind-merge keeps
+    // the last class in the group, so it silently replaces `min-h-0` and the
+    // scroller can no longer shrink inside the dialog body's capped, clipped
+    // box — pushing the commit button out of view on short windows. The floor
+    // belongs to the content, which grows the dialog while there is room and
+    // scrolls once there isn't.
+    const scroll = findScrollContainer();
+    expect(scroll.classList.contains("min-h-0")).toBe(true);
+    expect([...scroll.classList].some((c) => /^min-h-(?!0$)/.test(c))).toBe(false);
+
+    const reservation = screen.getByTestId("review-hub-body-reservation");
+    expect(scroll.contains(reservation)).toBe(true);
+    expect([...reservation.classList].some((c) => /^min-h-(?!0$)/.test(c))).toBe(true);
+  });
+
+  it("reserves nothing in the grid host, where the tile owns its height", async () => {
+    render(<ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("index.ts"));
+
+    const reservation = screen.getByTestId("review-hub-body-reservation");
+    expect([...reservation.classList].some((c) => /^min-h-/.test(c))).toBe(false);
+  });
 });

--- a/src/components/Worktree/ReviewHub/useReviewHubStagingActions.ts
+++ b/src/components/Worktree/ReviewHub/useReviewHubStagingActions.ts
@@ -3,6 +3,17 @@ import type { Dispatch, RefObject, SetStateAction } from "react";
 import type { StagingFileEntry } from "@shared/types";
 import type { debounce } from "@/utils/debounce";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+/**
+ * A failed review-hub operation. The title is the operation, so the banner can
+ * lead with what the user was doing ("Couldn't stage files") instead of a
+ * generic label; the detail is git's own message, demoted to supporting copy.
+ * Keeping them separate is what stops raw stderr becoming the headline.
+ */
+export interface ReviewHubActionFailure {
+  title: string;
+  detail: string;
+}
 import type { FileStageRowSection } from "./FileStageRow";
 
 interface UseReviewHubStagingActionsArgs {
@@ -12,7 +23,7 @@ interface UseReviewHubStagingActionsArgs {
   derivedUnstaged: StagingFileEntry[];
   selectedPaths: Set<string>;
   selectionSection: FileStageRowSection | null;
-  setActionError: (message: string | null) => void;
+  setActionError: (failure: ReviewHubActionFailure | null) => void;
   setSelectedPaths: Dispatch<SetStateAction<Set<string>>>;
   setSelectionSection: Dispatch<SetStateAction<FileStageRowSection | null>>;
   selectionAnchorRef: RefObject<string | null>;
@@ -55,7 +66,10 @@ export function useReviewHubStagingActions({
         await window.electron.git.stageFile(worktreePath, filePath);
         await refresh();
       } catch (err) {
-        setActionError(formatErrorMessage(err, "Failed to stage file"));
+        setActionError({
+          title: "Couldn't stage file",
+          detail: formatErrorMessage(err, "Failed to stage file"),
+        });
       }
     },
     [worktreePath, refresh, setActionError, debouncedBgRefreshRef]
@@ -69,7 +83,10 @@ export function useReviewHubStagingActions({
         await window.electron.git.unstageFile(worktreePath, filePath);
         await refresh();
       } catch (err) {
-        setActionError(formatErrorMessage(err, "Failed to unstage file"));
+        setActionError({
+          title: "Couldn't unstage file",
+          detail: formatErrorMessage(err, "Failed to unstage file"),
+        });
       }
     },
     [worktreePath, refresh, setActionError, debouncedBgRefreshRef]
@@ -82,7 +99,10 @@ export function useReviewHubStagingActions({
       await window.electron.git.stageAll(worktreePath);
       await refresh();
     } catch (err) {
-      setActionError(formatErrorMessage(err, "Failed to stage all files"));
+      setActionError({
+        title: "Couldn't stage all files",
+        detail: formatErrorMessage(err, "Failed to stage all files"),
+      });
     }
   }, [worktreePath, refresh, setActionError, debouncedBgRefreshRef]);
 
@@ -93,7 +113,10 @@ export function useReviewHubStagingActions({
       await window.electron.git.unstageAll(worktreePath);
       await refresh();
     } catch (err) {
-      setActionError(formatErrorMessage(err, "Failed to unstage all files"));
+      setActionError({
+        title: "Couldn't unstage all files",
+        detail: formatErrorMessage(err, "Failed to unstage all files"),
+      });
     }
   }, [worktreePath, refresh, setActionError, debouncedBgRefreshRef]);
 
@@ -105,7 +128,10 @@ export function useReviewHubStagingActions({
     try {
       await window.electron.git.stageFiles(worktreePath, paths);
     } catch (err) {
-      setActionError(formatErrorMessage(err, "Failed to stage files"));
+      setActionError({
+        title: "Couldn't stage files",
+        detail: formatErrorMessage(err, "Failed to stage files"),
+      });
     } finally {
       await refresh();
     }
@@ -119,7 +145,10 @@ export function useReviewHubStagingActions({
     try {
       await window.electron.git.unstageFiles(worktreePath, paths);
     } catch (err) {
-      setActionError(formatErrorMessage(err, "Failed to unstage files"));
+      setActionError({
+        title: "Couldn't unstage files",
+        detail: formatErrorMessage(err, "Failed to unstage files"),
+      });
     } finally {
       await refresh();
     }
@@ -139,7 +168,10 @@ export function useReviewHubStagingActions({
       selectionAnchorRef.current = null;
       await refresh();
     } catch (err) {
-      setActionError(formatErrorMessage(err, "Failed to stage selected files"));
+      setActionError({
+        title: "Couldn't stage selected files",
+        detail: formatErrorMessage(err, "Failed to stage selected files"),
+      });
     } finally {
       isBulkStagingRef.current = false;
     }
@@ -169,7 +201,10 @@ export function useReviewHubStagingActions({
       selectionAnchorRef.current = null;
       await refresh();
     } catch (err) {
-      setActionError(formatErrorMessage(err, "Failed to unstage selected files"));
+      setActionError({
+        title: "Couldn't unstage selected files",
+        detail: formatErrorMessage(err, "Failed to unstage selected files"),
+      });
     } finally {
       isBulkStagingRef.current = false;
     }

--- a/src/components/Worktree/ReviewHub/useReviewHubStagingActions.ts
+++ b/src/components/Worktree/ReviewHub/useReviewHubStagingActions.ts
@@ -3,6 +3,7 @@ import type { Dispatch, RefObject, SetStateAction } from "react";
 import type { StagingFileEntry } from "@shared/types";
 import type { debounce } from "@/utils/debounce";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { FileStageRowSection } from "./FileStageRow";
 
 /**
  * A failed review-hub operation. The title is the operation, so the banner can
@@ -14,7 +15,6 @@ export interface ReviewHubActionFailure {
   title: string;
   detail: string;
 }
-import type { FileStageRowSection } from "./FileStageRow";
 
 interface UseReviewHubStagingActionsArgs {
   worktreePath: string;

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -90,7 +90,7 @@ function renderInner(
   return (
     <>
       {icon ? (
-        <div className={iconClass} aria-hidden="true">
+        <div className={iconClass} data-empty-state-icon="" aria-hidden="true">
           {icon}
         </div>
       ) : null}

--- a/src/index.css
+++ b/src/index.css
@@ -2676,6 +2676,16 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     background-color: Canvas;
   }
 
+  /* Empty-state icons carry a 30%-opacity text colour, which the UA maps to a
+     near-Canvas value in forced-colors — measured at roughly 1.06:1 on white,
+     i.e. invisible. These states are often icon-plus-one-line, so losing the
+     icon removes half the state. Repaint with CanvasText and drop the opacity
+     mixing that caused it. */
+  [data-empty-state-icon] {
+    color: CanvasText !important;
+    opacity: 1 !important;
+  }
+
   .terminal-selected {
     outline: 2px solid Highlight;
     outline-offset: -2px;


### PR DESCRIPTION
## Summary

The states around the Review Hub's main flow had drifted apart. Three quiet states rendered as one identical composition, so a clean tree with unpushed commits looked exactly like a finished one. Four failure states rendered four different ways, and three of them printed raw git stderr as the user-facing message.

This gives them one visual grammar, and splits the quiet states by what they actually mean.

Resolves #11985

## What changed

**Quiet states now differ by meaning, not by subtitle.** A clean tree with unpushed commits is not a completion, so it stops looking like one: it leads with the commit count and the push glyph `CommitPanel` already uses, and keeps its Push action. The two genuinely finished states use `EmptyState`'s `user-cleared` variant with a circle checkmark. That variant forbids a description at the type level, which is what removed "No changes to commit" and "This branch has no commits ahead of main". Both only restated their own headline. `CheckSquare` is gone, since at panel size it read as an interactive checkbox sitting in an empty pane.

**Failures share one grammar.** Root load, base-branch comparison, staging actions and conflicts all render through `InlineStatusBanner` now: icon, verb-noun title, git's message demoted to supporting copy, one recovery. Previously the two load failures printed raw stderr with no icon and no role, and the action failure had no recovery and no dismiss at all, so an unreadable run-on git string sat in the layout permanently.

Roles split by whether the failure actually blocks. The root load failure is `role="alert"` because nothing else rendered. The secondary ones are `role="status"` with `aria-live="polite"` and no focus movement (WCAG 2.2 SC 3.2.1/3.2.2). None of the four announced anything before. The icon is also what carries severity under `forced-colors: active`, where the UA strips the tint and the old treatment was typographically identical to body text.

**The push failure no longer appears twice.** The readiness rail and `PushErrorBanner` were stacked on top of each other in different severities and different wording, and the louder of the two was the one with no action. Only what the rail renders is filtered; the summary keeps the blocker, so readiness and push gating are unchanged.

**The dialog body has a floor.** Loading, failure, empty and resolved each produced a different height, and the same "Working tree clean" composition measured 458px on one route and 522px after a base-branch round trip. State heights now sit within 1.08x of each other instead of 2.6x. Named after `McpConfirmDialog`'s `PREVIEW_MIN_BODY_HEIGHT`, which reserves a dialog body for the same reason.

Two fixes landed in the shared components rather than here, so every consumer gets them: `InlineStatusBanner`'s entry transition was a bare `transition duration-250` (unscoped, and off the house tier scale), and it guarded `window` for SSR then called `window.matchMedia` unconditionally, so in a window-without-matchMedia environment it threw and took its whole subtree down.

## Screenshot harness

`e2e/screenshots/review-hub-states-review.spec.ts` captures all eight states across narrow, keyboard, `prefers-contrast` and `forced-colors`. Real git drives what git can reach deterministically. The failures use the existing `DAINTREE_E2E_FAULT_MODE` registry, so a `git:*` invoke genuinely rejects in the main process rather than being stubbed in the renderer.

It hashes its own output and fails if two different states render byte-identical. The first version reported success while writing twelve PNGs that collapsed into four images, which is worse than failing: a review then gets scored against evidence that looks fine.

It also fixes `SEL.worktree.reviewHubButton`, stale since `ffd3cb2ad`. The card builds its label from review state (`Open Review & commit` / `Open Review & push`) and the selector hardcoded the old casing, so twelve specs including four release-gating `full-panels` ones could not open the hub at all.

## Design review

Score 4.1 to 8.8 over three rounds against state legibility, error grammar, geometry, recovery affordance, accessibility and house-rule fidelity.

The consistency survey found no new outlier. Every pattern adopted here was already the house-dominant one (`EmptyState` at 36 files, `InlineStatusBanner` at 46), the bespoke counts went down rather than up, and the three shared-component fixes roll out to all consumers by construction. No follow-up roll-out is owed.

## One item left for a decision

Skeleton bones measure 1.09:1 against the panel, so the Doherty-gated skeleton reads as an empty panel rather than as loading. `SkeletonBone` uses `bg-muted`, and `--muted` resolves to `var(--theme-surface-panel)`, so the fix is a theme-token change across 15 built-in themes rather than a change to this panel. Retinting it locally would give this one surface a private skeleton colour, which is the kind of local exception worth avoiding. Priced at roughly 0.3 points. Happy either way, but it wants its own cross-theme pass.

## Testing

Full unit suite: 51,639 tests across 2,348 files, green. Run unscoped deliberately, since `InlineStatusBanner`, `EmptyState` and a repo-wide `forced-colors` rule were all touched.

The clean-state tests now assert the rule rather than the copy: an unfinished state must never render the completion headline, and a completed state must carry no action. Mutation-checked by reinstating the shared headline, which fails four tests. The `InlineStatusBanner` duration test asserted the literal `duration-250` copied from the component, so retiming forced the identical edit in the test and it proved nothing. It now asserts that the entry transition exists and is property-scoped, never bare and never `transition-all`.