### PR TITLE
Refine TerminalInfoDialog into a diagnostic overview

### DIFF
--- a/e2e/screenshots/terminal-info-review.spec.ts
+++ b/e2e/screenshots/terminal-info-review.spec.ts
@@ -37,7 +37,15 @@
 
 import { test, type Page, type ElectronApplication } from "@playwright/test";
 import { execFileSync } from "child_process";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+  statSync,
+} from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import { launchApp, closeApp, type AppContext } from "../helpers/launch";
@@ -85,7 +93,7 @@ const DIALOG = "[data-app-dialog-surface] > div";
  */
 const TID = {
   body: '[data-testid="terminal-info-body"]',
-  loading: '[data-testid="terminal-info-loading"]',
+  pending: '[data-testid="terminal-info-pending"]',
   error: '[data-testid="terminal-info-error"]',
   copy: '[data-testid="terminal-info-copy"]',
 } as const;
@@ -242,6 +250,34 @@ async function waitForShellPrompt(page: Page, terminalId: string): Promise<void>
   throw new Error(`[terminfo-shots] shell ${terminalId} never produced output`);
 }
 
+/**
+ * Wait until a panel's process has actually gone.
+ *
+ * A fixed `waitForTimeout` after writing a stop token proves nothing: if the write is
+ * swallowed the panel simply stays alive and the step goes on to screenshot a running
+ * terminal under the name "exited" — which is precisely what round 2 shipped. There is
+ * no `data-runtime-status` attribute to poll, so this reads the two signals that do
+ * exist: the marker the dying process prints, and the exit banner the panel renders.
+ */
+async function waitForExited(page: Page, terminalId: string, marker: string): Promise<void> {
+  const deadline = Date.now() + 25_000;
+  while (Date.now() < deadline) {
+    const text = await getTerminalTextById(page, terminalId).catch(() => "");
+    if (text.includes(marker)) return;
+    const banner = await page
+      .locator(
+        `[data-panel-id="${terminalId}"] [role="alert"], [data-panel-id="${terminalId}"] [role="status"]`
+      )
+      .allTextContents()
+      .catch(() => [] as string[]);
+    if (banner.some((entry) => /exit/i.test(entry))) return;
+    await page.waitForTimeout(250);
+  }
+  throw new Error(
+    `[terminfo-shots] ${terminalId} never showed "${marker}" or an exit banner — its process did not die, so any shot of it would be mislabelled`
+  );
+}
+
 /** Open the info dialog for one panel by dispatching the real action. */
 async function openInfo(page: Page, terminalId: string): Promise<void> {
   await dispatch(page, "terminal.info.open", { terminalId });
@@ -371,6 +407,9 @@ test("terminal info review — diagnostic states", async () => {
   test.skip(!ENABLED, "Set DAINTREE_SHOT_TERMINFO to run the terminal-info capture");
 
   failures.length = 0;
+  // Stamped before anything is captured so the tally at the end can tell this run's
+  // artifacts from the previous run's. 1s of slack absorbs filesystem mtime coarseness.
+  const runStartedAt = Date.now() - 1000;
   mkdirSync(OUTPUT_DIR, { recursive: true });
   const repo = createFixtureRepo();
   const binDir = installFakeAgent(repo.dir);
@@ -432,15 +471,20 @@ test("terminal info review — diagnostic states", async () => {
     // `everDetectedAgent` with no `detectedAgentId` — the "None — agent has exited" row.
     ids.exitedAgent = await newAgent(page, { name: "Claude: schema migration" });
     await trustAgent(page, ids.exitedAgent);
-    await ptyWrite(page, ids.exitedAgent, FAKE_AGENT_STOP);
-    await page.waitForTimeout(2500);
+    // The trailing CR is load-bearing. The PTY slave is in canonical mode, so the line
+    // discipline buffers input until a line terminator arrives — without it the fake
+    // agent's stdin handler never fires, the process never exits, and this step
+    // screenshots a RUNNING agent while calling it exited. That is exactly what round 2
+    // captured, and it is the same trap `waitForShellPrompt` above already warns about.
+    await ptyWrite(page, ids.exitedAgent, FAKE_AGENT_STOP + "\r");
+    await waitForExited(page, ids.exitedAgent, "FAKE_CLAUDE_EXIT");
 
     // Exited plain shell: a non-zero code is always preserved, and it is the only way
     // to see the Exit Code row on a terminal that never ran an agent.
     ids.exitedPlain = await newTerminal(page);
     await waitForShellPrompt(page, ids.exitedPlain);
     await ptyWrite(page, ids.exitedPlain, "exit 3\r");
-    await page.waitForTimeout(2500);
+    await waitForExited(page, ids.exitedPlain, "__never__");
 
     await dismissBlockingPalette(page);
     await settle(page, 800);
@@ -546,11 +590,18 @@ test("terminal info review — diagnostic states", async () => {
 
     // 9. Loading held open by a main-process delay, so the shot is the real in-flight
     //    render rather than a paused animation frame. Past the 400ms Doherty gate.
+    //
+    //    The marker is a pending CELL, not a loading screen: the dialog no longer has an
+    //    all-or-nothing loading branch. Everything the panel store owns paints on the
+    //    first frame and only the rows waiting on the host carry a skeleton, so the shot
+    //    has to prove the shell AND a bone are on screen together — which is the whole
+    //    claim being made about this state.
     await step("loading", async () => {
       await injectDelay(app, CH_GET_INFO, 9000);
       await openInfo(page, ids.agentFull);
       await page.waitForTimeout(1200);
-      await snap(page, "50-loading", { marker: TID.loading, locator: DIALOG });
+      await page.locator(TID.body).first().waitFor({ state: "visible", timeout: 10_000 });
+      await snap(page, "50-loading", { marker: TID.pending, locator: DIALOG });
     });
 
     // 10. Keyboard focus on the copy action — the only affordance on the surface, and
@@ -592,15 +643,23 @@ test("terminal info review — diagnostic states", async () => {
 
   // Counted here rather than trusted from the exit code: swallowed per-step errors are
   // exactly how a harness reports PASS over an empty directory.
+  //
+  // Counted by MTIME, not by existence. A plain file count is satisfied by last run's
+  // PNGs still sitting in the output directory, so a run that launched, failed every
+  // step and wrote nothing would report the previous run's total and read as a pass —
+  // the same class of lie as trusting the exit code, one level further in.
   const written = existsSync(OUTPUT_DIR)
-    ? readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`)).length
+    ? readdirSync(OUTPUT_DIR).filter(
+        (f) =>
+          f.endsWith(`${TAG}.png`) && statSync(path.join(OUTPUT_DIR, f)).mtimeMs >= runStartedAt
+      ).length
     : 0;
-  console.log(`[terminfo-shots] wrote ${written} png(s) to ${OUTPUT_DIR}`);
+  console.log(`[terminfo-shots] wrote ${written} png(s) this run to ${OUTPUT_DIR}`);
 
   if (failures.length > 0) {
     throw new Error(`[terminfo-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`);
   }
   if (written === 0) {
-    throw new Error(`[terminfo-shots] no PNGs written to ${OUTPUT_DIR}`);
+    throw new Error(`[terminfo-shots] no PNGs written this run to ${OUTPUT_DIR}`);
   }
 });

--- a/e2e/screenshots/terminal-info-review.spec.ts
+++ b/e2e/screenshots/terminal-info-review.spec.ts
@@ -1,0 +1,606 @@
+/**
+ * `TerminalInfoDialog` visual-review harness (#11978).
+ *
+ * A forty-row properties sheet is judged on rendered pixels. Half of what is wrong
+ * with one — a value column nothing shares a left edge with, a path that eats its own
+ * filename, a section header that reads at the same weight as the rows under it, a
+ * tooltip that fires on a value already fully visible — is invisible in the JSX and
+ * unmissable in a PNG.
+ *
+ * Every state here is driven through the REAL seams, never a renderer mock:
+ *
+ *   - terminals are created by dispatching `terminal.new` and `agent.launch`, so the
+ *     panel-store half of the dialog (spawnedBy, location, spawnStatus, launch flags)
+ *     is whatever the app actually stamped.
+ *   - the agent states come from `e2e/helpers/fakeAgent`, a real CLI on a real PTY
+ *     emitting real OSC 9;4 progress, so `AgentStateService` runs its genuine FSM.
+ *   - the exited states are reached by letting the process EXIT, not by killing the
+ *     panel: `terminal.kill` removes the panel outright, which is the one thing that
+ *     cannot show what an exited terminal's info dialog looks like. An agent exiting
+ *     0 and a plain shell exiting non-zero are both preserved by
+ *     `src/store/listeners/panel/lifecycle.ts`, which is exactly the state we want.
+ *   - loading and load-failure come from the main-process fault registry
+ *     (`DAINTREE_E2E_FAULT_MODE=1` + `e2e/helpers/ipcFaults`) on `terminal:get-info`,
+ *     so the dialog takes its genuine slow path and its genuine error path.
+ *
+ *   DAINTREE_SHOT_TERMINFO=1 npx playwright test --project=screenshots terminal-info-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_TERMINFO  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME     optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG       optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY      comma-separated step filter (see step names below)
+ *   DAINTREE_SHOT_OUT       optional absolute output dir (default artifacts/terminal-info-shots)
+ *
+ * Output: <out>/<NN-slug>[-tag].png (artifacts/ is gitignored).
+ */
+
+import { test, type Page, type ElectronApplication } from "@playwright/test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { injectDelay, injectFault, clearAllFaults } from "../helpers/ipcFaults";
+import {
+  installFakeAgent,
+  fakeAgentEnv,
+  ptyWrite,
+  FAKE_AGENT_STOP,
+  FAKE_AGENT_READY,
+} from "../helpers/fakeAgent";
+import { getTerminalTextById } from "../helpers/terminal";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+import { BUILT_IN_THEME_SOURCES } from "@shared/theme/builtInThemeSources";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_TERMINFO;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ?? path.resolve(process.cwd(), "artifacts", "terminal-info-shots");
+
+/**
+ * The dialog CARD, not the surface element.
+ *
+ * `AppDialog` puts `role="dialog"` on the `fixed inset-0` scrim, so screenshotting the
+ * role selector silently returns the whole window — a full-window PNG that looks like a
+ * successful crop until you compare its dimensions.
+ */
+const DIALOG = "[data-app-dialog-surface] > div";
+
+/**
+ * The stable hooks this harness asserts against before it will write a file. The
+ * redesign may move, restyle, or re-shape any of these — it must not delete them, or
+ * the harness stops being able to prove the state it captured is the state it meant to.
+ *
+ * Deliberately mixed: `body`/`loading`/`error` are testids the dialog owns, while the
+ * per-state markers are the rendered TEXT of a value only that state produces. Text
+ * markers survive a restyle and fail loudly on a relabel, which is the correct
+ * sensitivity for a design harness — a renamed label is a thing the review should see.
+ */
+const TID = {
+  body: '[data-testid="terminal-info-body"]',
+  loading: '[data-testid="terminal-info-loading"]',
+  error: '[data-testid="terminal-info-error"]',
+  copy: '[data-testid="terminal-info-copy"]',
+} as const;
+
+/** The IPC channel behind `window.electron.terminal.getInfo` (electron/ipc/channels.ts). */
+const CH_GET_INFO = "terminal:get-info";
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+  /*
+   * Skeleton bones start at opacity 0 and are faded in by the pulse keyframes after
+   * the 400ms Doherty delay, so the animation freeze above leaves them INVISIBLE — a
+   * loading shot that looks like an empty panel and sends the whole review off
+   * reviewing a screen that does not exist. Pin them visible.
+   */
+  [class*="animate-pulse-"] { opacity: 1 !important; }
+`;
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+/**
+ * The repo is named at absurd length on purpose.
+ *
+ * `cwd` is the dialog's longest guaranteed value and the one most likely to be
+ * mistreated — a short `/tmp/x` fixture makes every alignment and truncation decision
+ * on this surface look correct. The nesting also gives the middle-vs-end truncation
+ * question a real subject: the leaf directory is the informative half of a path, and a
+ * plain `text-overflow: ellipsis` throws it away.
+ */
+function createFixtureRepo(): { dir: string; cleanup: () => void } {
+  const root = mkdtempSync(path.join(tmpdir(), "daintree-terminfo-shots-"));
+  const dir = path.join(
+    root,
+    "acme-platform",
+    "services",
+    "telemetry-ingest-worker-eu-west-1-canary"
+  );
+  const wtRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(dir, { recursive: true });
+  mkdirSync(wtRoot, { recursive: true });
+
+  git(["init", "-b", "main", dir], root);
+  git(["config", "user.email", "dev@daintree.dev"], dir);
+  git(["config", "user.name", "Daintree Test"], dir);
+  git(["config", "commit.gpgsign", "false"], dir);
+  writeFileSync(path.join(dir, "README.md"), "# Telemetry ingest worker\n");
+  git(["add", "-A"], dir);
+  git(["commit", "-m", "initial commit"], dir);
+
+  return {
+    dir,
+    cleanup: () => {
+      if (existsSync(wtRoot)) rmSync(wtRoot, { recursive: true, force: true });
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/** Dispatch a real action through the E2E hook and return its result. */
+async function dispatch(page: Page, id: string, args?: unknown): Promise<unknown> {
+  return page.evaluate(
+    async ([actionId, actionArgs]) => {
+      const run = (
+        window as unknown as {
+          __daintreeDispatchAction?: (
+            id: string,
+            args: unknown,
+            opts: unknown
+          ) => Promise<{ ok: boolean; result?: unknown; error?: { message: string } }>;
+        }
+      ).__daintreeDispatchAction;
+      if (typeof run !== "function") throw new Error("Action dispatch hook not available");
+      const outcome = await run(actionId as string, actionArgs, { source: "test" });
+      if (!outcome?.ok) throw new Error(outcome?.error?.message ?? "dispatch failed");
+      return outcome.result ?? null;
+    },
+    [id, args] as [string, unknown]
+  );
+}
+
+/** Create a plain shell terminal and return its panel id. */
+async function newTerminal(page: Page, spawnedBy?: string): Promise<string> {
+  const result = (await dispatch(page, "terminal.new", spawnedBy ? { spawnedBy } : undefined)) as {
+    terminalId?: string;
+  } | null;
+  const id = result?.terminalId;
+  if (!id)
+    throw new Error(`terminal.new returned no terminalId (spawnedBy=${spawnedBy ?? "none"})`);
+  return id;
+}
+
+/** Launch the fake agent and return its panel id. */
+async function newAgent(page: Page, options: Record<string, unknown> = {}): Promise<string> {
+  const result = (await dispatch(page, "agent.launch", {
+    agentId: "claude",
+    location: "grid",
+    force: true,
+    ...options,
+  })) as { terminalId?: string | null } | null;
+  const id = result?.terminalId;
+  if (!id) throw new Error(`agent.launch returned no terminalId (${JSON.stringify(options)})`);
+  return id;
+}
+
+/**
+ * Walk the fake agent through its trust prompt so it starts emitting OSC 9;4 progress.
+ * Until this lands the FSM has nothing to read and `agentState` stays unset — which is
+ * a real state, but not the populated one this harness is trying to show.
+ */
+async function trustAgent(page: Page, terminalId: string): Promise<void> {
+  const deadline = Date.now() + 25_000;
+  let answered = false;
+  while (Date.now() < deadline) {
+    const text = (await getTerminalTextById(page, terminalId).catch(() => "")).toLowerCase();
+    if (text.includes(FAKE_AGENT_READY.toLowerCase())) return;
+    if (!answered && (text.includes("enter to confirm") || text.includes("trust this folder"))) {
+      await ptyWrite(page, terminalId, "\r");
+      answered = true;
+    }
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`[terminfo-shots] agent ${terminalId} never reached ${FAKE_AGENT_READY}`);
+}
+
+/**
+ * Wait until a plain shell has actually painted something before writing to it. A
+ * `exit 3` sent into a PTY that has not finished spawning is swallowed, and the panel
+ * then sits alive through the whole run with no exit code — a state the harness would
+ * screenshot and label "exited".
+ */
+async function waitForShellPrompt(page: Page, terminalId: string): Promise<void> {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const text = await getTerminalTextById(page, terminalId).catch(() => "");
+    if (text.trim().length > 0) return;
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`[terminfo-shots] shell ${terminalId} never produced output`);
+}
+
+/** Open the info dialog for one panel by dispatching the real action. */
+async function openInfo(page: Page, terminalId: string): Promise<void> {
+  await dispatch(page, "terminal.info.open", { terminalId });
+}
+
+async function closeDialog(page: Page): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    if (
+      !(await page
+        .locator(DIALOG)
+        .first()
+        .isVisible()
+        .catch(() => false))
+    )
+      return;
+    await page.keyboard.press("Escape").catch(() => {});
+    await settle(page, 200);
+  }
+}
+
+/**
+ * Screenshot, but only after the state it claims to be has been proven on screen.
+ *
+ * This is the hard rule of the whole harness: a capture run that quietly writes a
+ * plausible-looking wrong artifact is worse than one that fails, because the review
+ * then reasons about a screen that never existed.
+ */
+async function snap(
+  page: Page,
+  slug: string,
+  opts: { marker: string; text?: string; locator?: string; markerTimeout?: number }
+): Promise<void> {
+  await page
+    .locator(opts.marker)
+    .first()
+    .waitFor({ state: "visible", timeout: opts.markerTimeout ?? 10_000 });
+  if (opts.text) {
+    await page
+      .locator(DIALOG)
+      .getByText(opts.text, { exact: false })
+      .first()
+      .waitFor({ state: "visible", timeout: opts.markerTimeout ?? 10_000 });
+  }
+  await settle(page);
+  // Re-checked AFTER the settle, not only before it: the app's own later render can
+  // replace the state between the assertion and the shutter.
+  if (!(await page.locator(opts.marker).first().isVisible())) {
+    throw new Error(`[terminfo-shots] "${slug}": marker ${opts.marker} vanished before the shot`);
+  }
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (opts.locator) {
+    await page.locator(opts.locator).last().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+}
+
+/**
+ * Capture a surface that can legitimately land in more than one state, and record which.
+ *
+ * Same hard rule as `snap` — nothing is written until a state is proven on screen — but
+ * the caller names the states it will accept instead of the one it expects. The reached
+ * state is appended to the filename, so the artifact carries its own label and a review
+ * can never mistake an error shot for a populated one.
+ */
+async function snapEither(
+  page: Page,
+  slug: string,
+  opts: { locator?: string } & Record<string, string>
+): Promise<string> {
+  const { locator, ...states } = opts;
+  const deadline = Date.now() + 15_000;
+  let reached: string | null = null;
+  while (Date.now() < deadline && !reached) {
+    for (const [name, selector] of Object.entries(states)) {
+      if (
+        await page
+          .locator(selector)
+          .first()
+          .isVisible()
+          .catch(() => false)
+      ) {
+        reached = name;
+        break;
+      }
+    }
+    if (!reached) await page.waitForTimeout(250);
+  }
+  if (!reached) {
+    const text = await page
+      .locator(DIALOG)
+      .innerText()
+      .catch(() => "<dialog not rendered>");
+    throw new Error(
+      `[terminfo-shots] "${slug}": none of [${Object.keys(states).join(", ")}] appeared. ` +
+        `Dialog read: ${text.slice(0, 300).replace(/\s+/g, " ")}`
+    );
+  }
+  await snap(page, `${slug}-${reached}`, { marker: states[reached]!, locator });
+  return reached;
+}
+
+/**
+ * Every built-in theme. Switching themes in place reloads the renderer (see
+ * `setAppTheme`), which destroys every terminal this harness spent a minute spawning,
+ * so a cross-theme sweep boots once per theme:
+ *
+ *   for t in <these ids>; do
+ *     DAINTREE_SHOT_TERMINFO=1 DAINTREE_SHOT_THEME=$t DAINTREE_SHOT_TAG=$t \
+ *     DAINTREE_SHOT_ONLY=agent-full npx playwright test --project=screenshots terminal-info-review
+ *   done
+ */
+export const ALL_THEMES = BUILT_IN_THEME_SOURCES.map((theme) => theme.id);
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — the remaining shots are still worth having,
+// and a per-theme sweep should not lose fourteen themes to one bad selector. But the
+// run must still FAIL: a silent exit 0 over an empty output directory reads as success.
+const failures: string[] = [];
+
+test("terminal info review — diagnostic states", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_TERMINFO is required for the terminal-info capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_TERMINFO to run the terminal-info capture");
+
+  failures.length = 0;
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo();
+  const binDir = installFakeAgent(repo.dir);
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-terminfoshot-"));
+  let ctx: AppContext | undefined;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      env: { ...fakeAgentEnv(binDir), DAINTREE_E2E_FAULT_MODE: "1" },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const app: ElectronApplication = ctx.app;
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Telemetry Ingest");
+    // Before any terminal is spawned: setAppTheme reloads the renderer.
+    if (THEME) await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 1500);
+    await dismissBlockingPalette(page);
+
+    /**
+     * Every terminal this run inspects, spawned up front.
+     *
+     * Up front rather than per-step because each one is a real PTY on a real fixture
+     * repo: spawning them lazily inside a step means a step that fails leaves the next
+     * one inspecting a panel that does not exist, and the failure reads as a dialog bug.
+     */
+    const ids: Record<string, string> = {};
+
+    // The headline state. Long flags and a long model id on purpose — the launch-context
+    // rows are where argv chips have to wrap, and a two-flag fixture proves nothing.
+    ids.agentFull = await newAgent(page, {
+      name: "Claude: ingest backfill",
+      model: "claude-opus-4-6-20260115-preview",
+      agentLaunchFlags: [
+        "--dangerously-skip-permissions",
+        "--add-dir=/Users/dev/acme-platform/services/telemetry-ingest-worker-eu-west-1-canary",
+        "--mcp-config=.daintree/mcp.json",
+        "--verbose",
+      ],
+    });
+    await trustAgent(page, ids.agentFull);
+
+    // Sparse: a plain shell, nothing detected, most optional rows absent.
+    ids.plain = await newTerminal(page);
+
+    // Provenance rows (#11808): MCP transport, and the assistant on the other end of it.
+    ids.mcp = await newTerminal(page, "mcp");
+    ids.assistant = await newTerminal(page, "assistant");
+
+    // Exited agent: the process leaves with 0, which lifecycle.ts preserves. Gives
+    // `everDetectedAgent` with no `detectedAgentId` — the "None — agent has exited" row.
+    ids.exitedAgent = await newAgent(page, { name: "Claude: schema migration" });
+    await trustAgent(page, ids.exitedAgent);
+    await ptyWrite(page, ids.exitedAgent, FAKE_AGENT_STOP);
+    await page.waitForTimeout(2500);
+
+    // Exited plain shell: a non-zero code is always preserved, and it is the only way
+    // to see the Exit Code row on a terminal that never ran an agent.
+    ids.exitedPlain = await newTerminal(page);
+    await waitForShellPrompt(page, ids.exitedPlain);
+    await ptyWrite(page, ids.exitedPlain, "exit 3\r");
+    await page.waitForTimeout(2500);
+
+    await dismissBlockingPalette(page);
+    await settle(page, 800);
+
+    /**
+     * Runs one state, then unconditionally returns to rest. Unconditionally, not on the
+     * success path only: a step that dies holding the dialog open would otherwise wedge
+     * every step after it behind a modal.
+     */
+    const step = async (name: string, fn: () => Promise<void>): Promise<void> => {
+      if (ONLY.length > 0 && !ONLY.includes(name)) return;
+      try {
+        await fn();
+      } catch (error) {
+        const detail = String(error).slice(0, 300);
+        console.warn(`[terminfo-shots] step "${name}" failed:`, detail);
+        failures.push(`${name}: ${detail}`);
+      } finally {
+        await clearAllFaults(app).catch(() => {});
+        await closeDialog(page).catch((error) => {
+          failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+        });
+        await page.emulateMedia({ forcedColors: null, contrast: null }).catch(() => {});
+      }
+    };
+
+    // 1. The headline: a live agent, every section populated, long values throughout.
+    await step("agent-full", async () => {
+      await openInfo(page, ids.agentFull);
+      await snap(page, "10-agent-full", { marker: TID.body, locator: DIALOG });
+      await snap(page, "11-agent-full-in-window", { marker: TID.body });
+    });
+
+    // 2. The tail of the same dialog. Half the sections live below the fold and nobody
+    //    has looked at them; scrolling there is the only way the review sees them.
+    await step("agent-full-tail", async () => {
+      await openInfo(page, ids.agentFull);
+      await page.locator(TID.body).first().waitFor({ state: "visible", timeout: 10_000 });
+      // ScrollShadow renders the scroll box as `flex-1 overflow-y-auto` inside the card
+      // (src/components/ui/ScrollShadow.tsx:59) — AppDialog.Body's own element.
+      const scrolled = await page.evaluate(() => {
+        const scroller = document
+          .querySelector("[data-app-dialog-surface]")
+          ?.querySelector<HTMLElement>(".overflow-y-auto");
+        if (!scroller) return false;
+        scroller.scrollTop = scroller.scrollHeight;
+        return scroller.scrollTop > 0;
+      });
+      if (!scrolled) {
+        throw new Error("dialog body did not scroll — nothing below the fold to capture");
+      }
+      await snap(page, "12-agent-full-tail", { marker: TID.body, locator: DIALOG });
+    });
+
+    // 3. Sparse plain shell — where the unavailable-value treatment is the whole design.
+    await step("plain-sparse", async () => {
+      await openInfo(page, ids.plain);
+      await snap(page, "20-plain-sparse", { marker: TID.body, locator: DIALOG });
+    });
+
+    // 4/5. Provenance: transport vs actor, deliberately two rows (#11808).
+    await step("mcp", async () => {
+      await openInfo(page, ids.mcp);
+      await snap(page, "25-spawned-mcp", { marker: TID.body, locator: DIALOG });
+    });
+
+    await step("assistant", async () => {
+      await openInfo(page, ids.assistant);
+      await snap(page, "26-spawned-assistant", { marker: TID.body, locator: DIALOG });
+    });
+
+    // 6. Agent that has exited — the sticky-detection state the live view cannot show.
+    await step("exited-agent", async () => {
+      await openInfo(page, ids.exitedAgent);
+      await snap(page, "30-exited-agent", { marker: TID.body, locator: DIALOG });
+    });
+
+    // 7. Plain shell that exited non-zero — the only route to the Exit Code row.
+    //
+    // Captured through `snapEither` rather than `snap`, because which state this
+    // reaches is itself the question. `handleTerminalGetInfo` resolves through
+    // `ptyClient.getTerminalInfo`, which has nothing to return once the PTY record is
+    // gone, so a panel Daintree deliberately PRESERVES for debugging can answer its own
+    // info request with "Terminal <id> not found". Asserting the body here would fail
+    // the step and hide that; asserting the error would bless it. Prove whichever it is
+    // and name the file for it.
+    await step("exited-plain", async () => {
+      await openInfo(page, ids.exitedPlain);
+      const reached = await snapEither(page, "31-exited-plain", {
+        body: TID.body,
+        error: TID.error,
+        locator: DIALOG,
+      });
+      console.log(`[terminfo-shots] exited-plain reached the "${reached}" state`);
+    });
+
+    // 8. Load failure through the real error path, on the real channel.
+    await step("error", async () => {
+      await injectFault(app, CH_GET_INFO, "EPIPE: the pty host is not responding");
+      await openInfo(page, ids.agentFull);
+      await snap(page, "40-load-error", { marker: TID.error, locator: DIALOG });
+    });
+
+    // 9. Loading held open by a main-process delay, so the shot is the real in-flight
+    //    render rather than a paused animation frame. Past the 400ms Doherty gate.
+    await step("loading", async () => {
+      await injectDelay(app, CH_GET_INFO, 9000);
+      await openInfo(page, ids.agentFull);
+      await page.waitForTimeout(1200);
+      await snap(page, "50-loading", { marker: TID.loading, locator: DIALOG });
+    });
+
+    // 10. Keyboard focus on the copy action — the only affordance on the surface, and
+    //     one reached by Tab on a dialog opened from the command palette.
+    await step("focus", async () => {
+      await openInfo(page, ids.agentFull);
+      await page.locator(TID.body).first().waitFor({ state: "visible", timeout: 10_000 });
+      await page.locator(TID.copy).first().focus();
+      await snap(page, "60-focus-copy", { marker: TID.copy, locator: DIALOG });
+    });
+
+    // 11. prefers-contrast: more — macOS "Increase contrast".
+    await step("contrast", async () => {
+      await page.emulateMedia({ contrast: "more" });
+      await openInfo(page, ids.agentFull);
+      await snap(page, "70-contrast-more", { marker: TID.body, locator: DIALOG });
+    });
+
+    // 12. forced-colors: active — Windows high contrast swaps in system colours, and
+    //     anything carrying meaning in a tint alone collapses here.
+    await step("forced", async () => {
+      await page.emulateMedia({ forcedColors: "active" });
+      await openInfo(page, ids.agentFull);
+      await snap(page, "75-forced-colors", { marker: TID.body, locator: DIALOG });
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    try {
+      repo.cleanup();
+    } catch {
+      /* best effort */
+    }
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+
+  // Counted here rather than trusted from the exit code: swallowed per-step errors are
+  // exactly how a harness reports PASS over an empty directory.
+  const written = existsSync(OUTPUT_DIR)
+    ? readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`)).length
+    : 0;
+  console.log(`[terminfo-shots] wrote ${written} png(s) to ${OUTPUT_DIR}`);
+
+  if (failures.length > 0) {
+    throw new Error(`[terminfo-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`);
+  }
+  if (written === 0) {
+    throw new Error(`[terminfo-shots] no PNGs written to ${OUTPUT_DIR}`);
+  }
+});

--- a/e2e/screenshots/terminal-info-review.spec.ts
+++ b/e2e/screenshots/terminal-info-review.spec.ts
@@ -336,51 +336,6 @@ async function snap(
 }
 
 /**
- * Capture a surface that can legitimately land in more than one state, and record which.
- *
- * Same hard rule as `snap` — nothing is written until a state is proven on screen — but
- * the caller names the states it will accept instead of the one it expects. The reached
- * state is appended to the filename, so the artifact carries its own label and a review
- * can never mistake an error shot for a populated one.
- */
-async function snapEither(
-  page: Page,
-  slug: string,
-  opts: { locator?: string } & Record<string, string>
-): Promise<string> {
-  const { locator, ...states } = opts;
-  const deadline = Date.now() + 15_000;
-  let reached: string | null = null;
-  while (Date.now() < deadline && !reached) {
-    for (const [name, selector] of Object.entries(states)) {
-      if (
-        await page
-          .locator(selector)
-          .first()
-          .isVisible()
-          .catch(() => false)
-      ) {
-        reached = name;
-        break;
-      }
-    }
-    if (!reached) await page.waitForTimeout(250);
-  }
-  if (!reached) {
-    const text = await page
-      .locator(DIALOG)
-      .innerText()
-      .catch(() => "<dialog not rendered>");
-    throw new Error(
-      `[terminfo-shots] "${slug}": none of [${Object.keys(states).join(", ")}] appeared. ` +
-        `Dialog read: ${text.slice(0, 300).replace(/\s+/g, " ")}`
-    );
-  }
-  await snap(page, `${slug}-${reached}`, { marker: states[reached]!, locator });
-  return reached;
-}
-
-/**
  * Every built-in theme. Switching themes in place reloads the renderer (see
  * `setAppTheme`), which destroys every terminal this harness spent a minute spawning,
  * so a cross-theme sweep boots once per theme:
@@ -564,21 +519,16 @@ test("terminal info review — diagnostic states", async () => {
 
     // 7. Plain shell that exited non-zero — the only route to the Exit Code row.
     //
-    // Captured through `snapEither` rather than `snap`, because which state this
-    // reaches is itself the question. `handleTerminalGetInfo` resolves through
-    // `ptyClient.getTerminalInfo`, which has nothing to return once the PTY record is
-    // gone, so a panel Daintree deliberately PRESERVES for debugging can answer its own
-    // info request with "Terminal <id> not found". Asserting the body here would fail
-    // the step and hide that; asserting the error would bless it. Prove whichever it is
-    // and name the file for it.
+    //    This step used to ask "body or error?" via `snapEither`, because a preserved
+    //    non-zero shell answered its own info request with nothing but
+    //    "Terminal <id> not found". That question is settled: the body renders from the
+    //    panel store whatever the host says. So assert BOTH — the inspector is present
+    //    AND the degradation is disclosed — which is the contract that replaced it.
     await step("exited-plain", async () => {
       await openInfo(page, ids.exitedPlain);
-      const reached = await snapEither(page, "31-exited-plain", {
-        body: TID.body,
-        error: TID.error,
-        locator: DIALOG,
-      });
-      console.log(`[terminfo-shots] exited-plain reached the "${reached}" state`);
+      await page.locator(TID.body).first().waitFor({ state: "visible", timeout: 10_000 });
+      await page.locator(TID.error).first().waitFor({ state: "visible", timeout: 10_000 });
+      await snap(page, "31-exited-plain", { marker: TID.body, locator: DIALOG });
     });
 
     // 8. Load failure through the real error path, on the real channel.

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -331,7 +331,7 @@ Performance & Diagnostics:
   };
 
   return (
-    <AppDialog isOpen={isOpen} onClose={onClose} size="lg">
+    <AppDialog isOpen={isOpen} onClose={onClose} size="lg" data-testid="terminal-info-dialog">
       <AppDialog.Header>
         <AppDialog.Title icon={<Info className="h-5 w-5" />}>Terminal Information</AppDialog.Title>
         <AppDialog.CloseButton />
@@ -339,7 +339,12 @@ Performance & Diagnostics:
 
       <AppDialog.Body>
         {loading && (
-          <div className="text-center text-daintree-text/70 py-8" role="status" aria-live="polite">
+          <div
+            className="text-center text-daintree-text/70 py-8"
+            role="status"
+            aria-live="polite"
+            data-testid="terminal-info-loading"
+          >
             Loading terminal info...
           </div>
         )}
@@ -348,6 +353,7 @@ Performance & Diagnostics:
           <div
             className="bg-status-error/10 border border-status-error/30 rounded-[var(--radius-lg)] p-4 text-status-error select-text"
             role="alert"
+            data-testid="terminal-info-error"
           >
             <p className="font-semibold mb-1">Failed to load terminal information</p>
             <p className="text-sm font-mono break-all">{error}</p>
@@ -355,7 +361,7 @@ Performance & Diagnostics:
         )}
 
         {info && !loading && (
-          <div className="space-y-6">
+          <div className="space-y-6" data-testid="terminal-info-body">
             <InfoSection title="Session Metadata">
               <InfoRow label="Terminal ID" value={info.id} mono />
               <InfoRow label="Kind" value={info.kind || "terminal"} />
@@ -464,7 +470,7 @@ Performance & Diagnostics:
           <Button variant="ghost" onClick={onClose}>
             Close
           </Button>
-          <Button variant="contrast" onClick={copyToClipboard}>
+          <Button variant="contrast" onClick={copyToClipboard} data-testid="terminal-info-copy">
             Copy to Clipboard
           </Button>
         </AppDialog.Footer>

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -656,9 +656,10 @@ Performance:
               // old treatment was the loudest thing on the surface while its own body
               // text said the values above were still accurate.
               //
-              // No tinted fill: `bg-status-*/10` composites the banner's own text down
+              // No tinted fill. A 10% status tint behind this text composites it down
               // below the 4.5:1 floor, where the same token on the bare dialog surface
-              // clears it.
+              // clears it — the tint was costing the banner its legibility to look
+              // like a banner.
               className="rounded-[var(--radius-lg)] border border-status-warning/40 p-3 space-y-2"
               role="alert"
               data-testid="terminal-info-error"

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -1,23 +1,53 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
-import { Info } from "lucide-react";
-import { logError } from "@/utils/logger";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ChevronRight, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
+import { SkeletonBone } from "@/components/ui/Skeleton";
 import type { TerminalInfoPayload } from "@/types/electron";
 import { actionService } from "@/services/ActionService";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { getAgentConfig } from "@shared/config/agentRegistry";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 
 const SYNC_MODE_POLL_MS = 250;
 
-function formatSyncMode(value: boolean | null): string {
-  if (value === null) return "Unavailable";
-  return value ? "On" : "Off";
-}
+/**
+ * One vocabulary per kind of absence, because three were doing the work of one.
+ *
+ * The old surface used "N/A" for a field that has no value, for a field whose value
+ * could not be read, and for a question we simply cannot answer — three different
+ * facts that a support engineer reads differently. `—` means the field does not apply
+ * to this terminal, "Unknown" means we could not determine it, "Unavailable" means the
+ * source could not be reached.
+ */
+const NONE = "—";
+const UNKNOWN = "Unknown";
+const UNAVAILABLE = "Unavailable";
+
+/**
+ * Section header treatment, matching `GitPushConfirmDialog` and `McpConfirmDialog`.
+ *
+ * Uppercase micro-label rather than sentence-case prose: it is a rail marker, not a
+ * sentence, and at 11px it reads as structure instead of competing with the rows for
+ * the same tab stop of the eye.
+ */
+const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
+
+/**
+ * The label rail.
+ *
+ * Fixed width, not `auto`: with `auto` the longest label in a group sets the rail for
+ * every group, so one 30-character label ("Synchronized output") pushes every value on
+ * the surface right and the rail stops being a rail. A fixed rail means labels wrap and
+ * values keep one predictable left edge, which is the entire point.
+ */
+const ROW_GRID = "grid grid-cols-[minmax(0,8.5rem)_minmax(0,1fr)] gap-x-4 gap-y-2";
 
 interface TerminalInfoDialogProps {
   isOpen: boolean;
@@ -56,75 +86,155 @@ function formatRelativeTime(timestamp: number): string {
   return `${formatDuration(diff)} ago`;
 }
 
-interface InfoSectionProps {
-  title: string;
-  children: React.ReactNode;
+function formatSyncMode(value: boolean | null): string {
+  if (value === null) return UNAVAILABLE;
+  return value ? "On" : "Off";
 }
 
-function InfoSection({ title, children }: InfoSectionProps) {
-  return (
-    <div className="space-y-3">
-      <h3 className="text-sm font-semibold text-daintree-text/90 border-b border-daintree-border pb-2">
-        {title}
-      </h3>
-      <div className="space-y-2">{children}</div>
-    </div>
-  );
+function formatYesNo(value: boolean | undefined): string {
+  if (value === undefined) return UNKNOWN;
+  return value ? "Yes" : "No";
 }
 
-interface InfoRowProps {
+/** Prefer an agent's product name over its slug; fall back to the slug we were given. */
+function agentLabel(agentId: string | undefined): string | undefined {
+  if (!agentId) return undefined;
+  return getAgentConfig(agentId)?.name ?? agentId;
+}
+
+type RowValue = string | number | null | undefined;
+
+interface RowProps {
   label: string;
-  value: string | number | undefined;
+  value: RowValue;
   mono?: boolean;
+  /** Render a delayed skeleton instead of the fallback while the remote read is in flight. */
+  pending?: boolean;
+  /** What to show when the value is absent. Defaults to the not-applicable dash. */
+  fallback?: string;
 }
 
-function InfoRow({ label, value, mono = false }: InfoRowProps) {
-  const displayValue = value ?? "N/A";
-  const valueElement = (
-    <span
-      className={`text-daintree-text text-right select-text ${mono ? "font-mono text-xs" : ""}`}
-    >
-      {displayValue}
-    </span>
-  );
+/**
+ * One label/value pair.
+ *
+ * A fragment of `<dt>`/`<dd>` rather than a wrapper element, so the pairs are direct
+ * grid children of their `<dl>` and every row in a group shares one rail. The
+ * alternative — a `<div>` per pair — needs `display: contents` to participate in the
+ * grid, which has a documented history of dropping the row from the accessibility tree.
+ */
+function Row({ label, value, mono = false, pending = false, fallback = NONE }: RowProps) {
+  const hasValue = value !== undefined && value !== null && value !== "";
+  const display = hasValue ? String(value) : fallback;
 
   return (
-    <div className="flex justify-between items-start gap-4 text-sm">
-      <span className="text-daintree-text/70 shrink-0 select-none">{label}:</span>
-      {typeof displayValue === "string" ? (
-        <Tooltip>
-          <TooltipTrigger asChild>{valueElement}</TooltipTrigger>
-          <TooltipContent side="bottom">{displayValue}</TooltipContent>
-        </Tooltip>
-      ) : (
-        valueElement
-      )}
-    </div>
+    <>
+      <dt className="text-daintree-text/70 select-none min-w-0 break-words">{label}</dt>
+      <dd className="min-w-0 text-daintree-text">
+        {!hasValue && pending ? (
+          <SkeletonBone className="h-4 w-32" />
+        ) : (
+          <TruncatedTooltip content={display}>
+            <span
+              className={cn(
+                "block select-text",
+                // `anywhere`, not `break-all`: a path breaks at its separators where it
+                // can and mid-token only where it must, so the leaf directory — the
+                // informative half — survives instead of being ellipsed away.
+                mono ? "font-mono text-xs [overflow-wrap:anywhere] tabular-nums" : "break-words",
+                !hasValue && "text-daintree-text/70"
+              )}
+            >
+              {display}
+            </span>
+          </TruncatedTooltip>
+        )}
+      </dd>
+    </>
   );
 }
 
-interface InfoListRowProps {
+interface ChipRowProps {
   label: string;
   items: string[] | undefined;
+  pending?: boolean;
 }
 
-function InfoListRow({ label, items }: InfoListRowProps) {
-  if (!items || items.length === 0) return null;
+function ChipRow({ label, items, pending = false }: ChipRowProps) {
+  const isEmpty = !items || items.length === 0;
 
   return (
-    <div className="flex justify-between items-start gap-4 text-sm">
-      <span className="text-daintree-text/70 shrink-0 select-none">{label}:</span>
-      <div className="flex flex-wrap gap-1 justify-end">
-        {items.map((item, i) => (
-          <code
-            key={`${i}-${item}`}
-            className="bg-daintree-bg/50 border border-daintree-border font-mono text-xs px-1.5 py-0.5 rounded select-text break-all"
-          >
-            {item}
-          </code>
-        ))}
+    <>
+      <dt className="text-daintree-text/70 select-none min-w-0 break-words">{label}</dt>
+      <dd className="min-w-0">
+        {isEmpty && pending ? (
+          <SkeletonBone className="h-4 w-40" />
+        ) : isEmpty ? (
+          <span className="text-daintree-text/70">{NONE}</span>
+        ) : (
+          <div className="flex flex-wrap gap-1">
+            {items.map((item, i) => (
+              <code
+                key={`${i}-${item}`}
+                className="bg-overlay-subtle border border-border-default font-mono text-xs px-1.5 py-0.5 rounded-[var(--radius-sm)] select-text [overflow-wrap:anywhere]"
+              >
+                {item}
+              </code>
+            ))}
+          </div>
+        )}
+      </dd>
+    </>
+  );
+}
+
+function Group({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h3 className={MICRO_LABEL}>{title}</h3>
+      <dl className={cn(ROW_GRID, "text-sm")}>{children}</dl>
+    </section>
+  );
+}
+
+/**
+ * A group that starts closed.
+ *
+ * PTY internals and buffer sizes are wanted perhaps once a year, and while they sit
+ * permanently open they cost every reader a scroll past them to reach anything else.
+ * Collapsed they are one keystroke away — and they stay in the copied payload whatever
+ * their open state, because a support engineer pasting diagnostics into an issue must
+ * never have to know which sections they left expanded.
+ */
+function DisclosureGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  const [expanded, setExpanded] = useState(false);
+  const panelId = useId();
+
+  return (
+    <section>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        onClick={() => setExpanded((value) => !value)}
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded-[var(--radius-sm)] py-1 text-left",
+          "transition-colors duration-150 ease-out hover:bg-overlay-subtle",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2"
+        )}
+      >
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            "w-3 h-3 shrink-0 text-daintree-text/40 transition-transform duration-150 ease-out",
+            expanded && "rotate-90"
+          )}
+        />
+        <span className={MICRO_LABEL}>{title}</span>
+      </button>
+      <div id={panelId} hidden={!expanded}>
+        <dl className={cn(ROW_GRID, "text-sm pt-2 pl-[1.125rem]")}>{children}</dl>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -133,8 +243,12 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [syncMode, setSyncMode] = useState<boolean | null>(null);
+  const [showErrorDetail, setShowErrorDetail] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+  const errorDetailId = useId();
   const panelRaw = usePanelStore((state) => state.panelsById[terminalId]);
   const panel = panelRaw && isPtyPanel(panelRaw) ? panelRaw : undefined;
+  const { copied, copy } = useCopyWithFeedback({ announcement: "Diagnostics copied" });
 
   useEffect(() => {
     if (!isOpen) {
@@ -142,6 +256,7 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
       setError(null);
       setLoading(false);
       setSyncMode(null);
+      setShowErrorDetail(false);
       return;
     }
 
@@ -179,7 +294,7 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
     return () => {
       isMounted = false;
     };
-  }, [isOpen, terminalId]);
+  }, [isOpen, terminalId, reloadKey]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -211,270 +326,484 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   // still an MCP dispatch, which is the useful half when debugging routing.
   const startedByAssistant = spawnSource === "assistant";
   const startedViaMcp =
-    spawnSource === "mcp" || startedByAssistant ? "Yes" : spawnSource ? "No" : "Unknown";
+    spawnSource === "mcp" || startedByAssistant ? "Yes" : spawnSource ? "No" : UNKNOWN;
   const uiStartedAt = panel?.startedAt;
-  const spawnStatus = panel?.spawnStatus;
   const location = panel?.location;
   const agentPresetId = panel?.agentPresetId ?? info?.agentPresetId;
   const agentPresetColor = panel?.agentPresetColor ?? info?.agentPresetColor;
   const originalPresetId = panel?.originalPresetId ?? info?.originalAgentPresetId;
   const agentSessionId = panel?.agentSessionId ?? info?.agentSessionId;
 
+  const title = panel?.title ?? info?.title;
+  const cwd = info?.cwd ?? panel?.cwd;
+  const detectedAgentId = info?.detectedAgentId ?? panel?.detectedAgentId;
+  const everDetectedAgent = info?.everDetectedAgent ?? panel?.everDetectedAgent;
+  const agentState = info?.agentState ?? panel?.agentState;
+  const exitCode = panel?.exitCode ?? info?.exitCode;
+  const agentLaunchFlags = info?.agentLaunchFlags ?? panel?.agentLaunchFlags;
+  const agentModelId = info?.agentModelId ?? panel?.agentModelId;
+
+  // `runtimeStatus` over `hasPty`: the store's own contract note in
+  // `src/store/fleetEligibility.ts` records that `hasPty` lags after backend
+  // snapshots and reconnects for panels preserved past exit, while
+  // `runtimeStatus` is the renderer's authoritative liveness signal. It is also
+  // local, so it survives the payload read failing — which is exactly the case
+  // where liveness matters most.
+  const runtimeStatus = panel?.runtimeStatus;
+  const hasExited = runtimeStatus === "exited" || info?.hasPty === false;
+  const liveness = hasExited
+    ? exitCode != null
+      ? `Exited · code ${exitCode}`
+      : "Exited"
+    : runtimeStatus === "error"
+      ? "Error"
+      : panel || info
+        ? "Running"
+        : UNKNOWN;
+
+  // The remote read is in flight and has never landed. Rows the payload owns show a
+  // delayed skeleton; rows the panel store owns are already correct and never flicker.
+  const pending = loading && !info && !error;
+
+  const agentName = agentLabel(detectedAgentId ?? launchAgentId);
+  const runningLabel = info?.ptyForegroundProcess ?? (hasExited ? NONE : undefined);
+
   // "Launch Context" reflects how the panel was configured at spawn time.
   const showAgentLaunchSection = !!(
     launchAgentId ||
-    (info?.agentLaunchFlags && info.agentLaunchFlags.length > 0) ||
-    info?.agentModelId ||
+    (agentLaunchFlags && agentLaunchFlags.length > 0) ||
+    agentModelId ||
     agentPresetId ||
     originalPresetId
   );
   // "Live State" reflects what's running right now. Shown for agent launches,
   // while a runtime agent is detected, or once an agent has ever been detected
   // in this session (so plain terminals that ran `claude` still show the exit).
-  const showAgentLiveSection = !!(
-    launchAgentId ||
-    info?.detectedAgentId ||
-    info?.everDetectedAgent
-  );
+  const showAgentLiveSection = !!(launchAgentId || detectedAgentId || everDetectedAgent);
 
   const formatArgsForClipboard = (args: string[] | undefined): string => {
-    if (args === undefined) return "N/A";
+    if (args === undefined) return UNKNOWN;
     if (args.length === 0) return "(none)";
     return args.join(" ");
   };
 
-  const copyToClipboard = async () => {
-    if (!info) return;
-
+  /**
+   * The full payload, built from data rather than from the DOM.
+   *
+   * Deliberately independent of which disclosures are open and of whether the remote
+   * read succeeded: a support engineer pasting this into an issue must get everything
+   * the app knows, and on a terminal whose PTY record is gone the panel-store half is
+   * the only half there is.
+   */
+  const buildDiagnostics = useCallback((): string => {
     const launchSection = showAgentLaunchSection
       ? `
 
-Agent — Launch Context:
-  Launch Agent: ${launchAgentId ?? "N/A"}
-  Command: ${command ?? "N/A"}
-  Launch Flags: ${formatArgsForClipboard(info.agentLaunchFlags)}
-  Model: ${info.agentModelId ?? "N/A"}
-  Preset: ${agentPresetId ?? "N/A"}
-  Preset Color: ${agentPresetColor ?? "N/A"}
-  Original Preset: ${originalPresetId ?? "N/A"}`
+Agent — launch context:
+  Launch agent: ${launchAgentId ?? NONE}
+  Command: ${command ?? NONE}
+  Launch flags: ${formatArgsForClipboard(agentLaunchFlags)}
+  Model: ${agentModelId ?? NONE}
+  Preset: ${agentPresetId ?? NONE}
+  Preset color: ${agentPresetColor ?? NONE}
+  Original preset: ${originalPresetId ?? NONE}`
       : "";
 
     const liveSection = showAgentLiveSection
       ? `
 
-Agent — Live State:
-  Detected Agent ID: ${info.detectedAgentId ?? (info.everDetectedAgent ? "None — agent has exited" : "Not detected yet")}
-  Agent State: ${info.agentState ?? "N/A"}
-  Session ID: ${agentSessionId ?? "N/A"}`
+Agent — live state:
+  Detected agent ID: ${detectedAgentId ?? (everDetectedAgent ? "None — agent has exited" : "Not detected yet")}
+  Agent state: ${agentState ?? NONE}
+  Session ID: ${agentSessionId ?? NONE}`
       : "";
 
     const agentSection = launchSection + liveSection;
 
-    const diagnosticInfo = `Terminal Diagnostic Information
+    return `Terminal Diagnostic Information
 =====================================
 
-Session Metadata:
-  ID: ${info.id}
-  Kind: ${info.kind || "terminal"}
-  Title: ${info.title || "N/A"}
-  Title Mode: ${titleMode ?? "default"}
-  Project ID: ${info.projectId || "N/A"}
-  Worktree ID: ${worktreeId || "N/A"}
-  CWD: ${info.cwd}
-  Location: ${location ?? "N/A"}
-  Spawn Source: ${spawnSource ?? "N/A"}
-${startedByAssistant ? "  Started By: Daintree Assistant\n" : ""}  Started via MCP: ${startedViaMcp}
-  Spawn Status: ${spawnStatus ?? "N/A"}
-  UI Created At: ${uiStartedAt != null ? formatTimestamp(uiStartedAt) : "N/A"}
+Status:
+  Liveness: ${liveness}
+  Runtime status: ${runtimeStatus ?? UNKNOWN}
+  Foreground process: ${info?.ptyForegroundProcess ?? NONE}
+  Exit code: ${exitCode != null ? exitCode : NONE}
+${info ? "" : `  NOTE: the live terminal record could not be read${error ? ` (${error})` : ""}; the values below come from the panel store only.\n`}
+Session metadata:
+  ID: ${info?.id ?? terminalId}
+  Kind: ${info?.kind || panel?.kind || "terminal"}
+  Title: ${title ?? NONE}
+  Title mode: ${titleMode ?? "default"}
+  Project ID: ${info?.projectId || NONE}
+  Worktree ID: ${worktreeId || NONE}
+  CWD: ${cwd ?? NONE}
+  Location: ${location ?? NONE}
+  Spawn source: ${spawnSource ?? NONE}
+${startedByAssistant ? "  Started by: Daintree Assistant\n" : ""}  Started via MCP: ${startedViaMcp}
+  UI created at: ${uiStartedAt != null ? formatTimestamp(uiStartedAt) : NONE}
 
-Spawn Command:
-  Shell: ${info.shell || "N/A"}
-  Command: ${command ?? "N/A"}
-  Args: ${formatArgsForClipboard(info.spawnArgs)}${agentSection}
+Spawn command:
+  Shell: ${info?.shell || NONE}
+  Command: ${command ?? NONE}
+  Args: ${formatArgsForClipboard(info?.spawnArgs)}${agentSection}
 
-Terminal Classification:
-  Agent Launch Hint: ${launchAgentId ? "Yes" : "No"}
-  PTY Active: ${info.hasPty ? "Yes" : "No"}
-  Analysis Enabled: ${info.analysisEnabled ? "Yes" : "No"}
-  Resize Strategy: ${info.resizeStrategy || "default"}
+Terminal internals:
+  Agent launch hint: ${launchAgentId ? "Yes" : "No"}
+  PTY active: ${formatYesNo(info?.hasPty)}
+  Analysis enabled: ${formatYesNo(info?.analysisEnabled)}
+  Resize strategy: ${info?.resizeStrategy || "default"}
+  Dimensions: ${info?.ptyCols != null && info?.ptyRows != null ? `${info.ptyCols} × ${info.ptyRows}` : UNAVAILABLE}
+  Shell PID: ${info?.ptyPid ?? UNAVAILABLE}
+  TTY device: ${info?.ptyTty ?? UNAVAILABLE}
 
-PTY Diagnostics:
-  Dimensions: ${info.ptyCols != null && info.ptyRows != null ? `${info.ptyCols} × ${info.ptyRows}` : "N/A"}
-  Shell PID: ${info.ptyPid ?? "N/A"}
-  TTY Device: ${info.ptyTty ?? "N/A"}
-  Foreground Process: ${info.ptyForegroundProcess ?? "N/A"}
-  Exit Code: ${info.exitCode != null ? info.exitCode : "N/A"}
+Runtime statistics:
+  Running time: ${info ? formatDuration(Date.now() - info.spawnedAt) : UNAVAILABLE}
+  Spawned at: ${info ? formatTimestamp(info.spawnedAt) : UNAVAILABLE}
+  Restart count: ${info?.restartCount ?? UNAVAILABLE}
 
-Runtime Statistics:
-  Running Time: ${formatDuration(Date.now() - info.spawnedAt)}
-  Spawned At: ${formatTimestamp(info.spawnedAt)}
-  Restart Count: ${info.restartCount}
+Activity metrics:
+  Last input: ${info ? `${formatRelativeTime(info.lastInputTime)} (${formatTimestamp(info.lastInputTime)})` : UNAVAILABLE}
+  Last output: ${info ? `${formatRelativeTime(info.lastOutputTime)} (${formatTimestamp(info.lastOutputTime)})` : UNAVAILABLE}
+  Agent state: ${agentState || NONE}
+  Last state change: ${info?.lastStateChange != null ? formatRelativeTime(info.lastStateChange) : NONE}
+  Activity tier: ${info?.activityTier ?? UNAVAILABLE}
 
-Activity Metrics:
-  Last Input: ${formatRelativeTime(info.lastInputTime)} (${formatTimestamp(info.lastInputTime)})
-  Last Output: ${formatRelativeTime(info.lastOutputTime)} (${formatTimestamp(info.lastOutputTime)})
-  Agent State: ${info.agentState || "N/A"}
-  Last State Change: ${info.lastStateChange != null ? formatRelativeTime(info.lastStateChange) : "N/A"}
-  Activity Tier: ${info.activityTier}
-
-Performance & Diagnostics:
-  Output Buffer Size: ${info.outputBufferSize} lines
-  Semantic Buffer: ${info.semanticBufferLines} lines
-  Synchronized Output (DEC 2026): ${formatSyncMode(syncMode)}
+Performance & diagnostics:
+  Output buffer size: ${info?.outputBufferSize ?? UNAVAILABLE} lines
+  Semantic buffer: ${info?.semanticBufferLines ?? UNAVAILABLE} lines
+  Synchronized output (DEC 2026): ${formatSyncMode(syncMode)}
 `;
+  }, [
+    agentLaunchFlags,
+    agentModelId,
+    agentPresetColor,
+    agentPresetId,
+    agentSessionId,
+    agentState,
+    command,
+    cwd,
+    detectedAgentId,
+    error,
+    everDetectedAgent,
+    exitCode,
+    info,
+    launchAgentId,
+    liveness,
+    location,
+    originalPresetId,
+    panel?.kind,
+    runtimeStatus,
+    showAgentLaunchSection,
+    showAgentLiveSection,
+    spawnSource,
+    startedByAssistant,
+    startedViaMcp,
+    syncMode,
+    terminalId,
+    title,
+    titleMode,
+    uiStartedAt,
+    worktreeId,
+  ]);
 
-    try {
-      await navigator.clipboard.writeText(diagnosticInfo);
-    } catch (err) {
-      logError("Failed to copy to clipboard", err);
-    }
-  };
+  const handleCopy = useCallback(() => {
+    void copy(buildDiagnostics());
+  }, [buildDiagnostics, copy]);
 
   return (
     <AppDialog isOpen={isOpen} onClose={onClose} size="lg" data-testid="terminal-info-dialog">
       <AppDialog.Header>
-        <AppDialog.Title icon={<Info className="h-5 w-5" />}>Terminal Information</AppDialog.Title>
+        <AppDialog.Title icon={<Info className="h-5 w-5" />}>Terminal information</AppDialog.Title>
         <AppDialog.CloseButton />
       </AppDialog.Header>
 
       <AppDialog.Body>
-        {loading && (
-          <div
-            className="text-center text-daintree-text/70 py-8"
-            role="status"
-            aria-live="polite"
-            data-testid="terminal-info-loading"
+        <div className="space-y-6" data-testid="terminal-info-body">
+          {/*
+           * The overview answers the first four ranked questions before anything else:
+           * is it alive, what is running in it, how long has it been going, and which
+           * terminal is this. It is never collapsed and never skeletoned away — every
+           * value in it has a panel-store source, so it is correct on the first frame
+           * and correct even when the remote read fails outright.
+           */}
+          <section
+            className="rounded-[var(--radius-lg)] border border-border-default bg-overlay-subtle px-4 py-3 space-y-3"
+            data-testid="terminal-info-overview"
           >
-            Loading terminal info...
-          </div>
-        )}
-
-        {error && (
-          <div
-            className="bg-status-error/10 border border-status-error/30 rounded-[var(--radius-lg)] p-4 text-status-error select-text"
-            role="alert"
-            data-testid="terminal-info-error"
-          >
-            <p className="font-semibold mb-1">Failed to load terminal information</p>
-            <p className="text-sm font-mono break-all">{error}</p>
-          </div>
-        )}
-
-        {info && !loading && (
-          <div className="space-y-6" data-testid="terminal-info-body">
-            <InfoSection title="Session Metadata">
-              <InfoRow label="Terminal ID" value={info.id} mono />
-              <InfoRow label="Kind" value={info.kind || "terminal"} />
-              <InfoRow label="Title" value={info.title} />
-              <InfoRow label="Title Mode" value={titleMode ?? "default"} />
-              <InfoRow label="Project ID" value={info.projectId} mono />
-              <InfoRow label="Worktree ID" value={worktreeId} mono />
-              <InfoRow label="Current Directory" value={info.cwd} mono />
-              <InfoRow label="Location" value={location} />
-              <InfoRow label="Spawn Source" value={spawnSource} />
-              {startedByAssistant && <InfoRow label="Started By" value="Daintree Assistant" />}
-              <InfoRow label="Started via MCP" value={startedViaMcp} />
-              <InfoRow label="Spawn Status" value={spawnStatus} />
-              {uiStartedAt != null && (
-                <InfoRow label="UI Created At" value={formatTimestamp(uiStartedAt)} />
-              )}
-            </InfoSection>
-
-            <InfoSection title="Spawn Command">
-              <InfoRow label="Shell" value={info.shell} mono />
-              {command && <InfoRow label="Command" value={command} mono />}
-              <InfoListRow label="Args" items={info.spawnArgs} />
-            </InfoSection>
-
-            {showAgentLaunchSection && (
-              <InfoSection title="Agent — Launch Context">
-                {launchAgentId && <InfoRow label="Launch Agent" value={launchAgentId} />}
-                <InfoListRow label="Launch Flags" items={info.agentLaunchFlags} />
-                {info.agentModelId && <InfoRow label="Model" value={info.agentModelId} mono />}
-                {agentPresetId && <InfoRow label="Preset" value={agentPresetId} mono />}
-                {agentPresetColor && <InfoRow label="Preset Color" value={agentPresetColor} mono />}
-                {originalPresetId && (
-                  <InfoRow label="Original Preset" value={originalPresetId} mono />
-                )}
-              </InfoSection>
-            )}
-
-            {showAgentLiveSection && (
-              <InfoSection title="Agent — Live State">
-                <InfoRow
-                  label="Detected Agent"
-                  value={
-                    info.detectedAgentId ??
-                    (info.everDetectedAgent ? "None — agent has exited" : "Not detected yet")
-                  }
-                />
-                {agentSessionId && <InfoRow label="Session ID" value={agentSessionId} mono />}
-              </InfoSection>
-            )}
-
-            <InfoSection title="Terminal Classification">
-              <InfoRow label="Agent Launch Hint" value={launchAgentId ? "Yes" : "No"} />
-              <InfoRow label="PTY Active" value={info.hasPty ? "Yes" : "No"} />
-              <InfoRow label="Analysis Enabled" value={info.analysisEnabled ? "Yes" : "No"} />
-              <InfoRow label="Resize Strategy" value={info.resizeStrategy || "default"} />
-            </InfoSection>
-
-            <InfoSection title="PTY Diagnostics">
-              {info.ptyCols != null && info.ptyRows != null && (
-                <InfoRow label="Dimensions" value={`${info.ptyCols} × ${info.ptyRows}`} />
-              )}
-              <InfoRow label="Shell PID" value={info.ptyPid} mono />
-              {info.ptyTty != null && <InfoRow label="TTY Device" value={info.ptyTty} mono />}
-              <InfoRow label="Foreground Process" value={info.ptyForegroundProcess} />
-              {info.exitCode != null && <InfoRow label="Exit Code" value={info.exitCode} mono />}
-            </InfoSection>
-
-            <InfoSection title="Runtime Statistics">
-              <InfoRow label="Running Time" value={formatDuration(Date.now() - info.spawnedAt)} />
-              <InfoRow label="Spawned At" value={formatTimestamp(info.spawnedAt)} />
-              <InfoRow label="Restart Count" value={info.restartCount} />
-            </InfoSection>
-
-            <InfoSection title="Activity Metrics">
-              <InfoRow
-                label="Last Input"
-                value={`${formatRelativeTime(info.lastInputTime)} (${formatTimestamp(info.lastInputTime)})`}
-              />
-              <InfoRow
-                label="Last Output"
-                value={`${formatRelativeTime(info.lastOutputTime)} (${formatTimestamp(info.lastOutputTime)})`}
-              />
-              <InfoRow label="Agent State" value={info.agentState || "N/A"} />
-              <InfoRow
-                label="Last State Change"
+            <div className="flex items-baseline justify-between gap-3">
+              <h3 className="text-base font-semibold text-daintree-text min-w-0 break-words select-text">
+                {title ?? "Terminal"}
+              </h3>
+              {/*
+               * Words, not a tint. A coloured status pill is the obvious move and it is
+               * the wrong one here: `forced-colors: active` replaces every fill with a
+               * system colour, so a pill that carries its meaning in green-vs-red reads
+               * as one indistinguishable shape on Windows high contrast. "Exited · code
+               * 3" survives that intact, and it needs no accent.
+               */}
+              <span
+                className="text-sm font-medium text-daintree-text shrink-0 tabular-nums select-text"
+                data-testid="terminal-info-liveness"
+              >
+                {liveness}
+              </span>
+            </div>
+            <dl className={cn(ROW_GRID, "text-sm")}>
+              <Row
+                label="Running"
                 value={
-                  info.lastStateChange != null
-                    ? `${formatRelativeTime(info.lastStateChange)} (${formatTimestamp(info.lastStateChange)})`
-                    : "N/A"
+                  agentName ? `${agentName}${agentState ? ` · ${agentState}` : ""}` : runningLabel
                 }
+                pending={pending}
+                fallback={hasExited ? NONE : UNKNOWN}
               />
-              <InfoRow label="Activity Tier" value={info.activityTier} />
-            </InfoSection>
+              <Row
+                label="Runtime"
+                value={info ? formatDuration(Date.now() - info.spawnedAt) : undefined}
+                pending={pending}
+                fallback={UNAVAILABLE}
+              />
+              <Row
+                label="Last output"
+                value={info ? formatRelativeTime(info.lastOutputTime) : undefined}
+                pending={pending}
+                fallback={UNAVAILABLE}
+              />
+              <Row label="Directory" value={cwd} mono pending={pending} />
+            </dl>
+          </section>
 
-            <InfoSection title="Performance & Diagnostics">
-              <InfoRow label="Output Buffer Size" value={`${info.outputBufferSize} lines`} />
-              <InfoRow label="Semantic Buffer" value={`${info.semanticBufferLines} lines`} />
-              <InfoRow label="Synchronized Output (DEC 2026)" value={formatSyncMode(syncMode)} />
-            </InfoSection>
-          </div>
-        )}
+          {error && (
+            <div
+              // No tinted fill. `bg-status-error/10` composites the error text down to
+              // 4.22:1 against the dialog surface — under the AA floor — where the same
+              // token on the bare surface measures 4.83:1. The tint was costing the
+              // banner its legibility to look like a banner.
+              className="rounded-[var(--radius-lg)] border border-status-error/40 p-4 space-y-3"
+              role="alert"
+              data-testid="terminal-info-error"
+            >
+              <div className="space-y-1">
+                <p className="font-semibold text-status-error">
+                  Couldn&apos;t load live terminal data
+                </p>
+                <p className="text-sm text-daintree-text/80">
+                  The values above come from this window and are still accurate. Process-level
+                  details — PID, TTY, buffers, activity — need the terminal host, which didn&apos;t
+                  answer.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={() => setReloadKey((k) => k + 1)}>
+                  Retry
+                </Button>
+                <button
+                  type="button"
+                  aria-expanded={showErrorDetail}
+                  aria-controls={errorDetailId}
+                  onClick={() => setShowErrorDetail((value) => !value)}
+                  className={cn(
+                    "flex items-center gap-1 rounded-[var(--radius-sm)] px-1.5 py-1 text-xs text-daintree-text/70",
+                    "transition-colors duration-150 ease-out hover:bg-overlay-subtle hover:text-daintree-text",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2"
+                  )}
+                >
+                  <ChevronRight
+                    aria-hidden="true"
+                    className={cn(
+                      "w-3 h-3 shrink-0 transition-transform duration-150 ease-out",
+                      showErrorDetail && "rotate-90"
+                    )}
+                  />
+                  Technical details
+                </button>
+              </div>
+              <p
+                id={errorDetailId}
+                hidden={!showErrorDetail}
+                // `anywhere` rather than `break-all`: the old rule split the terminal
+                // UUID mid-token so the wrapped line opened with a bare hyphen that read
+                // as a stray dash, and the id could not be selected as one string.
+                className="text-xs font-mono [overflow-wrap:anywhere] text-daintree-text/80 select-text"
+              >
+                {error}
+              </p>
+            </div>
+          )}
+
+          <Group title="Session">
+            <Row label="Terminal ID" value={info?.id ?? terminalId} mono />
+            <Row label="Kind" value={info?.kind || panel?.kind || "terminal"} />
+            <Row label="Title mode" value={titleMode ?? "default"} />
+            <Row label="Location" value={location} pending={pending} />
+            <Row label="Worktree ID" value={worktreeId} mono pending={pending} />
+            <Row label="Project ID" value={info?.projectId} mono pending={pending} />
+          </Group>
+
+          <Group title="How it launched">
+            <Row label="Shell" value={info?.shell} mono pending={pending} fallback={UNAVAILABLE} />
+            <Row label="Command" value={command} mono pending={pending} />
+            <ChipRow label="Arguments" items={info?.spawnArgs} pending={pending} />
+            <Row label="Spawn source" value={spawnSource} pending={pending} />
+            {startedByAssistant && <Row label="Started by" value="Daintree Assistant" />}
+            <Row label="Started via MCP" value={startedViaMcp} />
+            <Row
+              label="Created"
+              value={uiStartedAt != null ? formatTimestamp(uiStartedAt) : undefined}
+              fallback={UNAVAILABLE}
+            />
+            <Row
+              label="Spawned"
+              value={info ? formatTimestamp(info.spawnedAt) : undefined}
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+          </Group>
+
+          {showAgentLaunchSection && (
+            <Group title="Agent launch">
+              <Row label="Launch agent" value={agentLabel(launchAgentId)} />
+              <ChipRow label="Launch flags" items={agentLaunchFlags} pending={pending} />
+              <Row label="Model" value={agentModelId} mono pending={pending} />
+              <Row label="Preset" value={agentPresetId} mono />
+              <Row label="Preset color" value={agentPresetColor} mono />
+              <Row label="Original preset" value={originalPresetId} mono />
+            </Group>
+          )}
+
+          {showAgentLiveSection && (
+            <Group title="Agent state">
+              <Row
+                label="Detected agent"
+                value={
+                  agentLabel(detectedAgentId) ??
+                  (everDetectedAgent ? "None — agent has exited" : "Not detected yet")
+                }
+                pending={pending}
+              />
+              <Row label="State" value={agentState} pending={pending} />
+              <Row
+                label="State changed"
+                value={
+                  info?.lastStateChange != null
+                    ? formatRelativeTime(info.lastStateChange)
+                    : undefined
+                }
+                pending={pending}
+              />
+              <Row label="Session ID" value={agentSessionId} mono />
+            </Group>
+          )}
+
+          <Group title="Activity">
+            <Row
+              label="Last input"
+              value={info ? formatRelativeTime(info.lastInputTime) : undefined}
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+            <Row
+              label="Last output"
+              value={info ? formatRelativeTime(info.lastOutputTime) : undefined}
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+            <Row
+              label="Activity tier"
+              value={info?.activityTier}
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+            <Row
+              label="Restarts"
+              value={info?.restartCount}
+              mono
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+          </Group>
+
+          <DisclosureGroup title="Terminal internals">
+            <Row label="PTY active" value={formatYesNo(info?.hasPty)} pending={pending} />
+            <Row
+              label="Shell PID"
+              value={info?.ptyPid}
+              mono
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+            <Row
+              label="TTY device"
+              value={info?.ptyTty}
+              mono
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+            <Row
+              label="Dimensions"
+              value={
+                info?.ptyCols != null && info?.ptyRows != null
+                  ? `${info.ptyCols} × ${info.ptyRows}`
+                  : undefined
+              }
+              mono
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+            <Row label="Exit code" value={exitCode} mono fallback={hasExited ? UNKNOWN : NONE} />
+            <Row
+              label="Resize strategy"
+              value={info?.resizeStrategy || "default"}
+              pending={pending}
+            />
+            <Row
+              label="Analysis enabled"
+              value={formatYesNo(info?.analysisEnabled)}
+              pending={pending}
+            />
+            <Row label="Agent launch hint" value={launchAgentId ? "Yes" : "No"} />
+          </DisclosureGroup>
+
+          <DisclosureGroup title="Performance">
+            <Row
+              label="Output buffer"
+              value={info?.outputBufferSize != null ? `${info.outputBufferSize} lines` : undefined}
+              mono
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+            <Row
+              label="Semantic buffer"
+              value={
+                info?.semanticBufferLines != null ? `${info.semanticBufferLines} lines` : undefined
+              }
+              mono
+              pending={pending}
+              fallback={UNAVAILABLE}
+            />
+            <Row label="Synchronized output" value={formatSyncMode(syncMode)} />
+          </DisclosureGroup>
+        </div>
       </AppDialog.Body>
 
-      {info && !loading && (
-        <AppDialog.Footer>
-          <Button variant="ghost" onClick={onClose}>
-            Close
-          </Button>
-          <Button variant="contrast" onClick={copyToClipboard} data-testid="terminal-info-copy">
-            Copy to Clipboard
-          </Button>
-        </AppDialog.Footer>
-      )}
+      <AppDialog.Footer>
+        <Button variant="ghost" onClick={onClose}>
+          Close
+        </Button>
+        {/*
+         * The visible label changes but `aria-label` does not: `useCopyWithFeedback`
+         * already announces the result on the polite live region, and a changing
+         * accessible name would announce it a second time.
+         */}
+        <Button
+          variant="contrast"
+          onClick={handleCopy}
+          aria-label="Copy diagnostics"
+          data-testid="terminal-info-copy"
+        >
+          {copied ? "Copied" : "Copy diagnostics"}
+        </Button>
+      </AppDialog.Footer>
     </AppDialog>
   );
 }

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useId, useState } from "react";
+import { Children, isValidElement, useCallback, useEffect, useId, useState } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
 import { ChevronRight, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { SkeletonBone } from "@/components/ui/Skeleton";
 import type { TerminalInfoPayload } from "@/types/electron";
 import { actionService } from "@/services/ActionService";
@@ -13,6 +12,7 @@ import { getAgentConfig } from "@shared/config/agentRegistry";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
+import { notify } from "@/lib/notify";
 import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 
 const SYNC_MODE_POLL_MS = 250;
@@ -131,22 +131,24 @@ function Row({ label, value, mono = false, pending = false, fallback = NONE }: R
       <dt className="text-daintree-text/70 select-none min-w-0 break-words">{label}</dt>
       <dd className="min-w-0 text-daintree-text">
         {!hasValue && pending ? (
-          <SkeletonBone className="h-4 w-32" />
+          <SkeletonBone className="h-4 w-32" data-testid="terminal-info-pending" />
         ) : (
-          <TruncatedTooltip content={display}>
-            <span
-              className={cn(
-                "block select-text",
-                // `anywhere`, not `break-all`: a path breaks at its separators where it
-                // can and mid-token only where it must, so the leaf directory — the
-                // informative half — survives instead of being ellipsed away.
-                mono ? "font-mono text-xs [overflow-wrap:anywhere] tabular-nums" : "break-words",
-                !hasValue && "text-daintree-text/70"
-              )}
-            >
-              {display}
-            </span>
-          </TruncatedTooltip>
+          // No truncation tooltip. Every value here is a wrapping block, so
+          // `useTruncationDetection`'s `scrollWidth > clientWidth` can never fire — the
+          // wrapper was buying a ResizeObserver registration and a state hook per row
+          // for a tooltip that cannot open, and advertising a contract that isn't real.
+          <span
+            className={cn(
+              "block select-text",
+              // `anywhere`, not `break-all`: a path breaks at its separators where it
+              // can and mid-token only where it must, so the leaf directory — the
+              // informative half — survives instead of being ellipsed away.
+              mono ? "font-mono text-xs [overflow-wrap:anywhere] tabular-nums" : "break-words",
+              !hasValue && "text-daintree-text/70"
+            )}
+          >
+            {display}
+          </span>
         )}
       </dd>
     </>
@@ -167,7 +169,7 @@ function ChipRow({ label, items, pending = false }: ChipRowProps) {
       <dt className="text-daintree-text/70 select-none min-w-0 break-words">{label}</dt>
       <dd className="min-w-0">
         {isEmpty && pending ? (
-          <SkeletonBone className="h-4 w-40" />
+          <SkeletonBone className="h-4 w-40" data-testid="terminal-info-pending" />
         ) : isEmpty ? (
           <span className="text-daintree-text/70">{NONE}</span>
         ) : (
@@ -205,9 +207,19 @@ function Group({ title, children }: { title: string; children: React.ReactNode }
  * their open state, because a support engineer pasting diagnostics into an issue must
  * never have to know which sections they left expanded.
  */
-function DisclosureGroup({ title, children }: { title: string; children: React.ReactNode }) {
-  const [expanded, setExpanded] = useState(false);
+function DisclosureGroup({
+  title,
+  expanded,
+  onToggle,
+  children,
+}: {
+  title: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
   const panelId = useId();
+  const count = Children.toArray(children).filter(isValidElement).length;
 
   return (
     <section>
@@ -215,9 +227,13 @@ function DisclosureGroup({ title, children }: { title: string; children: React.R
         type="button"
         aria-expanded={expanded}
         aria-controls={panelId}
-        onClick={() => setExpanded((value) => !value)}
+        onClick={onToggle}
         className={cn(
-          "flex w-full items-center gap-1.5 rounded-[var(--radius-sm)] py-1 text-left",
+          // `-ml-[1.125rem]` pulls the chevron into its own gutter so the LABEL still
+          // starts on the same left edge as every static section header. Without it a
+          // disclosure header sits 18px right of its peers and the surface has two
+          // header alignments.
+          "flex w-full items-center gap-1.5 -ml-[1.125rem] rounded-[var(--radius-sm)] py-1 text-left",
           "transition-colors duration-150 ease-out hover:bg-overlay-subtle",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2"
         )}
@@ -225,14 +241,28 @@ function DisclosureGroup({ title, children }: { title: string; children: React.R
         <ChevronRight
           aria-hidden="true"
           className={cn(
-            "w-3 h-3 shrink-0 text-daintree-text/40 transition-transform duration-150 ease-out",
+            "w-3 h-3 shrink-0 text-daintree-text/60 transition-transform duration-150 ease-out",
             expanded && "rotate-90"
           )}
         />
         <span className={MICRO_LABEL}>{title}</span>
+        {/*
+         * The count is what stops a collapsed disclosure reading as a static header:
+         * five identical micro-labels, two of which happen to be buttons, is not an
+         * affordance. Same treatment as the commit count in `GitPushConfirmDialog`.
+         */}
+        <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal text-daintree-text/70">
+          {count}
+        </span>
       </button>
       <div id={panelId} hidden={!expanded}>
-        <dl className={cn(ROW_GRID, "text-sm pt-2 pl-[1.125rem]")}>{children}</dl>
+        {/*
+         * No left inset. The fixed rail exists to give the surface ONE vertical
+         * scanning axis, and indenting a disclosure's rows put its values 18px right
+         * of every other group's — the two groups added last round were the only two
+         * that broke the thing they were added alongside.
+         */}
+        <dl className={cn(ROW_GRID, "text-sm pt-2")}>{children}</dl>
       </div>
     </section>
   );
@@ -245,6 +275,11 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   const [syncMode, setSyncMode] = useState<boolean | null>(null);
   const [showErrorDetail, setShowErrorDetail] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
+  const [internalsOpen, setInternalsOpen] = useState(false);
+  // Lifted out of the disclosure so the synchronised-output poll can be gated on it:
+  // the only genuinely live value on this surface sits inside a group that is closed
+  // by default, so the old unconditional poll ran 4x/sec to update a hidden row.
+  const [performanceOpen, setPerformanceOpen] = useState(false);
   const errorDetailId = useId();
   const panelRaw = usePanelStore((state) => state.panelsById[terminalId]);
   const panel = panelRaw && isPtyPanel(panelRaw) ? panelRaw : undefined;
@@ -297,11 +332,12 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   }, [isOpen, terminalId, reloadKey]);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !performanceOpen) return;
     // Immediate read on open so the dialog reflects the current sync-mode
-    // before the first poll lands.
+    // before the first poll lands. Also fires when the group is expanded, so the
+    // first frame after opening it is current rather than up to 250ms stale.
     setSyncMode(terminalInstanceService.getSynchronizedOutputMode(terminalId));
-  }, [isOpen, terminalId]);
+  }, [isOpen, performanceOpen, terminalId]);
 
   // xterm 6 mutates terminal.modes asynchronously as the parser consumes
   // BSU/ESU sequences, and there is no change event. Poll at the same cadence
@@ -311,7 +347,7 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   useVisibilityAwareInterval(
     () => setSyncMode(terminalInstanceService.getSynchronizedOutputMode(terminalId)),
     SYNC_MODE_POLL_MS,
-    isOpen
+    isOpen && performanceOpen
   );
 
   const launchAgentId = panel?.launchAgentId ?? info?.launchAgentId;
@@ -360,6 +396,17 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
       : panel || info
         ? "Running"
         : UNKNOWN;
+  // Colour ON the word, never instead of it. The words alone survive
+  // `forced-colors: active`, where the UA discards these tints — which is the reason
+  // the status is a word and not a pill. Adding a status token costs nothing there and
+  // buys the glance everywhere else: a dead terminal and a healthy one were previously
+  // the same colour, same weight, same position, differing only in the string.
+  const livenessTone =
+    hasExited && exitCode !== 0 && exitCode != null
+      ? "text-status-error"
+      : runtimeStatus === "error"
+        ? "text-status-warning"
+        : "text-daintree-text";
 
   // The remote read is in flight and has never landed. Rows the payload owns show a
   // delayed skeleton; rows the panel store owns are already correct and never flicker.
@@ -399,7 +446,7 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
     const launchSection = showAgentLaunchSection
       ? `
 
-Agent — launch context:
+Agent launch:
   Launch agent: ${launchAgentId ?? NONE}
   Command: ${command ?? NONE}
   Launch flags: ${formatArgsForClipboard(agentLaunchFlags)}
@@ -412,8 +459,8 @@ Agent — launch context:
     const liveSection = showAgentLiveSection
       ? `
 
-Agent — live state:
-  Detected agent ID: ${detectedAgentId ?? (everDetectedAgent ? "None — agent has exited" : "Not detected yet")}
+Agent state:
+  Detected agent: ${detectedAgentId ?? (everDetectedAgent ? "Agent has exited" : "Not detected yet")}
   Agent state: ${agentState ?? NONE}
   Session ID: ${agentSessionId ?? NONE}`
       : "";
@@ -429,7 +476,7 @@ Status:
   Foreground process: ${info?.ptyForegroundProcess ?? NONE}
   Exit code: ${exitCode != null ? exitCode : NONE}
 ${info ? "" : `  NOTE: the live terminal record could not be read${error ? ` (${error})` : ""}; the values below come from the panel store only.\n`}
-Session metadata:
+Session:
   ID: ${info?.id ?? terminalId}
   Kind: ${info?.kind || panel?.kind || "terminal"}
   Title: ${title ?? NONE}
@@ -442,7 +489,7 @@ Session metadata:
 ${startedByAssistant ? "  Started by: Daintree Assistant\n" : ""}  Started via MCP: ${startedViaMcp}
   UI created at: ${uiStartedAt != null ? formatTimestamp(uiStartedAt) : NONE}
 
-Spawn command:
+How it launched:
   Shell: ${info?.shell || NONE}
   Command: ${command ?? NONE}
   Args: ${formatArgsForClipboard(info?.spawnArgs)}${agentSection}
@@ -456,20 +503,20 @@ Terminal internals:
   Shell PID: ${info?.ptyPid ?? UNAVAILABLE}
   TTY device: ${info?.ptyTty ?? UNAVAILABLE}
 
-Runtime statistics:
-  Running time: ${info ? formatDuration(Date.now() - info.spawnedAt) : UNAVAILABLE}
+Runtime:
+  Runtime: ${info ? formatDuration(Date.now() - info.spawnedAt) : UNAVAILABLE}
   Spawned at: ${info ? formatTimestamp(info.spawnedAt) : UNAVAILABLE}
-  Restart count: ${info?.restartCount ?? UNAVAILABLE}
+  Restarts: ${info?.restartCount ?? UNAVAILABLE}
 
-Activity metrics:
+Activity:
   Last input: ${info ? `${formatRelativeTime(info.lastInputTime)} (${formatTimestamp(info.lastInputTime)})` : UNAVAILABLE}
   Last output: ${info ? `${formatRelativeTime(info.lastOutputTime)} (${formatTimestamp(info.lastOutputTime)})` : UNAVAILABLE}
   Agent state: ${agentState || NONE}
   Last state change: ${info?.lastStateChange != null ? formatRelativeTime(info.lastStateChange) : NONE}
   Activity tier: ${info?.activityTier ?? UNAVAILABLE}
 
-Performance & diagnostics:
-  Output buffer size: ${info?.outputBufferSize ?? UNAVAILABLE} lines
+Performance:
+  Output buffer: ${info?.outputBufferSize ?? UNAVAILABLE} lines
   Semantic buffer: ${info?.semanticBufferLines ?? UNAVAILABLE} lines
   Synchronized output (DEC 2026): ${formatSyncMode(syncMode)}
 `;
@@ -507,7 +554,20 @@ Performance & diagnostics:
   ]);
 
   const handleCopy = useCallback(() => {
-    void copy(buildDiagnostics());
+    const payload = buildDiagnostics();
+    void copy(payload).then((ok) => {
+      if (ok) return;
+      // A clipboard rejection is invisible otherwise — the button simply never flips —
+      // and the whole point of this surface is getting the payload into a bug report.
+      // Timely, actionable, not already visible: that clears the notify() gate.
+      notify({
+        type: "error",
+        title: "Couldn't copy diagnostics",
+        message: "The clipboard refused the write. Selecting the values by hand still works.",
+        action: { label: "Try again", onClick: () => void copy(payload) },
+        context: { eventKind: "settings" },
+      });
+    });
   }, [buildDiagnostics, copy]);
 
   return (
@@ -542,7 +602,10 @@ Performance & diagnostics:
                * 3" survives that intact, and it needs no accent.
                */}
               <span
-                className="text-sm font-medium text-daintree-text shrink-0 tabular-nums select-text"
+                className={cn(
+                  "text-sm font-medium shrink-0 tabular-nums select-text",
+                  livenessTone
+                )}
                 data-testid="terminal-info-liveness"
               >
                 {liveness}
@@ -550,7 +613,10 @@ Performance & diagnostics:
             </div>
             <dl className={cn(ROW_GRID, "text-sm")}>
               <Row
-                label="Running"
+                // "Process", not "Running": the status word to the right of the title
+                // already owns the word "running", and a dead terminal rendering
+                // "Running —" beside "Exited · code 3" reads as a contradiction.
+                label="Process"
                 value={
                   agentName ? `${agentName}${agentState ? ` · ${agentState}` : ""}` : runningLabel
                 }
@@ -559,7 +625,17 @@ Performance & diagnostics:
               />
               <Row
                 label="Runtime"
-                value={info ? formatDuration(Date.now() - info.spawnedAt) : undefined}
+                // Falls back to the panel's own `startedAt` rather than reporting
+                // "Unavailable" directly above a banner claiming the values above are
+                // still accurate. The UI clock is a few ms later than the PTY's, which
+                // does not matter at this resolution.
+                value={
+                  info
+                    ? formatDuration(Date.now() - info.spawnedAt)
+                    : uiStartedAt != null
+                      ? formatDuration(Date.now() - uiStartedAt)
+                      : undefined
+                }
                 pending={pending}
                 fallback={UNAVAILABLE}
               />
@@ -575,24 +651,25 @@ Performance & diagnostics:
 
           {error && (
             <div
-              // No tinted fill. `bg-status-error/10` composites the error text down to
-              // 4.22:1 against the dialog surface — under the AA floor — where the same
-              // token on the bare surface measures 4.83:1. The tint was costing the
-              // banner its legibility to look like a banner.
-              className="rounded-[var(--radius-lg)] border border-status-error/40 p-4 space-y-3"
+              // Warning, not error. The headline answers are intact and correct — this
+              // is a partial degradation, which the runtime-signal tiers put at T2. The
+              // old treatment was the loudest thing on the surface while its own body
+              // text said the values above were still accurate.
+              //
+              // No tinted fill: `bg-status-*/10` composites the banner's own text down
+              // below the 4.5:1 floor, where the same token on the bare dialog surface
+              // clears it.
+              className="rounded-[var(--radius-lg)] border border-status-warning/40 p-3 space-y-2"
               role="alert"
               data-testid="terminal-info-error"
             >
-              <div className="space-y-1">
-                <p className="font-semibold text-status-error">
-                  Couldn&apos;t load live terminal data
-                </p>
-                <p className="text-sm text-daintree-text/80">
-                  The values above come from this window and are still accurate. Process-level
-                  details — PID, TTY, buffers, activity — need the terminal host, which didn&apos;t
-                  answer.
-                </p>
-              </div>
+              <p className="text-sm text-daintree-text/85">
+                <span className="font-semibold text-status-warning">
+                  Couldn&apos;t reach the terminal host.
+                </span>{" "}
+                Everything above is from this window and still accurate; process-level detail — PID,
+                TTY, buffers, activity — is missing.
+              </p>
               <div className="flex items-center gap-2">
                 <Button variant="outline" size="sm" onClick={() => setReloadKey((k) => k + 1)}>
                   Retry
@@ -631,20 +708,17 @@ Performance & diagnostics:
             </div>
           )}
 
-          <Group title="Session">
-            <Row label="Terminal ID" value={info?.id ?? terminalId} mono />
-            <Row label="Kind" value={info?.kind || panel?.kind || "terminal"} />
-            <Row label="Title mode" value={titleMode ?? "default"} />
-            <Row label="Location" value={location} pending={pending} />
-            <Row label="Worktree ID" value={worktreeId} mono pending={pending} />
-            <Row label="Project ID" value={info?.projectId} mono pending={pending} />
-          </Group>
-
+          {/*
+           * "How it launched" leads. `Session` used to, and its first screen was a
+           * UUID, two internal constants, and the working directory printed a second
+           * time — so question 5 (shell, command, argv) never reached the first screen
+           * for anyone while three of the six rows above it answered nothing.
+           */}
           <Group title="How it launched">
             <Row label="Shell" value={info?.shell} mono pending={pending} fallback={UNAVAILABLE} />
             <Row label="Command" value={command} mono pending={pending} />
             <ChipRow label="Arguments" items={info?.spawnArgs} pending={pending} />
-            <Row label="Spawn source" value={spawnSource} pending={pending} />
+            <Row label="Spawn source" value={spawnSource} pending={pending} fallback={UNKNOWN} />
             {startedByAssistant && <Row label="Started by" value="Daintree Assistant" />}
             <Row label="Started via MCP" value={startedViaMcp} />
             <Row
@@ -677,7 +751,7 @@ Performance & diagnostics:
                 label="Detected agent"
                 value={
                   agentLabel(detectedAgentId) ??
-                  (everDetectedAgent ? "None — agent has exited" : "Not detected yet")
+                  (everDetectedAgent ? "Agent has exited" : "Not detected yet")
                 }
                 pending={pending}
               />
@@ -723,7 +797,29 @@ Performance & diagnostics:
             />
           </Group>
 
-          <DisclosureGroup title="Terminal internals">
+          <Group title="Session">
+            <Row label="Terminal ID" value={info?.id ?? terminalId} mono />
+            <Row label="Location" value={location} pending={pending} />
+            {/*
+             * A worktree is identified by its normalised absolute path, so for the
+             * worktree-per-agent workflow this product is built around it is usually
+             * character-for-character the directory shown in the overview. Printing it
+             * again cost three wrapped lines of the first screen to say nothing.
+             */}
+            <Row
+              label="Worktree"
+              value={worktreeId && worktreeId === cwd ? "Same as directory" : worktreeId}
+              mono={worktreeId !== cwd}
+              pending={pending}
+            />
+            <Row label="Project ID" value={info?.projectId} mono pending={pending} />
+          </Group>
+
+          <DisclosureGroup
+            title="Terminal internals"
+            expanded={internalsOpen}
+            onToggle={() => setInternalsOpen((v) => !v)}
+          >
             <Row label="PTY active" value={formatYesNo(info?.hasPty)} pending={pending} />
             <Row
               label="Shell PID"
@@ -751,6 +847,8 @@ Performance & diagnostics:
               fallback={UNAVAILABLE}
             />
             <Row label="Exit code" value={exitCode} mono fallback={hasExited ? UNKNOWN : NONE} />
+            <Row label="Kind" value={info?.kind || panel?.kind || "terminal"} />
+            <Row label="Title mode" value={titleMode ?? "default"} />
             <Row
               label="Resize strategy"
               value={info?.resizeStrategy || "default"}
@@ -764,7 +862,11 @@ Performance & diagnostics:
             <Row label="Agent launch hint" value={launchAgentId ? "Yes" : "No"} />
           </DisclosureGroup>
 
-          <DisclosureGroup title="Performance">
+          <DisclosureGroup
+            title="Performance"
+            expanded={performanceOpen}
+            onToggle={() => setPerformanceOpen((v) => !v)}
+          >
             <Row
               label="Output buffer"
               value={info?.outputBufferSize != null ? `${info.outputBufferSize} lines` : undefined}
@@ -800,6 +902,10 @@ Performance & diagnostics:
           onClick={handleCopy}
           aria-label="Copy diagnostics"
           data-testid="terminal-info-copy"
+          // Fixed width: "Copied" is half the width of "Copy diagnostics", so the
+          // primary button shrank and slid `Close` across under the pointer for the
+          // whole dwell window.
+          className="min-w-[10.5rem]"
         >
           {copied ? "Copied" : "Copy diagnostics"}
         </Button>

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -304,7 +304,7 @@ describe("TerminalInfoDialog", () => {
       expect(text).toContain("Shell PID: 12345");
       expect(text).toContain("TTY device: /dev/ttys004");
       expect(text).toContain("Dimensions: 80 × 24");
-      expect(text).toContain("Output buffer size: 100 lines");
+      expect(text).toContain("Output buffer: 100 lines");
     });
 
     it("carries the panel-store facts when the live read failed", async () => {
@@ -402,7 +402,7 @@ describe("TerminalInfoDialog", () => {
       renderDialog();
       await screen.findByTestId("terminal-info-body");
 
-      expect(screen.getByText("None — agent has exited")).toBeTruthy();
+      expect(screen.getByText("Agent has exited")).toBeTruthy();
     });
   });
 });

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalInfoDialog } from "../TerminalInfoDialog";
 import type { TerminalInfoPayload } from "@/types/electron";
@@ -78,474 +78,331 @@ function makePayload(overrides?: Partial<TerminalInfoPayload>): TerminalInfoPayl
   };
 }
 
+function renderDialog() {
+  return render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+}
+
+async function copyPayload(): Promise<string> {
+  const writeTextMock = vi.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+  const button = await screen.findByRole("button", { name: "Copy diagnostics" });
+  fireEvent.click(button);
+  await waitFor(() => expect(writeTextMock).toHaveBeenCalledOnce());
+  return String(writeTextMock.mock.calls[0]![0]);
+}
+
+/**
+ * Assert an element is actually presented, not merely mounted.
+ *
+ * `getByTestId` returns elements inside a `hidden` subtree, so an assertion built on it
+ * alone passes against a body that renders and is then hidden — which is exactly the
+ * shape of the defect these tests exist to catch.
+ */
+function expectPresented(el: HTMLElement): void {
+  for (let node: HTMLElement | null = el; node; node = node.parentElement) {
+    expect(node.hasAttribute("hidden")).toBe(false);
+    expect(node.style.display).not.toBe("none");
+  }
+}
+
+/** Every label rendered in the body, in DOM order. */
+function labelsInOrder(): string[] {
+  const body = screen.getByTestId("terminal-info-body");
+  return Array.from(body.querySelectorAll("dt")).map((el) => el.textContent ?? "");
+}
+
 describe("TerminalInfoDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPanelsById = {};
   });
 
-  it("renders PTY Diagnostics section with all fields", async () => {
-    const payload = makePayload();
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+  describe("hierarchy", () => {
+    // The rule, not the labels: whatever the overview and the deep diagnostics end up
+    // being called, liveness must not sit below the low-frequency internals. This is
+    // the whole point of #11978 and it is the thing a future round is most likely to
+    // undo by adding "just one more" row to the top.
+    it("puts the liveness overview ahead of every deep-diagnostic row", async () => {
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+      renderDialog();
 
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+      const body = await screen.findByTestId("terminal-info-body");
+      const overview = screen.getByTestId("terminal-info-overview");
+      const disclosureToggles = screen.getAllByRole("button", { expanded: false });
 
-    await waitFor(() => {
-      expect(screen.getByText("PTY Diagnostics")).toBeTruthy();
+      expect(disclosureToggles.length).toBeGreaterThan(0);
+      for (const toggle of disclosureToggles) {
+        expect(
+          overview.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy();
+      }
+      expect(body.contains(overview)).toBe(true);
     });
 
-    expect(screen.getByText("80 × 24")).toBeTruthy();
-    expect(screen.getByText("12345")).toBeTruthy();
-    expect(screen.getByText("/dev/ttys004")).toBeTruthy();
-    expect(screen.getByText("vim")).toBeTruthy();
+    it("keeps the deep diagnostics collapsed until asked for", async () => {
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+      renderDialog();
+
+      const toggles = await screen.findAllByRole("button", { expanded: false });
+      for (const toggle of toggles) {
+        const panelId = toggle.getAttribute("aria-controls");
+        expect(panelId).toBeTruthy();
+        const region = document.getElementById(panelId!);
+        // The disclosure contract: the toggle names a real region, and that region is
+        // hidden while the toggle reports collapsed.
+        expect(region).toBeTruthy();
+        expect(region!.hasAttribute("hidden")).toBe(true);
+      }
+
+      fireEvent.click(toggles[0]!);
+      const panelId = toggles[0]!.getAttribute("aria-controls")!;
+      expect(document.getElementById(panelId)!.hasAttribute("hidden")).toBe(false);
+      expect(toggles[0]!.getAttribute("aria-expanded")).toBe("true");
+    });
   });
 
-  it("shows exit code when terminal has exited", async () => {
-    const payload = makePayload({
-      hasPty: false,
-      exitCode: 42,
-      ptyPid: undefined,
-      ptyCols: undefined,
-      ptyRows: undefined,
+  describe("positional memory", () => {
+    // A properties sheet is scanned by position. If a row vanishes when its value is
+    // absent, the reader's memory of "PID is the second row" is wrong on the next
+    // terminal — so within a group every row renders whether or not it has a value.
+    it("renders the same rows for a sparse payload as for a populated one", async () => {
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+      const populated = renderDialog();
+      await screen.findByTestId("terminal-info-body");
+      const populatedLabels = labelsInOrder();
+      populated.unmount();
+
+      dispatchMock.mockResolvedValue({
+        ok: true,
+        result: makePayload({
+          ptyPid: undefined,
+          ptyCols: undefined,
+          ptyRows: undefined,
+          ptyForegroundProcess: undefined,
+          ptyTty: undefined,
+          shell: undefined,
+          spawnArgs: undefined,
+        }),
+      });
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
+
+      expect(labelsInOrder()).toEqual(populatedLabels);
     });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
 
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+    it("distinguishes a field that does not apply from one it could not read", async () => {
+      dispatchMock.mockResolvedValue({
+        ok: true,
+        result: makePayload({ ptyPid: undefined, spawnArgs: [] }),
+      });
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
 
-    await waitFor(() => {
-      expect(screen.getByText("PTY Diagnostics")).toBeTruthy();
+      fireEvent.click(screen.getAllByRole("button", { expanded: false })[0]!);
+
+      const body = screen.getByTestId("terminal-info-body");
+      const cells = Array.from(body.querySelectorAll("dd")).map((el) => el.textContent ?? "");
+      // Unreadable telemetry and an empty-but-known list must not share one word.
+      expect(cells).toContain("Unavailable");
+      expect(cells.some((text) => text.includes("—"))).toBe(true);
     });
-
-    expect(screen.getByText("Exit Code:")).toBeTruthy();
-    expect(screen.getByText("42")).toBeTruthy();
   });
 
-  it("does not show exit code when PTY is active", async () => {
-    const payload = makePayload();
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+  describe("an exited terminal", () => {
+    // The defect this whole run was worth doing for. A terminal preserved after a
+    // non-zero exit has no PTY record left in the host, so `terminal.info.get` throws
+    // — and the dialog used to answer with nothing but that error, on precisely the
+    // terminal someone opened it to debug.
+    it("still renders an inspector when the live read fails", async () => {
+      mockPanelsById = {
+        "test-id": {
+          id: "test-id",
+          kind: "terminal",
+          title: "build worker",
+          cwd: "/repo/apps/worker",
+          location: "grid",
+          runtimeStatus: "exited",
+          exitCode: 3,
+          spawnStatus: "ready",
+        },
+      };
+      dispatchMock.mockResolvedValue({
+        ok: false,
+        error: { message: "Failed to get terminal info: Terminal test-id not found" },
+      });
 
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+      renderDialog();
 
-    await waitFor(() => {
-      expect(screen.getByText("PTY Diagnostics")).toBeTruthy();
+      await screen.findByTestId("terminal-info-error");
+      // The body survives the failure, and the exit code — the single most useful fact
+      // about a dead terminal — is on screen.
+      expectPresented(screen.getByTestId("terminal-info-body"));
+      const liveness = screen.getByTestId("terminal-info-liveness");
+      expectPresented(liveness);
+      expect(liveness.textContent).toContain("3");
+      expectPresented(screen.getByText("build worker"));
+      expectPresented(screen.getByText("/repo/apps/worker"));
     });
 
-    expect(screen.queryByText("Exit Code:")).toBeNull();
+    it("reports liveness from the runtime status, not the spawn status", async () => {
+      // `spawnStatus` is live-only spawn-lifecycle state that stays "ready" forever
+      // after a successful spawn; `runtimeStatus` is the store's authoritative
+      // liveness signal. Reading the wrong one told the user a dead terminal was fine.
+      mockPanelsById = {
+        "test-id": {
+          id: "test-id",
+          kind: "terminal",
+          runtimeStatus: "exited",
+          spawnStatus: "ready",
+          exitCode: 0,
+        },
+      };
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload({ hasPty: true }) });
+
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
+
+      const livenessEl = screen.getByTestId("terminal-info-liveness");
+      expectPresented(livenessEl);
+      const liveness = livenessEl.textContent ?? "";
+      expect(liveness).toContain("Exited");
+      expect(liveness).not.toContain("ready");
+    });
+
+    it("reports a live terminal as running", async () => {
+      mockPanelsById = { "test-id": { id: "test-id", kind: "terminal", runtimeStatus: "active" } };
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
+
+      expect(screen.getByTestId("terminal-info-liveness").textContent).toBe("Running");
+    });
+
+    it("offers a retry that re-issues the read", async () => {
+      dispatchMock.mockResolvedValue({ ok: false, error: { message: "pty host is gone" } });
+      renderDialog();
+      await screen.findByTestId("terminal-info-error");
+      const callsBefore = dispatchMock.mock.calls.length;
+
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+      await waitFor(() => expect(dispatchMock.mock.calls.length).toBeGreaterThan(callsBefore));
+    });
   });
 
-  it("omits TTY row when ptyTty is undefined", async () => {
-    const payload = makePayload({ ptyTty: undefined });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+  describe("the copied payload", () => {
+    it("stays complete when the deep diagnostics are collapsed", async () => {
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
 
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+      // Nothing expanded — the collapsed rows must still reach the clipboard.
+      expect(screen.queryAllByRole("button", { expanded: true })).toHaveLength(0);
 
-    await waitFor(() => {
-      expect(screen.getByText("PTY Diagnostics")).toBeTruthy();
+      const text = await copyPayload();
+      expect(text).toContain("Shell PID: 12345");
+      expect(text).toContain("TTY device: /dev/ttys004");
+      expect(text).toContain("Dimensions: 80 × 24");
+      expect(text).toContain("Output buffer size: 100 lines");
     });
 
-    expect(screen.queryByText("TTY Device:")).toBeNull();
+    it("carries the panel-store facts when the live read failed", async () => {
+      mockPanelsById = {
+        "test-id": {
+          id: "test-id",
+          kind: "terminal",
+          title: "build worker",
+          cwd: "/repo/apps/worker",
+          runtimeStatus: "exited",
+          exitCode: 3,
+          spawnedBy: "mcp",
+        },
+      };
+      dispatchMock.mockResolvedValue({ ok: false, error: { message: "Terminal not found" } });
+
+      renderDialog();
+      await screen.findByTestId("terminal-info-error");
+
+      const text = await copyPayload();
+      expect(text).toContain("Exit code: 3");
+      expect(text).toContain("build worker");
+      expect(text).toContain("/repo/apps/worker");
+      // And it says so, rather than presenting a half-payload as complete.
+      expect(text).toContain("could not be read");
+    });
+
+    it("names the assistant and the transport separately (#11808)", async () => {
+      mockPanelsById = { "test-id": { id: "test-id", kind: "terminal", spawnedBy: "assistant" } };
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
+
+      // Two facts, not one: the actor and the fact it was still an MCP dispatch.
+      expect(screen.getByText("Daintree Assistant")).toBeTruthy();
+      const text = await copyPayload();
+      expect(text).toContain("Started by: Daintree Assistant");
+      expect(text).toContain("Started via MCP: Yes");
+    });
+
+    it("omits the initiator row for external MCP and user-started runs (#11808)", async () => {
+      mockPanelsById = { "test-id": { id: "test-id", kind: "terminal", spawnedBy: "mcp" } };
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
+
+      expect(screen.queryByText("Daintree Assistant")).toBeNull();
+      const text = await copyPayload();
+      expect(text).toContain("Started via MCP: Yes");
+      expect(text).not.toContain("Started by:");
+    });
   });
 
-  it("renders gracefully when all new fields are undefined", async () => {
-    const payload = makePayload({
-      ptyPid: undefined,
-      ptyCols: undefined,
-      ptyRows: undefined,
-      ptyForegroundProcess: undefined,
-      ptyTty: undefined,
-      exitCode: undefined,
-    });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+  describe("agent sections", () => {
+    it("shows launch context and live state for an agent terminal", async () => {
+      dispatchMock.mockResolvedValue({
+        ok: true,
+        result: makePayload({
+          launchAgentId: "claude",
+          detectedAgentId: "claude",
+          agentState: "working",
+          agentLaunchFlags: ["--verbose"],
+          agentModelId: "claude-opus-4-6",
+        }),
+      });
 
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
 
-    await waitFor(() => {
-      expect(screen.getByText("PTY Diagnostics")).toBeTruthy();
-    });
-
-    // Should show N/A for PID and foreground process
-    const naElements = screen.getAllByText("N/A");
-    expect(naElements.length).toBeGreaterThanOrEqual(2);
-  });
-
-  it("includes PTY Diagnostics in clipboard export", async () => {
-    const payload = makePayload();
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
+      expect(screen.getByText("--verbose")).toBeTruthy();
+      expect(screen.getByText("claude-opus-4-6")).toBeTruthy();
+      const overview = screen.getByTestId("terminal-info-overview");
+      // The agent and its state belong in the overview, not four sections down.
+      expect(within(overview).getByText(/working/)).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
+    it("omits both agent sections for a terminal that never saw an agent", async () => {
+      dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
 
-    expect(writeTextMock).toHaveBeenCalledOnce();
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("PTY Diagnostics:");
-    expect(clipboardText).toContain("Shell PID: 12345");
-    expect(clipboardText).toContain("TTY Device: /dev/ttys004");
-    expect(clipboardText).toContain("Foreground Process: vim");
-    expect(clipboardText).toContain("Dimensions: 80 × 24");
-  });
-
-  it("renders Spawn Command section with shell and arg chips", async () => {
-    const payload = makePayload({
-      spawnArgs: ["-l", "--rcfile", "/tmp/rc"],
-    });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Spawn Command")).toBeTruthy();
+      const labels = labelsInOrder();
+      expect(labels).not.toContain("Launch agent");
+      expect(labels).not.toContain("Detected agent");
     });
 
-    expect(screen.getByText("Args:")).toBeTruthy();
-    expect(screen.getByText("-l")).toBeTruthy();
-    expect(screen.getByText("--rcfile")).toBeTruthy();
-    expect(screen.getByText("/tmp/rc")).toBeTruthy();
-  });
+    it("reports an agent that has exited rather than one that never started", async () => {
+      dispatchMock.mockResolvedValue({
+        ok: true,
+        result: makePayload({ detectedAgentId: undefined, everDetectedAgent: true }),
+      });
 
-  it("omits Args row when spawnArgs is undefined or empty", async () => {
-    const payload = makePayload({ spawnArgs: undefined });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+      renderDialog();
+      await screen.findByTestId("terminal-info-body");
 
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Spawn Command")).toBeTruthy();
+      expect(screen.getByText("None — agent has exited")).toBeTruthy();
     });
-
-    expect(screen.queryByText("Args:")).toBeNull();
-  });
-
-  it("renders startup metadata attached to the panel for MCP-spawned terminals", async () => {
-    mockPanelsById = {
-      "test-id": {
-        id: "test-id",
-        spawnedBy: "mcp",
-        location: "dock",
-        command: "claude --model claude-sonnet-4-5",
-        startedAt: new Date("2026-03-19T09:46:00Z").getTime(),
-        spawnStatus: "spawning",
-        launchAgentId: "claude",
-        titleMode: "manual",
-        worktreeId: "wt-1",
-        agentPresetId: "preset-review",
-        agentPresetColor: "#123456",
-        originalPresetId: "preset-original",
-        agentSessionId: "agent-session-1",
-      },
-    };
-    const payload = makePayload({
-      launchAgentId: undefined,
-      command: undefined,
-      worktreeId: undefined,
-      titleMode: undefined,
-      agentPresetId: undefined,
-      agentPresetColor: undefined,
-      originalAgentPresetId: undefined,
-      agentSessionId: undefined,
-    });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Session Metadata")).toBeTruthy();
-    });
-
-    expect(screen.getByText("Title Mode:")).toBeTruthy();
-    expect(screen.getByText("manual")).toBeTruthy();
-    expect(screen.getByText("Worktree ID:")).toBeTruthy();
-    expect(screen.getByText("wt-1")).toBeTruthy();
-    expect(screen.getByText("Location:")).toBeTruthy();
-    expect(screen.getByText("dock")).toBeTruthy();
-    expect(screen.getByText("Spawn Source:")).toBeTruthy();
-    expect(screen.getByText("mcp")).toBeTruthy();
-    expect(screen.getByText("Started via MCP:")).toBeTruthy();
-    expect(screen.getAllByText("Yes").length).toBeGreaterThan(0);
-    expect(screen.getByText("Spawn Status:")).toBeTruthy();
-    expect(screen.getByText("spawning")).toBeTruthy();
-    expect(screen.getByText("UI Created At:")).toBeTruthy();
-    expect(screen.getByText("Command:")).toBeTruthy();
-    expect(screen.getByText("claude --model claude-sonnet-4-5")).toBeTruthy();
-    expect(screen.getByText("Agent — Launch Context")).toBeTruthy();
-    expect(screen.getByText("Launch Agent:")).toBeTruthy();
-    expect(screen.getByText("preset-review")).toBeTruthy();
-    expect(screen.getByText("#123456")).toBeTruthy();
-    expect(screen.getByText("preset-original")).toBeTruthy();
-    expect(screen.getByText("Agent — Live State")).toBeTruthy();
-    expect(screen.getByText("agent-session-1")).toBeTruthy();
-
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Location: dock");
-    expect(clipboardText).toContain("Spawn Source: mcp");
-    expect(clipboardText).toContain("Started via MCP: Yes");
-    // An external client gets no initiator line — there is no Daintree surface
-    // to name, and claiming one would be worse than saying nothing (#11808).
-    expect(clipboardText).not.toContain("Started By:");
-    expect(clipboardText).toContain("Spawn Status: spawning");
-    expect(clipboardText).toContain("Command: claude --model claude-sonnet-4-5");
-    expect(clipboardText).toContain("Launch Agent: claude");
-    expect(clipboardText).toContain("Preset Color: #123456");
-    expect(clipboardText).toContain("Session ID: agent-session-1");
-  });
-
-  it("names the assistant as the initiator for assistant-launched runs (#11808)", async () => {
-    mockPanelsById = {
-      "test-id": { id: "test-id", spawnedBy: "assistant", location: "grid" },
-    };
-    dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Session Metadata")).toBeTruthy();
-    });
-
-    expect(screen.getByText("Started By:")).toBeTruthy();
-    expect(screen.getByText("Daintree Assistant")).toBeTruthy();
-    // Still an MCP dispatch — the actor is the new fact, not a replacement for
-    // the transport one.
-    expect(screen.getByText("Started via MCP:")).toBeTruthy();
-
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Spawn Source: assistant");
-    expect(clipboardText).toContain("Started By: Daintree Assistant");
-    expect(clipboardText).toContain("Started via MCP: Yes");
-  });
-
-  it("omits the initiator row for external MCP and user-started runs (#11808)", async () => {
-    mockPanelsById = {
-      "test-id": { id: "test-id", spawnedBy: "quickrun", location: "grid" },
-    };
-    dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Session Metadata")).toBeTruthy();
-    });
-
-    expect(screen.queryByText("Started By:")).toBeNull();
-
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Spawn Source: quickrun");
-    expect(clipboardText).not.toContain("Started By:");
-    expect(clipboardText).toContain("Started via MCP: No");
-  });
-
-  it("reports unknown provenance for a panel with no spawn source (#11808)", async () => {
-    // `spawnedBy` is runtime-only and never serialized, so every panel restored
-    // across a restart lands here — this is the common case, not an edge one.
-    mockPanelsById = { "test-id": { id: "test-id", location: "grid" } };
-    dispatchMock.mockResolvedValue({ ok: true, result: makePayload() });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Session Metadata")).toBeTruthy();
-    });
-
-    expect(screen.queryByText("Started By:")).toBeNull();
-
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Spawn Source: N/A");
-    expect(clipboardText).toContain("Started via MCP: Unknown");
-    expect(clipboardText).not.toContain("Started By:");
-  });
-
-  it("renders Launch Context and Live State sections for agent terminals", async () => {
-    const payload = makePayload({
-      kind: "terminal",
-      launchAgentId: "claude",
-      detectedAgentId: "claude",
-      agentLaunchFlags: ["--dangerously-skip-permissions", "--verbose"],
-      agentModelId: "claude-opus-4-7",
-    });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Agent — Launch Context")).toBeTruthy();
-    });
-
-    expect(screen.getByText("Launch Agent:")).toBeTruthy();
-    expect(screen.getAllByText("claude").length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText("Launch Flags:")).toBeTruthy();
-    expect(screen.getByText("--dangerously-skip-permissions")).toBeTruthy();
-    expect(screen.getByText("--verbose")).toBeTruthy();
-    expect(screen.getByText("Model:")).toBeTruthy();
-    expect(screen.getByText("claude-opus-4-7")).toBeTruthy();
-
-    // Live State section shows the detected agent identity
-    expect(screen.getByText("Agent — Live State")).toBeTruthy();
-    expect(screen.getByText("Detected Agent:")).toBeTruthy();
-    // "claude" appears for both launch hint and detected-agent rows.
-    expect(screen.getAllByText("claude").length).toBeGreaterThanOrEqual(2);
-  });
-
-  it("shows 'None — agent has exited' in Live State when agent panel has no detectedAgentId", async () => {
-    const payload = makePayload({
-      kind: "terminal",
-      launchAgentId: "claude",
-      detectedAgentId: undefined,
-      everDetectedAgent: true,
-      agentLaunchFlags: ["--verbose"],
-      agentModelId: "claude-opus-4-7",
-    });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Agent — Live State")).toBeTruthy();
-    });
-
-    expect(screen.getByText("None — agent has exited")).toBeTruthy();
-  });
-
-  it("omits Agent sections entirely for plain terminals with no agent metadata", async () => {
-    const payload = makePayload({
-      launchAgentId: undefined,
-      detectedAgentId: undefined,
-      agentLaunchFlags: undefined,
-      agentModelId: undefined,
-    });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Spawn Command")).toBeTruthy();
-    });
-
-    expect(screen.queryByText("Launch Agent:")).toBeNull();
-    expect(screen.queryByText("Launch Flags:")).toBeNull();
-    expect(screen.queryByText("Model:")).toBeNull();
-    expect(screen.queryByRole("heading", { name: "Agent — Launch Context" })).toBeNull();
-    expect(screen.queryByRole("heading", { name: "Agent — Live State" })).toBeNull();
-  });
-
-  it("includes Spawn Command and both Agent sections in clipboard export", async () => {
-    const payload = makePayload({
-      kind: "terminal",
-      launchAgentId: "claude",
-      detectedAgentId: "claude",
-      shell: "/usr/local/bin/claude",
-      command: "claude --model claude-opus-4-7",
-      spawnArgs: ["--model", "claude-opus-4-7"],
-      agentLaunchFlags: ["--dangerously-skip-permissions"],
-      agentModelId: "claude-opus-4-7",
-    });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
-    });
-
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
-
-    expect(writeTextMock).toHaveBeenCalledOnce();
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Spawn Command:");
-    expect(clipboardText).toContain("Shell: /usr/local/bin/claude");
-    expect(clipboardText).toContain("Args: --model claude-opus-4-7");
-    expect(clipboardText).toContain("Agent — Launch Context:");
-    expect(clipboardText).toContain("Launch Agent: claude");
-    expect(clipboardText).toContain("Command: claude --model claude-opus-4-7");
-    expect(clipboardText).toContain("Launch Flags: --dangerously-skip-permissions");
-    expect(clipboardText).toContain("Model: claude-opus-4-7");
-    expect(clipboardText).toContain("Agent — Live State:");
-    expect(clipboardText).toContain("Detected Agent ID: claude");
-  });
-
-  it("includes Live State but not Launch Context when only a runtime agent is detected", async () => {
-    const payload = makePayload({
-      launchAgentId: undefined,
-      detectedAgentId: "claude",
-    });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
-    });
-
-    expect(screen.getByText("Agent — Live State")).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "Agent — Launch Context" })).toBeNull();
-
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Agent — Live State:");
-    expect(clipboardText).toContain("Detected Agent ID: claude");
-    expect(clipboardText).not.toContain("Agent — Launch Context:");
-  });
-
-  it("renders empty spawnArgs as (none) in clipboard and omits the Args row in UI", async () => {
-    const payload = makePayload({ spawnArgs: [] });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
-    });
-
-    // UI omits the row entirely (matches InfoListRow convention)
-    expect(screen.queryByText("Args:")).toBeNull();
-
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Args: (none)");
-    expect(clipboardText).not.toContain("Args: N/A");
-  });
-
-  it("omits Agent sections from clipboard for non-agent terminals", async () => {
-    const payload = makePayload({ launchAgentId: undefined, spawnArgs: ["-l"] });
-    dispatchMock.mockResolvedValue({ ok: true, result: payload });
-    const writeTextMock = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
-
-    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
-    });
-
-    fireEvent.click(screen.getByText("Copy to Clipboard"));
-
-    const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Spawn Command:");
-    expect(clipboardText).toContain("Args: -l");
-    expect(clipboardText).not.toContain("Agent — Launch Context:");
-    expect(clipboardText).not.toContain("Agent — Live State:");
-    expect(clipboardText).not.toContain("Launch Flags:");
   });
 });

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -103,7 +103,15 @@ export function SkeletonBone({
       {...rest}
       aria-hidden="true"
       className={cn(
-        "bg-muted rounded",
+        // `bg-tint/[0.08]`, not `bg-muted`. `--muted` is aliased to
+        // `--theme-surface-panel` (src/index.css:734) and is never redefined by any
+        // theme, so a bone painted with it is EXACTLY its own background on any panel
+        // surface — all 15 themes — and on any dialog body on the 8 dark ones. The
+        // pulse animates opacity only, so it cannot rescue a same-colour bone: the
+        // composite is the background at every frame. `--theme-tint` is white on dark
+        // and black on light, so an alpha tint contrasts with whatever it is laid over
+        // by construction and cannot collide with a surface again.
+        "bg-tint/[0.08] rounded",
         pulseClass(immediate),
         shimmer && "animate-skeleton-shimmer",
         className
@@ -150,7 +158,8 @@ export function SkeletonText({
         <div
           key={i}
           className={cn(
-            "bg-muted rounded",
+            // Same surface collision as `SkeletonBone` — see the note there.
+            "bg-tint/[0.08] rounded",
             lineHeightClassName,
             TEXT_LINE_WIDTHS[i % TEXT_LINE_WIDTHS.length],
             pulseClass(immediate),

--- a/src/config/__tests__/skeletonSurfaceCollision.contract.test.ts
+++ b/src/config/__tests__/skeletonSurfaceCollision.contract.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// A loading skeleton painted in a colour its own background also uses is invisible, and
+// invisibly so — it renders, it animates, and it shows nothing. That is what shipped:
+// `--muted` is aliased to `--theme-surface-panel` and is never redefined by any theme,
+// so `bg-muted` bones matched their background exactly on every panel surface in all 15
+// themes, and on every dialog body in the 8 dark ones. The pulse animates opacity only,
+// so it composites to the background at every frame and cannot rescue it.
+//
+// This guard asserts the RULE rather than the replacement colour: a skeleton's fill must
+// not be a utility whose token is aliased to a surface. If someone later re-points
+// `--muted` away from `--theme-surface-panel`, this test correctly stops objecting to it;
+// if someone re-introduces any surface-aliased fill, it fails.
+//
+// KNOWN LIMITS (deliberate — a regression guard, not a sound checker):
+//   - Only the shared `Skeleton.tsx` primitives are in scope. Hand-rolled bones
+//     elsewhere (there are two) are not reached by a static read of this file.
+//   - Alias resolution is one level deep against `src/index.css`, which is how these
+//     tokens are actually declared. A multi-hop alias through a new indirection would
+//     not be followed.
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const INDEX_CSS = path.join(REPO_ROOT, "src/index.css");
+const SKELETON = path.join(REPO_ROOT, "src/components/ui/Skeleton.tsx");
+
+/** Every `--color-x: var(--y)` mapping declared in index.css. */
+function colorAliases(css: string): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const match of css.matchAll(/--color-([a-z0-9-]+):\s*var\(--([a-z0-9-]+)\)/g)) {
+    aliases.set(match[1]!, match[2]!);
+  }
+  return aliases;
+}
+
+/** Every `--x: var(--theme-surface-…)` mapping — the bare tokens that ARE a surface. */
+function surfaceAliasedTokens(css: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const match of css.matchAll(/^\s*--([a-z0-9-]+):\s*var\(--theme-surface-[a-z0-9-]+\)/gm)) {
+    tokens.add(match[1]!);
+  }
+  return tokens;
+}
+
+/** The `bg-*` utilities the skeleton primitives actually paint. */
+function skeletonBackgroundUtilities(source: string): string[] {
+  return [...source.matchAll(/"bg-([a-z0-9-]+)(?:\/\[[^\]]+\])?\s/g)].map((m) => m[1]!);
+}
+
+describe("skeleton surface-collision contract", () => {
+  const css = fs.readFileSync(INDEX_CSS, "utf8");
+  const source = fs.readFileSync(SKELETON, "utf8");
+
+  it("the collision this guard exists for is still real", () => {
+    // If this ever fails, `--muted` was re-pointed and the whole guard can be revisited.
+    // Asserted so the rest of the file cannot quietly become vacuous.
+    const surfaceTokens = surfaceAliasedTokens(css);
+    expect(surfaceTokens.size).toBeGreaterThan(0);
+    expect(surfaceTokens.has("muted")).toBe(true);
+  });
+
+  it("no skeleton fill resolves to a surface colour", () => {
+    const aliases = colorAliases(css);
+    const surfaceTokens = surfaceAliasedTokens(css);
+    const utilities = skeletonBackgroundUtilities(source);
+
+    expect(utilities.length).toBeGreaterThan(0);
+
+    const collisions = utilities.filter((utility) => {
+      const token = aliases.get(utility) ?? utility;
+      return surfaceTokens.has(token) || token.startsWith("theme-surface-");
+    });
+
+    expect(
+      collisions,
+      `Skeleton.tsx paints ${collisions.join(", ")}, which resolve(s) to a surface colour — ` +
+        `a bone the same colour as its own background renders nothing. Use a surface-relative ` +
+        `alpha tint (bg-tint/[…]) instead.`
+    ).toEqual([]);
+  });
+
+  it("the skeleton pulse cannot be the thing that makes a bone visible", () => {
+    // `pulse-delayed` animates opacity between 0 and 1. Opacity on a fill that matches
+    // its background composites to the background at every frame, so the animation is
+    // never a substitute for a fill that contrasts. Pinned so a future "the pulse makes
+    // it visible enough" argument has to contend with the keyframes.
+    const block = css.slice(css.indexOf("@keyframes pulse-delayed"));
+    const body = block.slice(0, block.indexOf("}\n}") + 3);
+    expect(body).toMatch(/opacity/);
+    expect(body).not.toMatch(/background|background-color/);
+  });
+});


### PR DESCRIPTION
## Summary

The info dialog opened on `Terminal ID` and `Project ID`. Whether the terminal was alive, what was running in it, and how long it had been going all sat below the fold, so its first screen answered the two questions nobody opens it to ask. A live agent terminal and a plain shell differed by four rows.

It now leads with a pinned overview that answers those first, and it renders that overview from the panel store, so it is correct on the first frame and still correct when the terminal host does not answer.

Resolves #11978

## What changed

**A terminal preserved after a non-zero exit used to show only an error.** `terminal.info.get` resolves through the PTY registry, and a preserved shell's record is already gone by then, so the dialog answered with a raw `Terminal <id> not found` on exactly the terminal someone opened it to debug. The body now renders regardless of the fetch, the error is an inline warning with `Retry` and the raw text behind a disclosure, and the copied payload says which half is missing rather than presenting itself as complete.

**`Spawn Status: ready` was being read as liveness.** It is documented as live-only spawn state that stays `"ready"` forever after a successful spawn, so an exited terminal reported itself healthy. Liveness now comes from `runtimeStatus`, which `src/store/fleetEligibility.ts` calls the renderer's authoritative signal, and the verdict carries a status tone as well as its word.

**Rows are a real description list on a fixed label rail**, values left-aligned. Before, every value was right-aligned, so a 60-character path and the word `Yes` shared a right edge and nothing shared a left one. Paths wrap at their separators instead of losing the leaf directory to an ellipsis.

**Deep diagnostics moved behind disclosures** and stay in the copy payload whatever their open state. `How it launched` leads the detail, so shell, command and argv reach the first screen. A worktree whose id is character-for-character the directory above it says so instead of printing the path twice.

Also: `useCopyWithFeedback` for the copy gesture, tooltips only where a value truncates, sentence case throughout, and one word per kind of absence instead of `"N/A"` for all three. This file held the last 45+ uses of `"N/A"` in the app.

## A separate bug this turned up

`--muted` is aliased to `--theme-surface-panel` and no theme redefines it, so `bg-muted` skeleton bones were painted in exactly their own background: measured 1.00:1 on a dialog body. Twelve surfaces across the app were rendering a loading indicator that shows nothing. The pulse animates opacity only, so it composites to the background at every frame and cannot rescue it.

Fixed at the shared component in its own commit (`52c219ce7`), taking the answer `GitPushConfirmDialog` had already worked around locally. `bg-tint/[0.08]` is white on dark and black on light, so it contrasts with whatever it is laid over by construction. `skeletonSurfaceCollision.contract.test.ts` pins the rule rather than the colour.

## Design review

Score 4.2 to 6.8 across two scored rounds, against information hierarchy, scannability, visual language, typography, density, affordance, states, accessibility, microcopy and craft.

The consistency survey came out the other way to the usual worry: this removed an outlier rather than creating one. The section-header treatment it replaced had zero other instances in the codebase, the micro-label it adopted is used by 15 files, and `"N/A"` is now at zero app-wide. No revert and no further roll-out is owed.

## Testing

`npm run test` (51,634 passing) and `npm run check` both clean. The lint ratchet dropped by 2.

Two unrelated failures showed up in the full run and are not from this branch. `electron/lifecycle/__tests__/shutdown.test.ts` reproduces at the merge-base with a byte-identical failure and passes on this branch, and the GitHub spinner-gate spec mocks the skeleton module out entirely so `Skeleton.tsx` never loads in it. Both are timing-sensitive and the machine was heavily loaded.

Six invariants pinned, each checked by reintroducing the defect it guards. They assert rules, not labels: liveness ahead of diagnostics, rows keeping their slot when empty, the payload staying complete when the host read fails, and a skeleton fill never resolving to a surface colour.

`e2e/screenshots/terminal-info-review.spec.ts` drives thirteen states on real PTYs and refuses to write a state it has not proven. It is what caught both the exited-terminal defect and, later, its own fixture writing a stop token into a canonical-mode PTY with no line terminator, which meant the "exited agent" capture was a running agent.

## Left for a decision

**The PTY host and the renderer disagree about what to preserve.** `shouldPreserveOnExit` keeps a terminal only when it is an agent AND exited 0, while the renderer preserves anything that exited non-zero. The renderer therefore keeps panels whose host record is already gone, which is why the fetch fails at all. This branch fixes the symptom properly, but widening the host policy or falling back to `AgentTerminalLifecycleLedger` is a PTY-lifecycle decision with fleet-wide reach.

**Under `forced-colors: active`, primary and secondary buttons are indistinguishable.** Only `[data-variant="destructive"]` is differentiated, by stroke weight. Affects all 24+ dialog footers, not just this one.