### PR TITLE
fix(overflow): give every "+N more" indicator somewhere to go

### DIFF
--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -19,6 +19,7 @@ import type {
   RepoState,
   StagingStatus,
 } from "../../../shared/types/git.js";
+import { GIT_REMOTE_COMMIT_PREVIEW_MAX } from "../../../shared/types/git.js";
 import {
   validateCwd,
   createHardenedGit,
@@ -833,7 +834,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       throw new Error("Invalid branch name");
     }
     const branchName = payload.branchName.trim();
-    const limit = Math.max(1, Math.min(100, payload.limit ?? 20));
+    const limit = Math.max(1, Math.min(GIT_REMOTE_COMMIT_PREVIEW_MAX, payload.limit ?? 20));
 
     const git = await createHardenedGit(payload.cwd);
     try {

--- a/electron/setup/__tests__/archiveInstallIntent.test.ts
+++ b/electron/setup/__tests__/archiveInstallIntent.test.ts
@@ -446,4 +446,64 @@ describe("archiveInstallIntent", () => {
     const [intent] = intentsFrom(painted.sent);
     expect(intent).toMatchObject({ manifest: { recipes: { count: 0, names: [] } } });
   });
+
+  it("sends every recipe name, not a leading subset (#12001)", async () => {
+    // The preview used to arrive truncated, leaving the D2 confirm to print
+    // "+N more" for executable content nothing downstream could open. The
+    // schema already bounds this at 50 recipes of 200 characters, so the
+    // dialog bounds its viewport instead of the data.
+    const painted = makePainted();
+    deepLinkMock.painted = painted.wc;
+    const declared = Array.from({ length: 24 }, (_, i) => ({
+      id: `r${i}`,
+      name: `Recipe ${i}`,
+      terminals: [],
+    }));
+    archiveMock.readArchiveManifest.mockResolvedValue(
+      manifest({ contributes: { recipes: declared } } as unknown as Partial<PluginManifest>)
+    );
+
+    const { enqueueArchiveInstallIntent } = await importFresh();
+    await enqueueArchiveInstallIntent(P("many-recipes.dntr"));
+
+    const [intent] = intentsFrom(painted.sent);
+    const recipes = (intent as { manifest: { recipes: { count: number; names: string[] } } })
+      .manifest.recipes;
+    expect(recipes.names).toHaveLength(declared.length);
+    expect(recipes.count).toBe(recipes.names.length);
+    // The last one specifically: a `.slice()` regression keeps the head intact.
+    expect(recipes.names.at(-1)).toBe(declared.at(-1)!.name);
+  });
+
+  it("still clamps and sanitizes names once the subset cap is gone (#12001)", async () => {
+    const painted = makePainted();
+    deepLinkMock.painted = painted.wc;
+    archiveMock.readArchiveManifest.mockResolvedValue(
+      manifest({
+        contributes: {
+          recipes: [
+            ...Array.from({ length: 15 }, (_, i) => ({
+              id: `p${i}`,
+              name: `Pad ${i}`,
+              terminals: [],
+            })),
+            { id: "long", name: "L".repeat(500), terminals: [] },
+            { id: "bidi", name: "Run \u202Etset", terminals: [] },
+          ],
+        },
+      } as unknown as Partial<PluginManifest>)
+    );
+
+    const { enqueueArchiveInstallIntent } = await importFresh();
+    await enqueueArchiveInstallIntent(P("hostile-recipes.dntr"));
+
+    const [intent] = intentsFrom(painted.sent);
+    const { names } = (intent as { manifest: { recipes: { count: number; names: string[] } } })
+      .manifest.recipes;
+    // Past the old cap of ten, so both would have been dropped before.
+    const long = names.at(-2)!;
+    expect(long.length).toBeLessThan(500);
+    expect(long.endsWith("\u2026")).toBe(true);
+    expect(names.at(-1)).not.toContain("\u202E");
+  });
 });

