### PR TITLE
fix(a11y): move meaningful text off the text-daintree-text/40 ramp

### DIFF
--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/hooks/useActionPalette";
 
 const SECTION_HEADER_CLASS =
-  "px-3 py-1 text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none";
+  "px-3 py-1 text-[10px] font-medium tracking-wider uppercase text-text-secondary select-none";
 
 // Module-level so SearchablePalette receives a stable reference and skips
 // re-renders driven only by a freshly-created callback identity.
@@ -74,7 +74,7 @@ function PrefixDiscoverabilityRow() {
       className="@max-[420px]/palette-footer:hidden flex items-center gap-x-3 gap-y-1 flex-wrap text-[11px] text-daintree-text/45"
       aria-label="Prefix shortcuts"
     >
-      <span className="text-daintree-text/40">Type</span>
+      <span className="text-text-secondary">Type</span>
       {Object.entries(PREFIX_MAP).map(([prefix, route]) => (
         <span key={prefix} className="inline-flex items-baseline">
           <kbd className={KBD_CLASS}>{prefix}</kbd>

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -74,7 +74,7 @@ function PrefixDiscoverabilityRow() {
       className="@max-[420px]/palette-footer:hidden flex items-center gap-x-3 gap-y-1 flex-wrap text-[11px] text-daintree-text/45"
       aria-label="Prefix shortcuts"
     >
-      <span className="text-text-secondary">Type</span>
+      <span className="text-daintree-text/40">Type</span>
       {Object.entries(PREFIX_MAP).map(([prefix, route]) => (
         <span key={prefix} className="inline-flex items-baseline">
           <kbd className={KBD_CLASS}>{prefix}</kbd>

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -587,7 +587,7 @@ export function BrowserToolbar({
                 <span className="text-xs text-daintree-text truncate">
                   {entry.title || entry.url}
                 </span>
-                <span className="text-[11px] text-daintree-text/40 truncate">{entry.url}</span>
+                <span className="text-[11px] text-text-secondary truncate">{entry.url}</span>
               </button>
             ))}
           </div>
@@ -633,7 +633,7 @@ export function BrowserToolbar({
                 <span className="text-xs text-daintree-text truncate">
                   {entry.title || entry.url}
                 </span>
-                <span className="text-[11px] text-daintree-text/40 truncate">{entry.url}</span>
+                <span className="text-[11px] text-text-secondary truncate">{entry.url}</span>
               </button>
             ))}
           </div>

--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -172,7 +172,7 @@ export function CommandPicker({
             {category && (
               <div
                 className={cn(
-                  "px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-daintree-text/40",
+                  "px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-text-secondary",
                   index > 0 && "mt-2"
                 )}
               >
@@ -224,7 +224,7 @@ export function CommandPicker({
       itemIdPrefix="command"
       emptyMessage="No commands available"
       emptyContent={
-        <p className="mt-2 text-xs text-daintree-text/40">
+        <p className="mt-2 text-xs text-text-secondary">
           Commands are context-dependent and may vary by project.
         </p>
       }

--- a/src/components/DevPreview/DevPreviewDestructiveConfirmDialog.tsx
+++ b/src/components/DevPreview/DevPreviewDestructiveConfirmDialog.tsx
@@ -215,7 +215,7 @@ function CacheDirsPreview({ meta, sizes, sizesPending }: CacheDirsPreviewProps) 
                   </span>
                   {dir.exists ? (
                     <>
-                      <span className="text-[10px] text-daintree-text/40 shrink-0">
+                      <span className="text-[10px] text-text-secondary shrink-0">
                         {dir.mtimeMs ? formatRelativeTime(dir.mtimeMs) : null}
                       </span>
                       <span className="ml-auto tabular-nums text-daintree-text/60 shrink-0">

--- a/src/components/DevPreview/DevPreviewEmptyStates.tsx
+++ b/src/components/DevPreview/DevPreviewEmptyStates.tsx
@@ -167,7 +167,7 @@ export function DevPreviewEmptyStates({
                   We found a script in your package.json that looks like a dev server.
                 </p>
                 <div className="mb-3 px-3 py-1.5 rounded bg-overlay-subtle border border-overlay/30 inline-flex items-center gap-2">
-                  <span className="text-[11px] text-daintree-text/40">Auto-detected</span>
+                  <span className="text-[11px] text-text-secondary">Auto-detected</span>
                   <code className="text-xs text-daintree-text/70 font-mono">
                     {primaryCandidate.command}
                   </code>
@@ -230,7 +230,7 @@ export function DevPreviewEmptyStates({
                               <code className="text-daintree-text/70 font-mono text-[11px] flex-1 truncate">
                                 {c.command}
                               </code>
-                              <span className="text-daintree-text/40 shrink-0">{c.name}</span>
+                              <span className="text-text-secondary shrink-0">{c.name}</span>
                             </button>
                           ))}
                         </div>

--- a/src/components/DevPreview/DevPreviewEmptyStates.tsx
+++ b/src/components/DevPreview/DevPreviewEmptyStates.tsx
@@ -167,7 +167,7 @@ export function DevPreviewEmptyStates({
                   We found a script in your package.json that looks like a dev server.
                 </p>
                 <div className="mb-3 px-3 py-1.5 rounded bg-overlay-subtle border border-overlay/30 inline-flex items-center gap-2">
-                  <span className="text-[11px] text-text-secondary">Auto-detected</span>
+                  <span className="text-[11px] text-daintree-text/40">Auto-detected</span>
                   <code className="text-xs text-daintree-text/70 font-mono">
                     {primaryCandidate.command}
                   </code>

--- a/src/components/DevPreview/DiagnosticsPanel.tsx
+++ b/src/components/DevPreview/DiagnosticsPanel.tsx
@@ -282,7 +282,7 @@ export function DiagnosticsPanel({ paneId, projectId, status }: DiagnosticsPanel
                       key={event.seq}
                       className="grid grid-cols-[auto_auto_minmax(0,1fr)] items-baseline gap-x-2 rounded px-2 py-0.5 hover:bg-overlay-subtle"
                     >
-                      <span className="font-mono tabular-nums text-daintree-text/40">
+                      <span className="font-mono tabular-nums text-text-secondary">
                         {formatTime(event.at)}
                       </span>
                       <span

--- a/src/components/DevPreview/ObjectInspector.tsx
+++ b/src/components/DevPreview/ObjectInspector.tsx
@@ -150,7 +150,7 @@ export function ObjectInspector({
           isExpanded ? "text-daintree-text/90" : "text-daintree-text/70"
         )}
       >
-        <span className="text-text-secondary mr-0.5 select-none">
+        <span className="text-daintree-text/40 mr-0.5 select-none">
           {isLoading ? "⏳" : isExpanded ? "▼" : "▶"}
         </span>
         {displayText}

--- a/src/components/DevPreview/ObjectInspector.tsx
+++ b/src/components/DevPreview/ObjectInspector.tsx
@@ -20,9 +20,9 @@ function PrimitiveValue({ arg }: { arg: CdpRemoteArg & { type: "primitive" } }) 
     case "boolean":
       return <span className="text-category-purple">{String(arg.value)}</span>;
     case "null":
-      return <span className="text-daintree-text/40">null</span>;
+      return <span className="text-text-secondary">null</span>;
     case "undefined":
-      return <span className="text-daintree-text/40">undefined</span>;
+      return <span className="text-text-secondary">undefined</span>;
     case "symbol":
       return <span className="text-syntax-keyword">{String(arg.value)}</span>;
     case "bigint":
@@ -51,7 +51,7 @@ function PropertyTree({
       {visibleProps.map((prop) => (
         <div key={prop.name} className="flex items-start gap-1">
           <span className="text-text-secondary shrink-0">{prop.name}</span>
-          <span className="text-daintree-text/40 shrink-0">:</span>
+          <span className="text-text-secondary shrink-0">:</span>
           {prop.value ? (
             <ObjectInspector
               arg={prop.value}
@@ -60,7 +60,7 @@ function PropertyTree({
               depth={depth + 1}
             />
           ) : (
-            <span className="text-daintree-text/40">undefined</span>
+            <span className="text-text-secondary">undefined</span>
           )}
         </div>
       ))}
@@ -150,7 +150,7 @@ export function ObjectInspector({
           isExpanded ? "text-daintree-text/90" : "text-daintree-text/70"
         )}
       >
-        <span className="text-daintree-text/40 mr-0.5 select-none">
+        <span className="text-text-secondary mr-0.5 select-none">
           {isLoading ? "⏳" : isExpanded ? "▼" : "▶"}
         </span>
         {displayText}

--- a/src/components/DevPreview/StackTrace.tsx
+++ b/src/components/DevPreview/StackTrace.tsx
@@ -23,7 +23,7 @@ export function StackTrace({ stackTrace }: StackTraceProps) {
       {isExpanded && (
         <div className="pl-3 border-l border-tint/10 mt-0.5 select-text">
           {stackTrace.callFrames.map((frame, i) => (
-            <div key={i} className="text-text-secondary text-[10px] leading-relaxed">
+            <div key={i} className="text-daintree-text/40 text-[10px] leading-relaxed">
               <span className="text-daintree-text/50">{frame.functionName || "(anonymous)"}</span>
               {frame.url && (
                 <span>

--- a/src/components/DevPreview/StackTrace.tsx
+++ b/src/components/DevPreview/StackTrace.tsx
@@ -23,7 +23,7 @@ export function StackTrace({ stackTrace }: StackTraceProps) {
       {isExpanded && (
         <div className="pl-3 border-l border-tint/10 mt-0.5 select-text">
           {stackTrace.callFrames.map((frame, i) => (
-            <div key={i} className="text-daintree-text/40 text-[10px] leading-relaxed">
+            <div key={i} className="text-text-secondary text-[10px] leading-relaxed">
               <span className="text-daintree-text/50">{frame.functionName || "(anonymous)"}</span>
               {frame.url && (
                 <span>

--- a/src/components/Diagnostics/WhySlowContent.tsx
+++ b/src/components/Diagnostics/WhySlowContent.tsx
@@ -234,7 +234,7 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
             ) : (
               <span
                 data-testid="why-slow-updated-note"
-                className="text-[10px] text-daintree-text/40 tabular-nums"
+                className="text-[10px] text-text-secondary tabular-nums"
               >
                 Updated {formatSnapshotAge(snapshotAgeMs)}
               </span>

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -197,7 +197,7 @@ export function DiffFileSidebar({
         )}
         {groups.map((group) => (
           <div key={group.dir || "(root)"} className="mb-1.5">
-            <div className="flex items-center gap-1.5 px-1.5 py-1 text-[11px] text-daintree-text/40">
+            <div className="flex items-center gap-1.5 px-1.5 py-1 text-[11px] text-text-secondary">
               <Folder className="h-3 w-3 shrink-0" />
               <span className="truncate font-mono">{formatDir(group.dir)}</span>
             </div>

--- a/src/components/FileViewer/diffChangeSet.ts
+++ b/src/components/FileViewer/diffChangeSet.ts
@@ -13,7 +13,7 @@ export const DIFF_STATUS_CONFIG: Record<GitStatus, { label: string; color: strin
   untracked: { label: "?", color: "text-status-success" },
   renamed: { label: "R", color: "text-status-info" },
   copied: { label: "C", color: "text-status-info" },
-  ignored: { label: "I", color: "text-daintree-text/40" },
+  ignored: { label: "I", color: "text-text-secondary" },
   conflicted: { label: "!", color: "text-status-error" },
 };
 

--- a/src/components/Fleet/FleetCountChip.tsx
+++ b/src/components/Fleet/FleetCountChip.tsx
@@ -183,7 +183,7 @@ export function FleetCountChip({
             {scope.worktreeCount > 1 ? ` · ${scope.worktreeCount} worktrees` : ""}
           </span>
           {scope.exitedCount > 0 ? (
-            <span className="text-daintree-text/40 tabular-nums" data-testid="fleet-exited-count">
+            <span className="text-text-secondary tabular-nums" data-testid="fleet-exited-count">
               · {scope.exitedCount} exited
             </span>
           ) : null}

--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -242,7 +242,7 @@ function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement 
       {!excluded && (
         <div className="mt-1 border-t border-border-subtle pt-0.5">
           <div className="flex items-start gap-1.5">
-            <span className="text-[9px] uppercase tracking-wide text-daintree-text/40 mt-px shrink-0">
+            <span className="text-[9px] uppercase tracking-wide text-text-secondary mt-px shrink-0">
               {isOverridden ? "edited" : "resolved"}
             </span>
             <textarea

--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -436,7 +436,7 @@ function SnippetLine({
   const after = line.slice(end);
   return (
     <p
-      className="font-mono text-[11px] text-daintree-text/40 truncate mt-0.5"
+      className="font-mono text-[11px] text-text-secondary truncate mt-0.5"
       data-testid={`${testIdPrefix}-snippet`}
     >
       {before}

--- a/src/components/Fleet/__tests__/renderPaneStateBadge.test.tsx
+++ b/src/components/Fleet/__tests__/renderPaneStateBadge.test.tsx
@@ -41,6 +41,23 @@ describe("renderPaneStateBadge", () => {
     expect(working.className).not.toContain("text-state-waiting");
   });
 
+  // The exited badge reads at the same text contrast as the live states, so the
+  // "dead pane recedes" signal rides the chip fill instead. Pinned as a relation
+  // between the states rather than against whichever fill class is in use.
+  it("drops the chip fill on exited panes while live states keep it", () => {
+    renderBadge("x", "exited");
+    renderBadge("w", "waiting", "question");
+    renderBadge("k", "working");
+    const fill = (id: string) =>
+      screen
+        .getByTestId(id)
+        .className.split(/\s+/)
+        .filter((c) => c.startsWith("bg-"))
+        .join(" ");
+    expect(fill("fleet-pane-state-w-waiting")).toBe(fill("fleet-pane-state-k-working"));
+    expect(fill("fleet-pane-state-x-exited")).not.toBe(fill("fleet-pane-state-w-waiting"));
+  });
+
   it("ignores a stale waiting reason on non-waiting states", () => {
     renderBadge("p2", "working", "approval");
     const badge = screen.getByTestId("fleet-pane-state-p2-working");

--- a/src/components/Fleet/renderPaneStateBadge.tsx
+++ b/src/components/Fleet/renderPaneStateBadge.tsx
@@ -24,7 +24,7 @@ export function renderPaneStateBadge(
   const reason = state === "waiting" ? actionableWaitingReason(waitingReason) : null;
   const tone =
     state === "exited"
-      ? "text-daintree-text/40"
+      ? "text-text-secondary"
       : state === "waiting"
         ? "text-state-waiting"
         : "text-daintree-text/70";

--- a/src/components/Fleet/renderPaneStateBadge.tsx
+++ b/src/components/Fleet/renderPaneStateBadge.tsx
@@ -22,9 +22,12 @@ export function renderPaneStateBadge(
   // waiting state color and name the classified reason when the classifier
   // had real evidence. The `prompt` fallback keeps the generic "Waiting".
   const reason = state === "waiting" ? actionableWaitingReason(waitingReason) : null;
+  // Exited keeps a readable text tone, so the "dead pane recedes" signal moves
+  // off contrast onto the chip surface: exited drops the fill the live states carry.
+  // The `outline` tone washes every chip, so exited clears it back to the hairline.
   const tone =
     state === "exited"
-      ? "text-text-secondary"
+      ? "bg-transparent text-text-secondary"
       : state === "waiting"
         ? "text-state-waiting"
         : "text-daintree-text/70";

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1535,7 +1535,7 @@ export function HelpPanel({
           edge. Raw args, the elapsed ticker, and the marketing link live in
           the popover / hover titles / header docs button now. */}
       {showTerminal && agentConfig && !isMissingCli && (
-        <div className="flex items-center justify-between gap-3 border-t border-daintree-border shrink-0 px-3 py-1.5 text-[11px] text-daintree-text/40">
+        <div className="flex items-center justify-between gap-3 border-t border-daintree-border shrink-0 px-3 py-1.5 text-[11px] text-text-secondary">
           <span className="flex items-center gap-2 min-w-0">
             <McpActivityStrip sessionId={sessionId} activity={session.mcpActivity} />
             <TurnOutcomePip outcome={session.outcomeAlert} onDismiss={dismissOutcomeAlert} />

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -94,7 +94,7 @@ export function RecentCallsPopover({ records, loading, error }: RecentCallsPopov
             {groups.map((group, index) => (
               <li key={group.turnId ?? `unassociated-${index}`} className="py-1">
                 {group.turnId === null && (
-                  <div className="px-2 pb-0.5 text-[10px] text-daintree-text/40">
+                  <div className="px-2 pb-0.5 text-[10px] text-text-secondary">
                     Not tied to a turn
                   </div>
                 )}
@@ -145,7 +145,7 @@ function RecentCallRow({ record }: { record: McpAuditRecord }) {
         <span className="min-w-0 font-mono text-daintree-text/80 truncate">{record.toolId}</span>
         {/* Recency, not duration — calls are almost always sub-100ms, so
             "when did this run" is the metric worth a column. */}
-        <span className="text-daintree-text/40 whitespace-nowrap tabular-nums">
+        <span className="text-text-secondary whitespace-nowrap tabular-nums">
           {formatTimeAgo(record.timestamp)}
         </span>
       </button>
@@ -165,14 +165,14 @@ function RecentCallRow({ record }: { record: McpAuditRecord }) {
           </div>
           {hasArgs && (
             <div>
-              <div className="text-daintree-text/40">Arguments</div>
+              <div className="text-text-secondary">Arguments</div>
               <pre className="mt-0.5 max-h-32 overflow-y-auto whitespace-pre-wrap break-all font-mono text-daintree-text/70">
                 {record.argsSummary}
               </pre>
             </div>
           )}
           <div>
-            <div className="text-daintree-text/40">Result</div>
+            <div className="text-text-secondary">Result</div>
             {record.result === "rate_limited" && record.resultMeta?.retryAfter !== undefined ? (
               <p className="mt-0.5 text-daintree-text/45">
                 Retry in {record.resultMeta.retryAfter}s

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -165,14 +165,14 @@ function RecentCallRow({ record }: { record: McpAuditRecord }) {
           </div>
           {hasArgs && (
             <div>
-              <div className="text-text-secondary">Arguments</div>
+              <div className="text-daintree-text/40">Arguments</div>
               <pre className="mt-0.5 max-h-32 overflow-y-auto whitespace-pre-wrap break-all font-mono text-daintree-text/70">
                 {record.argsSummary}
               </pre>
             </div>
           )}
           <div>
-            <div className="text-text-secondary">Result</div>
+            <div className="text-daintree-text/40">Result</div>
             {record.result === "rate_limited" && record.resultMeta?.retryAfter !== undefined ? (
               <p className="mt-0.5 text-daintree-text/45">
                 Retry in {record.resultMeta.retryAfter}s

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -605,7 +605,7 @@ function BackgroundGroupItem({
 
         <button
           type="button"
-          className="text-[10px] text-daintree-text/40 shrink-0 hover:text-daintree-text transition-colors"
+          className="text-[10px] text-text-secondary shrink-0 hover:text-daintree-text transition-colors"
           onClick={() => onRestoreGroup(groupRestoreId, groupMetadata)}
         >
           Restore all

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -452,7 +452,7 @@ function BackgroundSingleItem({
           {terminal.lastStateChange != null && (
             <LiveTimeAgo
               timestamp={terminal.lastStateChange}
-              className="text-[10px] text-daintree-text/40 shrink-0"
+              className="text-[10px] text-text-secondary shrink-0"
             />
           )}
         </div>

--- a/src/components/Layout/ChordIndicator.tsx
+++ b/src/components/Layout/ChordIndicator.tsx
@@ -204,7 +204,7 @@ export function ChordIndicator() {
           className="border-t border-[var(--border-overlay)] px-2 py-2 max-h-[22rem] overflow-y-auto"
         >
           {results.length === 0 ? (
-            <div className="px-2 py-3 text-xs text-daintree-text/40">No commands match</div>
+            <div className="px-2 py-3 text-xs text-text-secondary">No commands match</div>
           ) : (
             groups.map((group, groupIdx) => (
               <div key={group.category}>
@@ -249,7 +249,7 @@ export function ChordIndicator() {
           )}
         </div>
 
-        <div className="flex items-center gap-2 border-t border-[var(--border-overlay)] px-4 py-1.5 text-[11px] text-daintree-text/40 select-none">
+        <div className="flex items-center gap-2 border-t border-[var(--border-overlay)] px-4 py-1.5 text-[11px] text-text-secondary select-none">
           <span>↑↓ select</span>
           <span aria-hidden className="text-daintree-text/20">
             ·

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -649,7 +649,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
               </span>
 
               {/* Tab count indicator */}
-              <span className="text-[10px] text-daintree-text/40 tabular-nums shrink-0">
+              <span className="text-[10px] text-text-secondary tabular-nums shrink-0">
                 ({panels.length})
               </span>
 

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -102,7 +102,7 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
             "text-[11px] tabular-nums transition-opacity",
             seconds <= COUNTDOWN_CRITICAL_SECONDS
               ? "opacity-100 text-status-warning/70"
-              : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+              : "text-text-secondary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
           )}
           aria-hidden="true"
         >

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -311,7 +311,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
                   Empty trash
                 </Button>
               ) : (
-                <span className="text-[11px] text-daintree-text/40">Auto-clears</span>
+                <span className="text-[11px] text-text-secondary">Auto-clears</span>
               )}
             </div>
 

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -143,7 +143,7 @@ export function TrashGroupItem({
               "text-[11px] tabular-nums transition-opacity",
               seconds <= COUNTDOWN_CRITICAL_SECONDS
                 ? "opacity-100 text-status-warning/70"
-                : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                : "text-text-secondary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
             )}
             aria-hidden="true"
           >
@@ -230,7 +230,7 @@ export function TrashGroupItem({
                     className={`truncate flex-1 ${isActiveTab ? "text-daintree-text/70 font-medium" : "text-daintree-text/50"}`}
                   >
                     {terminalName}
-                    {isActiveTab && <span className="ml-1 text-daintree-text/40">(active)</span>}
+                    {isActiveTab && <span className="ml-1 text-text-secondary">(active)</span>}
                   </span>
                   <div className="flex gap-0.5 opacity-0 group-hover/panel:opacity-100 transition-opacity">
                     <Tooltip>

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -376,7 +376,7 @@ function WaitingSingleItem({
               <span className="text-daintree-text/30">·</span>
             )}
             {terminal.activityHeadline && (
-              <span className="truncate italic text-daintree-text/40">
+              <span className="truncate italic text-text-secondary">
                 {terminal.activityHeadline}
               </span>
             )}
@@ -402,7 +402,7 @@ function WaitingSingleItem({
         <LiveTimeAgo
           timestamp={terminal.lastStateChange}
           noTooltip
-          className="text-[10px] text-daintree-text/40 shrink-0"
+          className="text-[10px] text-text-secondary shrink-0"
         />
       )}
 

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1512,7 +1512,7 @@ function ContextSectionHeader({
             Mark read
           </button>
         )}
-        <span aria-hidden="true" className="text-daintree-text/40 tabular-nums">
+        <span aria-hidden="true" className="text-text-secondary tabular-nums">
           {count}
         </span>
       </div>

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1512,7 +1512,7 @@ function ContextSectionHeader({
             Mark read
           </button>
         )}
-        <span aria-hidden="true" className="text-text-secondary tabular-nums">
+        <span aria-hidden="true" className="text-daintree-text/40 tabular-nums">
           {count}
         </span>
       </div>

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -381,7 +381,7 @@ export function NotificationCenterEntry({
                 data-testid="notification-timestamp"
                 title={ts.absolute}
                 aria-label={ts.absolute}
-                // A solid token, not `text-daintree-text/40`: slash-alpha
+                // A solid token, not `text-text-secondary`: slash-alpha
                 // composites against whatever is behind it and read at ~3.2:1
                 // here. `theme-tokens.md` gates `text-secondary` at >=3:1 across
                 // every theme and prefers a solid token for exactly this.

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -369,7 +369,7 @@ export function NotificationCenterEntry({
               {/* The clock means "snoozed until later"; the stamp beside it means
                   "arrived at". Abutting they read as one fact, so they get a
                   separator. */}
-              <span aria-hidden="true" className="text-[10px] leading-none text-text-secondary">
+              <span aria-hidden="true" className="text-[10px] leading-none text-daintree-text/40">
                 ·
               </span>
             </>
@@ -381,7 +381,7 @@ export function NotificationCenterEntry({
                 data-testid="notification-timestamp"
                 title={ts.absolute}
                 aria-label={ts.absolute}
-                // A solid token, not `text-text-secondary`: slash-alpha
+                // A solid token, not `text-daintree-text/40`: slash-alpha
                 // composites against whatever is behind it and read at ~3.2:1
                 // here. `theme-tokens.md` gates `text-secondary` at >=3:1 across
                 // every theme and prefers a solid token for exactly this.

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -944,7 +944,7 @@ function PanelHeaderComponent({
       {/* Centered Zen Mode indicator (only visible when maximized) */}
       {isMaximized && activeCount > 0 && (
         <div
-          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-3 text-daintree-text/40 select-none pointer-events-none"
+          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-3 text-text-secondary select-none pointer-events-none"
           role="status"
           aria-live="polite"
         >

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -149,9 +149,7 @@ export function PanelPalette({
           )}
         </div>
         {badgeLabel && (
-          <span className="shrink-0 text-[10px] font-medium text-daintree-text/40">
-            {badgeLabel}
-          </span>
+          <span className="shrink-0 text-[10px] font-medium text-text-secondary">{badgeLabel}</span>
         )}
       </button>
     );

--- a/src/components/Plugin/PluginArchiveInstallConfirmDialog.tsx
+++ b/src/components/Plugin/PluginArchiveInstallConfirmDialog.tsx
@@ -235,10 +235,10 @@ function ArchiveRecipes({ recipes }: { recipes: { count: number; names: string[]
   if (recipes.count === 0) return null;
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
         Recipes
       </h4>
-      <p className="text-xs text-daintree-text/40">
+      <p className="text-xs text-text-secondary">
         Adds {recipes.count} launch {recipes.count === 1 ? "recipe" : "recipes"}, available in every
         project. Each starts terminals that run commands or agents.
       </p>
@@ -291,11 +291,11 @@ function ArchivePermissions({ capabilities }: { capabilities: readonly string[] 
 
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
         Permissions
       </h4>
       {granted.length === 0 ? (
-        <p className="text-xs text-daintree-text/40">No special permissions</p>
+        <p className="text-xs text-text-secondary">No special permissions</p>
       ) : (
         <>
           {worst === "danger" && (

--- a/src/components/Plugin/PluginCatalog.tsx
+++ b/src/components/Plugin/PluginCatalog.tsx
@@ -87,7 +87,7 @@ export function PluginCatalog({
             <div className="flex items-center gap-2">
               <CategoryIcon className="w-4 h-4 text-daintree-text/50" aria-hidden="true" />
               <h4 className="text-sm font-medium text-daintree-text">{category.label}</h4>
-              <span className="text-[11px] text-text-secondary">{sectionPlugins.length}</span>
+              <span className="text-[11px] text-daintree-text/40">{sectionPlugins.length}</span>
             </div>
             <p className="text-xs text-daintree-text/45 mt-0.5">{category.blurb}</p>
             <div className="mt-3 grid gap-3 grid-cols-[repeat(auto-fill,minmax(260px,1fr))]">

--- a/src/components/Plugin/PluginCatalog.tsx
+++ b/src/components/Plugin/PluginCatalog.tsx
@@ -32,7 +32,7 @@ function PluginCard({ plugin, onSelect }: { plugin: LoadedPluginInfo; onSelect: 
           >
             {pluginLabel(plugin)}
           </span>
-          <span className="text-[11px] font-normal text-daintree-text/40">
+          <span className="text-[11px] font-normal text-text-secondary">
             v{plugin.manifest.version}
           </span>
           {disabled && <span className={CARD_BADGE_CLASS}>Disabled</span>}
@@ -87,7 +87,7 @@ export function PluginCatalog({
             <div className="flex items-center gap-2">
               <CategoryIcon className="w-4 h-4 text-daintree-text/50" aria-hidden="true" />
               <h4 className="text-sm font-medium text-daintree-text">{category.label}</h4>
-              <span className="text-[11px] text-daintree-text/40">{sectionPlugins.length}</span>
+              <span className="text-[11px] text-text-secondary">{sectionPlugins.length}</span>
             </div>
             <p className="text-xs text-daintree-text/45 mt-0.5">{category.blurb}</p>
             <div className="mt-3 grid gap-3 grid-cols-[repeat(auto-fill,minmax(260px,1fr))]">

--- a/src/components/Plugin/PluginConfirmPromptDialog.tsx
+++ b/src/components/Plugin/PluginConfirmPromptDialog.tsx
@@ -77,9 +77,7 @@ export function PluginConfirmPromptDialog() {
         onConfirm={() => resolveOnce(confirm.promptId, true)}
         variant={variant}
       >
-        <p className="text-xs text-daintree-text/40">
-          Requested by the '{confirm.pluginId}' plugin
-        </p>
+        <p className="text-xs text-text-secondary">Requested by the '{confirm.pluginId}' plugin</p>
       </ConfirmDialog>
     </ErrorBoundary>
   );

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -74,7 +74,7 @@ function PluginCapabilityList({
 
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
         Permissions
       </h4>
       {plugin.pluginDanger === "confirm" && (
@@ -115,7 +115,7 @@ function PluginCapabilityList({
 function PluginContributedCommands({ commands }: { commands: PluginActionContribution[] }) {
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
         Commands
       </h4>
       <ul className="space-y-2">
@@ -127,7 +127,7 @@ function PluginContributedCommands({ commands }: { commands: PluginActionContrib
                 {command.description}
               </div>
             )}
-            <div className="text-[11px] text-daintree-text/40 mt-0.5">
+            <div className="text-[11px] text-text-secondary mt-0.5">
               {command.kind === "query"
                 ? "Available to agents and automation"
                 : "Run it from the command palette"}
@@ -148,14 +148,14 @@ function PluginContributedCommands({ commands }: { commands: PluginActionContrib
 function PluginContributedPanels({ panels }: { panels: PanelContribution[] }) {
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
         Panels
       </h4>
       <ul className="space-y-2">
         {panels.map((panel) => (
           <li key={panel.id} className="text-xs">
             <div className="text-daintree-text/80">{panel.name}</div>
-            <div className="text-[11px] text-daintree-text/40 mt-0.5">
+            <div className="text-[11px] text-text-secondary mt-0.5">
               {panel.showInPalette === false
                 ? "Opened by the plugin"
                 : "Open it from the new-panel menu"}
@@ -179,7 +179,7 @@ function PluginContributedPanels({ panels }: { panels: PanelContribution[] }) {
 function PluginContributors({ authors }: { authors: PluginAuthor[] }) {
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
         Contributors
       </h4>
       <ul className="space-y-2">
@@ -189,7 +189,7 @@ function PluginContributors({ authors }: { authors: PluginAuthor[] }) {
             <li key={`${name}-${index}`} className="text-xs">
               <div className="text-daintree-text/80">
                 {name}
-                {role && <span className="text-[11px] text-daintree-text/40"> · {role}</span>}
+                {role && <span className="text-[11px] text-text-secondary"> · {role}</span>}
               </div>
               {(url || email) && (
                 <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
@@ -322,7 +322,7 @@ export function PluginDetailPane({
           <div className="min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap">
               <h3 className="text-base font-medium truncate">{label}</h3>
-              <span className="text-xs font-normal text-daintree-text/40">
+              <span className="text-xs font-normal text-text-secondary">
                 v{plugin.manifest.version}
               </span>
               <span className={BADGE_CLASS}>{categoryLabel}</span>
@@ -345,7 +345,7 @@ export function PluginDetailPane({
               <p className="text-sm text-daintree-text/60 mt-1">{plugin.manifest.tagline}</p>
             )}
             {!plugin.isBuiltin && plugin.installedAt > 0 && (
-              <div className="text-[11px] text-daintree-text/40 mt-1">
+              <div className="text-[11px] text-text-secondary mt-1">
                 {plugin.updatedAt
                   ? `Updated ${formatRelativeTime(plugin.updatedAt)}`
                   : `Installed ${formatRelativeTime(plugin.installedAt)}`}
@@ -432,7 +432,7 @@ export function PluginDetailPane({
               {plugin.manifest.description}
             </p>
           ) : (
-            <p className="text-xs text-daintree-text/40">No description provided.</p>
+            <p className="text-xs text-text-secondary">No description provided.</p>
           )}
 
           {commands.length > 0 && <PluginContributedCommands commands={commands} />}

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -127,7 +127,7 @@ function PluginContributedCommands({ commands }: { commands: PluginActionContrib
                 {command.description}
               </div>
             )}
-            <div className="text-[11px] text-text-secondary mt-0.5">
+            <div className="text-[11px] text-daintree-text/40 mt-0.5">
               {command.kind === "query"
                 ? "Available to agents and automation"
                 : "Run it from the command palette"}
@@ -345,7 +345,7 @@ export function PluginDetailPane({
               <p className="text-sm text-daintree-text/60 mt-1">{plugin.manifest.tagline}</p>
             )}
             {!plugin.isBuiltin && plugin.installedAt > 0 && (
-              <div className="text-[11px] text-text-secondary mt-1">
+              <div className="text-[11px] text-daintree-text/40 mt-1">
                 {plugin.updatedAt
                   ? `Updated ${formatRelativeTime(plugin.updatedAt)}`
                   : `Installed ${formatRelativeTime(plugin.installedAt)}`}

--- a/src/components/Plugin/PluginInputBoxDialog.tsx
+++ b/src/components/Plugin/PluginInputBoxDialog.tsx
@@ -72,7 +72,7 @@ function InputBoxForm({ options, pluginId, onSubmit, onCancel }: InputBoxFormPro
             {options.validationMessage || "The value doesn't match the required format"}
           </p>
         )}
-        <p className="text-xs text-daintree-text/40">Requested by the '{pluginId}' plugin</p>
+        <p className="text-xs text-text-secondary">Requested by the '{pluginId}' plugin</p>
       </AppDialog.Body>
 
       <AppDialog.Footer

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -44,7 +44,7 @@ const ROW_BADGE_CLASS =
 // role="group" inside role="listbox" is broken under Chromium 146 + VoiceOver
 // (LESSON #9006), so headers masquerade as non-interactive options instead.
 const SECTION_HEADER_CLASS =
-  "px-3 text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none";
+  "px-3 text-[10px] font-medium uppercase tracking-wider text-text-secondary select-none";
 
 // Operator chips surfaced below the search input so the filter syntax is
 // discoverable instead of hidden. Categories are the headline filters; the
@@ -140,7 +140,7 @@ function PluginRow({
             )}
           >
             <span className="truncate">{label}</span>
-            <span className="text-[11px] font-normal text-daintree-text/40">
+            <span className="text-[11px] font-normal text-text-secondary">
               v{plugin.manifest.version}
             </span>
           </span>
@@ -743,10 +743,10 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
               network-backed catalog ships separately; the slot keeps its place
               in the master column so the layout doesn't shift when it lands. */}
           <div className="px-4 py-3 border-t border-daintree-border shrink-0">
-            <p className="text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-text-secondary select-none">
               Browse
             </p>
-            <p className="text-[11px] text-daintree-text/40 mt-1">
+            <p className="text-[11px] text-text-secondary mt-1">
               Online plugin catalog coming soon.
             </p>
           </div>

--- a/src/components/Plugin/PluginMcpServersSection.tsx
+++ b/src/components/Plugin/PluginMcpServersSection.tsx
@@ -259,10 +259,8 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
   if (rows.length === 0) {
     return (
       <div className="space-y-3">
-        {showLoading && <p className="text-xs text-daintree-text/40">Loading…</p>}
-        {!loading && (
-          <p className="text-xs text-daintree-text/40">This plugin has no MCP servers.</p>
-        )}
+        {showLoading && <p className="text-xs text-text-secondary">Loading…</p>}
+        {!loading && <p className="text-xs text-text-secondary">This plugin has no MCP servers.</p>}
         {error && <SectionError message={error} />}
       </div>
     );
@@ -297,7 +295,7 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
                 />
                 <div className="min-w-0 flex-1">
                   <div className="text-sm text-daintree-text truncate">{row.name}</div>
-                  <div className="text-[11px] text-daintree-text/40">
+                  <div className="text-[11px] text-text-secondary">
                     {STATUS_LABEL[status]}
                     {row.info?.pid != null && status === "ready" && ` · pid ${row.info.pid}`}
                   </div>
@@ -363,20 +361,20 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
 
 function StderrView({ state }: { state: StderrState | undefined }) {
   if (!state || (state.loading && !state.result)) {
-    return <p className="text-[11px] text-daintree-text/40">Loading output…</p>;
+    return <p className="text-[11px] text-text-secondary">Loading output…</p>;
   }
   if (state.error) {
     return <p className="text-[11px] text-status-danger">{state.error}</p>;
   }
   const result = state.result;
   if (!result || result.lines.length === 0) {
-    return <p className="text-[11px] text-daintree-text/40">No output captured.</p>;
+    return <p className="text-[11px] text-text-secondary">No output captured.</p>;
   }
   const hidden = result.totalLines - result.lines.length;
   return (
     <div className="space-y-1.5">
       {hidden > 0 && (
-        <p className="text-[10px] text-daintree-text/40">
+        <p className="text-[10px] text-text-secondary">
           Showing the most recent {result.lines.length} of {result.totalLines} lines.
         </p>
       )}

--- a/src/components/Plugin/PluginQuickPickDialog.tsx
+++ b/src/components/Plugin/PluginQuickPickDialog.tsx
@@ -166,7 +166,7 @@ export function PluginQuickPickDialog() {
               <div className="text-xs text-daintree-text/50 truncate">{item.description}</div>
             )}
             {item.detail && (
-              <div className="text-xs text-daintree-text/40 truncate">{item.detail}</div>
+              <div className="text-xs text-text-secondary truncate">{item.detail}</div>
             )}
           </div>
         </button>

--- a/src/components/Plugin/PluginQuickPickDialog.tsx
+++ b/src/components/Plugin/PluginQuickPickDialog.tsx
@@ -166,7 +166,7 @@ export function PluginQuickPickDialog() {
               <div className="text-xs text-daintree-text/50 truncate">{item.description}</div>
             )}
             {item.detail && (
-              <div className="text-xs text-text-secondary truncate">{item.detail}</div>
+              <div className="text-xs text-daintree-text/40 truncate">{item.detail}</div>
             )}
           </div>
         </button>

--- a/src/components/Plugin/capabilityMeta.tsx
+++ b/src/components/Plugin/capabilityMeta.tsx
@@ -114,7 +114,7 @@ export const CAPABILITY_META = {
 export const SEVERITY_TEXT_CLASS: Record<CapabilitySeverity, string> = {
   danger: "text-status-danger",
   warning: "text-status-warning",
-  neutral: "text-daintree-text/40",
+  neutral: "text-text-secondary",
 };
 
 export function CapabilityRow({
@@ -156,7 +156,7 @@ export function CapabilityRow({
         >
           {meta.label}
         </div>
-        <div className="text-[11px] text-daintree-text/40">{meta.description}</div>
+        <div className="text-[11px] text-text-secondary">{meta.description}</div>
         {scoped && (
           <ul className="mt-0.5 space-y-0.5">
             {scopeEntries.map((entry) => (

--- a/src/components/Portal/DevServerDashboard.tsx
+++ b/src/components/Portal/DevServerDashboard.tsx
@@ -83,7 +83,7 @@ function DevServerRow({
               :{port}
             </span>
           )}
-          <span className="flex-shrink-0 text-xs text-daintree-text/40">{presentation.label}</span>
+          <span className="flex-shrink-0 text-xs text-text-secondary">{presentation.label}</span>
         </div>
         {session.lastOutput && (
           <span className="truncate text-xs text-daintree-text/45">{session.lastOutput}</span>

--- a/src/components/Portal/PortalLaunchpad.tsx
+++ b/src/components/Portal/PortalLaunchpad.tsx
@@ -23,7 +23,7 @@ export function PortalLaunchpad({ links, onOpenUrl }: PortalLaunchpadProps) {
       <div className="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
         <Globe className="w-12 h-12 mb-2 text-text-muted" />
         <p className="text-sm text-daintree-text/50">No AI agents configured</p>
-        <p className="text-xs text-text-secondary">
+        <p className="text-xs text-daintree-text/40">
           Add a portal link to use as your AI agent web client.
         </p>
         <Button

--- a/src/components/Portal/PortalLaunchpad.tsx
+++ b/src/components/Portal/PortalLaunchpad.tsx
@@ -23,7 +23,7 @@ export function PortalLaunchpad({ links, onOpenUrl }: PortalLaunchpadProps) {
       <div className="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
         <Globe className="w-12 h-12 mb-2 text-text-muted" />
         <p className="text-sm text-daintree-text/50">No AI agents configured</p>
-        <p className="text-xs text-daintree-text/40">
+        <p className="text-xs text-text-secondary">
           Add a portal link to use as your AI agent web client.
         </p>
         <Button

--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -362,7 +362,7 @@ export function AutomationTab({
                   : "fix-bug"}
             </code>
             {branchPrefixMode === "username" && (
-              <p className="text-xs text-daintree-text/40 mt-1">
+              <p className="text-xs text-text-secondary mt-1">
                 Username is read from git config user.name at worktree creation time.
               </p>
             )}

--- a/src/components/Project/ContextTab.tsx
+++ b/src/components/Project/ContextTab.tsx
@@ -285,7 +285,7 @@ export function ContextTab({
                 placeholder="Default (100 MB)"
                 className="w-full bg-daintree-sidebar border border-daintree-border rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30"
               />
-              <p className="text-xs text-daintree-text/40 mt-1">Total size limit for all files</p>
+              <p className="text-xs text-text-secondary mt-1">Total size limit for all files</p>
             </div>
             <div>
               <label className="block text-xs text-daintree-text/60 mb-1">
@@ -303,7 +303,7 @@ export function ContextTab({
                 placeholder="Default (up to 10 MB)"
                 className="w-full bg-daintree-sidebar border border-daintree-border rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30"
               />
-              <p className="text-xs text-daintree-text/40 mt-1">Skip files larger than this</p>
+              <p className="text-xs text-text-secondary mt-1">Skip files larger than this</p>
             </div>
           </div>
 
@@ -323,9 +323,7 @@ export function ContextTab({
                 placeholder="Default (no truncation)"
                 className="w-full bg-daintree-sidebar border border-daintree-border rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30"
               />
-              <p className="text-xs text-daintree-text/40 mt-1">
-                Total characters across all files
-              </p>
+              <p className="text-xs text-text-secondary mt-1">Total characters across all files</p>
             </div>
             <div>
               <label className="block text-xs text-daintree-text/60 mb-1">
@@ -344,7 +342,7 @@ export function ContextTab({
                 <option value="all">Include all files</option>
                 <option value="modified">Recently modified first</option>
               </select>
-              <p className="text-xs text-daintree-text/40 mt-1">
+              <p className="text-xs text-text-secondary mt-1">
                 Which files to prioritize when truncating
               </p>
             </div>
@@ -355,7 +353,7 @@ export function ContextTab({
             <label className="block text-xs text-daintree-text/60 mb-1">
               Always include (glob patterns)
             </label>
-            <p className="text-xs text-daintree-text/40 mb-2">
+            <p className="text-xs text-text-secondary mb-2">
               Files matching these patterns are included even when an exclude rule or the max file
               size would drop them
             </p>
@@ -418,7 +416,7 @@ export function ContextTab({
             <label className="block text-xs text-daintree-text/60 mb-1">
               Always exclude (glob patterns)
             </label>
-            <p className="text-xs text-daintree-text/40 mb-2">
+            <p className="text-xs text-text-secondary mb-2">
               Additional exclusion patterns beyond the default excluded paths above
             </p>
             <div className="space-y-2">
@@ -480,7 +478,7 @@ export function ContextTab({
             <div className="flex items-center justify-between">
               <div>
                 <h4 className="text-sm font-medium text-daintree-text/80">Test configuration</h4>
-                <p className="text-xs text-daintree-text/40">
+                <p className="text-xs text-text-secondary">
                   Preview what files would be included with current settings
                 </p>
               </div>
@@ -556,7 +554,7 @@ export function ContextTab({
                     {copyTreeSettings.charLimit !== undefined && (
                       // The dry run plans the character budget from byte sizes
                       // without reading content, so this preview is an estimate.
-                      <p className="text-xs text-daintree-text/40">
+                      <p className="text-xs text-text-secondary">
                         Estimated — the character budget is planned from file sizes
                       </p>
                     )}
@@ -596,7 +594,7 @@ export function ContextTab({
                               >
                                 {file.path}
                               </span>
-                              <span className="text-daintree-text/40 shrink-0">
+                              <span className="text-text-secondary shrink-0">
                                 {formatBytes(file.size)}
                               </span>
                             </li>

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -379,7 +379,7 @@ export function GeneralTab({
 
           <div className="mt-3 flex items-center justify-between gap-3">
             <p
-              className="min-w-0 flex-1 truncate text-xs font-mono text-daintree-text/40"
+              className="min-w-0 flex-1 truncate text-xs font-mono text-text-secondary"
               title={currentProject.path}
             >
               {currentProject.path}
@@ -672,7 +672,7 @@ export function GeneralTab({
             <p className="text-sm text-daintree-text/60 text-center mb-1">
               Drag and drop an SVG file here
             </p>
-            <p className="text-xs text-daintree-text/40">or click to browse</p>
+            <p className="text-xs text-text-secondary">or click to browse</p>
           </div>
         )}
 

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -498,7 +498,7 @@ function RelocationPreviewSection({
                           </span>
                           <span className={`ml-1 ${p.className}`}> {p.label}</span>
                         </div>
-                        <div className="text-daintree-text/40">
+                        <div className="text-text-secondary">
                           {agent.detail ?? p.detailFallback}
                         </div>
                       </div>
@@ -534,7 +534,7 @@ function RelocationPreviewSection({
           {preview.runningTerminalCount === 0 &&
             preview.linkedWorktrees.length === 0 &&
             preview.affectedPanelCount === 0 && (
-              <li className="text-daintree-text/40">
+              <li className="text-text-secondary">
                 No running terminals, worktrees, or panels affected
               </li>
             )}

--- a/src/components/Project/ProjectNotificationsTab.tsx
+++ b/src/components/Project/ProjectNotificationsTab.tsx
@@ -334,7 +334,7 @@ function OverrideRow({
         />
         <span className="text-sm font-medium text-daintree-text">{label}</span>
         {!isOverridden && (
-          <span className="text-xs text-daintree-text/40">(using global default)</span>
+          <span className="text-xs text-text-secondary">(using global default)</span>
         )}
       </label>
       {description && !isOverridden && (

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -69,7 +69,7 @@ function HeapBar({ heapStats }: { heapStats: HeapStats }) {
     <div className="space-y-1">
       <div className="flex items-center justify-between text-[10px]">
         <span className="text-daintree-text/50">V8 Heap</span>
-        <span className="font-mono text-daintree-text/40">
+        <span className="font-mono text-text-secondary">
           {heapStats.usedMB.toFixed(0)} / {heapStats.limitMB}MB ({heapStats.percent.toFixed(0)}%)
         </span>
       </div>
@@ -92,7 +92,7 @@ function MemoryRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-center justify-between gap-2 text-[10px]">
       <span className="text-daintree-text/50 leading-tight">{label}</span>
-      <span className="font-mono tabular-nums text-daintree-text/40 shrink-0">{value}</span>
+      <span className="font-mono tabular-nums text-text-secondary shrink-0">{value}</span>
     </div>
   );
 }
@@ -176,7 +176,7 @@ function ProcessTable({ metrics }: { metrics: ProcessMetricEntry[] }) {
               >
                 {label} <span className="text-daintree-text/25">({proc.pid})</span>
               </span>
-              <div className="flex gap-2 text-daintree-text/40 shrink-0">
+              <div className="flex gap-2 text-text-secondary shrink-0">
                 <span>{proc.memoryMB}MB</span>
                 <span className="w-10 text-right">{proc.cpuPercent}%</span>
               </div>
@@ -224,7 +224,7 @@ function ProjectBreakdown({
                   <span className="text-daintree-text/25"> · {s.topProcess.name}</span>
                 )}
               </span>
-              <div className="flex gap-2 text-daintree-text/40 shrink-0">
+              <div className="flex gap-2 text-text-secondary shrink-0">
                 <span>{s.terminalCount} terms</span>
                 <span className="tabular-nums">{memLabel}</span>
               </div>
@@ -271,7 +271,7 @@ function DiagnosticsSection({
         Diagnostics
       </button>
       {expanded && (
-        <div className="space-y-1 text-[10px] font-mono text-daintree-text/40 pl-2">
+        <div className="space-y-1 text-[10px] font-mono text-text-secondary pl-2">
           <div>{trendText}</div>
           <div>Uptime: {formatUptime(diagnosticsInfo.uptimeSeconds)}</div>
           {diagnosticsInfo.eventLoopP99Ms > 50 && (
@@ -550,7 +550,7 @@ export function ProjectResourceBadge() {
               key={memoryState}
               className={`status-mark inline-flex h-2 w-2 rounded-full ${STATE_DOT_CLASSES[memoryState]} animate-diagnostics-flash shrink-0`}
             />
-            <span className="text-[10px] tabular-nums text-daintree-text/40 font-medium truncate">
+            <span className="text-[10px] tabular-nums text-text-secondary font-medium truncate">
               {stats.runningProjects} project{stats.runningProjects !== 1 ? "s" : ""} active
             </span>
           </div>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -477,7 +477,7 @@ function RowStatusLine({ status }: { status: ProjectRowStatus }) {
           {index > 0 && (
             <>
               <span className="sr-only">, </span>
-              <span className="shrink-0 text-text-secondary" aria-hidden="true">
+              <span className="shrink-0 text-daintree-text/40" aria-hidden="true">
                 ·
               </span>
             </>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -477,7 +477,7 @@ function RowStatusLine({ status }: { status: ProjectRowStatus }) {
           {index > 0 && (
             <>
               <span className="sr-only">, </span>
-              <span className="shrink-0 text-daintree-text/40" aria-hidden="true">
+              <span className="shrink-0 text-text-secondary" aria-hidden="true">
                 ·
               </span>
             </>
@@ -1706,7 +1706,7 @@ function ScratchSection({
       {!collapsed && (
         <div id="scratch-section-list">
           {scratches.length === 0 ? (
-            <div className="px-2 py-1 text-xs text-daintree-text/40">
+            <div className="px-2 py-1 text-xs text-text-secondary">
               Create a scratch workspace for a quick one-off task
             </div>
           ) : (
@@ -1798,7 +1798,7 @@ function ScratchSection({
                           <RowStatusLine status={status} />
                           {countdown && (
                             <div
-                              className="text-[11px] leading-none text-daintree-text/40 mt-0.5 truncate"
+                              className="text-[11px] leading-none text-text-secondary mt-0.5 truncate"
                               data-testid="scratch-cleanup-countdown"
                             >
                               {countdown}
@@ -2699,7 +2699,7 @@ function DeleteScratchConfirmDialog({
                  */}
                 Deleting scratch…
                 {progress.isStillWorking && (
-                  <span className="block text-daintree-text/40">Still working…</span>
+                  <span className="block text-text-secondary">Still working…</span>
                 )}
               </>
             )}

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -264,7 +264,7 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
         )}
 
         {/* Footer */}
-        <div className="flex items-center gap-4 text-xs text-daintree-text/40 pt-2">
+        <div className="flex items-center gap-4 text-xs text-text-secondary pt-2">
           <button
             type="button"
             onClick={() => {
@@ -402,12 +402,12 @@ function TopProjects({
               <span className="text-sm font-semibold text-daintree-text/85 truncate block">
                 {project.name}
               </span>
-              <span className="text-xs text-daintree-text/40 truncate block" title={project.path}>
+              <span className="text-xs text-text-secondary truncate block" title={project.path}>
                 {middleTruncate(project.path, 48)}
               </span>
             </div>
             <span
-              className="text-xs text-daintree-text/40 shrink-0"
+              className="text-xs text-text-secondary shrink-0"
               title={new Date(project.lastOpened).toLocaleString()}
             >
               {formatTimeAgo(project.lastOpened)}
@@ -618,7 +618,7 @@ function InlineChecklist({
         <h3 className="text-xs font-medium text-daintree-text/50 uppercase tracking-wider">
           Getting started
         </h3>
-        <span className="text-[10px] text-daintree-text/40 font-mono">
+        <span className="text-[10px] text-text-secondary font-mono">
           {progressDone}/{progressTotal}
         </span>
       </div>

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -264,7 +264,7 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
         )}
 
         {/* Footer */}
-        <div className="flex items-center gap-4 text-xs text-text-secondary pt-2">
+        <div className="flex items-center gap-4 text-xs text-daintree-text/40 pt-2">
           <button
             type="button"
             onClick={() => {

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -112,7 +112,7 @@ export function QuickSwitcher({
       emptyMessage="No panels open"
       totalResults={totalResults}
       emptyContent={
-        <p className="mt-2 text-xs text-daintree-text/40">
+        <p className="mt-2 text-xs text-text-secondary">
           {newTerminalShortcut ? (
             <>
               Press <kbd className={KBD_CLASS}>{newTerminalShortcut}</kbd> to create a terminal.

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -682,7 +682,7 @@ function PanelRow({
       <span className="text-daintree-text/60 shrink-0">{getPanelIcon(panel.kind)}</span>
       <div className="flex-1 min-w-0">
         <div className="text-sm text-daintree-text truncate">{panel.title || panel.kind}</div>
-        {panel.cwd && <div className="text-xs text-daintree-text/40 truncate">{panel.cwd}</div>}
+        {panel.cwd && <div className="text-xs text-text-secondary truncate">{panel.cwd}</div>}
       </div>
       <div className="flex items-center gap-1.5 shrink-0">
         {panel.agentState && (
@@ -690,7 +690,7 @@ function PanelRow({
             {panel.agentState}
           </span>
         )}
-        <span className="text-xs text-daintree-text/40">{panel.location}</span>
+        <span className="text-xs text-text-secondary">{panel.location}</span>
         {panel.isSuspect && (
           <span
             className="text-status-warning"
@@ -750,12 +750,12 @@ function ActionTrailRow({ action }: { action: ActionBreadcrumb }) {
       className="flex items-baseline gap-2 px-2 py-1 text-xs"
       data-testid={`action-row-${action.id}`}
     >
-      <span className="text-daintree-text/40 tabular-nums shrink-0">{time}</span>
+      <span className="text-text-secondary tabular-nums shrink-0">{time}</span>
       <span className="font-mono text-daintree-text/80 truncate">{action.actionId}</span>
       {action.count > 1 && (
         <span className="text-daintree-text/50 tabular-nums shrink-0">×{action.count}</span>
       )}
-      <span className="text-daintree-text/40 shrink-0">{action.source}</span>
+      <span className="text-text-secondary shrink-0">{action.source}</span>
       {action.danger !== "safe" && (
         <span className="text-daintree-text/50 shrink-0">{action.danger}</span>
       )}
@@ -765,7 +765,7 @@ function ActionTrailRow({ action }: { action: ActionBreadcrumb }) {
         </span>
       )}
       {args && (
-        <span className="text-daintree-text/40 truncate font-mono" title={args}>
+        <span className="text-text-secondary truncate font-mono" title={args}>
           {args}
         </span>
       )}

--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -198,7 +198,7 @@ export function AgentHelpOutput({
       {!isLoading && isAgentMissing(availability) && !isCliLoading && (
         <div className="px-4 py-6 rounded-[var(--radius-md)] border border-daintree-border bg-surface text-center space-y-2">
           <p className="text-sm text-daintree-text/60">CLI not found</p>
-          <p className="text-xs text-daintree-text/40 select-text">
+          <p className="text-xs text-text-secondary select-text">
             {agentName} is not installed or not in your PATH
           </p>
           {usageUrl && (

--- a/src/components/Settings/AgentScopeEditor/AgentScopeEditor.tsx
+++ b/src/components/Settings/AgentScopeEditor/AgentScopeEditor.tsx
@@ -44,7 +44,7 @@ export function AgentScopeEditor(props: AgentScopeEditorProps) {
         <div className="flex items-center justify-between">
           <div>
             <label className="text-sm font-medium text-daintree-text">{title}</label>
-            <p className="text-xs text-daintree-text/40 select-text">
+            <p className="text-xs text-text-secondary select-text">
               Pick a scope — Default applies everywhere; presets override it.
             </p>
           </div>

--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -115,7 +115,7 @@ export function BehavioralControls({
           placeholder={customArgsPlaceholder}
           data-testid={scopeKind === "custom" ? "preset-custom-flags-input" : undefined}
         />
-        <p className="text-xs text-daintree-text/40 select-text">{customArgsDescription}</p>
+        <p className="text-xs text-text-secondary select-text">{customArgsDescription}</p>
       </div>
 
       <div id="agents-skip-permissions" className="space-y-1.5">
@@ -128,14 +128,14 @@ export function BehavioralControls({
           options={dangerousModeOptions}
         />
         {dangerousMode === "inherit" && (
-          <p className="text-xs text-daintree-text/40 select-text">
+          <p className="text-xs text-text-secondary select-text">
             Inherited from {inheritOriginLabel}
           </p>
         )}
         {effectiveSkipPerms && defaultDangerousArg && (
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] bg-status-error/10 border border-status-error/20">
             <code className="text-xs text-status-error font-mono">{defaultDangerousArg}</code>
-            <span className="text-xs text-daintree-text/40">added to command</span>
+            <span className="text-xs text-text-secondary">added to command</span>
           </div>
         )}
       </div>
@@ -151,7 +151,7 @@ export function BehavioralControls({
             options={inlineModeOptions}
           />
           {inlineMode === "inherit" && (
-            <p className="text-xs text-daintree-text/40 select-text">
+            <p className="text-xs text-text-secondary select-text">
               Inherited from {inlineInheritOriginLabel}
             </p>
           )}

--- a/src/components/Settings/AgentScopeEditor/CustomPresetChrome.tsx
+++ b/src/components/Settings/AgentScopeEditor/CustomPresetChrome.tsx
@@ -110,7 +110,7 @@ export function CustomPresetChrome({
           placeholder={`Uses preset name (${selectedPreset.name})`}
           data-testid="preset-display-title-input"
         />
-        <p className="text-xs text-daintree-text/40 select-text">
+        <p className="text-xs text-text-secondary select-text">
           Shown on the panel tab and launch button. Leave empty to use the preset name.
         </p>
       </div>

--- a/src/components/Settings/AgentScopeEditor/EnvBlock.tsx
+++ b/src/components/Settings/AgentScopeEditor/EnvBlock.tsx
@@ -16,7 +16,7 @@ interface EnvBlockProps {
 function EnvVarReference({ suggestions }: { suggestions: EnvSuggestion[] }) {
   return (
     <div className="space-y-0.5 pt-1">
-      <p className="text-[11px] text-daintree-text/40 pb-0.5">Available env overrides:</p>
+      <p className="text-[11px] text-text-secondary pb-0.5">Available env overrides:</p>
       {suggestions.map(({ key, hint }) => (
         <div key={key} className="flex items-baseline gap-2 font-mono">
           <span className="text-[11px] text-daintree-text/60 shrink-0">{key}</span>
@@ -41,7 +41,7 @@ export function EnvBlock({
       <div id="agents-global-env" className="space-y-2">
         <div>
           <label className="text-sm font-medium text-daintree-text">Global env vars</label>
-          <p className="text-xs text-daintree-text/40 select-text">
+          <p className="text-xs text-text-secondary select-text">
             Applied to every launch. Preset-specific vars take precedence.
           </p>
         </div>

--- a/src/components/Settings/AgentScopeEditor/FallbackChainEditor.tsx
+++ b/src/components/Settings/AgentScopeEditor/FallbackChainEditor.tsx
@@ -38,7 +38,7 @@ export function FallbackChainEditor({
     <div className="space-y-1.5">
       <div>
         <label className="text-sm font-medium text-daintree-text">Fallback presets</label>
-        <p className="text-xs text-daintree-text/40 select-text">
+        <p className="text-xs text-text-secondary select-text">
           Tried in order if this preset's provider is unreachable. No retry for rate limits or
           prompt errors.
         </p>
@@ -54,7 +54,7 @@ export function FallbackChainEditor({
                 key={id}
                 className="flex items-center gap-2 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30 px-2 py-1.5"
               >
-                <span className="text-[10px] text-daintree-text/40 font-mono shrink-0">
+                <span className="text-[10px] text-text-secondary font-mono shrink-0">
                   {idx + 1}.
                 </span>
                 <span
@@ -99,12 +99,12 @@ export function FallbackChainEditor({
         </select>
       )}
       {chain.length >= FALLBACK_CHAIN_MAX && (
-        <p className="text-[11px] text-daintree-text/40">
+        <p className="text-[11px] text-text-secondary">
           Maximum of {FALLBACK_CHAIN_MAX} fallbacks reached.
         </p>
       )}
       {chain.length < FALLBACK_CHAIN_MAX && candidates.length === 0 && (
-        <p className="text-[11px] text-daintree-text/40">
+        <p className="text-[11px] text-text-secondary">
           No other presets available for this agent.
         </p>
       )}

--- a/src/components/Settings/AgentScopeEditor/ReadOnlyDetail.tsx
+++ b/src/components/Settings/AgentScopeEditor/ReadOnlyDetail.tsx
@@ -38,18 +38,18 @@ export function ReadOnlyDetail({ scopeKind, selectedPreset, onDuplicate }: ReadO
           </div>
         )}
         {selectedPreset.description && (
-          <p className="text-[11px] text-daintree-text/40 select-text">
+          <p className="text-[11px] text-text-secondary select-text">
             {selectedPreset.description}
           </p>
         )}
         {scopeKind === "project" && (
-          <p className="text-[10px] text-daintree-text/40 select-text">
+          <p className="text-[10px] text-text-secondary select-text">
             Sourced from <code>.daintree/presets/</code> in this project.
           </p>
         )}
       </div>
       <div className="px-3 py-2">
-        <p className="text-xs text-daintree-text/40 select-text">
+        <p className="text-xs text-text-secondary select-text">
           Read-only. Duplicate as custom to override behavioral settings or env.
         </p>
       </div>

--- a/src/components/Settings/AgentScopeEditor/ScopeBanner.tsx
+++ b/src/components/Settings/AgentScopeEditor/ScopeBanner.tsx
@@ -15,7 +15,7 @@ export function ScopeBanner({ scopeKind, scopeLabel }: ScopeBannerProps) {
       {scopeKind === "ccr" && (
         <span
           data-testid="preset-badge-auto"
-          className="text-[10px] text-daintree-text/40 bg-daintree-text/10 px-1.5 py-0.5 rounded"
+          className="text-[10px] text-text-secondary bg-daintree-text/10 px-1.5 py-0.5 rounded"
         >
           auto
         </span>
@@ -23,7 +23,7 @@ export function ScopeBanner({ scopeKind, scopeLabel }: ScopeBannerProps) {
       {scopeKind === "project" && (
         <span
           data-testid="preset-badge-project"
-          className="text-[10px] text-daintree-text/40 bg-daintree-text/10 px-1.5 py-0.5 rounded"
+          className="text-[10px] text-text-secondary bg-daintree-text/10 px-1.5 py-0.5 rounded"
         >
           project
         </span>

--- a/src/components/Settings/AgentSelectorDropdown.tsx
+++ b/src/components/Settings/AgentSelectorDropdown.tsx
@@ -207,7 +207,7 @@ export function AgentSelectorDropdown({
                     <Settings2 size={16} className="shrink-0 text-daintree-text/60" />
                     <div className="flex-1 min-w-0">
                       <div className="truncate">General</div>
-                      <div className="text-xs text-daintree-text/40 truncate">Global settings</div>
+                      <div className="text-xs text-text-secondary truncate">Global settings</div>
                     </div>
                   </>
                 ) : (
@@ -244,7 +244,7 @@ export function AgentSelectorDropdown({
             );
           })}
           {items.length === 1 && filterQuery && (
-            <div className="px-2 py-3 text-xs text-daintree-text/40 text-center">
+            <div className="px-2 py-3 text-xs text-text-secondary text-center">
               No agents match "{filterQuery}"
             </div>
           )}

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -410,7 +410,7 @@ export function AgentSettings({
                   </option>
                 ))}
               </select>
-              <p className="text-xs text-daintree-text/40 select-text">
+              <p className="text-xs text-text-secondary select-text">
                 Agent used for the help dock button
                 {helpShortcut && ` (${helpShortcut})`} and automated workflows ("What's Next?",
                 onboarding, project explanations). Distinct from the Portal "Default New Tab Agent"

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -93,7 +93,7 @@ function PreferredSchemePicker({
 }) {
   return (
     <div className="space-y-1">
-      <p className="text-[10px] font-medium uppercase tracking-wider text-daintree-text/40">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-text-secondary">
         {label}
       </p>
       <div className="flex flex-wrap gap-1.5">
@@ -567,7 +567,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
                         </summary>
                         <ul className="mt-1 space-y-0.5 pl-3">
                           {messages.map((message, index) => (
-                            <li key={index} className="break-words text-daintree-text/40">
+                            <li key={index} className="break-words text-text-secondary">
                               {message}
                             </li>
                           ))}

--- a/src/components/Settings/ColorVisionPicker.tsx
+++ b/src/components/Settings/ColorVisionPicker.tsx
@@ -65,7 +65,7 @@ function SwatchPreview() {
             style={{ backgroundColor: colors[i] }}
             title={token.label}
           />
-          <span className="text-[9px] text-daintree-text/40">{token.label}</span>
+          <span className="text-[9px] text-text-secondary">{token.label}</span>
         </div>
       ))}
     </div>

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -320,7 +320,7 @@ export function DiagnosticsReviewDialog({
                     "focus:outline-hidden focus:border-daintree-accent/40"
                   )}
                 />
-                <span className="text-text-secondary text-xs">→</span>
+                <span className="text-daintree-text/40 text-xs">→</span>
                 <input
                   type="text"
                   value={rule.replace}
@@ -337,7 +337,7 @@ export function DiagnosticsReviewDialog({
                     variant="ghost"
                     size="sm"
                     onClick={() => removeReplacement(i)}
-                    className="text-xs h-7 px-1.5 text-text-secondary hover:text-status-error"
+                    className="text-xs h-7 px-1.5 text-daintree-text/40 hover:text-status-error"
                   >
                     ×
                   </Button>

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -320,7 +320,7 @@ export function DiagnosticsReviewDialog({
                     "focus:outline-hidden focus:border-daintree-accent/40"
                   )}
                 />
-                <span className="text-daintree-text/40 text-xs">→</span>
+                <span className="text-text-secondary text-xs">→</span>
                 <input
                   type="text"
                   value={rule.replace}
@@ -337,7 +337,7 @@ export function DiagnosticsReviewDialog({
                     variant="ghost"
                     size="sm"
                     onClick={() => removeReplacement(i)}
-                    className="text-xs h-7 px-1.5 text-daintree-text/40 hover:text-status-error"
+                    className="text-xs h-7 px-1.5 text-text-secondary hover:text-status-error"
                   >
                     ×
                   </Button>

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -252,7 +252,7 @@ export function EditorIntegrationTab() {
                   placeholder="{file}:{line}:{col}"
                   className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent/40 transition-colors font-mono"
                 />
-                <p className="text-xs text-daintree-text/40 select-text">
+                <p className="text-xs text-text-secondary select-text">
                   Use <code className="font-mono">{"{file}"}</code>,{" "}
                   <code className="font-mono">{"{line}"}</code>,{" "}
                   <code className="font-mono">{"{col}"}</code> as placeholders.
@@ -294,7 +294,7 @@ export function EditorIntegrationTab() {
           {saveError && <p className="text-xs text-status-error">{saveError}</p>}
 
           {preferredEditor && (
-            <p className="text-xs text-daintree-text/40">
+            <p className="text-xs text-text-secondary">
               Saved: <span className="font-medium">{EDITOR_LABELS[preferredEditor.id]}</span>
             </p>
           )}

--- a/src/components/Settings/FileBrowserVisibilitySettings.tsx
+++ b/src/components/Settings/FileBrowserVisibilitySettings.tsx
@@ -68,7 +68,7 @@ export function FileBrowserVisibilitySettings() {
       <div className="space-y-3">
         <ul className="flex flex-wrap gap-1.5" aria-label="Always-hidden patterns">
           {patterns.length === 0 && (
-            <li className="text-xs text-daintree-text/40">Nothing is hidden</li>
+            <li className="text-xs text-text-secondary">Nothing is hidden</li>
           )}
           {patterns.map((pattern) => (
             <li

--- a/src/components/Settings/ForgeAuditLogViewer.tsx
+++ b/src/components/Settings/ForgeAuditLogViewer.tsx
@@ -322,7 +322,7 @@ export function ForgeAuditLogViewer({
                     {record.providerId}
                   </div>
                   {record.argsSummary && record.argsSummary !== "{}" && (
-                    <div className="mt-0.5 font-mono text-daintree-text/40 truncate">
+                    <div className="mt-0.5 font-mono text-text-secondary truncate">
                       {record.argsSummary}
                     </div>
                   )}
@@ -332,7 +332,7 @@ export function ForgeAuditLogViewer({
                     </div>
                   )}
                 </div>
-                <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                <div className="text-right text-text-secondary whitespace-nowrap">
                   <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
                   <div>{record.durationMs}ms</div>
                 </div>
@@ -401,7 +401,7 @@ export function ForgeAuditLogViewer({
         >
           Clear log
         </button>
-        <span className="ml-auto text-xs text-daintree-text/40">
+        <span className="ml-auto text-xs text-text-secondary">
           {isFiltering
             ? `${filteredRecords.length} of ${records.length}`
             : `${records.length} of ${maxRecords}`}

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -392,7 +392,7 @@ function ProjectRoutingPanel({
   }
 
   if (loading) {
-    return <p className="text-xs text-daintree-text/40">Loading remotes…</p>;
+    return <p className="text-xs text-text-secondary">Loading remotes…</p>;
   }
 
   if (error) {

--- a/src/components/Settings/ForgeProviderSelectorDropdown.tsx
+++ b/src/components/Settings/ForgeProviderSelectorDropdown.tsx
@@ -195,7 +195,7 @@ export function ForgeProviderSelectorDropdown({
                     <GitBranch size={16} className="shrink-0 text-daintree-text/60" />
                     <div className="flex-1 min-w-0">
                       <div className="truncate">General</div>
-                      <div className="text-xs text-daintree-text/40 truncate">
+                      <div className="text-xs text-text-secondary truncate">
                         Global forge settings
                       </div>
                     </div>
@@ -215,7 +215,7 @@ export function ForgeProviderSelectorDropdown({
             );
           })}
           {items.length === 1 && filterQuery && (
-            <div className="px-2 py-3 text-xs text-daintree-text/40 text-center">
+            <div className="px-2 py-3 text-xs text-text-secondary text-center">
               No providers match "{filterQuery}"
             </div>
           )}

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -1004,7 +1004,7 @@ export function GeneralTab({
                       </button>
                     ))}
                   </div>
-                  <p className="text-xs text-daintree-text/40">
+                  <p className="text-xs text-text-secondary">
                     A toast appears when background project terminals have been quiet this long,
                     with options to close them or dismiss the reminder.
                   </p>
@@ -1047,7 +1047,7 @@ export function GeneralTab({
                       </button>
                     ))}
                   </div>
-                  <p className="text-xs text-daintree-text/40">
+                  <p className="text-xs text-text-secondary">
                     Only projects with no terminals are auto-closed. The active project is never
                     touched, and reopening a project restores its panels.
                   </p>
@@ -1096,14 +1096,14 @@ export function GeneralTab({
                       </button>
                     ))}
                   </div>
-                  <p className="text-xs text-daintree-text/40">
+                  <p className="text-xs text-text-secondary">
                     Projects idle longer than this will have their processes stopped automatically.
                   </p>
                 </div>
               )}
             </SettingsSection>
           ) : (
-            <div className="text-sm text-daintree-text/40">Loading hibernation settings...</div>
+            <div className="text-sm text-text-secondary">Loading hibernation settings...</div>
           )}
         </>
       )}

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -466,7 +466,7 @@ export function KeyboardShortcutsTab() {
               <span className="text-xs text-daintree-text/60 text-right">Alt+Up / Alt+Down</span>
             </div>
           </div>
-          <p className="text-xs text-daintree-text/40 mt-2">
+          <p className="text-xs text-text-secondary mt-2">
             These shortcuts are fixed and can't be rebound
           </p>
         </div>
@@ -500,7 +500,7 @@ export function KeyboardShortcutsTab() {
               </span>
             </div>
           </div>
-          <p className="text-xs text-daintree-text/40 mt-2">
+          <p className="text-xs text-text-secondary mt-2">
             These shortcuts are fixed and can't be rebound
           </p>
         </div>

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -285,7 +285,7 @@ function GrantRow({
         )}
       </div>
       <div
-        className={cn("text-right text-daintree-text/40 whitespace-nowrap", !compact && "self-end")}
+        className={cn("text-right text-text-secondary whitespace-nowrap", !compact && "self-end")}
       >
         <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
       </div>
@@ -543,10 +543,10 @@ export function McpAuditLogViewer({
                   <span className="font-medium text-daintree-text/90">
                     {OUTCOME_LABEL[group.turnRecord.outcome] ?? group.turnRecord.outcome}
                   </span>
-                  <span className="text-daintree-text/40">
+                  <span className="text-text-secondary">
                     {formatRelativeTimestamp(group.turnRecord.timestamp, now)}
                   </span>
-                  <span className="text-daintree-text/40">
+                  <span className="text-text-secondary">
                     {group.callCount} call{group.callCount !== 1 ? "s" : ""}
                   </span>
                   {group.unauthorizedCount > 0 && (
@@ -559,7 +559,7 @@ export function McpAuditLogViewer({
                       {group.errorCount} error{group.errorCount !== 1 ? "s" : ""}
                     </span>
                   )}
-                  <span className="text-daintree-text/40">{group.totalDurationMs}ms</span>
+                  <span className="text-text-secondary">{group.totalDurationMs}ms</span>
                 </div>
                 <ul className="ml-3 space-y-1 border-l-2 border-daintree-border/50 pl-3">
                   {group.records.map((record) =>
@@ -595,7 +595,7 @@ export function McpAuditLogViewer({
                             </div>
                           )}
                         </div>
-                        <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                        <div className="text-right text-text-secondary whitespace-nowrap">
                           <div>{record.durationMs}ms</div>
                         </div>
                       </li>
@@ -617,7 +617,7 @@ export function McpAuditLogViewer({
               <li className="p-2 text-xs">
                 <div className="flex items-center gap-2 mb-1">
                   <span className="font-medium text-daintree-text/60">Unassociated</span>
-                  <span className="text-daintree-text/40">
+                  <span className="text-text-secondary">
                     {turnGroups.unassociated.length} record
                     {turnGroups.unassociated.length !== 1 ? "s" : ""}
                   </span>
@@ -646,7 +646,7 @@ export function McpAuditLogViewer({
                             {record.argsSummary || "{}"}
                           </div>
                         </div>
-                        <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                        <div className="text-right text-text-secondary whitespace-nowrap">
                           <div>{record.durationMs}ms</div>
                         </div>
                       </li>
@@ -661,7 +661,7 @@ export function McpAuditLogViewer({
               <li className="p-2 text-xs">
                 <div className="flex items-center gap-2 mb-1">
                   <span className="font-medium text-daintree-text/60">Lifecycle events</span>
-                  <span className="text-daintree-text/40">
+                  <span className="text-text-secondary">
                     {turnGroups.lifecycle.length} event
                     {turnGroups.lifecycle.length !== 1 ? "s" : ""}
                   </span>
@@ -719,7 +719,7 @@ export function McpAuditLogViewer({
                       </div>
                     )}
                   </div>
-                  <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                  <div className="text-right text-text-secondary whitespace-nowrap">
                     <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
                     <div>{record.durationMs}ms</div>
                   </div>
@@ -764,7 +764,7 @@ export function McpAuditLogViewer({
                       </div>
                     )}
                   </div>
-                  <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                  <div className="text-right text-text-secondary whitespace-nowrap">
                     <div>{formatRelativeTimestamp(record.timestamp, now)}</div>
                   </div>
                 </li>
@@ -837,7 +837,7 @@ export function McpAuditLogViewer({
             Clear log
           </button>
         )}
-        <span className="ml-auto text-xs text-daintree-text/40">
+        <span className="ml-auto text-xs text-text-secondary">
           {resultFilter !== "all" ||
           toolFilter.trim().length > 0 ||
           timeRange !== "all" ||

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -991,7 +991,7 @@ export function McpServerSettingsTab() {
                 >
                   Apply
                 </button>
-                <span className="text-xs text-daintree-text/40">
+                <span className="text-xs text-text-secondary">
                   Range {MCP_AUDIT_MIN_RECORDS}–{MCP_AUDIT_MAX_RECORDS}
                 </span>
               </div>

--- a/src/components/Settings/OverrideField.tsx
+++ b/src/components/Settings/OverrideField.tsx
@@ -45,7 +45,7 @@ export function OverrideField({
       <div className="flex items-center gap-2 mb-1 min-h-[1.25rem]">
         <label htmlFor={id} className="block text-xs font-medium text-daintree-text/60">
           {label}
-          {hint && <span className="ml-1 text-text-secondary">{hint}</span>}
+          {hint && <span className="ml-1 text-daintree-text/40">{hint}</span>}
         </label>
         {isOverriding && (
           <span

--- a/src/components/Settings/OverrideField.tsx
+++ b/src/components/Settings/OverrideField.tsx
@@ -45,7 +45,7 @@ export function OverrideField({
       <div className="flex items-center gap-2 mb-1 min-h-[1.25rem]">
         <label htmlFor={id} className="block text-xs font-medium text-daintree-text/60">
           {label}
-          {hint && <span className="ml-1 text-daintree-text/40">{hint}</span>}
+          {hint && <span className="ml-1 text-text-secondary">{hint}</span>}
         </label>
         {isOverriding && (
           <span
@@ -101,7 +101,7 @@ export function OverrideField({
         id={descriptionId}
         className={cn(
           "mt-1 text-xs",
-          isOverriding ? "text-text-muted" : "text-daintree-text/40 italic"
+          isOverriding ? "text-text-muted" : "text-text-secondary italic"
         )}
       >
         {isOverriding ? overrideDescription : inheritDescription}

--- a/src/components/Settings/PluginActionAuditLogViewer.tsx
+++ b/src/components/Settings/PluginActionAuditLogViewer.tsx
@@ -283,16 +283,16 @@ export function PluginActionAuditLogViewer({
                     </div>
                   ) : null}
                   {record.argsPlaintext ? (
-                    <div className="mt-0.5 font-mono text-daintree-text/40 truncate">
+                    <div className="mt-0.5 font-mono text-text-secondary truncate">
                       {record.argsPlaintext}
                     </div>
                   ) : record.argsHash ? (
-                    <div className="mt-0.5 font-mono text-daintree-text/40 truncate">
+                    <div className="mt-0.5 font-mono text-text-secondary truncate">
                       sha256:{record.argsHash.slice(0, 16)}…
                     </div>
                   ) : null}
                 </div>
-                <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                <div className="text-right text-text-secondary whitespace-nowrap">
                   <div>{formatRelativeTimestamp(record.ts, now)}</div>
                   <div>{record.durationMs}ms</div>
                 </div>
@@ -361,7 +361,7 @@ export function PluginActionAuditLogViewer({
         >
           Clear log
         </button>
-        <span className="ml-auto text-xs text-daintree-text/40">
+        <span className="ml-auto text-xs text-text-secondary">
           {isFiltering
             ? `${filteredRecords.length} of ${records.length}`
             : `${records.length} of ${maxRecords}`}

--- a/src/components/Settings/PluginSettingsForm.tsx
+++ b/src/components/Settings/PluginSettingsForm.tsx
@@ -458,7 +458,7 @@ function SettingField({
           {fieldLabel(def)}
         </label>
         <div className="flex items-center gap-1.5 shrink-0">
-          <span className="text-[10px] uppercase tracking-wide text-daintree-text/40">
+          <span className="text-[10px] uppercase tracking-wide text-text-secondary">
             {SCOPE_BADGE_LABEL[scope]}
           </span>
           {canReset && (
@@ -509,7 +509,7 @@ function SettingField({
       )}
 
       {!scopeReady && (
-        <p className="text-[11px] text-daintree-text/40">Open a project to edit this setting.</p>
+        <p className="text-[11px] text-text-secondary">Open a project to edit this setting.</p>
       )}
       {pathMissing && !error && (
         <p className="text-[11px] text-status-warning">

--- a/src/components/Settings/PresetSelector.tsx
+++ b/src/components/Settings/PresetSelector.tsx
@@ -114,7 +114,7 @@ export function PresetSelector({
           <span className="flex-1 text-left truncate">{selectedItem.label}</span>
           {selectedItem.source === "ccr" && (
             <span
-              className="text-[9px] uppercase tracking-wide text-daintree-text/40 bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
+              className="text-[9px] uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
               aria-hidden="true"
             >
               CCR
@@ -122,7 +122,7 @@ export function PresetSelector({
           )}
           {selectedItem.source === "project" && (
             <span
-              className="text-[9px] uppercase tracking-wide text-daintree-text/40 bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
+              className="text-[9px] uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
               aria-hidden="true"
             >
               Project
@@ -212,7 +212,7 @@ export function PresetSelector({
 function Divider({ label }: { label: string }) {
   return (
     <div
-      className="px-2 pt-1.5 pb-0.5 text-[10px] font-medium uppercase tracking-wide text-daintree-text/40"
+      className="px-2 pt-1.5 pb-0.5 text-[10px] font-medium uppercase tracking-wide text-text-secondary"
       data-testid={`preset-group-${label.toLowerCase().replace(/\s+/g, "-")}`}
     >
       {label}
@@ -265,7 +265,7 @@ function PresetOption({
       <span className="flex-1 truncate">{label}</span>
       {badge && (
         <span
-          className="text-[9px] uppercase tracking-wide text-daintree-text/40 bg-daintree-text/5 px-1 py-0.5 rounded"
+          className="text-[9px] uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded"
           aria-hidden="true"
         >
           {badge}

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -394,7 +394,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
               </button>
             ))}
           </div>
-          <p className="text-xs text-daintree-text/40 mt-2 select-text">
+          <p className="text-xs text-text-secondary mt-2 select-text">
             Changes to telemetry level take effect on next app restart.
           </p>
 
@@ -508,7 +508,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                 </button>
               ))}
             </div>
-            <p className="text-xs text-daintree-text/40 mt-2 select-text">
+            <p className="text-xs text-text-secondary mt-2 select-text">
               Log pruning happens at startup. Changing this setting takes effect on next launch.
             </p>
           </SettingsSection>
@@ -553,7 +553,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                 </button>
               ))}
             </div>
-            <p className="text-xs text-daintree-text/40 mt-2 select-text">
+            <p className="text-xs text-text-secondary mt-2 select-text">
               Applies to every project. Shortening the window prunes older records immediately.
             </p>
             <div className="mt-4">

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1527,7 +1527,7 @@ function SearchResults({
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between mb-3">
-        <p className="text-xs text-daintree-text/40">
+        <p className="text-xs text-text-secondary">
           <span className="tabular-nums">{results.length}</span> result
           {results.length === 1 ? "" : "s"}
         </p>
@@ -1562,7 +1562,7 @@ function SearchResults({
                   projectLabel={projectLabel}
                   crossScope={result.scope !== activeScope}
                 />
-                <span className="text-[10px] font-medium text-daintree-text/40 uppercase tracking-wide">
+                <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide">
                   {result.tabLabel}
                 </span>
                 {result.subtabLabel && (

--- a/src/components/Settings/TerminalAppearanceTab.tsx
+++ b/src/components/Settings/TerminalAppearanceTab.tsx
@@ -210,7 +210,7 @@ export function TerminalAppearanceTab({
                   aria-describedby={fontSizeError ? fontSizeErrorId : undefined}
                 />
                 <span className="text-sm text-daintree-text/50">px</span>
-                <span className="text-xs text-daintree-text/40 ml-auto">
+                <span className="text-xs text-text-secondary ml-auto">
                   Current: <span className="font-mono">{fontSize}px</span>
                 </span>
               </div>

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -668,7 +668,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                     {Math.round((1 - twoPaneSplitConfig.defaultRatio) * 100)}
                   </span>
                 </div>
-                <p className="text-xs text-daintree-text/40 select-text">
+                <p className="text-xs text-text-secondary select-text">
                   Default split ratio when no worktree-specific ratio is saved.
                 </p>
               </div>
@@ -732,7 +732,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
               />
             )}
 
-            <p className="text-xs text-daintree-text/40 leading-relaxed select-text">
+            <p className="text-xs text-text-secondary leading-relaxed select-text">
               {layoutConfig.strategy === "automatic" &&
                 "Uses a balanced square grid that adapts to the number of terminals (1-4 terminals use 2 columns, 5+ use up to 4 columns)."}
               {layoutConfig.strategy === "fixed-columns" &&

--- a/src/components/Settings/ThemeSelector.tsx
+++ b/src/components/Settings/ThemeSelector.tsx
@@ -170,7 +170,7 @@ export function ThemeSelector<T extends { id: string }>({
         <div role="listbox" id={id} aria-label="Theme list" className="space-y-2">
           {filteredGroups.map((group) => (
             <div key={group.label} role="group" aria-label={group.label}>
-              <p className="text-[10px] font-medium uppercase tracking-wider text-daintree-text/40 select-none px-1 mb-1">
+              <p className="text-[10px] font-medium uppercase tracking-wider text-text-secondary select-none px-1 mb-1">
                 {group.label}
               </p>
               <div className={cn("grid gap-2", colsClass)}>{group.items.map(renderCard)}</div>

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -266,7 +266,7 @@ function ToolbarSideColumn({
         <span className="text-xs font-medium uppercase tracking-wide text-daintree-text/60">
           {label}
         </span>
-        <span className="text-xs text-daintree-text/40 tabular-nums">
+        <span className="text-xs text-text-secondary tabular-nums">
           {visibleCount}/{buttonIds.length}
         </span>
       </div>
@@ -761,7 +761,7 @@ export function ToolbarSettingsTab() {
               <option value="browser">Browser</option>
               <option value="dev-server">Dev Preview</option>
             </select>
-            <p className="text-xs text-daintree-text/40 select-text">
+            <p className="text-xs text-text-secondary select-text">
               Default option to highlight when opening the launcher palette
             </p>
           </div>

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -98,7 +98,7 @@ function SystemHealthSection() {
                 )}
                 <span className="text-sm text-daintree-text">{label}</span>
                 {check.version && (
-                  <span className="text-xs text-daintree-text/40">v{check.version}</span>
+                  <span className="text-xs text-text-secondary">v{check.version}</span>
                 )}
                 {!check.available && (
                   <span className="ml-auto text-xs text-status-error">Not found</span>

--- a/src/components/Settings/TurnOutcomeDiagnostics.tsx
+++ b/src/components/Settings/TurnOutcomeDiagnostics.tsx
@@ -547,7 +547,7 @@ export function TurnOutcomeDiagnostics({
             >
               Clear log
             </button>
-            <span className="ml-auto text-xs text-daintree-text/40">
+            <span className="ml-auto text-xs text-text-secondary">
               {totalRecords} turn{totalRecords !== 1 ? "s" : ""}
             </span>
           </div>

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -467,7 +467,7 @@ export function VoiceInputSettingsTab() {
 
               <CorePromptViewer />
 
-              <p className="text-xs text-daintree-text/40">
+              <p className="text-xs text-text-secondary">
                 Your project name and custom dictionary are included automatically. Prompt caching
                 keeps costs minimal.
               </p>
@@ -669,7 +669,7 @@ function AdvancedSection({
       </button>
       {expanded && (
         <div className="space-y-3">
-          <p className="text-xs text-daintree-text/40">
+          <p className="text-xs text-text-secondary">
             Only needed for legacy user keys (starts with <code className="font-mono">sk-</code>).
           </p>
           <div className="space-y-1.5">
@@ -834,7 +834,7 @@ function MicPermissionRow({
         {statusDisplay.actions}
       </div>
       {statusDisplay.description && (
-        <p className="text-xs text-daintree-text/40 ml-[22px]">{statusDisplay.description}</p>
+        <p className="text-xs text-text-secondary ml-[22px]">{statusDisplay.description}</p>
       )}
     </div>
   );
@@ -1028,7 +1028,7 @@ function DictionarySection({
           ))}
         </div>
       ) : (
-        <p className="text-xs text-daintree-text/40 select-text">
+        <p className="text-xs text-text-secondary select-text">
           Domain-specific terms sent to the transcription service to boost recognition accuracy.
         </p>
       )}

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -337,7 +337,7 @@ export function WorktreeSettingsTab() {
             </button>
           </div>
 
-          <p className="text-xs text-daintree-text/40">
+          <p className="text-xs text-text-secondary">
             The path pattern determines where new worktrees are created when you use the New
             Worktree dialog. Relative paths (starting with . or ..) are resolved from the repository
             root.

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -264,7 +264,7 @@ export function AgentCliStep({
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-medium text-daintree-text">{config.name}</div>
                   {description && (
-                    <div className="text-[11px] text-daintree-text/40 truncate">{description}</div>
+                    <div className="text-[11px] text-text-secondary truncate">{description}</div>
                   )}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
@@ -299,7 +299,7 @@ export function AgentCliStep({
                       Failed
                     </span>
                   ) : isManual ? (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-daintree-text/40">
+                    <span className="inline-flex items-center gap-1 text-[11px] text-text-secondary">
                       Manual
                     </span>
                   ) : (
@@ -341,7 +341,7 @@ export function AgentCliStep({
 
               {isManual && currentBlock?.commands && (
                 <div className="pl-14 pt-1.5 pb-1 space-y-1">
-                  <div className="text-[11px] text-daintree-text/40 mb-1">
+                  <div className="text-[11px] text-text-secondary mb-1">
                     Run this command in your terminal. It will be detected automatically.
                   </div>
                   {currentBlock.commands.map((cmd) => (
@@ -379,7 +379,7 @@ export function AgentCliStep({
                   )}
                   {currentBlock?.commands && (
                     <div className="space-y-1">
-                      <div className="text-[11px] text-daintree-text/40">Or install manually:</div>
+                      <div className="text-[11px] text-text-secondary">Or install manually:</div>
                       {currentBlock.commands.map((cmd) => (
                         <CopyableCommand
                           key={cmd}

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -1141,7 +1141,7 @@ function AgentsStep({
               <>
                 <div className="flex items-center gap-2 py-1">
                   <div className="h-px flex-1 bg-border-divider" />
-                  <span className="text-[11px] text-daintree-text/40 font-medium">More agents</span>
+                  <span className="text-[11px] text-text-secondary font-medium">More agents</span>
                   <div className="h-px flex-1 bg-border-divider" />
                 </div>
 

--- a/src/components/Setup/InstallBlock.tsx
+++ b/src/components/Setup/InstallBlock.tsx
@@ -25,7 +25,7 @@ export function InstallBlock({ block }: { block: AgentInstallBlock }) {
         </div>
       )}
       {block.notes && block.notes.length > 0 && (
-        <div className="mt-2 text-[11px] text-daintree-text/40 space-y-0.5">
+        <div className="mt-2 text-[11px] text-text-secondary space-y-0.5">
           {block.notes.map((note, i) => (
             <p key={i}>{note}</p>
           ))}

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -82,7 +82,7 @@ export function SystemRequirementsSection({
         <span className="text-sm font-medium text-daintree-text">System requirements</span>
 
         {isChecking && (
-          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-daintree-text/40">
+          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-text-secondary">
             <Loader2 className="w-3 h-3 animate-spin" />
             Checking...
           </span>

--- a/src/components/Setup/SystemToolsStep.tsx
+++ b/src/components/Setup/SystemToolsStep.tsx
@@ -81,9 +81,9 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
             )}
           </div>
         ) : check?.version ? (
-          <span className="text-[11px] text-daintree-text/40 shrink-0">v{check.version}</span>
+          <span className="text-[11px] text-text-secondary shrink-0">v{check.version}</span>
         ) : check?.available ? (
-          <span className="text-[11px] text-daintree-text/40 shrink-0">Installed</span>
+          <span className="text-[11px] text-text-secondary shrink-0">Installed</span>
         ) : null}
       </div>
       {installBlocks && (

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -649,10 +649,10 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                   // open by default; the toggle only tames very long bulk sets.
                   <details key={patch.id} open className="group">
                     <summary className="flex items-baseline gap-2 px-3 py-2 cursor-pointer list-none">
-                      <span className="text-text-secondary text-[10px] shrink-0 group-open:hidden">
+                      <span className="text-daintree-text/40 text-[10px] shrink-0 group-open:hidden">
                         ▶
                       </span>
-                      <span className="text-text-secondary text-[10px] shrink-0 hidden group-open:inline">
+                      <span className="text-daintree-text/40 text-[10px] shrink-0 hidden group-open:inline">
                         ▼
                       </span>
                       <span className="text-daintree-text/80 truncate min-w-0">

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -21,7 +21,7 @@ export function getPatchStats(content: string): { additions: number; deletions: 
 
 export function patchLineClass(line: string): string {
   if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("@@")) {
-    return "text-daintree-text/40";
+    return "text-text-secondary";
   }
   if (line.startsWith("+")) return "text-status-success bg-status-success/10";
   if (line.startsWith("-")) return "text-status-error bg-status-error/10";
@@ -168,11 +168,11 @@ function ArtifactItem({
           <span className={cn("font-mono text-xs shrink-0", colorClass.split(" ")[2])}>{icon}</span>
           <span className="text-sm text-daintree-text font-medium truncate">{title}</span>
           {artifact.language && artifact.language !== artifact.type && (
-            <span className="text-xs text-daintree-text/40 shrink-0">{artifact.language}</span>
+            <span className="text-xs text-text-secondary shrink-0">{artifact.language}</span>
           )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          <span className="text-xs text-daintree-text/40">
+          <span className="text-xs text-text-secondary">
             {lineCount} line{lineCount !== 1 ? "s" : ""}
           </span>
           <span className="text-daintree-text/60">{isExpanded ? "▼" : "▶"}</span>
@@ -184,7 +184,7 @@ function ArtifactItem({
           <pre className="font-mono text-xs p-3 overflow-x-auto max-h-32 overflow-y-auto select-text">
             <code className="text-daintree-text">
               {previewLines.join("\n")}
-              {hasMore && <span className="text-daintree-text/40">{"\n"}...</span>}
+              {hasMore && <span className="text-text-secondary">{"\n"}...</span>}
             </code>
           </pre>
 
@@ -460,7 +460,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                   type="button"
                   onClick={clearArtifacts}
                   disabled={isBulkActionRunning}
-                  className="text-xs text-daintree-text/40 hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                  className="text-xs text-text-secondary hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                   aria-label="Clear all artifacts"
                 >
                   Clear
@@ -649,10 +649,10 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                   // open by default; the toggle only tames very long bulk sets.
                   <details key={patch.id} open className="group">
                     <summary className="flex items-baseline gap-2 px-3 py-2 cursor-pointer list-none">
-                      <span className="text-daintree-text/40 text-[10px] shrink-0 group-open:hidden">
+                      <span className="text-text-secondary text-[10px] shrink-0 group-open:hidden">
                         ▶
                       </span>
-                      <span className="text-daintree-text/40 text-[10px] shrink-0 hidden group-open:inline">
+                      <span className="text-text-secondary text-[10px] shrink-0 hidden group-open:inline">
                         ▼
                       </span>
                       <span className="text-daintree-text/80 truncate min-w-0">

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -139,7 +139,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
       >
         {(title || keyHint) && (
           <div className="flex items-center justify-between gap-2 border-b border-tint/5 px-2 py-1.5">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-daintree-text/40">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-text-secondary">
               {title}
             </span>
             {keyHint && (
@@ -151,7 +151,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
         )}
         <ScrollShadow className="max-h-64" scrollClassName="p-1">
           {isLoading && items.length === 0 && (
-            <div className="px-2 py-2 text-xs font-mono text-daintree-text/40">Searching…</div>
+            <div className="px-2 py-2 text-xs font-mono text-text-secondary">Searching…</div>
           )}
 
           {isEmpty && (
@@ -159,7 +159,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
               role="status"
               aria-live="polite"
               aria-atomic="true"
-              className="px-2 py-2 text-xs font-mono text-daintree-text/40"
+              className="px-2 py-2 text-xs font-mono text-text-secondary"
             >
               {emptyMessage}
             </div>

--- a/src/components/Terminal/DockedPanel.tsx
+++ b/src/components/Terminal/DockedPanel.tsx
@@ -123,7 +123,7 @@ export function DockedPanel({
             <div className="text-center">
               <p className="text-sm font-medium">Unknown Panel Type</p>
               <p className="text-xs mt-1 text-daintree-text/50">Kind: {kind}</p>
-              <p className="text-xs mt-2 text-daintree-text/40">
+              <p className="text-xs mt-2 text-text-secondary">
                 No component registered for this panel kind
               </p>
             </div>

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -244,7 +244,7 @@ export const GridPanel = React.memo(function GridPanel({
             <div className="text-center">
               <p className="text-sm font-medium">Unknown Panel Type</p>
               <p className="text-xs mt-1 text-daintree-text/50">Kind: {kind}</p>
-              <p className="text-xs mt-2 text-daintree-text/40">
+              <p className="text-xs mt-2 text-text-secondary">
                 No component registered for this panel kind
               </p>
             </div>

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -67,7 +67,7 @@ function StateBanner({ state, detail }: { state: AgentAvailabilityState; detail:
             {detail.message ?? "The agent executable was not detected on your system."}
           </p>
           {detail.resolvedPath && (
-            <p className="text-xs text-daintree-text/40 mt-1 font-mono select-text">
+            <p className="text-xs text-text-secondary mt-1 font-mono select-text">
               Last known path: {detail.resolvedPath}
             </p>
           )}
@@ -104,7 +104,7 @@ function StateBanner({ state, detail }: { state: AgentAvailabilityState; detail:
         <p className="text-xs text-daintree-text/60 mt-1">
           {detail.message ?? "The binary exists but execution was denied."}
         </p>
-        <p className="text-xs text-daintree-text/40 mt-1">
+        <p className="text-xs text-text-secondary mt-1">
           Check your endpoint security settings or add an allowlist entry.
         </p>
       </div>
@@ -139,7 +139,7 @@ function InstallCommands({ blocks }: { blocks: AgentInstallBlock[] }) {
           {block.notes && (
             <div className="mt-2 space-y-0.5">
               {block.notes.map((note, j) => (
-                <p key={j} className="text-xs text-daintree-text/40">
+                <p key={j} className="text-xs text-text-secondary">
                   {note}
                 </p>
               ))}
@@ -241,7 +241,7 @@ export function MissingCliGate({
           </div>
           <div>
             <h2 className="text-sm font-semibold">{agentName}</h2>
-            <p className="text-xs text-daintree-text/40">
+            <p className="text-xs text-text-secondary">
               {isAgentLaunchable(state)
                 ? "Ready to continue launch"
                 : "Setup required before launch"}
@@ -263,7 +263,7 @@ export function MissingCliGate({
             <p className="text-xs font-medium text-daintree-text/50">Troubleshooting</p>
             <ul className="list-disc list-inside space-y-0.5">
               {troubleshooting.map((tip, i) => (
-                <li key={i} className="text-xs text-daintree-text/40">
+                <li key={i} className="text-xs text-text-secondary">
                   {tip}
                 </li>
               ))}

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -164,7 +164,7 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
       itemIdPrefix="prompt-history-option"
       emptyMessage="No history yet"
       emptyContent={
-        <p className="mt-2 text-xs text-daintree-text/40">
+        <p className="mt-2 text-xs text-text-secondary">
           History appears here as you send prompts to agents.
         </p>
       }

--- a/src/components/Terminal/ResumeSessionsPalette.tsx
+++ b/src/components/Terminal/ResumeSessionsPalette.tsx
@@ -50,7 +50,7 @@ function ResumeSessionRow({ item, isSelected, matches, onSelect, itemRef }: Resu
         )}
       </div>
       {item.isStale && (
-        <span className="shrink-0 mt-0.5 text-[10px] font-medium text-daintree-text/40">
+        <span className="shrink-0 mt-0.5 text-[10px] font-medium text-text-secondary">
           Worktree removed
         </span>
       )}
@@ -196,7 +196,7 @@ export function ResumeSessionsPalette() {
               emptyMessage="No closed sessions yet"
               noMatchMessage={`No sessions match "${query.length > 40 ? query.slice(0, 40) + "…" : query}"`}
             >
-              <p className="mt-2 text-xs text-daintree-text/40">
+              <p className="mt-2 text-xs text-text-secondary">
                 Sessions you close appear here so you can pick them back up later.
               </p>
             </AppPaletteDialog.Empty>

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -129,7 +129,7 @@ export function SendToAgentPalette({
       emptyMessage="No other terminals available"
       totalResults={totalResults}
       emptyContent={
-        <p className="mt-2 text-xs text-daintree-text/40">
+        <p className="mt-2 text-xs text-text-secondary">
           {newTerminalShortcut ? (
             <>
               Press <kbd className={KBD_CLASS}>{newTerminalShortcut}</kbd> to create a new terminal.

--- a/src/components/Terminal/SubagentChip.tsx
+++ b/src/components/Terminal/SubagentChip.tsx
@@ -29,7 +29,7 @@ import type {
 const TONE_CLASSES: Record<"error" | "active" | "muted", string> = {
   error: "text-status-error",
   active: "text-status-info",
-  muted: "text-daintree-text/40",
+  muted: "text-text-secondary",
 };
 
 function TranscriptBody({
@@ -67,7 +67,7 @@ function TranscriptBody({
       )}
       {transcript.messages.map((message, index) => (
         <div key={`${transcript.subagentId}-${index}`} className="flex flex-col gap-0.5">
-          <span className="text-[10px] uppercase tracking-wider text-daintree-text/40">
+          <span className="text-[10px] uppercase tracking-wider text-text-secondary">
             {message.role === "task" ? "Task" : "Reply"}
           </span>
           <p className="text-xs text-daintree-text/80 whitespace-pre-wrap break-words">
@@ -142,7 +142,7 @@ function SubagentRow({
         aria-controls={panelId}
         className="w-full flex items-start gap-2 px-3 py-2 text-left hover:bg-overlay-subtle transition-colors"
       >
-        <Chevron className="w-3 h-3 mt-0.5 shrink-0 text-daintree-text/40" aria-hidden="true" />
+        <Chevron className="w-3 h-3 mt-0.5 shrink-0 text-text-secondary" aria-hidden="true" />
         <span className="flex-1 min-w-0 flex flex-col gap-0.5">
           <span className="flex items-center gap-2">
             <span className="text-xs font-medium text-daintree-text truncate">

--- a/src/components/Terminal/SubagentChip.tsx
+++ b/src/components/Terminal/SubagentChip.tsx
@@ -142,7 +142,7 @@ function SubagentRow({
         aria-controls={panelId}
         className="w-full flex items-start gap-2 px-3 py-2 text-left hover:bg-overlay-subtle transition-colors"
       >
-        <Chevron className="w-3 h-3 mt-0.5 shrink-0 text-text-secondary" aria-hidden="true" />
+        <Chevron className="w-3 h-3 mt-0.5 shrink-0 text-daintree-text/40" aria-hidden="true" />
         <span className="flex-1 min-w-0 flex flex-col gap-0.5">
           <span className="flex items-center gap-2">
             <span className="text-xs font-medium text-daintree-text truncate">

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -566,7 +566,7 @@ export function TerminalHeaderContent({
               className={cn(
                 "inline-flex items-center gap-1 text-[11px] font-mono shrink-0 transition-colors duration-150",
                 {
-                  "text-daintree-text/40": stickySeverity === "muted",
+                  "text-text-secondary": stickySeverity === "muted",
                   "text-status-warning": stickySeverity === "amber",
                   "text-status-error": stickySeverity === "red",
                 }

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -426,6 +426,15 @@ describe("TerminalHeaderContent — agent state chip tooltip", () => {
 });
 
 describe("TerminalHeaderContent — resource severity hysteresis", () => {
+  // Muted severity is pinned by the absence of both escalated tones rather than
+  // by its own colour class. Which colour "muted" paints in is an implementation
+  // value — it moved off `text-daintree-text/40` in #12003 — while the ladder
+  // position these hysteresis tests exist to prove is what stays true.
+  function expectMutedSeverity(className: string | null) {
+    expect(className).not.toContain("text-status-warning");
+    expect(className).not.toContain("text-status-error");
+  }
+
   function makeResourceState(cpuPercent: number, memoryKb = 200_000) {
     return {
       cpuPercent,
@@ -454,9 +463,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
 
     const { container } = render(<TerminalHeaderContent id="t1" kind="terminal" />);
     const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
-    expect(wrapper!.getAttribute("class")).toContain("text-daintree-text/40");
-    expect(wrapper!.getAttribute("class")).not.toContain("text-status-warning");
-    expect(wrapper!.getAttribute("class")).not.toContain("text-status-error");
+    expectMutedSeverity(wrapper!.getAttribute("class"));
   });
 
   // Vary `queueCount` between renders so React.memo doesn't skip the re-render
@@ -482,8 +489,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 60, 2);
 
     const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
-    expect(wrapper!.getAttribute("class")).toContain("text-daintree-text/40");
-    expect(wrapper!.getAttribute("class")).not.toContain("text-status-warning");
+    expectMutedSeverity(wrapper!.getAttribute("class"));
   });
 
   it("commits to amber after 3 consecutive polls above the threshold", () => {
@@ -500,7 +506,6 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
 
     const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
     expect(wrapper!.getAttribute("class")).toContain("text-status-warning");
-    expect(wrapper!.getAttribute("class")).not.toContain("text-daintree-text/40");
   });
 
   it("commits red, amber, then muted on a sustained downward sequence", () => {
@@ -533,8 +538,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 10, 11);
     pollResource(rerender, 10, 12);
     pollResource(rerender, 10, 13);
-    expect(wrapperFor().getAttribute("class")).toContain("text-daintree-text/40");
-    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-warning");
+    expectMutedSeverity(wrapperFor().getAttribute("class"));
   });
 
   it("does not de-escalate after only 4 polls below the threshold", () => {
@@ -638,9 +642,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 10, 6);
     pollResource(rerender, 10, 7);
     pollResource(rerender, 10, 8);
-    expect(wrapperFor().getAttribute("class")).toContain("text-daintree-text/40");
-    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-warning");
-    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-error");
+    expectMutedSeverity(wrapperFor().getAttribute("class"));
   });
 
   it("commits to red via the memory threshold alone", () => {
@@ -662,7 +664,6 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
 
     const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
     expect(wrapper!.getAttribute("class")).toContain("text-status-error");
-    expect(wrapper!.getAttribute("class")).not.toContain("text-daintree-text/40");
   });
 
   it("resets sticky severity to muted when monitoring is disabled and re-enabled", () => {
@@ -688,8 +689,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     rerender(<TerminalHeaderContent id="t1" kind="terminal" queueCount={5} />);
 
     wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
-    expect(wrapper!.getAttribute("class")).toContain("text-daintree-text/40");
-    expect(wrapper!.getAttribute("class")).not.toContain("text-status-warning");
+    expectMutedSeverity(wrapper!.getAttribute("class"));
   });
 
   it("resets candidate counter when severity oscillates back during the run", () => {
@@ -707,8 +707,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 60, 5);
 
     const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
-    expect(wrapper!.getAttribute("class")).toContain("text-daintree-text/40");
-    expect(wrapper!.getAttribute("class")).not.toContain("text-status-warning");
+    expectMutedSeverity(wrapper!.getAttribute("class"));
   });
 });
 

--- a/src/components/ThemeBrowser/ThemeBrowser.tsx
+++ b/src/components/ThemeBrowser/ThemeBrowser.tsx
@@ -107,9 +107,7 @@ function ThemeRow({
           )}
         </div>
         {scheme.location && (
-          <span className="text-[11px] text-daintree-text/40 truncate block">
-            {scheme.location}
-          </span>
+          <span className="text-[11px] text-text-secondary truncate block">{scheme.location}</span>
         )}
       </div>
       <PaletteStrip scheme={scheme} />

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -36,7 +36,7 @@ const STATE_CONFIG: Record<
   },
   exited: {
     icon: "–",
-    color: "text-daintree-text/40",
+    color: "text-text-secondary",
     tooltip: "Process exited",
   },
   directing: {

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -36,7 +36,7 @@ const STATE_CONFIG: Record<
   },
   exited: {
     icon: "–",
-    color: "text-text-secondary",
+    color: "text-daintree-text/40",
     tooltip: "Process exited",
   },
   directing: {

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -158,7 +158,7 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
       emptyMessage="No recipes yet"
       emptyContent={
         <div className="flex flex-col items-center gap-3 mt-4">
-          <p className="text-xs text-daintree-text/40">
+          <p className="text-xs text-text-secondary">
             Create a recipe in the recipe editor to get started.
           </p>
           <Button

--- a/src/components/Worktree/ReviewHub/CommitPanel.tsx
+++ b/src/components/Worktree/ReviewHub/CommitPanel.tsx
@@ -433,7 +433,7 @@ export function CommitPanel({
       <div
         className={cn(
           "flex justify-end text-[10px] tabular-nums -mt-1",
-          hasLineOverflow ? "text-status-warning" : "text-daintree-text/40"
+          hasLineOverflow ? "text-status-warning" : "text-text-secondary"
         )}
       >
         {subjectLine.length}/{MAX_SUBJECT_LENGTH}

--- a/src/components/Worktree/ReviewHub/ConflictPanel.tsx
+++ b/src/components/Worktree/ReviewHub/ConflictPanel.tsx
@@ -635,7 +635,7 @@ export function ConflictPanel({
                       <TruncatedTooltip content={file.path}>
                         <div className="flex-1 min-w-0 flex items-baseline">
                           {dir && (
-                            <span className="shrink truncate text-daintree-text/40 font-mono text-[11px]">
+                            <span className="shrink truncate text-text-secondary font-mono text-[11px]">
                               {dir}/
                             </span>
                           )}

--- a/src/components/Worktree/ReviewHub/ConflictPanel.tsx
+++ b/src/components/Worktree/ReviewHub/ConflictPanel.tsx
@@ -635,7 +635,7 @@ export function ConflictPanel({
                       <TruncatedTooltip content={file.path}>
                         <div className="flex-1 min-w-0 flex items-baseline">
                           {dir && (
-                            <span className="shrink truncate text-text-secondary font-mono text-[11px]">
+                            <span className="shrink truncate text-daintree-text/40 font-mono text-[11px]">
                               {dir}/
                             </span>
                           )}

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -45,7 +45,7 @@ const STATUS_CONFIG: Record<GitStatus, { label: string; bg: string; text: string
   ignored: {
     label: "I",
     bg: "bg-tint/[0.06]",
-    text: "text-daintree-text/40",
+    text: "text-text-secondary",
   },
   conflicted: {
     label: "!",

--- a/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
+++ b/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
@@ -223,13 +223,13 @@ export function ForcePushConfirmDialog({
                   >
                     <span
                       className={cn(
-                        "font-mono text-[10px] text-daintree-text/40 shrink-0 tabular-nums"
+                        "font-mono text-[10px] text-text-secondary shrink-0 tabular-nums"
                       )}
                     >
                       {commit.hash.slice(0, SHORT_HASH_LEN)}
                     </span>
                     <span className="text-daintree-text/80 truncate min-w-0">{commit.message}</span>
-                    <span className="text-[10px] text-daintree-text/40 shrink-0 ml-auto">
+                    <span className="text-[10px] text-text-secondary shrink-0 ml-auto">
                       {commit.author}
                     </span>
                   </li>
@@ -240,7 +240,7 @@ export function ForcePushConfirmDialog({
                   // is that the divergence runs to hundreds of commits, not
                   // what the hundred-and-first one says.
                   <li
-                    className="text-[10px] text-daintree-text/40 italic pt-1"
+                    className="text-[10px] text-text-secondary italic pt-1"
                     data-testid="force-push-commit-cap"
                   >
                     Listing the {commits.length} most recent of {totalRemote}

--- a/src/components/Worktree/ReviewHub/PrStatusChip.tsx
+++ b/src/components/Worktree/ReviewHub/PrStatusChip.tsx
@@ -58,11 +58,11 @@ export function PrStatusChip({ hasRemote, worktreePR, onOpenExternal }: PrStatus
           >
             #{worktreePR.prNumber}
           </span>
-          <span className="text-text-secondary">·</span>
+          <span className="text-daintree-text/40">·</span>
           <span className="text-daintree-text/60">{prStateLabel}</span>
           {ciVisual && (
             <>
-              <span className="text-text-secondary">·</span>
+              <span className="text-daintree-text/40">·</span>
               <span className="inline-flex items-center gap-1">
                 <span
                   className="inline-flex items-center justify-center w-3 h-3 shrink-0"

--- a/src/components/Worktree/ReviewHub/PrStatusChip.tsx
+++ b/src/components/Worktree/ReviewHub/PrStatusChip.tsx
@@ -58,11 +58,11 @@ export function PrStatusChip({ hasRemote, worktreePR, onOpenExternal }: PrStatus
           >
             #{worktreePR.prNumber}
           </span>
-          <span className="text-daintree-text/40">·</span>
+          <span className="text-text-secondary">·</span>
           <span className="text-daintree-text/60">{prStateLabel}</span>
           {ciVisual && (
             <>
-              <span className="text-daintree-text/40">·</span>
+              <span className="text-text-secondary">·</span>
               <span className="inline-flex items-center gap-1">
                 <span
                   className="inline-flex items-center justify-center w-3 h-3 shrink-0"
@@ -94,7 +94,7 @@ export function PrStatusChip({ hasRemote, worktreePR, onOpenExternal }: PrStatus
 
   if (hasRemote && !worktreePR) {
     return (
-      <Badge tone="outline" className="text-[11px] text-daintree-text/40">
+      <Badge tone="outline" className="text-[11px] text-text-secondary">
         <GitPullRequest />
         <span>No PR</span>
       </Badge>

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -250,7 +250,7 @@ export function getBaseBranchStatusConfig(status: string): {
     BASE_BRANCH_STATUS_CONFIG[status] ?? {
       label: status,
       bg: "bg-tint/[0.06]",
-      text: "text-daintree-text/40",
+      text: "text-text-secondary",
     }
   );
 }

--- a/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
@@ -239,7 +239,7 @@ function LabelRow({ labels, subject }: { labels: readonly ForgeLabel[]; subject:
         <LabelBadge key={label.name} name={label.name} color={label.color ?? "8b949e"} />
       ))}
       {labels.length > shown.length && (
-        <span className="text-[10px] text-daintree-text/40">
+        <span className="text-[10px] text-text-secondary">
           Showing {shown.length} of {labels.length} — open the {subject} for the rest
         </span>
       )}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -382,7 +382,7 @@ export function WorktreeHeader({
                 resourceEndpoint={resourceEndpoint}
                 resourceLastCheckedAt={resourceLastCheckedAt}
                 onCheckResourceStatus={onCheckResourceStatus}
-                className="w-3.5 h-3.5 text-text-secondary"
+                className="w-3.5 h-3.5 text-daintree-text/40"
               />
             )}
             <DevServerIndicator session={devServerSession} />

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -382,7 +382,7 @@ export function WorktreeHeader({
                 resourceEndpoint={resourceEndpoint}
                 resourceLastCheckedAt={resourceLastCheckedAt}
                 onCheckResourceStatus={onCheckResourceStatus}
-                className="w-3.5 h-3.5 text-daintree-text/40"
+                className="w-3.5 h-3.5 text-text-secondary"
               />
             )}
             <DevServerIndicator session={devServerSession} />

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -1216,7 +1216,7 @@ export function WorktreeOverviewModal({
                       <h3 className="text-xs font-medium text-daintree-text/60 uppercase tracking-wider">
                         {section.displayName}
                       </h3>
-                      <span className="text-xs text-daintree-text/40">
+                      <span className="text-xs text-text-secondary">
                         ({section.worktrees.length})
                       </span>
                     </div>,

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -131,7 +131,7 @@ export function WorktreePalette({
       emptyMessage="No worktrees yet"
       totalResults={totalResults}
       emptyContent={
-        <p className="mt-2 text-xs text-daintree-text/40">
+        <p className="mt-2 text-xs text-text-secondary">
           {createWorktreeShortcut ? (
             <>
               Press <kbd className={KBD_CLASS}>{createWorktreeShortcut}</kbd> to create a worktree.

--- a/src/components/Worktree/terminalStateConfig.tsx
+++ b/src/components/Worktree/terminalStateConfig.tsx
@@ -15,9 +15,9 @@ export const STATE_COLORS = {
   working: "text-state-working",
   waiting: "text-state-waiting",
   directing: "text-category-blue",
-  idle: "text-daintree-text/40",
+  idle: "text-text-secondary",
   completed: "text-category-slate",
-  exited: "text-daintree-text/40",
+  exited: "text-text-secondary",
 } as const satisfies Record<AgentState, string>;
 
 export const STATE_LABELS = {

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -173,7 +173,7 @@ export function AgentIdentityBlock({
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium text-daintree-text">{name}</div>
         {description && (
-          <div className="text-[11px] text-daintree-text/40 truncate">{description}</div>
+          <div className="text-[11px] text-text-secondary truncate">{description}</div>
         )}
       </div>
     </>
@@ -222,7 +222,7 @@ export function AgentInstallSection({
   if (isCliLoading) {
     return (
       <div className="pt-4 border-t border-daintree-border">
-        <div className="text-xs text-daintree-text/40">Checking CLI availability...</div>
+        <div className="text-xs text-text-secondary">Checking CLI availability...</div>
       </div>
     );
   }
@@ -328,7 +328,7 @@ export function AgentInstallSection({
             )}
 
           <div className="px-3 py-2 rounded-[var(--radius-md)] bg-daintree-bg/50 border border-daintree-border/50">
-            <p className="text-xs text-daintree-text/40 select-text">
+            <p className="text-xs text-text-secondary select-text">
               Warning: Review commands before running them in your terminal
             </p>
           </div>

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -66,7 +66,7 @@ export function KbdChord({
       {steps.map((tokens, stepIndex) => (
         <Fragment key={stepIndex}>
           {stepIndex > 0 && (
-            <span className="text-text-secondary text-[10px] select-none" aria-hidden>
+            <span className="text-daintree-text/40 text-[10px] select-none" aria-hidden>
               ,
             </span>
           )}
@@ -74,7 +74,7 @@ export function KbdChord({
             {tokens.map((token, tokenIndex) => (
               <Fragment key={tokenIndex}>
                 {tokenIndex > 0 && !mac && (
-                  <span className="text-text-secondary text-[10px] select-none" aria-hidden>
+                  <span className="text-daintree-text/40 text-[10px] select-none" aria-hidden>
                     +
                   </span>
                 )}

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -66,7 +66,7 @@ export function KbdChord({
       {steps.map((tokens, stepIndex) => (
         <Fragment key={stepIndex}>
           {stepIndex > 0 && (
-            <span className="text-daintree-text/40 text-[10px] select-none" aria-hidden>
+            <span className="text-text-secondary text-[10px] select-none" aria-hidden>
               ,
             </span>
           )}
@@ -74,7 +74,7 @@ export function KbdChord({
             {tokens.map((token, tokenIndex) => (
               <Fragment key={tokenIndex}>
                 {tokenIndex > 0 && !mac && (
-                  <span className="text-daintree-text/40 text-[10px] select-none" aria-hidden>
+                  <span className="text-text-secondary text-[10px] select-none" aria-hidden>
                     +
                   </span>
                 )}

--- a/src/components/ui/PaletteOverflowNotice.tsx
+++ b/src/components/ui/PaletteOverflowNotice.tsx
@@ -19,7 +19,7 @@ export function PaletteOverflowNotice({ shown, total }: PaletteOverflowNoticePro
     <div
       role="status"
       aria-label={`${hidden} more results not shown — type to narrow your search`}
-      className="px-3 py-2 text-xs tabular-nums text-daintree-text/40 text-center border-t border-daintree-border/30"
+      className="px-3 py-2 text-xs tabular-nums text-text-secondary text-center border-t border-daintree-border/30"
     >
       +{hidden} more — type to narrow
     </div>

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -363,7 +363,7 @@ export function SearchablePalette<T>({
 
   const autoEmptyChip =
     !emptyContent && emptyShortcut && emptyEntityName ? (
-      <p className="mt-2 text-xs text-daintree-text/40">
+      <p className="mt-2 text-xs text-text-secondary">
         Press <kbd className={KBD_CLASS}>{emptyShortcut}</kbd> to create {emptyEntityName}.
       </p>
     ) : null;

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -307,7 +307,7 @@ const SelectItem = React.forwardRef<
       {description ? (
         <span className="flex flex-col gap-0.5">
           <ItemText>{children}</ItemText>
-          <span className="text-[11px] text-daintree-text/40">{description}</span>
+          <span className="text-[11px] text-text-secondary">{description}</span>
         </span>
       ) : (
         <ItemText>{children}</ItemText>

--- a/src/lib/gitStatusPresentation.ts
+++ b/src/lib/gitStatusPresentation.ts
@@ -26,7 +26,7 @@ export const GIT_STATUS_PRESENTATION = {
   untracked: { marker: "?", name: "Untracked", colorClass: "text-status-success" },
   renamed: { marker: "R", name: "Renamed", colorClass: "text-status-info" },
   copied: { marker: "C", name: "Copied", colorClass: "text-status-info" },
-  ignored: { marker: "I", name: "Ignored", colorClass: "text-daintree-text/40" },
+  ignored: { marker: "I", name: "Ignored", colorClass: "text-text-secondary" },
   conflicted: { marker: "!", name: "Conflicted", colorClass: "text-status-error" },
 } satisfies Record<GitStatus, GitStatusPresentation>;
 

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1122,7 +1122,7 @@ export function FileBrowserPane({
                 </Tooltip>
               ) : (
                 <span
-                  className="min-w-0 flex-1 truncate font-mono text-[11px] text-daintree-text/40"
+                  className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-secondary"
                   title={rootHoverPath}
                 >
                   {rootPath || (basePath ? basename(basePath) : "")}

--- a/src/panels/file-browser/FolderListingView.tsx
+++ b/src/panels/file-browser/FolderListingView.tsx
@@ -101,7 +101,7 @@ export function FolderListingView({
       */}
       <div
         aria-hidden="true"
-        className="flex shrink-0 items-center gap-3 border-b border-overlay px-3 py-1 text-[11px] font-medium text-daintree-text/40"
+        className="flex shrink-0 items-center gap-3 border-b border-overlay px-3 py-1 text-[11px] font-medium text-text-secondary"
       >
         <span className="min-w-0 flex-1">Name</span>
         <span className="w-20 shrink-0 text-right">Size</span>


### PR DESCRIPTION
## Summary

- `text-daintree-text/40` composites to about 3.26:1 on the default theme's canvas, below WCAG's 4.5:1 floor for body text. 250 of the 427 uses across `src/` and `plugins/` carry prose, a label, or a value, so those move to `text-text-secondary`, the theme's own "muted but readable" token.
- Measured with the repo's own `contrastRatio()` (`shared/theme/contrast.ts`) against `BUILT_IN_APP_SCHEMES`, `text-text-secondary` ranges from 4.96:1 (redwoods dark on panel-elevated, the tightest pair in the whole matrix) to 9.61:1 (atacama light on panel-elevated). It clears the floor on every surface in all fifteen bundled themes.
- Worth stating outright: the existing `getThemeContrastWarnings()` gate only enforces `text-secondary` at 3.0:1, so CI doesn't by itself prove this safe. The 15-theme computation does. This finishes the migration `src/components/ui/paletteRowStyles.ts` started for palette section labels.

Resolves #12003

## Second benefit

A solid token escapes the `[class*="text-daintree-text/"]` override in `src/index.css`'s `prefers-contrast: more` block, so label and detail keep their hierarchy under Increase Contrast instead of flattening to one colour.

## What stays dim (177 occurrences)

Each one lands in a named category, not an oversight:

- 54 icon glyphs plus 33 icon-only controls. The colour is an affordance there, not prose.
- 31 text controls whose hover step is another `daintree-text/N`. `text-text-secondary` sits at 6.85:1 while `/60` is 5.71:1, so lifting only the resting colour would invert the hover direction. The ramp above `/40` belongs to #12031.
- 15 disabled, struck-through, or completed states, where low contrast is the signal.
- 1 `placeholder:` variant.
- 22 sites returned to `/40` after review: single-glyph content (disclosure triangles, `→`, `×`, `,`, `+`, interpuncts, an em dash, a chevron, a dash inside `role="img"`) and hierarchy inversions where the migrated element became the brightest thing in a group it's subordinate to.
- 8 reviewed one-offs, including two always-complete checklist rows already nested in `opacity-60`, and a disabled-reason string that only renders inside an `opacity-50` disabled button. Per lesson #9691, the composite is what matters, not the nominal token.

## Scope boundary

Flagging these up front since reviewers may expect them:

- No ESLint rule. #12029 owns the slash-alpha-on-text rule as part of a 5-rule batch and lands first so its ratchet baseline starts clean.
- No other opacity step touched. #12031 owns `/45` through `/90` and explicitly requires #12003 to land first, leaving `/40` alone.
- No theme, token, CSS, or docs changes.

## Test change

`TerminalHeaderContent.test.tsx` no longer names the muted colour class. Six assertions used it as a proxy for severity, which is a tautological assertion under this repo's testing rules, so they now pin the ladder position instead via an `expectMutedSeverity` helper: muted is defined as the absence of both escalated tones. The escalate-after-3-polls / de-escalate-after-5-polls hysteresis coverage is unchanged.

## Follow-up spotted, not fixed here

`EnvironmentPopover` merges the caller's `className` last (`cn(iconClass, className)`), so `WorktreeHeader`'s forwarded text colour beats the computed green/yellow/red status tone via `twMerge`. The environment status colour never renders at that call site. This is pre-existing on `develop` and it's a colour-precedence bug rather than a contrast one, so it's left alone here and worth its own issue.

## Testing

202 targeted test files (4680 tests) pass: every test twin of a changed file, every test importing one, plus the five constraint tests that assert on `/40`. Prettier is clean and there are 0 eslint errors on changed files. Every one of the 177 remaining `/40` occurrences is programmatically accounted for by a named keep category above; zero unaccounted.
