### PR TITLE
Rebuild the worktree overview on the shared dialog frame

### DIFF
--- a/e2e/full/worktree/core-project-management-advanced.spec.ts
+++ b/e2e/full/worktree/core-project-management-advanced.spec.ts
@@ -142,7 +142,7 @@ test.describe.serial("Core: Project Management Advanced", () => {
 
       const modal = window.locator(SEL.worktree.overviewModal);
       await expect(modal).toBeVisible({ timeout: T_LONG });
-      await expect(modal.locator("h2", { hasText: "Worktrees Overview" })).toBeVisible();
+      await expect(modal.locator("h2", { hasText: "Worktrees overview" })).toBeVisible();
 
       // At least one worktree card should be visible (main + feature branch = 2)
       const cards = modal.locator("[data-worktree-branch]");

--- a/e2e/full/worktree/core-worktree-cross-boundary.spec.ts
+++ b/e2e/full/worktree/core-worktree-cross-boundary.spec.ts
@@ -225,7 +225,7 @@ test.describe.serial("Core: Cross-Worktree Terminal Isolation", () => {
 
     const modal = window.locator(SEL.worktree.overviewModal);
     await expect(modal).toBeVisible({ timeout: T_LONG });
-    await expect(modal.locator("h2", { hasText: "Worktrees Overview" })).toBeVisible();
+    await expect(modal.locator("h2", { hasText: "Worktrees overview" })).toBeVisible();
 
     const cards = modal.locator("[data-worktree-branch]");
     await expect(cards.first()).toBeVisible({ timeout: T_LONG });

--- a/e2e/full/worktree/worktree-dashboard-cards.spec.ts
+++ b/e2e/full/worktree/worktree-dashboard-cards.spec.ts
@@ -52,14 +52,14 @@ test.describe.serial("Full: Worktree Dashboard Cards", () => {
     // Ctrl/Cmd-click selects a single cell and surfaces the bulk-action bar.
     await first.click({ modifiers: ["ControlOrMeta"], position: { x: 20, y: 20 } });
     await expect(first).toHaveAttribute("aria-selected", "true", { timeout: T_MEDIUM });
-    await expect(window.locator(SEL.worktree.overviewModal)).toContainText("1 selected");
+    await expect(window.locator(SEL.worktree.overviewModal)).toContainText("1 of 2 selected");
     await expect(window.locator(SEL.worktree.bulkRemove)).toBeVisible();
     await expect(window.locator(SEL.worktree.bulkCloseSessions)).toBeVisible();
 
     // Shift-click extends the selection range from the anchor to the target.
     await second.click({ modifiers: ["Shift"], position: { x: 20, y: 20 } });
     await expect(second).toHaveAttribute("aria-selected", "true", { timeout: T_MEDIUM });
-    await expect(window.locator(SEL.worktree.overviewModal)).toContainText("2 selected");
+    await expect(window.locator(SEL.worktree.overviewModal)).toContainText("2 of 2 selected");
 
     // Clearing the selection dismisses the bulk-action bar and deselects both cells.
     await window.locator(SEL.worktree.clearSelection).click();
@@ -67,6 +67,11 @@ test.describe.serial("Full: Worktree Dashboard Cards", () => {
     await expect(first).toHaveAttribute("aria-selected", "false", { timeout: T_MEDIUM });
     await expect(second).toHaveAttribute("aria-selected", "false", { timeout: T_MEDIUM });
 
+    // The close button dismisses in ONE click even with a selection active:
+    // only Escape carries the clear-then-close contract, and the bar above has
+    // its own Clear control.
+    await first.click({ modifiers: ["ControlOrMeta"], position: { x: 20, y: 20 } });
+    await expect(window.locator(SEL.worktree.overviewModal)).toContainText("1 of 2 selected");
     await window.locator(SEL.worktree.overviewClose).click();
     await expect(window.locator(SEL.worktree.overviewModal)).toBeHidden({ timeout: T_MEDIUM });
   });

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -129,7 +129,9 @@ export const SEL = {
     filterButton: '[aria-label="Filter and sort worktrees"]',
     filterPopover: '[data-testid="worktree-filter-popover"]',
     openOverviewButton: '[aria-label="Open worktrees overview"]',
-    overviewModal: '[role="dialog"][aria-labelledby="worktree-overview-title"]',
+    // Keyed on the test id rather than `aria-labelledby`: the overview is
+    // composed from AppDialog now, which mints its own title id via `useId()`.
+    overviewModal: '[data-testid="worktree-overview-modal"]',
     overviewClose: '[aria-label="Close overview"]',
     quickCreatePalette: '[role="dialog"][aria-label="Quick create worktree palette"]',
     quickCreateCustomize: "#quick-create-option-__customize__",

--- a/e2e/screenshots/forge-dropdown-review.spec.ts
+++ b/e2e/screenshots/forge-dropdown-review.spec.ts
@@ -328,7 +328,7 @@ test("forge dropdown review — issues and pull requests", async () => {
       }
     });
   } finally {
-    if (ctx) await closeApp(ctx);
+    if (ctx) await closeApp(ctx.app);
     repo.cleanup();
   }
 

--- a/e2e/screenshots/pilot-review.spec.ts
+++ b/e2e/screenshots/pilot-review.spec.ts
@@ -467,7 +467,7 @@ test("pilot review — the fleet overview, with a fleet", async () => {
 
         await closeOverlay(page);
       } finally {
-        if (ctx) await closeApp(ctx).catch(() => {});
+        if (ctx) await closeApp(ctx.app).catch(() => {});
       }
     }
   } finally {

--- a/e2e/screenshots/readiness-rail-review.spec.ts
+++ b/e2e/screenshots/readiness-rail-review.spec.ts
@@ -574,7 +574,7 @@ test("readiness rail review — ready, attention and blocked states", async () =
       }
     }
   } finally {
-    if (ctx) await closeApp(ctx).catch(() => {});
+    if (ctx) await closeApp(ctx.app).catch(() => {});
     repo.cleanup();
     rmSync(userDataDir, { recursive: true, force: true });
   }

--- a/e2e/screenshots/worktree-overview-review.spec.ts
+++ b/e2e/screenshots/worktree-overview-review.spec.ts
@@ -1,0 +1,1070 @@
+/**
+ * `WorktreeOverviewModal` visual-review harness (#11989).
+ *
+ * The overview is the app-scale worktree browser: a near-full-window modal with
+ * search, facet filters, clickable activity summaries, multi-selection, bulk
+ * actions and a responsive card grid. Its design questions — does the frame read
+ * as the same modal system as the other ~78 dialogs, does the header stay legible
+ * once identity, counts, chips, toggles and close all share one row, and does
+ * entering selection mode cost the user their result context — are all questions
+ * about rendered pixels at a real width with a real number of cards. None of them
+ * survive being reasoned about from the JSX.
+ *
+ * Everything is driven through the app's real seams:
+ *   - Worktrees are real `git worktree add` linked worktrees, so branch labels,
+ *     issue numbers, diff stats, ahead counts and type grouping are all genuine.
+ *   - AI notes are real `<gitdir>/daintree/note` files, which is what
+ *     NoteFileReader reads.
+ *   - Agent activity comes from real PTYs running the shared fake-claude CLI, so
+ *     the working/waiting summary chips are produced by the real FSM rather than
+ *     a class name.
+ *   - Filters, grouping, selection and both bulk confirmations are driven by
+ *     clicking the actual controls.
+ *
+ * Two states the harness deliberately does not fake:
+ *   - The `finished` summary chip needs `worktree.linked.pr`, which only a live
+ *     forge lookup produces. There is no offline seam for it, and inventing one
+ *     would mean reviewing a code path the app cannot reach in this fixture.
+ *   - The loading skeleton (`isLoading && worktrees.length === 0`) is a race
+ *     against the worktree MessagePort resolving; there is no handler to delay.
+ * Both are recorded rather than faked.
+ *
+ * Opt-in only, like the sibling review harnesses:
+ *
+ *   DAINTREE_SHOT_OVERVIEW=1 npx playwright test --project=screenshots worktree-overview-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_OVERVIEW   required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME      optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG        optional suffix so review rounds sit side by side
+ *   DAINTREE_SHOT_ONLY       comma-separated state filter (slugs below)
+ *   DAINTREE_SHOT_DIR        output directory override
+ *   DAINTREE_SHOT_SWEEP      only capture the states marked `sweep`
+ *   DAINTREE_SHOT_SESSIONS   set to "0" to skip the (slow) agent launches
+ *
+ * Switching themes in place is not attempted — a sweep boots once per theme:
+ *
+ *   for t in arashiyama atacama bali bondi daintree fiordland galapagos highlands \
+ *            hokkaido movile namib redwoods serengeti svalbard table-mountain; do
+ *     DAINTREE_SHOT_OVERVIEW=1 DAINTREE_SHOT_SWEEP=1 DAINTREE_SHOT_SESSIONS=0 \
+ *     DAINTREE_SHOT_THEME=$t npx playwright test --project=screenshots worktree-overview-review
+ *   done
+ *
+ * Output: artifacts/overview-shots/<slug>--<theme>[-tag].png (gitignored).
+ *
+ * Hard rule, shared with the sibling harnesses: never write a PNG that has not
+ * been verified. Every state asserts the content that makes it *that* state
+ * after the settle and before the shot, and throws otherwise — a missing file is
+ * a loud, correct failure, where a plausible-looking wrong file sends a whole
+ * design review off reasoning about a screen that does not exist.
+ */
+
+import { test, expect, type Page, type ElectronApplication } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { getGridPanelIds } from "../helpers/panels";
+import { getTerminalText, waitForTerminalText, writeTerminalInput } from "../helpers/terminal";
+import {
+  installFakeAgent,
+  fakeAgentEnv,
+  FAKE_AGENT_READY,
+  FAKE_AGENT_STOP,
+} from "../helpers/fakeAgent";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_OVERVIEW;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const THEME_SLUG = THEME || "default";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const SWEEP_ONLY = !!process.env.DAINTREE_SHOT_SWEEP;
+const WITH_SESSIONS = process.env.DAINTREE_SHOT_SESSIONS !== "0";
+const OUTPUT_DIR = process.env.DAINTREE_SHOT_DIR
+  ? path.resolve(process.env.DAINTREE_SHOT_DIR)
+  : path.resolve(process.cwd(), "artifacts", "overview-shots");
+
+/** Wide enough that the header has room; the size a real fleet is driven at. */
+const WIDE = { width: 1680, height: 1050 };
+/** The width the issue is about — a normal laptop, where the header rows compete. */
+const NARROW = { width: 1180, height: 900 };
+/** Past the point where anything can be assumed to fit. */
+const TIGHT = { width: 980, height: 820 };
+/** A large external display: does the grid earn the extra 900px? */
+const XL = { width: 2560, height: 1440 };
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+const MODAL = SEL.worktree.overviewModal;
+const CELL = SEL.worktree.overviewCell;
+const GRID = `${MODAL} [role="grid"]`;
+/** Either confirmation this surface raises, whichever ARIA role it ends up with. */
+const CONFIRM_DIALOG =
+  ':is([role="dialog"],[role="alertdialog"]):has([data-confirm-role="confirm"])';
+
+/**
+ * Thirteen worktrees across seven branch prefixes. The count is the point: the
+ * header's crowding, the grid's column behaviour and the type grouping are all
+ * only visible at a density a real fleet reaches, and a three-card fixture shows
+ * none of them. The long branch is the truncation case; the mixed prefixes give
+ * `groupByType` seven real sections.
+ */
+const WORKTREES = [
+  {
+    branch: "feature/issue-4821-stream-upload-retry-with-backoff",
+    slug: "stream-upload-retry",
+    note: "Reworked the retry ladder so a 429 backs off on the server's Retry-After instead of the fixed 2s step. Still deciding whether the jitter is per-attempt or per-request.",
+    dirty: true,
+  },
+  {
+    branch:
+      "feature/issue-9310-collapse-the-inspector-panel-when-the-window-narrows-below-the-medium-breakpoint",
+    slug: "collapse-inspector",
+    dirty: true,
+  },
+  { branch: "feature/issue-7702-dark-mode-token-audit", slug: "dark-mode-tokens" },
+  {
+    branch: "feature/issue-11204-overview-header-hierarchy",
+    slug: "overview-header",
+    note: "Header is carrying title, count, three chips, the main toggle, clear and close on one row.",
+  },
+  { branch: "fix/retry-backoff-jitter", slug: "retry-jitter", dirty: true },
+  { branch: "fix/issue-5533-checksum-off-by-one", slug: "checksum-off-by-one", ahead: true },
+  { branch: "chore/bump-electron-42", slug: "bump-electron" },
+  { branch: "chore/issue-8801-drop-dead-tokens", slug: "drop-dead-tokens", ahead: true },
+  { branch: "hotfix/issue-9002-crash-on-empty-branch", slug: "crash-empty-branch", dirty: true },
+  { branch: "docs/architecture-refresh", slug: "architecture-refresh" },
+  { branch: "refactor/issue-6120-extract-panel-registry", slug: "extract-panel-registry" },
+  { branch: "perf/issue-7345-grid-virtualization", slug: "grid-virtualization", ahead: true },
+] as const;
+
+/** The worktree an agent is launched into for the `working` summary chip. */
+const WORKING_WT = WORKTREES[0];
+/** The worktree driven past the heartbeat stop, for the `waiting` chip. */
+const WAITING_WT = WORKTREES[4];
+
+const SEED_FILES: Record<string, string> = {
+  "README.md": "# Helios Dashboard\n\nOperator console for the ingest fleet.\n",
+  "src/index.ts": "export { startCheckout } from './checkout';\nexport { retry } from './retry';\n",
+  "src/checkout.ts":
+    "export async function startCheckout(cartId: string): Promise<string> {\n  return `charge_${cartId}`;\n}\n",
+  "src/retry.ts":
+    "export interface RetryOptions {\n  attempts: number;\n  baseDelayMs: number;\n}\n\nexport async function retry<T>(fn: () => Promise<T>, opts: RetryOptions): Promise<T> {\n  let lastError: unknown;\n  for (let i = 0; i < opts.attempts; i++) {\n    try {\n      return await fn();\n    } catch (error) {\n      lastError = error;\n    }\n  }\n  throw lastError;\n}\n",
+  "src/upload/stream.ts":
+    "export async function streamUpload(body: ReadableStream): Promise<void> {\n  void body;\n}\n",
+  "src/upload/parts.ts": "export const PART_SIZE = 8 * 1024 * 1024;\n",
+  "src/api/client.ts": "export const BASE_URL = 'https://api.helios.dev';\n",
+  "docs/architecture.md": "# Architecture\n\nIngest -> queue -> worker -> store.\n",
+};
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+function writeFiles(root: string, files: Record<string, string>): void {
+  for (const [rel, body] of Object.entries(files)) {
+    const target = path.join(root, rel);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, body);
+  }
+}
+
+interface FixtureRepo {
+  dir: string;
+  cleanup: () => void;
+}
+
+function createFixtureRepo(): FixtureRepo {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-overviewshots-"));
+  const worktreeRoot = path.join(path.dirname(dir), `${path.basename(dir)}-worktrees`);
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  git("init -b main", dir);
+  git('config user.email "avery@helios.dev"', dir);
+  git('config user.name "Avery Lindqvist"', dir);
+  writeFiles(dir, SEED_FILES);
+  git("add -A", dir);
+  git('commit -m "Set up the ingest console skeleton"', dir);
+
+  for (const wt of WORKTREES) {
+    const wtDir = path.join(worktreeRoot, wt.slug);
+    git(`worktree add -b ${wt.branch} "${wtDir}" main`, dir);
+    git('config user.email "avery@helios.dev"', wtDir);
+    git('config user.name "Avery Lindqvist"', wtDir);
+
+    if ("note" in wt && wt.note) {
+      const noteDir = path.join(dir, ".git", "worktrees", wt.slug, "daintree");
+      mkdirSync(noteDir, { recursive: true });
+      writeFileSync(path.join(noteDir, "note"), wt.note);
+    }
+
+    if ("ahead" in wt && wt.ahead) {
+      writeFiles(wtDir, {
+        "src/retry.ts": SEED_FILES["src/retry.ts"] + "\nexport const J = 0.2;\n",
+      });
+      git("add -A", wtDir);
+      git(`commit -m "Tune the retry ladder for ${wt.slug}"`, wtDir);
+    }
+
+    if ("dirty" in wt && wt.dirty) {
+      writeFiles(wtDir, {
+        "src/upload/stream.ts":
+          "import { retry } from '../retry';\n\nexport async function streamUpload(body: ReadableStream): Promise<void> {\n  await retry(async () => {\n    void body;\n  }, { attempts: 5, baseDelayMs: 250 });\n}\n",
+        "src/upload/checksum.ts":
+          "export function checksum(chunk: Uint8Array): string {\n  return String(chunk.byteLength);\n}\n",
+        "docs/retry-policy.md": "# Retry policy\n\nRespect Retry-After. Cap at 30s.\n",
+      });
+    }
+  }
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(worktreeRoot)) rmSync(worktreeRoot, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 350): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+async function setWindowSize(
+  app: ElectronApplication,
+  size: { width: number; height: number }
+): Promise<void> {
+  await app.evaluate(({ BrowserWindow }, s) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    win?.setSize(s.width, s.height);
+  }, size);
+}
+
+async function dispatch(page: Page, actionId: string): Promise<void> {
+  await page.evaluate(async (id) => {
+    const fn = window.__daintreeDispatchAction;
+    if (typeof fn !== "function") throw new Error("Action dispatch hook not available");
+    await fn(id, undefined, { source: "test" });
+  }, actionId);
+}
+
+async function openOverview(page: Page): Promise<void> {
+  if (
+    await page
+      .locator(MODAL)
+      .isVisible()
+      .catch(() => false)
+  )
+    return;
+  await dismissBlockingPalette(page);
+  await dispatch(page, "worktree.overview.open");
+  await page.locator(MODAL).waitFor({ state: "visible", timeout: T_LONG });
+  await page.locator(CELL).first().waitFor({ state: "visible", timeout: T_LONG });
+}
+
+async function closeOverview(page: Page): Promise<void> {
+  if (
+    !(await page
+      .locator(MODAL)
+      .isVisible()
+      .catch(() => false))
+  )
+    return;
+  // Escape clears selection first, so press it until the modal is actually gone.
+  for (let i = 0; i < 3; i++) {
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+    if (
+      !(await page
+        .locator(MODAL)
+        .isVisible()
+        .catch(() => false))
+    )
+      return;
+  }
+  await page
+    .locator(SEL.worktree.overviewClose)
+    .first()
+    .click()
+    .catch(() => {});
+  await page
+    .locator(MODAL)
+    .waitFor({ state: "hidden", timeout: T_LONG })
+    .catch(() => {});
+}
+
+/** The search field the modal mounts below its header (`variant="modal"`). */
+const searchInput = (page: Page) => page.locator(`${MODAL} ${SEL.worktree.searchInput}`).first();
+
+async function typeQuery(page: Page, query: string): Promise<void> {
+  const input = searchInput(page);
+  await input.waitFor({ state: "visible", timeout: T_LONG });
+  await input.fill(query);
+  await settle(page, 400);
+}
+
+/**
+ * Put the surface back to a known resting state: no query, no facet filters, no
+ * selection, main visible, ungrouped. Filter state is persisted per project, so
+ * a state that leaves a filter on silently poisons every state after it.
+ */
+async function resetSurface(page: Page): Promise<void> {
+  // Sweep first. A state that left a confirmation up leaves its scrim swallowing
+  // every click, and without this one bad state takes the whole rest of the run
+  // down with it — which is exactly what a 22-state harness must not do.
+  await cancelConfirm(page);
+  await openOverview(page);
+
+  // Deliberately NOT Escape. The modal listens for Escape on `document` in the
+  // capture phase (`WorktreeOverviewModal.tsx:727`), so the key never reaches
+  // whatever is actually on top — pressing it to clear a selection closes the
+  // whole surface. The visible Clear control is the honest route.
+  const clearSelection = page.locator(`${MODAL} [aria-label="Clear selection"]`).first();
+  if (await clearSelection.isVisible().catch(() => false)) await clearSelection.click();
+
+  const input = searchInput(page);
+  if (await input.isVisible().catch(() => false)) {
+    const value = await input.inputValue().catch(() => "");
+    if (value) await input.fill("");
+  }
+
+  const clear = page.locator(`${MODAL} [aria-label="Clear all filters"]`).first();
+  if (await clear.isVisible().catch(() => false)) await clear.click();
+
+  await ensureMainVisible(page);
+  // Grouping is not reset here: only `09-grouped` changes it and it restores
+  // itself, and driving the facet popover open and shut on all 22 states costs
+  // minutes and adds a failure mode for nothing.
+  await settle(page, 350);
+}
+
+/** The `main` visibility switch lives in the default header. */
+async function ensureMainVisible(page: Page): Promise<void> {
+  const show = page.locator(`${MODAL} [aria-label="Show main worktree"]`).first();
+  if (await show.isVisible().catch(() => false)) await show.click();
+}
+
+async function openFilterPopover(page: Page): Promise<void> {
+  const trigger = page.locator(`${MODAL} ${SEL.worktree.filterButton}`).first();
+  await trigger.waitFor({ state: "visible", timeout: T_LONG });
+  if ((await trigger.getAttribute("aria-expanded")) !== "true") await trigger.click();
+  await page.locator(SEL.worktree.filterPopover).waitFor({ state: "visible", timeout: T_LONG });
+  await settle(page, 250);
+}
+
+/**
+ * Close the facet popover by toggling its trigger, never with Escape.
+ *
+ * Escape here closes the entire overview: the modal's document-level capture
+ * handler (`WorktreeOverviewModal.tsx:727`) sees the key first, calls
+ * `stopPropagation()` and dismisses the dialog, so the popover the user was
+ * actually looking at is never given the chance to consume it. That is a real
+ * defect in the surface, recorded as a finding — the harness only has to avoid
+ * tripping over it.
+ */
+async function closeFilterPopover(page: Page): Promise<void> {
+  const popover = page.locator(SEL.worktree.filterPopover);
+  if (!(await popover.isVisible().catch(() => false))) return;
+  await page
+    .locator(`${MODAL} ${SEL.worktree.filterButton}`)
+    .first()
+    .click()
+    .catch(() => {});
+  await popover.waitFor({ state: "hidden", timeout: T_LONG }).catch(() => {});
+  await settle(page, 200);
+}
+
+async function ensureGrouped(page: Page, grouped: boolean): Promise<void> {
+  await openFilterPopover(page);
+  const box = page.locator(`${SEL.worktree.filterPopover} input[type="checkbox"]`).first();
+  const checked = await box.isChecked().catch(() => false);
+  if (checked !== grouped) await box.setChecked(grouped);
+  await closeFilterPopover(page);
+  await settle(page, 300);
+}
+
+/**
+ * Clear a selection through the visible Clear control. Escape would do it too,
+ * but only by way of the modal's capture-phase document handler, which on this
+ * surface also closes the dialog outright — see {@link closeFilterPopover}.
+ */
+async function clearSelection(page: Page): Promise<void> {
+  const clear = page.locator(`${MODAL} [aria-label="Clear selection"]`).first();
+  if (await clear.isVisible().catch(() => false)) {
+    await clear.click();
+    await settle(page, 250);
+  }
+}
+
+/**
+ * Dismiss any confirmation that is up, by its own Cancel button.
+ *
+ * Page-scoped, not scoped under a dialog: `[role="dialog"]` also matches the
+ * overview's own scrim, so `.first()` resolves to the overview and finds no
+ * cancel — leaving the real confirmation open and its scrim swallowing every
+ * click for the rest of the run. Loops, because a state can raise two.
+ */
+async function cancelConfirm(page: Page): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    const cancel = page.locator('[data-confirm-role="cancel"]').first();
+    if (!(await cancel.isVisible().catch(() => false))) return;
+    await cancel.click({ timeout: 5000 }).catch(() => {});
+    await settle(page, 350);
+  }
+}
+
+/**
+ * Select N contiguous cells through the grid's own keyboard contract — Space to
+ * anchor, Shift+ArrowRight to extend. Clicking would be the other route, but a
+ * card is full of its own buttons and a modifier-click that lands on one selects
+ * nothing; the keyboard path is both robust and the contract the surface
+ * documents in its own footer.
+ */
+async function selectCells(page: Page, count: number): Promise<void> {
+  const grid = page.locator(GRID).first();
+  await grid.waitFor({ state: "visible", timeout: T_LONG });
+  await grid.focus();
+  await settle(page, 200);
+  await page.keyboard.press("Space");
+  for (let i = 1; i < count; i++) {
+    await page.keyboard.press("Shift+ArrowRight");
+    await settle(page, 80);
+  }
+  await settle(page, 250);
+}
+
+/**
+ * Launch one fake-claude session in the currently active worktree and drive it
+ * past the trust prompt, so the agent-state FSM reaches `working` for real.
+ */
+async function launchAgentSession(page: Page): Promise<string | null> {
+  const before = new Set(await getGridPanelIds(page));
+  await dismissBlockingPalette(page).catch(() => {});
+  await page
+    .locator(SEL.agent.trayButton)
+    .first()
+    .click()
+    .catch(() => {});
+  await page
+    .locator(SEL.agent.launcherRow("Claude"))
+    .first()
+    .click()
+    .catch(() => {});
+
+  let panelId: string | null = null;
+  for (let i = 0; i < 60 && !panelId; i++) {
+    const ids = await getGridPanelIds(page).catch(() => [] as string[]);
+    panelId = ids.find((id) => !before.has(id)) ?? null;
+    if (!panelId) await page.waitForTimeout(250);
+  }
+  if (!panelId) return null;
+
+  const panel = page.locator(`[data-panel-id="${panelId}"]`);
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const text = (await getTerminalText(panel).catch(() => "")).toLowerCase();
+    if (text.includes(FAKE_AGENT_READY.toLowerCase())) break;
+    if (text.includes("enter to confirm") || text.includes("trust this folder")) {
+      await writeTerminalInput(page, panel, "\r").catch(() => {});
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  await waitForTerminalText(panel, FAKE_AGENT_READY, T_LONG).catch(() => {});
+  return panelId;
+}
+
+/**
+ * Switch the active worktree through the overview itself. Going via the sidebar
+ * looks simpler but is wrong: that list is virtualized, so a card below the fold
+ * is not in the DOM at all and the click silently waits forever. The overview
+ * renders every cell, and activating one there is a real user path — clicking a
+ * card switches the worktree and closes the modal.
+ */
+async function activateWorktree(page: Page, branch: string): Promise<void> {
+  await openOverview(page);
+  // `data-worktree-branch` carries the DERIVED label, which drops the type
+  // prefix — `perf/issue-7345-x` renders as `issue-7345-x`. Match the suffix, or
+  // the locator can never resolve and the wait looks like a load failure.
+  const leaf = branch.split("/").pop() ?? branch;
+  const cell = page.locator(`${CELL}:has([data-worktree-branch$="${leaf}"])`).first();
+  await cell.waitFor({ state: "visible", timeout: T_LONG });
+  await cell.locator(`[aria-label^="Select worktree:"]`).first().click();
+  await page
+    .locator(MODAL)
+    .waitFor({ state: "hidden", timeout: T_LONG })
+    .catch(() => {});
+  await settle(page, 700);
+}
+
+/**
+ * Two real agent sessions: one left on its heartbeat (`working`), one stopped so
+ * the idle debounce lands it on `waiting`. That is the only honest way to get the
+ * header's activity summary chips on screen — the counts read the same FSM the
+ * terminal chips do.
+ */
+async function seedAgentActivity(page: Page): Promise<void> {
+  await activateWorktree(page, WORKING_WT.branch);
+  await launchAgentSession(page);
+
+  await activateWorktree(page, WAITING_WT.branch);
+  const waitingPanelId = await launchAgentSession(page);
+  if (waitingPanelId) {
+    const panel = page.locator(`[data-panel-id="${waitingPanelId}"]`);
+    await writeTerminalInput(page, panel, `${FAKE_AGENT_STOP}\r`).catch(() => {});
+    await expect
+      .poll(() => panel.getAttribute("data-agent-state"), {
+        timeout: T_LONG,
+        intervals: [400, 800],
+      })
+      .toBe("waiting");
+  }
+  await settle(page, 800);
+}
+
+interface OverviewState {
+  slug: string;
+  /** Included in the per-theme sweep. */
+  sweep?: boolean;
+  /** Also write a tight crop of the modal's top strip — the header question. */
+  header?: boolean;
+  /** `"page"` shoots the whole window: for portalled popovers and confirmations. */
+  capture?: "modal" | "page";
+  /** Requires the agent sessions; skipped under DAINTREE_SHOT_SESSIONS=0. */
+  needsSessions?: boolean;
+  /**
+   * Window size for this state. Set explicitly for EVERY state rather than left
+   * to a previous state's restore: `launchApp`'s initial size does not reliably
+   * apply, and a missed restore silently relabels a capture — a shot filed as
+   * "1680px" that actually rendered at 1200px sends the whole review reasoning
+   * about a width that was never on screen.
+   */
+  size?: { width: number; height: number };
+  arrange?: (page: Page, app: ElectronApplication) => Promise<void>;
+  /** Asserted after the settle, before the shot. Throwing beats a wrong PNG. */
+  verify: (page: Page) => Promise<void>;
+  restore?: (page: Page, app: ElectronApplication) => Promise<void>;
+}
+
+const modalVisible = async (page: Page): Promise<void> => {
+  await expect(page.locator(MODAL), "the overview modal is not on screen").toBeVisible({
+    timeout: T_LONG,
+  });
+};
+
+const cellsAtLeast = async (page: Page, n: number): Promise<void> => {
+  await modalVisible(page);
+  const count = await page.locator(CELL).count();
+  if (count < n) throw new Error(`expected at least ${n} worktree cells, found ${count}`);
+};
+
+const STATES: OverviewState[] = [
+  {
+    // The resting surface at a comfortable width. Every header finding starts here.
+    slug: "01-populated",
+    sweep: true,
+    header: true,
+    verify: async (page) => {
+      await cellsAtLeast(page, 8);
+      await expect(page.locator(`${MODAL} #worktree-overview-title`)).toBeVisible();
+    },
+  },
+  {
+    // A large external display: the grid caps at 480px columns and centres, so the
+    // question is whether 900 extra pixels buy anything.
+    slug: "02-xl",
+    size: XL,
+    verify: async (page) => cellsAtLeast(page, 8),
+  },
+  {
+    // The width the issue is actually about.
+    slug: "03-narrow",
+    sweep: true,
+    header: true,
+    size: NARROW,
+    verify: async (page) => cellsAtLeast(page, 4),
+  },
+  {
+    // Past the point where anything can be assumed to fit.
+    slug: "04-tight",
+    header: true,
+    size: TIGHT,
+    verify: async (page) => cellsAtLeast(page, 2),
+  },
+  {
+    // A query narrows the set: the header's count must switch to "N of M".
+    slug: "05-search",
+    header: true,
+    arrange: async (page) => typeQuery(page, "retry"),
+    verify: async (page) => {
+      await cellsAtLeast(page, 1);
+      await expect(
+        page.locator(`${MODAL} #worktree-overview-title`).locator("xpath=..")
+      ).toContainText(/of \d+/);
+    },
+  },
+  {
+    // Nothing matches: the filtered-empty state, and what it offers instead.
+    slug: "06-no-results",
+    sweep: true,
+    arrange: async (page) => typeQuery(page, "zzzznotathing"),
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(page.locator(MODAL)).toContainText("No matches for");
+      await expect(page.locator(CELL)).toHaveCount(0);
+    },
+  },
+  {
+    // A facet filter is on: the header grows a "Clear" control.
+    slug: "07-filters-active",
+    header: true,
+    arrange: async (page) => {
+      await openFilterPopover(page);
+      // The Status section starts collapsed (`defaultOpen` keys off the active
+      // count), and a collapsed section is `inert` — its chips are unclickable.
+      const section = page
+        .locator(`${SEL.worktree.filterPopover} button[aria-expanded]`)
+        .filter({ hasText: "Status" })
+        .first();
+      if ((await section.getAttribute("aria-expanded")) !== "true") await section.click();
+      await settle(page, 250);
+      await page
+        .locator(`${SEL.worktree.filterPopover} button`)
+        .filter({ hasText: /^Dirty/ })
+        .first()
+        .click();
+      await closeFilterPopover(page);
+      await settle(page, 400);
+    },
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(page.locator(`${MODAL} [aria-label="Clear all filters"]`)).toBeVisible({
+        timeout: T_LONG,
+      });
+    },
+  },
+  {
+    // The facet popover open over the grid — the tallest thing the surface shows.
+    slug: "08-filter-popover",
+    capture: "page",
+    arrange: async (page) => openFilterPopover(page),
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(page.locator(SEL.worktree.filterPopover)).toBeVisible({ timeout: T_LONG });
+    },
+    restore: async (page) => closeFilterPopover(page),
+  },
+  {
+    // Grouped by type: seven section headers break the grid at `col-[1/-1]`.
+    slug: "09-grouped",
+    arrange: async (page) => ensureGrouped(page, true),
+    verify: async (page) => {
+      await cellsAtLeast(page, 8);
+      const headings = await page.locator(`${GRID} h3`).count();
+      if (headings < 3) throw new Error(`expected grouped section headings, found ${headings}`);
+    },
+    restore: async (page) => ensureGrouped(page, false),
+  },
+  {
+    // Main hidden: the toggle's own struck-through state, and one fewer card.
+    slug: "10-main-hidden",
+    header: true,
+    arrange: async (page) => {
+      const hide = page.locator(`${MODAL} [aria-label="Hide main worktree"]`).first();
+      await hide.waitFor({ state: "visible", timeout: T_LONG });
+      await hide.click();
+      await settle(page, 400);
+    },
+    verify: async (page) => {
+      await cellsAtLeast(page, 8);
+      await expect(page.locator(`${MODAL} [aria-label="Show main worktree"]`)).toBeVisible();
+    },
+    restore: async (page) => ensureMainVisible(page),
+  },
+  {
+    // One card selected — the moment the header swaps.
+    slug: "11-select-one",
+    header: true,
+    arrange: async (page) => selectCells(page, 1),
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(page.locator(MODAL)).toContainText("1 selected");
+    },
+    restore: async (page) => clearSelection(page),
+  },
+  {
+    // Five selected: the bulk bar at the density where it matters.
+    slug: "12-select-many",
+    sweep: true,
+    header: true,
+    arrange: async (page) => selectCells(page, 5),
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(page.locator(MODAL)).toContainText("5 selected");
+      await expect(page.locator(SEL.worktree.bulkRemove)).toBeVisible();
+    },
+    restore: async (page) => clearSelection(page),
+  },
+  {
+    // The selection bar at the narrow width: does it fit?
+    slug: "13-select-narrow",
+    header: true,
+    size: NARROW,
+    arrange: async (page) => selectCells(page, 5),
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(page.locator(MODAL)).toContainText("5 selected");
+    },
+    restore: async (page) => clearSelection(page),
+  },
+  {
+    // D3 bulk remove: typed-name gate over the real target list.
+    slug: "14-bulk-remove-confirm",
+    capture: "page",
+    arrange: async (page) => {
+      await selectCells(page, 3);
+      await page.locator(SEL.worktree.bulkRemove).click();
+      await settle(page, 500);
+    },
+    verify: async (page) => {
+      // Not the count: main worktrees are filtered out at confirm-derive time, so
+      // selecting three cells can legitimately yield a two-target confirmation
+      // plus an "excluded" line. What must be true is that this is the D3 gate —
+      // the typed-count sentence and the per-target blast-radius list.
+      // `:is(dialog, alertdialog)` on purpose: this confirmation is destructive
+      // and is NOT passed `hasPreview`, so AppDialog gives it `role="alertdialog"`
+      // despite the scrollable target list inside it. Recorded as a finding; the
+      // harness just has to match what actually renders.
+      const confirm = page.locator(CONFIRM_DIALOG).first();
+      await expect(confirm, "the bulk-remove confirmation never opened").toBeVisible({
+        timeout: T_LONG,
+      });
+      await expect(
+        confirm,
+        "the confirmation is missing its typed-count gate — D3 safeguard"
+      ).toContainText("Type the count to confirm");
+    },
+    restore: async (page) => {
+      await cancelConfirm(page);
+      await clearSelection(page);
+    },
+  },
+  {
+    // D1 close sessions.
+    slug: "15-close-sessions-confirm",
+    capture: "page",
+    arrange: async (page) => {
+      await selectCells(page, 2);
+      await page.locator(SEL.worktree.bulkCloseSessions).click();
+      await settle(page, 500);
+    },
+    verify: async (page) => {
+      const confirm = page.locator(CONFIRM_DIALOG).first();
+      await expect(confirm, "the close-sessions confirmation never opened").toBeVisible({
+        timeout: T_LONG,
+      });
+      await expect(confirm).toContainText("Scrollback is lost");
+    },
+    restore: async (page) => {
+      await cancelConfirm(page);
+      await clearSelection(page);
+    },
+  },
+  {
+    // Where initial focus lands on open. The header crop is the evidence: a
+    // keyboard user's first ring should be somewhere useful.
+    slug: "16-focus-initial",
+    header: true,
+    arrange: async (page) => {
+      await closeOverview(page);
+      await settle(page, 400);
+      await openOverview(page);
+      // A real key event is required for :focus-visible to match at all.
+      await page.keyboard.press("Shift+Tab");
+      await page.keyboard.press("Tab");
+      await settle(page, 300);
+    },
+    verify: async (page) => {
+      await cellsAtLeast(page, 8);
+      const focused = await page.evaluate(() => {
+        const el = document.activeElement as HTMLElement | null;
+        return {
+          label: el?.getAttribute("aria-label") ?? el?.tagName ?? "none",
+          visible: !!el?.matches(":focus-visible"),
+        };
+      });
+      // Not an assertion about WHERE — that is the finding. Only that something
+      // inside the modal owns a visible ring, so the crop shows a real state.
+      if (!focused.visible) throw new Error(`no :focus-visible element (${focused.label})`);
+    },
+  },
+  {
+    // The grid focused, with its active descendant ring — the primary keyboard
+    // affordance, and the only one arrow-key navigation depends on.
+    slug: "17-focus-grid",
+    header: true,
+    arrange: async (page) => {
+      await page.locator(GRID).focus();
+      await page.keyboard.press("ArrowRight");
+      await page.keyboard.press("ArrowDown");
+      await settle(page, 300);
+    },
+    verify: async (page) => {
+      await cellsAtLeast(page, 8);
+      await expect(page.locator(GRID)).toHaveAttribute("aria-activedescendant", /.+/, {
+        timeout: T_LONG,
+      });
+    },
+  },
+  {
+    // Windows High Contrast. Selection is indicated by a tint plus a neutral
+    // inset ring; forced-colors drops backgrounds and box-shadows entirely.
+    slug: "18-forced-colors",
+    header: true,
+    arrange: async (page) => {
+      await selectCells(page, 3);
+      await page.emulateMedia({ forcedColors: "active" });
+      await settle(page, 400);
+    },
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(page.locator(MODAL)).toContainText("3 selected");
+    },
+    restore: async (page) => {
+      await page.emulateMedia({ forcedColors: "none" });
+      await clearSelection(page);
+    },
+  },
+  {
+    // macOS "Increase contrast".
+    slug: "19-contrast-more",
+    header: true,
+    arrange: async (page) => {
+      await selectCells(page, 3);
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 400);
+    },
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(page.locator(MODAL)).toContainText("3 selected");
+    },
+    restore: async (page) => {
+      await page.emulateMedia({ contrast: "no-preference" });
+      await clearSelection(page);
+    },
+  },
+  {
+    // Reduced motion: the working chip's pulsing dot is `motion-safe:` gated, so
+    // this is the shot that shows what a reduced-motion user actually sees.
+    slug: "20-reduced-motion",
+    header: true,
+    needsSessions: true,
+    arrange: async (page) => {
+      await page.emulateMedia({ reducedMotion: "reduce" });
+      await settle(page, 400);
+    },
+    verify: async (page) => cellsAtLeast(page, 8),
+    restore: async (page) => page.emulateMedia({ reducedMotion: "no-preference" }),
+  },
+  {
+    // The activity summary chips, produced by two real agent FSMs.
+    slug: "21-activity-chips",
+    sweep: true,
+    header: true,
+    needsSessions: true,
+    verify: async (page) => {
+      await cellsAtLeast(page, 8);
+      await expect(
+        page.locator(`${MODAL} [aria-label="Filter by agent state"]`),
+        "no activity summary chips — the agent sessions did not reach a reportable state"
+      ).toBeVisible({ timeout: T_LONG });
+    },
+  },
+  {
+    // A quick-state chip engaged: the header's own filter, active.
+    slug: "22-quickstate-active",
+    header: true,
+    needsSessions: true,
+    arrange: async (page) => {
+      await page.locator(`${MODAL} [aria-label="Filter by agent state"] button`).first().click();
+      await settle(page, 400);
+    },
+    verify: async (page) => {
+      await modalVisible(page);
+      await expect(
+        page.locator(`${MODAL} [aria-label="Filter by agent state"] button[aria-pressed="true"]`)
+      ).toBeVisible({ timeout: T_LONG });
+    },
+    restore: async (page) => {
+      await page
+        .locator(`${MODAL} [aria-label="Filter by agent state"] button[aria-pressed="true"]`)
+        .first()
+        .click()
+        .catch(() => {});
+    },
+  },
+];
+
+async function snap(page: Page, slug: string, target: string | null): Promise<void> {
+  const locator = target === null ? page : page.locator(target).first();
+  await locator.screenshot({
+    path: path.join(OUTPUT_DIR, `${slug}--${THEME_SLUG}${TAG}.png`),
+    type: "png",
+    animations: "disabled",
+    caret: "hide",
+  });
+}
+
+/**
+ * The header crop. Clipped from the window rather than shot from a container so
+ * the baseline needs no test id on product markup, and so the crop keeps the
+ * scrim on either side — which is itself part of the frame question.
+ */
+async function snapHeader(page: Page, slug: string): Promise<void> {
+  const box = await page.locator(MODAL).first().boundingBox();
+  if (!box) throw new Error(`${slug}: modal has no box — refusing to write a header crop`);
+  const height = Math.min(200, Math.round(box.height));
+  await page.screenshot({
+    path: path.join(OUTPUT_DIR, `${slug}-header--${THEME_SLUG}${TAG}.png`),
+    type: "png",
+    animations: "disabled",
+    caret: "hide",
+    clip: {
+      x: Math.max(0, box.x - 24),
+      y: Math.max(0, box.y - 24),
+      width: Math.round(box.width) + 48,
+      height: height + 24,
+    },
+  });
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+const failures: string[] = [];
+let captured = 0;
+
+test("worktree overview review — frame, header hierarchy and selection mode", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_OVERVIEW is required for the worktree-overview capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_OVERVIEW to run the worktree-overview capture");
+
+  failures.length = 0;
+  captured = 0;
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const fakeBinDir = installFakeAgent(repo.dir);
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-overviewshot-"));
+  let ctx: AppContext | undefined;
+
+  const planned = STATES.filter(
+    (s) =>
+      (ONLY.length === 0 || ONLY.includes(s.slug)) &&
+      (!SWEEP_ONLY || s.sweep) &&
+      (WITH_SESSIONS || !s.needsSessions)
+  );
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: WIDE,
+      env: fakeAgentEnv(fakeBinDir),
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Helios Dashboard");
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+
+    // Every worktree must be present before anything is judged, or the review is
+    // looking at a project that had not finished loading. The check runs against
+    // the overview's own grid rather than the sidebar: the sidebar list is
+    // virtualized, so a card below the fold is simply not in the DOM and waiting
+    // on one reports a load failure that never happened.
+    await expect(
+      page.locator(SEL.worktree.mainCard).first(),
+      "the project never finished loading its worktrees"
+    ).toBeVisible({ timeout: 60_000 });
+    await settle(page, 1500);
+    await openOverview(page);
+    await expect
+      .poll(() => page.locator(CELL).count(), { timeout: 60_000, intervals: [500, 1000] })
+      .toBeGreaterThanOrEqual(WORKTREES.length);
+    await closeOverview(page);
+    await settle(page, 500);
+
+    if (WITH_SESSIONS && planned.some((s) => s.needsSessions)) {
+      await seedAgentActivity(page).catch((error) => {
+        failures.push(`agent seeding: ${String(error).slice(0, 200)}`);
+      });
+    }
+
+    for (const state of planned) {
+      const app = ctx.app;
+      try {
+        await setWindowSize(app, state.size ?? WIDE);
+        await settle(page, 450);
+        await resetSurface(page);
+        if (state.arrange) await state.arrange(page, app);
+        await settle(page, 500);
+
+        await state.verify(page);
+
+        if (state.capture === "page") {
+          await snap(page, `${state.slug}--page`, null);
+        } else {
+          await snap(page, state.slug, MODAL);
+        }
+        captured++;
+
+        if (state.header) {
+          await snapHeader(page, state.slug);
+          captured++;
+        }
+      } catch (error) {
+        const detail = String(error).slice(0, 400);
+        console.warn(`[overview-shots] state "${state.slug}" failed:`, detail);
+        failures.push(`${state.slug}: ${detail}`);
+      } finally {
+        if (state.restore) {
+          await state.restore(page, app).catch((error) => {
+            failures.push(`${state.slug} (restore): ${String(error).slice(0, 200)}`);
+          });
+        }
+      }
+    }
+  } finally {
+    if (ctx) await closeApp(ctx.app).catch(() => {});
+    repo.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+
+  // The exit code only means something if it accounts for what landed on disk.
+  const expected = planned.reduce((n, s) => n + (s.header ? 2 : 1), 0);
+  console.log(`[overview-shots] ${captured}/${expected} PNGs → ${OUTPUT_DIR}`);
+  if (failures.length > 0) {
+    throw new Error(`worktree-overview capture failed:\n  ${failures.join("\n  ")}`);
+  }
+  expect(captured, `expected ${expected} PNGs, wrote ${captured}`).toBe(expected);
+});