--- a/electron/setup/__tests__/archiveInstallIntent.test.ts
+++ b/electron/setup/__tests__/archiveInstallIntent.test.ts
@@ -469,10 +469,34 @@ describe("archiveInstallIntent", () => {
     const [intent] = intentsFrom(painted.sent);
     const recipes = (intent as { manifest: { recipes: { count: number; names: string[] } } })
       .manifest.recipes;
-    expect(recipes.names).toHaveLength(declared.length);
+    // The whole ordered sequence: a length check alone would pass if a middle
+    // entry were duplicated or reordered.
+    expect(recipes.names).toEqual(declared.map((r) => r.name));
     expect(recipes.count).toBe(recipes.names.length);
-    // The last one specifically: a `.slice()` regression keeps the head intact.
-    expect(recipes.names.at(-1)).toBe(declared.at(-1)!.name);
+  });
+
+  it("preserves two recipes that declare the same name (#12001)", async () => {
+    const painted = makePainted();
+    deepLinkMock.painted = painted.wc;
+    archiveMock.readArchiveManifest.mockResolvedValue(
+      manifest({
+        contributes: {
+          recipes: [
+            { id: "a", name: "Deploy", terminals: [] },
+            { id: "b", name: "Deploy", terminals: [] },
+          ],
+        },
+      } as unknown as Partial<PluginManifest>)
+    );
+
+    const { enqueueArchiveInstallIntent } = await importFresh();
+    await enqueueArchiveInstallIntent(P("dupe-recipes.dntr"));
+
+    const [intent] = intentsFrom(painted.sent);
+    const recipes = (intent as { manifest: { recipes: { count: number; names: string[] } } })
+      .manifest.recipes;
+    // Two recipes are two things to approve even when they read alike.
+    expect(recipes.names).toEqual(["Deploy", "Deploy"]);
   });
 
   it("still clamps and sanitizes names once the subset cap is gone (#12001)", async () => {

--- a/electron/setup/archiveInstallIntent.ts
+++ b/electron/setup/archiveInstallIntent.ts
@@ -94,11 +94,6 @@ function surfaceArchiveError(fileName: string, detail: string): void {
 // the installer, which does its own validation.
 const PREVIEW_TEXT_MAX = 200;
 
-// How many contributed recipe names the install dialog lists. The manifest cap
-// allows dozens; the dialog shows a readable subset and reports the true total
-// alongside it, so a large manifest can't push the capability rows off-screen.
-const MAX_PREVIEW_RECIPE_NAMES = 10;
-
 // Unicode format controls (bidi overrides, zero-widths, line/paragraph
 // separators, C0/C1) can visually reorder or overpaint the trusted text beside
 // an interpolated field — U+202E flips everything rendered after it, which
@@ -180,17 +175,22 @@ async function runPreviewWorker(): Promise<void> {
             // advertise it, so the install confirmation is the only place a
             // user sees them before approving (#11860). Names are
             // plugin-author-controlled and cross IPC into a dialog, so they get
-            // the same clamp/sanitize treatment as author names. `count` stays
-            // the true total even when the name list is trimmed.
+            // the same clamp/sanitize treatment as author names.
             // Optional access even though a parsed manifest always materializes
             // `contributes`: this whole worker fails an archive closed on any
             // throw, so a manifest shape that surprises us must degrade to "no
             // recipes disclosed" rather than reject an otherwise-valid plugin.
             recipes: {
               count: recipeContributions.length,
-              names: recipeContributions
-                .slice(0, MAX_PREVIEW_RECIPE_NAMES)
-                .map((recipe) => clampPreviewText(recipe.name)),
+              // Every name, not a readable subset. The subset existed so a
+              // large manifest couldn't push the capability rows off-screen,
+              // but truncating here made the dialog's "+N more" name executable
+              // content that nothing downstream could reach — on a D2 confirm,
+              // where a count is explicitly not a preview (#12001). The list is
+              // already bounded by the schema at 50 recipes, and each name by
+              // `clampPreviewText` at 200 characters, so the payload is capped
+              // regardless; the dialog bounds the viewport instead.
+              names: recipeContributions.map((recipe) => clampPreviewText(recipe.name)),
             },
           },
         });

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -161,6 +161,16 @@ export interface GitRemoteCommit {
  * Discard preview for the force-push confirm: the commits, the destination they
  * live on, and the full count over the same range the rows came from.
  */
+/**
+ * The most commits `git:list-remote-commits` will return for one request.
+ *
+ * The contract, not a client preference: the handler clamps to it, and the
+ * force-push confirm asks for it so its D2 preview is never narrower than what
+ * the main process would serve. Both sides read this rather than restating a
+ * number, so the ceiling can only move in one place.
+ */
+export const GIT_REMOTE_COMMIT_PREVIEW_MAX = 100;
+
 export interface GitRemoteCommitPreview {
   destination: GitPushDestination;
   commits: GitRemoteCommit[];

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -925,9 +925,12 @@ export interface PluginArchiveManifestPreview {
   capabilities: PluginCapability[];
   /**
    * Contributed recipes, disclosed by name because a recipe is executable
-   * content that ships with no capability to advertise it (#11860). `count` is
-   * the manifest's true total; `names` is the (clamped, sanitized) subset the
-   * dialog lists, so a manifest declaring dozens can't flood the surface.
+   * content that ships with no capability to advertise it (#11860). `names` is
+   * the complete (clamped, sanitized) list — bounded by the manifest schema at
+   * 50 recipes and 200 characters each, so it can't flood the surface, and the
+   * dialog bounds its own viewport rather than the data (#12001). `count` is
+   * the same total, kept as the cross-process invariant the dialog's prose
+   * reads.
    */
   recipes: { count: number; names: string[] };
 }

--- a/src/components/Errors/CompactErrorList.tsx
+++ b/src/components/Errors/CompactErrorList.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { ErrorBanner } from "./ErrorBanner";
+import type { ErrorRecord, RetryAction } from "@/store/errorStore";
+
+/* Restated under the variant on purpose: Tailwind v4 compiles the
+   outline-suppressing utility to an unconditional `--tw-outline-style: none`,
+   which cancels `focus-visible:outline-2` unless the style is set again there.
+   Same string `ReadinessRail` uses — the accent appears only as a focus ring,
+   which is the one place the accent-restraint rule permits it. */
+const FOCUS_RING =
+  "outline-hidden focus-visible:outline focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
+
+interface CompactErrorListProps {
+  /** Every error for this surface, newest-first as the caller ordered them. */
+  errors: ErrorRecord[];
+  /** How many banners render inline before the rest move behind the trigger. */
+  maxInline: number;
+  onDismiss: (id: string) => void;
+  onRetry?: (id: string, action: RetryAction, args?: Record<string, unknown>) => void;
+  onCancelRetry?: (id: string) => void;
+  className?: string;
+}
+
+/**
+ * A bounded stack of compact error banners, with the tail behind a real
+ * disclosure.
+ *
+ * Both surfaces that use this used to cap the stack and print "+N more errors"
+ * as inert text: the errors were in memory, their retry and dismiss handlers
+ * were already wired, and the count named recovery the user had no way to
+ * reach (#12001). The tail now opens, and every hidden row keeps the CTA it
+ * would have had inline.
+ *
+ * Extracted rather than inlined twice because both callers pass the same
+ * `ErrorRecord` array and the same three handlers — they differ only in how
+ * many banners the surface has room for.
+ */
+export function CompactErrorList({
+  errors,
+  maxInline,
+  onDismiss,
+  onRetry,
+  onCancelRetry,
+  className,
+}: CompactErrorListProps) {
+  const [open, setOpen] = useState(false);
+
+  if (errors.length === 0) return null;
+
+  const inline = errors.slice(0, maxInline);
+  const hidden = errors.slice(maxInline);
+
+  return (
+    <div className={cn("space-y-1", className)}>
+      {inline.map((error) => (
+        <ErrorBanner
+          key={error.id}
+          error={error}
+          onDismiss={onDismiss}
+          onRetry={onRetry}
+          onCancelRetry={onCancelRetry}
+          compact
+        />
+      ))}
+
+      {hidden.length > 0 && (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger
+            type="button"
+            data-testid="compact-error-overflow"
+            // Spelled out rather than left as a bare count: the trigger has to
+            // say what opening it produces, and the messages are what a screen
+            // reader needs to decide whether it's worth opening.
+            aria-label={`Show ${hidden.length} more ${
+              hidden.length === 1 ? "error" : "errors"
+            }: ${hidden.map((e) => e.message).join(", ")}`}
+            className={cn(
+              "flex w-fit mx-auto items-center gap-0.5 px-1.5 py-0.5 rounded text-[0.65rem] transition-colors",
+              "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
+              FOCUS_RING
+            )}
+          >
+            {hidden.length} more {hidden.length === 1 ? "error" : "errors"}
+            <ChevronDown className="w-3 h-3 shrink-0" aria-hidden="true" />
+          </PopoverTrigger>
+          <PopoverContent
+            align="center"
+            sideOffset={8}
+            aria-label="More errors"
+            // Bounded against Radix's own available height rather than a fixed
+            // pixel cap, so a long tail scrolls inside the popover instead of
+            // running past the viewport edge.
+            className="p-1 min-w-72 max-w-sm max-h-[var(--radix-popover-content-available-height)] overflow-y-auto"
+          >
+            <ul className="flex flex-col gap-1">
+              {hidden.map((error) => (
+                <li key={error.id}>
+                  <ErrorBanner
+                    error={error}
+                    onDismiss={(id) => {
+                      onDismiss(id);
+                      // Dismissing the last hidden error leaves an empty
+                      // popover anchored to a trigger that is about to
+                      // unmount; close on the way out instead.
+                      if (hidden.length === 1) setOpen(false);
+                    }}
+                    onRetry={onRetry}
+                    onCancelRetry={onCancelRetry}
+                    compact
+                  />
+                </li>
+              ))}
+            </ul>
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/src/components/Errors/CompactErrorList.tsx
+++ b/src/components/Errors/CompactErrorList.tsx
@@ -13,14 +13,17 @@ import type { ErrorRecord, RetryAction } from "@/store/errorStore";
 const FOCUS_RING =
   "outline-hidden focus-visible:outline focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
 
-interface CompactErrorListProps {
+interface ErrorListHandlers {
+  onDismiss: (id: string) => void;
+  onRetry?: (id: string, action: RetryAction, args?: Record<string, unknown>) => void;
+  onCancelRetry?: (id: string) => void;
+}
+
+interface CompactErrorListProps extends ErrorListHandlers {
   /** Every error for this surface, newest-first as the caller ordered them. */
   errors: ErrorRecord[];
   /** How many banners render inline before the rest move behind the trigger. */
   maxInline: number;
-  onDismiss: (id: string) => void;
-  onRetry?: (id: string, action: RetryAction, args?: Record<string, unknown>) => void;
-  onCancelRetry?: (id: string) => void;
   className?: string;
 }
 
@@ -41,13 +44,9 @@ interface CompactErrorListProps {
 export function CompactErrorList({
   errors,
   maxInline,
-  onDismiss,
-  onRetry,
-  onCancelRetry,
   className,
+  ...handlers
 }: CompactErrorListProps) {
-  const [open, setOpen] = useState(false);
-
   if (errors.length === 0) return null;
 
   const inline = errors.slice(0, maxInline);
@@ -56,67 +55,65 @@ export function CompactErrorList({
   return (
     <div className={cn("space-y-1", className)}>
       {inline.map((error) => (
-        <ErrorBanner
-          key={error.id}
-          error={error}
-          onDismiss={onDismiss}
-          onRetry={onRetry}
-          onCancelRetry={onCancelRetry}
-          compact
-        />
+        <ErrorBanner key={error.id} error={error} compact {...handlers} />
       ))}
-
-      {hidden.length > 0 && (
-        <Popover open={open} onOpenChange={setOpen}>
-          <PopoverTrigger
-            type="button"
-            data-testid="compact-error-overflow"
-            // Spelled out rather than left as a bare count: the trigger has to
-            // say what opening it produces, and the messages are what a screen
-            // reader needs to decide whether it's worth opening.
-            aria-label={`Show ${hidden.length} more ${
-              hidden.length === 1 ? "error" : "errors"
-            }: ${hidden.map((e) => e.message).join(", ")}`}
-            className={cn(
-              "flex w-fit mx-auto items-center gap-0.5 px-1.5 py-0.5 rounded text-[0.65rem] transition-colors",
-              "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
-              FOCUS_RING
-            )}
-          >
-            {hidden.length} more {hidden.length === 1 ? "error" : "errors"}
-            <ChevronDown className="w-3 h-3 shrink-0" aria-hidden="true" />
-          </PopoverTrigger>
-          <PopoverContent
-            align="center"
-            sideOffset={8}
-            aria-label="More errors"
-            // Bounded against Radix's own available height rather than a fixed
-            // pixel cap, so a long tail scrolls inside the popover instead of
-            // running past the viewport edge.
-            className="p-1 min-w-72 max-w-sm max-h-[var(--radix-popover-content-available-height)] overflow-y-auto"
-          >
-            <ul className="flex flex-col gap-1">
-              {hidden.map((error) => (
-                <li key={error.id}>
-                  <ErrorBanner
-                    error={error}
-                    onDismiss={(id) => {
-                      onDismiss(id);
-                      // Dismissing the last hidden error leaves an empty
-                      // popover anchored to a trigger that is about to
-                      // unmount; close on the way out instead.
-                      if (hidden.length === 1) setOpen(false);
-                    }}
-                    onRetry={onRetry}
-                    onCancelRetry={onCancelRetry}
-                    compact
-                  />
-                </li>
-              ))}
-            </ul>
-          </PopoverContent>
-        </Popover>
-      )}
+      {hidden.length > 0 && <ErrorOverflow errors={hidden} {...handlers} />}
     </div>
+  );
+}
+
+/**
+ * The errors past the inline cap.
+ *
+ * Mounted only while a tail exists, so `open` dies with it. Holding that state
+ * in the parent instead would survive the tail: dismiss the last hidden error
+ * while the disclosure is open and a later error would remount it already
+ * open, stealing focus from whatever the user moved on to.
+ */
+function ErrorOverflow({ errors, ...handlers }: ErrorListHandlers & { errors: ErrorRecord[] }) {
+  const [open, setOpen] = useState(false);
+  const label = `Show ${errors.length} more ${errors.length === 1 ? "error" : "errors"}`;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        type="button"
+        data-testid="compact-error-overflow"
+        aria-label={label}
+        // These banners render inside a click-to-select worktree card, whose
+        // root handler would select the card and — from the overview modal —
+        // unmount it mid-open, so the disclosure would never appear. Same
+        // boundary the card's own overlay controls draw.
+        onClick={(e) => e.stopPropagation()}
+        className={cn(
+          "flex w-fit mx-auto items-center gap-0.5 px-1.5 py-0.5 rounded text-[0.65rem] transition-colors",
+          "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
+          FOCUS_RING
+        )}
+      >
+        {errors.length} more {errors.length === 1 ? "error" : "errors"}
+        <ChevronDown className="w-3 h-3 shrink-0" aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent
+        align="center"
+        sideOffset={8}
+        aria-label="More errors"
+        // A portal moves the DOM but not the React tree, so a row's Retry would
+        // still bubble into the card behind it.
+        onClick={(e) => e.stopPropagation()}
+        // Bounded against Radix's own available height rather than a fixed
+        // pixel cap, so a long tail scrolls inside the popover instead of
+        // running past the viewport edge.
+        className="p-1 min-w-72 max-w-sm max-h-[var(--radix-popover-content-available-height)] overflow-y-auto"
+      >
+        <ul className="flex flex-col gap-1">
+          {errors.map((error) => (
+            <li key={error.id}>
+              <ErrorBanner error={error} compact {...handlers} />
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/components/Errors/__tests__/CompactErrorList.test.tsx
+++ b/src/components/Errors/__tests__/CompactErrorList.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { primeRadix } from "@/components/ui/radix-loader";
+import { CompactErrorList } from "../CompactErrorList";
+import type { ErrorRecord } from "@/store/errorStore";
+
+const mockDispatch = vi.fn().mockResolvedValue({ ok: true });
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => mockDispatch(...args) },
+}));
+
+class StubResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(async () => {
+  await primeRadix();
+});
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", StubResizeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function makeErrors(count: number): ErrorRecord[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `err-${i}`,
+    timestamp: 1_700_000_000_000 + i,
+    type: "unknown",
+    message: `Failure ${i}`,
+    retryability: "none",
+    dismissed: false,
+  }));
+}
+
+const openOverflow = () => fireEvent.click(screen.getByTestId("compact-error-overflow"));
+
+describe("CompactErrorList", () => {
+  it("renders every error inline when the list fits under the cap", () => {
+    render(<CompactErrorList errors={makeErrors(3)} maxInline={3} onDismiss={vi.fn()} />);
+    expect(screen.getByText("Failure 0")).toBeTruthy();
+    expect(screen.getByText("Failure 2")).toBeTruthy();
+    expect(screen.queryByTestId("compact-error-overflow")).toBeNull();
+  });
+
+  it("splits at the cap, leaving the tail out of the DOM until it is opened", () => {
+    render(<CompactErrorList errors={makeErrors(6)} maxInline={2} onDismiss={vi.fn()} />);
+    expect(screen.getByText("Failure 1")).toBeTruthy();
+    expect(screen.queryByText("Failure 2")).toBeNull();
+    expect(screen.getByTestId("compact-error-overflow")).toBeTruthy();
+  });
+
+  it("opens the tail so every hidden error is readable (#12001)", () => {
+    render(<CompactErrorList errors={makeErrors(6)} maxInline={2} onDismiss={vi.fn()} />);
+    openOverflow();
+    for (const i of [2, 3, 4, 5]) {
+      expect(screen.getByText(`Failure ${i}`)).toBeTruthy();
+    }
+  });
+
+  it("counts only the hidden errors on the trigger, not the whole list", () => {
+    render(<CompactErrorList errors={makeErrors(6)} maxInline={2} onDismiss={vi.fn()} />);
+    const trigger = screen.getByTestId("compact-error-overflow");
+    expect(trigger.textContent).toContain("4");
+    expect(trigger.textContent).not.toContain("6");
+  });
+
+  it("pluralizes the trigger against the hidden count", () => {
+    const { rerender } = render(
+      <CompactErrorList errors={makeErrors(3)} maxInline={2} onDismiss={vi.fn()} />
+    );
+    expect(screen.getByTestId("compact-error-overflow").textContent).toMatch(/1 more error(?!s)/);
+
+    rerender(<CompactErrorList errors={makeErrors(4)} maxInline={2} onDismiss={vi.fn()} />);
+    expect(screen.getByTestId("compact-error-overflow").textContent).toMatch(/2 more errors/);
+  });
+
+  it("names the hidden messages on the trigger so AT can judge before opening", () => {
+    render(<CompactErrorList errors={makeErrors(5)} maxInline={3} onDismiss={vi.fn()} />);
+    const label = screen.getByTestId("compact-error-overflow").getAttribute("aria-label") ?? "";
+    expect(label).toContain("Failure 3");
+    expect(label).toContain("Failure 4");
+    // The inline ones are already on screen; repeating them would double the
+    // announcement.
+    expect(label).not.toContain("Failure 0");
+  });
+
+  it("keeps dismiss wired for a hidden error, forwarding its own id", () => {
+    const onDismiss = vi.fn();
+    render(<CompactErrorList errors={makeErrors(5)} maxInline={2} onDismiss={onDismiss} />);
+    openOverflow();
+
+    const row = screen.getByText("Failure 4").closest("div")!;
+    fireEvent.click(within(row.parentElement ?? row).getAllByLabelText(/dismiss/i)[0]!);
+    expect(onDismiss).toHaveBeenCalledWith("err-4");
+  });
+
+  it("keeps retry wired for a hidden error, forwarding its retry action", () => {
+    const onRetry = vi.fn();
+    const errors = makeErrors(5);
+    errors[4] = {
+      ...errors[4]!,
+      retryability: "auto",
+      retryAction: "git:status" as ErrorRecord["retryAction"],
+    };
+    render(
+      <CompactErrorList errors={errors} maxInline={2} onDismiss={vi.fn()} onRetry={onRetry} />
+    );
+    openOverflow();
+
+    fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
+    expect(onRetry).toHaveBeenCalledWith("err-4", "git:status", undefined);
+  });
+
+  it("renders nothing at all for an empty list", () => {
+    const { container } = render(
+      <CompactErrorList errors={[]} maxInline={3} onDismiss={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("drops the trigger once the tail shrinks back under the cap", () => {
+    const { rerender } = render(
+      <CompactErrorList errors={makeErrors(5)} maxInline={2} onDismiss={vi.fn()} />
+    );
+    openOverflow();
+    expect(screen.getByText("Failure 4")).toBeTruthy();
+
+    rerender(<CompactErrorList errors={makeErrors(2)} maxInline={2} onDismiss={vi.fn()} />);
+    // Unmounting the disclosure with the tail is what stops a reopened popover
+    // from anchoring to a trigger that no longer has anything behind it.
+    expect(screen.queryByTestId("compact-error-overflow")).toBeNull();
+    expect(screen.queryByText("Failure 4")).toBeNull();
+  });
+});

--- a/src/components/Errors/__tests__/CompactErrorList.test.tsx
+++ b/src/components/Errors/__tests__/CompactErrorList.test.tsx
@@ -83,14 +83,39 @@ describe("CompactErrorList", () => {
     expect(screen.getByTestId("compact-error-overflow").textContent).toMatch(/2 more errors/);
   });
 
-  it("names the hidden messages on the trigger so AT can judge before opening", () => {
-    render(<CompactErrorList errors={makeErrors(5)} maxInline={3} onDismiss={vi.fn()} />);
+  it("keeps the trigger's accessible name bounded, not an error-message dump", () => {
+    // An error message is an arbitrary-length string. Enumerating the hidden
+    // ones would make focusing this button read a paragraph before its state,
+    // and the popover exposes the rows themselves once opened.
+    const errors = makeErrors(4).map((e) => ({ ...e, message: "x".repeat(400) }));
+    render(<CompactErrorList errors={errors} maxInline={1} onDismiss={vi.fn()} />);
+
     const label = screen.getByTestId("compact-error-overflow").getAttribute("aria-label") ?? "";
-    expect(label).toContain("Failure 3");
-    expect(label).toContain("Failure 4");
-    // The inline ones are already on screen; repeating them would double the
-    // announcement.
-    expect(label).not.toContain("Failure 0");
+    expect(label).toContain("3");
+    expect(label.length).toBeLessThan(80);
+  });
+
+  it("puts everything behind the disclosure when nothing may render inline", () => {
+    render(<CompactErrorList errors={makeErrors(3)} maxInline={0} onDismiss={vi.fn()} />);
+    expect(screen.queryByText("Failure 0")).toBeNull();
+
+    openOverflow();
+    expect(screen.getByText("Failure 0")).toBeTruthy();
+  });
+
+  it("partitions the list without dropping or duplicating an error", () => {
+    const errors = makeErrors(9);
+    render(<CompactErrorList errors={errors} maxInline={4} onDismiss={vi.fn()} />);
+
+    const visible = () =>
+      errors.filter((e) => screen.queryByText(e.message) !== null).map((e) => e.message);
+    const inline = visible();
+    openOverflow();
+    const all = visible();
+
+    expect(inline.length).toBeGreaterThan(0);
+    expect(all).toHaveLength(errors.length);
+    expect(new Set(all).size).toBe(errors.length);
   });
 
   it("keeps dismiss wired for a hidden error, forwarding its own id", () => {
@@ -135,9 +160,59 @@ describe("CompactErrorList", () => {
     expect(screen.getByText("Failure 4")).toBeTruthy();
 
     rerender(<CompactErrorList errors={makeErrors(2)} maxInline={2} onDismiss={vi.fn()} />);
-    // Unmounting the disclosure with the tail is what stops a reopened popover
-    // from anchoring to a trigger that no longer has anything behind it.
     expect(screen.queryByTestId("compact-error-overflow")).toBeNull();
     expect(screen.queryByText("Failure 4")).toBeNull();
+  });
+
+  it("comes back closed after the tail empties and refills", () => {
+    // The open flag has to die with the tail. Held a level up it would survive
+    // it, and a later error would remount the disclosure already open — taking
+    // focus from whatever the user moved on to.
+    const { rerender } = render(
+      <CompactErrorList errors={makeErrors(5)} maxInline={2} onDismiss={vi.fn()} />
+    );
+    openOverflow();
+    expect(screen.getByText("Failure 4")).toBeTruthy();
+
+    rerender(<CompactErrorList errors={makeErrors(2)} maxInline={2} onDismiss={vi.fn()} />);
+    rerender(<CompactErrorList errors={makeErrors(5)} maxInline={2} onDismiss={vi.fn()} />);
+
+    expect(screen.getByTestId("compact-error-overflow")).toBeTruthy();
+    expect(screen.queryByText("Failure 4")).toBeNull();
+  });
+
+  it("keeps a click on the trigger out of an enclosing click handler", () => {
+    // These banners live inside a click-to-select worktree card; from the
+    // overview modal that selection unmounts the card, so an unstopped click
+    // would open the disclosure and destroy it in the same gesture.
+    const onParentClick = vi.fn();
+    render(
+      <div onClick={onParentClick}>
+        <CompactErrorList errors={makeErrors(5)} maxInline={2} onDismiss={vi.fn()} />
+      </div>
+    );
+
+    openOverflow();
+    expect(onParentClick).not.toHaveBeenCalled();
+    expect(screen.getByText("Failure 4")).toBeTruthy();
+  });
+
+  it("keeps a hidden row's own action out of an enclosing click handler", () => {
+    // A portal moves the DOM but not the React tree, so the row's buttons still
+    // bubble to the card without a boundary on the content itself.
+    const onParentClick = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <div onClick={onParentClick}>
+        <CompactErrorList errors={makeErrors(5)} maxInline={2} onDismiss={onDismiss} />
+      </div>
+    );
+
+    openOverflow();
+    const row = screen.getByText("Failure 4").closest("div")!;
+    fireEvent.click(within(row.parentElement ?? row).getAllByLabelText(/dismiss/i)[0]!);
+
+    expect(onDismiss).toHaveBeenCalledWith("err-4");
+    expect(onParentClick).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Errors/__tests__/CompactErrorList.test.tsx
+++ b/src/components/Errors/__tests__/CompactErrorList.test.tsx
@@ -83,16 +83,18 @@ describe("CompactErrorList", () => {
     expect(screen.getByTestId("compact-error-overflow").textContent).toMatch(/2 more errors/);
   });
 
-  it("keeps the trigger's accessible name bounded, not an error-message dump", () => {
+  it("keeps the trigger's accessible name a name, not an error-message dump", () => {
     // An error message is an arbitrary-length string. Enumerating the hidden
-    // ones would make focusing this button read a paragraph before its state,
-    // and the popover exposes the rows themselves once opened.
+    // ones would make focusing this button read a paragraph before its state;
+    // trimming it to a bare digit would be the opposite failure, so the noun
+    // has to survive. The popover exposes the rows themselves once opened.
     const errors = makeErrors(4).map((e) => ({ ...e, message: "x".repeat(400) }));
     render(<CompactErrorList errors={errors} maxInline={1} onDismiss={vi.fn()} />);
 
     const label = screen.getByTestId("compact-error-overflow").getAttribute("aria-label") ?? "";
     expect(label).toContain("3");
-    expect(label.length).toBeLessThan(80);
+    expect(label.toLowerCase()).toContain("error");
+    expect(label).not.toContain("xxx");
   });
 
   it("puts everything behind the disclosure when nothing may render inline", () => {
@@ -104,18 +106,19 @@ describe("CompactErrorList", () => {
   });
 
   it("partitions the list without dropping or duplicating an error", () => {
+    // Counts occurrences rather than presence: an error rendered both inline
+    // and in the tail would otherwise pass as "present once".
     const errors = makeErrors(9);
     render(<CompactErrorList errors={errors} maxInline={4} onDismiss={vi.fn()} />);
 
-    const visible = () =>
-      errors.filter((e) => screen.queryByText(e.message) !== null).map((e) => e.message);
-    const inline = visible();
-    openOverflow();
-    const all = visible();
+    const counts = () => errors.map((e) => screen.queryAllByText(e.message).length);
 
-    expect(inline.length).toBeGreaterThan(0);
-    expect(all).toHaveLength(errors.length);
-    expect(new Set(all).size).toBe(errors.length);
+    const inlineCounts = counts();
+    expect(inlineCounts.every((n) => n <= 1)).toBe(true);
+    expect(inlineCounts.filter((n) => n === 1)).toHaveLength(4);
+
+    openOverflow();
+    expect(counts()).toEqual(errors.map(() => 1));
   });
 
   it("keeps dismiss wired for a hidden error, forwarding its own id", () => {

--- a/src/components/Plugin/PluginArchiveInstallConfirmDialog.tsx
+++ b/src/components/Plugin/PluginArchiveInstallConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { AlertCircle, AlertTriangle, FileArchive, Users } from "lucide-react";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { usePluginArchiveInstallStore } from "@/store/pluginArchiveInstallStore";
@@ -232,7 +233,6 @@ const SEVERITY_RANK: Record<CapabilitySeverity, number> = { danger: 0, warning: 
  */
 function ArchiveRecipes({ recipes }: { recipes: { count: number; names: string[] } }) {
   if (recipes.count === 0) return null;
-  const undisclosed = recipes.count - recipes.names.length;
   return (
     <div className="space-y-2">
       <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
@@ -242,17 +242,31 @@ function ArchiveRecipes({ recipes }: { recipes: { count: number; names: string[]
         Adds {recipes.count} launch {recipes.count === 1 ? "recipe" : "recipes"}, available in every
         project. Each starts terminals that run commands or agents.
       </p>
-      <ul className="space-y-1">
-        {recipes.names.map((name, index) => (
-          <li
-            key={`${name}-${index}`}
-            className="text-xs text-daintree-text/70 break-words min-w-0"
-          >
-            {name}
-          </li>
-        ))}
-        {undisclosed > 0 && <li className="text-xs text-daintree-text/40">+{undisclosed} more</li>}
-      </ul>
+      {/* Every name, bounded by the viewport rather than by the data. The list
+          used to arrive pre-truncated at ten with "+N more" underneath, which
+          on a D2 confirm counts executable content the user can't read before
+          approving it (#12001). A scrollable region with no focusable children
+          has to be keyboard-reachable in its own right (WCAG 2.1.1), and the
+          fades are what say the list continues. */}
+      <ScrollShadow
+        className="max-h-[132px]"
+        scrollClassName="scroll-py-6"
+        tabIndex={0}
+        role="region"
+        aria-label={`${recipes.count} contributed ${recipes.count === 1 ? "recipe" : "recipes"}`}
+        data-testid="archive-recipe-list"
+      >
+        <ul className="space-y-1">
+          {recipes.names.map((name, index) => (
+            <li
+              key={`${name}-${index}`}
+              className="text-xs text-daintree-text/70 break-words min-w-0"
+            >
+              {name}
+            </li>
+          ))}
+        </ul>
+      </ScrollShadow>
     </div>
   );
 }

--- a/src/components/Plugin/__tests__/PluginArchiveInstallConfirmDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginArchiveInstallConfirmDialog.test.tsx
@@ -514,4 +514,74 @@ describe("PluginArchiveInstallConfirmDialog", () => {
       expect.objectContaining({ type: "success", title: "Plugin installed" })
     );
   });
+
+  describe("contributed recipes", () => {
+    const recipeIntent = (count: number) =>
+      intent({
+        manifest: {
+          ...intent().manifest,
+          recipes: {
+            count,
+            names: Array.from({ length: count }, (_, i) => `Recipe ${i}`),
+          },
+        },
+      });
+
+    it("lists every contributed recipe rather than counting a tail (#12001)", () => {
+      // A recipe runs shell commands and launches agents, so this D2 confirm is
+      // the only place the user reads them before approving. The list used to
+      // stop at ten with "+N more" underneath.
+      render(<PluginArchiveInstallConfirmDialog />);
+      enqueue(recipeIntent(24));
+
+      for (const i of [0, 9, 10, 23]) {
+        expect(screen.getByText(`Recipe ${i}`)).toBeTruthy();
+      }
+    });
+
+    it("leaves no overflow count beside the recipe list", () => {
+      render(<PluginArchiveInstallConfirmDialog />);
+      enqueue(recipeIntent(24));
+
+      const list = screen.getByTestId("archive-recipe-list");
+      expect(list.textContent).not.toMatch(/\+\d+ more/);
+    });
+
+    it("bounds the recipe list in a keyboard-reachable region, not by dropping rows", () => {
+      // A scrollable region with no focusable children of its own has to be
+      // reachable in its own right (WCAG 2.1.1) — that is what replaced the
+      // source-side truncation.
+      render(<PluginArchiveInstallConfirmDialog />);
+      enqueue(recipeIntent(24));
+
+      const list = screen.getByTestId("archive-recipe-list");
+      expect(list.getAttribute("tabindex")).toBe("0");
+      expect(list.getAttribute("role")).toBe("region");
+      expect(list.getAttribute("aria-label")).toContain("24");
+    });
+
+    it("renders no recipe block for an archive that contributes none", () => {
+      render(<PluginArchiveInstallConfirmDialog />);
+      enqueue(intent());
+
+      expect(screen.queryByTestId("archive-recipe-list")).toBeNull();
+      expect(screen.queryByText("Recipes")).toBeNull();
+    });
+
+    it("agrees in number between the prose and the rows it introduces", () => {
+      render(<PluginArchiveInstallConfirmDialog />);
+      enqueue(recipeIntent(3));
+
+      const list = screen.getByTestId("archive-recipe-list");
+      expect(list.querySelectorAll("li")).toHaveLength(3);
+      expect(screen.getByText(/Adds 3 launch recipes/)).toBeTruthy();
+    });
+
+    it("says 'recipe' for a single contribution", () => {
+      render(<PluginArchiveInstallConfirmDialog />);
+      enqueue(recipeIntent(1));
+
+      expect(screen.getByText(/Adds 1 launch recipe,/)).toBeTruthy();
+    });
+  });
 });

--- a/src/components/Plugin/__tests__/PluginArchiveInstallConfirmDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginArchiveInstallConfirmDialog.test.tsx
@@ -534,9 +534,26 @@ describe("PluginArchiveInstallConfirmDialog", () => {
       render(<PluginArchiveInstallConfirmDialog />);
       enqueue(recipeIntent(24));
 
-      for (const i of [0, 9, 10, 23]) {
-        expect(screen.getByText(`Recipe ${i}`)).toBeTruthy();
-      }
+      const rendered = Array.from(
+        screen.getByTestId("archive-recipe-list").querySelectorAll("li"),
+        (li) => li.textContent
+      );
+      expect(rendered).toEqual(Array.from({ length: 24 }, (_, i) => `Recipe ${i}`));
+    });
+
+    it("renders one row per contribution when two recipes share a name", () => {
+      render(<PluginArchiveInstallConfirmDialog />);
+      enqueue(
+        intent({
+          manifest: {
+            ...intent().manifest,
+            recipes: { count: 2, names: ["Deploy", "Deploy"] },
+          },
+        })
+      );
+
+      // Two recipes are two things to approve even when they read alike.
+      expect(screen.getByTestId("archive-recipe-list").querySelectorAll("li")).toHaveLength(2);
     });
 
     it("leaves no overflow count beside the recipe list", () => {

--- a/src/components/Project/RunningTaskList.tsx
+++ b/src/components/Project/RunningTaskList.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { X, Eye, RotateCw } from "lucide-react";
+import { ChevronDown, X, Eye, RotateCw } from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
@@ -149,7 +150,7 @@ export function RunningTaskList({ worktreeId }: RunningTaskListProps) {
   if (visibleTasks.length === 0) return null;
 
   const displayTasks = visibleTasks.slice(0, MAX_VISIBLE);
-  const overflowCount = visibleTasks.length - displayTasks.length;
+  const overflowTasks = visibleTasks.slice(MAX_VISIBLE);
 
   return (
     <div className="mb-2 space-y-0.5">
@@ -168,12 +169,92 @@ export function RunningTaskList({ worktreeId }: RunningTaskListProps) {
           />
         );
       })}
-      {overflowCount > 0 && (
-        <div className="text-[10px] text-daintree-text/30 px-2 py-0.5 font-sans">
-          +{overflowCount} more
-        </div>
+      {overflowTasks.length > 0 && (
+        <TaskOverflow
+          tasks={overflowTasks}
+          now={now}
+          onStop={handleStop}
+          onFocus={handleFocus}
+          onRestart={handleRestart}
+          onDismiss={handleDismiss}
+        />
       )}
     </div>
+  );
+}
+
+/**
+ * The tasks past the visible cap.
+ *
+ * This used to be "+N more" as static text, which named running processes the
+ * user could then neither watch, stop, nor restart — every handler the rows
+ * need was already in scope, only the rows weren't rendered (#12001). Mounted
+ * only while a tail exists, so the popover can't reopen against a stale one
+ * after the list shrinks.
+ */
+function TaskOverflow({
+  tasks,
+  now,
+  onStop,
+  onFocus,
+  onRestart,
+  onDismiss,
+}: {
+  tasks: PtyPanelData[];
+  now: number;
+  onStop: (id: string) => void;
+  onFocus: (id: string) => void;
+  onRestart: (id: string) => void;
+  onDismiss: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        type="button"
+        data-testid="running-task-overflow"
+        aria-label={`${tasks.length} more ${tasks.length === 1 ? "task" : "tasks"}: ${tasks
+          .map((t) => t.command || t.title)
+          .join(", ")}`}
+        className={cn(
+          "flex w-full items-center gap-0.5 px-2 py-0.5 rounded-[var(--radius-sm)] text-[10px] font-sans transition-colors",
+          "text-daintree-text/40 hover:text-daintree-text/70 hover:bg-tint/[0.04]",
+          "outline-hidden focus-visible:outline focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        )}
+      >
+        {tasks.length} more
+        <ChevronDown className="w-2.5 h-2.5 shrink-0" aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        aria-label="More running tasks"
+        className="p-1 min-w-64 max-w-sm max-h-[var(--radix-popover-content-available-height)] overflow-y-auto"
+      >
+        <ul className="flex flex-col gap-0.5">
+          {tasks.map((t) => (
+            <li key={t.id}>
+              <TaskRow
+                terminal={t}
+                status={deriveTaskStatus(t)}
+                now={now}
+                // Focusing a terminal moves the user out of this surface, so
+                // the popover has nothing left to anchor; stop, restart and
+                // dismiss all keep it open so several can be handled in a row.
+                onStop={onStop}
+                onFocus={(id) => {
+                  setOpen(false);
+                  onFocus(id);
+                }}
+                onRestart={onRestart}
+                onDismiss={onDismiss}
+              />
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/src/components/Project/RunningTaskList.tsx
+++ b/src/components/Project/RunningTaskList.tsx
@@ -214,9 +214,11 @@ function TaskOverflow({
       <PopoverTrigger
         type="button"
         data-testid="running-task-overflow"
-        aria-label={`${tasks.length} more ${tasks.length === 1 ? "task" : "tasks"}: ${tasks
-          .map((t) => t.command || t.title)
-          .join(", ")}`}
+        // Deliberately not an enumeration of every hidden command: a task
+        // command is an arbitrary-length string, and concatenating several
+        // makes focusing this button read a paragraph before its state. The
+        // popover is labelled and exposes the rows themselves once opened.
+        aria-label={`Show ${tasks.length} more running ${tasks.length === 1 ? "task" : "tasks"}`}
         className={cn(
           "flex w-full items-center gap-0.5 px-2 py-0.5 rounded-[var(--radius-sm)] text-[10px] font-sans transition-colors",
           "text-daintree-text/40 hover:text-daintree-text/70 hover:bg-tint/[0.04]",
@@ -308,7 +310,7 @@ function TaskRow({ terminal, status, now, onStop, onFocus, onRestart, onDismiss 
       )}
 
       {/* Actions */}
-      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shrink-0">
         {isActive && (
           <button
             onClick={(e) => {

--- a/src/components/Project/__tests__/RunningTaskList.test.tsx
+++ b/src/components/Project/__tests__/RunningTaskList.test.tsx
@@ -104,21 +104,45 @@ describe("RunningTaskList overflow", () => {
     }
   });
 
-  it("counts only the hidden tasks on the trigger", () => {
-    seedTasks(8);
+  it("keeps the trigger's accessible name bounded, not a command dump", () => {
+    // A task command is an arbitrary-length string; enumerating the hidden ones
+    // would read a paragraph before the button's own state.
+    seedTasks(9, { command: "x".repeat(300) });
     render(<RunningTaskList worktreeId={WORKTREE_ID} />);
-    const trigger = screen.getByTestId("running-task-overflow");
-    expect(trigger.textContent).toContain("3");
-    expect(trigger.textContent).not.toContain("8");
+
+    const label = screen.getByTestId("running-task-overflow").getAttribute("aria-label") ?? "";
+    expect(label).toContain("4");
+    expect(label.length).toBeLessThan(80);
   });
 
-  it("names the hidden commands on the trigger so AT can judge before opening", () => {
-    seedTasks(7);
+  it("partitions the tasks without dropping or duplicating one", () => {
+    // Reads the split off the rendered output rather than restating the
+    // component's private cap.
+    seedTasks(11);
     render(<RunningTaskList worktreeId={WORKTREE_ID} />);
-    const label = screen.getByTestId("running-task-overflow").getAttribute("aria-label") ?? "";
-    expect(label).toContain("cmd-5");
-    expect(label).toContain("cmd-6");
-    expect(label).not.toContain("cmd-0");
+
+    const commands = Array.from({ length: 11 }, (_, i) => `cmd-${i}`);
+    const visible = () => commands.filter((c) => screen.queryAllByText(c).length > 0);
+
+    const inline = visible();
+    expect(inline.length).toBeGreaterThan(0);
+    expect(inline.length).toBeLessThan(commands.length);
+
+    openOverflow();
+    const all = visible();
+    expect(all).toHaveLength(commands.length);
+    expect(new Set(all).size).toBe(commands.length);
+  });
+
+  it("keeps the trigger's count equal to what the disclosure reveals", () => {
+    seedTasks(11);
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+
+    const shownBefore = Array.from({ length: 11 }, (_, i) => `cmd-${i}`).filter(
+      (c) => screen.queryAllByText(c).length > 0
+    ).length;
+    const trigger = screen.getByTestId("running-task-overflow");
+    expect(trigger.textContent).toContain(String(11 - shownBefore));
   });
 
   it("stops a hidden task, killing that task's own terminal", () => {

--- a/src/components/Project/__tests__/RunningTaskList.test.tsx
+++ b/src/components/Project/__tests__/RunningTaskList.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { primeRadix } from "@/components/ui/radix-loader";
+import type { PtyPanelData } from "@shared/types/panel";
+import { RunningTaskList } from "../RunningTaskList";
+
+const WORKTREE_ID = "wt-1";
+
+const storeState = {
+  panelIds: [] as string[],
+  panelsById: {} as Record<string, PtyPanelData>,
+  activateTerminal: vi.fn(),
+  restartTerminal: vi.fn(),
+};
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (selector: (s: typeof storeState) => unknown) => selector(storeState),
+}));
+
+vi.mock("@/store/slices/panelRegistry/selectors", () => ({
+  getNarrowPanel: (byId: Record<string, PtyPanelData>, id: string) => byId[id],
+}));
+
+const killMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/clients", () => ({ terminalClient: { kill: (id: string) => killMock(id) } }));
+
+// The elapsed-time tick is irrelevant here and would keep a timer alive past
+// the test.
+vi.mock("@/hooks/useVisibilityAwareInterval", () => ({ useVisibilityAwareInterval: () => {} }));
+
+class StubResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(async () => {
+  await primeRadix();
+});
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", StubResizeObserver);
+  storeState.panelIds = [];
+  storeState.panelsById = {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function seedTasks(count: number, overrides: Partial<PtyPanelData> = {}) {
+  storeState.panelIds = [];
+  storeState.panelsById = {};
+  for (let i = 0; i < count; i++) {
+    const id = `task-${i}`;
+    storeState.panelIds.push(id);
+    storeState.panelsById[id] = {
+      id,
+      kind: "terminal",
+      title: `task ${i}`,
+      cwd: "/repo",
+      cols: 80,
+      rows: 24,
+      command: `cmd-${i}`,
+      spawnedBy: "quickrun",
+      worktreeId: WORKTREE_ID,
+      location: "grid",
+      runtimeStatus: "running",
+      startedAt: 1_700_000_000_000,
+      ...overrides,
+    } as PtyPanelData;
+  }
+}
+
+const openOverflow = () => fireEvent.click(screen.getByTestId("running-task-overflow"));
+
+/** The popover's own list, so a row assertion can't match its inline twin. */
+const overflowList = () => screen.getByRole("list");
+
+describe("RunningTaskList overflow", () => {
+  it("renders no disclosure while every task fits", () => {
+    seedTasks(5);
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    expect(screen.getByText("cmd-4")).toBeTruthy();
+    expect(screen.queryByTestId("running-task-overflow")).toBeNull();
+  });
+
+  it("keeps the tail out of the DOM until the disclosure is opened", () => {
+    seedTasks(8);
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    expect(screen.getByText("cmd-4")).toBeTruthy();
+    expect(screen.queryByText("cmd-5")).toBeNull();
+  });
+
+  it("opens the tail so every hidden task is reachable (#12001)", () => {
+    seedTasks(8);
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    openOverflow();
+    for (const i of [5, 6, 7]) {
+      expect(within(overflowList()).getByText(`cmd-${i}`)).toBeTruthy();
+    }
+  });
+
+  it("counts only the hidden tasks on the trigger", () => {
+    seedTasks(8);
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    const trigger = screen.getByTestId("running-task-overflow");
+    expect(trigger.textContent).toContain("3");
+    expect(trigger.textContent).not.toContain("8");
+  });
+
+  it("names the hidden commands on the trigger so AT can judge before opening", () => {
+    seedTasks(7);
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    const label = screen.getByTestId("running-task-overflow").getAttribute("aria-label") ?? "";
+    expect(label).toContain("cmd-5");
+    expect(label).toContain("cmd-6");
+    expect(label).not.toContain("cmd-0");
+  });
+
+  it("stops a hidden task, killing that task's own terminal", () => {
+    seedTasks(8);
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    openOverflow();
+
+    const row = within(overflowList()).getByText("cmd-7").closest('[role="button"]')!;
+    fireEvent.click(within(row as HTMLElement).getByLabelText("Stop task"));
+    expect(killMock).toHaveBeenCalledWith("task-7");
+  });
+
+  it("restarts a hidden failed task", () => {
+    seedTasks(8, { runtimeStatus: "exited", exitCode: 1 });
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    openOverflow();
+
+    const row = within(overflowList()).getByText("cmd-6").closest('[role="button"]')!;
+    fireEvent.click(within(row as HTMLElement).getByLabelText("Restart task"));
+    expect(storeState.restartTerminal).toHaveBeenCalledWith("task-6");
+  });
+
+  it("dismisses a hidden failed task, dropping it from the tail", () => {
+    seedTasks(8, { runtimeStatus: "exited", exitCode: 1 });
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    openOverflow();
+
+    const row = within(overflowList()).getByText("cmd-7").closest('[role="button"]')!;
+    fireEvent.click(within(row as HTMLElement).getByLabelText("Dismiss"));
+    expect(screen.queryByText("cmd-7")).toBeNull();
+    expect(screen.getByTestId("running-task-overflow").textContent).toContain("2");
+  });
+
+  it("closes on focus, because focusing moves the user off this surface", () => {
+    seedTasks(8);
+    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    openOverflow();
+
+    const row = within(overflowList()).getByText("cmd-5").closest('[role="button"]')!;
+    fireEvent.click(within(row as HTMLElement).getByLabelText("Focus terminal"));
+    expect(storeState.activateTerminal).toHaveBeenCalledWith("task-5");
+    expect(screen.queryByText("cmd-6")).toBeNull();
+  });
+
+  it("drops the disclosure once the tail shrinks back under the cap", () => {
+    seedTasks(6);
+    const { rerender } = render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    expect(screen.getByTestId("running-task-overflow")).toBeTruthy();
+
+    seedTasks(4);
+    rerender(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    expect(screen.queryByTestId("running-task-overflow")).toBeNull();
+  });
+
+  it("ignores tasks belonging to another worktree", () => {
+    seedTasks(8, { worktreeId: "other-wt" });
+    const { container } = render(<RunningTaskList worktreeId={WORKTREE_ID} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/Project/__tests__/RunningTaskList.test.tsx
+++ b/src/components/Project/__tests__/RunningTaskList.test.tsx
@@ -104,45 +104,41 @@ describe("RunningTaskList overflow", () => {
     }
   });
 
-  it("keeps the trigger's accessible name bounded, not a command dump", () => {
+  it("keeps the trigger's accessible name a name, not a command dump", () => {
     // A task command is an arbitrary-length string; enumerating the hidden ones
-    // would read a paragraph before the button's own state.
+    // would read a paragraph before the button's own state. Trimming it to a
+    // bare digit would be the opposite failure, so the noun has to survive.
     seedTasks(9, { command: "x".repeat(300) });
     render(<RunningTaskList worktreeId={WORKTREE_ID} />);
 
     const label = screen.getByTestId("running-task-overflow").getAttribute("aria-label") ?? "";
     expect(label).toContain("4");
-    expect(label.length).toBeLessThan(80);
+    expect(label.toLowerCase()).toContain("task");
+    expect(label).not.toContain("xxx");
   });
 
   it("partitions the tasks without dropping or duplicating one", () => {
-    // Reads the split off the rendered output rather than restating the
-    // component's private cap.
+    // Counts occurrences rather than presence: a task rendered both inline and
+    // in the tail would otherwise pass as "present once".
     seedTasks(11);
     render(<RunningTaskList worktreeId={WORKTREE_ID} />);
 
     const commands = Array.from({ length: 11 }, (_, i) => `cmd-${i}`);
-    const visible = () => commands.filter((c) => screen.queryAllByText(c).length > 0);
+    const counts = () => commands.map((c) => screen.queryAllByText(c).length);
 
-    const inline = visible();
-    expect(inline.length).toBeGreaterThan(0);
-    expect(inline.length).toBeLessThan(commands.length);
+    const inlineCounts = counts();
+    expect(inlineCounts.every((n) => n <= 1)).toBe(true);
+    const inlineShown = inlineCounts.filter((n) => n === 1).length;
+    expect(inlineShown).toBeGreaterThan(0);
+    expect(inlineShown).toBeLessThan(commands.length);
+
+    // The trigger promises exactly the remainder.
+    const trigger = screen.getByTestId("running-task-overflow");
+    expect(trigger.textContent).toContain(String(commands.length - inlineShown));
 
     openOverflow();
-    const all = visible();
-    expect(all).toHaveLength(commands.length);
-    expect(new Set(all).size).toBe(commands.length);
-  });
-
-  it("keeps the trigger's count equal to what the disclosure reveals", () => {
-    seedTasks(11);
-    render(<RunningTaskList worktreeId={WORKTREE_ID} />);
-
-    const shownBefore = Array.from({ length: 11 }, (_, i) => `cmd-${i}`).filter(
-      (c) => screen.queryAllByText(c).length > 0
-    ).length;
-    const trigger = screen.getByTestId("running-task-overflow");
-    expect(trigger.textContent).toContain(String(11 - shownBefore));
+    // Every task exactly once across both halves — no gap, no overlap.
+    expect(counts()).toEqual(commands.map(() => 1));
   });
 
   it("stops a hidden task, killing that task's own terminal", () => {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -45,7 +45,7 @@ import { useTerminalSubmitStatus } from "./useTerminalSubmitStatus";
 import { TerminalAttachErrorBanner } from "./TerminalAttachErrorBanner";
 import { useShouldSuppressLocalError } from "@/components/Recovery/useShouldSuppressLocalError";
 import { UpdateCwdDialog } from "./UpdateCwdDialog";
-import { ErrorBanner } from "../Errors/ErrorBanner";
+import { CompactErrorList } from "../Errors/CompactErrorList";
 import { AgentCompletionBanner } from "./AgentCompletionBanner";
 import { ContentPanel } from "@/components/Panel";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -1333,22 +1333,14 @@ function TerminalPaneComponent({
       })()}
     >
       {terminalErrors.length > 0 && (
-        <div className="px-2 py-1 border-b border-daintree-border bg-[color-mix(in_oklab,var(--color-status-error)_5%,transparent)] space-y-1 shrink-0">
-          {terminalErrors.slice(0, 2).map((error) => (
-            <ErrorBanner
-              key={error.id}
-              error={error}
-              onDismiss={dismissError}
-              onRetry={handleErrorRetry}
-              onCancelRetry={handleCancelRetry}
-              compact
-            />
-          ))}
-          {terminalErrors.length > 2 && (
-            <div className="text-xs text-daintree-text/40 px-2">
-              +{terminalErrors.length - 2} more errors
-            </div>
-          )}
+        <div className="px-2 py-1 border-b border-daintree-border bg-[color-mix(in_oklab,var(--color-status-error)_5%,transparent)] shrink-0">
+          <CompactErrorList
+            errors={terminalErrors}
+            maxInline={2}
+            onDismiss={dismissError}
+            onRetry={handleErrorRetry}
+            onCancelRetry={handleCancelRetry}
+          />
         </div>
       )}
 

--- a/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
+++ b/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
@@ -7,7 +7,7 @@ import { AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
-import type { GitRemoteCommitPreview } from "@shared/types/git";
+import { GIT_REMOTE_COMMIT_PREVIEW_MAX, type GitRemoteCommitPreview } from "@shared/types/git";
 import { formatGitPushDestination } from "@/components/Git/gitRemoteOperationPreview";
 
 interface ForcePushConfirmDialogProps {
@@ -21,13 +21,11 @@ interface ForcePushConfirmDialogProps {
 }
 
 /**
- * The main handler clamps this to 100 (`git-write.ts`, `list-remote-commits`),
- * so asking for its ceiling is what makes the preview complete for every
- * divergence a force-push realistically discards. It used to ask for 20 and
- * print "…and N more" for the rest — a count, on the one dialog where D2 says
- * a count is not enough, naming commits nothing could open (#12001).
+ * Ask for everything the handler will serve. It used to ask for 20 and print
+ * "…and N more" for the rest — a count, on the one dialog where D2 says a count
+ * is not enough, naming commits nothing could open (#12001).
  */
-const COMMIT_LIMIT = 100;
+const COMMIT_LIMIT = GIT_REMOTE_COMMIT_PREVIEW_MAX;
 const SHORT_HASH_LEN = 7;
 
 export function ForcePushConfirmDialog({
@@ -90,7 +88,7 @@ export function ForcePushConfirmDialog({
     // is checked too: on the first render after opening it is null while
     // `isLoading` is still false, so the two guards together are what close
     // the window on a click landing before the fetch starts.
-    if (loadError || preview === null) return;
+    if (loadError || preview === null || isPreviewStale) return;
     isExecutingRef.current = true;
     setIsPushing(true);
     try {
@@ -109,17 +107,27 @@ export function ForcePushConfirmDialog({
   const commits = preview?.commits ?? null;
   // Both the rows and the total come from the same `HEAD..<push ref>` range, so
   // the tail can't be computed against a different repository's ref (#11746).
-  // `git log` and the range count are two reads in the handler, so a fetch
-  // landing between them can return a total below the rows already in hand. The
-  // rows are proof the range holds at least that many, so the larger of the two
-  // is the only figure that can't understate what a force push would discard —
-  // and a badge reading 3 above 12 listed commits is the kind of contradiction
-  // a destructive confirm can least afford.
-  const totalRemote = Math.max(preview?.total ?? 0, commits?.length ?? 0);
-  const hiddenCount = commits !== null ? Math.max(0, totalRemote - commits.length) : 0;
+  const totalRemote = preview?.total ?? 0;
+  // `git log` and the range count are two reads over a symbolic range, so a
+  // concurrent fetch or branch move can leave them disagreeing. When it does,
+  // neither is trustworthy — the rows may name commits the range no longer
+  // holds, and the total may describe a range the rows don't. Picking one would
+  // be guessing about what a force push discards, so the preview reloads
+  // instead. Same fail-closed footing as a preview that never arrived.
+  const isPreviewStale = commits !== null && totalRemote < commits.length;
+  const hiddenCount =
+    commits !== null && totalRemote > commits.length ? totalRemote - commits.length : 0;
   // Optional-chained rather than keyed off `preview` alone: this crosses the
   // IPC boundary, so a payload missing the field must degrade to the branch
   // name rather than throwing inside a destructive confirm.
+  // One blocking message for both shapes: a preview that failed to load and one
+  // that arrived self-contradictory leave the user equally unable to see what
+  // would be discarded, and both recover the same way.
+  const blockingMessage =
+    loadError ??
+    (isPreviewStale
+      ? "This preview went stale while loading — reload it before force pushing"
+      : null);
   const destinationLabel = preview?.destination
     ? formatGitPushDestination(preview.destination)
     : null;
@@ -135,7 +143,7 @@ export function ForcePushConfirmDialog({
       variant="destructive"
       hasPreview={true}
       isConfirmLoading={isPushing}
-      confirmDisabled={isLoading || !!loadError || preview === null}
+      confirmDisabled={isLoading || !!loadError || preview === null || isPreviewStale}
     >
       <div className="space-y-3 text-xs text-daintree-text/80">
         <p>
@@ -165,11 +173,11 @@ export function ForcePushConfirmDialog({
             </div>
           )}
 
-          {!isLoading && loadError && (
+          {!isLoading && blockingMessage && (
             <div className="px-3 py-3 text-status-error flex items-start gap-2">
               <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
               <div className="flex-1 min-w-0">
-                <div>{loadError}</div>
+                <div>{blockingMessage}</div>
                 <button
                   type="button"
                   onClick={loadCommits}
@@ -186,13 +194,13 @@ export function ForcePushConfirmDialog({
             </div>
           )}
 
-          {!isLoading && !loadError && commits && commits.length === 0 && (
+          {!isLoading && !blockingMessage && commits && commits.length === 0 && (
             <div className="px-3 py-3 text-daintree-text/50">
               No remote commits to discard. The remote may already match your local branch.
             </div>
           )}
 
-          {!isLoading && !loadError && commits && commits.length > 0 && (
+          {!isLoading && !blockingMessage && commits && commits.length > 0 && (
             // A scrollable region with no focusable children of its own has to
             // be reachable by keyboard in its own right (WCAG 2.1.1), and the
             // fades are what say "there is more" — the same shape

--- a/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
+++ b/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
@@ -109,9 +109,14 @@ export function ForcePushConfirmDialog({
   const commits = preview?.commits ?? null;
   // Both the rows and the total come from the same `HEAD..<push ref>` range, so
   // the tail can't be computed against a different repository's ref (#11746).
-  const totalRemote = preview?.total ?? 0;
-  const hiddenCount =
-    commits !== null && totalRemote > commits.length ? totalRemote - commits.length : 0;
+  // `git log` and the range count are two reads in the handler, so a fetch
+  // landing between them can return a total below the rows already in hand. The
+  // rows are proof the range holds at least that many, so the larger of the two
+  // is the only figure that can't understate what a force push would discard —
+  // and a badge reading 3 above 12 listed commits is the kind of contradiction
+  // a destructive confirm can least afford.
+  const totalRemote = Math.max(preview?.total ?? 0, commits?.length ?? 0);
+  const hiddenCount = commits !== null ? Math.max(0, totalRemote - commits.length) : 0;
   // Optional-chained rather than keyed off `preview` alone: this crosses the
   // IPC boundary, so a payload missing the field must degrade to the branch
   // name rather than throwing inside a destructive confirm.

--- a/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
+++ b/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { Spinner } from "@/components/ui/Spinner";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
@@ -19,7 +20,14 @@ interface ForcePushConfirmDialogProps {
   onError: (err: unknown) => void;
 }
 
-const COMMIT_LIMIT = 20;
+/**
+ * The main handler clamps this to 100 (`git-write.ts`, `list-remote-commits`),
+ * so asking for its ceiling is what makes the preview complete for every
+ * divergence a force-push realistically discards. It used to ask for 20 and
+ * print "…and N more" for the rest — a count, on the one dialog where D2 says
+ * a count is not enough, naming commits nothing could open (#12001).
+ */
+const COMMIT_LIMIT = 100;
 const SHORT_HASH_LEN = 7;
 
 export function ForcePushConfirmDialog({
@@ -180,32 +188,53 @@ export function ForcePushConfirmDialog({
           )}
 
           {!isLoading && !loadError && commits && commits.length > 0 && (
-            <ul className="px-3 py-2 space-y-1.5 max-h-[180px] overflow-y-auto">
-              {commits.map((commit) => (
-                <li
-                  key={commit.hash}
-                  className="flex items-baseline gap-2"
-                  data-testid="force-push-commit-row"
-                >
-                  <span
-                    className={cn(
-                      "font-mono text-[10px] text-daintree-text/40 shrink-0 tabular-nums"
-                    )}
+            // A scrollable region with no focusable children of its own has to
+            // be reachable by keyboard in its own right (WCAG 2.1.1), and the
+            // fades are what say "there is more" — the same shape
+            // `GitPushConfirmDialog` uses for the identical problem.
+            <ScrollShadow
+              className="max-h-[180px]"
+              scrollClassName="scroll-py-8"
+              tabIndex={0}
+              role="region"
+              aria-label={`Remote commits to discard${
+                destinationLabel ? ` from ${destinationLabel}` : ""
+              }`}
+            >
+              <ul className="px-3 py-2 space-y-1.5">
+                {commits.map((commit) => (
+                  <li
+                    key={commit.hash}
+                    className="flex items-baseline gap-2"
+                    data-testid="force-push-commit-row"
                   >
-                    {commit.hash.slice(0, SHORT_HASH_LEN)}
-                  </span>
-                  <span className="text-daintree-text/80 truncate min-w-0">{commit.message}</span>
-                  <span className="text-[10px] text-daintree-text/40 shrink-0 ml-auto">
-                    {commit.author}
-                  </span>
-                </li>
-              ))}
-              {hiddenCount > 0 && (
-                <li className="text-[10px] text-daintree-text/40 italic pt-1">
-                  …and {hiddenCount} more
-                </li>
-              )}
-            </ul>
+                    <span
+                      className={cn(
+                        "font-mono text-[10px] text-daintree-text/40 shrink-0 tabular-nums"
+                      )}
+                    >
+                      {commit.hash.slice(0, SHORT_HASH_LEN)}
+                    </span>
+                    <span className="text-daintree-text/80 truncate min-w-0">{commit.message}</span>
+                    <span className="text-[10px] text-daintree-text/40 shrink-0 ml-auto">
+                      {commit.author}
+                    </span>
+                  </li>
+                ))}
+                {hiddenCount > 0 && (
+                  // Past the fetch ceiling the tail states a fact rather than
+                  // promising a list: at this magnitude what decides the answer
+                  // is that the divergence runs to hundreds of commits, not
+                  // what the hundred-and-first one says.
+                  <li
+                    className="text-[10px] text-daintree-text/40 italic pt-1"
+                    data-testid="force-push-commit-cap"
+                  >
+                    Listing the {commits.length} most recent of {totalRemote}
+                  </li>
+                )}
+              </ul>
+            </ScrollShadow>
           )}
         </div>
       </div>

--- a/src/components/Worktree/ReviewHub/__tests__/ForcePushConfirmDialog.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ForcePushConfirmDialog.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitRemoteCommitPreview } from "@shared/types/git";
+import { ForcePushConfirmDialog } from "../ForcePushConfirmDialog";
+
+vi.mock("zustand/react/shallow", () => ({ useShallow: (fn: unknown) => fn }));
+vi.mock("@/store", () => ({ usePortalStore: () => ({ isOpen: false, width: 0 }) }));
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useOverlayState: () => {} };
+});
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+const listRemoteCommits =
+  vi.fn<(cwd: string, branch: string, limit?: number) => Promise<GitRemoteCommitPreview>>();
+const forcePushWithLease = vi.fn().mockResolvedValue(undefined);
+
+const CWD = "/repo/wt";
+const BRANCH = "feature/x";
+
+function commits(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    hash: `${i}`.padStart(40, "a"),
+    date: "2026-01-01",
+    message: `remote commit ${i}`,
+    author: "Ada",
+  }));
+}
+
+function preview(shown: number, total = shown): GitRemoteCommitPreview {
+  return {
+    destination: { remote: "origin", branch: BRANCH },
+    total,
+    commits: commits(shown),
+  };
+}
+
+function renderDialog() {
+  return render(
+    <ForcePushConfirmDialog
+      isOpen
+      cwd={CWD}
+      branchName={BRANCH}
+      leaseSha="deadbeef"
+      onClose={vi.fn()}
+      onSuccess={vi.fn()}
+      onError={vi.fn()}
+    />
+  );
+}
+
+/** Settle the preview fetch's promise chain. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("ForcePushConfirmDialog preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listRemoteCommits.mockResolvedValue(preview(3));
+    Object.assign(window, {
+      electron: { git: { listRemoteCommits, forcePushWithLease } },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("asks for the handler's full ceiling so the preview isn't pre-truncated (#12001)", async () => {
+    renderDialog();
+    await flush();
+
+    const [, , limit] = listRemoteCommits.mock.calls[0]!;
+    // The main handler clamps to 100; anything below it caps the D2 preview
+    // client-side for no reason.
+    expect(limit).toBe(100);
+  });
+
+  it("renders one row per fetched commit", async () => {
+    listRemoteCommits.mockResolvedValue(preview(12));
+    renderDialog();
+    await waitFor(() => expect(screen.getAllByTestId("force-push-commit-row")).toHaveLength(12));
+  });
+
+  it("adds no cap notice while every diverged commit is listed", async () => {
+    listRemoteCommits.mockResolvedValue(preview(12));
+    renderDialog();
+    await flush();
+
+    expect(screen.queryByTestId("force-push-commit-cap")).toBeNull();
+  });
+
+  it("states the cap as a fact when the range runs past what was fetched", async () => {
+    listRemoteCommits.mockResolvedValue(preview(100, 237));
+    renderDialog();
+    await flush();
+
+    const cap = await screen.findByTestId("force-push-commit-cap");
+    // Both halves matter: how many are on screen, and how many exist. Neither
+    // is phrased as content waiting behind a control.
+    expect(cap.textContent).toContain("100");
+    expect(cap.textContent).toContain("237");
+    expect(cap.textContent?.toLowerCase()).not.toContain("more");
+  });
+
+  it("puts the commit list in a keyboard-reachable region", async () => {
+    listRemoteCommits.mockResolvedValue(preview(30));
+    renderDialog();
+    await flush();
+
+    // A scrollable region with no focusable children of its own has to be
+    // reachable in its own right (WCAG 2.1.1).
+    const region = screen.getByRole("region", { name: /remote commits to discard/i });
+    expect(region.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("names the resolved destination in the region label, not just the branch", async () => {
+    renderDialog();
+    await flush();
+
+    const region = screen.getByRole("region", { name: /remote commits to discard/i });
+    expect(region.getAttribute("aria-label")).toContain("origin");
+  });
+
+  it("says so plainly when the remote has nothing to discard", async () => {
+    listRemoteCommits.mockResolvedValue(preview(0));
+    renderDialog();
+    await flush();
+
+    expect(screen.getByText(/no remote commits to discard/i)).toBeTruthy();
+    expect(screen.queryByRole("region", { name: /remote commits to discard/i })).toBeNull();
+  });
+
+  it("blocks confirm while the preview has not resolved", async () => {
+    let resolvePreview: (p: GitRemoteCommitPreview) => void = () => {};
+    listRemoteCommits.mockReturnValue(
+      new Promise<GitRemoteCommitPreview>((resolve) => {
+        resolvePreview = resolve;
+      })
+    );
+    renderDialog();
+    await flush();
+
+    // Without the preview the user has no visibility into what would be
+    // discarded, so the destructive action stays closed.
+    const confirm = screen.getByRole("button", { name: /force push/i }) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+
+    await act(async () => {
+      resolvePreview(preview(2));
+      await Promise.resolve();
+    });
+    expect(
+      (screen.getByRole("button", { name: /force push/i }) as HTMLButtonElement).disabled
+    ).toBe(false);
+  });
+
+  it("offers a retry that refetches at the same ceiling after a failed load", async () => {
+    listRemoteCommits.mockRejectedValueOnce(new Error("no remote"));
+    renderDialog();
+    await flush();
+
+    const retry = await screen.findByTestId("force-push-commits-retry");
+    listRemoteCommits.mockResolvedValue(preview(2));
+    await act(async () => {
+      retry.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(listRemoteCommits).toHaveBeenCalledTimes(2);
+    expect(listRemoteCommits.mock.calls[1]![2]).toBe(100);
+  });
+});

--- a/src/components/Worktree/ReviewHub/__tests__/ForcePushConfirmDialog.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ForcePushConfirmDialog.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { GitRemoteCommitPreview } from "@shared/types/git";
+import { GIT_REMOTE_COMMIT_PREVIEW_MAX, type GitRemoteCommitPreview } from "@shared/types/git";
 import { ForcePushConfirmDialog } from "../ForcePushConfirmDialog";
 
 vi.mock("zustand/react/shallow", () => ({ useShallow: (fn: unknown) => fn }));
@@ -64,6 +64,10 @@ function renderDialog() {
   );
 }
 
+function confirmButton(): HTMLElement {
+  return screen.getByRole("button", { name: /force push/i });
+}
+
 /** Settle the preview fetch's promise chain. */
 async function flush() {
   await act(async () => {
@@ -91,9 +95,10 @@ describe("ForcePushConfirmDialog preview", () => {
     await flush();
 
     const [, , limit] = listRemoteCommits.mock.calls[0]!;
-    // The main handler clamps to 100; anything below it caps the D2 preview
-    // client-side for no reason.
-    expect(limit).toBe(100);
+    // Against the shared contract both sides read, not a copied number — the
+    // point is that the dialog never narrows the preview below what the main
+    // process would serve, whatever that ceiling becomes.
+    expect(limit).toBe(GIT_REMOTE_COMMIT_PREVIEW_MAX);
   });
 
   it("renders each fetched commit once, in the order the range returned them", async () => {
@@ -120,17 +125,28 @@ describe("ForcePushConfirmDialog preview", () => {
     expect(first.textContent).toContain("Ada");
   });
 
-  it("never reports a total below the commits it is already listing", async () => {
-    // `git log` and the range count are separate reads in the handler, so a
-    // fetch between them can return a stale, smaller total. The rows in hand
-    // prove the range holds at least that many.
+  it("refuses a self-contradictory preview instead of picking a number", async () => {
+    // `git log` and the range count are separate reads over a symbolic range,
+    // so a concurrent fetch or branch move can leave them disagreeing. Neither
+    // side is then trustworthy, and guessing which to believe would be guessing
+    // about what a force push discards.
     listRemoteCommits.mockResolvedValue(preview(12, 3));
     renderDialog();
     await flush();
 
-    expect(screen.getAllByTestId("force-push-commit-row")).toHaveLength(12);
-    expect(screen.queryByTestId("force-push-commit-cap")).toBeNull();
-    expect(screen.queryByText("3")).toBeNull();
+    expect(screen.queryAllByTestId("force-push-commit-row")).toHaveLength(0);
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
+    // And it recovers the same way a failed load does.
+    expect(screen.getByTestId("force-push-commits-retry")).toBeTruthy();
+  });
+
+  it("proceeds normally when the total merely exceeds the fetched rows", async () => {
+    listRemoteCommits.mockResolvedValue(preview(100, 237));
+    renderDialog();
+    await flush();
+
+    expect(screen.getAllByTestId("force-push-commit-row")).toHaveLength(100);
+    expect(confirmButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("adds no cap notice while every diverged commit is listed", async () => {
@@ -194,16 +210,13 @@ describe("ForcePushConfirmDialog preview", () => {
 
     // Without the preview the user has no visibility into what would be
     // discarded, so the destructive action stays closed.
-    const confirm = screen.getByRole("button", { name: /force push/i }) as HTMLButtonElement;
-    expect(confirm.disabled).toBe(true);
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
 
     await act(async () => {
       resolvePreview(preview(2));
       await Promise.resolve();
     });
-    expect(
-      (screen.getByRole("button", { name: /force push/i }) as HTMLButtonElement).disabled
-    ).toBe(false);
+    expect(confirmButton().hasAttribute("aria-disabled")).toBe(false);
   });
 
   it("offers a retry that refetches at the same ceiling after a failed load", async () => {
@@ -224,8 +237,6 @@ describe("ForcePushConfirmDialog preview", () => {
     // And it recovers: the error clears, rows appear, and confirm arms.
     expect(screen.queryByTestId("force-push-commits-retry")).toBeNull();
     expect(screen.getAllByTestId("force-push-commit-row")).toHaveLength(2);
-    expect(
-      (screen.getByRole("button", { name: /force push/i }) as HTMLButtonElement).disabled
-    ).toBe(false);
+    expect(confirmButton().hasAttribute("aria-disabled")).toBe(false);
   });
 });

--- a/src/components/Worktree/ReviewHub/__tests__/ForcePushConfirmDialog.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ForcePushConfirmDialog.test.tsx
@@ -96,10 +96,41 @@ describe("ForcePushConfirmDialog preview", () => {
     expect(limit).toBe(100);
   });
 
-  it("renders one row per fetched commit", async () => {
+  it("renders each fetched commit once, in the order the range returned them", async () => {
     listRemoteCommits.mockResolvedValue(preview(12));
     renderDialog();
     await waitFor(() => expect(screen.getAllByTestId("force-push-commit-row")).toHaveLength(12));
+
+    const rows = screen.getAllByTestId("force-push-commit-row");
+    const messages = rows.map((r) => r.textContent ?? "");
+    expect(messages[0]).toContain("remote commit 0");
+    expect(messages.at(-1)).toContain("remote commit 11");
+    expect(new Set(messages).size).toBe(rows.length);
+  });
+
+  it("shows each row's own short hash and author, not just its subject", async () => {
+    // A D2 preview is judged on whether the content identifies the commits, so
+    // a row that renders only a message is not a preview.
+    listRemoteCommits.mockResolvedValue(preview(2));
+    renderDialog();
+    await flush();
+
+    const first = screen.getAllByTestId("force-push-commit-row")[0]!;
+    expect(first.textContent).toContain("aaaaaaa");
+    expect(first.textContent).toContain("Ada");
+  });
+
+  it("never reports a total below the commits it is already listing", async () => {
+    // `git log` and the range count are separate reads in the handler, so a
+    // fetch between them can return a stale, smaller total. The rows in hand
+    // prove the range holds at least that many.
+    listRemoteCommits.mockResolvedValue(preview(12, 3));
+    renderDialog();
+    await flush();
+
+    expect(screen.getAllByTestId("force-push-commit-row")).toHaveLength(12);
+    expect(screen.queryByTestId("force-push-commit-cap")).toBeNull();
+    expect(screen.queryByText("3")).toBeNull();
   });
 
   it("adds no cap notice while every diverged commit is listed", async () => {
@@ -187,7 +218,14 @@ describe("ForcePushConfirmDialog preview", () => {
       await Promise.resolve();
     });
 
-    expect(listRemoteCommits).toHaveBeenCalledTimes(2);
-    expect(listRemoteCommits.mock.calls[1]![2]).toBe(100);
+    // Same request as the first attempt — a retry that quietly narrowed the
+    // range would hand back a different preview than the one that failed.
+    expect(listRemoteCommits.mock.calls[1]).toEqual(listRemoteCommits.mock.calls[0]);
+    // And it recovers: the error clears, rows appear, and confirm arms.
+    expect(screen.queryByTestId("force-push-commits-retry")).toBeNull();
+    expect(screen.getAllByTestId("force-push-commit-row")).toHaveLength(2);
+    expect(
+      (screen.getByRole("button", { name: /force push/i }) as HTMLButtonElement).disabled
+    ).toBe(false);
   });
 });

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.commitAndPushErrors.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.commitAndPushErrors.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, act, fireEvent, within } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { GIT_REMOTE_COMMIT_PREVIEW_MAX } from "@shared/types/git";
 import type { StagingStatus } from "@shared/types";
 import type { WorktreeState } from "@shared/types";
 
@@ -817,7 +818,11 @@ describe("ReviewHub", () => {
 
       // Dialog opens; commit list loads.
       await waitFor(() =>
-        expect(listRemoteCommitsMock).toHaveBeenCalledWith(WORKTREE_PATH, "feature/x", 100)
+        expect(listRemoteCommitsMock).toHaveBeenCalledWith(
+          WORKTREE_PATH,
+          "feature/x",
+          GIT_REMOTE_COMMIT_PREVIEW_MAX
+        )
       );
       await waitFor(() => screen.getByText("first remote commit"));
 

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.commitAndPushErrors.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.commitAndPushErrors.test.tsx
@@ -817,7 +817,7 @@ describe("ReviewHub", () => {
 
       // Dialog opens; commit list loads.
       await waitFor(() =>
-        expect(listRemoteCommitsMock).toHaveBeenCalledWith(WORKTREE_PATH, "feature/x", 20)
+        expect(listRemoteCommitsMock).toHaveBeenCalledWith(WORKTREE_PATH, "feature/x", 100)
       );
       await waitFor(() => screen.getByText("first remote commit"));
 

--- a/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
@@ -188,7 +188,11 @@ interface LabelBadgeProps {
 function LabelBadge({ name, color }: LabelBadgeProps) {
   return (
     <span
-      className="inline-flex items-center max-w-full min-w-0 break-words px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+      // `inline-block`, not `inline-flex`: `break-words` acts on an element's
+      // own inline content, and a flex container's anonymous text child keeps
+      // its min-content width instead, so one long label used to paint past
+      // the badge and get clipped by the tooltip.
+      className="inline-block max-w-full break-words [overflow-wrap:anywhere] px-1.5 py-0.5 rounded-full text-[10px] font-medium"
       style={{
         backgroundColor: `#${color}20`,
         color: `#${color}`,
@@ -201,22 +205,41 @@ function LabelBadge({ name, color }: LabelBadgeProps) {
 }
 
 /**
+ * How many label chips a hover tooltip will render.
+ *
+ * Double the builtin GitHub provider's own `labels(first: 10)` page, so in
+ * practice every label an issue carries is shown and this never engages. It
+ * exists because `ForgeLabel[]` is unbounded in the provider contract: a plugin
+ * forge could return hundreds, and a tooltip can't scroll, so the row would
+ * grow past the viewport and be clipped by the tooltip's own `overflow-hidden`.
+ */
+const MAX_TOOLTIP_LABELS = 20;
+
+/**
  * Every label, not the first four.
  *
  * The row used to cut off at four and count the rest, which put the tail behind
  * a "+N more" that sits inside a hover tooltip — there is no further surface to
  * open from there, so the count named content the user could not reach
- * (#12001). The forge queries already bound this: `labels(first: 10)`, so the
- * honest version adds at most six chips to a wrapping row. `LabelBadge` wraps
- * rather than widens, so a single long provider-supplied label can't push the
- * tooltip past its `max-w-[280px]`.
+ * (#12001). `LabelBadge` wraps rather than widens, so a single long
+ * provider-supplied label can't push the tooltip past its `max-w-[280px]`.
+ *
+ * Past `MAX_TOOLTIP_LABELS` the row states what it is showing as a fact rather
+ * than counting a remainder: there is genuinely no surface to route to from
+ * inside a tooltip, and the badge itself already opens the issue.
  */
 function LabelRow({ labels }: { labels: readonly ForgeLabel[] }) {
+  const shown = labels.slice(0, MAX_TOOLTIP_LABELS);
   return (
-    <div className="flex flex-wrap gap-1 pt-1">
-      {labels.map((label) => (
+    <div className="flex flex-wrap items-baseline gap-1 pt-1">
+      {shown.map((label) => (
         <LabelBadge key={label.name} name={label.name} color={label.color ?? "8b949e"} />
       ))}
+      {labels.length > shown.length && (
+        <span className="text-[10px] text-daintree-text/40">
+          Showing {shown.length} of {labels.length}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
@@ -192,7 +192,10 @@ function LabelBadge({ name, color }: LabelBadgeProps) {
       // own inline content, and a flex container's anonymous text child keeps
       // its min-content width instead, so one long label used to paint past
       // the badge and get clipped by the tooltip.
-      className="inline-block max-w-full break-words [overflow-wrap:anywhere] px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+      // `line-clamp-2` bounds height as well as width: a name is unbounded in
+      // the provider contract, and twenty of them wrapping freely would make the
+      // tooltip arbitrarily tall even under the chip cap.
+      className="inline-block max-w-full break-words [overflow-wrap:anywhere] line-clamp-2 px-1.5 py-0.5 rounded-full text-[10px] font-medium"
       style={{
         backgroundColor: `#${color}20`,
         color: `#${color}`,
@@ -224,11 +227,11 @@ const MAX_TOOLTIP_LABELS = 20;
  * (#12001). `LabelBadge` wraps rather than widens, so a single long
  * provider-supplied label can't push the tooltip past its `max-w-[280px]`.
  *
- * Past `MAX_TOOLTIP_LABELS` the row states what it is showing as a fact rather
- * than counting a remainder: there is genuinely no surface to route to from
- * inside a tooltip, and the badge itself already opens the issue.
+ * Past `MAX_TOOLTIP_LABELS` the row names the route rather than counting a
+ * remainder — a tooltip has no surface of its own to open, but the badge this
+ * one describes does open the item, so that is where the rest live.
  */
-function LabelRow({ labels }: { labels: readonly ForgeLabel[] }) {
+function LabelRow({ labels, subject }: { labels: readonly ForgeLabel[]; subject: string }) {
   const shown = labels.slice(0, MAX_TOOLTIP_LABELS);
   return (
     <div className="flex flex-wrap items-baseline gap-1 pt-1">
@@ -237,7 +240,7 @@ function LabelRow({ labels }: { labels: readonly ForgeLabel[] }) {
       ))}
       {labels.length > shown.length && (
         <span className="text-[10px] text-daintree-text/40">
-          Showing {shown.length} of {labels.length}
+          Showing {shown.length} of {labels.length} — open the {subject} for the rest
         </span>
       )}
     </div>
@@ -283,7 +286,7 @@ export function IssueTooltipContent({ data, freshness }: IssueTooltipContentProp
         <FreshnessMetaItem freshness={freshness} />
       </div>
 
-      {data.labels.length > 0 && <LabelRow labels={data.labels} />}
+      {data.labels.length > 0 && <LabelRow labels={data.labels} subject="issue" />}
     </div>
   );
 }
@@ -346,7 +349,7 @@ export function PRTooltipContent({ data, freshness }: PRTooltipContentProps) {
         <FreshnessMetaItem freshness={freshness} />
       </div>
 
-      {data.labels.length > 0 && <LabelRow labels={data.labels} />}
+      {data.labels.length > 0 && <LabelRow labels={data.labels} subject="pull request" />}
     </div>
   );
 }

--- a/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
@@ -1,4 +1,4 @@
-import type { ForgeUser, IssueTooltipData, PRTooltipData } from "@shared/types/forge";
+import type { ForgeLabel, ForgeUser, IssueTooltipData, PRTooltipData } from "@shared/types/forge";
 import { Calendar, KeyRound, PenLine, UserCheck, Clock, CirclePause } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { BadgeFreshnessCause } from "@/components/Layout/FreshnessUtils";
@@ -188,7 +188,7 @@ interface LabelBadgeProps {
 function LabelBadge({ name, color }: LabelBadgeProps) {
   return (
     <span
-      className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+      className="inline-flex items-center max-w-full min-w-0 break-words px-1.5 py-0.5 rounded-full text-[10px] font-medium"
       style={{
         backgroundColor: `#${color}20`,
         color: `#${color}`,
@@ -197,6 +197,27 @@ function LabelBadge({ name, color }: LabelBadgeProps) {
     >
       {name}
     </span>
+  );
+}
+
+/**
+ * Every label, not the first four.
+ *
+ * The row used to cut off at four and count the rest, which put the tail behind
+ * a "+N more" that sits inside a hover tooltip — there is no further surface to
+ * open from there, so the count named content the user could not reach
+ * (#12001). The forge queries already bound this: `labels(first: 10)`, so the
+ * honest version adds at most six chips to a wrapping row. `LabelBadge` wraps
+ * rather than widens, so a single long provider-supplied label can't push the
+ * tooltip past its `max-w-[280px]`.
+ */
+function LabelRow({ labels }: { labels: readonly ForgeLabel[] }) {
+  return (
+    <div className="flex flex-wrap gap-1 pt-1">
+      {labels.map((label) => (
+        <LabelBadge key={label.name} name={label.name} color={label.color ?? "8b949e"} />
+      ))}
+    </div>
   );
 }
 
@@ -239,18 +260,7 @@ export function IssueTooltipContent({ data, freshness }: IssueTooltipContentProp
         <FreshnessMetaItem freshness={freshness} />
       </div>
 
-      {data.labels.length > 0 && (
-        <div className="flex flex-wrap gap-1 pt-1">
-          {data.labels.slice(0, 4).map((label) => (
-            <LabelBadge key={label.name} name={label.name} color={label.color ?? "8b949e"} />
-          ))}
-          {data.labels.length > 4 && (
-            <span className="text-[10px] text-daintree-text/40">
-              +{data.labels.length - 4} more
-            </span>
-          )}
-        </div>
-      )}
+      {data.labels.length > 0 && <LabelRow labels={data.labels} />}
     </div>
   );
 }
@@ -313,18 +323,7 @@ export function PRTooltipContent({ data, freshness }: PRTooltipContentProps) {
         <FreshnessMetaItem freshness={freshness} />
       </div>
 
-      {data.labels.length > 0 && (
-        <div className="flex flex-wrap gap-1 pt-1">
-          {data.labels.slice(0, 4).map((label) => (
-            <LabelBadge key={label.name} name={label.name} color={label.color ?? "8b949e"} />
-          ))}
-          {data.labels.length > 4 && (
-            <span className="text-[10px] text-daintree-text/40">
-              +{data.labels.length - 4} more
-            </span>
-          )}
-        </div>
-      )}
+      {data.labels.length > 0 && <LabelRow labels={data.labels} />}
     </div>
   );
 }

--- a/src/components/Worktree/WorktreeCard/__tests__/ForgeTooltipContent.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/ForgeTooltipContent.test.tsx
@@ -322,10 +322,17 @@ describe("ForgeTooltipContent labels", () => {
     const rendered = container.textContent ?? "";
     const chips = flood.filter((l) => screen.queryByText(l.name) !== null);
     expect(chips.length).toBeLessThan(flood.length);
-    // And it says what it is showing rather than counting a remainder nothing
-    // could open.
+    // And it names the route rather than counting a remainder: a tooltip has no
+    // surface of its own to open, but the badge it describes opens the item.
     expect(rendered).toContain(String(flood.length));
+    expect(rendered).toContain("open the issue");
     expect(rendered).not.toMatch(/\+\d+ more/);
+  });
+
+  it("names the pull request, not the issue, on a PR tooltip", () => {
+    const flood = Array.from({ length: 40 }, (_, i) => ({ name: `flood-${i}`, color: "8b949e" }));
+    const { container } = render(<PRTooltipContent data={{ ...prData, labels: flood }} />);
+    expect(container.textContent).toContain("open the pull request");
   });
 
   it("falls back to a neutral colour for a label the provider left uncoloured", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/ForgeTooltipContent.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/ForgeTooltipContent.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { ForgeUser, IssueTooltipData, PRTooltipData } from "@shared/types/forge";
 
@@ -301,9 +301,31 @@ describe("ForgeTooltipContent labels", () => {
     expect(screen.queryByText(/more$/)).toBeNull();
   });
 
-  it("renders no label row when there are no labels", () => {
-    const { container } = render(<IssueTooltipContent data={{ ...issueData, labels: [] }} />);
-    expect(container.textContent).not.toContain("label-");
+  it("renders no label row at all when there are no labels", () => {
+    const withLabels = render(<IssueTooltipContent data={{ ...issueData, labels: manyLabels }} />);
+    const withLabelsNodes = withLabels.container.querySelectorAll("div").length;
+    cleanup();
+
+    const empty = render(<IssueTooltipContent data={{ ...issueData, labels: [] }} />);
+    // An empty row shell would still take the row's `pt-1`, opening a gap under
+    // the metadata line for nothing.
+    expect(empty.container.querySelectorAll("div").length).toBeLessThan(withLabelsNodes);
+  });
+
+  it("bounds the row when a provider returns far more labels than a forge page", () => {
+    // `ForgeLabel[]` is unbounded in the provider contract and a tooltip can't
+    // scroll, so an unbounded row would run past the viewport and be clipped by
+    // the tooltip's own overflow.
+    const flood = Array.from({ length: 300 }, (_, i) => ({ name: `flood-${i}`, color: "8b949e" }));
+    const { container } = render(<IssueTooltipContent data={{ ...issueData, labels: flood }} />);
+
+    const rendered = container.textContent ?? "";
+    const chips = flood.filter((l) => screen.queryByText(l.name) !== null);
+    expect(chips.length).toBeLessThan(flood.length);
+    // And it says what it is showing rather than counting a remainder nothing
+    // could open.
+    expect(rendered).toContain(String(flood.length));
+    expect(rendered).not.toMatch(/\+\d+ more/);
   });
 
   it("falls back to a neutral colour for a label the provider left uncoloured", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/ForgeTooltipContent.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/ForgeTooltipContent.test.tsx
@@ -274,3 +274,43 @@ describe("PRTooltipContent freshness item", () => {
     expect(screen.getByText(/data may be stale/)).toBeTruthy();
   });
 });
+
+describe("ForgeTooltipContent labels", () => {
+  // The forge queries ask for `labels(first: 10)`, so this is the widest row
+  // either tooltip can be handed.
+  const manyLabels = Array.from({ length: 10 }, (_, i) => ({
+    name: `label-${i}`,
+    color: "8b949e",
+  }));
+
+  it("renders every issue label rather than counting the tail (#12001)", () => {
+    // The row used to stop at four and print "+N more" — a count inside a
+    // hover tooltip, which has no further surface to open.
+    render(<IssueTooltipContent data={{ ...issueData, labels: manyLabels }} />);
+    for (const label of manyLabels) {
+      expect(screen.getByText(label.name)).toBeTruthy();
+    }
+    expect(screen.queryByText(/more$/)).toBeNull();
+  });
+
+  it("renders every PR label rather than counting the tail (#12001)", () => {
+    render(<PRTooltipContent data={{ ...prData, labels: manyLabels }} />);
+    for (const label of manyLabels) {
+      expect(screen.getByText(label.name)).toBeTruthy();
+    }
+    expect(screen.queryByText(/more$/)).toBeNull();
+  });
+
+  it("renders no label row when there are no labels", () => {
+    const { container } = render(<IssueTooltipContent data={{ ...issueData, labels: [] }} />);
+    expect(container.textContent).not.toContain("label-");
+  });
+
+  it("falls back to a neutral colour for a label the provider left uncoloured", () => {
+    render(<IssueTooltipContent data={{ ...issueData, labels: [{ name: "uncoloured" }] }} />);
+    const badge = screen.getByText("uncoloured");
+    // Any resolved colour beats none: an unset `color` used to produce
+    // `#undefined20`, which paints nothing.
+    expect(badge.getAttribute("style") ?? "").not.toContain("undefined");
+  });
+});

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef } from "react";
 import type { WorktreeState } from "../../types";
 import type { ErrorRecord, RetryAction } from "../../store/errorStore";
-import { ErrorBanner } from "../Errors/ErrorBanner";
+import { CompactErrorList } from "../Errors/CompactErrorList";
 import { FileChangeList, type FileChangeListHandle } from "./FileChangeList";
 import { ActivityLight } from "./ActivityLight";
 import { LiveTimeAgo } from "./LiveTimeAgo";
@@ -149,23 +149,13 @@ export function WorktreeDetails({
         <>
           {/* Errors (if any) */}
           {worktreeErrors.length > 0 && (
-            <div className="space-y-1">
-              {worktreeErrors.slice(0, 3).map((error) => (
-                <ErrorBanner
-                  key={error.id}
-                  error={error}
-                  onDismiss={onDismissError}
-                  onRetry={onRetryError}
-                  onCancelRetry={onCancelRetry}
-                  compact
-                />
-              ))}
-              {worktreeErrors.length > 3 && (
-                <div className="text-[0.65rem] text-daintree-text/60 text-center">
-                  +{worktreeErrors.length - 3} more errors
-                </div>
-              )}
-            </div>
+            <CompactErrorList
+              errors={worktreeErrors}
+              maxInline={3}
+              onDismiss={onDismissError}
+              onRetry={onRetryError}
+              onCancelRetry={onCancelRetry}
+            />
           )}
 
           {/* Block 2: Narrative — the AI note, the AI summary, or the last

--- a/src/components/Worktree/__tests__/WorktreeDetails.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDetails.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import type { WorktreeState } from "@/types";
 import type { WorktreeChanges } from "@shared/types/git";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -220,5 +220,47 @@ describe("WorktreeDetails — open changes button (#11041)", () => {
   it("hides the button when the change list is empty", () => {
     renderDetails({ worktree: baseWorktree, hasChanges: true });
     expect(screen.queryByRole("button", { name: "Open changes" })).toBeNull();
+  });
+});
+
+describe("WorktreeDetails error overflow", () => {
+  const errors = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      id: `err-${i}`,
+      timestamp: TEST_NOW + i,
+      type: "git" as const,
+      message: `Worktree failure ${i}`,
+      retryability: "none" as const,
+      dismissed: false,
+    }));
+
+  it("shows every error inline while the stack fits", () => {
+    renderDetails({ worktreeErrors: errors(3) });
+    expect(screen.getByText("Worktree failure 2")).toBeDefined();
+    expect(screen.queryByTestId("compact-error-overflow")).toBeNull();
+  });
+
+  it("moves the fourth error onwards behind a real disclosure (#12001)", () => {
+    // It used to be "+N more errors" as static text, next to retry and dismiss
+    // handlers the hidden rows never got to use.
+    renderDetails({ worktreeErrors: errors(6) });
+    expect(screen.getByText("Worktree failure 2")).toBeDefined();
+    expect(screen.queryByText("Worktree failure 3")).toBeNull();
+
+    const trigger = screen.getByTestId("compact-error-overflow");
+    expect(trigger.textContent).toContain("3");
+
+    fireEvent.click(trigger);
+    expect(screen.getByText("Worktree failure 5")).toBeDefined();
+  });
+
+  it("routes a hidden error's dismissal back to the surface's own handler", () => {
+    const onDismissError = vi.fn();
+    renderDetails({ worktreeErrors: errors(5), onDismissError });
+
+    fireEvent.click(screen.getByTestId("compact-error-overflow"));
+    const row = screen.getByText("Worktree failure 4").closest("div")!;
+    fireEvent.click(within(row.parentElement ?? row).getAllByLabelText(/dismiss/i)[0]!);
+    expect(onDismissError).toHaveBeenCalledWith("err-4");
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeDetails.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDetails.test.tsx
@@ -254,6 +254,24 @@ describe("WorktreeDetails error overflow", () => {
     expect(screen.getByText("Worktree failure 5")).toBeDefined();
   });
 
+  it("opens the disclosure without triggering the card behind it", () => {
+    // WorktreeDetails renders inside a click-to-select card; from the overview
+    // modal that selection unmounts the card, so an unstopped click would open
+    // the disclosure and destroy it in the same gesture.
+    const onParentClick = vi.fn();
+    render(
+      <TooltipProvider>
+        <div onClick={onParentClick}>
+          <WorktreeDetails {...baseProps} worktreeErrors={errors(6)} />
+        </div>
+      </TooltipProvider>
+    );
+
+    fireEvent.click(screen.getByTestId("compact-error-overflow"));
+    expect(onParentClick).not.toHaveBeenCalled();
+    expect(screen.getByText("Worktree failure 5")).toBeDefined();
+  });
+
   it("routes a hidden error's dismissal back to the surface's own handler", () => {
     const onDismissError = vi.fn();
     renderDetails({ worktreeErrors: errors(5), onDismissError });

--- a/src/components/ui/PaletteOverflowNotice.tsx
+++ b/src/components/ui/PaletteOverflowNotice.tsx
@@ -3,6 +3,14 @@ interface PaletteOverflowNoticeProps {
   total: number;
 }
 
+/**
+ * The tail a capped palette search didn't rank. Unlike the app's other overflow
+ * counts this one has no list to open: the hidden rows are the matches that
+ * scored below the cut, and the route to them is the search field that's
+ * already focused. So the recovery goes in the visible copy rather than behind
+ * a disclosure — a control here would either re-rank the same query or open a
+ * second focus domain inside a palette that owns the arrow keys (#12001).
+ */
 export function PaletteOverflowNotice({ shown, total }: PaletteOverflowNoticeProps) {
   if (total <= shown) return null;
 
@@ -10,10 +18,10 @@ export function PaletteOverflowNotice({ shown, total }: PaletteOverflowNoticePro
   return (
     <div
       role="status"
-      aria-label={`${hidden} more results not shown — refine your search to see them`}
+      aria-label={`${hidden} more results not shown — type to narrow your search`}
       className="px-3 py-2 text-xs tabular-nums text-daintree-text/40 text-center border-t border-daintree-border/30"
     >
-      +{hidden} more
+      +{hidden} more — type to narrow
     </div>
   );
 }

--- a/src/components/ui/__tests__/PaletteOverflowNotice.test.tsx
+++ b/src/components/ui/__tests__/PaletteOverflowNotice.test.tsx
@@ -4,9 +4,11 @@ import { describe, expect, it } from "vitest";
 import { PaletteOverflowNotice } from "../PaletteOverflowNotice";
 
 describe("PaletteOverflowNotice", () => {
-  it("renders when total exceeds shown", () => {
+  it("reports the remainder, not the total", () => {
     render(<PaletteOverflowNotice shown={20} total={47} />);
-    expect(screen.getByText("+27 more")).toBeTruthy();
+    const notice = screen.getByRole("status");
+    expect(notice.textContent).toContain("27");
+    expect(notice.textContent).not.toContain("47");
   });
 
   it("renders nothing when total equals shown", () => {
@@ -21,20 +23,25 @@ describe("PaletteOverflowNotice", () => {
 
   it("has role='status' so AT announces the count", () => {
     render(<PaletteOverflowNotice shown={20} total={47} />);
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("names the recovery in the visible copy, not only the aria-label", () => {
+    // The hidden rows are the matches that ranked below the cut, so there is no
+    // list to open — the route is the search field. A sighted user has to be
+    // able to read that route off the notice itself (#12001).
+    render(<PaletteOverflowNotice shown={20} total={47} />);
     const notice = screen.getByRole("status");
-    expect(notice).toBeTruthy();
-    expect(notice.textContent).toBe("+27 more");
+    expect(notice.textContent?.toLowerCase()).toContain("narrow");
   });
 
   it("exposes a descriptive aria-label so screen readers get context", () => {
-    // The visible text is terse for visual scanning, so AT users get a
-    // fuller phrase via aria-label that mentions "results" and the recovery
-    // ("refine your search").
+    // The visible text is terse for visual scanning, so AT users get a fuller
+    // phrase via aria-label that mentions "results" and the recovery.
     render(<PaletteOverflowNotice shown={20} total={47} />);
-    const notice = screen.getByRole("status");
-    const label = notice.getAttribute("aria-label") ?? "";
+    const label = screen.getByRole("status").getAttribute("aria-label") ?? "";
     expect(label).toContain("27");
     expect(label.toLowerCase()).toContain("results");
-    expect(label.toLowerCase()).toContain("refine");
+    expect(label.toLowerCase()).toContain("narrow");
   });
 });


### PR DESCRIPTION
## Summary
- Issue #12001 flagged overflow indicators like "+N more" that count hidden content but give no way to reach it. The title said nine; the body listed eight concrete locations, with `ForgeTooltipContent` counted twice.
- All eight are fixed here, each with the treatment its own surface calls for rather than one uniform popover wrap.

Resolves #12001

## Changes

### WorktreeDetails and TerminalPane
Both now use a new shared `CompactErrorList` component (`src/components/Errors/`). It shows the first N banners inline and puts the rest behind a real disclosure of full `ErrorBanner` rows, retry and dismiss handlers included. The errors and handlers were already in memory; only the rows weren't rendered.

### RunningTaskList
Gets a local `TaskOverflow` popover built from real `TaskRow` components, so hidden tasks keep their stop, restart, focus, and dismiss actions.

### ForcePushConfirmDialog (D2)
Now requests the handler's full 100-commit ceiling instead of 20, and lists them in a keyboard-reachable `ScrollShadow` matching the shape already used by `GitPushConfirmDialog`. Past the ceiling, the tail states a fact instead of promising a list.

### PluginArchiveInstallConfirmDialog (D2)
Recipe names are no longer truncated at the manifest read. The dialog bounds its viewport instead of the data. The manifest schema already caps recipes at 50 and each name at 200 characters.

### ForgeTooltipContent (×2)
Renders all labels instead of counting a tail. It's inside a hover tooltip, which has no further surface to open.

### PaletteOverflowNotice
Left as a status, deliberately. The hidden rows are matches that ranked below the search cap, and the route to see them is the already-focused search input. That route is now in the visible copy, not just the aria-label.

## Notable decisions
- No popover nested inside either D2 destructive confirm. The safeguard rule for those dialogs requires the preview to show actual content, and tucking it behind a second click cuts against that, so `ScrollShadow` keeps the full preview in the dialog's reading order instead.
- The force-push preview fails closed when the handler's two git reads disagree (`total < rows`). An earlier version took `max()` of the two, which was wrong: the total can legitimately shrink when the local branch advances, meaning the rows are stale rather than the total being wrong. Since neither value is trustworthy, the preview reloads instead of guessing.
- The preview ceiling is now a shared constant, `GIT_REMOTE_COMMIT_PREVIEW_MAX` in `shared/types/git.ts`, read by both the IPC handler and the dialog, so it can only move in one place.
- Popover triggers stop click propagation. They render inside a click-to-select worktree card, and from the overview modal, opening a popover would trigger the card's selection and unmount it mid-open, destroying the popover in the same gesture.

## Out of scope
- `NotificationCenter.tsx`'s "+N more below" indicator: not listed in the issue, and its items are already reachable further down the same chronological list.
- `TaskRow`'s pre-existing `role="button"`-containing-buttons structure.
- Forge-provider payload validation in `electron/ipc/handlers/forgeData.ts`: `title`, `bodyExcerpt`, and `assignees` are equally unvalidated there, so clamping only `labels` would be inconsistent. The label row is bounded in the renderer instead.

## Testing
326 tests passing across every module this branch touches, including four new test files (`CompactErrorList`, `RunningTaskList`, `ForcePushConfirmDialog`) plus extensions to `WorktreeDetails`, `ForgeTooltipContent`, `PluginArchiveInstallConfirmDialog`, `archiveInstallIntent`, `PaletteOverflowNotice`, and the `accentGuard` contract test. Prettier is clean, zero lint errors on changed files. Reviewed across three adversarial Codex passes; eleven findings fixed over two iterations.