### PR TITLE
fix(ui): rank label and detail by weight instead of an em dash

### DIFF
--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -347,12 +347,12 @@ export function SettingsShortcutCapture({
               "Press key combination..."
             ) : chordStep === "waiting" ? (
               <span>
-                <span className="font-mono">
+                <span className="font-mono font-medium">
                   {keybindingService.formatComboForDisplay(capturedCombos[0]!)}
                 </span>
-                <span className="text-daintree-accent/70">
+                <span className="ml-1 text-text-secondary">
                   {" "}
-                  — press second key or wait to finish
+                  Press second key or wait to finish
                 </span>
               </span>
             ) : null}

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -163,18 +163,17 @@ describe("SettingsShortcutCapture", () => {
       window.dispatchEvent(firstEvent);
     });
 
-    // Should show waiting state
+    // Should show waiting state, ranked against the captured combo by weight
+    // rather than a dash. Accent stays on the combo alone — the recording box
+    // already carries it as the one live signal, and a second accent tone
+    // would compete with it.
     const instruction = screen.getByText(/Press second key or wait to finish/);
-    expect(instruction).toBeTruthy();
-
-    // The captured combo and its instruction are ranked by weight, not by a dash.
-    // Accent stays on the combo alone — the recording box already carries it as
-    // the one live signal, and a second accent tone would compete with it.
     const combo = instruction.previousElementSibling;
     expect(combo).not.toBeNull();
