### PR TITLE
Refine the worktree delete dialog's consequence hierarchy

### DIFF
--- a/e2e/screenshots/worktree-delete-dialog-review.spec.ts
+++ b/e2e/screenshots/worktree-delete-dialog-review.spec.ts
@@ -1,0 +1,496 @@
+/**
+ * Worktree-delete dialog visual-review harness (#11977).
+ *
+ * `WorktreeDeleteDialog` is the app's highest-consequence local surface: it
+ * spans D2 and D3, its content is computed from live git status, and three
+ * checkboxes rewrite what the delete will actually do. None of that is
+ * reviewable from the JSX — the states that carry the design weight only exist
+ * once a real worktree is dirty, a real terminal is attached, or the fresh
+ * status fetch has actually failed. So the fixture builds four worktrees with
+ * genuinely different git states and drives the real dialog through the real
+ * actions menu.
+ *
+ * Opt-in only, like the other review specs: skips itself unless
+ * DAINTREE_SHOT_DELETE is set, so the marketing screenshots workflow never
+ * executes it.
+ *
+ *   DAINTREE_SHOT_DELETE=1 npx playwright test --project=screenshots worktree-delete-dialog-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_DELETE  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME   optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG     optional suffix so review rounds sit side by side
+ *   DAINTREE_SHOT_ONLY    comma-separated step filter (see step names below)
+ *   DAINTREE_SHOT_OUT     output directory override
+ *
+ * Cross-theme sweep: switching themes in place crashes the project view under
+ * this harness (same failure `worktree-dialog-review` documents), so the sweep
+ * boots once per theme:
+ *
+ *   for t in daintree bondi highlands; do
+ *     DAINTREE_SHOT_DELETE=1 DAINTREE_SHOT_THEME=$t DAINTREE_SHOT_TAG=$t \
+ *     DAINTREE_SHOT_ONLY=force-tracked npx playwright test \
+ *     --project=screenshots worktree-delete-dialog-review
+ *   done
+ *
+ * Output: artifacts/delete-dialog-shots/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_DELETE;
+/** The testid sits on the backdrop; the dialog panel is its first child. */
+const PANEL = `${SEL.worktree.deleteDialog} > div`;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ?? path.resolve(process.cwd(), "artifacts", "delete-dialog-shots");
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+/** Branches the fixture builds a worktree for, each with a distinct git state. */
+const WT_CLEAN = "feature/streaming-uploads";
+const WT_TRACKED = "fix/retry-backoff-jitter";
+const WT_UNTRACKED = "chore/bump-electron";
+const WT_LONG = "feature/observability-pipeline-opentelemetry-span-exporter-backpressure";
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/**
+ * A repo with four worktrees whose git states cover the dialog's tiers:
+ * clean (D2, nothing to lose), tracked-dirty (D3 once forced), untracked-only
+ * (D2 even when forced — the #4927 split), and a long-identifier worktree that
+ * stresses every truncation point at once.
+ */
+function createFixtureRepo(): { dir: string; wtRoot: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-delete-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  writeFileSync(path.join(dir, "src", "index.ts"), "export const main = (): number => 0;\n");
+  writeFileSync(path.join(dir, "src", "queue.ts"), "export const queue: string[] = [];\n");
+  writeFileSync(path.join(dir, "src", "retry.ts"), "export const retries = 3;\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  git("branch develop", dir);
+  git("checkout develop", dir);
+
+  for (const branch of [WT_CLEAN, WT_TRACKED, WT_UNTRACKED, WT_LONG]) {
+    git(`branch ${branch}`, dir);
+    const wtPath = path.join(wtRoot, branch.replace(/\//g, "-"));
+    git(`worktree add ${JSON.stringify(wtPath)} ${branch}`, dir);
+  }
+
+  // Tracked changes: modified + deleted + a couple of untracked, so the file
+  // list renders more than one status glyph and the counts split.
+  const tracked = path.join(wtRoot, WT_TRACKED.replace(/\//g, "-"));
+  writeFileSync(path.join(tracked, "src", "retry.ts"), "export const retries = 7;\n");
+  writeFileSync(path.join(tracked, "src", "queue.ts"), "export const queue: number[] = [];\n");
+  rmSync(path.join(tracked, "src", "index.ts"));
+  writeFileSync(path.join(tracked, "src", "jitter.ts"), "export const jitter = 0.3;\n");
+  writeFileSync(path.join(tracked, ".env.local"), "TOKEN=dev\n");
+
+  // Untracked only: the D2-that-must-not-escalate case (#4927).
+  const untracked = path.join(wtRoot, WT_UNTRACKED.replace(/\//g, "-"));
+  writeFileSync(path.join(untracked, "notes.md"), "# scratch\n");
+  writeFileSync(path.join(untracked, "electron-42.log"), "upgrade log\n");
+
+  // Long identifiers: a deep path, a long branch, and enough files to overflow
+  // the preview's 12-row cap so the "…and N more" tail renders too.
+  const long = path.join(wtRoot, WT_LONG.replace(/\//g, "-"));
+  mkdirSync(path.join(long, "packages", "telemetry-exporter", "src", "internal"), {
+    recursive: true,
+  });
+  for (let i = 0; i < 16; i++) {
+    writeFileSync(
+      path.join(
+        long,
+        "packages",
+        "telemetry-exporter",
+        "src",
+        "internal",
+        `span-exporter-backpressure-strategy-${i}.ts`
+      ),
+      `export const strategy${i} = ${i};\n`
+    );
+  }
+  writeFileSync(path.join(long, "src", "retry.ts"), "export const retries = 99;\n");
+
+  return {
+    dir,
+    wtRoot,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 500): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/** Written shots, so the run can assert it produced what it claimed to. */
+const written: string[] = [];
+
+async function snap(page: Page, slug: string, locator?: string): Promise<void> {
+  await settle(page);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (locator) {
+    await page.locator(locator).first().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+  written.push(path.basename(file));
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+/**
+ * Steps report their failure but never abort the run — one unreachable state
+ * shouldn't cost the other twelve. The file-count assertion at the end is what
+ * turns a silently-empty run into a failure.
+ */
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    console.warn(`[delete-shots] step "${name}" FAILED:`, String(error).slice(0, 400));
+  }
+}
+
+/**
+ * Open the card's actions menu — the same route `core-worktree-lifecycle`
+ * takes. Closes any menu left open by a previous step first: a Radix trigger
+ * whose `aria-expanded` is already true swallows the click, and the failure
+ * then cascades into every later step as a 30s timeout.
+ */
+async function openActionsMenu(page: Page, branch: string): Promise<void> {
+  if (
+    await page
+      .locator('[role="menu"]')
+      .first()
+      .isVisible()
+      .catch(() => false)
+  ) {
+    await page.keyboard.press("Escape");
+    await settle(page, 250);
+  }
+  const card = page.locator(SEL.worktree.card(branch)).first();
+  await card.scrollIntoViewIfNeeded().catch(() => {});
+  await card.hover().catch(() => {});
+  const trigger = card.locator(SEL.worktree.actionsMenu).first();
+  await trigger.click();
+  await page.locator('[role="menu"]').first().waitFor({ state: "visible", timeout: 5000 });
+  await settle(page, 300);
+}
+
+/** Open the actions menu's "Launch" submenu and pick one of its items. */
+async function launchFromMenu(page: Page, branch: string, item: RegExp): Promise<void> {
+  await openActionsMenu(page, branch);
+  const launch = page.getByRole("menuitem", { name: /^Launch$/ }).first();
+  // Radix SubTriggers open on hover, but a hover that lands before the menu
+  // finishes its enter animation is dropped — click is the reliable fallback.
+  await launch.hover();
+  await settle(page, 400);
+  const target = page.getByRole("menuitem", { name: item }).first();
+  if (!(await target.isVisible().catch(() => false))) {
+    await launch.click();
+    await settle(page, 400);
+  }
+  await target.click({ timeout: 10000 });
+}
+
+/** Open the delete dialog for a worktree card via its real actions menu. */
+async function openDialog(page: Page, branch: string): Promise<void> {
+  await openActionsMenu(page, branch);
+  const deleteItem = page.getByRole("menuitem", { name: /delete worktree/i }).first();
+  await deleteItem.hover();
+  await deleteItem.click();
+  await page.locator(SEL.worktree.deleteDialog).waitFor({ state: "visible", timeout: 8000 });
+  // `useWorktreeTerminals` debounces `counts` by 250ms while `terminals` is not
+  // debounced, and the fresh git-status fetch resolves over a MessagePort —
+  // settle past both or the terminal row and the file list capture stale.
+  await settle(page, 1200);
+}
+
+async function closeDialog(page: Page): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+  }
+}
+
+/** Click a checkbox inside the dialog by its visible label text. */
+async function toggle(page: Page, labelText: string): Promise<void> {
+  await page
+    .locator(`${SEL.worktree.deleteDialog} label`, { hasText: labelText })
+    .first()
+    .locator('input[type="checkbox"]')
+    .click();
+  await settle(page, 400);
+}
+
+test("worktree-delete dialog review — every consequence tier", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_DELETE is required for the delete-dialog capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_DELETE to run the delete-dialog capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-deleteshot-"));
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    // The worktree monitors have to finish their first git-status pass before
+    // the dirty fixtures read as dirty; without this the "clean" shot and the
+    // "tracked" shot are the same picture.
+    await settle(page, 4000);
+    await dismissBlockingPalette(page);
+
+    // 1. Clean worktree, no terminals — the D2 floor, and the shot that shows
+    //    how much of the dialog is spent on things that will not happen.
+    await step("clean", async () => {
+      await openDialog(page, WT_CLEAN);
+      await snap(page, "10-clean", PANEL);
+      await snap(page, "11-clean-in-window");
+      await closeDialog(page);
+    });
+
+    // 2. Clean + delete-branch checked — the one optional consequence that is
+    //    reachable without any dirt.
+    await step("clean-branch", async () => {
+      await openDialog(page, WT_CLEAN);
+      await toggle(page, "Delete branch");
+      await snap(page, "15-clean-delete-branch", PANEL);
+      await closeDialog(page);
+    });
+
+    // 3. Tracked changes, force OFF — the warning tier that tells the user the
+    //    standard delete is going to fail.
+    await step("dirty", async () => {
+      await openDialog(page, WT_TRACKED);
+      await snap(page, "20-tracked-force-off", PANEL);
+      await closeDialog(page);
+    });
+
+    // 4. Tracked changes, force ON — D3. Error banner + real file list + the
+    //    typed-name gate all on screen at once. The money shot.
+    await step("force-tracked", async () => {
+      await openDialog(page, WT_TRACKED);
+      await toggle(page, "Force delete");
+      await snap(page, "30-tracked-force-on", PANEL);
+      await snap(page, "31-tracked-force-on-in-window");
+      await closeDialog(page);
+    });
+
+    // 5. D3 with the name typed — the only state where the destructive button
+    //    is live.
+    await step("typed", async () => {
+      await openDialog(page, WT_TRACKED);
+      await toggle(page, "Force delete");
+      await page.locator(SEL.worktree.deleteConfirmInput).fill(WT_TRACKED);
+      await snap(page, "35-tracked-force-on-typed", PANEL);
+      await closeDialog(page);
+    });
+
+    // 6. Untracked only, force ON — D2 that must NOT escalate (#4927). Visually
+    //    near-identical to the D3 shot, which is the thing worth checking.
+    await step("untracked", async () => {
+      await openDialog(page, WT_UNTRACKED);
+      await toggle(page, "Force delete");
+      await snap(page, "40-untracked-force-on", PANEL);
+      await closeDialog(page);
+    });
+
+    // 7. Long branch, deep path, 17 changed files — every truncation point at
+    //    once, including the preview's "…and N more" tail.
+    await step("long", async () => {
+      await openDialog(page, WT_LONG);
+      await toggle(page, "Force delete");
+      await snap(page, "50-long-identifiers", PANEL);
+      await snap(page, "51-long-identifiers-in-window");
+      await closeDialog(page);
+    });
+
+    // 8. Terminals attached. Opening a terminal on the card is the real seam —
+    //    `useWorktreeTerminals` reads the panel store, so a spawned pane is
+    //    what the dialog actually counts.
+    await step("terminals", async () => {
+      for (let i = 0; i < 2; i++) {
+        await launchFromMenu(page, WT_CLEAN, /^Open Terminal$/);
+        await settle(page, 2500);
+        await dismissBlockingPalette(page);
+      }
+      await openDialog(page, WT_CLEAN);
+      await snap(page, "60-with-terminals", PANEL);
+      await closeDialog(page);
+    });
+
+    // 8b. Dev preview running — the other cascade the dialog discloses. Opened
+    //     through the same Launch submenu so the real IPC session exists.
+    await step("dev-preview", async () => {
+      await launchFromMenu(page, WT_CLEAN, /^Open Dev Preview$/);
+      await settle(page, 5000);
+      await dismissBlockingPalette(page);
+      await openDialog(page, WT_CLEAN);
+      // The row only un-strikes when a session exists and is not "stopped".
+      // Assert it rather than writing a PNG identical to the previous state —
+      // a lookalike shot is worse than a missing one, because it reads as
+      // evidence for a state nobody actually reached.
+      const devRow = page
+        .locator(`${SEL.worktree.deleteDialog} li`, { hasText: "Dev server will be stopped" })
+        .first();
+      const struck = await devRow.evaluate(
+        (el) => getComputedStyle(el).textDecorationLine.includes("line-through"),
+        undefined
+      );
+      if (struck) throw new Error("dev preview never reported running — row still struck through");
+      await snap(page, "65-with-dev-preview", PANEL);
+      await closeDialog(page);
+    });
+
+    // 9. Fail-closed verification. The fresh status ride is a MessagePort
+    //    request, not an IPC invoke, so the fault goes in at that seam — the
+    //    same one `worktreeClient.getFreshChanges` calls — rather than at the
+    //    UI. This is the only way to see the `verifyFailed` banner, and it is
+    //    the banner that guards the worst case.
+    // 9. Fail-closed verification. No mocking: the worktree directory is
+    //    removed from disk behind the app's back — a real scenario (someone
+    //    rm -rf'd it, or a volume unmounted) — so the fresh `git status` the
+    //    dialog runs on open genuinely fails and the dialog falls back to its
+    //    D3 fail-closed path. Patching the IPC bridge is not an option here:
+    //    `worktreePort` is a non-configurable contextBridge property, so both
+    //    assignment and defineProperty are rejected in the isolated world.
+    //    This runs LAST among the dirty-state steps because it destroys its
+    //    own fixture.
+    await step("verify-failed", async () => {
+      rmSync(path.join(repo.wtRoot, WT_UNTRACKED.replace(/\//g, "-")), {
+        recursive: true,
+        force: true,
+      });
+      await settle(page, 1500);
+      await openDialog(page, WT_UNTRACKED);
+      // The fail-closed banner is the whole point of this shot — refuse to
+      // write a PNG that does not contain it rather than ship a lookalike.
+      await page
+        .locator(SEL.worktree.deleteDialog)
+        .getByText(/Couldn't verify/i)
+        .waitFor({ state: "visible", timeout: 8000 });
+      await snap(page, "70-verify-failed", PANEL);
+      await closeDialog(page);
+    });
+
+    // 10. Keyboard focus. A destructive dialog opens focus on Cancel, and the
+    //     force checkbox is the control that changes the blast radius — both
+    //     rings have to be visible against the destructive surface.
+    await step("focus", async () => {
+      await openDialog(page, WT_TRACKED);
+      const describeFocus = () =>
+        page.evaluate(() => {
+          const el = document.activeElement as HTMLElement | null;
+          if (!el) return "none";
+          const label = (el.closest("label")?.textContent ?? el.textContent ?? "").trim();
+          return `${el.tagName.toLowerCase()}${
+            el.getAttribute("type") ? `[${el.getAttribute("type")}]` : ""
+          } :: ${label.slice(0, 60)}`;
+        });
+      const initial = await describeFocus();
+      await snap(page, "80-focus-initial", PANEL);
+      await page.keyboard.press("Tab");
+      await settle(page, 300);
+      const next = await describeFocus();
+      await snap(page, "81-focus-next", PANEL);
+      // Recorded, not asserted: WHERE initial focus lands is the finding, and
+      // it is the thing under review — the harness must report it, not judge it.
+      console.log(`[delete-shots] initial focus: ${initial}`);
+      console.log(`[delete-shots] focus after Tab: ${next}`);
+      if (initial === next) {
+        throw new Error(`Tab did not move focus (still ${initial}) — 80/81 are duplicates`);
+      }
+      await closeDialog(page);
+    });
+
+    // 11. Forced-colors, on the highest tier. The dialog leans on colour to
+    //     separate its warning tiers; forced-colors is where that collapses.
+    await step("forced-colors", async () => {
+      await page.emulateMedia({ forcedColors: "active" }).catch(() => {});
+      await openDialog(page, WT_TRACKED);
+      await toggle(page, "Force delete");
+      await snap(page, "90-forced-colors", PANEL);
+      await closeDialog(page);
+      await page.emulateMedia({ forcedColors: "none" }).catch(() => {});
+    });
+
+    // 12. prefers-contrast: more — the macOS "increase contrast" path, which
+    //     is a separate block from forced-colors in this codebase.
+    await step("high-contrast", async () => {
+      await page.emulateMedia({ contrast: "more" }).catch(() => {});
+      await openDialog(page, WT_TRACKED);
+      await toggle(page, "Force delete");
+      await snap(page, "95-high-contrast", PANEL);
+      await closeDialog(page);
+      await page.emulateMedia({ contrast: "no-preference" }).catch(() => {});
+    });
+  } finally {
+    if (ctx) await closeApp(ctx.app).catch(() => {});
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+
+  // Never report success on an artifact we did not verify: a harness that
+  // swallows per-step errors will happily exit 0 having written nothing.
+  const onDisk = readdirSync(OUTPUT_DIR).filter(
+    (f) => f.endsWith(`${TAG}.png`) || (!TAG && f.endsWith(".png"))
+  );
+  console.log(`[delete-shots] wrote ${written.length} shots to ${OUTPUT_DIR}`);
+  expect(written.length, "capture produced no screenshots").toBeGreaterThan(0);
+  expect(onDisk.length, "screenshots were not written to disk").toBeGreaterThanOrEqual(
+    written.length
+  );
+});

--- a/e2e/screenshots/worktree-delete-dialog-review.spec.ts
+++ b/e2e/screenshots/worktree-delete-dialog-review.spec.ts
@@ -186,8 +186,20 @@ async function step(name: string, fn: () => Promise<void>): Promise<void> {
     await fn();
   } catch (error) {
     console.warn(`[delete-shots] step "${name}" FAILED:`, String(error).slice(0, 400));
+    // A step that threw mid-dialog leaves the modal open, and the next step
+    // then spends 30s failing to click a worktree card the dialog is covering.
+    // One failure should cost one shot, not the rest of the run.
+    if (activePage) {
+      for (let i = 0; i < 3; i++) {
+        await activePage.keyboard.press("Escape").catch(() => {});
+        await activePage.waitForTimeout(200);
+      }
+    }
   }
 }
+
+/** Set once the app is up, so `step` can recover the UI after a failure. */
+let activePage: Page | undefined;
 
 /**
  * Open the card's actions menu — the same route `core-worktree-lifecycle`
@@ -280,6 +292,7 @@ test("worktree-delete dialog review — every consequence tier", async () => {
       extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
     });
     const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    activePage = page;
     if (THEME) await setAppTheme(page, THEME);
     await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
     await dismissBlockingPalette(page);
@@ -372,29 +385,6 @@ test("worktree-delete dialog review — every consequence tier", async () => {
       await closeDialog(page);
     });
 
-    // 8b. Dev preview running — the other cascade the dialog discloses. Opened
-    //     through the same Launch submenu so the real IPC session exists.
-    await step("dev-preview", async () => {
-      await launchFromMenu(page, WT_CLEAN, /^Open Dev Preview$/);
-      await settle(page, 5000);
-      await dismissBlockingPalette(page);
-      await openDialog(page, WT_CLEAN);
-      // The row only un-strikes when a session exists and is not "stopped".
-      // Assert it rather than writing a PNG identical to the previous state —
-      // a lookalike shot is worse than a missing one, because it reads as
-      // evidence for a state nobody actually reached.
-      const devRow = page
-        .locator(`${SEL.worktree.deleteDialog} li`, { hasText: "Dev server will be stopped" })
-        .first();
-      const struck = await devRow.evaluate(
-        (el) => getComputedStyle(el).textDecorationLine.includes("line-through"),
-        undefined
-      );
-      if (struck) throw new Error("dev preview never reported running — row still struck through");
-      await snap(page, "65-with-dev-preview", PANEL);
-      await closeDialog(page);
-    });
-
     // 9. Fail-closed verification. The fresh status ride is a MessagePort
     //    request, not an IPC invoke, so the fault goes in at that seam — the
     //    same one `worktreeClient.getFreshChanges` calls — rather than at the
@@ -420,7 +410,7 @@ test("worktree-delete dialog review — every consequence tier", async () => {
       // write a PNG that does not contain it rather than ship a lookalike.
       await page
         .locator(SEL.worktree.deleteDialog)
-        .getByText(/Couldn't verify/i)
+        .getByText(/Couldn't (verify|check)/i)
         .waitFor({ state: "visible", timeout: 8000 });
       await snap(page, "70-verify-failed", PANEL);
       await closeDialog(page);
@@ -451,7 +441,13 @@ test("worktree-delete dialog review — every consequence tier", async () => {
       console.log(`[delete-shots] initial focus: ${initial}`);
       console.log(`[delete-shots] focus after Tab: ${next}`);
       if (initial === next) {
-        throw new Error(`Tab did not move focus (still ${initial}) — 80/81 are duplicates`);
+        // Recorded, not thrown: in the packaged app the dialog lives in a
+        // per-project WebContentsView, so `document.activeElement` read from
+        // the top frame is not authoritative. The real focus contract is
+        // asserted against the actual AppDialog in
+        // `WorktreeDeleteDialog.focus.test.tsx`; this line is a hint, not a
+        // verdict, and it must not cost the later shots.
+        console.warn(`[delete-shots] Tab did not move focus in this frame (${initial})`);
       }
       await closeDialog(page);
     });
@@ -476,6 +472,28 @@ test("worktree-delete dialog review — every consequence tier", async () => {
       await snap(page, "95-high-contrast", PANEL);
       await closeDialog(page);
       await page.emulateMedia({ contrast: "no-preference" }).catch(() => {});
+    });
+    // LAST. Dev preview running — the other cascade the dialog discloses. Opened
+    //     through the same Launch submenu so the real IPC session exists.
+    await step("dev-preview", async () => {
+      await launchFromMenu(page, WT_CLEAN, /^Open Dev Preview$/);
+      await settle(page, 5000);
+      await dismissBlockingPalette(page);
+      await openDialog(page, WT_CLEAN);
+      // The row only un-strikes when a session exists and is not "stopped".
+      // Assert it rather than writing a PNG identical to the previous state —
+      // a lookalike shot is worse than a missing one, because it reads as
+      // evidence for a state nobody actually reached.
+      const devRow = page
+        .locator(`${SEL.worktree.deleteDialog} li`, { hasText: "Dev server will be stopped" })
+        .first();
+      const struck = await devRow.evaluate(
+        (el) => getComputedStyle(el).textDecorationLine.includes("line-through"),
+        undefined
+      );
+      if (struck) throw new Error("dev preview never reported running — row still struck through");
+      await snap(page, "65-with-dev-preview", PANEL);
+      await closeDialog(page);
     });
   } finally {
     if (ctx) await closeApp(ctx.app).catch(() => {});

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -433,7 +433,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           <div className="relative flex-1 min-w-0">
             {/* Left Scroll Chevron - Overlay */}
             {canScrollLeft && (
-              <div className="absolute left-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-r from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pr-4">
+              <div className="absolute left-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-r from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pr-4 contrast-more:bg-none">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
@@ -523,7 +523,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
             {/* Right Scroll Chevron - Overlay */}
             {canScrollRight && (
-              <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-l from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pl-4">
+              <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-l from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pl-4 contrast-more:bg-none">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -433,7 +433,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           <div className="relative flex-1 min-w-0">
             {/* Left Scroll Chevron - Overlay */}
             {canScrollLeft && (
-              <div className="absolute left-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-r from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pr-4 contrast-more:bg-none">
+              <div className="absolute left-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-r from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pr-4 contrast-more:bg-none contrast-more:bg-[var(--dock-bg)]">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
@@ -523,7 +523,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
             {/* Right Scroll Chevron - Overlay */}
             {canScrollRight && (
-              <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-l from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pl-4 contrast-more:bg-none">
+              <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-l from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pl-4 contrast-more:bg-none contrast-more:bg-[var(--dock-bg)]">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -465,9 +465,16 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                     className={cn("flex gap-2", row.isOverflow && "text-daintree-text/50 italic")}
                   >
                     {!row.isOverflow && (
-                      <span aria-hidden="true" className="w-3 shrink-0 text-daintree-text/50">
-                        {row.glyph}
-                      </span>
+                      <>
+                        <span aria-hidden="true" className="w-3 shrink-0 text-daintree-text/50">
+                          {row.glyph}
+                        </span>
+                        {/* The glyph column is right for scanning and useless
+                            to a screen reader, which would otherwise hear a
+                            list of paths with no way to tell a deletion from
+                            an addition. */}
+                        <span className="sr-only">{row.statusLabel}: </span>
+                      </>
                     )}
                     <span className="[overflow-wrap:anywhere]">{row.label}</span>
                   </li>
@@ -480,6 +487,11 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
               consequences they rewrite. Checking a box below content it
               changes is the "upstream state mutation" failure: the reader has
               already passed the text that just moved. */}
+          {/* `disabled` on the fieldset would also trap focus oddly, so the
+              controls carry it individually. Frozen during the submit-time
+              revalidation: that await can outlive a toggle, and the closure
+              would then dispatch the values the user had BEFORE they changed
+              their mind. Cancel and Escape stay live throughout. */}
           <fieldset className="space-y-3">
             <legend className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
               Options
@@ -490,7 +502,8 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                 type="checkbox"
                 checked={force}
                 onChange={(e) => setForce(e.target.checked)}
-                className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg"
+                disabled={isDeleting}
+                className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg disabled:opacity-50"
               />
               <span className="text-sm text-daintree-text">
                 {/* Constant by rule — a toggle label never changes with state
@@ -517,7 +530,8 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   type="checkbox"
                   checked={closeTerminals}
                   onChange={(e) => setCloseTerminals(e.target.checked)}
-                  className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg"
+                  disabled={isDeleting}
+                  className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg disabled:opacity-50"
                 />
                 <span className="text-sm text-daintree-text">
                   Close all terminals
@@ -534,7 +548,8 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   type="checkbox"
                   checked={deleteBranch}
                   onChange={(e) => setDeleteBranch(e.target.checked)}
-                  className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg"
+                  disabled={isDeleting}
+                  className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg disabled:opacity-50"
                 />
                 <span className="flex items-center gap-1.5 text-sm text-daintree-text">
                   <FolderGit2 className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
@@ -604,6 +619,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                 onChange={setConfirmInput}
                 onMatchSubmit={handleDelete}
                 preamble={highTierPreamble}
+                disabled={isDeleting}
                 data-testid="delete-worktree-confirm-input"
               />
             </div>

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from "react";
-import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { TypedNameConfirmInput } from "@/components/ui/TypedNameConfirmInput";
 import { AlertTriangle, Trash2 } from "lucide-react";
@@ -11,6 +10,7 @@ import {
   buildWorktreeDeletePreview,
   formatWorktreeChangeRows,
   summarizeWorktreeChanges,
+  PREVIEW_FILE_LIMIT,
   type WorktreeDeletePreview,
 } from "@/components/Worktree/worktreeDeletePreview";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
@@ -79,9 +79,14 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
 
   // Actual file list a force-delete would discard — a D2 preview must show
   // real content, not just a count (#11343). Prefer the fresh fetch's changes,
-  // fall back to the prop snapshot before it resolves.
+  // fall back to the prop snapshot before it resolves. Paths arrive absolute
+  // from the producer, so the root is passed to render them worktree-relative:
+  // repeating the full path on every row buries the filename past the wrap,
+  // which is the one part of a row that distinguishes it (#11977).
   const previewChangeRows = formatWorktreeChangeRows(
-    freshPreview?.changes ?? worktree.worktreeChanges?.changes ?? []
+    freshPreview?.changes ?? worktree.worktreeChanges?.changes ?? [],
+    PREVIEW_FILE_LIMIT,
+    freshPreview?.rootPath ?? worktree.worktreeChanges?.rootPath ?? worktree.path
   );
 
   const isProtectedBranch = isProtectedBranchName(worktree.branch?.toLowerCase());
@@ -237,80 +242,101 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     void revalidateThenDelete();
   };
 
-  const deleteButtonLabel = !force
-    ? "Delete worktree"
-    : isHighTier
-      ? `Force delete '${confirmTarget}'`
-      : "Force delete worktree";
+  // Verb-noun, and deliberately free of the branch name: interpolating an
+  // untruncated identifier here overflowed the footer and pushed Cancel out of
+  // the dialog entirely on long branches (#11977). The title and the
+  // typed-name gate both already name the target.
+  const deleteButtonLabel = force ? "Force delete worktree" : "Delete worktree";
 
-  let advisoryBanner: React.ReactNode = null;
-  if (verifyFailed) {
-    // Fresh-status fetch failed: we can't confirm what's in the tree, so we
-    // fail closed (the tier is already escalated via `hasTrackedChanges`) and
-    // say so plainly rather than implying a clean/known state.
-    advisoryBanner = (
-      <div
-        role="alert"
-        className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded text-status-error text-xs"
-      >
-        <AlertTriangle className="w-4 h-4 shrink-0" />
-        <p>
-          Couldn't verify this worktree's current changes. Force delete may discard uncommitted work
-          — proceed only if you're sure. This is irreversible.
-        </p>
-      </div>
-    );
-  } else if (hasChanges) {
-    if (!force) {
-      advisoryBanner = (
-        <div
-          role="alert"
-          className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded text-status-warning text-xs"
-        >
-          <AlertTriangle className="w-4 h-4 shrink-0" />
-          <p>
-            This worktree has{" "}
-            {hasTrackedChanges && hasUntrackedFiles
-              ? `${trackedChangeCount} uncommitted file${trackedChangeCount === 1 ? "" : "s"} and ${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`
-              : hasTrackedChanges
-                ? `${trackedChangeCount} uncommitted file${trackedChangeCount === 1 ? "" : "s"}`
-                : `${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`}
-            . Standard deletion will fail.
-          </p>
-        </div>
-      );
-    } else if (hasTrackedChanges) {
-      advisoryBanner = (
-        <div
-          role="alert"
-          className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded text-status-error text-xs"
-        >
-          <AlertTriangle className="w-4 h-4 shrink-0" />
-          <p>
-            Force delete will discard {trackedChangeCount} uncommitted tracked file
-            {trackedChangeCount === 1 ? "" : "s"}
-            {hasUntrackedFiles
-              ? ` and ${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`
-              : ""}
-            . This is irreversible.
-          </p>
-        </div>
-      );
-    } else {
-      advisoryBanner = (
-        <div
-          role="alert"
-          className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded text-status-error text-xs"
-        >
-          <AlertTriangle className="w-4 h-4 shrink-0" />
-          <p>
-            Force delete will permanently remove {untrackedFileCount} untracked file
-            {untrackedFileCount === 1 ? "" : "s"}.
-          </p>
-        </div>
-      );
-    }
+  const trackedLabel = `${trackedChangeCount} uncommitted file${trackedChangeCount === 1 ? "" : "s"}`;
+  const untrackedLabel = `${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`;
+  const changeSummaryLabel =
+    hasTrackedChanges && hasUntrackedFiles
+      ? `${trackedLabel} and ${untrackedLabel}`
+      : hasTrackedChanges
+        ? trackedLabel
+        : untrackedLabel;
+
+  /**
+   * The consequences that will ACTUALLY occur under the current options.
+   *
+   * Previously every possible outcome was rendered and the inapplicable ones
+   * were dimmed + struck through, so a clean delete showed five rows of which
+   * four were non-events and the user had to subtract them at the exact moment
+   * the dialog should be minimising interpretation (#11977). Strikethrough was
+   * also the ONLY signal — it carries no meaning to assistive tech, and it
+   * collapses entirely under forced-colors, where the dim tier disappears.
+   * Now a row exists only when it is true.
+   */
+  const consequences: { key: string; tone: "neutral" | "danger"; content: React.ReactNode }[] = [];
+  consequences.push({
+    key: "directory",
+    tone: "neutral",
+    content: "Worktree directory will be deleted from disk",
+  });
+  if (closeTerminals && hasTerminals) {
+    consequences.push({
+      key: "terminals",
+      tone: "neutral",
+      content: `${terminalCounts.total} terminal${terminalCounts.total === 1 ? "" : "s"} will be closed${
+        runningAgentCount > 0
+          ? ` — ${runningAgentCount} running an agent${runningAgentCount === 1 ? "" : "s"}`
+          : ""
+      }`,
+    });
   }
+  if (hasDevPreview) {
+    consequences.push({ key: "dev", tone: "neutral", content: "Dev server will be stopped" });
+  }
+  if (force && hasChanges) {
+    // The one irreversible outcome, stated once and specifically. This row
+    // replaces the old generic "Uncommitted changes will be lost" line, the
+    // separate red banner that repeated the same counts, and the standalone
+    // "This cannot be undone." — three assertions of one fact.
+    consequences.push({
+      key: "loss",
+      tone: "danger",
+      content: `${changeSummaryLabel} will be permanently lost`,
+    });
+  }
+  if (deleteBranch && canDeleteBranch) {
+    consequences.push({
+      key: "branch",
+      tone: "neutral",
+      content: (
+        <>
+          Branch <span className="font-mono break-all">{worktree.branch}</span> will be deleted
+          {" — "}
+          <span className="text-daintree-text/60">fails if it has unmerged changes</span>
+        </>
+      ),
+    });
+  }
+
+  // Fail-closed disclosure only. The option-driven consequences live in the
+  // list above and announce through a polite live region instead: `role="alert"`
+  // is assertive and would re-interrupt the user on every checkbox toggle.
+  const verifyFailedBanner = verifyFailed ? (
+    <div
+      role="alert"
+      className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)] text-status-error text-xs"
+    >
+      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
+      <p>
+        Couldn't check this worktree for uncommitted work. Force delete may discard changes that
+        aren't listed here.
+      </p>
+    </div>
+  ) : null;
+
+  // Standard (non-force) deletion is rejected by the backend when the tree is
+  // dirty, so the primary action would fail. Say so where the decision is made
+  // rather than letting the user find out from a toast.
+  const blockedHint =
+    hasChanges && !force ? `Standard deletion will fail — ${changeSummaryLabel} present` : null;
+
+  const changesHeadingId = "worktree-delete-changes-heading";
+  const consequencesHeadingId = "worktree-delete-consequences-heading";
 
   return (
     <AppDialog
@@ -324,152 +350,174 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       hasPreview
       data-testid="delete-worktree-dialog"
     >
+      <AppDialog.Header>
+        <AppDialog.Title icon={<Trash2 className="w-4 h-4 text-status-error" />}>
+          Delete '{confirmTarget}'?
+        </AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
       <AppDialog.Body>
-        <div className="flex items-center gap-3 mb-4 text-status-error">
-          <div className="p-2 bg-status-error/10 rounded-full">
-            <Trash2 className="w-6 h-6" />
-          </div>
-          <AppDialog.Title>Delete '{confirmTarget}'?</AppDialog.Title>
-        </div>
+        {/* Static, concise, and the target of the dialog's `aria-describedby`.
+            Deliberately not the dynamic consequence list: pointing the
+            description at live content makes a screen reader read the whole
+            payload before the focused control every time it changes. */}
+        <AppDialog.Description className="sr-only">
+          Deletes this worktree's directory from disk. The options below can also close its
+          terminals, discard uncommitted work, and delete its branch.
+        </AppDialog.Description>
 
-        <div className="space-y-4">
-          <div>
-            <span
-              role="heading"
-              aria-level={3}
-              className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
-            >
-              What will happen
-            </span>
-            <ul className="mt-2 space-y-1">
-              <li className="text-sm text-daintree-text">Worktree directory will be deleted</li>
-              <li
-                className={cn(
-                  "text-sm",
-                  closeTerminals && hasTerminals
-                    ? "text-daintree-text"
-                    : "text-daintree-text/40 line-through"
-                )}
-              >
-                {terminalCounts.total} terminal{terminalCounts.total === 1 ? "" : "s"} will be
-                closed
-                {runningAgentCount > 0 ? ` (${runningAgentCount} running an agent)` : ""}
-              </li>
-              <li
-                className={cn(
-                  "text-sm",
-                  hasDevPreview ? "text-daintree-text" : "text-daintree-text/40 line-through"
-                )}
-              >
-                Dev server will be stopped
-              </li>
-              <li
-                className={cn(
-                  "text-sm",
-                  force && hasChanges ? "text-status-error" : "text-daintree-text/40 line-through"
-                )}
-              >
-                Uncommitted changes will be lost
-              </li>
-              <li
-                className={cn(
-                  "text-sm",
-                  deleteBranch && canDeleteBranch && force
-                    ? "text-status-warning"
-                    : deleteBranch && canDeleteBranch
-                      ? "text-daintree-text"
-                      : "text-daintree-text/40 line-through"
-                )}
-              >
-                {worktree.branch ? (
-                  <>
-                    Branch <span className="font-mono break-all">{worktree.branch}</span> will be
-                    deleted
-                  </>
-                ) : (
-                  "Branch will be deleted"
-                )}
-              </li>
-            </ul>
-          </div>
-          <p className="text-xs text-daintree-text/50">This cannot be undone.</p>
+        <div className="space-y-5">
+          {/* 1. WHAT — the entity, named once, concretely. */}
+          <dl className="rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg px-3 py-2.5 text-xs">
+            {worktree.branch && (
+              <div className="flex gap-2">
+                <dt className="w-14 shrink-0 text-daintree-text/50">Branch</dt>
+                <dd className="font-mono text-daintree-text break-all">{worktree.branch}</dd>
+              </div>
+            )}
+            <div className={cn("flex gap-2", worktree.branch && "mt-1.5")}>
+              <dt className="w-14 shrink-0 text-daintree-text/50">Path</dt>
+              <dd className="font-mono text-daintree-text/70 break-all">{worktree.path}</dd>
+            </div>
+          </dl>
 
-          <div className="text-xs text-daintree-text/60 bg-daintree-bg p-3 rounded border border-border-strong font-mono break-all">
-            {worktree.path}
-          </div>
+          {verifyFailedBanner}
 
-          {advisoryBanner}
-
-          {force && !verifyFailed && previewChangeRows.length > 0 && (
+          {/* 2. WHAT'S IN THERE — the actual content, shown whenever the tree
+              is dirty, not only once force is on. A D2 confirm owes a preview
+              of real content; a count alone is insufficient, and the user
+              needs the list to decide whether forcing is safe. */}
+          {hasChanges && !verifyFailed && previewChangeRows.length > 0 && (
             <div>
-              <span
-                role="heading"
-                aria-level={3}
-                className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
-              >
-                Files that will be lost
-              </span>
+              <div className="flex items-baseline justify-between gap-2">
+                <span
+                  id={changesHeadingId}
+                  role="heading"
+                  aria-level={3}
+                  className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
+                >
+                  Uncommitted work
+                </span>
+                <span className="text-[11px] tabular-nums text-daintree-text/50">
+                  {changeSummaryLabel}
+                </span>
+              </div>
               <pre
                 data-testid="delete-worktree-file-list"
-                className="mt-2 max-h-32 overflow-auto text-xs text-daintree-text/70 bg-daintree-bg p-3 rounded border border-border-strong font-mono whitespace-pre-wrap break-all"
+                aria-labelledby={changesHeadingId}
+                tabIndex={0}
+                className="mt-2 max-h-32 overflow-auto text-xs text-daintree-text/70 bg-daintree-bg p-3 rounded-[var(--radius-md)] border border-border-strong font-mono whitespace-pre-wrap break-all"
               >
                 {previewChangeRows.join("\n")}
               </pre>
             </div>
           )}
 
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={force}
-              onChange={(e) => setForce(e.target.checked)}
-              className="rounded border-border-strong bg-daintree-bg text-status-error focus:ring-status-error"
-            />
-            <span className="text-sm text-daintree-text">
-              {hasTrackedChanges && hasUntrackedFiles
-                ? "Force delete (lose uncommitted changes and untracked files)"
-                : hasUntrackedFiles
-                  ? "Force delete (remove untracked files)"
-                  : "Force delete (lose uncommitted changes)"}
-            </span>
-          </label>
+          {/* 3. THE CAUSE — every optional operation, grouped, above the
+              consequences they rewrite. Checking a box below content it
+              changes is the "upstream state mutation" failure: the reader has
+              already passed the text that just moved. */}
+          <fieldset className="space-y-3">
+            <legend className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+              Options
+            </legend>
 
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={closeTerminals}
-              onChange={(e) => setCloseTerminals(e.target.checked)}
-              className="rounded border-border-strong bg-daintree-bg text-daintree-accent focus:ring-daintree-accent/30"
-            />
-            <span className="text-sm text-daintree-text">
-              Close all terminals{hasTerminals ? ` (${terminalCounts.total})` : ""}
-            </span>
-          </label>
-
-          {canDeleteBranch && (
             <label className="flex items-start gap-2 cursor-pointer">
               <input
                 type="checkbox"
-                checked={deleteBranch}
-                onChange={(e) => setDeleteBranch(e.target.checked)}
-                className="mt-0.5 rounded border-border-strong bg-daintree-bg text-status-error focus:ring-status-error"
+                checked={force}
+                onChange={(e) => setForce(e.target.checked)}
+                className="mt-0.5 rounded border-border-strong bg-daintree-bg"
               />
               <span className="text-sm text-daintree-text">
-                <span className="flex items-center gap-1.5">
-                  <FolderGit2 className="w-3.5 h-3.5" />
-                  Delete branch{" "}
-                  <code className="text-xs bg-daintree-bg px-1.5 py-0.5 rounded border border-border-strong">
-                    {worktree.branch}
-                  </code>
-                </span>
-                {deleteBranch && (
-                  <span className="block text-xs text-daintree-text/60 mt-1">
-                    Safe delete — fails if branch has unmerged changes
+                {/* Constant by rule — a toggle label never changes with state
+                    (house microcopy), and this one used to swap between three
+                    wordings. It also has to stay the same verb as the primary
+                    button ("Force delete worktree"), so checking the box and
+                    reading the button describe one action, not two. What
+                    actually varies is the consequence, stated below and in the
+                    "What will happen" list. */}
+                Force delete
+                {hasChanges && (
+                  <span className="block text-xs text-daintree-text/60 mt-0.5">
+                    Required to delete this worktree — {changeSummaryLabel} present
                   </span>
                 )}
               </span>
             </label>
-          )}
+
+            {hasTerminals && (
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={closeTerminals}
+                  onChange={(e) => setCloseTerminals(e.target.checked)}
+                  className="mt-0.5 rounded border-border-strong bg-daintree-bg"
+                />
+                <span className="text-sm text-daintree-text">
+                  Close all terminals
+                  <span className="ml-1 tabular-nums text-daintree-text/60">
+                    ({terminalCounts.total})
+                  </span>
+                </span>
+              </label>
+            )}
+
+            {canDeleteBranch && (
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={deleteBranch}
+                  onChange={(e) => setDeleteBranch(e.target.checked)}
+                  className="mt-0.5 rounded border-border-strong bg-daintree-bg"
+                />
+                <span className="flex items-center gap-1.5 text-sm text-daintree-text">
+                  <FolderGit2 className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                  Delete branch
+                  <code className="text-xs bg-daintree-bg px-1.5 py-0.5 rounded border border-border-strong break-all">
+                    {worktree.branch}
+                  </code>
+                </span>
+              </label>
+            )}
+          </fieldset>
+
+          {/* 4. THE EFFECT — computed from the options directly above. Only
+              outcomes that will actually occur are listed. */}
+          <div>
+            <span
+              id={consequencesHeadingId}
+              role="heading"
+              aria-level={3}
+              className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
+            >
+              What will happen
+            </span>
+            {/* The list IS the live region. Mirroring it into a second sr-only
+                node duplicated every string in the DOM, so assistive tech read
+                each consequence twice. `polite` (not `alert`) because these
+                change on every checkbox toggle and must not interrupt. */}
+            <ul
+              aria-labelledby={consequencesHeadingId}
+              aria-live="polite"
+              aria-relevant="all"
+              className="mt-2 space-y-1"
+            >
+              {consequences.map((row) => (
+                <li
+                  key={row.key}
+                  className={cn(
+                    "text-sm",
+                    row.tone === "danger" ? "text-status-error font-medium" : "text-daintree-text"
+                  )}
+                >
+                  {row.tone === "danger" && <span className="sr-only">Irreversible: </span>}
+                  {row.content}
+                </li>
+              ))}
+            </ul>
+          </div>
 
           {isHighTier && (
             <TypedNameConfirmInput
@@ -484,20 +532,20 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
         </div>
       </AppDialog.Body>
 
-      <AppDialog.Footer>
-        <Button variant="ghost" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button
-          variant="destructive"
-          onClick={handleDelete}
-          disabled={!canSubmit}
-          aria-live="polite"
-          data-testid="delete-worktree-confirm"
-        >
-          {deleteButtonLabel}
-        </Button>
-      </AppDialog.Footer>
+      <AppDialog.Footer
+        hint={
+          isHighTier && !isConfirmMatched
+            ? `Type ${confirmTarget} above to enable`
+            : (blockedHint ?? undefined)
+        }
+        secondaryAction={{ label: "Cancel", onClick: onClose }}
+        primaryAction={{
+          label: deleteButtonLabel,
+          onClick: handleDelete,
+          disabled: !canSubmit,
+          intent: "destructive",
+        }}
+      />
     </AppDialog>
   );
 }

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -8,7 +8,7 @@ import { collectRunningAgentTerminals } from "@/utils/destructiveSessionConfirm"
 import { deriveEffectiveTier } from "@/services/actions/deriveEffectiveTier";
 import {
   buildWorktreeDeletePreview,
-  formatWorktreeChangeRows,
+  buildWorktreeChangeRows,
   summarizeWorktreeChanges,
   PREVIEW_FILE_LIMIT,
   type WorktreeDeletePreview,
@@ -85,7 +85,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   // from the producer, so the root is passed to render them worktree-relative:
   // repeating the full path on every row buries the filename past the wrap,
   // which is the one part of a row that distinguishes it (#11977).
-  const previewChangeRows = formatWorktreeChangeRows(
+  const previewChangeRows = buildWorktreeChangeRows(
     freshPreview?.changes ?? worktree.worktreeChanges?.changes ?? [],
     PREVIEW_FILE_LIMIT,
     freshPreview?.rootPath ?? worktree.worktreeChanges?.rootPath ?? worktree.path
@@ -109,7 +109,14 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       hasTrackedChanges,
     }) === "D3";
   const isConfirmMatched = confirmInput === confirmTarget;
-  const canSubmit = (!isHighTier || isConfirmMatched) && !isDeleting;
+  // A standard (non-force) delete on a tree we KNOW is dirty is rejected by
+  // the backend, so offering it as the primary action ships a button whose
+  // only outcome is a toast and a reopened dialog. Gate it — but only when the
+  // dirtiness is verified: after a failed verification the safe non-force
+  // attempt is still the right first move, and disabling it would coerce the
+  // user into force on the very state we could not check.
+  const blockedByDirtyTree = hasChanges && !force && !verifyFailed;
+  const canSubmit = (!isHighTier || isConfirmMatched) && !isDeleting && !blockedByDirtyTree;
 
   useEffect(() => {
     if (isOpen) {
@@ -267,8 +274,19 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
 
   const trackedLabel = `${trackedChangeCount} uncommitted file${trackedChangeCount === 1 ? "" : "s"}`;
   const untrackedLabel = `${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`;
-  const changeSummaryLabel =
-    hasTrackedChanges && hasUntrackedFiles
+  /**
+   * Never state a count we could not verify.
+   *
+   * `hasTrackedChanges` is forced true when the fresh status fetch fails, so
+   * the tier fails closed — but the counts still come from the (possibly
+   * clean, possibly stale) prop seed. Interpolating them anyway produced
+   * "0 uncommitted files will be permanently lost" in exactly the state where
+   * the dialog knows least, which reads as false precision at the worst
+   * possible moment. When unverified, say so instead of inventing a number.
+   */
+  const changeSummaryLabel = verifyFailed
+    ? "unverified uncommitted work"
+    : hasTrackedChanges && hasUntrackedFiles
       ? `${trackedLabel} and ${untrackedLabel}`
       : hasTrackedChanges
         ? trackedLabel
@@ -349,8 +367,13 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   // Standard (non-force) deletion is rejected by the backend when the tree is
   // dirty, so the primary action would fail. Say so where the decision is made
   // rather than letting the user find out from a toast.
-  const blockedHint =
-    hasChanges && !force ? `Standard deletion will fail — ${changeSummaryLabel} present` : null;
+  const blockedHint = !hasChanges
+    ? null
+    : force
+      ? null
+      : verifyFailed
+        ? "Couldn't verify this worktree — force delete to proceed anyway"
+        : `Select Force delete to continue — ${changeSummaryLabel} present`;
 
   const changesHeadingId = "worktree-delete-changes-heading";
   const consequencesHeadingId = "worktree-delete-consequences-heading";
@@ -390,12 +413,16 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
             {worktree.branch && (
               <div className="flex gap-2">
                 <dt className="w-14 shrink-0 text-daintree-text/50">Branch</dt>
-                <dd className="font-mono text-daintree-text break-all">{worktree.branch}</dd>
+                <dd className="font-mono text-daintree-text [overflow-wrap:anywhere]">
+                  {worktree.branch}
+                </dd>
               </div>
             )}
             <div className={cn("flex gap-2", worktree.branch && "mt-1.5")}>
               <dt className="w-14 shrink-0 text-daintree-text/50">Path</dt>
-              <dd className="font-mono text-daintree-text/70 break-all">{worktree.path}</dd>
+              <dd className="font-mono text-daintree-text/70 [overflow-wrap:anywhere]">
+                {worktree.path}
+              </dd>
             </div>
           </dl>
 
@@ -420,14 +447,32 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   {changeSummaryLabel}
                 </span>
               </div>
-              <pre
+              {/* Rows, not a wrapping <pre> of joined strings. A path longer
+                  than the box used to continue at the left edge, under the
+                  status column, so two long paths read as four files and the
+                  glyph detached from the name it belonged to. The glyph now
+                  sits in its own fixed column and the wrap hangs under the
+                  path. */}
+              <ul
                 data-testid="delete-worktree-file-list"
                 aria-labelledby={changesHeadingId}
                 tabIndex={0}
-                className="mt-2 max-h-32 overflow-auto text-xs text-daintree-text/70 bg-daintree-bg p-3 rounded-[var(--radius-md)] border border-border-strong font-mono whitespace-pre-wrap break-all"
+                className="mt-2 max-h-32 overflow-auto text-xs text-daintree-text/70 bg-daintree-bg p-3 rounded-[var(--radius-md)] border border-border-strong font-mono space-y-0.5"
               >
-                {previewChangeRows.join("\n")}
-              </pre>
+                {previewChangeRows.map((row) => (
+                  <li
+                    key={row.isOverflow ? "__overflow" : `${row.glyph}:${row.label}`}
+                    className={cn("flex gap-2", row.isOverflow && "text-daintree-text/50 italic")}
+                  >
+                    {!row.isOverflow && (
+                      <span aria-hidden="true" className="w-3 shrink-0 text-daintree-text/50">
+                        {row.glyph}
+                      </span>
+                    )}
+                    <span className="[overflow-wrap:anywhere]">{row.label}</span>
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
 
@@ -445,7 +490,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                 type="checkbox"
                 checked={force}
                 onChange={(e) => setForce(e.target.checked)}
-                className="mt-0.5 rounded border-border-strong bg-daintree-bg"
+                className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg"
               />
               <span className="text-sm text-daintree-text">
                 {/* Constant by rule — a toggle label never changes with state
@@ -458,7 +503,9 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                 Force delete
                 {hasChanges && (
                   <span className="block text-xs text-daintree-text/60 mt-0.5">
-                    Required to delete this worktree — {changeSummaryLabel} present
+                    {verifyFailed
+                      ? "Required because this worktree's status couldn't be verified"
+                      : `Required to delete this worktree — ${changeSummaryLabel} present`}
                   </span>
                 )}
               </span>
@@ -470,7 +517,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   type="checkbox"
                   checked={closeTerminals}
                   onChange={(e) => setCloseTerminals(e.target.checked)}
-                  className="mt-0.5 rounded border-border-strong bg-daintree-bg"
+                  className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg"
                 />
                 <span className="text-sm text-daintree-text">
                   Close all terminals
@@ -487,7 +534,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   type="checkbox"
                   checked={deleteBranch}
                   onChange={(e) => setDeleteBranch(e.target.checked)}
-                  className="mt-0.5 rounded border-border-strong bg-daintree-bg"
+                  className="checkbox-neutral mt-0.5 rounded border-border-strong bg-daintree-bg"
                 />
                 <span className="flex items-center gap-1.5 text-sm text-daintree-text">
                   <FolderGit2 className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
@@ -517,6 +564,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                 each consequence twice. `polite` (not `alert`) because these
                 change on every checkbox toggle and must not interrupt. */}
             <ul
+              data-testid="delete-worktree-consequences"
               aria-labelledby={consequencesHeadingId}
               aria-live="polite"
               aria-relevant="all"

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -18,6 +18,7 @@ import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import type { WorktreeState } from "@/types";
 import { cn } from "@/lib/utils";
 import { isProtectedBranch as isProtectedBranchName } from "@shared/utils/gitConstants";
+import { prefersReducedMotion } from "@/lib/appThemeViewTransition";
 
 interface WorktreeDeleteDialogProps {
   isOpen: boolean;
@@ -47,6 +48,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   // (an ABA race a plain boolean flag would miss). `mountedRef` covers unmount.
   const sessionRef = useRef(0);
   const mountedRef = useRef(true);
+  const gateRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     // Set on SETUP as well as clearing on cleanup — under React StrictMode the
     // mount effect runs setup → cleanup → setup, so a setup that only cleared
@@ -171,6 +173,21 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       setConfirmInput("");
     }
   }, [force]);
+
+  // An escalation the user cannot see is not an escalation. On a tall state
+  // (long path, many changed files) the D3 gate renders below the body's
+  // scroll fold, so the footer would report a disabled action whose cause was
+  // off-screen. Bring the gate into view when the tier escalates — the user
+  // did not scroll away from it, it appeared somewhere they were not looking.
+  useEffect(() => {
+    if (!isHighTier) return;
+    const node = gateRef.current;
+    if (!node) return;
+    node.scrollIntoView({
+      block: "nearest",
+      behavior: prefersReducedMotion() ? "auto" : "smooth",
+    });
+  }, [isHighTier]);
 
   useEffect(() => {
     if (!canDeleteBranch && deleteBranch) {
@@ -474,10 +491,11 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                 />
                 <span className="flex items-center gap-1.5 text-sm text-daintree-text">
                   <FolderGit2 className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                  {/* No branch chip: the entity summary directly above names
+                      the branch, and so does the title. A third copy bought
+                      nothing and, on a long branch, forced this label to wrap
+                      while the chip took the whole remaining width. */}
                   Delete branch
-                  <code className="text-xs bg-daintree-bg px-1.5 py-0.5 rounded border border-border-strong break-all">
-                    {worktree.branch}
-                  </code>
                 </span>
               </label>
             )}
@@ -531,22 +549,28 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
           </div>
 
           {isHighTier && (
-            <TypedNameConfirmInput
-              target={confirmTarget}
-              value={confirmInput}
-              onChange={setConfirmInput}
-              onMatchSubmit={handleDelete}
-              preamble={highTierPreamble}
-              data-testid="delete-worktree-confirm-input"
-            />
+            <div ref={gateRef}>
+              <TypedNameConfirmInput
+                target={confirmTarget}
+                value={confirmInput}
+                onChange={setConfirmInput}
+                onMatchSubmit={handleDelete}
+                preamble={highTierPreamble}
+                data-testid="delete-worktree-confirm-input"
+              />
+            </div>
           )}
         </div>
       </AppDialog.Body>
 
       <AppDialog.Footer
         hint={
+          // No identifier interpolated here. The gate directly above already
+          // shows the exact string to type, and putting an untruncated branch
+          // name in the footer is what broke this footer in the first place —
+          // it just moves the overflow from the button to the hint.
           isHighTier && !isConfirmMatched
-            ? `Type ${confirmTarget} above to enable`
+            ? "Confirm the name above to enable"
             : (blockedHint ?? undefined)
         }
         secondaryAction={{ label: "Cancel", onClick: onClose }}

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -331,7 +331,11 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     consequences.push({
       key: "loss",
       tone: "danger",
-      content: `${changeSummaryLabel} will be permanently lost`,
+      // Hedged only when the status fetch failed: that state is the one the
+      // dialog knows least about, and the banner above already says the loss
+      // is possible rather than certain. Where the changes ARE listed, the
+      // outcome is stated flatly.
+      content: `${changeSummaryLabel} ${verifyFailed ? "may be" : "will be"} permanently lost`,
     });
   }
   if (deleteBranch && canDeleteBranch) {
@@ -372,7 +376,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     : force
       ? null
       : verifyFailed
-        ? "Couldn't verify this worktree — force delete to proceed anyway"
+        ? "Couldn't verify this worktree — standard delete may fail"
         : `Select Force delete to continue — ${changeSummaryLabel} present`;
 
   const changesHeadingId = "worktree-delete-changes-heading";

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -507,13 +507,24 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
               {consequences.map((row) => (
                 <li
                   key={row.key}
+                  data-tone={row.tone}
                   className={cn(
-                    "text-sm",
+                    "text-sm flex items-start gap-1.5",
                     row.tone === "danger" ? "text-status-error font-medium" : "text-daintree-text"
                   )}
                 >
-                  {row.tone === "danger" && <span className="sr-only">Irreversible: </span>}
-                  {row.content}
+                  {row.tone === "danger" && (
+                    <>
+                      {/* The irreversible row must not be distinguished by
+                          colour alone. Under `forced-colors: active` every
+                          status colour resolves to the same system ink, so a
+                          red row and a neutral row become identical — the glyph
+                          and the weight are what survive. */}
+                      <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                      <span className="sr-only">Irreversible: </span>
+                    </>
+                  )}
+                  <span>{row.content}</span>
                 </li>
               ))}
             </ul>

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.focus.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.focus.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Initial-focus contract, against the REAL AppDialog.
+ *
+ * The main suite stubs AppDialog so it can assert copy and consequence logic
+ * cheaply, which means it can only check that the dialog *passes* the focus
+ * markers — not that the chrome then does the right thing with them. That gap
+ * is exactly where the original bug lived: `variant="destructive"` intends to
+ * focus Cancel, resolves it via `[data-confirm-role="cancel"]`, and silently
+ * falls back to the first tabbable element when the marker is absent. With a
+ * hand-written footer that fallback was the force-delete checkbox — the one
+ * control that widens the blast radius, which WAI-ARIA APG specifically
+ * forbids as an initial focus target.
+ *
+ * So this file mounts the real chrome and asserts where focus actually lands.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import type { WorktreeState } from "@/types";
+import type { WorktreeChanges, GitStatus } from "@shared/types/git";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+const { startDeleteMock, devPreviewGetByWorktreeMock, buildPreviewMock } = vi.hoisted(() => ({
+  startDeleteMock: vi.fn(),
+  devPreviewGetByWorktreeMock: vi.fn(),
+  buildPreviewMock: vi.fn(),
+}));
+
+vi.mock("@/components/Worktree/worktreeDeletePreview", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../worktreeDeletePreview")>();
+  return { ...actual, buildWorktreeDeletePreview: buildPreviewMock };
+});
+
+(window as unknown as Record<string, unknown>).electron = {
+  ...((window as unknown as Record<string, unknown>).electron ?? {}),
+  devPreview: { getByWorktree: devPreviewGetByWorktreeMock, stopByWorktree: vi.fn() },
+};
+
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStore: () => ({ getState: () => ({ startDelete: startDeleteMock }) }),
+}));
+
+vi.mock("@/hooks/useWorktreeTerminals", () => ({
+  useWorktreeTerminals: () => ({ counts: { total: 0 }, terminals: [] }),
+}));
+
+vi.mock("@/utils/destructiveSessionConfirm", () => ({
+  collectRunningAgentTerminals: () => [],
+}));
+
+import { WorktreeDeleteDialog } from "../WorktreeDeleteDialog";
+
+function makeChanges(files: Array<{ path: string; status: GitStatus }>): WorktreeChanges {
+  return {
+    worktreeId: "wt-1",
+    rootPath: "/test/worktree",
+    changedFileCount: files.length,
+    changes: files.map((f) => ({
+      path: f.path,
+      status: f.status,
+      insertions: null,
+      deletions: null,
+    })),
+  };
+}
+
+function makeWorktree(worktreeChanges: WorktreeChanges | null = null): WorktreeState {
+  return {
+    id: "wt-1",
+    path: "/test/worktree",
+    name: "feature/test",
+    branch: "feature/test",
+    isCurrent: false,
+    isMainWorktree: false,
+    gitDir: "/test/.git/worktrees/wt-1",
+    worktreeChanges,
+    agentStates: {},
+    prNumber: null,
+    prState: null,
+    prUrl: null,
+    issueNumber: null,
+    mood: "stable",
+    moodLabel: null,
+  } as unknown as WorktreeState;
+}
+
+describe("WorktreeDeleteDialog — real-chrome focus contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    buildPreviewMock.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("puts initial focus on Cancel, never on a control that widens the blast radius", async () => {
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={makeWorktree()} />);
+
+    await waitFor(() => {
+      const active = document.activeElement as HTMLElement | null;
+      expect(active).not.toBeNull();
+      // The rule: focus is on the safest control. Asserted by role+name rather
+      // than by identity so it keeps holding if the footer is restructured.
+      expect(active?.tagName.toLowerCase()).toBe("button");
+      expect(active?.textContent?.trim()).toBe("Cancel");
+    });
+
+    // And explicitly NOT the force checkbox — the original defect.
+    expect((document.activeElement as HTMLElement).getAttribute("type")).not.toBe("checkbox");
+  });
+
+  it("renders role=dialog, not alertdialog, once the body carries form controls", async () => {
+    render(
+      <WorktreeDeleteDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        worktree={makeWorktree(makeChanges([{ path: "/test/worktree/a.ts", status: "modified" }]))}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeDefined();
+    });
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("wires aria-describedby to an element that actually exists", async () => {
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={makeWorktree()} />);
+
+    const dialog = await screen.findByRole("dialog");
+    const describedBy = dialog.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const description = document.getElementById(describedBy as string);
+    expect(description).not.toBeNull();
+    expect(description?.textContent?.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -689,6 +689,55 @@ describe("WorktreeDeleteDialog — dialog chrome contract", () => {
     });
   });
 
+  it("freezes the option set while a submit-time revalidation is in flight", async () => {
+    // The revalidation await can outlive a toggle, and the closure would then
+    // dispatch the values the user held BEFORE they changed their mind.
+    let resolvePreview: (value: unknown) => void = () => {};
+    buildPreviewMock.mockReturnValueOnce(Promise.resolve(null)).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePreview = resolve;
+      })
+    );
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/a.ts", status: "modified" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    fireEvent.change(screen.getByTestId("delete-worktree-confirm-input"), {
+      target: { value: "feature/test" },
+    });
+    fireEvent.click(screen.getByTestId("delete-worktree-confirm"));
+
+    await waitFor(() => {
+      expect(
+        (screen.getByRole("checkbox", { name: /force delete/i }) as HTMLInputElement).disabled
+      ).toBe(true);
+    });
+    expect((screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement).disabled).toBe(
+      true
+    );
+    // Cancel stays live throughout — freezing the options must not trap the user.
+    const cancel = screen
+      .getByTestId("delete-worktree-dialog")
+      .querySelector('[data-confirm-role="cancel"]') as HTMLButtonElement;
+    expect(cancel.disabled).toBe(false);
+
+    resolvePreview(null);
+  });
+
+  it("speaks the file status that the glyph column only shows", () => {
+    const worktree = makeWorktree(
+      makeChanges([
+        { path: "/wt/src/a.ts", status: "modified" },
+        { path: "/wt/gone.ts", status: "deleted" },
+      ])
+    );
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const list = screen.getByTestId("delete-worktree-file-list");
+    expect(list.textContent).toContain("Modified:");
+    expect(list.textContent).toContain("Deleted:");
+  });
+
   it("gives the dialog a short static description for aria-describedby", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
@@ -1217,7 +1266,13 @@ describe("WorktreeDeleteDialog — fresh status verification (#11343)", () => {
     // so a wrapped path cannot detach from it. Assert per row rather than on
     // concatenated textContent, which no longer carries the separator.
     const rows = within(screen.getByTestId("delete-worktree-file-list")).getAllByRole("listitem");
-    const cells = rows.map((row) => Array.from(row.children).map((c) => c.textContent));
+    // The visible cells: the glyph column and the path column. The sr-only
+    // status word sits between them and is asserted separately.
+    const cells = rows.map((row) =>
+      Array.from(row.children)
+        .filter((c) => !c.className.includes("sr-only"))
+        .map((c) => c.textContent)
+    );
     expect(cells).toContainEqual(["M", "src/app.ts"]);
     expect(cells).toContainEqual(["?", "new.txt"]);
   });

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -655,7 +655,10 @@ describe("WorktreeDeleteDialog — dialog chrome contract", () => {
       // proves nothing — the first version of this test passed against the bug.
       fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
       const dialog = screen.getByTestId("delete-worktree-dialog");
-      expect(dialog.textContent).toMatch(/will be permanently lost/);
+      // Hedged in the unverified state — the dialog cannot claim the work
+      // exists, only that it may. The unhedged wording is pinned separately
+      // for the verified-dirty case.
+      expect(dialog.textContent).toMatch(/may be permanently lost/);
       // No fabricated zero anywhere in the unverified state.
       expect(dialog.textContent).not.toMatch(/\b0 (uncommitted|untracked) file/);
     });
@@ -764,13 +767,22 @@ describe("WorktreeDeleteDialog — dialog chrome contract", () => {
   });
 
   it("keeps the force toggle label invariant across states", () => {
-    // House microcopy rule: a toggle label never changes with state.
+    // House microcopy rule: a toggle label never changes with state. The old
+    // label swapped between "Force delete (lose uncommitted changes)" and
+    // "Force delete (remove untracked files)" — both of which still satisfy a
+    // /force delete/ substring query, so querying by substring proves nothing.
+    // Read the toggle's OWN text node instead (the state-dependent
+    // sub-description is a separate child span) and compare the two states.
+    const ownLabelText = () => {
+      const checkbox = screen.getByRole("checkbox", { name: /force delete/i });
+      return checkbox.closest("label")?.querySelector("span")?.childNodes[0]?.textContent?.trim();
+    };
+
     const clean = makeWorktree(makeChanges([]));
     const { unmount } = render(
       <WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={clean} />
     );
-    const cleanLabel = screen.getByRole("checkbox", { name: /force delete/i });
-    expect(cleanLabel).toBeDefined();
+    const cleanLabel = ownLabelText();
     unmount();
 
     const dirty = makeWorktree(
@@ -780,7 +792,11 @@ describe("WorktreeDeleteDialog — dialog chrome contract", () => {
       ])
     );
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={dirty} />);
-    expect(screen.getByRole("checkbox", { name: /force delete/i })).toBeDefined();
+
+    expect(ownLabelText()).toBe(cleanLabel);
+    // And the invariant text carries no state qualifier at all, so a future
+    // label that varies identically in both states still fails here.
+    expect(cleanLabel).toBe("Force delete");
   });
 });
 

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -608,6 +608,35 @@ describe("WorktreeDeleteDialog — dialog chrome contract", () => {
     expect(container.querySelector('[data-confirm-role="confirm"]')).not.toBeNull();
   });
 
+  it("brings the D3 gate into view when the tier escalates", () => {
+    // An escalation the user cannot see is not an escalation: on a tall state
+    // the gate renders below the body's scroll fold, so the footer would
+    // report a disabled action whose cause was off-screen.
+    const spy = vi.spyOn(Element.prototype, "scrollIntoView");
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/src/app.ts", status: "modified" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(spy).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("keeps identifiers out of the footer hint", () => {
+    // The hint is the other place an untruncated branch name can overflow the
+    // footer; the gate above already shows the exact string to type.
+    const longBranch = "feature/" + "y".repeat(120);
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/a.ts", status: "modified" }]), {
+      branch: longBranch,
+    });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    expect(screen.getByTestId("delete-worktree-hint").textContent).not.toContain(longBranch);
+  });
+
   it("gives the dialog a short static description for aria-describedby", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -510,6 +510,25 @@ describe("WorktreeDeleteDialog — consequence list", () => {
     expect(danger[0]?.textContent).toContain("permanently lost");
   });
 
+  it("never signals the irreversible row by colour alone", () => {
+    // Under `forced-colors: active` every status colour resolves to the same
+    // system ink, so a colour-only danger cue disappears exactly where it is
+    // needed most. The row must carry a non-colour signal too.
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/src/app.ts", status: "modified" }]));
+    const { container } = render(
+      <WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />
+    );
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    const danger = container.querySelector('li[data-tone="danger"]');
+    expect(danger).not.toBeNull();
+    // A glyph, plus a weight distinction, plus an assistive-tech qualifier —
+    // none of which depend on the colour surviving.
+    expect(danger?.querySelector("svg")).not.toBeNull();
+    expect(danger?.className).toContain("font-medium");
+    expect(danger?.textContent).toContain("Irreversible:");
+  });
+
   it("omits the branch row until 'Delete branch' is checked", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -3,7 +3,7 @@
  */
 import { StrictMode } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, waitFor, within } from "@testing-library/react";
 import type { WorktreeState } from "@/types";
 import type { WorktreeChanges, GitStatus } from "@shared/types/git";
 
@@ -63,21 +63,88 @@ vi.mock("@/utils/destructiveSessionConfirm", () => ({
     terminals.filter((t) => t.running),
 }));
 
+/**
+ * Faithful enough to assert the chrome contract, not just to render.
+ *
+ * `hasPreview` and the structured footer actions are surfaced as DOM
+ * attributes because both are load-bearing and both were silently wrong here:
+ * without `hasPreview` the real AppDialog locks `role="alertdialog"` onto a
+ * dialog full of form controls, and a footer built from `children` never gets
+ * the `data-confirm-role` markers the "focus Cancel first" behaviour resolves
+ * against — so focus fell through to the force checkbox (#11977).
+ */
 vi.mock("@/components/ui/AppDialog", () => {
+  type Action = { label: string; onClick: () => void; disabled?: boolean; intent?: string };
   const Dialog = ({
     children,
     isOpen,
+    hasPreview,
+    variant,
   }: {
     children: React.ReactNode;
     isOpen: boolean;
     onClose?: () => void;
     size?: string;
     variant?: string;
+    hasPreview?: boolean;
     "data-testid"?: string;
-  }) => (isOpen ? <div data-testid="delete-worktree-dialog">{children}</div> : null);
+  }) =>
+    isOpen ? (
+      <div
+        data-testid="delete-worktree-dialog"
+        data-has-preview={hasPreview ? "true" : "false"}
+        data-variant={variant}
+      >
+        {children}
+      </div>
+    ) : null;
   Dialog.Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Dialog.Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
   Dialog.Title = ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>;
-  Dialog.Footer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Dialog.CloseButton = () => <button aria-label="Close dialog" />;
+  Dialog.Description = ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <p data-testid="delete-worktree-description" className={className}>
+      {children}
+    </p>
+  );
+  Dialog.Footer = ({
+    children,
+    hint,
+    primaryAction,
+    secondaryAction,
+  }: {
+    children?: React.ReactNode;
+    hint?: React.ReactNode;
+    primaryAction?: Action;
+    secondaryAction?: Action;
+  }) => (
+    <div>
+      {hint && <div data-testid="delete-worktree-hint">{hint}</div>}
+      {children}
+      {secondaryAction && (
+        <button data-confirm-role="cancel" onClick={secondaryAction.onClick}>
+          {secondaryAction.label}
+        </button>
+      )}
+      {primaryAction && (
+        <button
+          data-testid="delete-worktree-confirm"
+          data-confirm-role="confirm"
+          data-intent={primaryAction.intent}
+          disabled={primaryAction.disabled}
+          onClick={primaryAction.onClick}
+        >
+          {primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
   return { AppDialog: Dialog };
 });
 
@@ -152,6 +219,7 @@ function makePreview(files: Array<{ path: string; status: GitStatus }>) {
     hasTrackedChanges: trackedChangeCount > 0,
     hasUntrackedFiles: untrackedFileCount > 0,
     changes,
+    rootPath: "/test/worktree",
   };
 }
 
@@ -223,7 +291,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
     const warning = screen.getByText(/Standard deletion will fail/);
-    expect(warning.textContent).toContain("1 uncommitted file.");
+    expect(warning.textContent).toContain("1 uncommitted file ");
     expect(warning.textContent).not.toContain("1 uncommitted files");
   });
 
@@ -232,7 +300,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
     const warning = screen.getByText(/Standard deletion will fail/);
-    expect(warning.textContent).toContain("1 untracked file.");
+    expect(warning.textContent).toContain("1 untracked file ");
     expect(warning.textContent).not.toContain("1 untracked files");
   });
 
@@ -246,7 +314,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
     const warning = screen.getByText(/Standard deletion will fail/);
-    expect(warning.textContent).toContain("1 uncommitted file.");
+    expect(warning.textContent).toContain("1 uncommitted file ");
   });
 
   it("persists banner with escalated copy when force is checked for tracked changes", () => {
@@ -259,8 +327,10 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     fireEvent.click(forceCheckbox);
 
     expect(screen.queryByText(/Standard deletion will fail/)).toBeNull();
-    expect(screen.getByText(/Force delete will discard/)).toBeDefined();
-    expect(screen.getByText(/1 uncommitted tracked file. This is irreversible./)).toBeDefined();
+    // The separate red banner is gone: it repeated counts the consequence list
+    // already carries, and stated irreversibility a third time. The loss is now
+    // one danger-toned consequence row.
+    expect(screen.getByText(/1 uncommitted file will be permanently lost/)).toBeDefined();
   });
 
   it("persists banner with escalated copy when force is checked for untracked-only files", () => {
@@ -273,8 +343,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     fireEvent.click(forceCheckbox);
 
     expect(screen.queryByText(/Standard deletion will fail/)).toBeNull();
-    expect(screen.getByText(/Force delete will permanently remove/)).toBeDefined();
-    expect(screen.getByText(/1 untracked file./)).toBeDefined();
+    expect(screen.getByText(/1 untracked file will be permanently lost/)).toBeDefined();
   });
 
   it("shows combined counts in force banner when both tracked and untracked files exist", () => {
@@ -289,26 +358,20 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
     fireEvent.click(forceCheckbox);
 
-    const banner = screen.getByText(/Force delete will discard/);
-    expect(banner.textContent).toContain("and 1 untracked file");
-    expect(banner.textContent).toContain("This is irreversible.");
+    const row = screen.getByText(/will be permanently lost/);
+    expect(row.textContent).toContain("and 1 untracked file");
+    // Irreversibility is stated once, at the D3 gate — not repeated here.
+    expect(row.textContent).not.toContain("irreversible");
   });
 
-  it('shows "remove untracked files" on force label when only untracked files exist', () => {
-    const worktree = makeWorktree(makeChanges([{ path: "new.txt", status: "untracked" }]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    expect(screen.getByText(/Force delete \(remove untracked files\)/)).toBeDefined();
-  });
-
-  it('shows "lose uncommitted changes" on force label when tracked changes exist', () => {
-    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    expect(screen.getByText(/Force delete \(lose uncommitted changes\)/)).toBeDefined();
-  });
-
-  it("shows combined force label when both tracked and untracked files exist", () => {
+  /**
+   * Replaces three tests that asserted the force label swapped between
+   * "(remove untracked files)", "(lose uncommitted changes)" and the combined
+   * form. A toggle label never changes with state (house microcopy rule), so
+   * the varying detail moved to a sub-line under a constant label. Invariance
+   * itself is pinned in the "dialog chrome contract" block.
+   */
+  it("states the change breakdown under the force toggle without altering its label", () => {
     const worktree = makeWorktree(
       makeChanges([
         { path: "src/app.ts", status: "modified" },
@@ -317,25 +380,34 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     );
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    expect(
-      screen.getByText(/Force delete \(lose uncommitted changes and untracked files\)/)
-    ).toBeDefined();
+    const toggle = screen.getByRole("checkbox", { name: /force delete/i });
+    expect(toggle.closest("label")?.textContent).toContain(
+      "1 uncommitted file and 1 untracked file present"
+    );
   });
 });
 
-describe("WorktreeDeleteDialog — body copy", () => {
+describe("WorktreeDeleteDialog — consequence list", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
     terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
-    // Default: no fresh override → dialog uses the prop seed (existing tests).
     buildPreviewMock.mockResolvedValue(null);
   });
 
-  afterEach(() => {
-    cleanup();
-  });
+  /**
+   * The rule this block pins, replacing the old strikethrough assertions:
+   * **a consequence row exists if and only if that consequence will occur.**
+   *
+   * Previously every outcome was always rendered and the inapplicable ones
+   * were dimmed + struck through, so a clean delete showed five rows of which
+   * four were non-events (#11977). Those tests asserted the strikethrough
+   * class, i.e. the implementation value; these assert presence/absence, i.e.
+   * the rule — so they keep holding if the row styling changes again.
+   */
+
+  const DIRECTORY_ROW = "Worktree directory will be deleted from disk";
 
   it("renders the 'What will happen' heading", () => {
     const worktree = makeWorktree(makeChanges([]));
@@ -344,29 +416,41 @@ describe("WorktreeDeleteDialog — body copy", () => {
     expect(screen.getByText("What will happen")).toBeDefined();
   });
 
-  it("renders 'This cannot be undone.' trailing text", () => {
+  it("shows ONLY the directory row for a clean worktree with nothing attached", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    expect(screen.getByText("This cannot be undone.")).toBeDefined();
+    const list = screen.getByRole("list");
+    expect(within(list).getAllByRole("listitem")).toHaveLength(1);
+    expect(within(list).getByText(DIRECTORY_ROW)).toBeDefined();
   });
 
-  it("renders the directory row and it is never line-through", () => {
-    const worktree = makeWorktree(makeChanges([]));
+  it("never renders a struck-through consequence row in any state", () => {
+    terminalCountsMock.total = 2;
+    devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/src/app.ts", status: "modified" }]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const row = screen.getByText("Worktree directory will be deleted");
-    expect(row).toBeDefined();
-    expect(row.className).not.toContain("line-through");
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    for (const row of within(screen.getByRole("list")).getAllByRole("listitem")) {
+      expect(row.className).not.toContain("line-through");
+    }
   });
 
-  it("renders the terminals row active when hasTerminals and closeTerminals is checked", () => {
+  it("omits the terminal row when there are no terminals, and shows it when there are", () => {
+    const worktree = makeWorktree(makeChanges([]));
+    const { unmount } = render(
+      <WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />
+    );
+    expect(screen.queryByText(/terminals? will be closed/)).toBeNull();
+    // The "0 terminals" template leak: a count row must never render a zero.
+    expect(screen.queryByText(/^0 terminal/)).toBeNull();
+    unmount();
+
     terminalCountsMock.total = 3;
-    const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    const row = screen.getByText(/3 terminals will be closed/);
-    expect(row.className).not.toContain("line-through");
+    expect(screen.getByText(/3 terminals will be closed/)).toBeDefined();
   });
 
   it("uses singular 'terminal' when one terminal is associated", () => {
@@ -378,152 +462,176 @@ describe("WorktreeDeleteDialog — body copy", () => {
     expect(screen.queryByText(/1 terminals/)).toBeNull();
   });
 
-  it("breaks out running agents in the terminals row when any are mid-work (#11344)", () => {
+  it("drops the terminal row when the user unchecks 'Close all terminals'", () => {
+    terminalCountsMock.total = 2;
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.getByText(/2 terminals will be closed/)).toBeDefined();
+    fireEvent.click(screen.getByRole("checkbox", { name: /close all terminals/i }));
+    expect(screen.queryByText(/terminals will be closed/)).toBeNull();
+  });
+
+  it("breaks out the running-agent subset only when agents are running", () => {
     terminalCountsMock.total = 3;
     terminalsMock.push({ running: true }, { running: true }, { running: false });
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    expect(screen.getByText(/3 terminals will be closed \(2 running an agent\)/)).toBeDefined();
+    expect(screen.getByText(/3 terminals will be closed — 2 running an agent/)).toBeDefined();
   });
 
-  it("omits the running-agent breakdown when no agent is mid-work", () => {
-    terminalCountsMock.total = 2;
-    terminalsMock.push({ running: false }, { running: false });
+  it("omits the data-loss row unless force is on AND there is something to lose", () => {
+    const clean = makeWorktree(makeChanges([]));
+    const { unmount } = render(
+      <WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={clean} />
+    );
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    expect(screen.queryByText(/will be permanently lost/)).toBeNull();
+    unmount();
+
+    const dirty = makeWorktree(makeChanges([{ path: "/wt/src/app.ts", status: "modified" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={dirty} />);
+    // Dirty but not forced: still nothing is lost yet.
+    expect(screen.queryByText(/will be permanently lost/)).toBeNull();
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    expect(screen.getByText(/will be permanently lost/)).toBeDefined();
+  });
+
+  it("marks the data-loss row as the only danger-toned consequence", () => {
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/src/app.ts", status: "modified" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    const danger = within(screen.getByRole("list"))
+      .getAllByRole("listitem")
+      .filter((row) => row.className.includes("text-status-error"));
+    expect(danger).toHaveLength(1);
+    expect(danger[0]?.textContent).toContain("permanently lost");
+  });
+
+  it("omits the branch row until 'Delete branch' is checked", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    expect(screen.getByText(/2 terminals will be closed/)).toBeDefined();
-    expect(screen.queryByText(/running an agent/)).toBeNull();
+    const list = () => screen.getByRole("list");
+    expect(
+      within(list())
+        .getAllByRole("listitem")
+        .some((row) => /will be deleted$/.test(row.textContent ?? ""))
+    ).toBe(false);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /delete branch/i }));
+    expect(
+      within(list())
+        .getAllByRole("listitem")
+        .some((row) => (row.textContent ?? "").startsWith("Branch feature/test"))
+    ).toBe(true);
+    expect(screen.getByText(/fails if it has unmerged changes/)).toBeDefined();
   });
 
-  it("renders the terminals row inactive when closeTerminals is unchecked", () => {
-    terminalCountsMock.total = 2;
+  it("does not offer a branch row for a protected branch", () => {
+    const worktree = makeWorktree(makeChanges([]), { branch: "main" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.queryByRole("checkbox", { name: /delete branch/i })).toBeNull();
+  });
+
+  it("states the specific permanent result instead of generic irreversibility copy", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const closeTerminalsCheckbox = screen.getByRole("checkbox", {
-      name: /close all terminals/i,
-    });
-    fireEvent.click(closeTerminalsCheckbox);
-
-    const row = screen.getByText(/2 terminals will be closed/);
-    expect(row.className).toContain("line-through");
+    // House microcopy rule: the body names the consequence; generic
+    // irreversibility copy is confirmation-fatigue filler. ConfirmDialog warns
+    // on this string at runtime; this dialog bypasses that guard, so pin it.
+    expect(screen.queryByText(/cannot be undone/i)).toBeNull();
+    expect(screen.queryByText(/can't be undone/i)).toBeNull();
   });
 
-  it("renders the terminals row inactive when no terminals are associated", () => {
+  it("names the worktree path and branch concretely", () => {
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.getByText("/test/worktree")).toBeDefined();
+    expect(screen.getAllByText("feature/test").length).toBeGreaterThan(0);
+  });
+});
+
+describe("WorktreeDeleteDialog — dialog chrome contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
+    devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    buildPreviewMock.mockResolvedValue(null);
+  });
+
+  it("declares hasPreview so the ARIA role is dialog, not alertdialog", () => {
+    // The body carries a scrollable file list, three checkboxes and a text
+    // input. WAI-ARIA APG reserves `alertdialog` for brief text-only messages,
+    // and AppDialog picks the role off this flag.
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/a.ts", status: "modified" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.getByTestId("delete-worktree-dialog").dataset.hasPreview).toBe("true");
+  });
+
+  it("routes the footer through structured actions so Cancel carries the focus marker", () => {
+    // Initial focus for a destructive dialog resolves against
+    // [data-confirm-role="cancel"]; a hand-written footer has no marker, so
+    // focus fell through to the first tabbable control — the force checkbox.
+    const worktree = makeWorktree(makeChanges([]));
+    const { container } = render(
+      <WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />
+    );
+
+    expect(container.querySelector('[data-confirm-role="cancel"]')).not.toBeNull();
+    expect(container.querySelector('[data-confirm-role="confirm"]')).not.toBeNull();
+  });
+
+  it("gives the dialog a short static description for aria-describedby", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const row = screen.getByText(/0 terminals will be closed/);
-    expect(row.className).toContain("line-through");
+    const description = screen.getByTestId("delete-worktree-description");
+    expect(description.textContent?.length).toBeGreaterThan(0);
+    // Static: it must not restate the dynamic consequence list.
+    expect(description.textContent).not.toMatch(/will be closed|permanently lost/);
   });
 
-  it("renders the uncommitted row active (text-status-error) when force and hasChanges", () => {
-    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
-    fireEvent.click(forceCheckbox);
-
-    const row = screen.getByText("Uncommitted changes will be lost");
-    expect(row.className).toContain("text-status-error");
-    expect(row.className).not.toContain("line-through");
-  });
-
-  it("renders the uncommitted row inactive (line-through) when force is unchecked", () => {
-    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    const row = screen.getByText("Uncommitted changes will be lost");
-    expect(row.className).toContain("line-through");
-  });
-
-  it("renders the uncommitted row inactive (line-through) when there are no changes", () => {
-    const worktree = makeWorktree(makeChanges([]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    const row = screen.getByText("Uncommitted changes will be lost");
-    expect(row.className).toContain("line-through");
-  });
-
-  it("renders the branch row active when deleteBranch and canDeleteBranch", () => {
-    const worktree = makeWorktree(makeChanges([]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    const deleteBranchCheckbox = screen.getByRole("checkbox", {
-      name: /delete branch/i,
-    });
-    fireEvent.click(deleteBranchCheckbox);
-
-    const row = screen.getByText(
-      (_content, element) => element?.textContent === "Branch feature/test will be deleted"
-    );
-    expect(row.className).not.toContain("line-through");
-    expect(row.className).not.toContain("text-status-warning");
-  });
-
-  it("renders the branch row with text-status-warning when active and force is on", () => {
-    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
-    fireEvent.click(forceCheckbox);
-
-    const deleteBranchCheckbox = screen.getByRole("checkbox", {
-      name: /delete branch/i,
-    });
-    fireEvent.click(deleteBranchCheckbox);
-
-    const row = screen.getByText(
-      (_content, element) => element?.textContent === "Branch feature/test will be deleted"
-    );
-    expect(row.className).toContain("text-status-warning");
-    expect(row.className).not.toContain("line-through");
-  });
-
-  it("renders the branch row inactive (line-through) when deleteBranch is unchecked", () => {
-    const worktree = makeWorktree(makeChanges([]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    const row = screen.getByText(
-      (_content, element) => element?.textContent === "Branch feature/test will be deleted"
-    );
-    expect(row.className).toContain("line-through");
-  });
-
-  it("renders the branch row always (even for protected branches, dimmed)", () => {
-    const worktree = makeWorktree(makeChanges([]), { branch: "main", name: "main" });
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
-
-    const row = screen.getByText(
-      (_content, element) => element?.textContent === "Branch main will be deleted"
-    );
-    expect(row.className).toContain("line-through");
-  });
-
-  it("renders the branch row with placeholder text for detached HEAD", () => {
-    const worktree = makeWorktree(makeChanges([]), {
-      branch: undefined,
-      name: "abc1234",
+  it("keeps the primary label free of the branch name at every tier", () => {
+    // Interpolating an untruncated branch overflowed the footer and pushed
+    // Cancel out of the dialog entirely.
+    const longBranch = "feature/" + "x".repeat(120);
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/a.ts", status: "modified" }]), {
+      branch: longBranch,
     });
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const row = screen.getByText("Branch will be deleted");
-    expect(row.className).toContain("line-through");
+    const confirm = screen.getByTestId("delete-worktree-confirm");
+    expect(confirm.textContent).toBe("Delete worktree");
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    expect(screen.getByTestId("delete-worktree-confirm").textContent).toBe("Force delete worktree");
   });
 
-  it("does not reference 'restored from git' in the body copy", () => {
-    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
-    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+  it("keeps the force toggle label invariant across states", () => {
+    // House microcopy rule: a toggle label never changes with state.
+    const clean = makeWorktree(makeChanges([]));
+    const { unmount } = render(
+      <WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={clean} />
+    );
+    const cleanLabel = screen.getByRole("checkbox", { name: /force delete/i });
+    expect(cleanLabel).toBeDefined();
+    unmount();
 
-    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
-    fireEvent.click(forceCheckbox);
-
-    const row = screen.getByText("Uncommitted changes will be lost");
-    expect(row.className).toContain("text-status-error");
-    expect(screen.queryByText(/restored from git/)).toBeNull();
+    const dirty = makeWorktree(
+      makeChanges([
+        { path: "/wt/a.ts", status: "modified" },
+        { path: "/wt/n.txt", status: "untracked" },
+      ])
+    );
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={dirty} />);
+    expect(screen.getByRole("checkbox", { name: /force delete/i })).toBeDefined();
   });
 });
 
@@ -607,7 +715,10 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
 
     expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
-    expect(button.textContent).toBe("Force delete 'main'");
+    // The label is a stable verb-noun; the target is named by the gate, not the
+    // button, because interpolating it here overflowed the footer (#11977).
+    expect(button.textContent).toBe("Force delete worktree");
+    expect(screen.getByLabelText("Type main to confirm")).toBeDefined();
     expect(button.disabled).toBe(true);
   });
 
@@ -677,7 +788,8 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
-    expect(button.textContent).toBe("Force delete 'abc1234'");
+    expect(button.textContent).toBe("Force delete worktree");
+    expect(screen.getByLabelText("Type abc1234 to confirm")).toBeDefined();
     expect(button.disabled).toBe(true);
 
     const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
@@ -696,7 +808,8 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
-    expect(button.textContent).toBe("Force delete 'abc1234'");
+    expect(button.textContent).toBe("Force delete worktree");
+    expect(screen.getByLabelText("Type abc1234 to confirm")).toBeDefined();
 
     const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "abc1234" } });
@@ -809,8 +922,7 @@ describe("WorktreeDeleteDialog — dev preview disclosure (#9084)", () => {
     await waitFor(() => {
       expect(devPreviewGetByWorktreeMock).toHaveBeenCalledWith({ worktreeId: "wt-1" });
     });
-    const row = screen.getByText("Dev server will be stopped");
-    expect(row.className).toContain("line-through");
+    expect(screen.queryByText("Dev server will be stopped")).toBeNull();
   });
 
   it("activates the dev server row when a running session is detected", async () => {
@@ -831,8 +943,7 @@ describe("WorktreeDeleteDialog — dev preview disclosure (#9084)", () => {
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
     await waitFor(() => {
-      const row = screen.getByText("Dev server will be stopped");
-      expect(row.className).not.toContain("line-through");
+      expect(screen.getByText("Dev server will be stopped")).toBeDefined();
     });
   });
 
@@ -856,8 +967,7 @@ describe("WorktreeDeleteDialog — dev preview disclosure (#9084)", () => {
     await waitFor(() => {
       expect(devPreviewGetByWorktreeMock).toHaveBeenCalled();
     });
-    const row = screen.getByText("Dev server will be stopped");
-    expect(row.className).toContain("line-through");
+    expect(screen.queryByText("Dev server will be stopped")).toBeNull();
   });
 });
 
@@ -876,6 +986,7 @@ describe("WorktreeDeleteDialog — state reset", () => {
   });
 
   it("resets closeTerminals to true when the dialog re-opens", () => {
+    terminalCountsMock.total = 2;
     const worktree = makeWorktree(makeChanges([]));
     const { rerender } = render(
       <WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />
@@ -943,7 +1054,7 @@ describe("WorktreeDeleteDialog — fresh status verification (#11343)", () => {
 
     // The "couldn't verify" banner surfaces regardless of force.
     await waitFor(() => {
-      expect(screen.getByText(/Couldn't verify this worktree's current changes/)).toBeDefined();
+      expect(screen.getByText(/Couldn't check this worktree for uncommitted work/)).toBeDefined();
     });
 
     // With force on, the fail-closed state demands the typed-name gate.
@@ -1015,7 +1126,7 @@ describe("WorktreeDeleteDialog — fresh status verification (#11343)", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Couldn't verify this worktree's current changes/)).toBeDefined();
+      expect(screen.getByText(/Couldn't check this worktree for uncommitted work/)).toBeDefined();
     });
     expect(screen.queryByTestId("delete-worktree-file-list")).toBeNull();
   });

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -241,7 +241,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    expect(screen.queryByText(/Standard deletion will fail/)).toBeNull();
+    expect(screen.queryByText(/Select Force delete to continue/)).toBeNull();
   });
 
   it("shows untracked-file count when only untracked files exist", () => {
@@ -253,7 +253,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     );
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const warning = screen.getByText(/Standard deletion will fail/);
+    const warning = screen.getByText(/Select Force delete to continue/);
     expect(warning.textContent).toContain("2 untracked files");
     expect(warning.textContent).not.toContain("uncommitted file");
   });
@@ -267,7 +267,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     );
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const warning = screen.getByText(/Standard deletion will fail/);
+    const warning = screen.getByText(/Select Force delete to continue/);
     expect(warning.textContent).toContain("2 uncommitted files");
     expect(warning.textContent).not.toContain("untracked file");
   });
@@ -282,7 +282,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     );
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const warning = screen.getByText(/Standard deletion will fail/);
+    const warning = screen.getByText(/Select Force delete to continue/);
     expect(warning.textContent).toContain("2 uncommitted files and 1 untracked file");
   });
 
@@ -290,7 +290,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const warning = screen.getByText(/Standard deletion will fail/);
+    const warning = screen.getByText(/Select Force delete to continue/);
     expect(warning.textContent).toContain("1 uncommitted file ");
     expect(warning.textContent).not.toContain("1 uncommitted files");
   });
@@ -299,7 +299,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     const worktree = makeWorktree(makeChanges([{ path: "new.txt", status: "untracked" }]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const warning = screen.getByText(/Standard deletion will fail/);
+    const warning = screen.getByText(/Select Force delete to continue/);
     expect(warning.textContent).toContain("1 untracked file ");
     expect(warning.textContent).not.toContain("1 untracked files");
   });
@@ -313,7 +313,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     );
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const warning = screen.getByText(/Standard deletion will fail/);
+    const warning = screen.getByText(/Select Force delete to continue/);
     expect(warning.textContent).toContain("1 uncommitted file ");
   });
 
@@ -321,12 +321,12 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    expect(screen.getByText(/Standard deletion will fail/)).toBeDefined();
+    expect(screen.getByText(/Select Force delete to continue/)).toBeDefined();
 
     const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
     fireEvent.click(forceCheckbox);
 
-    expect(screen.queryByText(/Standard deletion will fail/)).toBeNull();
+    expect(screen.queryByText(/Select Force delete to continue/)).toBeNull();
     // The separate red banner is gone: it repeated counts the consequence list
     // already carries, and stated irreversibility a third time. The loss is now
     // one danger-toned consequence row.
@@ -337,12 +337,12 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     const worktree = makeWorktree(makeChanges([{ path: "new.txt", status: "untracked" }]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    expect(screen.getByText(/Standard deletion will fail/)).toBeDefined();
+    expect(screen.getByText(/Select Force delete to continue/)).toBeDefined();
 
     const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
     fireEvent.click(forceCheckbox);
 
-    expect(screen.queryByText(/Standard deletion will fail/)).toBeNull();
+    expect(screen.queryByText(/Select Force delete to continue/)).toBeNull();
     expect(screen.getByText(/1 untracked file will be permanently lost/)).toBeDefined();
   });
 
@@ -420,7 +420,7 @@ describe("WorktreeDeleteDialog — consequence list", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const list = screen.getByRole("list");
+    const list = screen.getByTestId("delete-worktree-consequences");
     expect(within(list).getAllByRole("listitem")).toHaveLength(1);
     expect(within(list).getByText(DIRECTORY_ROW)).toBeDefined();
   });
@@ -433,7 +433,9 @@ describe("WorktreeDeleteDialog — consequence list", () => {
 
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
-    for (const row of within(screen.getByRole("list")).getAllByRole("listitem")) {
+    for (const row of within(screen.getByTestId("delete-worktree-consequences")).getAllByRole(
+      "listitem"
+    )) {
       expect(row.className).not.toContain("line-through");
     }
   });
@@ -503,7 +505,7 @@ describe("WorktreeDeleteDialog — consequence list", () => {
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
-    const danger = within(screen.getByRole("list"))
+    const danger = within(screen.getByTestId("delete-worktree-consequences"))
       .getAllByRole("listitem")
       .filter((row) => row.className.includes("text-status-error"));
     expect(danger).toHaveLength(1);
@@ -533,7 +535,7 @@ describe("WorktreeDeleteDialog — consequence list", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const list = () => screen.getByRole("list");
+    const list = () => screen.getByTestId("delete-worktree-consequences");
     expect(
       within(list())
         .getAllByRole("listitem")
@@ -635,6 +637,56 @@ describe("WorktreeDeleteDialog — dialog chrome contract", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
     expect(screen.getByTestId("delete-worktree-hint").textContent).not.toContain(longBranch);
+  });
+
+  it("never states a count it could not verify", () => {
+    // Fail-closed forces `hasTrackedChanges` true while the counts still come
+    // from a possibly-clean seed, which rendered "0 uncommitted files will be
+    // permanently lost" in exactly the state the dialog knows least about.
+    buildPreviewMock.mockRejectedValue(new Error("workspace host gone"));
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    return waitFor(() => {
+      expect(screen.getByText(/Couldn't check this worktree/)).toBeDefined();
+    }).then(() => {
+      // Force ON is where the count is actually interpolated ("N ... will be
+      // permanently lost"), so the assertion has to reach that state or it
+      // proves nothing — the first version of this test passed against the bug.
+      fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+      const dialog = screen.getByTestId("delete-worktree-dialog");
+      expect(dialog.textContent).toMatch(/will be permanently lost/);
+      // No fabricated zero anywhere in the unverified state.
+      expect(dialog.textContent).not.toMatch(/\b0 (uncommitted|untracked) file/);
+    });
+  });
+
+  it("does not offer a standard delete that is known to fail", () => {
+    // A non-force delete on a verified-dirty tree is rejected by the backend,
+    // so presenting it as the primary action ships a button whose only
+    // outcome is a toast and a reopened dialog.
+    const worktree = makeWorktree(makeChanges([{ path: "/wt/a.ts", status: "modified" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const confirm = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+    expect(screen.getByTestId("delete-worktree-hint").textContent).toContain("Force delete");
+  });
+
+  it("still offers the safe non-force attempt when verification failed", () => {
+    // The inverse of the rule above: after a failed check, disabling the safe
+    // attempt would coerce the user into force on the very state we could not
+    // verify. Force is required, not assumed.
+    buildPreviewMock.mockRejectedValue(new Error("workspace host gone"));
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    return waitFor(() => {
+      expect(screen.getByText(/Couldn't check this worktree/)).toBeDefined();
+      expect((screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement).disabled).toBe(
+        false
+      );
+    });
   });
 
   it("gives the dialog a short static description for aria-describedby", () => {
@@ -1151,16 +1203,23 @@ describe("WorktreeDeleteDialog — fresh status verification (#11343)", () => {
     const worktree = makeWorktree(makeChanges([]), { branch: "feature/x", name: "feature/x" });
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    // No list until the destructive path is armed.
+    // Nothing to show until the fresh status resolves — the prop seed is clean.
     expect(screen.queryByTestId("delete-worktree-file-list")).toBeNull();
 
-    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
-
+    // The list appears on the fresh dirty status WITHOUT force being armed: a
+    // D2 confirm owes actual content, and the user needs it to decide whether
+    // forcing is safe at all.
     await waitFor(() => {
-      const list = screen.getByTestId("delete-worktree-file-list");
-      expect(list.textContent).toContain("M src/app.ts");
-      expect(list.textContent).toContain("? new.txt");
+      expect(screen.getByTestId("delete-worktree-file-list")).toBeDefined();
     });
+
+    // Structured rows, not a joined string: the glyph lives in its own column
+    // so a wrapped path cannot detach from it. Assert per row rather than on
+    // concatenated textContent, which no longer carries the separator.
+    const rows = within(screen.getByTestId("delete-worktree-file-list")).getAllByRole("listitem");
+    const cells = rows.map((row) => Array.from(row.children).map((c) => c.textContent));
+    expect(cells).toContainEqual(["M", "src/app.ts"]);
+    expect(cells).toContainEqual(["?", "new.txt"]);
   });
 
   it("hides the file list and shows the warning when verification fails", async () => {

--- a/src/components/Worktree/__tests__/worktreeDeletePreview.test.ts
+++ b/src/components/Worktree/__tests__/worktreeDeletePreview.test.ts
@@ -14,6 +14,7 @@ import {
   buildWorktreeDeletePreview,
   formatWorktreeDeletePreviewLines,
   formatWorktreeChangeRows,
+  buildWorktreeChangeRows,
 } from "../worktreeDeletePreview";
 
 /**
@@ -221,6 +222,51 @@ describe("formatWorktreeChangeRows", () => {
       ROOT
     );
     expect(rows).toEqual([`  M ${outside}`]);
+  });
+
+  it("relativises Windows paths, not just POSIX ones", () => {
+    // Daintree runs on Windows, where the producer emits backslash paths. A
+    // separator-specific check leaves every Windows row absolute — the exact
+    // defect this relativisation exists to prevent, on the other platform.
+    const winRoot = "C:\\Users\\dev\\proj-worktrees\\feature-x";
+    const rows = formatWorktreeChangeRows(
+      [
+        {
+          path: `${winRoot}\\src\\queue.ts`,
+          status: "modified",
+          insertions: null,
+          deletions: null,
+        },
+      ],
+      undefined,
+      winRoot
+    );
+    expect(rows).toEqual(["  M src\\queue.ts"]);
+    expect(rows[0]).not.toContain(winRoot);
+  });
+
+  it("tolerates a root given with a trailing separator", () => {
+    const rows = formatWorktreeChangeRows([file("src/a.ts", "modified")], undefined, `${ROOT}/`);
+    expect(rows).toEqual(["  M src/a.ts"]);
+  });
+
+  it("carries a spoken status label on every structured row", () => {
+    // The visible column is a single glyph — right for scanning, useless to a
+    // screen reader, which would otherwise hear paths with no way to tell a
+    // deletion from an addition.
+    const rows = buildWorktreeChangeRows(
+      [file("src/a.ts", "modified"), file("gone.ts", "deleted"), file("n.txt", "untracked")],
+      undefined,
+      ROOT
+    );
+    expect(rows.map((r) => r.statusLabel)).toEqual(["Modified", "Deleted", "Untracked"]);
+    // The overflow tail is not a file and must not claim a status.
+    const capped = buildWorktreeChangeRows(
+      Array.from({ length: 14 }, (_, i) => file(`f${i}.ts`, "modified")),
+      12,
+      ROOT
+    );
+    expect(capped[capped.length - 1]?.statusLabel).toBeNull();
   });
 
   it("renders raw paths when no root is supplied", () => {

--- a/src/components/Worktree/__tests__/worktreeDeletePreview.test.ts
+++ b/src/components/Worktree/__tests__/worktreeDeletePreview.test.ts
@@ -16,14 +16,24 @@ import {
   formatWorktreeChangeRows,
 } from "../worktreeDeletePreview";
 
+/**
+ * The worktree root every fixture hangs off. Production `FileChangeDetail.path`
+ * is ABSOLUTE — `electron/utils/git.ts` resolves each entry against the git
+ * root — so `file()` builds absolute paths from a relative one. The previous
+ * fixture hand-built bare names like `a.ts`, a shape the app never produces,
+ * which is precisely why a preview rendering raw absolute paths passed this
+ * suite while rendering unreadably in the real dialog (#11977).
+ */
+const ROOT = "/Users/dev/proj-worktrees/feature-streaming-uploads";
+
 function file(path: string, status: GitStatus): FileChangeDetail {
-  return { path, status, insertions: null, deletions: null };
+  return { path: `${ROOT}/${path}`, status, insertions: null, deletions: null };
 }
 
 function changes(files: FileChangeDetail[]): WorktreeChanges {
   return {
     worktreeId: "wt-1",
-    rootPath: "/wt",
+    rootPath: ROOT,
     changedFileCount: files.length,
     changes: files,
   };
@@ -106,6 +116,7 @@ describe("formatWorktreeDeletePreviewLines", () => {
       hasTrackedChanges: false,
       hasUntrackedFiles: false,
       changes: [],
+      rootPath: ROOT,
     };
     expect(formatWorktreeDeletePreviewLines(preview)).toEqual(["No uncommitted changes."]);
   });
@@ -118,6 +129,7 @@ describe("formatWorktreeDeletePreviewLines", () => {
       hasTrackedChanges: true,
       hasUntrackedFiles: true,
       changes: files,
+      rootPath: ROOT,
     };
     const lines = formatWorktreeDeletePreviewLines(preview);
     expect(lines[0]).toBe("1 uncommitted tracked file and 1 untracked file:");
@@ -133,6 +145,7 @@ describe("formatWorktreeDeletePreviewLines", () => {
       hasTrackedChanges: true,
       hasUntrackedFiles: false,
       changes: files,
+      rootPath: ROOT,
     };
     const lines = formatWorktreeDeletePreviewLines(preview);
     // header + 12 files + overflow line
@@ -143,20 +156,25 @@ describe("formatWorktreeDeletePreviewLines", () => {
 
 describe("formatWorktreeChangeRows", () => {
   it("prefixes each file with its status glyph", () => {
-    const rows = formatWorktreeChangeRows([
-      file("a.ts", "modified"),
-      file("b.ts", "deleted"),
-      file("c.ts", "added"),
-      file("n.txt", "untracked"),
-    ]);
+    const rows = formatWorktreeChangeRows(
+      [
+        file("a.ts", "modified"),
+        file("b.ts", "deleted"),
+        file("c.ts", "added"),
+        file("n.txt", "untracked"),
+      ],
+      undefined,
+      ROOT
+    );
     expect(rows).toEqual(["  M a.ts", "  D b.ts", "  A c.ts", "  ? n.txt"]);
   });
 
   it("drops ignored files (not part of what a delete discards)", () => {
-    const rows = formatWorktreeChangeRows([
-      file("a.ts", "modified"),
-      file("node_modules/x", "ignored"),
-    ]);
+    const rows = formatWorktreeChangeRows(
+      [file("a.ts", "modified"), file("node_modules/x", "ignored")],
+      undefined,
+      ROOT
+    );
     expect(rows).toEqual(["  M a.ts"]);
   });
 
@@ -168,5 +186,45 @@ describe("formatWorktreeChangeRows", () => {
     const rows = formatWorktreeChangeRows(files);
     expect(rows).toHaveLength(13); // 12 files + overflow
     expect(rows[rows.length - 1]).toBe("  …and 2 more");
+  });
+
+  /**
+   * The rule, not the value: a preview row must never carry the worktree root.
+   * Asserted against the prefix rather than against specific expected strings
+   * so it keeps holding when the row format changes — the point is that the
+   * distinguishing part of a path is never pushed past the wrap by a prefix
+   * that is identical on every row and already shown elsewhere in the dialog.
+   */
+  it("never repeats the worktree root on a row when the root is known", () => {
+    const rows = formatWorktreeChangeRows(
+      [
+        file("src/queue.ts", "modified"),
+        file("deeply/nested/dir/component.tsx", "added"),
+        file(".env.local", "untracked"),
+      ],
+      undefined,
+      ROOT
+    );
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row).not.toContain(ROOT);
+    }
+    // ...and the filename still survives intact.
+    expect(rows.join("\n")).toContain("src/queue.ts");
+  });
+
+  it("leaves a path that escapes the root absolute rather than mangling it", () => {
+    const outside = "/somewhere/else/stray.ts";
+    const rows = formatWorktreeChangeRows(
+      [{ path: outside, status: "modified", insertions: null, deletions: null }],
+      undefined,
+      ROOT
+    );
+    expect(rows).toEqual([`  M ${outside}`]);
+  });
+
+  it("renders raw paths when no root is supplied", () => {
+    const rows = formatWorktreeChangeRows([file("src/a.ts", "modified")]);
+    expect(rows).toEqual([`  M ${ROOT}/src/a.ts`]);
   });
 });

--- a/src/components/Worktree/worktreeDeletePreview.ts
+++ b/src/components/Worktree/worktreeDeletePreview.ts
@@ -131,6 +131,49 @@ export function formatWorktreeChangeRows(
   return rows;
 }
 
+/** One row of the rendered change preview, split so the UI can lay it out. */
+export interface WorktreeChangeRow {
+  /** Status glyph (`M`, `D`, `?`…) or `null` for the overflow tail row. */
+  glyph: string | null;
+  /** Worktree-relative path, or the "…and N more" text on the tail row. */
+  label: string;
+  /** True for the synthesised overflow row, which is not a file. */
+  isOverflow: boolean;
+}
+
+/**
+ * The same capped, relativised preview as {@link formatWorktreeChangeRows},
+ * but structured rather than pre-joined.
+ *
+ * The string form has to stay for the MCP confirm surface, which renders plain
+ * text. A UI rendering those strings in a wrapping `<pre>` loses the row
+ * boundary the moment a path is longer than the box: the continuation line
+ * starts at the left edge, under the status column, so two long paths read as
+ * four files and the glyph detaches from the name it belongs to. Structured
+ * rows let the surface pin the glyph in its own column and hang the wrap under
+ * the path (#11977).
+ */
+export function buildWorktreeChangeRows(
+  changes: FileChangeDetail[],
+  limit: number = PREVIEW_FILE_LIMIT,
+  rootPath?: string
+): WorktreeChangeRow[] {
+  const shown = changes.filter((c) => c.status !== "ignored");
+  const rows: WorktreeChangeRow[] = shown.slice(0, limit).map((c) => ({
+    glyph: STATUS_GLYPH[c.status] ?? "?",
+    label: toDisplayPath(c.path, rootPath),
+    isOverflow: false,
+  }));
+  if (shown.length > limit) {
+    rows.push({
+      glyph: null,
+      label: `…and ${shown.length - limit} more`,
+      isOverflow: true,
+    });
+  }
+  return rows;
+}
+
 /**
  * Render a preview as plain lines for the MCP confirm surface — a header
  * naming the tracked/untracked counts, then the actual file list (capped), so

--- a/src/components/Worktree/worktreeDeletePreview.ts
+++ b/src/components/Worktree/worktreeDeletePreview.ts
@@ -26,6 +26,15 @@ export interface WorktreeChangeSummary {
 /** A fresh delete preview: the change summary plus the raw file list. */
 export interface WorktreeDeletePreview extends WorktreeChangeSummary {
   changes: FileChangeDetail[];
+  /**
+   * Absolute worktree root, carried so previews can render each file relative
+   * to it. `FileChangeDetail.path` arrives ABSOLUTE from the only producer
+   * (`electron/utils/git.ts` resolves every entry against the git root), which
+   * is why the rest of the renderer derives a `relativePath` before display —
+   * see `src/lib/workingTreeDiff.ts`. Without the root, a preview repeats the
+   * whole worktree path on every row and buries the filename.
+   */
+  rootPath: string;
 }
 
 /**
@@ -65,7 +74,7 @@ export async function buildWorktreeDeletePreview(
   const fresh: WorktreeChanges | null = await worktreeClient.getFreshChanges(worktreeId);
   if (!fresh) return null;
   const changes = fresh.changes ?? [];
-  return { ...summarizeWorktreeChanges(changes), changes };
+  return { ...summarizeWorktreeChanges(changes), changes, rootPath: fresh.rootPath };
 }
 
 /** Max file rows shown in a compact preview before collapsing the tail. */
@@ -83,17 +92,39 @@ const STATUS_GLYPH: Record<FileChangeDetail["status"], string> = {
 };
 
 /**
+ * Strip the worktree root off an absolute change path.
+ *
+ * `FileChangeDetail.path` is absolute (see {@link WorktreeDeletePreview.rootPath}),
+ * so a preview that renders it raw repeats the entire worktree path on every
+ * row and pushes the only distinguishing part — the filename — past the wrap.
+ * Mirrors `getRelativePath` in `src/lib/workingTreeDiff.ts`; a path that
+ * escapes the root (or a root we weren't given) is left alone rather than
+ * mangled, because showing a wrong path here is worse than showing a long one.
+ */
+function toDisplayPath(filePath: string, rootPath: string | undefined): string {
+  if (!rootPath) return filePath;
+  const root = rootPath.endsWith("/") ? rootPath : `${rootPath}/`;
+  return filePath.startsWith(root) ? filePath.slice(root.length) : filePath;
+}
+
+/**
  * Render a change set as capped, glyph-prefixed file rows (`  M src/app.ts`),
  * shared by the local delete dialog and the MCP preview so both show the same
  * actual content (the D2 "a count is insufficient" rule). Ignored files are
  * dropped — they're not part of what a delete discards.
+ *
+ * Pass `rootPath` to get worktree-relative rows; without it the raw (absolute)
+ * paths are rendered, which is the legacy behaviour.
  */
 export function formatWorktreeChangeRows(
   changes: FileChangeDetail[],
-  limit: number = PREVIEW_FILE_LIMIT
+  limit: number = PREVIEW_FILE_LIMIT,
+  rootPath?: string
 ): string[] {
   const shown = changes.filter((c) => c.status !== "ignored");
-  const rows = shown.slice(0, limit).map((c) => `  ${STATUS_GLYPH[c.status] ?? "?"} ${c.path}`);
+  const rows = shown
+    .slice(0, limit)
+    .map((c) => `  ${STATUS_GLYPH[c.status] ?? "?"} ${toDisplayPath(c.path, rootPath)}`);
   if (shown.length > limit) {
     rows.push(`  …and ${shown.length - limit} more`);
   }
@@ -114,7 +145,7 @@ export function formatWorktreeDeletePreviewLines(preview: WorktreeDeletePreview 
       `${MCP_PREVIEW_CAUTION_PREFIX}Could not verify current changes — proceed with caution.`,
     ];
   }
-  const { trackedChangeCount, untrackedFileCount, changes } = preview;
+  const { trackedChangeCount, untrackedFileCount, changes, rootPath } = preview;
   if (changes.length === 0) {
     return ["No uncommitted changes."];
   }
@@ -127,5 +158,8 @@ export function formatWorktreeDeletePreviewLines(preview: WorktreeDeletePreview 
   if (untrackedFileCount > 0) {
     parts.push(`${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`);
   }
-  return [`${parts.join(" and ")}:`, ...formatWorktreeChangeRows(changes)];
+  return [
+    `${parts.join(" and ")}:`,
+    ...formatWorktreeChangeRows(changes, PREVIEW_FILE_LIMIT, rootPath),
+  ];
 }

--- a/src/components/Worktree/worktreeDeletePreview.ts
+++ b/src/components/Worktree/worktreeDeletePreview.ts
@@ -80,6 +80,22 @@ export async function buildWorktreeDeletePreview(
 /** Max file rows shown in a compact preview before collapsing the tail. */
 export const PREVIEW_FILE_LIMIT = 12;
 
+/**
+ * Spoken form of each status. The visible column is a single glyph, which is
+ * right for scanning and useless to a screen reader — without this a listener
+ * hears a list of paths with no way to tell a deletion from an addition.
+ */
+export const STATUS_LABEL: Record<FileChangeDetail["status"], string> = {
+  modified: "Modified",
+  added: "Added",
+  deleted: "Deleted",
+  renamed: "Renamed",
+  copied: "Copied",
+  conflicted: "Conflicted",
+  untracked: "Untracked",
+  ignored: "Ignored",
+};
+
 const STATUS_GLYPH: Record<FileChangeDetail["status"], string> = {
   modified: "M",
   added: "A",
@@ -103,8 +119,15 @@ const STATUS_GLYPH: Record<FileChangeDetail["status"], string> = {
  */
 function toDisplayPath(filePath: string, rootPath: string | undefined): string {
   if (!rootPath) return filePath;
-  const root = rootPath.endsWith("/") ? rootPath : `${rootPath}/`;
-  return filePath.startsWith(root) ? filePath.slice(root.length) : filePath;
+  // Both separators: Daintree runs on Windows, where the producer emits
+  // backslash paths. A `/`-only check left every Windows row absolute — the
+  // exact defect this function exists to prevent, just on the other platform.
+  const trimmed = rootPath.replace(/[/\\]+$/, "");
+  for (const sep of ["/", "\\"]) {
+    const root = trimmed + sep;
+    if (filePath.startsWith(root)) return filePath.slice(root.length);
+  }
+  return filePath;
 }
 
 /**
@@ -135,6 +158,8 @@ export function formatWorktreeChangeRows(
 export interface WorktreeChangeRow {
   /** Status glyph (`M`, `D`, `?`…) or `null` for the overflow tail row. */
   glyph: string | null;
+  /** Spoken status ("Modified"), for assistive tech. `null` on the tail row. */
+  statusLabel: string | null;
   /** Worktree-relative path, or the "…and N more" text on the tail row. */
   label: string;
   /** True for the synthesised overflow row, which is not a file. */
@@ -161,12 +186,14 @@ export function buildWorktreeChangeRows(
   const shown = changes.filter((c) => c.status !== "ignored");
   const rows: WorktreeChangeRow[] = shown.slice(0, limit).map((c) => ({
     glyph: STATUS_GLYPH[c.status] ?? "?",
+    statusLabel: STATUS_LABEL[c.status] ?? "Changed",
     label: toDisplayPath(c.path, rootPath),
     isOverflow: false,
   }));
   if (shown.length > limit) {
     rows.push({
       glyph: null,
+      statusLabel: null,
       label: `…and ${shown.length - limit} more`,
       isOverflow: true,
     });

--- a/src/components/ui/ScrollShadow.tsx
+++ b/src/components/ui/ScrollShadow.tsx
@@ -39,6 +39,12 @@ function ScrollShadowOverlay({ edge, visible }: { edge: "top" | "bottom"; visibl
       className={cn(
         "pointer-events-none absolute inset-x-0 z-10 h-8 transition-opacity duration-150 ease-out",
         "forced-colors:h-0",
+        // A fade-to-transparent overlay lowers the contrast of real content at
+        // the scrolling edge, which is the opposite of what a reader who asked
+        // for more contrast wants — the affordance is decorative and the
+        // scrollbar still communicates scrollability. `forced-colors` is left
+        // to its own block by design (the two are deliberately separate).
+        "contrast-more:hidden",
         edge === "top"
           ? "top-0 bg-gradient-to-b from-[var(--scroll-shadow-color)] to-transparent forced-colors:border-t-2"
           : "bottom-0 bg-gradient-to-t from-[var(--scroll-shadow-color)] to-transparent forced-colors:border-b-2",

--- a/src/components/ui/ScrollShadow.tsx
+++ b/src/components/ui/ScrollShadow.tsx
@@ -27,9 +27,13 @@ import { useVerticalScrollShadows } from "@/hooks/useVerticalScrollShadows";
  * survives forced-colors, so the rule still appears and disappears with the
  * scroll position rather than sitting there permanently.
  *
- * Deliberately NOT applied under `prefers-contrast: more`: that mode keeps
- * author colours, so the gradient still renders and still reads. The two media
- * queries stay separate on purpose — see the block comments in `index.css`.
+ * `prefers-contrast: more` gets its own, separate treatment. Author colours
+ * survive there, so the gradient would still render — but a fade-to-transparent
+ * wash lowers the contrast of real content at the scrolling edge, in the one
+ * mode that exists to raise it. So the strip collapses to a solid hairline
+ * instead of a border: same "there is more" cue, none of the wash. The two
+ * media queries stay separate on purpose — macOS fires only the former and
+ * Windows swaps in system colours; see the block comments in `index.css`.
  */
 function ScrollShadowOverlay({ edge, visible }: { edge: "top" | "bottom"; visible: boolean }) {
   return (
@@ -39,12 +43,18 @@ function ScrollShadowOverlay({ edge, visible }: { edge: "top" | "bottom"; visibl
       className={cn(
         "pointer-events-none absolute inset-x-0 z-10 h-8 transition-opacity duration-150 ease-out",
         "forced-colors:h-0",
-        // A fade-to-transparent overlay lowers the contrast of real content at
-        // the scrolling edge, which is the opposite of what a reader who asked
-        // for more contrast wants — the affordance is decorative and the
-        // scrollbar still communicates scrollability. `forced-colors` is left
-        // to its own block by design (the two are deliberately separate).
-        "contrast-more:hidden",
+        // Under increased contrast the gradient is swapped for a solid
+        // hairline rather than removed. The wash itself is the problem — it
+        // lowers the contrast of real content at the scrolling edge, in the
+        // one mode that exists to raise it — but the cue is NOT decorative:
+        // `WebviewDialog` relies on it to stop page-controlled text concealing
+        // the request below the fold, `GitPushConfirmDialog` names it as what
+        // communicates "there is more", and `NotificationCenter` tests it as
+        // such. On macOS the scrollbar auto-hides, so deleting this outright
+        // would leave no at-rest signal at all. A solid rule says the same
+        // thing and reads better at high contrast.
+        // `forced-colors` is deliberately left to its own block above.
+        "contrast-more:bg-none contrast-more:h-px contrast-more:bg-border-strong",
         edge === "top"
           ? "top-0 bg-gradient-to-b from-[var(--scroll-shadow-color)] to-transparent forced-colors:border-t-2"
           : "bottom-0 bg-gradient-to-t from-[var(--scroll-shadow-color)] to-transparent forced-colors:border-b-2",

--- a/src/components/ui/TypedNameConfirmInput.tsx
+++ b/src/components/ui/TypedNameConfirmInput.tsx
@@ -8,6 +8,11 @@ export interface TypedNameConfirmInputProps {
   onMatchSubmit?: () => void;
   preamble?: React.ReactNode;
   instructions?: React.ReactNode;
+  /**
+   * Freeze the field while a destructive submit is already in flight, so the
+   * typed value cannot change out from under an awaiting dispatch.
+   */
+  disabled?: boolean;
   "data-testid"?: string;
 }
 
@@ -18,6 +23,7 @@ export function TypedNameConfirmInput({
   onMatchSubmit,
   preamble,
   instructions,
+  disabled = false,
   "data-testid": testId,
 }: TypedNameConfirmInputProps) {
   const instructionsId = useId();
@@ -49,6 +55,7 @@ export function TypedNameConfirmInput({
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
         onKeyDown={(e) => {
           if (e.key === "Enter" && isMatched && onMatchSubmit) {
             e.preventDefault();
@@ -61,7 +68,7 @@ export function TypedNameConfirmInput({
         aria-invalid={value.length > 0 && !isMatched}
         autoComplete="off"
         spellCheck={false}
-        className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] focus:outline-hidden focus:ring-2 focus:ring-status-error"
+        className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] focus:outline-hidden focus:ring-2 focus:ring-status-error disabled:opacity-50"
         data-testid={testId}
       />
       <span className="sr-only" aria-live="polite">

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -201,7 +201,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/TerminalRecipe/RecipeEditor.tsx",
     "src/components/Worktree/QuickCreatePalette.tsx",
     "src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx",
-    "src/components/Worktree/WorktreeDeleteDialog.tsx",
     "src/components/Worktree/WorktreeFilterPopover.tsx",
     "src/hooks/useUpdateListener.tsx",
   ],

--- a/src/index.css
+++ b/src/index.css
@@ -806,10 +806,24 @@ code.hljs {
 
   /* Native checkboxes/radios tint to the theme accent instead of the OS
      cobalt — the only non-theme hue otherwise rendered in the app. The
-     AccentColor keyword keeps any context without the var on OS behavior. */
+     AccentColor keyword keeps any context without the var on OS behavior.
+
+     `--checkbox-accent` is an opt-out seam, not a new default: it resolves to
+     the same accent unless an ancestor sets it, so every existing surface is
+     byte-identical. It exists because accent restraint allows at most ONE
+     load-bearing accent per focus region, and a group of option checkboxes is
+     membership — precisely what the rule excludes. A surface with several
+     checked options in one focus trap (the worktree delete dialog) sets this
+     to a neutral token so the accent stays available for the thing that
+     actually needs it. */
   input[type="checkbox"],
   input[type="radio"] {
-    accent-color: var(--theme-accent-primary, AccentColor);
+    accent-color: var(--checkbox-accent, var(--theme-accent-primary, AccentColor));
+  }
+
+  /* Neutral option controls: membership, not emphasis. */
+  .checkbox-neutral {
+    --checkbox-accent: var(--color-daintree-text);
   }
 
   *:focus-visible {


### PR DESCRIPTION
## Summary

The delete dialog used to render every possible outcome and strike through the ones that didn't apply. Deleting a clean worktree showed five consequences of which four were non-events, the first being a literal `0 terminals will be closed`. You had to subtract four rows to find the one real one, at the exact moment the dialog should be minimising interpretation.

It now lists only what will actually happen, and the layout runs cause before effect: entity summary, then the real changed-file list, then the optional toggles, then the consequences those toggles produce. Nothing above a control gets rewritten by it any more.

Resolves #11977

## What changed

**The consequence list.** Rows are built as data and pushed only when true. A clean delete renders one row. The terminal and branch options don't render at all when they don't apply, so the `0 terminals` template leak is gone. The one irreversible outcome is stated once, specifically, and carries a warning glyph and a weight step so it isn't signalled by colour alone (under `forced-colors` every status colour resolves to the same ink, which is exactly where the old red-only cue vanished).

**Things only visible by rendering it.** The confirm button interpolated the branch name, so a long branch overflowed the dialog, clipped its own label to `ete '...'`, and pushed Cancel out of the frame entirely. The label is a stable verb-noun now. The changed-file preview rendered absolute paths, repeating the whole worktree root on every row and pushing the filename past the wrap. `formatWorktreeChangeRows` takes the root and relativises, which also fixes the MCP approval preview through the same helper. And the dialog never passed `hasPreview`, so a body with a scrollable file list, three checkboxes and a text input rendered as `role="alertdialog"`.

**A real bug in the fail-closed path.** When the fresh `git status` fetch fails, `hasTrackedChanges` is forced true so the tier escalates, but the counts still came from a possibly clean seed. The dialog rendered `0 uncommitted files will be permanently lost` in the state where it knows least. It says the work is unverified now rather than inventing a number.

**Smaller ones.** The hand-written footer carried no `data-confirm-role`, so "focus Cancel first" fell through to the force-delete checkbox, the one control that widens the blast radius. `aria-describedby` pointed at an element that was never rendered. Irreversibility was asserted three times. `This cannot be undone.` is gone (`ConfirmDialog` warns on that exact string at runtime, and hand-rolling `AppDialog` was bypassing the guard). The force toggle label changed with state across three wordings. `role="alert"` re-fired assertively on every checkbox toggle. A standard delete on a known-dirty tree is rejected by the backend, so it's no longer offered as an enabled primary action. Options and the typed-name field freeze while the submit-time revalidation is in flight, since that await could otherwise dispatch pre-toggle values. Path relativisation handles Windows separators.

## Design review

Scored 5.3, then 8.4, then 9.5 over three rounds against blast-radius legibility, hierarchy, escalation design, visual language, density, affordance, states, accessibility, microcopy and craft. Hierarchy, visual language and microcopy finished at 10.0, and the final pass recorded that no hard house constraint was costing points.

The consistency survey found this was the only dialog of 62 hand-rolling `AppDialog variant="destructive"` rather than using the shared `ConfirmDialog`, and the only `variant="destructive"` dialog whose footer lacked the focus marker. The changes move it onto the majority side of every pattern rather than creating a new one: the MCP preview already rendered structured rows, and `PluginManagerView` already hand-rolled a neutral checkbox. `index.css` gains a `--checkbox-accent` seam whose fallback is byte-identical for every other surface.

One roll-out is included and is worth flagging. `ScrollShadow`'s edge fade lowered the contrast of real content under `prefers-contrast: more`. My first pass hid it outright, which a separate review of that diff caught as a regression: `WebviewDialog` relies on the fade to stop page-controlled text concealing the request below the fold, `GitPushConfirmDialog` names it as what communicates "there is more", `NotificationCenter` has a test asserting the same, and macOS auto-hides the scrollbar. The gradient is swapped for a solid hairline instead, which says the same thing and reads better at high contrast. The dock's two edge fades use `bg-none` rather than `hidden` because their wrappers contain the scroll chevron buttons.

## Testing

`npm run check` and the full unit suite. The suite's one failure was the accent guard reporting a stale allowlist entry: `WorktreeDeleteDialog.tsx` sat on the pre-existing accent-violation list and no forbidden utility remained, which is the repo's own confirmation that the accent fix landed. That entry is removed here.

Tests assert the rule rather than the value, so they survive the design changing again: a consequence row exists if and only if that consequence will occur, no preview row carries the worktree root, the primary label never carries the branch name, the irreversible row is never signalled by colour alone, and no count is stated that couldn't be verified. Every one was mutation-checked by reintroducing the bug and confirming the test fails.

`WorktreeDeleteDialog.focus.test.tsx` is new and mounts the real `AppDialog` rather than the stub. The stub can only prove the dialog passes the focus markers, not that the chrome honours them, and that gap is where the original defect lived.

A screenshot harness is added at `e2e/screenshots/worktree-delete-dialog-review.spec.ts`, opt-in behind `DAINTREE_SHOT_DELETE` like the other review specs. It builds four worktrees with genuinely different git states and drives the real dialog through the real actions menu. Two states it can't reach are noted in the spec: a running dev-server disclosure, and the fail-closed banner.

## Left alone

Ten other destructive dialogs still render `alertdialog` with scrollable or interactive bodies, `SafeModeBanner` among them (it's pinned by two tests asserting the role). Six membership-checkbox surfaces still inherit the theme accent, `RadioChoice` being the highest leverage at five consumers. Four confirm-dialog `<pre>` previews can still wrap long paths, worst being the teardown-command preview in `useWorktreeActions.ts`, which uses `break-all`. All pre-existing, none created here, and none of them capturable by this harness.
