### PR TITLE
fix(github): pin the forge row's identity column and give it one action

### DIFF
--- a/e2e/full/panels/bulk-issue-worktree-recipe-perf.spec.ts
+++ b/e2e/full/panels/bulk-issue-worktree-recipe-perf.spec.ts
@@ -427,6 +427,12 @@ async function runSample(scale: number, round: number, warmup: boolean): Promise
     await expect(ctx.window.locator(SEL.github.item(issues[0]!.number))).toBeVisible({
       timeout: T_LONG,
     });
+    // The bulk helpers follow selection mode rather than a non-empty query, so
+    // enter selection first: the cursor moves to the first row and Shift+Space
+    // takes it.
+    await ctx.window.keyboard.press("ArrowDown");
+    await ctx.window.keyboard.press("Shift+Space");
+
     const selectAll = ctx.window
       .locator(SEL.github.selectionActions)
       .getByRole("button", { name: /Select all/ });

--- a/e2e/full/panels/core-github-panels.spec.ts
+++ b/e2e/full/panels/core-github-panels.spec.ts
@@ -109,9 +109,15 @@ test.describe.serial("Core: GitHub panels (dropdowns, rate-limit, token banner)"
 
     await openIssuesDropdown(window);
 
-    // The select-all control only renders with a non-empty search query AND data.
     await window.locator(SEL.github.searchIssues).fill("e2e");
     await expect(window.locator(SEL.github.item(101))).toBeVisible({ timeout: T_LONG });
+
+    // The bulk helpers follow selection mode rather than a non-empty query —
+    // typing used to grow the stacked header and shove the list down on the
+    // first keystroke. Entering selection is the deliberate act, so do it:
+    // the cursor moves to the first row and Shift+Space takes it.
+    await window.keyboard.press("ArrowDown");
+    await window.keyboard.press("Shift+Space");
 
     const selectAll = window
       .locator(SEL.github.selectionActions)
@@ -126,6 +132,64 @@ test.describe.serial("Core: GitHub panels (dropdowns, rate-limit, token banner)"
     await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
     // The dialog must carry the selected issues, not open empty/stale.
     await expect(dialog.locator('text="E2E issue one"')).toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("keeps every row's assignee avatar in one column", async () => {
+    // The reported defect: the trailing rail was a right-anchored flex row of
+    // conditional slots, so a neighbour appearing to the RIGHT of the avatar
+    // — a worktree glyph, or the "+N" more-assignees count — pushed it ~20px
+    // left and the avatars stopped lining up down the list. jsdom cannot see
+    // that: a DOM-order test still passes if a width or a gap changes. This is
+    // the assertion that actually measures the column.
+    const { window } = ctx;
+    await connectGitHub(ctx.app, window);
+    await stubRepoStats(ctx.app, { issueCount: 3, prCount: 0, commitCount: 5 }, window);
+    await stubListIssues(ctx.app, [
+      makeFixtureIssue(201, "One assignee", {
+        assignees: [{ login: "alice", avatarUrl: "" }],
+      }),
+      makeFixtureIssue(202, "Three assignees, so the row also carries a +2", {
+        assignees: [
+          { login: "alice", avatarUrl: "" },
+          { login: "bob", avatarUrl: "" },
+          { login: "carol", avatarUrl: "" },
+        ],
+      }),
+      makeFixtureIssue(203, "One assignee and a long title that will truncate hard", {
+        assignees: [{ login: "dave", avatarUrl: "" }],
+        labels: [{ name: "bug", color: "d73a4a" }],
+        commentCount: 12,
+      }),
+    ]);
+
+    await openIssuesDropdown(window);
+    await expect(window.locator(SEL.github.item(201))).toBeVisible({ timeout: T_LONG });
+
+    const slots = window.locator('[role="img"][aria-label^="Assigned to"]');
+    await expect(slots).toHaveCount(3);
+
+    const xs: number[] = [];
+    for (const slot of await slots.all()) {
+      const box = await slot.boundingBox();
+      expect(box).not.toBeNull();
+      xs.push(box!.x);
+    }
+    // Sub-pixel tolerance only: these are meant to be the same column, not a
+    // similar one.
+    for (const x of xs) {
+      expect(Math.abs(x - xs[0]!)).toBeLessThan(0.5);
+    }
+
+    // And the anchor they hang off — the actions menu — is itself a column.
+    const menus = window.locator('[aria-label^="Actions for #"]');
+    await expect(menus).toHaveCount(3);
+    const menuXs: number[] = [];
+    for (const menu of await menus.all()) {
+      menuXs.push((await menu.boundingBox())!.x);
+    }
+    for (const x of menuXs) {
+      expect(Math.abs(x - menuXs[0]!)).toBeLessThan(0.5);
+    }
   });
 
   test("issues dropdown renders search and filter chrome when connected", async () => {

--- a/e2e/helpers/githubHelpers.ts
+++ b/e2e/helpers/githubHelpers.ts
@@ -223,7 +223,11 @@ export async function restoreRepoStats(app: ElectronApplication): Promise<void> 
 }
 
 /** Build a minimal fixture issue (forge shape) for list stubbing. */
-export function makeFixtureIssue(number: number, title: string): Issue {
+export function makeFixtureIssue(
+  number: number,
+  title: string,
+  overrides: Partial<Issue> = {}
+): Issue {
   const updatedAt = Date.now() - number * 60_000;
   return {
     number,
@@ -239,6 +243,7 @@ export function makeFixtureIssue(number: number, title: string): Issue {
     createdAt: updatedAt,
     updatedAt,
     rawData: {},
+    ...overrides,
   };
 }
 

--- a/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent, act, cleanup } from "@testing-library/react"
 import { Activity, type ReactNode } from "react";
 import { GitHubListItem } from "../components/GitHubListItem";
 import type { Issue, PR } from "@shared/types/forge";
+import type { Worktree } from "@shared/types/worktree";
 import { actionService } from "@/services/ActionService";
 import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
 
@@ -13,18 +14,6 @@ vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
   return { ...actual, createPortal: (children: ReactNode) => children };
 });
-
-vi.mock("@/hooks/useWorktreeStore", () => ({
-  useWorktreeStore: vi.fn((selector: (s: { worktrees: Map<string, unknown> }) => unknown) =>
-    selector({ worktrees: new Map() })
-  ),
-}));
-
-vi.mock("@/store/worktreeStore", () => ({
-  useWorktreeSelectionStore: vi.fn((selector: (s: { activeWorktreeId: null }) => unknown) =>
-    selector({ activeWorktreeId: null })
-  ),
-}));
 
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: vi.fn() },
@@ -74,6 +63,14 @@ const basePR: PR = {
   rawData: null,
 };
 
+const makeWorktree = (overrides: Partial<Worktree>): Worktree => ({
+  id: "wt-42",
+  path: "/tmp/wt-42",
+  name: "issue-42-fix",
+  isCurrent: false,
+  ...overrides,
+});
+
 beforeEach(() => {
   vi.useFakeTimers();
   Object.defineProperty(navigator, "clipboard", {
@@ -90,21 +87,38 @@ afterEach(() => {
 });
 
 describe("GitHubListItem", () => {
-  it("renders issue title as a clickable button", () => {
+  it("does not make the title its own control", () => {
+    // The title used to be a button that always opened GitHub while the row
+    // around it created or switched a worktree, so which operation you got
+    // depended on whether you hit the text.
     render(<GitHubListItem item={baseIssue} type="issue" />);
-    const title = screen.getByText("Fix the thing");
-    expect(title.tagName).toBe("BUTTON");
+    const [title] = screen.getAllByText("Fix the thing");
+    expect(title!.tagName).not.toBe("BUTTON");
+    expect(title!.closest("button")).toBeNull();
   });
 
-  it("renders PR title as a clickable button", () => {
+  it("does not make a PR title its own control either", () => {
     render(<GitHubListItem item={basePR} type="pr" />);
-    const title = screen.getByText("Add new feature");
-    expect(title.tagName).toBe("BUTTON");
+    const [title] = screen.getAllByText("Add new feature");
+    expect(title!.tagName).not.toBe("BUTTON");
+    expect(title!.closest("button")).toBeNull();
   });
 
-  it("clicking issue title dispatches system.openExternal with item URL", () => {
-    render(<GitHubListItem item={baseIssue} type="issue" />);
-    fireEvent.click(screen.getByText("Fix the thing"));
+  it("runs the row's action when the title is clicked, not the forge", () => {
+    const onCreateWorktree = vi.fn();
+    render(<GitHubListItem item={baseIssue} type="issue" onCreateWorktree={onCreateWorktree} />);
+    fireEvent.click(screen.getAllByText("Fix the thing")[0]!);
+    expect(onCreateWorktree).toHaveBeenCalledWith(baseIssue);
+    expect(actionService.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the forge on the modifier click", () => {
+    const onCreateWorktree = vi.fn();
+    const { container } = render(
+      <GitHubListItem item={baseIssue} type="issue" onCreateWorktree={onCreateWorktree} />
+    );
+    fireEvent.click(container.querySelector("[role='row']")!, { metaKey: true });
+    expect(onCreateWorktree).not.toHaveBeenCalled();
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "system.openExternal",
       { url: "https://github.com/test/repo/issues/42" },
@@ -118,7 +132,7 @@ describe("GitHubListItem", () => {
       linkedPR: { number: 55, state: "open", url: "https://github.com/test/repo/pull/55" },
     };
     render(<GitHubListItem item={issueWithPR} type="issue" />);
-    fireEvent.click(screen.getByRole("button", { name: "Open linked pull request #55" }));
+    fireEvent.click(screen.getByRole("button", { name: /Open linked pull request #55/ }));
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "system.openExternal",
       { url: "https://github.com/test/repo/pull/55" },
@@ -279,7 +293,7 @@ describe("GitHubListItem", () => {
       linkedPR: { number: 55, state: "open", url: "https://github.com/test/repo/pull/55" },
     };
     render(<GitHubListItem item={issueWithPR} type="issue" />);
-    const prButton = screen.getByRole("button", { name: "Open linked pull request #55" });
+    const prButton = screen.getByRole("button", { name: /Open linked pull request #55/ });
     expect(prButton).toBeTruthy();
     expect(prButton.querySelector("svg")).not.toBeNull();
   });
@@ -298,8 +312,8 @@ describe("GitHubListItem", () => {
     expect(screen.getByText("bug")).toBeTruthy();
     expect(screen.getByText("+1")).toBeTruthy();
     expect(container.textContent).toContain("bug, high-priority");
-    expect(screen.getByRole("button", { name: "Open linked pull request #55" })).toBeTruthy();
-    expect(screen.getByAltText("alice")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Open linked pull request #55/ })).toBeTruthy();
+    expect(screen.getByLabelText("Assigned to alice")).toBeTruthy();
   });
 
   it("renders #number badge", () => {
@@ -405,7 +419,7 @@ describe("GitHubListItem", () => {
         onToggleSelect={onToggleSelect}
       />
     );
-    fireEvent.click(screen.getByText("Fix the thing"));
+    fireEvent.click(screen.getAllByText("Fix the thing")[0]!);
     expect(onToggleSelect).toHaveBeenCalled();
     expect(actionService.dispatch).not.toHaveBeenCalled();
   });
@@ -416,9 +430,8 @@ describe("GitHubListItem", () => {
       assignees: [{ login: "alice", avatarUrl: "https://example.com/alice.png", rawData: null }],
     };
     render(<GitHubListItem item={issueWithAssignee} type="issue" />);
-    const avatar = screen.getByAltText("alice");
-    expect(avatar).toBeTruthy();
-    expect(avatar.getAttribute("src")).toBe("https://example.com/alice.png");
+    const slot = screen.getByLabelText("Assigned to alice");
+    expect(slot.querySelector("img")?.getAttribute("src")).toBe("https://example.com/alice.png");
   });
 
   it("renders only first assignee avatar when multiple assignees", () => {
@@ -430,8 +443,12 @@ describe("GitHubListItem", () => {
       ],
     };
     render(<GitHubListItem item={issueWithMultiple} type="issue" />);
-    expect(screen.getByAltText("alice")).toBeTruthy();
-    expect(screen.queryByAltText("bob")).toBeNull();
+    // One face plus a count, but the accessible name names everyone — the
+    // image used to be labelled with the first assignee alone, so a screen
+    // reader was told a three-way assignment belonged to one person.
+    const slot = screen.getByLabelText("Assigned to alice, bob");
+    expect(slot.querySelectorAll("img")).toHaveLength(1);
+    expect(screen.getByText("+1")).toBeTruthy();
   });
 
   it("does not render assignee avatar when no assignees", () => {
@@ -442,8 +459,8 @@ describe("GitHubListItem", () => {
 
   it("does not render assignee avatar for PRs", () => {
     render(<GitHubListItem item={basePR} type="pr" />);
-    const images = screen.queryAllByRole("img");
-    expect(images).toHaveLength(0);
+    expect(screen.queryByLabelText(/^Assigned to/)).toBeNull();
+    expect(document.querySelector("img")).toBeNull();
   });
 
   it("makes creating a worktree the row's primary click, not a hover-only glyph", async () => {
@@ -562,5 +579,258 @@ describe("GitHubListItem", () => {
     // The # yields to the check during the copied state, and the digits stay
     // put so the row does not reflow.
     expect(copyButton.textContent).toBe("42");
+  });
+  it("keeps the identity slot pinned beside the menu whichever neighbours appear", () => {
+    // The reported defect: the trailing rail was a right-anchored flex row of
+    // conditional slots, so a worktree glyph or a "+2" count appearing to the
+    // RIGHT of the avatar shoved it left and the avatars stopped lining up
+    // down the list. jsdom cannot measure the 20px that moved, but it can hold
+    // the invariant that produces the column: whatever else the rail holds,
+    // the identity slot is the last thing before the always-present menu.
+    const withNeighbours = render(
+      <GitHubListItem
+        item={{
+          ...baseIssue,
+          assignees: [
+            { login: "alice", avatarUrl: "a.png", rawData: null },
+            { login: "bob", avatarUrl: "b.png", rawData: null },
+          ],
+        }}
+        type="issue"
+        worktree={makeWorktree({ issueNumber: 42 })}
+      />
+    );
+    const crowded = screen.getByLabelText("Assigned to alice, bob");
+    expect(crowded.nextElementSibling?.getAttribute("aria-label")).toBe("Actions for #42");
+    withNeighbours.unmount();
+
+    render(
+      <GitHubListItem
+        item={{
+          ...baseIssue,
+          assignees: [{ login: "alice", avatarUrl: "a.png", rawData: null }],
+        }}
+        type="issue"
+      />
+    );
+    const bare = screen.getByLabelText("Assigned to alice");
+    expect(bare.nextElementSibling?.getAttribute("aria-label")).toBe("Actions for #42");
+  });
+
+  it("keeps a PR's check glyph in that same slot", () => {
+    render(
+      <GitHubListItem
+        item={{ ...basePR, ciStatus: "success" }}
+        type="pr"
+        worktree={makeWorktree({ prNumber: 99 })}
+      />
+    );
+    const ci = screen.getByLabelText("All checks passed");
+    expect(ci.nextElementSibling?.getAttribute("aria-label")).toBe("Actions for #99");
+  });
+
+  it("states the local worktree as a fact, not as an action it does not perform", () => {
+    // The glyph's tooltip used to read "Switch to worktree" on a role="img"
+    // span that could not be clicked at all.
+    render(
+      <GitHubListItem
+        item={baseIssue}
+        type="issue"
+        worktree={makeWorktree({ issueNumber: 42, branch: "fix/thing" })}
+      />
+    );
+    const chip = screen.getByLabelText("Worktree: issue-42-fix on fix/thing");
+    expect(chip.textContent).toContain("Worktree");
+    expect(chip.querySelector("button")).toBeNull();
+  });
+
+  it("marks the worktree the view is standing in", () => {
+    render(
+      <GitHubListItem
+        item={baseIssue}
+        type="issue"
+        worktree={makeWorktree({ issueNumber: 42 })}
+        activeWorktreeId="wt-42"
+      />
+    );
+    const chip = screen.getByLabelText("Active worktree: issue-42-fix");
+    expect(chip.textContent).toContain("Current");
+  });
+
+  it("describes a detached worktree honestly", () => {
+    render(
+      <GitHubListItem
+        item={baseIssue}
+        type="issue"
+        worktree={makeWorktree({ issueNumber: 42, isDetached: true, head: "abc1234def" })}
+      />
+    );
+    expect(screen.getByLabelText("Worktree: issue-42-fix (detached at abc1234)")).toBeTruthy();
+  });
+
+  it("switches to an existing worktree instead of making a second one", () => {
+    const onSwitchToWorktree = vi.fn();
+    const onCreateWorktree = vi.fn();
+    const { container } = render(
+      <GitHubListItem
+        item={baseIssue}
+        type="issue"
+        worktree={makeWorktree({ issueNumber: 42 })}
+        onSwitchToWorktree={onSwitchToWorktree}
+        onCreateWorktree={onCreateWorktree}
+      />
+    );
+    fireEvent.click(container.querySelector("[role='row']")!);
+    expect(onSwitchToWorktree).toHaveBeenCalledWith("wt-42");
+    expect(onCreateWorktree).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a change request but stays quiet about a review that has not happened", () => {
+    const changes = render(
+      <GitHubListItem item={{ ...basePR, reviewDecision: "CHANGES_REQUESTED" }} type="pr" />
+    );
+    expect(screen.getByLabelText("Review: Changes requested")).toBeTruthy();
+    changes.unmount();
+
+    // REVIEW_REQUIRED is the resting state of nearly every open PR — printing
+    // it would put a word on almost every row to say nothing had happened.
+    render(<GitHubListItem item={{ ...basePR, reviewDecision: "REVIEW_REQUIRED" }} type="pr" />);
+    expect(screen.queryByLabelText(/^Review:/)).toBeNull();
+  });
+
+  it("says nothing about checks a linked PR does not report", () => {
+    render(
+      <GitHubListItem
+        item={{
+          ...baseIssue,
+          linkedPR: { number: 55, state: "open", url: "https://github.com/test/repo/pull/55" },
+        }}
+        type="issue"
+      />
+    );
+    const link = screen.getByRole("button", { name: /Open linked pull request #55/ });
+    expect(link.getAttribute("aria-label")).not.toContain("CI");
+  });
+
+  it("carries the linked PR's own state and checks", () => {
+    // Both arrive with the issue and were being thrown away, so a merged
+    // linkage and one with failing checks rendered identically.
+    render(
+      <GitHubListItem
+        item={{
+          ...baseIssue,
+          linkedPR: {
+            number: 55,
+            state: "merged",
+            url: "https://github.com/test/repo/pull/55",
+            ciStatus: "failure",
+          },
+        }}
+        type="issue"
+      />
+    );
+    const link = screen.getByRole("button", { name: /Open linked pull request #55/ });
+    expect(link.getAttribute("aria-label")).toContain("merged");
+    expect(link.getAttribute("aria-label")).toContain("failing");
+  });
+
+  it("shows the timestamp the panel's sort order implies", () => {
+    // Showing "updated" under a "Newest" sort made the ages read out of order
+    // against the very list they were sorting.
+    const updated = render(<GitHubListItem item={baseIssue} type="issue" />);
+    expect(screen.getByText("time:1001")).toBeTruthy();
+    updated.unmount();
+
+    render(<GitHubListItem item={baseIssue} type="issue" timeField="created" />);
+    expect(screen.getByText("time:1000")).toBeTruthy();
+  });
+
+  it("says what activating the row will do, without repeating what is already named", () => {
+    // Every tooltip in this widget is pointer-only — DOM focus stays in the
+    // search input by design — so the action contract needs a text home. The
+    // state glyph and the worktree chip carry their own names, so saying them
+    // again here made the row announce each of them twice.
+    const { container } = render(
+      <GitHubListItem
+        item={baseIssue}
+        type="issue"
+        worktree={makeWorktree({ issueNumber: 42 })}
+        onSwitchToWorktree={vi.fn()}
+      />
+    );
+    const row = container.querySelector("[role='row']")!;
+    expect(row.textContent!.split("Activate to switch to this worktree")).toHaveLength(2);
+    // Named once each by their own elements, and not a second time in the summary.
+    expect(screen.getAllByLabelText("Open issue")).toHaveLength(1);
+    expect(screen.getAllByLabelText("Worktree: issue-42-fix")).toHaveLength(1);
+  });
+
+  it("promises the forge when that is all it is wired to do", () => {
+    // The action the model wants is not always the action the caller wired. A
+    // row with no `onCreateWorktree` used to fall through to the forge; making
+    // the call optional turned it into a row that silently did nothing while
+    // still promising creation.
+    const { container } = render(<GitHubListItem item={baseIssue} type="issue" />);
+    expect(container.querySelector("[role='row']")!.textContent).toContain(
+      "Activate to open on GitHub"
+    );
+
+    fireEvent.click(container.querySelector("[role='row']")!);
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://github.com/test/repo/issues/42" },
+      { source: "user" }
+    );
+  });
+
+  it("opens the forge for a closed row rather than doing nothing", () => {
+    const onCreateWorktree = vi.fn();
+    const { container } = render(
+      <GitHubListItem
+        item={{ ...baseIssue, state: "closed" }}
+        type="issue"
+        onCreateWorktree={onCreateWorktree}
+      />
+    );
+    fireEvent.click(container.querySelector("[role='row']")!);
+    expect(onCreateWorktree).not.toHaveBeenCalled();
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://github.com/test/repo/issues/42" },
+      { source: "user" }
+    );
+  });
+
+  it.each([
+    ["meta", { metaKey: true }],
+    ["ctrl", { ctrlKey: true }],
+  ])("keeps the forge on a %s click even in selection mode", (_name, modifier) => {
+    // The keyboard honours Cmd/Ctrl+Enter whether or not selection is active,
+    // so a modifier click that quietly toggled membership instead would be a
+    // different command wearing the same gesture.
+    const onToggleSelect = vi.fn();
+    const onCreateWorktree = vi.fn();
+    const { container } = render(
+      <GitHubListItem
+        item={baseIssue}
+        type="issue"
+        isSelectionActive
+        onToggleSelect={onToggleSelect}
+        onCreateWorktree={onCreateWorktree}
+      />
+    );
+    fireEvent.click(container.querySelector("[role='row']")!, modifier);
+    expect(onToggleSelect).not.toHaveBeenCalled();
+    expect(onCreateWorktree).not.toHaveBeenCalled();
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://github.com/test/repo/issues/42" },
+      { source: "user" }
+    );
+  });
+
+  it("names a draft pull request's state, which only its glyph carried", () => {
+    render(<GitHubListItem item={{ ...basePR, isDraft: true }} type="pr" />);
+    expect(screen.getAllByLabelText("Draft pull request").length).toBeGreaterThan(0);
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
+import { render, screen, cleanup, waitFor, act, fireEvent } from "@testing-library/react";
 import React, { Activity, type ReactNode } from "react";
 import type { Issue, ListOptions, Page } from "@shared/types/forge";
 import { setCache, getCache, buildCacheKey, _resetForTests } from "@/lib/forgeResourceCache";
@@ -112,10 +112,13 @@ vi.mock("@/store/worktreeStore", () => ({
   ),
 }));
 
-vi.mock("@/store/createWorktreeStore", () => ({
-  getCurrentViewStore: () => ({
-    getState: () => ({ worktrees: new Map() }),
-  }),
+// The list resolves every row's worktree once and hands it down, so this is
+// the seam that decides what the rows are told.
+const worktreeMap = new Map<string, { id: string; issueNumber?: number; prNumber?: number }>();
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStoreOptional: (selector: (s: { worktrees: unknown }) => unknown) =>
+    selector({ worktrees: worktreeMap }),
 }));
 
 vi.mock("react-dom", async () => {
@@ -123,10 +126,22 @@ vi.mock("react-dom", async () => {
   return { ...actual, createPortal: (children: ReactNode) => children };
 });
 
+/** What the list passed each row, keyed by resource number. */
+const rowProps = new Map<number, { worktreeId?: string; timeField?: string }>();
+
 vi.mock("../components/GitHubListItem", () => ({
-  GitHubListItem: ({ item }: { item: Issue }) => (
-    <div data-testid={`item-${item.number}`}>{item.title}</div>
-  ),
+  GitHubListItem: ({
+    item,
+    worktree,
+    timeField,
+  }: {
+    item: Issue;
+    worktree?: { id: string };
+    timeField?: string;
+  }) => {
+    rowProps.set(item.number, { worktreeId: worktree?.id, timeField });
+    return <div data-testid={`item-${item.number}`}>{item.title}</div>;
+  },
 }));
 
 vi.mock("../components/BulkActionBar", () => ({
@@ -257,6 +272,8 @@ beforeEach(() => {
   filterStore.setPrFilter("open");
   filterStore.setIssueSortOrder("created");
   filterStore.setPrSortOrder("created");
+  worktreeMap.clear();
+  rowProps.clear();
 });
 
 afterEach(() => {
@@ -2879,5 +2896,145 @@ describe("GitHubResourceList dismissal preserves bulk selection", () => {
     );
     await act(async () => {});
     expect(notifyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHubResourceList — the row model it hands down", () => {
+  const key = buildCacheKey("/test/proj", "issue", "open", "created");
+
+  const seed = (items: Issue[]) => {
+    setCache(key, {
+      items,
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      freshBypassAt: Date.now(),
+      countAtWrite: items.length,
+    });
+    mockListIssues.mockResolvedValue(makeResponse(items));
+  };
+
+  it("resolves each row's worktree once and hands it down", async () => {
+    // The row used to scan the whole worktree map for itself, so nothing above
+    // it could be wrong — and nothing could test it either.
+    worktreeMap.set("wt-a", { id: "wt-a", issueNumber: 11 });
+    seed([makeIssue(10), makeIssue(11)]);
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await waitFor(() => expect(screen.getByTestId("item-11")).toBeTruthy());
+
+    expect(rowProps.get(11)?.worktreeId).toBe("wt-a");
+    expect(rowProps.get(10)?.worktreeId).toBeUndefined();
+  });
+
+  it("does not match an issue against a worktree made for the same-numbered PR", async () => {
+    worktreeMap.set("wt-a", { id: "wt-a", prNumber: 10 });
+    seed([makeIssue(10)]);
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await waitFor(() => expect(screen.getByTestId("item-10")).toBeTruthy());
+
+    expect(rowProps.get(10)?.worktreeId).toBeUndefined();
+  });
+
+  it("tells rows which timestamp the sort order implies", async () => {
+    // Showing "updated" under a "Newest" sort made the ages read out of order
+    // against the very list they were sorting.
+    seed([makeIssue(10)]);
+    const created = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await waitFor(() => expect(rowProps.get(10)?.timeField).toBe("created"));
+    created.unmount();
+
+    rowProps.clear();
+    useGitHubFilterStore.getState().setIssueSortOrder("updated");
+    setCache(buildCacheKey("/test/proj", "issue", "open", "updated"), {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      freshBypassAt: Date.now(),
+      countAtWrite: 1,
+    });
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await waitFor(() => expect(rowProps.get(10)?.timeField).toBe("updated"));
+  });
+});
+
+describe("GitHubResourceList — the keyboard cursor across a refresh", () => {
+  const key = buildCacheKey("/test/proj", "issue", "open", "created");
+
+  const seed = (items: Issue[]) => {
+    setCache(key, {
+      items,
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      freshBypassAt: Date.now(),
+      countAtWrite: items.length,
+    });
+  };
+
+  const activeDescendant = () => screen.getByRole("combobox").getAttribute("aria-activedescendant");
+
+  it("keeps the cursor on the same resource when a refresh reorders the list", async () => {
+    // A background revalidation landing mid-navigation used to reset the
+    // cursor to nothing, silently throwing away your place.
+    seed([makeIssue(10), makeIssue(11)]);
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10), makeIssue(11)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await waitFor(() => expect(screen.getByTestId("item-11")).toBeTruthy());
+
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(activeDescendant()).toBe("github-issue-option-11");
+
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(11), makeIssue(10)]));
+    fireEvent.click(screen.getByRole("button", { name: /^Refresh issues/ }));
+
+    await waitFor(() => expect(activeDescendant()).toBe("github-issue-option-11"));
+  });
+
+  it("drops the cursor when the resource it was on is gone", async () => {
+    seed([makeIssue(10), makeIssue(11)]);
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10), makeIssue(11)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await waitFor(() => expect(screen.getByTestId("item-11")).toBeTruthy());
+
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(activeDescendant()).toBe("github-issue-option-11");
+
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)]));
+    fireEvent.click(screen.getByRole("button", { name: /^Refresh issues/ }));
+
+    await waitFor(() => expect(activeDescendant()).toBeNull());
+  });
+
+  it("does not carry the cursor across a project switch", async () => {
+    // A resource number only identifies a row within one project and one kind:
+    // issue #10 over there is a different issue #10.
+    seed([makeIssue(10)]);
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)]));
+
+    const view = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await waitFor(() => expect(screen.getByTestId("item-10")).toBeTruthy());
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
+    expect(activeDescendant()).toBe("github-issue-option-10");
+
+    setCache(buildCacheKey("/other/proj", "issue", "open", "created"), {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      freshBypassAt: Date.now(),
+      countAtWrite: 1,
+    });
+    view.rerender(<GitHubResourceList type="issue" projectPath="/other/proj" />);
+
+    await waitFor(() => expect(activeDescendant()).toBeNull());
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/forgeRowModel.test.ts
+++ b/plugins/builtin/github/renderer/__tests__/forgeRowModel.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { buildWorktreeIndex, deriveRowModel, describeWorktree } from "../components/forgeRowModel";
+import type { Worktree } from "@shared/types/worktree";
+
+const wt = (overrides: Partial<Worktree>): Worktree => ({
+  id: "wt",
+  path: "/tmp/wt",
+  name: "wt",
+  isCurrent: false,
+  ...overrides,
+});
+
+describe("buildWorktreeIndex", () => {
+  it("indexes issue worktrees by issue number and ignores PR links", () => {
+    const index = buildWorktreeIndex(
+      [wt({ id: "a", issueNumber: 42 }), wt({ id: "b", prNumber: 42 })],
+      "issue",
+      null
+    );
+    expect(index.get(42)?.id).toBe("a");
+  });
+
+  it("indexes PR worktrees by PR number", () => {
+    const index = buildWorktreeIndex(
+      [wt({ id: "a", issueNumber: 42 }), wt({ id: "b", prNumber: 42 })],
+      "pr",
+      null
+    );
+    expect(index.get(42)?.id).toBe("b");
+  });
+
+  it("skips worktrees that name no resource", () => {
+    expect(buildWorktreeIndex([wt({ id: "a" })], "issue", null).size).toBe(0);
+  });
+
+  it("lets the active worktree win a duplicate, whichever order it arrives in", () => {
+    // Two worktrees can legitimately name one resource — a second made before
+    // the first was cleaned up. The old per-row scan took whichever the map
+    // happened to yield first, so the row you were standing in could lose.
+    const first = [wt({ id: "a", issueNumber: 7 }), wt({ id: "b", issueNumber: 7 })];
+    expect(buildWorktreeIndex(first, "issue", "b").get(7)?.id).toBe("b");
+    expect(buildWorktreeIndex([...first].reverse(), "issue", "b").get(7)?.id).toBe("b");
+  });
+
+  it("keeps the first of two inactive duplicates, in whichever order they arrive", () => {
+    // Asserting only [a,b] -> a cannot tell first-wins from lowest-id-wins.
+    const pair = [wt({ id: "a", issueNumber: 7 }), wt({ id: "b", issueNumber: 7 })];
+    expect(buildWorktreeIndex(pair, "issue", null).get(7)?.id).toBe("a");
+    expect(buildWorktreeIndex([...pair].reverse(), "issue", null).get(7)?.id).toBe("b");
+  });
+});
+
+describe("deriveRowModel", () => {
+  it("switches when a worktree already exists", () => {
+    const model = deriveRowModel({ state: "open" }, wt({ id: "x" }), null);
+    expect(model.primaryAction).toEqual({ kind: "switch", worktreeId: "x" });
+    expect(model.isActiveWorktree).toBe(false);
+  });
+
+  it("knows when that worktree is the one in view", () => {
+    expect(deriveRowModel({ state: "open" }, wt({ id: "x" }), "x").isActiveWorktree).toBe(true);
+  });
+
+  it("creates for an open resource with no worktree", () => {
+    expect(deriveRowModel({ state: "open" }, undefined, null).primaryAction).toEqual({
+      kind: "create",
+    });
+  });
+
+  it("falls through to the forge when there is nothing to make locally", () => {
+    // A closed issue or a merged PR has no worktree to create, so activation
+    // opens it rather than silently doing nothing.
+    expect(deriveRowModel({ state: "closed" }, undefined, null).primaryAction).toEqual({
+      kind: "open",
+    });
+    expect(deriveRowModel({ state: "merged" }, undefined, null).primaryAction).toEqual({
+      kind: "open",
+    });
+  });
+
+  it("switches to a closed resource's worktree rather than opening the forge", () => {
+    const model = deriveRowModel({ state: "closed" }, wt({ id: "x" }), null);
+    expect(model.primaryAction).toEqual({ kind: "switch", worktreeId: "x" });
+  });
+});
+
+describe("describeWorktree", () => {
+  it("names the worktree", () => {
+    expect(describeWorktree(wt({ name: "fix-42" }), false)).toBe("Worktree: fix-42");
+  });
+
+  it("says which one is active", () => {
+    expect(describeWorktree(wt({ name: "fix-42" }), true)).toBe("Active worktree: fix-42");
+  });
+
+  it("names a branch that differs from the worktree", () => {
+    // The match is on resource number, not branch, so the local branch can
+    // legitimately diverge from the PR's head ref.
+    expect(describeWorktree(wt({ name: "fix-42", branch: "feature/other" }), false)).toBe(
+      "Worktree: fix-42 on feature/other"
+    );
+  });
+
+  it("does not repeat a branch that is just the name again", () => {
+    expect(describeWorktree(wt({ name: "fix-42", branch: "fix-42" }), false)).toBe(
+      "Worktree: fix-42"
+    );
+  });
+
+  it("reports a detached head", () => {
+    expect(
+      describeWorktree(wt({ name: "fix-42", isDetached: true, head: "abc1234def" }), false)
+    ).toBe("Worktree: fix-42 (detached at abc1234)");
+    expect(describeWorktree(wt({ name: "fix-42", isDetached: true }), false)).toBe(
+      "Worktree: fix-42 (detached HEAD)"
+    );
+  });
+});

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -11,6 +11,9 @@ import {
   Check,
   Copy,
   MessageSquare,
+  CircleAlert,
+  CircleCheck,
+  ListChecks,
 } from "lucide-react";
 import { FolderGit2 } from "@/components/icons";
 import { Avatar } from "@/components/ui/Avatar";
@@ -18,6 +21,7 @@ import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import { actionService } from "@/services/ActionService";
 import type { ForgeLabel, Issue, PR } from "@shared/types/forge";
+import type { Worktree } from "@shared/types/worktree";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getPRCIStatusVisual, getPRCIStatusTooltip } from "../utils/prCIStatus";
 import { toGitHubCIStatus } from "../utils/forgeRowAdapters";
@@ -28,14 +32,22 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
-import { useWorktreeStore } from "@/hooks/useWorktreeStore";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
 import { RESOURCE_ITEM_HEIGHT_PX } from "./GitHubDropdownSkeletons";
+import { deriveRowModel, describeWorktree, type ForgeRowPrimaryAction } from "./forgeRowModel";
 
 interface GitHubListItemProps {
   item: Issue | PR;
   type: "issue" | "pr";
+  /**
+   * The worktree already made for this resource, resolved once by the list
+   * rather than rescanned by every mounted row. `undefined` means none.
+   */
+  worktree?: Worktree;
+  /** The worktree the project view is standing in, for the `Current` state. */
+  activeWorktreeId?: string | null;
+  /** Which timestamp the row shows, so it agrees with the panel's sort order. */
+  timeField?: "created" | "updated";
   onCreateWorktree?: (item: Issue | PR) => void;
   onSwitchToWorktree?: (worktreeId: string) => void;
   onOpenExternalUrl?: (url: string) => void;
@@ -53,7 +65,8 @@ interface GitHubListItemProps {
   isActive?: boolean;
   isSelected?: boolean;
   isSelectionActive?: boolean;
-  onToggleSelect?: (e: React.MouseEvent) => void;
+  /** Widened past `MouseEvent` so the actions menu can run the same command. */
+  onToggleSelect?: (e: { shiftKey: boolean }) => void;
 }
 
 function getStateIcon(state: string, type: "issue" | "pr", isDraft?: boolean) {
@@ -74,6 +87,18 @@ function getStateColor(state: string, isDraft?: boolean): string {
   return "text-pr-closed";
 }
 
+/**
+ * The state glyph's name. It carried none, so a draft PR — whose whole
+ * distinction from an open one is that glyph — was indistinguishable to a
+ * screen reader from the PR beside it.
+ */
+function getStateLabel(state: string, type: "issue" | "pr", isDraft?: boolean): string {
+  if (type === "issue") return state === "open" ? "Open issue" : "Closed issue";
+  if (state === "merged") return "Merged pull request";
+  if (state === "open") return isDraft ? "Draft pull request" : "Open pull request";
+  return "Closed pull request";
+}
+
 function isPR(item: Issue | PR): item is PR {
   return "isDraft" in item;
 }
@@ -84,6 +109,9 @@ const RAIL_SLOT = "shrink-0 flex items-center justify-center";
 export function GitHubListItem({
   item,
   type,
+  worktree,
+  activeWorktreeId = null,
+  timeField = "updated",
   onCreateWorktree,
   onSwitchToWorktree,
   onOpenExternalUrl,
@@ -101,6 +129,7 @@ export function GitHubListItem({
   const isItemPR = isPR(item);
   const StateIcon = getStateIcon(item.state, type, isItemPR && item.isDraft);
   const stateColor = getStateColor(item.state, isItemPR && item.isDraft);
+  const stateLabel = getStateLabel(item.state, type, isItemPR && item.isDraft);
 
   const [copied, setCopied] = useState(false);
   const copyTimeoutRef = useRef<number | undefined>(undefined);
@@ -114,16 +143,23 @@ export function GitHubListItem({
     };
   }, []);
 
-  const matchedWorktree = useWorktreeStore((s) => {
-    for (const wt of s.worktrees.values()) {
-      if (type === "issue" ? wt.issueNumber === item.number : wt.prNumber === item.number)
-        return wt;
-    }
-    return undefined;
-  });
-  const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
-  const hasWorktree = matchedWorktree !== undefined;
-  const isActiveWorktree = hasWorktree && matchedWorktree.id === activeWorktreeId;
+  const rowModel = deriveRowModel(item, worktree, activeWorktreeId);
+  const { isActiveWorktree } = rowModel;
+  /**
+   * What this row can actually do, as wired.
+   *
+   * The model says what the row MEANS to do; a caller that did not pass the
+   * handler for it cannot. Falling back to the forge keeps every row doing
+   * something — optional-chaining the call instead would leave a row that
+   * looks activatable, promises an action in its accessible name, and then
+   * silently does nothing.
+   */
+  const primaryAction: ForgeRowPrimaryAction =
+    (rowModel.primaryAction.kind === "switch" && !onSwitchToWorktree) ||
+    (rowModel.primaryAction.kind === "create" && !onCreateWorktree)
+      ? { kind: "open" }
+      : rowModel.primaryAction;
+  const worktreeDescription = worktree ? describeWorktree(worktree, isActiveWorktree) : null;
 
   const handleOpenExternal = () => {
     if (onOpenExternalUrl) {
@@ -145,24 +181,45 @@ export function GitHubListItem({
         UI_ACTION_SUCCESS_DWELL_MS
       );
     } catch {
+      // The clipboard can refuse (permissions, a headless context). Say so
+      // rather than flashing a success tick for a copy that did not happen.
       setCopied(false);
+      console.warn(`Could not copy #${item.number} to the clipboard`);
     }
   };
 
   /**
-   * The row's primary action — the same one Enter runs from the search field,
-   * and total: a closed issue or a merged PR has no worktree to make, so it
-   * falls through to the forge rather than swallowing the activation.
+   * The row's one action, run by the whole row — background and title alike.
+   *
+   * The title used to always open GitHub while the pixels beside it created or
+   * switched a worktree, so which operation you got depended on whether you
+   * hit the text. In a list whose purpose is running work locally, ordinary
+   * activation means "continue this work in Daintree"; the forge keeps the
+   * modifier click, Cmd/Ctrl+Enter, and its own menu item.
    */
   const runPrimaryAction = () => {
-    if (hasWorktree && matchedWorktree && onSwitchToWorktree) {
-      onSwitchToWorktree(matchedWorktree.id);
-    } else if (item.state === "open" && onCreateWorktree) {
-      onCreateWorktree(item);
-    } else {
-      handleOpenExternal();
+    switch (primaryAction.kind) {
+      case "switch":
+        onSwitchToWorktree?.(primaryAction.worktreeId);
+        break;
+      case "create":
+        onCreateWorktree?.(item);
+        break;
+      case "open":
+        handleOpenExternal();
+        break;
     }
   };
+
+  /** What a screen reader is told activation will do, since no tooltip here is reachable. */
+  const primaryActionHint =
+    primaryAction.kind === "switch"
+      ? isActiveWorktree
+        ? "Activate to return to this worktree"
+        : "Activate to switch to this worktree"
+      : primaryAction.kind === "create"
+        ? "Activate to create a worktree"
+        : "Activate to open on GitHub";
 
   const handleOpenLinkedPR = () => {
     const linked = !isItemPR && "linkedPR" in item ? item.linkedPR : undefined;
@@ -178,22 +235,43 @@ export function GitHubListItem({
   const [firstLabel, ...restLabels] = issueLabels;
   const assignees = !isItemPR ? item.assignees : [];
   const [firstAssignee, ...restAssignees] = assignees;
+  const assigneeLabel = firstAssignee
+    ? `Assigned to ${assignees.map((a) => a.login).join(", ")}`
+    : null;
 
-  const worktreeTooltip = isActiveWorktree
-    ? "Active worktree"
-    : hasWorktree && onSwitchToWorktree
-      ? "Switch to worktree"
-      : "Has worktree";
+  const linkedPR = !isItemPR && "linkedPR" in item ? item.linkedPR : undefined;
+  const linkedPRCIVisual = linkedPR?.ciStatus
+    ? getPRCIStatusVisual(toGitHubCIStatus(linkedPR.ciStatus))
+    : null;
+
+  /**
+   * Only the review decisions that change what you do next.
+   *
+   * `REVIEW_REQUIRED` is the resting state of nearly every open PR, so putting
+   * it on the surface would print a word on almost every row to say nothing
+   * had happened yet. Approval and a change request are events; the absence of
+   * a decision is not.
+   */
+  const reviewDecision = isItemPR ? item.reviewDecision : undefined;
+  const reviewVisual =
+    reviewDecision === "CHANGES_REQUESTED"
+      ? { Icon: CircleAlert, label: "Changes requested", colorClass: "text-status-warning" }
+      : reviewDecision === "APPROVED"
+        ? { Icon: CircleCheck, label: "Approved", colorClass: "text-status-success" }
+        : null;
+
+  const timestamp = timeField === "created" ? item.createdAt : item.updatedAt;
+  const timeLabel = `${timeField === "created" ? "Created" : "Updated"} ${new Date(timestamp).toLocaleString()}`;
 
   return (
     <div
       id={optionId}
       /* A row, not an option. `option` admits no interactive descendants, and
-         these rows genuinely carry them — a title that opens the issue, a
-         number that copies, a linked-PR jump, an actions menu. The APG's
-         editable-combobox-with-grid-popup pattern is the one that models this
-         honestly: the input keeps DOM focus and points `aria-activedescendant`
-         at a row, and every control lives inside a legal `gridcell`. */
+         these rows genuinely carry them — a number that copies, a linked-PR
+         jump, an actions menu. The APG's editable-combobox-with-grid-popup
+         pattern is the one that models this honestly: the input keeps DOM
+         focus and points `aria-activedescendant` at a row, and every control
+         lives inside a legal `gridcell`. */
       role="row"
       /* Virtualization means the DOM holds a window, not the list — without an
          explicit index a screen reader counts the handful of mounted rows. */
@@ -226,14 +304,27 @@ export function GitHubListItem({
       // fill and the hit area cover the whole slot with no unowned strip.
       style={{ height: RESOURCE_ITEM_HEIGHT_PX }}
       onClick={(e) => {
+        // The pointer's counterpart to Cmd/Ctrl+Enter: the forge on demand,
+        // without spending the row's default on it. Checked BEFORE selection
+        // so the two paths agree — the keyboard honours the modifier whether
+        // or not selection is active, and a modifier click that silently
+        // toggled membership instead would be a different command.
+        if (e.metaKey || e.ctrlKey) {
+          handleOpenExternal();
+          return;
+        }
         if (isSelectionActive && onToggleSelect) {
           onToggleSelect(e);
-        } else {
-          runPrimaryAction();
+          return;
         }
+        runPrimaryAction();
       }}
     >
       <div role="gridcell" className="flex items-start gap-2.5 px-3 py-2.5 h-full">
+        {/* The one thing nothing else in the row carries: what activating it
+            will do. State and worktree are named by their own elements, so
+            repeating them here made the row announce each of them twice. */}
+        <span className="sr-only">{primaryActionHint}</span>
         {onToggleSelect ? (
           <span className="group/icon shrink-0 relative w-4 h-4 mt-1">
             {/* State icon: visible by default, hidden on hover or when selection active */}
@@ -243,10 +334,14 @@ export function GitHubListItem({
                 stateColor,
                 isSelectionActive || isSelected ? "hidden" : "group-hover/icon:hidden"
               )}
+              role="img"
+              aria-label={stateLabel}
             >
               <StateIcon className="h-4 w-4" />
             </span>
-            {/* Checkbox: hidden by default, visible on hover or when selection active */}
+            {/* Checkbox: hidden by default, visible on hover or when selection active.
+                Pointer convenience only — the same command is a named item in the
+                row's actions menu, so entering selection never depends on hover. */}
             <span
               aria-hidden="true"
               onClick={(e) => {
@@ -266,7 +361,7 @@ export function GitHubListItem({
             </span>
           </span>
         ) : (
-          <span className={cn("shrink-0 mt-1", stateColor)}>
+          <span className={cn("shrink-0 mt-1", stateColor)} role="img" aria-label={stateLabel}>
             <StateIcon className="h-4 w-4" />
           </span>
         )}
@@ -274,28 +369,36 @@ export function GitHubListItem({
         <div className="flex-1 min-w-0">
           {/* Title line: the title owns the width; status and actions sit in the rail. */}
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              tabIndex={-1}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (isSelectionActive && onToggleSelect) {
-                  onToggleSelect(e);
-                } else {
-                  handleOpenExternal();
-                }
-              }}
-              className={cn(
-                "flex-1 min-w-0 text-sm font-medium text-foreground truncate text-left cursor-pointer rounded",
-                "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-                !isSelectionActive && "hover:underline"
-              )}
-            >
-              {item.title}
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/* Not a button. The whole row runs one action, and a nested
+                    control that ran a different one was the reason clicking the
+                    text and clicking beside it did different things. */}
+                <span className="flex-1 min-w-0 text-sm font-medium text-foreground truncate text-left">
+                  {item.title}
+                </span>
+              </TooltipTrigger>
+              {/* At 450px most titles truncate. The elaborate tooltips used to
+                  be on the trivia while the one line you actually need to read
+                  had none. */}
+              <TooltipContent side="bottom">{item.title}</TooltipContent>
+            </Tooltip>
 
-            {/* Trailing rail — every slot is persistent ink, no hover-only reveals. */}
+            {/* Trailing rail — every slot is persistent ink, no hover-only reveals.
+                Order matters: everything of variable width sits to the LEFT of the
+                fixed identity slot, which sits immediately before the always-present
+                menu. That is what keeps avatars (and CI glyphs) in one column down
+                the list instead of sliding left whenever a neighbour appears. */}
             <div className="flex items-center gap-1.5 shrink-0">
+              {restAssignees.length > 0 && (
+                <span
+                  className="shrink-0 text-3xs text-text-secondary tabular-nums"
+                  aria-hidden="true"
+                >
+                  +{restAssignees.length}
+                </span>
+              )}
+
               {isItemPR &&
                 item.state === "open" &&
                 item.ciStatus &&
@@ -307,7 +410,7 @@ export function GitHubListItem({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span
-                          className={cn(RAIL_SLOT, "w-3.5 h-3.5")}
+                          className={cn(RAIL_SLOT, "w-4 h-3.5")}
                           role="img"
                           aria-label={ciTooltip}
                         >
@@ -325,55 +428,14 @@ export function GitHubListItem({
                   );
                 })()}
 
-              {firstAssignee && (
+              {firstAssignee && assigneeLabel && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className={cn(RAIL_SLOT, "relative")}>
-                      <Avatar
-                        src={firstAssignee.avatarUrl ?? ""}
-                        alt={firstAssignee.login}
-                        className="w-4 h-4"
-                      />
-                      {restAssignees.length > 0 && (
-                        <span className="ml-0.5 text-3xs text-text-secondary tabular-nums">
-                          +{restAssignees.length}
-                        </span>
-                      )}
+                    <span className={cn(RAIL_SLOT, "w-4")} role="img" aria-label={assigneeLabel}>
+                      <Avatar src={firstAssignee.avatarUrl ?? ""} alt="" className="w-4 h-4" />
                     </span>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {restAssignees.length > 0
-                      ? `Assigned to ${assignees.map((a) => a.login).join(", ")}`
-                      : `Assigned to ${firstAssignee.login}`}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-
-              {hasWorktree && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      className={cn(
-                        RAIL_SLOT,
-                        "w-3.5 h-3.5",
-                        isActiveWorktree
-                          ? // The one place a status colour is load-bearing in
-                            // this row: this is the worktree you are standing
-                            // in. Colour carries it alone — a border drawn a
-                            // hair off a 14px glyph reads as a broken chip, not
-                            // as emphasis. Forced-colors strips the hue, so the
-                            // distinction moves to `Highlight` there, which is
-                            // the one system colour that survives it.
-                            "text-status-info forced-colors:text-[color:Highlight]"
-                          : "text-text-secondary"
-                      )}
-                      role="img"
-                      aria-label={worktreeTooltip}
-                    >
-                      <FolderGit2 className="w-3.5 h-3.5" />
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{worktreeTooltip}</TooltipContent>
+                  <TooltipContent side="bottom">{assigneeLabel}</TooltipContent>
                 </Tooltip>
               )}
 
@@ -421,7 +483,29 @@ export function GitHubListItem({
                      feedback. Same guard the sort popover carries. */
                   onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
                   onTouchStart={(e: React.TouchEvent) => e.stopPropagation()}
+                  /* The menu portals out of the row's DOM but not out of the
+                     React tree, so without this a click on any item also runs
+                     the row's primary action underneath it — "Copy number"
+                     would copy AND switch worktree, and "Select" would toggle
+                     and then activate. */
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
                 >
+                  {/* The row's own action leads. It used to sit below a
+                      separator under "Open on GitHub", which contradicted what
+                      the row actually does when you activate it. */}
+                  {primaryAction.kind === "switch" && onSwitchToWorktree && !isActiveWorktree && (
+                    <DropdownMenuItem onSelect={() => onSwitchToWorktree(primaryAction.worktreeId)}>
+                      <FolderGit2 className="h-3.5 w-3.5 mr-2" />
+                      Switch to worktree
+                    </DropdownMenuItem>
+                  )}
+                  {primaryAction.kind === "create" && onCreateWorktree && (
+                    <DropdownMenuItem onSelect={() => onCreateWorktree(item)}>
+                      <FolderGit2 className="h-3.5 w-3.5 mr-2" />
+                      Create worktree
+                    </DropdownMenuItem>
+                  )}
+
                   <DropdownMenuItem onSelect={() => handleOpenExternal()}>
                     <ExternalLink className="h-3.5 w-3.5 mr-2" />
                     Open on GitHub
@@ -430,29 +514,22 @@ export function GitHubListItem({
                     <Copy className="h-3.5 w-3.5 mr-2" />
                     Copy number
                   </DropdownMenuItem>
-                  {!isItemPR && "linkedPR" in item && item.linkedPR && (
+                  {linkedPR && (
                     <DropdownMenuItem onSelect={() => handleOpenLinkedPR()}>
                       <GitPullRequest className="h-3.5 w-3.5 mr-2" />
-                      Open pull request #{item.linkedPR.number}
+                      Open pull request #{linkedPR.number}
                     </DropdownMenuItem>
                   )}
 
-                  {hasWorktree && !isActiveWorktree && onSwitchToWorktree && matchedWorktree && (
+                  {/* Selection's only accessible, non-hover entry point. The
+                      checkbox on the state icon is a pointer shortcut for the
+                      same command, not the way you are meant to find it. */}
+                  {onToggleSelect && (
                     <>
                       <DropdownMenuSeparator />
-                      <DropdownMenuItem onSelect={() => onSwitchToWorktree(matchedWorktree.id)}>
-                        <FolderGit2 className="h-3.5 w-3.5 mr-2" />
-                        Switch to worktree
-                      </DropdownMenuItem>
-                    </>
-                  )}
-
-                  {!hasWorktree && onCreateWorktree && item.state === "open" && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem onSelect={() => onCreateWorktree(item)}>
-                        <FolderGit2 className="h-3.5 w-3.5 mr-2" />
-                        Create worktree
+                      <DropdownMenuItem onSelect={() => onToggleSelect({ shiftKey: false })}>
+                        <ListChecks className="h-3.5 w-3.5 mr-2" />
+                        {isSelected ? "Deselect" : "Select"}
                       </DropdownMenuItem>
                     </>
                   )}
@@ -461,7 +538,10 @@ export function GitHubListItem({
             </div>
           </div>
 
-          {/* Metadata line: identity first, then recency, then one label + count. */}
+          {/* Metadata line: identity, then what is happening locally, then the
+              forge's own trail. Local state comes early on purpose — it changes
+              what activating the row does, so it must not be the thing that
+              falls off the clipped end. */}
           <div className="flex items-center gap-1.5 mt-1 text-xs text-text-secondary flex-nowrap overflow-hidden">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -493,19 +573,96 @@ export function GitHubListItem({
               <TooltipContent side="bottom">{copied ? "Copied" : "Copy number"}</TooltipContent>
             </Tooltip>
 
-            <span className="shrink-0">&middot;</span>
-            <span className="truncate max-w-[110px]">{item.author?.login ?? "unknown"}</span>
-            <span className="shrink-0">&middot;</span>
-            <span className="whitespace-nowrap shrink-0">{formatTimeAgo(item.updatedAt)}</span>
+            {worktree && worktreeDescription && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* A word, not a 14px glyph wedged in the rail. This is the
+                      one fact on the row that changes what activation does, and
+                      in an IDE for running work in worktrees it is the most
+                      decision-relevant thing the row knows.
+
+                      It says `Worktree`, never the branch: the match is on
+                      resource number, so the local branch can legitimately
+                      differ from the PR's head ref. The tooltip and the
+                      accessible name carry the real name and branch. */}
+                  <span
+                    className={cn(
+                      "shrink-0 inline-flex items-center gap-1",
+                      isActiveWorktree
+                        ? // The one place a status colour is load-bearing in this
+                          // row: this is the worktree you are standing in.
+                          // Forced-colors strips the hue, so the distinction moves
+                          // to `Highlight`, the one system colour that survives it.
+                          "text-status-info forced-colors:text-[color:Highlight]"
+                        : "text-text-secondary"
+                    )}
+                    role="img"
+                    aria-label={worktreeDescription}
+                  >
+                    <span aria-hidden="true">&middot;</span>
+                    <FolderGit2 className="w-3 h-3" aria-hidden="true" />
+                    <span>{isActiveWorktree ? "Current" : "Worktree"}</span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{worktreeDescription}</TooltipContent>
+              </Tooltip>
+            )}
+
+            {reviewVisual && (
+              <span
+                className={cn("shrink-0 inline-flex items-center gap-1", reviewVisual.colorClass)}
+                role="img"
+                aria-label={`Review: ${reviewVisual.label}`}
+              >
+                <span aria-hidden="true" className="text-text-secondary">
+                  &middot;
+                </span>
+                <reviewVisual.Icon className="w-3 h-3" aria-hidden="true" />
+                <span>{reviewVisual.label}</span>
+              </span>
+            )}
+
+            {/* Separator kept inside the element it belongs to. Every middot
+                used to be independently `shrink-0`, so an author name squeezed
+                to nothing left its middot behind as a dangling dot. */}
+            <span className="inline-flex items-center gap-1.5 min-w-0">
+              <span className="shrink-0" aria-hidden="true">
+                &middot;
+              </span>
+              <span className="truncate max-w-[110px]">{item.author?.login ?? "unknown"}</span>
+            </span>
+
+            <span className="shrink-0" aria-hidden="true">
+              &middot;
+            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="whitespace-nowrap shrink-0" role="img" aria-label={timeLabel}>
+                  {formatTimeAgo(timestamp)}
+                </span>
+              </TooltipTrigger>
+              {/* Which timestamp this is depends on the panel's sort order —
+                  showing "updated" under a "Newest" sort made the ages read out
+                  of order against the list they were sorting. */}
+              <TooltipContent side="bottom">{timeLabel}</TooltipContent>
+            </Tooltip>
 
             {(item.commentCount ?? 0) >= 1 && (
               <>
-                <span className="shrink-0">&middot;</span>
+                <span className="shrink-0" aria-hidden="true">
+                  &middot;
+                </span>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className="inline-flex items-center gap-0.5 shrink-0 tabular-nums">
+                    <span
+                      className="inline-flex items-center gap-0.5 shrink-0 tabular-nums"
+                      role="img"
+                      aria-label={
+                        item.commentCount === 1 ? "1 comment" : `${item.commentCount} comments`
+                      }
+                    >
                       <MessageSquare className="w-3 h-3" aria-hidden="true" />
-                      <span>{item.commentCount}</span>
+                      <span aria-hidden="true">{item.commentCount}</span>
                     </span>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
@@ -516,22 +673,32 @@ export function GitHubListItem({
             )}
 
             {isItemPR && item.headRef && (
-              <>
-                <span className="shrink-0">&middot;</span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="truncate max-w-[150px]">{item.headRef}</span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {item.headRef} &rarr; {item.baseRef}
-                  </TooltipContent>
-                </Tooltip>
-              </>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex items-center gap-1.5 min-w-0"
+                    role="img"
+                    aria-label={`Merges ${item.headRef} into ${item.baseRef}`}
+                  >
+                    <span className="shrink-0" aria-hidden="true">
+                      &middot;
+                    </span>
+                    <span className="truncate max-w-[150px]" aria-hidden="true">
+                      {item.headRef}
+                    </span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {item.headRef} &rarr; {item.baseRef}
+                </TooltipContent>
+              </Tooltip>
             )}
 
-            {!isItemPR && "linkedPR" in item && item.linkedPR && (
+            {linkedPR && (
               <>
-                <span className="shrink-0">&middot;</span>
+                <span className="shrink-0" aria-hidden="true">
+                  &middot;
+                </span>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
@@ -546,46 +713,80 @@ export function GitHubListItem({
                         "hover:text-text-primary transition-colors duration-150 ease-out",
                         "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                       )}
-                      aria-label={`Open linked pull request #${item.linkedPR.number}`}
+                      aria-label={
+                        // The linked PR's own state and checks arrive with the
+                        // issue and used to be thrown away: a merged linkage and
+                        // one with failing checks rendered identically.
+                        `Open linked pull request #${linkedPR.number} (${linkedPR.state}${
+                          linkedPRCIVisual ? `, CI ${linkedPRCIVisual.shortLabel}` : ""
+                        })`
+                      }
                     >
-                      <GitPullRequest className="w-3 h-3" aria-hidden="true" />
-                      <span>{item.linkedPR.number}</span>
+                      <GitPullRequest
+                        className={cn("w-3 h-3", getStateColor(linkedPR.state))}
+                        aria-hidden="true"
+                      />
+                      <span>{linkedPR.number}</span>
+                      {linkedPRCIVisual &&
+                        (linkedPRCIVisual.kind === "icon" ? (
+                          <linkedPRCIVisual.Icon
+                            className={cn("w-3 h-3 ms-0.5", linkedPRCIVisual.colorClass)}
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <span
+                            className={cn(
+                              "block w-1.5 h-1.5 rounded-full ms-0.5",
+                              linkedPRCIVisual.colorClass
+                            )}
+                            aria-hidden="true"
+                          />
+                        ))}
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
-                    Linked pull request #{item.linkedPR.number}
+                    Pull request #{linkedPR.number} &middot; {linkedPR.state}
+                    {linkedPRCIVisual ? ` · CI ${linkedPRCIVisual.shortLabel}` : ""}
                   </TooltipContent>
                 </Tooltip>
               </>
             )}
 
             {firstLabel && (
-              <>
-                <span className="shrink-0">&middot;</span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    {/* One complete label plus a count. A label clipped to
-                        "enhanceme…" reads as broken data, and the labels past
-                        the second used to vanish with nothing to say so. */}
-                    <span className="inline-flex items-center gap-1 min-w-0">
-                      {firstLabel.color ? (
-                        <span
-                          className="w-2 h-2 rounded-full shrink-0"
-                          style={{ backgroundColor: `#${firstLabel.color}` }}
-                          aria-hidden="true"
-                        />
-                      ) : null}
-                      <span className="truncate max-w-[130px]">{firstLabel.name}</span>
-                      {restLabels.length > 0 && (
-                        <span className="shrink-0 tabular-nums">+{restLabels.length}</span>
-                      )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* One complete label plus a count. A label clipped to
+                      "enhanceme…" reads as broken data, and the labels past
+                      the second used to vanish with nothing to say so. */}
+                  <span
+                    className="inline-flex items-center gap-1 min-w-0"
+                    role="img"
+                    aria-label={`Labels: ${issueLabels.map((l) => l.name).join(", ")}`}
+                  >
+                    <span className="shrink-0" aria-hidden="true">
+                      &middot;
                     </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {issueLabels.map((l) => l.name).join(", ")}
-                  </TooltipContent>
-                </Tooltip>
-              </>
+                    {firstLabel.color ? (
+                      <span
+                        className="w-2 h-2 rounded-full shrink-0"
+                        style={{ backgroundColor: `#${firstLabel.color}` }}
+                        aria-hidden="true"
+                      />
+                    ) : null}
+                    <span className="truncate max-w-[130px]" aria-hidden="true">
+                      {firstLabel.name}
+                    </span>
+                    {restLabels.length > 0 && (
+                      <span className="shrink-0 tabular-nums" aria-hidden="true">
+                        +{restLabels.length}
+                      </span>
+                    )}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {issueLabels.map((l) => l.name).join(", ")}
+                </TooltipContent>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -736,7 +736,7 @@ export function GitHubListItem({
                         ) : (
                           <span
                             className={cn(
-                              "block w-1.5 h-1.5 rounded-full ms-0.5",
+                              "status-mark block w-1.5 h-1.5 rounded-full ms-0.5",
                               linkedPRCIVisual.colorClass
                             )}
                             aria-hidden="true"

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -30,11 +30,12 @@ import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
 import { safeStringify } from "@/lib/safeStringify";
 import { GitHubListItem } from "./GitHubListItem";
+import { buildWorktreeIndex, deriveRowModel } from "./forgeRowModel";
 import { BulkActionBar } from "./BulkActionBar";
 import { useIssueSelection } from "@/hooks/useIssueSelection";
 import { useIssueSelectionStore } from "@/store/issueSelectionStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { getCurrentViewStore } from "@/store/createWorktreeStore";
+import { useWorktreeStoreOptional } from "@/hooks/useWorktreeStore";
 import {
   useGitHubFilterStore,
   type IssueStateFilter,
@@ -42,6 +43,7 @@ import {
 } from "../stores/githubFilterStore";
 import { useGitHubConfigStore } from "../stores/githubConfigStore";
 import type { Issue, PR } from "@shared/types/forge";
+import type { Worktree } from "@shared/types/worktree";
 import type { GitHubSortOrder } from "../../shared/types.js";
 import { MULTI_FETCH_CAP } from "@/lib/parseNumberQuery";
 import {
@@ -60,6 +62,9 @@ import { UI_DOHERTY_THRESHOLD, UI_SKELETON_FLOOR_MS } from "@/lib/animationUtils
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 
 type StateFilter = IssueStateFilter | PRStateFilter;
+
+/** Stable empty snapshot for the views that have no worktree store to read. */
+const EMPTY_WORKTREES: ReadonlyMap<string, Worktree> = new Map();
 
 /**
  * How old the loaded page has to be before the footer says so out loud.
@@ -514,6 +519,25 @@ export function GitHubResourceList({
   );
 
   /**
+   * Which resources already have a worktree, resolved once for the whole list.
+   *
+   * Every mounted row used to linearly scan the worktree map for itself, and
+   * the Enter handler scanned it again through a third access path with its own
+   * copy of the match rule. One index, one rule, both paths.
+   */
+  // The optional read, not the throwing one: this panel is an overlay that
+  // only ENRICHES itself with the view's worktrees. Taking the whole forge
+  // surface down because it rendered without a worktree store would be a
+  // crash over a detail it can do without. The selector returns the map's own
+  // reference, which is the stability `useSyncExternalStore` requires.
+  const worktreeMap = useWorktreeStoreOptional((s) => s.worktrees, EMPTY_WORKTREES);
+  const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+  const worktreeIndex = useMemo(
+    () => buildWorktreeIndex(worktreeMap.values(), type, activeWorktreeId),
+    [worktreeMap, type, activeWorktreeId]
+  );
+
+  /**
    * Opening an item hands off to the browser, so the dropdown has nothing left
    * to show — closing it matches every other hand-off in the app and stops the
    * panel hanging over the window the user just switched away to.
@@ -701,9 +725,43 @@ export function GitHubResourceList({
       ? `github-${type}-load-more`
       : undefined;
 
+  /**
+   * Keep the cursor on the same resource across a refresh.
+   *
+   * Resetting to -1 whenever `data` changed identity meant a background
+   * revalidation landing mid-navigation silently threw away your place. The
+   * cursor tracks a resource number now, and only drops when that resource is
+   * genuinely no longer in the list.
+   */
+  const activeIndexRef = useRef(activeIndex);
   useEffect(() => {
-    setActiveIndex(-1);
-  }, [data]);
+    activeIndexRef.current = activeIndex;
+  }, [activeIndex]);
+
+  // A resource number only identifies a row within one project and one
+  // resource kind. Issue #42 in the project you just switched to is a
+  // different issue #42, and a warm cache can swap the rows straight in.
+  const cursorScope = `${projectPath}:${type}`;
+  const previousScopeRef = useRef(cursorScope);
+  const previousDataRef = useRef(data);
+  useEffect(() => {
+    const previousData = previousDataRef.current;
+    const previousScope = previousScopeRef.current;
+    previousDataRef.current = data;
+    previousScopeRef.current = cursorScope;
+    if (previousScope !== cursorScope) {
+      setActiveIndex(-1);
+      return;
+    }
+    if (previousData === data) return;
+    const previousNumber =
+      activeIndexRef.current >= 0 ? previousData[activeIndexRef.current]?.number : undefined;
+    if (previousNumber === undefined) {
+      setActiveIndex(-1);
+      return;
+    }
+    setActiveIndex(data.findIndex((item) => item.number === previousNumber));
+  }, [data, cursorScope]);
 
   useEffect(() => {
     if (activeIndex < 0) return;
@@ -743,27 +801,23 @@ export function GitHubResourceList({
             if (e.metaKey || e.ctrlKey) {
               handleOpenUrlExternal(activeItem.url);
             } else {
-              const worktrees = getCurrentViewStore().getState().worktrees;
-              let matchedWt: { id: string } | undefined;
-              for (const wt of worktrees.values()) {
-                if (
-                  type === "issue"
-                    ? wt.issueNumber === activeItem.number
-                    : wt.prNumber === activeItem.number
-                ) {
-                  matchedWt = wt;
+              // The same derivation the row runs for a click, so the two can
+              // never drift apart.
+              const { primaryAction } = deriveRowModel(
+                activeItem,
+                worktreeIndex.get(activeItem.number),
+                activeWorktreeId
+              );
+              switch (primaryAction.kind) {
+                case "switch":
+                  handleSwitchToWorktree(primaryAction.worktreeId);
                   break;
-                }
-              }
-              if (matchedWt) {
-                handleSwitchToWorktree(matchedWt.id);
-              } else if (activeItem.state === "open") {
-                handleCreateWorktree(activeItem);
-              } else {
-                // Closed issue, merged PR — nothing to make locally, so Enter
-                // falls through to the forge rather than doing nothing. Same
-                // fallback the row's click path takes.
-                handleOpenUrlExternal(activeItem.url);
+                case "create":
+                  handleCreateWorktree(activeItem);
+                  break;
+                case "open":
+                  handleOpenUrlExternal(activeItem.url);
+                  break;
               }
             }
           }
@@ -812,11 +866,12 @@ export function GitHubResourceList({
       activeIndex,
       activeItem,
       handleLoadMore,
+      worktreeIndex,
+      activeWorktreeId,
       handleSwitchToWorktree,
       handleCreateWorktree,
       handleOpenUrlExternal,
       handleClose,
-      type,
       searchQuery,
       setSearchQuery,
       selection,
@@ -1167,13 +1222,26 @@ export function GitHubResourceList({
           </Popover>
         </div>
 
-        {searchQuery.trim() !== "" &&
+        {/* Tied to selection mode rather than to a non-empty query: this is a
+            whole extra row in a vertically stacked header, so typing the first
+            character of a search used to grow the header and shove the list
+            down. Entering selection is a deliberate act; typing is not. */}
+        {selection.isSelectionActive &&
           data.length > 0 &&
           !loading &&
           (() => {
             const allSelected = data.every((item) => selection.selectedIds.has(item.number));
-            const unassigned =
-              type === "issue" ? data.filter((item) => (item as Issue).assignees.length === 0) : [];
+            // The bulk action these helpers feed is creating worktrees, so the
+            // useful filter is which rows do not have one yet. "Unassigned" was
+            // a proxy for that, and a poor one — plenty of assigned issues have
+            // no local worktree, and picking them selected rows the bulk create
+            // would immediately skip.
+            // Open as well as worktree-less: the bulk planner skips closed
+            // issues and merged PRs outright, so selecting them would walk you
+            // into a dialog with nothing left to create.
+            const withoutWorktree = data.filter(
+              (item) => item.state === "open" && !worktreeIndex.has(item.number)
+            );
             return (
               <div
                 className="flex items-center gap-1.5"
@@ -1193,15 +1261,15 @@ export function GitHubResourceList({
                 >
                   {allSelected ? "Deselect all" : `Select all (${data.length})`}
                 </button>
-                {unassigned.length > 0 && (
+                {withoutWorktree.length > 0 && withoutWorktree.length < data.length && (
                   <button
                     type="button"
                     onClick={() => {
-                      selection.selectAll(unassigned);
+                      selection.selectAll(withoutWorktree);
                     }}
                     className="text-xs text-text-secondary hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent-primary transition-colors duration-150 ease-out px-1 py-0.5 rounded"
                   >
-                    {`Select unassigned (${unassigned.length})`}
+                    {`Select without worktrees (${withoutWorktree.length})`}
                   </button>
                 )}
               </div>
@@ -1420,6 +1488,9 @@ export function GitHubResourceList({
                   <GitHubListItem
                     item={item}
                     type={type}
+                    worktree={worktreeIndex.get(item.number)}
+                    activeWorktreeId={activeWorktreeId}
+                    timeField={sortOrder === "created" ? "created" : "updated"}
                     onCreateWorktree={handleCreateWorktree}
                     onSwitchToWorktree={handleSwitchToWorktree}
                     optionId={`github-${type}-option-${item.number}`}
@@ -1434,7 +1505,7 @@ export function GitHubResourceList({
                     isActive={activeIndex === index}
                     isSelected={selection.selectedIds.has(item.number)}
                     isSelectionActive={selection.isSelectionActive}
-                    onToggleSelect={(e: React.MouseEvent) => {
+                    onToggleSelect={(e: { shiftKey: boolean }) => {
                       if (e.shiftKey) {
                         selection.toggleRange(item, data);
                       } else {

--- a/plugins/builtin/github/renderer/components/forgeRowModel.ts
+++ b/plugins/builtin/github/renderer/components/forgeRowModel.ts
@@ -1,0 +1,100 @@
+import type { Issue, PR } from "@shared/types/forge";
+import type { Worktree } from "@shared/types/worktree";
+
+/**
+ * What activating a forge row actually does.
+ *
+ * This used to live twice — once in the row for the pointer and once in the
+ * list shell for Enter — reached through two different worktree access paths.
+ * Two copies of a decision tree that has to agree is a divergence bug with a
+ * lit fuse, so both paths now run this one derivation.
+ */
+export type ForgeRowPrimaryAction =
+  { kind: "switch"; worktreeId: string } | { kind: "create" } | { kind: "open" };
+
+export interface ForgeRowModel {
+  /** The worktree this resource already has locally, when there is one. */
+  worktree?: Worktree;
+  /** Whether that worktree is the one the project view is currently standing in. */
+  isActiveWorktree: boolean;
+  primaryAction: ForgeRowPrimaryAction;
+}
+
+/**
+ * Index the view's worktrees by the resource number each one was made for.
+ *
+ * Every mounted row used to linearly scan the whole worktree map for itself.
+ * Virtualization kept that cheap enough not to show up, but it also meant the
+ * match rule lived in the row, where the list shell could not reuse it and no
+ * test could reach it.
+ *
+ * Two worktrees can legitimately name the same resource — a second one made
+ * before the first was cleaned up. The old scan took whichever the map handed
+ * it first, which is stable only by luck. The active worktree wins here, so
+ * the row you are standing in is never the one that loses the tie.
+ */
+export function buildWorktreeIndex(
+  worktrees: Iterable<Worktree>,
+  type: "issue" | "pr",
+  activeWorktreeId: string | null
+): Map<number, Worktree> {
+  const index = new Map<number, Worktree>();
+  for (const wt of worktrees) {
+    const number = type === "issue" ? wt.issueNumber : wt.prNumber;
+    if (number === undefined || number === null) continue;
+    const existing = index.get(number);
+    if (existing === undefined) {
+      index.set(number, wt);
+      continue;
+    }
+    if (existing.id !== activeWorktreeId && wt.id === activeWorktreeId) {
+      index.set(number, wt);
+    }
+  }
+  return index;
+}
+
+/**
+ * The row's action contract.
+ *
+ * A closed issue or a merged PR has nothing to make locally, so it falls
+ * through to the forge rather than swallowing the activation.
+ */
+export function deriveRowModel(
+  item: Pick<Issue | PR, "state">,
+  worktree: Worktree | undefined,
+  activeWorktreeId: string | null
+): ForgeRowModel {
+  if (worktree) {
+    return {
+      worktree,
+      isActiveWorktree: worktree.id === activeWorktreeId,
+      primaryAction: { kind: "switch", worktreeId: worktree.id },
+    };
+  }
+  return {
+    isActiveWorktree: false,
+    primaryAction: item.state === "open" ? { kind: "create" } : { kind: "open" },
+  };
+}
+
+/**
+ * The full, honest description of a local worktree, for a tooltip and an
+ * accessible name.
+ *
+ * The worktree is matched by resource NUMBER, not by branch, so its branch can
+ * legitimately diverge from the PR's head ref — renamed, switched, or detached
+ * after the fact. That is why this names the worktree and its branch rather
+ * than letting the row imply the PR's head ref is what is checked out locally.
+ */
+export function describeWorktree(wt: Worktree, isActive: boolean): string {
+  const lead = isActive ? "Active worktree" : "Worktree";
+  if (wt.isDetached) {
+    const at = wt.head ? ` (detached at ${wt.head.slice(0, 7)})` : " (detached HEAD)";
+    return `${lead}: ${wt.name}${at}`;
+  }
+  if (wt.branch && wt.branch !== wt.name) {
+    return `${lead}: ${wt.name} on ${wt.branch}`;
+  }
+  return `${lead}: ${wt.name}`;
+}


### PR DESCRIPTION
Fixes the row layout in the issues and pull requests dropdowns, and cleans up what turned out to be sitting behind it.

Each row has a trailing strip holding the assignee avatar (issues) or the CI glyph (PRs), a worktree marker, and the actions menu. The strip is right anchored, so anything appearing to the right of the avatar pushed it left. On rows with a worktree that was about 19px, and the avatars stopped forming a vertical column down the list. Same defect one slot over in the PR panel, where it moved the CI checks instead.

## What changed

**The strip is reordered** so everything of variable width sits to the left of the identity slot, which now sits immediately before the always present menu. That is what produces the column.

**The worktree marker moved to the second line**, where it reads `Current` or `Worktree` right after the number. It was a 14px grey glyph wedged between an avatar and a menu, which is thin ink for the single most decision relevant thing the row knows: whether the work is already running locally. It names the worktree and never a branch. The match is on resource number, so a local branch can legitimately diverge from a PR's head ref, and the tooltip carries the real name, branch and detached state.

**The row runs one action.** The title was a button that always opened GitHub while the pixels beside it created or switched a worktree, so which operation you got depended on whether you hit the text. In a list whose point is running work locally, activation means continue this work in Daintree. The forge keeps the modifier click, `Cmd/Ctrl+Enter`, and its own menu item.

**That decision existed twice**, once in the row for the pointer and once in the list shell for Enter, reached through two different worktree access paths. Both now run `deriveRowModel` in the new `forgeRowModel.ts`. Worktrees are indexed once for the list instead of every mounted row rescanning the whole map, and a duplicate resolves to the active worktree rather than to whichever the map happened to yield first.

A few things fell out along the way:

- `PR.reviewDecision` and a linked PR's own `state` and `ciStatus` were already being fetched and thrown away. A merged linkage and one with failing checks rendered identically.
- The row always showed `updatedAt` even when the panel was sorted by Newest, so the ages read out of order against their own sort.
- A refresh reset the keyboard cursor to nothing. It now tracks the resource, scoped by project and kind so it cannot jump to a same numbered row in another project.
- This widget deliberately keeps DOM focus in the search input, which means none of its tooltips is reachable by keyboard. The state glyph, comments, branch direction, labels and assignees now carry accessible names. The avatar named only the first of N assignees.
- Selection is a named item in the actions menu instead of only a hover revealed checkbox, the bulk helpers follow selection mode rather than a non-empty query (typing used to grow the header and shove the list down), and `Select unassigned` became `Select without worktrees`, which is what the bulk action actually feeds.

## Testing

The unit suite could not see the original bug. It hard mocked the worktree store to an empty map, so no test had ever rendered a row that had a worktree. That mock is gone: the row takes its resolved worktree as a prop now, which is what made all of this testable.

jsdom cannot measure a 19px layout shift, so the guard that matters is a geometry assertion in `core-github-panels.spec.ts` comparing `boundingBox().x` across rows. I checked it is not vacuous: reverting just the rail order fails it by 18.8px.

`npm run check` green, full vitest suite green, `full-panels` green locally.
