### PR TITLE
fix(fleet): keep the pty-host record's worktree in step with the panel's

### DIFF
--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -141,6 +141,14 @@ const DEAD_CHANNEL_ALLOWLIST = new Set<string>([
   // result worth awaiting.
   "terminal:update-title",
 
+  // fire-and-forget — renderer->main cross-worktree move, mirrored onto the
+  // pty-host terminal record so the fleet palette groups a run by the worktree
+  // it is in rather than the one it launched in (#12060). Send-only for the
+  // same reason as its `update-title` sibling: the renderer panel store is
+  // already authoritative for the grouping the user sees, so there is no result
+  // worth awaiting.
+  "terminal:update-worktree-id",
+
   // fire-and-forget — high-frequency renderer→main streaming audio chunks
   // for voice input. Same rationale as the terminal input channels.
   "voice-input:audio-chunk",

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -62,6 +62,7 @@ export const CHANNELS = {
   TERMINAL_AGENT_TITLE_STATE: "terminal:agent-title-state",
   TERMINAL_UPDATE_OBSERVED_TITLE: "terminal:update-observed-title",
   TERMINAL_UPDATE_TITLE: "terminal:update-title",
+  TERMINAL_UPDATE_WORKTREE_ID: "terminal:update-worktree-id",
   TERMINAL_REDUCE_SCROLLBACK: "terminal:reduce-scrollback",
   TERMINAL_RESTORE_SCROLLBACK: "terminal:restore-scrollback",
   TERMINAL_RESTART_SERVICE: "terminal:restart-service",

--- a/electron/ipc/handlers/terminal/__tests__/io.worktreeAttribution.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/io.worktreeAttribution.test.ts
@@ -1,0 +1,149 @@
+/**
+ * #12060: the fleet palette groups runs by the pty-host's copy of `worktreeId`,
+ * and nothing re-stamps that copy after spawn. This channel is the hop that
+ * carries a cross-worktree move to it.
+ *
+ * The contract these specs pin is the one the issue is explicit about: there is
+ * no silent fallback. `null` is the ONLY way to say "this run now has no
+ * worktree", a malformed payload is dropped rather than guessed at, and nothing
+ * here substitutes a project root, the active worktree, or the previous id for
+ * a value that failed validation.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+  on: vi.fn(),
+  removeListener: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  BrowserWindow: { fromWebContents: vi.fn(() => null), getAllWindows: () => [] },
+  webContents: { fromId: vi.fn(() => null) },
+}));
+
+vi.mock("../../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: vi.fn(() => null),
+  getProjectForWebContents: vi.fn(() => null),
+  getAppWebContents: vi.fn(() => null),
+  getAllAppWebContents: vi.fn(() => []),
+  getWebContentsForProject: vi.fn(() => []),
+  hasRegisteredProjectViews: vi.fn(() => true),
+  isCachedViewWebContents: vi.fn(() => false),
+}));
+
+vi.mock("../../../../window/portDistribution.js", () => ({
+  distributeTerminalWorkerPortToView: vi.fn(() => ({ token: "port-token" })),
+  releaseTerminalWorkerPort: vi.fn(),
+}));
+
+const emitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../../services/events.js", () => ({
+  events: { emit: emitMock, on: vi.fn(() => vi.fn()), off: vi.fn() },
+}));
+
+import { CHANNELS } from "../../../channels.js";
+import { registerTerminalIOHandlers } from "../io.js";
+import { _resetIpcGuardForTesting, markIpcSecurityReady } from "../../../ipcGuard.js";
+import type { HandlerDependencies } from "../../../types.js";
+
+const updateWorktreeId = vi.fn();
+
+function buildDeps(): HandlerDependencies {
+  return {
+    ptyClient: {
+      updateWorktreeId,
+      getTerminalAsync: vi.fn(() => Promise.resolve(null)),
+    },
+    windowRegistry: { getByWindowId: () => undefined },
+  } as unknown as HandlerDependencies;
+}
+
+/** Deliver a payload on the worktree channel exactly as the preload would. */
+function send(payload: unknown): void {
+  const call = ipcMainMock.on.mock.calls.find(
+    ([channel]) => channel === CHANNELS.TERMINAL_UPDATE_WORKTREE_ID
+  );
+  if (!call) throw new Error("worktree-update handler was never registered");
+  const registered = call[1] as (event: unknown, payload: unknown) => void;
+  registered({ sender: { id: 1 } }, payload);
+}
+
+describe("terminal:update-worktree-id", () => {
+  let dispose: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetIpcGuardForTesting();
+    markIpcSecurityReady();
+    dispose = registerTerminalIOHandlers(buildDeps());
+  });
+
+  it("re-files a run onto a real worktree id", () => {
+    send({ id: "t1", worktreeId: "/repo/.worktrees/feature" });
+
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", "/repo/.worktrees/feature");
+  });
+
+  it("forwards the id verbatim rather than canonicalizing the path", () => {
+    // A worktree id is a path, and the same path has more than one spelling.
+    // Re-deriving one here would file the run under an id the renderer does not
+    // recognize as the worktree the user dragged it to.
+    const id = "/Repo/../repo/.worktrees/feature/";
+    send({ id: "t1", worktreeId: id });
+
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", id);
+  });
+
+  it("treats null as an explicit clear", () => {
+    // The one path that really leaves a panel with no worktree: undoing a
+    // dock-to-grid move deletes the id the pane adopted on its way to the grid.
+    send({ id: "t1", worktreeId: null });
+
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", null);
+  });
+
+  it.each([
+    ["a missing field", { id: "t1" }],
+    ["undefined", { id: "t1", worktreeId: undefined }],
+    ["an empty string", { id: "t1", worktreeId: "" }],
+    ["whitespace only", { id: "t1", worktreeId: "   " }],
+    ["a number", { id: "t1", worktreeId: 7 }],
+    ["an object", { id: "t1", worktreeId: { path: "/repo" } }],
+    ["a blank terminal id", { id: "", worktreeId: "/repo" }],
+    ["a non-string terminal id", { id: 3, worktreeId: "/repo" }],
+    ["no payload at all", undefined],
+  ])("drops %s instead of guessing at it", (_label, payload) => {
+    send(payload);
+
+    expect(updateWorktreeId).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+
+  it("announces the change so the palette regroups before the next poll", () => {
+    send({ id: "t1", worktreeId: "/repo" });
+
+    expect(emitMock).toHaveBeenCalledWith(
+      "terminal:worktree-changed",
+      expect.objectContaining({ id: "t1" })
+    );
+  });
+
+  it("unhooks the listener on teardown so a re-register cannot double-apply", () => {
+    // A leaked listener would apply every move twice — harmless for a set, but
+    // it would also emit two fleet recomputes per drag.
+    const listener = ipcMainMock.on.mock.calls.find(
+      ([channel]) => channel === CHANNELS.TERMINAL_UPDATE_WORKTREE_ID
+    )?.[1];
+
+    dispose();
+
+    expect(ipcMainMock.removeListener).toHaveBeenCalledWith(
+      CHANNELS.TERMINAL_UPDATE_WORKTREE_ID,
+      listener
+    );
+  });
+});

--- a/electron/ipc/handlers/terminal/__tests__/io.worktreeAttribution.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/io.worktreeAttribution.test.ts
@@ -24,9 +24,13 @@ vi.mock("electron", () => ({
   webContents: { fromId: vi.fn(() => null) },
 }));
 
+const getProjectForWebContentsMock = vi.hoisted(() =>
+  vi.fn<(id: number) => string | null>(() => "project-a")
+);
+
 vi.mock("../../../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: vi.fn(() => null),
-  getProjectForWebContents: vi.fn(() => null),
+  getProjectForWebContents: getProjectForWebContentsMock,
   getAppWebContents: vi.fn(() => null),
   getAllAppWebContents: vi.fn(() => []),
   getWebContentsForProject: vi.fn(() => []),
@@ -79,13 +83,35 @@ describe("terminal:update-worktree-id", () => {
     vi.clearAllMocks();
     _resetIpcGuardForTesting();
     markIpcSecurityReady();
+    getProjectForWebContentsMock.mockReturnValue("project-a");
     dispose = registerTerminalIOHandlers(buildDeps());
   });
 
   it("re-files a run onto a real worktree id", () => {
     send({ id: "t1", worktreeId: "/repo/.worktrees/feature" });
 
-    expect(updateWorktreeId).toHaveBeenCalledWith("t1", "/repo/.worktrees/feature");
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", "/repo/.worktrees/feature", "project-a");
+  });
+
+  it("names the sender's own project so the host can refuse a foreign terminal", () => {
+    // The fleet snapshot hands every view every run's id, so a terminal id is
+    // not a capability. Resolving the sender's project here is what lets the
+    // record refuse a write from a renderer that does not own the run.
+    getProjectForWebContentsMock.mockReturnValue("project-b");
+
+    send({ id: "t1", worktreeId: "/repo" });
+
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", "/repo", "project-b");
+  });
+
+  it("passes an unbound window's null project through as an identity", () => {
+    // Null is not a wildcard: it has to reach the record as null so a
+    // project-picker window matches only its own projectless terminals.
+    getProjectForWebContentsMock.mockReturnValue(null);
+
+    send({ id: "t1", worktreeId: "/repo" });
+
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", "/repo", null);
   });
 
   it("forwards the id verbatim rather than canonicalizing the path", () => {
@@ -95,7 +121,7 @@ describe("terminal:update-worktree-id", () => {
     const id = "/Repo/../repo/.worktrees/feature/";
     send({ id: "t1", worktreeId: id });
 
-    expect(updateWorktreeId).toHaveBeenCalledWith("t1", id);
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", id, "project-a");
   });
 
   it("treats null as an explicit clear", () => {
@@ -103,7 +129,7 @@ describe("terminal:update-worktree-id", () => {
     // dock-to-grid move deletes the id the pane adopted on its way to the grid.
     send({ id: "t1", worktreeId: null });
 
-    expect(updateWorktreeId).toHaveBeenCalledWith("t1", null);
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", null, "project-a");
   });
 
   it.each([
@@ -114,6 +140,7 @@ describe("terminal:update-worktree-id", () => {
     ["a number", { id: "t1", worktreeId: 7 }],
     ["an object", { id: "t1", worktreeId: { path: "/repo" } }],
     ["a blank terminal id", { id: "", worktreeId: "/repo" }],
+    ["a whitespace-only terminal id", { id: "   ", worktreeId: "/repo" }],
     ["a non-string terminal id", { id: 3, worktreeId: "/repo" }],
     ["no payload at all", undefined],
   ])("drops %s instead of guessing at it", (_label, payload) => {

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -318,6 +318,41 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     ipcMain.removeListener(CHANNELS.TERMINAL_UPDATE_TITLE, handleTerminalUpdateTitle)
   );
 
+  // A cross-worktree move lands in the renderer panel store, but the record the
+  // fleet palette groups by is the pty-host's. Without this hop a moved — or
+  // restarted — run keeps whatever it was spawned with and the palette files it
+  // under the wrong heading, or under "No worktree" entirely (#12060).
+  //
+  // `null` is the explicit clear and the ONLY way to express "this run now has
+  // no worktree". Nothing here substitutes a project root, the active worktree
+  // or the previous id for a value that fails validation: a run with no
+  // worktree belongs in the no-worktree bucket, and a run with one belongs
+  // under its own real id. A malformed payload is dropped, never guessed at.
+  const handleTerminalUpdateWorktreeId = (
+    _event: Electron.IpcMainEvent,
+    payload: { id: string; worktreeId: string | null }
+  ) => {
+    try {
+      if (!payload || typeof payload !== "object") return;
+      const { id, worktreeId } = payload;
+      if (typeof id !== "string" || !id) return;
+      if (worktreeId !== null && (typeof worktreeId !== "string" || worktreeId.trim() === "")) {
+        return;
+      }
+      ptyClient.updateWorktreeId(id, worktreeId);
+      // Same reason the rename hop emits: the snapshot poll is 5s-aligned and
+      // no other feed reports a move, so the palette would regroup up to a full
+      // cycle after the drag that caused it.
+      events.emit("terminal:worktree-changed", { id, timestamp: Date.now() });
+    } catch (error) {
+      console.error("[IPC] Error handling worktree update:", error);
+    }
+  };
+  ipcMain.on(CHANNELS.TERMINAL_UPDATE_WORKTREE_ID, handleTerminalUpdateWorktreeId);
+  handlers.push(() =>
+    ipcMain.removeListener(CHANNELS.TERMINAL_UPDATE_WORKTREE_ID, handleTerminalUpdateWorktreeId)
+  );
+
   const handleTerminalForceResume = async (id: string): Promise<void> => {
     if (typeof id !== "string" || !id) {
       throw new AppError({

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -17,6 +17,7 @@ import { normalizeTerminalGridDimension } from "../../../../shared/types/termina
 import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
 import { isPanelTitleMode, type PanelTitleMode } from "../../../../shared/types/panel.js";
 import { events } from "../../../services/events.js";
+import { getProjectForWebContents } from "../../../window/webContentsRegistry.js";
 import { defineIpcNamespace, op } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
@@ -335,11 +336,13 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     try {
       if (!payload || typeof payload !== "object") return;
       const { id, worktreeId } = payload;
-      if (typeof id !== "string" || !id) return;
+      if (typeof id !== "string" || id.trim() === "") return;
       if (worktreeId !== null && (typeof worktreeId !== "string" || worktreeId.trim() === "")) {
         return;
       }
-      ptyClient.updateWorktreeId(id, worktreeId);
+      // Resolved synchronously, so the send path keeps its FIFO ordering — an
+      // awaited ownership lookup here could land two rapid moves out of order.
+      ptyClient.updateWorktreeId(id, worktreeId, getProjectForWebContents(_event.sender.id));
       // Same reason the rename hop emits: the snapshot poll is 5s-aligned and
       // no other feed reports a move, so the palette would regroup up to a full
       // cycle after the drag that caused it.

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1355,6 +1355,9 @@ function buildElectronApi(): ElectronAPI {
       updateTitle: (id: string, title: string, titleMode: PanelTitleMode) =>
         ipcRenderer.send(CHANNELS.TERMINAL_UPDATE_TITLE, { id, title, titleMode }),
 
+      updateWorktreeId: (id: string, worktreeId: string | null) =>
+        ipcRenderer.send(CHANNELS.TERMINAL_UPDATE_WORKTREE_ID, { id, worktreeId }),
+
       onSpawnResult: (callback: (id: string, result: SpawnResultPayload) => void): (() => void) =>
         _eventBusOn("terminal:spawn-result", (payload) => {
           if (!Array.isArray(payload)) return;

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -121,9 +121,18 @@ describe("lifecycle update-worktree-id handler", () => {
     const ctx = makeCtx();
     const dispatch = createPtyHostMessageDispatcher(ctx);
 
-    dispatch({ type: "update-worktree-id", id: "t1", worktreeId: "/repo/.worktrees/feature" });
+    dispatch({
+      type: "update-worktree-id",
+      id: "t1",
+      worktreeId: "/repo/.worktrees/feature",
+      expectedProjectId: "project-a",
+    });
 
-    expect(ctx.ptyManager.updateWorktreeId).toHaveBeenCalledWith("t1", "/repo/.worktrees/feature");
+    expect(ctx.ptyManager.updateWorktreeId).toHaveBeenCalledWith(
+      "t1",
+      "/repo/.worktrees/feature",
+      "project-a"
+    );
   });
 
   it("passes an explicit clear through as null rather than dropping it", () => {
@@ -132,9 +141,14 @@ describe("lifecycle update-worktree-id handler", () => {
     const ctx = makeCtx();
     const dispatch = createPtyHostMessageDispatcher(ctx);
 
-    dispatch({ type: "update-worktree-id", id: "t1", worktreeId: null });
+    dispatch({
+      type: "update-worktree-id",
+      id: "t1",
+      worktreeId: null,
+      expectedProjectId: null,
+    });
 
-    expect(ctx.ptyManager.updateWorktreeId).toHaveBeenCalledWith("t1", null);
+    expect(ctx.ptyManager.updateWorktreeId).toHaveBeenCalledWith("t1", null, null);
   });
 });
 

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -41,6 +41,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     markChecked: vi.fn(),
     updateObservedTitle: vi.fn(),
     updateTitle: vi.fn(),
+    updateWorktreeId: vi.fn(),
     transitionState: vi.fn(() => true),
     trimScrollback: vi.fn(),
     setActivityMonitorTier: vi.fn(),
@@ -114,6 +115,28 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
 function termInfo(pid?: number) {
   return { ptyProcess: { pid } };
 }
+
+describe("lifecycle update-worktree-id handler", () => {
+  it("re-files a run onto the worktree it was moved to", () => {
+    const ctx = makeCtx();
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "update-worktree-id", id: "t1", worktreeId: "/repo/.worktrees/feature" });
+
+    expect(ctx.ptyManager.updateWorktreeId).toHaveBeenCalledWith("t1", "/repo/.worktrees/feature");
+  });
+
+  it("passes an explicit clear through as null rather than dropping it", () => {
+    // The host is where `null` becomes a deleted key. Swallowing it here would
+    // leave the run filed under a worktree it has left (#12060).
+    const ctx = makeCtx();
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "update-worktree-id", id: "t1", worktreeId: null });
+
+    expect(ctx.ptyManager.updateWorktreeId).toHaveBeenCalledWith("t1", null);
+  });
+});
 
 describe("lifecycle update-title handler", () => {
   it("forwards the mode alongside the title so the lock survives the hop", () => {

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -232,7 +232,7 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
     },
 
     "update-worktree-id": (msg) => {
-      ptyManager.updateWorktreeId(msg.id, msg.worktreeId);
+      ptyManager.updateWorktreeId(msg.id, msg.worktreeId, msg.expectedProjectId);
     },
 
     "transition-state": (msg) => {

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -231,6 +231,10 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
       ptyManager.updateTitle(msg.id, msg.title, msg.titleMode);
     },
 
+    "update-worktree-id": (msg) => {
+      ptyManager.updateWorktreeId(msg.id, msg.worktreeId);
+    },
+
     "transition-state": (msg) => {
       const success = ptyManager.transitionState(
         msg.id,

--- a/electron/services/FleetSnapshotService.ts
+++ b/electron/services/FleetSnapshotService.ts
@@ -95,6 +95,9 @@ export class FleetSnapshotService {
     // A rename moves no agent state, so without this the row would carry the
     // old title until the next aligned poll (#11830).
     subscribe("terminal:title-changed");
+    // A move re-files the row without moving any agent state, so without this
+    // the palette keeps the old grouping until the next aligned poll (#12060).
+    subscribe("terminal:worktree-changed");
   }
 
   updatePollInterval(ms: number): void {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -2390,6 +2390,30 @@ export class PtyClient extends EventEmitter {
     this.shardForTerminal(id).send({ type: "update-title", id, title, titleMode });
   }
 
+  /**
+   * Mirror a renderer-side worktree move onto the pty-host record so the fleet
+   * projection groups the run where it now lives (#12060).
+   *
+   * The cached spawn options move with it for the same reason `updateTitle`
+   * keeps them in step: `respawnPendingForShard` replays them verbatim after a
+   * pty-host crash, so a stale entry would quietly re-file the run under the
+   * worktree it launched in. `null` deletes the key rather than storing
+   * `undefined`, so the replayed options carry no worktree at all.
+   */
+  updateWorktreeId(id: string, worktreeId: string | null): void {
+    const pending = this.pendingSpawns.get(id);
+    if (pending) {
+      const next = { ...pending };
+      if (worktreeId === null) {
+        delete next.worktreeId;
+      } else {
+        next.worktreeId = worktreeId;
+      }
+      this.pendingSpawns.set(id, next);
+    }
+    this.shardForTerminal(id).send({ type: "update-worktree-id", id, worktreeId });
+  }
+
   async transitionState(
     id: string,
     event: { type: string; [key: string]: unknown },

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -2400,9 +2400,14 @@ export class PtyClient extends EventEmitter {
    * worktree it launched in. `null` deletes the key rather than storing
    * `undefined`, so the replayed options carry no worktree at all.
    */
-  updateWorktreeId(id: string, worktreeId: string | null): void {
+  updateWorktreeId(id: string, worktreeId: string | null, expectedProjectId: string | null): void {
     const pending = this.pendingSpawns.get(id);
     if (pending) {
+      // Same gate the host applies to the live record, on the replay cache:
+      // otherwise a refused write would still come back true on the next
+      // crash respawn. Null is an identity here too, so an unbound window
+      // reaches its own projectless terminals and nothing else.
+      if ((pending.projectId ?? null) !== expectedProjectId) return;
       const next = { ...pending };
       if (worktreeId === null) {
         delete next.worktreeId;
@@ -2411,7 +2416,12 @@ export class PtyClient extends EventEmitter {
       }
       this.pendingSpawns.set(id, next);
     }
-    this.shardForTerminal(id).send({ type: "update-worktree-id", id, worktreeId });
+    this.shardForTerminal(id).send({
+      type: "update-worktree-id",
+      id,
+      worktreeId,
+      expectedProjectId,
+    });
   }
 
   async transitionState(

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -960,6 +960,17 @@ export class PtyManager extends EventEmitter {
   }
 
   /**
+   * Apply a renderer-side worktree move to the authoritative record. A move for
+   * a terminal that has already gone is a no-op — never a synthetic record, and
+   * never a back-filled id: the renderer store keeps the attribution either way.
+   */
+  updateWorktreeId(id: string, worktreeId: string | null): void {
+    const terminal = this.registry.get(id);
+    if (!terminal) return;
+    terminal.setWorktreeId(worktreeId);
+  }
+
+  /**
    * Enable or disable semantic analysis for a terminal.
    */
   setAnalysisEnabled(id: string, enabled: boolean): void {

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -964,9 +964,14 @@ export class PtyManager extends EventEmitter {
    * a terminal that has already gone is a no-op — never a synthetic record, and
    * never a back-filled id: the renderer store keeps the attribution either way.
    */
-  updateWorktreeId(id: string, worktreeId: string | null): void {
+  updateWorktreeId(id: string, worktreeId: string | null, expectedProjectId: string | null): void {
     const terminal = this.registry.get(id);
     if (!terminal) return;
+    // The record is the only place both halves of the identity are known, so
+    // the ownership check lands here rather than in main, where naming the
+    // terminal's project would have cost an await and with it the ordering
+    // that makes two rapid moves settle on the second one.
+    if ((terminal.getInfo().projectId ?? null) !== expectedProjectId) return;
     terminal.setWorktreeId(worktreeId);
   }
 

--- a/electron/services/__tests__/FleetSnapshotService.test.ts
+++ b/electron/services/__tests__/FleetSnapshotService.test.ts
@@ -590,6 +590,25 @@ describe("FleetSnapshotService", () => {
     service.stop();
   });
 
+  it("recomputes on a cross-worktree move, which moves no agent state either", async () => {
+    // The palette groups by `worktreeId`; without this subscription a drag would
+    // keep the run under its old heading until the next aligned poll (#12060).
+    const client = makePtyClient([terminal({ worktreeId: "/repo" })]);
+    const service = new FleetSnapshotService(client as never);
+    service.start();
+    service.refresh();
+    await vi.runOnlyPendingTimersAsync();
+    broadcastMock.mockClear();
+
+    client.setFleet([terminal({ worktreeId: "/repo/.worktrees/feature" })]);
+    eventEmitter.emit("terminal:worktree-changed", { id: "t1", timestamp: NOW });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+    expect(lastSnapshot().runs[0]?.worktreeId).toBe("/repo/.worktrees/feature");
+    service.stop();
+  });
+
   it("recomputes on agent state transitions after the debounce", async () => {
     const client = makePtyClient([terminal({ agentState: "working" })]);
     const service = new FleetSnapshotService(client as never);

--- a/electron/services/__tests__/PtyClient.fabric.test.ts
+++ b/electron/services/__tests__/PtyClient.fabric.test.ts
@@ -420,6 +420,62 @@ describe("PtyClient fabric", () => {
       client.dispose();
     });
 
+    it("respawns under the worktree a run was moved to, not the one it launched in", async () => {
+      // `pendingSpawns` is replayed verbatim on a crash respawn, so a move that
+      // only reached the live record would be silently undone by the next host
+      // crash — the run would reappear in the palette under the worktree the
+      // user dragged it out of (#12060).
+      const client = createFabricClient();
+      client.spawn("t1", {
+        cwd: "/a",
+        cols: 80,
+        rows: 24,
+        projectId: "project-a",
+        worktreeId: "/repo/.worktrees/old",
+      });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      client.updateWorktreeId("t1", "/repo/.worktrees/new");
+
+      shardA.child.emit("exit", 1);
+      await vi.advanceTimersByTimeAsync(15_000);
+      const restarted = forks[forks.length - 1];
+      restarted.child.emit("message", { type: "ready" });
+
+      const respawns = messagesOfType(restarted.child, "spawn");
+      expect((respawns[0].options as { worktreeId?: string }).worktreeId).toBe(
+        "/repo/.worktrees/new"
+      );
+      client.dispose();
+    });
+
+    it("respawns with no worktree at all after an explicit clear", async () => {
+      // The clear has to delete the cached key, not blank it: a replay carrying
+      // `worktreeId: ""` would re-file the run under a worktree named "".
+      const client = createFabricClient();
+      client.spawn("t1", {
+        cwd: "/a",
+        cols: 80,
+        rows: 24,
+        projectId: "project-a",
+        worktreeId: "/repo/.worktrees/old",
+      });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      client.updateWorktreeId("t1", null);
+
+      shardA.child.emit("exit", 1);
+      await vi.advanceTimersByTimeAsync(15_000);
+      const restarted = forks[forks.length - 1];
+      restarted.child.emit("message", { type: "ready" });
+
+      const respawns = messagesOfType(restarted.child, "spawn");
+      expect(respawns[0].options as Record<string, unknown>).not.toHaveProperty("worktreeId");
+      client.dispose();
+    });
+
     it("migrates a crash-looping project shard's terminals to the default shard without a global host-crash", async () => {
       const client = createFabricClient();
       const hostCrash = vi.fn();

--- a/electron/services/__tests__/PtyClient.fabric.test.ts
+++ b/electron/services/__tests__/PtyClient.fabric.test.ts
@@ -420,6 +420,51 @@ describe("PtyClient fabric", () => {
       client.dispose();
     });
 
+    it("sends a move to the owning shard only, and refuses a foreign project's", async () => {
+      // The crash-replay specs below prove only the cache. Without this one, a
+      // fix that mutated the cache but never sent would leave the live record —
+      // the thing the palette actually reads — stale until a host crash.
+      const client = createFabricClient();
+      client.spawn("t1", {
+        cwd: "/a",
+        cols: 80,
+        rows: 24,
+        projectId: "project-a",
+        worktreeId: "/repo",
+      });
+      client.spawn("t2", { cwd: "/tmp", cols: 80, rows: 24 });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+      const defaultChild = defaultShard().child;
+      shardA.child.postMessage.mockClear();
+      defaultChild.postMessage.mockClear();
+
+      client.updateWorktreeId("t1", "/repo/.worktrees/feature", "project-a");
+
+      const sent = messagesOfType(shardA.child, "update-worktree-id");
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toMatchObject({
+        id: "t1",
+        worktreeId: "/repo/.worktrees/feature",
+        expectedProjectId: "project-a",
+      });
+      expect(messagesOfType(defaultChild, "update-worktree-id")).toHaveLength(0);
+
+      // A sender on another project must not reach into this run's replay cache,
+      // or a refused live write would still come true on the next crash respawn.
+      client.updateWorktreeId("t1", "/elsewhere", "project-b");
+
+      shardA.child.emit("exit", 1);
+      await vi.advanceTimersByTimeAsync(15_000);
+      const restarted = forks[forks.length - 1];
+      restarted.child.emit("message", { type: "ready" });
+      const respawns = messagesOfType(restarted.child, "spawn");
+      expect((respawns[0].options as { worktreeId?: string }).worktreeId).toBe(
+        "/repo/.worktrees/feature"
+      );
+      client.dispose();
+    });
+
     it("respawns under the worktree a run was moved to, not the one it launched in", async () => {
       // `pendingSpawns` is replayed verbatim on a crash respawn, so a move that
       // only reached the live record would be silently undone by the next host
@@ -436,7 +481,7 @@ describe("PtyClient fabric", () => {
       const shardA = projectShard("project-a");
       shardA.child.emit("message", { type: "ready" });
 
-      client.updateWorktreeId("t1", "/repo/.worktrees/new");
+      client.updateWorktreeId("t1", "/repo/.worktrees/new", "project-a");
 
       shardA.child.emit("exit", 1);
       await vi.advanceTimersByTimeAsync(15_000);
@@ -464,7 +509,7 @@ describe("PtyClient fabric", () => {
       const shardA = projectShard("project-a");
       shardA.child.emit("message", { type: "ready" });
 
-      client.updateWorktreeId("t1", null);
+      client.updateWorktreeId("t1", null, "project-a");
 
       shardA.child.emit("exit", 1);
       await vi.advanceTimersByTimeAsync(15_000);

--- a/electron/services/__tests__/PtyManager.worktreeAttribution.test.ts
+++ b/electron/services/__tests__/PtyManager.worktreeAttribution.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `PtyManager.updateWorktreeId` is where a renderer-side move becomes the
+ * authoritative record the fleet palette groups by (#12060), and where the
+ * ownership identity is checked.
+ *
+ * The check lands here rather than in main because this is the only place both
+ * halves are known synchronously — naming the terminal's project in main would
+ * have cost an await, and with it the FIFO ordering that makes two rapid moves
+ * settle on the second one.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { PtyManager } from "../PtyManager.js";
+
+function managerWith(record: { projectId?: string | null } | undefined) {
+  const setWorktreeId = vi.fn();
+  const terminal = record
+    ? { getInfo: () => ({ projectId: record.projectId }), setWorktreeId }
+    : undefined;
+  const manager = Object.create(PtyManager.prototype) as PtyManager;
+  Object.defineProperty(manager, "registry", {
+    value: { get: (id: string) => (id === "t1" ? terminal : undefined) },
+    configurable: true,
+  });
+  return { manager, setWorktreeId };
+}
+
+describe("PtyManager.updateWorktreeId", () => {
+  it("writes the move onto the record when the sender owns the run", () => {
+    const { manager, setWorktreeId } = managerWith({ projectId: "project-a" });
+
+    manager.updateWorktreeId("t1", "/repo/.worktrees/feature", "project-a");
+
+    expect(setWorktreeId).toHaveBeenCalledWith("/repo/.worktrees/feature");
+  });
+
+  it("refuses a move for a run owned by another project", () => {
+    // The fleet snapshot pushes every run to every view, so a foreign terminal
+    // id is always in reach. Without this the palette could report project B's
+    // run paired with one of project A's worktrees.
+    const { manager, setWorktreeId } = managerWith({ projectId: "project-b" });
+
+    manager.updateWorktreeId("t1", "/project-a/.worktrees/feature", "project-a");
+
+    expect(setWorktreeId).not.toHaveBeenCalled();
+  });
+
+  it("treats null as an identity, not a wildcard, in both directions", () => {
+    // An unbound window (Cmd+N on the project picker) reaches its own
+    // projectless terminals and nothing else; a project-owned sender must not
+    // reach a projectless run either.
+    const unbound = managerWith({ projectId: undefined });
+    unbound.manager.updateWorktreeId("t1", "/repo", null);
+    expect(unbound.setWorktreeId).toHaveBeenCalledWith("/repo");
+
+    const owned = managerWith({ projectId: "project-a" });
+    owned.manager.updateWorktreeId("t1", "/repo", null);
+    expect(owned.setWorktreeId).not.toHaveBeenCalled();
+
+    const projectless = managerWith({ projectId: undefined });
+    projectless.manager.updateWorktreeId("t1", "/repo", "project-a");
+    expect(projectless.setWorktreeId).not.toHaveBeenCalled();
+  });
+
+  it("carries an explicit clear through to the record", () => {
+    const { manager, setWorktreeId } = managerWith({ projectId: "project-a" });
+
+    manager.updateWorktreeId("t1", null, "project-a");
+
+    expect(setWorktreeId).toHaveBeenCalledWith(null);
+  });
+
+  it("is a no-op for a run that has already gone", () => {
+    // Never a synthetic record: the renderer store keeps the filing either way.
+    const { manager, setWorktreeId } = managerWith(undefined);
+
+    manager.updateWorktreeId("gone", "/repo", "project-a");
+
+    expect(setWorktreeId).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -288,6 +288,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "A panel was renamed and the authoritative record now agrees",
   },
+  "terminal:worktree-changed": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "A run was re-filed onto another worktree (or none) and the record now agrees",
+  },
   "terminal:park-released": {
     category: "agent",
     requiresContext: false,
@@ -816,6 +822,17 @@ export type DaintreeEventMap = {
   };
 
   /**
+   * A cross-worktree move reached the authoritative terminal record. The fleet
+   * projection subscribes because the row's worktree grouping changed; no agent
+   * state moved, so no other feed reports it and the 5s poll would otherwise own
+   * the latency of a drag the user just made (#12060).
+   */
+  "terminal:worktree-changed": {
+    id: string;
+    timestamp: number;
+  };
+
+  /**
    * Emitted whenever a run's snooze record is created, replaced or removed —
    * by the user, or automatically when they typed at the run. Both attention
    * projections subscribe: `ProjectStatsService` because a snooze changes the
@@ -1012,6 +1029,7 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "terminal:park-changed",
   "terminal:park-released",
   "terminal:title-changed",
+  "terminal:worktree-changed",
   "terminal:snooze-changed",
   "agent-session:captured",
   "agent-session:recorded",

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1211,6 +1211,23 @@ export class TerminalProcess {
     this.terminalInfo.titleMode = titleMode;
   }
 
+  /**
+   * Mirror a renderer-side worktree move onto the authoritative record, so the
+   * fleet projection files the run under the worktree it is actually in rather
+   * than the one it launched in (#12060).
+   *
+   * `null` deletes the field rather than storing a blank: an absent worktree is
+   * a real state the fleet palette renders on its own terms, and an empty
+   * string would read as a worktree whose id is "".
+   */
+  setWorktreeId(worktreeId: string | null): void {
+    if (worktreeId === null) {
+      delete this.terminalInfo.worktreeId;
+      return;
+    }
+    this.terminalInfo.worktreeId = worktreeId;
+  }
+
   acknowledgeData(_byteCount: number): void {
     // No-op: SAB-based backpressure in pty-host.ts handles all flow control
   }

--- a/electron/services/pty/__tests__/TerminalProcess.setTitle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.setTitle.test.ts
@@ -45,3 +45,51 @@ describe("TerminalProcess.setTitle", () => {
     expect(info.lastObservedTitle).toBe("agent task");
   });
 });
+
+/**
+ * `setWorktreeId` is the mirror of a renderer-side cross-worktree move onto the
+ * authoritative record — the one the fleet palette groups by (#12060). Its
+ * contract is that `null` genuinely un-files the run: the key comes off, rather
+ * than being blanked to a string the palette would read as a worktree named "".
+ */
+function applySetWorktreeId(
+  info: { worktreeId?: string; title?: string },
+  worktreeId: string | null
+) {
+  TerminalProcess.prototype.setWorktreeId.call({ terminalInfo: info } as never, worktreeId);
+  return info;
+}
+
+describe("TerminalProcess.setWorktreeId", () => {
+  it("re-files a run onto the worktree it moved to", () => {
+    const info = applySetWorktreeId({ worktreeId: "/repo" }, "/repo/.worktrees/feature");
+
+    expect(info.worktreeId).toBe("/repo/.worktrees/feature");
+  });
+
+  it("files a run that had no worktree at all", () => {
+    const info = applySetWorktreeId({}, "/repo");
+
+    expect(info.worktreeId).toBe("/repo");
+  });
+
+  it("deletes the key on an explicit clear rather than blanking it", () => {
+    // `worktreeKey` in the palette folds a blank id in with the absent one, so a
+    // blank would land in the right bucket by luck — but every other reader
+    // (session journal, worktree-scoped clears) would see a worktree whose id is
+    // the empty string.
+    const info = applySetWorktreeId({ worktreeId: "/repo", title: "claude" }, null);
+
+    expect("worktreeId" in info).toBe(false);
+    expect(info.title).toBe("claude");
+  });
+
+  it("stores the id exactly as given, without normalizing the path", () => {
+    // Worktree ids are paths, and the same path has more than one spelling. A
+    // record that re-spells it stops matching the renderer's own index.
+    const spelling = "/Repo/../repo/.worktrees/feature/";
+    const info = applySetWorktreeId({}, spelling);
+
+    expect(info.worktreeId).toBe(spelling);
+  });
+});

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -349,6 +349,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     reportTitleState(id: string, state: "working" | "waiting"): void;
     updateObservedTitle(id: string, title: string): void;
     updateTitle(id: string, title: string, titleMode: PanelTitleMode): void;
+    updateWorktreeId(id: string, worktreeId: string | null): void;
     onSpawnResult(callback: (id: string, result: SpawnResult) => void): () => void;
     onReduceScrollback(
       callback: (data: { terminalIds: string[]; targetLines: number }) => void

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -277,7 +277,16 @@ export type PtyHostRequest =
   // worktree for none — undoing a dock->grid move deletes the adopted id
   // (`layoutUndoStore`) — and an optional field could not tell that apart from
   // a caller that simply forgot to send one (#12060).
-  | { type: "update-worktree-id"; id: string; worktreeId: string | null }
+  | {
+      type: "update-worktree-id";
+      id: string;
+      worktreeId: string | null;
+      // The sender's own project, resolved in main. The host checks it against
+      // the record before writing: the fleet snapshot hands every view every
+      // run's id, so without this any project's renderer could re-file another
+      // project's terminal. Null is an identity, not a wildcard (#11100).
+      expectedProjectId: string | null;
+    }
   | {
       type: "transition-state";
       id: string;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -273,6 +273,11 @@ export type PtyHostRequest =
   | { type: "mark-checked"; id: string }
   | { type: "update-observed-title"; id: string; title: string }
   | { type: "update-title"; id: string; title: string; titleMode: PanelTitleMode }
+  // `null` is an explicit clear, not "unchanged". A panel really can leave a
+  // worktree for none — undoing a dock->grid move deletes the adopted id
+  // (`layoutUndoStore`) — and an optional field could not tell that apart from
+  // a caller that simply forgot to send one (#12060).
+  | { type: "update-worktree-id"; id: string; worktreeId: string | null }
   | {
       type: "transition-state";
       id: string;

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -378,6 +378,10 @@ export const terminalClient = {
    * shutdown records all read the pty-host copy — without this they keep
    * naming the run by its launch title (#11830).
    */
+  updateWorktreeId: (id: string, worktreeId: string | null): void => {
+    window.electron.terminal.updateWorktreeId(id, worktreeId);
+  },
+
   updateTitle: (id: string, title: string, titleMode: PanelTitleMode): void => {
     window.electron.terminal.updateTitle(id, title, titleMode);
   },

--- a/src/controllers/TerminalRegistryController.ts
+++ b/src/controllers/TerminalRegistryController.ts
@@ -106,6 +106,7 @@ class TerminalRegistryController {
       kind,
       launchAgentId,
       title,
+      worktreeId: options.worktreeId,
     };
 
     const id = await terminalClient.spawn(spawnOptions);

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -810,3 +810,82 @@ describe("layoutUndoStore — cross-worktree move notice", () => {
     expect(noticeOf("t-still")).toBeUndefined();
   });
 });
+
+/**
+ * A layout restore rewrites `worktreeId` through a raw `setState`, so it
+ * bypasses the move choke point entirely — the same reason the move-notice
+ * reconcile pass exists here (#11853). The pty-host record the fleet palette
+ * groups by needs the same treatment, in both directions (#12060).
+ *
+ * Drives the real client rather than mocking `@/clients`, so the whole hop —
+ * helper, client, preload binding shape — is under test.
+ */
+describe("layoutUndoStore syncs restored worktree filings to the pty host", () => {
+  let updateWorktreeId: ReturnType<typeof vi.fn>;
+  let previousElectron: unknown;
+
+  beforeEach(() => {
+    updateWorktreeId = vi.fn();
+    previousElectron = (window as unknown as { electron?: unknown }).electron;
+    (window as unknown as { electron: unknown }).electron = { terminal: { updateWorktreeId } };
+
+    useLayoutUndoStore.setState({
+      undoStack: [],
+      redoStack: [],
+      canUndo: false,
+      canRedo: false,
+    });
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      activeDockTerminalId: null,
+    });
+  });
+
+  afterEach(() => {
+    (window as unknown as { electron?: unknown }).electron = previousElectron;
+  });
+
+  it("re-files a run when undo puts it back on its previous worktree", () => {
+    const t1 = makeTerminal({ id: "t1", location: "grid", worktreeId: "w1" });
+    seedTerminals([t1]);
+
+    useLayoutUndoStore.getState().pushLayoutSnapshot();
+    setTerminals([{ ...t1, location: "grid", worktreeId: "w2" }]);
+    useLayoutUndoStore.getState().undo();
+
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", "w1");
+  });
+
+  it("clears the filing explicitly when undo takes an adopted worktree back off", () => {
+    // The one genuine worktree -> no-worktree transition: a global dock pane
+    // adopts the active worktree on its way to the grid, and undo deletes it
+    // again. Skipping this hop would leave the palette grouping the run under a
+    // worktree the user has just undone it out of.
+    const t1 = makeTerminal({ id: "t1", location: "dock" });
+    delete (t1 as { worktreeId?: string }).worktreeId;
+    seedTerminals([t1]);
+
+    useLayoutUndoStore.getState().pushLayoutSnapshot();
+    setTerminals([{ ...t1, location: "grid", worktreeId: "w2" } as PtyPanelData]);
+    useLayoutUndoStore.getState().undo();
+
+    expect(updateWorktreeId).toHaveBeenCalledWith("t1", null);
+  });
+
+  it("says nothing when a restore leaves the filing where it was", () => {
+    // A location-only undo must not churn the record or the fleet recompute it
+    // triggers — every send costs a snapshot pass in main.
+    const t1 = makeTerminal({ id: "t1", location: "grid", worktreeId: "w1" });
+    seedTerminals([t1]);
+
+    useLayoutUndoStore.getState().pushLayoutSnapshot();
+    setTerminals([{ ...t1, location: "dock", worktreeId: "w1" }]);
+    useLayoutUndoStore.getState().undo();
+
+    expect(updateWorktreeId).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/layoutUndoStore.ts
+++ b/src/store/layoutUndoStore.ts
@@ -5,11 +5,13 @@ import type { PanelKind, PanelLocation } from "@shared/types/panel";
 import {
   normalizeDockLocation,
   normalizeGroupDockLocation,
+  panelKindHasPty,
   panelKindIsDockable,
 } from "@shared/config/panelKindRegistry";
 import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { buildWorktreeIndex } from "@/store/slices/panelRegistry/worktreeIndex";
+import { syncWorktreeAttributionToHost } from "@/store/slices/panelRegistry/helpers";
 import { reconcileMovedPanel } from "@/services/terminal/crossWorktreeMove";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
@@ -209,8 +211,21 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
   // the banner — and its queued instruction — for the destination it just left,
   // so "Tell the agent" would send it somewhere the user has undone (#11853).
   for (const [id, before] of worktreeBefore) {
-    const after = newTerminalsById[id]?.worktreeId;
-    if (before === after || after === undefined) continue;
+    const restoredPanel = newTerminalsById[id];
+    if (!restoredPanel) continue;
+    const after = restoredPanel.worktreeId;
+    if (before === after) continue;
+
+    // The pty-host record is re-filed for both directions, including the undo
+    // that takes an adopted worktree back off a global dock pane. That clear is
+    // sent explicitly as `null` rather than skipped: leaving the old id behind
+    // would keep the fleet palette grouping the run under a worktree the user
+    // has just undone it out of (#12060).
+    if (panelKindHasPty(restoredPanel.kind ?? "terminal")) {
+      syncWorktreeAttributionToHost(id, after ?? null);
+    }
+
+    if (after === undefined) continue;
     reconcileMovedPanel(id, after);
   }
 

--- a/src/store/slices/__tests__/moveTerminalToWorktree.test.ts
+++ b/src/store/slices/__tests__/moveTerminalToWorktree.test.ts
@@ -186,6 +186,11 @@ describe("moveTerminalToWorktree", () => {
     // palette disagree about where the very same run is (#12060).
     const t1 = createMockTerminal("t1", "wt-a");
     setTerminals([t1]);
+    // Explicit: a leftover group from a prior case would route this through
+    // `moveTabGroupToWorktree`, whose own sync would satisfy the spy and hide a
+    // regression in the single-panel path.
+    usePanelStore.setState({ tabGroups: new Map() });
+    expect(usePanelStore.getState().getPanelGroup("t1")).toBeUndefined();
 
     usePanelStore.getState().moveTerminalToWorktree("t1", "wt-b");
 
@@ -197,6 +202,7 @@ describe("moveTerminalToWorktree", () => {
     // drag must not churn the record or the fleet recompute it triggers.
     const t1 = createMockTerminal("t1", "wt-a");
     setTerminals([t1]);
+    usePanelStore.setState({ tabGroups: new Map() });
 
     usePanelStore.getState().moveTerminalToWorktree("t1", "wt-a");
 

--- a/src/store/slices/__tests__/moveTerminalToWorktree.test.ts
+++ b/src/store/slices/__tests__/moveTerminalToWorktree.test.ts
@@ -6,6 +6,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 vi.mock("@/clients", () => ({
   terminalClient: {
     resize: vi.fn(),
+    updateWorktreeId: vi.fn(),
   },
   agentSettingsClient: {
     get: vi.fn().mockResolvedValue(null),
@@ -30,6 +31,7 @@ vi.mock("../../persistence/panelPersistence", () => ({
 }));
 
 const { usePanelStore } = await import("../../panelStore");
+const { terminalClient } = await import("@/clients");
 const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
 const { panelPersistence } = await import("../../persistence/panelPersistence");
 
@@ -176,5 +178,28 @@ describe("moveTerminalToWorktree", () => {
     expect(movedGroup?.worktreeId).toBe("wt-b");
 
     expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledTimes(3);
+  });
+
+  it("re-files the run on the pty-host record so the fleet palette regroups it", () => {
+    // The palette groups by the pty-host's copy of `worktreeId`, and nothing
+    // re-stamps it after spawn — so without this hop the sidebar and the
+    // palette disagree about where the very same run is (#12060).
+    const t1 = createMockTerminal("t1", "wt-a");
+    setTerminals([t1]);
+
+    usePanelStore.getState().moveTerminalToWorktree("t1", "wt-b");
+
+    expect(terminalClient.updateWorktreeId).toHaveBeenCalledWith("t1", "wt-b");
+  });
+
+  it("does not re-file a run whose destination is the worktree it is already in", () => {
+    // The early return covers the whole move, the host hop included: a no-op
+    // drag must not churn the record or the fleet recompute it triggers.
+    const t1 = createMockTerminal("t1", "wt-a");
+    setTerminals([t1]);
+
+    usePanelStore.getState().moveTerminalToWorktree("t1", "wt-a");
+
+    expect(terminalClient.updateWorktreeId).not.toHaveBeenCalled();
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/groupWorktreeAttribution.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/groupWorktreeAttribution.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
-  terminalClient: { resize: vi.fn() },
+  terminalClient: { resize: vi.fn(), updateWorktreeId: vi.fn() },
   agentSettingsClient: { get: vi.fn().mockResolvedValue(null) },
   appClient: { setState: vi.fn().mockResolvedValue(undefined) },
 }));
@@ -29,6 +29,7 @@ vi.mock("@/store/persistence/panelPersistence", () => ({
 
 const { usePanelStore } = await import("@/store/panelStore");
 const { agentLifecycleLedger } = await import("@/services/terminal/lifecycleLedger");
+const { terminalClient } = await import("@/clients");
 
 function panel(id: string, worktreeId: string): PtyPanelData {
   return {
@@ -126,5 +127,24 @@ describe("grouped cross-worktree move attribution (#11840)", () => {
     const panels = usePanelStore.getState().panelsById;
     expect(panels["t1"]?.worktreeId).toBe("wt-b");
     expect(panels["t2"]?.worktreeId).toBe("wt-b");
+  });
+
+  it("re-files every member on the pty-host record, not just the dragged one", () => {
+    // The record the fleet palette groups by is the pty-host's, and nothing
+    // re-stamps it after spawn. A grouped drag that syncs only the panel the
+    // user grabbed leaves its tab-mates filed under the worktree they left
+    // (#12060).
+    seedGroup();
+
+    usePanelStore.getState().moveTerminalToWorktree("t1", "wt-b");
+
+    const synced = vi.mocked(terminalClient.updateWorktreeId).mock.calls;
+    expect(synced).toEqual(
+      expect.arrayContaining([
+        ["t1", "wt-b"],
+        ["t2", "wt-b"],
+      ])
+    );
+    expect(synced).toHaveLength(2);
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/promotionWorktreeHostSync.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/promotionWorktreeHostSync.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Every path that re-files a panel's worktree has to mirror the filing onto the
+ * pty-host record: the fleet palette groups runs by that record and nothing
+ * else re-stamps it after spawn (#12060).
+ *
+ * The moves and the trash restores were covered when the sync first landed.
+ * These are their siblings — the promotions (dock→grid, drag-to-position,
+ * grouped, dialog) and the background restores. Promotion matters most: it is
+ * how a run spawned without a worktree usually acquires one, so a promotion
+ * that skips the hop leaves the commonest case filed under "No worktree".
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PanelInstance, PtyPanelData, TabGroup } from "@shared/types/panel";
+import { setWorktreeSelectionAccessor } from "@/store/storeAccessors";
+import { getPanelKindConfig, registerPanelKind } from "@shared/config/panelKindRegistry";
+import { buildWorktreeIndex } from "../worktreeIndex";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    updateWorktreeId: vi.fn(),
+  },
+  agentSettingsClient: { get: vi.fn().mockResolvedValue(null) },
+  appClient: { setState: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    resize: vi.fn().mockReturnValue(null),
+    wake: vi.fn(),
+    getInstance: vi.fn(),
+    setInputLocked: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+vi.mock("../../../persistence/panelPersistence", () => ({
+  panelPersistence: {
+    setProjectIdGetter: vi.fn(),
+    save: vi.fn(),
+    saveTabGroups: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock("../../../persistence/tabGroupPersistence", () => ({
+  tabGroupPersistence: { save: vi.fn(), load: vi.fn().mockReturnValue([]) },
+}));
+
+const { usePanelStore } = await import("../../../panelStore");
+const { usePanelLimitStore } = await import("../../../panelLimitStore");
+const { terminalClient } = await import("@/clients");
+
+const ACTIVE_WORKTREE = "/repo/wt-active";
+const OTHER_WORKTREE = "/repo/wt-other";
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+function ptyPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
+  return {
+    id,
+    title: id,
+    kind: "terminal",
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    location: "dock",
+    isVisible: false,
+    ...overrides,
+  };
+}
+
+function seed(panels: PanelInstance[], tabGroups?: TabGroup[]): void {
+  const panelsById = Object.fromEntries(panels.map((p) => [p.id, p]));
+  const panelIds = panels.map((p) => p.id);
+  usePanelStore.setState({
+    panelsById,
+    panelIds,
+    panelIdsByWorktreeId: buildWorktreeIndex(panelIds, panelsById),
+    tabGroups: new Map((tabGroups ?? []).map((g) => [g.id, g])),
+  });
+}
+
+function syncCalls(): unknown[][] {
+  return vi.mocked(terminalClient.updateWorktreeId).mock.calls;
+}
+
+/** What the panel store now holds — the value the host copy must agree with. */
+function liveWorktreeId(id: string): string | undefined {
+  return usePanelStore.getState().panelsById[id]?.worktreeId;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setWorktreeSelectionAccessor(() => ({
+    activeWorktreeId: ACTIVE_WORKTREE,
+    restoreWorktreeId: null,
+  }));
+  usePanelLimitStore.setState({ hardLimit: 50 });
+  usePanelStore.setState({
+    panelsById: {},
+    panelIds: [],
+    panelIdsByWorktreeId: {},
+    tabGroups: new Map(),
+    trashedTerminals: new Map(),
+    backgroundedTerminals: new Map(),
+    focusedId: null,
+    maximizedId: null,
+  });
+});
+
+afterEach(() => {
+  setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+});
+
+describe("moveTerminalToGrid", () => {
+  it("files the promoted run on the host record under the worktree it adopted", () => {
+    seed([ptyPanel("p1")]);
+
+    usePanelStore.getState().moveTerminalToGrid("p1");
+
+    expect(liveWorktreeId("p1")).toBe(ACTIVE_WORKTREE);
+    expect(syncCalls()).toEqual([["p1", liveWorktreeId("p1")]]);
+  });
+
+  it("stays silent when the panel already carries its own filing", () => {
+    // Promotion never overwrites a real attribution, so there is nothing for
+    // the host to learn — a sync here would be pure IPC noise on every drag.
+    seed([ptyPanel("p1", { worktreeId: OTHER_WORKTREE })]);
+
+    usePanelStore.getState().moveTerminalToGrid("p1");
+
+    expect(liveWorktreeId("p1")).toBe(OTHER_WORKTREE);
+    expect(syncCalls()).toHaveLength(0);
+  });
+
+  it("skips a kind with no pty record to update", () => {
+    seed([
+      {
+        id: "f1",
+        kind: "file",
+        title: "notes",
+        location: "dock",
+        filePath: "/repo/notes.md",
+        fileViewMode: "source",
+      } as PanelInstance,
+    ]);
+
+    usePanelStore.getState().moveTerminalToGrid("f1");
+
+    expect(liveWorktreeId("f1")).toBe(ACTIVE_WORKTREE);
+    expect(syncCalls()).toHaveLength(0);
+  });
+});
+
+describe("promoteDialogPanelToGrid", () => {
+  it("files a promoted dialog run on the host record", () => {
+    seed([ptyPanel("d1", { location: "dialog", excludeFromPersistence: true })]);
+
+    expect(usePanelStore.getState().promoteDialogPanelToGrid("d1")).toBe(true);
+
+    expect(liveWorktreeId("d1")).toBe(ACTIVE_WORKTREE);
+    expect(syncCalls()).toEqual([["d1", liveWorktreeId("d1")]]);
+  });
+
+  it("stays silent when the ceiling refuses the promotion", () => {
+    // Nothing moved, so nothing may be re-filed: a sync on a refused promotion
+    // would hand the palette a worktree the panel never took.
+    usePanelLimitStore.setState({ hardLimit: 1 });
+    seed([
+      ptyPanel("g1", { location: "grid", worktreeId: OTHER_WORKTREE }),
+      ptyPanel("d1", { location: "dialog", excludeFromPersistence: true }),
+    ]);
+
+    expect(usePanelStore.getState().promoteDialogPanelToGrid("d1")).toBe(false);
+    expect(syncCalls()).toHaveLength(0);
+  });
+});
+
+describe("moveTerminalToPosition", () => {
+  it("files a run dragged out of the dock under the drop target's worktree", () => {
+    seed([ptyPanel("p1")]);
+
+    usePanelStore.getState().moveTerminalToPosition("p1", 0, "grid", OTHER_WORKTREE);
+
+    expect(liveWorktreeId("p1")).toBe(OTHER_WORKTREE);
+    expect(syncCalls()).toEqual([["p1", liveWorktreeId("p1")]]);
+  });
+
+  it("stays silent on a reorder inside the dock", () => {
+    seed([ptyPanel("p1"), ptyPanel("p2")]);
+
+    usePanelStore.getState().moveTerminalToPosition("p2", 0, "dock");
+
+    expect(syncCalls()).toHaveLength(0);
+  });
+});
+
+describe("moveTabGroupToLocation", () => {
+  it("files every member of a promoted group, not just the anchor", () => {
+    seed(
+      [ptyPanel("p1"), ptyPanel("p2")],
+      [{ id: "g1", location: "dock", activeTabId: "p1", panelIds: ["p1", "p2"] }]
+    );
+
+    expect(usePanelStore.getState().moveTabGroupToLocation("g1", "grid")).toBe(true);
+
+    expect(syncCalls()).toEqual(
+      expect.arrayContaining([
+        ["p1", liveWorktreeId("p1")],
+        ["p2", liveWorktreeId("p2")],
+      ])
+    );
+    expect(syncCalls()).toHaveLength(2);
+    expect(liveWorktreeId("p1")).toBe(ACTIVE_WORKTREE);
+  });
+
+  it("stays silent when the group already carries its own filing", () => {
+    seed(
+      [
+        ptyPanel("p1", { worktreeId: OTHER_WORKTREE }),
+        ptyPanel("p2", { worktreeId: OTHER_WORKTREE }),
+      ],
+      [
+        {
+          id: "g1",
+          location: "dock",
+          worktreeId: OTHER_WORKTREE,
+          activeTabId: "p1",
+          panelIds: ["p1", "p2"],
+        },
+      ]
+    );
+
+    usePanelStore.getState().moveTabGroupToLocation("g1", "grid");
+
+    expect(syncCalls()).toHaveLength(0);
+  });
+});
+
+describe("restoreBackgroundTerminal", () => {
+  it("files a run restored into another worktree on the host record", () => {
+    seed([ptyPanel("p1", { location: "grid", worktreeId: OTHER_WORKTREE })]);
+    usePanelStore.setState({
+      backgroundedTerminals: new Map([["p1", { id: "p1", originalLocation: "grid" as const }]]),
+    });
+
+    usePanelStore.getState().restoreBackgroundTerminal("p1", ACTIVE_WORKTREE);
+
+    expect(liveWorktreeId("p1")).toBe(ACTIVE_WORKTREE);
+    expect(syncCalls()).toEqual([["p1", liveWorktreeId("p1")]]);
+  });
+
+  it("stays silent when the restore leaves the filing where it was", () => {
+    seed([ptyPanel("p1", { location: "grid", worktreeId: OTHER_WORKTREE })]);
+    usePanelStore.setState({
+      backgroundedTerminals: new Map([["p1", { id: "p1", originalLocation: "grid" as const }]]),
+    });
+
+    usePanelStore.getState().restoreBackgroundTerminal("p1");
+
+    expect(liveWorktreeId("p1")).toBe(OTHER_WORKTREE);
+    expect(syncCalls()).toHaveLength(0);
+  });
+});
+
+describe("restoreBackgroundGroup", () => {
+  it("files every member restored into another worktree", () => {
+    seed([
+      ptyPanel("p1", { location: "grid", worktreeId: OTHER_WORKTREE }),
+      ptyPanel("p2", { location: "grid", worktreeId: OTHER_WORKTREE }),
+    ]);
+    usePanelStore.setState({
+      backgroundedTerminals: new Map([
+        ["p1", { id: "p1", originalLocation: "grid" as const, groupRestoreId: "gr1" }],
+        ["p2", { id: "p2", originalLocation: "grid" as const, groupRestoreId: "gr1" }],
+      ]),
+    });
+
+    usePanelStore.getState().restoreBackgroundGroup("gr1", ACTIVE_WORKTREE);
+
+    expect(syncCalls()).toEqual(
+      expect.arrayContaining([
+        ["p1", liveWorktreeId("p1")],
+        ["p2", liveWorktreeId("p2")],
+      ])
+    );
+    expect(syncCalls()).toHaveLength(2);
+    expect(liveWorktreeId("p2")).toBe(ACTIVE_WORKTREE);
+  });
+
+  it("stays silent when the group comes back where it left", () => {
+    seed([
+      ptyPanel("p1", { location: "grid", worktreeId: OTHER_WORKTREE }),
+      ptyPanel("p2", { location: "grid", worktreeId: OTHER_WORKTREE }),
+    ]);
+    usePanelStore.setState({
+      backgroundedTerminals: new Map([
+        ["p1", { id: "p1", originalLocation: "grid" as const, groupRestoreId: "gr1" }],
+        ["p2", { id: "p2", originalLocation: "grid" as const, groupRestoreId: "gr1" }],
+      ]),
+    });
+
+    usePanelStore.getState().restoreBackgroundGroup("gr1");
+
+    expect(syncCalls()).toHaveLength(0);
+  });
+});
+
+describe("dock→grid rescue of an undockable pty kind", () => {
+  // A restore rescues a pane out of the dock only when its kind stopped being
+  // dockable under it (#11375) — and that rescue is what adopts the active
+  // worktree. Flipping the terminal kind's own dockability is the shortest way
+  // to reach the branch without a panel shape outside the built-in union.
+  let originalTerminalKind: ReturnType<typeof getPanelKindConfig>;
+
+  beforeEach(() => {
+    originalTerminalKind = getPanelKindConfig("terminal");
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerPanelKind({ ...originalTerminalKind!, dockable: false });
+  });
+
+  afterEach(() => {
+    registerPanelKind(originalTerminalKind!);
+    warnSpy.mockRestore();
+  });
+
+  function seedRescuable(): void {
+    seed([ptyPanel("p1", { location: "dock" })]);
+  }
+
+  it("files a background restore that rescued the pane into the grid", () => {
+    seedRescuable();
+    usePanelStore.setState({
+      backgroundedTerminals: new Map([["p1", { id: "p1", originalLocation: "dock" as const }]]),
+    });
+
+    usePanelStore.getState().restoreBackgroundTerminal("p1");
+
+    expect(usePanelStore.getState().panelsById["p1"]?.location).toBe("grid");
+    expect(liveWorktreeId("p1")).toBe(ACTIVE_WORKTREE);
+    expect(syncCalls()).toEqual([["p1", liveWorktreeId("p1")]]);
+  });
+
+  it("files the same rescue when it arrives through markAsRestored", () => {
+    // The last defensive restore boundary adopts a worktree exactly as the
+    // ordinary restore does, so it owes the host record the same hop.
+    seedRescuable();
+    usePanelStore.setState({
+      trashedTerminals: new Map([
+        ["p1", { id: "p1", expiresAt: Date.now() + 60_000, originalLocation: "dock" as const }],
+      ]),
+    });
+
+    usePanelStore.getState().markAsRestored("p1");
+
+    expect(usePanelStore.getState().panelsById["p1"]?.location).toBe("grid");
+    expect(liveWorktreeId("p1")).toBe(ACTIVE_WORKTREE);
+    expect(syncCalls()).toEqual([["p1", liveWorktreeId("p1")]]);
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -1201,3 +1201,83 @@ describe("restartTerminal carries a rename that lands mid-restart", () => {
     expect(payload.titleMode).toBe("custom");
   });
 });
+
+/**
+ * A restart and a preset-fallback hop each respawn the id, and the pty-host
+ * record they create is what the fleet palette groups by. Both used to omit
+ * `worktreeId` from the spawn payload while the ledger write right above them
+ * read it off the panel — so a restarted run lost its worktree for the rest of
+ * its life and the palette filed it under "No worktree" (#12060).
+ */
+describe("restartTerminal carries the run's worktree onto the new pty record", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    getMergedPresetMock.mockReturnValue(undefined);
+    buildAgentLaunchFlagsMock.mockReturnValue([]);
+    const { agentSettingsClient, projectClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockReset();
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (projectClient.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { reset } = usePanelStore.getState();
+    await reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  it("respawns under the worktree the panel is filed in", async () => {
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      worktreeId: "/repo/.worktrees/feature",
+    };
+    usePanelStore.setState({ panelsById: { [active.id]: active }, panelIds: [active.id] });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockSpawn.mock.calls[0]![0].worktreeId).toBe("/repo/.worktrees/feature");
+  });
+
+  it("respawns under a worktree adopted while the restart was awaiting", async () => {
+    // Same window the mid-restart rename exploits: the panel is captured before
+    // settings, presets and the kill are awaited, so a drag landing in that gap
+    // has to be read at spawn time or the respawn undoes it.
+    const active = { ...agentPanelBase, agentState: "working" as const, worktreeId: "wt-a" };
+    usePanelStore.setState({ panelsById: { [active.id]: active }, panelIds: [active.id] });
+
+    const { agentSettingsClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      usePanelStore.setState((state) => ({
+        panelsById: {
+          ...state.panelsById,
+          "test-1": { ...state.panelsById["test-1"]!, worktreeId: "wt-b" },
+        },
+      }));
+      return {};
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockSpawn.mock.calls[0]![0].worktreeId).toBe("wt-b");
+  });
+
+  it("leaves a genuinely worktree-less run without one rather than inventing a root", async () => {
+    // The palette's "No worktree" bucket is for runs that really have none.
+    // Back-filling a project root here would move them out of it and claim a
+    // filing the run never had.
+    const active = { ...agentPanelBase, agentState: "working" as const };
+    delete (active as { worktreeId?: string }).worktreeId;
+    usePanelStore.setState({ panelsById: { [active.id]: active }, panelIds: [active.id] });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockSpawn.mock.calls[0]![0].worktreeId).toBeUndefined();
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -1268,6 +1268,55 @@ describe("restartTerminal carries the run's worktree onto the new pty record", (
     expect(mockSpawn.mock.calls[0]![0].worktreeId).toBe("wt-b");
   });
 
+  it("does not resurrect the old worktree when the move mid-restart was a clear", async () => {
+    // Pins the shape of the live read: `livePanel?.worktreeId ?? captured` would
+    // pass every other case here and still restore "wt-1" for a panel the user
+    // has just taken out of its worktree — the exact silent fallback the issue
+    // bans, in the direction that is easiest to miss.
+    const active = { ...agentPanelBase, agentState: "working" as const, worktreeId: "wt-1" };
+    usePanelStore.setState({ panelsById: { [active.id]: active }, panelIds: [active.id] });
+
+    const { agentSettingsClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      usePanelStore.setState((state) => {
+        const next = { ...state.panelsById["test-1"]! };
+        delete (next as { worktreeId?: string }).worktreeId;
+        return { panelsById: { ...state.panelsById, "test-1": next } };
+      });
+      return {};
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockSpawn.mock.calls[0]![0].worktreeId).toBeUndefined();
+  });
+
+  it("carries the worktree across a preset fallback hop too", async () => {
+    // The fallback hop is a second, independent respawn of the same id. It had
+    // the identical omission, so a fix that only covers `restartTerminal` still
+    // strands a fallen-back agent under "No worktree".
+    getMergedPresetMock.mockReturnValue({
+      id: "amber-provider",
+      name: "Amber Provider",
+      color: "#ffbb33",
+      args: ["--provider", "amber"],
+    });
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      worktreeId: "/repo/.worktrees/feature",
+      agentPresetId: "blue-provider",
+    };
+    usePanelStore.setState({ panelsById: { [active.id]: active }, panelIds: [active.id] });
+
+    await usePanelStore
+      .getState()
+      .activateFallbackPreset("test-1", "amber-provider", "blue-provider");
+
+    expect(mockSpawn).toHaveBeenCalled();
+    expect(mockSpawn.mock.calls[0]![0].worktreeId).toBe("/repo/.worktrees/feature");
+  });
+
   it("leaves a genuinely worktree-less run without one rather than inventing a root", async () => {
     // The palette's "No worktree" bucket is for runs that really have none.
     // Back-filling a project root here would move them out of it and claim a

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -29,6 +29,7 @@ import {
   DOCK_TERM_HEIGHT,
   DOCK_PREWARM_WIDTH_PX,
   DOCK_PREWARM_HEIGHT_PX,
+  reconcileWorktreeAfterSpawn,
 } from "./helpers";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import { markRendererPerformance } from "@/utils/performance";
@@ -942,6 +943,7 @@ export const createAddPanelActions = (
           markRendererPerformance("agentlaunch.env-ready", { id });
           const _p1 = get().panelsById[id];
           if (!_p1 || !isPtyPanel(_p1) || _p1.spawnStatus !== "spawning") return;
+          const spawnWorktreeId = _p1.worktreeId;
 
           const commandToExecute = options.skipCommandExecution ? undefined : options.command;
           // Spawn the PTY at the grid the renderer is actually showing. The
@@ -983,7 +985,7 @@ export const createAddPanelActions = (
             // Live, for the same reason as `title` above: a move landing while
             // the spawn was queued reaches a pty-host with no record yet and is
             // dropped, so the spawn itself has to carry the current filing.
-            worktreeId: _p1.worktreeId,
+            worktreeId: spawnWorktreeId,
             agentPresetId: options.agentPresetId,
             agentPresetColor: options.agentPresetColor,
             originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
@@ -1042,6 +1044,13 @@ export const createAddPanelActions = (
             });
           } else {
             if (mountedPanel) markRendererPerformance("agentlaunch.ready", { id });
+            // Recover the same race on the worktree axis: main awaits admission
+            // and settings before it reaches `PtyClient.spawn`, and that call
+            // overwrites the replay cache — so a move landing in that window
+            // reached a host with no record and was then clobbered. Placed past
+            // the incarnation gate, so a successor's filing is never re-stamped
+            // from this resolution (#12060).
+            reconcileWorktreeAfterSpawn(id, spawnWorktreeId, get().panelsById[id]);
             // Recover the attach-during-spawn race: a fit that ran while the
             // spawn IPC was in flight had its PTY resize dropped (no terminal
             // existed yet), which would strand the CLI at the spawn dims while

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -980,7 +980,10 @@ export const createAddPanelActions = (
             // the terminal record at spawn so a kill path that never runs a
             // capture (force quit, crash, SIGKILL) can't lose the conversation.
             agentSessionId: options.agentSessionId,
-            worktreeId: options.worktreeId,
+            // Live, for the same reason as `title` above: a move landing while
+            // the spawn was queued reaches a pty-host with no record yet and is
+            // dropped, so the spawn itself has to carry the current filing.
+            worktreeId: _p1.worktreeId,
             agentPresetId: options.agentPresetId,
             agentPresetColor: options.agentPresetColor,
             originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -18,6 +18,7 @@ import {
   stopDevPreviewByPanelId,
   dissolvePanelFromGroup,
   computeRestoredTabGroup,
+  syncWorktreeAttributionToHost,
 } from "./helpers";
 
 type Set = PanelRegistryStoreApi["setState"];
@@ -238,6 +239,15 @@ export const createBackgroundActions = (
     });
 
     if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
+      // A restore can re-file the run — onto a caller-named worktree, or onto
+      // the active one when it rescues a worktree-less pane dock→grid. The PTY
+      // survived the backgrounding, so its host record still carries the old
+      // filing and the fleet palette would keep grouping by it (#12060).
+      const restored = get().panelsById[id];
+      if (restored && restored.worktreeId !== terminal.worktreeId) {
+        syncWorktreeAttributionToHost(id, restored.worktreeId ?? null);
+      }
+
       if (restoreLocation === "dock") {
         optimizeForDock(id);
       } else {
@@ -291,6 +301,13 @@ export const createBackgroundActions = (
         : (anchorPanel?.groupMetadata?.worktreeId ??
           (rescuedToGrid && activeWorktreeId !== null ? activeWorktreeId : undefined));
 
+    // Captured before the commit: read afterwards, every member would already
+    // describe the destination and no move would look like one.
+    const worktreeBeforeRestore = new Map<string, string | undefined>();
+    for (const { id } of groupPanels) {
+      worktreeBeforeRestore.set(id, get().panelsById[id]?.worktreeId);
+    }
+
     set((state) => {
       const panelIdsInGroup = new Set(groupPanels.map(({ id }) => id));
       const newById = { ...state.panelsById };
@@ -320,6 +337,16 @@ export const createBackgroundActions = (
         backgroundedTerminals: newBackgrounded,
       };
     });
+
+    // Per member, exactly as the single restore does its own: a grouped restore
+    // re-files every one of them, and the host record each is grouped by in the
+    // fleet palette only moves if it is told (#12060).
+    for (const [pid, previous] of worktreeBeforeRestore) {
+      const restored = get().panelsById[pid];
+      if (!restored || !panelKindHasPty(restored.kind ?? "terminal")) continue;
+      if (restored.worktreeId === previous) continue;
+      syncWorktreeAttributionToHost(pid, restored.worktreeId ?? null);
+    }
 
     // Recreate the tab group if we have multiple valid panels
     const restoredPanelIds = groupPanels.map(({ id }) => id);

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -14,6 +14,7 @@ import {
   getDefaultTitle,
   removePanelIdsFromTabGroups,
   stopDevPreviewByPanelId,
+  syncLiveWorktreeAttributionToHost,
 } from "./helpers";
 import type { TrashExpiryHelpers } from "./trash";
 import { logError, logWarn } from "@/utils/logger";
@@ -629,6 +630,12 @@ export const createCorePanelActions = (
           "explicit"
         );
       }
+      // The promotion is how most runs acquire a worktree after spawn, and the
+      // pty-host record the fleet palette groups by is not re-stamped by
+      // anything else — without this the palette still files them under "No
+      // worktree" (#12060). Read back rather than reusing the adopted id so a
+      // move landing in between wins.
+      syncLiveWorktreeAttributionToHost(get().panelsById[id]);
     }
 
     // Only apply renderer policy for PTY-backed panels if move succeeded
@@ -710,6 +717,9 @@ export const createCorePanelActions = (
           "explicit"
         );
       }
+      // Same as the dock promotion above: the host record only moves if it is
+      // told, and a promoted dialog panel can be PTY-backed (#12060).
+      syncLiveWorktreeAttributionToHost(get().panelsById[id]);
     }
 
     if (atLimit) {

--- a/src/store/slices/panelRegistry/helpers.ts
+++ b/src/store/slices/panelRegistry/helpers.ts
@@ -6,9 +6,10 @@ import { AGENT_REGISTRY } from "@shared/config/agentRegistry";
 import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { ABSOLUTE_MAX_GRID_TERMINALS } from "@/lib/terminalLayout";
 import { deriveTerminalChrome, type TerminalChromeInput } from "@/utils/terminalChrome";
-import { logError } from "@/utils/logger";
+import { logError, logWarn } from "@/utils/logger";
 import { isPtyPanel } from "@shared/types/panel";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
+import { terminalClient } from "@/clients";
 import { getNarrowPanel } from "./selectors";
 
 /**
@@ -24,6 +25,31 @@ export function recordExplicitWorktreeAttribution(id: string, worktreeId: string
   const generation = agentLifecycleLedger.currentGeneration(id);
   if (generation === undefined) return;
   agentLifecycleLedger.recordWorktreeAttribution(id, generation, worktreeId, "explicit");
+}
+
+/**
+ * Mirror a worktree filing onto the pty-host terminal record, which is what the
+ * fleet palette groups by. The renderer panel store is authoritative for what
+ * the user sees; the pty-host copy is a downstream mirror that nothing else
+ * re-stamps, so a move that skips this hop leaves the palette filing the run
+ * under the worktree it launched in — or under "No worktree" (#12060).
+ *
+ * `null` is the explicit clear, for the one path that really does leave a panel
+ * with no worktree: undoing a dock-to-grid move deletes the adopted id
+ * (`layoutUndoStore`). Callers pass the panel's own value verbatim and never
+ * substitute a root or an active worktree for an absent one.
+ *
+ * Lives here for the same reason `recordExplicitWorktreeAttribution` does: the
+ * single-panel move (`restart.ts`), the grouped move (`tabGroups.ts`) and the
+ * layout-undo restore all need it, and importing one from another would close a
+ * cycle.
+ */
+export function syncWorktreeAttributionToHost(id: string, worktreeId: string | null): void {
+  try {
+    terminalClient.updateWorktreeId(id, worktreeId);
+  } catch (error) {
+    logWarn("[PanelRegistry] Failed to sync worktree filing to the pty host", { id, error });
+  }
 }
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];

--- a/src/store/slices/panelRegistry/helpers.ts
+++ b/src/store/slices/panelRegistry/helpers.ts
@@ -40,10 +40,35 @@ export function recordExplicitWorktreeAttribution(id: string, worktreeId: string
  * substitute a root or an active worktree for an absent one.
  *
  * Lives here for the same reason `recordExplicitWorktreeAttribution` does: the
- * single-panel move (`restart.ts`), the grouped move (`tabGroups.ts`) and the
- * layout-undo restore all need it, and importing one from another would close a
+ * moves (`restart.ts`, `tabGroups.ts`), the promotions (`core.ts`,
+ * `ordering.ts`), the restores (`trashActions.ts`, `background.ts`) and the
+ * layout-undo pass all need it, and importing one from another would close a
  * cycle.
  */
+export function syncWorktreeAttributionToHost(id: string, worktreeId: string | null): void {
+  try {
+    terminalClient.updateWorktreeId(id, worktreeId);
+  } catch (error) {
+    logWarn("[PanelRegistry] Failed to sync worktree filing to the pty host", { id, error });
+  }
+}
+
+/**
+ * Mirror a panel's own current filing onto the pty-host record, skipping
+ * non-PTY kinds that have no record to update.
+ *
+ * Callers read the panel back out of the store after their commit rather than
+ * reusing the value they wrote: a promotion or restore that adopted a worktree
+ * can be overtaken by a move landing between the two, and the live panel is
+ * what the palette should agree with.
+ */
+export function syncLiveWorktreeAttributionToHost(
+  livePanel: { id: string; worktreeId?: string; kind?: PanelKind } | undefined
+): void {
+  if (!livePanel || !panelKindHasPty(livePanel.kind ?? "terminal")) return;
+  syncWorktreeAttributionToHost(livePanel.id, livePanel.worktreeId ?? null);
+}
+
 /**
  * Close the window between reading a spawn payload's worktree and the pty-host
  * actually holding a record for it.
@@ -69,14 +94,6 @@ export function reconcileWorktreeAfterSpawn(
   if (!livePanel || !panelKindHasPty(livePanel.kind ?? "terminal")) return;
   if (livePanel.worktreeId === spawnedWith) return;
   syncWorktreeAttributionToHost(id, livePanel.worktreeId ?? null);
-}
-
-export function syncWorktreeAttributionToHost(id: string, worktreeId: string | null): void {
-  try {
-    terminalClient.updateWorktreeId(id, worktreeId);
-  } catch (error) {
-    logWarn("[PanelRegistry] Failed to sync worktree filing to the pty host", { id, error });
-  }
 }
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];

--- a/src/store/slices/panelRegistry/helpers.ts
+++ b/src/store/slices/panelRegistry/helpers.ts
@@ -1,7 +1,7 @@
 import type { PersistableFlowStatus, TerminalRuntimeStatus } from "@/types";
 import type { PanelKind } from "@/types";
 import type { TabGroup } from "@/types";
-import { getDefaultPanelTitle } from "@shared/config/panelKindRegistry";
+import { getDefaultPanelTitle, panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { AGENT_REGISTRY } from "@shared/config/agentRegistry";
 import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { ABSOLUTE_MAX_GRID_TERMINALS } from "@/lib/terminalLayout";
@@ -44,6 +44,33 @@ export function recordExplicitWorktreeAttribution(id: string, worktreeId: string
  * layout-undo restore all need it, and importing one from another would close a
  * cycle.
  */
+/**
+ * Close the window between reading a spawn payload's worktree and the pty-host
+ * actually holding a record for it.
+ *
+ * The renderer reads the panel immediately before calling spawn, but main then
+ * awaits rate-limit admission, settings and filesystem work before it reaches
+ * `PtyClient.spawn` — and that call overwrites the replay cache with the
+ * payload it was given. A move landing inside that window finds no record to
+ * update and is then clobbered by the spawn it raced, leaving the renderer and
+ * the host permanently disagreeing. Re-reading once the spawn has resolved is
+ * what makes the disagreement self-correcting (#12060).
+ *
+ * Takes the freshly-read panel rather than reaching for the store: this module
+ * is imported by the slices that build it, so a store import here would close
+ * a cycle.
+ */
+export function reconcileWorktreeAfterSpawn(
+  id: string,
+  spawnedWith: string | undefined,
+  livePanel: { worktreeId?: string; kind?: PanelKind } | undefined
+): void {
+  // Gone, or no longer PTY-backed — a successor incarnation owns its own filing.
+  if (!livePanel || !panelKindHasPty(livePanel.kind ?? "terminal")) return;
+  if (livePanel.worktreeId === spawnedWith) return;
+  syncWorktreeAttributionToHost(id, livePanel.worktreeId ?? null);
+}
+
 export function syncWorktreeAttributionToHost(id: string, worktreeId: string | null): void {
   try {
     terminalClient.updateWorktreeId(id, worktreeId);

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -5,7 +5,11 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
-import { deriveRuntimeStatus, removePanelIdsFromTabGroups } from "./helpers";
+import {
+  deriveRuntimeStatus,
+  removePanelIdsFromTabGroups,
+  syncLiveWorktreeAttributionToHost,
+} from "./helpers";
 import { buildWorktreeIndex, panelMatchesWorktreeScope } from "./worktreeIndex";
 import { getNarrowPanel } from "./selectors";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
@@ -188,6 +192,10 @@ export const createOrderingActions = (
           "explicit"
         );
       }
+      // A drag out of the dock onto a worktree's grid re-files the run, and the
+      // pty-host record the fleet palette groups by only moves if it is told
+      // (#12060).
+      syncLiveWorktreeAttributionToHost(get().panelsById[id]);
     }
 
     const terminal = get().panelsById[id];

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -35,7 +35,11 @@ import { computeEnvProvenance } from "@shared/utils/agentLifecycleLedger";
 import { markTerminalRestarting, unmarkTerminalRestarting } from "@/store/restartExitSuppression";
 import { saveNormalized } from "./persistence";
 import { optimizeForDock } from "./layout";
-import { deriveRuntimeStatus, recordExplicitWorktreeAttribution } from "./helpers";
+import {
+  deriveRuntimeStatus,
+  recordExplicitWorktreeAttribution,
+  syncWorktreeAttributionToHost,
+} from "./helpers";
 import { cancelReconnectErrorDebounce } from "./browser";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import {
@@ -765,6 +769,17 @@ export const createRestartActions = (
       // xterm 6.0 does not inherit `disableStdin` across instance recreation.
       terminalInstanceService.setInputLocked(id, true);
 
+      // Read at spawn time, not from the panel captured before the kill: a
+      // cross-worktree move landing during the restart would otherwise respawn
+      // the run under the worktree it left, and the ledger would record the
+      // same stale filing. Falls back to the captured panel only when the live
+      // one is gone entirely — a live panel with no worktree keeps none, never
+      // an inherited id (#12060).
+      const livePanelAtSpawn = get().panelsById[id];
+      const spawnWorktreeId = livePanelAtSpawn
+        ? livePanelAtSpawn.worktreeId
+        : currentTerminal.worktreeId;
+
       // A restart is a new incarnation of the same panel id — advance the
       // renderer ledger so post-restart attach/detection/close events record
       // against the respawned generation, not the killed one.
@@ -772,8 +787,8 @@ export const createRestartActions = (
         launchAgentId: isAgent ? currentTerminal.launchAgentId : undefined,
         cwd: currentTerminal.cwd,
         projectId: capturedWorkspaceId,
-        worktreeId: currentTerminal.worktreeId,
-        worktreeSource: currentTerminal.worktreeId !== undefined ? "explicit" : undefined,
+        worktreeId: spawnWorktreeId,
+        worktreeSource: spawnWorktreeId !== undefined ? "explicit" : undefined,
         agentModelId: isAgent ? currentTerminal.agentModelId : undefined,
         agentPresetId: nextAgentPresetId,
         originalPresetId: nextOriginalPresetId ?? nextAgentPresetId,
@@ -801,6 +816,10 @@ export const createRestartActions = (
         env: restartEnv,
         agentLaunchFlags: isAgent ? nextAgentLaunchFlags : undefined,
         agentModelId: isAgent ? currentTerminal.agentModelId : undefined,
+        // Without this the pty-host record loses its worktree for the rest of
+        // the run's life and the fleet palette files it under "No worktree"
+        // while the sidebar still has it right (#12060).
+        worktreeId: spawnWorktreeId,
         // Lands on the terminal record as the PTY is created, so the restarted
         // pane is addressable immediately rather than only if a later teardown
         // manages to observe an id (#11782).
@@ -978,6 +997,13 @@ export const createRestartActions = (
     });
 
     if (!movedToLocation) return;
+
+    // After the commit, so the reducer stays free of side effects — the same
+    // shape `updateTitle` uses for its own pty-host mirror. Grouped panels
+    // never reach here; `moveTabGroupToWorktree` syncs each member itself.
+    if (panelKindHasPty(terminal.kind ?? "terminal")) {
+      syncWorktreeAttributionToHost(id, worktreeId);
+    }
 
     if (movedToLocation === "dock") {
       optimizeForDock(id);
@@ -1287,14 +1313,21 @@ export const createRestartActions = (
 
       const restartEnv = await buildRestartEnv(capturedProjectId, runtimeSettings.env, "fallback");
 
+      // Live at spawn time for the same reason as the restart path above: the
+      // hop awaits, and a move that lands mid-hop must not be undone by it.
+      const liveFallbackPanel = get().panelsById[id];
+      const fallbackWorktreeId = liveFallbackPanel
+        ? liveFallbackPanel.worktreeId
+        : terminal.worktreeId;
+
       // A fallback hop respawns the id — new renderer ledger incarnation, with
       // the hopped preset recorded as the active one.
       agentLifecycleLedger.recordLaunch(id, {
         launchAgentId: terminal.launchAgentId,
         cwd: terminal.cwd,
         projectId: capturedWorkspaceId,
-        worktreeId: terminal.worktreeId,
-        worktreeSource: terminal.worktreeId !== undefined ? "explicit" : undefined,
+        worktreeId: fallbackWorktreeId,
+        worktreeSource: fallbackWorktreeId !== undefined ? "explicit" : undefined,
         agentModelId: terminal.agentModelId,
         agentPresetId: nextPreset.id,
         originalPresetId: originalPresetId,
@@ -1321,6 +1354,10 @@ export const createRestartActions = (
         env: restartEnv,
         agentLaunchFlags: nextLaunchFlags,
         agentModelId: terminal.agentModelId,
+        // Carried for the same reason as the restart path: a fallback hop that
+        // drops it strands the run in the palette's "No worktree" bucket for
+        // the rest of its life (#12060).
+        worktreeId: fallbackWorktreeId,
         agentPresetId: nextPreset.id,
         agentPresetColor: nextPreset.color,
         originalAgentPresetId: originalPresetId,

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -37,6 +37,7 @@ import { saveNormalized } from "./persistence";
 import { optimizeForDock } from "./layout";
 import {
   deriveRuntimeStatus,
+  reconcileWorktreeAfterSpawn,
   recordExplicitWorktreeAttribution,
   syncWorktreeAttributionToHost,
 } from "./helpers";
@@ -829,6 +830,12 @@ export const createRestartActions = (
         originalAgentPresetId: nextOriginalPresetId ?? nextAgentPresetId,
       });
 
+      // Main awaits admission, settings and filesystem work before it reaches
+      // `PtyClient.spawn`, and that call overwrites the replay cache with the
+      // payload it was handed — so a move landing after we read the panel and
+      // before the record existed would be lost for good without this.
+      reconcileWorktreeAfterSpawn(id, spawnWorktreeId, get().panelsById[id]);
+
       if (targetLocation === "dock") {
         optimizeForDock(id);
       } else {
@@ -1362,6 +1369,8 @@ export const createRestartActions = (
         agentPresetColor: nextPreset.color,
         originalAgentPresetId: originalPresetId,
       });
+
+      reconcileWorktreeAfterSpawn(id, fallbackWorktreeId, get().panelsById[id]);
 
       if (terminal.location === "dock") {
         optimizeForDock(id);

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -13,6 +13,7 @@ import {
   deriveRuntimeStatus,
   dissolvePanelFromGroup,
   recordExplicitWorktreeAttribution,
+  syncLiveWorktreeAttributionToHost,
   syncWorktreeAttributionToHost,
 } from "./helpers";
 import {
@@ -434,6 +435,10 @@ export const createTabGroupActions = (
     if (adoptedWorktreeId !== null) {
       for (const pid of backfilledPanelIds) {
         recordExplicitWorktreeAttribution(pid, adoptedWorktreeId);
+        // Per member, for the same reason the ledger write is: one promotion
+        // re-files every run in the group, and the pty-host record each is
+        // grouped by in the fleet palette only moves if it is told (#12060).
+        syncLiveWorktreeAttributionToHost(get().panelsById[pid]);
       }
     }
 

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -13,6 +13,7 @@ import {
   deriveRuntimeStatus,
   dissolvePanelFromGroup,
   recordExplicitWorktreeAttribution,
+  syncWorktreeAttributionToHost,
 } from "./helpers";
 import {
   buildWorktreeIndex,
@@ -522,6 +523,10 @@ export const createTabGroupActions = (
       }
       recordExplicitWorktreeAttribution(panelId, worktreeId);
       if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
+      // Per member, for the same reason the ledger write is: one drag re-files
+      // several runs, and the pty-host record each one is grouped by in the
+      // fleet palette only moves if it is told (#12060).
+      syncWorktreeAttributionToHost(panelId, worktreeId);
       if (targetLocation === "dock") {
         optimizeForDock(panelId);
       } else {

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -20,6 +20,7 @@ import {
   stopDevPreviewByPanelId,
   dissolvePanelFromGroup,
   computeRestoredTabGroup,
+  syncWorktreeAttributionToHost,
 } from "./helpers";
 import { logError } from "@/utils/logger";
 import { transferBetweenWorktreeIndex } from "./worktreeIndex";
@@ -293,6 +294,15 @@ export const createTrashActions = (
       });
 
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
+        // A restore can re-file the run — onto a caller-named worktree, or onto
+        // the active one when it rescues a worktree-less pane dock→grid. The
+        // PTY survived the trash, so its host record still carries the old
+        // filing and the fleet palette would keep grouping by it (#12060).
+        const restored = get().panelsById[id];
+        if (restored && restored.worktreeId !== terminal.worktreeId) {
+          syncWorktreeAttributionToHost(id, restored.worktreeId ?? null);
+        }
+
         if (restoreLocation === "dock") {
           optimizeForDock(id);
         } else {
@@ -358,6 +368,13 @@ export const createTrashActions = (
           : (anchorPanel?.groupMetadata?.worktreeId ??
             (rescuedToGrid && activeWorktreeId !== null ? activeWorktreeId : undefined));
 
+      // Captured before the commit: read afterwards, every member would already
+      // describe the destination and no move would look like one.
+      const worktreeBeforeRestore = new Map<string, string | undefined>();
+      for (const { id } of groupPanels) {
+        worktreeBeforeRestore.set(id, get().panelsById[id]?.worktreeId);
+      }
+
       set((state) => {
         const panelIdsInGroup = new Set(groupPanels.map(({ id }) => id));
         const newById = { ...state.panelsById };
@@ -387,6 +404,16 @@ export const createTrashActions = (
           trashedTerminals: newTrashed,
         };
       });
+
+      // Per member, exactly as the single restore does its own: a grouped
+      // restore re-files every one of them, and the host record each is grouped
+      // by in the fleet palette only moves if it is told (#12060).
+      for (const [pid, previous] of worktreeBeforeRestore) {
+        const restored = get().panelsById[pid];
+        if (!restored || !panelKindHasPty(restored.kind ?? "terminal")) continue;
+        if (restored.worktreeId === previous) continue;
+        syncWorktreeAttributionToHost(pid, restored.worktreeId ?? null);
+      }
 
       // Recreate the tab group if we have multiple panels
       const restoredPanelIds = groupPanels.map(({ id }) => id);

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -539,6 +539,15 @@ export const createTrashActions = (
       });
 
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
+        // This last defensive restore boundary rescues a worktree-less pane
+        // dock→grid onto the active worktree too, so it re-files the run the
+        // same way `restoreTerminal` does — and the host record the fleet
+        // palette groups by only moves if it is told (#12060).
+        const restored = get().panelsById[id];
+        if (restored && restored.worktreeId !== terminal.worktreeId) {
+          syncWorktreeAttributionToHost(id, restored.worktreeId ?? null);
+        }
+
         if (restoreLocation === "dock") {
           optimizeForDock(id);
         } else {


### PR DESCRIPTION
## Summary

- The fleet palette groups agent runs by `FleetRunRow.worktreeId`, which `FleetSnapshotService` copies straight off the pty-host's terminal record. Nothing ever re-stamped that record after spawn, and both `terminalClient.spawn` payloads in `restart.ts` dropped `worktreeId` entirely, even though the `agentLifecycleLedger.recordLaunch` call sitting right above each one read the same value off the panel correctly. A restarted or moved agent landed in the "No worktree" bucket while the sidebar, reading the renderer's panel store, had it filed right the whole time.
- Turned out to be three gaps, not the two the issue described. `moveTabGroupToWorktree` is a second, independent move path that `moveTerminalToWorktree` early-returns into for any panel sitting in a tab group, so fixing only the single-panel case would have left tab-group drags just as broken.

Resolves #12060

## Changes

- Both restart spawn payloads now read `worktreeId` off the live panel at spawn time, not the one captured before the awaits (same reasoning as `addPanel`'s live-panel read for `title`, #11830).
- New one-way `terminal:update-worktree-id` channel, mirroring `terminal:update-title` end to end: client -> preload -> `io.ts` -> `PtyClient` -> pty-host -> `PtyManager` -> `TerminalProcess`. `PtyClient` keeps its `pendingSpawns` replay cache in step too, otherwise a pty-host crash respawn would silently revert the move.
- Payload is `string | null`, not optional. There's a real worktree-to-no-worktree transition: undoing a dock-to-grid move deletes the worktree a global pane picked up on its way to the grid (`layoutUndoStore`). Optional couldn't tell that apart from a caller that forgot to send anything.
- Wired into every choke point that already owns worktree mutation: `moveTerminalToWorktree`, `moveTabGroupToWorktree`, `layoutUndoStore`'s restore pass, and both trash-restore paths, single and grouped, handled separately, which is exactly what made this three gaps instead of two.
- New `terminal:worktree-changed` event so the palette regroups on the drag instead of waiting up to 5s for its next poll.
- Channel is gated on project ownership. The fleet snapshot hands every view every run's id, so a terminal id alone isn't a capability. Main resolves the sender's project synchronously and the pty-host checks it against the record before writing, synchronous specifically so the send path keeps its FIFO ordering (an awaited lookup in main could let two rapid moves land out of order). Null is treated as an identity, not a wildcard, matching the #11100 precedent.
- All three spawn paths reconcile after spawning. Main awaits admission, settings, and filesystem work before it reaches `PtyClient.spawn`, and that call overwrites the replay cache with whatever payload it was handed. A move landing in that window found no record yet and then got clobbered, leaving renderer and host permanently disagreeing.

No silent fallback anywhere: a malformed payload gets dropped rather than guessed at, a genuinely worktree-less run stays worktree-less, and the base worktree arrives as its own real path id rather than the absent case.

## Known limits

- `DAINTREE_WORKTREE_ID` gets stamped into the process environment at fork time and can't change for a running shell. A move fixes the record (fleet grouping, session journaling, state-change events) immediately; the running agent's own env var only catches up on its next restart or host respawn.
- Left for follow-ups, same bug class but different scope: `rebaseProjectViewRuntimePaths` (a project relocation rebases paths while the xterms stay alive), reconnect/hydration re-attribution, dock-to-grid worktree adoption in `moveTerminalToGrid`, and multi-window convergence (two windows on the same project won't see each other's moves without a main-to-renderer broadcast).

## Testing

7,650 tests pass across every suite touching a changed module. New coverage: a dedicated IPC-handler suite pinning the no-silent-fallback contract (valid id, verbatim path forwarding, explicit null, ten rejection cases, ownership identity, listener teardown), a PtyManager ownership suite, PtyClient crash-replay and live-send-to-owning-shard specs, pty-host dispatch, `TerminalProcess` set/clear, fleet regroup-on-move, plus renderer specs for the single move, the grouped move, both restart paths (including the preset-fallback hop and a clear landing mid-restart), and layout-undo restore in both directions. eslint and prettier clean on all 30 changed files.