-    expect(combo).not.toBe(instruction);
-    const announced = (instruction.parentElement?.textContent ?? "").replace(/\s+/g, " ").trim();
-    expect(announced).toBe(`${combo?.textContent} Press second key or wait to finish`);
+    expect(instruction.textContent).toMatch(/^\s/);
+    expect(instruction.parentElement?.textContent).toBe(
+      `${combo?.textContent}${instruction.textContent}`
+    );
 
     // Second key of chord
     const secondEvent = new KeyboardEvent("keydown", {

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -164,7 +164,17 @@ describe("SettingsShortcutCapture", () => {
     });
 
     // Should show waiting state
-    expect(screen.getByText(/press second key or wait to finish/)).toBeTruthy();
+    const instruction = screen.getByText(/Press second key or wait to finish/);
+    expect(instruction).toBeTruthy();
+
+    // The captured combo and its instruction are ranked by weight, not by a dash.
+    // Accent stays on the combo alone — the recording box already carries it as
+    // the one live signal, and a second accent tone would compete with it.
+    const combo = instruction.previousElementSibling;
+    expect(combo).not.toBeNull();
+    expect(combo).not.toBe(instruction);
+    const announced = (instruction.parentElement?.textContent ?? "").replace(/\s+/g, " ").trim();
+    expect(announced).toBe(`${combo?.textContent} Press second key or wait to finish`);
 
     // Second key of chord
     const secondEvent = new KeyboardEvent("keydown", {
@@ -213,7 +223,7 @@ describe("SettingsShortcutCapture", () => {
 
     // Recording should be stopped (recording state is false)
     // The "press second key or wait" message should be gone
-    expect(screen.queryByText(/press second key or wait to finish/)).toBeNull();
+    expect(screen.queryByText(/Press second key or wait to finish/)).toBeNull();
   });
 
   it("calls onCapture with empty string when Clear is clicked", async () => {
@@ -676,7 +686,7 @@ describe("SettingsShortcutCapture", () => {
       act(() => {
         window.dispatchEvent(firstToken);
       });
-      expect(screen.getByText(/press second key or wait to finish/)).toBeTruthy();
+      expect(screen.getByText(/Press second key or wait to finish/)).toBeTruthy();
 
       // IME commit Enter while we're waiting must NOT become the second chord token.
       const composingEnter = new KeyboardEvent("keydown", {
@@ -692,7 +702,7 @@ describe("SettingsShortcutCapture", () => {
       });
 
       // The single-token Ctrl+K should finalize cleanly with no chord suffix.
-      expect(screen.queryByText(/press second key or wait to finish/)).toBeNull();
+      expect(screen.queryByText(/Press second key or wait to finish/)).toBeNull();
       expect(screen.queryByText(/\(chord\)/)).toBeNull();
       expect(screen.getByText("Save")).toBeTruthy();
     });
@@ -796,7 +806,7 @@ describe("SettingsShortcutCapture", () => {
         window.dispatchEvent(firstKey);
       });
 
-      expect(screen.getByText(/press second key or wait to finish/)).toBeTruthy();
+      expect(screen.getByText(/Press second key or wait to finish/)).toBeTruthy();
 
       // Simulate the window losing focus (e.g., user Cmd+Tabs away mid-chord).
       act(() => {
@@ -805,7 +815,7 @@ describe("SettingsShortcutCapture", () => {
 
       // Recording should be cancelled — the prompt and Save button both gone.
       expect(screen.queryByText("Save")).toBeNull();
-      expect(screen.queryByText(/press second key or wait to finish/)).toBeNull();
+      expect(screen.queryByText(/Press second key or wait to finish/)).toBeNull();
       expect(screen.getByText("Click to record shortcut")).toBeTruthy();
     });
 

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -168,7 +168,7 @@ describe("SettingsShortcutCapture", () => {
     // already carries it as the one live signal, and a second accent tone
     // would compete with it.
     const instruction = screen.getByText(/Press second key or wait to finish/);
-    const combo = instruction.previousElementSibling;
+    const combo = instruction.previousSibling;
     expect(combo).not.toBeNull();
     expect(instruction.textContent).toMatch(/^\s/);
     expect(instruction.parentElement?.textContent).toBe(

--- a/src/components/Portal/PortalCloseConfirmDialog.tsx
+++ b/src/components/Portal/PortalCloseConfirmDialog.tsx
@@ -102,8 +102,8 @@ export function PortalCloseConfirmDialog(): ReactElement | null {
       <ul className="max-h-48 space-y-1 overflow-y-auto rounded border border-daintree-border bg-daintree-bg/50 p-2">
         {pending.tabsToClose.map((tab) => (
           <li key={tab.id} className="truncate text-xs">
-            <span className="text-daintree-text">{tab.title || "Untitled"}</span>
-            {tab.url ? <span className="text-daintree-text/40"> — {tab.url}</span> : null}
+            <span className="font-medium text-daintree-text">{tab.title || "Untitled"}</span>
+            {tab.url ? <span className="ml-1 text-text-secondary"> {tab.url}</span> : null}
           </li>
         ))}
       </ul>

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -732,12 +732,19 @@ export function GeneralTab({
               </p>
               <ul className="space-y-1 text-xs text-daintree-text/60">
                 <li className="flex items-center gap-2">
-                  <span className="font-mono text-daintree-text/80">.daintree/project.json</span>—
-                  project name, emoji, color
+                  <span className="font-mono font-medium text-daintree-text/85">
+                    .daintree/project.json
+                  </span>
+                  <span className="text-text-secondary"> project name, emoji, color</span>
                 </li>
                 <li className="flex items-center gap-2">
-                  <span className="font-mono text-daintree-text/80">.daintree/settings.json</span>—
-                  run commands, dev server, context settings
+                  <span className="font-mono font-medium text-daintree-text/85">
+                    .daintree/settings.json
+                  </span>
+                  <span className="text-text-secondary">
+                    {" "}
+                    run commands, dev server, context settings
+                  </span>
                 </li>
               </ul>
               <p className="mt-2 text-xs text-daintree-text/50">

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -66,7 +66,7 @@ const CONTINUITY_PRESENTATION: Record<
   },
   unverified: {
     icon: HelpCircle,
-    className: "text-daintree-text/50",
+    className: "text-text-secondary",
     label: "Resume after move unverified",
     detailFallback: "Resuming this conversation after a move isn't confirmed",
   },

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -459,10 +459,12 @@ function RelocationPreviewSection({
         <ul className="space-y-1 text-xs text-daintree-text/70">
           {preview.runningTerminalCount > 0 && (
             <li>
-              {preview.runningTerminalCount === 1
-                ? "1 terminal will be gracefully stopped"
-                : `${preview.runningTerminalCount} terminals will be gracefully stopped`}{" "}
-              <span className="text-daintree-text/40">— they restart at the new location</span>
+              <span className="font-medium text-daintree-text/85">
+                {preview.runningTerminalCount === 1
+                  ? "1 terminal will be gracefully stopped"
+                  : `${preview.runningTerminalCount} terminals will be gracefully stopped`}
+              </span>
+              <span className="ml-1 text-text-secondary"> They restart at the new location</span>
             </li>
           )}
           {preview.agentContinuity.length > 0 && (
@@ -489,11 +491,12 @@ function RelocationPreviewSection({
                       />
                       <div className="space-y-0.5">
                         <div>
-                          {agent.count === 1
-                            ? agent.agentName
-                            : `${agent.agentName} (${agent.count})`}{" "}
-                          <span className="text-daintree-text/40">—</span>{" "}
-                          <span className={p.className}>{p.label}</span>
+                          <span className="font-medium text-daintree-text/85">
+                            {agent.count === 1
+                              ? agent.agentName
+                              : `${agent.agentName} (${agent.count})`}
+                          </span>
+                          <span className={`ml-1 ${p.className}`}> {p.label}</span>
                         </div>
                         <div className="text-daintree-text/40">
                           {agent.detail ?? p.detailFallback}

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, waitFor, within } from "@testing-library/react";
 import type { RelocationPreview } from "@shared/types/projectRelocation";
 
 // ConfirmDialog's scroll-shadow hook observes its scroll container, which jsdom
@@ -185,6 +185,14 @@ describe("MoveOrRenameProjectDialog", () => {
     expect(screen.getByText("Expected to resume automatically at the new location")).toBeTruthy();
     // Count > 1 is surfaced next to the agent name.
     expect(screen.getByText(/Codex \(2\)/)).toBeTruthy();
+    // The tier colour is meaning rather than emphasis, so it stays on the status
+    // and weight is what keeps the agent apart from it once increased contrast
+    // flattens the colour step.
+    const claudeRow = screen.getByTestId("relocate-continuity-claude");
+    const identity = within(claudeRow).getByText("Claude Code");
+    const status = within(claudeRow).getByText("Provider migration required");
+    expect(identity).not.toBe(status);
+    expect(claudeRow.textContent).not.toContain("\u2014");
     // Continuity is informational — it must NOT disable confirm (only blockers do).
     await waitFor(() => expect(confirmButton().hasAttribute("aria-disabled")).toBe(false));
   });
@@ -221,8 +229,16 @@ describe("MoveOrRenameProjectDialog", () => {
     // No agents → no continuity section.
     expect(screen.queryByTestId("relocate-continuity")).toBeNull();
     // The terminal line describes restart, not conversation preservation.
-    expect(screen.getByText(/they restart at the new location/)).toBeTruthy();
+    expect(screen.getByText(/They restart at the new location/)).toBeTruthy();
     expect(screen.queryByText(/sessions are preserved and restored/)).toBeNull();
+
+    // The consequence outranks the reassurance by weight, not punctuation.
+    const consequence = screen.getByText("2 terminals will be gracefully stopped");
+    const reassurance = screen.getByText("They restart at the new location");
+    expect(consequence).not.toBe(reassurance);
+    expect(consequence.parentElement?.textContent).toBe(
+      "2 terminals will be gracefully stopped They restart at the new location"
+    );
   });
 
   it("reattach mode browses to an existing folder then reattaches", async () => {

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -185,14 +185,14 @@ describe("MoveOrRenameProjectDialog", () => {
     expect(screen.getByText("Expected to resume automatically at the new location")).toBeTruthy();
     // Count > 1 is surfaced next to the agent name.
     expect(screen.getByText(/Codex \(2\)/)).toBeTruthy();
-    // The tier colour is meaning rather than emphasis, so it stays on the status
-    // and weight is what keeps the agent apart from it once increased contrast
-    // flattens the colour step.
+    // The tier colour is meaning rather than emphasis, so it stays on the
+    // status and weight is what keeps the agent name apart from it when
+    // forced-colors repaints both to the same ink.
     const claudeRow = screen.getByTestId("relocate-continuity-claude");
     const identity = within(claudeRow).getByText("Claude Code");
     const status = within(claudeRow).getByText("Provider migration required");
-    expect(identity).not.toBe(status);
-    expect(claudeRow.textContent).not.toContain("\u2014");
+    expect(status.previousElementSibling).toBe(identity);
+    expect(status.textContent).toMatch(/^\s/);
     // Continuity is informational — it must NOT disable confirm (only blockers do).
     await waitFor(() => expect(confirmButton().hasAttribute("aria-disabled")).toBe(false));
   });
@@ -235,9 +235,10 @@ describe("MoveOrRenameProjectDialog", () => {
     // The consequence outranks the reassurance by weight, not punctuation.
     const consequence = screen.getByText("2 terminals will be gracefully stopped");
     const reassurance = screen.getByText("They restart at the new location");
-    expect(consequence).not.toBe(reassurance);
+    expect(reassurance.previousElementSibling).toBe(consequence);
+    expect(reassurance.textContent).toMatch(/^\s/);
     expect(consequence.parentElement?.textContent).toBe(
-      "2 terminals will be gracefully stopped They restart at the new location"
+      `${consequence.textContent}${reassurance.textContent}`
     );
   });
 

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -191,7 +191,7 @@ describe("MoveOrRenameProjectDialog", () => {
     const claudeRow = screen.getByTestId("relocate-continuity-claude");
     const identity = within(claudeRow).getByText("Claude Code");
     const status = within(claudeRow).getByText("Provider migration required");
-    expect(status.previousElementSibling).toBe(identity);
+    expect(status.previousSibling).toBe(identity);
     expect(status.textContent).toMatch(/^\s/);
     // Continuity is informational — it must NOT disable confirm (only blockers do).
     await waitFor(() => expect(confirmButton().hasAttribute("aria-disabled")).toBe(false));
@@ -235,7 +235,7 @@ describe("MoveOrRenameProjectDialog", () => {
     // The consequence outranks the reassurance by weight, not punctuation.
     const consequence = screen.getByText("2 terminals will be gracefully stopped");
     const reassurance = screen.getByText("They restart at the new location");
-    expect(reassurance.previousElementSibling).toBe(consequence);
+    expect(reassurance.previousSibling).toBe(consequence);
     expect(reassurance.textContent).toMatch(/^\s/);
     expect(consequence.parentElement?.textContent).toBe(
       `${consequence.textContent}${reassurance.textContent}`

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -316,8 +316,15 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                     <li key={`${e.line}-${e.raw}`}>
                       <span className="text-text-secondary">Line {e.line}:</span>{" "}
                       <span className="font-medium text-daintree-text">{e.reason}</span>
+                      {/* Weight ranks the reason above the line it came from,
+                          the same way the outcome rows above rank a kept value.
+                          The raw line drops to its own row rather than sitting
+                          inline: it is arbitrary pasted text, and reasons like
+                          `Invalid key "2BAD_KEY"` already end in a quoted piece
+                          of it, so inline it reads as a continuation of the
+                          reason with or without a separator. */}
                       {e.raw.trim() !== "" && (
-                        <span className="ml-1 text-text-secondary"> {e.raw}</span>
+                        <div className="pl-4 break-all text-text-secondary">{e.raw}</div>
                       )}
                     </li>
                   ))}

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -315,9 +315,9 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                   {parsed.errors.map((e) => (
                     <li key={`${e.line}-${e.raw}`}>
                       <span className="text-text-secondary">Line {e.line}:</span>{" "}
-                      <span className="text-daintree-text">{e.reason}</span>
+                      <span className="font-medium text-daintree-text">{e.reason}</span>
                       {e.raw.trim() !== "" && (
-                        <span className="text-text-secondary"> — {e.raw}</span>
+                        <span className="ml-1 text-text-secondary"> {e.raw}</span>
                       )}
                     </li>
                   ))}

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -430,11 +430,10 @@ export function ResourceEnvironmentsSection({
           </div>
           {/* Weight and colour rank the token above its description — an em dash
               between them read as one run of prose. Weight is also the half that
-              survives `prefers-contrast: more`, where `text-daintree-text/N` is
-              forced back to the solid token and the colour step disappears. The
-              literal space inside each detail span stays: adjacent inline spans
-              concatenate in the accessibility tree, and `ml-1` is what opens the
-              optical gap. */}
+              holds under `forced-colors: active`, which repaints every author
+              colour to the same system ink. The literal space inside each detail
+              span stays: adjacent inline spans concatenate in the accessibility
+              tree, and `ml-1` is what opens the optical gap. */}
           <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
             <div>
               <code className="font-medium text-daintree-text/85">{"{branch}"}</code>

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -426,7 +426,7 @@ export function ResourceEnvironmentsSection({
         <div className="col-span-2 mt-3 px-3 py-2 rounded-[var(--radius-md)] bg-surface-inset border border-border-default text-xs text-text-muted space-y-1">
           <div>
             <span className="font-medium text-daintree-text/70">Variables</span>{" "}
-            <span className="text-daintree-text/40">(replaced at runtime in all commands):</span>
+            <span className="text-text-secondary">(replaced at runtime in all commands):</span>
           </div>
           {/* Weight and colour rank the token above its description — an em dash
               between them read as one run of prose. Weight is also the half that

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -428,38 +428,45 @@ export function ResourceEnvironmentsSection({
             <span className="font-medium text-daintree-text/70">Variables</span>{" "}
             <span className="text-daintree-text/40">(replaced at runtime in all commands):</span>
           </div>
+          {/* Weight and colour rank the token above its description — an em dash
+              between them read as one run of prose. Weight is also the half that
+              survives `prefers-contrast: more`, where `text-daintree-text/N` is
+              forced back to the solid token and the colour step disappears. The
+              literal space inside each detail span stays: adjacent inline spans
+              concatenate in the accessibility tree, and `ml-1` is what opens the
+              optical gap. */}
           <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
             <div>
-              <code className="text-text-secondary">{"{branch}"}</code>
-              <span className="text-daintree-text/40"> — branch name</span>
+              <code className="font-medium text-daintree-text/85">{"{branch}"}</code>
+              <span className="ml-1 text-text-secondary"> branch name</span>
             </div>
             <div>
-              <code className="text-text-secondary">{"{branch-slug}"}</code>
-              <span className="text-daintree-text/40"> — sanitized branch</span>
+              <code className="font-medium text-daintree-text/85">{"{branch-slug}"}</code>
+              <span className="ml-1 text-text-secondary"> sanitized branch</span>
             </div>
             <div>
-              <code className="text-text-secondary">{"{repo-name}"}</code>
-              <span className="text-daintree-text/40"> — repository folder</span>
+              <code className="font-medium text-daintree-text/85">{"{repo-name}"}</code>
+              <span className="ml-1 text-text-secondary"> repository folder</span>
             </div>
             <div>
-              <code className="text-text-secondary">{"{base-folder}"}</code>
-              <span className="text-daintree-text/40"> — alias for repo-name</span>
+              <code className="font-medium text-daintree-text/85">{"{base-folder}"}</code>
+              <span className="ml-1 text-text-secondary"> alias for repo-name</span>
             </div>
             <div>
-              <code className="text-text-secondary">{"{parent-dir}"}</code>
-              <span className="text-daintree-text/40"> — parent directory</span>
+              <code className="font-medium text-daintree-text/85">{"{parent-dir}"}</code>
+              <span className="ml-1 text-text-secondary"> parent directory</span>
             </div>
             <div>
-              <code className="text-text-secondary">{"{worktree_name}"}</code>
-              <span className="text-daintree-text/40"> — worktree name</span>
+              <code className="font-medium text-daintree-text/85">{"{worktree_name}"}</code>
+              <span className="ml-1 text-text-secondary"> worktree name</span>
             </div>
             <div>
-              <code className="text-text-secondary">{"{worktree_path}"}</code>
-              <span className="text-daintree-text/40"> — full worktree path</span>
+              <code className="font-medium text-daintree-text/85">{"{worktree_path}"}</code>
+              <span className="ml-1 text-text-secondary"> full worktree path</span>
             </div>
             <div>
-              <code className="text-text-secondary">{"{project_root}"}</code>
-              <span className="text-daintree-text/40"> — project root path</span>
+              <code className="font-medium text-daintree-text/85">{"{project_root}"}</code>
+              <span className="ml-1 text-text-secondary"> project root path</span>
             </div>
           </div>
         </div>

--- a/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
+++ b/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
@@ -147,7 +147,7 @@ describe("ResourceEnvironmentsSection", () => {
     // announcing as "{branch}branch name".
     const token = screen.getByText("{branch}");
     const description = screen.getByText("branch name");
-    expect(description.previousElementSibling).toBe(token);
+    expect(description.previousSibling).toBe(token);
     expect(description.textContent).toMatch(/^\s/);
     expect(token.parentElement?.textContent).toBe(`${token.textContent}${description.textContent}`);
   });

--- a/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
+++ b/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
@@ -140,6 +140,14 @@ describe("ResourceEnvironmentsSection", () => {
     expect(screen.getByText(/replaced at runtime in all commands/i)).toBeTruthy();
     expect(screen.getByText("{branch}")).toBeTruthy();
     expect(screen.getByText("{worktree_name}")).toBeTruthy();
+
+    // Token and description are ranked by weight and colour, so they have to be
+    // separately styleable rather than one dash-joined run. The single space
+    // between them is what keeps them from announcing as "{branch}branch name".
+    const token = screen.getByText("{branch}");
+    const description = screen.getByText("branch name");
+    expect(token).not.toBe(description);
+    expect(token.parentElement?.textContent).toBe("{branch} branch name");
   });
 
   it("renders add environment button when no environments exist", () => {

--- a/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
+++ b/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
@@ -142,12 +142,14 @@ describe("ResourceEnvironmentsSection", () => {
     expect(screen.getByText("{worktree_name}")).toBeTruthy();
 
     // Token and description are ranked by weight and colour, so they have to be
-    // separately styleable rather than one dash-joined run. The single space
-    // between them is what keeps them from announcing as "{branch}branch name".
+    // separately styleable rather than one dash-joined run. Nothing may sit
+    // between them, and the detail keeps the leading space that stops the pair
+    // announcing as "{branch}branch name".
     const token = screen.getByText("{branch}");
     const description = screen.getByText("branch name");
-    expect(token).not.toBe(description);
-    expect(token.parentElement?.textContent).toBe("{branch} branch name");
+    expect(description.previousElementSibling).toBe(token);
+    expect(description.textContent).toMatch(/^\s/);
+    expect(token.parentElement?.textContent).toBe(`${token.textContent}${description.textContent}`);
   });
 
   it("renders add environment button when no environments exist", () => {

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -328,7 +328,9 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
           {runningAgentCount > 0 && (
             <span className="ml-1 text-text-secondary">
               {" "}
-              {runningAgentCount === 1 ? "1 running agent" : `${runningAgentCount} running agents`}
+              {terminalCounts.total === 1
+                ? "running an agent"
+                : `${runningAgentCount} of them running an agent`}
             </span>
           )}
         </>

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -314,17 +314,24 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       key: "terminals",
       tone: "neutral",
       content: (
-        <span>
-          <span>
+        <>
+          {/* Weight ranks the outcome above the detail that qualifies it, in
+              place of the em dash that read as one run of prose. It is also
+              the half that holds under `forced-colors: active`, where every
+              author colour resolves to the same ink. The danger row below is
+              still marked by its glyph and by carrying weight across the whole
+              row, so ranking a neutral row's first half does not blunt it.
+              Rows with no detail stay unweighted: there is no pair to rank. */}
+          <span className={cn(runningAgentCount > 0 && "font-medium")}>
             {terminalCounts.total} terminal{terminalCounts.total === 1 ? "" : "s"} will be closed
           </span>
           {runningAgentCount > 0 && (
             <span className="ml-1 text-text-secondary">
               {" "}
-              {runningAgentCount} running an agent{runningAgentCount === 1 ? "" : "s"}
+              {runningAgentCount === 1 ? "1 running agent" : `${runningAgentCount} running agents`}
             </span>
           )}
-        </span>
+        </>
       ),
     });
   }
@@ -351,12 +358,12 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       key: "branch",
       tone: "neutral",
       content: (
-        <span>
-          <span>
+        <>
+          <span className="font-medium">
             Branch <span className="font-mono break-all">{worktree.branch}</span> will be deleted
           </span>
           <span className="ml-1 text-text-secondary"> Fails if it has unmerged changes</span>
-        </span>
+        </>
       ),
     });
   }

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -313,11 +313,19 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     consequences.push({
       key: "terminals",
       tone: "neutral",
-      content: `${terminalCounts.total} terminal${terminalCounts.total === 1 ? "" : "s"} will be closed${
-        runningAgentCount > 0
-          ? ` — ${runningAgentCount} running an agent${runningAgentCount === 1 ? "" : "s"}`
-          : ""
-      }`,
+      content: (
+        <span>
+          <span>
+            {terminalCounts.total} terminal{terminalCounts.total === 1 ? "" : "s"} will be closed
+          </span>
+          {runningAgentCount > 0 && (
+            <span className="ml-1 text-text-secondary">
+              {" "}
+              {runningAgentCount} running an agent{runningAgentCount === 1 ? "" : "s"}
+            </span>
+          )}
+        </span>
+      ),
     });
   }
   if (hasDevPreview) {
@@ -343,11 +351,12 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       key: "branch",
       tone: "neutral",
       content: (
-        <>
-          Branch <span className="font-mono break-all">{worktree.branch}</span> will be deleted
-          {" — "}
-          <span className="text-daintree-text/60">fails if it has unmerged changes</span>
-        </>
+        <span>
+          <span>
+            Branch <span className="font-mono break-all">{worktree.branch}</span> will be deleted
+          </span>
+          <span className="ml-1 text-text-secondary"> Fails if it has unmerged changes</span>
+        </span>
       ),
     });
   }

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -386,8 +386,8 @@ describe("NewWorktreeDialog — existing branch mode", () => {
     // speaks it fine.
     const number = screen.getByText("#42");
     const title = screen.getByText("Test PR");
-    expect(number).not.toBe(title);
-    expect(number.parentElement?.textContent).toBe("PR #42 Test PR");
+    expect(title.previousElementSibling).toBe(number);
+    expect(title.textContent).toMatch(/^\s/);
   });
 
   it("shows existing branch picker when mode is toggled to existing", async () => {

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -380,6 +380,14 @@ describe("NewWorktreeDialog — existing branch mode", () => {
     await advanceTimersGradually(500);
 
     expect(screen.queryByRole("radio", { name: /existing branch/i })).toBeNull();
+
+    // The PR number and its title are ranked by weight and colour. Only the
+    // visible pair loses the dash — the tooltip keeps it, since a screen reader
+    // speaks it fine.
+    const number = screen.getByText("#42");
+    const title = screen.getByText("Test PR");
+    expect(number).not.toBe(title);
+    expect(number.parentElement?.textContent).toBe("PR #42 Test PR");
   });
 
   it("shows existing branch picker when mode is toggled to existing", async () => {

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -386,7 +386,7 @@ describe("NewWorktreeDialog — existing branch mode", () => {
     // speaks it fine.
     const number = screen.getByText("#42");
     const title = screen.getByText("Test PR");
-    expect(title.previousElementSibling).toBe(number);
+    expect(title.previousSibling).toBe(number);
     expect(title.textContent).toMatch(/^\s/);
   });
 

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -480,7 +480,12 @@ describe("WorktreeDeleteDialog — consequence list", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    expect(screen.getByText(/3 terminals will be closed — 2 running an agent/)).toBeDefined();
+    const closed = screen.getByText("3 terminals will be closed");
+    const agents = screen.getByText("2 running an agents");
+    expect(closed).not.toBe(agents);
+    expect(closed.parentElement?.textContent).toBe(
+      "3 terminals will be closed 2 running an agents"
+    );
   });
 
   it("omits the data-loss row unless force is on AND there is something to lose", () => {
@@ -548,7 +553,14 @@ describe("WorktreeDeleteDialog — consequence list", () => {
         .getAllByRole("listitem")
         .some((row) => (row.textContent ?? "").startsWith("Branch feature/test"))
     ).toBe(true);
-    expect(screen.getByText(/fails if it has unmerged changes/)).toBeDefined();
+    // The outcome and the guard that qualifies it are separate elements: the
+    // dash that used to join them read as one sentence, and weight is the half
+    // of the ranking that survives `prefers-contrast: more`.
+    const guard = screen.getByText(/Fails if it has unmerged changes/);
+    const outcome = guard.previousElementSibling;
+    expect(outcome).not.toBeNull();
+    expect(outcome).not.toBe(guard);
+    expect(outcome?.textContent).toBe("Branch feature/test will be deleted");
   });
 
   it("does not offer a branch row for a protected branch", () => {

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -480,12 +480,10 @@ describe("WorktreeDeleteDialog — consequence list", () => {
     const worktree = makeWorktree(makeChanges([]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
-    const closed = screen.getByText("3 terminals will be closed");
-    const agents = screen.getByText("2 running an agents");
-    expect(closed).not.toBe(agents);
-    expect(closed.parentElement?.textContent).toBe(
-      "3 terminals will be closed 2 running an agents"
-    );
+    const closed = screen.getByText(/terminals will be closed/);
+    const agents = screen.getByText(/running agents/);
+    expect(agents.previousElementSibling).toBe(closed);
+    expect(agents.textContent).toMatch(/^\s/);
   });
 
   it("omits the data-loss row unless force is on AND there is something to lose", () => {
@@ -553,14 +551,12 @@ describe("WorktreeDeleteDialog — consequence list", () => {
         .getAllByRole("listitem")
         .some((row) => (row.textContent ?? "").startsWith("Branch feature/test"))
     ).toBe(true);
-    // The outcome and the guard that qualifies it are separate elements: the
-    // dash that used to join them read as one sentence, and weight is the half
-    // of the ranking that survives `prefers-contrast: more`.
+    // The outcome and the guard that qualifies it are separate elements — the
+    // dash that used to join them read as one sentence.
     const guard = screen.getByText(/Fails if it has unmerged changes/);
     const outcome = guard.previousElementSibling;
-    expect(outcome).not.toBeNull();
-    expect(outcome).not.toBe(guard);
-    expect(outcome?.textContent).toBe("Branch feature/test will be deleted");
+    expect(outcome?.textContent).toMatch(/^Branch .+ will be deleted$/);
+    expect(guard.textContent).toMatch(/^\s/);
   });
 
   it("does not offer a branch row for a protected branch", () => {

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -482,7 +482,7 @@ describe("WorktreeDeleteDialog — consequence list", () => {
 
     const closed = screen.getByText(/terminals will be closed/);
     const agents = screen.getByText(/running agents/);
-    expect(agents.previousElementSibling).toBe(closed);
+    expect(agents.previousSibling).toBe(closed);
     expect(agents.textContent).toMatch(/^\s/);
   });
 
@@ -554,8 +554,8 @@ describe("WorktreeDeleteDialog — consequence list", () => {
     // The outcome and the guard that qualifies it are separate elements — the
     // dash that used to join them read as one sentence.
     const guard = screen.getByText(/Fails if it has unmerged changes/);
-    const outcome = guard.previousElementSibling;
-    expect(outcome?.textContent).toMatch(/^Branch .+ will be deleted$/);
+    const outcome = guard.previousSibling;
+    expect(outcome?.textContent).toContain(worktree.branch);
     expect(guard.textContent).toMatch(/^\s/);
   });
 

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -481,7 +481,7 @@ describe("WorktreeDeleteDialog — consequence list", () => {
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
     const closed = screen.getByText(/terminals will be closed/);
-    const agents = screen.getByText(/running agents/);
+    const agents = screen.getByText(/of them running an agent/);
     expect(agents.previousSibling).toBe(closed);
     expect(agents.textContent).toMatch(/^\s/);
   });

--- a/src/components/Worktree/views/PrHeader.tsx
+++ b/src/components/Worktree/views/PrHeader.tsx
@@ -12,7 +12,8 @@ export function PrHeader({ pr }: PrHeaderProps) {
       <FolderGit2 className="w-4 h-4 text-daintree-text/60 shrink-0" aria-hidden="true" />
       <TruncatedTooltip content={`PR #${pr.number} — ${pr.title}`}>
         <span className="text-daintree-text/80 min-w-0 truncate">
-          PR <span className="font-medium text-daintree-text">#{pr.number}</span> — {pr.title}
+          PR <span className="font-medium text-daintree-text">#{pr.number}</span>
+          <span className="ml-1 text-text-secondary"> {pr.title}</span>
         </span>
       </TruncatedTooltip>
     </div>

--- a/src/components/Worktree/views/PrHeader.tsx
+++ b/src/components/Worktree/views/PrHeader.tsx
@@ -13,7 +13,7 @@ export function PrHeader({ pr }: PrHeaderProps) {
       <TruncatedTooltip content={`PR #${pr.number} — ${pr.title}`}>
         <span className="text-daintree-text/80 min-w-0 truncate">
           PR <span className="font-medium text-daintree-text">#{pr.number}</span>
-          <span className="ml-1 text-text-secondary"> {pr.title}</span>
+          <span className="ml-1"> {pr.title}</span>
         </span>
       </TruncatedTooltip>
     </div>


### PR DESCRIPTION
## Summary

- An em dash was separating a label from its subordinate detail in several places that paint to screen, so the pair read as one run-on sentence instead of two ranked pieces of information. `Only generated files changed — Check whether source changes are missing` scans as a malformed sentence, not a label plus a detail.
- This was flagged during the design review in #11983, where `ReadinessRail` switched from an em dash to font weight plus color to separate label from detail. This PR applies that same pattern to every remaining site named in #12004.
- The pattern: a full weight or `font-medium` label, a single space, then the detail on the audited `text-text-secondary` token, with `ml-1` for the optical gap. The space inside the detail span is deliberate. Adjacent inline spans concatenate in the accessibility tree, so dropping it would glue the words together for a screen reader.

Resolves #12004

## Changes

Sites converted to the weight/color pattern: `ResourceEnvironmentsSection` (8 variable rows), `PortalCloseConfirmDialog`, `MoveOrRenameProjectDialog` (the terminal-restart line and the agent-continuity row), `SettingsShortcutCapture`, `GeneralTab` (2 sites), `ImportEnvDialog`, `PrHeader`, `WorktreeDeleteDialog` (2 sites).

A few sites needed more than a mechanical swap:

- `SettingsShortcutCapture`'s instruction text was on `text-daintree-accent/70`. Accent now stays on the captured combo alone. The recording box already carries accent as its one live signal, and a second accent tone on the instruction text was secondary emphasis, which the accent-restraint rule reserves against.
- `MoveOrRenameProjectDialog`'s continuity row keeps its per-tier status color, since that's meaning rather than emphasis. Weight is what now holds the agent name apart from its status. The `unverified` tier moved off `text-daintree-text/50`, which measured under the text contrast floor and was coloring its icon through an alpha modifier.
- `WorktreeDeleteDialog`'s consequence rows only pick up extra weight where there's actually a detail to rank against a label. The danger row stays marked by its glyph and by carrying weight across the whole row.
- `ImportEnvDialog`'s raw pasted line moved to its own indented row. It's arbitrary user text, and error reasons like `Invalid key "2BAD_KEY"` already end in a quoted piece of it, so inline it read as a continuation of the reason with or without a separator.

Deliberately left alone, per the issue: the two native `<option>` sites (`GitInitDialog`, `CodeForgeTab`), where a dash is the only separator available; all tooltip and `aria-label` strings, including `PrHeader`'s own tooltip, since a dash reads fine spoken aloud; prose sentences where the dash is real punctuation; and the standalone `—` used as an empty-value placeholder glyph.

Two sites named in the issue turned out to already be fixed and weren't touched here: `PluginCapabilityConfirmDialog` (its `CapabilityRow` already stacks label and description) and `ReviewHubContent`'s conflict banner (now an `InlineStatusBanner` with separate `title`/`description` props).

Side effect worth flagging: the `text-text-secondary` token moves here also settle the overlapping sites from #12003 (meaningful text sitting on `text-daintree-text/40`, measuring around 3.2:1). That issue can be narrowed once this lands, though it's staying open since it names sites outside this change.

Copy note: detail text that reads as sentence-like without the dash moved to sentence case ("They restart at the new location", "Press second key or wait to finish", "Fails if it has unmerged changes"), matching the clause-fragment convention already used in `reviewReadiness.ts`. Detail text that's a noun phrase stays lowercase. Also fixed "2 running an agents" in the delete dialog, a typo the new markup would otherwise have set in place permanently.

## Testing

289 tests pass across the 14 suites covering every changed module. New assertions pin that each label/detail pair renders as two separate elements with nothing between them and that the detail's leading space survives, checked via `previousSibling` so a reintroduced dash fails the test instead of slipping through. Format is clean and lint is 0 errors on the branch's files.
