### PR TITLE
Refine ImportEnvDialog's paste and conflict-review states

### DIFF
--- a/e2e/screenshots/import-env-dialog-review.spec.ts
+++ b/e2e/screenshots/import-env-dialog-review.spec.ts
@@ -1,0 +1,591 @@
+/**
+ * Import-.env dialog visual-review harness.
+ *
+ * Boots a minimal fixture repo, walks to Settings → CLI Agents → the agent's
+ * global env editor, opens Import .env and writes PNGs of every state the paste
+ * and conflict-review steps carry design weight in — empty paste, a clean
+ * parse, parse errors, duplicate pasted keys, mixed valid/invalid, one conflict
+ * and many, both merge modes, empty and overlong values, keyboard focus, high
+ * contrast and forced colors — so the two steps can be judged against real
+ * rendered pixels (#11973).
+ *
+ * Opt-in only, like theme-review and add-preset-dialog-review: skips itself
+ * unless DAINTREE_SHOT_IMPORTENV is set, so the marketing screenshots workflow
+ * never executes it.
+ *
+ *   DAINTREE_SHOT_IMPORTENV=1 npx playwright test --project=screenshots import-env-dialog-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_IMPORTENV  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME      optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG        optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY       comma-separated step filter (see step names below)
+ *   DAINTREE_SHOT_SWEEP      set to run the all-themes sweep instead of the state matrix
+ *   DAINTREE_SHOT_OUT        optional absolute output dir (default artifacts/import-env-shots)
+ *
+ * Output: artifacts/import-env-shots/<NN-slug>[-tag].png (gitignored).
+ *
+ * Steps never swallow their own failures, and every capture asserts text that
+ * only appears once the state is genuinely reached — a state that cannot be
+ * built throws rather than leaving a plausible-but-wrong PNG behind. The run
+ * writes MANIFEST.txt so the caller can count captures without trusting the
+ * exit code.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, appendFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { navigateToAgentSettings } from "../helpers/presets";
+import { SEL } from "../helpers/selectors";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_IMPORTENV;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const SWEEP = !!process.env.DAINTREE_SHOT_SWEEP;
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ?? path.resolve(process.cwd(), "artifacts", "import-env-shots");
+
+/**
+ * Every built-in theme. Declared locally rather than imported from a sibling
+ * review spec: importing a spec file registers its tests into this one.
+ */
+const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+/** The testid sits on the backdrop; the dialog panel is its first child. */
+const DIALOG = '[data-testid="import-env-dialog"]';
+const PANEL = `${DIALOG} > div`;
+const TEXTAREA = '[data-testid="import-env-textarea"]';
+const CONFLICT_LIST = '[data-testid="import-env-conflict-list"]';
+/**
+ * The element that actually scrolls. Written as a selector list so the harness
+ * survives the list gaining a dedicated scroll wrapper: `querySelector` returns
+ * the first match in DOCUMENT order, and a wrapper necessarily precedes the
+ * `ul` it wraps.
+ */
+const CONFLICT_LIST_SCROLLER = `${CONFLICT_LIST} [data-testid="import-env-conflict-scroller"], ${CONFLICT_LIST} ul`;
+const ENV_EDITOR = '[data-testid="global-env-editor"]';
+
+/** Freeze animations and hide carets so captures are deterministic. */
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+/**
+ * The env the dialog is importing INTO. Every conflict state below is built by
+ * pasting values that collide with these, so the fixture has to carry the edge
+ * cases the comparison has to render: a long secret, a short word, and a key
+ * whose existing value is the empty string.
+ */
+const EXISTING_ENV: Record<string, string> = {
+  ANTHROPIC_API_KEY: "sk-ant-api03-Hk7v2QpLm9xR4tYbN1cZ",
+  ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+  NODE_ENV: "development",
+  LOG_LEVEL: "info",
+  HTTP_PROXY: "",
+  MAX_THINKING_TOKENS: "16384",
+};
+
+const PASTE = {
+  /** Clean parse, nothing collides — the "just import it" path. */
+  clean: ["# staging overrides", "FEATURE_FLAGS=beta,canary", "export REGION=eu-west-1", ""].join(
+    "\n"
+  ),
+
+  /** Errors only, so the parse-problem region is the whole story. */
+  errors: [
+    "GOOD_KEY=fine",
+    "this line has no equals sign",
+    "2BAD_KEY=starts with a digit",
+    'UNTERMINATED="oops',
+    "=missing the key",
+  ].join("\n"),
+
+  /** Valid lines, a duplicate, AND an error — the state the summary hides in. */
+  mixed: [
+    "# pulled from the staging box",
+    "NODE_ENV=production",
+    "NODE_ENV=staging",
+    'export GREETING="hello world"',
+    "oops this line is wrong",
+    "LOG_LEVEL=debug",
+  ].join("\n"),
+
+  /** No errors, one duplicate — the only path where the summary shows it. */
+  duplicates: ["FEATURE_FLAGS=beta", "FEATURE_FLAGS=beta,canary", "REGION=eu-west-1"].join("\n"),
+
+  /** Exactly one collision, plus one genuinely new key. */
+  oneConflict: ["NODE_ENV=production", "REGION=eu-west-1"].join("\n"),
+
+  /**
+   * Five collisions and one new key. Covers an existing empty value, an
+   * incoming empty value, and a long secret replaced by another long secret.
+   */
+  manyConflicts: [
+    "ANTHROPIC_API_KEY=sk-ant-api03-Zq8w3EhTn5vB7mJdX2fK",
+    "ANTHROPIC_BASE_URL=https://gateway.internal.example.com/v1/anthropic",
+    "NODE_ENV=production",
+    "LOG_LEVEL=",
+    "HTTP_PROXY=http://corp-proxy.internal:3128",
+    "REGION=eu-west-1",
+  ].join("\n"),
+
+  /** One collision where both sides are far wider than the dialog. */
+  longValues: [
+    "ANTHROPIC_BASE_URL=https://gateway.internal.example.com/v1/anthropic/proxy?tenant=platform-engineering&region=eu-west-1&trace=1",
+  ].join("\n"),
+};
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+/** Minimal repo — the dialog lives in Settings, so no worktree topology is needed. */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-importenv-shots-"));
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+  git("add -A", dir);
+  git('commit -m "initial commit"', dir);
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Seed the agent's global env through the real settings seam, then reload so
+ * the renderer rebuilds from persisted state rather than a live patch.
+ * `presetId: undefined` keeps the scope editor on Default, which is the branch
+ * that renders the global env editor.
+ */
+async function seedGlobalEnv(
+  page: Page,
+  agentId: string,
+  env: Record<string, string>
+): Promise<void> {
+  await page.evaluate(
+    async ({ targetAgentId, nextEnv }) => {
+      type AgentEntry = Record<string, unknown>;
+      type AgentSettings = { agents?: Record<string, AgentEntry | undefined> };
+      const settings = (await window.electron.agentSettings.get()) as AgentSettings;
+      const entry = settings.agents?.[targetAgentId] ?? {};
+      await window.electron.agentSettings.set(targetAgentId, {
+        ...entry,
+        globalEnv: nextEnv,
+        presetId: undefined,
+      } as never);
+    },
+    { targetAgentId: agentId, nextEnv: env }
+  );
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.addStyleTag({ content: POLISH_CSS });
+  await dismissBlockingPalette(page).catch(() => undefined);
+}
+
+/** Walk to the agent's global env editor and open the Import .env dialog. */
+async function openDialog(page: Page, agentId: string): Promise<void> {
+  await navigateToAgentSettings(page, agentId);
+  const section = page.locator(SEL.preset.section);
+  await expect(section).toBeVisible({ timeout: 15_000 });
+  const editor = section.locator(ENV_EDITOR);
+  await expect(
+    editor,
+    "the global env editor is not on screen — the scope editor is probably not on Default"
+  ).toBeVisible({ timeout: 10_000 });
+  const importButton = editor.locator('[data-testid="env-editor-import"]');
+  await importButton.scrollIntoViewIfNeeded().catch(() => undefined);
+  await importButton.click({ force: true });
+  await expect(page.locator(DIALOG)).toBeVisible({ timeout: 10_000 });
+  await settle(page, 500);
+}
+
+async function typePaste(page: Page, text: string): Promise<void> {
+  // `fill` rather than `type`: the parse is a pure function of the whole value,
+  // and keystroke-by-keystroke entry captures nothing extra while adding
+  // seconds per state.
+  await page.locator(TEXTAREA).fill(text);
+  await settle(page, 400);
+}
+
+/** Advance to the conflict step via the real primary action, not a state poke. */
+async function goToConflicts(page: Page): Promise<void> {
+  const primary = page.locator(`${PANEL} [data-confirm-role="confirm"]`);
+  await expect(
+    primary,
+    "primary action does not offer the conflict step — the paste produced no collisions"
+  ).toContainText("conflict", { timeout: 5000 });
+  await primary.click({ force: true });
+  await expect(page.locator(CONFLICT_LIST)).toBeVisible({ timeout: 5000 });
+  await settle(page, 400);
+}
+
+async function closeDialog(page: Page): Promise<void> {
+  const dialog = page.locator(DIALOG);
+  if (!(await dialog.isVisible().catch(() => false))) return;
+  await dialog.getByRole("button", { name: "Close dialog" }).click({ force: true });
+  await expect(dialog).not.toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * Walk focus with real Tab presses until it lands on a node matching
+ * `predicate`, so `:focus-visible` actually applies. Chromium only sets it when
+ * focus arrives by keyboard, so a programmatic `.focus()` captures a frame that
+ * looks exactly like rest and reads as "there is no focus ring" when there is.
+ */
+/**
+ * Walk focus with real Tab presses until it lands on the named control, so
+ * `:focus-visible` actually applies. Chromium only sets it when focus arrives
+ * by keyboard, so a programmatic `.focus()` captures a frame that looks exactly
+ * like rest and reads as "there is no focus ring" when there is.
+ */
+async function tabUntil(page: Page, target: "textarea" | "radio"): Promise<void> {
+  for (let i = 0; i < 12; i++) {
+    await page.keyboard.press("Tab");
+    await settle(page, 120);
+    const hit = await page.evaluate((kind) => {
+      const el = document.activeElement as HTMLElement | null;
+      if (!el || !el.matches(":focus-visible")) return false;
+      if (kind === "textarea") return el.tagName === "TEXTAREA";
+      return el.tagName === "INPUT" && (el as HTMLInputElement).type === "radio";
+    }, target);
+    if (hit) return;
+  }
+  throw new Error(`Tab never reached a keyboard-focused ${target}`);
+}
+
+/**
+ * Report how much of the conflict preview is reachable without scrolling, and
+ * whether the scroll container is keyboard-focusable. Reported, not asserted:
+ * how many rows should fit is a design judgement, but a list rendering fewer
+ * rows than its own header counts — with nothing on screen saying so — is the
+ * input to that judgement, and a screenshot cannot supply it.
+ */
+async function measureConflictOverflow(page: Page): Promise<string> {
+  return page.evaluate((sel) => {
+    const scroller = document.querySelector(sel);
+    if (!scroller) return "no conflict scroller found";
+    const rows = Array.from(scroller.querySelectorAll("li"));
+    const box = scroller.getBoundingClientRect();
+    const fullyVisible = rows.filter((r) => {
+      const b = r.getBoundingClientRect();
+      return b.top >= box.top - 1 && b.bottom <= box.bottom + 1;
+    }).length;
+    const overflow = scroller.scrollHeight - scroller.clientHeight;
+    const focusable = (scroller as HTMLElement).tabIndex >= 0;
+    const role = scroller.getAttribute("role") ?? "none";
+    return `conflict list: ${fullyVisible}/${rows.length} rows fully visible, ${overflow}px hidden below the fold, scroller tabIndex=${(scroller as HTMLElement).tabIndex} (keyboard-reachable: ${focusable}), role=${role}`;
+  }, CONFLICT_LIST_SCROLLER);
+}
+
+const written: string[] = [];
+
+/**
+ * Capture one state.
+ *
+ * `requiredText` is asserted AFTER the settle and immediately before the
+ * screenshot: it is what stops the harness writing a plausible-looking PNG of a
+ * dialog that never reached the state the filename claims.
+ */
+async function snap(
+  page: Page,
+  slug: string,
+  requiredText: string[],
+  locator: string = PANEL
+): Promise<void> {
+  await settle(page);
+  const target = page.locator(locator).first();
+  await expect(target, `"${slug}": capture target is not visible — refusing to write`).toBeVisible({
+    timeout: 5000,
+  });
+  for (const text of requiredText) {
+    await expect(
+      target,
+      `"${slug}": expected ${JSON.stringify(text)} on screen — refusing to write`
+    ).toContainText(text, { timeout: 5000 });
+  }
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  await target.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  written.push(path.basename(file));
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+/**
+ * Run a named capture step. Deliberately does NOT swallow errors — a step that
+ * cannot reach its state fails the run, because a silently missing capture
+ * sends the whole review off reviewing a screen that does not exist.
+ */
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  await test.step(name, fn);
+}
+
+async function boot(): Promise<{
+  ctx: AppContext;
+  page: Page;
+  cleanup: () => Promise<void>;
+}> {
+  const repo = createFixtureRepo();
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-importenvshot-"));
+  const ctx = await launchApp({
+    userDataDir,
+    screenshotScale: SCALE,
+    windowSize: { width: 1680, height: 1050 },
+    extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+  });
+  const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+  if (THEME) await setAppTheme(page, THEME);
+  await page.addStyleTag({ content: POLISH_CSS });
+  await dismissBlockingPalette(page).catch(() => undefined);
+  await settle(page, 1500);
+  return {
+    ctx,
+    page,
+    cleanup: async () => {
+      if (ctx.app) await closeApp(ctx.app);
+      repo.cleanup();
+      rmSync(userDataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function writeManifest(): void {
+  const manifest = path.join(OUTPUT_DIR, `MANIFEST${TAG}.txt`);
+  appendFileSync(manifest, written.join("\n") + "\n");
+}
+
+test("import-env dialog review — paste and conflict states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_IMPORTENV is required for the import-env capture",
+  });
+  test.skip(
+    !ENABLED || SWEEP,
+    "Set DAINTREE_SHOT_IMPORTENV, and unset SWEEP, for the state matrix"
+  );
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const { page, cleanup } = await boot();
+  try {
+    await seedGlobalEnv(page, "claude", EXISTING_ENV);
+
+    // ---- Paste step. The state a user actually opens into, then each way the
+    // paste can land.
+    await step("empty", async () => {
+      await openDialog(page, "claude");
+      await snap(page, "10-paste-empty", ["Import .env", "Paste variables"]);
+      await snap(page, "11-paste-empty-window", ["Import .env"], "body");
+      await closeDialog(page);
+    });
+
+    await step("focus", async () => {
+      await openDialog(page, "claude");
+      await tabUntil(page, "textarea");
+      await snap(page, "15-paste-focus-textarea", ["Paste variables"]);
+      await closeDialog(page);
+    });
+
+    await step("clean", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.clean);
+      await snap(page, "20-paste-clean", ["2 variables detected", "Import 2 variables"]);
+      await closeDialog(page);
+    });
+
+    await step("errors", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.errors);
+      await snap(page, "25-paste-errors", ["parse error", "Missing '='"]);
+      await closeDialog(page);
+    });
+
+    await step("mixed", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.mixed);
+      await snap(page, "30-paste-mixed", ["parse error", "oops this line is wrong"]);
+      await closeDialog(page);
+    });
+
+    await step("duplicates", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.duplicates);
+      await snap(page, "35-paste-duplicates", ["duplicate key", "2 variables detected"]);
+      await closeDialog(page);
+    });
+
+    await step("conflicts-detected", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.manyConflicts);
+      await snap(page, "40-paste-conflicts-detected", ["5 conflicts", "Review 5 conflicts"]);
+      await closeDialog(page);
+    });
+
+    // ---- Conflict step.
+    await step("one-conflict", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.oneConflict);
+      await goToConflicts(page);
+      await snap(page, "50-conflicts-one", ["Keep existing", "NODE_ENV", "development"]);
+      await closeDialog(page);
+    });
+
+    await step("many-conflicts", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.manyConflicts);
+      await goToConflicts(page);
+      await snap(page, "55-conflicts-many-keep", ["Keep existing", "ANTHROPIC_API_KEY"]);
+      await snap(page, "56-conflicts-many-window", ["Keep existing"], "body");
+      // How much of the preview is actually on screen. A destructive preview
+      // that renders fewer rows than its own header counts is hiding part of
+      // what it is previewing, and a screenshot alone cannot prove it — the
+      // rows below the fold look exactly like no rows at all.
+      console.log(`[import-env-shots] ${await measureConflictOverflow(page)}`);
+      // Scroll the list to the bottom and capture again. If the frame changes,
+      // content was hidden; if it does not, nothing was.
+      await page
+        .locator(CONFLICT_LIST_SCROLLER)
+        .first()
+        .evaluate((el) => {
+          el.scrollTop = el.scrollHeight;
+        });
+      await settle(page, 400);
+      await snap(page, "57-conflicts-many-scrolled", ["Keep existing"]);
+      // Back to the top first: the scrolled-to-bottom capture above would
+      // otherwise leave this frame showing a different slice of the list, and
+      // the two merge modes have to be comparable frame to frame.
+      await page
+        .locator(CONFLICT_LIST_SCROLLER)
+        .first()
+        .evaluate((el) => {
+          el.scrollTop = 0;
+        });
+      await page.locator('[data-testid="import-env-mode-overwrite"]').click({ force: true });
+      await settle(page, 400);
+      await snap(page, "60-conflicts-many-overwrite", [
+        "Overwrite conflicts",
+        "Import, overwrite conflicts",
+      ]);
+      await closeDialog(page);
+    });
+
+    await step("conflict-focus", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.manyConflicts);
+      await goToConflicts(page);
+      await tabUntil(page, "radio");
+      await snap(page, "65-conflicts-focus", ["Keep existing"]);
+      await closeDialog(page);
+    });
+
+    await step("long-values", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.longValues);
+      await goToConflicts(page);
+      await snap(page, "70-conflicts-long-values", ["ANTHROPIC_BASE_URL"]);
+      await closeDialog(page);
+    });
+
+    // ---- The accessibility media states, on the two screens carrying the most
+    // custom colour: the parse-problem region and the comparison list.
+    await step("contrast", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.manyConflicts);
+      await goToConflicts(page);
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 400);
+      await snap(page, "80-conflicts-high-contrast", ["Keep existing", "ANTHROPIC_API_KEY"]);
+      await page.emulateMedia({ contrast: null, forcedColors: "active" });
+      await settle(page, 400);
+      await snap(page, "81-conflicts-forced-colors", ["Keep existing", "ANTHROPIC_API_KEY"]);
+      await page.emulateMedia({ forcedColors: null });
+      await settle(page, 300);
+      await closeDialog(page);
+    });
+
+    await step("contrast-errors", async () => {
+      await openDialog(page, "claude");
+      await typePaste(page, PASTE.errors);
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 400);
+      await snap(page, "85-paste-errors-high-contrast", ["parse error"]);
+      await page.emulateMedia({ contrast: null, forcedColors: "active" });
+      await settle(page, 400);
+      await snap(page, "86-paste-errors-forced-colors", ["parse error"]);
+      await page.emulateMedia({ forcedColors: null });
+      await settle(page, 300);
+      await closeDialog(page);
+    });
+  } finally {
+    writeManifest();
+    await cleanup();
+  }
+});
+
+test("import-env dialog review — every theme", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_IMPORTENV and DAINTREE_SHOT_SWEEP are required for the theme sweep",
+  });
+  test.skip(
+    !ENABLED || !SWEEP,
+    "Set DAINTREE_SHOT_IMPORTENV and DAINTREE_SHOT_SWEEP for the sweep"
+  );
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const { page, cleanup } = await boot();
+  try {
+    await seedGlobalEnv(page, "claude", EXISTING_ENV);
+
+    for (const theme of ALL_THEMES) {
+      await test.step(theme, async () => {
+        await setAppTheme(page, theme);
+        await page.addStyleTag({ content: POLISH_CSS });
+        await dismissBlockingPalette(page).catch(() => undefined);
+        await openDialog(page, "claude");
+        await typePaste(page, PASTE.manyConflicts);
+        await goToConflicts(page);
+        await snap(page, `90-theme-${theme}`, ["Keep existing", "ANTHROPIC_API_KEY"]);
+        await closeDialog(page);
+      });
+    }
+  } finally {
+    writeManifest();
+    await cleanup();
+  }
+});

