### PR TITLE
Refine the canvas home's action hierarchy

### DIFF
--- a/e2e/screenshots/canvas-home-review.spec.ts
+++ b/e2e/screenshots/canvas-home-review.spec.ts
@@ -1,0 +1,586 @@
+/**
+ * Canvas-home visual-review harness.
+ *
+ * Drives `ContentGridEmptyState` — what the panel grid shows when a workspace
+ * has a launch target but nothing open — through every state that carries
+ * design weight, and writes a PNG of the canvas for each. The surface composes
+ * six independently-gated sections (identity, recipes, resume, quick actions,
+ * project pulse, teaching tip), so its hierarchy can only be judged against
+ * rendered pixels: which sections are present is a runtime question, and the
+ * vertical position of the primary launch affordance moves with the answer.
+ *
+ * Sibling of `launcher-review.spec.ts`, which goes deep on the `+` launcher
+ * palette. This one owns the canvas behind it.
+ *
+ * NOT covered: the four no-launch-target recovery states ("Select a worktree",
+ * "Open a project folder", "Worktree deleted", and the deleted-worktree ghost).
+ * Each needs the app parked in a state the real UI auto-corrects out of — a
+ * deleted worktree auto-switches selection back to main, and its ghost row only
+ * survives while it still owns a live terminal. They are plain `EmptyState`
+ * renders with no conditional composition, so they are reviewed from source.
+ *
+ * Opt-in only: skips itself unless DAINTREE_SHOT_THEME is set, so neither the
+ * marketing screenshots workflow nor a bare `--project=screenshots` runs it.
+ *
+ *   DAINTREE_SHOT_THEME=daintree npx playwright test --project=screenshots canvas-home-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_THEME  required — theme id to render (e.g. daintree, bondi)
+ *   DAINTREE_SHOT_TAG    optional suffix to keep before/after rounds side by side
+ *   DAINTREE_SHOT_ONLY   comma-separated step filter (see STEPS below)
+ *   DAINTREE_SCREENSHOT_SCALE  device scale factor (default 2)
+ *
+ * Output: artifacts/canvas-home-shots/<theme>/<NN-slug>[-tag].png (gitignored).
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { createHash } from "crypto";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+} from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, refreshActiveWindow, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { installFakeAgent, fakeAgentEnv } from "../helpers/fakeAgent";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.resolve(process.cwd(), "artifacts", "canvas-home-shots", THEME || "unset");
+
+const CANVAS = "#panel-grid";
+const PALETTE_SEARCH = 'button:has-text("Search agents")';
+const PULSE_STRIP = 'button[aria-label^="Show project activity"]';
+
+const WIDE = { width: 1680, height: 1050 };
+
+/**
+ * Every shot this harness owes, in capture order. Kept as data rather than
+ * spelled only inside the steps so the run can count what actually landed on
+ * disk against what was promised — an exit code alone has never been evidence
+ * that a capture harness produced anything.
+ */
+const STEPS = [
+  { name: "rest", slug: "01-rest" },
+  { name: "with-tip", slug: "02-with-tip" },
+  { name: "focus", slug: "03-focus-palette" },
+  { name: "pulse", slug: "04-pulse-expanded" },
+  { name: "short", slug: "05-short-canvas" },
+  { name: "narrow", slug: "06-narrow-canvas" },
+  { name: "forced-colors", slug: "07-forced-colors" },
+  { name: "contrast-more", slug: "08-contrast-more" },
+  { name: "recipes-many", slug: "09-recipes-many" },
+  { name: "no-recipes", slug: "10-no-recipes" },
+  { name: "quietest", slug: "11-quietest" },
+  { name: "long-identity", slug: "12-long-identity" },
+  { name: "scratch", slug: "13-scratch" },
+] as const;
+
+// Freeze animations and hide carets so captures are deterministic. Every
+// section of this surface enters on a staggered fade; a mid-transition frame
+// reads as a design flaw that isn't there.
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+function git(cmd: string, cwd: string, env?: Record<string, string>): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore", env: { ...process.env, ...env } });
+}
+
+interface RecipeSeed {
+  id: string;
+  name: string;
+  pinned: boolean;
+}
+
+const BASE_RECIPES: RecipeSeed[] = [
+  { id: "ship-review", name: "Review & ship", pinned: true },
+  { id: "work-issue", name: "Work an issue", pinned: true },
+  { id: "migrate-ts", name: "Migrate remaining JavaScript modules to TypeScript", pinned: false },
+];
+
+const EXTRA_RECIPES: RecipeSeed[] = [
+  { id: "dev-stack", name: "Dev stack", pinned: false },
+  { id: "pair-debug", name: "Pair debug", pinned: false },
+  { id: "docs-sweep", name: "Docs sweep", pinned: false },
+  { id: "perf-audit", name: "Perf audit", pinned: false },
+  { id: "release-cut", name: "Cut a release candidate", pinned: false },
+];
+
+function writeRecipes(dir: string, recipes: RecipeSeed[]): void {
+  const recipesDir = path.join(dir, ".daintree", "recipes");
+  mkdirSync(recipesDir, { recursive: true });
+  for (const recipe of recipes) {
+    writeFileSync(
+      path.join(recipesDir, `${recipe.id}.json`),
+      JSON.stringify(
+        {
+          id: recipe.id,
+          name: recipe.name,
+          terminals: [
+            { type: "claude", title: recipe.name, env: {}, initialPrompt: `/${recipe.id}` },
+          ],
+          createdAt: 1775381905486,
+          showInEmptyState: recipe.pinned,
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  }
+}
+
+function clearRecipes(dir: string): void {
+  const recipesDir = path.join(dir, ".daintree", "recipes");
+  if (existsSync(recipesDir)) rmSync(recipesDir, { recursive: true, force: true });
+  mkdirSync(recipesDir, { recursive: true });
+}
+
+/**
+ * A repo carrying the on-disk state this surface reads: `.daintree/recipes/`
+ * for the recipe band, a commit history spread across weeks so Project Pulse
+ * has a real ribbon and streak to draw, and sibling worktrees so the branch
+ * line and the worktree-recovery states have something to resolve against.
+ *
+ * Recipe names are deliberately uneven in length. A card whose name always
+ * fits hides exactly the truncation behaviour this review is about.
+ */
+function createRepo(): { dir: string; wtRoot: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-canvas-shots-"));
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  writeFileSync(path.join(dir, "README.md"), "# Helios Dashboard\n");
+
+  // Commits spread back across five weeks, densest in the last few days, so
+  // the pulse ribbon shows a real gradient and a live streak rather than one
+  // solid block. Both author and committer dates are set — the pulse scan
+  // reads the log, and a same-second history draws as a single cell.
+  const dayMs = 86_400_000;
+  const now = Date.now();
+  const daysAgo = [34, 31, 28, 21, 20, 14, 13, 12, 6, 5, 4, 3, 2, 1, 0];
+  daysAgo.forEach((day, index) => {
+    writeFileSync(path.join(dir, "src", `mod-${index}.ts`), `export const m${index} = ${index};\n`);
+    const stamp = new Date(now - day * dayMs).toISOString();
+    git("add -A", dir);
+    git(`commit -m "feat: module ${index}"`, dir, {
+      GIT_AUTHOR_DATE: stamp,
+      GIT_COMMITTER_DATE: stamp,
+    });
+  });
+
+  writeRecipes(dir, BASE_RECIPES);
+  git("add -A", dir);
+  git('commit -m "chore: recipes"', dir);
+
+  for (const branch of ["feature/oauth-device-flow", "fix/retry-backoff-jitter"]) {
+    const wtDir = path.join(wtRoot, branch.replace(/[/]/g, "-"));
+    git(`branch ${branch}`, dir);
+    git(`worktree add ${JSON.stringify(wtDir)} ${branch}`, dir);
+  }
+
+  return {
+    dir,
+    wtRoot,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Pre-seed the closed-session journal so `ResumeSessionLine` has something to
+ * offer. This is the file main itself reads (`agent-session-history.json` in
+ * userData) — written before launch so the first `list()` sees it, rather than
+ * stubbing the IPC the renderer calls.
+ *
+ * `projectId`/`worktreeId` are deliberately null: the runtime ids don't exist
+ * until the project is opened, and `buildResumeSessionItems` re-homes a
+ * record by longest-prefix `cwd` match against the live worktree map, which is
+ * the same path the real journal takes for pre-selection terminals.
+ */
+function seedSessionHistory(userDataDir: string, cwd: string): void {
+  const hourMs = 3_600_000;
+  const now = Date.now();
+  const records = [
+    {
+      sessionId: "sess-oauth-refresh",
+      agentId: "claude",
+      worktreeId: null,
+      projectId: null,
+      title: "Wire the OAuth device-flow refresh path",
+      savedAt: now - 2 * hourMs,
+      agentModelId: "anthropic/claude-opus-4-8",
+      cwd,
+      branch: "main",
+    },
+    {
+      sessionId: "sess-retry-jitter",
+      agentId: "claude",
+      worktreeId: null,
+      projectId: null,
+      title: "Add jitter to the retry backoff",
+      savedAt: now - 26 * hourMs,
+      agentModelId: "anthropic/claude-sonnet-4-8",
+      cwd,
+      branch: "main",
+    },
+    {
+      sessionId: "sess-heatmap",
+      agentId: "claude",
+      worktreeId: null,
+      projectId: null,
+      title: "Pulse heatmap cell alignment",
+      savedAt: now - 50 * hourMs,
+      cwd,
+      branch: "main",
+    },
+  ];
+  writeFileSync(
+    path.join(userDataDir, "agent-session-history.json"),
+    JSON.stringify(records, null, 2) + "\n"
+  );
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Wait for the canvas home to be the thing on screen, then settle. The palette
+ * search button is the one control every launch-target state renders, so it is
+ * the marker that the surface — not a panel, not a skeleton — is present.
+ */
+async function waitForCanvasHome(page: Page): Promise<void> {
+  await page.locator(CANVAS).waitFor({ state: "visible", timeout: T_LONG });
+  await page.locator(PALETTE_SEARCH).waitFor({ state: "visible", timeout: T_LONG });
+  await settle(page, 700);
+}
+
+/** Reload and bring the app back to a settled canvas home. */
+async function reload(page: Page): Promise<void> {
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.locator(SEL.toolbar.toggleSidebar).waitFor({ state: "visible", timeout: T_LONG });
+  await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+  await dismissBlockingPalette(page);
+  await waitForCanvasHome(page);
+}
+
+/**
+ * Clip to the canvas itself — the box `ContentGridEmptyState` is handed and has
+ * to compose within. Its height is what decides whether the primary launch
+ * affordance sits above the fold, so a full-page or element-tight crop would
+ * both answer the wrong question.
+ *
+ * Throws when the file did not land. A harness that writes a success artifact
+ * it has not verified is worse than one that fails.
+ */
+async function snapCanvas(page: Page, slug: string): Promise<void> {
+  await settle(page);
+  const box = await page.locator(CANVAS).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${CANVAS}`);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  await page.screenshot({
+    path: file,
+    type: "png",
+    animations: "disabled",
+    caret: "hide",
+    clip: { x: box.x, y: box.y, width: box.width, height: box.height },
+  });
+  if (!existsSync(file)) throw new Error(`screenshot did not land at ${file}`);
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+const stepFailures: string[] = [];
+
+/**
+ * Run a capture step. A failure never stops the remaining shots — one missing
+ * state should not cost the whole sweep — but it IS recorded, and the test
+ * fails at the end.
+ */
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).split("\n")[0];
+    console.warn(`[canvas-home-shots] step "${name}" FAILED:`, detail);
+    stepFailures.push(`${name}: ${detail}`);
+  }
+}
+
+test("canvas home review — every state of the empty grid", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_THEME is required for the canvas-home-review capture",
+  });
+  test.skip(!THEME, "Set DAINTREE_SHOT_THEME to run the canvas-home-review capture");
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createRepo();
+  const fakeBinDir = installFakeAgent(repo.dir);
+  // Prefix deliberately avoids "daintree-e2e" — launchApp's pre-launch hygiene
+  // pkills that pattern, and parallel theme captures would SIGKILL each other.
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-canvasshot-"));
+
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: WIDE,
+      env: fakeAgentEnv(fakeBinDir),
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    // Seed the resume journal against the path main actually reads. Electron
+    // derives `userData` from `--user-data-dir` rather than being it, so ask
+    // the app instead of assuming — a file written beside the real one is
+    // indistinguishable from a surface that has nothing to resume.
+    const userDataPath = await ctx.app.evaluate(async ({ app }) => app.getPath("userData"));
+    // realpath, not the mkdtemp path: on macOS the temp dir is a symlink, the
+    // app stores the resolved `/private/...` form, and `buildResumeSessionItems`
+    // re-homes a record by longest-prefix match — so an unresolved cwd matches
+    // no worktree and the resume line silently renders nothing.
+    seedSessionHistory(userDataPath, realpathSync(repo.dir));
+
+    let page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    await page.evaluate(async () => {
+      const cur = await window.electron.project.getCurrent();
+      if (cur?.id)
+        await window.electron.project.update(cur.id, { emoji: "☀️", name: "Helios Dashboard" });
+    });
+    await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await waitForCanvasHome(page);
+    await dismissBlockingPalette(page);
+
+    // 1. The returning-user rest state: identity, recipes, resume, quick
+    // actions and the pulse strip, with no teaching tip yet (no agent has been
+    // launched in this workspace).
+    await step("rest", async () => {
+      await snapCanvas(page, "01-rest");
+    });
+
+    // 2. Every section at once. Launching an agent and docking it flips
+    // `hasEverLaunchedAgent`, which is what gates the rotating tip — the
+    // maximal column, and the tallest the surface ever gets at rest.
+    await step("with-tip", async () => {
+      // The chip on the canvas, not the toolbar's plain terminal: the tip is
+      // gated on a panel carrying an agent id, which `terminal.new` never sets.
+      await page.locator('button:has-text("Claude")').first().click({ timeout: 10_000 });
+      await page
+        .locator(SEL.panel.gridPanel)
+        .first()
+        .waitFor({ state: "visible", timeout: T_LONG });
+      await settle(page, 2500);
+      const minimize = page.locator(SEL.panel.minimize).first();
+      await minimize.waitFor({ state: "visible", timeout: 8000 });
+      await minimize.click();
+      await waitForCanvasHome(page);
+      await snapCanvas(page, "02-with-tip");
+    });
+
+    // 3. Keyboard focus on the palette search button. This surface is reached
+    // by keyboard as often as by pointer, and the focus ring is the only thing
+    // that tells a keyboard user where the launch entry is.
+    await step("focus", async () => {
+      // Tabbed, never `.focus()`: Chromium only sets `:focus-visible` for
+      // keyboard-driven focus, so a programmatic focus photographs the rest
+      // state and calls it a focus ring.
+      await page.locator(CANVAS).click({ position: { x: 8, y: 8 } });
+      let reached = false;
+      for (let press = 0; press < 40 && !reached; press++) {
+        await page.keyboard.press("Tab");
+        reached = await page
+          .locator(PALETTE_SEARCH)
+          .evaluate((el) => el === document.activeElement)
+          .catch(() => false);
+      }
+      if (!reached) throw new Error("Tab never reached the palette search button");
+      await settle(page, 300);
+      await snapCanvas(page, "03-focus-palette");
+      await page.keyboard.press("Escape").catch(() => {});
+      await settle(page, 200);
+    });
+
+    // 4. Project Pulse expanded — the one section that can grow by several
+    // hundred pixels on click, pushing everything below it down.
+    await step("pulse", async () => {
+      await page.locator(PULSE_STRIP).click({ timeout: 8000 });
+      await settle(page, 1200);
+      await snapCanvas(page, "04-pulse-expanded");
+      await page
+        .locator('button:has-text("Collapse")')
+        .click({ timeout: 5000 })
+        .catch(() => {});
+      await settle(page, 500);
+    });
+
+    // 5. A short canvas. The column is vertically centered inside a scroller,
+    // so a laptop-height window is where "the highest-value action begins
+    // below the initial viewport" either happens or doesn't.
+    await step("short", async () => {
+      await page.setViewportSize({ width: WIDE.width, height: 760 });
+      await settle(page, 900);
+      await snapCanvas(page, "05-short-canvas");
+      await page.setViewportSize(WIDE);
+      await settle(page, 600);
+    });
+
+    // 6. A narrow canvas. The quick-action chips wrap, the recipe grid drops
+    // columns, and the identity line has to truncate against the same width.
+    await step("narrow", async () => {
+      await page.setViewportSize({ width: 900, height: WIDE.height });
+      await settle(page, 900);
+      await snapCanvas(page, "06-narrow-canvas");
+      await page.setViewportSize(WIDE);
+      await settle(page, 600);
+    });
+
+    // 7-8. The two accessibility media modes. `forced-colors: active` throws
+    // the theme's tokens away and redraws from system keywords, and
+    // `prefers-contrast: more` swaps in the high-contrast block — a column
+    // whose hierarchy is carried purely by opacity collapses in both.
+    await step("forced-colors", async () => {
+      await page.emulateMedia({ forcedColors: "active" });
+      await settle(page, 600);
+      await snapCanvas(page, "07-forced-colors");
+      await page.emulateMedia({ forcedColors: "none" });
+      await settle(page, 400);
+    });
+
+    await step("contrast-more", async () => {
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 600);
+      await snapCanvas(page, "08-contrast-more");
+      await page.emulateMedia({ contrast: "no-preference" });
+      await settle(page, 400);
+    });
+
+    // 9. Eight recipes. Past six the runner swaps its card grid for a
+    // searchable list with its own search field — a second search box on a
+    // surface that already has one, and the tallest the recipe band gets.
+    await step("recipes-many", async () => {
+      writeRecipes(repo.dir, [...BASE_RECIPES, ...EXTRA_RECIPES]);
+      await reload(page);
+      await snapCanvas(page, "09-recipes-many");
+    });
+
+    // 10. No recipes at all — `RecipeRunnerEmpty`, which is what a project
+    // that has never made one shows in the band's place.
+    await step("no-recipes", async () => {
+      clearRecipes(repo.dir);
+      await reload(page);
+      await snapCanvas(page, "10-no-recipes");
+    });
+
+    // 11. The quietest a project workspace gets: no recipes, nothing to
+    // resume. What is left is the spine every state shares.
+    await step("quietest", async () => {
+      await page.evaluate(async () => {
+        await window.electron.agentSessionHistory.clear();
+      });
+      await reload(page);
+      await snapCanvas(page, "11-quietest");
+    });
+
+    // 12. Extreme identity density — a long project name, a long branch and a
+    // deep path, all competing for the same centered width.
+    await step("long-identity", async () => {
+      writeRecipes(repo.dir, BASE_RECIPES);
+      await page.evaluate(async () => {
+        const cur = await window.electron.project.getCurrent();
+        if (cur?.id)
+          await window.electron.project.update(cur.id, {
+            name: "Helios Dashboard — Platform Reliability & Observability",
+          });
+      });
+      await reload(page);
+      await snapCanvas(page, "12-long-identity");
+    });
+
+    // 13. A scratch workspace: a launch target with no worktree, no branch, no
+    // recipes, no pulse and no project settings — the same component with half
+    // its sections gone.
+    await step("scratch", async () => {
+      await page.evaluate(async () => {
+        const scratch = await window.electron.scratch.create("Scratch pad");
+        if (scratch?.id) await window.electron.scratch.switch(scratch.id);
+      });
+      // Every workspace gets its own WebContentsView, so the switch does not
+      // re-render the page this handle points at — it strands it on the view
+      // the workspace just left. Re-acquire, or the next capture photographs
+      // the previous workspace and looks perfectly plausible.
+      page = await refreshActiveWindow(ctx!.app, page);
+      await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+      await dismissBlockingPalette(page);
+      await waitForCanvasHome(page);
+      await snapCanvas(page, "13-scratch");
+    });
+
+    // Count what landed against what was promised. The exit code says only
+    // that no step threw; this says the sweep actually produced its artifacts.
+    const expected = STEPS.filter((s) => ONLY.length === 0 || ONLY.includes(s.name)).map(
+      (s) => `${s.slug}${TAG}.png`
+    );
+    const present = new Set(readdirSync(OUTPUT_DIR));
+    const missing = expected.filter((f) => !present.has(f));
+
+    // Two states that render byte-identically mean one of them never actually
+    // happened — a step that drove nothing still writes a perfectly plausible
+    // PNG of the state before it, which is the worst artifact a capture
+    // harness can produce. Same-viewport states only: a resize changes every
+    // pixel, so cross-size pairs can never collide and would only add noise.
+    const SAME_VIEWPORT = new Set(expected.filter((f) => !/0[56]-/.test(f)));
+    const byHash = new Map<string, string[]>();
+    for (const file of SAME_VIEWPORT) {
+      if (!present.has(file)) continue;
+      const hash = createHash("sha256")
+        .update(readFileSync(path.join(OUTPUT_DIR, file)))
+        .digest("hex");
+      byHash.set(hash, [...(byHash.get(hash) ?? []), file]);
+    }
+    const duplicates = [...byHash.values()].filter((files) => files.length > 1);
+
+    expect(stepFailures, `canvas-home capture steps failed in "${THEME}"`).toEqual([]);
+    expect(missing, `canvas-home captures missing from ${OUTPUT_DIR}`).toEqual([]);
+    expect(duplicates, `identical canvas-home captures — a step drove nothing`).toEqual([]);
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -220,7 +220,7 @@ function PulseSkeleton({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "pulse-card w-fit rounded-[var(--radius-lg)] border border-daintree-border min-h-[240px]",
+        "pulse-card w-full min-w-0 rounded-[var(--radius-lg)] border border-daintree-border min-h-[240px]",
         className
       )}
     >
@@ -569,7 +569,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
   return (
     <div
       className={cn(
-        "pulse-card w-fit rounded-[var(--radius-lg)] border border-daintree-border min-h-[240px]",
+        "pulse-card w-full min-w-0 rounded-[var(--radius-lg)] border border-daintree-border min-h-[240px]",
         className
       )}
       aria-busy={isLoading}
@@ -630,13 +630,23 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
       </div>
 
       <div className="p-4 space-y-4">
-        <PulseHeatmap
-          cells={pulse.heatmap}
-          rangeDays={pulse.rangeDays}
-          describedBy={heatmapDescriptionId}
-        />
+        {/* The card used to be `w-fit`, so a 60-day row of fixed-size cells
+            decided its width and it came out a third wider than every other
+            band on the launcher — making the lowest-priority module the
+            largest object on the surface. The card now obeys the column, and
+            the row that genuinely needs the width scrolls inside it. */}
+        <div className="-mx-1 overflow-x-auto px-1">
+          <PulseHeatmap
+            cells={pulse.heatmap}
+            rangeDays={pulse.rangeDays}
+            describedBy={heatmapDescriptionId}
+          />
 
-        <PulseHeatmapLegend dayCount={pulse.heatmap.length} descriptionId={heatmapDescriptionId} />
+          <PulseHeatmapLegend
+            dayCount={pulse.heatmap.length}
+            descriptionId={heatmapDescriptionId}
+          />
+        </div>
 
         <p className="text-xs text-daintree-text/80">{getCoachLine(pulse, usableHealth)}</p>
 

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -224,7 +224,7 @@ function PulseSkeleton({ className }: { className?: string }) {
         className
       )}
     >
-      <div className="pulse-card-header px-4 py-3 border-b border-daintree-border flex items-center justify-between">
+      <div className="pulse-card-header animate-pulse-delayed px-4 py-3 border-b border-daintree-border flex items-center justify-between">
         <div className="flex items-center gap-2">
           <div className="w-4 h-4 rounded-[2px] pulse-skeleton-shimmer shrink-0" />
           <div className="h-4 pulse-skeleton-shimmer rounded w-36" />
@@ -235,7 +235,7 @@ function PulseSkeleton({ className }: { className?: string }) {
         </div>
       </div>
 
-      <div className="p-4 space-y-4 animate-pulse-delayed">
+      <div className="p-4 space-y-4 animate-pulse-delayed overflow-x-hidden">
         <div
           className="flex"
           style={{ gap: `${SKELETON_GAP}px`, width: `${SKELETON_ROW_WIDTH}px` }}
@@ -484,7 +484,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
     return (
       <div
         className={cn(
-          "pulse-card p-4 rounded-[var(--radius-lg)] border border-daintree-border",
+          "pulse-card w-full min-w-0 p-4 rounded-[var(--radius-lg)] border border-daintree-border",
           // Hold the slot at PulseSkeleton's natural height so the empty-state
           // column doesn't reflow when the skeleton swaps to this one-liner
           // (#7671). The card centers its short message inside the reserved
@@ -509,7 +509,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
     return (
       <div
         className={cn(
-          "pulse-card p-4 rounded-[var(--radius-lg)] border border-daintree-border",
+          "pulse-card w-full min-w-0 p-4 rounded-[var(--radius-lg)] border border-daintree-border",
           // Match PulseSkeleton height so the error swap doesn't collapse the
           // card and shift siblings up (#7671).
           "min-h-[240px] flex items-center",

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -554,6 +554,18 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
   void minuteTick;
   const updatedLabel = formatTimeSince(pulse.generatedAt, Date.now());
 
+  // pulse.rangeDays, not the selector's — the chip describes the same snapshot
+  // the coach line above it does.
+  const healthSection = usableHealth ? (
+    <HealthSignals health={usableHealth} rangeDays={pulse.rangeDays} />
+  ) : healthLoading ? (
+    <HealthSectionSkeleton />
+  ) : health && !health.hasRemote ? (
+    <NoRemoteHint />
+  ) : health && health.hasRemote ? (
+    <OfflineHint />
+  ) : null;
+
   return (
     <div
       className={cn(
@@ -628,24 +640,22 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
 
         <p className="text-xs text-daintree-text/80">{getCoachLine(pulse, usableHealth)}</p>
 
-        {/* Health section: always renders the wrapper so the 4 sub-variants
-            (signals, skeleton, no-remote hint, offline hint) can swap without
-            growing or collapsing the card. `min-h-9` matches the chip row
-            height (h-5 chip + pt-3 padding) so the loaded HealthSignals row
-            doesn't push siblings down when it resolves after pulse (#7671). */}
-        <div className="border-t border-daintree-border pt-3 min-h-9">
-          {usableHealth ? (
-            // pulse.rangeDays, not the selector's — the chip describes the same
-            // snapshot the coach line above it does.
-            <HealthSignals health={usableHealth} rangeDays={pulse.rangeDays} />
-          ) : healthLoading ? (
-            <HealthSectionSkeleton />
-          ) : health && !health.hasRemote ? (
-            <NoRemoteHint />
-          ) : health && health.hasRemote ? (
-            <OfflineHint />
-          ) : null}
-        </div>
+        {/* Health section: the wrapper reserves `min-h-9` (h-5 chip + pt-3) so
+            the four sub-variants — signals, skeleton, no-remote hint, offline
+            hint — swap without pushing siblings down when health resolves after
+            pulse (#7671).
+
+            But it only reserves for content that is actually coming. When no
+            forge provider ever resolves, `useProjectHealth` never enables its
+            poll, so `health` stays null and `healthLoading` stays false
+            forever: all four branches fall through and the rule plus the
+            reservation render a framed, permanently empty 36px block in the
+            middle of the card. A hairline around nothing reads as content that
+            failed to load. Reserve while a variant is still possible; render
+            nothing once it settles empty. */}
+        {healthSection !== null && (
+          <div className="border-t border-daintree-border pt-3 min-h-9">{healthSection}</div>
+        )}
 
         <div className="border-t border-daintree-border pt-3">
           <PulseSummary pulse={pulse} />

--- a/src/components/Pulse/ProjectPulseStrip.tsx
+++ b/src/components/Pulse/ProjectPulseStrip.tsx
@@ -125,7 +125,7 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
           ref={collapseButtonRef}
           type="button"
           onClick={collapse}
-          className="inline-flex items-center gap-1 self-start rounded-[var(--radius-md)] px-2 py-1 text-xs text-text-muted transition-colors hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+          className="inline-flex items-center gap-1 self-start rounded-[var(--radius-md)] px-2 py-1 text-xs text-text-secondary transition-colors hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
           aria-expanded={true}
         >
           <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
@@ -156,12 +156,12 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
       className="group flex w-full items-center gap-3 rounded-[var(--radius-md)] border border-border-subtle px-3 py-2 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
     >
       <Activity className="h-3.5 w-3.5 shrink-0 text-status-success/70" aria-hidden="true" />
-      <span className="shrink-0 text-xs font-medium text-daintree-text/70">Project pulse</span>
+      <span className="shrink-0 text-xs font-medium text-text-secondary">Project pulse</span>
       {pulse && miniCells.length > 0 && <MiniRibbon cells={miniCells} />}
       <span className="ml-auto flex shrink-0 items-center gap-2.5">
         {pulse ? (
           <>
-            <span className="font-mono text-xs text-text-muted">
+            <span className="font-mono text-xs text-text-secondary">
               {pulse.activeDays} active day{pulse.activeDays !== 1 ? "s" : ""}
             </span>
             {hasStreak && (
@@ -172,10 +172,10 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
             )}
           </>
         ) : (
-          <span className="text-xs text-text-muted">View activity</span>
+          <span className="text-xs text-text-secondary">View activity</span>
         )}
         <ChevronDown
-          className="h-4 w-4 text-text-muted transition-colors group-hover:text-daintree-text"
+          className="h-4 w-4 text-text-secondary transition-colors group-hover:text-daintree-text"
           aria-hidden="true"
         />
       </span>

--- a/src/components/Pulse/ProjectPulseStrip.tsx
+++ b/src/components/Pulse/ProjectPulseStrip.tsx
@@ -83,24 +83,19 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
     }
   }, [worktreeId, pulse, isLoading, error, fetchPulse]);
 
-  const expandedRef = useRef<HTMLDivElement>(null);
-
-  // Move focus into the expansion, but do NOT let the browser chase it. The
-  // collapse control sits at the bottom of a card several hundred pixels tall,
-  // so a plain `.focus()` scrolls the canvas until that button is visible —
-  // which drags the project identity and the launch anchor above it off the
-  // top of the screen. Expanding an ambient activity strip must not cost the
-  // user the thing they came here to click. `block: "nearest"` then keeps the
-  // card's own top edge in view, which is where the strip they clicked was.
+  // Move focus into the expansion without moving the viewport at all. The
+  // collapse control is rendered at the TOP of the expansion, exactly where
+  // the strip the user just clicked was standing, so it is already on screen
+  // and `preventScroll` costs nothing: no scrollIntoView is needed, and none
+  // is wanted. The earlier arrangement put the control at the card's bottom,
+  // several hundred pixels down, and any attempt to reveal it dragged the
+  // project identity and the launch anchor off the top of the canvas —
+  // expanding the lowest-priority band on the surface must not cost the user
+  // the thing they came here to click.
   useEffect(() => {
     if (!toggledRef.current) return;
-    if (expanded) {
-      collapseButtonRef.current?.focus({ preventScroll: true });
-      expandedRef.current?.scrollIntoView({ block: "nearest" });
-    } else {
-      stripButtonRef.current?.focus({ preventScroll: true });
-      stripButtonRef.current?.scrollIntoView({ block: "nearest" });
-    }
+    if (expanded) collapseButtonRef.current?.focus({ preventScroll: true });
+    else stripButtonRef.current?.focus({ preventScroll: true });
   }, [expanded]);
 
   const miniCells = useMemo(() => {
@@ -125,18 +120,18 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
 
   if (expanded) {
     return (
-      <div ref={expandedRef} className="flex w-full flex-col items-center gap-2">
-        <ProjectPulseCard worktreeId={worktreeId} />
+      <div className="flex w-full flex-col items-center gap-2">
         <button
           ref={collapseButtonRef}
           type="button"
           onClick={collapse}
-          className="inline-flex items-center gap-1 rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text/50 transition-colors hover:text-daintree-text/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+          className="inline-flex items-center gap-1 self-start rounded-[var(--radius-md)] px-2 py-1 text-xs text-text-muted transition-colors hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
           aria-expanded={true}
         >
           <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
           Collapse
         </button>
+        <ProjectPulseCard worktreeId={worktreeId} />
       </div>
     );
   }

--- a/src/components/Pulse/ProjectPulseStrip.tsx
+++ b/src/components/Pulse/ProjectPulseStrip.tsx
@@ -83,10 +83,24 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
     }
   }, [worktreeId, pulse, isLoading, error, fetchPulse]);
 
+  const expandedRef = useRef<HTMLDivElement>(null);
+
+  // Move focus into the expansion, but do NOT let the browser chase it. The
+  // collapse control sits at the bottom of a card several hundred pixels tall,
+  // so a plain `.focus()` scrolls the canvas until that button is visible —
+  // which drags the project identity and the launch anchor above it off the
+  // top of the screen. Expanding an ambient activity strip must not cost the
+  // user the thing they came here to click. `block: "nearest"` then keeps the
+  // card's own top edge in view, which is where the strip they clicked was.
   useEffect(() => {
     if (!toggledRef.current) return;
-    if (expanded) collapseButtonRef.current?.focus();
-    else stripButtonRef.current?.focus();
+    if (expanded) {
+      collapseButtonRef.current?.focus({ preventScroll: true });
+      expandedRef.current?.scrollIntoView({ block: "nearest" });
+    } else {
+      stripButtonRef.current?.focus({ preventScroll: true });
+      stripButtonRef.current?.scrollIntoView({ block: "nearest" });
+    }
   }, [expanded]);
 
   const miniCells = useMemo(() => {
@@ -111,7 +125,7 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
 
   if (expanded) {
     return (
-      <div className="flex w-full flex-col items-center gap-2">
+      <div ref={expandedRef} className="flex w-full flex-col items-center gap-2">
         <ProjectPulseCard worktreeId={worktreeId} />
         <button
           ref={collapseButtonRef}
@@ -144,7 +158,7 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
       onClick={expand}
       aria-expanded={false}
       aria-label={activityLabel}
-      className="group flex w-full max-w-lg items-center gap-3 rounded-[var(--radius-md)] border border-border-subtle px-3 py-2 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+      className="group flex w-full items-center gap-3 rounded-[var(--radius-md)] border border-border-subtle px-3 py-2 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
     >
       <Activity className="h-3.5 w-3.5 shrink-0 text-status-success/70" aria-hidden="true" />
       <span className="shrink-0 text-xs font-medium text-daintree-text/70">Project pulse</span>
@@ -152,7 +166,7 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
       <span className="ml-auto flex shrink-0 items-center gap-2.5">
         {pulse ? (
           <>
-            <span className="font-mono text-xs text-daintree-text/50">
+            <span className="font-mono text-xs text-text-muted">
               {pulse.activeDays} active day{pulse.activeDays !== 1 ? "s" : ""}
             </span>
             {hasStreak && (
@@ -163,10 +177,10 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
             )}
           </>
         ) : (
-          <span className="text-xs text-daintree-text/40">View activity</span>
+          <span className="text-xs text-text-muted">View activity</span>
         )}
         <ChevronDown
-          className="h-4 w-4 text-daintree-text/40 transition-colors group-hover:text-daintree-text/70"
+          className="h-4 w-4 text-text-muted transition-colors group-hover:text-daintree-text"
           aria-hidden="true"
         />
       </span>

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -299,7 +299,7 @@ export function ContentGridEmptyState({
               gutter collapse to zero when the column outgrows the canvas, so
               the first rows stay reachable — the property `justify-center`
               could not give. */}
-          <div aria-hidden="true" className="w-full shrink basis-16" />
+          <div aria-hidden="true" className="w-full shrink basis-4" />
           <section
             aria-label={workspaceName ? `${workspaceName} — workspace home` : "Workspace home"}
             className={cn(
@@ -308,7 +308,20 @@ export function ContentGridEmptyState({
             )}
           >
             {hasLaunchTarget && (
-              <div className={cn("mb-6 flex flex-col items-center text-center", SECTION_ENTRY)}>
+              // `min-h-*` reserves the identity block's tallest form — mark,
+              // name, branch row and path. Without it the anchor is invariant
+              // against everything BELOW it and still slides with what is
+              // ABOVE it: a scratch has no branch line, a non-git project has
+              // no branch and no worktree, and each missing row pulled the
+              // launch entry up. Reserving the footprint costs a scratch some
+              // empty air and buys the same launch position in every kind of
+              // workspace, which is the whole point of anchoring it.
+              <div
+                className={cn(
+                  "mb-6 flex min-h-[8.5rem] flex-col items-center justify-end text-center",
+                  SECTION_ENTRY
+                )}
+              >
                 <div className="mb-3">{identityMark}</div>
                 {hasWorkspaceIdentity ? (
                   <div className="flex flex-col items-center gap-1.5 min-w-0 max-w-full">
@@ -338,7 +351,7 @@ export function ContentGridEmptyState({
                       )}
                     </div>
                     {(branchLabel || pathLabel) && (
-                      <div className="flex flex-col items-center gap-0.5 text-daintree-text/60 max-w-full min-w-0 font-mono">
+                      <div className="flex flex-col items-center gap-0.5 text-text-secondary max-w-full min-w-0 font-mono">
                         {branchLabel && (
                           <div className="flex items-center gap-1.5 text-sm max-w-full min-w-0">
                             <GitBranch className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -285,10 +285,25 @@ export function ContentGridEmptyState({
           inside a grid, so a viewport breakpoint describes the wrong box. */}
       <div className="relative h-full w-full overflow-y-auto">
         <div className="flex min-h-full flex-col items-center p-8">
+          {/* A fixed, shrinkable top gutter — not `my-auto` on the column, and
+              certainly not `justify-center`. Centring the whole stack made the
+              anchor's screen position a function of the stack's HEIGHT, which
+              is a function of how many conditional bands resolved: the palette
+              button began 174px further down with no recipes than with eight.
+              Structurally invariant was not the same as spatially invariant,
+              and the muscle memory this surface is supposed to build lives in
+              the second one.
+
+              With the gutter fixed, everything below the anchor can grow and
+              shrink freely and the anchor does not move. `shrink` lets the
+              gutter collapse to zero when the column outgrows the canvas, so
+              the first rows stay reachable — the property `justify-center`
+              could not give. */}
+          <div aria-hidden="true" className="w-full shrink basis-16" />
           <section
             aria-label={workspaceName ? `${workspaceName} — workspace home` : "Workspace home"}
             className={cn(
-              "@container/launcher my-auto flex w-full flex-col items-center",
+              "@container/launcher flex w-full shrink-0 flex-col items-center",
               LAUNCHER_MEASURE
             )}
           >
@@ -469,6 +484,9 @@ export function ContentGridEmptyState({
               </div>
             )}
           </section>
+          {/* All remaining slack goes below the column, so the anchor keeps its
+              distance from the top of the canvas at every canvas height. */}
+          <div aria-hidden="true" className="w-full grow basis-0" />
         </div>
       </div>
     </div>

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -21,6 +21,13 @@ import { LauncherQuickActions } from "./LauncherQuickActions";
 
 const PATH_TRUNCATE_LENGTH = 52;
 
+// The column's single measure. Every band fills it rather than choosing its
+// own, so the stack has ONE pair of edges instead of the four it used to
+// (recipes and pulse at 32rem, the launcher at 38rem, the expanded pulse card
+// at the old 48rem container). The children are all exclusive to this surface,
+// so the measure belongs to the parent that composes them.
+const LAUNCHER_MEASURE = "max-w-[38rem]";
+
 // Marks a section as carrying the entry, so `replaySectionEntries` can find one
 // by the same name the class applies. The reduce-motion block in `index.css`
 // spells this selector out for itself — renaming it means changing both.
@@ -239,9 +246,13 @@ export function ContentGridEmptyState({
 
   // Centered stacked hero: mark above, name below — one alignment axis with
   // the rest of the launcher column (a left-aligned lockup and a floating
-  // watermark both read as misplaced against a centered page). ~10% smaller
-  // than the pre-redesign hero. Decorative; the project's own icon wins over
-  // the Daintree mark when one is set.
+  // watermark both read as misplaced against a centered page). Decorative; the
+  // project's own icon wins over the Daintree mark when one is set.
+  //
+  // Sized for a surface the user lands on many times a day, not for a splash:
+  // the mark orients ("which project am I in") and then gets out of the way of
+  // the launch anchor below it. At 100px the identity block alone ate the top
+  // quarter of the canvas and pushed the anchor past three-quarters down.
   //
   // The fallback mark rides the neutral `daintree-text` (text-primary) token,
   // NOT the hue-carrying `tint` — so it reads as the same grey the startup
@@ -250,9 +261,9 @@ export function ContentGridEmptyState({
   // construction: text-primary flips with light/dark.
   const sanitizedIcon = projectIconSvg ? sanitizeSvg(projectIconSvg) : null;
   const identityMark = sanitizedIcon?.ok ? (
-    <img src={svgToDataUrl(sanitizedIcon.svg)} alt="" className="h-25 w-25 object-contain" />
+    <img src={svgToDataUrl(sanitizedIcon.svg)} alt="" className="h-14 w-14 object-contain" />
   ) : (
-    <DaintreeIcon className="h-25 w-25 text-daintree-text/65" aria-hidden="true" />
+    <DaintreeIcon className="h-14 w-14 text-daintree-text/65" aria-hidden="true" />
   );
 
   // The container no longer fades as one block — each launcher section below
@@ -260,15 +271,30 @@ export function ContentGridEmptyState({
   // fade `EmptyState` already owns.
   return (
     <div ref={containerRef} className="relative h-full w-full overflow-hidden">
-      {/* Content scrolls independently of the fixed watermark so an expanded
-          pulse (or a tall recipe list) on a short canvas stays reachable
-          instead of being clipped; `min-h-full` keeps it centered when short. */}
+      {/* Content scrolls independently so an expanded pulse (or a tall recipe
+          list) on a short canvas stays reachable instead of being clipped.
+          `my-auto` on the column, NOT `justify-center` on this flex parent:
+          `justify-content: center` distributes overflow to BOTH ends, so once
+          the column outgrows the canvas its first rows — identity, and the
+          launch anchor right under it — spill above the scroll origin and
+          cannot be scrolled back to. Auto margins resolve to zero when there is
+          no free space, so the same centering degrades to top alignment.
+
+          `@container/launcher` lets the bands below respond to the CANVAS
+          width rather than the window's: this surface sits beside a sidebar and
+          inside a grid, so a viewport breakpoint describes the wrong box. */}
       <div className="relative h-full w-full overflow-y-auto">
-        <div className="flex min-h-full flex-col items-center justify-center p-8">
-          <div className="max-w-3xl w-full flex flex-col items-center">
+        <div className="flex min-h-full flex-col items-center p-8">
+          <section
+            aria-label={workspaceName ? `${workspaceName} — workspace home` : "Workspace home"}
+            className={cn(
+              "@container/launcher my-auto flex w-full flex-col items-center",
+              LAUNCHER_MEASURE
+            )}
+          >
             {hasLaunchTarget && (
               <div className={cn("mb-6 flex flex-col items-center text-center", SECTION_ENTRY)}>
-                <div className="mb-4">{identityMark}</div>
+                <div className="mb-3">{identityMark}</div>
                 {hasWorkspaceIdentity ? (
                   <div className="flex flex-col items-center gap-1.5 min-w-0 max-w-full">
                     {/* The name stays centered under the mark; the gear is
@@ -374,22 +400,35 @@ export function ContentGridEmptyState({
               />
             )}
 
-            {hasLaunchTarget && recipesProjectId !== null && !recipesLoading && (
+            {/* The launch anchor sits directly under identity, and nothing
+                conditional is allowed above it. That is the whole point of the
+                order: recipes come and go with the project, resume comes and
+                goes with history, the pulse can be switched off — so anything
+                above the anchor makes the anchor's position a function of
+                state the user did not choose. Identity is the one band that is
+                always present when there is a launch target, so anchoring to it
+                is anchoring to a constant.
+
+                It also inverts the stagger's meaning. The ladder used to reveal
+                recipes first and the anchor fourth, teaching "recipes matter
+                most"; now the sequence walks down the priority order it is
+                supposed to express. */}
+            {hasLaunchTarget && (
               <div
                 className={cn(
-                  "mb-3 w-full flex justify-center",
+                  "mb-6 w-full flex justify-center",
                   SECTION_ENTRY,
                   SECTION_ENTRY_DELAY_1
                 )}
               >
-                <RecipeRunner activeWorktreeId={activeWorktreeId} defaultCwd={defaultCwd} />
+                <LauncherQuickActions />
               </div>
             )}
 
             {hasLaunchTarget && (
               <div
                 className={cn(
-                  "mb-3 w-full flex justify-center",
+                  "mb-2.5 w-full flex justify-center",
                   SECTION_ENTRY,
                   SECTION_ENTRY_DELAY_2
                 )}
@@ -398,7 +437,7 @@ export function ContentGridEmptyState({
               </div>
             )}
 
-            {hasLaunchTarget && (
+            {hasLaunchTarget && recipesProjectId !== null && !recipesLoading && (
               <div
                 className={cn(
                   "mb-6 w-full flex justify-center",
@@ -406,7 +445,7 @@ export function ContentGridEmptyState({
                   SECTION_ENTRY_DELAY_3
                 )}
               >
-                <LauncherQuickActions />
+                <RecipeRunner activeWorktreeId={activeWorktreeId} defaultCwd={defaultCwd} />
               </div>
             )}
 
@@ -429,7 +468,7 @@ export function ContentGridEmptyState({
                 <RotatingTip />
               </div>
             )}
-          </div>
+          </section>
         </div>
       </div>
     </div>

--- a/src/components/Terminal/LauncherQuickActions.tsx
+++ b/src/components/Terminal/LauncherQuickActions.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 // `FolderTree` is the file browser's own icon, imported from lucide directly
 // the same way `FileBrowserPane` does — it has no alias in the icons index.
 import { SquareTerminal, Search, FolderTree } from "lucide-react";
@@ -21,17 +21,40 @@ interface QuickActionProps {
   /** Action whose live keybinding is shown as a chip (and, for agents, dispatched). */
   actionId: ActionId;
   onClick: () => void;
+  /** Roving tab stop: only the active chip is reachable with Tab. */
+  tabIndex: number;
+  buttonRef: (el: HTMLButtonElement | null) => void;
+  onFocus: () => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
 }
 
-function QuickAction({ icon, label, actionId, onClick }: QuickActionProps) {
+// No fill at rest. The chips and the palette button used to share a surface
+// only 1.018:1 apart in luminance, which is not a hierarchy — it is two of the
+// same control, and the wider one happened to be the important one. Letting the
+// chips sit on the canvas until hover leaves exactly one filled, bordered
+// control in the group, without spending accent to say so.
+function QuickAction({
+  icon,
+  label,
+  actionId,
+  onClick,
+  tabIndex,
+  buttonRef,
+  onFocus,
+  onKeyDown,
+}: QuickActionProps) {
   const combo = useEffectiveCombo(actionId);
   const ariaKeyshortcuts = useAriaKeyshortcuts(actionId);
   return (
     <button
       type="button"
+      ref={buttonRef}
       onClick={onClick}
+      onFocus={onFocus}
+      onKeyDown={onKeyDown}
+      tabIndex={tabIndex}
       aria-keyshortcuts={ariaKeyshortcuts}
-      className="launcher-press group inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-border-subtle bg-overlay-subtle px-2.5 py-1.5 text-sm text-daintree-text/80 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-soft hover:border-border-default hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+      className="launcher-press group inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-border-subtle px-2.5 py-1.5 text-sm text-daintree-text/80 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-soft hover:border-border-default hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
     >
       <span className="shrink-0">{icon}</span>
       <span className="truncate">{label}</span>
@@ -49,11 +72,17 @@ function QuickAction({ icon, label, actionId, onClick }: QuickActionProps) {
 
 /**
  * Search-shaped entry into the panel palette (⌘N) — the launcher's "find
- * anything" affordance, and its single most capable control (it reaches every
- * agent, panel kind, and resumable session). Carries a slightly raised surface
- * so it reads as the deliberate escape hatch rather than blending into the
- * quieter chips above — the launcher's one visually-weighted control (neutral,
- * never accent). The palette itself is the real search field.
+ * anything" affordance, and its single most capable control: it reaches every
+ * agent, panel kind and resumable session, which is exactly why it is the
+ * canvas home's invariant anchor and sits at the top of this group rather than
+ * beneath the chips.
+ *
+ * It is the launcher's one visually-weighted control, and the weight is
+ * neutral, never accent: a raised surface, a stronger border and a taller box
+ * against chips that carry no fill at rest. Those two used to be one step apart
+ * on a token scale whose adjacent steps differ by 0.01 alpha — 1.018:1 in
+ * luminance, which the eye cannot resolve, so "the weighted one" was really
+ * just "the wide one". The palette itself is the real search field.
  */
 function PaletteSearchButton() {
   const combo = useEffectiveCombo("panel.palette");
@@ -68,7 +97,7 @@ function PaletteSearchButton() {
       type="button"
       onClick={handleClick}
       aria-keyshortcuts={ariaKeyshortcuts}
-      className="launcher-press flex w-full items-center gap-2.5 rounded-[var(--radius-md)] border border-border-default bg-overlay-soft px-3 py-2.5 text-sm text-daintree-text/70 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-medium hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+      className="launcher-press flex w-full items-center gap-2.5 rounded-[var(--radius-md)] border border-border-default bg-overlay-medium px-3 py-3 text-sm text-daintree-text/70 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-strong hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
     >
       <Search className="h-4 w-4 shrink-0 text-daintree-text/55" aria-hidden="true" />
       <span className="min-w-0 flex-1 truncate text-left">Search agents &amp; panels…</span>
@@ -82,10 +111,15 @@ function PaletteSearchButton() {
 }
 
 /**
- * Compact launch row for the empty grid — the built-in agents the user keeps on
- * their toolbar plus the core "new terminal" action, with the panel palette one
- * step below. Recipes are the hero above this; these are the fallback launches
- * when no recipe fits.
+ * The canvas home's launch anchor: the panel palette, then the built-in agents
+ * the user keeps on their toolbar plus "new terminal" and "browse files" as
+ * one-press shortcuts beneath it.
+ *
+ * This group renders directly under project identity and above every
+ * conditional band (recipes, resume, pulse, tip), so its position depends on
+ * nothing the user did not choose — see the ordering note in
+ * `ContentGridEmptyState`. Recipes are a contextual shortcut below it, not the
+ * hero above it.
  *
  * Agent visibility mirrors the toolbar exactly: only ids the toolbar renders as
  * agent buttons (built-in launchable agents) count, resolved through the same
@@ -132,6 +166,19 @@ export function LauncherQuickActions() {
     void actionService.dispatch(actionId, args, { source: "user" });
   };
 
+  // Roving tab stop over the chip row. Clamped on read rather than reset on
+  // change: the pinned set can shrink between renders (an agent uninstalled, a
+  // toolbar button hidden), and a stale index would silently leave the group
+  // with no `tabIndex={0}` at all — i.e. unreachable by Tab.
+  const [activeChipRaw, setActiveChip] = useState(0);
+  const chipRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const setChipRef = useCallback(
+    (index: number) => (el: HTMLButtonElement | null) => {
+      chipRefs.current[index] = el;
+    },
+    []
+  );
+
   // The only chip whose action can legitimately refuse: it resolves its own
   // target, and a workspace with nothing to browse makes it throw. `dispatch`
   // turns that into `ok: false` rather than a rejection, so without this the
@@ -163,40 +210,110 @@ export function LauncherQuickActions() {
       });
   }
 
+  // Every chip in one line, so the roving tab stop can be indexed.
+  const chips: Array<{
+    key: string;
+    icon: React.ReactNode;
+    label: string;
+    actionId: ActionId;
+    onClick: () => void;
+  }> = [
+    ...agents.map((agent) => {
+      // Every launcher agent is a built-in toolbar agent, so it carries a
+      // canonical `agent.<id>` action (keybinding + label).
+      const actionId = `agent.${agent.launchAgentId!}` as ActionId;
+      return {
+        key: agent.id,
+        icon: agent.icon,
+        label: agent.label,
+        actionId,
+        onClick: () => dispatch(actionId),
+      };
+    }),
+    {
+      key: "terminal.new",
+      icon: <SquareTerminal className="h-4 w-4" />,
+      label: "New terminal",
+      actionId: "terminal.new" as ActionId,
+      onClick: () => dispatch("terminal.new"),
+    },
+    {
+      // No args: the action resolves its own target — the focused worktree,
+      // or the workspace root in a scratch or worktree-less project
+      // (#11482), which is exactly where this launcher is shown.
+      key: "browse-files",
+      icon: <FolderTree className="h-4 w-4" />,
+      label: "Browse files",
+      actionId: "worktree.openFileBrowserPanel" as ActionId,
+      onClick: openFileBrowser,
+    },
+  ];
+
+  const activeChip = Math.min(activeChipRaw, Math.max(0, chips.length - 1));
+
+  const moveChipFocus = (next: number) => {
+    setActiveChip(next);
+    chipRefs.current[next]?.focus();
+  };
+
+  const handleChipKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    // Modified chords belong to the app's global keybindings, not to us.
+    if (e.altKey || e.ctrlKey || e.metaKey || chips.length === 0) return;
+    let next = index;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") next = (index + 1) % chips.length;
+    else if (e.key === "ArrowLeft" || e.key === "ArrowUp")
+      next = (index - 1 + chips.length) % chips.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = chips.length - 1;
+    else return;
+    e.preventDefault();
+    if (next !== index) moveChipFocus(next);
+  };
+
+  // Arrow keys pressed on the container itself (nothing inside focused yet)
+  // still enter the group, which is what makes it behave like a toolbar rather
+  // than a div that happens to contain buttons.
+  const handleToolbarKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+    e.preventDefault();
+    moveChipFocus(e.key === "ArrowRight" ? 0 : Math.max(0, chips.length - 1));
+  };
+
   return (
-    <div className="flex w-full max-w-[38rem] flex-col items-center gap-2.5">
-      <div className="flex w-full flex-wrap items-center justify-center gap-2">
-        {agents.map((agent) => {
-          // Every launcher agent is a built-in toolbar agent, so it carries a
-          // canonical `agent.<id>` action (keybinding + label).
-          const actionId = `agent.${agent.launchAgentId!}` as ActionId;
-          return (
-            <QuickAction
-              key={agent.id}
-              icon={agent.icon}
-              label={agent.label}
-              actionId={actionId}
-              onClick={() => dispatch(actionId)}
-            />
-          );
-        })}
-        <QuickAction
-          icon={<SquareTerminal className="h-4 w-4" />}
-          label="New terminal"
-          actionId="terminal.new"
-          onClick={() => dispatch("terminal.new")}
-        />
-        {/* No args: the action resolves its own target — the focused worktree,
-            or the workspace root in a scratch or worktree-less project
-            (#11482), which is exactly where this launcher is shown. */}
-        <QuickAction
-          icon={<FolderTree className="h-4 w-4" />}
-          label="Browse files"
-          actionId="worktree.openFileBrowserPanel"
-          onClick={openFileBrowser}
-        />
-      </div>
+    <div className="flex w-full flex-col items-center gap-2.5">
+      {/* The palette comes FIRST. It is the only control here that reaches
+          every agent, panel kind and resumable session, and it is the one whose
+          position must not move — putting it above an uncapped, user-curated
+          chip row is what makes that true, since the row's height is a function
+          of how many agents the user pinned. It also drops the Tab cost to
+          reach it from "however many chips there are" to one. */}
       <PaletteSearchButton />
+      {/* One tab stop, arrows inside — the same roving model the real toolbar
+          these chips mirror already uses (`Toolbar.tsx`), so a keyboard user
+          who has learned one has learned the other, and an uncapped pinned set
+          can never turn into an uncapped run of tab stops. */}
+      <div
+        role="toolbar"
+        aria-label="Quick launch"
+        aria-orientation="horizontal"
+        onKeyDown={handleToolbarKeyDown}
+        className="flex w-full flex-wrap items-center justify-center gap-2"
+      >
+        {chips.map((chip, index) => (
+          <QuickAction
+            key={chip.key}
+            icon={chip.icon}
+            label={chip.label}
+            actionId={chip.actionId}
+            onClick={chip.onClick}
+            tabIndex={index === activeChip ? 0 : -1}
+            buttonRef={setChipRef(index)}
+            onFocus={() => setActiveChip(index)}
+            onKeyDown={(e) => handleChipKeyDown(e, index)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/Terminal/LauncherQuickActions.tsx
+++ b/src/components/Terminal/LauncherQuickActions.tsx
@@ -259,7 +259,9 @@ export function LauncherQuickActions() {
   const handleChipKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
     // Modified chords belong to the app's global keybindings, not to us.
     if (e.altKey || e.ctrlKey || e.metaKey || chips.length === 0) return;
-    let next = index;
+    // Declared without an initializer: every branch below either assigns or
+    // returns, so a default would be dead.
+    let next: number;
     if (e.key === "ArrowRight" || e.key === "ArrowDown") next = (index + 1) % chips.length;
     else if (e.key === "ArrowLeft" || e.key === "ArrowUp")
       next = (index - 1 + chips.length) % chips.length;

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -227,8 +227,14 @@ export function MissingCliGate({
   const docsUrl = agentConfig?.install?.docsUrl;
 
   return (
-    <div className="flex-1 min-h-0 bg-daintree-bg flex flex-col items-center justify-center overflow-auto">
-      <div className="w-full max-w-lg space-y-4 px-6 py-8">
+    // `my-auto` on the child rather than `justify-center` on the scrollport:
+    // `justify-content: center` distributes overflow to BOTH ends, so once the
+    // install blocks and troubleshooting list outgrow a short pane the agent
+    // name and "Setup required" spill above the scroll origin and cannot be
+    // scrolled back to. Auto margins collapse to zero when there is no free
+    // space, so the same centring degrades to top alignment instead.
+    <div className="flex-1 min-h-0 bg-daintree-bg flex flex-col items-center overflow-auto">
+      <div className="my-auto w-full max-w-lg space-y-4 px-6 py-8">
         <div className="flex items-center gap-2.5">
           <div className="w-8 h-8 rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border flex items-center justify-center">
             <Terminal className="w-4 h-4 text-daintree-text/40" />

--- a/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
@@ -69,7 +69,7 @@ export function RecipeRunner({ activeWorktreeId, defaultCwd }: RecipeRunnerProps
   const flatRecipes = runner.getFlatRecipes();
 
   return (
-    <div className="w-full max-w-lg">
+    <div className="w-full">
       {runner.spawnFailureSummary && (
         <div className="mb-3" data-testid="recipe-spawn-failure-banner">
           <InlineStatusBanner

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
@@ -20,7 +20,7 @@ export function RecipeRunnerEmpty({
   return (
     <div
       data-testid="recipe-runner-empty"
-      className="flex flex-col items-stretch gap-3 py-2 w-full max-w-lg mx-auto"
+      className="flex flex-col items-stretch gap-3 py-2 w-full"
     >
       {hasSuggestions ? (
         <div className="flex flex-col gap-2">

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
@@ -43,14 +43,14 @@ export function RecipeRunnerEmpty({
               <span className="flex-1 text-sm font-medium text-daintree-text truncate">
                 {suggestion.name}
               </span>
-              <span className="text-xs text-text-muted truncate max-w-[55%]">
+              <span className="text-xs text-text-secondary truncate max-w-[55%]">
                 {suggestion.command}
               </span>
             </button>
           ))}
         </div>
       ) : (
-        <div className="text-xs text-text-muted text-center">
+        <div className="text-xs text-text-secondary text-center">
           <p>Launch agents, dev servers, and terminals together with one click</p>
         </div>
       )}
@@ -61,10 +61,10 @@ export function RecipeRunnerEmpty({
           className="group flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
         >
           <Plus
-            className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
+            className="h-3.5 w-3.5 text-text-secondary group-hover:text-daintree-text transition-colors shrink-0"
             aria-hidden
           />
-          <span className="text-sm text-text-muted group-hover:text-daintree-text transition-colors">
+          <span className="text-sm text-text-secondary group-hover:text-daintree-text transition-colors">
             Create your first recipe…
           </span>
         </button>

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
@@ -50,8 +50,19 @@ export function RecipeRunnerGrid({
   // A lone recipe renders as one full-width hero card — a half-empty two-column
   // grid reads as a mistake when there's a single pinned recipe (the common
   // fresh-worktree case).
+  //
+  // The container-query overrides drop columns as the CANVAS narrows, not the
+  // window: this grid sits beside a sidebar, so a viewport breakpoint measures
+  // the wrong box. Held at three columns, a 550px canvas gave each card ~148px
+  // and truncated every name to an unreadable stub ("Review & s…", "Work an
+  // is…") while each card still reserved a full line for its scope label. Three
+  // names nobody can read is worse than one column of names they can.
   const gridCols =
-    recipes.length === 1 ? "grid-cols-1" : recipes.length === 2 ? "grid-cols-2" : "grid-cols-3";
+    recipes.length === 1
+      ? "grid-cols-1"
+      : recipes.length === 2
+        ? "grid-cols-2 @max-[26rem]/launcher:grid-cols-1"
+        : "grid-cols-3 @max-[34rem]/launcher:grid-cols-2 @max-[26rem]/launcher:grid-cols-1";
   const createIndex = recipes.length;
   const focusableCount = recipes.length + 1;
   const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
@@ -123,10 +123,10 @@ export function RecipeRunnerGrid({
         className="group col-span-full flex items-center justify-center gap-2 px-3 py-2 mt-1 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60"
       >
         <Plus
-          className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
+          className="h-3.5 w-3.5 text-text-secondary group-hover:text-daintree-text transition-colors shrink-0"
           aria-hidden
         />
-        <span className="text-sm text-text-muted group-hover:text-daintree-text transition-colors">
+        <span className="text-sm text-text-secondary group-hover:text-daintree-text transition-colors">
           Create new recipe…
         </span>
       </button>

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -83,7 +83,7 @@ export function RecipeRunnerItem({
             <div className="flex items-center gap-2 w-full">
               <Play
                 className={cn(
-                  "h-3.5 w-3.5 text-status-success/50 transition-colors shrink-0",
+                  "h-3.5 w-3.5 text-status-success transition-colors shrink-0",
                   !disabled && "group-hover:text-status-success"
                 )}
                 aria-hidden
@@ -94,7 +94,18 @@ export function RecipeRunnerItem({
               {recipe.shadowedBy && (
                 <span className="text-[11px] text-text-muted shrink-0">Overridden by Team</span>
               )}
-              {isPinned && <Pin className="h-3 w-3 text-daintree-accent/60 shrink-0" aria-hidden />}
+              {isPinned && (
+                // Neutral, not accent: pinning is membership, and the accent is
+                // the one signal that means "this is where the keyboard is".
+                // Spending it on a static badge left two greens on screen at
+                // once in the dense state, and made the brightest glyph on the
+                // card the one that does nothing. The state was also
+                // `aria-hidden`, so it existed for sighted users only.
+                <>
+                  <Pin className="h-3 w-3 text-text-muted shrink-0" aria-hidden />
+                  <span className="sr-only">Pinned</span>
+                </>
+              )}
             </div>
             <span className="flex items-center gap-2 w-full pl-5.5 text-xs text-text-muted">
               <span className="shrink-0">{scopeLabel}</span>
@@ -151,7 +162,18 @@ export function RecipeRunnerItem({
           {recipeSummary && recipeSummary !== recipe.name && (
             <span className="text-xs text-text-muted truncate max-w-[30%]">{recipeSummary}</span>
           )}
-          {isPinned && <Pin className="h-3 w-3 text-daintree-accent/60 shrink-0" aria-hidden />}
+          {isPinned && (
+            // Neutral, not accent: pinning is membership, and the accent is
+            // the one signal that means "this is where the keyboard is".
+            // Spending it on a static badge left two greens on screen at
+            // once in the dense state, and made the brightest glyph on the
+            // card the one that does nothing. The state was also
+            // `aria-hidden`, so it existed for sighted users only.
+            <>
+              <Pin className="h-3 w-3 text-text-muted shrink-0" aria-hidden />
+              <span className="sr-only">Pinned</span>
+            </>
+          )}
         </button>
       </ContextMenuTrigger>
       <RecipeContextMenu

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -102,12 +102,12 @@ export function RecipeRunnerItem({
                 // card the one that does nothing. The state was also
                 // `aria-hidden`, so it existed for sighted users only.
                 <>
-                  <Pin className="h-3 w-3 text-text-muted shrink-0" aria-hidden />
+                  <Pin className="h-3 w-3 text-text-secondary shrink-0" aria-hidden />
                   <span className="sr-only">Pinned</span>
                 </>
               )}
             </div>
-            <span className="flex items-center gap-2 w-full pl-5.5 text-xs text-text-muted">
+            <span className="flex items-center gap-2 w-full pl-5.5 text-xs text-text-secondary">
               <span className="shrink-0">{scopeLabel}</span>
               {recipeSummary && recipeSummary !== recipe.name && (
                 <span className="truncate">{recipeSummary}</span>
@@ -170,7 +170,7 @@ export function RecipeRunnerItem({
             // card the one that does nothing. The state was also
             // `aria-hidden`, so it existed for sighted users only.
             <>
-              <Pin className="h-3 w-3 text-text-muted shrink-0" aria-hidden />
+              <Pin className="h-3 w-3 text-text-secondary shrink-0" aria-hidden />
               <span className="sr-only">Pinned</span>
             </>
           )}

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef } from "react";
 import { Search, Plus } from "lucide-react";
 import { RecipeRunnerItem } from "./RecipeRunnerItem";
 import type { RecipeSections, RankedRecipe } from "./recipeRunnerUtils";
@@ -44,11 +44,14 @@ export function RecipeRunnerList({
   const inputRef = useRef<HTMLInputElement>(null);
   const isSearchActive = searchQuery.trim().length > 0;
 
-  useEffect(() => {
-    if (showSearch) {
-      inputRef.current?.focus();
-    }
-  }, [showSearch]);
+  // Deliberately NOT focused on mount. This list is not a palette — it renders
+  // inside the canvas home, which a user reaches by closing their last panel or
+  // switching worktree, never by asking to search recipes. Focusing here stole
+  // the caret from whatever the user was doing every time a project with more
+  // than six recipes showed its empty canvas, and painted an accent ring on a
+  // surface nobody had navigated to. `ProjectPulseStrip` states the same rule
+  // for the same reason: "the empty grid must not steal focus just by
+  // rendering". Tab and the arrow keys still reach the field normally.
 
   // Build flat list for index computation
   let flatRecipes: TerminalRecipe[];

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
@@ -109,17 +109,17 @@ export function RecipeRunnerList({
         <div className="mb-2 flex items-baseline gap-3 px-1">
           <span
             id="recipe-band-label"
-            className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-text-muted"
+            className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-text-secondary"
           >
             Recipes
           </span>
           <div className="relative min-w-0 flex-1">
-            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-text-muted pointer-events-none" />
+            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-text-secondary pointer-events-none" />
             <input
               ref={inputRef}
               type="text"
               role="combobox"
-              aria-expanded={isSearchActive}
+              aria-expanded={true}
               aria-controls="recipe-listbox"
               aria-activedescendant={focusedItemId}
               aria-label="Filter recipes"
@@ -158,36 +158,42 @@ export function RecipeRunnerList({
               <>
                 <div
                   id="section-pinned"
-                  className="px-3 pt-1 pb-0.5 text-xs font-medium text-text-muted uppercase tracking-wide"
+                  className="px-3 pt-1 pb-0.5 text-xs font-medium text-text-secondary uppercase tracking-wide"
                   role="presentation"
                 >
                   Pinned
                 </div>
-                <div role="presentation">{sections.pinned.map(renderItem)}</div>
+                <div role="group" aria-labelledby="section-pinned">
+                  {sections.pinned.map(renderItem)}
+                </div>
               </>
             )}
             {sections.recent.length > 0 && (
               <>
                 <div
                   id="section-recent"
-                  className="px-3 pt-2 pb-0.5 text-xs font-medium text-text-muted uppercase tracking-wide"
+                  className="px-3 pt-2 pb-0.5 text-xs font-medium text-text-secondary uppercase tracking-wide"
                   role="presentation"
                 >
                   Recent
                 </div>
-                <div role="presentation">{sections.recent.map(renderItem)}</div>
+                <div role="group" aria-labelledby="section-recent">
+                  {sections.recent.map(renderItem)}
+                </div>
               </>
             )}
             {sections.all.length > 0 && (
               <>
                 <div
                   id="section-all"
-                  className="px-3 pt-2 pb-0.5 text-xs font-medium text-text-muted uppercase tracking-wide"
+                  className="px-3 pt-2 pb-0.5 text-xs font-medium text-text-secondary uppercase tracking-wide"
                   role="presentation"
                 >
                   All
                 </div>
-                <div role="presentation">{sections.all.map(renderItem)}</div>
+                <div role="group" aria-labelledby="section-all">
+                  {sections.all.map(renderItem)}
+                </div>
               </>
             )}
           </>
@@ -203,10 +209,10 @@ export function RecipeRunnerList({
           className="group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60"
         >
           <Plus
-            className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
+            className="h-3.5 w-3.5 text-text-secondary group-hover:text-daintree-text transition-colors shrink-0"
             aria-hidden
           />
-          <span className="flex-1 text-sm text-text-muted group-hover:text-daintree-text transition-colors">
+          <span className="flex-1 text-sm text-text-secondary group-hover:text-daintree-text transition-colors">
             {isSearchActive && flatRecipes.length === 0
               ? `Create recipe: "${searchQuery}"`
               : "Create new recipe…"}

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
@@ -76,6 +76,14 @@ export function RecipeRunnerList({
         mode="list"
         disabled={disabled}
         id={`recipe-option-${recipe.id}`}
+        // The combobox above owns the only tab stop in this composite; every
+        // option is reached with the arrow keys and named through
+        // `aria-activedescendant`. Left at the default, eight recipes plus
+        // Create put nine extra stops between the user and whatever follows
+        // the recipe band — the same uncapped tab run the quick-launch chips
+        // were fixed for, and what WAI-ARIA's composite-widget contract
+        // exists to prevent.
+        tabIndex={-1}
         onRun={onRun}
         onEdit={onEdit}
         onDuplicate={onDuplicate}
@@ -92,9 +100,21 @@ export function RecipeRunnerList({
     // group must wrap both. At rest no ring shows — see RecipeRunnerItem.
     <div className="group/recipes" onKeyDown={onKeyDown}>
       {showSearch && (
-        <div className="mb-2 px-1">
-          <div className="relative">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-text-muted pointer-events-none" />
+        // A labelled header row, not a second full-width search field. Once
+        // every band shared one measure this input became the same width and
+        // shape as the palette button four bands above it, so the surface
+        // showed two equal search anchors and the lower one looked like
+        // another way to launch anything. Naming the band and shrinking the
+        // input to a filter says what its scope actually is.
+        <div className="mb-2 flex items-baseline gap-3 px-1">
+          <span
+            id="recipe-band-label"
+            className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-text-muted"
+          >
+            Recipes
+          </span>
+          <div className="relative min-w-0 flex-1">
+            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-text-muted pointer-events-none" />
             <input
               ref={inputRef}
               type="text"
@@ -102,11 +122,11 @@ export function RecipeRunnerList({
               aria-expanded={isSearchActive}
               aria-controls="recipe-listbox"
               aria-activedescendant={focusedItemId}
-              aria-label="Search recipes"
+              aria-label="Filter recipes"
               value={searchQuery}
               onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="Search recipes…"
-              className="w-full pl-8 pr-3 py-2 text-sm bg-daintree-sidebar border border-daintree-border rounded-[var(--radius-md)] text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/40 focus:border-daintree-accent/40"
+              placeholder="Filter recipes…"
+              className="w-full rounded-[var(--radius-md)] border border-border-subtle bg-transparent py-1 pl-7 pr-2 text-xs text-daintree-text placeholder:text-text-placeholder focus:border-daintree-accent/40 focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/40"
             />
           </div>
         </div>
@@ -116,7 +136,12 @@ export function RecipeRunnerList({
         {isSearchActive ? `${flatRecipes.length} recipes found` : ""}
       </div>
 
-      <div role="listbox" id="recipe-listbox" aria-label="Recipes" className="flex flex-col gap-1">
+      <div
+        role="listbox"
+        id="recipe-listbox"
+        aria-labelledby="recipe-band-label"
+        className="flex flex-col gap-1"
+      >
         {isSearchActive ? (
           <>
             {flatRecipes.length > 0 ? (
@@ -173,6 +198,7 @@ export function RecipeRunnerList({
           role="option"
           aria-selected={focusedIndex === createIndex}
           type="button"
+          tabIndex={-1}
           onClick={onCreate}
           className="group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60"
         >

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerList.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerList.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RecipeRunnerList } from "../RecipeRunnerList";
+import { buildRecipeSections } from "../recipeRunnerUtils";
+import type { TerminalRecipe } from "@/types";
+
+function makeRecipe(id: string, name: string, pinned = false): TerminalRecipe {
+  return {
+    id,
+    name,
+    terminals: [{ type: "terminal", env: {} }],
+    createdAt: 0,
+    showInEmptyState: pinned,
+  };
+}
+
+// Past six recipes the runner swaps its card grid for this searchable list.
+const RECIPES = [
+  makeRecipe("a", "Review & ship", true),
+  makeRecipe("b", "Work an issue", true),
+  makeRecipe("c", "Cut a release candidate"),
+  makeRecipe("d", "Dev stack"),
+  makeRecipe("e", "Docs sweep"),
+  makeRecipe("f", "Pair debug"),
+  makeRecipe("g", "Perf audit"),
+];
+
+const noop = () => {};
+
+function renderList() {
+  return render(
+    <RecipeRunnerList
+      sections={buildRecipeSections(RECIPES)}
+      searchQuery=""
+      searchResults={[]}
+      focusedIndex={0}
+      focusedItemId={undefined}
+      showSearch
+      onSearchChange={noop}
+      onKeyDown={noop}
+      onRun={noop}
+      onEdit={noop}
+      onDuplicate={noop}
+      onPin={noop}
+      onUnpin={noop}
+      onDelete={noop}
+      onCreate={noop}
+    />
+  );
+}
+
+describe("RecipeRunnerList — the canvas home does not take the caret", () => {
+  it("leaves focus where it was when the searchable list mounts", () => {
+    renderList();
+    // This list renders inside the empty canvas, which a user reaches by
+    // closing their last panel or switching worktree — never by asking to
+    // search recipes. Taking focus here steals the caret from whatever they
+    // were doing, and paints an accent ring on a surface nobody navigated to.
+    // Sibling `ProjectPulseStrip` states the same rule for the same reason.
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("still exposes the search field to the keyboard", () => {
+    renderList();
+    // Not focusing it is not the same as hiding it: Tab must still reach it.
+    const field = screen.getByPlaceholderText(/search recipes/i);
+    expect(field.hasAttribute("disabled")).toBe(false);
+    expect(field.getAttribute("tabindex")).not.toBe("-1");
+  });
+});

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerList.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerList.test.tsx
@@ -61,11 +61,23 @@ describe("RecipeRunnerList — the canvas home does not take the caret", () => {
     expect(document.activeElement).toBe(document.body);
   });
 
-  it("still exposes the search field to the keyboard", () => {
+  it("still exposes the filter to the keyboard", () => {
     renderList();
     // Not focusing it is not the same as hiding it: Tab must still reach it.
-    const field = screen.getByPlaceholderText(/search recipes/i);
+    // Queried by role and accessible name rather than placeholder text, so a
+    // copy change cannot fail a test about keyboard reachability.
+    const field = screen.getByRole("combobox", { name: /recipes/i });
     expect(field.hasAttribute("disabled")).toBe(false);
     expect(field.getAttribute("tabindex")).not.toBe("-1");
+  });
+
+  it("keeps the whole listbox to a single tab stop", () => {
+    renderList();
+    // The combobox owns the stop; seven recipes plus Create must not add eight
+    // more. Counted, not spot-checked — the failure mode is a count.
+    const stops = screen
+      .getAllByRole("option")
+      .filter((el) => el.getAttribute("tabindex") !== "-1");
+    expect(stops).toEqual([]);
   });
 });

--- a/src/components/Terminal/ResumeSessionLine.tsx
+++ b/src/components/Terminal/ResumeSessionLine.tsx
@@ -44,14 +44,15 @@ export function ResumeSessionLine() {
   return (
     // Hugs its content (centered) rather than stretching to the column width —
     // a stretched row strands "+N more" at the far edge, visually orphaned
-    // from the session it extends.
-    <div className="flex w-full max-w-lg items-center justify-center gap-1">
+    // from the session it extends. The width cap now comes from the launcher
+    // column, which owns the single measure every band shares.
+    <div className="flex w-full items-center justify-center gap-1">
       <button
         type="button"
         onClick={() => void resume(primary.session)}
         className="group flex min-w-0 items-center gap-2.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
       >
-        <History className="h-3.5 w-3.5 shrink-0 text-daintree-text/40" aria-hidden="true" />
+        <History className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
         <span className="shrink-0">
           <PanelKindIcon iconId={primary.iconId} color={primary.color} size={15} />
         </span>
@@ -60,17 +61,15 @@ export function ResumeSessionLine() {
         </span>
         {primary.description && (
           // Shrinkable (no shrink-0): a long worktree/branch description must
-          // truncate inside max-w-lg, not push the row past it.
-          <span className="min-w-0 truncate text-xs text-daintree-text/40">
-            {primary.description}
-          </span>
+          // truncate inside the column's measure, not push the row past it.
+          <span className="min-w-0 truncate text-xs text-text-muted">{primary.description}</span>
         )}
       </button>
       {extraCount > 0 && (
         <button
           type="button"
           onClick={openLauncher}
-          className="shrink-0 rounded-[var(--radius-md)] px-2 py-1.5 text-xs text-daintree-text/45 transition-colors hover:bg-overlay-subtle hover:text-daintree-text/75 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+          className="shrink-0 rounded-[var(--radius-md)] px-2 py-1.5 text-xs text-text-secondary transition-colors hover:bg-overlay-subtle hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
           aria-label={`Browse ${extraCount} more resumable session${extraCount !== 1 ? "s" : ""}`}
         >
           +{extraCount} more

--- a/src/components/Terminal/ResumeSessionLine.tsx
+++ b/src/components/Terminal/ResumeSessionLine.tsx
@@ -52,7 +52,7 @@ export function ResumeSessionLine() {
         onClick={() => void resume(primary.session)}
         className="group flex min-w-0 items-center gap-2.5 rounded-[var(--radius-md)] px-2.5 py-1.5 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
       >
-        <History className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+        <History className="h-3.5 w-3.5 shrink-0 text-text-secondary" aria-hidden="true" />
         <span className="shrink-0">
           <PanelKindIcon iconId={primary.iconId} color={primary.color} size={15} />
         </span>
@@ -68,7 +68,7 @@ export function ResumeSessionLine() {
           // title cut mid-word beside a model name cut mid-word, neither of
           // them readable. The title is what identifies the session; the model
           // and location are still on the row this line opens.
-          <span className="min-w-0 truncate text-xs text-text-muted @max-[26rem]/launcher:hidden">
+          <span className="min-w-0 truncate text-xs text-text-secondary @max-[31rem]/launcher:hidden">
             {primary.description}
           </span>
         )}

--- a/src/components/Terminal/ResumeSessionLine.tsx
+++ b/src/components/Terminal/ResumeSessionLine.tsx
@@ -62,7 +62,15 @@ export function ResumeSessionLine() {
         {primary.description && (
           // Shrinkable (no shrink-0): a long worktree/branch description must
           // truncate inside the column's measure, not push the row past it.
-          <span className="min-w-0 truncate text-xs text-text-muted">{primary.description}</span>
+          //
+          // And below the launcher's narrow breakpoint it is dropped outright.
+          // Sharing the row down there truncated BOTH halves at once — a task
+          // title cut mid-word beside a model name cut mid-word, neither of
+          // them readable. The title is what identifies the session; the model
+          // and location are still on the row this line opens.
+          <span className="min-w-0 truncate text-xs text-text-muted @max-[26rem]/launcher:hidden">
+            {primary.description}
+          </span>
         )}
       </button>
       {extraCount > 0 && (

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -8,7 +8,7 @@ describe("ContentGrid EmptyState — RecipeRunner integration", () => {
   it("identity is a centered stacked hero — mark above the name, one alignment axis", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     // Centered identity block…
-    expect(content).toContain('"mb-6 flex flex-col items-center text-center"');
+    expect(content).toMatch(/flex flex-col items-center text-center/);
     // …with the mark stacked above the name (no left-aligned lockup, no
     // gear-overlaid logo wrapper from the pre-redesign layout)…
     expect(content).toContain("identityMark");
@@ -32,8 +32,8 @@ describe("ContentGrid EmptyState — RecipeRunner integration", () => {
 
   it("derives hasEverLaunchedAgent from the panel store to gate teaching content", async () => {
     // RecipeRunner itself is deliberately NOT gated on hasEverLaunchedAgent
-    // (recipes are the launcher hero; see the CLAUDE.md recipe-gating gotcha) —
-    // the flag only gates teaching content like RotatingTip.
+    // (see the CLAUDE.md recipe-gating gotcha) — the flag only gates teaching
+    // content like RotatingTip.
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain("hasEverLaunchedAgent");
     expect(content).toContain("usePanelStore");
@@ -44,8 +44,8 @@ describe("ContentGrid EmptyState — RecipeRunner integration", () => {
   // wait for the first launch (#6752) and are withheld from scratches entirely.
 });
 
-describe("ContentGrid EmptyState — recipe-forward launcher composition", () => {
-  it("composes recipes (hero), a single-line resume, and quick-launch actions", async () => {
+describe("ContentGrid EmptyState — anchor-forward launcher composition", () => {
+  it("composes the launch anchor, a single-line resume, and recipes", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain("<RecipeRunner");
     expect(content).toContain("<ResumeSessionLine />");

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -7,8 +7,21 @@ const EMPTY_STATE_PATH = resolve(__dirname, "../ContentGridEmptyState.tsx");
 describe("ContentGrid EmptyState — RecipeRunner integration", () => {
   it("identity is a centered stacked hero — mark above the name, one alignment axis", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    // Centered identity block…
-    expect(content).toMatch(/flex flex-col items-center text-center/);
+    // Centered identity block — asserted as the two properties that make it
+    // one, not as a class string. The block has picked up a reserved height and
+    // a bottom-alignment since, and a literal would have failed on both without
+    // anything about the lockup having changed.
+    // Centered identity block — asserted as the two properties that make it
+    // one, not as a class string. The block has since picked up a reserved
+    // height and a bottom alignment, and a literal would have failed on both
+    // without anything about the lockup having changed.
+    const identity =
+      /"([^"]*)",\s*\n\s*SECTION_ENTRY\s*\n\s*\)\}\s*\n\s*>\s*\n\s*<div className="mb-3">\{identityMark\}/.exec(
+        content
+      );
+    expect(identity, "identity block wrapper not found").not.toBeNull();
+    expect(identity![1]).toContain("items-center");
+    expect(identity![1]).toContain("text-center");
     // …with the mark stacked above the name (no left-aligned lockup, no
     // gear-overlaid logo wrapper from the pre-redesign layout)…
     expect(content).toContain("identityMark");

--- a/src/components/Terminal/__tests__/contentGridTips.test.tsx
+++ b/src/components/Terminal/__tests__/contentGridTips.test.tsx
@@ -48,6 +48,16 @@ function makeAvailability(state: "ready" | "missing") {
   } as never;
 }
 
+/**
+ * The label the tip catalog gives an action. These tests are about which tip
+ * gets SELECTED, so they resolve the expected text from `TIPS` rather than
+ * restating it — a copy change should not fail a selection test, and a literal
+ * here would have to be edited in lockstep with the source it is checking.
+ */
+function labelFor(actionId: string): string | undefined {
+  return TIPS.find((tip) => (tip.shortcutActionId ?? tip.actionId) === actionId)?.actionLabel;
+}
+
 describe("RotatingTip — count-biased selection (#6756)", () => {
   beforeEach(() => {
     setUnhydrated();
@@ -115,7 +125,7 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     }
     const { container } = render(<RotatingTip />);
     setHydrated(counts);
-    expect(container.querySelector("button")?.textContent).toBe("Inject Context");
+    expect(container.querySelector("button")?.textContent).toBe(labelFor("terminal.inject"));
   });
 
   it("excludes shortcut-dependent tips whose binding has been removed", () => {
@@ -156,7 +166,7 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     const { container } = render(<RotatingTip />);
     setHydrated(counts);
     // quick-switcher has by far the largest count; it must NOT be the chosen tip.
-    expect(container.querySelector("button")?.textContent).not.toBe("Open Quick Switcher");
+    expect(container.querySelector("button")?.textContent).not.toBe(labelFor("nav.quickSwitcher"));
   });
 
   it("freezes the chosen tip — count updates after mount do not swap it", () => {
@@ -170,7 +180,7 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     const { container } = render(<RotatingTip />);
     setHydrated(counts);
     const before = container.querySelector("button")?.textContent;
-    expect(before).toBe("Open Quick Switcher");
+    expect(before).toBe(labelFor("nav.quickSwitcher"));
 
     // Simulate the user invoking some other shortcut after the tip mounted.
     act(() => {
@@ -230,7 +240,7 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     }
     const { container } = render(<RotatingTip />);
     setHydrated(counts);
-    expect(container.querySelector("button")?.textContent).toBe("Open Quick Switcher");
+    expect(container.querySelector("button")?.textContent).toBe(labelFor("nav.quickSwitcher"));
   });
 
   it("clicking the action label dispatches the tip's actionId", () => {

--- a/src/components/Terminal/__tests__/launcherHierarchy.test.tsx
+++ b/src/components/Terminal/__tests__/launcherHierarchy.test.tsx
@@ -170,15 +170,31 @@ describe("launcher column — one measure, owned by the parent", () => {
   });
 });
 
-describe("launcher column — overflow is reachable", () => {
-  it("centres the column with auto margins rather than justify-content", () => {
+describe("launcher column — the anchor holds its position", () => {
+  it("never centres the stack, so the anchor's offset cannot follow its height", () => {
     const source = readFileSync(EMPTY_STATE_PATH, "utf-8");
-    // `justify-content: center` distributes overflow to BOTH ends, so a column
-    // taller than the canvas loses its first rows above the scroll origin with
-    // no way to scroll back. Auto margins collapse to zero instead.
     const scroller = source.slice(source.indexOf("overflow-y-auto"));
-    expect(scroller).not.toMatch(/className="flex min-h-full flex-col items-center justify-center/);
-    expect(scroller).toContain("my-auto");
+    // Two failure modes, one rule. `justify-content: center` distributes
+    // overflow to BOTH ends, so a column taller than the canvas loses its
+    // first rows with no way to scroll back. `my-auto` fixes that but ties the
+    // anchor's offset to the stack's HEIGHT, so it slides as conditional bands
+    // resolve. Neither may come back: the offset above the column has to be
+    // independent of everything below it.
+    expect(scroller).not.toMatch(/flex min-h-full flex-col items-center justify-center/);
+    expect(scroller).not.toMatch(/@container\/launcher[^"]*\bmy-auto\b/);
+  });
+
+  it("holds the column with a fixed top gutter that can still collapse", () => {
+    const source = readFileSync(EMPTY_STATE_PATH, "utf-8");
+    // A fixed basis keeps the offset constant whatever renders below it, and
+    // `shrink` lets it collapse to zero when the column outgrows the canvas so
+    // the first rows stay reachable.
+    const gutter = /aria-hidden="true" className="w-full shrink basis-\d+"/;
+    expect(source).toMatch(gutter);
+    const gutterClass = gutter.exec(source)![0];
+    expect(gutterClass).not.toContain("shrink-0");
+    // …and all the slack goes below, so nothing pushes the column back down.
+    expect(source).toMatch(/aria-hidden="true" className="w-full grow basis-0"/);
   });
 });
 
@@ -233,5 +249,56 @@ describe("tip catalog — sentence case", () => {
       // no capitalised word after it (no product name appears in these today).
       expect(label, label).not.toMatch(/\s[A-Z]/);
     }
+  });
+});
+
+describe("launcher column — composite widgets are one tab stop", () => {
+  it("gives the quick-launch cluster a single tab stop", () => {
+    const source = readFileSync(resolve(LAUNCHER_DIR, "LauncherQuickActions.tsx"), "utf-8");
+    // The pinned agent set is uncapped by design, so without a roving stop the
+    // number of Tab presses between the user and the rest of the surface is a
+    // number the user chose in a settings dialog months ago.
+    expect(source).toContain('role="toolbar"');
+    expect(source).toMatch(/tabIndex=\{index === activeChip \? 0 : -1\}/);
+  });
+
+  it("gives the recipe listbox a single tab stop", () => {
+    const source = readFileSync(
+      resolve(LAUNCHER_DIR, "RecipeRunner/RecipeRunnerList.tsx"),
+      "utf-8"
+    );
+    // The combobox owns the stop; every option, Create included, is reached
+    // with the arrow keys and named through aria-activedescendant.
+    expect(source).toContain("aria-activedescendant");
+    const optionStops = source.match(/tabIndex=\{-1\}/g) ?? [];
+    expect(optionStops.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("launcher column — teaching never reads as an action", () => {
+  it("exempts the tip's control from the button borders in BOTH contrast modes", () => {
+    const css = readFileSync(resolve(LAUNCHER_DIR, "../../index.css"), "utf-8");
+    // macOS fires only `prefers-contrast: more`; Windows swaps in system
+    // colours via `forced-colors: active`. The blocks are separate on purpose,
+    // so the exemption has to exist in each of them independently — a single
+    // shared rule would silently cover only one platform.
+    for (const marker of ["@media (forced-colors: active)", "@media (prefers-contrast: more)"]) {
+      const start = css.indexOf(marker);
+      expect(start, `${marker} block is missing`).toBeGreaterThan(-1);
+      let depth = 0;
+      let end = css.indexOf("{", start);
+      for (let i = end; i < css.length; i++) {
+        if (css[i] === "{") depth++;
+        if (css[i] === "}" && --depth === 0) {
+          end = i;
+          break;
+        }
+      }
+      expect(css.slice(start, end), `${marker} does not exempt .tip-action`).toContain(
+        ".tip-action"
+      );
+    }
+    const tips = readFileSync(resolve(LAUNCHER_DIR, "contentGridTips.tsx"), "utf-8");
+    expect(tips).toContain("tip-action");
   });
 });

--- a/src/components/Terminal/__tests__/launcherHierarchy.test.tsx
+++ b/src/components/Terminal/__tests__/launcherHierarchy.test.tsx
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { reduceMotionSelectors } from "./launcherMotionContract";
+
+/**
+ * The composition contracts behind issue #11987.
+ *
+ * Every assertion here states a RULE — "the anchor precedes anything
+ * conditional", "the column has one measure", "nothing takes focus on mount" —
+ * rather than a class string or a pixel. The surface these govern is expected
+ * to keep changing; the rules are what must survive it.
+ */
+
+const h = vi.hoisted(() => ({
+  panelIds: [] as string[],
+  panelsById: {} as Record<string, unknown>,
+  recipes: { currentProjectId: "p1" as string | null, isLoading: false },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn(() => Promise.resolve({ ok: true })) },
+}));
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (sel: (s: typeof h) => unknown) => sel(h),
+}));
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: (sel: (s: typeof h.recipes) => unknown) => sel(h.recipes),
+}));
+vi.mock("@/hooks/app/useHomeDir", () => ({ useHomeDir: () => ({ homeDir: "/home/user" }) }));
+
+// The bands are stubbed to identifiable markers: this suite is about the ORDER
+// and the focus behaviour of the column, and each child owns its own suite.
+vi.mock("../LauncherQuickActions", () => ({
+  LauncherQuickActions: () => <div data-testid="band-launcher" />,
+}));
+vi.mock("../RecipeRunner/RecipeRunner", () => ({
+  RecipeRunner: () => <div data-testid="band-recipes" />,
+}));
+vi.mock("../ResumeSessionLine", () => ({
+  ResumeSessionLine: () => <div data-testid="band-resume" />,
+}));
+vi.mock("@/components/Pulse", () => ({
+  ProjectPulseStrip: () => <div data-testid="band-pulse" />,
+}));
+vi.mock("../contentGridTips", () => ({ RotatingTip: () => <div data-testid="band-tip" /> }));
+
+import { ContentGridEmptyState } from "../ContentGridEmptyState";
+
+const EMPTY_STATE_PATH = resolve(__dirname, "../ContentGridEmptyState.tsx");
+const LAUNCHER_DIR = resolve(__dirname, "..");
+
+function renderLauncher(overrides: Record<string, unknown> = {}) {
+  return render(
+    <ContentGridEmptyState
+      hasLaunchTarget
+      hasProjectContext
+      hasWorktrees
+      isWorktreeInitialized
+      activeWorktreeId="wt1"
+      activeWorktreeBranch="main"
+      activeWorktreePath="/home/user/proj"
+      workspaceName="Helios"
+      showProjectPulse
+      defaultCwd="/home/user/proj"
+      {...overrides}
+    />
+  );
+}
+
+/** Document order of the rendered band markers, top to bottom. */
+function bandOrder(): string[] {
+  const markers = Array.from(document.querySelectorAll<HTMLElement>("[data-testid^='band-']")).map(
+    (el) => el.dataset.testid!
+  );
+  return markers;
+}
+
+describe("launcher column — the launch anchor is invariant (#11987)", () => {
+  beforeEach(() => {
+    h.panelIds = [];
+    h.panelsById = {};
+    h.recipes = { currentProjectId: "p1", isLoading: false };
+  });
+
+  it("puts the launch anchor ahead of every conditionally-rendered band", () => {
+    h.panelIds = ["a"];
+    h.panelsById = { a: { id: "a", kind: "terminal", launchAgentId: "claude" } };
+    renderLauncher();
+    const order = bandOrder();
+    const anchor = order.indexOf("band-launcher");
+    expect(anchor).toBeGreaterThanOrEqual(0);
+    // Recipes, resume, pulse and the tip each appear or vanish with state the
+    // user did not choose. Any one of them above the anchor makes the anchor's
+    // position a function of that state.
+    for (const conditional of ["band-recipes", "band-resume", "band-pulse", "band-tip"]) {
+      expect(order.indexOf(conditional)).toBeGreaterThan(anchor);
+    }
+  });
+
+  it("keeps the anchor at the same band index whichever conditional bands render", () => {
+    const indices = new Set<number>();
+    for (const state of [
+      { recipes: { currentProjectId: "p1", isLoading: false }, pulse: true, agent: true },
+      { recipes: { currentProjectId: null, isLoading: false }, pulse: true, agent: true },
+      { recipes: { currentProjectId: "p1", isLoading: true }, pulse: false, agent: false },
+      { recipes: { currentProjectId: null, isLoading: true }, pulse: false, agent: false },
+    ]) {
+      h.recipes = state.recipes;
+      h.panelIds = state.agent ? ["a"] : [];
+      h.panelsById = state.agent
+        ? { a: { id: "a", kind: "terminal", launchAgentId: "claude" } }
+        : {};
+      const { unmount } = renderLauncher({ showProjectPulse: state.pulse });
+      indices.add(bandOrder().indexOf("band-launcher"));
+      unmount();
+    }
+    // One index across every permutation: the anchor is always the first band
+    // after identity, never the second or third depending on what resolved.
+    expect([...indices]).toEqual([0]);
+  });
+
+  it("does not move focus when it mounts", () => {
+    h.panelIds = ["a"];
+    h.panelsById = { a: { id: "a", kind: "terminal", launchAgentId: "claude" } };
+    renderLauncher();
+    // The user reaches this surface by closing their last panel or switching
+    // worktree — never by asking for it. Anything here that grabs the caret
+    // takes it from whatever they were actually doing.
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("names the surface as a region so it is not an anonymous run of buttons", () => {
+    renderLauncher();
+    expect(screen.getByRole("region", { name: /Helios/ })).toBeTruthy();
+  });
+});
+
+describe("launcher column — one measure, owned by the parent", () => {
+  const CHILDREN = [
+    "LauncherQuickActions.tsx",
+    "ResumeSessionLine.tsx",
+    "RecipeRunner/RecipeRunner.tsx",
+    "RecipeRunner/RecipeRunnerEmpty.tsx",
+  ];
+
+  it("caps the column's width in exactly one place", () => {
+    const parent = readFileSync(EMPTY_STATE_PATH, "utf-8");
+    // The parent declares the measure...
+    expect(parent).toMatch(/const LAUNCHER_MEASURE = "max-w-\[[^"]+\]"/);
+  });
+
+  it("leaves every band's width to the parent", () => {
+    for (const child of CHILDREN) {
+      const source = readFileSync(resolve(LAUNCHER_DIR, child), "utf-8");
+      // ...and no band re-declares one, which is what produced four different
+      // content widths stacked down one centred column.
+      // className attributes only — a `max-w-*` named in a comment is prose,
+      // not a rule, and flagging it would make the contract unwritable.
+      const ownMeasure = [...source.matchAll(/className=(?:"([^"]*)"|\{`([^`]*)`\})/g)]
+        .flatMap((m) => (m[1] ?? m[2] ?? "").split(/\s+/))
+        // Absolute caps only. A percentage cap (`max-w-[55%]` on a truncating
+        // span) is a share of whatever the parent granted, so it cannot
+        // introduce a second measure — an absolute one can and did.
+        .filter((c) => /^(?:[a-z-]+:)*max-w-/.test(c) && !/%\]$/.test(c) && !c.endsWith("full"));
+      expect(ownMeasure, `${child} sets its own width`).toEqual([]);
+    }
+  });
+});
+
+describe("launcher column — overflow is reachable", () => {
+  it("centres the column with auto margins rather than justify-content", () => {
+    const source = readFileSync(EMPTY_STATE_PATH, "utf-8");
+    // `justify-content: center` distributes overflow to BOTH ends, so a column
+    // taller than the canvas loses its first rows above the scroll origin with
+    // no way to scroll back. Auto margins collapse to zero instead.
+    const scroller = source.slice(source.indexOf("overflow-y-auto"));
+    expect(scroller).not.toMatch(/className="flex min-h-full flex-col items-center justify-center/);
+    expect(scroller).toContain("my-auto");
+  });
+});
+
+describe("launcher column — every entry animation is suppressible", () => {
+  it("registers each animated band with the in-app reduce-motion block", () => {
+    const suppressed = reduceMotionSelectors();
+    const sources = [EMPTY_STATE_PATH, resolve(LAUNCHER_DIR, "contentGridTips.tsx")];
+    for (const path of sources) {
+      const source = readFileSync(path, "utf-8");
+      // `motion-safe:` only reads the OS preference. Daintree's own
+      // "reduce animations" toggle is a body attribute no Tailwind variant can
+      // reach, so an animated element is suppressible if and only if one of its
+      // class names is named in the `@variant reduce-motion` block.
+      for (const match of source.matchAll(/className="([^"]*animate-in[^"]*)"/g)) {
+        const classes = (match[1] ?? "").split(/\s+/);
+        expect(
+          classes.some((c) => suppressed.has(c)),
+          `${path}: an animate-in element carries no reduce-motion marker`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("never feeds a keyframe animation through the transition utilities", () => {
+    const sources = [EMPTY_STATE_PATH, resolve(LAUNCHER_DIR, "contentGridTips.tsx")];
+    for (const path of sources) {
+      const source = readFileSync(path, "utf-8");
+      for (const match of source.matchAll(/className="([^"]*animate-in[^"]*)"/g)) {
+        // Tailwind core's `duration-*`/`delay-*` win over the animation
+        // library's same-named utilities and compile to `transition-duration` /
+        // `transition-delay`, which a @keyframes animation never reads — and,
+        // with no `transition-property` set, land on CSS's `all` default.
+        // See `.lessons/11180.md`.
+        const offenders = (match[1] ?? "")
+          .split(/\s+/)
+          .filter((c) => /^(?:[a-z-]+:)*(?:duration|delay)-/.test(c));
+        expect(offenders, `${path}: ${offenders.join(", ")}`).toEqual([]);
+      }
+    }
+  });
+});
+
+describe("tip catalog — sentence case", () => {
+  it("gives every tip action a sentence-case label", () => {
+    // Read from source rather than importing: this suite mocks the tip module
+    // so it can assert band order without a live tip catalog.
+    const source = readFileSync(resolve(LAUNCHER_DIR, "contentGridTips.tsx"), "utf-8");
+    const labels = [...source.matchAll(/actionLabel:\s*"([^"]+)"/g)].map((m) => m[1]!);
+    expect(labels.length).toBeGreaterThan(0);
+    for (const label of labels) {
+      // Sentence case per CLAUDE.md's microcopy rule: one leading capital, and
+      // no capitalised word after it (no product name appears in these today).
+      expect(label, label).not.toMatch(/\s[A-Z]/);
+    }
+  });
+});

--- a/src/components/Terminal/contentGridTips.tsx
+++ b/src/components/Terminal/contentGridTips.tsx
@@ -282,11 +282,19 @@ export function RotatingTip() {
             onClick={() =>
               void actionService.dispatch(tip.actionId!, undefined, { source: "user" })
             }
+            // `tip-action` opts this control out of the button-border rules
+            // that BOTH accessibility media modes apply. Without it the tip's
+            // link grows a pill in `forced-colors: active` and in
+            // `prefers-contrast: more` and reads as another action on the
+            // surface — the one thing teaching content must never do. The
+            // standing underline is the affordance in every mode, so nothing
+            // is lost by dropping the frame.
+            //
             // A standing underline, not a hover-only one. Rendered as bare
             // centred text at the same size and colour as the sentence above
             // it, the only control that names the user's actual goal read as a
             // second sentence — an affordance nobody could see was there.
-            className="text-xs text-text-secondary underline decoration-text-muted underline-offset-2 hover:text-daintree-text hover:decoration-current transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 rounded px-1"
+            className="tip-action text-xs text-text-secondary underline decoration-text-muted underline-offset-2 hover:text-daintree-text hover:decoration-current transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 rounded px-1"
           >
             {tip.actionLabel}
           </button>

--- a/src/components/Terminal/contentGridTips.tsx
+++ b/src/components/Terminal/contentGridTips.tsx
@@ -39,7 +39,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "nav.quickSwitcher",
-    actionLabel: "Open Quick Switcher",
+    actionLabel: "Open quick switcher",
     requiresShortcut: true,
   },
   {
@@ -55,7 +55,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "terminal.new",
-    actionLabel: "New Terminal",
+    actionLabel: "New terminal",
     requiresShortcut: true,
   },
   {
@@ -73,7 +73,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "panel.palette",
-    actionLabel: "Open Panel Palette",
+    actionLabel: "Open panel palette",
     requiresShortcut: true,
   },
   {
@@ -89,7 +89,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "agent.terminal",
-    actionLabel: "Launch Agent",
+    actionLabel: "Launch agent",
     requiresShortcut: true,
     requiredAgents: ["claude"],
   },
@@ -106,7 +106,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "agent.terminal",
-    actionLabel: "Launch Agent",
+    actionLabel: "Launch agent",
     requiresShortcut: true,
     requiredAgents: ["gemini"],
   },
@@ -123,7 +123,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "terminal.inject",
-    actionLabel: "Inject Context",
+    actionLabel: "Inject context",
     requiresShortcut: true,
   },
   {
@@ -139,7 +139,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "action.palette.open",
-    actionLabel: "Open Command Palette",
+    actionLabel: "Open command palette",
     requiresShortcut: true,
   },
   {
@@ -155,7 +155,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "worktree.openPalette",
-    actionLabel: "Open Worktree Palette",
+    actionLabel: "Open worktree palette",
     requiresShortcut: true,
   },
   {
@@ -172,7 +172,7 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "worktree.overview.open",
     shortcutActionId: "worktree.overview",
-    actionLabel: "Open Worktrees Overview",
+    actionLabel: "Open worktrees overview",
     requiresShortcut: true,
   },
   {
@@ -188,14 +188,14 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "agent.palette",
-    actionLabel: "Open Agent Switcher",
+    actionLabel: "Open agent switcher",
     requiresShortcut: true,
   },
   {
     id: "recipes",
     message: <>Create a recipe to run multi-terminal workflows with a single click</>,
     actionId: "recipe.manager.open",
-    actionLabel: "Open Recipes",
+    actionLabel: "Open recipes",
   },
   {
     id: "new-worktree",
@@ -206,7 +206,7 @@ export const TIPS: TipEntry[] = [
       </>
     ),
     actionId: "worktree.createDialog.open",
-    actionLabel: "New Worktree",
+    actionLabel: "New worktree",
   },
 ];
 
@@ -263,8 +263,17 @@ export function RotatingTip() {
 
   if (tip) {
     return (
-      <div className="flex flex-col items-center gap-2 animate-in fade-in duration-200">
-        <p className="text-xs text-daintree-text/70 text-center">
+      // `motion-safe:` + the shared entry tier fed to the ANIMATION's own slot.
+      // The bare `duration-200` this used to carry compiled to
+      // `transition-duration` on an element with no `transition-property`,
+      // landing on CSS's `all` default — an every-property transition nobody
+      // asked for — while the keyframe animation it was meant to time ignored
+      // it entirely. Exactly the trap `.lessons/11180.md` documents for the
+      // sections above. The marker class is what lets Daintree's own
+      // reduce-animations toggle reach this fade; `motion-safe:` only covers
+      // the OS preference.
+      <div className="launcher-section-enter flex flex-col items-center gap-2 motion-safe:animate-in motion-safe:fade-in motion-safe:[--tw-animation-duration:var(--duration-200)]">
+        <p className="text-xs text-text-secondary text-center">
           Tip: <LiveTipMessage tip={tip} />
         </p>
         {tip.actionId && tip.actionLabel && (
@@ -273,7 +282,11 @@ export function RotatingTip() {
             onClick={() =>
               void actionService.dispatch(tip.actionId!, undefined, { source: "user" })
             }
-            className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 rounded px-1"
+            // A standing underline, not a hover-only one. Rendered as bare
+            // centred text at the same size and colour as the sentence above
+            // it, the only control that names the user's actual goal read as a
+            // second sentence — an affordance nobody could see was there.
+            className="text-xs text-text-secondary underline decoration-text-muted underline-offset-2 hover:text-daintree-text hover:decoration-current transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 rounded px-1"
           >
             {tip.actionLabel}
           </button>

--- a/src/index.css
+++ b/src/index.css
@@ -2851,6 +2851,21 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border: 1px solid ButtonText;
   }
 
+  /* The launcher's teaching link is a control that must never read as one.
+     The blanket border above frames it into a pill sitting under the canvas
+     home's tip sentence, which is exactly the "another action module" the tip
+     is designed not to be — and the surface already carries a real primary
+     action four bands above it. Its permanent underline is the affordance in
+     every mode, so dropping the frame costs nothing.
+
+     Deliberately duplicated rather than shared with the `prefers-contrast`
+     block below: macOS fires only `prefers-contrast: more` and Windows swaps
+     in system colours, so the two blocks stay independent (see the rationale
+     at the top of each). */
+  .tip-action {
+    border: none;
+  }
+
   /* A destructive button is distinguished only by its fill, and the UA replaces
    * every fill with a system colour — so "Delete worktree" and "Cancel" render
    * as the same white pill with the same border, and nothing marks which one
@@ -3027,6 +3042,13 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   select,
   textarea {
     border-width: 2px;
+  }
+
+  /* Same exemption as the forced-colors block, and deliberately restated here
+     rather than merged: the launcher's teaching link must not be framed into a
+     button. Its underline carries the affordance. */
+  .tip-action {
+    border-width: 0;
   }
 
   /* Tailwind v4 emits `text-daintree-text/N` with a literal slash in the

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -1155,7 +1155,13 @@ export function FilePane({
         )}
 
         {!filePath && (
-          <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-6">
+          // Auto margins on the end children rather than `justify-center`:
+          // `h-full` pins this box to the scrollport, and centred overflow
+          // spills at BOTH ends, so the empty state's icon and title become
+          // unreachable in a short pane once the recent-files list fills. Auto
+          // margins split the free space the same way and collapse to zero when
+          // there is none. Same fix as `ContentGridEmptyState`.
+          <div className="flex h-full w-full flex-col items-center gap-4 p-6 [&>*:first-child]:mt-auto [&>*:last-child]:mb-auto">
             <EmptyState
               variant="zero-data"
               scale="canvas"
@@ -1210,7 +1216,7 @@ export function FilePane({
         )}
 
         {filePath && viewMode !== "diff" && loadState === "error" && errorCode && (
-          <div className="flex h-full flex-col items-center justify-center gap-3 p-6">
+          <div className="flex h-full flex-col items-center gap-3 p-6 [&>*:first-child]:mt-auto [&>*:last-child]:mb-auto">
             <p className="text-sm text-muted-foreground">
               {errorMessage ?? FILE_READ_ERROR_MESSAGES[errorCode]}
             </p>


### PR DESCRIPTION
## Summary

- The canvas home stacked six independently-gated sections in one centred column, and the panel palette button (the only control that reaches every agent, panel kind and resumable session) was fifth of six. Its vertical position was a function of how many recipes the project happened to have: 63% of the canvas height in the quietest state, 88% with eight recipes, 32% with the activity card expanded.
- It now sits directly under project identity, above every conditional band, at a fixed offset. Measured across all 13 captured states it lands at **221 CSS px from the top of the canvas**, in every one of them.
- Reviewed over three scored rounds against an adversarial reviewer working from rendered pixels: **5.3 → 7.6 → 8.9 out of 10**.

Resolves #11987

## What changed

**The launch anchor.** `PaletteSearchButton` renders above the quick-action chips inside `LauncherQuickActions`, and that group moved to position two. An uncapped, user-curated chip row can no longer push it down either. The column is held by a fixed shrinkable top gutter instead of being centred, and identity reserves its tallest footprint, so nothing above or below the anchor moves it.

**Overflow was unreachable.** `justify-content: center` on a flex column distributes overflow to *both* ends, so once the column outgrew the canvas its first rows spilled above the scroll origin with no way to scroll back. A survey of the renderer found this in two other places with the same real failure mode, fixed in a separate commit: `MissingCliGate` had `overflow-auto` and `justify-center` on the same element, and `FilePane` pins two columns to the scrollport with `h-full`.

**Focus.** `RecipeRunnerList` focused its search field on mount, so any project with more than six recipes took the caret every time its canvas went empty and painted a second accent ring beside the roving one. Both the chip cluster and the recipe listbox are now single tab stops with roving focus, matching the toolbar the chips mirror.

**Contrast.** Resume metadata (3.24:1), `+N more` (3.80:1), the activity count (4.44:1) and the recipe run glyph (2.16:1) were alpha modifiers on the primary text token. The first pass moved them to `text-muted`, which clears 5.65:1 on `daintree` but only 2.97:1 on Namib and 3.10:1 on Redwoods. They use `text-secondary` now, which clears 6.15:1 on every shipped theme.

**Accent.** The pinned-recipe badge spent the accent on membership and was `aria-hidden`, so the state existed for sighted users only. Neutral now, with an `sr-only` label.

**Motion.** `RotatingTip`'s entry ignored both reduced-motion suppressors and fed `duration-200` to a keyframe animation, which compiles to `transition-duration` on an element with no `transition-property` and lands on CSS's `all` default. Exactly the trap `.lessons/11180.md` documents for the sections above it.

**Measure.** Four content widths down one centred axis (512 / 608 / 512 / 768) collapsed to one, owned by the parent. The expanded pulse card was `w-fit`, so a 60-day row of fixed-size cells made the lowest-priority module the widest object on the surface.

**Also:** expanding project pulse scrolled identity and the anchor off the top; the pulse card framed a permanently empty block when no forge provider resolves; the recipe grid held three columns at a 550px canvas and truncated every name; both high-contrast modes framed the teaching link into a pill button; 12 tip action labels were Title Case; the recipe list's visible Pinned/Recent/All groupings were `role="presentation"`.

## Design review

Score 5.3 → 8.9 across three rounds against information hierarchy, layout stability, scannability, visual language, typography, affordance, states, accessibility, microcopy and craft. Microcopy finished at 10.0. The reviewer explicitly ruled that the accent-restraint constraint costs zero points here: the neutral hierarchy works.

New harness at `e2e/screenshots/canvas-home-review.spec.ts`, opt-in behind `DAINTREE_SHOT_THEME`, covering 13 states. It verifies its own output three ways: every promised file landed, no step threw, and no two same-viewport captures are byte-identical. That last check caught a step that drove nothing and wrote a perfectly plausible PNG of the previous state.

Consistency survey found the safe-centring fix was an outlier worth rolling out (2 files, separate commit, reviewed on its own). It also found roughly 900 occurrences of low-alpha primary text across 228 files below the contrast floor. That is a pre-existing migration rather than something this branch introduced, and 21 test files assert the old class strings, so it is left alone here.

Three findings pushed back on and not done: "Worktree deleted" keeps its title (it names what happened, which is what a user whose selection just vanished needs, and the button already names the recovery); ellipsis-suffixed buttons stay (platform convention for "opens further UI", not the terminal punctuation the rule bans); and the pulse "60d vs 35 cells" reading is correct behaviour, pinned by two existing tests.

## Testing

`npm run check` and the full `npx vitest run`: **51,651 passing**. The run caught one real defect in this branch, a dead initializer in the chip key handler, now fixed; the lint ratchet ends 2 warnings below baseline. Four tests timed out under a load average of 26 from parallel sessions and pass in isolation.

13 new invariants across `launcherHierarchy.test.tsx` and `RecipeRunnerList.test.tsx`, every one mutation-checked by reintroducing the bug and confirming the test fails. They assert rules rather than values: the anchor precedes every conditional band and holds one band index across module permutations, the column is never centred, exactly one file declares the measure, both composites are one tab stop, nothing takes focus on mount, every `animate-in` element carries a reduce-motion marker, no transition utility feeds a keyframe animation, and `.tip-action` is exempted independently in each of the two accessibility media blocks.