### PR TITLE
Rebuild git setup as four modes of one surface

### DIFF
--- a/e2e/screenshots/git-init-review.spec.ts
+++ b/e2e/screenshots/git-init-review.spec.ts
@@ -1,0 +1,621 @@
+/**
+ * `GitInitDialog` visual-review harness (#11975).
+ *
+ * The dialog gathers configuration, then runs a multi-step git routine and reports it
+ * in place. Most of what is wrong with a surface like that is invisible in the JSX and
+ * obvious in a PNG: a dependent field that reads as a peer of the checkbox controlling
+ * it, a monospace transcript that reads as a terminal dropped into a form, two error
+ * treatments for one failure, a success state that is still mostly a disabled form.
+ *
+ * Every state here is driven through the REAL seams, never a renderer mock:
+ *
+ *   - the dialog is opened the way a user opens it: pick a folder that is not a
+ *     repository, which fails `NOT_A_GIT_REPO` in `addProjectByPath` and re-emerges as
+ *     `NonGitFolderDialog`; "Initialize repository" then hands over to `GitInitDialog`.
+ *     The carried-identity state comes from the create-project-folder flow, which is
+ *     the only path that supplies one.
+ *   - initialization is real. `project:init-git-guided` runs against a real folder and
+ *     the progress rows come from the main process's own events.
+ *   - the git-identity failure is real: the app is launched with `GIT_CONFIG_GLOBAL`
+ *     pointed at a file this harness owns, so emptying it makes `git commit` fail the
+ *     way it does for a user who has never configured git.
+ *   - the mid-flight progress state is real too — a fixture with 60k files makes
+ *     `git add .` take seconds, so the shot is a genuine in-flight render rather than
+ *     a paused animation frame.
+ *   - "connecting" and the thrown-failure state come from the main-process fault
+ *     registry (`DAINTREE_E2E_FAULT_MODE=1` + `e2e/helpers/ipcFaults`).
+ *
+ *   DAINTREE_SHOT_GITINIT=1 npx playwright test --project=screenshots git-init-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_GITINIT  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_THEME    optional theme id (default: the app default)
+ *   DAINTREE_SHOT_TAG      optional suffix so rounds sit side by side
+ *   DAINTREE_SHOT_ONLY     comma-separated step filter (see step names below)
+ *   DAINTREE_SHOT_OUT      optional absolute output dir (default artifacts/git-init-shots)
+ *
+ * Output: <out>/<NN-slug>[-tag].png (artifacts/ is gitignored).
+ */
+
+import { test, type Page } from "@playwright/test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, mockOpenDialog, type AppContext } from "../helpers/launch";
+import { dismissTelemetryConsent } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { injectDelay, injectFault, clearAllFaults } from "../helpers/ipcFaults";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_GITINIT;
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR =
+  process.env.DAINTREE_SHOT_OUT ?? path.resolve(process.cwd(), "artifacts", "git-init-shots");
+
+/**
+ * The dialog CARD, not the surface element.
+ *
+ * `AppDialog` puts `role="dialog"` on the `fixed inset-0` scrim, so screenshotting the
+ * role selector silently returns the whole window — a full-window PNG that looks like a
+ * successful crop until you compare its dimensions.
+ */
+const DIALOG = "[data-app-dialog-surface] > div";
+
+/**
+ * The stable testid contract this harness asserts against. The redesign may move,
+ * restyle, or re-shape any of these — it must not delete them, or the harness stops
+ * being able to prove the state it captured is the state it meant to capture.
+ */
+const TID = {
+  dialog: '[data-testid="git-init-dialog"]',
+  nameError: '[data-testid="git-init-name-error"]',
+  progress: '[data-testid="git-init-progress"]',
+  connecting: '[data-testid="git-init-connecting"]',
+  step: '[data-testid="git-init-step"]',
+  commandBlock: '[data-testid="git-init-command-block"]',
+  error: '[data-testid="git-init-error"]',
+} as const;
+
+const CH = {
+  initGitGuided: "project:init-git-guided",
+} as const;
+
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+  /*
+   * Skeleton bones start at opacity 0 and are faded in by the pulse keyframes after
+   * the 400ms Doherty delay, so the animation freeze above leaves them INVISIBLE — a
+   * loading shot that looks like an empty panel and sends the whole review off
+   * reviewing a screen that does not exist. Pin them visible.
+   */
+  [class*="animate-pulse-"] { opacity: 1 !important; }
+`;
+
+/**
+ * A folder that is deliberately NOT a repository, populated enough that `git add`
+ * has something to do and the .gitignore template has something to exclude.
+ */
+function makePlainFolder(root: string, name: string): string {
+  const dir = path.join(root, name);
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  mkdirSync(path.join(dir, "node_modules", "left-pad"), { recursive: true });
+  writeFileSync(path.join(dir, "README.md"), `# ${name}\n\nNotes.\n`);
+  writeFileSync(path.join(dir, "package.json"), `{ "name": "${name}", "version": "0.1.0" }\n`);
+  writeFileSync(path.join(dir, ".env"), "API_TOKEN=not-a-real-token\n");
+  writeFileSync(path.join(dir, "src", "index.ts"), "export const start = () => {};\n");
+  writeFileSync(path.join(dir, "node_modules", "left-pad", "index.js"), "module.exports = 1;\n");
+  return dir;
+}
+
+/**
+ * Same, but big enough that `git add .` genuinely takes seconds.
+ *
+ * The mid-flight progress state is the one this dialog exists to render, and it is
+ * also the one a fast fixture makes impossible to photograph. 60k small files put
+ * `git add` at roughly three seconds on a warm SSD — long enough to assert the live
+ * step is on screen and then take the shot, without stubbing anything.
+ */
+function makeSlowFolder(root: string, name: string): string {
+  const dir = path.join(root, name);
+  const body = "export const value = 1;\n".repeat(20);
+  for (let d = 0; d < 120; d++) {
+    const sub = path.join(dir, "src", `mod${String(d).padStart(3, "0")}`);
+    mkdirSync(sub, { recursive: true });
+    for (let i = 0; i < 500; i++) {
+      writeFileSync(path.join(sub, `f${String(i).padStart(3, "0")}.ts`), body);
+    }
+  }
+  writeFileSync(path.join(dir, "README.md"), `# ${name}\n`);
+  return dir;
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Screenshot, but only after the state it claims to be has been proven on screen.
+ *
+ * This is the hard rule of the whole harness: a capture run that quietly writes a
+ * plausible-looking wrong artifact is worse than one that fails, because the review
+ * then reasons about a screen that never existed.
+ */
+async function snap(
+  page: Page,
+  slug: string,
+  opts: { marker: string; locator?: string; markerTimeout?: number; settleMs?: number }
+): Promise<void> {
+  await page
+    .locator(opts.marker)
+    .first()
+    .waitFor({ state: "visible", timeout: opts.markerTimeout ?? 8000 });
+  await settle(page, opts.settleMs);
+  // Re-checked AFTER the settle, not only before it: the app's own later render can
+  // replace the state between the assertion and the shutter.
+  if (!(await page.locator(opts.marker).first().isVisible())) {
+    throw new Error(`[git-init-shots] "${slug}": marker ${opts.marker} vanished before the shot`);
+  }
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  if (opts.locator) {
+    await page.locator(opts.locator).last().screenshot({ path: file, type: "png" });
+  } else {
+    await page.screenshot({ path: file, type: "png", animations: "disabled", caret: "hide" });
+  }
+}
+
+export const ALL_THEMES = [
+  "arashiyama",
+  "atacama",
+  "bali",
+  "bondi",
+  "daintree",
+  "fiordland",
+  "galapagos",
+  "highlands",
+  "hokkaido",
+  "movile",
+  "namib",
+  "redwoods",
+  "serengeti",
+  "svalbard",
+  "table-mountain",
+];
+
+/**
+ * The shared `setAppTheme` waits on project-view chrome (sidebar toggle, project
+ * switcher, command input). This harness never opens a project — every state is
+ * reached from the welcome screen — so it waits on the welcome screen instead.
+ */
+async function setWelcomeTheme(page: Page, schemeId: string): Promise<void> {
+  await page.evaluate(async (id) => {
+    await window.electron.appTheme.setColorScheme(id);
+  }, schemeId);
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.locator(SEL.welcome.openFolder).waitFor({ state: "visible", timeout: T_LONG });
+  const applied = await page
+    .locator("html")
+    .evaluate((element) => element.getAttribute("data-theme"));
+  if (applied !== schemeId) {
+    throw new Error(`[git-init-shots] theme ${schemeId} did not apply (got ${applied})`);
+  }
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+
+// A failed step must not abort the run — the remaining shots are still worth having,
+// and a per-theme sweep should not lose fourteen themes to one bad selector. But the
+// run must still FAIL: a silent exit 0 over an empty output directory reads as success.
+const failures: string[] = [];
+
+test("git init dialog review — configuration, progress, recovery and success", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_GITINIT is required for the git-init capture",
+  });
+  test.skip(!ENABLED, "Set DAINTREE_SHOT_GITINIT to run the git-init capture");
+
+  failures.length = 0;
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "daintree-gitinit-shots-"));
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-gitinitshot-"));
+
+  /**
+   * The app's git identity, owned by this harness rather than by whoever is running it.
+   *
+   * Via HOME, deliberately, and NOT via `GIT_CONFIG_GLOBAL`: the app's git hardening
+   * strips `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` out of every spawn env on purpose
+   * (`BLOCKED_INHERITED_GIT_ENV_KEYS` in `electron/utils/hardenedGit.ts`), so setting
+   * them here changes nothing and the app quietly keeps reading the developer's own
+   * `~/.gitconfig`. `HOME` is what is left, and it is what git resolves the global
+   * config from. `XDG_CONFIG_HOME` rides along because git prefers it when set.
+   *
+   * Rewriting the file between steps flips the real behaviour: with a `[user]` block the
+   * initial commit succeeds, without one it fails exactly the way it does for someone
+   * who has never configured git — which is the whole point of the recovery state.
+   */
+  const fakeHome = path.join(fixtureRoot, "home");
+  mkdirSync(path.join(fakeHome, ".config"), { recursive: true });
+  const gitConfigPath = path.join(fakeHome, ".gitconfig");
+  const writeGitIdentity = (present: boolean): void => {
+    writeFileSync(
+      gitConfigPath,
+      present
+        ? "[init]\n\tdefaultBranch = main\n[user]\n\tname = Daintree Test\n\temail = dev@daintree.dev\n"
+        : // `useConfigOnly` is what makes the absence deterministic. Left off, git guesses
+          // an identity from the login name and hostname, the commit SUCCEEDS, the dialog
+          // reaches its success state, the project is added and the app leaves the welcome
+          // screen — taking the page every later step is holding with it.
+          "[init]\n\tdefaultBranch = main\n[user]\n\tuseConfigOnly = true\n"
+    );
+  };
+
+  /**
+   * Prove the identity switch actually works before relying on it.
+   *
+   * Whether a bare `git commit` fails depends on the host's git version, hostname and
+   * environment. If it quietly succeeds here, every recovery state in this harness
+   * silently becomes a success state — the exact class of wrong-but-plausible artifact
+   * this file must never produce. Better to fail now, loudly.
+   */
+  const assertIdentitySwitchWorks = (): void => {
+    const probe = path.join(fixtureRoot, "identity-probe");
+    mkdirSync(probe, { recursive: true });
+    writeFileSync(path.join(probe, "a.txt"), "probe\n");
+    const env = {
+      ...process.env,
+      HOME: fakeHome,
+      XDG_CONFIG_HOME: path.join(fakeHome, ".config"),
+      GIT_CONFIG_NOSYSTEM: "1",
+    };
+    execFileSync("git", ["init", "-q", "."], { cwd: probe, env, stdio: "ignore" });
+    execFileSync("git", ["add", "-A"], { cwd: probe, env, stdio: "ignore" });
+    writeGitIdentity(false);
+    let failed = false;
+    try {
+      execFileSync("git", ["commit", "-m", "probe"], { cwd: probe, env, stdio: "pipe" });
+    } catch {
+      failed = true;
+    }
+    if (!failed) {
+      throw new Error(
+        "[git-init-shots] git committed without a configured identity — the recovery states " +
+          "in this harness would silently capture success instead. Check the HOME override " +
+          "and user.useConfigOnly support in this git version."
+      );
+    }
+    rmSync(probe, { recursive: true, force: true });
+  };
+  // Absent for the whole run, and switched on only by the final `success` step.
+  //
+  // This is not a detail: every state that starts initialization eventually resolves,
+  // and one that resolves SUCCESSFULLY adds the project and switches the app out of the
+  // welcome screen — destroying the page every later step is holding. Leaving the
+  // identity absent makes those runs land in the recovery state instead, which is
+  // dismissible, so the harness keeps its footing.
+  writeGitIdentity(false);
+  assertIdentitySwitchWorks();
+
+  // One folder per step. A step that starts initialization leaves a repository behind,
+  // and a second visit to it would open the project instead of the dialog.
+  const folder = (name: string) => makePlainFolder(fixtureRoot, name);
+  const parentForCreateFlow = path.join(fixtureRoot, "workspace");
+  mkdirSync(parentForCreateFlow, { recursive: true });
+
+  let ctx: AppContext | undefined;
+
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: { width: 1680, height: 1050 },
+      env: {
+        DAINTREE_E2E_FAULT_MODE: "1",
+        HOME: fakeHome,
+        XDG_CONFIG_HOME: path.join(fakeHome, ".config"),
+        // The host's /etc/gitconfig must not decide whether the recovery state is
+        // reachable. Unlike GIT_CONFIG_GLOBAL, this one survives the hardening filter.
+        GIT_CONFIG_NOSYSTEM: "1",
+      },
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+    const app = ctx.app;
+    const page = ctx.window;
+
+    await dismissTelemetryConsent(page);
+    await dismissBlockingPalette(page);
+    await page.locator(SEL.welcome.openFolder).waitFor({ state: "visible", timeout: T_LONG });
+    if (THEME) await setWelcomeTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await settle(page, 600);
+
+    /**
+     * Controls inside whichever dialog is up.
+     *
+     * Scoped and exact on purpose: the app toolbar carries a permanently disabled
+     * "Browse files" button, and `getByRole`'s name match is a substring by default, so a
+     * bare `{ name: "Browse" }` resolves to the toolbar and waits out its timeout on a
+     * control that can never be clicked.
+     */
+    const dialogButton = (name: string) =>
+      page.locator("[data-app-dialog-surface]").getByRole("button", { name, exact: true });
+
+    /** Open a non-repo folder the way a user does, and land on the git setup step. */
+    const openGitSetup = async (dir: string): Promise<void> => {
+      await mockOpenDialog(app, dir);
+      await page.locator(SEL.welcome.openFolder).click();
+      // The folder is not a repository, so `addProjectByPath` fails NOT_A_GIT_REPO and
+      // re-emerges as the choice screen. Its "Initialize repository" button is what
+      // hands over to the dialog under review.
+      await dialogButton("Initialize repository").waitFor({
+        state: "visible",
+        timeout: 15000,
+      });
+      await dialogButton("Initialize repository").click();
+      await page.locator(TID.dialog).waitFor({ state: "visible", timeout: 8000 });
+    };
+
+    const startInit = async (): Promise<void> => {
+      await dialogButton("Initialize repository").click();
+    };
+
+    /**
+     * Escape, patiently.
+     *
+     * `dismissible={!isInitializing}` means Escape is inert while an operation is in
+     * flight, and some of these operations are deliberately slow. A four-try teardown
+     * gives up while the modal is still up, and every step after it then spends its own
+     * timeout clicking at a scrim. Keep pressing until the dialog is actually gone or the
+     * budget is spent — the budget is longer than the slowest state this harness drives.
+     */
+    const closeDialog = async (): Promise<void> => {
+      for (let i = 0; i < 30; i++) {
+        if (
+          !(await page
+            .locator(DIALOG)
+            .first()
+            .isVisible()
+            .catch(() => false))
+        )
+          return;
+        await page.keyboard.press("Escape").catch(() => {});
+        await settle(page, i < 4 ? 250 : 2000);
+      }
+      throw new Error("[git-init-shots] dialog would not close");
+    };
+
+    /**
+     * Runs one state, then unconditionally returns to rest. Unconditionally, not on the
+     * success path only: a step that dies holding the dialog open would otherwise wedge
+     * every step after it behind a modal.
+     */
+    const step = async (name: string, fn: () => Promise<void>): Promise<void> => {
+      if (ONLY.length > 0 && !ONLY.includes(name)) return;
+      try {
+        await fn();
+      } catch (error) {
+        const detail = String(error).slice(0, 600);
+        console.warn(`[git-init-shots] step "${name}" failed:`, detail);
+        failures.push(`${name}: ${detail}`);
+      } finally {
+        await clearAllFaults(app).catch(() => {});
+        await closeDialog().catch((error) => {
+          failures.push(`${name} (reset): ${String(error).slice(0, 200)}`);
+        });
+        await page.emulateMedia({ forcedColors: null, contrast: null }).catch(() => {});
+      }
+    };
+
+    // 1. The headline configuration state: reached directly by opening a non-repo
+    //    folder, initial commit on, defaults everywhere.
+    await step("direct", async () => {
+      await openGitSetup(folder("aurora-notes"));
+      await snap(page, "10-configure-default", { marker: TID.dialog, locator: DIALOG });
+      await snap(page, "11-configure-default-in-window", { marker: TID.dialog });
+    });
+
+    // 2. Arrival with an identity already chosen. The create-project-folder flow is the
+    //    only path that carries one, so it is the only honest way to reach this state.
+    await step("identity-carried", async () => {
+      await page.getByRole("button", { name: "Create project", exact: true }).click();
+      await dialogButton("Browse").waitFor({ state: "visible", timeout: 8000 });
+      await mockOpenDialog(app, parentForCreateFlow);
+      await dialogButton("Browse").click();
+      await page.locator("#create-folder-name").fill("telemetry-pipeline");
+      await dialogButton("Create folder").click();
+      await dialogButton("Initialize repository").waitFor({
+        state: "visible",
+        timeout: 15000,
+      });
+      await dialogButton("Initialize repository").click();
+      await page.locator(TID.dialog).waitFor({ state: "visible", timeout: 8000 });
+      await snap(page, "15-configure-carried-identity", { marker: TID.dialog, locator: DIALOG });
+    });
+
+    // 3. Initial commit off — the dependent field disappears, which is the state that
+    //    shows whether it ever read as dependent in the first place.
+    await step("commit-off", async () => {
+      await openGitSetup(folder("harbour-lights"));
+      await page.locator(TID.dialog).locator('input[type="checkbox"]').first().uncheck();
+      await snap(page, "20-configure-commit-off", { marker: TID.dialog, locator: DIALOG });
+    });
+
+    // 4. Both validation states. The name one paints the field AND says why the button
+    //    went dead; the commit-message one is the state where the button goes dead with
+    //    nothing said at all.
+    await step("empty-name", async () => {
+      await openGitSetup(folder("cinder-block"));
+      await page.locator("#git-init-project-name").fill("");
+      await snap(page, "25-configure-empty-name", { marker: TID.nameError, locator: DIALOG });
+    });
+
+    await step("empty-message", async () => {
+      await openGitSetup(folder("quiet-harbor"));
+      await page.locator("#git-init-commit-message").fill("");
+      await snap(page, "26-configure-empty-commit-message", {
+        marker: TID.dialog,
+        locator: DIALOG,
+      });
+    });
+
+    // 5. A long project name and the longest gitignore template label — where the
+    //    configuration mode truncates, if it does.
+    await step("long-values", async () => {
+      await openGitSetup(folder("meridian-observability-platform-services"));
+      await page
+        .locator("#git-init-project-name")
+        .fill("Meridian Observability Platform — ingestion, rollup and alerting services");
+      await snap(page, "27-configure-long-values", { marker: TID.dialog, locator: DIALOG });
+    });
+
+    // 6. Started, but the main process has not spoken yet: past the 400ms Doherty gate
+    //    with zero progress events. Held open by a real IPC delay.
+    await step("connecting", async () => {
+      await openGitSetup(folder("still-water"));
+      await injectDelay(app, CH.initGitGuided, 6000);
+      await startInit();
+      await snap(page, "30-running-connecting", { marker: TID.connecting, locator: DIALOG });
+      // The delayed invoke is still in flight, and `dismissible={!isInitializing}` means
+      // Escape does nothing until it lands. Wait it out here rather than leaving a modal
+      // no later step can get past.
+      await page.locator(TID.commandBlock).first().waitFor({ state: "visible", timeout: 25000 });
+    });
+
+    // 7. Mid-flight, with real steps behind it. The 60k-file fixture makes `git add`
+    //    take seconds, and the identity is cleared first so the run lands in the
+    //    recovery state rather than adding a project and leaving the welcome screen.
+    await step("running", async () => {
+      const slow = makeSlowFolder(fixtureRoot, "atlas-monorepo");
+      await openGitSetup(slow);
+      await startInit();
+      await page
+        .locator(TID.step)
+        .filter({ hasText: "Staging files" })
+        .first()
+        .waitFor({ state: "visible", timeout: 20000 });
+      await snap(page, "35-running-mid-flight", {
+        marker: TID.step,
+        locator: DIALOG,
+        settleMs: 150,
+      });
+      // `git add` is still chewing through 60k files and the dialog is not dismissible
+      // until it lands. Wait for the run to terminate rather than leaving a modal the
+      // next step has to fight.
+      await page.locator(TID.commandBlock).first().waitFor({ state: "visible", timeout: 60000 });
+    });
+
+    // 8. The identity failure and its multi-line command block — the one place this
+    //    dialog puts shell commands in front of a user.
+    await step("identity-error", async () => {
+      await openGitSetup(folder("lantern-works"));
+      await startInit();
+      await snap(page, "40-failed-git-identity", {
+        marker: TID.commandBlock,
+        locator: DIALOG,
+        markerTimeout: 20000,
+      });
+      await snap(page, "41-failed-git-identity-in-window", { marker: TID.commandBlock });
+    });
+
+    // 9. A thrown failure, which takes the OTHER error path: no progress events at all,
+    //    so the separately styled block is the only thing on screen.
+    await step("generic-error", async () => {
+      await openGitSetup(folder("copper-forge"));
+      await injectFault(
+        app,
+        CH.initGitGuided,
+        "EACCES: permission denied, mkdir '/Users/dev/copper-forge/.git'"
+      );
+      await startInit();
+      await snap(page, "45-failed-generic", {
+        marker: TID.error,
+        locator: DIALOG,
+        markerTimeout: 15000,
+      });
+    });
+
+    // 10. Keyboard focus on the primary control. This dialog is reached from Cmd+O and
+    //     a Dock drop, so its keyboard affordances are design, not detail.
+    await step("focus", async () => {
+      await openGitSetup(folder("north-quay"));
+      await dialogButton("Initialize repository").focus();
+      await snap(page, "60-focus-primary", { marker: TID.dialog, locator: DIALOG });
+    });
+
+    // 11. prefers-contrast: more — macOS "Increase contrast".
+    await step("contrast", async () => {
+      await page.emulateMedia({ contrast: "more" });
+      await openGitSetup(folder("slate-run"));
+      await snap(page, "70-contrast-more", { marker: TID.dialog, locator: DIALOG });
+    });
+
+    // 12. forced-colors: active — Windows high contrast swaps in system colours, and
+    //     anything carrying meaning in a tint alone collapses here. Captured on the
+    //     identity failure because that is where this surface leans hardest on tint.
+    await step("forced", async () => {
+      await page.emulateMedia({ forcedColors: "active" });
+      await openGitSetup(folder("ironbark"));
+      await startInit();
+      await snap(page, "75-forced-colors", {
+        marker: TID.commandBlock,
+        locator: DIALOG,
+        markerTimeout: 20000,
+      });
+    });
+
+    // 13. Success. LAST, because finishing adds the project and switches the app out of
+    //     the welcome screen, and the dialog auto-continues two seconds later — so this
+    //     shot has a two-second window and takes a short settle to fit inside it.
+    await step("success", async () => {
+      writeGitIdentity(true);
+      await openGitSetup(folder("beacon-hill"));
+      await startInit();
+      await snap(page, "50-success", {
+        marker: 'button:has-text("Continue")',
+        locator: DIALOG,
+        markerTimeout: 20000,
+        settleMs: 120,
+      });
+      // Success auto-continues, adds the project and switches the app out of the welcome
+      // screen. Let that finish here rather than racing the teardown against it.
+      await page.locator(DIALOG).first().waitFor({ state: "hidden", timeout: 15000 });
+    });
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+    for (const dir of [fixtureRoot, userDataDir]) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+
+  // Counted here rather than trusted from the exit code: swallowed per-step errors are
+  // exactly how a harness reports PASS over an empty directory.
+  const written = existsSync(OUTPUT_DIR)
+    ? readdirSync(OUTPUT_DIR).filter((f) => f.endsWith(`${TAG}.png`)).length
+    : 0;
+  console.log(`[git-init-shots] wrote ${written} png(s) to ${OUTPUT_DIR}`);
+
+  if (failures.length > 0) {
+    throw new Error(`[git-init-shots] ${failures.length} step(s) failed:\n${failures.join("\n")}`);
+  }
+  if (written === 0) {
+    throw new Error(`[git-init-shots] no PNGs written to ${OUTPUT_DIR}`);
+  }
+});