--- a/e2e/screenshots/import-env-dialog-review.spec.ts
+++ b/e2e/screenshots/import-env-dialog-review.spec.ts
@@ -309,7 +309,15 @@ async function measureConflictOverflow(page: Page): Promise<string> {
     const overflow = scroller.scrollHeight - scroller.clientHeight;
     const focusable = (scroller as HTMLElement).tabIndex >= 0;
     const role = scroller.getAttribute("role") ?? "none";
-    return `conflict list: ${fullyVisible}/${rows.length} rows fully visible, ${overflow}px hidden below the fold, scroller tabIndex=${(scroller as HTMLElement).tabIndex} (keyboard-reachable: ${focusable}), role=${role}`;
+    // The dialog body scrolls independently. If it ALSO overflows, the preview
+    // has two scroll owners and its own bottom border sits below a second fold
+    // — which is the same hidden-content defect the inner scroller fixes,
+    // reappearing one level up.
+    const body = document.querySelector(
+      '[data-testid="import-env-dialog"] .flex-1.overflow-y-auto'
+    );
+    const bodyOverflow = body ? body.scrollHeight - body.clientHeight : -1;
+    return `conflict list: ${fullyVisible}/${rows.length} rows fully visible, ${overflow}px hidden below the fold, scroller tabIndex=${(scroller as HTMLElement).tabIndex} (keyboard-reachable: ${focusable}), role=${role} | dialog body overflow: ${bodyOverflow}px (0 = single scroll owner)`;
   }, CONFLICT_LIST_SCROLLER);
 }
 

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { RadioChoiceGroup, RadioChoiceRow } from "@/components/ui/RadioChoice";
 import { AlertTriangle } from "lucide-react";
 import { AppDialog } from "@/components/ui/AppDialog";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { cn } from "@/lib/utils";
 import { parseEnvPaste, type ParseEnvResult } from "@/utils/parseEnvPaste";
 
 type ConflictResolution = "keep" | "overwrite";
