### PR TITLE
fix(a11y): rescue status marks from forced-colors

### DIFF
--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -274,7 +274,12 @@ export function ConsoleDrawer({
         </button>
 
         <div className={statusClass} role="status" aria-live="polite">
-          <span className={cn("mr-2 h-1.5 w-1.5 shrink-0 rounded-full", statusLabel.dotClass)} />
+          <span
+            className={cn(
+              "status-mark mr-2 h-1.5 w-1.5 shrink-0 rounded-full",
+              statusLabel.dotClass
+            )}
+          />
           {statusLabel.label}
         </div>
 

--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -67,7 +67,7 @@ export function FleetDraftingPill(): ReactElement | null {
               <span
                 data-testid="fleet-drafting-pill-divergence-dot"
                 aria-label={`${overridesCount + skippedCount} per-target edit${overridesCount + skippedCount === 1 ? "" : "s"} pending`}
-                className="ml-0.5 inline-block h-1.5 w-1.5 rounded-full bg-category-amber-border"
+                className="status-mark ml-0.5 inline-block h-1.5 w-1.5 rounded-full bg-category-amber-border"
               />
             )}
             {hasVariables && (

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1567,7 +1567,7 @@ export function HelpPanel({
                 >
                   <span
                     aria-hidden
-                    className="w-1.5 h-1.5 rounded-full shrink-0 bg-status-warning"
+                    className="status-mark w-1.5 h-1.5 rounded-full shrink-0 bg-status-warning"
                   />
                   <span className="truncate">
                     {[pinnedContext.worktreeName, pinnedContext.worktreeBranch]

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1582,7 +1582,7 @@ export function HelpPanel({
                 >
                   <span
                     aria-hidden
-                    className="w-1.5 h-1.5 rounded-full shrink-0 bg-daintree-text/30"
+                    className="status-mark w-1.5 h-1.5 rounded-full shrink-0 bg-daintree-text/30"
                   />
                   <span className="truncate">
                     {[pinnedContext.worktreeName, pinnedContext.worktreeBranch]

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -141,7 +141,6 @@ function RecentCallRow({ record }: { record: McpAuditRecord }) {
           severity={RESULT_SEVERITY[record.result]}
           label={RESULT_LABEL[record.result]}
           className="h-3 w-3"
-          decorative
         />
         <span className="min-w-0 font-mono text-daintree-text/80 truncate">{record.toolId}</span>
         {/* Recency, not duration — calls are almost always sub-100ms, so

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -2,20 +2,22 @@ import { useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
+import { SeverityMark, type StatusSeverity } from "@/lib/statusSeverity";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import type { McpAuditRecord, McpAuditResult } from "@shared/types";
 
-// Local, deliberately-minimal mirror of the Settings audit viewer's styling.
-// The popover is a simpler read-only view; cross-importing from Settings would
-// create a HelpPanel → Settings layer dependency for two stable constants.
-const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
-  success: "bg-status-success",
-  error: "bg-status-danger",
-  "confirmation-pending": "bg-status-warning",
-  unauthorized: "bg-status-danger",
-  dedup: "bg-status-info",
-  collision: "bg-status-warning",
-  rate_limited: "bg-status-warning",
+// Local mirror of the Settings audit viewer's outcome→severity mapping. The
+// popover is a simpler read-only view; cross-importing from Settings would
+// create a HelpPanel → Settings layer dependency for two stable constants. The
+// glyphs themselves are shared, so the two views still agree on shape and tone.
+const RESULT_SEVERITY: Record<McpAuditResult, StatusSeverity> = {
+  success: "success",
+  error: "error",
+  "confirmation-pending": "warning",
+  unauthorized: "error",
+  dedup: "info",
+  collision: "warning",
+  rate_limited: "warning",
 };
 
 const RESULT_LABEL: Record<McpAuditResult, string> = {
@@ -135,10 +137,11 @@ function RecentCallRow({ record }: { record: McpAuditRecord }) {
             expanded && "rotate-90"
           )}
         />
-        <span
-          aria-hidden
-          className={cn("h-1.5 w-1.5 rounded-full shrink-0", RESULT_DOT_CLASS[record.result])}
-          title={RESULT_LABEL[record.result]}
+        <SeverityMark
+          severity={RESULT_SEVERITY[record.result]}
+          label={RESULT_LABEL[record.result]}
+          className="h-3 w-3"
+          decorative
         />
         <span className="min-w-0 font-mono text-daintree-text/80 truncate">{record.toolId}</span>
         {/* Recency, not duration — calls are almost always sub-100ms, so

--- a/src/components/HelpPanel/TurnOutcomePip.tsx
+++ b/src/components/HelpPanel/TurnOutcomePip.tsx
@@ -48,7 +48,10 @@ export function TurnOutcomePip({ outcome, onDismiss }: TurnOutcomePipProps) {
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
       )}
     >
-      <span aria-hidden className="w-1.5 h-1.5 rounded-full shrink-0 bg-status-warning" />
+      <span
+        aria-hidden
+        className="status-mark w-1.5 h-1.5 rounded-full shrink-0 bg-status-warning"
+      />
       <span className="truncate font-medium">{label}</span>
     </button>
   );

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -1353,7 +1353,7 @@ function DockLaunchOption({
             <span
               data-testid={`launcher-new-pill-${agent.id}`}
               aria-hidden="true"
-              className="ml-2 shrink-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+              className="status-mark ml-2 shrink-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
             />
           )}
         </span>

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -860,7 +860,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                               <ChevronDown className="w-3 h-3" aria-hidden="true" />
                               {activeTabIsHidden && (
                                 <span
-                                  className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-daintree-text/70"
+                                  className="status-mark absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-daintree-text/70"
                                   aria-hidden="true"
                                 />
                               )}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -548,7 +548,7 @@ function AgentOverflowItem({
           <span
             aria-hidden="true"
             className={cn(
-              "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-bg",
+              "status-mark absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-bg",
               dotColor
             )}
           />

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -833,7 +833,7 @@ function PanelHeaderComponent({
             <Tooltip>
               <TooltipTrigger asChild>
                 <span
-                  className="w-2 h-2 rounded-full bg-status-danger shrink-0"
+                  className="status-mark w-2 h-2 rounded-full bg-status-danger shrink-0"
                   aria-label="Launched with dangerous permissions"
                 />
               </TooltipTrigger>
@@ -855,7 +855,7 @@ function PanelHeaderComponent({
                   onPointerDown={(e) => e.stopPropagation()}
                   aria-label="Last fleet broadcast failed on this terminal — click to acknowledge"
                   data-testid="panel-fleet-failure-dot"
-                  className="w-2 h-2 rounded-full bg-status-error shrink-0 hover:scale-125 transition-transform"
+                  className="status-mark w-2 h-2 rounded-full bg-status-error shrink-0 hover:scale-125 transition-transform"
                 />
               </TooltipTrigger>
               <TooltipContent side="bottom">

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -31,7 +31,7 @@ function BadgeIndicator({ pluginId, badge }: { pluginId: string; badge: PluginPa
       <span
         role="status"
         aria-label={badge.tooltip ?? `${pluginId} status`}
-        className={`w-2 h-2 rounded-full shrink-0 ${DOT_COLOR[color]}`}
+        className={`status-mark w-2 h-2 rounded-full shrink-0 ${DOT_COLOR[color]}`}
       />
     ) : (
       <span

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -399,7 +399,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
             <Tooltip>
               <TooltipTrigger asChild>
                 <span
-                  className="w-2 h-2 rounded-full bg-status-danger shrink-0"
+                  className="status-mark w-2 h-2 rounded-full bg-status-danger shrink-0"
                   aria-label="Launched with dangerous permissions"
                 />
               </TooltipTrigger>

--- a/src/components/Portal/DevServerDashboard.tsx
+++ b/src/components/Portal/DevServerDashboard.tsx
@@ -72,7 +72,7 @@ function DevServerRow({
   return (
     <li className="flex items-center gap-2 px-3 py-1.5 hover:bg-overlay-subtle transition-colors">
       <span
-        className={cn("flex-shrink-0 w-1.5 h-1.5 rounded-full", presentation.dotClass)}
+        className={cn("status-mark flex-shrink-0 w-1.5 h-1.5 rounded-full", presentation.dotClass)}
         aria-hidden="true"
       />
       <div className="flex flex-col min-w-0 flex-1">

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -548,7 +548,7 @@ export function ProjectResourceBadge() {
           <div className="flex items-center gap-2 min-w-0">
             <span
               key={memoryState}
-              className={`inline-flex h-2 w-2 rounded-full ${STATE_DOT_CLASSES[memoryState]} animate-diagnostics-flash shrink-0`}
+              className={`status-mark inline-flex h-2 w-2 rounded-full ${STATE_DOT_CLASSES[memoryState]} animate-diagnostics-flash shrink-0`}
             />
             <span className="text-[10px] tabular-nums text-daintree-text/40 font-medium truncate">
               {stats.runningProjects} project{stats.runningProjects !== 1 ? "s" : ""} active

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -415,7 +415,7 @@ export function ProjectSwitcher() {
                 >
                   <span
                     className={cn(
-                      "h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
+                      "status-mark h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
                       badgeStatus.color
                     )}
                     data-testid="project-switcher-badge-dot"

--- a/src/components/Project/RunningTaskList.tsx
+++ b/src/components/Project/RunningTaskList.tsx
@@ -281,11 +281,20 @@ function TaskRow({ terminal, status, now, onStop, onFocus, onRestart, onDismiss 
   );
 }
 
+const TASK_STATUS_LABEL: Record<TaskStatus, string> = {
+  running: "Running",
+  restarting: "Restarting",
+  success: "Finished",
+  failed: "Failed",
+};
+
 function StatusDot({ status }: { status: TaskStatus }) {
   return (
     <span
+      role="img"
+      aria-label={TASK_STATUS_LABEL[status]}
       className={cn(
-        "h-1.5 w-1.5 rounded-full shrink-0",
+        "status-mark h-1.5 w-1.5 rounded-full shrink-0",
         status === "running" && "bg-status-success animate-activity-pulse",
         status === "restarting" && "bg-status-warning animate-activity-pulse",
         status === "success" && "bg-status-success",

--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -92,7 +92,10 @@ export function BehavioralControls({
           <label className="text-sm font-medium text-daintree-text">Custom arguments</label>
           {scopeKind === "custom" && customFlagsOverride !== undefined && (
             <>
-              <span className="w-1.5 h-1.5 rounded-full bg-state-modified" aria-hidden="true" />
+              <span
+                className="status-mark w-1.5 h-1.5 rounded-full bg-state-modified"
+                aria-hidden="true"
+              />
               <button
                 type="button"
                 aria-label={`Reset custom arguments override for ${scopeLabel}`}

--- a/src/components/Settings/AgentSelectorDropdown.tsx
+++ b/src/components/Settings/AgentSelectorDropdown.tsx
@@ -113,7 +113,7 @@ export function AgentSelectorDropdown({
                   {!selectedAgent.selected && (
                     <>
                       <span
-                        className="w-1.5 h-1.5 rounded-full bg-daintree-text/30"
+                        className="status-mark w-1.5 h-1.5 rounded-full bg-daintree-text/30"
                         aria-hidden="true"
                       />
                       <span className="sr-only">Not in workflow</span>
@@ -122,7 +122,7 @@ export function AgentSelectorDropdown({
                   {selectedAgent.dangerousEnabled && (
                     <>
                       <span
-                        className="w-1.5 h-1.5 rounded-full bg-status-error"
+                        className="status-mark w-1.5 h-1.5 rounded-full bg-status-error"
                         aria-hidden="true"
                       />
                       <span className="sr-only">Skip permissions enabled</span>
@@ -221,7 +221,7 @@ export function AgentSelectorDropdown({
                         {!item.agent.selected && (
                           <>
                             <span
-                              className="w-1.5 h-1.5 rounded-full bg-daintree-text/30"
+                              className="status-mark w-1.5 h-1.5 rounded-full bg-daintree-text/30"
                               aria-hidden="true"
                             />
                             <span className="sr-only">Not in workflow</span>
@@ -230,7 +230,7 @@ export function AgentSelectorDropdown({
                         {item.agent.dangerousEnabled && (
                           <>
                             <span
-                              className="w-1.5 h-1.5 rounded-full bg-status-error"
+                              className="status-mark w-1.5 h-1.5 rounded-full bg-status-error"
                               aria-hidden="true"
                             />
                             <span className="sr-only">Skip permissions enabled</span>

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -1179,7 +1179,7 @@ export function DaintreeAssistantSettingsTab() {
           </div>
         ) : runtimeSnapshot.state === "starting" ? (
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 rounded-full bg-daintree-text/30 shrink-0" />
+            <div className="status-mark w-2 h-2 rounded-full bg-daintree-text/30 shrink-0" />
             <span className="text-xs text-daintree-text/60">Server is starting…</span>
           </div>
         ) : runtimeSnapshot.state === "failed" ? (
@@ -1206,7 +1206,7 @@ export function DaintreeAssistantSettingsTab() {
         ) : (
           <div className="contents">
             <div className="flex items-center gap-2">
-              <div className="w-2 h-2 rounded-full bg-status-success shrink-0" />
+              <div className="status-mark w-2 h-2 rounded-full bg-status-success shrink-0" />
               <span className="text-xs text-daintree-text/60">
                 {runtimeSnapshot.port ? `Running on port ${runtimeSnapshot.port}` : "Running"}
               </span>
@@ -1542,7 +1542,7 @@ function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
         <span className="flex items-center gap-2">
           <span
             className={cn(
-              "w-1.5 h-1.5 rounded-full shrink-0",
+              "status-mark w-1.5 h-1.5 rounded-full shrink-0",
               connected ? "bg-status-success" : "bg-daintree-text/30"
             )}
             aria-hidden="true"

--- a/src/components/Settings/ForgeAuditLogViewer.tsx
+++ b/src/components/Settings/ForgeAuditLogViewer.tsx
@@ -291,7 +291,7 @@ export function ForgeAuditLogViewer({
           <ul className="divide-y divide-daintree-border">
             {filteredRecords.map((record) => (
               <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                <div className="flex items-center gap-1 mt-0.5">
+                <div className="flex self-start items-center gap-1 mt-0.5">
                   <SeverityMark
                     severity={RESULT_SEVERITY[record.result]}
                     label={RESULT_LABEL[record.result]}

--- a/src/components/Settings/ForgeAuditLogViewer.tsx
+++ b/src/components/Settings/ForgeAuditLogViewer.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Check, Clock, Copy, Download, Eye, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { SeverityMark, type StatusSeverity } from "@/lib/statusSeverity";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
@@ -22,10 +23,10 @@ const RESULT_LABEL: Record<ForgeAuditResult, string> = {
   error: "Error",
 };
 
-const RESULT_DOT_CLASS: Record<ForgeAuditResult, string> = {
-  success: "bg-status-success",
-  "not-found": "bg-status-info",
-  error: "bg-status-danger",
+const RESULT_SEVERITY: Record<ForgeAuditResult, StatusSeverity> = {
+  success: "success",
+  "not-found": "info",
+  error: "error",
 };
 
 const ANOMALY_KIND_LABEL: Record<ForgeAnomalyKind, string> = {
@@ -291,14 +292,16 @@ export function ForgeAuditLogViewer({
             {filteredRecords.map((record) => (
               <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
                 <div className="flex items-start gap-1 mt-1">
-                  <span
-                    className={cn("h-2 w-2 rounded-full shrink-0", RESULT_DOT_CLASS[record.result])}
-                    aria-label={RESULT_LABEL[record.result]}
-                    title={RESULT_LABEL[record.result]}
+                  <SeverityMark
+                    severity={RESULT_SEVERITY[record.result]}
+                    label={RESULT_LABEL[record.result]}
+                    className="h-3 w-3"
                   />
                   {signalRecordIds.has(record.id) && (
                     <span
-                      className="h-2 w-2 rounded-sm rotate-45 shrink-0 bg-status-danger"
+                      role="img"
+                      aria-label="Anomaly"
+                      className="status-mark h-2 w-2 rounded-sm rotate-45 shrink-0 bg-status-danger"
                       title="Anomaly"
                     />
                   )}

--- a/src/components/Settings/ForgeAuditLogViewer.tsx
+++ b/src/components/Settings/ForgeAuditLogViewer.tsx
@@ -291,7 +291,7 @@ export function ForgeAuditLogViewer({
           <ul className="divide-y divide-daintree-border">
             {filteredRecords.map((record) => (
               <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                <div className="flex items-start gap-1 mt-1">
+                <div className="flex items-center gap-1 mt-0.5">
                   <SeverityMark
                     severity={RESULT_SEVERITY[record.result]}
                     label={RESULT_LABEL[record.result]}

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -246,6 +246,7 @@ function GrantRow({
         severity={GRANT_TYPE_SEVERITY[record.type]}
         label={GRANT_TYPE_LABEL[record.type]}
         className="mt-0.5 h-3 w-3"
+        decorative
       />
       <div className="min-w-0">
         <div className="flex items-center gap-2">
@@ -678,7 +679,7 @@ export function McpAuditLogViewer({
             {filteredRecords.map((record) =>
               isAuditRecord(record) ? (
                 <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                  <div className="flex items-start gap-1 mt-1">
+                  <div className="flex items-center gap-1 mt-0.5">
                     <SeverityMark
                       severity={RESULT_SEVERITY[record.result]}
                       label={RESULT_LABEL[record.result]}
@@ -729,6 +730,7 @@ export function McpAuditLogViewer({
                     severity={GRANT_TYPE_SEVERITY[record.type]}
                     label={GRANT_TYPE_LABEL[record.type]}
                     className="mt-0.5 h-3 w-3"
+                    decorative
                   />
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Check, Clock, Copy, Download, Layers, RefreshCw, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { SeverityMark, type StatusSeverity } from "@/lib/statusSeverity";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
@@ -33,14 +34,14 @@ const RESULT_LABEL: Record<McpAuditResult, string> = {
   rate_limited: "Rate limited",
 };
 
-const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
-  success: "bg-status-success",
-  error: "bg-status-danger",
-  "confirmation-pending": "bg-status-warning",
-  unauthorized: "bg-status-danger",
-  dedup: "bg-status-info",
-  collision: "bg-status-warning",
-  rate_limited: "bg-status-warning",
+const RESULT_SEVERITY: Record<McpAuditResult, StatusSeverity> = {
+  success: "success",
+  error: "error",
+  "confirmation-pending": "warning",
+  unauthorized: "error",
+  dedup: "info",
+  collision: "warning",
+  rate_limited: "warning",
 };
 
 const GRANT_TYPE_LABEL: Record<McpGrantRecordType, string> = {
@@ -53,14 +54,14 @@ const GRANT_TYPE_LABEL: Record<McpGrantRecordType, string> = {
   "tier.decayed": "Tier decayed",
 };
 
-const GRANT_TYPE_DOT_CLASS: Record<McpGrantRecordType, string> = {
-  "grant.issued": "bg-status-info",
-  "grant.expired": "bg-status-warning",
-  "grant.revoked": "bg-status-danger",
-  "grant.used": "bg-status-info",
-  "grant.exhausted": "bg-status-warning",
-  "tier.elevated": "bg-status-warning",
-  "tier.decayed": "bg-status-info",
+const GRANT_TYPE_SEVERITY: Record<McpGrantRecordType, StatusSeverity> = {
+  "grant.issued": "info",
+  "grant.expired": "warning",
+  "grant.revoked": "error",
+  "grant.used": "info",
+  "grant.exhausted": "warning",
+  "tier.elevated": "warning",
+  "tier.decayed": "info",
 };
 
 type TimeRange = "5m" | "1h" | "24h" | "all";
@@ -241,10 +242,10 @@ function GrantRow({
 }) {
   return (
     <li className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
-      <span
-        className={cn("mt-1 h-1.5 w-1.5 rounded-full shrink-0", GRANT_TYPE_DOT_CLASS[record.type])}
-        aria-label={GRANT_TYPE_LABEL[record.type]}
-        title={GRANT_TYPE_LABEL[record.type]}
+      <SeverityMark
+        severity={GRANT_TYPE_SEVERITY[record.type]}
+        label={GRANT_TYPE_LABEL[record.type]}
+        className="mt-0.5 h-3 w-3"
       />
       <div className="min-w-0">
         <div className="flex items-center gap-2">
@@ -563,13 +564,10 @@ export function McpAuditLogViewer({
                   {group.records.map((record) =>
                     isAuditRecord(record) ? (
                       <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
-                        <span
-                          className={cn(
-                            "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
-                            RESULT_DOT_CLASS[record.result]
-                          )}
-                          aria-label={RESULT_LABEL[record.result]}
-                          title={RESULT_LABEL[record.result]}
+                        <SeverityMark
+                          severity={RESULT_SEVERITY[record.result]}
+                          label={RESULT_LABEL[record.result]}
+                          className="mt-0.5 h-3 w-3"
                         />
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
@@ -627,13 +625,10 @@ export function McpAuditLogViewer({
                   {turnGroups.unassociated.map((record) =>
                     isAuditRecord(record) ? (
                       <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
-                        <span
-                          className={cn(
-                            "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
-                            RESULT_DOT_CLASS[record.result]
-                          )}
-                          aria-label={RESULT_LABEL[record.result]}
-                          title={RESULT_LABEL[record.result]}
+                        <SeverityMark
+                          severity={RESULT_SEVERITY[record.result]}
+                          label={RESULT_LABEL[record.result]}
+                          className="mt-0.5 h-3 w-3"
                         />
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
@@ -684,17 +679,16 @@ export function McpAuditLogViewer({
               isAuditRecord(record) ? (
                 <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
                   <div className="flex items-start gap-1 mt-1">
-                    <span
-                      className={cn(
-                        "h-2 w-2 rounded-full shrink-0",
-                        RESULT_DOT_CLASS[record.result]
-                      )}
-                      aria-label={RESULT_LABEL[record.result]}
-                      title={RESULT_LABEL[record.result]}
+                    <SeverityMark
+                      severity={RESULT_SEVERITY[record.result]}
+                      label={RESULT_LABEL[record.result]}
+                      className="h-3 w-3"
                     />
                     {signalRecordIds.has(record.id) && (
                       <span
-                        className="h-2 w-2 rounded-sm rotate-45 shrink-0 bg-status-danger"
+                        role="img"
+                        aria-label="Anomaly"
+                        className="status-mark h-2 w-2 rounded-sm rotate-45 shrink-0 bg-status-danger"
                         title="Anomaly"
                       />
                     )}
@@ -731,13 +725,10 @@ export function McpAuditLogViewer({
                 </li>
               ) : (
                 <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                  <span
-                    className={cn(
-                      "mt-1 h-2 w-2 rounded-full shrink-0",
-                      GRANT_TYPE_DOT_CLASS[record.type]
-                    )}
-                    aria-label={GRANT_TYPE_LABEL[record.type]}
-                    title={GRANT_TYPE_LABEL[record.type]}
+                  <SeverityMark
+                    severity={GRANT_TYPE_SEVERITY[record.type]}
+                    label={GRANT_TYPE_LABEL[record.type]}
+                    className="mt-0.5 h-3 w-3"
                   />
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -679,7 +679,7 @@ export function McpAuditLogViewer({
             {filteredRecords.map((record) =>
               isAuditRecord(record) ? (
                 <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                  <div className="flex items-center gap-1 mt-0.5">
+                  <div className="flex self-start items-center gap-1 mt-0.5">
                     <SeverityMark
                       severity={RESULT_SEVERITY[record.result]}
                       label={RESULT_LABEL[record.result]}

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -636,7 +636,7 @@ export function McpServerSettingsTab() {
               ) : null
             ) : runtimeSnapshot.state === "starting" ? (
               <div className="flex items-center gap-2">
-                <div className="w-2 h-2 rounded-full bg-daintree-text/30 shrink-0" />
+                <div className="status-mark w-2 h-2 rounded-full bg-daintree-text/30 shrink-0" />
                 <span className="text-xs text-daintree-text/60">Server is starting…</span>
               </div>
             ) : runtimeSnapshot.state === "failed" ? (
@@ -650,7 +650,7 @@ export function McpServerSettingsTab() {
             ) : (
               <div className="contents">
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 rounded-full bg-status-success shrink-0" />
+                  <div className="status-mark w-2 h-2 rounded-full bg-status-success shrink-0" />
                   <span className="text-xs text-daintree-text/60">Running on port {boundPort}</span>
                 </div>
 
@@ -938,7 +938,7 @@ export function McpServerSettingsTab() {
             ) : (
               <div className="contents">
                 <div className="flex items-center gap-2 p-3 rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border">
-                  <div className="w-2 h-2 rounded-full bg-daintree-text/30" />
+                  <div className="status-mark w-2 h-2 rounded-full bg-daintree-text/30" />
                   <span className="text-xs text-daintree-text/60">
                     Key will be generated when the server starts.
                   </span>

--- a/src/components/Settings/OverrideField.tsx
+++ b/src/components/Settings/OverrideField.tsx
@@ -49,7 +49,7 @@ export function OverrideField({
         </label>
         {isOverriding && (
           <span
-            className="w-1.5 h-1.5 rounded-full bg-status-info"
+            className="status-mark w-1.5 h-1.5 rounded-full bg-status-info"
             aria-hidden="true"
             data-testid="override-indicator"
           />

--- a/src/components/Settings/PluginActionAuditLogViewer.tsx
+++ b/src/components/Settings/PluginActionAuditLogViewer.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Check, Copy, Download, Eye, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { SeverityMark, type StatusSeverity } from "@/lib/statusSeverity";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
@@ -26,11 +27,11 @@ const RESULT_LABEL: Record<PluginActionAuditResult, string> = {
   restricted: "Restricted",
 };
 
-const RESULT_DOT_CLASS: Record<PluginActionAuditResult, string> = {
-  success: "bg-status-success",
-  error: "bg-status-danger",
-  disabled: "bg-status-warning",
-  restricted: "bg-status-danger",
+const RESULT_SEVERITY: Record<PluginActionAuditResult, StatusSeverity> = {
+  success: "success",
+  error: "error",
+  disabled: "warning",
+  restricted: "error",
 };
 
 type TimeRange = "5m" | "1h" | "24h" | "all";
@@ -250,13 +251,10 @@ export function PluginActionAuditLogViewer({
           <ul className="divide-y divide-daintree-border">
             {filteredRecords.map((record) => (
               <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                <span
-                  className={cn(
-                    "mt-1 h-2 w-2 rounded-full shrink-0",
-                    RESULT_DOT_CLASS[record.result]
-                  )}
-                  aria-label={RESULT_LABEL[record.result]}
-                  title={RESULT_LABEL[record.result]}
+                <SeverityMark
+                  severity={RESULT_SEVERITY[record.result]}
+                  label={RESULT_LABEL[record.result]}
+                  className="mt-0.5 h-3 w-3"
                 />
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -381,7 +381,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                     )}
                   >
                     {telemetryLevel === option.level && (
-                      <div className="w-2 h-2 rounded-full bg-daintree-text" />
+                      <div className="status-mark w-2 h-2 rounded-full bg-daintree-text" />
                     )}
                   </div>
                   <div>

--- a/src/components/Settings/SettingsChoicebox.tsx
+++ b/src/components/Settings/SettingsChoicebox.tsx
@@ -134,7 +134,10 @@ export function SettingsChoicebox<T extends string = string>({
             {label}
           </label>
           {isModified && (
-            <span className="w-1.5 h-1.5 rounded-full bg-state-modified" aria-hidden="true" />
+            <span
+              className="status-mark w-1.5 h-1.5 rounded-full bg-state-modified"
+              aria-hidden="true"
+            />
           )}
           {showReset && (
             <button

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1303,7 +1303,7 @@ export function NavItem({
         {(hasError || modified) && (
           <span
             className={cn(
-              "absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full",
+              "status-mark absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full",
               hasError ? "bg-status-warning" : "bg-state-modified"
             )}
             role="img"

--- a/src/components/Settings/SettingsInput.tsx
+++ b/src/components/Settings/SettingsInput.tsx
@@ -56,7 +56,10 @@ export function SettingsInput({
         </label>
         {scopeBadge}
         {isModified && (
-          <span className="w-1.5 h-1.5 rounded-full bg-state-modified" aria-hidden="true" />
+          <span
+            className="status-mark w-1.5 h-1.5 rounded-full bg-state-modified"
+            aria-hidden="true"
+          />
         )}
         {showReset && (
           <button

--- a/src/components/Settings/SettingsSelect.tsx
+++ b/src/components/Settings/SettingsSelect.tsx
@@ -76,7 +76,10 @@ export function SettingsSelect({
         </label>
         {scopeBadge}
         {isModified && (
-          <span className="w-1.5 h-1.5 rounded-full bg-state-modified" aria-hidden="true" />
+          <span
+            className="status-mark w-1.5 h-1.5 rounded-full bg-state-modified"
+            aria-hidden="true"
+          />
         )}
         {showReset && (
           <button

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -78,7 +78,7 @@ export function SettingsSwitchCard({
     >
       {isModified && isCard && (
         <div
-          className="absolute left-0 top-2 bottom-2 w-0.5 rounded-full bg-state-modified"
+          className="status-mark absolute left-0 top-2 bottom-2 w-0.5 rounded-full bg-state-modified"
           aria-hidden="true"
         />
       )}

--- a/src/components/Settings/SettingsTextarea.tsx
+++ b/src/components/Settings/SettingsTextarea.tsx
@@ -47,7 +47,10 @@ export function SettingsTextarea({
           {label}
         </label>
         {isModified && (
-          <span className="w-1.5 h-1.5 rounded-full bg-state-modified" aria-hidden="true" />
+          <span
+            className="status-mark w-1.5 h-1.5 rounded-full bg-state-modified"
+            aria-hidden="true"
+          />
         )}
         {showReset && (
           <button

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -299,7 +299,7 @@ export function TerminalHeaderContent({
               </div>
               {errorCount > 0 && (
                 <span
-                  className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-status-error"
+                  className="status-mark absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-status-error"
                   aria-label={`${errorCount} error${errorCount > 1 ? "s" : ""}`}
                 />
               )}

--- a/src/components/Terminal/VoiceInputButton.tsx
+++ b/src/components/Terminal/VoiceInputButton.tsx
@@ -357,13 +357,13 @@ export function VoiceInputButton({
             className="flex h-2.5 w-2.5 items-stretch justify-between"
             aria-hidden="true"
           >
-            <span className="block w-[2px] rounded-[1px] bg-current opacity-70" />
-            <span className="block w-[2px] rounded-[1px] bg-current opacity-70" />
+            <span className="status-mark block w-[2px] rounded-[1px] bg-current opacity-70" />
+            <span className="status-mark block w-[2px] rounded-[1px] bg-current opacity-70" />
           </span>
         ) : showOrbit ? (
           <span
             ref={iconRef}
-            className="block h-2 w-2 rounded-[1.5px] bg-current transition-transform duration-100"
+            className="status-mark block h-2 w-2 rounded-[1.5px] bg-current transition-transform duration-100"
           />
         ) : (
           <Mic className="h-3.5 w-3.5 relative" />

--- a/src/components/Worktree/ReviewHub/PrStatusChip.tsx
+++ b/src/components/Worktree/ReviewHub/PrStatusChip.tsx
@@ -69,17 +69,9 @@ export function PrStatusChip({ hasRemote, worktreePR, onOpenExternal }: PrStatus
                   className="inline-flex items-center justify-center w-3 h-3 shrink-0"
                   aria-hidden="true"
                 >
-                  {ciVisual.kind === "icon" ? (
-                    <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
-                  ) : (
-                    <span className={cn("block w-2 h-2 rounded-full", ciVisual.colorClass)} />
-                  )}
+                  <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
                 </span>
-                <span
-                  className={ciVisual.kind === "icon" ? ciVisual.colorClass : "text-status-warning"}
-                >
-                  {ciVisual.shortLabel}
-                </span>
+                <span className={ciVisual.colorClass}>{ciVisual.shortLabel}</span>
               </span>
             </>
           )}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -923,7 +923,7 @@ export function WorktreeCard({
               <TooltipTrigger asChild>
                 <div
                   className={cn(
-                    "absolute w-3 h-3 z-10 cursor-default",
+                    "status-mark absolute w-3 h-3 z-10 cursor-default",
                     chipState === "waiting" && "bg-activity-waiting",
                     chipState === "cleanup" && "bg-pr-merged",
                     chipState === "complete" && "bg-category-blue",

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -186,11 +186,7 @@ export function PRBadge({
               className="inline-flex items-center justify-center w-3 h-3 shrink-0"
               aria-hidden="true"
             >
-              {ciVisual.kind === "icon" ? (
-                <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
-              ) : (
-                <span className={cn("block w-2 h-2 rounded-full", ciVisual.colorClass)} />
-              )}
+              <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
             </span>
           )}
           {showPausedGlyph && (

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -331,7 +331,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                     <span className="flex items-center gap-1.5 text-text-secondary">
                       <span
                         aria-hidden="true"
-                        className="inline-block w-2 h-2 rounded-full bg-text-secondary animate-pulse-immediate shrink-0"
+                        className="status-mark inline-block w-2 h-2 rounded-full bg-text-secondary animate-pulse-immediate shrink-0"
                       />
                       <span className="truncate">{lifecycleLabel}</span>
                     </span>

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -502,7 +502,7 @@ export function WorktreeFilterPopover({
                   >
                     {orderBy === option.value && (
                       <div className="w-full h-full flex items-center justify-center">
-                        <div className="w-1.5 h-1.5 bg-text-inverse rounded-full" />
+                        <div className="status-mark w-1.5 h-1.5 bg-text-inverse rounded-full" />
                       </div>
                     )}
                   </div>

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -862,7 +862,7 @@ export function WorktreeOverviewModal({
                           : "hover:bg-tint/[0.04]"
                       )}
                     >
-                      <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
+                      <span className="status-mark w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
                       <span
                         className={
                           quickStateFilter === "working"

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -889,7 +889,7 @@ export function WorktreeOverviewModal({
                           : "hover:bg-tint/[0.04]"
                       )}
                     >
-                      <span className="w-1.5 h-1.5 rounded-full bg-status-warning" />
+                      <span className="status-mark w-1.5 h-1.5 rounded-full bg-status-warning" />
                       <span
                         className={
                           quickStateFilter === "waiting"
@@ -916,7 +916,7 @@ export function WorktreeOverviewModal({
                           : "hover:bg-tint/[0.04]"
                       )}
                     >
-                      <span className="w-1.5 h-1.5 rounded-full bg-category-blue" />
+                      <span className="status-mark w-1.5 h-1.5 rounded-full bg-category-blue" />
                       <span
                         className={
                           quickStateFilter === "finished"

--- a/src/components/Worktree/views/IssueSelectorView.tsx
+++ b/src/components/Worktree/views/IssueSelectorView.tsx
@@ -86,7 +86,7 @@ export function AssignIssueToggle({
         />
         <span
           className={cn(
-            "pointer-events-none absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full",
+            "status-mark pointer-events-none absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full",
             "transition-[left] duration-150 ease-out",
             assignWorktreeToSelf ? "left-[0.875rem] bg-text-inverse" : "left-0.5 bg-text-secondary"
           )}

--- a/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
+++ b/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
@@ -132,6 +132,16 @@ describe("forced-colors shared status-mark contract (#12000)", () => {
     expect(block).toMatch(/\.status-mark\s*\{[^}]*background-color:\s*CanvasText[^}]*!important/);
   });
 
+  // Canvas and ButtonFace are the same colour in the stock high-contrast themes,
+  // so dropping this rule looks harmless in testing and only breaks for users on
+  // a palette that separates them.
+  it("repaints marks inside a control with ButtonText, the pair that matches ButtonFace", () => {
+    const block = readForcedColorsBlocks(INDEX_CSS);
+    expect(block).toMatch(
+      /button\s+\.status-mark,[\s\S]{0,80}?\.status-mark\s*\{[^}]*background-color:\s*ButtonText[^}]*!important/
+    );
+  });
+
   it("does not reach for forced-color-adjust, which would opt out of the user's palette", () => {
     const block = readForcedColorsBlocks(INDEX_CSS);
     const rule = block.match(/\.status-mark\s*\{([^}]*)\}/);

--- a/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
+++ b/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
@@ -147,7 +147,9 @@ describe("forced-colors shared status-mark contract (#12000)", () => {
       path.join(REPO_ROOT, "src/components/Panel/PluginPanelBadges.tsx"),
       "utf8"
     );
-    expect(badges).toContain("status-mark");
+    // Bound to the className the dot branch actually builds, not a loose
+    // substring — a passing mention in a comment would prove nothing.
+    expect(badges).toMatch(/className=\{`[^`]*\bstatus-mark\b[^`]*\$\{DOT_COLOR\[/);
   });
 
   // Whatever `DOT_COLOR` resolves to is still a background, so the hook stays

--- a/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
+++ b/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
@@ -119,6 +119,53 @@ describe("forced-colors status-indicator contract (#8936)", () => {
   });
 });
 
+// #12000: forty-odd status marks across the app were an empty span whose only
+// visual was a background colour, so forced colors rendered every one of them as
+// nothing. The fix is one shared `.status-mark` hook repainted in the same block
+// — but a rule with no emitter is as silent a regression as an emitter with no
+// rule, so both halves are guarded here.
+describe("forced-colors shared status-mark contract (#12000)", () => {
+  it("index.css repaints the shared status mark with CanvasText !important", () => {
+    const block = readForcedColorsBlocks(INDEX_CSS);
+    // !important for the reason ActivityLight needs it: it has to beat the
+    // author background the UA otherwise forces to Canvas.
+    expect(block).toMatch(/\.status-mark\s*\{[^}]*background-color:\s*CanvasText[^}]*!important/);
+  });
+
+  it("does not reach for forced-color-adjust, which would opt out of the user's palette", () => {
+    const block = readForcedColorsBlocks(INDEX_CSS);
+    const rule = block.match(/\.status-mark\s*\{([^}]*)\}/);
+    expect(rule).not.toBeNull();
+    expect(rule?.[1]).not.toMatch(/forced-color-adjust/);
+  });
+
+  // The plugin dot is the sharpest case: `host.setPanelBadge` lets a plugin ask
+  // for a bare dot with no adjacent text, so without the hook a forced-colors
+  // user sees nothing where the plugin reported something.
+  it("is actually emitted: the plugin panel dot carries the class the rule targets", () => {
+    const badges = fs.readFileSync(
+      path.join(REPO_ROOT, "src/components/Panel/PluginPanelBadges.tsx"),
+      "utf8"
+    );
+    expect(badges).toContain("status-mark");
+  });
+
+  // Whatever `DOT_COLOR` resolves to is still a background, so the hook stays
+  // load-bearing; if that map ever stops painting backgrounds this assertion
+  // should be revisited rather than deleted.
+  it("still needs the hook: the plugin dot is painted as a background, not a glyph", () => {
+    const badges = fs.readFileSync(
+      path.join(REPO_ROOT, "src/components/Panel/PluginPanelBadges.tsx"),
+      "utf8"
+    );
+    const map = badges.match(/const DOT_COLOR[^=]*=\s*\{([^}]*)\}/);
+    expect(map).not.toBeNull();
+    const values = [...(map?.[1] ?? "").matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+    expect(values.length).toBeGreaterThan(0);
+    expect(values.every((v) => v.startsWith("bg-"))).toBe(true);
+  });
+});
+
 // #11981: a destructive button is distinguished from Cancel only by its fill,
 // and forced-colors replaces every fill with a system colour — so the two
 // render as identical pills and nothing marks which one destroys. The fallback

--- a/src/index.css
+++ b/src/index.css
@@ -2897,6 +2897,21 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border: 1px solid CanvasText;
   }
 
+  /* Shared hook for status marks painted as a background — the small discs and
+     the rotated anomaly diamond scattered across settings, panels, the toolbar
+     and the worktree surfaces (#12000). The UA forces every one of those fills
+     to Canvas, so the mark renders as nothing; `ring-*` is no rescue either
+     since it compiles to box-shadow, which is removed outright and cannot be
+     repainted. Repaint the fill instead.
+
+     One CanvasText disc for all of them on purpose: hue is gone here whatever we
+     do, so this rule only owes that the mark is still THERE. Marks whose
+     severity is the signal do not use this hook — they carry a glyph from
+     `src/lib/statusSeverity.ts`, whose shape survives where colour cannot. */
+  .status-mark {
+    background-color: CanvasText !important;
+  }
+
   /* Project-switcher row marks. The solid states are a CSS background, which
      forced colors pushes toward Canvas, so the whole 8px slot would read as
      empty. Repaint them as a CanvasText disc: hue is gone here either way, and

--- a/src/index.css
+++ b/src/index.css
@@ -2912,6 +2912,16 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     background-color: CanvasText !important;
   }
 
+  /* Marks that live inside a control. The UA paints button surfaces ButtonFace,
+     and only ButtonText is guaranteed to contrast against it — Canvas and
+     ButtonFace happen to be the same colour in the stock high-contrast themes,
+     but a user's own palette is free to separate them. Same repaint, matched
+     pair. */
+  button .status-mark,
+  [role="button"] .status-mark {
+    background-color: ButtonText !important;
+  }
+
   /* Project-switcher row marks. The solid states are a CSS background, which
      forced colors pushes toward Canvas, so the whole 8px slot would read as
      empty. Repaint them as a CanvasText disc: hue is gone here either way, and

--- a/src/lib/__tests__/statusSeverity.test.tsx
+++ b/src/lib/__tests__/statusSeverity.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { SEVERITY_VISUAL, SeverityMark, type StatusSeverity } from "@/lib/statusSeverity";
+
+const LEVELS: StatusSeverity[] = ["success", "error", "warning", "info"];
+
+describe("SEVERITY_VISUAL", () => {
+  it("gives each level a shape of its own", () => {
+    // Shape is what survives forced-colors; if two levels shared a glyph they
+    // would be indistinguishable exactly where the palette has already gone.
+    const icons = LEVELS.map((level) => SEVERITY_VISUAL[level].Icon);
+    expect(new Set(icons).size).toBe(LEVELS.length);
+  });
+
+  it("tones every level with a text colour, so it strokes in currentColor", () => {
+    for (const level of LEVELS) {
+      expect(SEVERITY_VISUAL[level].toneClass.startsWith("text-")).toBe(true);
+    }
+  });
+});
+
+describe("SeverityMark", () => {
+  it("names the outcome for assistive tech and on hover", () => {
+    const { container } = render(<SeverityMark severity="error" label="Unauthorized" />);
+    const mark = container.firstElementChild!;
+    expect(mark.getAttribute("role")).toBe("img");
+    expect(mark.getAttribute("aria-label")).toBe("Unauthorized");
+    // The dot this replaces carried a `title`; losing it would drop the hover
+    // affordance on rows whose visible text is only an id.
+    expect(mark.getAttribute("title")).toBe("Unauthorized");
+  });
+
+  it("hides itself from assistive tech when decorative, keeping the hover title", () => {
+    const { container } = render(<SeverityMark severity="info" label="Deduplicated" decorative />);
+    const mark = container.firstElementChild!;
+    expect(mark.getAttribute("aria-hidden")).toBe("true");
+    expect(mark.getAttribute("aria-label")).toBeNull();
+    expect(mark.getAttribute("title")).toBe("Deduplicated");
+  });
+
+  it("renders a different glyph per level", () => {
+    const shapes = LEVELS.map((level) => {
+      const { container } = render(<SeverityMark severity={level} label={level} />);
+      return container.querySelector("svg")!.innerHTML;
+    });
+    expect(new Set(shapes).size).toBe(LEVELS.length);
+  });
+});

--- a/src/lib/__tests__/worktreeCIStatus.test.ts
+++ b/src/lib/__tests__/worktreeCIStatus.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getCIStatusVisual } from "@/lib/worktreeCIStatus";
+import type { CIStatus } from "@shared/types/forge";
+
+const status = (state: CIStatus["state"]): CIStatus => ({ state }) as CIStatus;
+
+describe("getCIStatusVisual", () => {
+  it("gives every reportable state a glyph, not a background-painted dot", () => {
+    // The point of #12000: a `bg-*` disc is erased by forced-colors, so a state
+    // that only had one communicated nothing. Every state that reports at all
+    // has to hand back something that strokes.
+    for (const state of ["success", "failure", "pending", "neutral"] as const) {
+      const visual = getCIStatusVisual(status(state));
+      expect(visual).not.toBeNull();
+      expect(visual!.Icon).toBeTruthy();
+      expect(visual!.colorClass.startsWith("text-")).toBe(true);
+    }
+  });
+
+  it("keeps the four states visually distinct by shape", () => {
+    const icons = (["success", "failure", "pending", "neutral"] as const).map(
+      (state) => getCIStatusVisual(status(state))!.Icon
+    );
+    expect(new Set(icons).size).toBe(icons.length);
+  });
+
+  it("labels every state it renders", () => {
+    for (const state of ["success", "failure", "pending", "neutral"] as const) {
+      const visual = getCIStatusVisual(status(state))!;
+      expect(visual.shortLabel).toBeTruthy();
+      expect(visual.ariaLabel).toBeTruthy();
+    }
+  });
+
+  it("renders nothing for an absent or unknown status", () => {
+    expect(getCIStatusVisual(null)).toBeNull();
+    expect(getCIStatusVisual(undefined)).toBeNull();
+    expect(getCIStatusVisual(status("unknown"))).toBeNull();
+  });
+});

--- a/src/lib/statusSeverity.tsx
+++ b/src/lib/statusSeverity.tsx
@@ -7,8 +7,8 @@ import { cn } from "@/lib/utils";
  * id and the severity word lives only in the accessible name.
  *
  * A glyph, not a coloured dot: `forced-colors: active` forces every author
- * background to Canvas, so a `bg-status-*` disc renders as nothing at all and
- * takes the severity distinction with it (#12000). A Lucide glyph strokes in
+ * background to Canvas, so a disc painted with a status background renders as
+ * nothing at all and takes the severity distinction with it (#12000). A glyph strokes in
  * `currentColor`, which the UA repaints rather than erases, so the shape keeps
  * the levels apart where the palette can no longer tell them apart.
  *

--- a/src/lib/statusSeverity.tsx
+++ b/src/lib/statusSeverity.tsx
@@ -1,0 +1,62 @@
+import { AlertTriangle, Check, CircleAlert, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared severity vocabulary for status marks that carry their meaning in the
+ * mark itself — audit-log outcomes, mostly, where the row's visible text is an
+ * id and the severity word lives only in the accessible name.
+ *
+ * A glyph, not a coloured dot: `forced-colors: active` forces every author
+ * background to Canvas, so a `bg-status-*` disc renders as nothing at all and
+ * takes the severity distinction with it (#12000). A Lucide glyph strokes in
+ * `currentColor`, which the UA repaints rather than erases, so the shape keeps
+ * the levels apart where the palette can no longer tell them apart.
+ *
+ * The four shapes are the ones `ReadinessRail` settled on in #11983 plus
+ * `worktreeCIStatus`'s `Check`, so the app speaks one severity language.
+ */
+export type StatusSeverity = "success" | "error" | "warning" | "info";
+
+export const SEVERITY_VISUAL: Record<StatusSeverity, { Icon: typeof Check; toneClass: string }> = {
+  success: { Icon: Check, toneClass: "text-status-success" },
+  error: { Icon: CircleAlert, toneClass: "text-status-danger" },
+  warning: { Icon: AlertTriangle, toneClass: "text-status-warning" },
+  // `text-secondary`, not `text-muted`, for the reason ReadinessRail gives: as
+  // the only visual carrier the glyph owes the 3:1 non-text floor, and
+  // `text-muted` only clears that on light themes (`shared/theme/contrast.ts`).
+  info: { Icon: Info, toneClass: "text-text-secondary" },
+};
+
+/**
+ * The glyph in the leading slot of a log row. `label` is the outcome in words —
+ * usually the row's only statement of severity, so it lands on both the
+ * accessible name and the hover title. Pass `decorative` where the row already
+ * announces its outcome and the glyph would only repeat it.
+ */
+export function SeverityMark({
+  severity,
+  label,
+  className,
+  decorative = false,
+}: {
+  severity: StatusSeverity;
+  label: string;
+  className?: string;
+  decorative?: boolean;
+}) {
+  const { Icon, toneClass } = SEVERITY_VISUAL[severity];
+  // Wrapped rather than bare: `title` is what gave the dot it replaces a hover
+  // tooltip, and Lucide's props don't carry one through to the SVG. The wrapper
+  // owns the semantics and the layout box; the glyph just fills it.
+  return (
+    <span
+      role={decorative ? undefined : "img"}
+      aria-hidden={decorative || undefined}
+      aria-label={decorative ? undefined : label}
+      title={label}
+      className={cn("inline-flex shrink-0", className)}
+    >
+      <Icon aria-hidden="true" className={cn("h-full w-full", toneClass)} />
+    </span>
+  );
+}

--- a/src/lib/worktreeCIStatus.ts
+++ b/src/lib/worktreeCIStatus.ts
@@ -3,8 +3,9 @@ import type { CIStatus } from "@shared/types/forge";
 
 /**
  * Every state gets a glyph, terminal or not (#12000). The non-terminal states
- * used to render a `bg-status-*` disc, which `forced-colors: active` strips to
- * nothing — pending and neutral simply disappeared while passing and failing
+ * used to render a disc painted with a status background, which
+ * `forced-colors: active` strips to nothing — pending and neutral simply
+ * disappeared while passing and failing
  * stayed. A stroked icon inherits `currentColor`, which the UA repaints, so the
  * shape carries the state where the palette no longer can.
  */

--- a/src/lib/worktreeCIStatus.ts
+++ b/src/lib/worktreeCIStatus.ts
@@ -1,16 +1,25 @@
-import { Check, X } from "lucide-react";
+import { Check, CircleMinus, Clock, X } from "lucide-react";
 import type { CIStatus } from "@shared/types/forge";
 
-export type CIStatusVisual =
-  | { kind: "icon"; Icon: typeof Check; colorClass: string; shortLabel: string; ariaLabel: string }
-  | { kind: "dot"; colorClass: string; shortLabel: string; ariaLabel: string };
+/**
+ * Every state gets a glyph, terminal or not (#12000). The non-terminal states
+ * used to render a `bg-status-*` disc, which `forced-colors: active` strips to
+ * nothing — pending and neutral simply disappeared while passing and failing
+ * stayed. A stroked icon inherits `currentColor`, which the UA repaints, so the
+ * shape carries the state where the palette no longer can.
+ */
+export type CIStatusVisual = {
+  Icon: typeof Check;
+  colorClass: string;
+  shortLabel: string;
+  ariaLabel: string;
+};
 
 export function getCIStatusVisual(status: CIStatus | undefined | null): CIStatusVisual | null {
   if (!status) return null;
   switch (status.state) {
     case "success":
       return {
-        kind: "icon",
         Icon: Check,
         colorClass: "text-status-success",
         shortLabel: "passing",
@@ -18,7 +27,6 @@ export function getCIStatusVisual(status: CIStatus | undefined | null): CIStatus
       };
     case "failure":
       return {
-        kind: "icon",
         Icon: X,
         colorClass: "text-status-error",
         shortLabel: "failing",
@@ -26,15 +34,18 @@ export function getCIStatusVisual(status: CIStatus | undefined | null): CIStatus
       };
     case "pending":
       return {
-        kind: "dot",
-        colorClass: "bg-status-warning",
+        Icon: Clock,
+        colorClass: "text-status-warning",
         shortLabel: "pending",
         ariaLabel: "CI pending",
       };
     case "neutral":
+      // `text-secondary` rather than the old dot's `text-muted`: as a lone glyph
+      // it owes the 3:1 non-text floor, which `text-muted` only clears on light
+      // themes (`shared/theme/contrast.ts`).
       return {
-        kind: "dot",
-        colorClass: "bg-text-muted",
+        Icon: CircleMinus,
+        colorClass: "text-text-secondary",
         shortLabel: "neutral",
         ariaLabel: "CI neutral",
       };


### PR DESCRIPTION
## Summary

- About 40 small status indicators across the app were an empty span whose only visual was a `background-color` class (`bg-status-*`, `bg-state-modified`, `bg-text-muted`). Under `forced-colors: active` (Windows High Contrast) the browser forces every author background to `Canvas`, so all of them rendered as nothing. `ring-*` classes are no rescue either, since they compile to `box-shadow`, which forced-colors strips outright and can't repaint. Only borders, outlines, and an explicit system-color repaint survive.
- The fix runs two tracks, picked per site by whether the mark's severity is the only signal, or whether adjacent text, position, or an accessible name already carries the meaning.

Resolves #12000

## Changes

**Track one: glyph route**, for marks that carry the meaning with nothing nearby stating it. New `src/lib/statusSeverity.tsx` holds one shared severity vocabulary (`Check` / `CircleAlert` / `AlertTriangle` / `Info`) plus a `SeverityMark` component, matching the pattern `ReadinessRail` settled on in #11983.

- Applied to all four audit log outcome maps: `McpAuditLogViewer` (result and grant type), `ForgeAuditLogViewer`, `PluginActionAuditLogViewer`, and `HelpPanel`/`RecentCallsPopover`, which carried a fourth copy of the same map.
- `src/lib/worktreeCIStatus.ts` loses its `kind: "dot"` branch entirely: pending is now a `Clock` icon, neutral a `CircleMinus`, so every CI state has a distinct shape, which is what the file's own house rule already asked for.
- `PrStatusChip` and `PRBadge` simplify to render the icon unconditionally.

**Track two: shared `.status-mark` CSS hook**, for marks that only need to stay present because text, position, or an accessible name elsewhere already carries the meaning. One rule in `src/index.css`'s existing forced-colors block repaints the mark `CanvasText !important`, mirroring the existing `div.workspace-mark` precedent. A companion rule repaints marks inside a control with `ButtonText`, since the browser paints button surfaces `ButtonFace` and only `ButtonText` is a guaranteed pair.

- Applied at ~30 sites across Settings, Panel, Layout, HelpPanel, Terminal, Worktree, Project, Portal, and Fleet.
- The existing `bg-*` class stays in place everywhere, so normal (non forced-colors) mode is unchanged.

**Catches beyond the issue's own list.** Four marks filed under other categories turned out to be the entire selection signal, not decoration: the telemetry radio's fill, the sort-order radio's inner dot, the assign-to-me switch thumb, and the voice button's pause bars and stop square (`bg-current` is still a background-color, and gets the same treatment). The worktree card's corner chip, a clip-path triangle painted only with a background, was invisible too.

Also fixed while in there: `RunningTaskList`'s status mark had no accessible name at all, it now has one. The recent-calls mark is announced (the collapsed row states only a tool id and a time, never the outcome), while the grant marks are now decorative, since they repeated the label already printed right beside them.

**Scope note.** A handful of rescued marks stay color-only multi-state under forced colors: `SettingsDialog`'s error-vs-modified tab dot, `AgentSelectorDropdown`, `ProjectSwitcher`, `Toolbar`, and `RunningTaskList`. That's deliberate: each carries an accessible label or screen-reader-only text already, none of them is a regression since all were fully invisible before this change, and turning them into glyphs would mean redesigning dense UI this issue doesn't name.

## Testing

`src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts` gains a `#12000` describe block locking both halves of the contract: the CSS rules, and that the plugin panel dot actually emits the classes they target. New `src/lib/__tests__/worktreeCIStatus.test.ts` and `src/lib/__tests__/statusSeverity.test.tsx` assert shape distinctness and accessible naming rather than literal class strings.

81 spec files covering every changed module ran green locally, along with `tsc --noEmit` and prettier/eslint on all 45 changed files. One unrelated pre-existing flake, `PluginViewHost.test.tsx` (a 15s timeout on "componentPath is missing"), reproduces the same way on a clean `origin/develop` worktree.