--- a/e2e/screenshots/git-init-review.spec.ts
+++ b/e2e/screenshots/git-init-review.spec.ts
@@ -16,9 +16,10 @@
  *     the only path that supplies one.
  *   - initialization is real. `project:init-git-guided` runs against a real folder and
  *     the progress rows come from the main process's own events.
- *   - the git-identity failure is real: the app is launched with `GIT_CONFIG_GLOBAL`
- *     pointed at a file this harness owns, so emptying it makes `git commit` fail the
- *     way it does for a user who has never configured git.
+ *   - the git-identity failure is real: the app is launched with `HOME`/`XDG_CONFIG_HOME`
+ *     pointed at a fake home this harness owns — NOT `GIT_CONFIG_GLOBAL`, which the app's
+ *     git hardening strips out of every spawn env — so rewriting that home's `.gitconfig`
+ *     makes `git commit` fail the way it does for a user who has never configured git.
  *   - the mid-flight progress state is real too — a fixture with 60k files makes
  *     `git add .` take seconds, so the shot is a genuine in-flight render rather than
  *     a paused animation frame.

--- a/e2e/screenshots/git-init-review.spec.ts
+++ b/e2e/screenshots/git-init-review.spec.ts
@@ -558,6 +558,20 @@ test("git init dialog review — configuration, progress, recovery and success",
       // `:focus-visible` in Chromium, so the shot came back pixel-identical to the
       // unfocused default and read as "this button has no focus ring" — a defect that
       // was the harness's, not the dialog's. Walk the real tab order instead.
+      // The dialog focuses its name field on a rAF, and under load the first Tab
+      // could fire before that landed — which spent the budget walking in from
+      // wherever focus happened to be. Wait for the handoff, then walk.
+      await page
+        .locator("#git-init-project-name")
+        .evaluate((el) => el === document.activeElement)
+        .then(async (ok) => {
+          if (ok) return;
+          await page.waitForFunction(
+            () => document.activeElement?.id === "git-init-project-name",
+            undefined,
+            { timeout: 5000 }
+          );
+        });
       let focused = false;
       for (let i = 0; i < 12 && !focused; i++) {
         await page.keyboard.press("Tab");

--- a/e2e/screenshots/git-init-review.spec.ts
+++ b/e2e/screenshots/git-init-review.spec.ts
@@ -552,7 +552,20 @@ test("git init dialog review — configuration, progress, recovery and success",
     //     a Dock drop, so its keyboard affordances are design, not detail.
     await step("focus", async () => {
       await openGitSetup(folder("north-quay"));
-      await dialogButton("Initialize repository").focus();
+      // Tabbed to, not `.focus()`-ed. A programmatic focus call does not satisfy
+      // `:focus-visible` in Chromium, so the shot came back pixel-identical to the
+      // unfocused default and read as "this button has no focus ring" — a defect that
+      // was the harness's, not the dialog's. Walk the real tab order instead.
+      let focused = false;
+      for (let i = 0; i < 12 && !focused; i++) {
+        await page.keyboard.press("Tab");
+        focused = await dialogButton("Initialize repository").evaluate(
+          (el) => el === document.activeElement
+        );
+      }
+      if (!focused) {
+        throw new Error("[git-init-shots] tab order never reached the primary action");
+      }
       await snap(page, "60-focus-primary", { marker: TID.dialog, locator: DIALOG });
     });
 

--- a/e2e/screenshots/git-init-review.spec.ts
+++ b/e2e/screenshots/git-init-review.spec.ts
@@ -78,6 +78,8 @@ const TID = {
   step: '[data-testid="git-init-step"]',
   commandBlock: '[data-testid="git-init-command-block"]',
   error: '[data-testid="git-init-error"]',
+  success: '[data-testid="git-init-success"]',
+  openProject: '[data-testid="git-init-open"]',
 } as const;
 
 const CH = {
@@ -598,7 +600,7 @@ test("git init dialog review — configuration, progress, recovery and success",
       await openGitSetup(folder("beacon-hill"));
       await startInit();
       await snap(page, "50-success", {
-        marker: 'button:has-text("Continue")',
+        marker: TID.success,
         locator: DIALOG,
         markerTimeout: 20000,
         settleMs: 120,

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -501,7 +501,11 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       isOpen={isOpen}
       onClose={handleClose}
       size="md"
-      dismissible={!isCloning}
+      // Complete is deliberately not dismissible. Escape, the backdrop and the
+      // header X all route to `handleClose`, which in this mode opens the
+      // project — so leaving them live would dress the forward action up as a
+      // dismissal. The mode has one action and it is labelled.
+      dismissible={!isCloning && !isComplete}
       initialFocus="none"
     >
       <AppDialog.Header>
@@ -510,7 +514,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
         <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-text-secondary" />}>
           Clone repository
         </AppDialog.Title>
-        {!isCloning && <AppDialog.CloseButton />}
+        {!isCloning && !isComplete && <AppDialog.CloseButton />}
       </AppDialog.Header>
 
       <AppDialog.Body className="space-y-5">
@@ -526,9 +530,11 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             </div>
             <div className="space-y-1">
               <h3 className="text-base font-semibold text-daintree-text">Repository cloned</h3>
+              {/* Says what is about to happen, not merely what is possible:
+                  this mode opens the project on its own two seconds later. */}
               <p className="text-sm text-daintree-text/60">
-                <span aria-hidden="true">{effectiveEmoji} </span>
-                {trimmedFolderName} is ready to open
+                Opening <span aria-hidden="true">{effectiveEmoji} </span>
+                {trimmedFolderName}…
               </p>
             </div>
             {clonedPath !== null && <PathCaption path={clonedPath} className="max-w-full" />}

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -343,9 +343,18 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     void projectClient.cancelClone();
   };
 
+  /**
+   * Complete mode's one action is `finalizeSuccess`, and that bails without a
+   * `clonedPath`. Since this mode withdraws Escape, the backdrop and the header
+   * X, a missing path would otherwise leave the user holding a dialog with no
+   * working way out at all — so the withdrawal is gated on the forward action
+   * actually being able to fire.
+   */
+  const canFinalize = isComplete && clonedPath !== null;
+
   const handleClose = () => {
     if (isCloning) return;
-    if (isComplete) {
+    if (canFinalize) {
       finalizeSuccess();
     } else {
       onCancel();
@@ -505,7 +514,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       // header X all route to `handleClose`, which in this mode opens the
       // project — so leaving them live would dress the forward action up as a
       // dismissal. The mode has one action and it is labelled.
-      dismissible={!isCloning && !isComplete}
+      dismissible={!isCloning && !canFinalize}
       initialFocus="none"
     >
       <AppDialog.Header>
@@ -514,7 +523,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
         <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-text-secondary" />}>
           Clone repository
         </AppDialog.Title>
-        {!isCloning && !isComplete && <AppDialog.CloseButton />}
+        {!isCloning && !canFinalize && <AppDialog.CloseButton />}
       </AppDialog.Header>
 
       <AppDialog.Body className="space-y-5">

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -217,7 +217,13 @@ export function GitInitDialog({
     trimmedProjectName !== "" && (!createInitialCommit || initialCommitMessage.trim() !== "");
 
   return (
-    <AppDialog isOpen={isOpen} onClose={handleClose} size="md" dismissible={!isInitializing}>
+    <AppDialog
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="md"
+      dismissible={!isInitializing}
+      data-testid="git-init-dialog"
+    >
       <AppDialog.Header>
         <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-daintree-accent" />}>
           Set up project
@@ -253,6 +259,7 @@ export function GitInitDialog({
             <p
               id={nameErrorId}
               role="alert"
+              data-testid="git-init-name-error"
               className={`${FIELD_EMOJI_ROW_INDENT} text-xs text-status-error`}
             >
               Enter a project name
@@ -313,9 +320,15 @@ export function GitInitDialog({
         </div>
 
         {showProgress && (
-          <div className="rounded-lg bg-muted/50 p-4 min-h-[120px] max-h-[300px] overflow-y-auto font-mono text-sm">
+          <div
+            data-testid="git-init-progress"
+            className="rounded-lg bg-muted/50 p-4 min-h-[120px] max-h-[300px] overflow-y-auto font-mono text-sm"
+          >
             {progressEvents.length === 0 && isInitializing && (
-              <div className="flex items-center gap-2 text-muted-foreground">
+              <div
+                data-testid="git-init-connecting"
+                className="flex items-center gap-2 text-muted-foreground"
+              >
                 <Spinner size="md" />
                 <span>Starting initialization...</span>
               </div>
@@ -324,7 +337,11 @@ export function GitInitDialog({
             {progressEvents.map((event, index) => {
               const showCommands = !!event.error?.includes("git config --global");
               return (
-                <div key={index} className="flex items-start gap-2 mb-2">
+                <div
+                  key={index}
+                  data-testid="git-init-step"
+                  className="flex items-start gap-2 mb-2"
+                >
                   {getStepIcon(event)}
                   <div className="flex-1 min-w-0">
                     <div
@@ -342,7 +359,10 @@ export function GitInitDialog({
                       <div className="text-xs text-status-error mt-1">{event.error}</div>
                     )}
                     {event.error && showCommands && (
-                      <pre className="text-xs text-status-error mt-1 whitespace-pre-wrap font-mono">
+                      <pre
+                        data-testid="git-init-command-block"
+                        className="text-xs text-status-error mt-1 whitespace-pre-wrap font-mono"
+                      >
                         {event.error}
                       </pre>
                     )}
@@ -356,7 +376,10 @@ export function GitInitDialog({
         )}
 
         {error && !progressEvents.some((e) => e.status === "error") && (
-          <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive flex items-start gap-2">
+          <div
+            data-testid="git-init-error"
+            className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive flex items-start gap-2"
+          >
             <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
             <div>
               <div className="font-medium">Initialization failed</div>

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -397,6 +397,7 @@ export function GitInitDialog({
         {mode === "complete" ? (
           <div
             className="flex flex-col items-center gap-4 py-6 text-center"
+            data-testid="git-init-success"
             role="status"
             aria-live="polite"
             aria-atomic="true"
@@ -419,13 +420,16 @@ export function GitInitDialog({
                 in the app reports itself, and first — "what is happening now"
                 is the question this mode exists to answer. The transcript this
                 replaced answered it with four simultaneous spinners. */}
-            <div className="space-y-2">
+            <div className="space-y-2" data-testid="git-init-progress">
               {/* Carries the phase and nothing else, so step changes are
                   announced and the step counter ticking is not. */}
               <span className="sr-only" role="status" aria-live="polite">
                 {currentPhase?.live ?? "Starting"}
               </span>
-              <div className="flex items-center gap-2">
+              <div
+                className="flex items-center gap-2"
+                data-testid={currentPhase ? "git-init-step" : "git-init-connecting"}
+              >
                 <Spinner size="sm" className="shrink-0 text-text-secondary" />
                 <span aria-hidden="true" className="text-sm text-daintree-text">
                   {currentPhase?.live ?? "Starting…"}
@@ -478,6 +482,7 @@ export function GitInitDialog({
                 {completedPhases.map((phase) => (
                   <li
                     key={phase.step}
+                    data-testid="git-init-step"
                     className="flex items-start gap-2 text-xs text-daintree-text/45"
                   >
                     <Check className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
@@ -500,31 +505,34 @@ export function GitInitDialog({
                 as an event or as a thrown error: the two used to render as two
                 unrelated components, and the identity case printed its
                 remediation twice. */}
-            {error &&
-              (identityCommands.length > 0 ? (
-                <InlineStatusBanner
-                  icon={AlertCircle}
-                  severity="error"
-                  title="Initial commit skipped"
-                  description="The repository was created, but Git needs a name and email before it can commit. Set them, then retry."
-                  descriptionExtras={
-                    <div className="mt-2 space-y-1.5">
-                      {identityCommands.map((command) => (
-                        <CopyableCommand key={command} command={command} />
-                      ))}
-                    </div>
-                  }
-                  className="rounded-[var(--radius-md)]"
-                />
-              ) : (
-                <InlineStatusBanner
-                  icon={AlertCircle}
-                  severity="error"
-                  title="Initialization failed"
-                  description={error}
-                  className="rounded-[var(--radius-md)]"
-                />
-              ))}
+            {error && (
+              <div data-testid="git-init-error">
+                {identityCommands.length > 0 ? (
+                  <InlineStatusBanner
+                    icon={AlertCircle}
+                    severity="error"
+                    title="Initial commit skipped"
+                    description="The repository was created, but Git needs a name and email before it can commit. Set them, then retry."
+                    descriptionExtras={
+                      <div className="mt-2 space-y-1.5" data-testid="git-init-command-block">
+                        {identityCommands.map((command) => (
+                          <CopyableCommand key={command} command={command} />
+                        ))}
+                      </div>
+                    }
+                    className="rounded-[var(--radius-md)]"
+                  />
+                ) : (
+                  <InlineStatusBanner
+                    icon={AlertCircle}
+                    severity="error"
+                    title="Initialization failed"
+                    description={error}
+                    className="rounded-[var(--radius-md)]"
+                  />
+                )}
+              </div>
+            )}
 
             <div className="space-y-1.5">
               <label htmlFor="git-init-project-name" className={FIELD_LABEL_CLASS}>

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -152,6 +152,7 @@ export function GitInitDialog({
   const sawErrorEventRef = useRef(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const footerActionRef = useRef<HTMLButtonElement>(null);
+  const runningHeadingRef = useRef<HTMLDivElement>(null);
   const previousModeRef = useRef<"configure" | "running" | "failed" | "complete">("configure");
   const nameErrorId = useId();
   const commitMessageErrorId = useId();
@@ -331,9 +332,11 @@ export function GitInitDialog({
 
   // Each mode replaces the controls the previous one owned, so keyboard focus
   // has to follow or it lands on a node that no longer exists — the WCAG 2.4.3
-  // failure documented as F85. Running hands it to the disabled Cancel's
-  // neighbour, failure to Retry, success to Open project. Configuration is
-  // excluded on the way in: the open effect already put focus in the name
+  // failure documented as F85. Failure hands it to Retry and success to Open
+  // project. Running is the awkward one: it owns no enabled control at all, so
+  // focus goes to the live-phase readout itself, which is both the thing that
+  // changed and the thing a screen reader should be sitting on. Configuration
+  // is excluded on the way in — the open effect already put focus in the name
   // field, and re-running this on every keystroke would fight it.
   useEffect(() => {
     const previousMode = previousModeRef.current;
@@ -344,7 +347,9 @@ export function GitInitDialog({
         ? previousMode === "running"
           ? nameInputRef.current
           : null
-        : footerActionRef.current;
+        : mode === "running"
+          ? runningHeadingRef.current
+          : footerActionRef.current;
     if (!target) return;
     const frame = requestAnimationFrame(() => target.focus());
     return () => cancelAnimationFrame(frame);
@@ -380,7 +385,11 @@ export function GitInitDialog({
       isOpen={isOpen}
       onClose={handleClose}
       size="md"
-      dismissible={!isInitializing}
+      // Complete is deliberately not dismissible. Escape, the backdrop and the
+      // header X all route to `handleClose`, which in this mode opens the
+      // project — so leaving them live would dress the forward action up as a
+      // dismissal. The mode has one action and it is labelled.
+      dismissible={!isInitializing && !isComplete}
       initialFocus="none"
       data-testid="git-init-dialog"
     >
@@ -390,7 +399,7 @@ export function GitInitDialog({
         <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-text-secondary" />}>
           Set up repository
         </AppDialog.Title>
-        {!isInitializing && <AppDialog.CloseButton />}
+        {!isInitializing && !isComplete && <AppDialog.CloseButton />}
       </AppDialog.Header>
 
       <AppDialog.Body className="space-y-5">
@@ -407,9 +416,12 @@ export function GitInitDialog({
             </div>
             <div className="space-y-1">
               <h3 className="text-base font-semibold text-daintree-text">Repository initialized</h3>
+              {/* Says what is about to happen, not merely what is possible:
+                  this mode opens the project on its own two seconds later, and
+                  "is ready to open" read as though it were waiting. */}
               <p className="text-sm text-daintree-text/60">
-                <span aria-hidden="true">{emoji} </span>
-                {trimmedProjectName} is ready to open
+                Opening <span aria-hidden="true">{emoji} </span>
+                {trimmedProjectName}…
               </p>
             </div>
             <PathCaption path={directoryPath} className="max-w-full" />
@@ -420,7 +432,14 @@ export function GitInitDialog({
                 in the app reports itself, and first — "what is happening now"
                 is the question this mode exists to answer. The transcript this
                 replaced answered it with four simultaneous spinners. */}
-            <div className="space-y-2" data-testid="git-init-progress">
+            <div
+              className="space-y-2"
+              data-testid="git-init-progress"
+              ref={runningHeadingRef}
+              // Focusable only programmatically: starting the operation destroys
+              // the button that had focus, and this is where focus is handed.
+              tabIndex={-1}
+            >
               {/* Carries the phase and nothing else, so step changes are
                   announced and the step counter ticking is not. */}
               <span className="sr-only" role="status" aria-live="polite">
@@ -435,11 +454,15 @@ export function GitInitDialog({
                   {currentPhase?.live ?? "Starting…"}
                 </span>
                 {currentPhase && (
+                  // Steps FINISHED, not the ordinal of the live one. The live
+                  // step is already named to the left, and a counter reading
+                  // "3 of 4" beside a bar filled to 50% left the two disagreeing
+                  // about the same fact.
                   <span
                     aria-hidden="true"
                     className="ml-auto text-xs tabular-nums text-daintree-text/60"
                   >
-                    {completedCount + 1} of {plannedSteps.length}
+                    {completedCount} of {plannedSteps.length} done
                   </span>
                 )}
               </div>

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -1,9 +1,12 @@
-import { useState, useEffect, useRef, useCallback, useId } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Check, AlertCircle } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
+import { SkeletonHint } from "@/components/ui/Skeleton";
 import { FolderGit2 } from "@/components/icons";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
+import { CopyableCommand } from "@/components/Setup/CopyableCommand";
 import { projectClient } from "@/clients";
 import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -22,7 +25,7 @@ import {
   DEFAULT_GITIGNORE_TEMPLATE_ID,
   isGitignoreTemplateId,
 } from "@shared/config/gitignoreTemplates";
-import type { GitInitProgressEvent } from "@shared/types/ipc/gitInit";
+import type { GitInitProgressEvent, GitInitStepType } from "@shared/types/ipc/gitInit";
 import type { ProjectCreationIdentity } from "@shared/types";
 
 interface GitInitDialogProps {
@@ -41,6 +44,91 @@ interface GitInitDialogProps {
 
 const AUTO_CLOSE_DELAY_MS = 2000;
 
+/**
+ * House rule for a wait with nothing to show is reassurance past five seconds;
+ * `SkeletonHint`'s own default is eight, which suits a skeleton that at least
+ * has shape. Only the first threshold moves — the later escalations keep the
+ * shared cadence. Matches `CloneRepoDialog`.
+ */
+const STILL_WORKING_AFTER_MS = 5000;
+
+/** The steps the main process reports. `complete` and `error` are outcomes, not steps. */
+type WorkStep = Extract<GitInitStepType, "init" | "gitignore" | "add" | "commit">;
+
+const WORK_STEPS: readonly WorkStep[] = ["init", "gitignore", "add", "commit"];
+
+function isWorkStep(step: GitInitStepType): step is WorkStep {
+  return (WORK_STEPS as readonly GitInitStepType[]).includes(step);
+}
+
+/**
+ * The steps a run with these options will actually take.
+ *
+ * Pinned when the run is launched rather than read live: a failure hands the
+ * form back editable, and deriving the denominator from the current fields
+ * would retitle a finished run's progress after the fact.
+ */
+function planSteps(createGitignore: boolean, createInitialCommit: boolean): WorkStep[] {
+  const steps: WorkStep[] = ["init"];
+  if (createGitignore) steps.push("gitignore");
+  if (createInitialCommit) steps.push("add", "commit");
+  return steps;
+}
+
+/**
+ * The main process narrates a start as `"Staging files for initial commit..."`.
+ * The trailing dots are its own progress punctuation and this surface supplies
+ * its own, so strip them rather than rendering an ellipsis followed by three more dots.
+ */
+function liveLabel(message: string): string {
+  return message.replace(/\.{3}$/, "").trim();
+}
+
+interface PhaseState {
+  step: WorkStep;
+  /** Present once the step has reported success — this is what the quiet list shows. */
+  done?: string;
+  /** The start message, kept for the live readout while `done` is absent. */
+  live?: string;
+}
+
+/**
+ * Collapse the raw event stream into one row per step.
+ *
+ * The stream carries a `start` and then a `success` for every step, so
+ * rendering it verbatim states each step twice and — because a start event's
+ * status never changes — leaves its spinner turning forever underneath its own
+ * completion line. Four steps became nine rows and four live spinners on a run
+ * that had already finished.
+ */
+function collapsePhases(events: GitInitProgressEvent[]): PhaseState[] {
+  const byStep = new Map<WorkStep, PhaseState>();
+  for (const event of events) {
+    if (!isWorkStep(event.step)) continue;
+    const phase = byStep.get(event.step) ?? { step: event.step };
+    if (event.status === "start") phase.live = liveLabel(event.message);
+    if (event.status === "success") phase.done = event.message;
+    byStep.set(event.step, phase);
+  }
+  return [...byStep.values()];
+}
+
+/**
+ * The two `git config` lines out of the main process's identity help.
+ *
+ * Extracted rather than reformatted: these exact strings are the recovery, and
+ * they are what goes on the clipboard. Anything that is not a command line
+ * falls back to the whole block so a reworded help message degrades to the
+ * old verbatim rendering instead of vanishing.
+ */
+function extractCommands(help: string): string[] {
+  const commands = help
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("git "));
+  return commands.length > 0 ? commands : [];
+}
+
 export function GitInitDialog({
   isOpen,
   directoryPath,
@@ -57,17 +145,26 @@ export function GitInitDialog({
   const [isInitializing, setIsInitializing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isComplete, setIsComplete] = useState(false);
-  const logEndRef = useRef<HTMLDivElement>(null);
+  const [plannedSteps, setPlannedSteps] = useState<WorkStep[]>(() => planSteps(true, true));
   const hasFinalizedSuccessRef = useRef(false);
   const inFlightRef = useRef(false);
   const sawTerminalEventRef = useRef(false);
   const sawErrorEventRef = useRef(false);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  const footerActionRef = useRef<HTMLButtonElement>(null);
+  const previousModeRef = useRef<"configure" | "running" | "failed" | "complete">("configure");
   const nameErrorId = useId();
+  const commitMessageErrorId = useId();
+  const commitOptionsId = useId();
 
   const trimmedProjectName = projectName.trim();
   // The name is seeded from the folder, so this only ever fires after the user
   // clears the field — the one state where the start button silently disables.
   const isNameMissing = trimmedProjectName === "";
+  // Symmetric with the name: the button goes dead either way, so both should
+  // say why. The placeholder repeats the default value, which makes an emptied
+  // field otherwise near-indistinguishable from a filled one.
+  const isCommitMessageMissing = createInitialCommit && initialCommitMessage.trim() === "";
 
   const finalizeSuccess = useCallback(() => {
     if (hasFinalizedSuccessRef.current) {
@@ -103,6 +200,7 @@ export function GitInitDialog({
       setIsInitializing(false);
       setError(null);
       setIsComplete(false);
+      setPlannedSteps(planSteps(true, true));
       hasFinalizedSuccessRef.current = false;
       inFlightRef.current = false;
       sawTerminalEventRef.current = false;
@@ -133,10 +231,6 @@ export function GitInitDialog({
     return cleanup;
   }, [isOpen]);
 
-  useEffect(() => {
-    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [progressEvents]);
-
   const startInitialization = useCallback(async () => {
     if (inFlightRef.current) {
       return;
@@ -145,6 +239,8 @@ export function GitInitDialog({
     sawTerminalEventRef.current = false;
     sawErrorEventRef.current = false;
 
+    const createGitignore = gitignoreTemplate !== "none";
+    setPlannedSteps(planSteps(createGitignore, createInitialCommit));
     setIsInitializing(true);
     setError(null);
     setIsComplete(false);
@@ -156,7 +252,7 @@ export function GitInitDialog({
         directoryPath,
         createInitialCommit,
         initialCommitMessage: initialCommitMessage.trim(),
-        createGitignore: gitignoreTemplate !== "none",
+        createGitignore,
         gitignoreTemplate,
       });
       if (result.outcome === "success") {
@@ -199,22 +295,85 @@ export function GitInitDialog({
     }
   };
 
-  const getStepIcon = (event: GitInitProgressEvent) => {
-    if (event.status === "start") {
-      return <Spinner size="md" className="text-status-info" />;
-    } else if (event.status === "success") {
-      return <Check className="h-4 w-4 text-status-success" />;
-    } else if (event.status === "error") {
-      return <AlertCircle className="h-4 w-4 text-status-error" />;
-    }
-    return null;
-  };
+  // Gated, not raw: a folder that initializes inside 400ms should never flash a
+  // progress panel over the form it just replaced.
+  const isRunning = useDohertyGate(isInitializing);
+  const mode: "configure" | "running" | "failed" | "complete" = isComplete
+    ? "complete"
+    : error
+      ? "failed"
+      : isRunning
+        ? "running"
+        : "configure";
 
-  const showConnecting = useDohertyGate(isInitializing && progressEvents.length === 0);
-  const showProgress = showConnecting || progressEvents.length > 0;
-  const configDisabled = isInitializing || isComplete;
-  const canStart =
-    trimmedProjectName !== "" && (!createInitialCommit || initialCommitMessage.trim() !== "");
+  const phases = useMemo(() => collapsePhases(progressEvents), [progressEvents]);
+  const completedPhases = useMemo(() => phases.filter((phase) => phase.done), [phases]);
+  // The step that has started and not yet reported. Read from the end so a
+  // stream that somehow overlaps two steps reports the most recent one.
+  const currentPhase = useMemo(
+    () => [...phases].reverse().find((phase) => !phase.done && phase.live),
+    [phases]
+  );
+  const completedCount = Math.min(completedPhases.length, plannedSteps.length);
+  const identityCommands = useMemo(() => (error ? extractCommands(error) : []), [error]);
+
+  const configDisabled = isInitializing;
+  const canStart = !isNameMissing && !isCommitMessageMissing;
+
+  // AppDialog's default `initialFocus="first"` lands on the header close
+  // button, which spends this focus region's one accent signal on the dismiss
+  // control while the field the user came here to check sits unmarked.
+  useEffect(() => {
+    if (!isOpen) return;
+    const frame = requestAnimationFrame(() => nameInputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen]);
+
+  // Each mode replaces the controls the previous one owned, so keyboard focus
+  // has to follow or it lands on a node that no longer exists — the WCAG 2.4.3
+  // failure documented as F85. Running hands it to the disabled Cancel's
+  // neighbour, failure to Retry, success to Open project. Configuration is
+  // excluded on the way in: the open effect already put focus in the name
+  // field, and re-running this on every keystroke would fight it.
+  useEffect(() => {
+    const previousMode = previousModeRef.current;
+    previousModeRef.current = mode;
+    if (!isOpen) return;
+    const target =
+      mode === "configure"
+        ? previousMode === "running"
+          ? nameInputRef.current
+          : null
+        : footerActionRef.current;
+    if (!target) return;
+    const frame = requestAnimationFrame(() => target.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, mode]);
+
+  const summary = (
+    <div className="space-y-2.5 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg px-3 py-3">
+      <div className="space-y-1">
+        <span className="text-xs font-medium text-daintree-text/60">Repository</span>
+        <p className="truncate text-xs text-daintree-text/80">
+          <span aria-hidden="true">{emoji} </span>
+          {trimmedProjectName}
+        </p>
+      </div>
+      <div className="space-y-1">
+        <span className="text-xs font-medium text-daintree-text/60">Folder</span>
+        <PathCaption path={directoryPath} className="text-daintree-text/80" />
+      </div>
+    </div>
+  );
+
+  // What the primary action will actually write, in the user's own terms. This
+  // dialog is the one place the app touches a folder it does not own yet, and
+  // the folder path alone does not say that.
+  const consequence = [
+    "Creates a Git repository in this folder",
+    gitignoreTemplate !== "none" ? "adds a .gitignore" : null,
+    createInitialCommit ? "commits everything in it" : null,
+  ].filter(Boolean);
 
   return (
     <AppDialog
@@ -222,178 +381,290 @@ export function GitInitDialog({
       onClose={handleClose}
       size="md"
       dismissible={!isInitializing}
+      initialFocus="none"
       data-testid="git-init-dialog"
     >
       <AppDialog.Header>
-        <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-daintree-accent" />}>
-          Set up project
+        {/* Neutral, not accent: the header glyph is decoration, and this focus
+            region's one load-bearing accent is the keyboard focus ring. */}
+        <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-text-secondary" />}>
+          Set up repository
         </AppDialog.Title>
         {!isInitializing && <AppDialog.CloseButton />}
       </AppDialog.Header>
 
       <AppDialog.Body className="space-y-5">
-        <div className="space-y-1.5">
-          <label htmlFor="git-init-project-name" className={FIELD_LABEL_CLASS}>
-            Project name
-          </label>
-          <div className="flex items-center gap-2">
-            <ProjectEmojiButton
-              emoji={emoji}
-              onEmojiChange={setEmoji}
-              disabled={configDisabled}
-              ariaLabel="Choose project emoji"
-            />
-            <input
-              id="git-init-project-name"
-              type="text"
-              value={projectName}
-              onChange={(e) => setProjectName(e.target.value)}
-              disabled={configDisabled}
-              aria-invalid={isNameMissing}
-              aria-describedby={isNameMissing ? nameErrorId : undefined}
-              className={FIELD_INPUT_CLASS}
-              placeholder="My project"
-            />
-          </div>
-          {isNameMissing && (
-            <p
-              id={nameErrorId}
-              role="alert"
-              data-testid="git-init-name-error"
-              className={`${FIELD_EMOJI_ROW_INDENT} text-xs text-status-error`}
-            >
-              Enter a project name
-            </p>
-          )}
-          <PathCaption path={directoryPath} className={FIELD_EMOJI_ROW_INDENT} />
-        </div>
-
-        <div className="space-y-1.5">
-          <label htmlFor="git-init-template" className={FIELD_LABEL_CLASS}>
-            Gitignore template
-          </label>
-          <select
-            id="git-init-template"
-            value={gitignoreTemplate}
-            onChange={(e) => {
-              if (isGitignoreTemplateId(e.target.value)) setGitignoreTemplate(e.target.value);
-            }}
-            disabled={configDisabled}
-            className={FIELD_INPUT_CLASS}
-          >
-            {GITIGNORE_TEMPLATE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label} — {opt.description}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="space-y-3">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={createInitialCommit}
-              onChange={(e) => setCreateInitialCommit(e.target.checked)}
-              disabled={configDisabled}
-              className={FIELD_CHECKBOX_CLASS}
-            />
-            <span className="text-sm text-daintree-text/80">Create initial commit</span>
-          </label>
-
-          {createInitialCommit && (
-            <div className="space-y-1.5">
-              <label htmlFor="git-init-commit-message" className={FIELD_LABEL_CLASS}>
-                Initial commit message
-              </label>
-              <input
-                id="git-init-commit-message"
-                type="text"
-                value={initialCommitMessage}
-                onChange={(e) => setInitialCommitMessage(e.target.value)}
-                disabled={configDisabled}
-                placeholder="Initial commit"
-                className={FIELD_INPUT_CLASS}
-              />
-            </div>
-          )}
-        </div>
-
-        {showProgress && (
+        {mode === "complete" ? (
           <div
-            data-testid="git-init-progress"
-            className="rounded-lg bg-muted/50 p-4 min-h-[120px] max-h-[300px] overflow-y-auto font-mono text-sm"
+            className="flex flex-col items-center gap-4 py-6 text-center"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
           >
-            {progressEvents.length === 0 && isInitializing && (
-              <div
-                data-testid="git-init-connecting"
-                className="flex items-center gap-2 text-muted-foreground"
-              >
-                <Spinner size="md" />
-                <span>Starting initialization...</span>
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-status-success/15">
+              <Check className="h-6 w-6 text-status-success" />
+            </div>
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold text-daintree-text">Repository initialized</h3>
+              <p className="text-sm text-daintree-text/60">
+                <span aria-hidden="true">{emoji} </span>
+                {trimmedProjectName} is ready to open
+              </p>
+            </div>
+            <PathCaption path={directoryPath} className="max-w-full" />
+          </div>
+        ) : mode === "running" ? (
+          <>
+            {/* One current phase, the way every other running-operation surface
+                in the app reports itself, and first — "what is happening now"
+                is the question this mode exists to answer. The transcript this
+                replaced answered it with four simultaneous spinners. */}
+            <div className="space-y-2">
+              {/* Carries the phase and nothing else, so step changes are
+                  announced and the step counter ticking is not. */}
+              <span className="sr-only" role="status" aria-live="polite">
+                {currentPhase?.live ?? "Starting"}
+              </span>
+              <div className="flex items-center gap-2">
+                <Spinner size="sm" className="shrink-0 text-text-secondary" />
+                <span aria-hidden="true" className="text-sm text-daintree-text">
+                  {currentPhase?.live ?? "Starting…"}
+                </span>
+                {currentPhase && (
+                  <span
+                    aria-hidden="true"
+                    className="ml-auto text-xs tabular-nums text-daintree-text/60"
+                  >
+                    {completedCount + 1} of {plannedSteps.length}
+                  </span>
+                )}
               </div>
+              {/* Determinate on purpose: the step list is decided by the options
+                  the user submitted, so "2 of 4" is something this surface
+                  actually knows. Before the first event there is no step to
+                  count, so the track omits `aria-valuenow` and pulses instead. */}
+              <div
+                role="progressbar"
+                aria-label={currentPhase?.live ?? "Starting"}
+                {...(currentPhase ? { "aria-valuenow": completedCount } : {})}
+                aria-valuemin={0}
+                aria-valuemax={plannedSteps.length}
+                className={`h-1 w-full overflow-hidden rounded-full bg-daintree-border/50 ${
+                  currentPhase ? "" : "animate-pulse-immediate"
+                }`}
+              >
+                {currentPhase && (
+                  <div
+                    className="h-full rounded-full bg-daintree-text/60 transition-[width] duration-150 ease-out"
+                    style={{
+                      width: `${(completedCount / Math.max(plannedSteps.length, 1)) * 100}%`,
+                    }}
+                  />
+                )}
+              </div>
+              {/* Only while nothing has been reported yet — once steps are
+                  ticking, "Still working…" would be telling the user something
+                  the counter already says. */}
+              {!currentPhase && (
+                <SkeletonHint message="Still working…" firstThreshold={STILL_WORKING_AFTER_MS} />
+              )}
+            </div>
+
+            {/* Steps already finished, quieted to a static check. They are what
+                makes a long staging step read as "step three of four" rather
+                than as the operation having stalled. */}
+            {completedPhases.length > 0 && (
+              <ul className="space-y-1">
+                {completedPhases.map((phase) => (
+                  <li
+                    key={phase.step}
+                    className="flex items-start gap-2 text-xs text-daintree-text/45"
+                  >
+                    <Check className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    <span>{phase.done}</span>
+                  </li>
+                ))}
+              </ul>
             )}
 
-            {progressEvents.map((event, index) => {
-              const showCommands = !!event.error?.includes("git config --global");
-              return (
-                <div
-                  key={index}
-                  data-testid="git-init-step"
-                  className="flex items-start gap-2 mb-2"
-                >
-                  {getStepIcon(event)}
-                  <div className="flex-1 min-w-0">
-                    <div
-                      className={
-                        event.status === "error"
-                          ? "text-status-error"
-                          : event.status === "success"
-                            ? "text-status-success"
-                            : "text-foreground"
-                      }
-                    >
-                      {event.message}
+            {/* Subordinate to the live phase: which folder is being written to,
+                kept legible now that the form is gone. */}
+            {summary}
+          </>
+        ) : (
+          <>
+            {/* Outcome first. A failure hands the user back the form with the
+                fields they typed intact, so the explanation belongs above the
+                inputs it is about — not below them, where the body scrolls it
+                out of sight entirely. One banner, whether the failure arrived
+                as an event or as a thrown error: the two used to render as two
+                unrelated components, and the identity case printed its
+                remediation twice. */}
+            {error &&
+              (identityCommands.length > 0 ? (
+                <InlineStatusBanner
+                  icon={AlertCircle}
+                  severity="error"
+                  title="Initial commit skipped"
+                  description="The repository was created, but Git needs a name and email before it can commit. Set them, then retry."
+                  descriptionExtras={
+                    <div className="mt-2 space-y-1.5">
+                      {identityCommands.map((command) => (
+                        <CopyableCommand key={command} command={command} />
+                      ))}
                     </div>
-                    {event.error && !showCommands && (
-                      <div className="text-xs text-status-error mt-1">{event.error}</div>
-                    )}
-                    {event.error && showCommands && (
-                      <pre
-                        data-testid="git-init-command-block"
-                        className="text-xs text-status-error mt-1 whitespace-pre-wrap font-mono"
-                      >
-                        {event.error}
-                      </pre>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
+                  }
+                  className="rounded-[var(--radius-md)]"
+                />
+              ) : (
+                <InlineStatusBanner
+                  icon={AlertCircle}
+                  severity="error"
+                  title="Initialization failed"
+                  description={error}
+                  className="rounded-[var(--radius-md)]"
+                />
+              ))}
 
-            <div ref={logEndRef} />
-          </div>
-        )}
-
-        {error && !progressEvents.some((e) => e.status === "error") && (
-          <div
-            data-testid="git-init-error"
-            className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive flex items-start gap-2"
-          >
-            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-            <div>
-              <div className="font-medium">Initialization failed</div>
-              <div className="text-xs mt-1">{error}</div>
+            <div className="space-y-1.5">
+              <label htmlFor="git-init-project-name" className={FIELD_LABEL_CLASS}>
+                Project name
+              </label>
+              <div className="flex items-center gap-2">
+                <ProjectEmojiButton
+                  emoji={emoji}
+                  onEmojiChange={setEmoji}
+                  disabled={configDisabled}
+                  ariaLabel="Choose project emoji"
+                />
+                <input
+                  id="git-init-project-name"
+                  ref={nameInputRef}
+                  type="text"
+                  value={projectName}
+                  onChange={(e) => setProjectName(e.target.value)}
+                  disabled={configDisabled}
+                  aria-invalid={isNameMissing}
+                  aria-describedby={isNameMissing ? nameErrorId : undefined}
+                  className={FIELD_INPUT_CLASS}
+                  placeholder="My project"
+                />
+              </div>
+              {isNameMissing && (
+                <p
+                  id={nameErrorId}
+                  role="alert"
+                  data-testid="git-init-name-error"
+                  className={`${FIELD_EMOJI_ROW_INDENT} text-xs text-status-error`}
+                >
+                  Enter a project name
+                </p>
+              )}
+              <PathCaption path={directoryPath} className={FIELD_EMOJI_ROW_INDENT} />
             </div>
-          </div>
+
+            <div className="space-y-1.5">
+              <label htmlFor="git-init-template" className={FIELD_LABEL_CLASS}>
+                Gitignore template
+              </label>
+              <select
+                id="git-init-template"
+                value={gitignoreTemplate}
+                onChange={(e) => {
+                  if (isGitignoreTemplateId(e.target.value)) setGitignoreTemplate(e.target.value);
+                }}
+                disabled={configDisabled}
+                className={FIELD_INPUT_CLASS}
+              >
+                {GITIGNORE_TEMPLATE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label} — {opt.description}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-3">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={createInitialCommit}
+                  onChange={(e) => setCreateInitialCommit(e.target.checked)}
+                  disabled={configDisabled}
+                  aria-expanded={createInitialCommit}
+                  aria-controls={commitOptionsId}
+                  className={FIELD_CHECKBOX_CLASS}
+                />
+                <span className="text-sm text-daintree-text/80">Create initial commit</span>
+              </label>
+
+              {/* Indented behind a rule, the way every other dependent field in
+                  Settings is presented. Left flat it sat at the same indent,
+                  width and label weight as the gitignore select above it, so
+                  the one field that only exists because a box is ticked read as
+                  another permanent setting. */}
+              {createInitialCommit && (
+                <div
+                  id={commitOptionsId}
+                  className="ml-6 space-y-1.5 border-l border-daintree-border pl-4"
+                >
+                  <label htmlFor="git-init-commit-message" className={FIELD_LABEL_CLASS}>
+                    Initial commit message
+                  </label>
+                  <input
+                    id="git-init-commit-message"
+                    type="text"
+                    value={initialCommitMessage}
+                    onChange={(e) => setInitialCommitMessage(e.target.value)}
+                    disabled={configDisabled}
+                    aria-invalid={isCommitMessageMissing}
+                    aria-describedby={isCommitMessageMissing ? commitMessageErrorId : undefined}
+                    placeholder="Initial commit"
+                    className={FIELD_INPUT_CLASS}
+                  />
+                  {isCommitMessageMissing && (
+                    <p
+                      id={commitMessageErrorId}
+                      role="alert"
+                      data-testid="git-init-commit-message-error"
+                      className="text-xs text-status-error"
+                    >
+                      Enter a commit message
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* The one thing the path alone does not say: this writes into a
+                folder the app does not own yet, and exactly what it writes
+                depends on the two controls above. */}
+            <p className="text-xs text-daintree-text/50" data-testid="git-init-consequence">
+              {consequence.join(", ")}.
+            </p>
+          </>
         )}
       </AppDialog.Body>
 
       <AppDialog.Footer>
-        {isComplete ? (
-          <Button variant="contrast" onClick={handleClose} className="gap-2">
+        {mode === "complete" ? (
+          <Button
+            ref={footerActionRef}
+            variant="contrast"
+            data-testid="git-init-open"
+            onClick={handleClose}
+            className="gap-2"
+          >
             <Check className="h-4 w-4" />
-            Continue
+            Open project
+          </Button>
+        ) : mode === "running" ? (
+          // No primary while it runs. There is no safe way to stop a git init
+          // part-way, so the only honest footer is the escape hatch, visibly
+          // unavailable — rather than a primary button wearing a spinner over
+          // its own label.
+          <Button variant="outline" data-testid="git-init-cancel" disabled>
+            Cancel
           </Button>
         ) : error ? (
           <>
@@ -401,11 +672,13 @@ export function GitInitDialog({
               Cancel
             </Button>
             <Button
+              ref={footerActionRef}
               variant="contrast"
+              data-testid="git-init-retry"
               onClick={() => void startInitialization()}
               disabled={isInitializing || !canStart}
             >
-              Try again
+              Retry
             </Button>
           </>
         ) : (
@@ -415,9 +688,9 @@ export function GitInitDialog({
             </Button>
             <Button
               variant="contrast"
+              data-testid="git-init-start"
               onClick={() => void startInitialization()}
               disabled={isInitializing || !canStart}
-              loading={isInitializing}
             >
               Initialize repository
             </Button>

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { Check, AlertCircle } from "lucide-react";
+import { Check, AlertCircle, AlertTriangle } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { SkeletonHint } from "@/components/ui/Skeleton";
 import { FolderGit2 } from "@/components/icons";
@@ -117,16 +117,53 @@ function collapsePhases(events: GitInitProgressEvent[]): PhaseState[] {
  * The two `git config` lines out of the main process's identity help.
  *
  * Extracted rather than reformatted: these exact strings are the recovery, and
- * they are what goes on the clipboard. Anything that is not a command line
- * falls back to the whole block so a reworded help message degrades to the
- * old verbatim rendering instead of vanishing.
+ * they are what goes on the clipboard. Only ever called on an error already
+ * identified as the identity failure — this is a formatter, not a classifier,
+ * and it returns nothing at all when a reworded help block carries no command
+ * lines. The banner then renders its prose without a command block.
  */
 function extractCommands(help: string): string[] {
-  const commands = help
+  return help
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.startsWith("git "));
-  return commands.length > 0 ? commands : [];
+}
+
+/**
+ * The main process's own discriminator for the identity failure
+ * (`projectCrud/gitInit.ts`), applied to the help text it forwards.
+ *
+ * Keyed on the signal rather than on "the error text happens to contain a line
+ * starting with `git `": an `init` or `add` failure whose message mentions a
+ * git command would otherwise be handed the identity diagnosis, including its
+ * claim that the repository WAS created.
+ */
+function isIdentityError(error: string): boolean {
+  return error.includes("user.email") || error.includes("user.name");
+}
+
+/** The main process's prefix for "there was already a .gitignore here". */
+const KEPT_GITIGNORE_PREFIX = "Existing .gitignore kept";
+/** The one kept-.gitignore outcome that is reassurance rather than a warning. */
+const KEPT_GITIGNORE_ALL_CLEAR = "covers all template entries";
+
+/**
+ * The kept-.gitignore warning, when the run produced one.
+ *
+ * The main process delivers it as the `gitignore` step's SUCCESS message, so it
+ * exists only inside the progress stream — and `complete` replaces the whole
+ * body, while a run that finishes inside the Doherty gate never renders
+ * `running` at all. Without carrying it forward, the one line telling the user
+ * their existing .gitignore may not cover secrets is shown to nobody.
+ */
+function keptGitignoreWarning(events: GitInitProgressEvent[]): string | null {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (!event || event.step !== "gitignore" || event.status !== "success") continue;
+    if (!event.message.startsWith(KEPT_GITIGNORE_PREFIX)) return null;
+    return event.message.includes(KEPT_GITIGNORE_ALL_CLEAR) ? null : event.message;
+  }
+  return null;
 }
 
 export function GitInitDialog({
@@ -316,7 +353,12 @@ export function GitInitDialog({
     [phases]
   );
   const completedCount = Math.min(completedPhases.length, plannedSteps.length);
-  const identityCommands = useMemo(() => (error ? extractCommands(error) : []), [error]);
+  const isIdentityFailure = error !== null && isIdentityError(error);
+  const identityCommands = useMemo(
+    () => (error && isIdentityFailure ? extractCommands(error) : []),
+    [error, isIdentityFailure]
+  );
+  const keptGitignore = useMemo(() => keptGitignoreWarning(progressEvents), [progressEvents]);
 
   const configDisabled = isInitializing;
   const canStart = !isNameMissing && !isCommitMessageMissing;
@@ -404,28 +446,45 @@ export function GitInitDialog({
 
       <AppDialog.Body className="space-y-5">
         {mode === "complete" ? (
-          <div
-            className="flex flex-col items-center gap-4 py-6 text-center"
-            data-testid="git-init-success"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-status-success/15">
-              <Check className="h-6 w-6 text-status-success" />
+          <>
+            {/* Above the confirmation, not inside it: the run succeeded, but it
+                left a .gitignore this dialog did not write, and the only place
+                that was ever said is a progress row nobody sees when the run
+                beats the Doherty gate. */}
+            {keptGitignore && (
+              <InlineStatusBanner
+                icon={AlertTriangle}
+                severity="warning"
+                title="Review the existing .gitignore"
+                description={keptGitignore}
+                className="rounded-[var(--radius-md)]"
+              />
+            )}
+            <div
+              className="flex flex-col items-center gap-4 py-6 text-center"
+              data-testid="git-init-success"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-status-success/15">
+                <Check className="h-6 w-6 text-status-success" />
+              </div>
+              <div className="space-y-1">
+                <h3 className="text-base font-semibold text-daintree-text">
+                  Repository initialized
+                </h3>
+                {/* Says what is about to happen, not merely what is possible:
+                    this mode opens the project on its own two seconds later, and
+                    "is ready to open" read as though it were waiting. */}
+                <p className="text-sm text-daintree-text/60">
+                  Opening <span aria-hidden="true">{emoji} </span>
+                  {trimmedProjectName}…
+                </p>
+              </div>
+              <PathCaption path={directoryPath} className="max-w-full" />
             </div>
-            <div className="space-y-1">
-              <h3 className="text-base font-semibold text-daintree-text">Repository initialized</h3>
-              {/* Says what is about to happen, not merely what is possible:
-                  this mode opens the project on its own two seconds later, and
-                  "is ready to open" read as though it were waiting. */}
-              <p className="text-sm text-daintree-text/60">
-                Opening <span aria-hidden="true">{emoji} </span>
-                {trimmedProjectName}…
-              </p>
-            </div>
-            <PathCaption path={directoryPath} className="max-w-full" />
-          </div>
+          </>
         ) : mode === "running" ? (
           <>
             {/* One current phase, the way every other running-operation surface
@@ -530,18 +589,20 @@ export function GitInitDialog({
                 remediation twice. */}
             {error && (
               <div data-testid="git-init-error">
-                {identityCommands.length > 0 ? (
+                {isIdentityFailure ? (
                   <InlineStatusBanner
                     icon={AlertCircle}
                     severity="error"
                     title="Initial commit skipped"
                     description="The repository was created, but Git needs a name and email before it can commit. Set them, then retry."
                     descriptionExtras={
-                      <div className="mt-2 space-y-1.5" data-testid="git-init-command-block">
-                        {identityCommands.map((command) => (
-                          <CopyableCommand key={command} command={command} />
-                        ))}
-                      </div>
+                      identityCommands.length > 0 ? (
+                        <div className="mt-2 space-y-1.5" data-testid="git-init-command-block">
+                          {identityCommands.map((command) => (
+                            <CopyableCommand key={command} command={command} />
+                          ))}
+                        </div>
+                      ) : undefined
                     }
                     className="rounded-[var(--radius-md)]"
                   />

--- a/src/components/Project/NonGitFolderDialog.tsx
+++ b/src/components/Project/NonGitFolderDialog.tsx
@@ -77,7 +77,8 @@ export function NonGitFolderDialog({
         <p className="text-sm text-daintree-text/70">
           This folder isn&rsquo;t a git repository. Open it as-is and terminals, agents, recipes,
           and the file browser all work — worktrees, review, and diffs stay unavailable until it
-          becomes a repository. Nothing in the folder is changed either way.
+          becomes a repository, and nothing in the folder is touched. Setting up a repository writes
+          into it: you&rsquo;ll see exactly what before it runs.
         </p>
       </AppDialog.Body>
 

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -93,12 +93,18 @@ vi.mock("@/components/ui/AppDialog", () => {
     className?: string;
   }
 
+  // The synthetic close button stands in for Escape and the backdrop, both of
+  // which the real AppDialog withholds when `dismissible` is false. Rendering it
+  // unconditionally made the mock unable to express the one thing the completed
+  // mode changed.
   const AppDialog = ({ isOpen, children, onClose, dismissible = true }: AppDialogMockProps) =>
     isOpen ? (
       <div data-testid="app-dialog" data-dismissible={dismissible ? "true" : "false"}>
-        <button type="button" onClick={onClose}>
-          dialog-close
-        </button>
+        {dismissible && (
+          <button type="button" onClick={onClose}>
+            dialog-close
+          </button>
+        )}
         {children}
       </div>
     ) : null;
@@ -305,6 +311,29 @@ describe("CloneRepoDialog", () => {
     });
 
     expect((await findProgressBar()).getAttribute("aria-label")).toBe("receiving");
+  });
+
+  it("stops offering a dismissal once the only thing it can do is open the project", async () => {
+    const onCancel = vi.fn();
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.change(screen.getByPlaceholderText("owner/repo or repository URL"), {
+      target: { value: "https://github.com/user/my-repo.git" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Browse"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Clone"));
+    });
+
+    await waitFor(() => expect(screen.getByText("Open project")).toBeTruthy());
+    // Escape, the backdrop and the header X all route to the same handler, and
+    // in this mode that handler OPENS the project. A control that presents as a
+    // dismissal must not be the forward action wearing a disguise.
+    expect(screen.getByTestId("app-dialog").getAttribute("data-dismissible")).toBe("false");
+    expect(screen.queryByText("dialog-close")).toBeNull();
+    expect(onCancel).not.toHaveBeenCalled();
   });
 
   it("calls onSuccess with clonedPath after successful clone", async () => {

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -839,6 +839,85 @@ describe("GitInitDialog", () => {
       expect(screen.queryByLabelText(/project name/i)).toBeNull();
     });
 
+    it("hands focus to the running readout when the mode destroys the focused control", async () => {
+      initGitGuidedMock.mockImplementationOnce(() => new Promise(() => {}));
+      renderDialog();
+      const start = startButton();
+      start.focus();
+      expect(document.activeElement).toBe(start);
+
+      fireEvent.click(start);
+      await waitFor(() => expect(progressHandler).not.toBeNull());
+      act(() => {
+        progressHandler?.({
+          step: "init",
+          status: "start",
+          message: "Initializing Git repository...",
+          timestamp: Date.now(),
+        });
+      });
+
+      // The control that had focus is gone. Focus must land inside the new
+      // mode rather than falling to <body> — WCAG 2.4.3, failure technique F85.
+      await waitFor(
+        () => {
+          const active = document.activeElement;
+          expect(active).not.toBe(document.body);
+          expect(screen.getByTestId("git-init-progress").contains(active)).toBe(true);
+        },
+        { timeout: 2000 }
+      );
+    });
+
+    it("shows a step count that agrees with the bar it sits beside", async () => {
+      startAndHang();
+      await waitFor(() => expect(progressHandler).not.toBeNull());
+
+      act(() => {
+        for (const [step, message] of [
+          ["init", "Initializing Git repository..."],
+          ["gitignore", "Creating .gitignore file..."],
+        ] as const) {
+          progressHandler?.({ step, status: "start", message, timestamp: Date.now() });
+          progressHandler?.({
+            step,
+            status: "success",
+            message: `${step} ok`,
+            timestamp: Date.now(),
+          });
+        }
+        progressHandler?.({
+          step: "add",
+          status: "start",
+          message: "Staging files for initial commit...",
+          timestamp: Date.now(),
+        });
+      });
+
+      const bar = await waitFor(() => screen.getByRole("progressbar"), { timeout: 2000 });
+      const now = Number(bar.getAttribute("aria-valuenow"));
+      const max = Number(bar.getAttribute("aria-valuemax"));
+      // Whatever the wording, the number the user reads must be the number the
+      // bar is drawn from — a counter saying "3 of 4" over a half-filled bar is
+      // two answers to one question.
+      expect(screen.getByTestId("git-init-progress").textContent).toContain(`${now} of ${max}`);
+    });
+
+    it("does not dress the forward action up as a dismissal once it has succeeded", async () => {
+      const onSuccess = vi.fn();
+      const onCancel = vi.fn();
+      renderDialog({ onSuccess, onCancel });
+      fireEvent.click(startButton());
+
+      await waitFor(() => expect(screen.getByTestId("git-init-success")).toBeTruthy());
+      // Escape, the backdrop and the header X all route to the same handler,
+      // and in this mode that handler OPENS the project. So the dialog must not
+      // offer them: the mode has one action and it is labelled.
+      expect(screen.getByTestId("app-dialog").getAttribute("data-dismissible")).toBe("false");
+      expect(screen.queryByRole("button", { name: /^close$/i })).toBeNull();
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
     it("explains every field that can dead the primary action", () => {
       renderDialog();
       const start = startButton();

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -559,7 +559,7 @@ describe("GitInitDialog", () => {
     expect(retryButton()).toBeTruthy();
   });
 
-  it("surfaces the git config commands and offers Try again on identity error", async () => {
+  it("surfaces the git config commands and offers Retry on identity error", async () => {
     renderDialog();
 
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
@@ -598,6 +598,74 @@ describe("GitInitDialog", () => {
     fireEvent.click(retryButton());
 
     await waitFor(() => expect(initGitGuidedMock).toHaveBeenCalledTimes(1));
+  });
+
+  // Real `git` output that carries a command line without being an identity
+  // failure. Selecting the identity banner on "the text contains a line
+  // starting with `git `" hands this one a confidently wrong diagnosis —
+  // including the claim that the repository was created, which it was not.
+  it("does not diagnose a non-identity failure as a missing git identity", async () => {
+    initGitGuidedMock.mockImplementationOnce(() => {
+      progressHandler?.({
+        step: "error",
+        status: "error",
+        message: "Git initialization failed",
+        error:
+          "fatal: detected dubious ownership in repository at '/tmp/new-repo'\n" +
+          "To add an exception for this directory, call:\n\n" +
+          "\tgit config --global --add safe.directory /tmp/new-repo",
+        timestamp: Date.now(),
+      });
+      return Promise.resolve({ outcome: "error", completedSteps: [] });
+    });
+
+    renderDialog();
+    fireEvent.click(startButton());
+
+    await waitFor(() => expect(screen.getByTestId("git-init-error")).toBeTruthy());
+    expect(screen.queryByText(/initial commit skipped/i)).toBeNull();
+    expect(screen.queryByTestId("git-init-command-block")).toBeNull();
+    expect(screen.getByText(/dubious ownership/i)).toBeTruthy();
+    expect(retryButton()).toBeTruthy();
+  });
+
+  // The warning only ever exists as the gitignore step's SUCCESS message, and a
+  // run this fast never renders the progress panel that used to carry it.
+  it("carries the kept-.gitignore warning into the success state when init beats the gate", async () => {
+    initGitGuidedMock.mockImplementationOnce(() => {
+      progressHandler?.({
+        step: "gitignore",
+        status: "success",
+        message: "Existing .gitignore kept — missing 3 template entries; review it for secrets",
+        timestamp: Date.now(),
+      });
+      return Promise.resolve({ outcome: "success", completedSteps: ["init", "gitignore"] });
+    });
+
+    renderDialog();
+    fireEvent.click(startButton());
+
+    await waitFor(() => expect(screen.getByTestId("git-init-success")).toBeTruthy());
+    expect(screen.queryByTestId("git-init-progress")).toBeNull();
+    expect(screen.getByText(/review it for secrets/i)).toBeTruthy();
+  });
+
+  it("stays quiet when the existing .gitignore already covers the template", async () => {
+    initGitGuidedMock.mockImplementationOnce(() => {
+      progressHandler?.({
+        step: "gitignore",
+        status: "success",
+        message: "Existing .gitignore kept — covers all template entries",
+        timestamp: Date.now(),
+      });
+      return Promise.resolve({ outcome: "success", completedSteps: ["init", "gitignore"] });
+    });
+
+    renderDialog();
+    fireEvent.click(startButton());
+
+    await waitFor(() => expect(screen.getByTestId("git-init-success")).toBeTruthy());
+    expect(screen.queryByText(/review the existing \.gitignore/i)).toBeNull();
   });
 
   describe("project identity row", () => {

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import type { ReactNode, ButtonHTMLAttributes } from "react";
 import type { GitInitProgressEvent } from "@shared/types/ipc/gitInit";
@@ -21,6 +21,16 @@ vi.mock("@/clients", () => ({
     initGitGuided: initGitGuidedMock,
     onInitGitProgress: onInitGitProgressMock,
   },
+}));
+
+// `CopyableCommand` — the house component that now carries the git-identity
+// recovery lines — wraps its copy button in a Radix tooltip, which throws
+// outside a provider. In the app the provider is App.tsx's, above ModalHostLayer.
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 vi.mock("@/components/ui/button", () => ({
@@ -63,6 +73,34 @@ vi.mock("@/components/ui/AppDialog", () => {
 });
 
 import { GitInitDialog } from "../GitInitDialog";
+
+// `InlineStatusBanner` — the failure treatment this dialog now shares with the
+// rest of the app — reads `prefers-reduced-motion` on render, and jsdom ships no
+// `matchMedia`. Same shim the other banner suites use.
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+/**
+ * Queried by their role in the dialog's mode, not by their label. "Try again"
+ * became "Retry" and "Continue" became "Open project" during the design pass,
+ * and a test that pins the words re-breaks on every copy change while proving
+ * nothing about behaviour.
+ */
+const startButton = () => screen.getByTestId<HTMLButtonElement>("git-init-start");
+const retryButton = () => screen.getByTestId<HTMLButtonElement>("git-init-retry");
 
 describe("GitInitDialog", () => {
   let progressHandler: ((event: GitInitProgressEvent) => void) | null = null;
@@ -115,9 +153,7 @@ describe("GitInitDialog", () => {
     await waitFor(() => expect(onInitGitProgressMock).toHaveBeenCalled());
     expect(initGitGuidedMock).not.toHaveBeenCalled();
 
-    const button = screen.getByRole("button", {
-      name: /initialize repository/i,
-    }) as HTMLButtonElement;
+    const button = startButton();
     expect(button.disabled).toBe(false);
 
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
@@ -171,7 +207,7 @@ describe("GitInitDialog", () => {
     const input = screen.getByLabelText(/initial commit message/i) as HTMLInputElement;
     expect(input.value).toBe("Initial commit");
 
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(initGitGuidedMock).toHaveBeenCalledWith(
@@ -187,9 +223,7 @@ describe("GitInitDialog", () => {
       target: { value: "   " },
     });
 
-    const button = screen.getByRole("button", {
-      name: /initialize repository/i,
-    }) as HTMLButtonElement;
+    const button = startButton();
     expect(button.disabled).toBe(true);
 
     fireEvent.click(button);
@@ -228,7 +262,7 @@ describe("GitInitDialog", () => {
     initGitGuidedMock.mockResolvedValueOnce({ outcome: "error", completedSteps: [] });
     renderDialog();
 
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(screen.getByText(/without a status update/i)).toBeTruthy();
@@ -245,7 +279,7 @@ describe("GitInitDialog", () => {
 
     await waitFor(() => {
       expect(screen.queryByText(/without a status update/i)).toBeNull();
-      expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+      expect(screen.getByTestId("git-init-open")).toBeTruthy();
     });
   });
 
@@ -261,7 +295,7 @@ describe("GitInitDialog", () => {
       target: { value: "feat: bootstrap" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(initGitGuidedMock).toHaveBeenCalledWith(
@@ -281,7 +315,7 @@ describe("GitInitDialog", () => {
     fireEvent.click(screen.getByLabelText(/create initial commit/i));
     expect(screen.queryByLabelText(/initial commit message/i)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(initGitGuidedMock).toHaveBeenCalledWith(
@@ -299,7 +333,7 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(initGitGuidedMock).toHaveBeenCalledWith(
@@ -316,7 +350,7 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    const button = screen.getByRole("button", { name: /initialize repository/i });
+    const button = startButton();
     fireEvent.click(button);
     fireEvent.click(button);
 
@@ -330,7 +364,7 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
     await waitFor(() => expect(progressHandler).not.toBeNull());
 
     act(() => {
@@ -353,7 +387,7 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
     await waitFor(() => expect(progressHandler).not.toBeNull());
 
     act(() => {
@@ -375,7 +409,7 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
     await waitFor(() => expect(progressHandler).not.toBeNull());
 
     act(() => {
@@ -389,7 +423,7 @@ describe("GitInitDialog", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+      expect(retryButton()).toBeTruthy();
     });
 
     act(() => {
@@ -402,7 +436,7 @@ describe("GitInitDialog", () => {
     });
 
     expect(screen.queryByRole("button", { name: /continue/i })).toBeNull();
-    expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+    expect(retryButton()).toBeTruthy();
   });
 
   it("recovers cleanly when a retry succeeds", async () => {
@@ -412,16 +446,16 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(screen.getByText(/finished without a status update/i)).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    fireEvent.click(retryButton());
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+      expect(screen.getByTestId("git-init-open")).toBeTruthy();
     });
     expect(screen.queryByText(/finished without a status update/i)).toBeNull();
     expect(screen.queryByText(/initialization failed/i)).toBeNull();
@@ -433,10 +467,10 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+      expect(screen.getByTestId("git-init-open")).toBeTruthy();
     });
     expect(screen.queryByText(/initialization failed/i)).toBeNull();
   });
@@ -449,12 +483,12 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(screen.getByText(/finished without a status update/i)).toBeTruthy();
     });
-    expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+    expect(retryButton()).toBeTruthy();
   });
 
   it("clears a stale fallback error when the success event arrives late", async () => {
@@ -465,7 +499,7 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(screen.getByText(/finished without a status update/i)).toBeTruthy();
@@ -481,7 +515,7 @@ describe("GitInitDialog", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+      expect(screen.getByTestId("git-init-open")).toBeTruthy();
     });
     expect(screen.queryByText(/finished without a status update/i)).toBeNull();
     expect(screen.queryByText(/initialization failed/i)).toBeNull();
@@ -516,13 +550,13 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
 
     await waitFor(() => {
       expect(screen.getAllByText(/git config --global user\.name/i).length).toBeGreaterThan(0);
     });
     expect(screen.queryByText(/finished without a status update/i)).toBeNull();
-    expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+    expect(retryButton()).toBeTruthy();
   });
 
   it("surfaces the git config commands and offers Try again on identity error", async () => {
@@ -531,7 +565,7 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    fireEvent.click(startButton());
     await waitFor(() => expect(progressHandler).not.toBeNull());
 
     const identityHelp =
@@ -561,7 +595,7 @@ describe("GitInitDialog", () => {
     });
 
     initGitGuidedMock.mockClear();
-    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    fireEvent.click(retryButton());
 
     await waitFor(() => expect(initGitGuidedMock).toHaveBeenCalledTimes(1));
   });
@@ -594,9 +628,7 @@ describe("GitInitDialog", () => {
       renderDialog();
       fireEvent.change(nameInput(), { target: { value: "   " } });
 
-      const start = screen.getByRole<HTMLButtonElement>("button", {
-        name: /initialize repository/i,
-      });
+      const start = startButton();
       expect(start.disabled).toBe(true);
     });
 
@@ -616,7 +648,7 @@ describe("GitInitDialog", () => {
       renderDialog({ onSuccess });
 
       fireEvent.change(nameInput(), { target: { value: "  Renamed  " } });
-      fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+      fireEvent.click(startButton());
 
       await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 3000 });
       // Emoji is seeded from the folder name, and renaming must not re-derive it.
@@ -647,6 +679,187 @@ describe("GitInitDialog", () => {
 
       expect(nameInput().value).toBe("Second");
       expect(screen.getByRole("button", { name: /choose project emoji/i }).textContent).toBe("📦");
+    });
+  });
+
+  /**
+   * The design rules this dialog was rebuilt around, asserted as rules.
+   *
+   * Every one of these is a defect the surface actually shipped, and each is
+   * stated so that the labels, copy and layout can all move without the test
+   * needing an edit — only a change that reintroduces the defect fails.
+   */
+  describe("design invariants", () => {
+    /** Hold the IPC promise open so the dialog stays in its running mode. */
+    function startAndHang() {
+      initGitGuidedMock.mockImplementationOnce(() => new Promise(() => {}));
+      renderDialog();
+      fireEvent.click(startButton());
+    }
+
+    it("reports a step once — a finished step is stated by its completion, not also by its start", async () => {
+      startAndHang();
+      await waitFor(() => expect(progressHandler).not.toBeNull());
+
+      act(() => {
+        progressHandler?.({
+          step: "init",
+          status: "start",
+          message: "Initializing Git repository...",
+          timestamp: Date.now(),
+        });
+        progressHandler?.({
+          step: "init",
+          status: "success",
+          message: "Git repository initialized",
+          timestamp: Date.now(),
+        });
+        progressHandler?.({
+          step: "gitignore",
+          status: "start",
+          message: "Creating .gitignore file...",
+          timestamp: Date.now(),
+        });
+      });
+
+      await waitFor(
+        () => expect(screen.getAllByText(/Git repository initialized/).length).toBe(1),
+        {
+          timeout: 2000,
+        }
+      );
+      // The start narration for a step that already succeeded must not survive
+      // alongside its completion — that is what put four live spinners on a
+      // finished run.
+      expect(screen.queryByText(/Initializing Git repository/)).toBeNull();
+      // ...and the step that IS live is the one the progress readout names.
+      // (The label itself deliberately appears twice — once visibly, once in the
+      // sr-only live region — so count rows, not text nodes.)
+      expect(screen.getByRole("progressbar").getAttribute("aria-label")).toMatch(
+        /Creating \.gitignore file/
+      );
+    });
+
+    it("counts progress against the steps the submitted options imply, not a fixed total", async () => {
+      initGitGuidedMock.mockImplementationOnce(() => new Promise(() => {}));
+      renderDialog();
+      // Everything off: no gitignore, no commit — one step remains.
+      fireEvent.change(screen.getByLabelText(/gitignore template/i), {
+        target: { value: "none" },
+      });
+      fireEvent.click(screen.getByRole("checkbox"));
+      fireEvent.click(startButton());
+      await waitFor(() => expect(progressHandler).not.toBeNull());
+
+      act(() => {
+        progressHandler?.({
+          step: "init",
+          status: "start",
+          message: "Initializing Git repository...",
+          timestamp: Date.now(),
+        });
+      });
+
+      const bar = await waitFor(() => screen.getByRole("progressbar"), { timeout: 2000 });
+      expect(bar.getAttribute("aria-valuemax")).toBe("1");
+      expect(bar.getAttribute("aria-valuenow")).toBe("0");
+    });
+
+    it("states a failure once, however many error events describe it", async () => {
+      renderDialog();
+      fireEvent.click(startButton());
+      await waitFor(() => expect(progressHandler).not.toBeNull());
+
+      const identityHelp =
+        "Set your git identity, then create the initial commit manually:\n" +
+        '  git config --global user.name "Your Name"\n' +
+        '  git config --global user.email "you@example.com"';
+
+      // The main process reports the failing step AND the terminal outcome, both
+      // carrying the same remediation. The surface owes the user one statement.
+      act(() => {
+        progressHandler?.({
+          step: "commit",
+          status: "error",
+          message: "Git user identity not configured",
+          error: identityHelp,
+          timestamp: Date.now(),
+        });
+        progressHandler?.({
+          step: "complete",
+          status: "error",
+          message: "Repository initialized — initial commit skipped",
+          error: identityHelp,
+          timestamp: Date.now(),
+        });
+      });
+
+      await waitFor(() => expect(retryButton()).toBeTruthy());
+      expect(screen.getAllByText(/user\.name/).length).toBe(1);
+      expect(screen.getAllByText(/user\.email/).length).toBe(1);
+    });
+
+    it("keeps the recovery commands copyable rather than inert text", async () => {
+      renderDialog();
+      fireEvent.click(startButton());
+      await waitFor(() => expect(progressHandler).not.toBeNull());
+
+      act(() => {
+        progressHandler?.({
+          step: "commit",
+          status: "error",
+          message: "Git user identity not configured",
+          error:
+            "Set your git identity, then create the initial commit manually:\n" +
+            '  git config --global user.name "Your Name"\n' +
+            '  git config --global user.email "you@example.com"',
+          timestamp: Date.now(),
+        });
+      });
+
+      await waitFor(() => expect(retryButton()).toBeTruthy());
+      expect(screen.getAllByRole("button", { name: /copy command to clipboard/i }).length).toBe(2);
+    });
+
+    it("does not leave the configuration form standing while the operation runs", async () => {
+      startAndHang();
+      await waitFor(() => expect(progressHandler).not.toBeNull());
+
+      act(() => {
+        progressHandler?.({
+          step: "init",
+          status: "start",
+          message: "Initializing Git repository...",
+          timestamp: Date.now(),
+        });
+      });
+
+      await waitFor(() => expect(screen.getByRole("progressbar")).toBeTruthy(), { timeout: 2000 });
+      expect(screen.queryByLabelText(/gitignore template/i)).toBeNull();
+      expect(screen.queryByLabelText(/project name/i)).toBeNull();
+    });
+
+    it("explains every field that can dead the primary action", () => {
+      renderDialog();
+      const start = startButton();
+      const inputs = [
+        screen.getByLabelText<HTMLInputElement>(/project name/i),
+        screen.getByLabelText<HTMLInputElement>(/initial commit message/i),
+      ];
+
+      for (const input of inputs) {
+        const original = input.value;
+        fireEvent.change(input, { target: { value: "   " } });
+        expect(start.disabled).toBe(true);
+        // Emptying it must produce an explanation, and that explanation must be
+        // wired to the field it is about — not merely painted on the border.
+        const describedBy = input.getAttribute("aria-describedby");
+        expect(describedBy).toBeTruthy();
+        const message = document.getElementById(describedBy as string);
+        expect(message?.getAttribute("role")).toBe("alert");
+        expect(message?.textContent?.trim().length).toBeGreaterThan(0);
+        fireEvent.change(input, { target: { value: original } });
+      }
     });
   });
 });

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -986,8 +986,8 @@ export function AgentSetupWizard({
             </Button>
           )}
           {/* Completion resolves to the forward move, matching CloneRepoDialog's
-              "Open Project" and GitInitDialog's "Continue" — the wizard's last
-              screen should start the work, not merely dismiss itself. With no
+              and GitInitDialog's "Open project" — the wizard's last screen
+              should start the work, not merely dismiss itself. With no
               agents installed there is nothing to launch, so finishing is the
               only action and it takes the primary slot. */}
           {state.step.type === "complete" &&

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -242,7 +242,11 @@ export function InlineStatusBanner({
         hasDescription
           ? "flex flex-col gap-2 px-3 py-2 shrink-0"
           : "flex items-center justify-between gap-3 px-3 py-2 shrink-0",
-        shouldAnimate && "transition duration-250",
+        // Scoped, not bare: `transition` carries box-shadow, every colour
+        // property and filter along with it, and this banner's entry is an
+        // opacity-and-slide. 250ms is BANNER_ENTER_DURATION from the motion
+        // scale, which is what generates this utility.
+        shouldAnimate && "transition-[opacity,translate] duration-250",
         shouldAnimate && (isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2"),
         isNeutral && "bg-overlay-subtle",
         // The native caption strip is a fixed 48px tall. A shorter banner would

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -172,7 +172,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Portal/PortalToolbar.tsx",
     "src/components/Project/CreateProjectFolderDialog.tsx",
     "src/components/Project/GeneralTab.tsx",
-    "src/components/Project/GitInitDialog.tsx",
     "src/components/Project/ProjectNotificationsTab.tsx",
     "src/components/Project/WelcomeScreen.tsx",
     "src/components/Recovery/CrashRecoveryDialog.tsx",


### PR DESCRIPTION
## Summary

`GitInitDialog` gathered its settings, then ran a four step Git routine underneath the form it had just greyed out, narrating the whole thing into a scrolling monospace log. The log printed a row per event, so every step got stated twice, and because a start event's status never changes its spinner kept turning under its own completion line. A finished run showed four live spinners across nine rows for four operations, scrolled past the folder path it had just written into.

It's now four exclusive modes: configuration, running, failure, success. Same shape `CloneRepoDialog` already uses.

Resolves #11975

## What changed

**Running** reports one live phase with the finished ones quieted to checks, and counts against the steps the submitted options actually imply. "2 of 4 done" is something this surface knows, so the `role="progressbar"` is determinate instead of a guess, and step changes are announced from a separate polite live region rather than the bar.

**Failure** was two unrelated components: a tinted box for a thrown error, red monospace log lines for a reported one. The Git identity case, which is the most common failure here, printed its diagnosis and its two commands twice over. Both paths render one `InlineStatusBanner` now, and the commands go through `CopyableCommand` so they can be copied instead of retyped.

**Success** is a short confirmation naming the repository, not a log.

**The commit message field** sat at the same indent, width and label weight as the gitignore select, so the one field that only exists because a box is ticked read as another permanent setting. It's nested behind a rule with `aria-expanded`/`aria-controls`, matching the Settings reveals. Clearing it used to dead the primary button in silence while clearing the project name explained itself. Both explain themselves now, which matters more here because the placeholder repeats the default value, so an emptied field looked filled.

**Keyboard focus** opened on the header close button, spending the modal's one accent signal on dismiss, and no mode swap handed focus on when it destroyed the control holding it (WCAG 2.4.3, failure technique F85). It opens on the name field and follows every swap.

**The header glyph** was decorative accent. It's neutral, and the file comes off the allowlist in `accentGuard.contract.test.ts`.

**`NonGitFolderDialog`** promised "Nothing in the folder is changed either way" while one of its two buttons leads here and writes `.git/`, a `.gitignore` and a commit. It says which branch writes, and this dialog now says what it will write before you press the button.

## Out of scope but fixed on the way past

`CloneRepoDialog` had the same bug in its completed state: `handleClose` calls `finalizeSuccess()`, so Escape, the backdrop and the header X all opened the project while presenting as a dismissal. Withdrawing those exits then created a trap, since `finalizeSuccess` bails without a `clonedPath`, so the withdrawal is gated on the forward action actually being able to fire.

`InlineStatusBanner` rode a bare `transition`, which carries box-shadow, every colour property and filter along with the opacity and slide it actually animates. Scoped to `transition-[opacity,translate]`. The 250ms stays, that's `BANNER_ENTER_DURATION` from the motion scale. Both are separate commits so they revert on their own.

## Design review

Scored 3.8 to 8.0 over two rounds against mode legibility, dependency hierarchy, progress truthfulness, recovery, house pattern fidelity, accessibility and craft.

Two review findings didn't survive verification and were dropped: a forced-colors button mismatch that turned out to be a Chromium emulation artifact, and a "silent fallback default" on the main process commit message, which sits on a path the destructive ladder never classifies, behind a UI gate that already blocks it. Both were conceded by the reviewer at zero points.

One is left deliberately, worth 0.25: the checked checkbox still carries `accent-daintree-accent` alongside the focus ring. That comes from the shared `FIELD_CHECKBOX_CLASS`, and the accent guard's own negative case list rejects `accent-*` as a native CSS property rather than a Tailwind colour utility. By the reviewer's reading every checkbox in the app is non compliant, which points at the reading.

## Consistency

Counted before implementing, since it decided whether any of this was a new pattern. Of 14 in place progress surfaces this was the only transcript, seven already report one live phase. 43 files import `InlineStatusBanner` against 18 that hand roll a block. Six of the 13 surfaces showing shell commands already use `CopyableCommand`. Of five checkbox reveals, three already nest the dependent field behind a rule. Every change here joins a majority, so nothing owes a roll out.

## Testing

`npm run check` clean. Full unit suite: 2348 files, 51,648 passed, 0 failed.

Ten invariants pinned as rules rather than values: one row per step, progress counted from the submitted options, one statement per failure, copyable recovery, no form standing during the run, an explanation for every field that can dead the primary action, focus handed on across a mode swap, the visible count agreeing with the bar, and both dialogs withdrawing dismissals that actually advance. Each was mutation checked by reintroducing the defect and confirming the test fails.

Also adds `e2e/screenshots/git-init-review.spec.ts`, a 16 state capture harness driven end to end through the real seams. The Git identity failure is real: the app runs under a `HOME` the harness owns, so emptying its `.gitconfig` makes commit fail the way it does for someone who has never configured Git. `GIT_CONFIG_GLOBAL` was the obvious lever and does nothing, `hardenedGit` strips it out of every spawn env on purpose.