@@ -19,6 +21,35 @@ interface ImportEnvDialogProps {
   env: Record<string, string>;
   onImport: (merged: Record<string, string>) => void;
 }
+
+/**
+ * Named stages, so the dialog answers "where am I" without a stepper. Two
+ * conditional steps do not warrant one, and the second step only exists when
+ * something collides — a "Step 1 of 2" counter would be a lie on every clean
+ * import. Matches the step heading `AgentSetupWizard` owns, minus its counter.
+ */
+const STEP_TITLE: Record<Step, string> = {
+  paste: "Paste variables",
+  conflicts: "Resolve conflicts",
+};
+
+/**
+ * The merge policy restated where the evidence is. Without it the conflict list
+ * shows the same old/new pair under both policies, which reads as "all of these
+ * are about to change" even when "Keep existing" means none of them are.
+ */
+const OUTCOME_LABEL: Record<ConflictResolution, string> = {
+  keep: "Existing values kept",
+  overwrite: "Incoming values applied",
+};
+
+/** The caption-strip recipe shared by the app's other destructive previews. */
+const PREVIEW_FRAME = "rounded border border-tint/[0.08] bg-tint/[0.04] text-xs";
+const PREVIEW_STRIP =
+  "px-3 py-2 border-b border-tint/[0.08] flex items-center justify-between gap-2";
+const PREVIEW_CAPTION = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
+const PREVIEW_COUNT =
+  "ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal";
 
 function collapsePairs(result: ParseEnvResult): Record<string, string> {
   const out: Record<string, string> = {};
@@ -52,10 +83,44 @@ function buildMerged(
   return merged;
 }
 
+/**
+ * One side of a conflict.
+ *
+ * The side that survives carries the readable tier and the other the secondary
+ * one, so the two merge modes no longer render identically — but the weight is
+ * the redundant cue, not the load-bearing one. What actually names each side is
+ * the `<dt>`, because a difference carried by colour, weight, or a strikethrough
+ * alone does not survive `forced-colors: active` and is not announced at all
+ * (WCAG 1.4.1, 1.3.1). `(empty)` is italicised so a value being blanked cannot
+ * be mistaken for a value named "(empty)".
+ */
+function ConflictSide({ label, value, kept }: { label: string; value: string; kept: boolean }) {
+  const isEmpty = value === "";
+  return (
+    <>
+      <dt className="text-[10px] uppercase tracking-wide text-text-secondary">{label}</dt>
+      <dd
+        className={cn(
+          "font-mono text-[11px] break-all",
+          kept ? "text-daintree-text" : "text-text-secondary",
+          isEmpty && "italic"
+        )}
+      >
+        {isEmpty ? "(empty)" : value}
+      </dd>
+    </>
+  );
+}
+
 export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDialogProps) {
   const [pastedText, setPastedText] = useState("");
   const [step, setStep] = useState<Step>("paste");
   const [conflictResolution, setConflictResolution] = useState<ConflictResolution>("keep");
+
+  const errorsId = useId();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const stepHeadingRef = useRef<HTMLHeadingElement>(null);
+  const prevStepRef = useRef<Step>("paste");
 
   // Single reset effect keyed on [isOpen] — avoids the split-effect trap from #4958.
   useEffect(() => {
@@ -63,8 +128,39 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
       setPastedText("");
       setStep("paste");
       setConflictResolution("keep");
+      prevStepRef.current = "paste";
     }
   }, [isOpen]);
