### PR TITLE
fix(notifications): align the inbox row icon and drop the menu's dead gutter

### DIFF
--- a/e2e/screenshots/notification-entry-review.spec.ts
+++ b/e2e/screenshots/notification-entry-review.spec.ts
@@ -3,10 +3,12 @@
  *
  * One inbox row carries severity, unread state, title, message, thread count,
  * contextual actions, timestamp, snooze state, an overflow menu and dismissal —
- * inside a 360px popover. The trailing rail is the contested space: at rest it
- * shows snooze state and time, and on hover/focus/open-menu an absolutely
- * positioned action layer fades in *over* it. Whether that reads as a stable
- * row or a temporary patch is a pixel question, so it gets captured.
+ * inside a 360px popover. The trailing rail is the contested space: snooze
+ * state, time and the two management controls now hold one grid cell at every
+ * state, quiet at rest and stronger under the pointer — the build this harness
+ * was written against instead faded an absolutely positioned action layer in
+ * *over* the metadata. Whether the rail reads as a stable row or a temporary
+ * patch is a pixel question, so it gets captured.
  *
  * Seeds the full history through `seedHistory` on the E2E notification backdoor
  * (`src/lib/e2eNotificationBackdoor.ts`) — the store's own setState, with real
@@ -175,6 +177,23 @@ function buildFixture(now: number): SeedHistoryEntry[] {
       message: "Switched to Fiordland.",
       timestamp: now - 5 * DAY,
       seenAsToast: true,
+    },
+    // The lone-menu-item case. An eventKind with no correlationId and no
+    // projectId leaves exactly one item in the overflow menu — every
+    // icon-bearing one is filtered out — which is what the conditional icon
+    // gutter has to notice. It is also the shape that shipped indented against
+    // nothing, so it gets a capture of its own in the `menu` step.
+    {
+      id: "warn-connectivity-bare",
+      type: "warning" as const,
+      title: "GitHub token expired",
+      message: "GitHub token expired — reconnect to restore GitHub features.",
+      // Older than `info-bare` above it: `seedHistory` preserves input order and
+      // the chronological list does not re-sort, so a newer entry here would
+      // render an impossible 5-day -> 3-day sequence in every other capture.
+      timestamp: now - 6 * DAY,
+      seenAsToast: true,
+      context: { eventKind: "connectivity" as const },
     },
     // The density case: long title, long message, prior-year timestamp, a big
     // thread count, and three actions all at once.
