### PR TITLE
fix(dialog): give footer actions aria-disabled and a JS guard

### DIFF
--- a/src/components/DevPreview/__tests__/DevPreviewDestructiveConfirmDialog.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewDestructiveConfirmDialog.test.tsx
@@ -123,7 +123,7 @@ describe("DevPreviewDestructiveConfirmDialog", () => {
 
     // Confirm button is enabled once meta loads, even though sizes haven't resolved yet.
     const confirmBtn = screen.getByRole<HTMLButtonElement>("button", { name: /clear cache/i });
-    expect(confirmBtn.disabled).toBe(false);
+    expect(confirmBtn.hasAttribute("aria-disabled")).toBe(false);
 
     await act(async () => {
       sizesDeferred.resolve(baseSizes);
@@ -244,7 +244,7 @@ describe("DevPreviewDestructiveConfirmDialog", () => {
       expect(screen.getByTestId("dev-preview-destructive-meta-error")).toBeTruthy();
     });
     const confirmBtn = screen.getByRole<HTMLButtonElement>("button", { name: /clear cache/i });
-    expect(confirmBtn.disabled).toBe(true);
+    expect(confirmBtn.getAttribute("aria-disabled")).toBe("true");
 
     await act(async () => {
       sizesDeferred.resolve(baseSizes);
@@ -270,16 +270,18 @@ describe("DevPreviewDestructiveConfirmDialog", () => {
     );
 
     const confirmBtn = screen.getByRole<HTMLButtonElement>("button", { name: /clear cache/i });
-    expect(confirmBtn.disabled).toBe(true);
+    expect(confirmBtn.getAttribute("aria-disabled")).toBe("true");
 
     await act(async () => {
       metaDeferred.resolve(baseMeta);
     });
 
     await waitFor(() => {
-      expect(screen.getByRole<HTMLButtonElement>("button", { name: /clear cache/i }).disabled).toBe(
-        false
-      );
+      expect(
+        screen
+          .getByRole<HTMLButtonElement>("button", { name: /clear cache/i })
+          .hasAttribute("aria-disabled")
+      ).toBe(false);
     });
   });
 
@@ -305,7 +307,7 @@ describe("DevPreviewDestructiveConfirmDialog", () => {
     });
 
     const confirmBtn = screen.getByRole<HTMLButtonElement>("button", { name: /clear cache/i });
-    expect(confirmBtn.disabled).toBe(false);
+    expect(confirmBtn.hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("passes panelId/projectId to both IPC calls and sets skipNodeModules for the cache tier", async () => {

--- a/src/components/Git/GitPullRebaseConfirmDialog.tsx
+++ b/src/components/Git/GitPullRebaseConfirmDialog.tsx
@@ -238,9 +238,8 @@ function GitPullRebaseConfirmDialogInner() {
       // confirmed action is running": it overlays a spinner on the primary, dims its
       // label to 30%, and disables Cancel. Wiring the PREVIEW read to it drew a
       // spinner across the word "rebase" while the full label was still rendered
-      // underneath, and — because AppDialog's initial-focus pass finds the Cancel
-      // button by selector and calls `.focus()` on it without checking it is enabled
-      // — left focus outside the dialog entirely for the whole read.
+      // underneath, and made Cancel unavailable for the whole read — a preview
+      // fetch is not a reason to take away the way out of the dialog.
       confirmDisabled={confirmDisabled}
       hint={blockedReason}
       onConfirm={() => resolveConfirmation(true)}

--- a/src/components/Git/GitPushConfirmDialog.tsx
+++ b/src/components/Git/GitPushConfirmDialog.tsx
@@ -208,10 +208,9 @@ function GitPushConfirmDialogInner() {
       // Deliberately NOT `isConfirmLoading={isLoading}`. That prop means "the
       // confirmed action is running": it overlays a spinner on the primary,
       // dims its label to 30%, and disables Cancel. Wiring the PREVIEW fetch to
-      // it drew a spinner across the word "Push", and — because AppDialog's
-      // initial-focus pass finds the Cancel button by selector and calls
-      // `.focus()` on it without checking it is enabled — left focus outside
-      // the dialog entirely for the whole fetch.
+      // it drew a spinner across the word "Push", and made Cancel unavailable
+      // for the whole fetch — a preview fetch is not a reason to take away the
+      // way out of the dialog.
       confirmDisabled={confirmDisabled}
       hint={blockedReason}
       onConfirm={() => resolveConfirmation(true)}

--- a/src/components/Git/__tests__/GitPullRebaseConfirmDialog.test.tsx
+++ b/src/components/Git/__tests__/GitPullRebaseConfirmDialog.test.tsx
@@ -102,7 +102,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       void useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(rebaseButton().hasAttribute("disabled")).toBe(true);
+    expect(rebaseButton().getAttribute("aria-disabled")).toBe("true");
 
     await act(async () => {
       gate.resolve({
@@ -116,7 +116,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       await gate.promise;
     });
 
-    expect(rebaseButton().hasAttribute("disabled")).toBe(false);
+    expect(rebaseButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("keeps approval blocked when the preview fetch fails", async () => {
@@ -127,7 +127,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       void useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(rebaseButton().hasAttribute("disabled")).toBe(true);
+    expect(rebaseButton().getAttribute("aria-disabled")).toBe("true");
   });
 
   it("resolves the awaited confirm promise with the user's decision", async () => {
@@ -199,10 +199,8 @@ describe("GitPullRebaseConfirmDialog", () => {
     expect(whileLoading).not.toContain("main");
   });
 
-  // The preview read must never disable the dialog's safe exit. AppDialog's
-  // initial-focus pass finds Cancel by selector and calls `.focus()` without
-  // checking it is enabled, so a disabled Cancel leaves focus outside the dialog
-  // for the whole read — and takes the keyboard exit with it.
+  // The preview read must never disable the dialog's safe exit: a Cancel the
+  // user cannot reach for the whole read takes the keyboard way out with it.
   it("leaves Cancel usable while the preview is still in flight", async () => {
     const gate = deferred<ReturnType<typeof loaded>>();
     mocks.buildPreview.mockReturnValue(gate.promise);
@@ -212,14 +210,14 @@ describe("GitPullRebaseConfirmDialog", () => {
       void useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(cancelButton().hasAttribute("disabled")).toBe(false);
-    expect(rebaseButton().hasAttribute("disabled")).toBe(true);
+    expect(cancelButton().hasAttribute("aria-disabled")).toBe(false);
+    expect(rebaseButton().getAttribute("aria-disabled")).toBe("true");
 
     await act(async () => {
       gate.resolve(loaded());
       await gate.promise;
     });
-    expect(cancelButton().hasAttribute("disabled")).toBe(false);
+    expect(cancelButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   // Scoped to what a component test can actually prove. The host stays mounted
@@ -252,7 +250,7 @@ describe("GitPullRebaseConfirmDialog", () => {
     });
 
     expect(screen.queryByText("From repo A")).toBeNull();
-    expect(rebaseButton().hasAttribute("disabled")).toBe(true);
+    expect(rebaseButton().getAttribute("aria-disabled")).toBe("true");
 
     await act(async () => {
       gate.resolve(
@@ -261,7 +259,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       await gate.promise;
     });
     expect(screen.getByText("From repo B")).toBeTruthy();
-    expect(rebaseButton().hasAttribute("disabled")).toBe(false);
+    expect(rebaseButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   // A measured-empty range is a real answer and a different one from "not measured".
@@ -281,7 +279,7 @@ describe("GitPullRebaseConfirmDialog", () => {
     expect(screen.getByTestId("git-pull-rebase-in-sync")).toBeTruthy();
     // Approvable: a branch level with its upstream rebases to a no-op, which is
     // a different thing from a rebase we could not describe.
-    expect(rebaseButton().hasAttribute("disabled")).toBe(false);
+    expect(rebaseButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   // An unfetched upstream measured nothing, so it may not borrow the empty note —
@@ -303,7 +301,7 @@ describe("GitPullRebaseConfirmDialog", () => {
 
     expect(screen.queryByTestId("git-pull-rebase-in-sync")).toBeNull();
     expect(screen.getByTestId("git-pull-rebase-empty-unfetched")).toBeTruthy();
-    expect(rebaseButton().hasAttribute("disabled")).toBe(true);
+    expect(rebaseButton().getAttribute("aria-disabled")).toBe("true");
     expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
     expect(screen.getByTestId("app-dialog-hint").textContent?.trim()).toBeTruthy();
   });
@@ -327,7 +325,7 @@ describe("GitPullRebaseConfirmDialog", () => {
     // — it just replays nothing, which is the part the copy has to get right. What
     // it must NOT do is promise a fast-forward, which `behind` alone can't establish.
     expect(screen.queryByText(/fast-forward/i)).toBeNull();
-    expect(rebaseButton().hasAttribute("disabled")).toBe(false);
+    expect(rebaseButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   // The conflict caution describes what happens DURING a replay. Rendering it in a
@@ -382,7 +380,7 @@ describe("GitPullRebaseConfirmDialog", () => {
       void useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(rebaseButton().hasAttribute("disabled")).toBe(true);
+    expect(rebaseButton().getAttribute("aria-disabled")).toBe("true");
     // Announced: assistive tech learns why without having to hunt for it.
     expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
     // And stated beside the control it disables, so a sighted user does not have

--- a/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
+++ b/src/components/Git/__tests__/GitPushConfirmDialog.test.tsx
@@ -104,7 +104,7 @@ describe("GitPushConfirmDialog", () => {
       void useGitPushConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(pushButton().hasAttribute("disabled")).toBe(true);
+    expect(pushButton().getAttribute("aria-disabled")).toBe("true");
 
     await act(async () => {
       gate.resolve({
@@ -117,7 +117,7 @@ describe("GitPushConfirmDialog", () => {
       await gate.promise;
     });
 
-    expect(pushButton().hasAttribute("disabled")).toBe(false);
+    expect(pushButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   // `commits.length === 0` is a VALID loaded state — it means "nothing ahead",
@@ -136,7 +136,7 @@ describe("GitPushConfirmDialog", () => {
       void useGitPushConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(pushButton().hasAttribute("disabled")).toBe(false);
+    expect(pushButton().hasAttribute("aria-disabled")).toBe(false);
     expect(screen.getByTestId("git-push-in-sync").textContent).toContain("Nothing to publish");
   });
 
@@ -148,7 +148,7 @@ describe("GitPushConfirmDialog", () => {
       void useGitPushConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(pushButton().hasAttribute("disabled")).toBe(true);
+    expect(pushButton().getAttribute("aria-disabled")).toBe("true");
     const retry = screen.getByTestId("git-push-commits-retry");
 
     mocks.buildPreview.mockResolvedValue({
@@ -163,7 +163,7 @@ describe("GitPushConfirmDialog", () => {
     });
 
     expect(mocks.buildPreview).toHaveBeenCalledTimes(2);
-    expect(pushButton().hasAttribute("disabled")).toBe(false);
+    expect(pushButton().hasAttribute("aria-disabled")).toBe(false);
     expect(screen.getByText("Fix it")).toBeTruthy();
   });
 
@@ -187,9 +187,7 @@ describe("GitPushConfirmDialog", () => {
   });
 
   // A preview fetch is not the action running. Wiring it to `isConfirmLoading`
-  // disabled Cancel, and AppDialog's initial-focus pass calls `.focus()` on the
-  // Cancel button it finds by selector without checking it is enabled — so a
-  // disabled Cancel left focus outside the dialog for the whole fetch.
+  // disabled Cancel, leaving the dialog without a usable exit for the whole fetch.
   it("keeps Cancel usable while the preview is still loading", async () => {
     const gate = deferred<never>();
     mocks.buildPreview.mockReturnValue(gate.promise);
@@ -200,8 +198,8 @@ describe("GitPushConfirmDialog", () => {
     });
 
     const cancel = screen.getByRole("button", { name: "Cancel" });
-    expect(cancel.hasAttribute("disabled")).toBe(false);
-    expect(pushButton().hasAttribute("disabled")).toBe(true);
+    expect(cancel.hasAttribute("aria-disabled")).toBe(false);
+    expect(pushButton().getAttribute("aria-disabled")).toBe("true");
   });
 
   // The rows and the count have to describe the same range, or the tail states
@@ -290,7 +288,7 @@ describe("GitPushConfirmDialog", () => {
       void useGitPushConfirmStore.getState().requestConfirmation("/repo");
     });
 
-    expect(pushButton().hasAttribute("disabled")).toBe(true);
+    expect(pushButton().getAttribute("aria-disabled")).toBe("true");
     expect(screen.getByTestId("git-push-no-destination")).toBeTruthy();
   });
 
@@ -312,7 +310,7 @@ describe("GitPushConfirmDialog", () => {
 
     expect(screen.getByTestId("git-push-detached-head")).toBeTruthy();
     expect(screen.queryByTestId("git-push-no-destination")).toBeNull();
-    expect(pushButton().hasAttribute("disabled")).toBe(true);
+    expect(pushButton().getAttribute("aria-disabled")).toBe("true");
   });
 
   // An untracked range can only over-report, so the surface must say the list is
@@ -399,7 +397,7 @@ describe("GitPushConfirmDialog", () => {
 
     // It must neither render nor enable approval: it describes /repo-a, and the
     // dialog on screen is asking about /repo-b.
-    expect(pushButton().hasAttribute("disabled")).toBe(true);
+    expect(pushButton().getAttribute("aria-disabled")).toBe("true");
     expect(screen.queryAllByTestId("git-push-commit-row")).toHaveLength(0);
   });
 

--- a/src/components/Plugin/__tests__/PluginArchiveInstallConfirmDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginArchiveInstallConfirmDialog.test.tsx
@@ -321,12 +321,12 @@ describe("PluginArchiveInstallConfirmDialog", () => {
     render(<PluginArchiveInstallConfirmDialog />);
     enqueue(intent());
 
-    expect(confirmButton().disabled).toBe(true);
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
     click(confirmButton());
     expect(installFromPath).not.toHaveBeenCalled();
 
     armConfirm();
-    expect(confirmButton().disabled).toBe(false);
+    expect(confirmButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("hands the approved archive path to the installer exactly once", async () => {
@@ -366,7 +366,7 @@ describe("PluginArchiveInstallConfirmDialog", () => {
 
     // The promoted item earns its own read time — a click landing now must not
     // approve an archive the user hasn't read.
-    expect(confirmButton().disabled).toBe(true);
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
     click(confirmButton());
     expect(installFromPath).toHaveBeenCalledOnce();
 

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -83,7 +83,7 @@ describe("MoveOrRenameProjectDialog", () => {
     expect(screen.getByText("Move or rename project")).toBeTruthy();
     expect((screen.getByTestId("relocate-name-input") as HTMLInputElement).value).toBe("Proj");
     expect((screen.getByTestId("relocate-folder-input") as HTMLInputElement).value).toBe("proj");
-    expect(confirmButton().disabled).toBe(true);
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
     expect(previewRelocation).not.toHaveBeenCalled();
   });
 
@@ -95,7 +95,7 @@ describe("MoveOrRenameProjectDialog", () => {
 
     const btn = confirmButton();
     expect(btn.textContent).toContain("Rename project");
-    expect(btn.disabled).toBe(false);
+    expect(btn.hasAttribute("aria-disabled")).toBe(false);
 
     fireEvent.click(btn);
     await waitFor(() => expect(updateProject).toHaveBeenCalledWith("p1", { name: "Renamed" }));
@@ -111,10 +111,10 @@ describe("MoveOrRenameProjectDialog", () => {
 
     fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
     // Folder changed, preview not yet loaded → confirm gated.
-    expect(confirmButton().disabled).toBe(true);
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
 
     await waitFor(() => expect(previewRelocation).toHaveBeenCalled());
-    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+    await waitFor(() => expect(confirmButton().hasAttribute("aria-disabled")).toBe(false));
   });
 
   it("blockers in the preview keep confirm disabled and surface their messages", async () => {
@@ -133,7 +133,7 @@ describe("MoveOrRenameProjectDialog", () => {
     await waitFor(() =>
       expect(screen.getByText(/Moving across volumes isn't supported yet/)).toBeTruthy()
     );
-    expect(confirmButton().disabled).toBe(true);
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
   });
 
   it("a full move calls applyRelocation with the previewed destination", async () => {
@@ -142,7 +142,7 @@ describe("MoveOrRenameProjectDialog", () => {
     render(<MoveOrRenameProjectDialog />);
 
     fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
-    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+    await waitFor(() => expect(confirmButton().hasAttribute("aria-disabled")).toBe(false));
 
     fireEvent.click(confirmButton());
     await waitFor(() =>
@@ -186,7 +186,7 @@ describe("MoveOrRenameProjectDialog", () => {
     // Count > 1 is surfaced next to the agent name.
     expect(screen.getByText(/Codex \(2\)/)).toBeTruthy();
     // Continuity is informational — it must NOT disable confirm (only blockers do).
-    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+    await waitFor(() => expect(confirmButton().hasAttribute("aria-disabled")).toBe(false));
   });
 
   it("renders a single-terminal agent without a count suffix (#11282 phase 5)", async () => {
@@ -217,7 +217,7 @@ describe("MoveOrRenameProjectDialog", () => {
 
     fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
 
-    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+    await waitFor(() => expect(confirmButton().hasAttribute("aria-disabled")).toBe(false));
     // No agents → no continuity section.
     expect(screen.queryByTestId("relocate-continuity")).toBeNull();
     // The terminal line describes restart, not conversation preservation.
@@ -240,7 +240,7 @@ describe("MoveOrRenameProjectDialog", () => {
     await waitFor(() => {
       const btn = confirmButton();
       expect(btn.textContent).toContain("Reattach project");
-      expect(btn.disabled).toBe(false);
+      expect(btn.hasAttribute("aria-disabled")).toBe(false);
     });
 
     fireEvent.click(confirmButton());
@@ -263,7 +263,7 @@ describe("MoveOrRenameProjectDialog", () => {
 
     fireEvent.click(screen.getByTestId("relocate-browse-existing"));
     await waitFor(() => expect(previewRelocation).toHaveBeenCalled());
-    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+    await waitFor(() => expect(confirmButton().hasAttribute("aria-disabled")).toBe(false));
 
     fireEvent.click(confirmButton());
     await waitFor(() =>
@@ -312,6 +312,6 @@ describe("MoveOrRenameProjectDialog", () => {
     resolveA(cleanPreview());
     await new Promise((r) => setTimeout(r, 0));
     expect(document.querySelector('[data-testid="relocate-preview"]')).toBeNull();
-    expect(confirmButton().disabled).toBe(true);
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
   });
 });

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -621,7 +621,7 @@ describe("DaintreeAssistantSettingsTab", () => {
       name: /^rotate key$/i,
     }) as HTMLButtonElement;
     // Rotation is recoverable (#10547): no typed-name gate, button is live immediately.
-    expect(confirmButton.disabled).toBe(false);
+    expect(confirmButton.hasAttribute("aria-disabled")).toBe(false);
     expect(screen.queryByLabelText(/^Type .* to confirm$/i)).toBeNull();
 
     fireEvent.click(confirmButton);

--- a/src/components/Settings/__tests__/ImportEnvDialog.test.tsx
+++ b/src/components/Settings/__tests__/ImportEnvDialog.test.tsx
@@ -159,14 +159,14 @@ describe("ImportEnvDialog", () => {
     it("never advertises a count while it is disabled", () => {
       renderDialog();
       paste("GOOD=fine\nthis line has no equals sign");
-      expect(primary().disabled).toBe(true);
+      expect(primary().getAttribute("aria-disabled")).toBe("true");
       expect(primary().textContent).not.toMatch(/\d/);
     });
 
     it("advertises a count once it can actually be pressed", () => {
       renderDialog();
       paste("BRAND_NEW=1\nALSO_NEW=2");
-      expect(primary().disabled).toBe(false);
+      expect(primary().hasAttribute("aria-disabled")).toBe(false);
       expect(primary().textContent).toMatch(/\d/);
     });
 
@@ -174,13 +174,13 @@ describe("ImportEnvDialog", () => {
     it("says why it is disabled whenever the user has pasted something", () => {
       renderDialog();
       paste("this line has no equals sign");
-      expect(primary().disabled).toBe(true);
+      expect(primary().getAttribute("aria-disabled")).toBe("true");
       expect(screen.getByTestId("app-dialog-hint").textContent?.trim()).toBeTruthy();
     });
 
     it("stays quiet about it before anything is pasted", () => {
       renderDialog();
-      expect(primary().disabled).toBe(true);
+      expect(primary().getAttribute("aria-disabled")).toBe("true");
       expect(screen.queryByTestId("app-dialog-hint")).toBeNull();
     });
   });

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -254,7 +254,7 @@ describe("McpServerSettingsTab", () => {
       name: /^rotate key$/i,
     }) as HTMLButtonElement;
     // Rotation is recoverable (#10547): no typed-name gate, button is live immediately.
-    expect(confirmButton.disabled).toBe(false);
+    expect(confirmButton.hasAttribute("aria-disabled")).toBe(false);
     expect(screen.queryByLabelText(/^Type .* to confirm$/i)).toBeNull();
 
     fireEvent.click(confirmButton);

--- a/src/components/__tests__/McpConfirmDialog.test.tsx
+++ b/src/components/__tests__/McpConfirmDialog.test.tsx
@@ -144,16 +144,16 @@ describe("McpConfirmDialog", () => {
       });
 
       const confirm = screen.getByRole("button", { name: "Delete worktree" });
-      expect(confirm.hasAttribute("disabled")).toBe(true);
+      expect(confirm.getAttribute("aria-disabled")).toBe("true");
       expect(screen.getByRole("status", { name: /checking what this affects/i })).toBeTruthy();
 
       // Only the preview landing unblocks it.
       act(() => {
         useMcpConfirmStore.getState().setPreview("req-pending", ["No uncommitted changes."]);
       });
-      expect(screen.getByRole("button", { name: "Delete worktree" }).hasAttribute("disabled")).toBe(
-        false
-      );
+      expect(
+        screen.getByRole("button", { name: "Delete worktree" }).hasAttribute("aria-disabled")
+      ).toBe(false);
     } finally {
       vi.useRealTimers();
     }
@@ -319,12 +319,12 @@ describe("McpConfirmDialog", () => {
       const confirmBtn = screen.getByRole("button", {
         name: "Delete worktree",
       }) as HTMLButtonElement;
-      expect(confirmBtn.disabled).toBe(true);
+      expect(confirmBtn.getAttribute("aria-disabled")).toBe("true");
 
       act(() => {
         vi.advanceTimersByTime(1200);
       });
-      expect(confirmBtn.disabled).toBe(false);
+      expect(confirmBtn.hasAttribute("aria-disabled")).toBe(false);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
@@ -340,7 +340,7 @@ describe("McpConfirmDialog", () => {
       const confirmBtn = screen.getByRole("button", {
         name: "List worktrees",
       }) as HTMLButtonElement;
-      expect(confirmBtn.disabled).toBe(false);
+      expect(confirmBtn.hasAttribute("aria-disabled")).toBe(false);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
@@ -361,7 +361,7 @@ describe("McpConfirmDialog", () => {
       const firstBtn = screen.getByRole("button", {
         name: "Delete worktree",
       }) as HTMLButtonElement;
-      expect(firstBtn.disabled).toBe(false);
+      expect(firstBtn.hasAttribute("aria-disabled")).toBe(false);
 
       act(() => {
         firstBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -373,12 +373,12 @@ describe("McpConfirmDialog", () => {
       const secondBtn = screen.getByRole("button", {
         name: "Reset branch",
       }) as HTMLButtonElement;
-      expect(secondBtn.disabled).toBe(true);
+      expect(secondBtn.getAttribute("aria-disabled")).toBe("true");
 
       act(() => {
         vi.advanceTimersByTime(1200);
       });
-      expect(secondBtn.disabled).toBe(false);
+      expect(secondBtn.hasAttribute("aria-disabled")).toBe(false);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
@@ -399,7 +399,7 @@ describe("McpConfirmDialog", () => {
       const btn = screen.getByRole("button", {
         name: "Delete worktree",
       }) as HTMLButtonElement;
-      expect(btn.disabled).toBe(true);
+      expect(btn.getAttribute("aria-disabled")).toBe("true");
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
@@ -622,7 +622,7 @@ describe("McpConfirmDialog", () => {
       const btn = screen.getByRole("button", {
         name: "Delete worktree",
       }) as HTMLButtonElement;
-      expect(btn.disabled).toBe(true);
+      expect(btn.getAttribute("aria-disabled")).toBe("true");
 
       // The 1200ms cooldown must clear before the auto-timeout fires — the old
       // Math.max(500, …) floor would have timed the item out first, making it
@@ -630,7 +630,7 @@ describe("McpConfirmDialog", () => {
       act(() => {
         vi.advanceTimersByTime(1200);
       });
-      expect(btn.disabled).toBe(false);
+      expect(btn.hasAttribute("aria-disabled")).toBe(false);
 
       act(() => {
         btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/src/components/__tests__/PluginConfirmDialog.test.tsx
+++ b/src/components/__tests__/PluginConfirmDialog.test.tsx
@@ -148,12 +148,12 @@ describe("PluginConfirmDialog", () => {
       const confirmBtn = screen.getByRole("button", {
         name: "Delete worktree",
       }) as HTMLButtonElement;
-      expect(confirmBtn.disabled).toBe(true);
+      expect(confirmBtn.getAttribute("aria-disabled")).toBe("true");
 
       act(() => {
         vi.advanceTimersByTime(1200);
       });
-      expect(confirmBtn.disabled).toBe(false);
+      expect(confirmBtn.hasAttribute("aria-disabled")).toBe(false);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
@@ -169,7 +169,7 @@ describe("PluginConfirmDialog", () => {
       const confirmBtn = screen.getByRole("button", {
         name: "List worktrees",
       }) as HTMLButtonElement;
-      expect(confirmBtn.disabled).toBe(false);
+      expect(confirmBtn.hasAttribute("aria-disabled")).toBe(false);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
@@ -194,7 +194,7 @@ describe("PluginConfirmDialog", () => {
       const firstBtn = screen.getByRole("button", {
         name: "Delete worktree",
       }) as HTMLButtonElement;
-      expect(firstBtn.disabled).toBe(false);
+      expect(firstBtn.hasAttribute("aria-disabled")).toBe(false);
 
       act(() => {
         firstBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -204,12 +204,12 @@ describe("PluginConfirmDialog", () => {
       const secondBtn = screen.getByRole("button", {
         name: "Reset branch",
       }) as HTMLButtonElement;
-      expect(secondBtn.disabled).toBe(true);
+      expect(secondBtn.getAttribute("aria-disabled")).toBe("true");
 
       act(() => {
         vi.advanceTimersByTime(1200);
       });
-      expect(secondBtn.disabled).toBe(false);
+      expect(secondBtn.hasAttribute("aria-disabled")).toBe(false);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
@@ -228,7 +228,7 @@ describe("PluginConfirmDialog", () => {
       const btn = screen.getByRole("button", {
         name: "Delete worktree",
       }) as HTMLButtonElement;
-      expect(btn.disabled).toBe(true);
+      expect(btn.getAttribute("aria-disabled")).toBe("true");
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -497,6 +497,18 @@ interface AppDialogHeaderProps {
 const CHROME_INSET = "px-[calc(1.5rem+11px)]";
 const PLAIN_INSET = "px-6";
 
+// Footer actions announce unavailability with `aria-disabled`, never the native
+// attribute — a natively-disabled button leaves the tab order and refuses focus,
+// so the initial-focus pass above (which resolves Cancel/Confirm by
+// `data-confirm-role` and calls `.focus()` on the match) would silently strand
+// focus outside the dialog. The attribute is advisory, so each action vetoes its
+// own activation in JS; these classes stand in for the `disabled:` variants that
+// stop matching. Applied only when the action itself is disabled: `Button` also
+// synthesises `aria-disabled` while `loading`, and dimming there would fade the
+// spinner it overlays. No `aria-disabled:pointer-events-none` — that would
+// suppress hover and put the control back out of reach.
+const DISABLED_ACTION_CLASSES = "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed";
+
 AppDialog.Header = function AppDialogHeader({
   children,
   className,
@@ -622,6 +634,11 @@ AppDialog.BodyScroll = function AppDialogBodyScroll({
 export interface DialogAction {
   label: string;
   onClick: () => void;
+  /**
+   * The action is unavailable. Rendered as `aria-disabled` — the button stays
+   * focusable and keeps its place in the tab order, and the footer vetoes the
+   * activation in JS rather than relying on the attribute to block it.
+   */
   disabled?: boolean;
   loading?: boolean;
   intent?: "default" | "destructive";
@@ -690,9 +707,19 @@ AppDialog.Footer = function AppDialogFooter({
           {secondaryAction && (
             <Button
               variant="ghost"
-              onClick={secondaryAction.onClick}
-              disabled={secondaryAction.disabled}
-              className="text-daintree-text/70 hover:text-daintree-text"
+              onClick={(event) => {
+                if (secondaryAction.disabled) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  return;
+                }
+                secondaryAction.onClick();
+              }}
+              aria-disabled={secondaryAction.disabled || undefined}
+              className={cn(
+                "text-daintree-text/70 hover:text-daintree-text",
+                secondaryAction.disabled && DISABLED_ACTION_CLASSES
+              )}
               data-confirm-role="cancel"
             >
               {secondaryAction.label}
@@ -701,9 +728,17 @@ AppDialog.Footer = function AppDialogFooter({
           {primaryAction && (
             <Button
               variant={getPrimaryVariant()}
-              onClick={primaryAction.onClick}
-              disabled={primaryAction.disabled}
+              onClick={(event) => {
+                if (primaryAction.disabled) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  return;
+                }
+                primaryAction.onClick();
+              }}
+              aria-disabled={primaryAction.disabled || undefined}
               loading={primaryAction.loading}
+              className={primaryAction.disabled ? DISABLED_ACTION_CLASSES : undefined}
               data-confirm-role="confirm"
             >
               {primaryAction.label}

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -212,6 +212,11 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
   const isTypedMatched = !hasTypedNameGate || typedValue === typedNameTarget;
 
   const handleConfirm = () => {
+    // `TypedNameConfirmInput` submits on Enter by calling straight through here,
+    // so neither `Button`'s loading guard nor the footer's disabled guard is on
+    // this path — without the check, Enter could fire the action a second time
+    // while the first is still running.
+    if (isConfirmLoading) return;
     if (isCooldownActive) return;
     if (hasTypedNameGate && !isTypedMatched) return;
     if (confirmDisabled) return;

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act, fireEvent, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { AppDialog } from "../AppDialog";
 import { buttonVariants } from "../button";
+import { getVisibleTabbableElements } from "@/lib/accessibility";
 import { _resetForTests } from "@/lib/escapeStack";
 import { _resetForTests as _resetBackstopForTests } from "@/lib/dialogEscapeBackstop";
 import { handleDockEscapeKeyDown } from "@/components/Layout/dockPopoverGuard";
@@ -644,7 +645,117 @@ describe("AppDialog focus trapping", () => {
       const secondary = screen.getByRole("button", { name: "Cancel" });
       expect(secondary.hasAttribute("aria-busy")).toBe(false);
       // Not disabled by the unused loading flag
-      expect((secondary as HTMLButtonElement).disabled).toBe(false);
+      expect(secondary.hasAttribute("aria-disabled")).toBe(false);
+      expect(secondary.hasAttribute("disabled")).toBe(false);
+    });
+  });
+
+  describe("AppDialog Footer disabled actions", () => {
+    const renderBothDisabled = async (onPrimary: () => void, onSecondary: () => void) => {
+      render(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={true} onClose={() => {}} data-testid="test-dialog">
+            <AppDialog.Body>
+              <p>Content</p>
+            </AppDialog.Body>
+            <AppDialog.Footer
+              primaryAction={{ label: "Save", onClick: onPrimary, disabled: true }}
+              secondaryAction={{ label: "Cancel", onClick: onSecondary, disabled: true }}
+            />
+          </AppDialog>
+        </>
+      );
+      await act(() => vi.runAllTimersAsync());
+      return {
+        primary: screen.getByRole("button", { name: "Save" }),
+        secondary: screen.getByRole("button", { name: "Cancel" }),
+      };
+    };
+
+    it("marks disabled actions aria-disabled and never natively disabled", async () => {
+      const { primary, secondary } = await renderBothDisabled(
+        () => {},
+        () => {}
+      );
+
+      for (const button of [primary, secondary]) {
+        expect(button.getAttribute("aria-disabled")).toBe("true");
+        expect(button.hasAttribute("disabled")).toBe(false);
+      }
+    });
+
+    it("does not invoke a disabled action when it is clicked", async () => {
+      const onPrimary = vi.fn();
+      const onSecondary = vi.fn();
+      const { primary, secondary } = await renderBothDisabled(onPrimary, onSecondary);
+
+      fireEvent.click(primary);
+      fireEvent.click(secondary);
+
+      // The attribute is advisory — jsdom dispatches the click either way, so a
+      // handler that stayed silent proves the footer's own guard ran.
+      expect(onPrimary).not.toHaveBeenCalled();
+      expect(onSecondary).not.toHaveBeenCalled();
+    });
+
+    it("still invokes an enabled action, so the guard is not blocking everything", async () => {
+      const onPrimary = vi.fn();
+      render(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={true} onClose={() => {}} data-testid="test-dialog">
+            <AppDialog.Body>
+              <p>Content</p>
+            </AppDialog.Body>
+            <AppDialog.Footer primaryAction={{ label: "Save", onClick: onPrimary }} />
+          </AppDialog>
+        </>
+      );
+      await act(() => vi.runAllTimersAsync());
+
+      const primary = screen.getByRole("button", { name: "Save" });
+      expect(primary.hasAttribute("aria-disabled")).toBe(false);
+      fireEvent.click(primary);
+      expect(onPrimary).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps a swallowed click from reaching an ancestor", async () => {
+      const onAncestor = vi.fn();
+      const onPrimary = vi.fn();
+      // Rendered outside AppDialog: the dialog surface stops click propagation of
+      // its own accord, which would hide whether the footer swallowed anything. A
+      // natively-disabled button never produced an ancestor-visible click at all,
+      // and that is the behaviour the guard has to preserve.
+      render(
+        <div onClick={onAncestor}>
+          <AppDialog.Footer primaryAction={{ label: "Save", onClick: onPrimary, disabled: true }} />
+        </div>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(onPrimary).not.toHaveBeenCalled();
+      expect(onAncestor).not.toHaveBeenCalled();
+    });
+
+    it("keeps disabled actions focusable and in the tab order", async () => {
+      const { primary, secondary } = await renderBothDisabled(
+        () => {},
+        () => {}
+      );
+
+      // The point of the convention: an unavailable action can still be reached
+      // and announced. Asserted through the helper AppDialog's focus trap and
+      // initial-focus fallback both use, not through a bare tabIndex read.
+      const tabbable = getVisibleTabbableElements(screen.getByTestId("test-dialog"));
+      expect(tabbable).toContain(primary);
+      expect(tabbable).toContain(secondary);
+
+      for (const button of [primary, secondary]) {
+        act(() => button.focus());
+        expect(document.activeElement).toBe(button);
+      }
     });
   });
 

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -393,16 +393,16 @@ describe("ConfirmDialog — typed-name gate", () => {
     const button = findConfirmButton();
 
     expect(input).toBeDefined();
-    expect(button.disabled).toBe(true);
+    expect(button.getAttribute("aria-disabled")).toBe("true");
 
     fireEvent.change(input, { target: { value: "my-rep" } });
-    expect(button.disabled).toBe(true);
+    expect(button.getAttribute("aria-disabled")).toBe("true");
 
     fireEvent.change(input, { target: { value: "My-Repo" } });
-    expect(button.disabled).toBe(true);
+    expect(button.getAttribute("aria-disabled")).toBe("true");
 
     fireEvent.change(input, { target: { value: "my-repo" } });
-    expect(button.disabled).toBe(false);
+    expect(button.hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("does not call onConfirm when primary action is invoked while unmatched", () => {
@@ -478,7 +478,7 @@ describe("ConfirmDialog — typed-name gate", () => {
 
     const input = findTypedInput();
     fireEvent.change(input, { target: { value: "my-repo" } });
-    expect(findConfirmButton().disabled).toBe(false);
+    expect(findConfirmButton().hasAttribute("aria-disabled")).toBe(false);
 
     rerender(
       <ConfirmDialog
@@ -505,7 +505,7 @@ describe("ConfirmDialog — typed-name gate", () => {
 
     const reopenedInput = findTypedInput();
     expect(reopenedInput.value).toBe("");
-    expect(findConfirmButton().disabled).toBe(true);
+    expect(findConfirmButton().getAttribute("aria-disabled")).toBe("true");
   });
 
   it("does not render the input or gate the button when typedNameTarget is empty", () => {
@@ -522,7 +522,7 @@ describe("ConfirmDialog — typed-name gate", () => {
     );
 
     expect(screen.queryByLabelText(/^Type .* to confirm$/i)).toBeNull();
-    expect(findConfirmButton().disabled).toBe(false);
+    expect(findConfirmButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("warns in dev when typedNameTarget is set with a non-destructive variant", () => {
@@ -1057,17 +1057,17 @@ describe("ConfirmDialog confirmCooldownMs gate", () => {
       />
     );
 
-    expect(getConfirm().disabled).toBe(true);
+    expect(getConfirm().getAttribute("aria-disabled")).toBe("true");
 
     act(() => {
       vi.advanceTimersByTime(1199);
     });
-    expect(getConfirm().disabled).toBe(true);
+    expect(getConfirm().getAttribute("aria-disabled")).toBe("true");
 
     act(() => {
       vi.advanceTimersByTime(1);
     });
-    expect(getConfirm().disabled).toBe(false);
+    expect(getConfirm().hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("does not gate the button when confirmCooldownMs is absent", () => {
@@ -1082,7 +1082,7 @@ describe("ConfirmDialog confirmCooldownMs gate", () => {
       />
     );
 
-    expect(getConfirm().disabled).toBe(false);
+    expect(getConfirm().hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("treats zero and negative cooldowns as no cooldown", () => {
@@ -1097,7 +1097,7 @@ describe("ConfirmDialog confirmCooldownMs gate", () => {
         confirmCooldownMs={0}
       />
     );
-    expect(getConfirm().disabled).toBe(false);
+    expect(getConfirm().hasAttribute("aria-disabled")).toBe(false);
 
     rerender(
       <ConfirmDialog
@@ -1110,7 +1110,7 @@ describe("ConfirmDialog confirmCooldownMs gate", () => {
         confirmCooldownMs={-5}
       />
     );
-    expect(getConfirm().disabled).toBe(false);
+    expect(getConfirm().hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("ignores a click while the cooldown is active, then fires after it elapses", () => {
@@ -1179,15 +1179,94 @@ describe("ConfirmDialog confirmCooldownMs gate", () => {
     act(() => {
       vi.advanceTimersByTime(1200);
     });
-    expect(getConfirm().disabled).toBe(false);
+    expect(getConfirm().hasAttribute("aria-disabled")).toBe(false);
 
     // A new item is promoted into the same mounted dialog — the clock restarts.
     rerender(<ConfirmDialog {...props} cooldownKey="B" />);
-    expect(getConfirm().disabled).toBe(true);
+    expect(getConfirm().getAttribute("aria-disabled")).toBe("true");
 
     act(() => {
       vi.advanceTimersByTime(1200);
     });
-    expect(getConfirm().disabled).toBe(false);
+    expect(getConfirm().hasAttribute("aria-disabled")).toBe(false);
+  });
+});
+
+describe("ConfirmDialog activation guards while the confirm is running", () => {
+  const findConfirm = () =>
+    document.querySelector<HTMLButtonElement>('[data-confirm-role="confirm"]')!;
+  const findCancel = () =>
+    document.querySelector<HTMLButtonElement>('[data-confirm-role="cancel"]')!;
+
+  it("does not close when Cancel is clicked mid-confirm", () => {
+    const onClose = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={onClose}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={() => {}}
+        variant="destructive"
+        isConfirmLoading={true}
+      />
+    );
+
+    const cancel = findCancel();
+    expect(cancel.getAttribute("aria-disabled")).toBe("true");
+    expect(cancel.hasAttribute("disabled")).toBe(false);
+
+    fireEvent.click(cancel);
+
+    // Cancel is the one interlock with no re-check of its own inside
+    // ConfirmDialog — the footer guard is all that stands between a click and
+    // closing the dialog out from under a running action.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not re-confirm when the typed name is submitted mid-confirm", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={onConfirm}
+        variant="destructive"
+        typedNameTarget="my-repo"
+        isConfirmLoading={true}
+      />
+    );
+
+    const input = screen.getByLabelText(/^Type my-repo to confirm$/i);
+    fireEvent.change(input, { target: { value: "my-repo" } });
+    // Enter here calls handleConfirm directly, reaching neither the footer's
+    // guard nor Button's own loading short-circuit.
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("confirms on typed-name submit once the confirm is no longer running", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={onConfirm}
+        variant="destructive"
+        typedNameTarget="my-repo"
+      />
+    );
+
+    const input = screen.getByLabelText(/^Type my-repo to confirm$/i);
+    fireEvent.change(input, { target: { value: "my-repo" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(findConfirm().hasAttribute("aria-disabled")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `AppDialog.Footer`'s primary and secondary action buttons were using the native HTML `disabled` attribute, where the rest of the codebase (24 non-test files) has settled on `aria-disabled`. A natively-disabled button drops out of the tab order and can't receive focus, so the dialog's initial-focus logic (which finds Cancel or Confirm by a data attribute and calls `.focus()` on it) was silently failing and leaving focus outside the dialog whenever that button was disabled.
- `AppDialog.Footer` now renders the disabled state as `aria-disabled` and adds a `DISABLED_ACTION_CLASSES` constant for the dimmed/not-allowed styling, applied only when disabled so it doesn't interfere with the loading spinner state (which also sets `aria-disabled`).
- Since `aria-disabled` is only advisory and doesn't stop a click on its own, both footer action buttons now veto their own activation in JS too, and `ConfirmDialog` gets a matching guard against a double-fire on Enter.

Resolves #12014

## Changes

- `src/components/ui/AppDialog.tsx`: `AppDialog.Footer` renders `aria-disabled` instead of the native attribute, plus the `DISABLED_ACTION_CLASSES` constant. Both footer action buttons now call `preventDefault`, `stopPropagation`, and return early when disabled, so a disabled action can't actually fire. This guard lives in `AppDialogFooter` itself rather than the shared `Button` component, matching how the app already guards clicks at the call site elsewhere (`AgentButton`, `CommitPanel`, `SidebarContent`). One choke point covers `ConfirmDialog`'s cancel path and every other `AppDialog.Footer` consumer with no per-consumer changes needed.
- `src/components/ui/ConfirmDialog.tsx`: `handleConfirm` now short-circuits while a confirm is already loading. The typed-name confirmation input submits on Enter by calling straight through, which bypasses both the new footer guard and `Button`'s own loading check, so without this a destructive action could fire a second time while the first was still running.
- `src/components/Git/GitPullRebaseConfirmDialog.tsx` and `GitPushConfirmDialog.tsx`: corrected comments that described the focus-escape bug this PR fixes.
- 81 test assertions across 12 dialog test files converted from checking the native `disabled` property to `aria-disabled`. This isn't just cosmetic: `jest-dom`'s `toBeDisabled()` ignores `aria-disabled` entirely, so those assertions were passing vacuously and would never have caught a regression. Left alone on purpose: tests with hand-rolled native `<button disabled>` elements (`FleetCountChip`) or a mocked dialog with its own native button.
- New regression tests: disabled actions carry `aria-disabled` and never the native attribute, a disabled action's `onClick` never fires, the swallowed click doesn't bubble to an ancestor, disabled footer buttons stay focusable and in the tab order, `ConfirmDialog` doesn't close on a mid-confirm cancel, and doesn't re-fire on a mid-confirm Enter in the typed-name input.

## Testing

- 2276 tests across all 88 test files referencing `AppDialog` or `ConfirmDialog` pass.
- Mutation-checked: stripped both new guards and confirmed exactly the four new regression tests fail, and nothing else, so each guard is independently covered and none of the new tests is vacuous.
- Two parallel Codex reviews (implementation, and test-conversion integrity) came back with no findings.
- Prettier clean, eslint 0 errors on changed files (8 pre-existing `no-unsafe-type-assertion` warnings, none introduced).

Side effect worth calling out: since a disabled Cancel/Confirm is focusable now, `AppDialog`'s initial-focus pass actually succeeds where it used to silently no-op, closing the focus-escape hole those two Git dialog comments were describing.