### PR TITLE
feat(plugin-dialogs): roll the redacted-payload disclosure to the plugin approval dialogs

### DIFF
--- a/electron/services/plugin-mcp/PluginMcpConsentService.ts
+++ b/electron/services/plugin-mcp/PluginMcpConsentService.ts
@@ -34,7 +34,11 @@ export interface PluginMcpConsentRequest {
   pluginDisplayName: string;
   /** Tool description, ANSI/OSC stripped, ready to render verbatim. */
   descriptionDisplay: string;
-  /** Sanitised, single-level args preview for D2+ tiers. Empty when no args. */
+  /**
+   * Sanitised, single-level args preview. Empty for D0 and for a call with no
+   * arguments; produced for every other tier — D1 included, which the consent
+   * dialog renders behind a disclosure.
+   */
   argsSummary: string;
   dangerTier: PluginMcpDangerTier;
   /** Plugin's manifest `capabilities[]` list — surfaced for transparency. */

--- a/shared/types/pluginMcpConsent.ts
+++ b/shared/types/pluginMcpConsent.ts
@@ -172,7 +172,11 @@ export interface PluginMcpConsentRequestEvent {
   pluginDisplayName: string;
   /** Tool description, ANSI/OSC stripped, ready to render verbatim. */
   descriptionDisplay: string;
-  /** Sanitised, single-level args preview for D2+ tiers. Empty when no args. */
+  /**
+   * Sanitised, single-level args preview. Empty for D0 and for a call with no
+   * arguments; produced for every other tier — D1 included, which the consent
+   * dialog renders behind a disclosure.
+   */
   argsSummary: string;
   dangerTier: PluginMcpDangerTier;
   /** Plugin's manifest `capabilities[]` list — surfaced for transparency. */

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -455,6 +455,9 @@ function ArgumentsDisclosure({ argsSummary }: { argsSummary: string }) {
       >
         <ChevronRight
           aria-hidden="true"
+          // `src/index.css` drops the rotation transition for this marker under
+          // prefers-reduced-motion; every other chevron in the app carries it.
+          data-animated-chevron
           className={cn(
             "w-3 h-3 shrink-0 text-daintree-text/40 transition-transform duration-150 ease-out",
             expanded && "rotate-90"

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -456,7 +456,8 @@ function ArgumentsDisclosure({ argsSummary }: { argsSummary: string }) {
         <ChevronRight
           aria-hidden="true"
           // `src/index.css` drops the rotation transition for this marker under
-          // prefers-reduced-motion; every other chevron in the app carries it.
+          // prefers-reduced-motion. This disclosure is the one the plugin
+          // dialogs copy, so the marker travels with the pattern.
           data-animated-chevron
           className={cn(
             "w-3 h-3 shrink-0 text-daintree-text/40 transition-transform duration-150 ease-out",

--- a/src/components/Plugin/PluginConfirmDialog.tsx
+++ b/src/components/Plugin/PluginConfirmDialog.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { usePluginConfirmStore, type PluginConfirmationDecision } from "@/store/pluginConfirmStore";
@@ -10,6 +12,9 @@ import { usePluginConfirmStore, type PluginConfirmationDecision } from "@/store/
  * freshly-promoted destructive write before the user has read it.
  */
 const CONFIRM_COOLDOWN_MS = 1_200;
+
+/** Shared micro-label, matching the section-heading grammar used app-wide. */
+const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
 
 /**
  * Singleton dialog driven by the plugin-action confirmation queue. Mounted
@@ -80,22 +85,69 @@ export function PluginConfirmDialog() {
         variant={variant}
         // A redacted args block is structured evidence, so this is a dialog
         // rather than an alertdialog. A no-argument action drops the block
-        // entirely and really is the brief message alertdialog is for.
+        // entirely and really is the brief message alertdialog is for. This
+        // tracks whether the payload exists, never whether the disclosure
+        // below happens to be open — the role must not flip as the user toggles.
         hasPreview={hasArgs}
+        // The queue advances by swapping `current` on a mounted dialog, so the
+        // body's scroll offset would otherwise carry into the next request.
+        bodyResetKey={current.requestId}
         confirmCooldownMs={isDestructive ? CONFIRM_COOLDOWN_MS : undefined}
         cooldownKey={current.requestId}
       >
         {hasArgs ? (
-          <div className="space-y-2">
-            <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-              Arguments
-            </div>
-            <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
-              {current.argsSummary}
-            </pre>
-          </div>
+          // Keyed on the request for the same reason: without this the next
+          // promoted action inherits this one's expanded disclosure, showing a
+          // payload the user never asked to see for an action they haven't read.
+          <ArgumentsDisclosure key={current.requestId} argsSummary={current.argsSummary} />
         ) : null}
       </ConfirmDialog>
     </ErrorBoundary>
+  );
+}
+
+/**
+ * The redacted argument summary, behind a disclosure.
+ *
+ * Raw payloads shown inline are the classic driver of consent-dialog
+ * click-through: they read as noise, and the noise trains people to skip the
+ * whole surface. Collapsed, they stay one keystroke away for anyone who wants
+ * them without competing with the title and description — which are what this
+ * approval actually rests on — for attention. Unlike the plugin-MCP sibling
+ * there is no audited content-preview requirement to weigh against that:
+ * `docs/architecture/destructive-action-safeguards.md` caps plugin-contributed
+ * actions at D1, whose safeguard is the confirm step itself.
+ */
+function ArgumentsDisclosure({ argsSummary }: { argsSummary: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded-[var(--radius-sm)] py-1 text-left",
+          "transition-colors duration-150 ease-out hover:bg-overlay-subtle",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2"
+        )}
+      >
+        <ChevronRight
+          aria-hidden="true"
+          data-animated-chevron
+          className={cn(
+            "w-3 h-3 shrink-0 text-daintree-text/40 transition-transform duration-150 ease-out",
+            expanded && "rotate-90"
+          )}
+        />
+        <span className={MICRO_LABEL}>Arguments</span>
+      </button>
+      {expanded && (
+        <pre className="mt-1 max-h-40 overflow-y-auto rounded-[var(--radius-md)] bg-overlay-subtle px-2 py-1.5 font-mono text-xs break-words whitespace-pre-wrap text-daintree-text/80">
+          {argsSummary}
+        </pre>
+      )}
+    </div>
   );
 }

--- a/src/components/Plugin/PluginMcpConfirmDialog.tsx
+++ b/src/components/Plugin/PluginMcpConfirmDialog.tsx
@@ -32,6 +32,14 @@ const DESCRIPTION_MAX_HEIGHT = "max-h-[9rem]";
 const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
 
 /**
+ * The redacted payload's own treatment, shared by both tier paths. The same
+ * bytes must not change appearance because the tier changed — only whether
+ * they are shown outright or offered behind a disclosure does.
+ */
+const ARGS_PRE =
+  "text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle border border-tint/[0.08] rounded max-h-40 overflow-y-auto px-2 py-1.5 text-daintree-text/80";
+
+/**
  * Singleton dialog driven by the plugin-MCP consent queue. Mounted once near
  * the top of `App.tsx`, sibling to `PluginConfirmDialog` and `McpConfirmDialog`.
  *
@@ -51,14 +59,18 @@ const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-dai
  * sanitisation and does not need to: React text-node interpolation escapes
  * by default, and the bytes the renderer holds are the display-safe form.
  *
- * For D2+ tiers, a redacted `argsSummary` (produced by `summarizeMcpArgs` in
- * main) appears below the description; raw call arguments are never sent
- * across IPC. That block stays expanded rather than moving behind a
- * disclosure: `docs/architecture/destructive-action-safeguards.md` records the
- * redacted summary as the content preview that satisfies this surface's D2
- * requirement, so collapsing it would weaken an audited safeguard. The
- * capability list is collapsed instead — it describes the plugin, not this
- * call, and is identical on every prompt the plugin ever raises.
+ * A redacted `argsSummary` (produced by `summarizeMcpArgs` in main) appears
+ * below the description; raw call arguments are never sent across IPC. How it
+ * appears is split by tier. On D2+ it stays expanded rather than moving behind
+ * a disclosure: `docs/architecture/destructive-action-safeguards.md` records
+ * the redacted summary as the content preview that satisfies this surface's D2
+ * requirement, so collapsing it would weaken an audited safeguard. On D0/D1
+ * there is no such requirement — the tier's safeguard is the confirm step
+ * itself — so a non-empty summary is collapsed there, matching the sibling
+ * `McpConfirmDialog` and `PluginConfirmDialog`: an inline payload on a routine
+ * prompt reads as noise, and the noise is what trains people to click through.
+ * The capability list is collapsed on every tier — it describes the plugin,
+ * not this call, and is identical on every prompt the plugin ever raises.
  */
 export function PluginMcpConfirmDialog() {
   const current = usePluginMcpConfirmStore((state) => state.current);
@@ -158,14 +170,15 @@ export function PluginMcpConfirmDialog() {
 
           <CapabilitiesDisclosure capabilities={current.declaredCapabilities} />
 
-          {showArgsPreview && (
-            <div>
-              <div className={cn(MICRO_LABEL, "mb-1")}>Arguments</div>
-              <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle border border-tint/[0.08] rounded max-h-40 overflow-y-auto px-2 py-1.5 text-daintree-text/80">
-                {current.argsSummary || "No arguments"}
-              </pre>
-            </div>
-          )}
+          {showArgsPreview &&
+            (isDestructive ? (
+              <div>
+                <div className={cn(MICRO_LABEL, "mb-1")}>Arguments</div>
+                <pre className={ARGS_PRE}>{current.argsSummary || "No arguments"}</pre>
+              </div>
+            ) : (
+              <ArgumentsDisclosure argsSummary={current.argsSummary} />
+            ))}
         </div>
       </ConfirmDialog>
     </ErrorBoundary>
@@ -345,6 +358,49 @@ function CapabilitiesDisclosure({
           ))}
         </ul>
       )}
+    </div>
+  );
+}
+
+/**
+ * The redacted arguments, collapsed — non-destructive tiers only.
+ *
+ * Specific to this call, so unlike the capability list it is worth reading;
+ * but on D0/D1 it is technical detail rather than the evidence the decision
+ * turns on, and a raw payload sitting open on a routine prompt is the classic
+ * driver of consent-dialog click-through. Collapsed it stays one keystroke
+ * away without competing with the consequence copy above it.
+ *
+ * The caller renders this on D0/D1 only. D2+ must show the summary outright —
+ * it is that tier's audited content preview, and there is no second piece of
+ * evidence on this surface to carry the requirement in its place.
+ */
+function ArgumentsDisclosure({ argsSummary }: { argsSummary: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded-[var(--radius-sm)] py-1 text-left",
+          "transition-colors duration-150 ease-out hover:bg-overlay-subtle",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:-outline-offset-2"
+        )}
+      >
+        <ChevronRight
+          aria-hidden="true"
+          data-animated-chevron
+          className={cn(
+            "w-3 h-3 shrink-0 text-daintree-text/40 transition-transform duration-150 ease-out",
+            expanded && "rotate-90"
+          )}
+        />
+        <span className={MICRO_LABEL}>Arguments</span>
+      </button>
+      {expanded && <pre className={cn(ARGS_PRE, "mt-1.5")}>{argsSummary}</pre>}
     </div>
   );
 }

--- a/src/components/Plugin/__tests__/PluginMcpConfirmDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginMcpConfirmDialog.test.tsx
@@ -326,6 +326,28 @@ describe("PluginMcpConfirmDialog structure", () => {
     }
   );
 
+  // The tier split made the empty-summary path conditional for the first time.
+  // D2+ owes a content preview even when there is nothing to preview — saying
+  // so IS the preview — while the tiers that owe nothing drop the section
+  // rather than offer a disclosure over an empty payload.
+  it.each([
+    ["D0", false],
+    ["D1", false],
+    ["D2", true],
+    ["D3", true],
+  ] as const)("with no arguments, %s states the absence inline: %s", (dangerTier, statesIt) => {
+    enqueue({ dangerTier, argsSummary: "" });
+    render(<PluginMcpConfirmDialog />);
+
+    // Never a disclosure over nothing, on any tier.
+    expect(screen.queryByRole("button", { name: /^arguments$/i })).toBeNull();
+    if (statesIt) {
+      expect(screen.getByText(/^no arguments$/i)).toBeTruthy();
+    } else {
+      expect(screen.queryByText(/^no arguments$/i)).toBeNull();
+    }
+  });
+
   it("keeps the redacted arguments expanded on a destructive tier", () => {
     // docs/architecture/destructive-action-safeguards.md records the redacted
     // argsSummary as the content preview that satisfies this surface's D2

--- a/src/components/Plugin/__tests__/PluginMcpConfirmDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginMcpConfirmDialog.test.tsx
@@ -348,13 +348,21 @@ describe("PluginMcpConfirmDialog structure", () => {
     }
   });
 
-  it("keeps the redacted arguments expanded on a destructive tier", () => {
-    // docs/architecture/destructive-action-safeguards.md records the redacted
-    // argsSummary as the content preview that satisfies this surface's D2
-    // requirement. Collapsing it behind a disclosure would weaken an audited
-    // safeguard, so only the capability list collapses.
-    enqueue({ dangerTier: "D2", argsSummary: '{\n  "app": "helios-prod"\n}' });
-    render(<PluginMcpConfirmDialog />);
-    expect(screen.getByText(/helios-prod/)).toBeTruthy();
-  });
+  // docs/architecture/destructive-action-safeguards.md records the redacted
+  // argsSummary as the content preview that satisfies this surface's D2
+  // requirement. Collapsing it behind a disclosure would weaken an audited
+  // safeguard, so only the capability list collapses. A disclosure defaulted
+  // to open is not the same safeguard either — it is one click from hidden and
+  // one queue advance from remounting shut — so the absence of a trigger is
+  // half of what this pins.
+  it.each(["D2", "D3"] as const)(
+    "shows the redacted arguments outright on %s, with nothing to collapse them",
+    (dangerTier) => {
+      enqueue({ dangerTier, argsSummary: '{\n  "app": "helios-prod"\n}' });
+      render(<PluginMcpConfirmDialog />);
+
+      expect(screen.getByText(/helios-prod/)).toBeTruthy();
+      expect(screen.queryByRole("button", { name: /^arguments$/i })).toBeNull();
+    }
+  );
 });