@@ -430,8 +449,10 @@ test("notification entry review — trailing rail, actions, and time", async () 
     await reopenCenter(page);
     await assertSeeded(page, 4);
 
-    // 1. Rest — what the row looks like when nobody is touching it. This is the
-    //    only state that shows the timestamp today.
+    // 1. Rest — what the row looks like when nobody is touching it. The rail no
+    //    longer hides the timestamp under hover, so this is the baseline the
+    //    hover and focus captures are compared against rather than the only
+    //    state that carries time.
     await step(page, "rest", async () => {
       await assertSeeded(page, 4);
       await snap(page, "10-rest-popover", POPOVER);
@@ -465,6 +486,49 @@ test("notification entry review — trailing rail, actions, and time", async () 
       await page.locator('button[aria-label="Notification options"]').first().click();
       await settle(page, 500);
       await snap(page, "40-menu-open-window");
+
+      // The same menu reduced to its single text-only item. The gutter the
+      // shot above allocates has to be gone here, not left as dead indent.
+      // Re-seeded on its own for the same reason the dense step is: the row
+      // sits far enough down the full fixture that it is never mounted, and
+      // this harness has already established that scrolling the inbox to a
+      // given row does not work. Restored before the next step.
+      await page.keyboard.press("Escape");
+      await settle(page, 250);
+      try {
+        await seedNotificationHistory(
+          page,
+          buildFixture(now).filter((e) => e.id === "warn-connectivity-bare")
+        );
+        await reopenCenter(page);
+        const bareRow = page
+          .locator(SEL.notifications.centerList)
+          .locator(SEL.notifications.centerRow)
+          .first();
+        await bareRow.hover();
+        await settle(page, 250);
+        await bareRow.locator('button[aria-label="Notification options"]').click();
+        await settle(page, 500);
+        // The capture is only evidence if the menu really did reduce to one
+        // item — otherwise a fixture drift that restores Snooze would leave a
+        // correctly-guttered menu in the file under a name claiming otherwise.
+        const itemCount = await page.locator('[role="menu"] [role="menuitem"]').count();
+        if (itemCount !== 1) {
+          throw new Error(`expected a single-item overflow menu, found ${itemCount}`);
+        }
+        await snap(page, "41-menu-lone-item-window");
+      } finally {
+        // In a finally, and carrying the snooze map the opening seed set: this
+        // step is the only one that narrows the fixture without restoring it
+        // through `dense`, and `contrast`, `forced` and `snoozed` all read the
+        // full list. Dropping the map silently un-snoozes "Update available".
+        await page.keyboard.press("Escape");
+        await settle(page, 250);
+        await seedNotificationHistory(page, buildFixture(now), {
+          [SNOOZED_THREAD]: now + 8 * HOUR,
+        });
+        await reopenCenter(page);
+      }
     });
 
     // 5. Coarse pointer has no capture of its own, deliberately. Chromium's

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -204,13 +204,38 @@ export function NotificationCenterEntry({
         tabIndex !== undefined && PALETTE_ROW_FOCUS_CLASS
       )}
     >
-      <div className={cn("relative shrink-0", config.className)}>
-        {/* The unread dot floats in the row's left gutter (absolute, anchored to
-            the icon) so read rows don't carry a phantom spacer column. The
-            gutter is 16px rather than 12px so this 6px dot sits inside the
-            panel's margin instead of hanging off the edge next to the thread
-            rail — the icon still shares that gutter with the header, the chip
-            row and the section labels. */}
+      <div
+        className={cn(
+          "relative flex w-4 shrink-0 items-center justify-center",
+          // Grid row 1 is 24px tall on a titled row — the trailing rail's
+          // controls set that height and the title centres inside it. The icon
+          // is a flex sibling of that grid rather than a cell in it, so
+          // `items-start` parked it at the top of a 16px box and left it 4px
+          // above the title it labels. Matching the height and centring in it
+          // puts the two on the same optical line. An untitled row has no such
+          // cell: its message starts at the top of the track, which is where a
+          // top-aligned icon already sits, so that case keeps its natural box.
+          entry.title ? "h-6" : "h-4",
+          config.className
+        )}
+      >
+        {/* The dot is aria-hidden, so unread was carried by nothing but colour
+            and a heavier title weight — neither of which reaches a screen
+            reader. First in the row's DOM order, which is where it reads. */}
+        {isNew && <span className="sr-only">Unread. </span>}
+        <Icon className="h-4 w-4" />
+        {/* The unread dot badges the status icon's top-right corner rather than
+            floating in the row's left gutter, where it sat 3px off the icon and
+            7px off the panel edge — closer to the chrome than to the thing it
+            marked, and on the icon's own centre line, so it read as part of the
+            glyph. Straddling the corner it belongs to the icon unambiguously
+            and costs no horizontal space, so read rows still carry no spacer.
+
+            The ring is not decoration: the corner of a 16px Lucide circle
+            (CheckCircle2, XCircle, Info) passes under this dot, so without a
+            cut-out in the row's own backdrop the two silhouettes merge. It has
+            to be a flat colour — `.surface-overlay` is 94% + backdrop-blur, and
+            a translucent ring would show the desktop through it. */}
         {isNew && (
           <span
             aria-hidden="true"
@@ -219,12 +244,21 @@ export function NotificationCenterEntry({
             // ActivityLight's dot is handled. Without it the UA forces this
             // background to Canvas and the dot disappears, and an unread row
             // carries no border or tint by design, so an untitled one was left
-            // with no unread signal at all.
+            // with no unread signal at all. The ring below needs a counterpart
+            // in that block: it is a box-shadow, forced colors does not paint
+            // box-shadows, and the icon this dot now overlaps is flattened to
+            // the same CanvasText — so the cut-out is re-declared there as an
+            // outline.
             data-notification-unread="true"
-            className="absolute right-full mr-[3px] top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full bg-status-info"
+            className={cn(
+              "absolute right-0 h-1.5 w-1.5 translate-x-1/3 -translate-y-1/3 rounded-full",
+              "bg-status-info ring-[1.5px] ring-[var(--overlay-surface-solid)]",
+              // Anchored to the icon box, not the wrapper: on a titled row the
+              // wrapper is 4px taller than the glyph at each end.
+              entry.title ? "top-1" : "top-0"
+            )}
           />
         )}
-        <Icon className="h-4 w-4" />
       </div>
       <div className="grid flex-1 min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-x-2">
         {entry.title && (
@@ -367,7 +401,11 @@ export function NotificationCenterEntry({
             grid placement gets both: this rail is last in the DOM and reads
             last, but paints in row 1's trailing column, and the message and
             actions below it span the full width. */}
-        <div className="col-start-2 row-start-1 flex items-center gap-1.5">
+        {/* `min-h-6` and `self-start` pin the first line to 24px and hold the
+            rail on it: the icon opposite is centred against that height, and an
+            untitled row whose message wraps must not drag the controls down to
+            the middle of the block they act on. */}
+        <div className="col-start-2 row-start-1 flex min-h-6 items-center self-start gap-1.5">
           {isSnoozed && snoozedUntil !== undefined && (
             <>
               <span
@@ -645,7 +683,7 @@ function RowOptionsMenu({
                 onUnsnooze?.();
               }}
             >
-              <Clock className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+              <Clock data-menu-icon className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
               {snoozedUntil !== undefined
                 ? `Snoozed until ${formatSnoozedUntil(snoozedUntil)} · Unsnooze`
                 : "Unsnooze"}
@@ -653,7 +691,7 @@ function RowOptionsMenu({
           ) : (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
-                <Clock className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+                <Clock data-menu-icon className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
                 Snooze
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
@@ -673,13 +711,13 @@ function RowOptionsMenu({
         {supportsSnooze && hasDiagnosticsActions && <DropdownMenuSeparator />}
         {supportsCopyCorrelationId && (
           <DropdownMenuItem onSelect={handleCopyCorrelationId}>
-            <Copy className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+            <Copy data-menu-icon className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
             Copy correlation ID
           </DropdownMenuItem>
         )}
         {supportsGoToSource && (
           <DropdownMenuItem onSelect={handleGoToSource}>
-            <ArrowRight className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+            <ArrowRight data-menu-icon className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
             Go to source
           </DropdownMenuItem>
         )}
@@ -690,7 +728,7 @@ function RowOptionsMenu({
               void handleReportOnGitHub();
             }}
           >
-            <Bug className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+            <Bug data-menu-icon className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
             Report on GitHub
           </DropdownMenuItem>
         )}
@@ -707,10 +745,13 @@ function RowOptionsMenu({
               });
             }}
           >
-            <span className="ml-[1.375rem]">
-              Silence {EVENT_KIND_LABEL[eventKind]}
-              {entry.context?.projectId && eventKind !== "uiFeedback" ? " from this project" : ""}
-            </span>
+            {/* No shim. The gutter these two need in a menu that also offers
+                Snooze / Copy / Report is allocated by the `:has([data-menu-icon])`
+                rule in index.css, and withdrawn when every icon-bearing item is
+                filtered out — an entry with no correlationId and no panelId
+                leaves only these, and with no projectId either, only this one. */}
+            Silence {EVENT_KIND_LABEL[eventKind]}
+            {entry.context?.projectId && eventKind !== "uiFeedback" ? " from this project" : ""}
           </DropdownMenuItem>
         )}
         {entry.context?.projectId && (
@@ -721,7 +762,7 @@ function RowOptionsMenu({
               void actionService.dispatch("project.muteNotifications", { projectId });
             }}
           >
-            <span className="ml-[1.375rem]">Mute project notifications</span>
+            Mute project notifications
           </DropdownMenuItem>
         )}
       </DropdownMenuContent>

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -129,9 +129,9 @@ describe("NotificationCenterEntry unread signal", () => {
     const dot = container.querySelector(".bg-status-info.rounded-full");
     expect(dot).not.toBeNull();
     if (iconWrapper instanceof HTMLElement && dot instanceof HTMLElement) {
-      // The dot lives in the gutter via absolute positioning — it must not
-      // participate in the row's flex flow, or read/unread toggles would
-      // shift the icon column.
+      // The dot badges the icon's top-right corner via absolute positioning —
+      // it must not participate in the row's flex flow, or read/unread toggles
+      // would shift the icon column.
       expect(iconWrapper.contains(dot)).toBe(true);
       expect(dot.className).toMatch(/\babsolute\b/);
     }
@@ -646,6 +646,33 @@ describe("NotificationCenterEntry roving focus props", () => {
     const dot = container.querySelector('[data-notification-unread="true"]');
     expect(dot).not.toBeNull();
     expect(container.querySelectorAll('[data-notification-unread="true"]')).toHaveLength(1);
+  });
+
+  it("announces unread state ahead of the row's content, and drops it once read", () => {
+    // The dot is aria-hidden and the weight change on the title is invisible to
+    // a screen reader, so this text is the whole assistive signal. Asserting the
+    // announcement's presence and its position relative to the title tests
+    // `isNew -> assistive output`, which is behaviour, not a copied literal.
+    const { container: unread } = render(
+      <NotificationCenterEntry entry={makeEntry({ title: "Push rejected" })} isNew />
+    );
+    const spoken = unread.textContent ?? "";
+    expect(spoken).toMatch(/unread/i);
+    expect(spoken.search(/unread/i)).toBeLessThan(spoken.indexOf("Push rejected"));
+    // `textContent` reaches into aria-hidden subtrees, so the assertions above
+    // would stay green if the announcement were hidden from the very API it
+    // exists to serve — the dot two elements away is aria-hidden for exactly
+    // that reason. Prove this one is not.
+    const announcement = Array.from(unread.querySelectorAll("span")).find((el) =>
+      /unread/i.test(el.textContent ?? "")
+    );
+    expect(announcement).toBeDefined();
+    expect(announcement?.closest('[aria-hidden="true"]')).toBeNull();
+
+    const { container: read } = render(
+      <NotificationCenterEntry entry={makeEntry({ title: "Push rejected" })} />
+    );
+    expect(read.textContent ?? "").not.toMatch(/unread/i);
   });
 
   it("carries the forced-colors repaint handle on the thread-count chip", () => {

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -323,6 +323,10 @@ type DropdownMenuItemProps = React.ComponentPropsWithoutRef<
   destructive?: boolean;
 };
 
+/* Leading icons: mark the icon `data-menu-icon` and the text-only items in the
+ * same menu pick up a matching gutter from the `[role="menu"]:has(...)` rule in
+ * index.css — and lose it again when the icon-bearing items are filtered out.
+ * `inset` is the static alternative for a menu whose shape never changes. */
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitiveType.Item>,
   DropdownMenuItemProps

--- a/src/index.css
+++ b/src/index.css
@@ -2021,6 +2021,22 @@ label:focus-within .brand-mark,
   color: var(--brand-mark-active);
 }
 
+/* Menu icon gutter, allocated only when an item in the SAME menu actually has
+   an icon. Items opt in by marking their icon `data-menu-icon`; a text-only
+   item in a mixed menu then aligns with them, and a menu whose icon-bearing
+   items are all filtered out at runtime collapses the gutter instead of
+   leaving its survivors indented against nothing. That is the NSMenu / WinUI
+   MenuFlyout / GtkPopoverMenu rule, and it is why this cannot be a static
+   class on the text-only item — the item cannot see its siblings.
+   2rem = the item's own px-2.5 plus a 3.5 icon and its mr-2. Submenus portal
+   into their own [role="menu"], so they are scored separately, which is what
+   we want: a submenu of plain durations keeps no gutter. Unlayered and (0,4,0),
+   so it outranks a caller's own `pl-*` utility — an item that needs to opt out
+   has to do it with an inline style. */
+[role="menu"]:has([data-menu-icon]) [role="menuitem"]:not(:has([data-menu-icon])) {
+  padding-left: 2rem;
+}
+
 /* Panel Agent State Borders — grid panel container state-driven styling */
 .panel-state-waiting {
   border-color: color-mix(in oklab, var(--color-activity-waiting) 75%, transparent);
@@ -3005,6 +3021,13 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
      row can be both unread and focused. */
   [data-notification-unread="true"] {
     background-color: CanvasText !important;
+    /* The dot badges the status icon now instead of sitting off in the row's
+       left gutter, and this block paints the icon CanvasText too — so the two
+       fuse into one malformed glyph without a cut-out between them. The ring
+       that separates them in the normal cascade is a box-shadow, and box
+       shadows are not painted here, so the cut-out has to be an outline.
+       Outlines follow border-radius, so it stays round. */
+    outline: 1.5px solid Canvas;
   }
 
   /* Inbox thread-count chip. The tint fill is forced to Canvas, which strips the
@@ -3295,6 +3318,20 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   .light .surface-overlay {
     --scroll-shadow-color: var(--color-surface-panel-elevated);
     background-color: var(--color-surface-panel-elevated);
+  }
+
+  /* Solid stand-in for the frosted overlay background, for marks that have to
+     punch a hole in their own backdrop — the inbox unread badge sitting on the
+     corner of a status icon. The surface is 94% + backdrop-blur on dark and no
+     flat colour reproduces that, but at ring width the missing 6% is invisible,
+     whereas mixing in transparency would tint the ring with whatever the
+     popover happens to be floating over. */
+  .surface-overlay {
+    --overlay-surface-solid: var(--color-surface-sidebar);
+  }
+
+  .light .surface-overlay {
+    --overlay-surface-solid: var(--color-surface-panel-elevated);
   }
 
   /* Cmd+K command HUD — a distinct dark-glass "spotlight" surface. Deeper and


### PR DESCRIPTION
This fixes three visual issues in the notification panel, all reported against the row redesign that just merged in #12062.

**The leading status icon sat 4px above the title it belongs to.** Each row's trailing controls are 24px tall, so they set the height of the first line and the title centres inside it. The icon is a flex sibling of that grid rather than a cell in it, so `items-start` parked it at the top of its own 16px box. It now matches the height of the first line and centres in it. An untitled row has no such cell (its message starts at the top of the track) so that case keeps its natural box, which is where a top-aligned icon already lines up.

**The unread dot sat in the row's left margin,** 3px from the icon and 7px from the panel edge. Closer to the chrome than to the thing it marked, and on the icon's own centre line, so it read as part of the glyph. It now badges the top right corner of the icon. The circle icons (`CheckCircle2`, `XCircle`, `Info`) nearly fill their box and pass underneath the dot, so it carries a ring cut out of the panel background to separate the two silhouettes. That ring has to be a flat colour: `.surface-overlay` is 94% plus a `backdrop-filter`, and a translucent ring would show the desktop through it, so there's a new `--overlay-surface-solid` custom property holding the flat equivalent for both schemes.

Under `forced-colors: active` the ring is a box-shadow, which isn't painted, and the icon flattens to the same `CanvasText` as the dot. The two fused into one malformed glyph. The cut-out is re-declared there as a `Canvas` outline, which is painted and follows `border-radius`.

**The overflow menu had 22px of dead indent.** The two icon-less items (`Silence <kind> notifications`, `Mute project notifications`) were wrapped in `<span className="ml-[1.375rem]">` so they lined up with the items that do have icons. An entry with no `correlationId` and no `panelId` has every icon-bearing item filtered out, and the single survivor was left indented against nothing. That's the screenshot in the report.

The shim is gone. Icons are marked `data-menu-icon` and the gutter is allocated by a `:has()` rule in `src/index.css`, so a text-only item picks it up only when a sibling in the same menu actually carries an icon, and loses it again when they're all filtered out. That's the NSMenu, WinUI `MenuFlyout` and `GtkPopoverMenu` rule. Submenus portal into their own `[role="menu"]` and are scored separately, which is what we want: the snooze durations keep no gutter.

The dot is `aria-hidden` and the weight change on an unread title is invisible to a screen reader, so unread state reached no assistive tech at all. There's now an `sr-only` announcement ahead of the row's content.

## Verification

Checked the rendered output with the `notification-entry-review` harness rather than by reading the CSS: the mixed menu, the reduced one-item menu, the icon against the title, the badge on both a triangle (empty corner) and a circle (ring cuts through), hover, and `forced-colors`. The harness gained a `warn-connectivity-bare` fixture and a `41-menu-lone-item-window` capture for the reduced menu, and that step now asserts the menu really is down to one item before it captures, so a fixture drift can't leave a correctly-guttered menu in a file whose name claims otherwise.

`npm run check` clean (lint ratchet down 15). Full vitest: 2375 files, 52157 tests.

## One thing I found and did not fix

`project.silenceNotificationKind` only accepts `completed`, `waiting`, `workingPulse` and `uiFeedback`, but the row menu offers `Silence <kind> notifications` for every recognised `eventKind`. So on a `connectivity`, `git`, `host`, `recovery`, `agent` or `settings` entry, the item renders, dispatches, fails Zod validation and is swallowed by the fire-and-forget call. The "Silence connection notifications" item in the original report is one of these: it does nothing. It predates this PR and fixing it means deciding whether those six kinds get persisted silence toggles or the item gets hidden, which is a product call rather than an alignment fix. Filing separately.
