### PR TITLE
refactor(theme): put the type and radius scales back in charge

### DIFF
--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -1251,7 +1251,7 @@ export function BulkCreateWorktreeDialog({
                       )}
                     </div>
                     {item.skipped && (
-                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-warning/10 text-status-warning shrink-0">
+                      <span className="text-3xs px-1.5 py-0.5 rounded bg-status-warning/10 text-status-warning shrink-0">
                         {item.skipReason}
                       </span>
                     )}
@@ -1297,7 +1297,7 @@ export function BulkCreateWorktreeDialog({
                           </span>
                           <span className="text-daintree-text truncate">{item.item.title}</span>
                           {isInProgress && itemStatus.attempt > 1 && (
-                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-info/10 text-status-info shrink-0">
+                            <span className="text-3xs px-1.5 py-0.5 rounded bg-status-info/10 text-status-info shrink-0">
                               retry {itemStatus.attempt - 1}
                             </span>
                           )}

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -335,7 +335,7 @@ export function GitHubListItem({
                         className="w-4 h-4"
                       />
                       {restAssignees.length > 0 && (
-                        <span className="ml-0.5 text-[10px] text-text-secondary tabular-nums">
+                        <span className="ml-0.5 text-3xs text-text-secondary tabular-nums">
                           +{restAssignees.length}
                         </span>
                       )}

--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -675,11 +675,12 @@ const NON_EXTENSION_VAR_NAMES = new Set<string>([
   "radius-md",
   "radius-lg",
   "radius-xl",
-  // Stock Tailwind type step, consumed by name where a size has to be written as
-  // a value rather than a utility class (CodeMirror theme objects). The steps
-  // below it (--text-2xs/3xs/4xs) are declared in src/index.css, so the
-  // `declared` half of the scan already covers those.
+  // Stock Tailwind type steps, consumed by name where a size has to be written as
+  // a value rather than a utility class (CodeMirror theme objects, the diff
+  // text-size preference). The steps below them (--text-2xs/3xs/4xs) are declared
+  // in src/index.css, so the `declared` half of the scan already covers those.
   "text-xs",
+  "text-sm",
   "chart-1",
   "chart-2",
   "chart-3",

--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -675,6 +675,11 @@ const NON_EXTENSION_VAR_NAMES = new Set<string>([
   "radius-md",
   "radius-lg",
   "radius-xl",
+  // Stock Tailwind type step, consumed by name where a size has to be written as
+  // a value rather than a utility class (CodeMirror theme objects). The steps
+  // below it (--text-2xs/3xs/4xs) are declared in src/index.css, so the
+  // `declared` half of the scan already covers those.
+  "text-xs",
   "chart-1",
   "chart-2",
   "chart-3",

--- a/shared/theme/builtInThemes/atacama.ts
+++ b/shared/theme/builtInThemes/atacama.ts
@@ -198,7 +198,6 @@ export const theme: BuiltInThemeSource = {
     "toolbar-control-hover-fg": "#272119",
     "toolbar-control-hover-shadow": "none",
     "toolbar-divider": "rgba(212,203,189,0.7)",
-    "toolbar-pill-radius": "0.5rem",
     // Pills sit lighter than the chrome strip (raised, like all content).
     "toolbar-project-bg":
       "linear-gradient(180deg, rgba(178,80,36,0.06), rgba(39,33,25,0.02)), #FBF7F0",

--- a/shared/theme/builtInThemes/bali.ts
+++ b/shared/theme/builtInThemes/bali.ts
@@ -193,7 +193,6 @@ export const theme: BuiltInThemeSource = {
     "toolbar-control-hover-fg": "#20241E",
     "toolbar-control-hover-shadow": "none",
     "toolbar-divider": "rgba(203,208,193,0.7)",
-    "toolbar-pill-radius": "0.5rem",
     // Pills sit lighter than the chrome strip (raised, like all content).
     "toolbar-project-bg":
       "linear-gradient(180deg, rgba(224,179,65,0.08), rgba(32,36,30,0.02)), #F6F7F2",

--- a/shared/theme/builtInThemes/bondi.ts
+++ b/shared/theme/builtInThemes/bondi.ts
@@ -292,7 +292,6 @@ export const theme: BuiltInThemeSource = {
     "toolbar-control-hover-fg": "#1C2028",
     "toolbar-control-hover-shadow": "none",
     "toolbar-divider": "rgba(207,199,184,0.7)",
-    "toolbar-pill-radius": "0.5rem",
     // Pills sit lighter than the chrome strip (raised, like all content). The
     // base has to out-run this pill's own two washes: at #F6F0E7 the composed
     // gradient landed at L 0.9453 against a strip at L 0.9453 — zero lift,

--- a/shared/theme/builtInThemes/hokkaido.ts
+++ b/shared/theme/builtInThemes/hokkaido.ts
@@ -214,7 +214,6 @@ export const theme: BuiltInThemeSource = {
     "toolbar-control-hover-fg": "#282630",
     "toolbar-control-hover-shadow": "none",
     "toolbar-divider": "rgba(211,207,221,0.7)",
-    "toolbar-pill-radius": "0.5rem",
     // Pills sit lighter than the chrome strip (raised, like all content).
     "toolbar-project-bg":
       "linear-gradient(180deg, rgba(226,139,177,0.08), rgba(40,38,48,0.02)), #F8F7FB",

--- a/shared/theme/builtInThemes/serengeti.ts
+++ b/shared/theme/builtInThemes/serengeti.ts
@@ -197,7 +197,6 @@ export const theme: BuiltInThemeSource = {
     "toolbar-control-hover-fg": "#26211A",
     "toolbar-control-hover-shadow": "none",
     "toolbar-divider": "rgba(210,205,180,0.7)",
-    "toolbar-pill-radius": "0.5rem",
     // Pills sit lighter than the chrome strip (raised, like all content).
     "toolbar-project-bg":
       "linear-gradient(180deg, rgba(232,168,28,0.08), rgba(38,33,26,0.02)), #FBF9F0",

--- a/shared/theme/builtInThemes/svalbard.ts
+++ b/shared/theme/builtInThemes/svalbard.ts
@@ -205,7 +205,6 @@ export const theme: BuiltInThemeSource = {
     "toolbar-control-hover-fg": "#192128",
     "toolbar-control-hover-shadow": "none",
     "toolbar-divider": "rgba(197,207,214,0.7)",
-    "toolbar-pill-radius": "0.5rem",
     // Pills sit lighter than the chrome strip (raised, like all content).
     "toolbar-project-bg": "#F7FAFC",
     "toolbar-project-border": "rgba(197,207,214,0.75)",

--- a/shared/theme/builtInThemes/table-mountain.ts
+++ b/shared/theme/builtInThemes/table-mountain.ts
@@ -200,7 +200,6 @@ export const theme: BuiltInThemeSource = {
     "toolbar-control-hover-fg": "#231F1A",
     "toolbar-control-hover-shadow": "none",
     "toolbar-divider": "rgba(213,203,189,0.7)",
-    "toolbar-pill-radius": "0.5rem",
     // Lichen-gold whisper, deliberately not the protea accent — the accent
     // stays scarce (rail/marker/CTA/ring only). Pills sit lighter than the
     // chrome strip.

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/hooks/useActionPalette";
 
 const SECTION_HEADER_CLASS =
-  "px-3 py-1 text-[10px] font-medium tracking-wider uppercase text-text-secondary select-none";
+  "px-3 py-1 text-3xs font-medium tracking-wider uppercase text-text-secondary select-none";
 
 // Module-level so SearchablePalette receives a stable reference and skips
 // re-renders driven only by a freshly-created callback identity.
@@ -71,7 +71,7 @@ function PrefixDiscoverabilityRow() {
       // Spacing does the separating, not interpuncts. The row wraps at the
       // palette's width, and a per-item separator ends a wrapped line with a
       // dangling dot pointing at nothing.
-      className="@max-[420px]/palette-footer:hidden flex items-center gap-x-3 gap-y-1 flex-wrap text-[11px] text-daintree-text/45"
+      className="@max-[420px]/palette-footer:hidden flex items-center gap-x-3 gap-y-1 flex-wrap text-2xs text-daintree-text/45"
       aria-label="Prefix shortcuts"
     >
       <span className="text-daintree-text/40">Type</span>

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -186,7 +186,7 @@ function ActionPaletteItemInner({
             className={cn(
               // Natural width inside the fixed column, not stretched to fill it:
               // a 3-letter category in an 80px pill reads as a stretched button.
-              "inline-block max-w-full truncate rounded px-1.5 py-0.5 text-[10px] font-medium leading-tight",
+              "inline-block max-w-full truncate rounded px-1.5 py-0.5 text-3xs font-medium leading-tight",
               categoryColor
             )}
           >
@@ -202,7 +202,7 @@ function ActionPaletteItemInner({
             </div>
           )}
           {!item.enabled && item.disabledReason && (
-            <div className="text-[10px] leading-snug text-daintree-text/50 italic truncate">
+            <div className="text-3xs leading-snug text-daintree-text/50 italic truncate">
               {item.disabledReason}
             </div>
           )}
@@ -216,7 +216,7 @@ function ActionPaletteItemInner({
           )}
           {pinRejected && (
             <div
-              className="text-[10px] leading-snug text-status-error mt-0.5 truncate"
+              className="text-3xs leading-snug text-status-error mt-0.5 truncate"
               role="status"
               aria-live="polite"
             >
@@ -276,7 +276,7 @@ function ActionPaletteItemInner({
         )}
 
         {item.keybinding && (
-          <span className="text-[11px] font-mono text-daintree-text/50 transition-colors group-aria-selected:text-daintree-text/70">
+          <span className="text-2xs font-mono text-daintree-text/50 transition-colors group-aria-selected:text-daintree-text/70">
             {item.keybinding}
           </span>
         )}

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -587,7 +587,7 @@ export function BrowserToolbar({
                 <span className="text-xs text-daintree-text truncate">
                   {entry.title || entry.url}
                 </span>
-                <span className="text-[11px] text-text-secondary truncate">{entry.url}</span>
+                <span className="text-2xs text-text-secondary truncate">{entry.url}</span>
               </button>
             ))}
           </div>
@@ -633,7 +633,7 @@ export function BrowserToolbar({
                 <span className="text-xs text-daintree-text truncate">
                   {entry.title || entry.url}
                 </span>
-                <span className="text-[11px] text-text-secondary truncate">{entry.url}</span>
+                <span className="text-2xs text-text-secondary truncate">{entry.url}</span>
               </button>
             ))}
           </div>

--- a/src/components/Browser/FindBar.tsx
+++ b/src/components/Browser/FindBar.tsx
@@ -79,7 +79,7 @@ export function FindBar({ find }: FindBarProps) {
         id={counterId}
         role="status"
         aria-atomic="true"
-        className={`text-[11px] tabular-nums whitespace-nowrap mr-0.5 ${
+        className={`text-2xs tabular-nums whitespace-nowrap mr-0.5 ${
           noResults ? "text-status-error" : "text-daintree-text/50"
         }`}
       >

--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -172,7 +172,7 @@ export function CommandPicker({
             {category && (
               <div
                 className={cn(
-                  "px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-text-secondary",
+                  "px-3 py-1.5 text-2xs font-medium uppercase tracking-wider text-text-secondary",
                   index > 0 && "mt-2"
                 )}
               >
@@ -203,14 +203,14 @@ export function CommandPicker({
               <div className="flex items-center justify-between">
                 <span className="font-mono text-sm text-daintree-text/90">/{cmd.id}</span>
                 {cmd.hasBuilder && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-overlay-medium text-daintree-text/70">
+                  <span className="text-3xs px-1.5 py-0.5 rounded bg-overlay-medium text-daintree-text/70">
                     Builder
                   </span>
                 )}
               </div>
               <div className="text-xs text-daintree-text/50 line-clamp-1">{cmd.description}</div>
               {!cmd.enabled && cmd.disabledReason && (
-                <div className="text-[10px] text-daintree-text/40 italic">{cmd.disabledReason}</div>
+                <div className="text-3xs text-daintree-text/40 italic">{cmd.disabledReason}</div>
               )}
             </button>
           </div>

--- a/src/components/CopyTree/CopyTreeRecentsPanel.tsx
+++ b/src/components/CopyTree/CopyTreeRecentsPanel.tsx
@@ -173,7 +173,7 @@ export function CopyTreeRecentsPanel({
                   >
                     <span className="min-w-0 flex-1 flex flex-col gap-0.5">
                       <span className="truncate text-sm">{record.name}</span>
-                      <span className="truncate text-[11px] text-daintree-text/50">
+                      <span className="truncate text-2xs text-daintree-text/50">
                         {formatRecentMeta(record)}
                       </span>
                     </span>

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -245,7 +245,7 @@ export function ConsoleDrawer({
       status === "stopping");
   const stopDisabled = isRestarting || status === "stopping";
   const statusClass = cn(
-    "inline-flex min-h-8 items-center px-3 text-[10px] font-semibold uppercase tracking-wide",
+    "inline-flex min-h-8 items-center px-3 text-3xs font-semibold uppercase tracking-wide",
     (hasRestartControls || stopVisible) && "border-r border-overlay/70",
     statusLabel.textClass
   );

--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -116,7 +116,7 @@ const ConsoleRow = memo(function ConsoleRow({
       </span>
       <span
         className={cn(
-          "shrink-0 text-[9px] font-bold tracking-wide px-1 py-0.5 rounded select-none",
+          "shrink-0 text-4xs font-bold tracking-wide px-1 py-0.5 rounded select-none",
           style.badge
         )}
       >
@@ -322,13 +322,13 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
   }, []);
 
   const buttonClass =
-    "px-2 py-0.5 rounded text-[10px] font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent/50";
+    "px-2 py-0.5 rounded text-3xs font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent/50";
 
   return (
     <div className="flex h-full flex-col bg-daintree-bg">
       {/* Toolbar */}
       <div className="flex items-center gap-1.5 px-2 py-1 border-b border-overlay bg-surface shrink-0">
-        <span className="text-[10px] font-semibold uppercase tracking-wide text-daintree-text/50 mr-1">
+        <span className="text-3xs font-semibold uppercase tracking-wide text-daintree-text/50 mr-1">
           Console
         </span>
 
@@ -365,7 +365,7 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Filter…"
           aria-label="Filter console messages"
-          className="flex-1 min-w-0 max-w-[160px] px-2 py-0.5 text-[11px] rounded bg-daintree-bg border border-overlay focus:outline-hidden focus:border-border-strong text-daintree-text placeholder:text-text-placeholder"
+          className="flex-1 min-w-0 max-w-[160px] px-2 py-0.5 text-2xs rounded bg-daintree-bg border border-overlay focus:outline-hidden focus:border-border-strong text-daintree-text placeholder:text-text-placeholder"
         />
 
         <div className="flex-1" />
@@ -425,7 +425,7 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
 
       {/* Message list */}
       {filtered.length === 0 ? (
-        <div className="flex-1 overflow-y-auto font-mono text-[11px] leading-relaxed">
+        <div className="flex-1 overflow-y-auto font-mono text-2xs leading-relaxed">
           <div className="flex items-center justify-center h-full text-daintree-text/30 text-xs select-none">
             {allMessages.length === 0 ? "No console output" : "No messages match filter"}
           </div>
@@ -445,7 +445,7 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
               onToggleGroup={msg.isGroupHeader ? toggleGroup : undefined}
             />
           )}
-          className="flex-1 font-mono text-[11px] leading-relaxed"
+          className="flex-1 font-mono text-2xs leading-relaxed"
         />
       )}
     </div>

--- a/src/components/DevPreview/DevPreviewDestructiveConfirmDialog.tsx
+++ b/src/components/DevPreview/DevPreviewDestructiveConfirmDialog.tsx
@@ -176,10 +176,10 @@ function CacheDirsPreview({ meta, sizes, sizesPending }: CacheDirsPreviewProps) 
       data-testid="dev-preview-destructive-cache-preview"
     >
       <div className="px-3 py-2 border-b border-tint/[0.08] flex items-center justify-between">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+        <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
           Directories to delete
           {cacheDirs && (
-            <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+            <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal">
               {presentCount} of {cacheDirs.length}
             </span>
           )}
@@ -215,7 +215,7 @@ function CacheDirsPreview({ meta, sizes, sizesPending }: CacheDirsPreviewProps) 
                   </span>
                   {dir.exists ? (
                     <>
-                      <span className="text-[10px] text-text-secondary shrink-0">
+                      <span className="text-3xs text-text-secondary shrink-0">
                         {dir.mtimeMs ? formatRelativeTime(dir.mtimeMs) : null}
                       </span>
                       <span className="ml-auto tabular-nums text-daintree-text/60 shrink-0">
@@ -232,7 +232,7 @@ function CacheDirsPreview({ meta, sizes, sizesPending }: CacheDirsPreviewProps) 
                       </span>
                     </>
                   ) : (
-                    <span className="ml-auto text-[10px] text-daintree-text/35 italic shrink-0">
+                    <span className="ml-auto text-3xs text-daintree-text/35 italic shrink-0">
                       not present
                     </span>
                   )}
@@ -262,7 +262,7 @@ function NodeModulesPreview({ meta, sizes, sizesPending }: NodeModulesPreviewPro
       data-testid="dev-preview-destructive-reinstall-preview"
     >
       <div className="px-3 py-2 border-b border-tint/[0.08]">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+        <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
           What will happen
         </span>
       </div>
@@ -284,12 +284,12 @@ function NodeModulesPreview({ meta, sizes, sizesPending }: NodeModulesPreviewPro
         </Row>
         <Row label="Size">
           {nodeModules?.exists === false ? (
-            <span className="text-[10px] text-daintree-text/35 italic">not present</span>
+            <span className="text-3xs text-daintree-text/35 italic">not present</span>
           ) : sizeBytes !== null ? (
             <span className="tabular-nums text-daintree-text/80">
               {formatBytes(sizeBytes)}
               {isPnpm && (
-                <span className="ml-1.5 text-[10px] text-daintree-text/45 italic">
+                <span className="ml-1.5 text-3xs text-daintree-text/45 italic">
                   apparent — pnpm store files remain
                 </span>
               )}
@@ -326,7 +326,7 @@ function NodeModulesPreview({ meta, sizes, sizesPending }: NodeModulesPreviewPro
             meta.lockfileName ? (
               <span className="font-mono text-daintree-text/80">{meta.lockfileName}</span>
             ) : (
-              <span className="text-[10px] text-daintree-text/45 italic">none — npm fallback</span>
+              <span className="text-3xs text-daintree-text/45 italic">none — npm fallback</span>
             )
           ) : (
             <RowSkeleton width="w-32" />
@@ -340,7 +340,7 @@ function NodeModulesPreview({ meta, sizes, sizesPending }: NodeModulesPreviewPro
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-baseline gap-2">
-      <dt className="text-[10px] uppercase tracking-wider text-daintree-text/50 shrink-0 w-28">
+      <dt className="text-3xs uppercase tracking-wider text-daintree-text/50 shrink-0 w-28">
         {label}
       </dt>
       <dd className="flex-1 min-w-0">{children}</dd>

--- a/src/components/DevPreview/DevPreviewEmptyStates.tsx
+++ b/src/components/DevPreview/DevPreviewEmptyStates.tsx
@@ -167,7 +167,7 @@ export function DevPreviewEmptyStates({
                   We found a script in your package.json that looks like a dev server.
                 </p>
                 <div className="mb-3 px-3 py-1.5 rounded bg-overlay-subtle border border-overlay/30 inline-flex items-center gap-2">
-                  <span className="text-[11px] text-daintree-text/40">Auto-detected</span>
+                  <span className="text-2xs text-daintree-text/40">Auto-detected</span>
                   <code className="text-xs text-daintree-text/70 font-mono">
                     {primaryCandidate.command}
                   </code>
@@ -227,7 +227,7 @@ export function DevPreviewEmptyStates({
                               }}
                               className="flex items-center gap-2 px-2 py-1.5 rounded text-xs hover:bg-overlay-subtle transition-colors text-left"
                             >
-                              <code className="text-daintree-text/70 font-mono text-[11px] flex-1 truncate">
+                              <code className="text-daintree-text/70 font-mono text-2xs flex-1 truncate">
                                 {c.command}
                               </code>
                               <span className="text-text-secondary shrink-0">{c.name}</span>
@@ -280,7 +280,7 @@ export function DevPreviewEmptyStates({
                     <span className="text-xs">Run</span>
                   </Button>
                   {commandInput.trim() && commandInputError && (
-                    <p className="text-[11px] text-status-warning">{commandInputError}</p>
+                    <p className="text-2xs text-status-warning">{commandInputError}</p>
                   )}
                 </div>
                 <Button

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -909,7 +909,7 @@ export function DevPreviewPane({
           )}
         >
           {viewportPreset && effectiveViewport && (
-            <div className="absolute top-1 left-1/2 -translate-x-1/2 z-10 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface/90 text-daintree-text/60 border border-overlay/50">
+            <div className="absolute top-1 left-1/2 -translate-x-1/2 z-10 px-1.5 py-0.5 rounded text-3xs font-medium bg-surface/90 text-daintree-text/60 border border-overlay/50">
               {getViewportPreset(viewportPreset).label} · {effectiveViewport.width}×
               {effectiveViewport.height}
               {viewportFit && fitScale < 1 && ` · ${Math.round(fitScale * 100)}%`}

--- a/src/components/DevPreview/DiagnosticsPanel.tsx
+++ b/src/components/DevPreview/DiagnosticsPanel.tsx
@@ -293,7 +293,7 @@ export function DiagnosticsPanel({ paneId, projectId, status }: DiagnosticsPanel
                       >
                         {label}
                         {event.count !== undefined && event.count > 1 && (
-                          <span className="ml-1 rounded-full bg-overlay-medium px-1.5 text-[10px] tabular-nums text-daintree-text/60">
+                          <span className="ml-1 rounded-full bg-overlay-medium px-1.5 text-3xs tabular-nums text-daintree-text/60">
                             ×{event.count}
                           </span>
                         )}

--- a/src/components/DevPreview/ObjectInspector.tsx
+++ b/src/components/DevPreview/ObjectInspector.tsx
@@ -155,7 +155,7 @@ export function ObjectInspector({
         </span>
         {displayText}
       </button>
-      {fetchError && <span className="text-status-error text-[10px] ml-1">unavailable</span>}
+      {fetchError && <span className="text-status-error text-3xs ml-1">unavailable</span>}
       {isExpanded && properties && (
         <PropertyTree
           properties={properties}

--- a/src/components/DevPreview/StackTrace.tsx
+++ b/src/components/DevPreview/StackTrace.tsx
@@ -15,7 +15,7 @@ export function StackTrace({ stackTrace }: StackTraceProps) {
       <button
         type="button"
         onClick={() => setIsExpanded((prev) => !prev)}
-        className="text-[10px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors select-none"
+        className="text-3xs text-daintree-text/40 hover:text-daintree-text/60 transition-colors select-none"
       >
         <span className="mr-0.5">{isExpanded ? "▼" : "▶"}</span>
         stack trace
@@ -23,7 +23,7 @@ export function StackTrace({ stackTrace }: StackTraceProps) {
       {isExpanded && (
         <div className="pl-3 border-l border-tint/10 mt-0.5 select-text">
           {stackTrace.callFrames.map((frame, i) => (
-            <div key={i} className="text-daintree-text/40 text-[10px] leading-relaxed">
+            <div key={i} className="text-daintree-text/40 text-3xs leading-relaxed">
               <span className="text-daintree-text/50">{frame.functionName || "(anonymous)"}</span>
               {frame.url && (
                 <span>

--- a/src/components/DevPreview/useDevPreviewCommandConfig.tsx
+++ b/src/components/DevPreview/useDevPreviewCommandConfig.tsx
@@ -181,9 +181,7 @@ export function useDevPreviewCommandConfig({
                 aria-current={isActive ? "true" : undefined}
               >
                 <span className="text-xs font-medium">{c.name}</span>
-                <code className="text-[11px] text-daintree-text/50 truncate ml-auto">
-                  {c.command}
-                </code>
+                <code className="text-2xs text-daintree-text/50 truncate ml-auto">{c.command}</code>
               </DropdownMenuItem>
             );
           })}

--- a/src/components/Diagnostics/PerfContent.tsx
+++ b/src/components/Diagnostics/PerfContent.tsx
@@ -46,7 +46,7 @@ function MetricTile({ label, value, unit, tone = "default" }: MetricTileProps) {
         tone === "alert" && "border-status-error/40 bg-status-error/5"
       )}
     >
-      <span className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium">
+      <span className="text-3xs uppercase tracking-wide text-daintree-text/55 font-medium">
         {label}
       </span>
       <div className="flex items-baseline gap-1">
@@ -85,11 +85,11 @@ function LiveMetricsBar() {
   return (
     <div className="px-3 py-2 border-b border-daintree-border/40 bg-daintree-sidebar/20">
       <div className="flex items-center justify-between mb-1.5">
-        <span className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium">
+        <span className="text-3xs uppercase tracking-wide text-daintree-text/55 font-medium">
           Live renderer
         </span>
         {isBackgrounded ? (
-          <span className="text-[10px] text-daintree-text/45">Backgrounded</span>
+          <span className="text-3xs text-daintree-text/45">Backgrounded</span>
         ) : null}
       </div>
       <div className="grid grid-cols-3 gap-2">
@@ -117,7 +117,7 @@ function BudgetRow({ row }: { row: PerfSummaryRow }) {
       )}
     >
       <td className="px-3 py-1.5 text-xs font-mono text-daintree-text truncate">{row.name}</td>
-      <td className="px-3 py-1.5 text-[10px] text-daintree-text/55 font-mono uppercase tracking-wide">
+      <td className="px-3 py-1.5 text-3xs text-daintree-text/55 font-mono uppercase tracking-wide">
         {MODE_LABEL[row.mode] ?? row.mode}
       </td>
       <td className="px-3 py-1.5 text-xs font-mono tabular-nums text-daintree-text text-right">
@@ -125,16 +125,16 @@ function BudgetRow({ row }: { row: PerfSummaryRow }) {
       </td>
       <td className="px-3 py-1.5 text-xs">
         {row.failedBudget ? (
-          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide border border-status-error/30 bg-status-error/15 text-status-error">
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-3xs font-medium uppercase tracking-wide border border-status-error/30 bg-status-error/15 text-status-error">
             Over budget
           </span>
         ) : (
-          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide border border-daintree-border bg-overlay-subtle text-daintree-text/60">
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-3xs font-medium uppercase tracking-wide border border-daintree-border bg-overlay-subtle text-daintree-text/60">
             Within budget
           </span>
         )}
       </td>
-      <td className="px-3 py-1.5 text-[11px] text-daintree-text/55 truncate">
+      <td className="px-3 py-1.5 text-2xs text-daintree-text/55 truncate">
         {row.budgetReason ?? ""}
       </td>
     </tr>
@@ -147,19 +147,19 @@ function BudgetTable({ rows }: { rows: PerfSummaryRow[] }) {
       <table className="w-full border-collapse">
         <thead className="sticky top-0 bg-daintree-sidebar/80 backdrop-blur-sm">
           <tr className="border-b border-daintree-border/60">
-            <th className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium text-left">
+            <th className="px-3 py-1.5 text-3xs uppercase tracking-wide text-daintree-text/55 font-medium text-left">
               Scenario
             </th>
-            <th className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium text-left">
+            <th className="px-3 py-1.5 text-3xs uppercase tracking-wide text-daintree-text/55 font-medium text-left">
               Mode
             </th>
-            <th className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium text-right">
+            <th className="px-3 py-1.5 text-3xs uppercase tracking-wide text-daintree-text/55 font-medium text-right">
               p95 (ms)
             </th>
-            <th className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium text-left">
+            <th className="px-3 py-1.5 text-3xs uppercase tracking-wide text-daintree-text/55 font-medium text-left">
               Budget
             </th>
-            <th className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium text-left">
+            <th className="px-3 py-1.5 text-3xs uppercase tracking-wide text-daintree-text/55 font-medium text-left">
               Reason
             </th>
           </tr>
@@ -239,11 +239,11 @@ export function PerfContent({ className }: PerfContentProps) {
     <div className={cn("flex flex-col h-full min-h-0", className)}>
       <LiveMetricsBar />
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-daintree-border/30 bg-daintree-sidebar/10">
-        <span className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium">
+        <span className="text-3xs uppercase tracking-wide text-daintree-text/55 font-medium">
           CI budgets
         </span>
         {lastLoadedAt !== null && !isLoadingSummaries ? (
-          <span className="text-[10px] text-daintree-text/45 font-mono">
+          <span className="text-3xs text-daintree-text/45 font-mono">
             Updated {formatRelative(lastLoadedAt)}
           </span>
         ) : null}

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -145,7 +145,7 @@ function ErrorRow({
           <div className="flex items-center gap-1">
             {isRetrying && onCancelRetry && (
               <>
-                <span className="text-[10px] text-status-warning">
+                <span className="text-3xs text-status-warning">
                   Retrying {error.retryProgress!.attempt}/{error.retryProgress!.maxAttempts}...
                 </span>
                 <button

--- a/src/components/Diagnostics/TelemetryContent.tsx
+++ b/src/components/Diagnostics/TelemetryContent.tsx
@@ -49,7 +49,7 @@ function TelemetryRow({ event, isSelected, onSelect }: RowProps) {
       <div className="flex items-center gap-2">
         <span
           className={cn(
-            "px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wide shrink-0",
+            "px-1.5 py-0.5 rounded text-3xs font-mono uppercase tracking-wide shrink-0",
             event.kind === "sentry"
               ? "bg-status-error/15 text-status-error"
               : "bg-status-info/15 text-status-info"
@@ -58,7 +58,7 @@ function TelemetryRow({ event, isSelected, onSelect }: RowProps) {
           {kindLabel(event.kind)}
         </span>
         <span className="font-mono text-xs text-daintree-text truncate flex-1">{event.label}</span>
-        <span className="text-[10px] text-daintree-text/50 font-mono tabular-nums shrink-0">
+        <span className="text-3xs text-daintree-text/50 font-mono tabular-nums shrink-0">
           {formatClockTime(event.timestamp)}
         </span>
       </div>
@@ -129,7 +129,7 @@ function TelemetryDetail({ event }: DetailProps) {
             <div className="flex items-center gap-2">
               <span
                 className={cn(
-                  "px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wide",
+                  "px-1.5 py-0.5 rounded text-3xs font-mono uppercase tracking-wide",
                   event.kind === "sentry"
                     ? "bg-status-error/15 text-status-error"
                     : "bg-status-info/15 text-status-info"
@@ -139,7 +139,7 @@ function TelemetryDetail({ event }: DetailProps) {
               </span>
               <span className="font-mono text-sm text-daintree-text truncate">{event.label}</span>
             </div>
-            <div className="flex items-center gap-2 text-[11px] text-daintree-text/50 font-mono">
+            <div className="flex items-center gap-2 text-2xs text-daintree-text/50 font-mono">
               <span>{new Date(event.timestamp).toISOString()}</span>
               <span aria-hidden>•</span>
               <span>ID {event.id.slice(0, 8)}</span>

--- a/src/components/Diagnostics/WhySlowContent.tsx
+++ b/src/components/Diagnostics/WhySlowContent.tsx
@@ -104,7 +104,7 @@ function MetricTile({ label, value, unit, tone = "default" }: MetricTileProps) {
         tone === "alert" && "border-status-error/40 bg-status-error/5"
       )}
     >
-      <span className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium">
+      <span className="text-3xs uppercase tracking-wide text-daintree-text/55 font-medium">
         {label}
       </span>
       <div className="flex items-baseline gap-1">
@@ -227,14 +227,14 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
             error ? (
               <span
                 data-testid="why-slow-stale-note"
-                className="text-[10px] text-status-warning/80 tabular-nums"
+                className="text-3xs text-status-warning/80 tabular-nums"
               >
                 Refresh failed · data from {formatSnapshotAge(snapshotAgeMs)}
               </span>
             ) : (
               <span
                 data-testid="why-slow-updated-note"
-                className="text-[10px] text-text-secondary tabular-nums"
+                className="text-3xs text-text-secondary tabular-nums"
               >
                 Updated {formatSnapshotAge(snapshotAgeMs)}
               </span>
@@ -268,7 +268,7 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
         <div className="flex flex-col gap-4">
           {/* Resource profile + reasons */}
           <section>
-            <h3 className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
+            <h3 className="text-3xs uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
               Resource profile
             </h3>
             {resource ? (
@@ -340,7 +340,7 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
 
           {/* Rendering + throttle */}
           <section>
-            <h3 className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
+            <h3 className="text-3xs uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
               Rendering &amp; throttle
             </h3>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
@@ -383,7 +383,7 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
 
           {/* Memory: Daintree's own processes vs terminal descendant workloads */}
           <section>
-            <h3 className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
+            <h3 className="text-3xs uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
               Memory
             </h3>
             {memory && memoryWorkloads ? (
@@ -426,7 +426,7 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
 
           {/* PTY + worktrees */}
           <section>
-            <h3 className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
+            <h3 className="text-3xs uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
               PTY &amp; worktrees
             </h3>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
@@ -491,7 +491,7 @@ function Badge({ children, tone = "default" }: { children: ReactNode; tone?: Met
   return (
     <span
       className={cn(
-        "inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-mono border border-daintree-border/40 bg-daintree-sidebar/40 text-daintree-text/75",
+        "inline-flex items-center px-1.5 py-0.5 rounded text-2xs font-mono border border-daintree-border/40 bg-daintree-sidebar/40 text-daintree-text/75",
         tone === "warn" && "border-status-warning/40 bg-status-warning/10 text-status-warning",
         tone === "alert" && "border-status-error/40 bg-status-error/10 text-status-error"
       )}

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -56,7 +56,7 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
             color: "var(--color-daintree-bg)",
             borderRadius: "9999px",
             padding: "2px 6px",
-            fontSize: 10,
+            fontSize: "var(--text-3xs)",
             fontWeight: 600,
             display: "flex",
             alignItems: "center",
@@ -98,7 +98,7 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
         <span
           style={{
             fontFamily: "var(--font-mono)",
-            fontSize: 11,
+            fontSize: "var(--text-2xs)",
             fontWeight: 500,
             color: "var(--color-daintree-text)",
             whiteSpace: "nowrap",

--- a/src/components/DragDrop/WorktreeDragPreview.tsx
+++ b/src/components/DragDrop/WorktreeDragPreview.tsx
@@ -46,7 +46,7 @@ export function WorktreeDragPreview({ worktree }: WorktreeDragPreviewProps) {
             />
             <span
               style={{
-                fontSize: 12,
+                fontSize: "var(--text-xs)",
                 fontWeight: 500,
                 color: "var(--color-text-primary)",
                 whiteSpace: "nowrap",
@@ -60,7 +60,7 @@ export function WorktreeDragPreview({ worktree }: WorktreeDragPreviewProps) {
           <span
             style={{
               fontFamily: "var(--font-mono)",
-              fontSize: 10,
+              fontSize: "var(--text-3xs)",
               color: "color-mix(in srgb, var(--color-daintree-text) 50%, transparent)",
               whiteSpace: "nowrap",
               overflow: "hidden",
@@ -90,7 +90,7 @@ export function WorktreeDragPreview({ worktree }: WorktreeDragPreviewProps) {
           <span
             style={{
               fontFamily: "var(--font-mono)",
-              fontSize: 11,
+              fontSize: "var(--text-2xs)",
               fontWeight: 500,
               color: "var(--color-daintree-text)",
               whiteSpace: "nowrap",

--- a/src/components/Errors/CompactErrorList.tsx
+++ b/src/components/Errors/CompactErrorList.tsx
@@ -86,7 +86,7 @@ function ErrorOverflow({ errors, ...handlers }: ErrorListHandlers & { errors: Er
         // boundary the card's own overlay controls draw.
         onClick={(e) => e.stopPropagation()}
         className={cn(
-          "flex w-fit mx-auto items-center gap-0.5 px-1.5 py-0.5 rounded text-[0.65rem] transition-colors",
+          "flex w-fit mx-auto items-center gap-0.5 px-1.5 py-0.5 rounded text-3xs transition-colors",
           "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
           FOCUS_RING
         )}

--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -188,7 +188,7 @@ export function ErrorBanner({
         )}
         {isRetrying && onCancelRetry && (
           <>
-            <span className="text-status-warning text-[10px] shrink-0">{retryLabel}</span>
+            <span className="text-status-warning text-3xs shrink-0">{retryLabel}</span>
             <Button variant="ghost-danger" size="xs" onClick={handleCancel}>
               Cancel
             </Button>
@@ -250,7 +250,7 @@ export function ErrorBanner({
               aria-label={
                 copiedId ? "Correlation ID copied" : `Copy correlation ID ${error.correlationId}`
               }
-              className="font-mono text-[10px] text-status-error/40 hover:text-status-error/70 cursor-copy transition-colors text-left break-all"
+              className="font-mono text-3xs text-status-error/40 hover:text-status-error/70 cursor-copy transition-colors text-left break-all"
             >
               Ref: {copiedId ? "Copied" : error.correlationId}
             </button>
@@ -270,7 +270,7 @@ export function ErrorBanner({
           )}
           {isRetrying && onCancelRetry && (
             <>
-              <span className="text-status-warning text-[10px]">{retryLabel}</span>
+              <span className="text-status-warning text-3xs">{retryLabel}</span>
               <Button variant="ghost-danger" size="xs" onClick={handleCancel}>
                 Cancel
               </Button>

--- a/src/components/EventInspector/EventFilters.tsx
+++ b/src/components/EventInspector/EventFilters.tsx
@@ -259,7 +259,7 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
                   {count > 0 && (
                     <span
                       className={cn(
-                        "text-[11px] tabular-nums",
+                        "text-2xs tabular-nums",
                         isActive ? "opacity-80" : "opacity-60"
                       )}
                     >

--- a/src/components/EventInspector/EventTimeline.tsx
+++ b/src/components/EventInspector/EventTimeline.tsx
@@ -79,7 +79,7 @@ function EventRow({ event, isSelected, onSelect }: EventRowProps) {
           <TooltipTrigger asChild>
             <span
               className={cn(
-                "flex-shrink-0 inline-flex items-center justify-center w-8 px-1 py-0.5 rounded text-[11px] font-medium border",
+                "flex-shrink-0 inline-flex items-center justify-center w-8 px-1 py-0.5 rounded text-2xs font-medium border",
                 categoryStyle.color
               )}
             >

--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -78,7 +78,7 @@ const searchPanelTheme = EditorView.theme({
     backgroundColor: "var(--theme-surface-canvas)",
     color: "var(--theme-text-primary)",
     border: "1px solid var(--theme-border-default)",
-    borderRadius: "3px",
+    borderRadius: "var(--radius-xs)",
     outline: "none",
   },
   ".cm-search .cm-button": {
@@ -86,7 +86,7 @@ const searchPanelTheme = EditorView.theme({
     backgroundColor: "var(--theme-surface-canvas)",
     color: "var(--theme-text-primary)",
     border: "1px solid var(--theme-border-default)",
-    borderRadius: "3px",
+    borderRadius: "var(--radius-xs)",
   },
   ".cm-search .cm-button:hover": {
     backgroundColor: "var(--theme-border-default)",
@@ -107,7 +107,7 @@ const searchPanelTheme = EditorView.theme({
     backgroundColor: "var(--theme-surface-canvas)",
     color: "var(--theme-text-primary)",
     border: "1px solid var(--theme-border-default)",
-    borderRadius: "3px",
+    borderRadius: "var(--radius-xs)",
     outline: "none",
   },
 });
@@ -359,7 +359,7 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
       ref={scrollRef}
       onScroll={handleScroll}
       className={cn(
-        "overflow-auto text-[13px] [&_.cm-editor]:min-h-full [&_.cm-scroller]:!overflow-visible",
+        "overflow-auto text-sm leading-[inherit] [&_.cm-editor]:min-h-full [&_.cm-scroller]:!overflow-visible",
         className
       )}
     >

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -129,7 +129,7 @@ export function DiffFileSidebar({
           <span className="font-medium text-daintree-text">
             {files.length} {files.length === 1 ? "file" : "files"}
           </span>
-          <span className="flex items-center gap-1.5 font-mono text-[11px]">
+          <span className="flex items-center gap-1.5 font-mono text-2xs">
             {summary.insertions > 0 && (
               <span className="text-status-success">+{summary.insertions}</span>
             )}
@@ -139,7 +139,7 @@ export function DiffFileSidebar({
           </span>
         </div>
         <div className="mt-1" data-testid="diff-sidebar-progress">
-          <span className="text-[11px] text-text-muted">
+          <span className="text-2xs text-text-muted">
             {viewedCount} of {files.length} viewed
           </span>
           {/* The track only appears once review has started — an empty
@@ -197,7 +197,7 @@ export function DiffFileSidebar({
         )}
         {groups.map((group) => (
           <div key={group.dir || "(root)"} className="mb-1.5">
-            <div className="flex items-center gap-1.5 px-1.5 py-1 text-[11px] text-text-secondary">
+            <div className="flex items-center gap-1.5 px-1.5 py-1 text-2xs text-text-secondary">
               <Folder className="h-3 w-3 shrink-0" />
               <span className="truncate font-mono">{formatDir(group.dir)}</span>
             </div>
@@ -252,7 +252,7 @@ export function DiffFileSidebar({
                       >
                         {basename(file.path)}
                       </span>
-                      <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 text-[11px]">
+                      <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 text-2xs">
                         {(file.insertions ?? 0) > 0 && (
                           <span className="text-status-success/80">+{file.insertions}</span>
                         )}

--- a/src/components/FileViewer/ImageDiffViewer.tsx
+++ b/src/components/FileViewer/ImageDiffViewer.tsx
@@ -52,7 +52,7 @@ function SideChip({ label, floating }: { label: string; floating?: boolean }) {
   return (
     <span
       className={cn(
-        "rounded bg-daintree-sidebar px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground",
+        "rounded bg-daintree-sidebar px-1.5 py-0.5 text-3xs font-medium text-muted-foreground",
         floating && "bg-daintree-sidebar/90"
       )}
     >
@@ -195,7 +195,7 @@ function ImagePane({
         )}
       </div>
       {side.ok && !decodeFailed ? (
-        <p className="text-[11px] tabular-nums text-muted-foreground">
+        <p className="text-2xs tabular-nums text-muted-foreground">
           {dims ? `${dims.width}×${dims.height} px · ` : ""}
           {formatBytes(side.byteSize)}
         </p>
@@ -511,7 +511,7 @@ export function ImageDiffViewer({ relPath, worktreePath, status }: ImageDiffView
         <div className="flex shrink-0 items-center justify-between gap-2 px-3 pt-3">
           <SegmentedToggle options={MODE_OPTIONS} value={effectiveMode} onChange={setMode} />
           {effectiveMode === "onion" ? (
-            <label className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <label className="flex items-center gap-2 text-2xs text-muted-foreground">
               Working tree opacity
               <input
                 type="range"

--- a/src/components/FileViewer/ZoomableImage.tsx
+++ b/src/components/FileViewer/ZoomableImage.tsx
@@ -142,7 +142,7 @@ export function ZoomableImage({ filePath, rootPath, alt, cacheBust, onError }: Z
           className="max-h-full max-w-full object-contain"
         />
       </div>
-      <div className="flex shrink-0 items-center justify-between border-t border-daintree-border px-3 py-1 text-[11px] text-muted-foreground">
+      <div className="flex shrink-0 items-center justify-between border-t border-daintree-border px-3 py-1 text-2xs text-muted-foreground">
         <span>{Math.round(zoom * 100)}%</span>
         <button
           type="button"

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -323,7 +323,7 @@ export function FleetArmingRibbon(): ReactElement | null {
           aria-live="polite"
           aria-atomic="true"
           className={cn(
-            "relative flex items-center gap-3 border-b border-daintree-border px-3 py-2 text-[12px] text-daintree-text",
+            "relative flex items-center gap-3 border-b border-daintree-border px-3 py-2 text-xs leading-[inherit] text-daintree-text",
             // Keep the Fleet surface continuous through confirm-pending so the
             // mode chrome doesn't visually exit and re-enter during a confirm.
             "bg-category-amber-subtle",
@@ -333,15 +333,15 @@ export function FleetArmingRibbon(): ReactElement | null {
           data-pending-action={pending.kind}
         >
           <span className="font-medium text-daintree-accent">{message}</span>
-          <div className="ml-auto flex items-center gap-2 text-[11px] text-daintree-text/70">
+          <div className="ml-auto flex items-center gap-2 text-2xs text-daintree-text/70">
             <span>
-              <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-[10px]">
+              <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-3xs">
                 Enter
               </kbd>{" "}
               to confirm
             </span>
             <span>
-              <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-[10px]">
+              <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-3xs">
                 Esc
               </kbd>{" "}
               to cancel
@@ -376,7 +376,7 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewByState("waiting", "current"))}
       >
         All waiting — this worktree
-        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+        <span className="ml-auto text-2xs tabular-nums text-daintree-text/50">
           {presetCounts.waitingCurrent}
         </span>
       </DropdownMenuItem>
@@ -387,7 +387,7 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewByState("waiting", "all"))}
       >
         All waiting — all worktrees
-        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+        <span className="ml-auto text-2xs tabular-nums text-daintree-text/50">
           {presetCounts.waitingAll}
         </span>
       </DropdownMenuItem>
@@ -398,7 +398,7 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewByState("working", "current"))}
       >
         All working — this worktree
-        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+        <span className="ml-auto text-2xs tabular-nums text-daintree-text/50">
           {presetCounts.workingCurrent}
         </span>
       </DropdownMenuItem>
@@ -409,7 +409,7 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewByState("working", "all"))}
       >
         All working — all worktrees
-        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+        <span className="ml-auto text-2xs tabular-nums text-daintree-text/50">
           {presetCounts.workingAll}
         </span>
       </DropdownMenuItem>
@@ -421,7 +421,7 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewAll("current"))}
       >
         All in this worktree
-        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+        <span className="ml-auto text-2xs tabular-nums text-daintree-text/50">
           {presetCounts.eligibleCurrent}
         </span>
       </DropdownMenuItem>
@@ -504,7 +504,7 @@ export function FleetArmingRibbon(): ReactElement | null {
           tabIndex={-1}
           onKeyDown={handleRibbonKeyDown}
           className={cn(
-            "relative flex items-center gap-3 overflow-hidden border-b border-daintree-border px-3 py-2 text-[12px] text-daintree-text outline-hidden",
+            "relative flex items-center gap-3 overflow-hidden border-b border-daintree-border px-3 py-2 text-xs leading-[inherit] text-daintree-text outline-hidden",
             "bg-category-amber-subtle",
             // Non-color structural cue: 2px amber left-edge stripe, so the
             // "mode surface" reads even with CVD / low-saturation themes where
@@ -530,7 +530,7 @@ export function FleetArmingRibbon(): ReactElement | null {
           />
           {showProgress && (
             <span
-              className="text-[11px] tabular-nums text-daintree-text/70"
+              className="text-2xs tabular-nums text-daintree-text/70"
               data-testid="fleet-broadcast-progress"
             >
               {progressCompleted}/{progressTotal}
@@ -550,14 +550,14 @@ export function FleetArmingRibbon(): ReactElement | null {
               onClick={cancelActiveBroadcast}
               aria-label="Cancel broadcast"
               data-testid="fleet-broadcast-cancel"
-              className="rounded px-1.5 py-0.5 text-[11px] text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+              className="rounded px-1.5 py-0.5 text-2xs text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
             >
               Cancel
             </button>
           )}
           {runStatus !== null && (
             <span
-              className="flex items-center gap-1 text-[11px] tabular-nums text-daintree-text/70"
+              className="flex items-center gap-1 text-2xs tabular-nums text-daintree-text/70"
               data-testid="fleet-run-status"
             >
               <span>{runStatus.label}</span>
@@ -602,12 +602,12 @@ export function FleetArmingRibbon(): ReactElement | null {
               aria-label={`Exit fleet mode (${exitChordLabel})`}
               data-testid="fleet-exit"
               className={cn(
-                "inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-[11px] transition-colors",
+                "inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-2xs transition-colors",
                 "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.14] hover:text-daintree-text"
               )}
             >
               <span>Exit</span>
-              <kbd className="rounded border border-category-amber-border bg-category-amber-subtle px-1 font-mono text-[10px] leading-tight text-category-amber-text">
+              <kbd className="rounded border border-category-amber-border bg-category-amber-subtle px-1 font-mono text-3xs leading-tight text-category-amber-text">
                 {exitChordLabel}
               </kbd>
             </button>

--- a/src/components/Fleet/FleetCountChip.tsx
+++ b/src/components/Fleet/FleetCountChip.tsx
@@ -169,7 +169,7 @@ export function FleetCountChip({
           aria-expanded={open}
           data-testid="fleet-armed-count-chip"
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[12px] transition-colors",
+            "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs leading-[inherit] transition-colors",
             "bg-tint/[0.08] hover:bg-tint/[0.14]"
           )}
         >
@@ -201,12 +201,12 @@ export function FleetCountChip({
       >
         {popoverMode === "list" ? (
           <>
-            <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-daintree-text/50">
+            <div className="px-2 py-1 text-3xs font-medium uppercase tracking-wide text-daintree-text/50">
               Fleet terminals
             </div>
             <ul className="flex flex-col overflow-y-auto">
               {armOrder.length === 0 ? (
-                <li className="px-2 py-1 text-[12px] text-daintree-text/60">None</li>
+                <li className="px-2 py-1 text-xs leading-[inherit] text-daintree-text/60">None</li>
               ) : (
                 armOrder.map((id) => {
                   const title = titlesByPane[id] ?? id;
@@ -219,13 +219,13 @@ export function FleetCountChip({
                         type="button"
                         onClick={() => focusArmedPane(id)}
                         aria-label={`Focus ${title}`}
-                        className="flex-1 truncate px-2 py-1 text-left text-[12px] text-daintree-text"
+                        className="flex-1 truncate px-2 py-1 text-left text-xs leading-[inherit] text-daintree-text"
                       >
                         {title}
                       </button>
                       {sendFailed && (
                         <span
-                          className="shrink-0 text-[10px] text-status-error"
+                          className="shrink-0 text-3xs text-status-error"
                           data-testid={`fleet-row-send-failed-${id}`}
                         >
                           Send failed
@@ -250,7 +250,7 @@ export function FleetCountChip({
               onClick={() => setPopoverMode("picker")}
               data-testid="fleet-armed-list-add-panes"
               className={cn(
-                "mt-1 flex items-center gap-2 rounded px-2 py-1.5 text-[12px] text-daintree-text/80",
+                "mt-1 flex items-center gap-2 rounded px-2 py-1.5 text-xs leading-[inherit] text-daintree-text/80",
                 "hover:bg-tint/[0.08] hover:text-daintree-text",
                 "border-t border-daintree-border/50 pt-2",
                 "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
@@ -269,7 +269,7 @@ export function FleetCountChip({
                 aria-label="Back to fleet list"
                 data-testid="fleet-picker-back"
                 className={cn(
-                  "inline-flex items-center gap-1 rounded px-1.5 py-1 text-[12px] text-daintree-text/70",
+                  "inline-flex items-center gap-1 rounded px-1.5 py-1 text-xs leading-[inherit] text-daintree-text/70",
                   "hover:bg-tint/[0.08] hover:text-daintree-text",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
                 )}
@@ -277,13 +277,13 @@ export function FleetCountChip({
                 <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
                 <span>Back</span>
               </button>
-              <span className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/50">
+              <span className="text-2xs font-medium uppercase tracking-wide text-daintree-text/50">
                 Add panes
               </span>
             </div>
             <FleetPickerContent picker={picker} testIdPrefix="fleet-picker-add" autoFocusSearch />
             <div className="mt-1 flex items-center justify-between gap-2 border-t border-daintree-border/50 px-1 pt-2">
-              <span className="text-[11px] tabular-nums text-daintree-text/55">
+              <span className="text-2xs tabular-nums text-daintree-text/55">
                 {picker.confirmedIds.length === 0
                   ? "Select panes to add"
                   : `${picker.confirmedIds.length} selected`}
@@ -293,7 +293,7 @@ export function FleetCountChip({
                   type="button"
                   onClick={() => setPopoverMode("list")}
                   className={cn(
-                    "rounded px-2 py-1 text-[11px] text-daintree-text/70",
+                    "rounded px-2 py-1 text-2xs text-daintree-text/70",
                     "hover:bg-tint/[0.08] hover:text-daintree-text",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
                   )}
@@ -306,7 +306,7 @@ export function FleetCountChip({
                   disabled={picker.confirmedIds.length === 0}
                   data-testid="fleet-picker-add-confirm"
                   className={cn(
-                    "rounded border border-category-amber-border bg-category-amber-subtle px-2 py-1 text-[11px] text-category-amber-text transition",
+                    "rounded border border-category-amber-border bg-category-amber-subtle px-2 py-1 text-2xs text-category-amber-text transition",
                     "hover:brightness-110",
                     "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"

--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -94,7 +94,7 @@ export function FleetDraftingPill(): ReactElement | null {
           data-testid="fleet-resolution-popover"
           className="max-h-[400px] w-[400px] overflow-y-auto p-1"
         >
-          <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-daintree-text/50">
+          <div className="px-2 py-1 text-3xs font-medium uppercase tracking-wide text-daintree-text/50">
             Fleet broadcast preview
           </div>
           {previews.length === 0 ? (
@@ -193,7 +193,7 @@ function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement 
         isSkipped && !excluded && "opacity-50"
       )}
     >
-      <div className="flex items-center gap-1.5 text-[11px] font-medium text-daintree-text/70">
+      <div className="flex items-center gap-1.5 text-2xs font-medium text-daintree-text/70">
         {!excluded && (
           <label className="inline-flex shrink-0 items-center">
             <input
@@ -208,24 +208,24 @@ function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement 
         )}
         <span className={cn("truncate", isSkipped && "line-through")}>{title}</span>
         {excluded && exclusionReason && (
-          <span className="inline-flex items-center gap-0.5 text-[10px] text-category-rose-text shrink-0">
+          <span className="inline-flex items-center gap-0.5 text-3xs text-category-rose-text shrink-0">
             <AlertTriangle className="h-2.5 w-2.5" aria-hidden="true" />
             {exclusionReason}
           </span>
         )}
         {isSkipped && !excluded && (
-          <span className="ml-auto shrink-0 text-[10px] text-daintree-text/50">Skipped</span>
+          <span className="ml-auto shrink-0 text-3xs text-daintree-text/50">Skipped</span>
         )}
         {showsOverride && (
           <span
-            className="ml-auto shrink-0 text-[10px] text-category-amber-text"
+            className="ml-auto shrink-0 text-3xs text-category-amber-text"
             data-testid="fleet-resolution-row-overridden"
           >
             Edited
           </span>
         )}
       </div>
-      <div className="mt-0.5 text-[11px] leading-relaxed text-daintree-text/60 break-all">
+      <div className="mt-0.5 text-2xs leading-relaxed text-daintree-text/60 break-all">
         {parts.map((part, i) =>
           part.isVar ? (
             <span
@@ -242,7 +242,7 @@ function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement 
       {!excluded && (
         <div className="mt-1 border-t border-border-subtle pt-0.5">
           <div className="flex items-start gap-1.5">
-            <span className="text-[9px] uppercase tracking-wide text-text-secondary mt-px shrink-0">
+            <span className="text-4xs uppercase tracking-wide text-text-secondary mt-px shrink-0">
               {isOverridden ? "edited" : "resolved"}
             </span>
             <textarea
@@ -256,7 +256,7 @@ function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement 
               data-testid="fleet-resolution-row-textarea"
               aria-label={`Override payload for ${title}`}
               className={cn(
-                "flex-1 resize-y bg-transparent text-[11px] leading-relaxed break-all text-daintree-text",
+                "flex-1 resize-y bg-transparent text-2xs leading-relaxed break-all text-daintree-text",
                 "rounded-sm border border-transparent px-1 py-0.5 outline-hidden transition-colors duration-150",
                 "hover:border-border-subtle focus:border-border-subtle",
                 isSkipped && "cursor-not-allowed line-through",
@@ -270,7 +270,7 @@ function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement 
               {unresolvedVars.map((v) => (
                 <span
                   key={v}
-                  className="inline-flex items-center rounded-full px-1.5 py-px text-[9px] bg-category-rose-subtle text-category-rose-text"
+                  className="inline-flex items-center rounded-full px-1.5 py-px text-4xs bg-category-rose-subtle text-category-rose-text"
                 >
                   {`{{${v}}}`} unresolved
                 </span>

--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -244,7 +244,7 @@ function ShortcutsPopover(): ReactElement {
         className="w-auto p-3"
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
-        <div className="flex flex-col gap-1.5 text-[12px] text-daintree-text/60">
+        <div className="flex flex-col gap-1.5 text-xs leading-[inherit] text-daintree-text/60">
           <span className="inline-flex items-center gap-1">
             <Kbd>{isMac() ? "⌘A" : "Ctrl+A"}</Kbd>
             <span>Select all</span>
@@ -326,10 +326,10 @@ function WorktreeGroupSection({
           <button
             type="button"
             onClick={() => onToggleGroup(group)}
-            className="flex flex-1 items-center justify-between gap-2 text-left text-[12px] font-medium text-daintree-text/80 hover:text-daintree-text"
+            className="flex flex-1 items-center justify-between gap-2 text-left text-xs leading-[inherit] font-medium text-daintree-text/80 hover:text-daintree-text"
           >
             <span className="truncate">{group.worktreeName}</span>
-            <span className="shrink-0 tabular-nums text-[11px] text-daintree-text/55">
+            <span className="shrink-0 tabular-nums text-2xs text-daintree-text/55">
               {selectedInGroup} / {group.terminals.length}
             </span>
           </button>
@@ -387,7 +387,7 @@ function TerminalRow({
         role="option"
         aria-selected={checked}
         className={cn(
-          "flex flex-1 items-start gap-2 pl-5 pr-2 py-1.5 rounded text-[13px] text-daintree-text cursor-pointer outline-hidden",
+          "flex flex-1 items-start gap-2 pl-5 pr-2 py-1.5 rounded text-sm leading-[inherit] text-daintree-text cursor-pointer outline-hidden",
           "hover:bg-tint/[0.06]",
           "focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
         )}
@@ -436,7 +436,7 @@ function SnippetLine({
   const after = line.slice(end);
   return (
     <p
-      className="font-mono text-[11px] text-text-secondary truncate mt-0.5"
+      className="font-mono text-2xs text-text-secondary truncate mt-0.5"
       data-testid={`${testIdPrefix}-snippet`}
     >
       {before}
@@ -452,7 +452,7 @@ function renderStateBadge(agentState: AgentState | undefined): ReactElement | nu
   return (
     <span
       className={cn(
-        "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums",
+        "shrink-0 rounded-full px-1.5 py-0.5 text-3xs font-medium tabular-nums",
         "bg-tint/[0.08] text-daintree-text/70"
       )}
     >

--- a/src/components/Fleet/FleetPickerPalette.tsx
+++ b/src/components/Fleet/FleetPickerPalette.tsx
@@ -141,7 +141,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
         disabled={picker.visibleIds.length === 0}
         data-testid="fleet-picker-cold-start-select-all"
         className={cn(
-          "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
+          "rounded px-2.5 py-1 text-xs leading-[inherit] text-daintree-text/70",
           "hover:bg-tint/[0.08] hover:text-daintree-text",
           "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
@@ -155,7 +155,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
         disabled={agentVisibleIds.length === 0}
         data-testid="fleet-picker-cold-start-select-agents"
         className={cn(
-          "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
+          "rounded px-2.5 py-1 text-xs leading-[inherit] text-daintree-text/70",
           "hover:bg-tint/[0.08] hover:text-daintree-text",
           "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
@@ -187,7 +187,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
           )}
         >
           <Zap className="h-4 w-4 text-daintree-text/70" aria-hidden="true" />
-          <h2 className="text-[14px] font-semibold">Select terminals to arm</h2>
+          <h2 className="text-sm leading-[inherit] font-semibold">Select terminals to arm</h2>
         </div>
 
         {picker.acquired ? (
@@ -202,7 +202,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
             </div>
 
             {showFooterHint && (
-              <div className="flex flex-wrap items-center gap-1.5 border-t border-daintree-border/50 px-3 py-1.5 text-[11px] text-daintree-text/55">
+              <div className="flex flex-wrap items-center gap-1.5 border-t border-daintree-border/50 px-3 py-1.5 text-2xs text-daintree-text/55">
                 <FleetPickerFooterHint
                   confirmedCount={picker.confirmedIds.length}
                   driftCount={picker.driftCount}
@@ -213,7 +213,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
 
             <div className="flex flex-nowrap items-center justify-between gap-2 border-t border-daintree-border px-3 py-2">
               <div
-                className="relative isolate flex bg-tint/[0.04] rounded text-[11px]"
+                className="relative isolate flex bg-tint/[0.04] rounded text-2xs"
                 role="radiogroup"
                 aria-label="Commit mode"
                 data-testid="fleet-picker-cold-start-commit-mode"
@@ -258,7 +258,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
                   type="button"
                   onClick={onClose}
                   className={cn(
-                    "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
+                    "rounded px-2.5 py-1 text-xs leading-[inherit] text-daintree-text/70",
                     "hover:bg-tint/[0.08] hover:text-daintree-text",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
                   )}
@@ -271,7 +271,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
                   disabled={picker.confirmedIds.length === 0}
                   data-testid="fleet-picker-cold-start-confirm"
                   className={cn(
-                    "rounded border border-category-amber-border bg-category-amber-subtle px-2.5 py-1 text-[12px] text-category-amber-text transition",
+                    "rounded border border-category-amber-border bg-category-amber-subtle px-2.5 py-1 text-xs leading-[inherit] text-category-amber-text transition",
                     "hover:brightness-110",
                     "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
@@ -296,10 +296,12 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
             className="flex flex-col items-center justify-center gap-1 px-6 py-12 text-center"
             data-testid="fleet-picker-cold-start-blocked"
           >
-            <div className="text-[13px] font-medium text-daintree-text">
+            <div className="text-sm leading-[inherit] font-medium text-daintree-text">
               Another fleet picker is open
             </div>
-            <div className="text-[12px] text-daintree-text/60">Close it and try again.</div>
+            <div className="text-xs leading-[inherit] text-daintree-text/60">
+              Close it and try again.
+            </div>
           </div>
         )}
       </div>

--- a/src/components/Fleet/SaveFleetForm.tsx
+++ b/src/components/Fleet/SaveFleetForm.tsx
@@ -45,11 +45,11 @@ export function SaveFleetForm({ armedCount }: SaveFleetFormProps): ReactElement 
       className="flex flex-col items-stretch gap-1.5 py-2"
       data-testid="fleet-save-form"
     >
-      <div className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-daintree-text/50">
+      <div className="flex items-center gap-1 text-3xs font-medium uppercase tracking-wide text-daintree-text/50">
         <Save className="h-3 w-3" />
         <span>Save current as…</span>
       </div>
-      <div className="flex gap-1 text-[11px]" role="radiogroup" aria-label="Save fleet flavor">
+      <div className="flex gap-1 text-2xs" role="radiogroup" aria-label="Save fleet flavor">
         <button
           type="button"
           role="radio"
@@ -88,7 +88,7 @@ export function SaveFleetForm({ armedCount }: SaveFleetFormProps): ReactElement 
         </button>
       </div>
       {kind === "predicate" ? (
-        <div className="flex gap-1 text-[11px]">
+        <div className="flex gap-1 text-2xs">
           <select
             aria-label="Predicate scope"
             value={predicateScope}
@@ -146,7 +146,7 @@ export function SaveFleetForm({ armedCount }: SaveFleetFormProps): ReactElement 
                 : "Arm panes first…"
               : "Name…"
           }
-          className="flex-1 rounded bg-tint/[0.08] px-2 py-1 text-[11px] text-daintree-text placeholder:text-text-placeholder outline-hidden focus:bg-tint/[0.14]"
+          className="flex-1 rounded bg-tint/[0.08] px-2 py-1 text-2xs text-daintree-text placeholder:text-text-placeholder outline-hidden focus:bg-tint/[0.14]"
           data-testid="fleet-save-form-name"
         />
         <button
@@ -158,7 +158,7 @@ export function SaveFleetForm({ armedCount }: SaveFleetFormProps): ReactElement 
           onPointerDown={(e) => e.stopPropagation()}
           disabled={!canSave}
           data-testid="fleet-save-form-submit"
-          className="rounded bg-category-amber-subtle border border-category-amber-border px-2 py-1 text-[11px] text-category-amber-text transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded bg-category-amber-subtle border border-category-amber-border px-2 py-1 text-2xs text-category-amber-text transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Save
         </button>

--- a/src/components/Fleet/SavedFleetRow.tsx
+++ b/src/components/Fleet/SavedFleetRow.tsx
@@ -31,7 +31,7 @@ export function SavedFleetRow({
       className={isStale ? "flex items-center gap-2 opacity-50" : "flex items-center gap-2"}
     >
       <span className="flex-1 truncate">{scope.name}</span>
-      <span className="text-[10px] text-daintree-text/50 tabular-nums">
+      <span className="text-3xs text-daintree-text/50 tabular-nums">
         {count} · {flavorLabel}
       </span>
       <button

--- a/src/components/Git/GitPullRebaseConfirmDialog.tsx
+++ b/src/components/Git/GitPullRebaseConfirmDialog.tsx
@@ -283,11 +283,11 @@ function GitPullRebaseConfirmDialogInner() {
           <span
             role="heading"
             aria-level={3}
-            className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
+            className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60"
           >
             Commits to replay
             {isSettled && total > 0 && (
-              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal">
                 {total}
               </span>
             )}
@@ -325,7 +325,7 @@ function GitPullRebaseConfirmDialogInner() {
                 size="sm"
                 onClick={loadPreview}
                 data-testid="git-pull-rebase-commits-retry"
-                className="mt-1.5 h-6 px-2 text-[11px]"
+                className="mt-1.5 h-6 px-2 text-2xs"
               >
                 <RefreshCw className="w-3 h-3" />
                 Retry
@@ -432,7 +432,7 @@ function GitPullRebaseConfirmDialogInner() {
                   className="flex items-baseline gap-2"
                   data-testid="git-pull-rebase-commit-row"
                 >
-                  <span className="font-mono text-[11px] text-daintree-text/55 shrink-0 tabular-nums">
+                  <span className="font-mono text-2xs text-daintree-text/55 shrink-0 tabular-nums">
                     {commit.hash.slice(0, SHORT_HASH_LEN)}
                   </span>
                   <span className="flex-1 min-w-0 truncate text-daintree-text/90">
@@ -441,13 +441,13 @@ function GitPullRebaseConfirmDialogInner() {
                   {/* Bounded, unlike the rest of the row: an author is the least
                       important column here, and left unbounded a long name took 45%
                       of the width and truncated the subject to twenty characters. */}
-                  <span className="text-[11px] text-daintree-text/55 shrink-0 max-w-[7rem] truncate">
+                  <span className="text-2xs text-daintree-text/55 shrink-0 max-w-[7rem] truncate">
                     {commit.author}
                   </span>
                 </li>
               ))}
               {hiddenCount > 0 && (
-                <li className="text-[11px] text-daintree-text/55 italic pt-0.5">
+                <li className="text-2xs text-daintree-text/55 italic pt-0.5">
                   &hellip;and {hiddenCount} more
                 </li>
               )}
@@ -465,7 +465,7 @@ function GitPullRebaseConfirmDialogInner() {
           directly above had just said would not happen — and it made the empty
           state taller than the one-commit state. */}
       {isLoaded && commits.length > 0 && (
-        <p className="text-[11px] text-daintree-text/55">
+        <p className="text-2xs text-daintree-text/55">
           If a replay hits a conflict, Git stops mid-rebase and leaves the branch there to resolve.
         </p>
       )}
@@ -476,7 +476,7 @@ function GitPullRebaseConfirmDialogInner() {
 function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-baseline gap-2">
-      <dt className="text-[10px] uppercase tracking-wider text-daintree-text/55 shrink-0 w-14">
+      <dt className="text-3xs uppercase tracking-wider text-daintree-text/55 shrink-0 w-14">
         {label}
       </dt>
       <dd className="flex-1 min-w-0">{children}</dd>
@@ -496,7 +496,7 @@ function RefChip({ value, emphasis }: { value: string; emphasis?: boolean }) {
   return (
     <span
       className={cn(
-        "inline-flex items-baseline px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] font-mono break-words",
+        "inline-flex items-baseline px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-2xs font-mono break-words",
         emphasis ? "text-daintree-text" : "text-daintree-text/70"
       )}
     >
@@ -507,12 +507,12 @@ function RefChip({ value, emphasis }: { value: string; emphasis?: boolean }) {
 
 /** Git answered, and the answer was "no upstream anyone can name". */
 function Unresolved() {
-  return <span className="text-status-error text-[11px]">Not resolved</span>;
+  return <span className="text-status-error text-2xs">Not resolved</span>;
 }
 
 /** Git did not answer at all. The failure is stated once, below, not per row. */
 function Unknown() {
-  return <span className="text-daintree-text/55 text-[11px]">&mdash;</span>;
+  return <span className="text-daintree-text/55 text-2xs">&mdash;</span>;
 }
 
 /**

--- a/src/components/Git/GitPushConfirmDialog.tsx
+++ b/src/components/Git/GitPushConfirmDialog.tsx
@@ -233,9 +233,9 @@ function GitPushConfirmDialogInner() {
               <span className="flex flex-wrap items-baseline gap-1.5">
                 <RefChip value={destinationLabel} emphasis />
                 {isCreatingBranch && (
-                  <span className="text-[10px] text-daintree-text/55">creates this branch</span>
+                  <span className="text-3xs text-daintree-text/55">creates this branch</span>
                 )}
-                {isUnverified && <span className="text-[10px] text-status-error">unverified</span>}
+                {isUnverified && <span className="text-3xs text-status-error">unverified</span>}
               </span>
             ) : !isSettled && !loadError ? (
               <Bone className="w-48" />
@@ -251,11 +251,11 @@ function GitPushConfirmDialogInner() {
           <span
             role="heading"
             aria-level={3}
-            className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
+            className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60"
           >
             Commits to push
             {isSettled && total > 0 && (
-              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal">
                 {total}
               </span>
             )}
@@ -290,7 +290,7 @@ function GitPushConfirmDialogInner() {
                 size="sm"
                 onClick={loadPreview}
                 data-testid="git-push-commits-retry"
-                className="mt-1.5 h-6 px-2 text-[11px]"
+                className="mt-1.5 h-6 px-2 text-2xs"
               >
                 <RefreshCw className="w-3 h-3" />
                 Retry
@@ -365,7 +365,7 @@ function GitPushConfirmDialogInner() {
                   className="flex items-baseline gap-2"
                   data-testid="git-push-commit-row"
                 >
-                  <span className="font-mono text-[11px] text-daintree-text/55 shrink-0 tabular-nums">
+                  <span className="font-mono text-2xs text-daintree-text/55 shrink-0 tabular-nums">
                     {commit.hash.slice(0, SHORT_HASH_LEN)}
                   </span>
                   <span className="flex-1 min-w-0 truncate text-daintree-text/90">
@@ -374,19 +374,19 @@ function GitPushConfirmDialogInner() {
                   {/* Bounded, unlike the rest of the row: an author is the least
                     important column here, and left unbounded a long name took
                     40% of the width and truncated the subject to nothing. */}
-                  <span className="text-[11px] text-daintree-text/55 shrink-0 max-w-[7rem] truncate">
+                  <span className="text-2xs text-daintree-text/55 shrink-0 max-w-[7rem] truncate">
                     {commit.author}
                   </span>
                 </li>
               ))}
               {isUnverified && (
-                <li className="text-[11px] text-status-error pt-0.5">
+                <li className="text-2xs text-status-error pt-0.5">
                   Couldn&apos;t reach {destination?.remote} to check {destinationLabel}, so this
                   list is unverified.
                 </li>
               )}
               {hiddenCount > 0 && (
-                <li className="text-[11px] text-daintree-text/55 italic pt-0.5">
+                <li className="text-2xs text-daintree-text/55 italic pt-0.5">
                   &hellip;and {hiddenCount} more
                 </li>
               )}
@@ -397,7 +397,7 @@ function GitPushConfirmDialogInner() {
       {/* The quietest tier on the surface, and last: this is the least specific
           thing the dialog has to say, but it is the one question a push raises
           that nothing else here answers. */}
-      <p className="text-[11px] text-daintree-text/55">
+      <p className="text-2xs text-daintree-text/55">
         If the remote has moved on, Git refuses the push rather than overwriting it.
       </p>
     </ConfirmDialog>
@@ -407,7 +407,7 @@ function GitPushConfirmDialogInner() {
 function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-baseline gap-2">
-      <dt className="text-[10px] uppercase tracking-wider text-daintree-text/55 shrink-0 w-10">
+      <dt className="text-3xs uppercase tracking-wider text-daintree-text/55 shrink-0 w-10">
         {label}
       </dt>
       <dd className="flex-1 min-w-0">{children}</dd>
@@ -427,7 +427,7 @@ function RefChip({ value, emphasis }: { value: string; emphasis?: boolean }) {
   return (
     <span
       className={cn(
-        "inline-flex items-baseline px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] font-mono break-words",
+        "inline-flex items-baseline px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-2xs font-mono break-words",
         emphasis ? "text-daintree-text" : "text-daintree-text/70"
       )}
     >
@@ -438,12 +438,12 @@ function RefChip({ value, emphasis }: { value: string; emphasis?: boolean }) {
 
 /** Git answered, and the answer was "no destination anyone can name". */
 function Unresolved() {
-  return <span className="text-status-error text-[11px]">Not resolved</span>;
+  return <span className="text-status-error text-2xs">Not resolved</span>;
 }
 
 /** Git did not answer at all. The failure is stated once, below, not per row. */
 function Unknown() {
-  return <span className="text-daintree-text/55 text-[11px]">&mdash;</span>;
+  return <span className="text-daintree-text/55 text-2xs">&mdash;</span>;
 }
 
 /**

--- a/src/components/HelpPanel/FigureLightbox.tsx
+++ b/src/components/HelpPanel/FigureLightbox.tsx
@@ -131,7 +131,7 @@ export function FigureLightbox({
         <div className="flex flex-col gap-1 border-t border-daintree-border pt-3">
           <div className="flex items-baseline justify-between gap-2">
             <p className="text-sm font-medium text-daintree-text">Figure {figure.figureNumber}</p>
-            <p className="text-[11px] text-daintree-text/45 shrink-0">
+            <p className="text-2xs text-daintree-text/45 shrink-0">
               {figure.figureLabel} · Daintree docs
             </p>
           </div>

--- a/src/components/HelpPanel/FigureRail.tsx
+++ b/src/components/HelpPanel/FigureRail.tsx
@@ -100,7 +100,7 @@ function FigureThumbnail({ figure, isNewest, onClick }: FigureThumbnailProps) {
             type="button"
             onClick={handleRetry}
             aria-label={`Retry figure ${figure.figureNumber}`}
-            className="flex items-center gap-1 text-[10px] text-daintree-text/60 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent rounded"
+            className="flex items-center gap-1 text-3xs text-daintree-text/60 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent rounded"
           >
             <RotateCw className="w-2.5 h-2.5" aria-hidden="true" />
             Retry
@@ -152,7 +152,7 @@ function FigureThumbnail({ figure, isNewest, onClick }: FigureThumbnailProps) {
       )}
 
       {status === "loaded" && (
-        <span className="pointer-events-none absolute bottom-0 left-0 right-0 bg-scrim-medium px-1.5 py-0.5 text-[10px] font-medium text-daintree-text/90">
+        <span className="pointer-events-none absolute bottom-0 left-0 right-0 bg-scrim-medium px-1.5 py-0.5 text-3xs font-medium text-daintree-text/90">
           {figure.figureLabel}
         </span>
       )}

--- a/src/components/HelpPanel/HelpIntroBanner.tsx
+++ b/src/components/HelpPanel/HelpIntroBanner.tsx
@@ -10,7 +10,7 @@ export function HelpIntroBanner({ onDismiss }: HelpIntroBannerProps) {
     <div
       className={cn(
         "flex items-center gap-2 px-3 py-1.5 shrink-0",
-        "bg-overlay-subtle border-b border-daintree-border text-[11px] text-daintree-text/50"
+        "bg-overlay-subtle border-b border-daintree-border text-2xs text-daintree-text/50"
       )}
     >
       <span className="flex-1 min-w-0 truncate">

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1486,7 +1486,7 @@ export function HelpPanel({
                   </Button>
                   {!hasEverLaunchedAgent && (
                     <div className="flex flex-col gap-1.5 w-full">
-                      <p className="text-[11px] text-daintree-text/60">Or start with a question</p>
+                      <p className="text-2xs text-daintree-text/60">Or start with a question</p>
                       {STARTER_PROMPTS.map((prompt) => (
                         <button
                           key={prompt}
@@ -1510,7 +1510,7 @@ export function HelpPanel({
                 <button
                   type="button"
                   onClick={handleOpenSettings}
-                  className="flex items-center gap-1 text-[11px] text-daintree-text/70 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                  className="flex items-center gap-1 text-2xs text-daintree-text/70 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 >
                   <Settings2 className="w-3.5 h-3.5" />
                   Assistant settings
@@ -1518,7 +1518,7 @@ export function HelpPanel({
                 <button
                   type="button"
                   onClick={handleOpenAssistantDocs}
-                  className="flex items-center gap-1 text-[11px] text-daintree-text/70 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                  className="flex items-center gap-1 text-2xs text-daintree-text/70 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 >
                   <ExternalLink className="w-3.5 h-3.5" />
                   Daintree Assistant guide
@@ -1535,7 +1535,7 @@ export function HelpPanel({
           edge. Raw args, the elapsed ticker, and the marketing link live in
           the popover / hover titles / header docs button now. */}
       {showTerminal && agentConfig && !isMissingCli && (
-        <div className="flex items-center justify-between gap-3 border-t border-daintree-border shrink-0 px-3 py-1.5 text-[11px] text-text-secondary">
+        <div className="flex items-center justify-between gap-3 border-t border-daintree-border shrink-0 px-3 py-1.5 text-2xs text-text-secondary">
           <span className="flex items-center gap-2 min-w-0">
             <McpActivityStrip sessionId={sessionId} activity={session.mcpActivity} />
             <TurnOutcomePip outcome={session.outcomeAlert} onDismiss={dismissOutcomeAlert} />
@@ -1558,7 +1558,7 @@ export function HelpPanel({
                     }
                   }}
                   className={cn(
-                    "flex items-center gap-1.5 min-w-0 p-0 bg-transparent border-none text-[11px]",
+                    "flex items-center gap-1.5 min-w-0 p-0 bg-transparent border-none text-2xs",
                     "text-status-warning hover:text-status-warning/80 transition-colors duration-150",
                     "rounded-[var(--radius-sm)]",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"

--- a/src/components/HelpPanel/HelpPanelVersionGate.tsx
+++ b/src/components/HelpPanel/HelpPanelVersionGate.tsx
@@ -45,7 +45,7 @@ export function HelpPanelVersionGate({
         onClick={onCheckAgain}
         disabled={isCheckingVersion}
         className={cn(
-          "text-[11px] text-daintree-text/40 transition-colors",
+          "text-2xs text-daintree-text/40 transition-colors",
           "hover:text-daintree-text/60",
           "disabled:opacity-50 disabled:cursor-default disabled:hover:text-daintree-text/40",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -75,7 +75,7 @@ export function RecentCallsPopover({ records, loading, error }: RecentCallsPopov
   const groups = useMemo(() => groupCallsByTurn(records), [records]);
 
   return (
-    <div className="flex flex-col text-[11px] text-daintree-text">
+    <div className="flex flex-col text-2xs text-daintree-text">
       <div className="px-3 pt-2.5 pb-1.5 text-daintree-text/50 font-medium">Recent tool calls</div>
 
       <div className="max-h-[min(360px,var(--radix-popover-content-available-height,360px))] overflow-y-auto px-1 pb-1">
@@ -94,9 +94,7 @@ export function RecentCallsPopover({ records, loading, error }: RecentCallsPopov
             {groups.map((group, index) => (
               <li key={group.turnId ?? `unassociated-${index}`} className="py-1">
                 {group.turnId === null && (
-                  <div className="px-2 pb-0.5 text-[10px] text-text-secondary">
-                    Not tied to a turn
-                  </div>
+                  <div className="px-2 pb-0.5 text-3xs text-text-secondary">Not tied to a turn</div>
                 )}
                 <ul className="space-y-0.5">
                   {group.records.map((record) => (

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -285,7 +285,7 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
               {compact && displayCount > 0 && (
                 <span
                   className={cn(
-                    "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm",
+                    "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-3xs font-bold tabular-nums shadow-sm",
                     waitingCount > 0
                       ? "bg-state-waiting text-daintree-bg"
                       : "bg-daintree-text/20 text-daintree-text"
@@ -339,7 +339,7 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
             <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
               <span className="text-xs font-medium text-daintree-text/70">Background panels</span>
               {waitingCount > 0 && (
-                <span className="text-[10px] font-medium text-state-waiting tabular-nums">
+                <span className="text-3xs font-medium text-state-waiting tabular-nums">
                   {waitingCount} waiting
                 </span>
               )}
@@ -444,7 +444,7 @@ function BackgroundSingleItem({
           <span
             className={cn(
               "truncate font-medium text-daintree-text/80 group-hover:text-daintree-text transition-colors",
-              compact ? "text-[11px]" : "text-xs"
+              compact ? "text-2xs" : "text-xs"
             )}
           >
             {title}
@@ -452,11 +452,11 @@ function BackgroundSingleItem({
           {terminal.lastStateChange != null && (
             <LiveTimeAgo
               timestamp={terminal.lastStateChange}
-              className="text-[10px] text-text-secondary shrink-0"
+              className="text-3xs text-text-secondary shrink-0"
             />
           )}
         </div>
-        <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-daintree-text/55">
+        <div className="flex items-center gap-1.5 mt-0.5 text-2xs text-daintree-text/55">
           {worktreeName && <span className="truncate">{worktreeName}</span>}
           {worktreeName && (stateLabel || terminal.activityHeadline) && (
             <span className="text-daintree-text/30">·</span>
@@ -596,7 +596,7 @@ function BackgroundGroupItem({
           <div className="text-xs font-medium text-daintree-text/70 group-hover:text-daintree-text truncate transition-colors">
             {groupName}
             {groupWaiting > 0 && (
-              <span className="ml-1.5 text-[10px] text-state-waiting font-normal tabular-nums">
+              <span className="ml-1.5 text-3xs text-state-waiting font-normal tabular-nums">
                 · {groupWaiting} waiting
               </span>
             )}
@@ -605,7 +605,7 @@ function BackgroundGroupItem({
 
         <button
           type="button"
-          className="text-[10px] text-text-secondary shrink-0 hover:text-daintree-text transition-colors"
+          className="text-3xs text-text-secondary shrink-0 hover:text-daintree-text transition-colors"
           onClick={() => onRestoreGroup(groupRestoreId, groupMetadata)}
         >
           Restore all

--- a/src/components/Layout/ChordIndicator.tsx
+++ b/src/components/Layout/ChordIndicator.tsx
@@ -210,7 +210,7 @@ export function ChordIndicator() {
               <div key={group.category}>
                 {groupIdx > 0 && <div className="border-t border-[var(--border-overlay)] my-1.5" />}
                 <div
-                  className="text-[10px] font-medium uppercase tracking-wider text-daintree-text/30 px-1 py-1"
+                  className="text-3xs font-medium uppercase tracking-wider text-daintree-text/30 px-1 py-1"
                   role="presentation"
                 >
                   {group.category}
@@ -249,7 +249,7 @@ export function ChordIndicator() {
           )}
         </div>
 
-        <div className="flex items-center gap-2 border-t border-[var(--border-overlay)] px-4 py-1.5 text-[11px] text-text-secondary select-none">
+        <div className="flex items-center gap-2 border-t border-[var(--border-overlay)] px-4 py-1.5 text-2xs text-text-secondary select-none">
           <span>↑↓ select</span>
           <span aria-hidden className="text-daintree-text/20">
             ·

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -1393,7 +1393,7 @@ function DockLaunchOption({
           <span
             data-launcher-qualifier=""
             className={cn(
-              "ml-2 min-w-0 max-w-[40%] shrink truncate text-[11px] text-text-secondary",
+              "ml-2 min-w-0 max-w-[40%] shrink truncate text-2xs text-text-secondary",
               "transition-colors group-aria-selected:text-daintree-text/80"
             )}
           >

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -129,7 +129,7 @@ export function DockLaunchMenuItems({
     >
       <Workflow className="w-3.5 h-3.5 mr-2 shrink-0" />
       <span className="truncate">{item.name}</span>
-      <span className="ml-auto pl-2 text-[11px] text-text-muted shrink-0">
+      <span className="ml-auto pl-2 text-2xs text-text-muted shrink-0">
         {item.isShadowed ? `${item.scopeLabel} · Overridden by Team` : item.scopeLabel}
       </span>
     </C.Item>

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -649,7 +649,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
               </span>
 
               {/* Tab count indicator */}
-              <span className="text-[10px] text-text-secondary tabular-nums shrink-0">
+              <span className="text-3xs text-text-secondary tabular-nums shrink-0">
                 ({panels.length})
               </span>
 
@@ -658,7 +658,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                   <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
                   <Tooltip open={commandTip.open} onOpenChange={commandTip.onOpenChange}>
                     <TooltipTrigger asChild onPointerEnter={commandTip.onPointerEnter}>
-                      <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                      <span className="truncate flex-1 min-w-0 text-2xs text-daintree-text/50 font-mono">
                         {commandText}
                       </span>
                     </TooltipTrigger>

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -384,7 +384,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                     <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
                     <Tooltip open={commandTip.open} onOpenChange={commandTip.onOpenChange}>
                       <TooltipTrigger asChild onPointerEnter={commandTip.onPointerEnter}>
-                        <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                        <span className="truncate flex-1 min-w-0 text-2xs text-daintree-text/50 font-mono">
                           {commandText}
                         </span>
                       </TooltipTrigger>

--- a/src/components/Layout/ForgeStatsToolbarButton.tsx
+++ b/src/components/Layout/ForgeStatsToolbarButton.tsx
@@ -859,7 +859,7 @@ export const ForgeStatsToolbarButton = memo(
       <ContextMenu>
         <ContextMenuTrigger asChild>
           <div
-            className="toolbar-stats app-no-drag relative mr-2 flex h-8 shrink-0 items-center overflow-hidden rounded-[var(--toolbar-pill-radius,0.5rem)] border divide-x divide-[var(--toolbar-stats-divider,var(--theme-border-subtle))] transition-[width] duration-150 ease-out"
+            className="toolbar-stats app-no-drag relative mr-2 flex h-8 shrink-0 items-center overflow-hidden rounded-[var(--toolbar-pill-radius,var(--radius-md))] border divide-x divide-[var(--toolbar-stats-divider,var(--theme-border-subtle))] transition-[width] duration-150 ease-out"
             style={{
               width: statsContainerWidth,
               ["--toolbar-stats-divider" as string]:

--- a/src/components/Layout/RateLimitDetails.tsx
+++ b/src/components/Layout/RateLimitDetails.tsx
@@ -78,7 +78,7 @@ export function RateLimitDetailsPanel({
     <div className="w-[260px] px-3.5 py-3.5">
       <div className="pb-5">
         <div className="text-text-primary text-sm font-semibold leading-tight">{heading}</div>
-        <div className="text-muted-foreground mt-1 text-[11px] leading-snug">{subheading}</div>
+        <div className="text-muted-foreground mt-1 text-2xs leading-snug">{subheading}</div>
       </div>
       {details ? (
         <div className="flex flex-col gap-4">
@@ -92,7 +92,7 @@ export function RateLimitDetailsPanel({
           ))}
         </div>
       ) : (
-        <div className="text-muted-foreground text-[11px] tabular-nums">
+        <div className="text-muted-foreground text-2xs tabular-nums">
           {fallbackResetAt && fallbackResetAt > now
             ? formatRateLimitCountdown(fallbackResetAt - now)
             : "Loading…"}
@@ -122,13 +122,13 @@ function RateLimitBucketRow({ label, bucket, now }: RateLimitBucketRowProps) {
       <div className="flex items-baseline justify-between gap-3">
         <span
           className={cn(
-            "text-[13px] font-medium leading-none",
+            "text-sm font-medium leading-none",
             exhausted ? "text-text-primary" : "text-text-secondary"
           )}
         >
           {label}
         </span>
-        <span className="text-muted-foreground text-[11px] leading-none tabular-nums">
+        <span className="text-muted-foreground text-2xs leading-none tabular-nums">
           {timeLabel}
         </span>
       </div>

--- a/src/components/Layout/StatusContainer.tsx
+++ b/src/components/Layout/StatusContainer.tsx
@@ -85,7 +85,7 @@ export function StatusContainer({ config, terminals, compact = false }: StatusCo
               {compact && displayCount > 0 && (
                 <span
                   className={cn(
-                    "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm",
+                    "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-3xs font-bold tabular-nums shadow-sm",
                     config.badgeColor,
                     config.badgeTextColor
                   )}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -165,7 +165,7 @@ const NO_PINNED_IDS: ReadonlySet<AnyToolbarButtonId> = new Set();
 
 function ForgeStatsPlaceholder() {
   return (
-    <div className="toolbar-stats app-no-drag relative mr-2 flex h-8 w-[13rem] shrink-0 items-center overflow-hidden rounded-[var(--toolbar-pill-radius,0.5rem)] border divide-x divide-[var(--toolbar-stats-divider,var(--theme-border-subtle))] opacity-0 pointer-events-none">
+    <div className="toolbar-stats app-no-drag relative mr-2 flex h-8 w-[13rem] shrink-0 items-center overflow-hidden rounded-[var(--toolbar-pill-radius,var(--radius-md))] border divide-x divide-[var(--toolbar-stats-divider,var(--theme-border-subtle))] opacity-0 pointer-events-none">
       <div className="h-8 flex-1" />
       <div className="h-8 flex-1" />
       <div className="h-8 flex-1" />
@@ -2179,7 +2179,7 @@ export function Toolbar({
                       {currentProject.name}
                       {branchName ? ` · ${branchName}` : ""}
                     </div>
-                    <div className="text-text-muted font-mono text-[11px] truncate">
+                    <div className="text-text-muted font-mono text-2xs truncate">
                       {currentProject.path}
                     </div>
                   </div>
@@ -2189,7 +2189,7 @@ export function Toolbar({
                 <TooltipContent side="bottom" className="max-w-[28rem]">
                   <div className="flex flex-col gap-0.5">
                     <div className="text-xs font-medium">{currentScratch.name}</div>
-                    <div className="text-text-muted text-[11px]">Scratch workspace</div>
+                    <div className="text-text-muted text-2xs">Scratch workspace</div>
                   </div>
                 </TooltipContent>
               )}

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -92,14 +92,12 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
           {worktreeName ? (
             <span className="text-daintree-text/50 ml-1 font-normal">({worktreeName})</span>
           ) : isOrphan ? (
-            <span className="text-status-warning/70 ml-1 font-normal text-[11px]">
-              (deleted tree)
-            </span>
+            <span className="text-status-warning/70 ml-1 font-normal text-2xs">(deleted tree)</span>
           ) : null}
         </div>
         <div
           className={cn(
-            "text-[11px] tabular-nums transition-opacity",
+            "text-2xs tabular-nums transition-opacity",
             seconds <= COUNTDOWN_CRITICAL_SECONDS
               ? "opacity-100 text-status-warning/70"
               : "text-text-secondary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -263,7 +263,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
                 >
                   <Trash2 className="w-3.5 h-3.5 text-daintree-text/60" aria-hidden="true" />
                   {compact && count > 0 && (
-                    <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-daintree-text/40 text-[10px] font-bold tabular-nums text-text-inverse">
+                    <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-daintree-text/40 text-3xs font-bold tabular-nums text-text-inverse">
                       {count > 9 ? "9+" : count}
                     </span>
                   )}
@@ -304,14 +304,14 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
                 <Button
                   variant="ghost-danger"
                   size="sm"
-                  className="text-[11px] h-auto py-0.5 px-1.5"
+                  className="text-2xs h-auto py-0.5 px-1.5"
                   onClick={() => setEmptyTrashConfirmOpen(true)}
                   data-testid="empty-trash-button"
                 >
                   Empty trash
                 </Button>
               ) : (
-                <span className="text-[11px] text-text-secondary">Auto-clears</span>
+                <span className="text-2xs text-text-secondary">Auto-clears</span>
               )}
             </div>
 

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -133,14 +133,14 @@ export function TrashGroupItem({
             {worktreeName ? (
               <span className="text-daintree-text/50 ml-1 font-normal">({worktreeName})</span>
             ) : isOrphan ? (
-              <span className="text-status-warning/70 ml-1 font-normal text-[11px]">
+              <span className="text-status-warning/70 ml-1 font-normal text-2xs">
                 (deleted tree)
               </span>
             ) : null}
           </div>
           <div
             className={cn(
-              "text-[11px] tabular-nums transition-opacity",
+              "text-2xs tabular-nums transition-opacity",
               seconds <= COUNTDOWN_CRITICAL_SECONDS
                 ? "opacity-100 text-status-warning/70"
                 : "text-text-secondary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
@@ -219,7 +219,7 @@ export function TrashGroupItem({
               return (
                 <div
                   key={terminal.id}
-                  className="flex items-center gap-2 px-2 py-1 text-[11px] rounded hover:bg-tint/5 group/panel"
+                  className="flex items-center gap-2 px-2 py-1 text-2xs rounded hover:bg-tint/5 group/panel"
                 >
                   <TerminalIcon
                     kind={terminal.kind}

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -334,9 +334,7 @@ export function VoiceRecordingToolbarButton({
           </TooltipTrigger>
           <TooltipContent side="bottom" className="text-center">
             <div className="font-medium">{tooltipTitle}</div>
-            {tooltipExtra && (
-              <div className="text-[11px] text-daintree-text/60">{tooltipExtra}</div>
-            )}
+            {tooltipExtra && <div className="text-2xs text-daintree-text/60">{tooltipExtra}</div>}
           </TooltipContent>
         </Tooltip>
       </ContextMenuTrigger>

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -213,7 +213,7 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
             <span className="relative">
               <WaitingIcon className="w-3.5 h-3.5 text-state-waiting" aria-hidden="true" />
               {compact && displayCount > 0 && (
-                <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm bg-state-waiting text-daintree-bg">
+                <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-3xs font-bold tabular-nums shadow-sm bg-state-waiting text-daintree-bg">
                   <AnimatedLabel label={displayCount > 9 ? "9+" : String(displayCount)} />
                 </span>
               )}
@@ -250,7 +250,7 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
           <div className="flex flex-col">
             <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
               <span className="text-xs font-medium text-daintree-text/70">Waiting for input</span>
-              <span className="text-[10px] font-medium text-state-waiting tabular-nums">
+              <span className="text-3xs font-medium text-state-waiting tabular-nums">
                 {count} {count === 1 ? "agent" : "agents"}
               </span>
             </div>
@@ -364,13 +364,13 @@ function WaitingSingleItem({
         <span
           className={cn(
             "min-w-0 truncate font-medium text-daintree-text/80 group-hover/row:text-daintree-text transition-colors",
-            compact ? "text-[11px]" : "text-xs"
+            compact ? "text-2xs" : "text-xs"
           )}
         >
           {title}
         </span>
         {(worktreeName || terminal.activityHeadline) && (
-          <span className="flex items-center gap-1 min-w-0 truncate text-[10px] text-daintree-text/45">
+          <span className="flex items-center gap-1 min-w-0 truncate text-3xs text-daintree-text/45">
             {worktreeName && <span className="truncate">{worktreeName}</span>}
             {worktreeName && terminal.activityHeadline && (
               <span className="text-daintree-text/30">·</span>
@@ -387,7 +387,7 @@ function WaitingSingleItem({
       {reason && (
         <span
           className={cn(
-            "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
+            "shrink-0 rounded px-1.5 py-0.5 text-3xs font-medium",
             reason === "error"
               ? "bg-status-error/10 text-status-error"
               : "bg-state-waiting/15 text-state-waiting"
@@ -402,7 +402,7 @@ function WaitingSingleItem({
         <LiveTimeAgo
           timestamp={terminal.lastStateChange}
           noTooltip
-          className="text-[10px] text-text-secondary shrink-0"
+          className="text-3xs text-text-secondary shrink-0"
         />
       )}
 

--- a/src/components/LogLevelPalette/LogLevelPalette.tsx
+++ b/src/components/LogLevelPalette/LogLevelPalette.tsx
@@ -163,7 +163,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
             {item.current && (
               <span
                 className={cn(
-                  "text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded",
+                  "text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded",
                   isSelected
                     ? "bg-overlay-medium text-daintree-text/70"
                     : "bg-daintree-border/60 text-daintree-text/70"
@@ -200,7 +200,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
       renderItem={(item) => (
         <div className="flex-1 min-w-0">
           <div className="text-sm text-daintree-text">{item.label}</div>
-          <div className="text-[11px] text-daintree-text/50">{item.hint}</div>
+          <div className="text-2xs text-daintree-text/50">{item.hint}</div>
         </div>
       )}
     />

--- a/src/components/Markdown/MarkdownDocument.css
+++ b/src/components/Markdown/MarkdownDocument.css
@@ -31,7 +31,7 @@
   /* Document scale: prose sizes are em-based, so one font-size tunes the
      whole hierarchy to the app's 14px reading surfaces. The measure caps
      line length for comfortable reading in maximized panels and dialogs. */
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   max-width: 48rem;
   margin-inline: auto;
 }

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -252,7 +252,7 @@ export function confirmTitle(current: PendingMcpConfirm): string {
 }
 
 /** Shared micro-label, matching the section-heading grammar used app-wide. */
-const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
+const MICRO_LABEL = "text-2xs font-semibold uppercase tracking-wider text-daintree-text/60";
 
 /**
  * Who is asking, in one line.
@@ -299,7 +299,7 @@ function RequesterRow({ current }: { current: PendingMcpConfirm }) {
           {name}
         </span>
         {detail && (
-          <span className="shrink-0 font-mono text-[11px] text-daintree-text/45">{detail}</span>
+          <span className="shrink-0 font-mono text-2xs text-daintree-text/45">{detail}</span>
         )}
       </span>
     </div>

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -888,7 +888,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               <button
                 type="button"
                 onClick={handleMarkAllRead}
-                className="toolbar-icon-button inline-flex items-center gap-1 px-1.5 py-1 rounded-[var(--radius-sm)] text-[11px] text-daintree-text/50 whitespace-nowrap"
+                className="toolbar-icon-button inline-flex items-center gap-1 px-1.5 py-1 rounded-[var(--radius-sm)] text-2xs text-daintree-text/50 whitespace-nowrap"
               >
                 <CheckCheck className="w-3 h-3" aria-hidden="true" />
                 Mark all read
@@ -960,7 +960,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 setFrozenUnreadIds(null);
               }}
               className={cn(
-                "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                "inline-flex items-center px-2 py-0.5 text-2xs rounded-full transition-colors",
                 filter === "all"
                   ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
                   : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
@@ -973,7 +973,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               aria-pressed={filter === "unread"}
               onClick={() => setFilter("unread")}
               className={cn(
-                "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                "inline-flex items-center px-2 py-0.5 text-2xs rounded-full transition-colors",
                 filter === "unread"
                   ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
                   : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
@@ -989,7 +989,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 setFrozenUnreadIds(null);
               }}
               className={cn(
-                "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                "inline-flex items-center px-2 py-0.5 text-2xs rounded-full transition-colors",
                 filter === "archived"
                   ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
                   : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
@@ -1006,7 +1006,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                   setFrozenUnreadIds(null);
                 }}
                 className={cn(
-                  "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                  "inline-flex items-center px-2 py-0.5 text-2xs rounded-full transition-colors",
                   filter === "snoozed"
                     ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
                     : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
@@ -1021,7 +1021,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       {showMutedPill && (
         <div
           data-testid="notification-muted-pill"
-          className="flex flex-col gap-0.5 px-3 py-1.5 bg-overlay-raised text-[11px] text-daintree-text/70"
+          className="flex flex-col gap-0.5 px-3 py-1.5 bg-overlay-raised text-2xs text-daintree-text/70"
         >
           <div className="flex items-center gap-1.5">
             <span className="min-w-0 flex-1 truncate font-medium">{summaryHeroLine}</span>
@@ -1031,7 +1031,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 onClick={handleResumeNotifications}
                 aria-label="Resume notifications"
                 title="Resume notifications"
-                className="inline-flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-[11px] font-medium text-daintree-text/70 hover:bg-overlay-raised hover:text-daintree-text transition-colors"
+                className="inline-flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-2xs font-medium text-daintree-text/70 hover:bg-overlay-raised hover:text-daintree-text transition-colors"
               >
                 Resume
               </button>
@@ -1173,7 +1173,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               "inline-flex items-center gap-1.5 px-3 py-1 rounded-full",
               "bg-overlay-raised border border-border-strong",
               "shadow-[var(--theme-shadow-floating)]",
-              "text-[11px] font-medium text-daintree-text/80",
+              "text-2xs font-medium text-daintree-text/80",
               "hover:text-daintree-text hover:bg-overlay-raised",
               "transition-[translate,opacity] motion-reduce:transition-none",
               showJumpPill
@@ -1233,7 +1233,7 @@ function NeedsAttentionSection({
 } & RovingSectionProps) {
   return (
     <div data-testid="needs-attention-section" className="border-b border-divider">
-      <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-daintree-text/50">
+      <div className="px-3 pt-2 pb-1 text-3xs font-semibold uppercase tracking-wide text-daintree-text/50">
         Needs attention
       </div>
       <div role="group" aria-label="Needs attention">
@@ -1268,7 +1268,7 @@ function NeedsAttentionSection({
       {overflowCount > 0 && (
         <div
           data-testid="needs-attention-overflow"
-          className="px-3 pb-2 text-[10px] text-daintree-text/45"
+          className="px-3 pb-2 text-3xs text-daintree-text/45"
         >
           +{overflowCount} more below
         </div>
@@ -1499,7 +1499,7 @@ function ContextSectionHeader({
   return (
     <div
       data-testid="context-section-header"
-      className="group/section flex items-center justify-between px-3 py-1 bg-overlay-raised text-[10px] font-medium uppercase tracking-wide text-daintree-text/60"
+      className="group/section flex items-center justify-between px-3 py-1 bg-overlay-raised text-3xs font-medium uppercase tracking-wide text-daintree-text/60"
     >
       <span className="truncate">{label}</span>
       <div className="ml-2 shrink-0 flex items-center gap-2">
@@ -1534,7 +1534,7 @@ function NewSinceLastLookedDivider({
       ref={ref}
       tabIndex={-1}
       data-testid="new-since-last-looked"
-      className="flex items-center gap-2 px-3 py-1 bg-overlay-raised text-[10px] font-medium uppercase tracking-wide text-daintree-text/50 outline-hidden"
+      className="flex items-center gap-2 px-3 py-1 bg-overlay-raised text-3xs font-medium uppercase tracking-wide text-daintree-text/50 outline-hidden"
     >
       <span>New since you last looked</span>
       {unreadCount > 0 && (

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -244,7 +244,7 @@ export function NotificationCenterEntry({
                 data-notification-count="true"
                 style={{ animationDuration: "150ms" }}
                 className={cn(
-                  "shrink-0 rounded-full bg-tint/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
+                  "shrink-0 rounded-full bg-tint/15 px-1.5 py-0.5 text-3xs font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
                   bumpKey > 0 && "animate-badge-bump"
                 )}
               >
@@ -276,7 +276,7 @@ export function NotificationCenterEntry({
             data-notification-count="true"
             style={{ animationDuration: "150ms" }}
             className={cn(
-              "col-span-2 row-start-2 mt-0.5 justify-self-start rounded-full bg-tint/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
+              "col-span-2 row-start-2 mt-0.5 justify-self-start rounded-full bg-tint/15 px-1.5 py-0.5 text-3xs font-medium leading-none text-daintree-text/60 tabular-nums min-w-[2.5ch] text-center",
               bumpKey > 0 && "animate-badge-bump"
             )}
           >
@@ -306,7 +306,7 @@ export function NotificationCenterEntry({
                       : undefined
                   }
                   className={cn(
-                    "h-6 rounded-[var(--radius-sm)] px-2 text-[11px] font-medium transition-colors",
+                    "h-6 rounded-[var(--radius-sm)] px-2 text-2xs font-medium transition-colors",
                     isAvailable
                       ? action.variant === "secondary"
                         ? "border border-daintree-text/20 text-text-secondary hover:bg-overlay-medium"
@@ -369,7 +369,7 @@ export function NotificationCenterEntry({
               {/* The clock means "snoozed until later"; the stamp beside it means
                   "arrived at". Abutting they read as one fact, so they get a
                   separator. */}
-              <span aria-hidden="true" className="text-[10px] leading-none text-daintree-text/40">
+              <span aria-hidden="true" className="text-3xs leading-none text-daintree-text/40">
                 ·
               </span>
             </>
@@ -385,7 +385,7 @@ export function NotificationCenterEntry({
                 // composites against whatever is behind it and read at ~3.2:1
                 // here. `theme-tokens.md` gates `text-secondary` at >=3:1 across
                 // every theme and prefers a solid token for exactly this.
-                className="text-[10px] text-text-secondary tabular-nums"
+                className="text-3xs text-text-secondary tabular-nums"
               >
                 {ts.label}
               </span>

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -213,7 +213,7 @@ export function GettingStartedChecklist({
                   label={counterLabel}
                   animateKey={counterAnimateKey}
                   textClassName={cn(
-                    "text-[10px] font-mono tabular-nums",
+                    "text-3xs font-mono tabular-nums",
                     allComplete ? "text-daintree-accent" : "text-daintree-text/50"
                   )}
                 />
@@ -296,7 +296,7 @@ export function GettingStartedChecklist({
                       {description && (
                         <span
                           className={cn(
-                            "text-[10px] leading-snug",
+                            "text-3xs leading-snug",
                             done ? "text-daintree-text/30" : "text-daintree-text/50"
                           )}
                         >
@@ -354,7 +354,7 @@ export function GettingStartedChecklist({
               }}
               className={cn(
                 "w-full text-left px-2 py-1 rounded-[var(--radius-xs)]",
-                "text-[10px] text-daintree-text/50 transition-colors duration-150",
+                "text-3xs text-daintree-text/50 transition-colors duration-150",
                 "hover:text-daintree-text/80 hover:bg-tint/10",
                 "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
               )}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -922,7 +922,7 @@ function PanelHeaderComponent({
           {/* Worktree branch badge — shown when multiple worktrees are active */}
           {worktreeBranch && worktreeAccentColor && (
             <span
-              className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium leading-none select-none max-w-[120px]"
+              className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-3xs font-medium leading-none select-none max-w-[120px]"
               style={
                 {
                   color: worktreeAccentColor,
@@ -948,7 +948,7 @@ function PanelHeaderComponent({
           role="status"
           aria-live="polite"
         >
-          <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wider font-semibold whitespace-nowrap">
+          <div className="flex items-center gap-1.5 text-2xs uppercase tracking-wider font-semibold whitespace-nowrap">
             <Grid2X2 className="w-3 h-3 shrink-0" aria-hidden="true" />
             <span className="tabular-nums inline-flex items-center gap-1">
               <AnimatedLabel label={String(activeCount)} textClassName="tabular-nums" /> Background
@@ -1273,7 +1273,7 @@ function PanelHeaderComponent({
               {location === "dock"
                 ? createTooltipContent("Dismiss preview")
                 : createTooltipContent("Close Session", closeShortcut)}
-              <span className="text-daintree-text/50 text-[11px]">
+              <span className="text-daintree-text/50 text-2xs">
                 {formatShortcutForTooltip("Alt+Click to force close")}
               </span>
             </div>

--- a/src/components/Panel/PanelTransitionOverlay.tsx
+++ b/src/components/Panel/PanelTransitionOverlay.tsx
@@ -178,7 +178,7 @@ function TransitionGhost({ transition, onComplete }: TransitionGhostProps) {
         transitionProperty: "left, top, width, height, opacity",
         transitionTimingFunction: timingFunction,
         willChange: "left, top, width, height, opacity",
-        borderRadius: "6px",
+        borderRadius: "var(--radius-sm)",
       }}
     />
   );

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -37,7 +37,7 @@ function BadgeIndicator({ pluginId, badge }: { pluginId: string; badge: PluginPa
       <span
         role="status"
         aria-label={badge.tooltip ?? `${pluginId}: ${badge.text}`}
-        className={`shrink-0 rounded px-1 text-[10px] font-medium leading-4 ${LABEL_COLOR[color]}`}
+        className={`shrink-0 rounded px-1 text-3xs font-medium leading-4 ${LABEL_COLOR[color]}`}
       >
         {badge.text}
       </span>

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -149,7 +149,7 @@ export function PanelPalette({
           )}
         </div>
         {badgeLabel && (
-          <span className="shrink-0 text-[10px] font-medium text-text-secondary">{badgeLabel}</span>
+          <span className="shrink-0 text-3xs font-medium text-text-secondary">{badgeLabel}</span>
         )}
       </button>
     );

--- a/src/components/Pilot/PilotParkEditor.tsx
+++ b/src/components/Pilot/PilotParkEditor.tsx
@@ -220,7 +220,7 @@ export function PilotParkEditor({
       </div>
 
       <label className="flex flex-col gap-1">
-        <span className="text-[10px] font-medium tracking-wide text-text-secondary uppercase">
+        <span className="text-3xs font-medium tracking-wide text-text-secondary uppercase">
           Note
         </span>
         <input
@@ -242,7 +242,7 @@ export function PilotParkEditor({
       <div className="flex flex-col gap-1">
         <span
           id="pilot-park-gate-label"
-          className="text-[10px] font-medium tracking-wide text-text-secondary uppercase"
+          className="text-3xs font-medium tracking-wide text-text-secondary uppercase"
         >
           Park until
         </span>
@@ -312,7 +312,7 @@ export function PilotParkEditor({
             );
           })}
         </div>
-        <p className="text-[11px] leading-snug text-text-secondary">
+        <p className="text-2xs leading-snug text-text-secondary">
           Gated parks lift when that agent next finishes working — the run pops back into Waiting
           with your note.
         </p>

--- a/src/components/Pilot/PilotView.tsx
+++ b/src/components/Pilot/PilotView.tsx
@@ -209,7 +209,7 @@ const ROW_TONE = "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daint
  * it just no longer outweighs the agents it organises.
  */
 const TILE_BASE =
-  "flex h-4 w-4 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[9px]";
+  "flex h-4 w-4 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-4xs";
 
 /**
  * The workspace's identity tile, at the switcher's colour and a heading's size.
@@ -285,7 +285,7 @@ function GroupDemandChip({ group }: { group: PilotGroupCore }) {
     <span
       aria-hidden="true"
       data-testid="pilot-group-demand"
-      className="flex shrink-0 items-center gap-2 text-[10px] leading-none tabular-nums"
+      className="flex shrink-0 items-center gap-2 text-3xs leading-none tabular-nums"
     >
       {group.attention.map(({ band, count }) => {
         const ChipGlyph = BAND_GLYPH[band];
@@ -360,7 +360,7 @@ function GroupHeader({
           textual — membership is never an accent signal.
         */}
         {group.isCurrent && (
-          <span className="shrink-0 text-[10px] leading-none text-text-secondary">Current</span>
+          <span className="shrink-0 text-3xs leading-none text-text-secondary">Current</span>
         )}
       </div>
 
@@ -563,7 +563,7 @@ function RunRow({
           aria-hidden="true"
           data-testid="pilot-row-age"
           className={cn(
-            "shrink-0 text-right text-[11px] leading-none tabular-nums",
+            "shrink-0 text-right text-2xs leading-none tabular-nums",
             row.ageLabel === null ? "min-w-[3.5rem] text-text-secondary" : "text-state-waiting"
           )}
         >
@@ -1733,7 +1733,7 @@ export function PilotView() {
               does everywhere else in the app.
             */}
             {scopedName !== null && (
-              <div className="mb-1.5 flex min-w-0 items-center gap-1 text-[11px] leading-none">
+              <div className="mb-1.5 flex min-w-0 items-center gap-1 text-2xs leading-none">
                 <button
                   type="button"
                   data-testid="pilot-scope-back"
@@ -1780,7 +1780,7 @@ export function PilotView() {
               <p
                 role="status"
                 data-testid="pilot-fallback-note"
-                className="mb-1.5 min-w-0 text-[11px] leading-snug text-daintree-text/60"
+                className="mb-1.5 min-w-0 text-2xs leading-snug text-daintree-text/60"
               >
                 {fallbackName} has nothing to group by worktree, so this is every agent
               </p>
@@ -1881,7 +1881,7 @@ export function PilotView() {
         )}
 
         {!parkEditing && status.kind === "stale" && (
-          <div data-testid="pilot-stale" className="px-3 py-1.5 text-[11px] text-activity-waiting">
+          <div data-testid="pilot-stale" className="px-3 py-1.5 text-2xs text-activity-waiting">
             {/*
               The announced copy is fixed and the ticking age is hidden from it.
               Putting the age inside the live region made a disconnected host

--- a/src/components/Plugin/FileDecorationBadge.tsx
+++ b/src/components/Plugin/FileDecorationBadge.tsx
@@ -36,7 +36,7 @@ export function FileDecorationBadge({ decoration, className }: FileDecorationBad
   // accent-restraint rule).
   const shared = cn(
     "shrink-0 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full",
-    "text-[10px] font-semibold tabular-nums",
+    "text-3xs font-semibold tabular-nums",
     "bg-overlay-subtle text-daintree-text/80",
     decoration?.color,
     className

--- a/src/components/Plugin/PluginArchiveInstallConfirmDialog.tsx
+++ b/src/components/Plugin/PluginArchiveInstallConfirmDialog.tsx
@@ -161,7 +161,7 @@ export function PluginArchiveInstallConfirmDialog() {
             className="flex items-start gap-2 px-2.5 py-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20"
           >
             <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-            <p className="text-[11px] text-status-danger break-words min-w-0">{error}</p>
+            <p className="text-2xs text-status-danger break-words min-w-0">{error}</p>
           </div>
         )}
       </div>
@@ -195,21 +195,21 @@ function ArchiveIdentityCard({ intent }: { intent: PendingPluginArchiveInstall }
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 min-w-0">
             <span className="text-sm font-medium text-daintree-text truncate">{label}</span>
-            <span className="inline-block shrink-0 px-1.5 py-0.5 rounded-sm text-[10px] font-mono tabular-nums bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 max-w-[10rem] truncate">
+            <span className="inline-block shrink-0 px-1.5 py-0.5 rounded-sm text-3xs font-mono tabular-nums bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 max-w-[10rem] truncate">
               v{manifest.version}
             </span>
           </div>
-          <div className="mt-0.5 text-[11px] font-mono text-daintree-text/45 truncate">
+          <div className="mt-0.5 text-2xs font-mono text-daintree-text/45 truncate">
             {manifest.name}
           </div>
         </div>
       </div>
       <div className="mt-3 pt-2.5 border-t border-tint/[0.08] space-y-1.5">
-        <div className="flex items-start gap-1.5 text-[11px] text-daintree-text/50">
+        <div className="flex items-start gap-1.5 text-2xs text-daintree-text/50">
           <FileArchive className="w-3 h-3 shrink-0 mt-[1.5px] text-daintree-text/35" aria-hidden />
           <span className="font-mono break-all min-w-0">{archiveFileName}</span>
         </div>
-        <div className="flex items-start gap-1.5 text-[11px] text-daintree-text/50">
+        <div className="flex items-start gap-1.5 text-2xs text-daintree-text/50">
           <Users className="w-3 h-3 shrink-0 mt-[1.5px] text-daintree-text/35" aria-hidden />
           {manifest.authors.length > 0 ? (
             <span className="break-words min-w-0">{formatAuthors(manifest.authors)}</span>
@@ -235,9 +235,7 @@ function ArchiveRecipes({ recipes }: { recipes: { count: number; names: string[]
   if (recipes.count === 0) return null;
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
-        Recipes
-      </h4>
+      <h4 className="text-2xs font-medium uppercase tracking-wide text-text-secondary">Recipes</h4>
       <p className="text-xs text-text-secondary">
         Adds {recipes.count} launch {recipes.count === 1 ? "recipe" : "recipes"}, available in every
         project. Each starts terminals that run commands or agents.
@@ -291,7 +289,7 @@ function ArchivePermissions({ capabilities }: { capabilities: readonly string[] 
 
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
+      <h4 className="text-2xs font-medium uppercase tracking-wide text-text-secondary">
         Permissions
       </h4>
       {granted.length === 0 ? (
@@ -301,7 +299,7 @@ function ArchivePermissions({ capabilities }: { capabilities: readonly string[] 
           {worst === "danger" && (
             <div className="flex items-start gap-2 px-2.5 py-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
               <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-              <p className="text-[11px] text-status-danger break-words">
+              <p className="text-2xs text-status-danger break-words">
                 Can run arbitrary commands on your machine
               </p>
             </div>
@@ -309,7 +307,7 @@ function ArchivePermissions({ capabilities }: { capabilities: readonly string[] 
           {worst === "warning" && (
             <div className="flex items-start gap-2 px-2.5 py-2 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
               <AlertTriangle className="w-3.5 h-3.5 text-status-warning shrink-0 mt-0.5" />
-              <p className="text-[11px] text-status-warning break-words">
+              <p className="text-2xs text-status-warning break-words">
                 Requests sensitive permissions — review before installing
               </p>
             </div>

--- a/src/components/Plugin/PluginCapabilityConfirmDialog.tsx
+++ b/src/components/Plugin/PluginCapabilityConfirmDialog.tsx
@@ -76,7 +76,7 @@ export function PluginCapabilityConfirmDialog() {
       >
         <div className="space-y-3">
           <div>
-            <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
+            <div className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
               Capability
             </div>
             <ul>
@@ -86,7 +86,7 @@ export function PluginCapabilityConfirmDialog() {
 
           {current.declaredCapabilities.length > 0 && (
             <div>
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
+              <div className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
                 All declared capabilities
               </div>
               <ul className="space-y-1.5">

--- a/src/components/Plugin/PluginCatalog.tsx
+++ b/src/components/Plugin/PluginCatalog.tsx
@@ -6,7 +6,7 @@ import { pluginLabel } from "./PluginDetailPane";
 import { groupPluginsByCategory } from "./pluginGrouping";
 
 const CARD_BADGE_CLASS =
-  "inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
+  "inline-flex items-center px-1.5 py-0.5 rounded-sm text-3xs font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
 
 function PluginCard({ plugin, onSelect }: { plugin: LoadedPluginInfo; onSelect: () => void }) {
   const disabled = plugin.disabled === true;
@@ -32,7 +32,7 @@ function PluginCard({ plugin, onSelect }: { plugin: LoadedPluginInfo; onSelect: 
           >
             {pluginLabel(plugin)}
           </span>
-          <span className="text-[11px] font-normal text-text-secondary">
+          <span className="text-2xs font-normal text-text-secondary">
             v{plugin.manifest.version}
           </span>
           {disabled && <span className={CARD_BADGE_CLASS}>Disabled</span>}
@@ -87,7 +87,7 @@ export function PluginCatalog({
             <div className="flex items-center gap-2">
               <CategoryIcon className="w-4 h-4 text-daintree-text/50" aria-hidden="true" />
               <h4 className="text-sm font-medium text-daintree-text">{category.label}</h4>
-              <span className="text-[11px] text-daintree-text/40">{sectionPlugins.length}</span>
+              <span className="text-2xs text-daintree-text/40">{sectionPlugins.length}</span>
             </div>
             <p className="text-xs text-daintree-text/45 mt-0.5">{category.blurb}</p>
             <div className="mt-3 grid gap-3 grid-cols-[repeat(auto-fill,minmax(260px,1fr))]">

--- a/src/components/Plugin/PluginConfirmDialog.tsx
+++ b/src/components/Plugin/PluginConfirmDialog.tsx
@@ -14,7 +14,7 @@ import { usePluginConfirmStore, type PluginConfirmationDecision } from "@/store/
 const CONFIRM_COOLDOWN_MS = 1_200;
 
 /** Shared micro-label, matching the section-heading grammar used app-wide. */
-const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
+const MICRO_LABEL = "text-2xs font-semibold uppercase tracking-wider text-daintree-text/60";
 
 /**
  * Singleton dialog driven by the plugin-action confirmation queue. Mounted

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -40,7 +40,7 @@ export function pluginLabel(plugin: LoadedPluginInfo): string {
 }
 
 const BADGE_CLASS =
-  "inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
+  "inline-flex items-center px-1.5 py-0.5 rounded-sm text-3xs font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
 
 /**
  * Declared capabilities in the order {@link BUILT_IN_PLUGIN_CAPABILITIES} defines
@@ -74,13 +74,13 @@ function PluginCapabilityList({
 
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
+      <h4 className="text-2xs font-medium uppercase tracking-wide text-text-secondary">
         Permissions
       </h4>
       {plugin.pluginDanger === "confirm" && (
         <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
           <AlertTriangle className="w-3.5 h-3.5 text-status-warning shrink-0 mt-0.5" />
-          <p className="text-[11px] text-status-warning break-words">
+          <p className="text-2xs text-status-warning break-words">
             Requests sensitive permissions — review before enabling
           </p>
         </div>
@@ -115,19 +115,17 @@ function PluginCapabilityList({
 function PluginContributedCommands({ commands }: { commands: PluginActionContribution[] }) {
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
-        Commands
-      </h4>
+      <h4 className="text-2xs font-medium uppercase tracking-wide text-text-secondary">Commands</h4>
       <ul className="space-y-2">
         {commands.map((command) => (
           <li key={command.id} className="text-xs">
             <div className="text-daintree-text/80">{command.title}</div>
             {command.description && (
-              <div className="text-[11px] text-daintree-text/50 mt-0.5 break-words">
+              <div className="text-2xs text-daintree-text/50 mt-0.5 break-words">
                 {command.description}
               </div>
             )}
-            <div className="text-[11px] text-daintree-text/40 mt-0.5">
+            <div className="text-2xs text-daintree-text/40 mt-0.5">
               {command.kind === "query"
                 ? "Available to agents and automation"
                 : "Run it from the command palette"}
@@ -148,14 +146,12 @@ function PluginContributedCommands({ commands }: { commands: PluginActionContrib
 function PluginContributedPanels({ panels }: { panels: PanelContribution[] }) {
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
-        Panels
-      </h4>
+      <h4 className="text-2xs font-medium uppercase tracking-wide text-text-secondary">Panels</h4>
       <ul className="space-y-2">
         {panels.map((panel) => (
           <li key={panel.id} className="text-xs">
             <div className="text-daintree-text/80">{panel.name}</div>
-            <div className="text-[11px] text-text-secondary mt-0.5">
+            <div className="text-2xs text-text-secondary mt-0.5">
               {panel.showInPalette === false
                 ? "Opened by the plugin"
                 : "Open it from the new-panel menu"}
@@ -179,7 +175,7 @@ function PluginContributedPanels({ panels }: { panels: PanelContribution[] }) {
 function PluginContributors({ authors }: { authors: PluginAuthor[] }) {
   return (
     <div className="space-y-2">
-      <h4 className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
+      <h4 className="text-2xs font-medium uppercase tracking-wide text-text-secondary">
         Contributors
       </h4>
       <ul className="space-y-2">
@@ -189,7 +185,7 @@ function PluginContributors({ authors }: { authors: PluginAuthor[] }) {
             <li key={`${name}-${index}`} className="text-xs">
               <div className="text-daintree-text/80">
                 {name}
-                {role && <span className="text-[11px] text-text-secondary"> · {role}</span>}
+                {role && <span className="text-2xs text-text-secondary"> · {role}</span>}
               </div>
               {(url || email) && (
                 <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
@@ -197,7 +193,7 @@ function PluginContributors({ authors }: { authors: PluginAuthor[] }) {
                     <button
                       type="button"
                       onClick={() => void systemClient.openExternal(url)}
-                      className="text-[11px] text-daintree-text/50 hover:text-daintree-text/80 hover:underline break-all"
+                      className="text-2xs text-daintree-text/50 hover:text-daintree-text/80 hover:underline break-all"
                     >
                       {url}
                     </button>
@@ -206,7 +202,7 @@ function PluginContributors({ authors }: { authors: PluginAuthor[] }) {
                     <button
                       type="button"
                       onClick={() => void systemClient.openExternal(`mailto:${email}`)}
-                      className="text-[11px] text-daintree-text/50 hover:text-daintree-text/80 hover:underline break-all"
+                      className="text-2xs text-daintree-text/50 hover:text-daintree-text/80 hover:underline break-all"
                     >
                       {email}
                     </button>
@@ -328,7 +324,7 @@ export function PluginDetailPane({
               <span className={BADGE_CLASS}>{categoryLabel}</span>
               <span className={BADGE_CLASS}>{sourceLabel}</span>
               {plugin.blocklisted === true && (
-                <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-status-danger uppercase tracking-wide">
+                <span className="inline-flex items-center gap-0.5 text-3xs font-medium text-status-danger uppercase tracking-wide">
                   <AlertCircle className="w-3 h-3" aria-hidden="true" />
                   Blocked
                 </span>
@@ -345,14 +341,14 @@ export function PluginDetailPane({
               <p className="text-sm text-daintree-text/60 mt-1">{plugin.manifest.tagline}</p>
             )}
             {!plugin.isBuiltin && plugin.installedAt > 0 && (
-              <div className="text-[11px] text-daintree-text/40 mt-1">
+              <div className="text-2xs text-daintree-text/40 mt-1">
                 {plugin.updatedAt
                   ? `Updated ${formatRelativeTime(plugin.updatedAt)}`
                   : `Installed ${formatRelativeTime(plugin.installedAt)}`}
               </div>
             )}
             {upToDate && (
-              <div className="text-[11px] text-daintree-text/50 mt-1" role="status">
+              <div className="text-2xs text-daintree-text/50 mt-1" role="status">
                 Already up to date
               </div>
             )}
@@ -446,7 +442,7 @@ export function PluginDetailPane({
           {plugin.blocklisted === true && (
             <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
               <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-              <p className="text-[11px] text-status-danger break-words">
+              <p className="text-2xs text-status-danger break-words">
                 Blocked from loading:{" "}
                 {plugin.blocklistReason ?? "flagged by the Daintree blocklist"}
               </p>
@@ -456,7 +452,7 @@ export function PluginDetailPane({
           {plugin.loadError && (
             <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
               <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-              <p className="text-[11px] text-status-danger break-words">
+              <p className="text-2xs text-status-danger break-words">
                 Failed to load: {plugin.loadError.message}
               </p>
             </div>

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -38,13 +38,13 @@ import { PLUGIN_CATEGORIES } from "@shared/config/pluginCategoryRegistry";
 import type { LoadedPluginInfo, PluginDeepLinkIntent } from "@shared/types/plugin";
 
 const ROW_BADGE_CLASS =
-  "inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
+  "inline-flex items-center px-1.5 py-0.5 rounded-sm text-3xs font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
 
 // Disabled-option separator class for section headers inside the listbox.
 // role="group" inside role="listbox" is broken under Chromium 146 + VoiceOver
 // (LESSON #9006), so headers masquerade as non-interactive options instead.
 const SECTION_HEADER_CLASS =
-  "px-3 text-[10px] font-medium uppercase tracking-wider text-text-secondary select-none";
+  "px-3 text-3xs font-medium uppercase tracking-wider text-text-secondary select-none";
 
 // Operator chips surfaced below the search input so the filter syntax is
 // discoverable instead of hidden. Categories are the headline filters; the
@@ -140,14 +140,14 @@ function PluginRow({
             )}
           >
             <span className="truncate">{label}</span>
-            <span className="text-[11px] font-normal text-text-secondary">
+            <span className="text-2xs font-normal text-text-secondary">
               v{plugin.manifest.version}
             </span>
           </span>
           {tagline && (
             <span
               className={cn(
-                "mt-0.5 block text-[11px] truncate",
+                "mt-0.5 block text-2xs truncate",
                 enabled ? "text-daintree-text/50" : "text-daintree-text/35"
               )}
             >
@@ -162,7 +162,7 @@ function PluginRow({
             blocklisted) && (
             <span className="mt-1 flex items-center gap-1 flex-wrap">
               {blocklisted && (
-                <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-status-danger uppercase tracking-wide">
+                <span className="inline-flex items-center gap-0.5 text-3xs font-medium text-status-danger uppercase tracking-wide">
                   <AlertCircle className="w-3 h-3" aria-hidden="true" />
                   Blocked
                 </span>
@@ -176,7 +176,7 @@ function PluginRow({
                 <span className={`${ROW_BADGE_CLASS} text-daintree-text/50`}>Restart required</span>
               )}
               {plugin.loadError && (
-                <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-status-danger uppercase tracking-wide">
+                <span className="inline-flex items-center gap-0.5 text-3xs font-medium text-status-danger uppercase tracking-wide">
                   <AlertCircle className="w-3 h-3" aria-hidden="true" />
                   Failed
                 </span>
@@ -601,7 +601,7 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
                       aria-pressed={active}
                       onClick={() => toggleFilterToken(token)}
                       className={cn(
-                        "px-1.5 py-0.5 rounded-sm text-[10px] font-medium border transition-colors",
+                        "px-1.5 py-0.5 rounded-sm text-3xs font-medium border transition-colors",
                         active
                           ? "bg-overlay-strong border-daintree-border text-daintree-text"
                           : "bg-overlay-subtle border-daintree-border/50 text-daintree-text/60 hover:text-daintree-text/80 hover:border-daintree-border"
@@ -616,13 +616,13 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
             {pm.notice && (
               <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border">
                 <Info className="w-3.5 h-3.5 text-daintree-text/50 shrink-0 mt-0.5" />
-                <p className="text-[11px] text-daintree-text/70">{pm.notice}</p>
+                <p className="text-2xs text-daintree-text/70">{pm.notice}</p>
               </div>
             )}
             {pm.error && (
               <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
                 <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-                <p className="text-[11px] text-status-danger">{pm.error}</p>
+                <p className="text-2xs text-status-danger">{pm.error}</p>
               </div>
             )}
           </div>
@@ -743,12 +743,10 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
               network-backed catalog ships separately; the slot keeps its place
               in the master column so the layout doesn't shift when it lands. */}
           <div className="px-4 py-3 border-t border-daintree-border shrink-0">
-            <p className="text-[10px] font-medium uppercase tracking-wider text-text-secondary select-none">
+            <p className="text-3xs font-medium uppercase tracking-wider text-text-secondary select-none">
               Browse
             </p>
-            <p className="text-[11px] text-text-secondary mt-1">
-              Online plugin catalog coming soon.
-            </p>
+            <p className="text-2xs text-text-secondary mt-1">Online plugin catalog coming soon.</p>
           </div>
         </div>
 

--- a/src/components/Plugin/PluginMcpConfirmDialog.tsx
+++ b/src/components/Plugin/PluginMcpConfirmDialog.tsx
@@ -29,7 +29,7 @@ const MAX_TOOL_NAME_IN_TITLE = 32;
 const DESCRIPTION_MAX_HEIGHT = "max-h-[9rem]";
 
 /** Shared micro-label, matching the section-heading grammar used app-wide. */
-const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
+const MICRO_LABEL = "text-2xs font-semibold uppercase tracking-wider text-daintree-text/60";
 
 /**
  * The redacted payload's own treatment, shared by both tier paths. The same
@@ -235,7 +235,7 @@ function IdentityRow({
       <span className={cn(MICRO_LABEL, "shrink-0 w-[5.5rem]")}>{label}</span>
       <span className="flex min-w-0 flex-1 items-baseline gap-2">
         <span
-          className={cn("min-w-0 break-all text-daintree-text/85", mono && "font-mono text-[11px]")}
+          className={cn("min-w-0 break-all text-daintree-text/85", mono && "font-mono text-2xs")}
           title={value}
         >
           {value}
@@ -599,7 +599,7 @@ export function tierLabelFor(tier: PluginMcpDangerTier): string {
  */
 function DangerTierBadge({ tier }: { tier: PluginMcpDangerTier }) {
   return (
-    <span className="shrink-0 rounded border border-tint/[0.08] bg-overlay-subtle px-1.5 py-0.5 font-mono text-[10px] text-daintree-text/70">
+    <span className="shrink-0 rounded border border-tint/[0.08] bg-overlay-subtle px-1.5 py-0.5 font-mono text-3xs text-daintree-text/70">
       {tier} · {tierLabelFor(tier)}
     </span>
   );

--- a/src/components/Plugin/PluginMcpServersSection.tsx
+++ b/src/components/Plugin/PluginMcpServersSection.tsx
@@ -295,7 +295,7 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
                 />
                 <div className="min-w-0 flex-1">
                   <div className="text-sm text-daintree-text truncate">{row.name}</div>
-                  <div className="text-[11px] text-text-secondary">
+                  <div className="text-2xs text-text-secondary">
                     {STATUS_LABEL[status]}
                     {row.info?.pid != null && status === "ready" && ` · pid ${row.info.pid}`}
                   </div>
@@ -315,7 +315,7 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
               {row.info?.lastError && status === "crashed" && (
                 <div className="mx-3 mb-2.5 flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
                   <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-                  <p className="text-[11px] text-status-danger break-words select-text">
+                  <p className="text-2xs text-status-danger break-words select-text">
                     {row.info.lastError}
                   </p>
                 </div>
@@ -324,7 +324,7 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
               {rowRestartError && (
                 <div className="mx-3 mb-2.5 flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
                   <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-                  <p className="text-[11px] text-status-danger break-words">{rowRestartError}</p>
+                  <p className="text-2xs text-status-danger break-words">{rowRestartError}</p>
                 </div>
               )}
 
@@ -334,7 +334,7 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
                     type="button"
                     onClick={() => void toggleStderr(row, isOpen)}
                     aria-expanded={isOpen}
-                    className="flex items-center gap-1.5 w-full px-3 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-text/80 transition-[color] duration-150"
+                    className="flex items-center gap-1.5 w-full px-3 py-2 text-2xs text-daintree-text/50 hover:text-daintree-text/80 transition-[color] duration-150"
                   >
                     {isOpen ? (
                       <ChevronDown className="w-3.5 h-3.5 shrink-0" />
@@ -361,24 +361,24 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
 
 function StderrView({ state }: { state: StderrState | undefined }) {
   if (!state || (state.loading && !state.result)) {
-    return <p className="text-[11px] text-text-secondary">Loading output…</p>;
+    return <p className="text-2xs text-text-secondary">Loading output…</p>;
   }
   if (state.error) {
-    return <p className="text-[11px] text-status-danger">{state.error}</p>;
+    return <p className="text-2xs text-status-danger">{state.error}</p>;
   }
   const result = state.result;
   if (!result || result.lines.length === 0) {
-    return <p className="text-[11px] text-text-secondary">No output captured.</p>;
+    return <p className="text-2xs text-text-secondary">No output captured.</p>;
   }
   const hidden = result.totalLines - result.lines.length;
   return (
     <div className="space-y-1.5">
       {hidden > 0 && (
-        <p className="text-[10px] text-text-secondary">
+        <p className="text-3xs text-text-secondary">
           Showing the most recent {result.lines.length} of {result.totalLines} lines.
         </p>
       )}
-      <pre className="max-h-48 overflow-auto rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border p-2 font-mono text-[11px] leading-relaxed text-daintree-text/80 whitespace-pre-wrap break-words select-text">
+      <pre className="max-h-48 overflow-auto rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border p-2 font-mono text-2xs leading-relaxed text-daintree-text/80 whitespace-pre-wrap break-words select-text">
         {result.lines.join("\n")}
       </pre>
     </div>
@@ -389,7 +389,7 @@ function SectionError({ message }: { message: string }) {
   return (
     <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
       <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
-      <p className="text-[11px] text-status-danger break-words">{message}</p>
+      <p className="text-2xs text-status-danger break-words">{message}</p>
     </div>
   );
 }

--- a/src/components/Plugin/capabilityMeta.tsx
+++ b/src/components/Plugin/capabilityMeta.tsx
@@ -156,11 +156,11 @@ export function CapabilityRow({
         >
           {meta.label}
         </div>
-        <div className="text-[11px] text-text-secondary">{meta.description}</div>
+        <div className="text-2xs text-text-secondary">{meta.description}</div>
         {scoped && (
           <ul className="mt-0.5 space-y-0.5">
             {scopeEntries.map((entry) => (
-              <li key={entry} className="text-[11px] font-mono text-daintree-text/50 break-all">
+              <li key={entry} className="text-2xs font-mono text-daintree-text/50 break-all">
                 {entry}
               </li>
             ))}

--- a/src/components/Project/EnvironmentVariablesEditor.tsx
+++ b/src/components/Project/EnvironmentVariablesEditor.tsx
@@ -188,11 +188,11 @@ export function EnvironmentVariablesEditor({
                     {isSensitive ? "********" : value}
                   </span>
                   {isOverridden ? (
-                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-warning/15 text-status-warning font-medium">
+                    <span className="text-3xs px-1.5 py-0.5 rounded bg-status-warning/15 text-status-warning font-medium">
                       Overridden
                     </span>
                   ) : (
-                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-info/15 text-status-info font-medium">
+                    <span className="text-3xs px-1.5 py-0.5 rounded bg-status-info/15 text-status-info font-medium">
                       Global
                     </span>
                   )}
@@ -314,7 +314,7 @@ export function EnvironmentVariablesEditor({
                     <Trash2 className="h-4 w-4 text-status-error" />
                   </button>
                 </div>
-                {error && <p className="text-[11px] text-status-error mt-1 ml-1">{error}</p>}
+                {error && <p className="text-2xs text-status-error mt-1 ml-1">{error}</p>}
               </div>
             );
           })

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -67,7 +67,7 @@ function HeapBar({ heapStats }: { heapStats: HeapStats }) {
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center justify-between text-[10px]">
+      <div className="flex items-center justify-between text-3xs">
         <span className="text-daintree-text/50">V8 Heap</span>
         <span className="font-mono text-text-secondary">
           {heapStats.usedMB.toFixed(0)} / {heapStats.limitMB}MB ({heapStats.percent.toFixed(0)}%)
@@ -80,7 +80,7 @@ function HeapBar({ heapStats }: { heapStats: HeapStats }) {
         />
       </div>
       {heapStats.externalMB > 50 && (
-        <div className="text-[9px] text-daintree-text/30 font-mono">
+        <div className="text-4xs text-daintree-text/30 font-mono">
           External: {heapStats.externalMB.toFixed(0)}MB
         </div>
       )}
@@ -90,7 +90,7 @@ function HeapBar({ heapStats }: { heapStats: HeapStats }) {
 
 function MemoryRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-center justify-between gap-2 text-[10px]">
+    <div className="flex items-center justify-between gap-2 text-3xs">
       <span className="text-daintree-text/50 leading-tight">{label}</span>
       <span className="font-mono tabular-nums text-text-secondary shrink-0">{value}</span>
     </div>
@@ -144,13 +144,13 @@ function MemorySummary({
         />
       )}
       {workloadNote !== null && (
-        <div className="text-[9px] text-status-warning/70 leading-tight">{workloadNote}</div>
+        <div className="text-4xs text-status-warning/70 leading-tight">{workloadNote}</div>
       )}
       {systemAvailableMB !== null && (
         <MemoryRow label="System available" value={formatMemory(systemAvailableMB)} />
       )}
       {shown !== null && (
-        <div className="text-[9px] text-daintree-text/25 leading-tight">
+        <div className="text-4xs text-daintree-text/25 leading-tight">
           Workloads = dev servers, agents, and tools your terminals launched
         </div>
       )}
@@ -161,14 +161,14 @@ function MemorySummary({
 function ProcessTable({ metrics }: { metrics: ProcessMetricEntry[] }) {
   return (
     <div className="space-y-1">
-      <div className="text-[10px] text-daintree-text/50 font-medium">Daintree processes</div>
+      <div className="text-3xs text-daintree-text/50 font-medium">Daintree processes</div>
       <div className="space-y-px">
         {metrics.map((proc) => {
           const label = formatProcessLabel(proc);
           return (
             <div
               key={proc.pid}
-              className="flex items-center justify-between text-[10px] font-mono py-0.5"
+              className="flex items-center justify-between text-3xs font-mono py-0.5"
             >
               <span
                 className="text-daintree-text/60 truncate max-w-[140px]"
@@ -203,7 +203,7 @@ function ProjectBreakdown({
 
   return (
     <div className="space-y-1">
-      <div className="text-[10px] text-daintree-text/50 font-medium">Projects</div>
+      <div className="text-3xs text-daintree-text/50 font-medium">Projects</div>
       <div className="space-y-px">
         {entries.map((entry) => {
           const s = entry.stats!;
@@ -216,7 +216,7 @@ function ProjectBreakdown({
           return (
             <div
               key={entry.id}
-              className="flex items-center justify-between text-[10px] font-mono py-0.5 gap-2"
+              className="flex items-center justify-between text-3xs font-mono py-0.5 gap-2"
             >
               <span className="text-daintree-text/60 truncate min-w-0">
                 {entry.name}
@@ -233,7 +233,7 @@ function ProjectBreakdown({
         })}
       </div>
       {hasEstimates && (
-        <div className="text-[9px] text-daintree-text/25 leading-tight">
+        <div className="text-4xs text-daintree-text/25 leading-tight">
           ~ estimated from terminal count, not measured
         </div>
       )}
@@ -264,14 +264,14 @@ function DiagnosticsSection({
   return (
     <div className="space-y-1">
       <button
-        className="text-[10px] text-daintree-text/50 font-medium hover:text-daintree-text/70 transition-colors flex items-center gap-1"
+        className="text-3xs text-daintree-text/50 font-medium hover:text-daintree-text/70 transition-colors flex items-center gap-1"
         onClick={() => setExpanded(!expanded)}
       >
         <span className="text-[8px]">{expanded ? "\u25BC" : "\u25B6"}</span>
         Diagnostics
       </button>
       {expanded && (
-        <div className="space-y-1 text-[10px] font-mono text-text-secondary pl-2">
+        <div className="space-y-1 text-3xs font-mono text-text-secondary pl-2">
           <div>{trendText}</div>
           <div>Uptime: {formatUptime(diagnosticsInfo.uptimeSeconds)}</div>
           {diagnosticsInfo.eventLoopP99Ms > 50 && (
@@ -550,7 +550,7 @@ export function ProjectResourceBadge() {
               key={memoryState}
               className={`status-mark inline-flex h-2 w-2 rounded-full ${STATE_DOT_CLASSES[memoryState]} animate-diagnostics-flash shrink-0`}
             />
-            <span className="text-[10px] tabular-nums text-text-secondary font-medium truncate">
+            <span className="text-3xs tabular-nums text-text-secondary font-medium truncate">
               {stats.runningProjects} project{stats.runningProjects !== 1 ? "s" : ""} active
             </span>
           </div>
@@ -579,8 +579,8 @@ export function ProjectResourceBadge() {
                 trendSamples={samples}
               />
               <div className="pt-1 border-t border-divider space-y-0.5">
-                {ageLabel && <div className="text-[9px] text-daintree-text/30">{ageLabel}</div>}
-                <div className="text-[9px] text-daintree-text/25 leading-tight">
+                {ageLabel && <div className="text-4xs text-daintree-text/30">{ageLabel}</div>}
+                <div className="text-4xs text-daintree-text/25 leading-tight">
                   Figures sum working-set memory and count shared pages once per process
                 </div>
               </div>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -460,7 +460,7 @@ function RowStatusLine({ status }: { status: ProjectRowStatus }) {
   if (parts.length === 0) return null;
 
   return (
-    <div className="flex items-center gap-1 min-w-0 mt-0.5 text-[11px] leading-none">
+    <div className="flex items-center gap-1 min-w-0 mt-0.5 text-2xs leading-none">
       {parts.map((part, index) => (
         <Fragment key={part.key}>
           {/*
@@ -876,7 +876,7 @@ function ScratchListItem({
           >
             {scratch.name}
           </span>
-          <span className="text-[11px] leading-none text-daintree-text/50 shrink-0">· Scratch</span>
+          <span className="text-2xs leading-none text-daintree-text/50 shrink-0">· Scratch</span>
           {scratch.isActive && <span className="sr-only">, current</span>}
           {showResumeDot && <ResumableAgentsLabel count={scratch.resumableAgentCount ?? 0} />}
         </div>
@@ -977,7 +977,7 @@ function BandCollapseToggle({
  * screen.
  */
 function BandCollapsedCount({ count }: { count: number }) {
-  return <span className="shrink-0 text-[10px] tabular-nums">{count}</span>;
+  return <span className="shrink-0 text-3xs tabular-nums">{count}</span>;
 }
 
 /** Stable `aria-controls` target for a band's rows. */
@@ -1798,7 +1798,7 @@ function ScratchSection({
                           <RowStatusLine status={status} />
                           {countdown && (
                             <div
-                              className="text-[11px] leading-none text-text-secondary mt-0.5 truncate"
+                              className="text-2xs leading-none text-text-secondary mt-0.5 truncate"
                               data-testid="scratch-cleanup-countdown"
                             >
                               {countdown}

--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -511,7 +511,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                     onMouseDown={(e) => e.preventDefault()}
                     className="absolute bottom-full left-0 right-0 z-50 mb-1 flex max-h-64 flex-col overflow-hidden rounded-[var(--radius-md)] border border-border-default bg-surface-panel-elevated shadow-[var(--theme-shadow-floating)]"
                   >
-                    <div className="shrink-0 border-b border-border-subtle bg-surface-input px-3 py-1 text-[11px] font-sans tracking-wider text-text-muted">
+                    <div className="shrink-0 border-b border-border-subtle bg-surface-input px-3 py-1 text-2xs font-sans tracking-wider text-text-muted">
                       COMMANDS
                     </div>
                     <div className="overflow-y-auto flex-1">
@@ -550,19 +550,19 @@ export function QuickRun({ projectId }: QuickRunProps) {
                                 {item.type === "saved" ? item.label : item.value}
                               </span>
                               {item.type === "script" && item.label !== item.value && (
-                                <span className="ml-2 text-[11px] font-sans text-text-muted">
+                                <span className="ml-2 text-2xs font-sans text-text-muted">
                                   ({item.label})
                                 </span>
                               )}
                               {item.type === "saved" && item.label !== item.value && (
-                                <span className="ml-2 text-[11px] font-sans text-text-muted">
+                                <span className="ml-2 text-2xs font-sans text-text-muted">
                                   {item.value}
                                 </span>
                               )}
                               {(item.type === "script" || item.type === "saved") &&
                                 "description" in item &&
                                 item.description && (
-                                  <span className="mt-0.5 block truncate text-[11px] font-sans text-text-muted">
+                                  <span className="mt-0.5 block truncate text-2xs font-sans text-text-muted">
                                     {item.description}
                                   </span>
                                 )}

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -282,7 +282,7 @@ export function RecipesTab({
                             const scopeInfo = getRecipeScope(recipe, resolveWorktreeName);
                             return (
                               <span
-                                className={`text-[11px] px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1 ${
+                                className={`text-2xs px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1 ${
                                   scopeInfo.isGlobal
                                     ? "text-status-info bg-status-info/10"
                                     : "text-muted-foreground bg-muted"
@@ -293,23 +293,23 @@ export function RecipesTab({
                               </span>
                             );
                           })()}
-                          <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
+                          <span className="text-2xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
                             {recipe.terminals.length} terminal
                             {recipe.terminals.length !== 1 ? "s" : ""}
                           </span>
                           {isShadowed && (
-                            <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
+                            <span className="text-2xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
                               Overridden
                             </span>
                           )}
                           {isDefault && (
-                            <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1">
+                            <span className="text-2xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1">
                               <Pin className="h-3 w-3" />
                               Default
                             </span>
                           )}
                           {recipe.showInEmptyState && (
-                            <span className="text-[11px] text-status-info bg-status-info/10 px-1.5 py-0.5 rounded font-medium shrink-0">
+                            <span className="text-2xs text-status-info bg-status-info/10 px-1.5 py-0.5 rounded font-medium shrink-0">
                               Empty State
                             </span>
                           )}

--- a/src/components/Project/RunningTaskList.tsx
+++ b/src/components/Project/RunningTaskList.tsx
@@ -220,7 +220,7 @@ function TaskOverflow({
         // popover is labelled and exposes the rows themselves once opened.
         aria-label={`Show ${tasks.length} more running ${tasks.length === 1 ? "task" : "tasks"}`}
         className={cn(
-          "flex w-full items-center gap-0.5 px-2 py-0.5 rounded-[var(--radius-sm)] text-[10px] font-sans transition-colors",
+          "flex w-full items-center gap-0.5 px-2 py-0.5 rounded-[var(--radius-sm)] text-3xs font-sans transition-colors",
           "text-daintree-text/40 hover:text-daintree-text/70 hover:bg-tint/[0.04]",
           "outline-hidden focus-visible:outline focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         )}
@@ -279,7 +279,7 @@ function TaskRow({ terminal, status, now, onStop, onFocus, onRestart, onDismiss 
   return (
     <div
       className={cn(
-        "flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-sm)] text-[11px] font-mono group",
+        "flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-sm)] text-2xs font-mono group",
         "hover:bg-tint/[0.04] transition-colors cursor-pointer",
         status === "failed" && "border-l-2 border-status-error",
         status === "success" && "opacity-60"
@@ -304,7 +304,7 @@ function TaskRow({ terminal, status, now, onStop, onFocus, onRestart, onDismiss 
 
       {/* Elapsed time */}
       {isActive && (
-        <span className="text-[10px] text-daintree-text/30 tabular-nums shrink-0">
+        <span className="text-3xs text-daintree-text/30 tabular-nums shrink-0">
           {formatElapsed(elapsed)}
         </span>
       )}

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -618,7 +618,7 @@ function InlineChecklist({
         <h3 className="text-xs font-medium text-daintree-text/50 uppercase tracking-wider">
           Getting started
         </h3>
-        <span className="text-[10px] text-text-secondary font-mono">
+        <span className="text-3xs text-text-secondary font-mono">
           {progressDone}/{progressTotal}
         </span>
       </div>
@@ -680,7 +680,7 @@ function InlineChecklist({
                       {description && (
                         <span
                           className={cn(
-                            "text-[10px] leading-snug",
+                            "text-3xs leading-snug",
                             done ? "text-daintree-text/30" : "text-daintree-text/50"
                           )}
                         >

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -128,7 +128,7 @@ function HealthChip({ icon, label, onClick, className, tone = "neutral" }: Healt
   return (
     <Wrapper
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-2xs font-medium",
         onClick && "cursor-pointer transition-colors hover:opacity-85",
         className
       )}
@@ -325,7 +325,7 @@ function PulseHeatmapLegend({
       <div
         aria-hidden="true"
         data-testid="pulse-heatmap-legend"
-        className="flex items-center justify-end text-[10px] text-daintree-text/55 select-none"
+        className="flex items-center justify-end text-3xs text-daintree-text/55 select-none"
         style={{ width: `${rowWidth}px`, gap: `${HEATMAP_LEGEND_GAP_PX}px` }}
       >
         <span>Less</span>
@@ -586,7 +586,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
 
         <div className="flex items-center gap-2">
           <div
-            className="pulse-range flex items-center rounded-md border border-transparent text-[11px] font-medium"
+            className="pulse-range flex items-center rounded-md border border-transparent text-2xs font-medium"
             role="radiogroup"
             aria-label="Activity range"
             onKeyDown={handleRangeKeyDown}
@@ -673,7 +673,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
             type="button"
             onClick={handleRefresh}
             disabled={isLoading}
-            className="pulse-control mt-2 inline-flex items-center text-[11px] text-daintree-text/55 transition-colors hover:text-daintree-text/80 disabled:opacity-50 disabled:pointer-events-none"
+            className="pulse-control mt-2 inline-flex items-center text-2xs text-daintree-text/55 transition-colors hover:text-daintree-text/80 disabled:opacity-50 disabled:pointer-events-none"
             aria-label={`Refresh — last updated ${updatedLabel}`}
             data-testid="pulse-last-updated"
           >

--- a/src/components/Recovery/SafeModeBanner.tsx
+++ b/src/components/Recovery/SafeModeBanner.tsx
@@ -56,7 +56,7 @@ function QuarantinedPanelRow({ panel }: QuarantinedPanelRowProps) {
           {displayTitle}
         </p>
         {subtitle && (
-          <p className="truncate text-[10px] text-daintree-text/50" title={subtitle}>
+          <p className="truncate text-3xs text-daintree-text/50" title={subtitle}>
             {subtitle}
           </p>
         )}
@@ -65,22 +65,22 @@ function QuarantinedPanelRow({ panel }: QuarantinedPanelRowProps) {
         <button
           type="button"
           onClick={handleRestore}
-          className="shrink-0 rounded border border-[var(--color-status-warning)]/30 px-2 py-0.5 text-[10px] transition-colors hover:bg-[var(--color-status-warning)]/10"
+          className="shrink-0 rounded border border-[var(--color-status-warning)]/30 px-2 py-0.5 text-3xs transition-colors hover:bg-[var(--color-status-warning)]/10"
         >
           Restore panel
         </button>
       )}
       {state === "clearing" && (
-        <span className="shrink-0 text-[10px] text-daintree-text/60">Clearing…</span>
+        <span className="shrink-0 text-3xs text-daintree-text/60">Clearing…</span>
       )}
       {state === "cleared" && (
-        <span className="shrink-0 text-[10px] text-daintree-text/60">Restoring on next launch</span>
+        <span className="shrink-0 text-3xs text-daintree-text/60">Restoring on next launch</span>
       )}
       {state === "failed" && (
         <button
           type="button"
           onClick={handleRestore}
-          className="shrink-0 rounded border border-[var(--color-status-warning)]/30 px-2 py-0.5 text-[10px] transition-colors hover:bg-[var(--color-status-warning)]/10"
+          className="shrink-0 rounded border border-[var(--color-status-warning)]/30 px-2 py-0.5 text-3xs transition-colors hover:bg-[var(--color-status-warning)]/10"
         >
           Retry
         </button>
@@ -161,7 +161,7 @@ export function SafeModeBanner() {
             </p>
             <ul
               role="list"
-              className="-mx-1 max-h-64 overflow-y-auto divide-y divide-daintree-text/10 text-[11px]"
+              className="-mx-1 max-h-64 overflow-y-auto divide-y divide-daintree-text/10 text-2xs"
             >
               {quarantined.map((panel) => (
                 <QuarantinedPanelRow key={panel.id} panel={panel} />

--- a/src/components/Settings/AgentScopeEditor/EnvBlock.tsx
+++ b/src/components/Settings/AgentScopeEditor/EnvBlock.tsx
@@ -16,11 +16,11 @@ interface EnvBlockProps {
 function EnvVarReference({ suggestions }: { suggestions: EnvSuggestion[] }) {
   return (
     <div className="space-y-0.5 pt-1">
-      <p className="text-[11px] text-text-secondary pb-0.5">Available env overrides:</p>
+      <p className="text-2xs text-text-secondary pb-0.5">Available env overrides:</p>
       {suggestions.map(({ key, hint }) => (
         <div key={key} className="flex items-baseline gap-2 font-mono">
-          <span className="text-[11px] text-daintree-text/60 shrink-0">{key}</span>
-          <span className="text-[10px] text-daintree-text/30">{hint}</span>
+          <span className="text-2xs text-daintree-text/60 shrink-0">{key}</span>
+          <span className="text-3xs text-daintree-text/30">{hint}</span>
         </div>
       ))}
     </div>
@@ -61,7 +61,7 @@ export function EnvBlock({
   return (
     <>
       <div className="space-y-1.5">
-        <span className="text-[11px] text-daintree-text/50 font-medium uppercase tracking-wide block">
+        <span className="text-2xs text-daintree-text/50 font-medium uppercase tracking-wide block">
           Env overrides
         </span>
         <EnvVarEditor

--- a/src/components/Settings/AgentScopeEditor/FallbackChainEditor.tsx
+++ b/src/components/Settings/AgentScopeEditor/FallbackChainEditor.tsx
@@ -54,9 +54,7 @@ export function FallbackChainEditor({
                 key={id}
                 className="flex items-center gap-2 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30 px-2 py-1.5"
               >
-                <span className="text-[10px] text-text-secondary font-mono shrink-0">
-                  {idx + 1}.
-                </span>
+                <span className="text-3xs text-text-secondary font-mono shrink-0">{idx + 1}.</span>
                 <span
                   className={
                     missing
@@ -99,14 +97,12 @@ export function FallbackChainEditor({
         </select>
       )}
       {chain.length >= FALLBACK_CHAIN_MAX && (
-        <p className="text-[11px] text-text-secondary">
+        <p className="text-2xs text-text-secondary">
           Maximum of {FALLBACK_CHAIN_MAX} fallbacks reached.
         </p>
       )}
       {chain.length < FALLBACK_CHAIN_MAX && candidates.length === 0 && (
-        <p className="text-[11px] text-text-secondary">
-          No other presets available for this agent.
-        </p>
+        <p className="text-2xs text-text-secondary">No other presets available for this agent.</p>
       )}
     </div>
   );

--- a/src/components/Settings/AgentScopeEditor/ReadOnlyDetail.tsx
+++ b/src/components/Settings/AgentScopeEditor/ReadOnlyDetail.tsx
@@ -29,7 +29,7 @@ export function ReadOnlyDetail({ scopeKind, selectedPreset, onDuplicate }: ReadO
         {selectedPreset.env && Object.keys(selectedPreset.env).length > 0 && (
           <div className="space-y-1">
             {Object.entries(selectedPreset.env).map(([k, v]) => (
-              <div key={k} className="flex items-center gap-2 font-mono text-[11px]">
+              <div key={k} className="flex items-center gap-2 font-mono text-2xs">
                 <span className="text-daintree-text/50 shrink-0">{k}</span>
                 <span className="text-daintree-text/30">=</span>
                 <span className="text-daintree-text/60 truncate">{v}</span>
@@ -38,12 +38,10 @@ export function ReadOnlyDetail({ scopeKind, selectedPreset, onDuplicate }: ReadO
           </div>
         )}
         {selectedPreset.description && (
-          <p className="text-[11px] text-text-secondary select-text">
-            {selectedPreset.description}
-          </p>
+          <p className="text-2xs text-text-secondary select-text">{selectedPreset.description}</p>
         )}
         {scopeKind === "project" && (
-          <p className="text-[10px] text-text-secondary select-text">
+          <p className="text-3xs text-text-secondary select-text">
             Sourced from <code>.daintree/presets/</code> in this project.
           </p>
         )}

--- a/src/components/Settings/AgentScopeEditor/ScopeBanner.tsx
+++ b/src/components/Settings/AgentScopeEditor/ScopeBanner.tsx
@@ -15,7 +15,7 @@ export function ScopeBanner({ scopeKind, scopeLabel }: ScopeBannerProps) {
       {scopeKind === "ccr" && (
         <span
           data-testid="preset-badge-auto"
-          className="text-[10px] text-text-secondary bg-daintree-text/10 px-1.5 py-0.5 rounded"
+          className="text-3xs text-text-secondary bg-daintree-text/10 px-1.5 py-0.5 rounded"
         >
           auto
         </span>
@@ -23,7 +23,7 @@ export function ScopeBanner({ scopeKind, scopeLabel }: ScopeBannerProps) {
       {scopeKind === "project" && (
         <span
           data-testid="preset-badge-project"
-          className="text-[10px] text-text-secondary bg-daintree-text/10 px-1.5 py-0.5 rounded"
+          className="text-3xs text-text-secondary bg-daintree-text/10 px-1.5 py-0.5 rounded"
         >
           project
         </span>
@@ -31,7 +31,7 @@ export function ScopeBanner({ scopeKind, scopeLabel }: ScopeBannerProps) {
       {scopeKind === "custom" && (
         <span
           data-testid="preset-badge-custom"
-          className="text-[10px] text-status-info bg-status-info/10 px-1.5 py-0.5 rounded"
+          className="text-3xs text-status-info bg-status-info/10 px-1.5 py-0.5 rounded"
         >
           custom
         </span>

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -93,9 +93,7 @@ function PreferredSchemePicker({
 }) {
   return (
     <div className="space-y-1">
-      <p className="text-[10px] font-medium uppercase tracking-wider text-text-secondary">
-        {label}
-      </p>
+      <p className="text-3xs font-medium uppercase tracking-wider text-text-secondary">{label}</p>
       <div className="flex flex-wrap gap-1.5">
         {schemes.map((scheme) => (
           <button
@@ -559,7 +557,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
               {importWarnings.length > 0 && (
                 <ul className="mt-1 space-y-1.5">
                   {groupWarningsByKind(importWarnings).map(({ kind, messages }) => (
-                    <li key={kind} className="text-[11px] text-daintree-text/60">
+                    <li key={kind} className="text-2xs text-daintree-text/60">
                       {WARNING_KIND_COPY[kind] ?? "Some theme values may need attention"}
                       <details className="mt-0.5">
                         <summary className="cursor-pointer text-daintree-text/40 transition-colors hover:text-daintree-text/70">
@@ -610,7 +608,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
               {selectedScheme.name}
             </span>
             {selectedScheme.location && (
-              <span className="text-[11px] text-white/75 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
+              <span className="text-2xs text-white/75 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
                 {selectedScheme.location}
               </span>
             )}

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -23,7 +23,7 @@ function SchemePreview({ scheme }: { scheme: TerminalColorScheme }) {
         backgroundColor: c.background ?? "#000",
         padding: "6px 8px",
         fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-        fontSize: "9px",
+        fontSize: "var(--text-4xs)",
         lineHeight: "1.4",
         whiteSpace: "nowrap",
         WebkitFontSmoothing: "antialiased",
@@ -191,7 +191,7 @@ export function ColorSchemePicker() {
               type="button"
               onClick={() => setTypeFilter("dark")}
               className={cn(
-                "px-2.5 py-0.5 text-[11px] font-medium transition-colors",
+                "px-2.5 py-0.5 text-2xs font-medium transition-colors",
                 typeFilter === "dark"
                   ? "bg-overlay-selected text-daintree-text"
                   : "text-daintree-text/50 hover:text-daintree-text/70"
@@ -203,7 +203,7 @@ export function ColorSchemePicker() {
               type="button"
               onClick={() => setTypeFilter("light")}
               className={cn(
-                "px-2.5 py-0.5 text-[11px] font-medium transition-colors border-l border-daintree-border",
+                "px-2.5 py-0.5 text-2xs font-medium transition-colors border-l border-daintree-border",
                 typeFilter === "light"
                   ? "bg-overlay-selected text-daintree-text"
                   : "text-daintree-text/50 hover:text-daintree-text/70"

--- a/src/components/Settings/ColorVisionPicker.tsx
+++ b/src/components/Settings/ColorVisionPicker.tsx
@@ -65,7 +65,7 @@ function SwatchPreview() {
             style={{ backgroundColor: colors[i] }}
             title={token.label}
           />
-          <span className="text-[9px] text-text-secondary">{token.label}</span>
+          <span className="text-4xs text-text-secondary">{token.label}</span>
         </div>
       ))}
     </div>

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -355,7 +355,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                         {command.id}
                       </span>
                       {hasOverride(command.id) && (
-                        <span className="text-[11px] text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded font-medium">
+                        <span className="text-2xs text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded font-medium">
                           {override?.prompt ? "Custom Prompt" : "Modified"}
                         </span>
                       )}
@@ -471,7 +471,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                                     )}
                                   </label>
                                   {hasDefaultValue && (
-                                    <span className="text-[10px] text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded">
+                                    <span className="text-3xs text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded">
                                       Custom
                                     </span>
                                   )}
@@ -562,7 +562,7 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
                     <button
                       onClick={() => onChange(value + `{${arg.name}}`)}
                       className={cn(
-                        "text-[11px] px-2 py-0.5 rounded font-mono transition-colors",
+                        "text-2xs px-2 py-0.5 rounded font-mono transition-colors",
                         usedVariables.includes(arg.name)
                           ? "bg-overlay-medium text-daintree-text/70 border border-border-strong"
                           : "bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border border border-daintree-border"

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -898,8 +898,8 @@ export function DaintreeAssistantSettingsTab() {
           description={
             <>
               Advanced — whitespace-separated flags appended to the launch command. Use the Model
-              picker above for the model; a <code className="font-mono text-[11px]">--model</code>{" "}
-              flag here overrides it. Applies to new assistant sessions.
+              picker above for the model; a <code className="font-mono text-2xs">--model</code> flag
+              here overrides it. Applies to new assistant sessions.
             </>
           }
           type="text"
@@ -975,14 +975,14 @@ export function DaintreeAssistantSettingsTab() {
       >
         <div className="flex items-start gap-3">
           <div className="flex-1 text-xs text-daintree-text/70 leading-relaxed select-text">
-            Files in <code className="font-mono text-[11px]">~/.daintree/assistant</code> are copied
+            Files in <code className="font-mono text-2xs">~/.daintree/assistant</code> are copied
             into each new assistant session. Claude Code picks up{" "}
-            <code className="font-mono text-[11px]">.claude/commands</code> and{" "}
-            <code className="font-mono text-[11px]">.claude/skills</code>; Codex picks up{" "}
-            <code className="font-mono text-[11px]">.agents/skills</code> and{" "}
-            <code className="font-mono text-[11px]">.codex/skills</code>; Copilot reads both skill
+            <code className="font-mono text-2xs">.claude/commands</code> and{" "}
+            <code className="font-mono text-2xs">.claude/skills</code>; Codex picks up{" "}
+            <code className="font-mono text-2xs">.agents/skills</code> and{" "}
+            <code className="font-mono text-2xs">.codex/skills</code>; Copilot reads both skill
             trees. A per-project variant in{" "}
-            <code className="font-mono text-[11px]">&lt;project&gt;/.daintree/assistant</code> takes
+            <code className="font-mono text-2xs">&lt;project&gt;/.daintree/assistant</code> takes
             precedence and can be committed to git.
           </div>
           <Button
@@ -1337,7 +1337,7 @@ function BlastRadiusPreview({ tier, isOpen, onToggle }: BlastRadiusPreviewProps)
         <div className="px-3 pb-3 pt-1 space-y-2">
           {groups.map(([ns, tools]) => (
             <div key={ns} className="space-y-1">
-              <div className="text-[10px] uppercase tracking-wide text-daintree-text/50 font-mono">
+              <div className="text-3xs uppercase tracking-wide text-daintree-text/50 font-mono">
                 {ns}
                 <span className="ml-1 text-daintree-text/30">({tools.length})</span>
               </div>
@@ -1346,7 +1346,7 @@ function BlastRadiusPreview({ tier, isOpen, onToggle }: BlastRadiusPreviewProps)
                   <span
                     key={tool}
                     className={cn(
-                      "px-1.5 py-0.5 rounded text-[10px] font-mono",
+                      "px-1.5 py-0.5 rounded text-3xs font-mono",
                       "bg-daintree-bg border border-daintree-border text-daintree-text/70"
                     )}
                   >
@@ -1442,7 +1442,7 @@ function NativeGrantsSection({
 
   return (
     <div className="space-y-2 pt-1">
-      <div className="text-[10px] uppercase tracking-wide text-daintree-text/50 font-mono">
+      <div className="text-3xs uppercase tracking-wide text-daintree-text/50 font-mono">
         Automation grants{grants.length > 0 ? ` (${grants.length})` : ""}
       </div>
       {grants.length > 0 ? (
@@ -1452,19 +1452,19 @@ function NativeGrantsSection({
               key={grant.grantId}
               className="rounded-[var(--radius-sm)] border border-daintree-border bg-daintree-bg/40 px-2 py-1.5 space-y-1"
             >
-              <div className="flex items-center justify-between gap-2 text-[11px]">
+              <div className="flex items-center justify-between gap-2 text-2xs">
                 <span className="font-mono text-daintree-text/70 truncate">
                   {(grant.allowedTools ?? []).join(", ") || "no tools"}
                 </span>
                 <button
                   type="button"
                   onClick={() => grant.grantId && revoke(grant.grantId)}
-                  className="shrink-0 text-[10px] text-daintree-text/60 hover:text-status-danger transition-colors"
+                  className="shrink-0 text-3xs text-daintree-text/60 hover:text-status-danger transition-colors"
                 >
                   Revoke
                 </button>
               </div>
-              <div className="flex items-center justify-between gap-2 text-[10px] text-daintree-text/50">
+              <div className="flex items-center justify-between gap-2 text-3xs text-daintree-text/50">
                 <span className="tabular-nums">
                   {grant.remainingUses ?? 0} of {grant.maxUses ?? 0} uses left
                 </span>
@@ -1474,7 +1474,7 @@ function NativeGrantsSection({
           ))}
         </div>
       ) : (
-        <div className="text-[11px] text-daintree-text/50">No automation grants active</div>
+        <div className="text-2xs text-daintree-text/50">No automation grants active</div>
       )}
 
       <div className="flex items-end gap-1.5 pt-0.5">
@@ -1483,7 +1483,7 @@ function NativeGrantsSection({
           value={toolsInput}
           onChange={(e) => setToolsInput(e.target.value)}
           placeholder="git.commit terminal.new"
-          className="flex-1 min-w-0 rounded-[var(--radius-sm)] border border-daintree-border bg-daintree-bg px-2 py-1 text-[11px] font-mono text-daintree-text placeholder:text-daintree-text/30 focus-visible:outline-2 focus-visible:outline-daintree-accent"
+          className="flex-1 min-w-0 rounded-[var(--radius-sm)] border border-daintree-border bg-daintree-bg px-2 py-1 text-2xs font-mono text-daintree-text placeholder:text-daintree-text/30 focus-visible:outline-2 focus-visible:outline-daintree-accent"
         />
         <input
           type="number"
@@ -1492,18 +1492,18 @@ function NativeGrantsSection({
           value={usesInput}
           onChange={(e) => setUsesInput(e.target.value)}
           aria-label="Maximum uses"
-          className="w-12 rounded-[var(--radius-sm)] border border-daintree-border bg-daintree-bg px-1.5 py-1 text-[11px] tabular-nums text-daintree-text focus-visible:outline-2 focus-visible:outline-daintree-accent"
+          className="w-12 rounded-[var(--radius-sm)] border border-daintree-border bg-daintree-bg px-1.5 py-1 text-2xs tabular-nums text-daintree-text focus-visible:outline-2 focus-visible:outline-daintree-accent"
         />
         <button
           type="button"
           onClick={approve}
           disabled={issuing}
-          className="shrink-0 rounded-[var(--radius-sm)] border border-daintree-border bg-overlay-subtle px-2 py-1 text-[11px] text-daintree-text/80 hover:text-daintree-text disabled:opacity-50 transition-colors"
+          className="shrink-0 rounded-[var(--radius-sm)] border border-daintree-border bg-overlay-subtle px-2 py-1 text-2xs text-daintree-text/80 hover:text-daintree-text disabled:opacity-50 transition-colors"
         >
           Approve grant
         </button>
       </div>
-      {issueError && <div className="text-[10px] text-status-danger">{issueError}</div>}
+      {issueError && <div className="text-3xs text-status-danger">{issueError}</div>}
     </div>
   );
 }
@@ -1552,7 +1552,7 @@ function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
           </span>
         </span>
         {connected && (
-          <span className="px-1.5 py-0.5 rounded text-[10px] font-mono bg-daintree-bg border border-daintree-border text-daintree-text/70">
+          <span className="px-1.5 py-0.5 rounded text-3xs font-mono bg-daintree-bg border border-daintree-border text-daintree-text/70">
             {TIER_SHORT_LABEL[tier]}
           </span>
         )}
@@ -1567,14 +1567,14 @@ function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
           </div>
           {perToolGrants.length > 0 ? (
             <div className="space-y-1">
-              <div className="text-[10px] uppercase tracking-wide text-daintree-text/50 font-mono">
+              <div className="text-3xs uppercase tracking-wide text-daintree-text/50 font-mono">
                 Active grants ({perToolGrants.length})
               </div>
               <div className="space-y-1">
                 {perToolGrants.map((grant) => (
                   <div
                     key={grant.toolId}
-                    className="flex items-center justify-between gap-2 text-[11px]"
+                    className="flex items-center justify-between gap-2 text-2xs"
                   >
                     <span className="font-mono text-daintree-text/70 truncate">{grant.toolId}</span>
                     <GrantCountdown expiresAt={grant.expiresAt} />
@@ -1583,7 +1583,7 @@ function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
               </div>
             </div>
           ) : (
-            <div className="text-[11px] text-daintree-text/50">No per-tool grants active</div>
+            <div className="text-2xs text-daintree-text/50">No per-tool grants active</div>
           )}
           {sessionId && <NativeGrantsSection helpSessionId={sessionId} grants={nativeGrants} />}
         </>

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -358,7 +358,7 @@ export function DiagnosticsReviewDialog({
             {showPreview ? "Hide Preview" : "Show Preview"}
           </Button>
           {showPreview && (
-            <pre className="text-[10px] leading-relaxed font-mono bg-daintree-bg border border-daintree-border rounded p-3 max-h-64 overflow-auto text-daintree-text/80 whitespace-pre-wrap break-all">
+            <pre className="text-3xs leading-relaxed font-mono bg-daintree-bg border border-daintree-border rounded p-3 max-h-64 overflow-auto text-daintree-text/80 whitespace-pre-wrap break-all">
               {previewJson}
             </pre>
           )}

--- a/src/components/Settings/EnvVarEditor.tsx
+++ b/src/components/Settings/EnvVarEditor.tsx
@@ -248,7 +248,7 @@ function EnvVarKeyCell({
             }}
             type="text"
             className={cn(
-              "w-full h-full bg-transparent border-0 outline-hidden py-2 font-mono text-[12px]",
+              "w-full h-full bg-transparent border-0 outline-hidden py-2 font-mono text-xs leading-[inherit]",
               "focus:ring-2 focus:ring-inset focus:ring-daintree-accent/40",
               "disabled:cursor-default",
               showChevron ? "pl-2.5 pr-8" : "px-2.5",
@@ -361,7 +361,7 @@ function EnvVarKeyCell({
               >
                 <span className="font-mono text-xs text-daintree-text/80 shrink-0">{s.key}</span>
                 {s.hint && (
-                  <span className="text-[11px] text-daintree-text/50 leading-snug">{s.hint}</span>
+                  <span className="text-2xs text-daintree-text/50 leading-snug">{s.hint}</span>
                 )}
               </div>
             ))}
@@ -371,7 +371,7 @@ function EnvVarKeyCell({
       {(isEmptyKey || isDuplicate) && (
         <p
           className={cn(
-            "absolute left-2.5 bottom-0.5 text-[9px] leading-none pointer-events-none",
+            "absolute left-2.5 bottom-0.5 text-4xs leading-none pointer-events-none",
             isEmptyKey ? "text-status-error" : "text-status-warning"
           )}
           data-testid={isEmptyKey ? "env-editor-error-empty" : "env-editor-error-duplicate"}
@@ -694,7 +694,7 @@ export function EnvVarEditor({
       data-testid={dataTestId}
     >
       {/* Header */}
-      <div className="grid grid-cols-[2fr_3fr_auto] text-[10px] uppercase tracking-wide text-daintree-text/50 bg-daintree-bg/40 border-b border-daintree-border">
+      <div className="grid grid-cols-[2fr_3fr_auto] text-3xs uppercase tracking-wide text-daintree-text/50 bg-daintree-bg/40 border-b border-daintree-border">
         <div className="px-2.5 py-1.5">Key</div>
         <div className="px-2.5 py-1.5 border-l border-daintree-border/60">Value</div>
         <div className="px-2.5 py-1.5 w-9" aria-hidden="true" />
@@ -705,7 +705,7 @@ export function EnvVarEditor({
           <button
             type="button"
             onClick={handleAdd}
-            className="w-full flex items-center justify-center gap-1.5 py-4 text-[12px] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors border border-dashed border-daintree-border/60 rounded-[var(--radius-sm)]"
+            className="w-full flex items-center justify-center gap-1.5 py-4 text-xs leading-[inherit] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors border border-dashed border-daintree-border/60 rounded-[var(--radius-sm)]"
             data-testid="env-editor-add"
           >
             <Plus size={12} aria-hidden="true" />
@@ -714,7 +714,7 @@ export function EnvVarEditor({
           <button
             type="button"
             onClick={() => setIsImportOpen(true)}
-            className="w-full flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors rounded-[var(--radius-sm)]"
+            className="w-full flex items-center justify-center gap-1.5 py-2 text-2xs text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors rounded-[var(--radius-sm)]"
             data-testid="env-editor-import"
           >
             <Upload size={12} aria-hidden="true" />
@@ -782,7 +782,7 @@ export function EnvVarEditor({
                   <input
                     type={valueInputType}
                     className={cn(
-                      "w-full h-full bg-transparent border-0 outline-hidden py-2 font-mono text-[12px]",
+                      "w-full h-full bg-transparent border-0 outline-hidden py-2 font-mono text-xs leading-[inherit]",
                       "focus:ring-2 focus:ring-inset focus:ring-daintree-accent/40",
                       "disabled:cursor-default",
                       isSecret ? "pl-2.5 pr-8" : "px-2.5",
@@ -840,7 +840,7 @@ export function EnvVarEditor({
                   )}
                   {hasSecretWarning && (
                     <p
-                      className="absolute left-2.5 bottom-0.5 text-[9px] leading-none text-status-warning pointer-events-none"
+                      className="absolute left-2.5 bottom-0.5 text-4xs leading-none text-status-warning pointer-events-none"
                       data-testid="env-editor-warning-secret"
                       title="Looks like a secret. Prefer a ${ENV_VAR} reference to your shell environment."
                     >
@@ -849,7 +849,7 @@ export function EnvVarEditor({
                   )}
                   {!hasSecretWarning && normalizedRows.has(row.rowId) && (
                     <p
-                      className="absolute left-2.5 bottom-0.5 text-[9px] leading-none text-status-info pointer-events-none"
+                      className="absolute left-2.5 bottom-0.5 text-4xs leading-none text-status-info pointer-events-none"
                       data-testid="env-editor-normalized"
                     >
                       Pasted text normalized
@@ -903,7 +903,7 @@ export function EnvVarEditor({
           <button
             type="button"
             onClick={handleAdd}
-            className="flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors"
+            className="flex items-center justify-center gap-1.5 py-2 text-2xs text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors"
             data-testid="env-editor-add"
           >
             <Plus size={12} aria-hidden="true" />
@@ -912,7 +912,7 @@ export function EnvVarEditor({
           <button
             type="button"
             onClick={() => setIsImportOpen(true)}
-            className="flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors"
+            className="flex items-center justify-center gap-1.5 py-2 text-2xs text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors"
             data-testid="env-editor-import"
           >
             <Upload size={12} aria-hidden="true" />

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -322,7 +322,7 @@ export function EnvironmentSettingsTab() {
                     </button>
                   </div>
                   {error && (
-                    <p id={errorId} className="text-[11px] text-status-error mt-1 ml-1">
+                    <p id={errorId} className="text-2xs text-status-error mt-1 ml-1">
                       {error}
                     </p>
                   )}

--- a/src/components/Settings/ForgeAuditLogViewer.tsx
+++ b/src/components/Settings/ForgeAuditLogViewer.tsx
@@ -312,7 +312,7 @@ export function ForgeAuditLogViewer({
                       {record.methodName}
                     </span>
                     {(record.repoOwner || record.repoName) && (
-                      <span className="font-mono text-[10px] text-daintree-text/50 truncate">
+                      <span className="font-mono text-3xs text-daintree-text/50 truncate">
                         {record.repoOwner ? `${record.repoOwner}/` : ""}
                         {record.repoName ?? ""}
                       </span>
@@ -327,7 +327,7 @@ export function ForgeAuditLogViewer({
                     </div>
                   )}
                   {record.errorMessage && (
-                    <div className="mt-0.5 text-[10px] text-status-danger/80 truncate">
+                    <div className="mt-0.5 text-3xs text-status-danger/80 truncate">
                       {record.errorMessage}
                     </div>
                   )}

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -430,7 +430,7 @@ function ProjectRoutingPanel({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span
-                        className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium border border-daintree-border/60 text-daintree-text/70 cursor-default"
+                        className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-3xs font-medium border border-daintree-border/60 text-daintree-text/70 cursor-default"
                         tabIndex={0}
                       >
                         Active
@@ -465,7 +465,7 @@ function RoutingBadge({ resolved }: { resolved: ResolvedForgeProvider }) {
       <Tooltip>
         <TooltipTrigger asChild>
           <span
-            className="inline-flex items-center px-2 py-0.5 rounded-sm text-[10px] font-medium border border-daintree-border/60 text-daintree-text/50 cursor-default"
+            className="inline-flex items-center px-2 py-0.5 rounded-sm text-3xs font-medium border border-daintree-border/60 text-daintree-text/50 cursor-default"
             tabIndex={0}
           >
             No match
@@ -484,7 +484,7 @@ function RoutingBadge({ resolved }: { resolved: ResolvedForgeProvider }) {
     <Tooltip>
       <TooltipTrigger asChild>
         <span
-          className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-sm text-[10px] font-medium border border-daintree-border/60 bg-status-info/10 text-daintree-text/80 cursor-default"
+          className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-sm text-3xs font-medium border border-daintree-border/60 bg-status-info/10 text-daintree-text/80 cursor-default"
           tabIndex={0}
         >
           <span>{providerName}</span>

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -712,7 +712,7 @@ export function GeneralTab({
                 {buildChannelLabel && (
                   <span
                     data-testid="about-build-channel"
-                    className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-status-info/15 text-status-info leading-none"
+                    className="text-3xs font-medium px-1.5 py-0.5 rounded-full bg-status-info/15 text-status-info leading-none"
                   >
                     {buildChannelLabel}
                   </span>

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -47,9 +47,9 @@ const OUTCOME_LABEL: Record<ConflictResolution, string> = {
 const PREVIEW_FRAME = "rounded border border-tint/[0.08] bg-tint/[0.04] text-xs";
 const PREVIEW_STRIP =
   "px-3 py-2 border-b border-tint/[0.08] flex items-center justify-between gap-2";
-const PREVIEW_CAPTION = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
+const PREVIEW_CAPTION = "text-2xs font-semibold uppercase tracking-wider text-daintree-text/60";
 const PREVIEW_COUNT =
-  "ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal";
+  "ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal";
 
 function collapsePairs(result: ParseEnvResult): Record<string, string> {
   const out: Record<string, string> = {};
@@ -98,7 +98,7 @@ function ConflictSide({ label, value, kept }: { label: string; value: string; ke
   const isEmpty = value === "";
   return (
     <>
-      <dt className="text-[10px] uppercase tracking-wide text-text-secondary">{label}</dt>
+      <dt className="text-3xs uppercase tracking-wide text-text-secondary">{label}</dt>
       <dd
         className={cn(
           // BOTH sides read at the audited 4.5:1 tier. The losing value is
@@ -106,7 +106,7 @@ function ConflictSide({ label, value, kept }: { label: string; value: string; ke
           // being protected the hardest thing in the row to read. The surviving
           // side is marked by weight instead, which costs no contrast and
           // survives forced-colors, where a colour difference would not.
-          "font-mono text-[11px] break-all text-daintree-text",
+          "font-mono text-2xs break-all text-daintree-text",
           kept ? "font-medium" : "font-normal",
           isEmpty && "italic"
         )}
@@ -258,8 +258,8 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
           <AppDialog.Description>
             {step === "paste" ? (
               <>
-                Keys must match <code className="text-[11px]">[A-Za-z_][A-Za-z0-9_]*</code>. Quoted
-                values, comments, and <code className="text-[11px]">export</code> prefixes are
+                Keys must match <code className="text-2xs">[A-Za-z_][A-Za-z0-9_]*</code>. Quoted
+                values, comments, and <code className="text-2xs">export</code> prefixes are
                 supported.
               </>
             ) : (
@@ -286,7 +286,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
               // for `focus-visible:outline-*` for keyboard focus, and the ring
               // this replaced measured ~2.2:1 — under the 3:1 floor for a
               // non-text indicator, on the step's primary input.
-              className="w-full h-56 resize-y font-mono text-[12px] bg-surface-input border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-daintree-text placeholder:text-text-placeholder transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              className="w-full h-56 resize-y font-mono text-xs leading-[inherit] bg-surface-input border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-daintree-text placeholder:text-text-placeholder transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
               aria-label="Paste .env content"
               aria-invalid={hasErrors || undefined}
               aria-describedby={hasErrors ? errorsId : undefined}
@@ -296,7 +296,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
               <div
                 id={errorsId}
                 role="alert"
-                className="rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/10 px-3 py-2 text-[12px]"
+                className="rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/10 px-3 py-2 text-xs leading-[inherit]"
                 data-testid="import-env-errors"
               >
                 <div className="flex items-center gap-1.5 font-medium mb-1 text-status-warning">
@@ -311,7 +311,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                     so they run on the audited text tiers — the amber tri-tone
                     this replaced flattened to one uniform run under
                     `forced-colors: active` anyway. */}
-                <ul className="space-y-0.5 font-mono text-[11px]">
+                <ul className="space-y-0.5 font-mono text-2xs">
                   {parsed.errors.map((e) => (
                     <li key={`${e.line}-${e.raw}`}>
                       <span className="text-text-secondary">Line {e.line}:</span>{" "}
@@ -335,7 +335,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                 meant a paste that had both a bad line and a duplicated key
                 reported the bad line and silently dropped the duplicate. */}
             {incomingCount > 0 && (
-              <p className="text-[11px] text-text-secondary" data-testid="import-env-summary">
+              <p className="text-2xs text-text-secondary" data-testid="import-env-summary">
                 {incomingCount} variable{incomingCount === 1 ? "" : "s"} detected
                 {conflicts.length > 0
                   ? ` · ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"}`
@@ -389,7 +389,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                   Conflicts
                   <span className={PREVIEW_COUNT}>{conflicts.length}</span>
                 </span>
-                <span className="text-[11px] text-text-secondary">
+                <span className="text-2xs text-text-secondary">
                   {OUTCOME_LABEL[conflictResolution]}
                 </span>
               </div>
@@ -410,7 +410,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                 <ul className="divide-y divide-tint/[0.06]">
                   {conflicts.map((c) => (
                     <li key={c.key} className="px-3 py-2">
-                      <div className="font-mono text-[11px] text-daintree-text">{c.key}</div>
+                      <div className="font-mono text-2xs text-daintree-text">{c.key}</div>
                       <dl className="mt-0.5 grid grid-cols-[max-content_1fr] items-baseline gap-x-3 gap-y-0.5">
                         <ConflictSide
                           label="Existing"

--- a/src/components/Settings/McpAuditLatencyTable.tsx
+++ b/src/components/Settings/McpAuditLatencyTable.tsx
@@ -99,13 +99,13 @@ export function McpAuditLatencyTable({ records, includeRecord }: McpAuditLatency
     const band = sloBand(block.p95);
     return (
       <tr className="text-daintree-text/70">
-        <td className="py-1 pl-6 pr-2 text-[10px] text-daintree-text/50 truncate">{blockLabel}</td>
+        <td className="py-1 pl-6 pr-2 text-3xs text-daintree-text/50 truncate">{blockLabel}</td>
         <td className="py-1 px-2 text-right text-daintree-text/50 tabular-nums">{block.count}</td>
         <td className="py-1 px-2 text-right tabular-nums">{block.p50}ms</td>
         <td className="py-1 pl-2 text-right tabular-nums">
           {block.p95}ms
           {band.label && (
-            <span className={cn("ml-1.5 text-[10px]", band.className)}>{band.label}</span>
+            <span className={cn("ml-1.5 text-3xs", band.className)}>{band.label}</span>
           )}
         </td>
       </tr>

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -254,28 +254,28 @@ function GrantRow({
           <span className="font-mono text-daintree-text/60 truncate">{record.toolId}</span>
         </div>
         {record.type === "tier.elevated" && record.tier && record.previousTier && (
-          <div className="mt-0.5 text-[10px] text-daintree-text/50">
+          <div className="mt-0.5 text-3xs text-daintree-text/50">
             {record.previousTier} → {record.tier}
           </div>
         )}
         {record.type === "tier.decayed" && record.tier && record.previousTier && (
-          <div className="mt-0.5 text-[10px] text-daintree-text/50">
+          <div className="mt-0.5 text-3xs text-daintree-text/50">
             {record.previousTier} → {record.tier}
           </div>
         )}
         {record.type === "grant.revoked" && record.revokedReason && (
-          <div className="mt-0.5 text-[10px] text-daintree-text/50">
+          <div className="mt-0.5 text-3xs text-daintree-text/50">
             Reason: {record.revokedReason}
           </div>
         )}
         {record.maxUses !== undefined &&
           (record.type === "grant.used" || record.type === "grant.exhausted") && (
-            <div className="mt-0.5 text-[10px] text-daintree-text/50">
+            <div className="mt-0.5 text-3xs text-daintree-text/50">
               {record.remainingUses ?? 0} of {record.maxUses} uses left
             </div>
           )}
         {record.expiresAt !== undefined && record.type === "grant.issued" && (
-          <div className="mt-0.5 text-[10px] text-daintree-text/50">
+          <div className="mt-0.5 text-3xs text-daintree-text/50">
             Expires{" "}
             {new Date(record.expiresAt).toLocaleTimeString([], {
               hour: "2-digit",
@@ -576,7 +576,7 @@ export function McpAuditLogViewer({
                               {record.toolId}
                             </span>
                             {record.errorCode && (
-                              <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                              <span className="text-3xs uppercase tracking-wide text-status-danger/80">
                                 {record.errorCode}
                               </span>
                             )}
@@ -585,12 +585,12 @@ export function McpAuditLogViewer({
                             {record.argsSummary || "{}"}
                           </div>
                           {record.result === "unauthorized" && record.tierHint && (
-                            <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                            <div className="mt-0.5 text-3xs text-daintree-text/50">
                               Raise capability tier to {TIER_HINT_LABEL[record.tierHint]} to allow.
                             </div>
                           )}
                           {record.result === "unauthorized" && record.tierHint === null && (
-                            <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                            <div className="mt-0.5 text-3xs text-daintree-text/50">
                               Tool isn't permitted at any tier.
                             </div>
                           )}
@@ -637,7 +637,7 @@ export function McpAuditLogViewer({
                               {record.toolId}
                             </span>
                             {record.errorCode && (
-                              <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                              <span className="text-3xs uppercase tracking-wide text-status-danger/80">
                                 {record.errorCode}
                               </span>
                             )}
@@ -700,7 +700,7 @@ export function McpAuditLogViewer({
                         {record.toolId}
                       </span>
                       {record.errorCode && (
-                        <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                        <span className="text-3xs uppercase tracking-wide text-status-danger/80">
                           {record.errorCode}
                         </span>
                       )}
@@ -709,12 +709,12 @@ export function McpAuditLogViewer({
                       {record.argsSummary || "{}"}
                     </div>
                     {record.result === "unauthorized" && record.tierHint && (
-                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                      <div className="mt-0.5 text-3xs text-daintree-text/50">
                         Raise capability tier to {TIER_HINT_LABEL[record.tierHint]} to allow.
                       </div>
                     )}
                     {record.result === "unauthorized" && record.tierHint === null && (
-                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                      <div className="mt-0.5 text-3xs text-daintree-text/50">
                         Tool isn't permitted at any tier.
                       </div>
                     )}
@@ -740,22 +740,22 @@ export function McpAuditLogViewer({
                       </span>
                     </div>
                     {record.type === "tier.elevated" && record.tier && record.previousTier && (
-                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                      <div className="mt-0.5 text-3xs text-daintree-text/50">
                         {record.previousTier} → {record.tier}
                       </div>
                     )}
                     {record.type === "tier.decayed" && record.tier && record.previousTier && (
-                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                      <div className="mt-0.5 text-3xs text-daintree-text/50">
                         {record.previousTier} → {record.tier}
                       </div>
                     )}
                     {record.type === "grant.revoked" && record.revokedReason && (
-                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                      <div className="mt-0.5 text-3xs text-daintree-text/50">
                         Reason: {record.revokedReason}
                       </div>
                     )}
                     {record.expiresAt !== undefined && record.type === "grant.issued" && (
-                      <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                      <div className="mt-0.5 text-3xs text-daintree-text/50">
                         Expires{" "}
                         {new Date(record.expiresAt).toLocaleTimeString([], {
                           hour: "2-digit",

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -752,7 +752,7 @@ export function McpServerSettingsTab() {
                               <div className="truncate text-xs text-daintree-text/80">
                                 {bearer.userAgent}
                               </div>
-                              <div className="text-[11px] text-daintree-text/50">
+                              <div className="text-2xs text-daintree-text/50">
                                 <span className="font-mono">…{bearer.token4LastChars}</span>
                                 {" · "}
                                 {bearer.requestsSinceLaunch}{" "}
@@ -808,7 +808,7 @@ export function McpServerSettingsTab() {
                               <div className="truncate text-xs text-daintree-text/80">
                                 {bearer.userAgent}
                               </div>
-                              <div className="text-[11px] text-daintree-text/50">
+                              <div className="text-2xs text-daintree-text/50">
                                 {bearer.sessionCount}{" "}
                                 {bearer.sessionCount === 1 ? "session" : "sessions"}
                                 {" · "}
@@ -1056,7 +1056,7 @@ export function McpServerSettingsTab() {
               <span className="text-xs text-daintree-text/80 truncate">
                 {client.userAgent ?? "Unknown client"}
               </span>
-              <span className="text-[11px] text-daintree-text/50 shrink-0">
+              <span className="text-2xs text-daintree-text/50 shrink-0">
                 connected {formatRelativeTime(client.connectedAtMs)}
               </span>
             </li>

--- a/src/components/Settings/OverrideField.tsx
+++ b/src/components/Settings/OverrideField.tsx
@@ -60,7 +60,7 @@ export function OverrideField({
             aria-label="Reset to global"
             onClick={onReset}
             className={cn(
-              "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm text-[11px] text-text-muted hover:text-daintree-text hover:bg-overlay-subtle",
+              "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm text-2xs text-text-muted hover:text-daintree-text hover:bg-overlay-subtle",
               "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
               "transition-colors"

--- a/src/components/Settings/PluginActionAuditLogViewer.tsx
+++ b/src/components/Settings/PluginActionAuditLogViewer.tsx
@@ -262,11 +262,11 @@ export function PluginActionAuditLogViewer({
                       {record.actionId}
                     </span>
                     {record.source ? (
-                      <span className="text-[10px] uppercase tracking-wide text-daintree-text/50">
+                      <span className="text-3xs uppercase tracking-wide text-daintree-text/50">
                         {record.source}
                       </span>
                     ) : record.recordType && RECORD_TYPE_LABEL[record.recordType] ? (
-                      <span className="text-[10px] uppercase tracking-wide text-daintree-text/50">
+                      <span className="text-3xs uppercase tracking-wide text-daintree-text/50">
                         {RECORD_TYPE_LABEL[record.recordType]}
                       </span>
                     ) : null}

--- a/src/components/Settings/PluginSettingsForm.tsx
+++ b/src/components/Settings/PluginSettingsForm.tsx
@@ -458,7 +458,7 @@ function SettingField({
           {fieldLabel(def)}
         </label>
         <div className="flex items-center gap-1.5 shrink-0">
-          <span className="text-[10px] uppercase tracking-wide text-text-secondary">
+          <span className="text-3xs uppercase tracking-wide text-text-secondary">
             {SCOPE_BADGE_LABEL[scope]}
           </span>
           {canReset && (
@@ -480,7 +480,7 @@ function SettingField({
       {type === "boolean" ? (
         <div className="flex items-center justify-between gap-3">
           {def.description ? (
-            <p id={`${fieldId}-desc`} className="text-[11px] text-daintree-text/50">
+            <p id={`${fieldId}-desc`} className="text-2xs text-daintree-text/50">
               {def.description}
             </p>
           ) : (
@@ -492,7 +492,7 @@ function SettingField({
         <>
           {renderControl()}
           {isSecret && scopeReady && (
-            <p className="text-[11px] text-daintree-text/50">
+            <p className="text-2xs text-daintree-text/50">
               {secretTier === "plaintext"
                 ? "Stored as plaintext — keychain unavailable"
                 : hasStored && secretIsPlaintext && !migratedToKeychain
@@ -501,7 +501,7 @@ function SettingField({
             </p>
           )}
           {def.description && (
-            <p id={`${fieldId}-desc`} className="text-[11px] text-daintree-text/50">
+            <p id={`${fieldId}-desc`} className="text-2xs text-daintree-text/50">
               {def.description}
             </p>
           )}
@@ -509,15 +509,15 @@ function SettingField({
       )}
 
       {!scopeReady && (
-        <p className="text-[11px] text-text-secondary">Open a project to edit this setting.</p>
+        <p className="text-2xs text-text-secondary">Open a project to edit this setting.</p>
       )}
       {pathMissing && !error && (
-        <p className="text-[11px] text-status-warning">
+        <p className="text-2xs text-status-warning">
           This {type === "file" ? "file" : "folder"} no longer exists — pick a new one.
         </p>
       )}
       {error && (
-        <p id={`${fieldId}-error`} className="text-[11px] text-status-danger">
+        <p id={`${fieldId}-error`} className="text-2xs text-status-danger">
           {error}
         </p>
       )}

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -258,7 +258,7 @@ export function PortalSettingsTab() {
             {!allowDelete && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="text-[11px] font-mono text-daintree-text/50 truncate min-w-0">
+                  <span className="text-2xs font-mono text-daintree-text/50 truncate min-w-0">
                     {link.url}
                   </span>
                 </TooltipTrigger>

--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -165,14 +165,14 @@ export function PresetColorPicker({
             color={draftColor}
             onChange={setDraftColor}
             prefixed
-            className="w-20 rounded border border-daintree-border/60 bg-daintree-bg px-1.5 py-0.5 text-[11px] font-mono uppercase text-daintree-text focus:outline-hidden focus:border-daintree-accent/40"
+            className="w-20 rounded border border-daintree-border/60 bg-daintree-bg px-1.5 py-0.5 text-2xs font-mono uppercase text-daintree-text focus:outline-hidden focus:border-daintree-accent/40"
             aria-label="Hex color"
             data-testid="preset-color-hex-input"
           />
           <div className="flex-1" />
           <button
             type="button"
-            className="flex items-center gap-1 text-[11px] text-daintree-text/60 hover:text-daintree-text transition-colors"
+            className="flex items-center gap-1 text-2xs text-daintree-text/60 hover:text-daintree-text transition-colors"
             onClick={handleClear}
             data-testid="preset-color-clear"
           >
@@ -181,7 +181,7 @@ export function PresetColorPicker({
           </button>
           <button
             type="button"
-            className="text-[11px] font-medium text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="text-2xs font-medium text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={handleDone}
             disabled={!isValidHex(draftColor)}
             data-testid="preset-color-done"

--- a/src/components/Settings/PresetSelector.tsx
+++ b/src/components/Settings/PresetSelector.tsx
@@ -114,7 +114,7 @@ export function PresetSelector({
           <span className="flex-1 text-left truncate">{selectedItem.label}</span>
           {selectedItem.source === "ccr" && (
             <span
-              className="text-[9px] uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
+              className="text-4xs uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
               aria-hidden="true"
             >
               CCR
@@ -122,7 +122,7 @@ export function PresetSelector({
           )}
           {selectedItem.source === "project" && (
             <span
-              className="text-[9px] uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
+              className="text-4xs uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
               aria-hidden="true"
             >
               Project
@@ -212,7 +212,7 @@ export function PresetSelector({
 function Divider({ label }: { label: string }) {
   return (
     <div
-      className="px-2 pt-1.5 pb-0.5 text-[10px] font-medium uppercase tracking-wide text-text-secondary"
+      className="px-2 pt-1.5 pb-0.5 text-3xs font-medium uppercase tracking-wide text-text-secondary"
       data-testid={`preset-group-${label.toLowerCase().replace(/\s+/g, "-")}`}
     >
       {label}
@@ -265,7 +265,7 @@ function PresetOption({
       <span className="flex-1 truncate">{label}</span>
       {badge && (
         <span
-          className="text-[9px] uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded"
+          className="text-4xs uppercase tracking-wide text-text-secondary bg-daintree-text/5 px-1 py-0.5 rounded"
           aria-hidden="true"
         >
           {badge}

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -447,7 +447,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                         {entry.events.map((name) => (
                           <li
                             key={name}
-                            className="font-mono text-[11px] text-daintree-text/70 bg-daintree-bg px-1.5 py-0.5 rounded border border-daintree-border/60"
+                            className="font-mono text-2xs text-daintree-text/70 bg-daintree-bg px-1.5 py-0.5 rounded border border-daintree-border/60"
                           >
                             {name}
                           </li>

--- a/src/components/Settings/RunHistorySettingsTab.tsx
+++ b/src/components/Settings/RunHistorySettingsTab.tsx
@@ -14,7 +14,7 @@ function CountPill({ tone, label }: { tone: "success" | "danger" | "muted"; labe
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium",
+        "inline-flex items-center rounded px-1.5 py-0.5 text-2xs font-medium",
         tone === "success" && "bg-status-success/15 text-status-success",
         tone === "danger" && "bg-status-error/15 text-status-error",
         tone === "muted" && "bg-overlay-subtle text-daintree-text/70"

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1377,7 +1377,7 @@ function MatchBadge({ count }: { count: number }) {
   return (
     <span
       aria-hidden="true"
-      className="ml-auto text-[10px] font-medium tabular-nums px-1.5 py-0.5 rounded-full bg-tint/10 text-daintree-text/60 leading-none"
+      className="ml-auto text-3xs font-medium tabular-nums px-1.5 py-0.5 rounded-full bg-tint/10 text-daintree-text/60 leading-none"
     >
       {count}
     </span>
@@ -1451,7 +1451,7 @@ export function ScopeChip({
     <span
       className={cn(
         "inline-flex items-center gap-1 max-w-[14rem] min-w-0 shrink-0",
-        "text-[10px] font-medium leading-none px-1.5 py-0.5 rounded-full",
+        "text-3xs font-medium leading-none px-1.5 py-0.5 rounded-full",
         // Neutral by construction: this sits next to N other results and the dialog's
         // one accent is already spent on the nav's active marker.
         crossScope ? "bg-tint/20 text-daintree-text/80" : "bg-tint/10 text-daintree-text/60"
@@ -1531,7 +1531,7 @@ function SearchResults({
           <span className="tabular-nums">{results.length}</span> result
           {results.length === 1 ? "" : "s"}
         </p>
-        <p className="text-[10px] text-daintree-text/30">
+        <p className="text-3xs text-daintree-text/30">
           <kbd className="settings-kbd px-1 py-0.5 rounded border font-mono">↑↓</kbd> navigate{" "}
           <kbd className="settings-kbd px-1 py-0.5 rounded border font-mono">↵</kbd> go
         </p>
@@ -1562,19 +1562,19 @@ function SearchResults({
                   projectLabel={projectLabel}
                   crossScope={result.scope !== activeScope}
                 />
-                <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide">
+                <span className="text-3xs font-medium text-text-secondary uppercase tracking-wide">
                   {result.tabLabel}
                 </span>
                 {result.subtabLabel && (
                   <>
-                    <span className="text-[10px] text-daintree-text/30">›</span>
-                    <span className="text-[10px] text-daintree-text/50">{result.subtabLabel}</span>
+                    <span className="text-3xs text-daintree-text/30">›</span>
+                    <span className="text-3xs text-daintree-text/50">{result.subtabLabel}</span>
                   </>
                 )}
-                <span className="text-[10px] text-daintree-text/30">›</span>
-                <span className="text-[10px] text-daintree-text/50">{result.section}</span>
+                <span className="text-3xs text-daintree-text/30">›</span>
+                <span className="text-3xs text-daintree-text/50">{result.section}</span>
                 {result.requiresEnabled && (
-                  <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-status-warning/10 px-1.5 py-0.5 text-[10px] font-medium text-status-warning shrink-0">
+                  <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-status-warning/10 px-1.5 py-0.5 text-3xs font-medium text-status-warning shrink-0">
                     <AlertTriangle className="w-3 h-3" />
                     Requires {midSentenceLabel(result.requiresEnabled.label)}
                   </span>

--- a/src/components/Settings/SettingsSection.tsx
+++ b/src/components/Settings/SettingsSection.tsx
@@ -40,7 +40,7 @@ export function SettingsSection({
           <Icon className={cn("w-4 h-4", iconColor)} aria-hidden="true" />
           {title}
           {badge && (
-            <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-text-secondary/10 border border-daintree-border/50 text-text-secondary uppercase tracking-wide">
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-3xs font-medium bg-text-secondary/10 border border-daintree-border/50 text-text-secondary uppercase tracking-wide">
               {badge}
             </span>
           )}

--- a/src/components/Settings/SettingsSelect.tsx
+++ b/src/components/Settings/SettingsSelect.tsx
@@ -63,7 +63,7 @@ export function SettingsSelect({
     undefined;
 
   const scopeBadge = scope ? (
-    <span className="text-[10px] px-1.5 py-0.5 rounded-sm font-medium bg-text-secondary/10 text-text-secondary dark:bg-text-secondary/20">
+    <span className="text-3xs px-1.5 py-0.5 rounded-sm font-medium bg-text-secondary/10 text-text-secondary dark:bg-text-secondary/20">
       {scope === "project" ? "Project" : scope === "global" ? "Global" : "Default"}
     </span>
   ) : null;

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -59,7 +59,7 @@ export function SettingsSwitchCard({
   };
 
   const scopeBadge = scope ? (
-    <span className="text-[10px] px-1.5 py-0.5 rounded-sm font-medium bg-text-secondary/10 text-text-secondary dark:bg-text-secondary/20">
+    <span className="text-3xs px-1.5 py-0.5 rounded-sm font-medium bg-text-secondary/10 text-text-secondary dark:bg-text-secondary/20">
       {scope === "project" ? "Project" : scope === "global" ? "Global" : "Default"}
     </span>
   ) : null;
@@ -94,7 +94,7 @@ export function SettingsSwitchCard({
             {title}
             {scopeBadge}
             {lifecycleBadge && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/50 uppercase tracking-wide">
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-3xs font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/50 uppercase tracking-wide">
                 {lifecycleBadge}
               </span>
             )}

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -554,7 +554,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 )}
               >
                 <span className="text-xs font-medium">{label}</span>
-                <span className="text-[11px] mt-0.5 opacity-60">{description}</span>
+                <span className="text-2xs mt-0.5 opacity-60">{description}</span>
               </button>
             ))}
           </div>
@@ -710,7 +710,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 >
                   <Icon className="w-6 h-6 mb-2" />
                   <span className="text-xs font-medium">{label}</span>
-                  <span className="text-[11px] text-center mt-1 opacity-60">{description}</span>
+                  <span className="text-2xs text-center mt-1 opacity-60">{description}</span>
                 </button>
               ))}
             </div>
@@ -771,7 +771,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 )}
               >
                 <span className="text-xs font-medium">{label}</span>
-                <span className="text-[11px] mt-0.5 opacity-60">{description}</span>
+                <span className="text-2xs mt-0.5 opacity-60">{description}</span>
               </button>
             ))}
           </div>
@@ -863,7 +863,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 )}
               >
                 <span className="text-xs font-medium">{label}</span>
-                <span className="text-[11px] mt-0.5 opacity-60">{description}</span>
+                <span className="text-2xs mt-0.5 opacity-60">{description}</span>
               </button>
             ))}
           </div>

--- a/src/components/Settings/ThemeSelector.tsx
+++ b/src/components/Settings/ThemeSelector.tsx
@@ -170,7 +170,7 @@ export function ThemeSelector<T extends { id: string }>({
         <div role="listbox" id={id} aria-label="Theme list" className="space-y-2">
           {filteredGroups.map((group) => (
             <div key={group.label} role="group" aria-label={group.label}>
-              <p className="text-[10px] font-medium uppercase tracking-wider text-text-secondary select-none px-1 mb-1">
+              <p className="text-3xs font-medium uppercase tracking-wider text-text-secondary select-none px-1 mb-1">
                 {group.label}
               </p>
               <div className={cn("grid gap-2", colsClass)}>{group.items.map(renderCard)}</div>

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -628,7 +628,7 @@ export function TroubleshootingTab() {
                   className="flex items-center justify-between px-3 py-1.5 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30"
                 >
                   <span className="text-xs font-mono text-daintree-text truncate">{name}</span>
-                  <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-daintree-border/60 text-daintree-text/80">
+                  <span className="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-daintree-border/60 text-daintree-text/80">
                     {level}
                   </span>
                 </div>

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -264,7 +264,7 @@ export function AgentCliStep({
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-medium text-daintree-text">{config.name}</div>
                   {description && (
-                    <div className="text-[11px] text-text-secondary truncate">{description}</div>
+                    <div className="text-2xs text-text-secondary truncate">{description}</div>
                   )}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
@@ -284,26 +284,26 @@ export function AgentCliStep({
                     </Tooltip>
                   )}
                   {isInstalled ? (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-status-success font-medium">
+                    <span className="inline-flex items-center gap-1 text-2xs text-status-success font-medium">
                       <CircleCheck className="w-3 h-3" />
                       Installed
                     </span>
                   ) : isInstalling ? (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-text-secondary font-medium">
+                    <span className="inline-flex items-center gap-1 text-2xs text-text-secondary font-medium">
                       <Loader2 className="w-3 h-3 animate-spin" />
                       Installing
                     </span>
                   ) : isError ? (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-status-error font-medium">
+                    <span className="inline-flex items-center gap-1 text-2xs text-status-error font-medium">
                       <AlertCircle className="w-3 h-3" />
                       Failed
                     </span>
                   ) : isManual ? (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-text-secondary">
+                    <span className="inline-flex items-center gap-1 text-2xs text-text-secondary">
                       Manual
                     </span>
                   ) : (
-                    <span className="inline-flex items-center gap-1 text-[11px] text-text-muted">
+                    <span className="inline-flex items-center gap-1 text-2xs text-text-muted">
                       <CircleDashed className="w-3 h-3" />
                       Not installed
                     </span>
@@ -312,7 +312,7 @@ export function AgentCliStep({
                     <button
                       type="button"
                       onClick={() => handleInstall(agentId)}
-                      className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium text-daintree-text hover:bg-overlay-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
+                      className="inline-flex items-center gap-1 px-2 py-1 rounded text-2xs font-medium text-daintree-text hover:bg-overlay-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
                     >
                       <Download className="w-3 h-3" />
                       Install
@@ -323,7 +323,7 @@ export function AgentCliStep({
 
               {hasMultipleMethods && !isInstalled && (
                 <div className="flex items-center gap-1 pl-14 pt-1 pb-0.5">
-                  <span className="text-[10px] text-daintree-text/30 mr-1">via</span>
+                  <span className="text-3xs text-daintree-text/30 mr-1">via</span>
                   {blocks.map((block, idx) => (
                     <button
                       key={idx}
@@ -331,7 +331,7 @@ export function AgentCliStep({
                       disabled={isInstalling || isBatchRunning}
                       onClick={() => handleMethodChange(agentId, idx)}
                       data-selected={idx === currentMethodIdx || undefined}
-                      className="px-1.5 py-0.5 rounded text-[10px] text-daintree-text/50 transition-colors hover:text-daintree-text/80 data-[selected]:bg-tint/[0.12] data-[selected]:text-daintree-text disabled:opacity-50 disabled:pointer-events-none"
+                      className="px-1.5 py-0.5 rounded text-3xs text-daintree-text/50 transition-colors hover:text-daintree-text/80 data-[selected]:bg-tint/[0.12] data-[selected]:text-daintree-text disabled:opacity-50 disabled:pointer-events-none"
                     >
                       {block.label ?? `Method ${idx + 1}`}
                     </button>
@@ -341,7 +341,7 @@ export function AgentCliStep({
 
               {isManual && currentBlock?.commands && (
                 <div className="pl-14 pt-1.5 pb-1 space-y-1">
-                  <div className="text-[11px] text-text-secondary mb-1">
+                  <div className="text-2xs text-text-secondary mb-1">
                     Run this command in your terminal. It will be detected automatically.
                   </div>
                   {currentBlock.commands.map((cmd) => (
@@ -359,7 +359,7 @@ export function AgentCliStep({
                         onClick={() => toggleErrorExpanded(agentId)}
                         aria-expanded={isErrorExpanded ?? false}
                         aria-controls={`error-log-${agentId}`}
-                        className="inline-flex items-center gap-1 text-[11px] text-daintree-text/50 hover:text-daintree-text/80 transition-colors"
+                        className="inline-flex items-center gap-1 text-2xs text-daintree-text/50 hover:text-daintree-text/80 transition-colors"
                       >
                         {isErrorExpanded ? (
                           <ChevronDown className="w-3 h-3" />
@@ -371,7 +371,7 @@ export function AgentCliStep({
                       <pre
                         id={`error-log-${agentId}`}
                         hidden={!isErrorExpanded}
-                        className="text-[10px] text-status-error/80 bg-daintree-bg border border-daintree-border rounded-[var(--radius-sm)] p-2 max-h-[120px] overflow-y-auto whitespace-pre-wrap font-mono"
+                        className="text-3xs text-status-error/80 bg-daintree-bg border border-daintree-border rounded-[var(--radius-sm)] p-2 max-h-[120px] overflow-y-auto whitespace-pre-wrap font-mono"
                       >
                         {errorLog}
                       </pre>
@@ -379,7 +379,7 @@ export function AgentCliStep({
                   )}
                   {currentBlock?.commands && (
                     <div className="space-y-1">
-                      <div className="text-[11px] text-text-secondary">Or install manually:</div>
+                      <div className="text-2xs text-text-secondary">Or install manually:</div>
                       {currentBlock.commands.map((cmd) => (
                         <CopyableCommand
                           key={cmd}
@@ -446,7 +446,7 @@ export function AgentCliStep({
                   />
                   <span className="text-xs text-daintree-text/70">{config.name}</span>
                   {isEnabled && (
-                    <code className="text-[10px] text-status-error font-mono ml-auto">
+                    <code className="text-3xs text-status-error font-mono ml-auto">
                       {dangerousArg}
                     </code>
                   )}
@@ -454,7 +454,7 @@ export function AgentCliStep({
               );
             })}
           </div>
-          <p className="text-[11px] text-daintree-text/30">
+          <p className="text-2xs text-daintree-text/30">
             Auto-approve all actions. Use with caution.
           </p>
         </div>

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -1141,7 +1141,7 @@ function AgentsStep({
               <>
                 <div className="flex items-center gap-2 py-1">
                   <div className="h-px flex-1 bg-border-divider" />
-                  <span className="text-[11px] text-text-secondary font-medium">More agents</span>
+                  <span className="text-2xs text-text-secondary font-medium">More agents</span>
                   <div className="h-px flex-1 bg-border-divider" />
                 </div>
 
@@ -1288,15 +1288,13 @@ export function CompleteStep({ installedAgents }: { installedAgents: string[] })
                 {presetCount > 1 && (
                   <span
                     data-testid="preset-count-badge"
-                    className="text-[10px] text-status-info font-medium bg-status-info/10 px-1.5 py-0.5 rounded"
+                    className="text-3xs text-status-info font-medium bg-status-info/10 px-1.5 py-0.5 rounded"
                   >
                     {presetCount} presets
                   </span>
                 )}
                 {shortcut && (
-                  <span className="text-[11px] text-text-muted ml-auto tabular-nums">
-                    {shortcut}
-                  </span>
+                  <span className="text-2xs text-text-muted ml-auto tabular-nums">{shortcut}</span>
                 )}
               </div>
             );

--- a/src/components/Setup/InstallBlock.tsx
+++ b/src/components/Setup/InstallBlock.tsx
@@ -25,7 +25,7 @@ export function InstallBlock({ block }: { block: AgentInstallBlock }) {
         </div>
       )}
       {block.notes && block.notes.length > 0 && (
-        <div className="mt-2 text-[11px] text-text-secondary space-y-0.5">
+        <div className="mt-2 text-2xs text-text-secondary space-y-0.5">
           {block.notes.map((note, i) => (
             <p key={i}>{note}</p>
           ))}

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -82,28 +82,28 @@ export function SystemRequirementsSection({
         <span className="text-sm font-medium text-daintree-text">System requirements</span>
 
         {isChecking && (
-          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-text-secondary">
+          <span className="flex items-center gap-1.5 ml-auto text-2xs text-text-secondary">
             <Loader2 className="w-3 h-3 animate-spin" />
             Checking...
           </span>
         )}
 
         {allDone && !hasFatalFailure && !hasWarning && !error && (
-          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-status-success">
+          <span className="flex items-center gap-1.5 ml-auto text-2xs text-status-success">
             <CircleCheck className="w-3.5 h-3.5" />
             All system tools ready
           </span>
         )}
 
         {allDone && hasFatalFailure && (
-          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-status-error">
+          <span className="flex items-center gap-1.5 ml-auto text-2xs text-status-error">
             <CircleX className="w-3.5 h-3.5" />
             Action required: {readyCount} of {totalCount} tools ready
           </span>
         )}
 
         {allDone && !hasFatalFailure && hasWarning && (
-          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-status-warning">
+          <span className="flex items-center gap-1.5 ml-auto text-2xs text-status-warning">
             <AlertTriangle className="w-3.5 h-3.5" />
             Warning: {readyCount} of {totalCount} tools ready
           </span>

--- a/src/components/Setup/SystemToolsStep.tsx
+++ b/src/components/Setup/SystemToolsStep.tsx
@@ -43,11 +43,11 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
           <div className="text-sm font-medium text-daintree-text truncate">{label}</div>
         </div>
         {loading ? (
-          <span className="text-[11px] text-daintree-text/30 shrink-0">Checking…</span>
+          <span className="text-2xs text-daintree-text/30 shrink-0">Checking…</span>
         ) : needsInstall ? (
           <div className="flex items-center gap-2 shrink-0 min-w-0">
             {versionMismatch && (
-              <span className="text-[11px] text-status-warning whitespace-nowrap truncate min-w-0">
+              <span className="text-2xs text-status-warning whitespace-nowrap truncate min-w-0">
                 v{check.version} → v{check.minVersion}+
               </span>
             )}
@@ -57,7 +57,7 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
                 onClick={() => setExpanded((v) => !v)}
                 aria-expanded={expanded}
                 aria-controls={`install-panel-${spec.tool}`}
-                className="inline-flex items-center gap-1 text-[11px] text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline shrink-0"
+                className="inline-flex items-center gap-1 text-2xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline shrink-0"
               >
                 {expanded ? (
                   <ChevronDown className="w-3 h-3" />
@@ -70,7 +70,7 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
             {check.installUrl && (
               <a
                 href={check.installUrl}
-                className="inline-flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text shrink-0"
+                className="inline-flex items-center gap-1 text-2xs text-daintree-text/40 hover:text-daintree-text shrink-0"
                 onClick={(e) => {
                   e.preventDefault();
                   void systemClient.openExternal(check.installUrl!);
@@ -81,9 +81,9 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
             )}
           </div>
         ) : check?.version ? (
-          <span className="text-[11px] text-text-secondary shrink-0">v{check.version}</span>
+          <span className="text-2xs text-text-secondary shrink-0">v{check.version}</span>
         ) : check?.available ? (
-          <span className="text-[11px] text-text-secondary shrink-0">Installed</span>
+          <span className="text-2xs text-text-secondary shrink-0">Installed</span>
         ) : null}
       </div>
       {installBlocks && (

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -257,12 +257,12 @@ export function DeletedWorktreeCard({
               aria-hidden="true"
             />
             <span
-              className="truncate font-mono text-[11px] font-medium text-text-muted"
+              className="truncate font-mono text-2xs font-medium text-text-muted"
               title={worktree.title}
             >
               {worktree.title}
             </span>
-            <span className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-[10px] font-medium text-text-muted">
+            <span className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-3xs font-medium text-text-muted">
               Deleted
             </span>
           </span>
@@ -271,7 +271,7 @@ export function DeletedWorktreeCard({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span
-                    className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-[10px] font-medium text-text-muted"
+                    className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-3xs font-medium text-text-muted"
                     data-testid="deleted-worktree-countdown-hold"
                     data-hold-reason={worktree.holdReason}
                   >
@@ -283,7 +283,7 @@ export function DeletedWorktreeCard({
             )}
             {hasCountdown && (
               <span
-                className="font-mono text-[11px] tabular-nums text-text-muted"
+                className="font-mono text-2xs tabular-nums text-text-muted"
                 title={
                   hold !== undefined
                     ? `${hold.tooltip}, holding at ${remainingSeconds}s`

--- a/src/components/Sidebar/DeletedWorktreeGroup.tsx
+++ b/src/components/Sidebar/DeletedWorktreeGroup.tsx
@@ -183,7 +183,7 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
             strokeWidth={2.5}
             aria-hidden="true"
           />
-          <span className="truncate text-[11px] font-medium text-text-muted">
+          <span className="truncate text-2xs font-medium text-text-muted">
             {members.length} {worktreeNoun}
             <span aria-hidden="true"> · </span>
             <span className="sr-only">, </span>
@@ -193,7 +193,7 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
         <div className="flex shrink-0 items-center gap-2">
           {hasCountdown && (
             <span
-              className="font-mono text-[11px] tabular-nums text-text-muted"
+              className="font-mono text-2xs tabular-nums text-text-muted"
               title={`Next cleanup in ${remainingSeconds}s`}
               data-testid="deleted-worktree-group-countdown"
             >
@@ -294,7 +294,7 @@ function DeletedWorktreeTerminalChip({
         aria-label={label}
       >
         <TerminalIcon chrome={chrome} className="w-3 h-3 shrink-0" />
-        <span className="truncate text-[11px] text-text-muted">{terminal.title}</span>
+        <span className="truncate text-2xs text-text-muted">{terminal.title}</span>
       </button>
     </div>
   );

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -314,7 +314,7 @@ function renderSidebarFlatItem(
         <div
           role="rowheader"
           aria-colspan={1}
-          className="px-4 py-2 text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide"
+          className="px-4 py-2 text-3xs font-medium text-daintree-text/50 uppercase tracking-wide"
         >
           {item.displayName} ({item.count})
         </div>

--- a/src/components/Sidebar/WorkspaceRootRow.tsx
+++ b/src/components/Sidebar/WorkspaceRootRow.tsx
@@ -88,7 +88,7 @@ export function WorkspaceRootRow({
             <div className="flex items-center gap-2 min-w-0">
               <KindIcon className="w-4 h-4 shrink-0 text-daintree-text/60" aria-hidden="true" />
               <TruncatedTooltip content={workspace.name}>
-                <span className="truncate min-w-0 text-[13px] font-medium text-daintree-text">
+                <span className="truncate min-w-0 text-sm leading-[inherit] font-medium text-daintree-text">
                   {workspace.name}
                 </span>
               </TruncatedTooltip>

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -32,7 +32,7 @@ function PatchDiffLines({ content, className }: { content: string; className?: s
   return (
     <pre
       className={cn(
-        "font-mono text-[11px] leading-4 overflow-y-auto overflow-x-auto select-text",
+        "font-mono text-2xs leading-4 overflow-y-auto overflow-x-auto select-text",
         className
       )}
     >
@@ -49,7 +49,7 @@ function PatchDiffPreview({ content }: { content: string }) {
   return (
     <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
       <div className="px-3 py-2 border-b border-tint/[0.08]">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+        <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
           Patch contents
         </span>
       </div>
@@ -637,7 +637,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
         {pendingBulkPatches && (
           <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
             <div className="px-3 py-2 border-b border-tint/[0.08]">
-              <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+              <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
                 Patches to apply
               </span>
             </div>
@@ -649,16 +649,16 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                   // open by default; the toggle only tames very long bulk sets.
                   <details key={patch.id} open className="group">
                     <summary className="flex items-baseline gap-2 px-3 py-2 cursor-pointer list-none">
-                      <span className="text-daintree-text/40 text-[10px] shrink-0 group-open:hidden">
+                      <span className="text-daintree-text/40 text-3xs shrink-0 group-open:hidden">
                         ▶
                       </span>
-                      <span className="text-daintree-text/40 text-[10px] shrink-0 hidden group-open:inline">
+                      <span className="text-daintree-text/40 text-3xs shrink-0 hidden group-open:inline">
                         ▼
                       </span>
                       <span className="text-daintree-text/80 truncate min-w-0">
                         {patch.filename || patch.language || "patch"}
                       </span>
-                      <span className="font-mono text-[10px] shrink-0 ml-auto tabular-nums">
+                      <span className="font-mono text-3xs shrink-0 ml-auto tabular-nums">
                         <span className="text-status-success">+{stats.additions}</span>{" "}
                         <span className="text-status-error">-{stats.deletions}</span>
                       </span>

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -139,11 +139,11 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
       >
         {(title || keyHint) && (
           <div className="flex items-center justify-between gap-2 border-b border-tint/5 px-2 py-1.5">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-text-secondary">
+            <span className="text-3xs font-semibold uppercase tracking-wider text-text-secondary">
               {title}
             </span>
             {keyHint && (
-              <span aria-hidden="true" className="shrink-0 text-[10px] text-daintree-text/30">
+              <span aria-hidden="true" className="shrink-0 text-3xs text-daintree-text/30">
                 {keyHint}
               </span>
             )}
@@ -208,7 +208,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
                         <>
                           <span
                             aria-hidden="true"
-                            className="shrink-0 rounded-sm border border-tint/10 bg-overlay-subtle px-1 text-[9px] font-medium uppercase leading-4 tracking-wide text-daintree-text/50"
+                            className="shrink-0 rounded-sm border border-tint/10 bg-overlay-subtle px-1 text-4xs font-medium uppercase leading-4 tracking-wide text-daintree-text/50"
                           >
                             {badge}
                           </span>
@@ -218,7 +218,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
                       {descriptionSnippet && (
                         <span
                           className={cn(
-                            "min-w-0 truncate text-[10px] leading-4",
+                            "min-w-0 truncate text-3xs leading-4",
                             idx === selectedIndex
                               ? "text-daintree-text/80"
                               : "text-daintree-text/30"

--- a/src/components/Terminal/DiagnosticCopyButton.tsx
+++ b/src/components/Terminal/DiagnosticCopyButton.tsx
@@ -88,7 +88,7 @@ export function DiagnosticCopyButton({ diagnostics, className }: DiagnosticCopyB
         type="button"
         onClick={handleClick}
         aria-label={copied ? "Diagnostics copied" : "Copy diagnostics"}
-        className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/40 rounded transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
+        className="flex items-center gap-1 px-1.5 py-0.5 text-3xs font-medium text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/40 rounded transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
       >
         <Copy className="w-3 h-3" aria-hidden="true" />
         {copied ? "Copied" : "Copy"}

--- a/src/components/Terminal/GridScrollbar.tsx
+++ b/src/components/Terminal/GridScrollbar.tsx
@@ -216,7 +216,7 @@ export function GridScrollbar({
       data-no-dnd
       onPointerDown={onTrackPointerDown}
       onWheel={onWheel}
-      className="absolute z-20 rounded-[7px] bg-[var(--scrollbar-track)]"
+      className="absolute z-20 rounded-full bg-[var(--scrollbar-track)]"
       style={{
         right: BAR_INSET_PX,
         top: TRACK_INSET_PX,
@@ -244,7 +244,7 @@ export function GridScrollbar({
         onPointerEnter={() => setPhase((p) => (p === "drag" ? p : "hover"))}
         onPointerLeave={() => setPhase((p) => (p === "drag" ? p : "idle"))}
         className={cn(
-          "absolute inset-x-0 cursor-default rounded-[7px] border-2 border-transparent bg-clip-padding transition-colors",
+          "absolute inset-x-0 cursor-default rounded-full border-2 border-transparent bg-clip-padding transition-colors",
           phase === "idle" ? "bg-[var(--scrollbar-thumb)]" : "bg-[var(--scrollbar-thumb-hover)]"
         )}
         style={{ height: geometry.height, top: 0 }}

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -61,11 +61,11 @@ export function PromptHistoryRow({
       <span className="truncate font-mono text-xs">{truncatePrompt(item.prompt)}</span>
       <div className="flex items-center gap-2 shrink-0">
         {item.agentId && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-daintree-border text-daintree-text/60">
+          <span className="text-3xs px-1.5 py-0.5 rounded bg-daintree-border text-daintree-text/60">
             {item.agentId}
           </span>
         )}
-        <span className="text-[10px] text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
+        <span className="text-3xs text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
           {formatRelativeTime(item.addedAt)}
         </span>
       </div>
@@ -133,7 +133,7 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
       <button
         type="button"
         onClick={toggleScope}
-        className="shrink-0 text-[11px] px-2 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border/50 hover:bg-daintree-border text-daintree-text/60 hover:text-daintree-text/80 transition-colors"
+        className="shrink-0 text-2xs px-2 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border/50 hover:bg-daintree-border text-daintree-text/60 hover:text-daintree-text/80 transition-colors"
       >
         {scope === "project" ? "This project" : "All projects"}
       </button>

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -92,7 +92,7 @@ export function RecipeRunnerItem({
                 {recipe.name}
               </span>
               {recipe.shadowedBy && (
-                <span className="text-[11px] text-text-muted shrink-0">Overridden by Team</span>
+                <span className="text-2xs text-text-muted shrink-0">Overridden by Team</span>
               )}
               {isPinned && (
                 // Neutral, not accent: pinning is membership, and the accent is
@@ -155,9 +155,9 @@ export function RecipeRunnerItem({
           <span className="flex-1 text-sm font-medium text-daintree-text truncate">
             {recipe.name}
           </span>
-          <span className="text-[11px] text-text-muted shrink-0">{scopeLabel}</span>
+          <span className="text-2xs text-text-muted shrink-0">{scopeLabel}</span>
           {recipe.shadowedBy && (
-            <span className="text-[11px] text-text-muted shrink-0">Overridden by Team</span>
+            <span className="text-2xs text-text-muted shrink-0">Overridden by Team</span>
           )}
           {recipeSummary && recipeSummary !== recipe.name && (
             <span className="text-xs text-text-muted truncate max-w-[30%]">{recipeSummary}</span>

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
@@ -109,7 +109,7 @@ export function RecipeRunnerList({
         <div className="mb-2 flex items-baseline gap-3 px-1">
           <span
             id="recipe-band-label"
-            className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-text-secondary"
+            className="shrink-0 text-2xs font-medium uppercase tracking-wide text-text-secondary"
           >
             Recipes
           </span>

--- a/src/components/Terminal/ResumeSessionsPalette.tsx
+++ b/src/components/Terminal/ResumeSessionsPalette.tsx
@@ -50,7 +50,7 @@ function ResumeSessionRow({ item, isSelected, matches, onSelect, itemRef }: Resu
         )}
       </div>
       {item.isStale && (
-        <span className="shrink-0 mt-0.5 text-[10px] font-medium text-text-secondary">
+        <span className="shrink-0 mt-0.5 text-3xs font-medium text-text-secondary">
           Worktree removed
         </span>
       )}

--- a/src/components/Terminal/SubagentChip.tsx
+++ b/src/components/Terminal/SubagentChip.tsx
@@ -63,11 +63,11 @@ function TranscriptBody({
   return (
     <div className="flex flex-col gap-2">
       {transcript.truncated && (
-        <p className="text-[10px] text-daintree-text/35">Showing the latest messages</p>
+        <p className="text-3xs text-daintree-text/35">Showing the latest messages</p>
       )}
       {transcript.messages.map((message, index) => (
         <div key={`${transcript.subagentId}-${index}`} className="flex flex-col gap-0.5">
-          <span className="text-[10px] uppercase tracking-wider text-text-secondary">
+          <span className="text-3xs uppercase tracking-wider text-text-secondary">
             {message.role === "task" ? "Task" : "Reply"}
           </span>
           <p className="text-xs text-daintree-text/80 whitespace-pre-wrap break-words">
@@ -148,16 +148,14 @@ function SubagentRow({
             <span className="text-xs font-medium text-daintree-text truncate">
               {subagentTitle(subagent)}
             </span>
-            <span className={cn("text-[10px] shrink-0", TONE_CLASSES[tone])}>
+            <span className={cn("text-3xs shrink-0", TONE_CLASSES[tone])}>
               {subagentStatusLabel(subagent.status)}
             </span>
           </span>
-          {subtitle && (
-            <span className="text-[11px] text-daintree-text/50 truncate">{subtitle}</span>
-          )}
+          {subtitle && <span className="text-2xs text-daintree-text/50 truncate">{subtitle}</span>}
         </span>
         {subagent.updatedAt > 0 && (
-          <span className="text-[10px] text-daintree-text/35 shrink-0 mt-0.5 tabular-nums">
+          <span className="text-3xs text-daintree-text/35 shrink-0 mt-0.5 tabular-nums">
             {formatTimeAgo(subagent.updatedAt)}
           </span>
         )}

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -153,7 +153,7 @@ function GroupDismissPreview({ preview }: { preview: DeletedWorktreeGroupPreview
     <ul className="mt-3 max-h-56 space-y-3 overflow-y-auto rounded border border-border-default bg-overlay-subtle p-3">
       {preview.map((entry) => (
         <li key={entry.worktreeId}>
-          <span className="block truncate font-mono text-[11px] font-medium text-text-secondary">
+          <span className="block truncate font-mono text-2xs font-medium text-text-secondary">
             {entry.worktreeTitle}
           </span>
           <ul className="mt-1 space-y-0.5">
@@ -164,7 +164,7 @@ function GroupDismissPreview({ preview }: { preview: DeletedWorktreeGroupPreview
               >
                 <span className="truncate">{terminal.terminalTitle}</span>
                 {terminal.hasRunningAgent && (
-                  <span className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-[10px] text-text-muted">
+                  <span className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-3xs text-text-muted">
                     Running
                   </span>
                 )}

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -229,7 +229,7 @@ export function TerminalHeaderContent({
         <Tooltip>
           <TooltipTrigger asChild>
             <span
-              className="inline-flex items-center gap-1 shrink-0 px-2 py-0.5 rounded-full text-[11px] bg-overlay-soft border border-divider text-daintree-text/60"
+              className="inline-flex items-center gap-1 shrink-0 px-2 py-0.5 rounded-full text-2xs bg-overlay-soft border border-divider text-daintree-text/60"
               role="status"
               aria-label="Agent finished with no file changes"
             >
@@ -306,7 +306,7 @@ export function TerminalHeaderContent({
             </div>
             {(agentState === "completed" || agentState === "exited") && sessionCost != null && (
               <span
-                className="text-[11px] text-daintree-text/50 font-mono shrink-0"
+                className="text-2xs text-daintree-text/50 font-mono shrink-0"
                 style={{ fontVariantNumeric: "tabular-nums" }}
               >
                 ${sessionCost.toFixed(2)}
@@ -529,7 +529,7 @@ export function TerminalHeaderContent({
       {showCommandPill && (
         <Tooltip autoDismiss={false}>
           <TooltipTrigger asChild>
-            <span className="px-2 py-0.5 rounded-full text-[11px] font-mono bg-overlay-soft text-daintree-text/60 border border-divider truncate max-w-[20rem]">
+            <span className="px-2 py-0.5 rounded-full text-2xs font-mono bg-overlay-soft text-daintree-text/60 border border-divider truncate max-w-[20rem]">
               {lastCommand}
             </span>
           </TooltipTrigger>
@@ -564,7 +564,7 @@ export function TerminalHeaderContent({
           <TooltipTrigger asChild>
             <div
               className={cn(
-                "inline-flex items-center gap-1 text-[11px] font-mono shrink-0 transition-colors duration-150",
+                "inline-flex items-center gap-1 text-2xs font-mono shrink-0 transition-colors duration-150",
                 {
                   "text-text-secondary": stickySeverity === "muted",
                   "text-status-warning": stickySeverity === "amber",

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -37,7 +37,7 @@ const UNAVAILABLE = "Unavailable";
  * sentence, and at 11px it reads as structure instead of competing with the rows for
  * the same tab stop of the eye.
  */
-const MICRO_LABEL = "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60";
+const MICRO_LABEL = "text-2xs font-semibold uppercase tracking-wider text-daintree-text/60";
 
 /**
  * The label rail.
@@ -251,7 +251,7 @@ function DisclosureGroup({
          * five identical micro-labels, two of which happen to be buttons, is not an
          * affordance. Same treatment as the commit count in `GitPushConfirmDialog`.
          */}
-        <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal text-daintree-text/70">
+        <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal text-daintree-text/70">
           {count}
         </span>
       </button>

--- a/src/components/Terminal/VoiceInputButton.tsx
+++ b/src/components/Terminal/VoiceInputButton.tsx
@@ -357,8 +357,8 @@ export function VoiceInputButton({
             className="flex h-2.5 w-2.5 items-stretch justify-between"
             aria-hidden="true"
           >
-            <span className="status-mark block w-[2px] rounded-[1px] bg-current opacity-70" />
-            <span className="status-mark block w-[2px] rounded-[1px] bg-current opacity-70" />
+            <span className="status-mark block w-[2px] rounded-full bg-current opacity-70" />
+            <span className="status-mark block w-[2px] rounded-full bg-current opacity-70" />
           </span>
         ) : showOrbit ? (
           <span

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -449,7 +449,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     mockResourceState = makeResourceState(10);
 
     const { container } = render(<TerminalHeaderContent id="t1" kind="terminal" />);
-    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-2xs");
     expect(wrapper).toBeTruthy();
     const cls = wrapper!.getAttribute("class")!;
     expect(cls).toContain("transition-colors");
@@ -462,7 +462,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     mockResourceState = makeResourceState(10);
 
     const { container } = render(<TerminalHeaderContent id="t1" kind="terminal" />);
-    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-2xs");
     expectMutedSeverity(wrapper!.getAttribute("class"));
   });
 
@@ -488,7 +488,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 60, 1);
     pollResource(rerender, 60, 2);
 
-    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-2xs");
     expectMutedSeverity(wrapper!.getAttribute("class"));
   });
 
@@ -504,7 +504,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 60, 2);
     pollResource(rerender, 60, 3);
 
-    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-2xs");
     expect(wrapper!.getAttribute("class")).toContain("text-status-warning");
   });
 
@@ -515,8 +515,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     const { rerender, container } = render(
       <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
     );
-    const wrapperFor = () =>
-      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+    const wrapperFor = () => container.querySelector(".inline-flex.items-center.gap-1.text-2xs")!;
 
     // Escalation reacts in 3 polls.
     pollResource(rerender, 90, 1);
@@ -548,8 +547,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     const { rerender, container } = render(
       <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
     );
-    const wrapperFor = () =>
-      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+    const wrapperFor = () => container.querySelector(".inline-flex.items-center.gap-1.text-2xs")!;
 
     pollResource(rerender, 90, 1);
     pollResource(rerender, 90, 2);
@@ -571,8 +569,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     const { rerender, container } = render(
       <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
     );
-    const wrapperFor = () =>
-      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+    const wrapperFor = () => container.querySelector(".inline-flex.items-center.gap-1.text-2xs")!;
 
     pollResource(rerender, 90, 1);
     pollResource(rerender, 90, 2);
@@ -595,8 +592,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     const { rerender, container } = render(
       <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
     );
-    const wrapperFor = () =>
-      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+    const wrapperFor = () => container.querySelector(".inline-flex.items-center.gap-1.text-2xs")!;
 
     pollResource(rerender, 90, 1);
     pollResource(rerender, 90, 2);
@@ -629,8 +625,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     const { rerender, container } = render(
       <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
     );
-    const wrapperFor = () =>
-      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+    const wrapperFor = () => container.querySelector(".inline-flex.items-center.gap-1.text-2xs")!;
 
     pollResource(rerender, 90, 1);
     pollResource(rerender, 90, 2);
@@ -662,7 +657,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollMemory(2_500_000, 2);
     pollMemory(2_500_000, 3);
 
-    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-2xs");
     expect(wrapper!.getAttribute("class")).toContain("text-status-error");
   });
 
@@ -677,7 +672,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 60, 1);
     pollResource(rerender, 60, 2);
     pollResource(rerender, 60, 3);
-    let wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    let wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-2xs");
     expect(wrapper!.getAttribute("class")).toContain("text-status-warning");
 
     mockResourceEnabled = false;
@@ -688,7 +683,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     mockResourceState = makeResourceState(10);
     rerender(<TerminalHeaderContent id="t1" kind="terminal" queueCount={5} />);
 
-    wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-2xs");
     expectMutedSeverity(wrapper!.getAttribute("class"));
   });
 
@@ -706,7 +701,7 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 60, 4);
     pollResource(rerender, 60, 5);
 
-    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-2xs");
     expectMutedSeverity(wrapper!.getAttribute("class"));
   });
 });

--- a/src/components/Terminal/inputEditorExtensions/base.ts
+++ b/src/components/Terminal/inputEditorExtensions/base.ts
@@ -25,7 +25,7 @@ const INLINE_CHIP_BASE = {
   gap: "4px",
   padding: "0 5px",
   fontWeight: 600,
-  borderRadius: "3px",
+  borderRadius: "var(--radius-xs)",
 } as const;
 
 const CHIP_SVG_SIZE = {
@@ -54,7 +54,7 @@ export function buildInputBarTheme(theme: ITheme): Extension {
       },
       ".cm-content": {
         fontFamily: "var(--font-mono, monospace)",
-        fontSize: "12px",
+        fontSize: "var(--text-xs)",
         lineHeight: "20px",
         padding: "0 4px 0 0",
         caretColor: c.accent,
@@ -132,7 +132,7 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         height: "16px",
         width: "16px",
         objectFit: "cover",
-        borderRadius: "2px",
+        borderRadius: "var(--radius-xs)",
         flexShrink: "0",
       },
       ".cm-file-drop-chip": {
@@ -146,7 +146,7 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         width: "14px",
         height: "14px",
         marginLeft: "2px",
-        borderRadius: "2px",
+        borderRadius: "var(--radius-xs)",
         color: `color-mix(in oklab, ${c.foreground} 55%, transparent)`,
         cursor: "pointer",
         flexShrink: "0",
@@ -154,7 +154,7 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         pointerEvents: "none",
         transition: "opacity 100ms ease-out",
         lineHeight: "1",
-        fontSize: "12px",
+        fontSize: "var(--text-xs)",
         border: "none",
         background: "transparent",
         padding: "0",

--- a/src/components/Terminal/inputEditorExtensions/diffChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/diffChip.ts
@@ -104,13 +104,13 @@ export function createDiffChipTooltip() {
         dom.className = "px-2 py-1 text-xs";
         dom.style.cssText = `
           background: color-mix(in oklab, var(--theme-surface-canvas) 95%, transparent);
-          border-radius: 4px;
+          border-radius: var(--radius-xs);
           border: 1px solid var(--theme-border-subtle);
           box-shadow: 0 2px 8px var(--theme-scrim-soft);
         `;
 
         const desc = document.createElement("p");
-        desc.className = "text-[11px] text-text-primary/80 leading-snug";
+        desc.className = "text-2xs text-text-primary/80 leading-snug";
         desc.textContent = `Attaches ${DIFF_LABELS[token.diffType].toLowerCase()} as context`;
         dom.appendChild(desc);
 

--- a/src/components/Terminal/inputEditorExtensions/fileChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/fileChip.ts
@@ -110,7 +110,7 @@ function createFileTooltipContent(token: AtFileToken): HTMLElement {
   container.className = "max-w-[300px]";
 
   const pathEl = document.createElement("p");
-  pathEl.className = "text-[11px] text-daintree-text/90 leading-snug font-mono break-all";
+  pathEl.className = "text-2xs text-daintree-text/90 leading-snug font-mono break-all";
   pathEl.textContent = token.path;
   container.appendChild(pathEl);
 
@@ -134,7 +134,7 @@ export function createFileChipTooltip() {
         dom.className = "px-2 py-1 text-xs";
         dom.style.cssText = `
           background: var(--theme-surface-panel-elevated);
-          border-radius: 4px;
+          border-radius: var(--radius-xs);
           box-shadow: 0 2px 8px var(--theme-scrim-soft);
         `;
 

--- a/src/components/Terminal/inputEditorExtensions/fileDropChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/fileDropChip.ts
@@ -154,20 +154,20 @@ export function createFileDropChipTooltip() {
         dom.className = "px-2 py-1 text-xs";
         dom.style.cssText = `
           background: var(--theme-surface-panel-elevated);
-          border-radius: 4px;
+          border-radius: var(--radius-xs);
           box-shadow: 0 2px 8px var(--theme-scrim-soft);
         `;
 
         const pathEl = document.createElement("p");
         pathEl.style.cssText =
-          "font-size: 10px; color: var(--theme-text-secondary); word-break: break-all; max-width: 300px; font-family: var(--font-mono, monospace);";
+          "font-size: var(--text-3xs); color: var(--theme-text-secondary); word-break: break-all; max-width: 300px; font-family: var(--font-mono, monospace);";
         pathEl.textContent = entry.filePath;
         dom.appendChild(pathEl);
 
         if (entry.fileSize != null) {
           const sizeEl = document.createElement("p");
           sizeEl.style.cssText =
-            "font-size: 10px; color: var(--theme-text-muted); margin-top: 2px;";
+            "font-size: var(--text-3xs); color: var(--theme-text-muted); margin-top: 2px;";
           sizeEl.textContent = formatFileSize(entry.fileSize);
           dom.appendChild(sizeEl);
         }

--- a/src/components/Terminal/inputEditorExtensions/imageChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/imageChip.ts
@@ -141,7 +141,7 @@ export function createImageChipTooltip() {
         dom.className = "px-2 py-2";
         dom.style.cssText = `
           background: var(--theme-surface-panel-elevated);
-          border-radius: 6px;
+          border-radius: var(--radius-sm);
           box-shadow: 0 4px 12px var(--theme-scrim-medium);
         `;
 
@@ -149,12 +149,12 @@ export function createImageChipTooltip() {
         img.src = entry.thumbnailUrl;
         img.alt = "Screenshot preview";
         img.style.cssText =
-          "max-width: 200px; max-height: 200px; border-radius: 4px; display: block;";
+          "max-width: 200px; max-height: 200px; border-radius: var(--radius-xs); display: block;";
         dom.appendChild(img);
 
         const pathEl = document.createElement("p");
         pathEl.style.cssText =
-          "font-size: 10px; color: var(--theme-text-muted); margin-top: 4px; word-break: break-all; max-width: 200px;";
+          "font-size: var(--text-3xs); color: var(--theme-text-muted); margin-top: 4px; word-break: break-all; max-width: 200px;";
         pathEl.textContent = entry.filePath;
         dom.appendChild(pathEl);
 

--- a/src/components/Terminal/inputEditorExtensions/selectionChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/selectionChip.ts
@@ -96,13 +96,13 @@ export function createSelectionChipTooltip() {
         dom.className = "px-2 py-1 text-xs";
         dom.style.cssText = `
           background: color-mix(in oklab, var(--theme-surface-canvas) 95%, transparent);
-          border-radius: 4px;
+          border-radius: var(--radius-xs);
           border: 1px solid var(--theme-border-subtle);
           box-shadow: 0 2px 8px var(--theme-scrim-soft);
         `;
 
         const desc = document.createElement("p");
-        desc.className = "text-[11px] text-text-primary/80 leading-snug";
+        desc.className = "text-2xs text-text-primary/80 leading-snug";
         desc.textContent = "Attaches current terminal text selection as context";
         dom.appendChild(desc);
 

--- a/src/components/Terminal/inputEditorExtensions/slashChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/slashChip.ts
@@ -108,7 +108,7 @@ function createTooltipContent(command: SlashCommand): HTMLElement {
   container.className = "max-w-[260px]";
 
   const description = document.createElement("p");
-  description.className = "text-[11px] text-text-primary/80 leading-snug";
+  description.className = "text-2xs text-text-primary/80 leading-snug";
   description.textContent = command.description ?? command.label ?? "";
   container.appendChild(description);
 
@@ -133,7 +133,7 @@ export function createSlashTooltip(commandMap: Map<string, SlashCommand>) {
         dom.className = "px-2 py-1 text-xs";
         dom.style.cssText = `
           background: color-mix(in oklab, var(--theme-surface-canvas) 95%, transparent);
-          border-radius: 4px;
+          border-radius: var(--radius-xs);
           border: 1px solid var(--theme-border-subtle);
           box-shadow: 0 2px 8px var(--theme-scrim-soft);
         `;

--- a/src/components/Terminal/inputEditorExtensions/terminalChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/terminalChip.ts
@@ -96,13 +96,13 @@ export function createTerminalChipTooltip() {
         dom.className = "px-2 py-1 text-xs";
         dom.style.cssText = `
           background: color-mix(in oklab, var(--theme-surface-canvas) 95%, transparent);
-          border-radius: 4px;
+          border-radius: var(--radius-xs);
           border: 1px solid var(--theme-border-subtle);
           box-shadow: 0 2px 8px var(--theme-scrim-soft);
         `;
 
         const desc = document.createElement("p");
-        desc.className = "text-[11px] text-text-primary/80 leading-snug";
+        desc.className = "text-2xs text-text-primary/80 leading-snug";
         desc.textContent = "Attaches last 100 lines of terminal output as context";
         dom.appendChild(desc);
 

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -190,32 +190,32 @@ export function RecipeManager({
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-foreground truncate">{recipe.name}</span>
               {readOnly && (
-                <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1">
+                <span className="text-2xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1">
                   <Lock className="h-3 w-3" />
                   Read-only
                 </span>
               )}
               {isShadowed && (
-                <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
+                <span className="text-2xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
                   Overridden by team recipe
                 </span>
               )}
               {isGlobal && (
-                <span className="text-[11px] text-status-info bg-status-info/10 px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1">
+                <span className="text-2xs text-status-info bg-status-info/10 px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1">
                   <Globe className="h-3 w-3" />
                   Global
                 </span>
               )}
               {fromPlugin && (
-                <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0 truncate">
+                <span className="text-2xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0 truncate">
                   {recipe.origin.pluginId}
                 </span>
               )}
-              <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
+              <span className="text-2xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
                 {recipe.terminals.length} terminal{recipe.terminals.length !== 1 ? "s" : ""}
               </span>
               {recipe.showInEmptyState && (
-                <span className="text-[11px] text-status-info bg-status-info/10 px-1.5 py-0.5 rounded font-medium shrink-0">
+                <span className="text-2xs text-status-info bg-status-info/10 px-1.5 py-0.5 rounded font-medium shrink-0">
                   Empty State
                 </span>
               )}

--- a/src/components/TerminalRecipe/RecipeVariablePreview.tsx
+++ b/src/components/TerminalRecipe/RecipeVariablePreview.tsx
@@ -56,13 +56,13 @@ export function RecipeVariablePreview({ initialPrompt, worktreeId }: RecipeVaria
               )
             )}
       </div>
-      {!hasContext && <p className="text-[10px] text-text-muted mt-1">Resolving at run time</p>}
+      {!hasContext && <p className="text-3xs text-text-muted mt-1">Resolving at run time</p>}
       {hasContext && unresolvedVars.length > 0 && (
         <div className="mt-1 flex flex-wrap gap-1">
           {unresolvedVars.map((name) => (
             <span
               key={name}
-              className="inline-flex items-center gap-1 rounded-full px-1.5 py-px text-[9px] bg-category-rose-subtle text-category-rose-text"
+              className="inline-flex items-center gap-1 rounded-full px-1.5 py-px text-4xs bg-category-rose-subtle text-category-rose-text"
             >
               <AlertTriangle className="h-2.5 w-2.5" aria-hidden="true" />
               {`{{${name}}}`} unresolved

--- a/src/components/ThemeBrowser/ThemeBrowser.tsx
+++ b/src/components/ThemeBrowser/ThemeBrowser.tsx
@@ -100,14 +100,14 @@ function ThemeRow({
         <div className="flex items-center gap-1.5">
           <span className="text-xs font-medium text-daintree-text truncate">{scheme.name}</span>
           {warnings.length > 0 && (
-            <span className="inline-flex items-center gap-0.5 rounded-full bg-status-warning/10 px-1.5 py-0.5 text-[10px] text-status-warning shrink-0">
+            <span className="inline-flex items-center gap-0.5 rounded-full bg-status-warning/10 px-1.5 py-0.5 text-3xs text-status-warning shrink-0">
               <AlertTriangle className="h-2.5 w-2.5" />
               {warnings.length}
             </span>
           )}
         </div>
         {scheme.location && (
-          <span className="text-[11px] text-text-secondary truncate block">{scheme.location}</span>
+          <span className="text-2xs text-text-secondary truncate block">{scheme.location}</span>
         )}
       </div>
       <PaletteStrip scheme={scheme} />
@@ -468,7 +468,7 @@ export function ThemeBrowser() {
             {activeScheme.name}
           </span>
           {activeScheme.location && (
-            <span className="text-[11px] text-white/75 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
+            <span className="text-2xs text-white/75 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
               {activeScheme.location}
             </span>
           )}
@@ -503,7 +503,7 @@ export function ThemeBrowser() {
               setTypeFilter("dark");
             }}
             className={cn(
-              "px-2.5 py-0.5 text-[11px] font-medium transition-colors",
+              "px-2.5 py-0.5 text-2xs font-medium transition-colors",
               typeFilter === "dark"
                 ? "bg-daintree-accent/15 text-daintree-text"
                 : "text-daintree-text/50 hover:text-daintree-text/70"
@@ -519,7 +519,7 @@ export function ThemeBrowser() {
               setTypeFilter("light");
             }}
             className={cn(
-              "px-2.5 py-0.5 text-[11px] font-medium transition-colors border-l border-daintree-border",
+              "px-2.5 py-0.5 text-2xs font-medium transition-colors border-l border-daintree-border",
               typeFilter === "light"
                 ? "bg-daintree-accent/15 text-daintree-text"
                 : "text-daintree-text/50 hover:text-daintree-text/70"

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -54,15 +54,15 @@ function ThemeListItem({
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium text-daintree-text truncate">{scheme.name}</div>
         {scheme.location && (
-          <div className="text-[11px] text-daintree-text/50 truncate">{scheme.location}</div>
+          <div className="text-2xs text-daintree-text/50 truncate">{scheme.location}</div>
         )}
       </div>
       <div className="flex items-center gap-2 shrink-0">
-        <span className="text-[10px] uppercase tracking-wider text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
+        <span className="text-3xs uppercase tracking-wider text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
           {scheme.type === "light" ? "Light" : "Dark"}
         </span>
         {isActive && (
-          <span className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-[var(--color-state-active)]/15 text-[var(--color-state-active)] text-[10px] font-semibold">
+          <span className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-[var(--color-state-active)]/15 text-[var(--color-state-active)] text-3xs font-semibold">
             Active
           </span>
         )}

--- a/src/components/Worktree/BranchLabel.tsx
+++ b/src/components/Worktree/BranchLabel.tsx
@@ -99,7 +99,9 @@ export function BranchLabel({
           <span
             className={cn(
               "truncate font-mono transition-colors duration-150",
-              isMainWorktree ? "text-[13px] font-bold tracking-wide" : "text-[11px] font-medium",
+              isMainWorktree
+                ? "text-sm leading-[inherit] font-bold tracking-wide"
+                : "text-2xs font-medium",
               isActive
                 ? "text-text-primary/90"
                 : isMuted

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -68,7 +68,7 @@ function CrossWorktreeFileRow({ file, isSelected, onClick }: CrossWorktreeFileRo
           {file.path.split(/[/\\]/).filter(Boolean).pop()}
         </span>
         {hasChurn && (
-          <span className="ml-auto flex items-center gap-1 shrink-0 text-[10px] tabular-nums">
+          <span className="ml-auto flex items-center gap-1 shrink-0 text-3xs tabular-nums">
             {insertions > 0 && <span className="text-status-success/80">+{insertions}</span>}
             {deletions > 0 && <span className="text-status-error/80">-{deletions}</span>}
           </span>

--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -14,7 +14,7 @@
 .diff-viewer {
   font-family: var(--font-mono);
   /* Set per-surface by the diff workspace's text-size control (S/M/L). */
-  font-size: var(--diff-font-size, 12px);
+  font-size: var(--diff-font-size, var(--text-xs));
   line-height: 1.5;
 }
 

--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -335,7 +335,7 @@
   background: var(--color-surface);
   color: var(--color-status-info);
   padding: 4px 12px;
-  font-size: 11px;
+  font-size: var(--text-2xs);
   border-top: 1px solid var(--color-daintree-border);
   border-bottom: 1px solid var(--color-daintree-border);
 }
@@ -379,7 +379,7 @@
   border-radius: var(--radius-sm);
   color: var(--color-daintree-text);
   background: var(--color-daintree-border);
-  font-size: 11px;
+  font-size: var(--text-2xs);
   transition-property: color, background-color;
   transition-duration: 150ms;
   transition-timing-function: ease-out;

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -187,7 +187,7 @@ function FileChangeRow({
                 </span>
               </div>
 
-              <div className="flex items-center gap-2 shrink-0 text-[11px]">
+              <div className="flex items-center gap-2 shrink-0 text-2xs">
                 {(change.insertions ?? 0) > 0 && (
                   <span className="text-status-success/80">+{change.insertions}</span>
                 )}
@@ -434,7 +434,7 @@ export const FileChangeList = forwardRef<FileChangeListHandle, FileChangeListPro
                     token for the same reason — how many files a folder holds
                     is information, and `text-muted` has no contrast floor on
                     the dark palettes (2.22:1 on namib) to carry it. */}
-                <div className="flex items-center gap-1.5 text-[11px] text-text-secondary mb-1">
+                <div className="flex items-center gap-1.5 text-2xs text-text-secondary mb-1">
                   <Folder className="w-3 h-3 shrink-0" />
                   <span className="min-w-0 truncate font-mono">{group.displayDir}</span>
                   <span className="shrink-0 text-text-secondary">({group.files.length})</span>
@@ -461,7 +461,7 @@ export const FileChangeList = forwardRef<FileChangeListHandle, FileChangeListPro
               </div>
             ))}
             {remainingCount > 0 && (
-              <div className="text-[11px] text-daintree-text/60 pl-4 pt-1">
+              <div className="text-2xs text-daintree-text/60 pl-4 pt-1">
                 ...and {remainingCount} more
                 {remainingFiles.length > 0 && (
                   <span className="ml-1 opacity-75">
@@ -507,7 +507,7 @@ export const FileChangeList = forwardRef<FileChangeListHandle, FileChangeListPro
           })}
 
           {remainingCount > 0 && (
-            <div className="text-[11px] text-daintree-text/60 pl-5 pt-1">
+            <div className="text-2xs text-daintree-text/60 pl-5 pt-1">
               ...and {remainingCount} more
               {remainingFiles.length > 0 && (
                 <span className="ml-1 opacity-75">

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -60,7 +60,7 @@ function IssueOptionRow({ issue, isSelected, isCurrentlyAttached, onClick }: Iss
               {issue.title}
             </span>
             {isCurrentlyAttached && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-success/10 text-status-success shrink-0">
+              <span className="text-3xs px-1.5 py-0.5 rounded bg-status-success/10 text-status-success shrink-0">
                 attached
               </span>
             )}

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -1299,7 +1299,7 @@ export function NewWorktreeDialog({
             >
               {initialPR ? "Check out" : "Create worktree"}
               <span
-                className="ml-1 rounded-[3px] bg-text-inverse/15 px-1 py-0.5 font-mono text-[10px] leading-none text-text-inverse"
+                className="ml-1 rounded-xs bg-text-inverse/15 px-1 py-0.5 font-mono text-3xs leading-none text-text-inverse"
                 aria-hidden="true"
               >
                 {isMac() ? "\u2318\u21A9" : "Ctrl\u21A9"}

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -88,14 +88,14 @@ function RecipeListItem({
           {uniqueTypes.map((type) => (
             <span
               key={type}
-              className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-overlay-medium text-daintree-text/70 text-[11px]"
+              className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-overlay-medium text-daintree-text/70 text-2xs"
             >
               {type}
             </span>
           ))}
         </div>
       </div>
-      <div className="flex items-center gap-2 text-[11px] text-daintree-text/50">
+      <div className="flex items-center gap-2 text-2xs text-daintree-text/50">
         <span className="truncate">{getRecipeScope(recipe, () => worktreeName).label}</span>
         {recipe.shadowedBy && <span className="shrink-0">Overridden by Team</span>}
         <span className="ml-auto shrink-0">

--- a/src/components/Worktree/ReviewHub/BaseBranchFileRow.tsx
+++ b/src/components/Worktree/ReviewHub/BaseBranchFileRow.tsx
@@ -55,7 +55,7 @@ export function BaseBranchFileRow({
             aria-hidden="true"
             className={cn(
               "inline-flex items-center justify-center rounded-sm px-1 mr-2 shrink-0",
-              "text-[10px] font-medium leading-4 h-4 min-w-[16px]",
+              "text-3xs font-medium leading-4 h-4 min-w-[16px]",
               config.bg,
               config.text
             )}
@@ -66,7 +66,7 @@ export function BaseBranchFileRow({
             <span
               data-testid="base-branch-file-row-dir"
               className={cn(
-                "shrink truncate font-mono text-[11px] transition-colors",
+                "shrink truncate font-mono text-2xs transition-colors",
                 "text-daintree-text/50 group-hover/baserow:text-daintree-text/70"
               )}
             >
@@ -76,7 +76,7 @@ export function BaseBranchFileRow({
           <span
             data-testid="base-branch-file-row-base"
             className={cn(
-              "shrink truncate font-medium font-mono text-[11px] transition-colors",
+              "shrink truncate font-medium font-mono text-2xs transition-colors",
               "text-daintree-text group-hover/baserow:text-daintree-text"
             )}
           >
@@ -86,7 +86,7 @@ export function BaseBranchFileRow({
         {hasChurn && (
           <div
             data-testid="base-branch-file-row-churn"
-            className="ml-2 flex items-center gap-1 shrink-0 text-[10px] tabular-nums"
+            className="ml-2 flex items-center gap-1 shrink-0 text-3xs tabular-nums"
           >
             {insertions > 0 && <span className="text-status-success/80">+{insertions}</span>}
             {deletions > 0 && <span className="text-status-error/80">-{deletions}</span>}
@@ -100,7 +100,7 @@ export function BaseBranchFileRow({
             disabled={!onBadgeClick}
             className={cn(
               "shrink-0 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 ml-2 rounded-full",
-              "text-[10px] font-semibold tabular-nums",
+              "text-3xs font-semibold tabular-nums",
               "bg-status-warning/15 text-status-warning",
               onBadgeClick
                 ? "hover:bg-status-warning/25 transition-colors cursor-pointer"

--- a/src/components/Worktree/ReviewHub/CommitPanel.tsx
+++ b/src/components/Worktree/ReviewHub/CommitPanel.tsx
@@ -363,7 +363,7 @@ export function CommitPanel({
 
   const blockerTooltip = (
     <div>
-      <div className="text-[11px] font-semibold text-daintree-text/60 mb-2">Cannot commit</div>
+      <div className="text-2xs font-semibold text-daintree-text/60 mb-2">Cannot commit</div>
       <ul className="flex flex-col gap-1.5 text-xs">
         {blockers.map((b) => (
           <li key={b.key} className="flex items-center gap-2">
@@ -432,7 +432,7 @@ export function CommitPanel({
       />
       <div
         className={cn(
-          "flex justify-end text-[10px] tabular-nums -mt-1",
+          "flex justify-end text-3xs tabular-nums -mt-1",
           hasLineOverflow ? "text-status-warning" : "text-text-secondary"
         )}
       >
@@ -440,7 +440,7 @@ export function CommitPanel({
       </div>
 
       {isPushing && pushTargetBranch && (
-        <div className="text-[10px] text-daintree-text/50 truncate">
+        <div className="text-3xs text-daintree-text/50 truncate">
           Pushing to <span className="text-daintree-text/70 font-mono">{pushTargetBranch}</span>
         </div>
       )}
@@ -448,10 +448,7 @@ export function CommitPanel({
       {isPushing && hasProgress && (
         <div className="space-y-1">
           {progressEntries.map((e) => (
-            <div
-              key={e.stage}
-              className="flex items-center gap-2 text-[10px] text-daintree-text/70"
-            >
+            <div key={e.stage} className="flex items-center gap-2 text-3xs text-daintree-text/70">
               <span className="w-20 truncate capitalize">{e.stage}</span>
               <div className="flex-1 h-1 bg-daintree-bg rounded-full overflow-hidden">
                 <div
@@ -495,7 +492,7 @@ export function CommitPanel({
         <div className="flex flex-col gap-2">
           {pushDestination === null && (
             <div
-              className="rounded border border-status-error/30 bg-status-error/10 px-2 py-1.5 text-[11px] text-status-error"
+              className="rounded border border-status-error/30 bg-status-error/10 px-2 py-1.5 text-2xs text-status-error"
               data-testid="commit-panel-push-no-destination"
             >
               No push destination is configured for this branch. Set an upstream, or configure a
@@ -505,7 +502,7 @@ export function CommitPanel({
           <div>
             <span
               data-testid="commit-panel-push-confirm-branch"
-              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] font-mono text-daintree-text"
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-2xs font-mono text-daintree-text"
             >
               {destinationLabel ?? currentBranch ?? ""}
             </span>

--- a/src/components/Worktree/ReviewHub/ConflictPanel.tsx
+++ b/src/components/Worktree/ReviewHub/ConflictPanel.tsx
@@ -95,9 +95,9 @@ function RebaseSequenceRail({ entries }: { entries: RebaseEntry[] }) {
     <div className="border-b border-divider" data-testid="conflict-rebase-sequence">
       <div className={REVIEW_HUB_STICKY_BAND}>
         <div className="px-4 py-2 bg-overlay-subtle flex items-center">
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+          <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
             Rebase sequence
-            <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+            <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal">
               {display.length}
             </span>
           </span>
@@ -149,25 +149,22 @@ function RebaseSequenceRow({ entry }: { entry: RebaseDisplayEntry }) {
       <StateIcon className="w-3 h-3 shrink-0" aria-hidden />
       <span
         className={cn(
-          "text-[10px] uppercase tracking-wider font-mono w-12 shrink-0 text-daintree-text/55",
+          "text-3xs uppercase tracking-wider font-mono w-12 shrink-0 text-daintree-text/55",
           isCurrent && "text-accent-primary/80"
         )}
       >
         {REBASE_ACTION_LABEL[entry.action]}
       </span>
       {entry.sha != null && entry.sha.length > 0 ? (
-        <span className="font-mono text-[11px] tabular-nums text-daintree-text/55 shrink-0">
+        <span className="font-mono text-2xs tabular-nums text-daintree-text/55 shrink-0">
           {entry.sha.slice(0, 7)}
         </span>
       ) : (
-        <span className="font-mono text-[11px] text-daintree-text/30 shrink-0">—</span>
+        <span className="font-mono text-2xs text-daintree-text/30 shrink-0">—</span>
       )}
       <TruncatedTooltip content={entry.subject || REBASE_ACTION_LABEL[entry.action]}>
         <span
-          className={cn(
-            "flex-1 min-w-0 truncate font-mono text-[11px]",
-            isDropped && "line-through"
-          )}
+          className={cn("flex-1 min-w-0 truncate font-mono text-2xs", isDropped && "line-through")}
         >
           {entry.subject}
         </span>
@@ -444,7 +441,7 @@ export function ConflictPanel({
                 status.rebaseStep != null &&
                 status.rebaseTotalSteps != null && (
                   <span
-                    className="text-[11px] tabular-nums text-daintree-text/70 bg-tint/[0.08] border border-tint/[0.08] rounded px-1.5 py-0.5"
+                    className="text-2xs tabular-nums text-daintree-text/70 bg-tint/[0.08] border border-tint/[0.08] rounded px-1.5 py-0.5"
                     data-testid="conflict-rebase-progress"
                   >
                     Step {status.rebaseStep} of {status.rebaseTotalSteps}
@@ -484,9 +481,9 @@ export function ConflictPanel({
       <div className="border-b border-divider">
         <div className={REVIEW_HUB_STICKY_BAND}>
           <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle">
-            <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+            <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
               Conflicted
-              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal">
                 {conflictCount}
               </span>
             </span>
@@ -512,21 +509,21 @@ export function ConflictPanel({
                   <TruncatedTooltip content={`${file.path} (${file.label})`}>
                     <div className="flex-1 min-w-0 flex items-baseline">
                       {dir && (
-                        <span className="shrink truncate text-daintree-text/50 font-mono text-[11px]">
+                        <span className="shrink truncate text-daintree-text/50 font-mono text-2xs">
                           {dir}/
                         </span>
                       )}
-                      <span className="shrink truncate text-daintree-text font-medium font-mono text-[11px]">
+                      <span className="shrink truncate text-daintree-text font-medium font-mono text-2xs">
                         {base}
                       </span>
-                      <span className="ml-2 text-[10px] uppercase tracking-wider text-daintree-text/50 font-mono">
+                      <span className="ml-2 text-3xs uppercase tracking-wider text-daintree-text/50 font-mono">
                         {file.label}
                       </span>
                     </div>
                   </TruncatedTooltip>
                   {hunkCount != null && hunkCount > 0 && (
                     <span
-                      className="shrink-0 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium text-daintree-text/70"
+                      className="shrink-0 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium text-daintree-text/70"
                       title={`${hunkCount} conflict ${hunkCount === 1 ? "region" : "regions"}`}
                       data-testid={`conflict-hunk-count-${file.path}`}
                     >
@@ -541,7 +538,7 @@ export function ConflictPanel({
                         setPendingCheckout({ filePath: file.path, side: "ours" });
                       }}
                       disabled={isBusy}
-                      className="h-5 px-1.5 text-[10px]"
+                      className="h-5 px-1.5 text-3xs"
                       aria-label={`Take ours for ${file.path}`}
                       title={oursHint}
                     >
@@ -554,7 +551,7 @@ export function ConflictPanel({
                         setPendingCheckout({ filePath: file.path, side: "theirs" });
                       }}
                       disabled={isBusy}
-                      className="h-5 px-1.5 text-[10px]"
+                      className="h-5 px-1.5 text-3xs"
                       aria-label={`Take theirs for ${file.path}`}
                       title={theirsHint}
                     >
@@ -565,7 +562,7 @@ export function ConflictPanel({
                       size="sm"
                       onClick={() => handleOpenRow(file.path)}
                       disabled={isBusy}
-                      className="h-5 px-1.5 text-[10px]"
+                      className="h-5 px-1.5 text-3xs"
                       aria-label={`Open ${file.path} in external editor`}
                     >
                       <ExternalLink className="w-3 h-3 mr-1" />
@@ -578,7 +575,7 @@ export function ConflictPanel({
                         handleMarkResolvedClick(file.path).catch(() => {});
                       }}
                       disabled={isBusy}
-                      className="h-5 px-1.5 text-[10px]"
+                      className="h-5 px-1.5 text-3xs"
                       aria-label={`Mark ${file.path} as resolved`}
                     >
                       {isBusy ? (
@@ -603,7 +600,7 @@ export function ConflictPanel({
             <button
               type="button"
               onClick={() => setShowResolved((v) => !v)}
-              className="w-full flex items-center gap-1.5 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-daintree-text/50 hover:text-daintree-text/70 hover:bg-overlay-subtle transition-colors"
+              className="w-full flex items-center gap-1.5 px-4 py-1.5 text-2xs font-semibold uppercase tracking-wider text-daintree-text/50 hover:text-daintree-text/70 hover:bg-overlay-subtle transition-colors"
               aria-expanded={showResolved}
               data-testid="conflict-resolved-toggle"
             >
@@ -614,7 +611,7 @@ export function ConflictPanel({
                 )}
               />
               Resolved
-              <span className="tabular-nums bg-tint/[0.06] rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal text-daintree-text/50">
+              <span className="tabular-nums bg-tint/[0.06] rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal text-daintree-text/50">
                 {status.staged.length}
               </span>
             </button>
@@ -635,11 +632,11 @@ export function ConflictPanel({
                       <TruncatedTooltip content={file.path}>
                         <div className="flex-1 min-w-0 flex items-baseline">
                           {dir && (
-                            <span className="shrink truncate text-daintree-text/40 font-mono text-[11px]">
+                            <span className="shrink truncate text-daintree-text/40 font-mono text-2xs">
                               {dir}/
                             </span>
                           )}
-                          <span className="shrink truncate text-daintree-text/60 font-mono text-[11px]">
+                          <span className="shrink truncate text-daintree-text/60 font-mono text-2xs">
                             {base}
                           </span>
                         </div>

--- a/src/components/Worktree/ReviewHub/FileSection.tsx
+++ b/src/components/Worktree/ReviewHub/FileSection.tsx
@@ -160,11 +160,11 @@ export function FileSection({
           while a long changeset scrolls. */}
       <div className={cn("@container/file-section", REVIEW_HUB_STICKY_BAND)}>
         <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle gap-2">
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 shrink-0 flex items-center">
+          <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60 shrink-0 flex items-center">
             {title}
             <span
               data-testid={countTestId}
-              className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal inline-flex items-center gap-1"
+              className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal inline-flex items-center gap-1"
             >
               <span>
                 {totalCount} file{totalCount !== 1 ? "s" : ""}
@@ -190,7 +190,7 @@ export function FileSection({
                 role="status"
                 data-testid={`${section}-section-shown-chip`}
                 aria-label={`${shownCount} of ${totalCount} files shown`}
-                className="ml-1 tabular-nums rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal text-daintree-text/50 bg-overlay-medium"
+                className="ml-1 tabular-nums rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal text-daintree-text/50 bg-overlay-medium"
               >
                 {shownCount} shown
               </span>
@@ -224,7 +224,7 @@ export function FileSection({
                 defaultValue={view.filterQuery}
                 onChange={(e) => setFilterQuery(e.target.value)}
                 className={cn(
-                  "w-[104px] min-w-0 bg-transparent text-[11px]",
+                  "w-[104px] min-w-0 bg-transparent text-2xs",
                   "text-daintree-text placeholder:text-text-placeholder",
                   // The transparent-outline utility below is what forced
                   // colors would normally turn into a visible box. That is
@@ -260,7 +260,7 @@ export function FileSection({
                   {nonDefaultViewCount > 0 && (
                     <span
                       aria-hidden="true"
-                      className="text-[10px] font-medium leading-none tabular-nums"
+                      className="text-3xs font-medium leading-none tabular-nums"
                     >
                       {nonDefaultViewCount}
                     </span>
@@ -346,7 +346,7 @@ export function FileSection({
                 // justify-start so the glyph keeps the same x in both stacked
                 // sections; the ghost button has no chrome at rest, so the
                 // reserved trailing space is invisible.
-                className="h-5 px-1.5 text-[10px] shrink-0 min-w-[9rem] justify-start"
+                className="h-5 px-1.5 text-3xs shrink-0 min-w-[9rem] justify-start"
                 data-testid={bulkActionTestId}
               >
                 <BulkActionIcon className="w-3 h-3 mr-1" />

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -205,7 +205,7 @@ function FileStageRowComponent({
             aria-hidden="true"
             className={cn(
               "inline-flex items-center justify-center rounded-sm px-1 mr-2 shrink-0",
-              "text-[10px] font-medium leading-4 h-4 min-w-[16px]",
+              "text-3xs font-medium leading-4 h-4 min-w-[16px]",
               config.bg,
               config.text
             )}
@@ -216,7 +216,7 @@ function FileStageRowComponent({
             <span
               data-testid="file-stage-row-dir"
               className={cn(
-                "shrink truncate font-mono text-[11px] transition-colors",
+                "shrink truncate font-mono text-2xs transition-colors",
                 generated
                   ? "text-daintree-text/30"
                   : "text-daintree-text/50 group-hover/stagerow:text-daintree-text/70"
@@ -228,7 +228,7 @@ function FileStageRowComponent({
           <span
             data-testid="file-stage-row-base"
             className={cn(
-              "shrink truncate font-medium font-mono text-[11px] transition-colors",
+              "shrink truncate font-medium font-mono text-2xs transition-colors",
               generated
                 ? "text-daintree-text/40"
                 : "text-daintree-text group-hover/stagerow:text-daintree-text"
@@ -243,7 +243,7 @@ function FileStageRowComponent({
         <div
           data-testid="file-stage-row-churn"
           className={cn(
-            "ml-2 flex items-center gap-1 shrink-0 text-[10px] tabular-nums",
+            "ml-2 flex items-center gap-1 shrink-0 text-3xs tabular-nums",
             generated && "opacity-60"
           )}
         >
@@ -259,7 +259,7 @@ function FileStageRowComponent({
               onClick={handleViewedClick}
               className={cn(
                 "flex items-center gap-1 ml-2 shrink-0 cursor-pointer select-none rounded px-1.5 py-0.5",
-                "text-[10px] font-medium uppercase tracking-wider transition-colors",
+                "text-3xs font-medium uppercase tracking-wider transition-colors",
                 viewed
                   ? "text-daintree-text/60"
                   : "text-daintree-text/30 hover:text-daintree-text/60"

--- a/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
+++ b/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
@@ -154,10 +154,10 @@ export function ForcePushConfirmDialog({
 
         <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
           <div className="px-3 py-2 border-b border-tint/[0.08] flex items-center justify-between">
-            <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+            <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
               Remote commits to discard
               {totalRemote > 0 && (
-                <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+                <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal">
                   {totalRemote}
                 </span>
               )}
@@ -183,7 +183,7 @@ export function ForcePushConfirmDialog({
                   onClick={loadCommits}
                   data-testid="force-push-commits-retry"
                   className={cn(
-                    "mt-1 inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
+                    "mt-1 inline-flex items-center px-2 py-0.5 rounded text-2xs font-medium transition-colors",
                     "bg-status-error/15 hover:bg-status-error/25 text-status-error",
                     "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-error"
                   )}
@@ -222,14 +222,12 @@ export function ForcePushConfirmDialog({
                     data-testid="force-push-commit-row"
                   >
                     <span
-                      className={cn(
-                        "font-mono text-[10px] text-text-secondary shrink-0 tabular-nums"
-                      )}
+                      className={cn("font-mono text-3xs text-text-secondary shrink-0 tabular-nums")}
                     >
                       {commit.hash.slice(0, SHORT_HASH_LEN)}
                     </span>
                     <span className="text-daintree-text/80 truncate min-w-0">{commit.message}</span>
-                    <span className="text-[10px] text-text-secondary shrink-0 ml-auto">
+                    <span className="text-3xs text-text-secondary shrink-0 ml-auto">
                       {commit.author}
                     </span>
                   </li>
@@ -240,7 +238,7 @@ export function ForcePushConfirmDialog({
                   // is that the divergence runs to hundreds of commits, not
                   // what the hundred-and-first one says.
                   <li
-                    className="text-[10px] text-text-secondary italic pt-1"
+                    className="text-3xs text-text-secondary italic pt-1"
                     data-testid="force-push-commit-cap"
                   >
                     Listing the {commits.length} most recent of {totalRemote}

--- a/src/components/Worktree/ReviewHub/PrStatusChip.tsx
+++ b/src/components/Worktree/ReviewHub/PrStatusChip.tsx
@@ -30,7 +30,7 @@ export function PrStatusChip({ hasRemote, worktreePR, onOpenExternal }: PrStatus
       <>
         <Badge
           tone="outline"
-          className="text-[11px] font-mono"
+          className="text-2xs font-mono"
           aria-label={
             ciVisual
               ? `Pull request #${worktreePR.prNumber} ${prStateLabel} — CI ${ciVisual.shortLabel}`
@@ -94,7 +94,7 @@ export function PrStatusChip({ hasRemote, worktreePR, onOpenExternal }: PrStatus
 
   if (hasRemote && !worktreePR) {
     return (
-      <Badge tone="outline" className="text-[11px] text-text-secondary">
+      <Badge tone="outline" className="text-2xs text-text-secondary">
         <GitPullRequest />
         <span>No PR</span>
       </Badge>

--- a/src/components/Worktree/ReviewHub/PushErrorBanner.tsx
+++ b/src/components/Worktree/ReviewHub/PushErrorBanner.tsx
@@ -56,7 +56,7 @@ export function PushErrorBanner({
       data-testid={isPrimary ? "review-hub-push-error-cta" : "review-hub-push-error-secondary-cta"}
       data-cta-kind={cta.kind}
       className={cn(
-        "inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
+        "inline-flex items-center gap-1 px-2 py-0.5 rounded text-2xs font-medium transition-colors",
         "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-warning",
         "disabled:opacity-50 disabled:cursor-not-allowed",
         isPrimary
@@ -82,7 +82,7 @@ export function PushErrorBanner({
         {forgeErrorCode && (
           <div
             data-testid="review-hub-push-error-code"
-            className="mt-1 text-[10px] font-mono opacity-80"
+            className="mt-1 text-3xs font-mono opacity-80"
           >
             {forgeErrorCode}
           </div>
@@ -97,7 +97,7 @@ export function PushErrorBanner({
               className={cn(
                 "inline-flex items-center px-1.5 py-0.5 rounded",
                 "text-status-warning/80 hover:text-status-warning",
-                "text-[10px] font-medium underline-offset-2 hover:underline transition-colors",
+                "text-3xs font-medium underline-offset-2 hover:underline transition-colors",
                 "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-warning"
               )}
             >
@@ -108,7 +108,7 @@ export function PushErrorBanner({
         {canCollapse && showPushDetails && (
           <pre
             data-testid="review-hub-push-error-details"
-            className="mt-1 text-[10px] font-mono whitespace-pre-wrap break-all opacity-70"
+            className="mt-1 text-3xs font-mono whitespace-pre-wrap break-all opacity-70"
           >
             {pushError.rawMessage}
           </pre>

--- a/src/components/Worktree/ReviewHub/ReadinessRail.tsx
+++ b/src/components/Worktree/ReviewHub/ReadinessRail.tsx
@@ -55,7 +55,7 @@ const FOCUS_RING =
   "outline-hidden focus-visible:outline focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
 
 const CTA_CLASS = cn(
-  "inline-flex items-center gap-1 shrink-0 px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
+  "inline-flex items-center gap-1 shrink-0 px-2 py-0.5 rounded text-2xs font-medium transition-colors",
   "bg-filter-selected-bg-soft hover:bg-tint/[0.14] text-daintree-text/80",
   FOCUS_RING
 );
@@ -94,7 +94,7 @@ export function ReadinessRail({ summary, onCta }: ReadinessRailProps) {
       data-testid="review-readiness-rail"
       role="group"
       aria-label="Review readiness"
-      className="flex items-center gap-2 px-4 py-1.5 border-b border-divider text-[11px]"
+      className="flex items-center gap-2 px-4 py-1.5 border-b border-divider text-2xs"
     >
       <span
         data-testid="review-readiness-level"
@@ -160,7 +160,7 @@ function ReadinessOverflow({
         data-testid="review-readiness-overflow"
         aria-label={`${items.length} more: ${items.map((i) => i.label).join(", ")}`}
         className={cn(
-          "inline-flex items-center gap-0.5 shrink-0 px-1.5 py-0.5 rounded text-[11px] transition-colors",
+          "inline-flex items-center gap-0.5 shrink-0 px-1.5 py-0.5 rounded text-2xs transition-colors",
           "text-text-secondary hover:text-daintree-text hover:bg-tint/[0.06]",
           FOCUS_RING
         )}

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -1597,7 +1597,7 @@ export function ReviewHubContent({
             )}
             {status?.currentBranch && (
               <TruncatedTooltip content={status.currentBranch}>
-                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] text-daintree-text/60 font-mono truncate max-w-[200px]">
+                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-2xs text-daintree-text/60 font-mono truncate max-w-[200px]">
                   <GitBranch className="w-3 h-3 shrink-0" />
                   <span className="truncate">{status.currentBranch}</span>
                 </span>
@@ -1605,7 +1605,7 @@ export function ReviewHubContent({
             )}
             {status?.currentBranch && isProtectedBranch(status.currentBranch.toLowerCase()) && (
               <span
-                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-status-warning/10 border border-status-warning/30 text-[11px] text-status-warning shrink-0"
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-status-warning/10 border border-status-warning/30 text-2xs text-status-warning shrink-0"
                 data-testid="review-hub-protected-branch-chip"
               >
                 <AlertTriangle className="w-3 h-3 shrink-0" aria-hidden="true" />
@@ -1621,7 +1621,7 @@ export function ReviewHubContent({
           <div className="flex items-center gap-2 shrink-0">
             {/* Diff mode toggle */}
             <div
-              className="flex items-center rounded border border-tint/[0.08] overflow-hidden text-[11px]"
+              className="flex items-center rounded border border-tint/[0.08] overflow-hidden text-2xs"
               role="group"
               aria-label="Diff mode"
               data-testid="review-hub-diff-mode"
@@ -1855,9 +1855,9 @@ export function ReviewHubContent({
                 <div>
                   <div className={REVIEW_HUB_STICKY_BAND}>
                     <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle border-b border-divider">
-                      <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+                      <span className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
                         Changed vs {mainBranch}
-                        <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+                        <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-3xs font-medium normal-case tracking-normal">
                           {sortedBaseBranchFiles.length} file
                           {sortedBaseBranchFiles.length !== 1 ? "s" : ""}
                           {(baseBranchChurn.ins > 0 || baseBranchChurn.del > 0) && (
@@ -2023,7 +2023,7 @@ export function ReviewHubContent({
                         aria-controls={`review-hub-files-${worktreePath}`}
                         data-testid="review-hub-file-list-toggle"
                         className={cn(
-                          "inline-flex items-center gap-1 text-[11px] font-medium text-daintree-text/70 hover:text-daintree-text transition-colors",
+                          "inline-flex items-center gap-1 text-2xs font-medium text-daintree-text/70 hover:text-daintree-text transition-colors",
                           "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent rounded"
                         )}
                       >

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.conflictMode.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.conflictMode.test.tsx
@@ -647,7 +647,7 @@ describe("ReviewHub", () => {
       render(<ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
 
       await waitFor(() => screen.getByTestId("conflict-panel"));
-      // The Abort control is now sized `xs` (text-[10px]); Continue is the
+      // The Abort control is now sized `xs` (text-3xs); Continue is the
       // only `sm` primary in the footer region. Verify both exist and that
       // there is exactly one Continue and exactly one Abort.
       expect(screen.getAllByRole("button", { name: /^Continue /i })).toHaveLength(1);

--- a/src/components/Worktree/WorktreeCard/CollapsedSessionIndicators.tsx
+++ b/src/components/Worktree/WorktreeCard/CollapsedSessionIndicators.tsx
@@ -27,7 +27,7 @@ export function CollapsedSessionIndicators({
               <span
                 key={state}
                 aria-hidden="true"
-                className={cn("flex items-center gap-0.5 text-[10px]", STATE_COLORS[state])}
+                className={cn("flex items-center gap-0.5 text-3xs", STATE_COLORS[state])}
               >
                 <Icon
                   className={cn(

--- a/src/components/Worktree/WorktreeCard/CommitInfoTooltip.tsx
+++ b/src/components/Worktree/WorktreeCard/CommitInfoTooltip.tsx
@@ -65,7 +65,7 @@ export function CommitInfoTooltip({
             <span className="truncate text-xs font-semibold text-daintree-text">
               {author ? author.name : "Last commit"}
             </span>
-            <span className="text-[11px] text-text-muted" title={committedAbsolute!}>
+            <span className="text-2xs text-text-muted" title={committedAbsolute!}>
               Committed {committed}
             </span>
           </div>
@@ -80,7 +80,7 @@ export function CommitInfoTooltip({
 
       {hasActivity && !activityMatchesCommit && (
         <div className={hasCommit ? "mt-2.5 border-t border-border-divider pt-2.5" : undefined}>
-          <div className="flex items-center gap-1.5 text-[11px] text-text-muted">
+          <div className="flex items-center gap-1.5 text-2xs text-text-muted">
             <ActivityLight lastActivityTimestamp={lastActivityTimestamp} className="h-1.5 w-1.5" />
             <span title={activityAbsolute!}>Last active {activityPhrase}</span>
           </div>

--- a/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
+++ b/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
@@ -117,12 +117,12 @@ export function EnvironmentPopover({
           )}
         </div>
         {resourceEndpoint && (
-          <div className="mb-2 font-mono text-[11px] text-text-secondary break-all">
+          <div className="mb-2 font-mono text-2xs text-text-secondary break-all">
             {resourceEndpoint}
           </div>
         )}
         {resourceLastOutput && (
-          <pre className="mb-2 max-h-32 overflow-y-auto whitespace-pre-wrap break-all rounded bg-surface-panel-elevated p-2 font-mono text-[11px] text-text-secondary">
+          <pre className="mb-2 max-h-32 overflow-y-auto whitespace-pre-wrap break-all rounded bg-surface-panel-elevated p-2 font-mono text-2xs text-text-secondary">
             {resourceLastOutput.trim()}
           </pre>
         )}

--- a/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/ForgeTooltipContent.tsx
@@ -195,7 +195,7 @@ function LabelBadge({ name, color }: LabelBadgeProps) {
       // `line-clamp-2` bounds height as well as width: a name is unbounded in
       // the provider contract, and twenty of them wrapping freely would make the
       // tooltip arbitrarily tall even under the chip cap.
-      className="inline-block max-w-full break-words [overflow-wrap:anywhere] line-clamp-2 px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+      className="inline-block max-w-full break-words [overflow-wrap:anywhere] line-clamp-2 px-1.5 py-0.5 rounded-full text-3xs font-medium"
       style={{
         backgroundColor: `#${color}20`,
         color: `#${color}`,
@@ -239,7 +239,7 @@ function LabelRow({ labels, subject }: { labels: readonly ForgeLabel[]; subject:
         <LabelBadge key={label.name} name={label.name} color={label.color ?? "8b949e"} />
       ))}
       {labels.length > shown.length && (
-        <span className="text-[10px] text-text-secondary">
+        <span className="text-3xs text-text-secondary">
           Showing {shown.length} of {labels.length} — open the {subject} for the rest
         </span>
       )}
@@ -263,10 +263,10 @@ export function IssueTooltipContent({ data, freshness }: IssueTooltipContentProp
       </div>
 
       {data.bodyExcerpt && (
-        <p className="text-[11px] text-daintree-text/60 line-clamp-3">{data.bodyExcerpt}</p>
+        <p className="text-2xs text-daintree-text/60 line-clamp-3">{data.bodyExcerpt}</p>
       )}
 
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-daintree-text/50">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-daintree-text/50">
         {data.author && (
           <span className="flex items-center gap-1">
             <PenLine className="w-3 h-3 shrink-0" aria-hidden="true" />
@@ -313,7 +313,7 @@ export function PRTooltipContent({ data, freshness }: PRTooltipContentProps) {
         <span className="text-xs text-daintree-text/90 line-clamp-2">{data.title}</span>
         <span
           className={cn(
-            "text-[10px] px-1.5 py-0.5 rounded-full shrink-0 capitalize",
+            "text-3xs px-1.5 py-0.5 rounded-full shrink-0 capitalize",
             data.state === "merged"
               ? "bg-pr-merged/20 text-pr-merged"
               : data.state === "closed" || data.state === "declined"
@@ -326,10 +326,10 @@ export function PRTooltipContent({ data, freshness }: PRTooltipContentProps) {
       </div>
 
       {data.bodyExcerpt && (
-        <p className="text-[11px] text-daintree-text/60 line-clamp-3">{data.bodyExcerpt}</p>
+        <p className="text-2xs text-daintree-text/60 line-clamp-3">{data.bodyExcerpt}</p>
       )}
 
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-daintree-text/50">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-daintree-text/50">
         {data.author && (
           <span className="flex items-center gap-1">
             <PenLine className="w-3 h-3 shrink-0" aria-hidden="true" />

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -80,7 +80,7 @@ export function IssueBadge({
           className={cn(
             "flex items-center gap-1 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
             freshnessClass(freshnessLevel),
-            isHeadline ? "gap-1.5 text-[13px]" : "text-xs"
+            isHeadline ? "gap-1.5 text-sm leading-[inherit]" : "text-xs"
           )}
           aria-disabled={!isActive || undefined}
           aria-label={
@@ -142,7 +142,7 @@ export function IssueBadge({
           <span className="text-xs text-text-secondary">Issue #{issueNumber}</span>
         )}
         {!data && (
-          <FreshnessMetaItem freshness={freshness} className="text-[11px] text-text-muted mt-1" />
+          <FreshnessMetaItem freshness={freshness} className="text-2xs text-text-muted mt-1" />
         )}
       </TooltipContent>
     </Tooltip>

--- a/src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx
@@ -68,13 +68,13 @@ export function MainWorktreeSecondaryRow({
       )}
       {aggregateCounts && aggregateCounts.worktrees > 0 && (
         <>
-          <span className="text-text-muted/40 text-[10px]" aria-hidden="true">
+          <span className="text-text-muted/40 text-3xs" aria-hidden="true">
             ·
           </span>
           <Tooltip>
             <TooltipTrigger asChild>
               <span
-                className="flex items-center gap-1.5 text-[10px] text-daintree-text/50"
+                className="flex items-center gap-1.5 text-3xs text-daintree-text/50"
                 data-testid="aggregate-worktree-row"
               >
                 <span className="flex items-center gap-0.5">

--- a/src/components/Worktree/WorktreeCard/MainWorktreeSummaryRows.tsx
+++ b/src/components/Worktree/WorktreeCard/MainWorktreeSummaryRows.tsx
@@ -52,7 +52,7 @@ export function MainWorktreeSummaryRows({ health }: MainWorktreeSummaryRowsProps
       <Tooltip>
         <TooltipTrigger asChild>
           <div
-            className="flex items-center gap-2 text-[10px] text-daintree-text/60"
+            className="flex items-center gap-2 text-3xs text-daintree-text/60"
             data-testid="github-pulse-row"
           >
             <span className="flex items-center gap-0.5">

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -127,7 +127,7 @@ export function PRBadge({
           data-no-dnd
           className={cn(
             "flex items-center gap-1 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
-            isHeadline ? "gap-1.5 text-[13px]" : "text-xs"
+            isHeadline ? "gap-1.5 text-sm leading-[inherit]" : "text-xs"
           )}
           aria-disabled={!isActive || undefined}
           aria-label={ariaLabel}
@@ -207,7 +207,7 @@ export function PRBadge({
           <span className="text-xs text-text-secondary">PR #{prNumber}</span>
         )}
         {!data && (
-          <FreshnessMetaItem freshness={freshness} className="text-[11px] text-text-muted mt-1" />
+          <FreshnessMetaItem freshness={freshness} className="text-2xs text-text-muted mt-1" />
         )}
       </TooltipContent>
     </Tooltip>

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -128,7 +128,7 @@ export function UpstreamSyncBadge({
             onClick={handleSignInClick}
             data-no-dnd
             className={cn(
-              "flex items-center text-[10px] font-mono tabular-nums cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
+              "flex items-center text-3xs font-mono tabular-nums cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
               containerGapClass
             )}
             data-testid="upstream-sync-indicator"
@@ -160,7 +160,7 @@ export function UpstreamSyncBadge({
       <TooltipTrigger asChild>
         <span
           className={cn(
-            "flex items-center text-[10px] font-mono tabular-nums",
+            "flex items-center text-3xs font-mono tabular-nums",
             containerGapClass,
             isFlashing && "animate-upstream-badge-flash",
             fetchNetworkFailed && "opacity-75",

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -569,7 +569,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                       <ChevronDown className="w-3 h-3" aria-hidden="true" />
                       Show details
                     </summary>
-                    <pre className="mt-1.5 max-h-32 overflow-auto rounded bg-status-error/5 p-2 font-mono text-[11px] text-text-secondary whitespace-pre-wrap break-all select-text">
+                    <pre className="mt-1.5 max-h-32 overflow-auto rounded bg-status-error/5 p-2 font-mono text-2xs text-text-secondary whitespace-pre-wrap break-all select-text">
                       {[lifecycleError, lifecycleOutput].filter(Boolean).join("\n\n")}
                     </pre>
                   </details>

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -288,7 +288,7 @@ export function WorktreeHeader({
             <TruncatedTooltip content={worktree.name}>
               <span
                 className={cn(
-                  "truncate text-[13px] font-medium transition-colors duration-150",
+                  "truncate text-sm leading-[inherit] font-medium transition-colors duration-150",
                   isActive
                     ? "text-text-primary/90"
                     : isMuted
@@ -353,9 +353,7 @@ export function WorktreeHeader({
                 </TooltipTrigger>
                 <TooltipContent side="bottom" className="max-w-xs">
                   <span className="block">Outside the project directory</span>
-                  <span className="mt-0.5 block font-mono text-[11px] break-all">
-                    {worktree.path}
-                  </span>
+                  <span className="mt-0.5 block font-mono text-2xs break-all">{worktree.path}</span>
                 </TooltipContent>
               </Tooltip>
             )}

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -107,7 +107,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
               {!chrome.isAgent && term.activityStatus === "working" && term.lastCommand && (
                 <Tooltip autoDismiss={false}>
                   <TooltipTrigger asChild>
-                    <span className="truncate text-[11px] font-mono text-text-muted">
+                    <span className="truncate text-2xs font-mono text-text-muted">
                       {term.lastCommand}
                     </span>
                   </TooltipTrigger>
@@ -121,7 +121,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
         <div className="flex items-center gap-2.5 shrink-0">
           {isArmed && armBadge !== undefined && (
             <span
-              className="inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-daintree-accent px-1 text-[9px] font-mono font-semibold text-accent-primary-foreground tabular-nums"
+              className="inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-daintree-accent px-1 text-4xs font-mono font-semibold text-accent-primary-foreground tabular-nums"
               aria-label={`Armed position ${armBadge}`}
             >
               {armBadge}
@@ -414,7 +414,7 @@ export function WorktreeTerminalSection({
           onClick={onStartSession}
           className={cn(
             SECTION_ROW,
-            "gap-1.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+            "gap-1.5 text-2xs text-text-secondary transition-colors hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
           )}
         >
           <Plus className="h-3 w-3 shrink-0" aria-hidden="true" />
@@ -446,7 +446,7 @@ export function WorktreeTerminalSection({
             <span
               className={cn(
                 "flex items-center gap-1.5",
-                isSidebar ? SECTION_LABEL : "text-[11px] font-medium text-text-muted"
+                isSidebar ? SECTION_LABEL : "text-2xs font-medium text-text-muted"
               )}
             >
               {/* The expanded sidebar trigger drops the summary glyph. It led
@@ -476,7 +476,7 @@ export function WorktreeTerminalSection({
             {eligibleTerminals.length >= 2 && armedIdsSize === 0 && !hintDismissed && (
               <div
                 className={cn(
-                  "flex items-center justify-between py-1.5 text-[11px] text-text-muted",
+                  "flex items-center justify-between py-1.5 text-2xs text-text-muted",
                   isSidebar ? "px-3" : "border-b border-border-default bg-surface-inset px-3"
                 )}
               >
@@ -548,7 +548,7 @@ export function WorktreeTerminalSection({
           )}
           id={`${terminalsId}-button`}
         >
-          <div className="flex items-center gap-1.5 text-[11px] text-text-secondary">
+          <div className="flex items-center gap-1.5 text-2xs text-text-secondary">
             {isSidebar && (
               <ChevronRight className="h-3 w-3 shrink-0 text-text-secondary" aria-hidden="true" />
             )}

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -216,7 +216,7 @@ export function useWorktreeActions({
       createElement(
         "span",
         {
-          className: "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60",
+          className: "text-2xs font-semibold uppercase tracking-wider text-daintree-text/60",
         },
         hasCommands ? "Commands that will run" : "Teardown commands"
       ),

--- a/src/components/Worktree/WorktreeCard/sectionChrome.ts
+++ b/src/components/Worktree/WorktreeCard/sectionChrome.ts
@@ -21,7 +21,7 @@
  * passive metadata. The 11px size does the de-emphasis; the tone does not have
  * to as well.
  */
-export const SECTION_LABEL = "text-[11px] font-medium text-text-secondary";
+export const SECTION_LABEL = "text-2xs font-medium text-text-secondary";
 
 /**
  * The geometry of a sidebar disclosure row — the collapsed Details trigger,

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -461,11 +461,11 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   id={changesHeadingId}
                   role="heading"
                   aria-level={3}
-                  className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
+                  className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60"
                 >
                   Uncommitted work
                 </span>
-                <span className="text-[11px] tabular-nums text-daintree-text/50">
+                <span className="text-2xs tabular-nums text-daintree-text/50">
                   {changeSummaryLabel}
                 </span>
               </div>
@@ -515,7 +515,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
               would then dispatch the values the user had BEFORE they changed
               their mind. Cancel and Escape stay live throughout. */}
           <fieldset className="space-y-3">
-            <legend className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+            <legend className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60">
               Options
             </legend>
 
@@ -592,7 +592,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
               id={consequencesHeadingId}
               role="heading"
               aria-level={3}
-              className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
+              className="text-2xs font-semibold uppercase tracking-wider text-daintree-text/60"
             >
               What will happen
             </span>

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -33,7 +33,7 @@ const NARRATIVE_RAIL = "border-l-2 border-border-strong pl-2.5";
 // namib, where it drops out of the rail entirely. The 10px uppercase size and
 // the tracking already do the de-emphasis.
 const NARRATIVE_LABEL =
-  "flex items-center gap-1 text-[10px] font-medium uppercase tracking-[0.06em] text-text-secondary";
+  "flex items-center gap-1 text-3xs font-medium uppercase tracking-[0.06em] text-text-secondary";
 
 export interface WorktreeDetailsProps {
   worktree: WorktreeState;

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -50,7 +50,7 @@ function FilterSection({
           <span className="flex items-center gap-1.5">
             {title}
             {hasActive && (
-              <span className="rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none tabular-nums text-daintree-text/60">
+              <span className="rounded-full bg-tint/10 px-1.5 py-0.5 text-3xs font-medium leading-none tabular-nums text-daintree-text/60">
                 {activeCount}
               </span>
             )}
@@ -71,7 +71,7 @@ function FilterSection({
               onClear();
             }}
             aria-label={`Clear ${title} filters`}
-            className="shrink-0 px-2 py-1.5 text-[11px] text-text-secondary transition-colors hover:text-daintree-text"
+            className="shrink-0 px-2 py-1.5 text-2xs text-text-secondary transition-colors hover:text-daintree-text"
           >
             Clear
           </button>
@@ -115,7 +115,7 @@ function FilterChip({ label, isActive, onClick, count }: FilterChipProps) {
       onClick={onClick}
       aria-pressed={isActive}
       className={cn(
-        "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full border transition-colors",
+        "inline-flex items-center px-2 py-0.5 text-2xs rounded-full border transition-colors",
         isActive
           ? "bg-filter-selected-bg-soft border-daintree-border text-daintree-text"
           : isDimmed
@@ -409,7 +409,7 @@ export function WorktreeFilterPopover({
         >
           <Filter className="w-3.5 h-3.5 shrink-0" />
           {showBadge && (
-            <span className="text-[10px] font-medium leading-none tabular-nums">{filterCount}</span>
+            <span className="text-3xs font-medium leading-none tabular-nums">{filterCount}</span>
           )}
         </button>
       </PopoverTrigger>
@@ -462,7 +462,7 @@ export function WorktreeFilterPopover({
           <div className="px-3 pt-2.5 pb-2 border-b border-daintree-border">
             <div
               id="worktree-sort-by-label"
-              className="text-[10px] font-medium text-text-secondary uppercase tracking-wide mb-1.5"
+              className="text-3xs font-medium text-text-secondary uppercase tracking-wide mb-1.5"
             >
               Sort by
             </div>

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -44,7 +44,7 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
               <span className="font-mono text-daintree-text/70 truncate">{worktree.branch}</span>
             )}
             {isActive && (
-              <span className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-[var(--color-state-active)]/15 text-[var(--color-state-active)] text-[11px] font-semibold">
+              <span className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-[var(--color-state-active)]/15 text-[var(--color-state-active)] text-2xs font-semibold">
                 Active
               </span>
             )}
@@ -52,7 +52,7 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
         </div>
         <div
           ref={ref}
-          className="text-[11px] text-daintree-text/50 truncate transition-colors group-aria-selected:text-daintree-text/60"
+          className="text-2xs text-daintree-text/50 truncate transition-colors group-aria-selected:text-daintree-text/60"
         >
           {worktree.path}
         </div>

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -260,7 +260,7 @@ export function WorktreeSidebarSearchBar({
         // floating clear of the rule below.
         <div className="flex items-center gap-2 pt-2">
           {statusText && (
-            <span className="min-w-0 flex-1 truncate text-[11px] text-text-secondary">
+            <span className="min-w-0 flex-1 truncate text-2xs text-text-secondary">
               {statusText}
             </span>
           )}
@@ -268,7 +268,7 @@ export function WorktreeSidebarSearchBar({
             <button
               type="button"
               onClick={handleClearAll}
-              className="ml-auto shrink-0 rounded text-[11px] text-text-secondary hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-daintree-accent"
+              className="ml-auto shrink-0 rounded text-2xs text-text-secondary hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-daintree-accent"
             >
               Clear all
             </button>

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -104,14 +104,14 @@ function OnboardingCard({
       />
       <div className="flex items-center gap-2 shrink-0">
         {presetCount > 1 && (
-          <span className="text-[10px] text-status-info font-medium bg-status-info/10 px-1.5 py-0.5 rounded">
+          <span className="text-3xs text-status-info font-medium bg-status-info/10 px-1.5 py-0.5 rounded">
             {presetCount} presets
           </span>
         )}
         {installed ? (
-          <span className="text-[11px] text-status-success font-medium">Installed</span>
+          <span className="text-2xs text-status-success font-medium">Installed</span>
         ) : (
-          <span className="text-[11px] text-daintree-text/30">Not installed</span>
+          <span className="text-2xs text-daintree-text/30">Not installed</span>
         )}
       </div>
     </label>
@@ -172,9 +172,7 @@ export function AgentIdentityBlock({
       </div>
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium text-daintree-text">{name}</div>
-        {description && (
-          <div className="text-[11px] text-text-secondary truncate">{description}</div>
-        )}
+        {description && <div className="text-2xs text-text-secondary truncate">{description}</div>}
       </div>
     </>
   );

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -695,7 +695,7 @@ AppDialog.Footer = function AppDialogFooter({
           lets a hint measure its own box and crop to it. */}
       {hint && (
         <div
-          className="text-[12px] text-daintree-text/55 flex min-w-0 flex-1 items-center gap-1"
+          className="text-xs leading-[inherit] text-daintree-text/55 flex min-w-0 flex-1 items-center gap-1"
           data-testid="app-dialog-hint"
         >
           {hint}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -426,7 +426,7 @@ AppPaletteDialog.Header = function AppPaletteHeader({
         className
       )}
     >
-      <div className="flex justify-between items-center mb-1.5 text-[11px] text-daintree-text/50">
+      <div className="flex justify-between items-center mb-1.5 text-2xs text-daintree-text/50">
         <span>{label}</span>
         {/*
          * Grouped only when there is something to group. `justify-between`

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -17,7 +17,7 @@ export const KBD_CLASS =
  * loudest on the light themes.
  */
 export const KBD_COMPACT_CLASS =
-  "px-1 py-px rounded-sm text-[10px] font-mono tabular-nums leading-none bg-overlay-subtle text-daintree-text/70 border border-border-subtle";
+  "px-1 py-px rounded-sm text-3xs font-mono tabular-nums leading-none bg-overlay-subtle text-daintree-text/70 border border-border-subtle";
 
 export interface KbdProps {
   children: React.ReactNode;
@@ -66,7 +66,7 @@ export function KbdChord({
       {steps.map((tokens, stepIndex) => (
         <Fragment key={stepIndex}>
           {stepIndex > 0 && (
-            <span className="text-daintree-text/40 text-[10px] select-none" aria-hidden>
+            <span className="text-daintree-text/40 text-3xs select-none" aria-hidden>
               ,
             </span>
           )}
@@ -74,7 +74,7 @@ export function KbdChord({
             {tokens.map((token, tokenIndex) => (
               <Fragment key={tokenIndex}>
                 {tokenIndex > 0 && !mac && (
-                  <span className="text-daintree-text/40 text-[10px] select-none" aria-hidden>
+                  <span className="text-daintree-text/40 text-3xs select-none" aria-hidden>
                     +
                   </span>
                 )}

--- a/src/components/ui/__tests__/badge.test.tsx
+++ b/src/components/ui/__tests__/badge.test.tsx
@@ -17,9 +17,9 @@ const SIZES = ["xs", "sm", "md"] as const;
 
 const GEOMETRY = /^(px|py|p|gap|rounded)-/;
 const COLOUR = /^(bg|text|border)-/;
-// `text-xs` and `text-[10px]` set a size, not a colour — they belong to the
+// `text-xs` and `text-3xs` set a size, not a colour — they belong to the
 // geometry axis, so a naive /^text-/ would make the two axes look coupled.
-const FONT_SIZE = /^text-(xs|sm|base|lg|xl|\[[^\]]+\])$/;
+const FONT_SIZE = /^text-([2-4]xs|xs|sm|base|lg|xl|\[[^\]]+\])$/;
 
 function tokens(classes: string, pattern: RegExp): string[] {
   return classes

--- a/src/components/ui/__tests__/variantAssertions.ts
+++ b/src/components/ui/__tests__/variantAssertions.ts
@@ -14,7 +14,7 @@ const GROUP_PATTERNS = {
   // to X alongside `pl-`/`pr-` and never to Y.
   paddingX: /^p([xselr])?-/,
   paddingY: /^p([ytb])?-/,
-  fontSize: /^text-(xs|sm|base|lg|[2-9]?xl|\[[\d.]+(px|rem|em)\])$/,
+  fontSize: /^text-([2-4]xs|xs|sm|base|lg|[2-9]?xl|\[[\d.]+(px|rem|em)\])$/,
   radius: /^rounded(-|$)/,
   resize: /^resize(-|$)/,
   width: /^w-/,

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -16,9 +16,9 @@ const badgeVariants = cva(
   {
     variants: {
       size: {
-        xs: "gap-1 px-1.5 py-0.5 text-[10px] [&_svg]:w-2.5 [&_svg]:h-2.5",
+        xs: "gap-1 px-1.5 py-0.5 text-3xs [&_svg]:w-2.5 [&_svg]:h-2.5",
         sm: "gap-1 px-1.5 py-0.5 text-xs [&_svg]:w-3 [&_svg]:h-3",
-        md: "gap-1.5 px-2 py-1 text-[13px] [&_svg]:w-3.5 [&_svg]:h-3.5",
+        md: "gap-1.5 px-2 py-1 text-sm leading-[inherit] [&_svg]:w-3.5 [&_svg]:h-3.5",
       },
       tone: {
         neutral: "bg-overlay-subtle text-text-secondary",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -55,7 +55,7 @@ const buttonVariants = cva(
       size: {
         default: "h-8 px-4 py-1.5 gap-2 [&_svg]:size-4",
         sm: "h-7 px-3 py-1 gap-1.5 text-xs [&_svg]:size-3.5",
-        xs: "h-6 px-2.5 py-0.5 gap-1 text-[10px] leading-none [&_svg]:size-3",
+        xs: "h-6 px-2.5 py-0.5 gap-1 text-3xs leading-none [&_svg]:size-3",
         lg: "h-9 px-6 py-2 gap-2.5 text-sm [&_svg]:size-4",
         icon: "h-8 w-8 [&_svg]:size-4",
         "icon-sm": "h-7 w-7 [&_svg]:size-3.5",

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -352,7 +352,7 @@ const ContextMenuLabel = React.forwardRef<
     <Label
       ref={ref}
       className={cn(
-        "px-2.5 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
+        "px-2.5 py-1.5 text-2xs font-bold tracking-wider uppercase text-daintree-text/50",
         inset && "pl-8",
         className
       )}
@@ -365,7 +365,7 @@ ContextMenuLabel.displayName = "ContextMenuLabel";
 const ContextMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto pl-2 text-[11px] font-mono text-daintree-text/50", className)}
+      className={cn("ml-auto pl-2 text-2xs font-mono text-daintree-text/50", className)}
       {...props}
     />
   );

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -417,7 +417,7 @@ const DropdownMenuLabel = React.forwardRef<
     <Label
       ref={ref}
       className={cn(
-        "px-2.5 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
+        "px-2.5 py-1.5 text-2xs font-bold tracking-wider uppercase text-daintree-text/50",
         inset && "pl-8",
         className
       )}
@@ -430,7 +430,7 @@ DropdownMenuLabel.displayName = "DropdownMenuLabel";
 const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto pl-2 text-[11px] font-mono text-daintree-text/50", className)}
+      className={cn("ml-auto pl-2 text-2xs font-mono text-daintree-text/50", className)}
       {...props}
     />
   );

--- a/src/components/ui/paletteRowStyles.ts
+++ b/src/components/ui/paletteRowStyles.ts
@@ -66,7 +66,7 @@ export const PALETTE_ROW_CLASS = cn(
  * otherwise, because the size and the tracking were never the problem.
  */
 export const PALETTE_SECTION_LABEL_CLASS =
-  "text-[10px] font-medium tracking-wider uppercase text-text-secondary select-none";
+  "text-3xs font-medium tracking-wider uppercase text-text-secondary select-none";
 
 /**
  * The keyboard-focus ring every palette control wears.

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -261,7 +261,7 @@ const SelectLabel = React.forwardRef<
     <Label
       ref={ref}
       className={cn(
-        "px-2.5 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
+        "px-2.5 py-1.5 text-2xs font-bold tracking-wider uppercase text-daintree-text/50",
         className
       )}
       {...props}
@@ -307,7 +307,7 @@ const SelectItem = React.forwardRef<
       {description ? (
         <span className="flex flex-col gap-0.5">
           <ItemText>{children}</ItemText>
-          <span className="text-[11px] text-text-secondary">{description}</span>
+          <span className="text-2xs text-text-secondary">{description}</span>
         </span>
       ) : (
         <ItemText>{children}</ItemText>

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -431,7 +431,7 @@ function Toast({
                     data-testid="toast-coalesce-badge"
                     aria-label={formatNotificationCountAriaLabel(notification.count)}
                     className={cn(
-                      "shrink-0 rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
+                      "shrink-0 rounded-full bg-tint/10 px-1.5 py-0.5 text-3xs font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
                       isCountBumping && "animate-badge-bump"
                     )}
                     style={{ animationDuration: `${DURATION_150}ms` }}
@@ -451,7 +451,7 @@ function Toast({
                 data-testid="toast-coalesce-badge"
                 aria-label={formatNotificationCountAriaLabel(notification.count)}
                 className={cn(
-                  "inline-block rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
+                  "inline-block rounded-full bg-tint/10 px-1.5 py-0.5 text-3xs font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
                   isCountBumping && "animate-badge-bump"
                 )}
                 style={{ animationDuration: `${DURATION_150}ms` }}
@@ -700,7 +700,7 @@ function OverflowPill({ count }: { count: number }) {
         "inline-flex items-center gap-1 rounded-full",
         "bg-surface-panel/85 backdrop-blur-xl",
         "border border-tint/[0.08] ring-1 ring-inset ring-tint/[0.05]",
-        "px-2.5 py-1 text-[11px] font-medium leading-none tabular-nums",
+        "px-2.5 py-1 text-2xs font-medium leading-none tabular-nums",
         "text-daintree-text/70 hover:text-daintree-text",
         "shadow-[var(--theme-shadow-floating)]",
         "transition-colors",

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -441,7 +441,7 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
   },
   {
     file: "src/components/Worktree/ReviewHub/FileSection.tsx",
-    fragment: "w-[104px] min-w-0 bg-transparent text-[11px]",
+    fragment: "w-[104px] min-w-0 bg-transparent text-2xs",
     reason:
       "Section filter is a strip: the wrapper carries the border, focus-within and the forced-colors outline, so the bare input must not paint a second box inside it (that nested rectangle is exactly what #11984 removed)",
   },

--- a/src/config/__tests__/numericScales.contract.test.ts
+++ b/src/config/__tests__/numericScales.contract.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const INDEX_CSS = path.join(REPO_ROOT, "src/index.css");
+const TAILWIND_THEME_CSS = path.join(REPO_ROOT, "node_modules/tailwindcss/theme.css");
+const TOOLBAR_CSS = path.join(REPO_ROOT, "src/styles/components/toolbar.css");
+const BUILT_IN_THEMES = path.join(REPO_ROOT, "shared/theme/builtInThemes");
+
+/**
+ * Two numeric scales — radius and type — are only worth having if the whole app
+ * is on them. #12033 catalogued ~1400 sites that had invented their own values.
+ *
+ * The radius scale is the load-bearing one: every `--radius-*` step derives from
+ * `--radius`, which multiplies by `--theme-radius-scale`, which built-in themes
+ * set per-theme (Movile 0.6 … Hokkaido 1.05). A value that sits outside that
+ * derivation chain stays put while its neighbours move, which is how you get a
+ * half-scaled UI. The bug is invisible at the default scale of 1, so it needs a
+ * test rather than an eye.
+ */
+
+const SOURCE_ROOTS = ["src", "plugins"];
+const SKIP_DIRS = new Set(["node_modules", "dist", "__tests__", "__mocks__"]);
+
+/**
+ * Fixed values that survive review. `9999px` is deliberately absent from the
+ * patterns: it is a topology ("fully round"), not a step on the scale.
+ */
+const PATTERNS = {
+  "text-[Npx]": /\btext-\[\d+(?:\.\d+)?px\]/g,
+  "rounded-[Npx]": /\brounded(?:-[trblse])?-\[\d+(?:\.\d+)?px\]/g,
+  "font-size px": /(?:\bfont-size:\s*|\bfontSize:\s*")(?!9999px)\d+(?:\.\d+)?px/g,
+  "border-radius px": /(?:\bborder-radius:\s*|\bborderRadius:\s*")(?!9999px)\d+(?:\.\d+)?px/g,
+} as const;
+
+type PatternName = keyof typeof PATTERNS;
+
+/**
+ * Exact-count allowlist. Counting rather than just naming the file means a new
+ * offender slipped into an already-listed file still fails, and an entry left
+ * behind after its site is removed fails too — without pinning line numbers.
+ */
+const EXCEPTIONS: {
+  file: string;
+  pattern: PatternName;
+  match: string;
+  count: number;
+  reason: string;
+}[] = [
+  {
+    file: "src/components/Setup/AgentSetupWizard.tsx",
+    pattern: "text-[Npx]",
+    match: "text-[6px]",
+    count: 3,
+    reason:
+      "Miniature of the app UI inside the setup wizard — the type is scenery at a fixed miniature ratio, not text anyone reads, so it must not track the real type scale",
+  },
+  {
+    file: "src/components/Setup/AgentSetupWizard.tsx",
+    pattern: "text-[Npx]",
+    match: "text-[7px]",
+    count: 2,
+    reason: "Same miniature; the 7px rows are the mock terminal body against the 6px chrome",
+  },
+  {
+    file: "src/components/Project/ProjectResourceBadge.tsx",
+    pattern: "text-[Npx]",
+    match: "text-[8px]",
+    count: 1,
+    reason:
+      "A ▼/▶ disclosure glyph, sized to the caret rather than to text — putting it on the type scale would oversize the triangle",
+  },
+  {
+    file: "src/components/Pulse/PulseHeatmap.tsx",
+    pattern: "rounded-[Npx]",
+    match: "rounded-[2px]",
+    count: 1,
+    reason:
+      "Heat cells read as squares on purpose (#2645); pinned by pulseContrast.test.ts, and a theme radius would round them into dots",
+  },
+  {
+    file: "src/components/Pulse/ProjectPulseCard.tsx",
+    pattern: "rounded-[Npx]",
+    match: "rounded-[2px]",
+    count: 3,
+    reason: "Same heat-cell geometry as PulseHeatmap, plus its loading skeleton",
+  },
+  {
+    file: "src/components/Pulse/ProjectPulseStrip.tsx",
+    pattern: "rounded-[Npx]",
+    match: "rounded-[1px]",
+    count: 1,
+    reason: "Same heat-cell family at strip size, where 1px is already most of the cell",
+  },
+  {
+    file: "src/components/Terminal/VoiceInputButton.tsx",
+    pattern: "rounded-[Npx]",
+    match: "rounded-[1.5px]",
+    count: 1,
+    reason:
+      "An 8×8px status mark: rounded-full would make it a circle and any scale step would round it past recognition",
+  },
+  {
+    file: "src/components/Worktree/NewWorktreeDialog.tsx",
+    pattern: "rounded-[Npx]",
+    match: "rounded-[4px]",
+    count: 1,
+    reason:
+      "Deliberately off the scale — a 16px box at the theme radius reads as a radio button rather than a checkbox (see the comment at the call site)",
+  },
+  {
+    file: "src/index.css",
+    pattern: "border-radius px",
+    match: "border-radius: 3px",
+    count: 1,
+    reason:
+      "Scrollbar thumb: radius is half the thumb width, so it tracks the scrollbar, not the theme",
+  },
+  {
+    file: "src/index.css",
+    pattern: "border-radius px",
+    match: "border-radius: 1px",
+    count: 1,
+    reason: "File-change recency rail is 2px wide; 1px is its half-width cap",
+  },
+  {
+    file: "src/components/Worktree/DiffViewer.css",
+    pattern: "border-radius px",
+    match: "border-radius: 6px",
+    count: 1,
+    reason:
+      "Diff horizontal scrollbar thumb — scrollbar geometry, same rationale as the global one",
+  },
+  {
+    file: "src/styles/components/toolbar.css",
+    pattern: "border-radius px",
+    match: "border-radius: 2px",
+    count: 1,
+    reason:
+      "WCAG 1.4.1 shape differentiator: the overflow badge encodes severity as square/slightly-rounded/pill, so its radius is semantic and must not move with the theme",
+  },
+];
+
+function collectSourceFiles(dir: string): string[] {
+  const result: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      result.push(...collectSourceFiles(fullPath));
+      continue;
+    }
+    if (!/\.(ts|tsx|css)$/.test(entry.name)) continue;
+    if (/\.(test|spec)\./.test(entry.name)) continue;
+    result.push(fullPath);
+  }
+  return result;
+}
+
+function relative(file: string): string {
+  return path.relative(REPO_ROOT, file).split(path.sep).join("/");
+}
+
+/** Every `--name: value;` declaration in a stylesheet, last one wins. */
+function readDeclarations(cssPath: string, prefix: string): Map<string, string> {
+  const css = fs.readFileSync(cssPath, "utf8");
+  const decls = new Map<string, string>();
+  const re = new RegExp(String.raw`^\s*(${prefix}[\w-]*)\s*:\s*([^;]+);`, "gm");
+  for (const m of css.matchAll(re)) decls.set(m[1], m[2].trim());
+  return decls;
+}
+
+describe("numeric scales contract (#12033)", () => {
+  const files = SOURCE_ROOTS.flatMap((root) => collectSourceFiles(path.join(REPO_ROOT, root)));
+
+  it("scans a plausible slice of the app", () => {
+    // Guards the guards: a broken root or an over-eager skip list would make
+    // every assertion below pass by scanning nothing.
+    expect(files.length).toBeGreaterThan(1000);
+  });
+
+  it("keeps type and radius sizes on the shared scales", () => {
+    const seen = new Map<string, number>();
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, "utf8");
+      for (const [name, re] of Object.entries(PATTERNS) as [PatternName, RegExp][]) {
+        for (const match of content.match(re) ?? []) {
+          const normalized = match.replace(/\s+/g, " ").replace(/"$/, "");
+          const key = `${relative(file)}|${name}|${normalized}`;
+          seen.set(key, (seen.get(key) ?? 0) + 1);
+        }
+      }
+    }
+
+    const allowed = new Map(
+      EXCEPTIONS.map((e) => [`${e.file}|${e.pattern}|${e.match}`, e.count] as const)
+    );
+
+    for (const [key, count] of seen) {
+      const [file, pattern, match] = key.split("|");
+      const budget = allowed.get(key);
+      if (budget === undefined) {
+        offenders.push(
+          `  ${file} — ${count}× ${match} (${pattern}) is not on the scale. ` +
+            `Use text-4xs/3xs/2xs/xs/sm or var(--radius-xs…4xl); if the value is deliberately ` +
+            `off-scale, add it to EXCEPTIONS with a reason.`
+        );
+      } else if (count !== budget) {
+        offenders.push(
+          `  ${file} — ${match} (${pattern}) appears ${count}×, allowlisted for ${budget}. ` +
+            `Update the EXCEPTIONS entry if this is intended.`
+        );
+      }
+    }
+
+    for (const [key, budget] of allowed) {
+      if (!seen.has(key)) {
+        const [file, pattern, match] = key.split("|");
+        offenders.push(
+          `  ${file} — stale EXCEPTIONS entry for ${match} (${pattern}, expected ${budget}×); it is gone, so drop the entry.`
+        );
+      }
+    }
+
+    if (offenders.length > 0) throw new Error(`Off-scale sizes:\n${offenders.join("\n")}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("overrides every radius step Tailwind ships", () => {
+    // Tailwind's stock steps are fixed constants. Any step we leave un-overridden
+    // silently stops tracking --theme-radius-scale the moment someone uses it —
+    // which is exactly how --radius-4xl was missed.
+    const stock = readDeclarations(TAILWIND_THEME_CSS, "--radius");
+    const ours = readDeclarations(INDEX_CSS, "--radius");
+    const missing = [...stock.keys()].filter((token) => !ours.has(token));
+    expect({ missing, stockCount: stock.size }).toEqual({ missing: [], stockCount: stock.size });
+    expect(stock.size).toBeGreaterThan(1);
+  });
+
+  it("derives every radius token from the theme radius scale", () => {
+    const ours = readDeclarations(INDEX_CSS, "--radius");
+    const SCALE = "--theme-radius-scale";
+
+    const reaches = (token: string, seen = new Set<string>()): boolean => {
+      if (seen.has(token)) return false;
+      seen.add(token);
+      const value = ours.get(token);
+      if (value === undefined) return false;
+      const refs = [...value.matchAll(/var\(\s*(--[\w-]+)/g)].map((m) => m[1]);
+      return refs.some((ref) => ref === SCALE || reaches(ref, seen));
+    };
+
+    const detached = [...ours.keys()].filter((token) => !reaches(token));
+    expect(detached).toEqual([]);
+    expect(ours.size).toBeGreaterThan(1);
+  });
+
+  it("emits the sub-xs type steps as font-size only", () => {
+    // A --text-<name>--line-height sibling makes the utility set line-height too.
+    // These steps replace bare arbitrary values that only ever set font-size, so
+    // a paired leading here would reflow hundreds of call sites that inherit it.
+    const text = readDeclarations(INDEX_CSS, "--text-");
+    const steps = ["--text-2xs", "--text-3xs", "--text-4xs"];
+    expect(steps.filter((s) => !text.has(s))).toEqual([]);
+    expect([...text.keys()].filter((token) => token.endsWith("--line-height"))).toEqual([]);
+  });
+
+  it("reaches the type steps from plain CSS", () => {
+    // settings.css and the CodeMirror chip styles consume these as var(--text-*),
+    // which only works if the tokens are declared in a plain @theme block rather
+    // than an inlined one.
+    const css = fs.readFileSync(INDEX_CSS, "utf8");
+    let depth = 0;
+    let inlineThemeDepth: number | null = null;
+    const inlined: string[] = [];
+
+    for (const line of css.split("\n")) {
+      const declared = /^\s*(--text-[\w-]+)\s*:/.exec(line);
+      if (declared && inlineThemeDepth !== null) inlined.push(declared[1]);
+      if (/@theme\s+inline\s*\{/.test(line)) inlineThemeDepth = depth;
+      for (const ch of line) {
+        if (ch === "{") depth++;
+        else if (ch === "}") {
+          depth--;
+          if (inlineThemeDepth !== null && depth <= inlineThemeDepth) inlineThemeDepth = null;
+        }
+      }
+    }
+
+    expect(inlined).toEqual([]);
+  });
+
+  it("keeps the toolbar pill radius on the scale", () => {
+    // Every theme that set this token set it to the same 0.5rem literal, and the
+    // fallback was that literal too — so the pill was the one piece of chrome that
+    // never moved with the theme's radius. Both halves have to stay on the scale.
+    const fallbacks = [TOOLBAR_CSS, ...SOURCE_ROOTS.map((r) => path.join(REPO_ROOT, r))]
+      .flatMap((p) => (fs.statSync(p).isDirectory() ? collectSourceFiles(p) : [p]))
+      .flatMap((file) =>
+        [
+          ...fs
+            .readFileSync(file, "utf8")
+            .matchAll(/--toolbar-pill-radius\s*,\s*([^)]*\)?[^),]*)/g),
+        ].map((m) => ({ file: relative(file), fallback: m[1].trim() }))
+      );
+
+    expect(fallbacks.length).toBeGreaterThan(0);
+    expect(fallbacks.filter((f) => !f.fallback.includes("var(--radius"))).toEqual([]);
+
+    const pinned = fs
+      .readdirSync(BUILT_IN_THEMES)
+      .filter((f) => f.endsWith(".ts"))
+      .flatMap((f) =>
+        [
+          ...fs
+            .readFileSync(path.join(BUILT_IN_THEMES, f), "utf8")
+            .matchAll(/"toolbar-pill-radius":\s*"([^"]*)"/g),
+        ].map((m) => ({ theme: f, value: m[1] }))
+      )
+      .filter((entry) => !entry.value.includes("var(--radius"));
+
+    expect(pinned).toEqual([]);
+  });
+});

--- a/src/config/__tests__/numericScales.contract.test.ts
+++ b/src/config/__tests__/numericScales.contract.test.ts
@@ -7,7 +7,6 @@ const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
 const INDEX_CSS = path.join(REPO_ROOT, "src/index.css");
 const TAILWIND_THEME_CSS = path.join(REPO_ROOT, "node_modules/tailwindcss/theme.css");
-const TOOLBAR_CSS = path.join(REPO_ROOT, "src/styles/components/toolbar.css");
 const BUILT_IN_THEMES = path.join(REPO_ROOT, "shared/theme/builtInThemes");
 
 /**
@@ -25,67 +24,99 @@ const BUILT_IN_THEMES = path.join(REPO_ROOT, "shared/theme/builtInThemes");
 const SOURCE_ROOTS = ["src", "plugins"];
 const SKIP_DIRS = new Set(["node_modules", "dist", "__tests__", "__mocks__"]);
 
-/**
- * A fixed step is one that cannot follow the scale. `em` and `%` are deliberately
- * absent: they resolve against an ancestor that IS on the scale, so they track it.
- * `rem` is not — it is an absolute step in disguise, which is how `text-[0.65rem]`
- * (a 10.4px tier invented by eye) got in. Zero and the `9999px` "fully round"
- * idiom are topology, not steps.
- */
-const FIXED_LENGTH = /^(?:length:)?\s*(-?\d*\.?\d+)(px|rem|pt|pc|in|cm|mm|q|ex|ch)?\s*$/i;
+/** Which scale a value is supposed to be following. */
+type Scale = "type" | "radius";
 
-function isFixedLength(raw: string): boolean {
-  const m = FIXED_LENGTH.exec(raw.trim());
-  if (!m) return false;
+/**
+ * Whether a unit still tracks its scale. This is deliberately different per
+ * scale, because the same unit can be honest for one and a disguise for the
+ * other:
+ *   - `em`/`%` resolve against the parent's font size, so they follow the TYPE
+ *     scale. For radius they follow the type scale instead of the radius one,
+ *     which is precisely a corner that moves for the wrong reason.
+ *   - `%` on a radius is topology ("half the box"), not a step, so it is fine.
+ *   - `rem` follows neither: it is an absolute step in disguise, which is how
+ *     `text-[0.65rem]` (a 10.4px tier invented by eye) got in.
+ *   - viewport and container units follow neither.
+ */
+const FOLLOWS_SCALE: Record<Scale, Set<string>> = {
+  type: new Set(["em", "%"]),
+  radius: new Set(["%"]),
+};
+
+const LENGTH = /^(?:length:)?\s*(-?\d*\.?\d+)\s*(%|[a-z]+)?$/i;
+
+function isFixedLength(raw: string, scale: Scale): boolean {
+  const m = LENGTH.exec(raw.trim());
+  if (!m?.[1]) return false;
   const value = Number.parseFloat(m[1]);
-  if (value === 0) return false;
-  if (m[2]?.toLowerCase() === "px" && Math.abs(value) >= 9999) return false;
+  if (value === 0) return false; // zero is the same at every scale
+  const unit = m[2]?.toLowerCase();
+  if (unit && FOLLOWS_SCALE[scale].has(unit)) return false;
+  // The "fully round" idiom is topology, not a step.
+  if (unit === "px" && Math.abs(value) >= 9999) return false;
   return true;
 }
 
-/** Any fixed length inside a value, including one hiding in a `var()` fallback. */
-const hasFixedLength = (value: string): boolean => value.split(/[\s,()]+/).some(isFixedLength);
+/**
+ * Any fixed length anywhere in a value — inside `calc()`, inside a `var()`
+ * fallback, inside a shorthand. Splitting on separators is enough because a
+ * length is always its own token.
+ */
+const containsFixedLength = (value: string, scale: Scale): boolean =>
+  value
+    .split(/[\s,()]+/)
+    .filter(Boolean)
+    .some((token) => isFixedLength(token, scale));
 
 /**
- * Each matcher captures the payload, then classifies it. Classifying rather than
- * banning outright is what lets `text-[CanvasText]` and `text-[var(--x)]` through
- * while still catching `text-[0.65rem]` and `text-[length:11px]`.
+ * Each matcher captures a payload, then classifies it. Classifying rather than
+ * banning outright is what lets `text-[CanvasText]`, `text-[var(--x)]` and
+ * `border-radius: 50%` through while still catching `text-[0.65rem]`,
+ * `text-[length:11px]`, `rounded-[calc(4px)]` and `text-[var(--x, 11px)]`.
  */
-const MATCHERS: { name: string; re: RegExp; isOffender: (payload: string) => boolean }[] = [
-  { name: "text-[…]", re: /\btext-\[([^\]]+)\]/g, isOffender: isFixedLength },
+const MATCHERS: { re: RegExp; scale: Scale }[] = [
+  { re: /\btext-\[([^\]]+)\]/g, scale: "type" },
   // `-[a-z]{1,2}` covers every corner/side form: -t, -r, -tl, -ss, -ee …
-  { name: "rounded-[…]", re: /\brounded(?:-[a-z]{1,2})?-\[([^\]]+)\]/g, isOffender: isFixedLength },
+  { re: /\brounded(?:-[a-z]{1,2})?-\[([^\]]+)\]/g, scale: "radius" },
+  { re: /\[font-size\s*:\s*([^\]]+)\]/g, scale: "type" },
+  { re: /\[border-[a-z-]*radius\s*:\s*([^\]]+)\]/g, scale: "radius" },
+  { re: /(?:^|[^-\w])font-size\s*:\s*([^;}\n]+)/g, scale: "type" },
+  { re: /(?:^|[^-\w])border-(?:[a-z-]+-)?radius\s*:\s*([^;}\n]+)/g, scale: "radius" },
+  // A bare number in a style object is a fixed pixel size — React serialises it as px.
+  { re: /\bfontSize\s*(?:=|:)\s*(-?\d+(?:\.\d+)?|"[^"]*"|'[^']*'|`[^`]*`)/g, scale: "type" },
   {
-    name: "[font-size:…] / [border-radius:…]",
-    re: /\[(?:font-size|border-radius)\s*:\s*([^\]]+)\]/g,
-    isOffender: isFixedLength,
-  },
-  {
-    name: "css declaration",
-    re: /(?:^|[^-\w])(?:font-size|border-radius|border-[a-z-]+-radius)\s*:\s*([^;}\n]+)/g,
-    isOffender: hasFixedLength,
-  },
-  {
-    // A bare number here is a fixed pixel size — React serialises it as px.
-    name: "style object",
-    re: /\b(?:fontSize|borderRadius)\s*:\s*(-?\d+(?:\.\d+)?|"[^"]*"|'[^']*'|`[^`]*`)/g,
-    isOffender: (payload) =>
-      /^-?\d+(?:\.\d+)?$/.test(payload)
-        ? Number.parseFloat(payload) !== 0
-        : hasFixedLength(payload.replace(/^["\'`]|["\'`]$/g, "")),
+    re: /\b(?:borderRadius|border[A-Z][a-zA-Z]*Radius)\s*(?:=|:)\s*(-?\d+(?:\.\d+)?|"[^"]*"|'[^']*'|`[^`]*`)/g,
+    scale: "radius",
   },
 ];
+
+function isOffender(payload: string, scale: Scale): boolean {
+  const unquoted = payload.replace(/^["'`]|["'`]$/g, "");
+  if (/^-?\d+(?:\.\d+)?$/.test(unquoted)) return Number.parseFloat(unquoted) !== 0;
+  return containsFixedLength(unquoted, scale);
+}
 
 /**
  * Exact-count allowlist. Counting rather than just naming the file means a new
  * offender slipped into an already-listed file still fails, and an entry left
  * behind after its site is removed fails too — without pinning line numbers.
  */
+/**
+ * Exact-count allowlist. Counting rather than just naming the file means a new
+ * offender slipped into an already-listed file still fails, and an entry left
+ * behind after its site is removed fails too — without pinning line numbers.
+ *
+ * `match` is compared exactly by default so an entry cannot quietly cover a
+ * different value in the same file; `prefix: true` opts into covering a whole
+ * property, which only makes sense when the exemption is the file, not the value.
+ */
 const EXCEPTIONS: {
   file: string;
   match: string;
   count: number;
   reason: string;
+  prefix?: boolean;
 }[] = [
   {
     file: "src/components/Setup/AgentSetupWizard.tsx",
@@ -170,6 +201,7 @@ const EXCEPTIONS: {
   {
     file: "src/utils/renderBootstrapError.ts",
     match: "font-size:",
+    prefix: true,
     count: 4,
     reason:
       "Paints the fatal-boot error screen, which is exactly the case where the app stylesheet may not have loaded — it cannot reference tokens that might not exist",
@@ -177,6 +209,7 @@ const EXCEPTIONS: {
   {
     file: "src/utils/renderBootstrapError.ts",
     match: "border-radius:",
+    prefix: true,
     count: 2,
     reason: "Same fatal-boot screen; see above",
   },
@@ -283,53 +316,52 @@ describe("numeric scales contract (#12033)", () => {
   });
 
   it("keeps type and radius sizes on the shared scales", () => {
-    const seen = new Map<string, { count: number; lines: number[] }>();
+    type Hit = { file: string; token: string; lines: number[] };
+    const hits = new Map<string, Hit>();
     const offenders: string[] = [];
 
     for (const file of files) {
       const content = fs.readFileSync(file, "utf8");
-      const lineStarts = [...content.matchAll(/\n/g)].map((m) => m.index ?? 0);
-      const lineOf = (index: number) => lineStarts.filter((start) => start < index).length + 1;
+      const rel = relative(file);
 
-      for (const { re, isOffender } of MATCHERS) {
+      for (const { re, scale } of MATCHERS) {
         re.lastIndex = 0;
         for (const m of content.matchAll(re)) {
-          if (!isOffender(m[1])) continue;
-          // The css-declaration matcher consumes the delimiter before the property
-          // (`;`, `{`, whitespace); drop it so a token reads as the declaration itself.
+          const payload = m[1];
+          if (payload === undefined || !isOffender(payload, scale)) continue;
+          // The css-declaration matchers consume the delimiter before the
+          // property (`;`, `{`, whitespace); drop it so the token reads as the
+          // declaration itself.
           const token = m[0]
             .trim()
             .replace(/\s+/g, " ")
             .replace(/^[^\w[]+/, "");
-          const key = `${relative(file)}|${token}`;
-          const entry = seen.get(key) ?? { count: 0, lines: [] };
-          entry.count += 1;
-          entry.lines.push(lineOf(m.index ?? 0));
-          seen.set(key, entry);
+          const key = `${rel}\u0000${token}`;
+          const hit = hits.get(key) ?? { file: rel, token, lines: [] };
+          hit.lines.push(content.slice(0, m.index ?? 0).split("\n").length);
+          hits.set(key, hit);
         }
       }
     }
 
-    // An exception is keyed by a token PREFIX so a whole-declaration match
-    // (`font-size: 0.875rem`) can be allowlisted by its property alone.
-    const findException = (file: string, token: string) =>
-      EXCEPTIONS.find((e) => e.file === file && token.startsWith(e.match));
+    const matches = (exception: (typeof EXCEPTIONS)[number], hit: Hit) =>
+      exception.file === hit.file &&
+      (exception.prefix ? hit.token.startsWith(exception.match) : hit.token === exception.match);
 
     const used = new Map<(typeof EXCEPTIONS)[number], number>();
 
-    for (const [key, { count, lines }] of seen) {
-      const [file, token] = key.split("|");
-      const exception = findException(file, token);
+    for (const hit of hits.values()) {
+      const exception = EXCEPTIONS.find((e) => matches(e, hit));
       if (!exception) {
         offenders.push(
-          `  ${file}:${lines.join(",")} — ${token}\n` +
+          `  ${hit.file}:${hit.lines.join(",")} — ${hit.token}\n` +
             `    Not on a scale. Use text-4xs/3xs/2xs/xs/sm (or var(--text-*)) for type and\n` +
             `    var(--radius-xs…4xl) / rounded-xs…4xl for radius. If it genuinely cannot follow\n` +
             `    the scale, add an EXCEPTIONS entry saying why — do not widen an existing one.`
         );
         continue;
       }
-      used.set(exception, (used.get(exception) ?? 0) + count);
+      used.set(exception, (used.get(exception) ?? 0) + hit.lines.length);
     }
 
     for (const exception of EXCEPTIONS) {
@@ -337,11 +369,15 @@ describe("numeric scales contract (#12033)", () => {
       if (actual === exception.count) continue;
       offenders.push(
         actual === 0
-          ? `  ${exception.file} — stale EXCEPTIONS entry for "${exception.match}" (expected ${exception.count}). ` +
-              `It is gone, so drop the entry; if the file moved, update the path.`
-          : `  ${exception.file} — "${exception.match}" appears ${actual}×, allowlisted for ${exception.count}.\n` +
+          ? `  ${exception.file} — stale EXCEPTIONS entry for "${exception.match}" ` +
+              `(expected ${exception.count}). It is gone, so drop the entry; if the file moved, update the path.`
+          : `  ${exception.file} — "${exception.match}" appears ${actual}x, allowlisted for ${exception.count}.\n` +
               `    Existing reason: ${exception.reason}\n` +
-              `    ${actual > exception.count ? "Each NEW site must independently satisfy that reason — do not just raise the number." : "Lower the count to match."}`
+              `    ${
+                actual > exception.count
+                  ? "Each NEW site must independently satisfy that reason — do not just raise the number."
+                  : "Lower the count to match."
+              }`
       );
     }
 
@@ -390,20 +426,21 @@ describe("numeric scales contract (#12033)", () => {
     // Names alone would let the three steps be equal, reversed, or arbitrary.
     // Comparing them to each other and to Tailwind's own floor tests the shape of
     // the scale without copying any of its values into the test.
-    const rem = (value: string) => {
-      const m = /^(-?\d*\.?\d+)rem$/.exec(value.trim());
-      return m ? Number.parseFloat(m[1]) : Number.NaN;
+    const rem = (value: string | undefined) => {
+      const m = value === undefined ? null : /^(-?\d*\.?\d+)rem$/.exec(value.trim());
+      return m?.[1] === undefined ? Number.NaN : Number.parseFloat(m[1]);
     };
+    const ours = readDeclarations(INDEX_CSS, "--text-");
     const ladder = [
-      rem(readDeclarations(TAILWIND_THEME_CSS, "--text-xs").get("--text-xs") ?? ""),
-      ...["--text-2xs", "--text-3xs", "--text-4xs"].map((step) =>
-        rem(readDeclarations(INDEX_CSS, "--text-").get(step) ?? "")
-      ),
+      rem(readDeclarations(TAILWIND_THEME_CSS, "--text-xs").get("--text-xs")),
+      ...["--text-2xs", "--text-3xs", "--text-4xs"].map((step) => rem(ours.get(step))),
     ];
 
     expect(ladder.filter(Number.isNaN)).toEqual([]);
-    const gaps = ladder.slice(1).map((value, i) => Number((ladder[i] - value).toFixed(6)));
-    expect(gaps.filter((gap) => gap <= 0)).toEqual([]); // strictly descending
+    const gaps = ladder
+      .slice(1)
+      .map((value, i) => Number(((ladder[i] ?? Number.NaN) - value).toFixed(6)));
+    expect(gaps.filter((gap) => !(gap > 0))).toEqual([]); // strictly descending
     expect(new Set(gaps).size).toBe(1); // evenly spaced
   });
 
@@ -438,32 +475,28 @@ describe("numeric scales contract (#12033)", () => {
     // Every theme that set this token set it to the same 0.5rem literal, and the
     // fallback was that literal too — so the pill was the one piece of chrome that
     // never moved with the theme's radius. Both halves have to stay on the scale.
-    //
-    // Each consumer is checked by name: a global "at least one is fine" count would
-    // still pass if one call site quietly dropped its fallback.
-    const CONSUMERS = [
-      "src/styles/components/toolbar.css",
-      "src/components/Layout/Toolbar.tsx",
-      "src/components/Layout/ForgeStatsToolbarButton.tsx",
-    ];
+    const TOKEN = "--toolbar-pill-radius";
 
-    const fallbacks = CONSUMERS.map((file) => {
-      const source = fs.readFileSync(path.join(REPO_ROOT, file), "utf8");
-      // Every reference in the file, not just the first — one call site quietly
-      // dropping its fallback is exactly the regression this is here to catch.
-      const references = [...source.matchAll(/--toolbar-pill-radius/g)].map((m) =>
-        varFallback(source.slice(m.index ?? 0), "--toolbar-pill-radius")
-      );
-      return {
-        file,
-        fallback:
-          references.length > 0 && references.every((f) => f?.includes("var(--radius"))
-            ? references[0]
-            : null,
-      };
+    // Discovered repo-wide, not from a fixed list: a fourth consumer added later
+    // with a hardcoded fallback has to fail too.
+    const references = files.flatMap((file) => {
+      const source = fs.readFileSync(file, "utf8");
+      return [...source.matchAll(new RegExp(`var\\(\\s*${TOKEN}`, "g"))].map((m) => ({
+        file: relative(file),
+        fallback: varFallback(source.slice(m.index ?? 0), TOKEN),
+      }));
     });
 
-    expect(fallbacks.filter((f) => !f.fallback?.includes("var(--radius"))).toEqual([]);
+    expect(references.length).toBeGreaterThan(0);
+
+    // A fallback only tracks the scale if a radius token is its PRIMARY reference —
+    // `var(--fixed, var(--radius-md))` is the same disguise reaches() rejects.
+    const detached = references.filter(
+      (ref) =>
+        ref.fallback === null ||
+        !primaryVarRefs(ref.fallback).some((name) => name.startsWith("--radius"))
+    );
+    expect(detached).toEqual([]);
 
     const pinned = fs
       .readdirSync(BUILT_IN_THEMES)
@@ -472,10 +505,10 @@ describe("numeric scales contract (#12033)", () => {
         [
           ...fs
             .readFileSync(path.join(BUILT_IN_THEMES, f), "utf8")
-            .matchAll(/"toolbar-pill-radius":\s*"([^"]*)"/g),
-        ].map((m) => ({ theme: f, value: m[1] }))
+            .matchAll(new RegExp(`"${TOKEN.slice(2)}":\\s*"([^"]*)"`, "g")),
+        ].map((m) => ({ theme: f, value: m[1] ?? "" }))
       )
-      .filter((entry) => !entry.value.includes("var(--radius"));
+      .filter((entry) => !primaryVarRefs(entry.value).some((n) => n.startsWith("--radius")));
 
     expect(pinned).toEqual([]);
   });

--- a/src/config/__tests__/numericScales.contract.test.ts
+++ b/src/config/__tests__/numericScales.contract.test.ts
@@ -207,6 +207,53 @@ function readCss(cssPath: string): string {
   return fs.readFileSync(cssPath, "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
+/**
+ * The variables a value actually depends on: the primary of each `var(--x, …)`,
+ * skipping any `var()` nested inside another one's fallback. A fallback is inert
+ * whenever its primary resolves, so `var(--fixed, var(--scale))` is a fixed value
+ * wearing the scale as a disguise — counting it would let a detached token pass.
+ */
+function primaryVarRefs(value: string): string[] {
+  const refs: string[] = [];
+  const openIsVar: boolean[] = [];
+
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === "(") {
+      const isVar = /\bvar\s*$/.test(value.slice(0, i));
+      if (isVar && !openIsVar.some(Boolean)) {
+        const named = /^\(\s*(--[\w-]+)/.exec(value.slice(i));
+        if (named) refs.push(named[1]);
+      }
+      openIsVar.push(isVar);
+    } else if (ch === ")") {
+      openIsVar.pop();
+    }
+  }
+
+  return refs;
+}
+
+/** The fallback of `var(--name, fallback)`, read by walking to its matching paren. */
+function varFallback(source: string, name: string): string | null {
+  const at = source.indexOf(name);
+  if (at === -1) return null;
+
+  let depth = 1; // `at` sits just inside the enclosing `var(`
+  let comma = -1;
+  for (let i = at; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0) return comma === -1 ? null : source.slice(comma + 1, i).trim();
+    } else if (ch === "," && depth === 1 && comma === -1) {
+      comma = i;
+    }
+  }
+  return null;
+}
+
 /** Every `--name: value;` declaration in a stylesheet, last one wins. */
 function readDeclarations(cssPath: string, prefix: string): Map<string, string> {
   const css = readCss(cssPath);
@@ -321,18 +368,7 @@ describe("numeric scales contract (#12033)", () => {
       seen.add(token);
       const value = ours.get(token);
       if (value === undefined) return false;
-      // Only the PRIMARY of each `var(--primary, fallback)` counts. A fallback is
-      // inert whenever the primary resolves, so `var(--fixed, var(--scale))` is a
-      // fixed value wearing the scale as a disguise.
-      const refs = [...value.matchAll(/var\(\s*(--[\w-]+)/g)]
-        .filter((m) => {
-          const before = value.slice(0, m.index ?? 0);
-          const opens = (before.match(/var\(/g) ?? []).length;
-          const closes = (before.match(/\)/g) ?? []).length;
-          return opens === closes; // not nested inside another var()'s fallback
-        })
-        .map((m) => m[1]);
-      return refs.some((ref) => ref === SCALE || reaches(ref, seen));
+      return primaryVarRefs(value).some((ref) => ref === SCALE || reaches(ref, seen));
     };
 
     const detached = [...ours.keys()].filter((token) => !reaches(token));
@@ -413,21 +449,17 @@ describe("numeric scales contract (#12033)", () => {
 
     const fallbacks = CONSUMERS.map((file) => {
       const source = fs.readFileSync(path.join(REPO_ROOT, file), "utf8");
-      const at = source.indexOf("--toolbar-pill-radius");
-      if (at === -1) return { file, fallback: null };
-      // Walk the balanced var(...) so a calc() or nested var() fallback stays intact.
-      const rest = source.slice(at);
-      let depth = 1;
-      let end = rest.indexOf("(");
-      for (let i = rest.indexOf(",") + 1; i < rest.length && depth > 0; i++) {
-        if (rest[i] === "(") depth++;
-        else if (rest[i] === ")") depth--;
-        if (depth === 0) end = i;
-      }
-      const comma = rest.indexOf(",");
+      // Every reference in the file, not just the first — one call site quietly
+      // dropping its fallback is exactly the regression this is here to catch.
+      const references = [...source.matchAll(/--toolbar-pill-radius/g)].map((m) =>
+        varFallback(source.slice(m.index ?? 0), "--toolbar-pill-radius")
+      );
       return {
         file,
-        fallback: comma === -1 || comma > end ? null : rest.slice(comma + 1, end).trim(),
+        fallback:
+          references.length > 0 && references.every((f) => f?.includes("var(--radius"))
+            ? references[0]
+            : null,
       };
     });
 

--- a/src/config/__tests__/numericScales.contract.test.ts
+++ b/src/config/__tests__/numericScales.contract.test.ts
@@ -91,6 +91,45 @@ const MATCHERS: { re: RegExp; scale: Scale }[] = [
   },
 ];
 
+/**
+ * A fixed length can hide one hop behind a custom property: `--_size: 10px`
+ * consumed by `font-size: var(--_size)` never appears in a font-size declaration
+ * at all. Resolve one hop per file so what actually lands on the element is what
+ * gets classified — that indirection is how the toolbar chip stayed at 10px.
+ */
+function indirectHits(content: string): { token: string; line: number }[] {
+  const consumed = new Map<string, Scale>();
+  const consumers: { re: RegExp; scale: Scale }[] = [
+    { re: /(?:^|[^-\w])font-size\s*:\s*([^;}\n]+)/g, scale: "type" },
+    { re: /(?:^|[^-\w])border-(?:[a-z-]+-)?radius\s*:\s*([^;}\n]+)/g, scale: "radius" },
+  ];
+
+  for (const { re, scale } of consumers) {
+    re.lastIndex = 0;
+    for (const m of content.matchAll(re)) {
+      for (const name of primaryVarRefs(m[1] ?? "")) consumed.set(name, scale);
+    }
+  }
+
+  const hits: { token: string; line: number }[] = [];
+  for (const [name, scale] of consumed) {
+    // The scale's own steps are defined in terms of fixed offsets (`--radius-md:
+    // calc(var(--radius) - 2px)`) — that IS the scale, not an escape from it.
+    // Their correctness is the derivation and ladder tests' job, not this one's.
+    if (/^--(radius|text)(-|$)/.test(name)) continue;
+    const declaration = new RegExp(`^\\s*(${name})\\s*:\\s*([^;}\\n]+)`, "gm");
+    for (const m of content.matchAll(declaration)) {
+      const value = m[2];
+      if (value === undefined || !isOffender(value, scale)) continue;
+      hits.push({
+        token: `${name}: ${value.trim()}`,
+        line: content.slice(0, m.index ?? 0).split("\n").length,
+      });
+    }
+  }
+  return hits;
+}
+
 function isOffender(payload: string, scale: Scale): boolean {
   const unquoted = payload.replace(/^["'`]|["'`]$/g, "");
   if (/^-?\d+(?:\.\d+)?$/.test(unquoted)) return Number.parseFloat(unquoted) !== 0;
@@ -323,6 +362,13 @@ describe("numeric scales contract (#12033)", () => {
     for (const file of files) {
       const content = fs.readFileSync(file, "utf8");
       const rel = relative(file);
+
+      for (const indirect of indirectHits(content)) {
+        const key = `${rel}\u0000${indirect.token}`;
+        const hit = hits.get(key) ?? { file: rel, token: indirect.token, lines: [] };
+        hit.lines.push(indirect.line);
+        hits.set(key, hit);
+      }
 
       for (const { re, scale } of MATCHERS) {
         re.lastIndex = 0;

--- a/src/config/__tests__/numericScales.contract.test.ts
+++ b/src/config/__tests__/numericScales.contract.test.ts
@@ -294,8 +294,8 @@ function primaryVarRefs(value: string): string[] {
     if (ch === "(") {
       const isVar = /\bvar\s*$/.test(value.slice(0, i));
       if (isVar && !openIsVar.some(Boolean)) {
-        const named = /^\(\s*(--[\w-]+)/.exec(value.slice(i));
-        if (named) refs.push(named[1]);
+        const named = /^\(\s*(--[\w-]+)/.exec(value.slice(i))?.[1];
+        if (named !== undefined) refs.push(named);
       }
       openIsVar.push(isVar);
     } else if (ch === ")") {
@@ -331,7 +331,10 @@ function readDeclarations(cssPath: string, prefix: string): Map<string, string> 
   const css = readCss(cssPath);
   const decls = new Map<string, string>();
   const re = new RegExp(String.raw`^\s*(${prefix}[\w-]*)\s*:\s*([^;]+);`, "gm");
-  for (const m of css.matchAll(re)) decls.set(m[1], m[2].trim());
+  for (const m of css.matchAll(re)) {
+    const [, name, value] = m;
+    if (name !== undefined && value !== undefined) decls.set(name, value.trim());
+  }
   return decls;
 }
 
@@ -503,8 +506,8 @@ describe("numeric scales contract (#12033)", () => {
       // Opening detection runs first so a same-line `@theme inline { --text-x: … }`
       // is still attributed to the inline block.
       if (/@theme\s+inline\s*\{/.test(line)) inlineThemeDepth = depth;
-      const declared = /^\s*(--text-[\w-]+)\s*:/.exec(line);
-      if (declared && inlineThemeDepth !== null) inlined.push(declared[1]);
+      const declared = /^\s*(--text-[\w-]+)\s*:/.exec(line)?.[1];
+      if (declared !== undefined && inlineThemeDepth !== null) inlined.push(declared);
       for (const ch of line) {
         if (ch === "{") depth++;
         else if (ch === "}") {

--- a/src/config/__tests__/numericScales.contract.test.ts
+++ b/src/config/__tests__/numericScales.contract.test.ts
@@ -140,11 +140,6 @@ function isOffender(payload: string, scale: Scale): boolean {
  * Exact-count allowlist. Counting rather than just naming the file means a new
  * offender slipped into an already-listed file still fails, and an entry left
  * behind after its site is removed fails too — without pinning line numbers.
- */
-/**
- * Exact-count allowlist. Counting rather than just naming the file means a new
- * offender slipped into an already-listed file still fails, and an entry left
- * behind after its site is removed fails too — without pinning line numbers.
  *
  * `match` is compared exactly by default so an entry cannot quietly cover a
  * different value in the same file; `prefix: true` opts into covering a whole

--- a/src/config/__tests__/numericScales.contract.test.ts
+++ b/src/config/__tests__/numericScales.contract.test.ts
@@ -26,17 +26,55 @@ const SOURCE_ROOTS = ["src", "plugins"];
 const SKIP_DIRS = new Set(["node_modules", "dist", "__tests__", "__mocks__"]);
 
 /**
- * Fixed values that survive review. `9999px` is deliberately absent from the
- * patterns: it is a topology ("fully round"), not a step on the scale.
+ * A fixed step is one that cannot follow the scale. `em` and `%` are deliberately
+ * absent: they resolve against an ancestor that IS on the scale, so they track it.
+ * `rem` is not — it is an absolute step in disguise, which is how `text-[0.65rem]`
+ * (a 10.4px tier invented by eye) got in. Zero and the `9999px` "fully round"
+ * idiom are topology, not steps.
  */
-const PATTERNS = {
-  "text-[Npx]": /\btext-\[\d+(?:\.\d+)?px\]/g,
-  "rounded-[Npx]": /\brounded(?:-[trblse])?-\[\d+(?:\.\d+)?px\]/g,
-  "font-size px": /(?:\bfont-size:\s*|\bfontSize:\s*")(?!9999px)\d+(?:\.\d+)?px/g,
-  "border-radius px": /(?:\bborder-radius:\s*|\bborderRadius:\s*")(?!9999px)\d+(?:\.\d+)?px/g,
-} as const;
+const FIXED_LENGTH = /^(?:length:)?\s*(-?\d*\.?\d+)(px|rem|pt|pc|in|cm|mm|q|ex|ch)?\s*$/i;
 
-type PatternName = keyof typeof PATTERNS;
+function isFixedLength(raw: string): boolean {
+  const m = FIXED_LENGTH.exec(raw.trim());
+  if (!m) return false;
+  const value = Number.parseFloat(m[1]);
+  if (value === 0) return false;
+  if (m[2]?.toLowerCase() === "px" && Math.abs(value) >= 9999) return false;
+  return true;
+}
+
+/** Any fixed length inside a value, including one hiding in a `var()` fallback. */
+const hasFixedLength = (value: string): boolean => value.split(/[\s,()]+/).some(isFixedLength);
+
+/**
+ * Each matcher captures the payload, then classifies it. Classifying rather than
+ * banning outright is what lets `text-[CanvasText]` and `text-[var(--x)]` through
+ * while still catching `text-[0.65rem]` and `text-[length:11px]`.
+ */
+const MATCHERS: { name: string; re: RegExp; isOffender: (payload: string) => boolean }[] = [
+  { name: "text-[…]", re: /\btext-\[([^\]]+)\]/g, isOffender: isFixedLength },
+  // `-[a-z]{1,2}` covers every corner/side form: -t, -r, -tl, -ss, -ee …
+  { name: "rounded-[…]", re: /\brounded(?:-[a-z]{1,2})?-\[([^\]]+)\]/g, isOffender: isFixedLength },
+  {
+    name: "[font-size:…] / [border-radius:…]",
+    re: /\[(?:font-size|border-radius)\s*:\s*([^\]]+)\]/g,
+    isOffender: isFixedLength,
+  },
+  {
+    name: "css declaration",
+    re: /(?:^|[^-\w])(?:font-size|border-radius|border-[a-z-]+-radius)\s*:\s*([^;}\n]+)/g,
+    isOffender: hasFixedLength,
+  },
+  {
+    // A bare number here is a fixed pixel size — React serialises it as px.
+    name: "style object",
+    re: /\b(?:fontSize|borderRadius)\s*:\s*(-?\d+(?:\.\d+)?|"[^"]*"|'[^']*'|`[^`]*`)/g,
+    isOffender: (payload) =>
+      /^-?\d+(?:\.\d+)?$/.test(payload)
+        ? Number.parseFloat(payload) !== 0
+        : hasFixedLength(payload.replace(/^["\'`]|["\'`]$/g, "")),
+  },
+];
 
 /**
  * Exact-count allowlist. Counting rather than just naming the file means a new
@@ -45,14 +83,12 @@ type PatternName = keyof typeof PATTERNS;
  */
 const EXCEPTIONS: {
   file: string;
-  pattern: PatternName;
   match: string;
   count: number;
   reason: string;
 }[] = [
   {
     file: "src/components/Setup/AgentSetupWizard.tsx",
-    pattern: "text-[Npx]",
     match: "text-[6px]",
     count: 3,
     reason:
@@ -60,22 +96,19 @@ const EXCEPTIONS: {
   },
   {
     file: "src/components/Setup/AgentSetupWizard.tsx",
-    pattern: "text-[Npx]",
     match: "text-[7px]",
     count: 2,
     reason: "Same miniature; the 7px rows are the mock terminal body against the 6px chrome",
   },
   {
     file: "src/components/Project/ProjectResourceBadge.tsx",
-    pattern: "text-[Npx]",
     match: "text-[8px]",
     count: 1,
     reason:
-      "A ▼/▶ disclosure glyph, sized to the caret rather than to text — putting it on the type scale would oversize the triangle",
+      "A disclosure caret glyph, sized to the triangle rather than to text — putting it on the type scale would oversize it",
   },
   {
     file: "src/components/Pulse/PulseHeatmap.tsx",
-    pattern: "rounded-[Npx]",
     match: "rounded-[2px]",
     count: 1,
     reason:
@@ -83,29 +116,25 @@ const EXCEPTIONS: {
   },
   {
     file: "src/components/Pulse/ProjectPulseCard.tsx",
-    pattern: "rounded-[Npx]",
     match: "rounded-[2px]",
     count: 3,
     reason: "Same heat-cell geometry as PulseHeatmap, plus its loading skeleton",
   },
   {
     file: "src/components/Pulse/ProjectPulseStrip.tsx",
-    pattern: "rounded-[Npx]",
     match: "rounded-[1px]",
     count: 1,
     reason: "Same heat-cell family at strip size, where 1px is already most of the cell",
   },
   {
     file: "src/components/Terminal/VoiceInputButton.tsx",
-    pattern: "rounded-[Npx]",
     match: "rounded-[1.5px]",
     count: 1,
     reason:
-      "An 8×8px status mark: rounded-full would make it a circle and any scale step would round it past recognition",
+      "An 8x8px status mark: rounded-full would make it a circle and any scale step would round it past recognition",
   },
   {
     file: "src/components/Worktree/NewWorktreeDialog.tsx",
-    pattern: "rounded-[Npx]",
     match: "rounded-[4px]",
     count: 1,
     reason:
@@ -113,7 +142,6 @@ const EXCEPTIONS: {
   },
   {
     file: "src/index.css",
-    pattern: "border-radius px",
     match: "border-radius: 3px",
     count: 1,
     reason:
@@ -121,14 +149,12 @@ const EXCEPTIONS: {
   },
   {
     file: "src/index.css",
-    pattern: "border-radius px",
     match: "border-radius: 1px",
     count: 1,
     reason: "File-change recency rail is 2px wide; 1px is its half-width cap",
   },
   {
     file: "src/components/Worktree/DiffViewer.css",
-    pattern: "border-radius px",
     match: "border-radius: 6px",
     count: 1,
     reason:
@@ -136,11 +162,23 @@ const EXCEPTIONS: {
   },
   {
     file: "src/styles/components/toolbar.css",
-    pattern: "border-radius px",
     match: "border-radius: 2px",
     count: 1,
     reason:
       "WCAG 1.4.1 shape differentiator: the overflow badge encodes severity as square/slightly-rounded/pill, so its radius is semantic and must not move with the theme",
+  },
+  {
+    file: "src/utils/renderBootstrapError.ts",
+    match: "font-size:",
+    count: 4,
+    reason:
+      "Paints the fatal-boot error screen, which is exactly the case where the app stylesheet may not have loaded — it cannot reference tokens that might not exist",
+  },
+  {
+    file: "src/utils/renderBootstrapError.ts",
+    match: "border-radius:",
+    count: 2,
+    reason: "Same fatal-boot screen; see above",
   },
 ];
 
@@ -164,9 +202,14 @@ function relative(file: string): string {
   return path.relative(REPO_ROOT, file).split(path.sep).join("/");
 }
 
+/** CSS with comments blanked out, so a commented-out rule can never satisfy a check. */
+function readCss(cssPath: string): string {
+  return fs.readFileSync(cssPath, "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
 /** Every `--name: value;` declaration in a stylesheet, last one wins. */
 function readDeclarations(cssPath: string, prefix: string): Map<string, string> {
-  const css = fs.readFileSync(cssPath, "utf8");
+  const css = readCss(cssPath);
   const decls = new Map<string, string>();
   const re = new RegExp(String.raw`^\s*(${prefix}[\w-]*)\s*:\s*([^;]+);`, "gm");
   for (const m of css.matchAll(re)) decls.set(m[1], m[2].trim());
@@ -177,58 +220,85 @@ describe("numeric scales contract (#12033)", () => {
   const files = SOURCE_ROOTS.flatMap((root) => collectSourceFiles(path.join(REPO_ROOT, root)));
 
   it("scans a plausible slice of the app", () => {
-    // Guards the guards: a broken root or an over-eager skip list would make
-    // every assertion below pass by scanning nothing.
+    // Guards the guards: a broken root or an over-eager skip list would make every
+    // assertion below pass by scanning nothing. A total alone is too coarse — src/
+    // dwarfs plugins/, so losing the plugin walk or every .css file still clears it.
     expect(files.length).toBeGreaterThan(1000);
+    for (const root of SOURCE_ROOTS) {
+      expect({ root, scanned: files.some((f) => relative(f).startsWith(`${root}/`)) }).toEqual({
+        root,
+        scanned: true,
+      });
+    }
+    for (const ext of [".ts", ".tsx", ".css"]) {
+      expect({ ext, scanned: files.some((f) => f.endsWith(ext)) }).toEqual({ ext, scanned: true });
+    }
   });
 
   it("keeps type and radius sizes on the shared scales", () => {
-    const seen = new Map<string, number>();
+    const seen = new Map<string, { count: number; lines: number[] }>();
     const offenders: string[] = [];
 
     for (const file of files) {
       const content = fs.readFileSync(file, "utf8");
-      for (const [name, re] of Object.entries(PATTERNS) as [PatternName, RegExp][]) {
-        for (const match of content.match(re) ?? []) {
-          const normalized = match.replace(/\s+/g, " ").replace(/"$/, "");
-          const key = `${relative(file)}|${name}|${normalized}`;
-          seen.set(key, (seen.get(key) ?? 0) + 1);
+      const lineStarts = [...content.matchAll(/\n/g)].map((m) => m.index ?? 0);
+      const lineOf = (index: number) => lineStarts.filter((start) => start < index).length + 1;
+
+      for (const { re, isOffender } of MATCHERS) {
+        re.lastIndex = 0;
+        for (const m of content.matchAll(re)) {
+          if (!isOffender(m[1])) continue;
+          // The css-declaration matcher consumes the delimiter before the property
+          // (`;`, `{`, whitespace); drop it so a token reads as the declaration itself.
+          const token = m[0]
+            .trim()
+            .replace(/\s+/g, " ")
+            .replace(/^[^\w[]+/, "");
+          const key = `${relative(file)}|${token}`;
+          const entry = seen.get(key) ?? { count: 0, lines: [] };
+          entry.count += 1;
+          entry.lines.push(lineOf(m.index ?? 0));
+          seen.set(key, entry);
         }
       }
     }
 
-    const allowed = new Map(
-      EXCEPTIONS.map((e) => [`${e.file}|${e.pattern}|${e.match}`, e.count] as const)
-    );
+    // An exception is keyed by a token PREFIX so a whole-declaration match
+    // (`font-size: 0.875rem`) can be allowlisted by its property alone.
+    const findException = (file: string, token: string) =>
+      EXCEPTIONS.find((e) => e.file === file && token.startsWith(e.match));
 
-    for (const [key, count] of seen) {
-      const [file, pattern, match] = key.split("|");
-      const budget = allowed.get(key);
-      if (budget === undefined) {
+    const used = new Map<(typeof EXCEPTIONS)[number], number>();
+
+    for (const [key, { count, lines }] of seen) {
+      const [file, token] = key.split("|");
+      const exception = findException(file, token);
+      if (!exception) {
         offenders.push(
-          `  ${file} — ${count}× ${match} (${pattern}) is not on the scale. ` +
-            `Use text-4xs/3xs/2xs/xs/sm or var(--radius-xs…4xl); if the value is deliberately ` +
-            `off-scale, add it to EXCEPTIONS with a reason.`
+          `  ${file}:${lines.join(",")} — ${token}\n` +
+            `    Not on a scale. Use text-4xs/3xs/2xs/xs/sm (or var(--text-*)) for type and\n` +
+            `    var(--radius-xs…4xl) / rounded-xs…4xl for radius. If it genuinely cannot follow\n` +
+            `    the scale, add an EXCEPTIONS entry saying why — do not widen an existing one.`
         );
-      } else if (count !== budget) {
-        offenders.push(
-          `  ${file} — ${match} (${pattern}) appears ${count}×, allowlisted for ${budget}. ` +
-            `Update the EXCEPTIONS entry if this is intended.`
-        );
+        continue;
       }
+      used.set(exception, (used.get(exception) ?? 0) + count);
     }
 
-    for (const [key, budget] of allowed) {
-      if (!seen.has(key)) {
-        const [file, pattern, match] = key.split("|");
-        offenders.push(
-          `  ${file} — stale EXCEPTIONS entry for ${match} (${pattern}, expected ${budget}×); it is gone, so drop the entry.`
-        );
-      }
+    for (const exception of EXCEPTIONS) {
+      const actual = used.get(exception) ?? 0;
+      if (actual === exception.count) continue;
+      offenders.push(
+        actual === 0
+          ? `  ${exception.file} — stale EXCEPTIONS entry for "${exception.match}" (expected ${exception.count}). ` +
+              `It is gone, so drop the entry; if the file moved, update the path.`
+          : `  ${exception.file} — "${exception.match}" appears ${actual}×, allowlisted for ${exception.count}.\n` +
+              `    Existing reason: ${exception.reason}\n` +
+              `    ${actual > exception.count ? "Each NEW site must independently satisfy that reason — do not just raise the number." : "Lower the count to match."}`
+      );
     }
 
     if (offenders.length > 0) throw new Error(`Off-scale sizes:\n${offenders.join("\n")}`);
-    expect(offenders).toEqual([]);
   });
 
   it("overrides every radius step Tailwind ships", () => {
@@ -238,7 +308,7 @@ describe("numeric scales contract (#12033)", () => {
     const stock = readDeclarations(TAILWIND_THEME_CSS, "--radius");
     const ours = readDeclarations(INDEX_CSS, "--radius");
     const missing = [...stock.keys()].filter((token) => !ours.has(token));
-    expect({ missing, stockCount: stock.size }).toEqual({ missing: [], stockCount: stock.size });
+    expect(missing).toEqual([]);
     expect(stock.size).toBeGreaterThan(1);
   });
 
@@ -251,7 +321,17 @@ describe("numeric scales contract (#12033)", () => {
       seen.add(token);
       const value = ours.get(token);
       if (value === undefined) return false;
-      const refs = [...value.matchAll(/var\(\s*(--[\w-]+)/g)].map((m) => m[1]);
+      // Only the PRIMARY of each `var(--primary, fallback)` counts. A fallback is
+      // inert whenever the primary resolves, so `var(--fixed, var(--scale))` is a
+      // fixed value wearing the scale as a disguise.
+      const refs = [...value.matchAll(/var\(\s*(--[\w-]+)/g)]
+        .filter((m) => {
+          const before = value.slice(0, m.index ?? 0);
+          const opens = (before.match(/var\(/g) ?? []).length;
+          const closes = (before.match(/\)/g) ?? []).length;
+          return opens === closes; // not nested inside another var()'s fallback
+        })
+        .map((m) => m[1]);
       return refs.some((ref) => ref === SCALE || reaches(ref, seen));
     };
 
@@ -266,23 +346,46 @@ describe("numeric scales contract (#12033)", () => {
     // a paired leading here would reflow hundreds of call sites that inherit it.
     const text = readDeclarations(INDEX_CSS, "--text-");
     const steps = ["--text-2xs", "--text-3xs", "--text-4xs"];
-    expect(steps.filter((s) => !text.has(s))).toEqual([]);
-    expect([...text.keys()].filter((token) => token.endsWith("--line-height"))).toEqual([]);
+    expect(steps.filter((step) => !text.has(step))).toEqual([]);
+    expect(steps.filter((step) => text.has(`${step}--line-height`))).toEqual([]);
+  });
+
+  it("keeps the sub-xs steps a descending scale under text-xs", () => {
+    // Names alone would let the three steps be equal, reversed, or arbitrary.
+    // Comparing them to each other and to Tailwind's own floor tests the shape of
+    // the scale without copying any of its values into the test.
+    const rem = (value: string) => {
+      const m = /^(-?\d*\.?\d+)rem$/.exec(value.trim());
+      return m ? Number.parseFloat(m[1]) : Number.NaN;
+    };
+    const ladder = [
+      rem(readDeclarations(TAILWIND_THEME_CSS, "--text-xs").get("--text-xs") ?? ""),
+      ...["--text-2xs", "--text-3xs", "--text-4xs"].map((step) =>
+        rem(readDeclarations(INDEX_CSS, "--text-").get(step) ?? "")
+      ),
+    ];
+
+    expect(ladder.filter(Number.isNaN)).toEqual([]);
+    const gaps = ladder.slice(1).map((value, i) => Number((ladder[i] - value).toFixed(6)));
+    expect(gaps.filter((gap) => gap <= 0)).toEqual([]); // strictly descending
+    expect(new Set(gaps).size).toBe(1); // evenly spaced
   });
 
   it("reaches the type steps from plain CSS", () => {
-    // settings.css and the CodeMirror chip styles consume these as var(--text-*),
-    // which only works if the tokens are declared in a plain @theme block rather
-    // than an inlined one.
-    const css = fs.readFileSync(INDEX_CSS, "utf8");
+    // settings.css, the diff viewer and the CodeMirror chip styles consume these
+    // as var(--text-*), which only works if the tokens are declared in a plain
+    // @theme block rather than an inlined one.
+    const css = readCss(INDEX_CSS); // comments stripped: a `/* } */` must not close a block
     let depth = 0;
     let inlineThemeDepth: number | null = null;
     const inlined: string[] = [];
 
     for (const line of css.split("\n")) {
+      // Opening detection runs first so a same-line `@theme inline { --text-x: … }`
+      // is still attributed to the inline block.
+      if (/@theme\s+inline\s*\{/.test(line)) inlineThemeDepth = depth;
       const declared = /^\s*(--text-[\w-]+)\s*:/.exec(line);
       if (declared && inlineThemeDepth !== null) inlined.push(declared[1]);
-      if (/@theme\s+inline\s*\{/.test(line)) inlineThemeDepth = depth;
       for (const ch of line) {
         if (ch === "{") depth++;
         else if (ch === "}") {
@@ -299,18 +402,36 @@ describe("numeric scales contract (#12033)", () => {
     // Every theme that set this token set it to the same 0.5rem literal, and the
     // fallback was that literal too — so the pill was the one piece of chrome that
     // never moved with the theme's radius. Both halves have to stay on the scale.
-    const fallbacks = [TOOLBAR_CSS, ...SOURCE_ROOTS.map((r) => path.join(REPO_ROOT, r))]
-      .flatMap((p) => (fs.statSync(p).isDirectory() ? collectSourceFiles(p) : [p]))
-      .flatMap((file) =>
-        [
-          ...fs
-            .readFileSync(file, "utf8")
-            .matchAll(/--toolbar-pill-radius\s*,\s*([^)]*\)?[^),]*)/g),
-        ].map((m) => ({ file: relative(file), fallback: m[1].trim() }))
-      );
+    //
+    // Each consumer is checked by name: a global "at least one is fine" count would
+    // still pass if one call site quietly dropped its fallback.
+    const CONSUMERS = [
+      "src/styles/components/toolbar.css",
+      "src/components/Layout/Toolbar.tsx",
+      "src/components/Layout/ForgeStatsToolbarButton.tsx",
+    ];
 
-    expect(fallbacks.length).toBeGreaterThan(0);
-    expect(fallbacks.filter((f) => !f.fallback.includes("var(--radius"))).toEqual([]);
+    const fallbacks = CONSUMERS.map((file) => {
+      const source = fs.readFileSync(path.join(REPO_ROOT, file), "utf8");
+      const at = source.indexOf("--toolbar-pill-radius");
+      if (at === -1) return { file, fallback: null };
+      // Walk the balanced var(...) so a calc() or nested var() fallback stays intact.
+      const rest = source.slice(at);
+      let depth = 1;
+      let end = rest.indexOf("(");
+      for (let i = rest.indexOf(",") + 1; i < rest.length && depth > 0; i++) {
+        if (rest[i] === "(") depth++;
+        else if (rest[i] === ")") depth--;
+        if (depth === 0) end = i;
+      }
+      const comma = rest.indexOf(",");
+      return {
+        file,
+        fallback: comma === -1 || comma > end ? null : rest.slice(comma + 1, end).trim(),
+      };
+    });
+
+    expect(fallbacks.filter((f) => !f.fallback?.includes("var(--radius"))).toEqual([]);
 
     const pinned = fs
       .readdirSync(BUILT_IN_THEMES)

--- a/src/index.css
+++ b/src/index.css
@@ -387,6 +387,9 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  /* Every step Tailwind ships must be overridden here, or the ones we skip keep
+   * their stock constants and stop tracking --theme-radius-scale. Bare `rounded`
+   * and its directional forms resolve through --radius, so they scale too. */
   --radius-xs: calc(var(--radius) - 6px);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
@@ -394,6 +397,7 @@
   --radius-xl: calc(var(--radius) + 4px);
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
+  --radius-4xl: calc(var(--radius) + 16px);
   --height-xs: 1.75rem;
   --height-sm: 2rem;
   --height-md: 2.5rem;
@@ -446,6 +450,29 @@
   unicode-range:
     U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
     U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* Type scale below Tailwind's floor. A lot of this chrome lives under 12px, and
+ * without names for those tiers every author picked a pixel value by eye.
+ * Emitted to :root (plain @theme, not inline) so plain CSS and CodeMirror/inline
+ * style consumers can reach the same steps via var().
+ *
+ * No paired --text-*--line-height: a size token without one emits font-size and
+ * nothing else, which is what the arbitrary values these replace did. Adding
+ * leading here would silently reflow every call site that inherits it today.
+ *
+ * These are fixed rem, deliberately NOT multiplied by a theme scalar the way
+ * --radius is by --theme-radius-scale. Radius scaling is theme aesthetics; text
+ * size is not something a colour scheme should decide. App-wide text scaling
+ * already exists as Chromium zoom (View ▸ Zoom In/Out), which scales rem and px
+ * alike. If a text scalar is ever wanted it has to cover the whole --text-*
+ * family at once — wiring it to these three steps alone would reproduce, for
+ * type, exactly the split-scale defect this scale exists to avoid.
+ */
+@theme {
+  --text-2xs: 0.6875rem;
+  --text-3xs: 0.625rem;
+  --text-4xs: 0.5625rem;
 }
 
 /* Motion token scale — single source of truth for durations and easings.

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -81,9 +81,13 @@ const GENERIC_AUDIO_ERROR: MediaPreviewError = {
   description: "The format is supported but the codec may not be — Refresh to try again.",
 };
 
-// Mirrors the ladder the modal used, so the preference keeps meaning the same
-// sizes it always did.
-const DIFF_FONT_SIZE_PX: Record<DiffFontSize, string> = { s: "11px", m: "12px", l: "14px" };
+// The S/M/L rungs are the shared type steps, so the preference keeps meaning the
+// same sizes it always did while still tracking the scale.
+const DIFF_FONT_SIZE: Record<DiffFontSize, string> = {
+  s: "var(--text-2xs)",
+  m: "var(--text-xs)",
+  l: "var(--text-sm)",
+};
 
 export interface DiffPaneProps extends BasePanelProps {
   tabs?: TabInfo[];
@@ -178,7 +182,7 @@ export function DiffPane({
   const diffShowFileList = usePreferencesStore((s) => s.diffShowFileList);
   const diffFontSize = usePreferencesStore((s) => s.diffFontSize);
   const diffFontStyle: CSSProperties & Record<"--diff-font-size", string> = {
-    "--diff-font-size": DIFF_FONT_SIZE_PX[diffFontSize],
+    "--diff-font-size": DIFF_FONT_SIZE[diffFontSize],
   };
   const setDiffShowFileList = usePreferencesStore((s) => s.setDiffShowFileList);
 

--- a/src/panels/file-browser/FileBrowserChangeSummary.tsx
+++ b/src/panels/file-browser/FileBrowserChangeSummary.tsx
@@ -88,7 +88,7 @@ export function FileBrowserChangeSummary({ changes, onSelect }: FileBrowserChang
                   <span className="truncate font-medium">{base}</span>
                 </span>
                 <span
-                  className="flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums"
+                  className="flex shrink-0 items-center gap-1.5 text-2xs tabular-nums"
                   aria-hidden="true"
                 >
                   {insertions > 0 && <span className="text-status-success/80">+{insertions}</span>}

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1098,7 +1098,7 @@ export function FileBrowserPane({
                       onClick={handleCopyRootPath}
                       aria-label={`Copy folder path: ${rootAbsolutePath}`}
                       className={cn(
-                        "min-w-0 flex-1 cursor-pointer truncate text-left font-mono text-[11px] transition-colors duration-150 ease-out",
+                        "min-w-0 flex-1 cursor-pointer truncate text-left font-mono text-2xs transition-colors duration-150 ease-out",
                         showRootPathCopied
                           ? "text-status-success"
                           : "text-daintree-text/40 hover:text-daintree-text/70"
@@ -1122,7 +1122,7 @@ export function FileBrowserPane({
                 </Tooltip>
               ) : (
                 <span
-                  className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-secondary"
+                  className="min-w-0 flex-1 truncate font-mono text-2xs text-text-secondary"
                   title={rootHoverPath}
                 >
                   {rootPath || (basePath ? basename(basePath) : "")}
@@ -1401,7 +1401,7 @@ export function FileBrowserPane({
             <button
               type="button"
               onClick={revealSelection}
-              className="shrink-0 truncate border-t border-daintree-border px-3 py-1 text-left font-mono text-[11px] text-daintree-text/60 transition-colors duration-150 ease-out hover:bg-tint/5 hover:text-daintree-text"
+              className="shrink-0 truncate border-t border-daintree-border px-3 py-1 text-left font-mono text-2xs text-daintree-text/60 transition-colors duration-150 ease-out hover:bg-tint/5 hover:text-daintree-text"
             >
               Reveal {selectedFileName}
             </button>

--- a/src/panels/file-browser/FolderListingView.tsx
+++ b/src/panels/file-browser/FolderListingView.tsx
@@ -101,7 +101,7 @@ export function FolderListingView({
       */}
       <div
         aria-hidden="true"
-        className="flex shrink-0 items-center gap-3 border-b border-overlay px-3 py-1 text-[11px] font-medium text-text-secondary"
+        className="flex shrink-0 items-center gap-3 border-b border-overlay px-3 py-1 text-2xs font-medium text-text-secondary"
       >
         <span className="min-w-0 flex-1">Name</span>
         <span className="w-20 shrink-0 text-right">Size</span>

--- a/src/styles/components/settings.css
+++ b/src/styles/components/settings.css
@@ -46,7 +46,7 @@
 
 .settings-meta {
   color: var(--settings-meta-fg, var(--theme-text-muted));
-  font-size: var(--settings-meta-size, 11px);
+  font-size: var(--settings-meta-size, var(--text-2xs));
 }
 
 .settings-nav-item:hover {

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -232,7 +232,7 @@
   );
   --_border: var(--toolbar-project-border, var(--theme-border-subtle));
   --_shadow: var(--toolbar-project-shadow, var(--theme-shadow-ambient));
-  --_radius: var(--toolbar-pill-radius, 0.5rem);
+  --_radius: var(--toolbar-pill-radius, var(--radius-md));
   position: relative;
   isolation: isolate;
   background: var(--_bg);

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -309,7 +309,7 @@
   --_bg: var(--toolbar-project-chip-bg, var(--theme-overlay-hover));
   --_border: var(--toolbar-project-chip-border, var(--theme-border-subtle));
   --_fg: var(--toolbar-project-meta-fg, var(--theme-text-secondary));
-  --_size: var(--toolbar-project-chip-size, 10px);
+  --_size: var(--toolbar-project-chip-size, var(--text-3xs));
   background: var(--_bg);
   border-color: var(--_border);
   color: var(--_fg);


### PR DESCRIPTION
**Important: the issue's radius premise turned out to be wrong, and the fix is different from what it describes.** I compiled the real stylesheet to check. Bare `rounded`, `rounded-sm/md/lg/xs/xl/2xl/3xl` and `rounded-[var(--radius-*)]` all already resolve through `--radius` → `calc(0.625rem * var(--theme-radius-scale, 1))`, so they *do* scale. Tailwind v4 maps bare `rounded` to the `--radius` theme key, and `src/index.css` overrides that key — which is also why bare `rounded` is byte-equivalent to `rounded-lg` today. There was no half-scaled UI from those 662 "raw" utilities, and the ~1100-site spelling normalisation the issue implies would have been pure churn. The contract test now proves the equivalence instead.

There *is* a real unscaled-radius defect, just not in the Tailwind utilities:

- `--toolbar-pill-radius` fell back to a hardcoded `0.5rem`, and all 7 themes that set it set it to that same literal — so the toolbar pill was the one piece of chrome that never moved with the theme's radius. That is exactly the "some corners move, some stay put" symptom, reachable today by switching to Movile (`radiusScale: 0.6`).
- `--radius-4xl` was never overridden, so Tailwind's stock 2rem constant would silently not scale the moment anyone used `rounded-4xl`.
- ~20 fixed `border-radius`/`font-size` declarations in plain CSS and CodeMirror/inline styles bypassed both scales, including one hidden a hop behind a custom property (`--_size: 10px` consumed as `font-size: var(--_size)`).

The type half of the issue was entirely valid and is the bulk of the change.

### Type
- New `--text-2xs` (11px), `--text-3xs` (10px), `--text-4xs` (9px) in a plain `@theme` block, deliberately with **no** paired `--text-*--line-height` so each utility emits `font-size` only — an exact drop-in for the arbitrary values it replaces. A paired leading would have silently reflowed ~655 call sites that inherit it today.
- 701 mechanical replacements: `text-[11px]`→`text-2xs` (390), `text-[10px]`→`text-3xs` (291), `text-[9px]`→`text-4xs` (20).
- 30 long-hand folds: `text-[12px]`→`text-xs`, `text-[13px]`/`[14px]`→`text-sm`, each pinned with `leading-[inherit]` because `text-xs`/`text-sm` *do* emit a line-height. Nine `13px`→`14px` sites are an intentional 1px change, sanctioned by the issue.
- `text-[0.65rem]` — an invented 10.4px tier — folded onto `text-3xs`.
- The diff viewer's S/M/L text-size preference and the markdown prose size now reference the steps instead of pixel literals.

### The decision the issue asked us to write down
The new steps are **fixed rem and deliberately do not get a theme multiplier**, recorded in a comment beside the tokens in `src/index.css`. Three reasons: `radius-scale` is a theme *aesthetic* knob and a colour scheme should not decide your text size; app-wide text scaling already exists as Chromium zoom (View ▸ Zoom In/Out, `electron/menu.ts`), which scales rem and px alike, so WCAG 1.4.4 is satisfied without new plumbing; and decisively, `text-xs` (1295 uses) and `text-sm` (499 uses) resolve to stock unscaled Tailwind values, so wiring only the three new steps to a scalar would have reproduced *precisely* the split-scale defect this issue exists to remove. A text scale, if ever wanted, has to cover the whole `--text-*` family at once.

### Guard
New `src/config/__tests__/numericScales.contract.test.ts`, following the repo's source-contract pattern. It classifies arbitrary payloads rather than banning them, so `text-[CanvasText]` and `border-radius: 50%` pass while `text-[0.65rem]`, `text-[length:11px]`, `rounded-[calc(4px)]` and `text-[var(--x, 11px)]` fail. Units are judged per scale — `em`/`%` follow the type scale, but on a radius they follow font size instead. It also asserts behavioural invariants: every radius step Tailwind ships is overridden, every radius token's `var()` graph reaches `--theme-radius-scale` (counting only primaries, since a fallback is inert), the sub-xs steps form a strictly descending evenly-spaced ladder under `text-xs`, and the toolbar pill stays on the scale in every consumer and theme. Off-scale values that survive review are allowlisted with an exact count and a reason.

Mutation-tested with 23 seeded violations; all 23 fail the guard.

### Verification
- `npx tsc --noEmit` — 0 diagnostics project-wide
- `npm run lint:ratchet` — passes, warnings decreased by 4
- `npx prettier --check` on all 227 changed files — clean
- 17,577 unit tests pass

### Not done, deliberately
- Bare `rounded` / `rounded-[var(--radius-*)]` are left alone. They already scale; normalising ~1100 sites to one spelling is reviewable churn better done separately, and the contract test documents the equivalence.
- `index.html`'s cold-start skeleton keeps its 33 fixed radii. It paints before the stylesheet defines `--radius-*`, so the fallback would apply during its actual lifetime anyway.

Resolves #12033