--- a/src/components/Plugin/__tests__/PluginMcpConfirmDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginMcpConfirmDialog.test.tsx
@@ -305,6 +305,27 @@ describe("PluginMcpConfirmDialog structure", () => {
     expect(screen.getByText("Run shell commands")).toBeTruthy();
   });
 
+  // #12015 — on the tiers with no content-preview requirement the payload is
+  // offered rather than shown, matching McpConfirmDialog and
+  // PluginConfirmDialog. What splits the two paths is the safeguard the tier
+  // owes, not the shape of the data.
+  it.each(["D0", "D1"] as const)(
+    "keeps the redacted arguments behind a disclosure on %s",
+    (dangerTier) => {
+      enqueue({ dangerTier, argsSummary: '{\n  "path": "README.md"\n}' });
+      render(<PluginMcpConfirmDialog />);
+
+      const disclosure = screen.getByRole("button", { name: /^arguments$/i });
+      expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+      expect(screen.queryByText(/README\.md/)).toBeNull();
+
+      act(() => disclosure.click());
+
+      expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+      expect(screen.getByText(/README\.md/)).toBeTruthy();
+    }
+  );
+
   it("keeps the redacted arguments expanded on a destructive tier", () => {
     // docs/architecture/destructive-action-safeguards.md records the redacted
     // argsSummary as the content preview that satisfies this surface's D2

--- a/src/components/__tests__/PluginConfirmDialog.test.tsx
+++ b/src/components/__tests__/PluginConfirmDialog.test.tsx
@@ -304,9 +304,15 @@ describe("PluginConfirmDialog", () => {
     void enqueue({ argsSummary: '{"key":"value"}' });
     render(<PluginConfirmDialog />);
 
-    const disclosure = screen.getByRole("button", { name: /arguments/i });
+    const disclosure = screen.getByRole("button", { name: /^arguments$/i });
     expect(disclosure.getAttribute("aria-expanded")).toBe("false");
     expect(screen.queryByText('{"key":"value"}')).toBeNull();
+    // The role is fixed by whether a payload exists, not by whether it is
+    // currently revealed. Asserted on both sides of the toggle: wiring
+    // `hasPreview` to the disclosure's own state would start this destructive
+    // request as an alertdialog and flip it to a dialog mid-decision, which a
+    // post-click assertion alone would wave through.
+    expect(screen.getByRole("dialog")).toBeTruthy();
 
     act(() => {
       disclosure.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -314,9 +320,7 @@ describe("PluginConfirmDialog", () => {
 
     expect(disclosure.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText('{"key":"value"}')).toBeTruthy();
-    // The role is fixed by whether a payload exists, not by whether it is
-    // currently revealed — toggling must not move the dialog between the two
-    // ARIA roles under a screen reader mid-decision.
+    expect(screen.getByRole("dialog")).toBeTruthy();
     expect(screen.queryByRole("alertdialog")).toBeNull();
   });
 
@@ -335,7 +339,7 @@ describe("PluginConfirmDialog", () => {
 
     act(() => {
       screen
-        .getByRole("button", { name: /arguments/i })
+        .getByRole("button", { name: /^arguments$/i })
         .dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     expect(screen.getByText('{"first":"payload"}')).toBeTruthy();
@@ -346,8 +350,8 @@ describe("PluginConfirmDialog", () => {
         .dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(screen.getByText("Run 'Push branch'?")).toBeTruthy();
-    expect(screen.getByRole("button", { name: /arguments/i }).getAttribute("aria-expanded")).toBe(
+    expect(screen.getByRole("button", { name: "Push branch" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^arguments$/i }).getAttribute("aria-expanded")).toBe(
       "false"
     );
     expect(screen.queryByText('{"second":"payload"}')).toBeNull();
@@ -374,7 +378,7 @@ describe("PluginConfirmDialog", () => {
     void enqueue({ argsSummary: "null" });
     render(<PluginConfirmDialog />);
 
-    const disclosure = screen.getByRole("button", { name: /arguments/i });
+    const disclosure = screen.getByRole("button", { name: /^arguments$/i });
     expect(disclosure.getAttribute("aria-expanded")).toBe("false");
 
     act(() => {

--- a/src/components/__tests__/PluginConfirmDialog.test.tsx
+++ b/src/components/__tests__/PluginConfirmDialog.test.tsx
@@ -297,12 +297,60 @@ describe("PluginConfirmDialog", () => {
     expect(screen.getByText("Action contributed by the 'my-plugin' plugin.")).toBeTruthy();
   });
 
-  it("renders the args preview block", () => {
+  // #12015 — the payload is offered, not shown. A raw args blob sitting open
+  // on every prompt reads as noise, and the noise is what trains people to
+  // click through the surface it sits on.
+  it("keeps the args payload behind a collapsed disclosure until asked for", () => {
     void enqueue({ argsSummary: '{"key":"value"}' });
     render(<PluginConfirmDialog />);
 
-    expect(screen.getByText("Arguments")).toBeTruthy();
+    const disclosure = screen.getByRole("button", { name: /arguments/i });
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText('{"key":"value"}')).toBeNull();
+
+    act(() => {
+      disclosure.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(disclosure.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText('{"key":"value"}')).toBeTruthy();
+    // The role is fixed by whether a payload exists, not by whether it is
+    // currently revealed — toggling must not move the dialog between the two
+    // ARIA roles under a screen reader mid-decision.
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  // The queue advances by swapping `current` on a mounted dialog, so the
+  // disclosure's expanded state survives unless it is keyed — showing a
+  // freshly promoted action's payload already open, in a state the user chose
+  // for a different action.
+  it("does not carry an expanded disclosure over to the next queued action", () => {
+    void enqueue({ requestId: "A", argsSummary: '{"first":"payload"}' });
+    void enqueue({
+      requestId: "B",
+      actionTitle: "Push branch",
+      argsSummary: '{"second":"payload"}',
+    });
+    render(<PluginConfirmDialog />);
+
+    act(() => {
+      screen
+        .getByRole("button", { name: /arguments/i })
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(screen.getByText('{"first":"payload"}')).toBeTruthy();
+
+    act(() => {
+      screen
+        .getByRole("button", { name: "Cancel" })
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(screen.getByText("Run 'Push branch'?")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /arguments/i }).getAttribute("aria-expanded")).toBe(
+      "false"
+    );
+    expect(screen.queryByText('{"second":"payload"}')).toBeNull();
   });
 
   it("omits the Arguments section entirely for an action with no arguments", () => {
@@ -326,7 +374,13 @@ describe("PluginConfirmDialog", () => {
     void enqueue({ argsSummary: "null" });
     render(<PluginConfirmDialog />);
 
-    expect(screen.getByText("Arguments")).toBeTruthy();
+    const disclosure = screen.getByRole("button", { name: /arguments/i });
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => {
+      disclosure.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
     expect(screen.getByText("null")).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary

PR #11981 put `McpConfirmDialog`'s redacted `argsSummary` behind a collapsed disclosure. This rolls that same local idiom to the two sibling plugin consent dialogs, so the collapsed treatment is the rule rather than a 1-of-1 outlier.

- `PluginConfirmDialog`: the args block moves fully behind an `ArgumentsDisclosure`. Plugin-contributed actions are capped at D1 (`docs/architecture/destructive-action-safeguards.md`), whose safeguard is the confirm step itself, so there's no content preview here to weaken.
- `PluginMcpConfirmDialog`: split by tier. D0/D1 collapse behind the disclosure, D2/D3 keep the payload inline and expanded.

Resolves #12015

## The one deliberate exception

This is the thing a reviewer most needs to know. The issue asks to roll the disclosure to `PluginMcpConfirmDialog` wholesale, and that's not safe for D2 and above.

The safeguards doc names this dialog's redacted `argsSummary` as *the* content preview satisfying its D2 requirement. `McpConfirmDialog` has two pieces of D2 evidence: a `PreviewCard` that stays expanded, plus secondary args that safely collapse. This surface only has the one. Collapsing it would remove the only audited D2 evidence from the primary view, which is exactly what `ArgumentsDisclosure`'s own doc comment in `McpConfirmDialog` warns against ("a D2 approval has to show actual content, not offer it").

PR #12043 made this call explicitly, a few hours after #12015 was filed, and pinned it with a test. #12015 predates that decision, it cites a line number from the pre-#12043 file, so this exception is deliberate, not an oversight. The safeguards doc needed no changes.

## Also in this PR

A few small related changes, flagged as deliberate scope:

- The FIFO queue advances by swapping `current` on a mounted dialog, so `PluginConfirmDialog`'s new per-request disclosure state is keyed on `requestId`. Without that, the next promoted action inherits an expanded payload the user never asked to see. Added `bodyResetKey` for the outer body scroll too, matching the sibling dialog, and a new regression test covers it.
- Added `data-animated-chevron` to `McpConfirmDialog`'s reference chevron. `src/index.css` uses that attribute to drop the rotation transition under `prefers-reduced-motion`, and the component being copied was missing it. One attribute, but the marker should travel with the pattern.
- The `argsSummary` contract comments in `PluginMcpConsentService.ts` and `shared/types/pluginMcpConsent.ts` said "for D2+ tiers". It's actually produced for D1 too (blanked only for D0 and argument-less calls), and this change makes D1 summaries first-class, so the stale wording was actively misleading. Comment-only fix.

## Testing

156 tests passing across the touched specs. New/updated coverage:

- Collapsed-by-default then reveal-on-click for both dialogs.
- The dialog's ARIA role asserted on both sides of the toggle. Wiring `hasPreview` to expansion state would flip `alertdialog` to `dialog` mid-decision, and a post-click-only assertion would have waved that through.
- The empty-`argsSummary` case across all four tiers. D2+ states the absence inline, D0/D1 drop the section, none offer a disclosure over nothing.
- The queue-carryover regression.

The existing test pinning D2 expansion was deliberately left untouched.

Known follow-up: `src/components/HelpPanel/RecentCallsPopover.tsx` has the same rotating chevron without `data-animated-chevron`. Left alone, it isn't the component being copied and isn't otherwise touched here.