+
+  // The dialog is opened to be pasted into, so the caret starts in the textarea
+  // rather than on the header close button `initialFocus: "first"` would pick.
+  // `initialFocus="none"` hands the whole job over — the same arrangement
+  // `AgentSetupWizard` uses — so there is no race between two focus calls.
+  useEffect(() => {
+    if (!isOpen) return;
+    const frame = requestAnimationFrame(() => textareaRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen]);
+
+  /**
+   * Move focus deliberately on a step change, rather than leaving it on the
+   * footer button whose label just changed underneath it (WAI-ARIA APG, dialog
+   * pattern).
+   *
+   * Forward lands on the step heading: the conflict step is new information and
+   * a decision, so it gets announced before the controls. Back lands on the
+   * textarea instead — that step is already known and the reason for returning
+   * is to edit the paste.
+   */
+  useEffect(() => {
+    if (!isOpen || prevStepRef.current === step) return;
+    prevStepRef.current = step;
+    const frame = requestAnimationFrame(() => {
+      if (step === "conflicts") stepHeadingRef.current?.focus();
+      else textareaRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, step]);
 
   const parsed = useMemo(() => parseEnvPaste(pastedText), [pastedText]);
   const incoming = useMemo(() => collapsePairs(parsed), [parsed]);
@@ -94,16 +190,32 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
     handleImport(conflictResolution);
   };
 
+  /**
+   * The label names what pressing it will do — which means it must not name a
+   * count while the button cannot be pressed. A disabled "Import 1 variable"
+   * reads as an offer to import the lines that did parse and skip the rest,
+   * which is not what happens.
+   */
   const primaryLabel =
     step === "conflicts"
       ? conflictResolution === "keep"
         ? "Import, keep existing"
         : "Import, overwrite conflicts"
-      : conflicts.length > 0
-        ? `Review ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"}`
-        : incomingCount > 0
-          ? `Import ${incomingCount} variable${incomingCount === 1 ? "" : "s"}`
-          : "Import";
+      : !canProceed
+        ? "Import"
+        : conflicts.length > 0
+          ? `Review ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"}`
+          : `Import ${incomingCount} variable${incomingCount === 1 ? "" : "s"}`;
+
+  /** Why the primary action is dead. A disabled button that explains nothing is a dead end. */
+  const blockedHint =
+    step !== "paste" || canProceed
+      ? null
+      : hasErrors
+        ? `Fix ${parsed.errors.length} parse error${parsed.errors.length === 1 ? "" : "s"} to continue`
+        : pastedText.trim() !== ""
+          ? "No variables found in that paste"
+          : null;
 
   const secondaryLabel = step === "conflicts" ? "Back" : "Cancel";
   const handleSecondary = () => {
@@ -120,6 +232,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
       onClose={onClose}
       size="md"
       zIndex="nested"
+      initialFocus="none"
       data-testid="import-env-dialog"
     >
       <AppDialog.Header>
@@ -128,67 +241,106 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
       </AppDialog.Header>
 
       <AppDialog.Body className="space-y-4">
+        <div className="space-y-1">
+          <h3
+            ref={stepHeadingRef}
+            tabIndex={-1}
+            className="text-sm font-medium text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 rounded-xs"
+            data-testid="import-env-step-heading"
+          >
+            {STEP_TITLE[step]}
+          </h3>
+          <AppDialog.Description>
+            {step === "paste" ? (
+              <>
+                Keys must match <code className="text-[11px]">[A-Za-z_][A-Za-z0-9_]*</code>. Quoted
+                values, comments, and <code className="text-[11px]">export</code> prefixes are
+                supported.
+              </>
+            ) : (
+              <>
+                {conflicts.length} key{conflicts.length === 1 ? "" : "s"} already exist
+                {conflicts.length === 1 ? "s" : ""} with a different value. Choose which one wins.
+              </>
+            )}
+          </AppDialog.Description>
+        </div>
+
         {step === "paste" ? (
           <>
-            <AppDialog.Description>
-              Paste the contents of a .env file. Keys must match{" "}
-              <code className="text-[11px]">[A-Za-z_][A-Za-z0-9_]*</code>. Quoted values, comments,
-              and <code className="text-[11px]">export</code> prefixes are supported.
-            </AppDialog.Description>
             <textarea
+              ref={textareaRef}
               value={pastedText}
               onChange={(e) => setPastedText(e.target.value)}
               placeholder={'FOO=bar\nexport BAZ="hello world"\n# comments supported'}
               spellCheck={false}
               autoCapitalize="off"
               autoCorrect="off"
-              className="w-full h-56 resize-y font-mono text-[12px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30 text-daintree-text"
+              // Focus ring is the documented shared recipe rather than a local
+              // `focus:ring-*`: `docs/themes/interaction-state-recipes.md` calls
+              // for `focus-visible:outline-*` for keyboard focus, and the ring
+              // this replaced measured ~2.2:1 — under the 3:1 floor for a
+              // non-text indicator, on the step's primary input.
+              className="w-full h-56 resize-y font-mono text-[12px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
               aria-label="Paste .env content"
+              aria-invalid={hasErrors || undefined}
+              aria-describedby={hasErrors ? errorsId : undefined}
               data-testid="import-env-textarea"
             />
             {hasErrors && (
               <div
-                className="rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/10 px-3 py-2 text-[12px] text-status-warning"
+                id={errorsId}
+                role="alert"
+                className="rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/10 px-3 py-2 text-[12px]"
                 data-testid="import-env-errors"
               >
-                <div className="flex items-center gap-1.5 font-medium mb-1">
+                <div className="flex items-center gap-1.5 font-medium mb-1 text-status-warning">
                   <AlertTriangle size={12} aria-hidden="true" />
                   <span>
                     {parsed.errors.length} parse error
                     {parsed.errors.length === 1 ? "" : "s"}
                   </span>
                 </div>
+                {/* The tint, border and icon carry "this is a warning". The
+                    lines themselves are what the user has to read and act on,
+                    so they run on the audited text tiers — the amber tri-tone
+                    this replaced flattened to one uniform run under
+                    `forced-colors: active` anyway. */}
                 <ul className="space-y-0.5 font-mono text-[11px]">
                   {parsed.errors.map((e) => (
                     <li key={`${e.line}-${e.raw}`}>
-                      <span className="text-status-warning/70">Line {e.line}:</span> {e.reason}
+                      <span className="text-text-secondary">Line {e.line}:</span>{" "}
+                      <span className="text-daintree-text">{e.reason}</span>
                       {e.raw.trim() !== "" && (
-                        <span className="text-daintree-text/50"> — {e.raw}</span>
+                        <span className="text-text-secondary"> — {e.raw}</span>
                       )}
                     </li>
                   ))}
                 </ul>
               </div>
             )}
-            {!hasErrors && incomingCount > 0 && (
-              <p className="text-[11px] text-daintree-text/50" data-testid="import-env-summary">
+            {/* Shown alongside parse errors too. Gating this on a clean parse
+                meant a paste that had both a bad line and a duplicated key
+                reported the bad line and silently dropped the duplicate. */}
+            {incomingCount > 0 && (
+              <p className="text-[11px] text-text-secondary" data-testid="import-env-summary">
                 {incomingCount} variable{incomingCount === 1 ? "" : "s"} detected
                 {conflicts.length > 0
                   ? ` · ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"}`
                   : ""}
                 {newCount > 0 && conflicts.length > 0 ? ` · ${newCount} new` : ""}
-                {duplicateInPasteCount > 0
-                  ? ` · ${duplicateInPasteCount} duplicate key${duplicateInPasteCount === 1 ? "" : "s"} in paste (last value kept)`
-                  : ""}
+                {duplicateInPasteCount > 0 ? (
+                  <span className="text-daintree-text">
+                    {" "}
+                    · {duplicateInPasteCount} duplicate key
+                    {duplicateInPasteCount === 1 ? "" : "s"} in paste (last value kept)
+                  </span>
+                ) : null}
               </p>
             )}
           </>
         ) : (
           <>
-            <AppDialog.Description>
-              {conflicts.length} key{conflicts.length === 1 ? "" : "s"} already exist
-              {conflicts.length === 1 ? "s" : ""}. Choose how to merge.
-            </AppDialog.Description>
             <RadioChoiceGroup legend="Conflict resolution" legendHidden>
               <RadioChoiceRow
                 name="import-env-conflict-mode"
@@ -209,31 +361,57 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                 testId="import-env-mode-overwrite"
               />
             </RadioChoiceGroup>
-            <div
-              className="rounded-[var(--radius-md)] border border-daintree-border overflow-hidden"
-              data-testid="import-env-conflict-list"
-            >
-              <div className="bg-daintree-bg/40 px-3 py-1.5 text-[10px] uppercase tracking-wide text-daintree-text/50 border-b border-daintree-border">
-                Conflicts ({conflicts.length})
+            <div className={PREVIEW_FRAME} data-testid="import-env-conflict-list">
+              <div className={PREVIEW_STRIP}>
+                <span role="heading" aria-level={4} className={PREVIEW_CAPTION}>
+                  Conflicts
+                  <span className={PREVIEW_COUNT}>{conflicts.length}</span>
+                </span>
+                <span className="text-[11px] text-text-secondary">
+                  {OUTCOME_LABEL[conflictResolution]}
+                </span>
               </div>
-              <ul className="max-h-48 overflow-y-auto divide-y divide-daintree-border/60">
-                {conflicts.map((c) => (
-                  <li key={c.key} className="px-3 py-1.5 font-mono text-[11px]">
-                    <div className="text-daintree-text/80">{c.key}</div>
-                    <div className="text-daintree-text/50">
-                      <span className="line-through">{c.oldValue || "(empty)"}</span>
-                      <span className="mx-1.5">→</span>
-                      <span className="text-daintree-accent">{c.newValue || "(empty)"}</span>
-                    </div>
-                  </li>
-                ))}
-              </ul>
+              {/* Bounded and scrolled inside itself so the footer never moves,
+                  but with the fade the plain `overflow-y-auto` never had: at
+                  `max-h` the list rendered four of five conflicts and its own
+                  clean bottom border, so a destructive preview looked complete
+                  while hiding part of what it was previewing. `tabIndex`
+                  + `role="region"` make the hidden part reachable by keyboard.  */}
+              <ScrollShadow
+                className="max-h-[260px]"
+                scrollClassName="scroll-py-8"
+                tabIndex={0}
+                role="region"
+                aria-label={`Conflicting keys — ${OUTCOME_LABEL[conflictResolution].toLowerCase()}`}
+                data-testid="import-env-conflict-scroller"
+              >
+                <ul className="divide-y divide-tint/[0.06]">
+                  {conflicts.map((c) => (
+                    <li key={c.key} className="px-3 py-2">
+                      <div className="font-mono text-[11px] text-daintree-text">{c.key}</div>
+                      <dl className="mt-0.5 grid grid-cols-[max-content_1fr] items-baseline gap-x-3 gap-y-0.5">
+                        <ConflictSide
+                          label="Existing"
+                          value={c.oldValue}
+                          kept={conflictResolution === "keep"}
+                        />
+                        <ConflictSide
+                          label="Incoming"
+                          value={c.newValue}
+                          kept={conflictResolution === "overwrite"}
+                        />
+                      </dl>
+                    </li>
+                  ))}
+                </ul>
+              </ScrollShadow>
             </div>
           </>
         )}
       </AppDialog.Body>
 
       <AppDialog.Footer
+        hint={blockedHint}
         secondaryAction={{ label: secondaryLabel, onClick: handleSecondary }}
         primaryAction={{
           label: primaryLabel,

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -286,7 +286,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
               // for `focus-visible:outline-*` for keyboard focus, and the ring
               // this replaced measured ~2.2:1 — under the 3:1 floor for a
               // non-text indicator, on the step's primary input.
-              className="w-full h-56 resize-y font-mono text-[12px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              className="w-full h-56 resize-y font-mono text-[12px] bg-surface-input border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-daintree-text placeholder:text-text-placeholder transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
               aria-label="Paste .env content"
               aria-invalid={hasErrors || undefined}
               aria-describedby={hasErrors ? errorsId : undefined}

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -101,8 +101,13 @@ function ConflictSide({ label, value, kept }: { label: string; value: string; ke
       <dt className="text-[10px] uppercase tracking-wide text-text-secondary">{label}</dt>
       <dd
         className={cn(
-          "font-mono text-[11px] break-all",
-          kept ? "text-daintree-text" : "text-text-secondary",
+          // BOTH sides read at the audited 4.5:1 tier. The losing value is
+          // still evidence the user has to inspect — dimming it made the half
+          // being protected the hardest thing in the row to read. The surviving
+          // side is marked by weight instead, which costs no contrast and
+          // survives forced-colors, where a colour difference would not.
+          "font-mono text-[11px] break-all text-daintree-text",
+          kept ? "font-medium" : "font-normal",
           isEmpty && "italic"
         )}
       >
@@ -240,7 +245,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
         <AppDialog.CloseButton />
       </AppDialog.Header>
 
-      <AppDialog.Body className="space-y-4">
+      <AppDialog.Body className={step === "conflicts" ? "space-y-3" : "space-y-4"}>
         <div className="space-y-1">
           <h3
             ref={stepHeadingRef}
@@ -329,6 +334,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                   ? ` · ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"}`
                   : ""}
                 {newCount > 0 && conflicts.length > 0 ? ` · ${newCount} new` : ""}
+                {conflicts.length === 0 ? " · existing values unchanged" : ""}
                 {duplicateInPasteCount > 0 ? (
                   <span className="text-daintree-text">
                     {" "}
@@ -378,7 +384,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                   while hiding part of what it was previewing. `tabIndex`
                   + `role="region"` make the hidden part reachable by keyboard.  */}
               <ScrollShadow
-                className="max-h-[260px]"
+                className="max-h-[224px]"
                 scrollClassName="scroll-py-8"
                 tabIndex={0}
                 role="region"

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -369,7 +369,16 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
             </RadioChoiceGroup>
             <div className={PREVIEW_FRAME} data-testid="import-env-conflict-list">
               <div className={PREVIEW_STRIP}>
-                <span role="heading" aria-level={4} className={PREVIEW_CAPTION}>
+                {/* The count sits in its own inline pill, so name computation
+                    would run the two text nodes together as "Conflicts2" —
+                    the gap is CSS margin, and margins are not text. The label
+                    stays first so voice control still matches what is shown. */}
+                <span
+                  role="heading"
+                  aria-level={4}
+                  aria-label={`Conflicts ${conflicts.length}`}
+                  className={PREVIEW_CAPTION}
+                >
                   Conflicts
                   <span className={PREVIEW_COUNT}>{conflicts.length}</span>
                 </span>

--- a/src/components/Settings/__tests__/ImportEnvDialog.test.tsx
+++ b/src/components/Settings/__tests__/ImportEnvDialog.test.tsx
@@ -124,6 +124,18 @@ describe("ImportEnvDialog", () => {
     });
 
     /**
+     * The caption pairs a label with a count pill, and the gap between them is
+     * margin — which name computation does not see. Asserting the count reads
+     * as its own word keeps the heading from announcing "Conflicts2"; the
+     * label itself is free to change, so nothing here pins the wording.
+     */
+    it("separates the caption's count from its label in the announced name", () => {
+      renderDialog();
+      const list = goToConflicts();
+      expect(within(list).getByRole("heading", { name: /\s\d+$/ })).toBeTruthy();
+    });
+
+    /**
      * The list is capped, so some of it is off-screen whenever there are more
      * conflicts than fit — which makes reaching the rest by keyboard part of
      * the destructive preview, not a nicety.

--- a/src/components/Settings/__tests__/ImportEnvDialog.test.tsx
+++ b/src/components/Settings/__tests__/ImportEnvDialog.test.tsx
@@ -1,0 +1,257 @@
+// @vitest-environment jsdom
+/**
+ * ImportEnvDialog — the rules the two steps have to keep obeying (#11973).
+ *
+ * These assert invariants rather than values, because the values are exactly
+ * what a design pass changes: the labels, the tiers and the copy are all free
+ * to move, but "the preview must reflect the selected policy" and "both sides
+ * of a comparison must be named in text" are not. Each one was written against
+ * a defect the captured pixels actually showed, and each was mutation-checked
+ * by reintroducing that defect.
+ *
+ * `EnvVarEditor.test.tsx` covers the merge semantics, the dynamic labels and
+ * the Back-preserves-the-paste contract against a mocked AppDialog. This file
+ * deliberately renders the real one, because focus choreography, the footer
+ * hint slot and the scroll region only exist there.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, screen, within, waitFor, cleanup } from "@testing-library/react";
+import { ImportEnvDialog } from "../ImportEnvDialog";
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+const EXISTING = {
+  ANTHROPIC_API_KEY: "sk-ant-old",
+  ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+  NODE_ENV: "development",
+};
+
+function renderDialog(env: Record<string, string> = EXISTING) {
+  const onImport = vi.fn<(merged: Record<string, string>) => void>();
+  const onClose = vi.fn();
+  render(<ImportEnvDialog isOpen onClose={onClose} env={env} onImport={onImport} />);
+  return { onImport, onClose };
+}
+
+function paste(text: string) {
+  fireEvent.change(screen.getByTestId("import-env-textarea"), { target: { value: text } });
+}
+
+const primary = () =>
+  screen
+    .getByTestId("import-env-dialog")
+    .querySelector<HTMLButtonElement>('[data-confirm-role="confirm"]')!;
+
+/** Paste two colliding keys and advance to the conflict step. */
+function goToConflicts() {
+  paste("ANTHROPIC_API_KEY=sk-ant-new\nNODE_ENV=production");
+  fireEvent.click(primary());
+  return screen.getByTestId("import-env-conflict-list");
+}
+
+describe("ImportEnvDialog", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  describe("the conflict preview", () => {
+    /**
+     * The defect: the list rendered every existing value struck through with
+     * the incoming value in accent, identically under both policies — so with
+     * "Keep existing" selected the preview claimed the opposite of what the
+     * import would do. Asserting only that the two renders DIFFER keeps this
+     * honest without pinning any particular treatment.
+     */
+    it("renders the rows differently under each merge policy", () => {
+      renderDialog();
+      goToConflicts();
+      // Scoped to the scrolling rows, NOT the whole list: the caption strip
+      // restates the policy, so asserting on the container would pass on that
+      // alone while the rows carried on contradicting it.
+      const rows = screen.getByTestId("import-env-conflict-scroller");
+      const keep = rows.innerHTML;
+
+      fireEvent.click(screen.getByTestId("import-env-mode-overwrite"));
+      expect(rows.innerHTML).not.toBe(keep);
+
+      fireEvent.click(screen.getByTestId("import-env-mode-keep"));
+      expect(rows.innerHTML).toBe(keep);
+    });
+
+    /** The policy is also stated in words, for anyone who cannot see the weight. */
+    it("states the resulting policy in text, and restates it when the policy changes", () => {
+      renderDialog();
+      const list = goToConflicts();
+      const strip = list.firstElementChild!;
+      const keep = strip.textContent?.trim();
+      expect(keep).toBeTruthy();
+
+      fireEvent.click(screen.getByTestId("import-env-mode-overwrite"));
+      expect(strip.textContent?.trim()).not.toBe(keep);
+    });
+
+    /**
+     * WCAG 1.4.1 / 1.3.1: which value is the existing one and which is the
+     * incoming one cannot rest on colour, order, or a strikethrough — every row
+     * has to say so in text. Checks that each row names both of its sides
+     * without pinning what it calls them.
+     */
+    it("names both sides of every row in text", () => {
+      renderDialog();
+      const list = goToConflicts();
+      const rows = within(list).getAllByRole("listitem");
+      expect(rows.length).toBe(2);
+
+      for (const row of rows) {
+        const labels = Array.from(row.querySelectorAll("dt")).map((t) => t.textContent?.trim());
+        expect(labels).toHaveLength(2);
+        expect(labels.every((l) => !!l && l.length > 0)).toBe(true);
+        // The two sides must be told apart from each other, not just labelled.
+        expect(new Set(labels).size).toBe(2);
+        expect(row.querySelectorAll("dd")).toHaveLength(2);
+      }
+    });
+
+    /** Strikethrough is not announced, and does not survive forced-colors. */
+    it("does not carry the comparison on a strikethrough", () => {
+      renderDialog();
+      expect(goToConflicts().innerHTML).not.toMatch(/line-through/);
+    });
+
+    /**
+     * The list is capped, so some of it is off-screen whenever there are more
+     * conflicts than fit — which makes reaching the rest by keyboard part of
+     * the destructive preview, not a nicety.
+     */
+    it("exposes the capped list as a reachable, named scroll region", () => {
+      renderDialog();
+      goToConflicts();
+      const scroller = screen.getByTestId("import-env-conflict-scroller");
+      expect(scroller.tabIndex).toBeGreaterThanOrEqual(0);
+      expect(scroller.getAttribute("aria-label")?.trim()).toBeTruthy();
+    });
+  });
+
+  describe("the primary action", () => {
+    /**
+     * The defect: with four parse errors the disabled button still read
+     * "Import 1 variable", which describes a partial import that never happens.
+     * A count on a button that cannot be pressed is a promise, so there must
+     * not be one.
+     */
+    it("never advertises a count while it is disabled", () => {
+      renderDialog();
+      paste("GOOD=fine\nthis line has no equals sign");
+      expect(primary().disabled).toBe(true);
+      expect(primary().textContent).not.toMatch(/\d/);
+    });
+
+    it("advertises a count once it can actually be pressed", () => {
+      renderDialog();
+      paste("BRAND_NEW=1\nALSO_NEW=2");
+      expect(primary().disabled).toBe(false);
+      expect(primary().textContent).toMatch(/\d/);
+    });
+
+    /** A dead button that explains nothing is a dead end. */
+    it("says why it is disabled whenever the user has pasted something", () => {
+      renderDialog();
+      paste("this line has no equals sign");
+      expect(primary().disabled).toBe(true);
+      expect(screen.getByTestId("app-dialog-hint").textContent?.trim()).toBeTruthy();
+    });
+
+    it("stays quiet about it before anything is pasted", () => {
+      renderDialog();
+      expect(primary().disabled).toBe(true);
+      expect(screen.queryByTestId("app-dialog-hint")).toBeNull();
+    });
+  });
+
+  describe("parse problems", () => {
+    /**
+     * WCAG 3.3.1: the error region has to be reachable FROM the field, not just
+     * visible near it. Resolves the association through the DOM so no id string
+     * is duplicated into the test.
+     */
+    it("associates the error region with the field it describes", () => {
+      renderDialog();
+      paste("this line has no equals sign");
+      const textarea = screen.getByTestId("import-env-textarea");
+      expect(textarea.getAttribute("aria-invalid")).toBe("true");
+
+      const describedBy = textarea.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy!)).toBe(screen.getByTestId("import-env-errors"));
+    });
+
+    it("drops the association again once the paste parses", () => {
+      renderDialog();
+      paste("this line has no equals sign");
+      paste("FINE=yes");
+      const textarea = screen.getByTestId("import-env-textarea");
+      expect(textarea.getAttribute("aria-invalid")).toBeNull();
+      expect(textarea.getAttribute("aria-describedby")).toBeNull();
+    });
+
+    /**
+     * The defect: the detection summary was gated on a clean parse, so a paste
+     * containing both a bad line and a duplicated key reported the bad line and
+     * said nothing about the value it had already discarded.
+     */
+    it("still reports discarded duplicate keys when the paste also fails to parse", () => {
+      renderDialog();
+      paste("DUPED=one\nDUPED=two\nthis line has no equals sign");
+      expect(screen.getByTestId("import-env-summary").textContent).toMatch(/duplicate key/i);
+    });
+  });
+
+  describe("stage orientation", () => {
+    it("names the current stage, and renames it on advancing", () => {
+      renderDialog();
+      const heading = screen.getByTestId("import-env-step-heading");
+      const pasteStage = heading.textContent?.trim();
+      expect(pasteStage).toBeTruthy();
+
+      goToConflicts();
+      const conflictStage = screen.getByTestId("import-env-step-heading").textContent?.trim();
+      expect(conflictStage).toBeTruthy();
+      expect(conflictStage).not.toBe(pasteStage);
+    });
+
+    /** The dialog exists to be pasted into, so the caret starts there. */
+    it("opens with focus in the paste field", async () => {
+      renderDialog();
+      await waitFor(() =>
+        expect(document.activeElement).toBe(screen.getByTestId("import-env-textarea"))
+      );
+    });
+
+    /**
+     * APG dialog pattern: a step change must move focus deliberately rather
+     * than stranding it on the footer button whose label just changed. Forward
+     * announces the new stage; Back returns to the field the user came back to
+     * edit.
+     */
+    it("moves focus to the new stage, and back to the paste field on Back", async () => {
+      renderDialog();
+      goToConflicts();
+      await waitFor(() =>
+        expect(document.activeElement).toBe(screen.getByTestId("import-env-step-heading"))
+      );
+
+      const back = screen
+        .getByTestId("import-env-dialog")
+        .querySelector<HTMLButtonElement>('[data-confirm-role="cancel"]')!;
+      fireEvent.click(back);
+      await waitFor(() =>
+        expect(document.activeElement).toBe(screen.getByTestId("import-env-textarea"))
+      );
+    });
+  });
+});

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -675,7 +675,10 @@ AppDialog.Footer = function AppDialogFooter({
           the primary label gets clipped. The actions never yield — a hint is
           explanatory, an action is how the dialog is answered. */}
       {hint && (
-        <div className="text-[12px] text-daintree-text/55 flex min-w-0 items-center gap-1">
+        <div
+          className="text-[12px] text-daintree-text/55 flex min-w-0 items-center gap-1"
+          data-testid="app-dialog-hint"
+        >
           {hint}
         </div>
       )}

--- a/src/components/ui/ScrollShadow.tsx
+++ b/src/components/ui/ScrollShadow.tsx
@@ -12,6 +12,25 @@ import {
 import { cn } from "@/lib/utils";
 import { useVerticalScrollShadows } from "@/hooks/useVerticalScrollShadows";
 
+/**
+ * The "there is more this way" cue.
+ *
+ * Normally a fade. Under `forced-colors: active` the UA drops the gradient, so
+ * the only signal that a bounded list continues would disappear — and a list
+ * that is cut off but looks finished is worse than one with no cue at all. A
+ * capped conflict preview showing four of five keys reads as complete
+ * (#11973).
+ *
+ * So in that mode only, the strip collapses to a rule on the scrollable edge.
+ * `border-color` resolves to `currentColor` and the UA repaints it to a system
+ * colour, which is the one thing guaranteed to be visible there. `opacity`
+ * survives forced-colors, so the rule still appears and disappears with the
+ * scroll position rather than sitting there permanently.
+ *
+ * Deliberately NOT applied under `prefers-contrast: more`: that mode keeps
+ * author colours, so the gradient still renders and still reads. The two media
+ * queries stay separate on purpose — see the block comments in `index.css`.
+ */
 function ScrollShadowOverlay({ edge, visible }: { edge: "top" | "bottom"; visible: boolean }) {
   return (
     <div
@@ -19,9 +38,10 @@ function ScrollShadowOverlay({ edge, visible }: { edge: "top" | "bottom"; visibl
       data-visible={visible}
       className={cn(
         "pointer-events-none absolute inset-x-0 z-10 h-8 transition-opacity duration-150 ease-out",
+        "forced-colors:h-0",
         edge === "top"
-          ? "top-0 bg-gradient-to-b from-[var(--scroll-shadow-color)] to-transparent"
-          : "bottom-0 bg-gradient-to-t from-[var(--scroll-shadow-color)] to-transparent",
+          ? "top-0 bg-gradient-to-b from-[var(--scroll-shadow-color)] to-transparent forced-colors:border-t-2"
+          : "bottom-0 bg-gradient-to-t from-[var(--scroll-shadow-color)] to-transparent forced-colors:border-b-2",
         visible ? "opacity-100" : "opacity-0"
       )}
     />

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -180,7 +180,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Settings/EditorIntegrationTab.tsx",
     "src/components/Settings/EnvVarEditor.tsx",
     "src/components/Settings/ImageViewerTab.tsx",
-    "src/components/Settings/ImportEnvDialog.tsx",
     "src/components/Settings/KeyboardShortcutsTab.tsx",
     "src/components/Settings/PortalSettingsTab.tsx",
     "src/components/Settings/PresetSelector.tsx",


### PR DESCRIPTION
## Summary

The two steps of the .env import now read as two stages of one task, and the conflict list is an honest preview of what the import will actually do. Previously it showed the old value struck through with the new value in the accent colour, which vanished under `forced-colors: active` and rendered identically whether you picked **Keep existing** or **Overwrite conflicts**.

Resolves #11973

## What changed

**The conflict comparison.** Each row is now a `<dl>` with the key on its own line and both values labelled `Existing` and `Incoming`. No strikethrough, no accent, both values on the audited 4.5:1 text tier. The side the selected policy keeps is marked by weight, and the caption strip says which one that is ("Existing values kept" / "Incoming values applied"). The two merge modes used to be pixel-identical over the whole list, so the preview claimed every value was about to change even when the chosen policy said none of them were.

**The list itself.** It was capped at `max-h-48` and rendered four of five conflicts behind a clean bottom border, with no scrollbar, no fade and no partial row. It now follows the same destructive-preview idiom as `GitPushConfirmDialog`: a `ScrollShadow` at `max-h-[224px]`, a keyboard-reachable `role="region"`, and the shared caption strip with a count chip. The harness measures this rather than trusting a screenshot, and reports `3/5 rows fully visible, 100px hidden below the fold, dialog body overflow: 0px`.

**Stage orientation and focus.** A step heading names each stage. Focus lands in the textarea on open (it used to land on the header close button), moves to the step heading on advancing, and returns to the textarea on Back.

**Parse errors.** The error region has `role="alert"` and an id, and the textarea carries `aria-invalid` plus `aria-describedby` pointing at it. It was the only counted, itemised parse-error region in the repo with no ARIA at all.

**The primary action.** With parse errors present the button read `Import 1 variable` while disabled, which describes a partial import that never happens. It now falls back to a plain `Import`, and the footer hint says what is blocking: `Fix 1 parse error to continue`. The detection summary is no longer suppressed when the paste also fails to parse, so a discarded duplicate key still gets reported.

**Tokens.** Local alpha tiers swapped for audited ones, the documented `focus-visible:outline-*` recipe on the textarea (the old ring measured about 2.2:1), and the textarea moved onto `surface-input` with `text-placeholder` so both its text and its placeholder fall inside the contrast matrix. `ImportEnvDialog.tsx` comes off the accent-guard allowlist.

`ScrollShadow` is fixed at the shared level, in its own commit: the gradient is dropped under forced colors, so every bounded list in the app lost its only continuation cue. That reaches all 14 render sites.

## Design review

Score 6.2 to 9.7 over three rounds against rendered screenshots, judged on stage legibility, comparison clarity, hierarchy, visual language, typography, density, states, accessibility, microcopy and craft.

The consistency survey found this surface was the outlier in every pattern it touched: 1 of 7 bounded previews on a private recipe, the only diff in the app colouring its new value with the accent, and the only itemised parse-error region without ARIA. Each change joins an existing majority rather than starting a new one. The one genuinely new pattern is the forced-colors scroll cue, and that was rolled out to all 14 consumers in this PR rather than left as a local exception.

Two things I argued rather than changed. Escape still closes the dialog instead of stepping back, because that is what the APG dialog pattern specifies and what every other dialog here does. And `text-text-secondary` stays on the labels and captions: it is the app's sanctioned secondary tier, audited at 3.0 rather than 4.5, and a reading that condemns it here condemns every secondary label in the app. Raising that floor and recalibrating the palettes is a real piece of work, just not this one.

## Testing

`vitest run` full suite: 51652 passed of 51661. The one failure is a 15s timeout in `portalCloseEscalation.test.ts`, which fails the same way on `5bbf9e0db` with none of these changes present, on a machine that sat at load average 50 to 85 throughout. `npm run check` passes, and `lint:ratchet` drops from 1090 warnings to 1088. `e2e/full/worktree/dialog-body-spacing.spec.ts` passes.

Twelve invariants added in `src/components/Settings/__tests__/ImportEnvDialog.test.tsx`, each mutation-checked by reintroducing the defect it was written to close. Two of them passed the first time with the bug back in place and had to be rewritten: one was satisfied by the caption changing rather than the rows, the other targeted the prop instead of the behaviour.

A screenshot harness is committed at `e2e/screenshots/import-env-dialog-review.spec.ts`, covering 19 states across both steps including high contrast and forced colors:

    DAINTREE_SHOT_IMPORTENV=1 npx playwright test --project=screenshots import-env-dialog-review