--- a/e2e/screenshots/worktree-overview-review.spec.ts
+++ b/e2e/screenshots/worktree-overview-review.spec.ts
@@ -347,7 +347,11 @@ async function resetSurface(page: Page): Promise<void> {
   }
 
   const clear = page.locator(`${MODAL} [aria-label="Clear all filters"]`).first();
-  if (await clear.isVisible().catch(() => false)) await clear.click();
+  if (await clear.isVisible().catch(() => false)) {
+    // This control unmounts itself the instant the filters clear, so a strict
+    // click can resolve the element and then lose it mid-actionability check.
+    await clear.click({ timeout: 5000 }).catch(() => {});
+  }
 
   await ensureMainVisible(page);
   // Grouping is not reset here: only `09-grouped` changes it and it restores
@@ -358,8 +362,11 @@ async function resetSurface(page: Page): Promise<void> {
 
 /** The `main` visibility switch lives in the default header. */
 async function ensureMainVisible(page: Page): Promise<void> {
-  const show = page.locator(`${MODAL} [aria-label="Show main worktree"]`).first();
-  if (await show.isVisible().catch(() => false)) await show.click();
+  // The switch keeps one accessible name and carries its state on
+  // `aria-checked`, so the state — not the label — is what to read.
+  const sw = page.locator(`${MODAL} [role="switch"][aria-label="Show main worktree"]`).first();
+  if (!(await sw.isVisible().catch(() => false))) return;
+  if ((await sw.getAttribute("aria-checked")) === "false") await sw.click();
 }
 
 async function openFilterPopover(page: Page): Promise<void> {
@@ -584,7 +591,9 @@ const STATES: OverviewState[] = [
     header: true,
     verify: async (page) => {
       await cellsAtLeast(page, 8);
-      await expect(page.locator(`${MODAL} #worktree-overview-title`)).toBeVisible();
+      // Identity, asserted by what the user sees rather than by an id: the
+      // surface composes AppDialog now, which mints its own title id.
+      await expect(page.locator(MODAL)).toContainText("Worktrees overview");
     },
   },
   {
@@ -616,9 +625,7 @@ const STATES: OverviewState[] = [
     arrange: async (page) => typeQuery(page, "retry"),
     verify: async (page) => {
       await cellsAtLeast(page, 1);
-      await expect(
-        page.locator(`${MODAL} #worktree-overview-title`).locator("xpath=..")
-      ).toContainText(/of \d+/);
+      await expect(page.locator(MODAL)).toContainText(/\(\d+ of \d+\)/);
     },
   },
   {
@@ -688,14 +695,16 @@ const STATES: OverviewState[] = [
     slug: "10-main-hidden",
     header: true,
     arrange: async (page) => {
-      const hide = page.locator(`${MODAL} [aria-label="Hide main worktree"]`).first();
-      await hide.waitFor({ state: "visible", timeout: T_LONG });
-      await hide.click();
+      const sw = page.locator(`${MODAL} [role="switch"][aria-label="Show main worktree"]`).first();
+      await sw.waitFor({ state: "visible", timeout: T_LONG });
+      if ((await sw.getAttribute("aria-checked")) === "true") await sw.click();
       await settle(page, 400);
     },
     verify: async (page) => {
       await cellsAtLeast(page, 8);
-      await expect(page.locator(`${MODAL} [aria-label="Show main worktree"]`)).toBeVisible();
+      await expect(
+        page.locator(`${MODAL} [role="switch"][aria-label="Show main worktree"]`)
+      ).toHaveAttribute("aria-checked", "false", { timeout: T_LONG });
     },
     restore: async (page) => ensureMainVisible(page),
   },
@@ -706,7 +715,7 @@ const STATES: OverviewState[] = [
     arrange: async (page) => selectCells(page, 1),
     verify: async (page) => {
       await modalVisible(page);
-      await expect(page.locator(MODAL)).toContainText("1 selected");
+      await expect(page.locator(MODAL)).toContainText(/\b1 of \d+ selected/);
     },
     restore: async (page) => clearSelection(page),
   },
@@ -718,7 +727,7 @@ const STATES: OverviewState[] = [
     arrange: async (page) => selectCells(page, 5),
     verify: async (page) => {
       await modalVisible(page);
-      await expect(page.locator(MODAL)).toContainText("5 selected");
+      await expect(page.locator(MODAL)).toContainText(/\b5 of \d+ selected/);
       await expect(page.locator(SEL.worktree.bulkRemove)).toBeVisible();
     },
     restore: async (page) => clearSelection(page),
@@ -731,7 +740,7 @@ const STATES: OverviewState[] = [
     arrange: async (page) => selectCells(page, 5),
     verify: async (page) => {
       await modalVisible(page);
-      await expect(page.locator(MODAL)).toContainText("5 selected");
+      await expect(page.locator(MODAL)).toContainText(/\b5 of \d+ selected/);
     },
     restore: async (page) => clearSelection(page),
   },
@@ -846,7 +855,7 @@ const STATES: OverviewState[] = [
     },
     verify: async (page) => {
       await modalVisible(page);
-      await expect(page.locator(MODAL)).toContainText("3 selected");
+      await expect(page.locator(MODAL)).toContainText(/\b3 of \d+ selected/);
     },
     restore: async (page) => {
       await page.emulateMedia({ forcedColors: "none" });
@@ -864,7 +873,7 @@ const STATES: OverviewState[] = [
     },
     verify: async (page) => {
       await modalVisible(page);
-      await expect(page.locator(MODAL)).toContainText("3 selected");
+      await expect(page.locator(MODAL)).toContainText(/\b3 of \d+ selected/);
     },
     restore: async (page) => {
       await page.emulateMedia({ contrast: "no-preference" });

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useEffect, useEffectEvent, useRef, useMemo, useState } from "react";
-import { X, FilterX, AlertTriangle, Trash2, GitBranch } from "lucide-react";
+import { FilterX, AlertTriangle, Trash2, GitBranch } from "lucide-react";
 import { Layers, Plug } from "@/components/icons";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { KBD_CLASS } from "@/components/ui/Kbd";
 import { cn } from "@/lib/utils";
 import { useShallow } from "zustand/react/shallow";
 import { WorktreeCard } from "./WorktreeCard";
 import { WorktreeFilterPopover } from "./WorktreeFilterPopover";
 import { WorktreeSidebarSearchBar } from "./WorktreeSidebarSearchBar";
-import { useWorktreeBulkRemove } from "./useWorktreeBulkRemove";
+import { useWorktreeBulkRemove, describeBulkRemoveRisks } from "./useWorktreeBulkRemove";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
   useWorktreeOverviewKeyboard,
@@ -17,7 +19,6 @@ import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { useWorktreeDevServerStore } from "@/store/worktreeDevServerStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
-import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -40,6 +41,12 @@ import { isAgentTerminal } from "@/utils/terminalType";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
 import { useWorktreeIds } from "@/hooks/useTerminalSelectors";
 import { computeChipState } from "@/components/Worktree/utils/computeChipState";
+
+/**
+ * One frame past the dialog's mount so the search input exists and AppDialog's
+ * own focus pass (disabled here via `initialFocus="none"`) cannot race it.
+ */
+const SEARCH_FOCUS_DELAY_MS = 50;
 
 interface OverviewWorktreeCardProps {
   worktreeId: string;
@@ -145,16 +152,27 @@ function OverviewWorktreeCard({
  * styling uses `bg-overlay-subtle` + a neutral inset ring per CLAUDE.md's
  * accent-color restraint — accent is reserved for one load-bearing signal
  * per active focus region and is never used as a multi-select indicator.
+ *
+ * Two independent states live on this box and they are deliberately drawn with
+ * different marks, the same way `.palette-row` and `.forge-row` separate theirs
+ * in `index.css`: MEMBERSHIP is the neutral tint plus inset ring, and the
+ * KEYBOARD CURSOR is the accent outline. The grid is its own arrow-key domain,
+ * so the cursor is that region's single load-bearing accent — which is what the
+ * accent-restraint rule reserves it for. Drawing both as an outline would let
+ * the later one overwrite the earlier, and a selected cell under the cursor
+ * would lose the cursor.
  */
-function OverviewGridCell(props: OverviewWorktreeCardProps) {
+function OverviewGridCell(props: OverviewWorktreeCardProps & { isCursor?: boolean }) {
   const cellId = getWorktreeOverviewCellId(props.worktreeId);
   const isSelected = props.isSelected ?? false;
+  const isCursor = props.isCursor ?? false;
   return (
     <div
       id={cellId}
       role="gridcell"
       aria-selected={isSelected}
       data-worktree-overview-cell={props.worktreeId}
+      data-overview-cursor={isCursor ? "true" : undefined}
       style={{
         contentVisibility: "auto",
         containIntrinsicSize: "auto 240px",
@@ -163,9 +181,12 @@ function OverviewGridCell(props: OverviewWorktreeCardProps) {
         "rounded-lg overflow-hidden",
         "border border-divider",
         "bg-daintree-sidebar/50",
-        "transition duration-150",
+        // Narrowest property set the states here actually animate — a bare
+        // `transition` would also cover transform, filter and backdrop-filter.
+        "transition-[background-color,box-shadow,outline-color] duration-150 ease-out",
         "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]",
-        isSelected && "bg-overlay-subtle ring-1 ring-inset ring-border-default"
+        isSelected && "bg-overlay-subtle ring-1 ring-inset ring-border-default",
+        isCursor && "outline outline-2 -outline-offset-2 outline-daintree-accent"
       )}
     >
       <OverviewWorktreeCard {...props} variant="grid" />
@@ -204,8 +225,7 @@ export function WorktreeOverviewModal({
   agentSettings,
   homeDir,
 }: WorktreeOverviewModalProps) {
-  const modalRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Filter store state
   const {
@@ -645,6 +665,13 @@ export function WorktreeOverviewModal({
   const gridRef = useRef<HTMLDivElement | null>(null);
   const closeModal = useCallback(() => onClose(), [onClose]);
 
+  const hasActivitySummary =
+    aggregateStats.waitingCount > 0 ||
+    aggregateStats.workingCount > 0 ||
+    aggregateStats.finishedCount > 0;
+  const showMainToggle = (hasNonMainWorktrees || hideMainWorktree) && !hasOnlyMainWorktree;
+  const selectAllChord = navigator.platform.toLowerCase().includes("mac") ? "⌘A" : "Ctrl+A";
+
   // Section sizes drive section-aware Arrow navigation across the col-[1/-1]
   // header breaks. Undefined when ungrouped — the hook degrades to flat-list
   // stride math.
@@ -670,6 +697,18 @@ export function WorktreeOverviewModal({
     hasSelection,
   });
 
+  // Keep the keyboard cursor on screen. `aria-activedescendant` moves a cursor
+  // that is not DOM focus, so the browser does no scrolling of its own — without
+  // this, arrowing past the visible rows walked the cursor off the bottom of the
+  // scroll box and the user was selecting cards they could not see.
+  useEffect(() => {
+    if (!isOpen || !activeDescendantId) return;
+    const cell = gridRef.current?.querySelector<HTMLElement>(
+      `[id="${CSS.escape(activeDescendantId)}"]`
+    );
+    cell?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [isOpen, activeDescendantId]);
+
   // Reset modifier-driven anchor state when the window loses focus (lesson
   // #4591) — prevents a stuck Shift after Cmd+Tab from producing phantom
   // range selections on the next click.
@@ -685,22 +724,10 @@ export function WorktreeOverviewModal({
     return () => window.removeEventListener("blur", handleWindowBlur);
   }, [isOpen]);
 
-  // Document-level keydown — fallback for keys fired outside the grid (e.g.
-  // when focus is on the close button or filter popover trigger). The grid
-  // hook handles Escape / Cmd+A when the grid is focused.
+  // Document-level keydown — fallback for Cmd/Ctrl+A fired outside the grid
+  // (e.g. when focus is on the search field or the filter popover trigger).
+  // The grid hook handles Cmd+A when the grid itself is focused.
   const handleKeyDown = useEffectEvent((e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      if (hasSelection) {
-        e.preventDefault();
-        e.stopPropagation();
-        clearSelection();
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-      onClose();
-      return;
-    }
     if ((e.metaKey || e.ctrlKey) && (e.key === "a" || e.key === "A")) {
       // Only intercept when focus is inside the modal but not in a text
       // input — otherwise Cmd+A in a filter input must select the text.
@@ -716,65 +743,109 @@ export function WorktreeOverviewModal({
     }
   });
 
+  // Initial focus goes to search, not to Close. This is a browse-and-search
+  // surface, so the APG dialog guidance puts first focus on the primary input;
+  // landing on the dismiss control spent the one accent focus ring in the
+  // region on "leave". AppDialog is told `initialFocus="none"` so it does not
+  // race this.
   useEffect(() => {
     if (!isOpen) return;
-    const timeoutId = setTimeout(() => closeButtonRef.current?.focus(), 50);
+    const timeoutId = setTimeout(() => searchInputRef.current?.focus(), SEARCH_FOCUS_DELAY_MS);
     return () => clearTimeout(timeoutId);
   }, [isOpen]);
 
+  // Cmd/Ctrl+A only. Escape is deliberately NOT handled here any more: this
+  // listener used to run on `document` in the CAPTURE phase and swallow the key
+  // before the facet popover or a confirmation could act on it, so dismissing a
+  // nested layer tore down the whole overview. AppDialog's layer-aware escape
+  // stack owns dismissal now, and `onBeforeClose` keeps the two-stage
+  // clear-selection-then-close behaviour.
   useEffect(() => {
     if (!isOpen) return;
-    document.addEventListener("keydown", handleKeyDown, { capture: true });
-    return () => document.removeEventListener("keydown", handleKeyDown, { capture: true });
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen]);
 
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose]
-  );
-
-  if (!isOpen) return null;
+  /**
+   * Escape's first press clears a selection; the second closes. Returning
+   * `false` cancels AppDialog's close, which is the same two-stage contract the
+   * grid hook implements for when focus is inside the grid.
+   */
+  const handleBeforeClose = useCallback(() => {
+    if (hasSelection) {
+      clearSelection();
+      return false;
+    }
+    return true;
+  }, [hasSelection, clearSelection]);
 
   return (
-    <div
-      ref={modalRef}
-      className={cn(
-        "fixed inset-0 z-[var(--z-modal)] flex items-center justify-center",
-        "bg-scrim-medium backdrop-blur-sm",
-        "motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150"
-      )}
-      onClick={handleBackdropClick}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="worktree-overview-title"
-    >
-      <div
-        className={cn(
-          "relative flex flex-col",
-          "w-[calc(100vw-80px)] h-[calc(100vh-80px)]",
-          "max-w-[1800px] max-h-[1200px]",
-          "bg-daintree-bg rounded-xl",
-          "border border-divider",
-          "shadow-[var(--theme-shadow-dialog)]",
-          "motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200"
-        )}
-        onClick={(e) => e.stopPropagation()}
+    <>
+      <AppDialog
+        isOpen={isOpen}
+        onClose={onClose}
+        onBeforeClose={handleBeforeClose}
+        // The app-scale tier the shared primitive already declares. It was
+        // added for a workspace-sized surface and had no consumer; this is the
+        // surface it was sized for, and its width lands within ~2% of the
+        // hand-rolled box it replaces.
+        size="workspace"
+        maxHeight="h-[calc(100vh-80px)] max-h-[1200px]"
+        // Focus is placed on the search field by this component; AppDialog must
+        // not race it onto the first tabbable (the close button).
+        initialFocus="none"
+        data-testid="worktree-overview-modal"
       >
-        {/* Header — swaps to a contextual action bar while a selection
-            is active. The Clear control and Close button always remain
-            so the user can escape selection mode without keyboard. */}
+        {/* Selection is a mode change, and a screen reader has to hear it.
+            The region is rendered unconditionally so it exists in the
+            accessibility tree BEFORE its text changes — a live region mounted
+            at the same moment as its content is frequently missed — and it is
+            atomic so "3 of 13 selected" is read as one phrase rather than a
+            stray digit. */}
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {hasSelection ? `${selectedIds.size} of ${filteredWorktrees.length} selected` : ""}
+        </div>
+
+        {/* Tier 1 — identity. Title, result context and close, and nothing
+            else. This row does not change when filters narrow the list or when
+            a selection starts: it is what tells the user which surface they are
+            on and how much of it they are seeing. */}
+        <AppDialog.Header plainBody>
+          <AppDialog.Title icon={<Layers className="w-5 h-5 text-daintree-text/60" />}>
+            <span>Worktrees overview</span>
+            <span className="text-daintree-text/50 text-sm font-normal tabular-nums">
+              ({filteredWorktrees.length}
+              {filteredWorktrees.length !== worktrees.length && ` of ${worktrees.length}`})
+            </span>
+          </AppDialog.Title>
+          <AppDialog.CloseButton aria-label="Close overview" />
+        </AppDialog.Header>
+
+        {/* Tier 2 — the working toolbar: search and facets. Stays mounted
+            during selection so the user can refine the target set without
+            losing what they picked (visible-id sync drops hidden selections
+            naturally — see the selectedIds reconciliation). */}
+        {hasNonMainWorktrees && (
+          <WorktreeSidebarSearchBar
+            variant="modal"
+            inputRef={searchInputRef}
+            chipCounts={chipCounts}
+          />
+        )}
+
+        {/* Tier 3 — quick controls, and the contextual action bar that replaces
+            them while a selection is active. The CAB displaces this tier and
+            not the identity row above it: that is the data-dense desktop
+            convention (Carbon batch-action toolbar, Primer, Atlassian), and it
+            is what keeps the title and the `N of M` count on screen while a
+            destructive bulk action is one click away. */}
         {hasSelection ? (
-          <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
-            <div className="flex items-center gap-3">
-              <span
-                className="text-daintree-text font-semibold text-base tracking-wide tabular-nums"
-                aria-live="polite"
-              >
-                {selectedIds.size} selected
+          <div className="flex items-center justify-between gap-3 px-[calc(1.5rem+11px)] py-2 border-b border-divider shrink-0">
+            <div className="flex items-center gap-3 min-w-0">
+              {/* Visual only — the announcement is owned by the status region
+                  above, so this must not be a second live region. */}
+              <span className="text-daintree-text font-medium text-sm tabular-nums">
+                {selectedIds.size} of {filteredWorktrees.length} selected
               </span>
               <button
                 type="button"
@@ -807,73 +878,24 @@ export function WorktreeOverviewModal({
                 disabled={bulkRemove.isExecuting}
                 data-testid="worktree-bulk-remove"
               >
+                <Trash2 className="w-3.5 h-3.5" />
                 Remove worktrees
               </Button>
-              <button
-                ref={closeButtonRef}
-                onClick={onClose}
-                className={cn(
-                  "p-2 rounded-lg transition-colors",
-                  "text-daintree-text/60 hover:text-daintree-text",
-                  "hover:bg-tint/[0.06]",
-                  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
-                )}
-                aria-label="Close overview"
-              >
-                <X className="w-5 h-5" />
-              </button>
             </div>
           </div>
         ) : (
-          <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
-            <div className="flex items-center gap-3">
-              <Layers className="w-5 h-5 text-daintree-text/60" />
-              <h2
-                id="worktree-overview-title"
-                className="text-daintree-text font-semibold text-base tracking-wide"
-              >
-                Worktrees Overview
-              </h2>
-              <span className="text-daintree-text/50 text-sm tabular-nums">
-                ({filteredWorktrees.length}
-                {filteredWorktrees.length !== worktrees.length && ` of ${worktrees.length}`})
-              </span>
-              {/* Aggregate activity statistics — clickable chips that set quickStateFilter */}
-              {(aggregateStats.workingCount > 0 ||
-                aggregateStats.waitingCount > 0 ||
-                aggregateStats.finishedCount > 0) && (
+          (hasActivitySummary || showMainToggle || hasActiveFilters()) && (
+            <div className="flex items-center gap-2 px-[calc(1.5rem+11px)] py-2 border-b border-divider shrink-0 flex-wrap">
+              {/* Aggregate activity statistics — clickable chips that set quickStateFilter.
+                  Ordered waiting → working → finished: "something is asking me
+                  for input" is the highest-value signal on this surface, so it
+                  reads first. */}
+              {hasActivitySummary && (
                 <div
-                  className="flex items-center gap-1 ml-2 pl-3 border-l border-divider"
+                  className="flex items-center gap-1"
                   role="group"
                   aria-label="Filter by agent state"
                 >
-                  {aggregateStats.workingCount > 0 && (
-                    <button
-                      type="button"
-                      aria-pressed={quickStateFilter === "working"}
-                      onClick={() =>
-                        setQuickStateFilter(quickStateFilter === "working" ? "all" : "working")
-                      }
-                      className={cn(
-                        "flex items-center gap-1 text-xs tabular-nums rounded-full px-2 py-0.5 transition-colors",
-                        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
-                        quickStateFilter === "working"
-                          ? "bg-overlay-subtle shadow-[inset_0_-2px_0_0_var(--color-text-secondary)]"
-                          : "hover:bg-tint/[0.04]"
-                      )}
-                    >
-                      <span className="status-mark w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
-                      <span
-                        className={
-                          quickStateFilter === "working"
-                            ? "text-daintree-text"
-                            : "text-daintree-text/60"
-                        }
-                      >
-                        {aggregateStats.workingCount} working
-                      </span>
-                    </button>
-                  )}
                   {aggregateStats.waitingCount > 0 && (
                     <button
                       type="button"
@@ -882,7 +904,7 @@ export function WorktreeOverviewModal({
                         setQuickStateFilter(quickStateFilter === "waiting" ? "all" : "waiting")
                       }
                       className={cn(
-                        "flex items-center gap-1 text-xs tabular-nums rounded-full px-2 py-0.5 transition-colors",
+                        "flex items-center gap-1 text-xs tabular-nums rounded-full px-2 py-1 transition-colors",
                         "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
                         quickStateFilter === "waiting"
                           ? "bg-overlay-subtle shadow-[inset_0_-2px_0_0_var(--color-text-secondary)]"
@@ -901,6 +923,33 @@ export function WorktreeOverviewModal({
                       </span>
                     </button>
                   )}
+                  {aggregateStats.workingCount > 0 && (
+                    <button
+                      type="button"
+                      aria-pressed={quickStateFilter === "working"}
+                      onClick={() =>
+                        setQuickStateFilter(quickStateFilter === "working" ? "all" : "working")
+                      }
+                      className={cn(
+                        "flex items-center gap-1 text-xs tabular-nums rounded-full px-2 py-1 transition-colors",
+                        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
+                        quickStateFilter === "working"
+                          ? "bg-overlay-subtle shadow-[inset_0_-2px_0_0_var(--color-text-secondary)]"
+                          : "hover:bg-tint/[0.04]"
+                      )}
+                    >
+                      <span className="status-mark w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
+                      <span
+                        className={
+                          quickStateFilter === "working"
+                            ? "text-daintree-text"
+                            : "text-daintree-text/60"
+                        }
+                      >
+                        {aggregateStats.workingCount} working
+                      </span>
+                    </button>
+                  )}
                   {aggregateStats.finishedCount > 0 && (
                     <button
                       type="button"
@@ -909,7 +958,7 @@ export function WorktreeOverviewModal({
                         setQuickStateFilter(quickStateFilter === "finished" ? "all" : "finished")
                       }
                       className={cn(
-                        "flex items-center gap-1 text-xs tabular-nums rounded-full px-2 py-0.5 transition-colors",
+                        "flex items-center gap-1 text-xs tabular-nums rounded-full px-2 py-1 transition-colors",
                         "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
                         quickStateFilter === "finished"
                           ? "bg-overlay-subtle shadow-[inset_0_-2px_0_0_var(--color-text-secondary)]"
@@ -930,108 +979,93 @@ export function WorktreeOverviewModal({
                   )}
                 </div>
               )}
-            </div>
-            <div className="flex items-center gap-2">
-              {/* Hide main worktree toggle - show if there are non-main worktrees OR if filter is active (to allow recovery) */}
-              {(hasNonMainWorktrees || hideMainWorktree) && !hasOnlyMainWorktree && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={!hideMainWorktree}
-                      aria-label={hideMainWorktree ? "Show main worktree" : "Hide main worktree"}
-                      onClick={() => setHideMainWorktree(!hideMainWorktree)}
-                      className={cn(
-                        "flex items-center gap-1.5 px-2 py-1 rounded-full text-xs transition-colors",
-                        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
-                        hideMainWorktree
-                          ? "bg-tint/[0.06] text-daintree-text/40 hover:text-daintree-text/60"
-                          : "bg-tint/[0.10] text-daintree-text/70 hover:text-daintree-text/90"
-                      )}
-                    >
-                      <Plug
+
+              <div className="ml-auto flex items-center gap-2">
+                {/* Main-worktree visibility. The accessible name is fixed —
+                    `aria-checked` carries the state — because a toggle whose
+                    label flips is announced as a different control each time
+                    it is used. */}
+                {showMainToggle && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={!hideMainWorktree}
+                        aria-label="Show main worktree"
+                        onClick={() => setHideMainWorktree(!hideMainWorktree)}
                         className={cn(
-                          "w-3 h-3 transition-colors",
-                          hideMainWorktree ? "text-daintree-text/30" : "text-daintree-text/50"
-                        )}
-                      />
-                      <span
-                        className={cn(
-                          "transition-colors",
-                          hideMainWorktree && "line-through decoration-daintree-text/30"
+                          "flex items-center gap-1.5 px-2 py-1 rounded-full text-xs transition-colors",
+                          "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
+                          hideMainWorktree
+                            ? "bg-tint/[0.06] text-daintree-text/40 hover:text-daintree-text/60"
+                            : "bg-tint/[0.10] text-daintree-text/70 hover:text-daintree-text/90"
                         )}
                       >
-                        main
-                      </span>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {hideMainWorktree ? "Show main worktree" : "Hide main worktree"}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {/* Filter Popover — only shown in header when the search bar (with its own popover) is absent */}
-              {!hasNonMainWorktrees && (
-                <WorktreeFilterPopover hideSearchInput chipCounts={chipCounts} />
-              )}
-              {/* Clear Filters Button - only shown when filters are active */}
-              {hasActiveFilters() && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={clearAllFilters}
-                      className={cn(
-                        "flex items-center gap-1.5 px-2 py-1.5 rounded text-xs",
-                        "text-daintree-text/60 hover:text-daintree-text",
-                        "hover:bg-tint/[0.06]",
-                        "transition-colors",
-                        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
-                      )}
-                      aria-label="Clear all filters"
-                    >
-                      <FilterX className="w-3.5 h-3.5" />
-                      <span>Clear</span>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Clear all filters</TooltipContent>
-                </Tooltip>
-              )}
-              {/* Close Button */}
-              <button
-                ref={closeButtonRef}
-                onClick={onClose}
-                className={cn(
-                  "p-2 rounded-lg transition-colors",
-                  "text-daintree-text/60 hover:text-daintree-text",
-                  "hover:bg-tint/[0.06]",
-                  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                        <Plug
+                          className={cn(
+                            "w-3 h-3 transition-colors",
+                            hideMainWorktree ? "text-daintree-text/30" : "text-daintree-text/50"
+                          )}
+                        />
+                        <span
+                          className={cn(
+                            "transition-colors",
+                            hideMainWorktree && "line-through decoration-daintree-text/30"
+                          )}
+                        >
+                          main
+                        </span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {hideMainWorktree ? "Main worktree hidden" : "Main worktree shown"}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
-                aria-label="Close overview"
-              >
-                <X className="w-5 h-5" />
-              </button>
+                {/* Clear Filters Button - only shown when filters are active */}
+                {hasActiveFilters() && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={clearAllFilters}
+                        className={cn(
+                          "flex items-center gap-1.5 px-2 py-1 rounded text-xs",
+                          "text-daintree-text/60 hover:text-daintree-text",
+                          "hover:bg-tint/[0.06]",
+                          "transition-colors",
+                          "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                        )}
+                        aria-label="Clear all filters"
+                      >
+                        <FilterX className="w-3.5 h-3.5" />
+                        <span>Clear</span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Clear all filters</TooltipContent>
+                  </Tooltip>
+                )}
+                {/* Filter Popover — only shown here when the search bar (with its own popover) is absent */}
+                {!hasNonMainWorktrees && (
+                  <WorktreeFilterPopover hideSearchInput chipCounts={chipCounts} />
+                )}
+              </div>
             </div>
-          </div>
+          )
         )}
 
-        {/* Search bar — always visible when there are non-main worktrees.
-            Stays mounted during selection mode so the user can refine the
-            target set without losing the selection (visible-id sync drops
-            hidden selections naturally — see selectedIds reconciliation). */}
-        {hasNonMainWorktrees && (
-          <WorktreeSidebarSearchBar variant="modal" chipCounts={chipCounts} />
-        )}
-
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
+        {/* Content. `AppDialog.Body` brings the shared scroll box: a
+            ScrollShadow at both edges, so content no longer just stops
+            mid-glyph against the footer, and a reserved scrollbar gutter so
+            the grid does not shift by 11px the moment it starts to overflow. */}
+        <AppDialog.Body className="p-6">
           {isLoading && worktrees.length === 0 ? (
             <Skeleton label="Loading worktrees">
               <div
                 className={cn(
                   "grid gap-3",
-                  "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
-                  "justify-center"
+                  "grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))]",
+                  "[&>*]:max-w-[480px]"
                 )}
               >
                 {Array.from({ length: 6 }).map((_, i) => (
@@ -1076,7 +1110,13 @@ export function WorktreeOverviewModal({
               }
               description={
                 worktrees.length > 0
-                  ? `${worktrees.length} worktree${worktrees.length !== 1 ? "s" : ""} hidden by active filters`
+                  ? `${worktrees.length} worktree${worktrees.length !== 1 ? "s" : ""} hidden by ${
+                      query.trim() && !hasFacetFiltersActive
+                        ? "your search"
+                        : hasFacetFiltersActive && !query.trim()
+                          ? "active filters"
+                          : "your search and filters"
+                    }`
                   : undefined
               }
               action={
@@ -1096,8 +1136,12 @@ export function WorktreeOverviewModal({
               onFocus={handleGridFocus}
               className={cn(
                 "grid gap-3",
-                "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
-                "justify-center",
+                // `auto-fill`, not `auto-fit`: auto-fit collapses the empty
+                // tracks, so the track count followed the RESULT count and the
+                // whole grid slid sideways as the user typed. `1fr` with a
+                // per-cell max keeps cards from stretching on a wide display.
+                "grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))]",
+                "[&>*]:max-w-[480px]",
                 "auto-rows-min items-start",
                 "focus:outline-hidden"
               )}
@@ -1132,6 +1176,7 @@ export function WorktreeOverviewModal({
                         homeDir={homeDir}
                         onClose={onClose}
                         isSelected={selectedIds.has(worktree.id)}
+                        isCursor={activeDescendantId === getWorktreeOverviewCellId(worktree.id)}
                         onToggleSelect={handleCardToggleSelect}
                       />
                     )),
@@ -1152,37 +1197,48 @@ export function WorktreeOverviewModal({
                       homeDir={homeDir}
                       onClose={onClose}
                       isSelected={selectedIds.has(worktree.id)}
+                      isCursor={activeDescendantId === getWorktreeOverviewCellId(worktree.id)}
                       onToggleSelect={handleCardToggleSelect}
                     />
                   ))}
             </div>
           )}
-        </div>
+        </AppDialog.Body>
 
-        {/* Footer hint */}
-        <div className="px-6 py-3 border-t border-divider shrink-0">
-          <div className="flex items-center justify-center gap-x-4 gap-y-1 flex-wrap text-xs text-daintree-text/40">
-            <span>
-              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">↑↓←→</kbd> navigate
-            </span>
-            <span>
-              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Enter</kbd> switch
-            </span>
-            <span>
-              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Space</kbd> select
-            </span>
-            <span>
-              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Esc</kbd>
-              {hasSelection ? " clear selection" : " close"}
-            </span>
-            {hasSelection && (
-              <span className="text-daintree-text/60 tabular-nums">
-                {selectedIds.size} selected
+        {/* Footer — the keyboard contract, in the shared chip style, plus the
+            two operations that make a 5-to-30 item cleanup quick. The selected
+            count is NOT repeated here: it now lives in the contextual bar
+            above, next to the actions it applies to. */}
+        <AppDialog.Footer
+          plainBody
+          // Container-scoped so the two lower-priority hints drop out on a
+          // narrow window instead of wrapping the row onto a second line.
+          className="justify-center @container/overview-footer"
+          hint={
+            <div className="flex items-center justify-center gap-x-4 gap-y-1 flex-wrap text-daintree-text/50">
+              <span>
+                <kbd className={KBD_CLASS}>↑↓←→</kbd> navigate
               </span>
-            )}
-          </div>
-        </div>
-      </div>
+              <span>
+                <kbd className={KBD_CLASS}>Enter</kbd> switch
+              </span>
+              <span>
+                <kbd className={KBD_CLASS}>Space</kbd> select
+              </span>
+              <span className="hidden @2xl/overview-footer:inline">
+                <kbd className={KBD_CLASS}>{selectAllChord}</kbd> select all
+              </span>
+              <span className="hidden @3xl/overview-footer:inline">
+                <kbd className={KBD_CLASS}>Shift</kbd>+<kbd className={KBD_CLASS}>↑↓←→</kbd> extend
+              </span>
+              <span>
+                <kbd className={KBD_CLASS}>Esc</kbd>
+                {hasSelection ? " clear selection" : " close"}
+              </span>
+            </div>
+          }
+        />
+      </AppDialog>
 
       {/* D1 — close sessions confirm. No typed-name gate (action is local,
           reversible by re-launching the agent), but the explicit yes/no
@@ -1200,6 +1256,7 @@ export function WorktreeOverviewModal({
         confirmLabel="Close sessions"
         cancelLabel="Cancel"
         variant="default"
+        zIndex="nested"
         onConfirm={handleCloseSessionsConfirm}
       />
 
@@ -1218,9 +1275,13 @@ export function WorktreeOverviewModal({
             : `Remove ${bulkRemove.targets.length} worktrees?`
         }
         description={
+          // The consequence sentence is never traded away for the exclusion
+          // note. It used to be an either/or, so selecting a main worktree
+          // alongside real targets silently removed the only line telling the
+          // user that directories are deleted and uncommitted work discarded.
           bulkRemove.excludedMainCount > 0
-            ? `${bulkRemove.excludedMainCount} main worktree${bulkRemove.excludedMainCount === 1 ? "" : "s"} excluded — only non-main worktrees can be removed here.`
-            : "Each worktree directory is deleted from disk and the branch worktree association is removed. Uncommitted changes are discarded."
+            ? `Each worktree directory is deleted from disk and the branch worktree association is removed. Uncommitted and untracked changes are discarded. ${bulkRemove.excludedMainCount} main worktree${bulkRemove.excludedMainCount === 1 ? " is" : "s are"} excluded — only non-main worktrees can be removed here.`
+            : "Each worktree directory is deleted from disk and the branch worktree association is removed. Uncommitted and untracked changes are discarded."
         }
         confirmLabel={
           bulkRemove.targets.length === 1
@@ -1232,6 +1293,7 @@ export function WorktreeOverviewModal({
         // Scrollable per-worktree table of what is about to be deleted — a
         // dialog, not an alertdialog.
         hasPreview={bulkRemove.targets.length > 0}
+        zIndex="nested"
         typedNameTarget={bulkRemove.typedNameTarget}
         onConfirm={bulkRemove.handleConfirm}
         isConfirmLoading={bulkRemove.isExecuting}
@@ -1239,26 +1301,25 @@ export function WorktreeOverviewModal({
         {bulkRemove.targets.length > 0 && (
           <div className="border border-divider rounded max-h-64 overflow-y-auto divide-y divide-divider">
             {bulkRemove.targets.map((target) => {
-              const hasTrackedChanges = target.trackedChangeCount > 0;
-              const hasUnpushed = target.aheadCount > 0;
+              const risks = describeBulkRemoveRisks(target);
               return (
                 <div key={target.id} className="flex flex-col gap-1 px-3 py-2 bg-daintree-bg/40">
                   <div className="flex items-center gap-2 text-sm text-daintree-text">
                     <GitBranch className="w-3.5 h-3.5 shrink-0 text-daintree-text/50" />
-                    <span className="font-mono truncate" title={target.path}>
+                    {/* The branch is what truncates, so the branch is what the
+                        tooltip has to reveal — it used to show the path, which
+                        is not the string being clipped. */}
+                    <span
+                      className="font-mono truncate"
+                      title={`${target.branch ?? target.name}\n${target.path}`}
+                    >
                       {target.branch ?? target.name}
                     </span>
                   </div>
-                  {(hasTrackedChanges || hasUnpushed) && (
+                  {risks.length > 0 && (
                     <div className="flex items-start gap-1.5 text-xs text-status-warning">
                       <AlertTriangle className="w-3 h-3 shrink-0 mt-0.5" />
-                      <span>
-                        {hasTrackedChanges &&
-                          `${target.trackedChangeCount} uncommitted file${target.trackedChangeCount === 1 ? "" : "s"}`}
-                        {hasTrackedChanges && hasUnpushed && " · "}
-                        {hasUnpushed &&
-                          `${target.aheadCount} unpushed commit${target.aheadCount === 1 ? "" : "s"}`}
-                      </span>
+                      <span>{risks.join(" · ")}</span>
                     </div>
                   )}
                 </div>
@@ -1271,10 +1332,6 @@ export function WorktreeOverviewModal({
           <span>This is irreversible. Type the count to confirm.</span>
         </div>
       </ConfirmDialog>
-      {/* Co-located live region: VoiceOver suppresses announcements made
-          from `aria-live` regions outside the focused `aria-modal` subtree
-          when `document.ariaNotify` is unavailable (Chromium 354736464). */}
-      <AccessibilityAnnouncer />
-    </div>
+    </>
   );
 }

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -830,6 +830,51 @@ export function WorktreeOverviewModal({
             variant="modal"
             inputRef={searchInputRef}
             chipCounts={chipCounts}
+            trailing={
+              // Main-worktree visibility rides with the facets rather than in a
+              // band of its own: it is a filter, and next to the funnel is
+              // where the rest of them live. The accessible name is fixed —
+              // `aria-checked` carries the state — because a toggle whose label
+              // flips is announced as a different control each time it is used.
+              showMainToggle ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={!hideMainWorktree}
+                      aria-label="Show main worktree"
+                      onClick={() => setHideMainWorktree(!hideMainWorktree)}
+                      className={cn(
+                        "flex shrink-0 items-center gap-1.5 px-2 rounded-full text-xs transition-colors",
+                        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
+                        hideMainWorktree
+                          ? "bg-tint/[0.06] text-daintree-text/40 hover:text-daintree-text/60"
+                          : "bg-tint/[0.10] text-daintree-text/70 hover:text-daintree-text/90"
+                      )}
+                    >
+                      <Plug
+                        className={cn(
+                          "w-3 h-3 transition-colors",
+                          hideMainWorktree ? "text-daintree-text/30" : "text-daintree-text/50"
+                        )}
+                      />
+                      <span
+                        className={cn(
+                          "transition-colors",
+                          hideMainWorktree && "line-through decoration-daintree-text/30"
+                        )}
+                      >
+                        main
+                      </span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {hideMainWorktree ? "Main worktree hidden" : "Main worktree shown"}
+                  </TooltipContent>
+                </Tooltip>
+              ) : null
+            }
           />
         )}
 
@@ -884,7 +929,7 @@ export function WorktreeOverviewModal({
             </div>
           </div>
         ) : (
-          (hasActivitySummary || showMainToggle || hasActiveFilters()) && (
+          (hasActivitySummary || hasActiveFilters()) && (
             <div className="flex items-center gap-2 px-[calc(1.5rem+11px)] py-2 border-b border-divider shrink-0 flex-wrap">
               {/* Aggregate activity statistics — clickable chips that set quickStateFilter.
                   Ordered waiting → working → finished: "something is asking me
@@ -981,48 +1026,6 @@ export function WorktreeOverviewModal({
               )}
 
               <div className="ml-auto flex items-center gap-2">
-                {/* Main-worktree visibility. The accessible name is fixed —
-                    `aria-checked` carries the state — because a toggle whose
-                    label flips is announced as a different control each time
-                    it is used. */}
-                {showMainToggle && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        role="switch"
-                        aria-checked={!hideMainWorktree}
-                        aria-label="Show main worktree"
-                        onClick={() => setHideMainWorktree(!hideMainWorktree)}
-                        className={cn(
-                          "flex items-center gap-1.5 px-2 py-1 rounded-full text-xs transition-colors",
-                          "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
-                          hideMainWorktree
-                            ? "bg-tint/[0.06] text-daintree-text/40 hover:text-daintree-text/60"
-                            : "bg-tint/[0.10] text-daintree-text/70 hover:text-daintree-text/90"
-                        )}
-                      >
-                        <Plug
-                          className={cn(
-                            "w-3 h-3 transition-colors",
-                            hideMainWorktree ? "text-daintree-text/30" : "text-daintree-text/50"
-                          )}
-                        />
-                        <span
-                          className={cn(
-                            "transition-colors",
-                            hideMainWorktree && "line-through decoration-daintree-text/30"
-                          )}
-                        >
-                          main
-                        </span>
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      {hideMainWorktree ? "Main worktree hidden" : "Main worktree shown"}
-                    </TooltipContent>
-                  </Tooltip>
-                )}
                 {/* Clear Filters Button - only shown when filters are active */}
                 {hasActiveFilters() && (
                   <Tooltip>

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -2,8 +2,9 @@ import React, { useCallback, useEffect, useEffectEvent, useRef, useMemo, useStat
 import { FilterX, AlertTriangle, Trash2, GitBranch } from "lucide-react";
 import { Layers, Plug } from "@/components/icons";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { KBD_CLASS } from "@/components/ui/Kbd";
+import { KBD_CLASS, KbdChord } from "@/components/ui/Kbd";
 import { cn } from "@/lib/utils";
+import { getVisibleTabbableElements } from "@/lib/accessibility";
 import { useShallow } from "zustand/react/shallow";
 import { WorktreeCard } from "./WorktreeCard";
 import { WorktreeFilterPopover } from "./WorktreeFilterPopover";
@@ -178,6 +179,11 @@ function OverviewGridCell(props: OverviewWorktreeCardProps & { isCursor?: boolea
         containIntrinsicSize: "auto 240px",
       }}
       className={cn(
+        // The per-cell width cap lives on the cell, not as a `[&>*]` rule on
+        // the grid: the grouped-section headers are `col-[1/-1]` direct
+        // children too, and a 480px cap on a row spanning every track is not
+        // what that rule means.
+        "max-w-[480px]",
         "rounded-lg overflow-hidden",
         "border border-divider",
         "bg-daintree-sidebar/50",
@@ -226,6 +232,9 @@ export function WorktreeOverviewModal({
   homeDir,
 }: WorktreeOverviewModalProps) {
   const searchInputRef = useRef<HTMLInputElement>(null);
+  // First child of the dialog surface, so its parent is the surface itself —
+  // the anchor the initial-focus fallback below scopes its tabbable lookup to.
+  const liveRegionRef = useRef<HTMLDivElement>(null);
 
   // Filter store state
   const {
@@ -670,7 +679,6 @@ export function WorktreeOverviewModal({
     aggregateStats.workingCount > 0 ||
     aggregateStats.finishedCount > 0;
   const showMainToggle = (hasNonMainWorktrees || hideMainWorktree) && !hasOnlyMainWorktree;
-  const selectAllChord = navigator.platform.toLowerCase().includes("mac") ? "⌘A" : "Ctrl+A";
 
   // Section sizes drive section-aware Arrow navigation across the col-[1/-1]
   // header breaks. Undefined when ungrouped — the hook degrades to flat-list
@@ -750,7 +758,24 @@ export function WorktreeOverviewModal({
   // race this.
   useEffect(() => {
     if (!isOpen) return;
-    const timeoutId = setTimeout(() => searchInputRef.current?.focus(), SEARCH_FOCUS_DELAY_MS);
+    const timeoutId = setTimeout(() => {
+      const searchInput = searchInputRef.current;
+      if (searchInput) {
+        searchInput.focus();
+        return;
+      }
+      // No search field to take it: the toolbar only mounts when there are
+      // non-main worktrees, and it has not rendered yet while the loading
+      // skeleton is up. AppDialog's own focus pass is off, so without this
+      // focus would stay on whatever the app shell had behind the scrim. Fall
+      // back to the dialog's first tabbable — the close button, where focus
+      // landed before this surface had a search field at all.
+      const surface = liveRegionRef.current?.parentElement;
+      if (!surface) return;
+      const fallback = getVisibleTabbableElements(surface)[0];
+      if (fallback) fallback.focus();
+      else surface.focus();
+    }, SEARCH_FOCUS_DELAY_MS);
     return () => clearTimeout(timeoutId);
   }, [isOpen]);
 
@@ -766,13 +791,35 @@ export function WorktreeOverviewModal({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen]);
 
+  // AppDialog routes every dismissal through `onBeforeClose` — Escape, the
+  // close button and a scrim click alike — but the two-stage contract below
+  // belongs to Escape alone. The X and the scrim have to leave in one click
+  // (the CAB already carries its own Clear control, so guarding them is
+  // redundant as well as surprising), so record whether the close being
+  // resolved originated from an Escape keypress. Capture phase, because both
+  // the escape stack and AppDialog's backstop dispatch on bubble; cleared on a
+  // microtask, so a later pointer dismissal can never inherit the flag.
+  const escapeDismissRef = useRef(false);
+  useEffect(() => {
+    if (!isOpen) return;
+    const markEscapeDismissal = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      escapeDismissRef.current = true;
+      queueMicrotask(() => {
+        escapeDismissRef.current = false;
+      });
+    };
+    document.addEventListener("keydown", markEscapeDismissal, true);
+    return () => document.removeEventListener("keydown", markEscapeDismissal, true);
+  }, [isOpen]);
+
   /**
    * Escape's first press clears a selection; the second closes. Returning
    * `false` cancels AppDialog's close, which is the same two-stage contract the
    * grid hook implements for when focus is inside the grid.
    */
   const handleBeforeClose = useCallback(() => {
-    if (hasSelection) {
+    if (escapeDismissRef.current && hasSelection) {
       clearSelection();
       return false;
     }
@@ -802,7 +849,13 @@ export function WorktreeOverviewModal({
             at the same moment as its content is frequently missed — and it is
             atomic so "3 of 13 selected" is read as one phrase rather than a
             stray digit. */}
-        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        <div
+          ref={liveRegionRef}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
           {hasSelection ? `${selectedIds.size} of ${filteredWorktrees.length} selected` : ""}
         </div>
 
@@ -810,7 +863,7 @@ export function WorktreeOverviewModal({
             else. This row does not change when filters narrow the list or when
             a selection starts: it is what tells the user which surface they are
             on and how much of it they are seeing. */}
-        <AppDialog.Header plainBody>
+        <AppDialog.Header>
           <AppDialog.Title icon={<Layers className="w-5 h-5 text-daintree-text/60" />}>
             <span>Worktrees overview</span>
             <span className="text-daintree-text/50 text-sm font-normal tabular-nums">
@@ -929,7 +982,13 @@ export function WorktreeOverviewModal({
             </div>
           </div>
         ) : (
-          (hasActivitySummary || hasActiveFilters()) && (
+          // `!hasNonMainWorktrees` is part of the gate, not just of the row's
+          // contents: on a main-worktree-only project with no agent activity
+          // the fallback facet popover below is the ONLY control that can open
+          // the filters, so gating the row on activity or an active filter
+          // would make filtering permanently unreachable — no filter could be
+          // set, so `hasActiveFilters()` could never become true.
+          (hasActivitySummary || hasActiveFilters() || !hasNonMainWorktrees) && (
             <div className="flex items-center gap-2 px-[calc(1.5rem+11px)] py-2 border-b border-divider shrink-0 flex-wrap">
               {/* Aggregate activity statistics — clickable chips that set quickStateFilter.
                   Ordered waiting → working → finished: "something is asking me
@@ -1067,15 +1126,14 @@ export function WorktreeOverviewModal({
               <div
                 className={cn(
                   "grid gap-3",
-                  "grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))]",
-                  "[&>*]:max-w-[480px]"
+                  "grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))]"
                 )}
               >
                 {Array.from({ length: 6 }).map((_, i) => (
                   <SkeletonBone
                     key={i}
                     heightPx={220}
-                    className="rounded-lg border border-divider"
+                    className="max-w-[480px] rounded-lg border border-divider"
                   />
                 ))}
               </div>
@@ -1144,7 +1202,6 @@ export function WorktreeOverviewModal({
                 // whole grid slid sideways as the user typed. `1fr` with a
                 // per-cell max keeps cards from stretching on a wide display.
                 "grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))]",
-                "[&>*]:max-w-[480px]",
                 "auto-rows-min items-start",
                 "focus:outline-hidden"
               )}
@@ -1213,7 +1270,6 @@ export function WorktreeOverviewModal({
             count is NOT repeated here: it now lives in the contextual bar
             above, next to the actions it applies to. */}
         <AppDialog.Footer
-          plainBody
           // Container-scoped so the two lower-priority hints drop out on a
           // narrow window instead of wrapping the row onto a second line.
           className="justify-center @container/overview-footer"
@@ -1229,7 +1285,7 @@ export function WorktreeOverviewModal({
                 <kbd className={KBD_CLASS}>Space</kbd> select
               </span>
               <span className="hidden @2xl/overview-footer:inline">
-                <kbd className={KBD_CLASS}>{selectAllChord}</kbd> select all
+                <KbdChord shortcut="Cmd+A" /> select all
               </span>
               <span className="hidden @3xl/overview-footer:inline">
                 <kbd className={KBD_CLASS}>Shift</kbd>+<kbd className={KBD_CLASS}>↑↓←→</kbd> extend

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -16,6 +16,13 @@ interface WorktreeSidebarSearchBarProps {
    */
   variant?: "sidebar" | "modal";
   /**
+   * Controls rendered on the trailing edge of the field row, after the facet
+   * button. For callers whose view-scope controls belong with the filters
+   * rather than in their own band — the overview passes its main-worktree
+   * switch here so the whole working toolbar stays one line.
+   */
+  trailing?: React.ReactNode;
+  /**
    * Filter scope / sort status ("1 of 2 worktrees · Sorting disabled while
    * searching") rendered under the field, sharing a row with "Clear all".
    * Visual-only — screen readers are served by the caller's debounced
@@ -41,6 +48,7 @@ export function WorktreeSidebarSearchBar({
   chipCounts,
   variant = "sidebar",
   statusText,
+  trailing,
 }: WorktreeSidebarSearchBarProps) {
   const query = useWorktreeFilterStore((state) => state.query);
   const liveQuery = useWorktreeFilterStore((state) => state.liveQuery);
@@ -240,6 +248,7 @@ export function WorktreeSidebarSearchBar({
           open={isPopoverOpen}
           onOpenChange={setIsPopoverOpen}
         />
+        {trailing}
       </div>
       {(statusText || showClearAll) && (
         // pt-2, not pt-1: the rail's own bottom padding is 12px, so a 4px gap

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -192,7 +192,11 @@ export function WorktreeSidebarSearchBar({
         // variant supplies the inset itself rather than sitting flush against
         // the rule above it.
         "px-3 pb-3 border-b border-divider shrink-0",
-        variant === "modal" && "pt-3",
+        // In the dialog the horizontal neighbours are different too: the header,
+        // the footer and the rows below all sit on AppDialog's chrome inset
+        // (24px plus the 11px scrollbar gutter `AppDialog.Body` reserves), so
+        // the bar carries that one instead of the rail's 12px.
+        variant === "modal" && "pt-3 px-[calc(1.5rem+11px)]",
         variant === "sidebar" && "worktree-filter-bar"
       )}
     >

--- a/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
+++ b/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
@@ -362,7 +362,14 @@ describe("WorktreeOverviewModal — clickable aggregate stats (#8385)", () => {
     });
 
     it("imports the bulk-remove hook so the modal owns the orchestrator state", () => {
-      expect(modalSource).toMatch(/import\s*\{\s*useWorktreeBulkRemove\s*\}/);
+      // Matches the named import wherever it sits in the specifier list. The
+      // original pattern required `useWorktreeBulkRemove` to be the ONLY name
+      // in the braces, which asserted the punctuation of an import statement
+      // rather than the fact under test — adding a second export from the same
+      // module broke it without changing any behaviour.
+      expect(modalSource).toMatch(
+        /import\s*\{[^}]*\buseWorktreeBulkRemove\b[^}]*\}\s*from\s*"\.\/useWorktreeBulkRemove"/
+      );
     });
 
     it("imports ConfirmDialog for the D1 close-sessions and D3 remove gates", () => {

--- a/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
+++ b/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
@@ -311,7 +311,19 @@ describe("WorktreeOverviewModal — clickable aggregate stats (#8385)", () => {
     });
 
     it("Escape with selection clears it instead of closing the modal", () => {
-      expect(source).toMatch(/if\s*\(hasSelection\)\s*\{[\s\S]*?clearSelection\(\)/);
+      expect(source).toMatch(
+        /escapeDismissRef\.current\s*&&\s*hasSelection\)\s*\{[\s\S]*?clearSelection\(\)/
+      );
+    });
+
+    it("scopes the two-stage clear-then-close guard to Escape", () => {
+      // AppDialog routes the close button and a scrim click through
+      // `onBeforeClose` as well, and both have to dismiss in one click with a
+      // selection active — so the guard reads a flag set only by an Escape
+      // keypress, recorded in capture phase ahead of the bubble-phase escape
+      // stack.
+      expect(source).toMatch(/"keydown",\s*markEscapeDismissal,\s*true\)/);
+      expect(source).toMatch(/e\.key\s*!==\s*"Escape"/);
     });
 
     it("Cmd/Ctrl+A triggers selectAllVisible", () => {

--- a/src/components/Worktree/__tests__/describeBulkRemoveRisks.test.ts
+++ b/src/components/Worktree/__tests__/describeBulkRemoveRisks.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { describeBulkRemoveRisks, type BulkRemoveTarget } from "../useWorktreeBulkRemove";
+
+function target(over: Partial<BulkRemoveTarget> = {}): BulkRemoveTarget {
+  return {
+    id: "wt-1",
+    name: "retry-jitter",
+    branch: "fix/retry-backoff-jitter",
+    path: "/tmp/worktrees/retry-jitter",
+    trackedChangeCount: 0,
+    untrackedFileCount: 0,
+    aheadCount: 0,
+    ...over,
+  };
+}
+
+describe("describeBulkRemoveRisks", () => {
+  /**
+   * The invariant, asserted over the target's shape rather than over any
+   * wording: every count this preview carries has to reach the confirmation.
+   *
+   * Written this way deliberately. `BulkRemoveTarget`'s numeric fields are all
+   * risk counts, so a new one added later is covered here without anyone
+   * remembering to extend this test — which is the whole point, because the bug
+   * this guards against was a count being derived and silently never rendered.
+   */
+  it("surfaces every non-zero count the target carries", () => {
+    const populated = target({
+      trackedChangeCount: 3,
+      untrackedFileCount: 5,
+      aheadCount: 7,
+    });
+    const line = describeBulkRemoveRisks(populated).join(" · ");
+
+    for (const [field, value] of Object.entries(populated)) {
+      if (typeof value !== "number" || value === 0) continue;
+      expect(
+        line,
+        `${field} is derived onto the target but never reaches the confirmation`
+      ).toContain(String(value));
+    }
+  });
+
+  it("reports nothing when nothing is at risk", () => {
+    expect(describeBulkRemoveRisks(target())).toEqual([]);
+  });
+
+  it("treats untracked-only work as a risk in its own right", () => {
+    // The regression case: a worktree with no tracked changes and no unpushed
+    // commits still loses real files when its directory is deleted.
+    const risks = describeBulkRemoveRisks(target({ untrackedFileCount: 2 }));
+    expect(risks).toHaveLength(1);
+    expect(risks[0]).toContain("2");
+  });
+
+  it("keeps each risk to its own phrase so they can be joined", () => {
+    const risks = describeBulkRemoveRisks(
+      target({ trackedChangeCount: 1, untrackedFileCount: 1, aheadCount: 1 })
+    );
+    expect(risks).toHaveLength(3);
+    for (const risk of risks) {
+      expect(risk).not.toContain("·");
+    }
+  });
+
+  it("singularises a count of one and pluralises the rest", () => {
+    const one = describeBulkRemoveRisks(target({ untrackedFileCount: 1 }))[0];
+    const many = describeBulkRemoveRisks(target({ untrackedFileCount: 2 }))[0];
+    expect(one?.endsWith("s")).toBe(false);
+    expect(many?.endsWith("s")).toBe(true);
+  });
+});

--- a/src/components/Worktree/useWorktreeBulkRemove.ts
+++ b/src/components/Worktree/useWorktreeBulkRemove.ts
@@ -17,6 +17,35 @@ export interface BulkRemoveTarget {
   aheadCount: number;
 }
 
+/**
+ * The per-target risk line for the D3 confirmation.
+ *
+ * Every count this preview derives has to reach the user: a worktree holding
+ * nothing but untracked files is not a safe deletion, and for a long time it
+ * rendered as a row with no warning at all because only tracked changes and
+ * unpushed commits were surfaced. Adding a count to {@link BulkRemoveTarget}
+ * without adding it here is the #7880 failure mode — the confirmation
+ * understating what the action destroys — so the invariant is asserted over the
+ * target's numeric fields rather than over this function's wording.
+ */
+export function describeBulkRemoveRisks(target: BulkRemoveTarget): string[] {
+  const risks: string[] = [];
+  if (target.trackedChangeCount > 0) {
+    risks.push(
+      `${target.trackedChangeCount} uncommitted file${target.trackedChangeCount === 1 ? "" : "s"}`
+    );
+  }
+  if (target.untrackedFileCount > 0) {
+    risks.push(
+      `${target.untrackedFileCount} untracked file${target.untrackedFileCount === 1 ? "" : "s"}`
+    );
+  }
+  if (target.aheadCount > 0) {
+    risks.push(`${target.aheadCount} unpushed commit${target.aheadCount === 1 ? "" : "s"}`);
+  }
+  return risks;
+}
+
 interface UseWorktreeBulkRemoveArgs {
   selectedIds: Set<string>;
   worktreeMap: Map<string, WorktreeState>;

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -142,6 +142,15 @@ const DURABLE_ALLOWLIST = new Set([
   // one keyboard-focusable separator (single focus anchor per active focus
   // region), mirroring the PortalDock/Sidebar resize-handle convention (#11331)
   "src/panels/file-browser/FileBrowserPane.tsx",
+
+  // Worktree overview grid: the active-descendant cursor. The grid is a single
+  // tab stop whose 2D arrow keys move `aria-activedescendant`, so the cursor is
+  // NOT DOM focus and cannot be written as a `focus-visible:` variant the way
+  // the auto-exclusion above expects. It is nonetheless the one load-bearing
+  // anchor in that arrow-key domain, which is what accent is reserved for.
+  // Membership deliberately takes a neutral tint plus inset ring instead, so
+  // the two marks cannot be confused with each other (#11989).
+  "src/components/Worktree/WorktreeOverviewModal.tsx",
 ]);
 
 // Pre-existing accent usage inherited from cleanup buckets #5978-#5986 (all

--- a/src/index.css
+++ b/src/index.css
@@ -2820,6 +2820,24 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     opacity: 1;
   }
 
+  /* The worktree overview grid has the same two states as the forge rows, and
+     both of its normal-mode marks are stripped here: membership paints a tint
+     plus a Tailwind `ring` (a box-shadow), and the keyboard cursor paints an
+     accent outline that the UA recolours. Split them the same way — membership
+     keeps the outline, the cursor moves to the cell's border, which is a
+     property nothing else on the cell is using. Giving both an outline would
+     let the later rule win and a selected cell under the cursor would lose the
+     cursor. */
+  [role="gridcell"][aria-selected="true"][data-worktree-overview-cell] {
+    outline: 2px solid SelectedItem;
+    outline-offset: -2px;
+  }
+
+  [data-worktree-overview-cell][data-overview-cursor="true"] {
+    border-color: Highlight;
+    border-width: 2px;
+  }
+
   /* The project switcher's command rows run full-bleed, so their border box
      reaches the palette's own clipped edge. The blanket `outline-offset: 2px`
      above would draw their focus ring outside that clip and lose its left and
@@ -3084,6 +3102,15 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   .terminal-selected-quiet,
   .terminal-focused {
     border-width: 2px;
+  }
+
+  /* Overview grid membership: the neutral inset ring is deliberately quiet at
+     normal contrast (accent restraint reserves the loud mark for the keyboard
+     cursor), which leaves it thin here. Widen the ring rather than recolour it
+     — the mark stays neutral, it just stops being a hairline. */
+  [role="gridcell"][aria-selected="true"][data-worktree-overview-cell] {
+    --tw-ring-offset-width: 0px;
+    box-shadow: inset 0 0 0 2px var(--color-border-strong);
   }
 
   /* Track the widened border so the cue's hairline stays inside it rather


### PR DESCRIPTION
## Summary

The worktree overview was the only feature-level surface in the app drawing its own modal chrome. Its own scrim, its own frame, its own close button, its own zoom and fade, and no portal, while roughly 78 other dialogs compose `AppDialog`.

It now composes `AppDialog` at the `size="workspace"` tier. That size already existed and had no consumers, and its width lands within about 2% of the box this surface was hand-rolling.

Resolves #11989

## What changed

**The frame.** Composing `AppDialog` brings the portal, the focus trap and focus restoration, the shared motion constants, the scroll shadows, and the layer-aware escape stack. Several defects went with it:

- A document-level Escape listener registered in the capture phase meant dismissing the facet popover, or cancelling either confirmation, tore down the whole overview instead. That listener is gone. `onBeforeClose` keeps the two-stage clear-selection-then-close behaviour.
- Initial focus landed on the close button. It now lands on the search field, which is what the APG dialog guidance asks for on a browse-and-search surface, and it stops the one accent focus ring in the region being spent on "leave".

**The header.** It splits into tiers. Identity (title, the `N of M` count, close) stays put. Entering multi-select used to replace that entire row, so the user lost both the name of the surface and the size of the result set at exactly the moment a destructive bulk action became available. Selection is now a contextual bar in the working tier reading `N of M selected`, which is how the other six multi-select surfaces in this codebase already behave. It announces through a persistent atomic `role="status"`.

The activity chips move out of the identity row into the working toolbar and lead with waiting, since "something is asking me for input" is the signal this surface exists to surface. The main-worktree switch moves next to the facet button, where the rest of the filters live, and keeps one accessible name with `aria-checked` carrying its state.

**The grid.** Arrow-key navigation had no visible cursor and never scrolled. `aria-activedescendant` moved across cells while nothing rendered, because the cell styled only hover and membership, and the `isFocused` prop it passed down came from the sidebar's focus rather than the grid's own. The active cell now takes the accent outline (the single load-bearing accent the grid's arrow-key domain gets), membership keeps the neutral tint and ring, and the cursor scrolls into view. `index.css` gains the matching `forced-colors` and `prefers-contrast` rules, split the way `.forge-row` splits its cursor and membership marks so neither overwrites the other.

The grid also moves from `auto-fit` to `auto-fill`, so the track count stops following the result count and the cards stop sliding sideways as you type.

**The bulk remove confirmation.** `untrackedFileCount` was derived onto every target and never displayed, so a worktree holding nothing but untracked files rendered as a row with no warning at all while `worktree.delete` removes the directory and takes those files with it. It is reported now. Two related fixes: the consequence sentence used to be traded away for the main-worktree exclusion note, so selecting a main worktree alongside real targets silently removed the only line explaining that directories are deleted; and the tooltip on the truncated branch name showed the path rather than the branch. The dialog also passes `hasPreview`, so it stops claiming `role="alertdialog"` over a scrollable list.

**Smaller things.** The footer uses the shared `KBD_CLASS` chips instead of a hand-rolled recipe, drops the count it duplicated from the header, and teaches `⌘A` and `Shift`+arrows, which the grid already supported and nothing advertised. The title moves to sentence case, matching every other place the app names this surface.

## Design review

Scored 5.7/10 in round one against seven dimensions (frame coherence, header hierarchy, selection mode, answering the surface's ranked questions, density and overflow, accessibility and keyboard, craft). Accessibility scored lowest at 3.5.

The consistency survey found this surface was an outlier of one on three separate counts: the only feature surface hand-rolling a scrim, the only modal-tier surface not portalling, and the only multi-select surface replacing its title. So the decision was reuse rather than roll-out, because there was no cohort still on the old pattern. Verified after the change: zero feature surfaces hand-roll a viewport scrim, and `size="workspace"` has one consumer where it had none.

One finding I raised and then withdrew: I thought the destructive button was indistinguishable from the benign one in Windows High Contrast. It is not. `src/index.css` already carries `button[data-variant="destructive"] { border: 2px solid ButtonText }`, keyed off an attribute `button.tsx` exists specifically to provide. Zooming the capture shows the heavier border plainly.

## Testing

`npm run check` passes clean, and the lint ratchet drops 3 (1090 to 1087).

The full `npx vitest run` turned up one genuine failure, which is exactly what a repo-wide gate is for: `accentGuard.contract.test.ts` flagged the grid cursor's bare `outline-daintree-accent`. The guard auto-excludes accent outlines behind a focus variant on the reasoning that those are structural focus indicators, and the cursor is structurally one, but it cannot be written that way. The grid is a single tab stop whose arrow keys move `aria-activedescendant`, so the cursor is not DOM focus and no `focus-visible:` variant applies to it. It is now a `DURABLE_ALLOWLIST` entry with a rationale, in the same shape as the `WorktreeCard`, `PluginManagerView`, `ConflictPanel` and `FileBrowserPane` entries above it.

With that fixed, the final full run is `51,642 passed | 1 failed | 7 skipped | 1 todo` across 2,349 files. The one remaining failure is not from this branch: `terminalGetOutputAction` fails as `Test timed out in 15000ms` rather than on an assertion. `createRegistry()` calls `vi.resetModules()` and re-imports the whole action-definitions graph, and transform alone takes 15 to 16 seconds on this machine. It passes 18/18 with `--testTimeout=60000` at the same duration, and the action-definition graph does not import `WorktreeOverviewModal` at all (the only reference under `src/services/actions/` is a comment in `worktreeBulkActions.ts`). It surfaced at load average 35 with three other worktrees running full suites concurrently, so it should not reproduce on a CI runner.

There is also a new opt-in capture harness at `e2e/screenshots/worktree-overview-review.spec.ts`: 19 states across four window widths, both empty states, grouped and ungrouped grids, selection at one and five cards, both confirmations, keyboard focus, `forced-colors` and `prefers-contrast`. 32 PNGs, zero failures. It is gated behind `DAINTREE_SHOT_OVERVIEW` and never runs in CI.

Two invariants pinned in `src/components/Worktree/__tests__/describeBulkRemoveRisks.test.ts`, both mutation-checked (reintroduce the untracked-files bug and 4 of 5 tests fail). The load-bearing one asserts over the target's numeric fields rather than over any wording, so a risk count added to `BulkRemoveTarget` later is covered without anyone remembering to extend the test. That is the shape of the bug it guards against.

Also fixed in passing: four capture harnesses passed the whole `AppContext` to `closeApp` instead of `ctx.app`, so `app.process()` threw, `app.close()` was undefined, and every run leaked the Electron process tree. It survived because no tsconfig in the repo includes `e2e/`.
